### PR TITLE
feat(vmware): migrate 8 write composites to direct-session dispatch (#2256)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any, Literal, NamedTuple
 
+from meho_backplane.connectors import OperationResult
 from meho_backplane.connectors.vmware_rest.composites._read import (
     cluster_drs_recommendations_composite,
     datastore_usage_composite,
@@ -205,7 +206,11 @@ class _CompositeSpec(NamedTuple):
     """
 
     op_id: str
-    handler: Callable[..., Awaitable[dict[str, Any]]]
+    # Read composites return a plain aggregation dict; migrated write
+    # composites (#2256) may instead return an ``OperationResult`` verbatim
+    # when the direct-session governance seam parks/denies an internal write,
+    # so the handler contract widens to that union.
+    handler: Callable[..., Awaitable[dict[str, Any] | OperationResult]]
     summary: str
     description: str
     parameter_schema: dict[str, Any]

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -9,36 +9,57 @@
 
 """Write-shaped ``vmware.composite.*`` handler functions (8 composites).
 
-Companion to :mod:`._read`. Same handler-shape contract -- each handler
-is a module-level ``async def`` taking the dispatcher's composite-branch
-keyword args ``(operator, target, params, dispatch_child)`` and
-returning a single aggregated dict via ``dispatch_child`` calls to
-2-N typed sub-ops (or, for :func:`host_evacuate_composite`, recursive
-calls into another vmware.composite).
+Companion to :mod:`._read`. Post-#2256 each handler is a module-level
+``async def`` taking the dispatcher's composite-branch keyword args
+``(operator, target, params, connector)`` -- the resolved connector
+instance the #2251 substrate injects -- and issues every raw-REST sub-op
+**directly on the connector's own authenticated session**
+(``connector._get_json`` / ``connector._post_json`` mounted through
+``connector.mount_op_path``) with no ``endpoint_descriptor`` lookup, so
+the composite works on a fresh boot with **zero catalog ingest**
+(Initiative #2249 / Goal #2247, the I-A write migration).
 
-The 8 composites this module ships (G3.1-T6 / #509):
+The one exception is :func:`host_evacuate_composite`, which additionally
+declares ``dispatch_child`` for its recursive call into
+``vmware.composite.vm.migrate`` -- a ``source_kind="composite"`` sub-op
+routed through a registrar-guaranteed row (never an ingested primitive),
+so that recursion keeps its ``dispatch_child`` path per #2248.
 
-* :func:`vm_create_composite` -- folder lookup -> ``POST:/vcenter/vm``
-  -> NIC attach loop -> optional power-on. Partial-failure rollback
-  via ``DELETE:/vcenter/vm/{vm}``.
-* :func:`vm_clone_composite` -- content-library deploy with task
-  polling. Long-running; ``wait_for_completion=False`` returns the
-  task id immediately.
-* :func:`vm_snapshot_revert_composite` -- list -> match by name ->
-  revert. Idempotent; ambiguity-rejection on name collision.
-* :func:`vm_migrate_composite` -- DRS recommendation lookup ->
-  relocate. ``target_host`` overrides DRS.
-* :func:`vm_power_bulk_composite` -- filter -> fan-out power action.
-  Per-VM partial-failure tolerated by default.
-* :func:`host_evacuate_composite` -- list VMs on host -> recursive
-  :func:`vm_migrate_composite` per VM -> maintenance-enter. First
-  production composite that calls another composite via
-  ``dispatch_child``.
-* :func:`host_detach_from_vds_composite` -- per-VM NIC migration to
-  a fallback network -> DVS host-detach. Refuses detach when any NIC
-  migration failed.
-* :func:`cluster_patch_composite` -- sequential per-host maintenance
-  + patch + exit. Stops the loop on the first per-host failure.
+Preserving write governance on the direct path
+----------------------------------------------
+
+``dispatch_child`` re-ran the dispatcher's per-sub-op policy/approval
+gate (property 3 of #508's four guarantees); a direct session call
+bypasses :func:`~meho_backplane.operations.dispatcher.dispatch`, so a
+now-internal *write* sub-op would otherwise execute un-gated. Every
+mutating sub-call therefore routes through
+:func:`~meho_backplane.operations.composite.enforce_subop_policy`
+(Task #2254) **before** the direct ``connector._post_json`` fires: the
+seam re-runs the same ``policy_gate`` against an in-memory descriptor
+carrying the sub-op's declared governance and returns an
+``awaiting_approval`` / ``denied`` :class:`OperationResult` when the gate
+does not clear. The handler returns that verbatim -- the dispatcher
+passes a handler-returned :class:`OperationResult` straight through, so an
+internal write **queues** (or is denied) instead of silently running.
+
+Sub-op governance posture
+-------------------------
+
+Each write sub-op declares ``safety_level="dangerous"`` +
+``requires_approval=False``. The ``dangerous`` label is the honest
+intrinsic-risk classification (create / delete / power / relocate /
+patch / maintenance are all state-mutating); ``requires_approval=False``
+keeps the **top-level composite** (``requires_approval=True`` in
+:mod:`._register`) the single primary approval gate. Flooring a sub-op to
+``requires_approval=True`` would double-gate: the approval-resume path
+re-runs the handler with the top-level gate already satisfied, but
+:func:`enforce_subop_policy` is not resume-aware, so it would re-queue the
+first internal write forever. With ``requires_approval=False`` the seam
+still (a) auto-executes for a human/service operator whose composite was
+already approved, and (b) denies -- or, with an explicit
+per-``(principal, op, target)`` grant, queues -- a ``dangerous`` write for
+an agent principal, so no internal write drops below the governance it had
+under ``dispatch_child``.
 
 Every sub-op_id below is the canonical ``METHOD:/path`` key produced
 by :func:`~meho_backplane.operations.ingest.openapi.parse_openapi`
@@ -46,7 +67,12 @@ from the ingested ``vcenter.yaml`` (G3.1-T2 / #408) and
 ``vi-json.yaml`` (G3.1-T3 / #503). The path strings come from
 inspecting the canonical ``GOVC_PARITY_BENCHMARK`` tuple at
 ``backend/tests/acceptance/test_g07_vsphere_canary.py`` and the
-vSphere REST URL anchors in #509's issue body -- never guessed.
+vSphere REST URL anchors in #509's issue body -- never guessed. Post-#2256
+they no longer resolve an ``endpoint_descriptor`` row; each handler splits
+the ``METHOD:/path`` into its verb + spec-relative path, substitutes the
+``{var}`` path params, and mounts the remainder onto the target's live
+``/api`` (modern) / ``/rest`` (legacy/vcsim) prefix for the direct call
+(see :func:`_read_sub_op` / :func:`_write_sub_op`).
 
 Each composite returns a structured ``{"status": ...}`` envelope so
 callers can branch on ``status`` without parsing free-form prose. The
@@ -57,15 +83,18 @@ status enums are listed on each composite's ``response_schema`` in
 from __future__ import annotations
 
 import asyncio
+import re
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+import httpx
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors import OperationResult
-from meho_backplane.connectors.vmware_rest.composites._preflight import (
-    preflight_l2_dependencies,
-)
-from meho_backplane.operations.composite import DispatchChild
+from meho_backplane.operations.composite import DispatchChild, enforce_subop_policy
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
 
 __all__ = [
     "cluster_patch_composite",
@@ -79,19 +108,32 @@ __all__ = [
 ]
 
 
-# Connector_id every write composite dispatches sub-ops against.
+# Connector_id every write composite governs its sub-ops against (fed to
+# :func:`enforce_subop_policy` for the in-memory descriptor + the
+# ``vmware.composite.vm.migrate`` recursion routed through ``dispatch_child``).
 _CONNECTOR_ID = "vmware-rest-9.0"
+
+# Declared governance for every raw-REST *write* sub-op. ``dangerous`` is
+# the intrinsic-risk label; ``requires_approval=False`` keeps the top-level
+# composite the single approval gate (see the module docstring on why
+# flooring a sub-op to True would double-gate the resume path).
+_WRITE_SAFETY_LEVEL = "dangerous"
+_WRITE_REQUIRES_APPROVAL = False
+
+# ``{var}`` path-template placeholder pattern. vCenter moids are bare
+# ``[A-Za-z0-9-]`` tokens, so a plain ``str.format`` matches the RFC6570
+# simple-expansion the ingested path did.
+_PATH_VAR_RE = re.compile(r"\{([^{}]+)\}")
 
 # vCenter REST op_ids (canonical METHOD:/path keys from vcenter.yaml).
 #
 # Action-bearing endpoints. vCenter's OpenAPI spec models POST-with-side-effect
 # endpoints as ``/<path>?action=<verb>`` — i.e. the action verb is part of the
-# path key, not a body parameter. The ingestion pipeline preserves the query
-# verbatim, so the canonical ``op_id`` for "power on a VM" is
-# ``POST:/vcenter/vm/{vm}/power?action=start`` (not ``POST:/vcenter/vm/{vm}/power``
-# with ``action=start`` in body params — that op_id is not a descriptor row).
-# These constants therefore embed the action verb. Endpoints whose action verb
-# is operator-chosen (power start/stop, maintenance enter/exit) build the op_id
+# path key, not a body parameter. The canonical ``op_id`` for "power on a VM" is
+# ``POST:/vcenter/vm/{vm}/power?action=start``; the ``?action=<verb>`` rides on
+# the mounted path verbatim (httpx sends it as the request query string), so no
+# ``action`` body param is ever constructed. Endpoints whose action verb is
+# operator-chosen (power start/stop, maintenance enter/exit) build the op_id
 # per-call via :func:`_power_vm_op_id` / :func:`_host_maintenance_op_id`.
 _OP_LIST_FOLDERS = "GET:/vcenter/folder"
 _OP_LIST_VMS = "GET:/vcenter/vm"
@@ -115,10 +157,9 @@ def _power_vm_op_id(action: str) -> str:
     """Build the per-action canonical op_id for ``POST:/vcenter/vm/{vm}/power``.
 
     vCenter exposes ``start`` / ``stop`` / ``suspend`` / ``reset`` as four
-    distinct descriptor rows under the ``?action=<verb>`` discriminator. The
-    composite picks the row at call time so each action lands on its own
-    audit row + policy evaluation, not as a free-form ``action`` parameter
-    on a single shared op_id (which wouldn't resolve against an ingested row).
+    distinct ``?action=<verb>`` keys. The composite picks the key at call time
+    so each action lands on its own governance evaluation, not as a free-form
+    ``action`` parameter on a single shared op_id.
     """
     return f"POST:/vcenter/vm/{{vm}}/power?action={action}"
 
@@ -126,17 +167,19 @@ def _power_vm_op_id(action: str) -> str:
 def _host_maintenance_op_id(action: str) -> str:
     """Build the per-action canonical op_id for ``PATCH:/vcenter/host/{host}/maintenance``.
 
-    Maintenance enter / exit are two descriptor rows under ``?action=enter`` /
+    Maintenance enter / exit are two keys under ``?action=enter`` /
     ``?action=exit``; same reasoning as :func:`_power_vm_op_id`.
     """
     return f"PATCH:/vcenter/host/{{host}}/maintenance?action={action}"
 
 
-# Recursive composite sub-op_id (host.evacuate -> vm.migrate).
+# Recursive composite sub-op_id (host.evacuate -> vm.migrate). Routed
+# through ``dispatch_child`` (a registrar-guaranteed ``source_kind="composite"``
+# row), not the direct session -- per #2248 the composite->composite recursion
+# is out of scope for the ingested-dispatch migration.
 _OP_COMPOSITE_VM_MIGRATE = "vmware.composite.vm.migrate"
 
-# Composite op_ids -- used by the preflight cache key. Mirrors the
-# pattern in ``_read.py``.
+# Composite op_ids -- retained as the canonical documentation anchor.
 _COMPOSITE_OP_ID_VM_CREATE = "vmware.composite.vm.create"
 _COMPOSITE_OP_ID_VM_CLONE = "vmware.composite.vm.clone"
 _COMPOSITE_OP_ID_VM_SNAPSHOT_REVERT = "vmware.composite.vm.snapshot.revert"
@@ -146,16 +189,14 @@ _COMPOSITE_OP_ID_HOST_EVACUATE = "vmware.composite.host.evacuate"
 _COMPOSITE_OP_ID_HOST_DETACH_FROM_VDS = "vmware.composite.host.detach_from_vds"
 _COMPOSITE_OP_ID_CLUSTER_PATCH = "vmware.composite.cluster.patch"
 
-# Per-composite sub-op-id tuples consumed by the L2 pre-flight check
-# (G0.14-T10 / #1151). Each tuple lists every raw-REST L2 sub-op the
-# composite might dispatch against. Composite-to-composite sub-ops
-# (``vmware.composite.*``) are *not* included -- the preflight helper
-# skips them because they are registered by the same lifespan
-# registrar that brought their parent composite in.
-#
-# Action-discriminated endpoints (power start/stop/suspend/reset;
-# maintenance enter/exit) are spelled out per action because each verb
-# is a distinct ``endpoint_descriptor`` row, not a shared base path.
+# Per-composite sub-op-id tuples. Pre-#2256 these fed the L2 pre-flight
+# check that guarded a missing catalog ingest; the direct-session migration
+# removed that coupling, so the tuples now serve as the canonical sub-op-path
+# manifest the ingest-reconcile acceptance guard
+# (``tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py``)
+# checks against the vCenter spec. Composite-to-composite sub-ops
+# (``vmware.composite.*``) are listed for host.evacuate but are routed through
+# ``dispatch_child``, not the direct session.
 _POWER_ACTIONS: tuple[str, ...] = ("start", "stop", "suspend", "reset")
 _SUB_OPS_VM_CREATE: tuple[str, ...] = (
     _OP_LIST_FOLDERS,
@@ -181,9 +222,6 @@ _SUB_OPS_VM_POWER_BULK: tuple[str, ...] = (
     _OP_LIST_VMS,
     *(_power_vm_op_id(action) for action in _POWER_ACTIONS),
 )
-# host.evacuate dispatches to vm.migrate (composite -> composite); the
-# preflight helper skips ``vmware.composite.*`` entries. It also calls
-# maintenance enter directly.
 _SUB_OPS_HOST_EVACUATE: tuple[str, ...] = (
     _OP_LIST_VMS,
     _OP_COMPOSITE_VM_MIGRATE,
@@ -210,14 +248,92 @@ def _unwrap_value(payload: Any) -> Any:
     return payload
 
 
-def _require_ok(result: OperationResult) -> Any:
-    """Return :attr:`OperationResult.result` or raise on a non-OK status."""
-    if result.status != "ok":
-        raise RuntimeError(
-            f"composite sub-op {result.op_id!r} returned status="
-            f"{result.status!r}: {result.error or '<no error message>'}"
-        )
-    return result.result
+def _split_sub_op(op_id: str, params: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
+    """Split *op_id* + *params* into ``(method, spec-relative path, remainder)``.
+
+    Extracts the ``{var}`` names from the ``METHOD:/path`` template,
+    substitutes the matching *params* entries into the path (any
+    ``?action=<verb>`` query segment rides along verbatim), and returns the
+    remaining params -- the query bucket for a ``GET`` or the JSON body for a
+    write. Mirrors the ``x-meho-param-loc`` path/query/body split the ingested
+    dispatch performed, without any descriptor lookup.
+    """
+    method, _, path_template = op_id.partition(":")
+    var_names = _PATH_VAR_RE.findall(path_template)
+    path_params = {name: params[name] for name in var_names}
+    path = path_template.format(**path_params) if path_params else path_template
+    remainder = {k: v for k, v in params.items() if k not in path_params}
+    return method, path, remainder
+
+
+async def _read_sub_op(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    op_id: str,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    """Issue one read sub-call (``GET``) directly on the connector session.
+
+    Splits the canonical ``METHOD:/path`` *op_id*, mounts the substituted
+    path onto the target's live ``/api`` / ``/rest`` prefix, and dispatches
+    through :meth:`~meho_backplane.connectors.adapters.http.HttpConnector._get_json`
+    (tenacity-retried, idempotent) with the remainder params as the query
+    bucket. Read sub-ops carry no governance gate -- they are the safe
+    resolution reads the write composites build their request bodies from.
+    Transport / status failures raise :exc:`httpx.HTTPError`; load-bearing
+    callers let it propagate (the dispatcher wraps it as ``connector_error``
+    for the composite parent).
+    """
+    method, path, query = _split_sub_op(op_id, params or {})
+    if method != "GET":
+        raise RuntimeError(f"_read_sub_op called with non-GET op_id {op_id!r}")
+    mounted = await connector.mount_op_path(target, path, operator)
+    return await connector._get_json(target, mounted, operator=operator, params=query or None)
+
+
+async def _write_sub_op(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    op_id: str,
+    params: dict[str, Any],
+) -> tuple[OperationResult | None, Any]:
+    """Gate then issue one *write* sub-call directly on the connector session.
+
+    Runs :func:`~meho_backplane.operations.composite.enforce_subop_policy`
+    with the sub-op's full logical *params* (so the durable
+    :class:`~meho_backplane.db.models.ApprovalRequest` names the entity the
+    write would touch) and the declared ``dangerous`` /
+    ``requires_approval=False`` governance. When the seam returns a result
+    (``awaiting_approval`` / ``denied``) the write is **not** issued -- the
+    ``(gate, None)`` tuple signals the caller to return that
+    :class:`OperationResult` verbatim. When the seam clears the gate
+    (``None``), the sub-op is split into ``(verb, path, body)`` and dispatched
+    through
+    :meth:`~meho_backplane.connectors.adapters.http.HttpConnector._post_json`
+    (honouring the actual ``POST`` / ``PATCH`` / ``DELETE`` verb); the parsed
+    JSON payload rides back as ``(None, payload)``. Transport failures raise
+    :exc:`httpx.HTTPError` for the caller to catch (partial-failure legs) or
+    let propagate (load-bearing legs).
+    """
+    gate = await enforce_subop_policy(
+        operator=operator,
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        safety_level=_WRITE_SAFETY_LEVEL,
+        requires_approval=_WRITE_REQUIRES_APPROVAL,
+        target=target,
+        params=params,
+    )
+    if gate is not None:
+        return gate, None
+    method, path, body = _split_sub_op(op_id, params)
+    mounted = await connector.mount_op_path(target, path, operator)
+    payload = await connector._post_json(
+        target, mounted, operator=operator, verb=method, json=body or None
+    )
+    return None, payload
 
 
 def _rolled_back(
@@ -238,33 +354,36 @@ def _rolled_back(
 
 async def _resolve_vm_list(
     *,
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
     filter_dict: dict[str, Any],
 ) -> list[dict[str, Any]]:
     """Resolve a VM filter to its listing rows via ``GET:/vcenter/vm``.
 
-    Read-only: issues exactly one listing GET, never a mutation. Filter
-    keys are forwarded as ``filter.<key>`` query params per the vCenter
-    listing contract.
+    Read-only: issues exactly one listing GET directly on the connector
+    session, never a mutation. Filter keys are forwarded as ``filter.<key>``
+    query params per the vCenter listing contract.
 
     Shared seam (#1608): the write handlers that fan out over a filtered
     VM set (:func:`vm_power_bulk_composite`, :func:`host_evacuate_composite`,
-    :func:`host_detach_from_vds_composite`) call this at dispatch time,
-    and their park-time preview builders (:mod:`._write_preview`) call the
-    same function at approval-park time — so the entity set the reviewer
-    sees in ``proposed_effect`` is resolved by the same code path the
-    approved dispatch will use.
+    :func:`host_detach_from_vds_composite`) call this at dispatch time, and
+    their park-time preview builders (:mod:`._write_preview`) call the same
+    function against the resolved connector at approval-park time — so the
+    entity set the reviewer sees in ``proposed_effect`` is resolved by the
+    same code path the approved dispatch will use.
 
-    Raises :class:`RuntimeError` when the listing sub-op fails or returns
-    a non-list payload. Non-dict rows are dropped (the listing contract
-    yields summary objects); per-row key validation stays with callers.
+    Raises :class:`RuntimeError` when the listing returns a non-list
+    payload and :exc:`httpx.HTTPError` when the sub-op transport fails.
+    Non-dict rows are dropped (the listing contract yields summary objects);
+    per-row key validation stays with callers.
     """
-    listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_VMS,
-            params={f"filter.{k}": v for k, v in filter_dict.items()},
-        )
+    listing = await _read_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_LIST_VMS,
+        {f"filter.{k}": v for k, v in filter_dict.items()},
     )
     vms = _unwrap_value(listing)
     if not isinstance(vms, list):
@@ -274,25 +393,23 @@ async def _resolve_vm_list(
 
 async def _resolve_cluster_hosts(
     *,
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
     cluster_moid: str,
 ) -> list[dict[str, Any]]:
     """Resolve a cluster's host listing rows via ``GET:/vcenter/cluster/{cluster}/host``.
 
-    Read-only single GET. Shared between :func:`cluster_patch_composite`
-    (dispatch time) and its park-time preview builder in
-    :mod:`._write_preview` (#1608) — same rationale as
+    Read-only single GET directly on the connector session. Shared between
+    :func:`cluster_patch_composite` (dispatch time) and its park-time preview
+    builder in :mod:`._write_preview` (#1608) — same rationale as
     :func:`_resolve_vm_list`.
 
-    Raises :class:`RuntimeError` when the listing sub-op fails or returns
-    a non-list payload. Non-dict rows are dropped.
+    Raises :class:`RuntimeError` on a non-list payload and
+    :exc:`httpx.HTTPError` on a transport fault. Non-dict rows are dropped.
     """
-    listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_CLUSTER_HOSTS,
-            params={"cluster": cluster_moid},
-        )
+    listing = await _read_sub_op(
+        connector, target, operator, _OP_LIST_CLUSTER_HOSTS, {"cluster": cluster_moid}
     )
     entries = _unwrap_value(listing)
     if not isinstance(entries, list):
@@ -308,7 +425,11 @@ async def _resolve_cluster_hosts(
 
 
 async def _resolve_folder_moid(
-    *, dispatch_child: DispatchChild, folder_name: str
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    folder_name: str,
 ) -> tuple[str | None, str | None]:
     """Look up a folder moid by display name.
 
@@ -317,12 +438,8 @@ async def _resolve_folder_moid(
     envelope. Failure modes: empty match list, listing row missing
     the ``folder`` key.
     """
-    folder_listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_FOLDERS,
-            params={"filter.names": [folder_name]},
-        )
+    folder_listing = await _read_sub_op(
+        connector, target, operator, _OP_LIST_FOLDERS, {"filter.names": [folder_name]}
     )
     folder_entries = _unwrap_value(folder_listing)
     if not isinstance(folder_entries, list) or not folder_entries:
@@ -334,74 +451,25 @@ async def _resolve_folder_moid(
     return folder_moid_raw, None
 
 
-async def _dispatch_create_vm(
+async def _rollback_created_vm(
     *,
-    dispatch_child: DispatchChild,
-    folder_moid: str,
-    name: str,
-    guest_os: str,
-    cpu_count: int,
-    memory_mib: int,
-) -> tuple[str | None, str | None]:
-    """POST:/vcenter/vm; return ``(vm_id, None)`` or ``(None, error_reason)``."""
-    create_result = await dispatch_child(
-        connector_id=_CONNECTOR_ID,
-        op_id=_OP_CREATE_VM,
-        params={
-            "spec": {
-                "name": name,
-                "guest_OS": guest_os,
-                "placement": {"folder": folder_moid},
-                "cpu": {"count": cpu_count},
-                "memory": {"size_MiB": memory_mib},
-            },
-        },
-    )
-    if create_result.status != "ok":
-        return None, (
-            f"create returned status={create_result.status!r}: "
-            f"{create_result.error or '<no error message>'}"
-        )
-    vm_id_raw = _unwrap_value(create_result.result)
-    if not isinstance(vm_id_raw, str):
-        return None, f"create returned non-string vm id payload: {type(vm_id_raw).__name__}"
-    return vm_id_raw, None
-
-
-async def _attach_vm_nics(
-    *,
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
     vm_id: str,
-    nics: list[dict[str, Any]],
-) -> str | None:
-    """Attach NICs one-by-one; return ``None`` on success or a failure reason."""
-    for nic in nics:
-        nic_result = await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_ATTACH_VM_NIC,
-            params={"vm": vm_id, "spec": nic},
-        )
-        if nic_result.status != "ok":
-            return (
-                f"nic attach for network={nic.get('network')!r} failed: "
-                f"{nic_result.error or '<no error message>'}"
-            )
-    return None
-
-
-async def _rollback_created_vm(*, dispatch_child: DispatchChild, vm_id: str) -> None:
+) -> None:
     """Issue ``DELETE:/vcenter/vm/{vm}`` to remove a half-created VM.
 
-    Best-effort: rollback failures are not surfaced -- the operator
-    already knows the create flow failed. If the DELETE returns
-    non-ok, the audit row of that sub-op records it for forensic
-    review.
+    Best-effort: rollback faults are swallowed -- the operator already knows
+    the create flow failed, and a denied/queued rollback sub-op or a
+    transport error must not mask the original failure. A gate result from
+    the seam is ignored here for the same reason (the rollback DELETE is a
+    cleanup, not an operator-requested action).
     """
-    await dispatch_child(
-        connector_id=_CONNECTOR_ID,
-        op_id=_OP_DELETE_VM,
-        params={"vm": vm_id},
-    )
+    try:
+        await _write_sub_op(connector, target, operator, _OP_DELETE_VM, {"vm": vm_id})
+    except httpx.HTTPError:
+        return
 
 
 async def vm_create_composite(
@@ -409,19 +477,13 @@ async def vm_create_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
-) -> dict[str, Any]:
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
     """Create a VM with NIC attach + optional power-on; rollback on failure.
 
     Op-id: ``vmware.composite.vm.create``. See module docstring for the
-    sub-op chain and rollback semantics.
+    sub-op chain, the direct-session governance seam, and rollback semantics.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_VM_CREATE,
-        sub_op_ids=_SUB_OPS_VM_CREATE,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     folder_name = params["folder_name"]
     name = params["name"]
     guest_os = params["guest_os"]
@@ -433,45 +495,74 @@ async def vm_create_composite(
     steps: list[str] = []
 
     folder_moid, folder_err = await _resolve_folder_moid(
-        dispatch_child=dispatch_child, folder_name=folder_name
+        connector=connector, target=target, operator=operator, folder_name=folder_name
     )
     if folder_moid is None:
         return _rolled_back(steps=steps, failed_step="folder_lookup", reason=folder_err or "")
     steps.append("folder_lookup")
 
-    vm_id, create_err = await _dispatch_create_vm(
-        dispatch_child=dispatch_child,
-        folder_moid=folder_moid,
-        name=name,
-        guest_os=guest_os,
-        cpu_count=cpu_count,
-        memory_mib=memory_mib,
-    )
-    if vm_id is None:
+    create_spec = {
+        "spec": {
+            "name": name,
+            "guest_OS": guest_os,
+            "placement": {"folder": folder_moid},
+            "cpu": {"count": cpu_count},
+            "memory": {"size_MiB": memory_mib},
+        },
+    }
+    try:
+        gate, create_payload = await _write_sub_op(
+            connector, target, operator, _OP_CREATE_VM, create_spec
+        )
+    except httpx.HTTPError as exc:
         # Create failed; nothing to roll back.
-        return _rolled_back(steps=steps, failed_step="create", reason=create_err or "")
+        return _rolled_back(steps=steps, failed_step="create", reason=f"create failed: {exc}")
+    if gate is not None:
+        return gate
+    vm_id = _unwrap_value(create_payload)
+    if not isinstance(vm_id, str):
+        return _rolled_back(
+            steps=steps,
+            failed_step="create",
+            reason=f"create returned non-string vm id payload: {type(vm_id).__name__}",
+        )
     steps.append("create")
 
-    nic_err = await _attach_vm_nics(dispatch_child=dispatch_child, vm_id=vm_id, nics=nics)
-    if nic_err is not None:
-        await _rollback_created_vm(dispatch_child=dispatch_child, vm_id=vm_id)
-        return _rolled_back(steps=steps, failed_step="nic_attach", reason=nic_err)
+    for nic in nics:
+        try:
+            gate, _ = await _write_sub_op(
+                connector, target, operator, _OP_ATTACH_VM_NIC, {"vm": vm_id, "spec": nic}
+            )
+        except httpx.HTTPError as exc:
+            await _rollback_created_vm(
+                connector=connector, target=target, operator=operator, vm_id=vm_id
+            )
+            return _rolled_back(
+                steps=steps,
+                failed_step="nic_attach",
+                reason=f"nic attach for network={nic.get('network')!r} failed: {exc}",
+            )
+        if gate is not None:
+            return gate
     if nics:
         steps.append("nic_attach")
 
     if power_on:
-        power_result = await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_power_vm_op_id("start"),
-            params={"vm": vm_id},
-        )
-        if power_result.status != "ok":
-            await _rollback_created_vm(dispatch_child=dispatch_child, vm_id=vm_id)
+        try:
+            gate, _ = await _write_sub_op(
+                connector, target, operator, _power_vm_op_id("start"), {"vm": vm_id}
+            )
+        except httpx.HTTPError as exc:
+            await _rollback_created_vm(
+                connector=connector, target=target, operator=operator, vm_id=vm_id
+            )
             return _rolled_back(
                 steps=steps,
                 failed_step="power_on",
-                reason=f"power_on failed: {power_result.error or '<no error message>'}",
+                reason=f"power_on failed: {exc}",
             )
+        if gate is not None:
+            return gate
         steps.append("power_on")
 
     return {
@@ -513,7 +604,9 @@ def _extract_clone_vm_id(task_result_payload: Any) -> str | None:
 
 async def _poll_clone_task(
     *,
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
     task_id: str,
     timeout_seconds: int,
 ) -> dict[str, Any]:
@@ -526,12 +619,8 @@ async def _poll_clone_task(
     deadline = time.monotonic() + timeout_seconds
     poll_interval = 1.0
     while time.monotonic() < deadline:
-        task_payload = _require_ok(
-            await dispatch_child(
-                connector_id=_CONNECTOR_ID,
-                op_id=_OP_GET_TASK,
-                params={"task": task_id},
-            )
+        task_payload = await _read_sub_op(
+            connector, target, operator, _OP_GET_TASK, {"task": task_id}
         )
         task = _unwrap_value(task_payload)
         if isinstance(task, dict):
@@ -566,20 +655,14 @@ async def vm_clone_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
-) -> dict[str, Any]:
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
     """Clone a VM from a content-library template; poll the deploy task.
 
     Op-id: ``vmware.composite.vm.clone``. Long-running -- blocks for
     up to ``timeout_seconds`` (default 600) when
     ``wait_for_completion=True``.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_VM_CLONE,
-        sub_op_ids=_SUB_OPS_VM_CLONE,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     source_vm = params["source_vm"]
     target_name = params["target_name"]
     library_item = params["library_item"]
@@ -587,25 +670,18 @@ async def vm_clone_composite(
     timeout_seconds = int(params.get("timeout_seconds", 600))
 
     # Source config drives CloneSpec; the read is a no-op when the
-    # source VM lookup fails (RuntimeError surfaces upstream).
-    _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_GET_VM,
-            params={"vm": source_vm},
-        )
-    )
+    # source VM lookup fails (httpx.HTTPError surfaces upstream).
+    await _read_sub_op(connector, target, operator, _OP_GET_VM, {"vm": source_vm})
 
-    deploy_payload = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_DEPLOY_LIBRARY_VM,
-            params={
-                "library_item": library_item,
-                "spec": {"name": target_name},
-            },
-        )
+    gate, deploy_payload = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_DEPLOY_LIBRARY_VM,
+        {"library_item": library_item, "spec": {"name": target_name}},
     )
+    if gate is not None:
+        return gate
     task_id = _extract_clone_task_id(deploy_payload)
     if task_id is None:
         raise RuntimeError(f"vm.clone: deploy returned no task id (payload={deploy_payload!r})")
@@ -619,7 +695,9 @@ async def vm_clone_composite(
         }
 
     return await _poll_clone_task(
-        dispatch_child=dispatch_child,
+        connector=connector,
+        target=target,
+        operator=operator,
         task_id=task_id,
         timeout_seconds=timeout_seconds,
     )
@@ -635,29 +713,19 @@ async def vm_snapshot_revert_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
-) -> dict[str, Any]:
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
     """Revert a VM to a named snapshot. Idempotent; ambiguity-rejecting.
 
     Op-id: ``vmware.composite.vm.snapshot.revert``. Multiple snapshots
     sharing the name -> ``status='ambiguous'``; missing -> ``not_found``.
     Revert never dispatches on either.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_VM_SNAPSHOT_REVERT,
-        sub_op_ids=_SUB_OPS_VM_SNAPSHOT_REVERT,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     vm_moid = params["vm"]
     snapshot_name = params["snapshot_name"]
 
-    listing = _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_VM_SNAPSHOTS,
-            params={"vm": vm_moid},
-        )
+    listing = await _read_sub_op(
+        connector, target, operator, _OP_LIST_VM_SNAPSHOTS, {"vm": vm_moid}
     )
     entries = _unwrap_value(listing)
     if not isinstance(entries, list):
@@ -691,13 +759,15 @@ async def vm_snapshot_revert_composite(
             "candidates": matches,
             "guidance": "matched snapshot row missing ``snapshot`` key",
         }
-    _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_REVERT_VM_SNAPSHOT,
-            params={"vm": vm_moid, "snap": snapshot_moid},
-        )
+    gate, _ = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_REVERT_VM_SNAPSHOT,
+        {"vm": vm_moid, "snap": snapshot_moid},
     )
+    if gate is not None:
+        return gate
     return {
         "status": "reverted",
         "snapshot_id": snapshot_moid,
@@ -731,20 +801,19 @@ async def vm_migrate_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
-) -> dict[str, Any]:
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
     """Migrate a VM via DRS recommendation or explicit ``target_host``.
 
     Op-id: ``vmware.composite.vm.migrate``. ``target_host`` overrides
     the DRS lookup. No-recommendation path returns
     ``status='no_recommendation'`` so the caller can re-dispatch.
+
+    Also the recursion target of :func:`host_evacuate_composite`: invoked
+    through ``dispatch_child`` there, the dispatcher resolves this composite
+    and injects ``connector`` so its own relocate write runs on the direct
+    session under the governance seam, exactly as a top-level dispatch does.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_VM_MIGRATE,
-        sub_op_ids=_SUB_OPS_VM_MIGRATE,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     vm_moid = params["vm"]
     cluster_moid = params["cluster"]
     explicit_target = params.get("target_host")
@@ -755,12 +824,12 @@ async def vm_migrate_composite(
         target_host = explicit_target
         source = "operator"
     else:
-        recs_payload = _require_ok(
-            await dispatch_child(
-                connector_id=_CONNECTOR_ID,
-                op_id=_OP_GET_DRS_RECOMMENDATIONS,
-                params={"cluster": cluster_moid},
-            )
+        recs_payload = await _read_sub_op(
+            connector,
+            target,
+            operator,
+            _OP_GET_DRS_RECOMMENDATIONS,
+            {"cluster": cluster_moid},
         )
         target_host = _pick_drs_target_host(_unwrap_value(recs_payload), vm_moid)
         if target_host is not None:
@@ -777,16 +846,15 @@ async def vm_migrate_composite(
             ),
         }
 
-    _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_RELOCATE_VM,
-            params={
-                "vm": vm_moid,
-                "spec": {"placement": {"host": target_host}},
-            },
-        )
+    gate, _ = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_RELOCATE_VM,
+        {"vm": vm_moid, "spec": {"placement": {"host": target_host}}},
     )
+    if gate is not None:
+        return gate
     return {
         "status": "migrated",
         "target_host": target_host,
@@ -805,28 +873,24 @@ async def vm_power_bulk_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
-) -> dict[str, Any]:
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
     """Apply a power action to every VM matching a filter; aggregate results.
 
     Op-id: ``vmware.composite.vm.power.bulk``. ``fail_fast=True``
-    aborts on first failure; default tolerates per-VM failures.
+    aborts on first failure; default tolerates per-VM failures. A governance
+    verdict is identical across the fan-out (same op_id + target), so a
+    gated/denied per-VM power short-circuits the whole composite with the
+    seam's result rather than half-executing the batch.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_VM_POWER_BULK,
-        sub_op_ids=_SUB_OPS_VM_POWER_BULK,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     filter_dict: dict[str, Any] = dict(params.get("filter") or {})
     action = params["action"]
     fail_fast = bool(params.get("fail_fast", False))
-    # Resolve the action verb to a concrete descriptor op_id once before the
-    # fan-out loop. Each ``?action=<verb>`` is a distinct descriptor row, so
-    # every per-VM dispatch must target the matching one.
     power_op_id = _power_vm_op_id(action)
 
-    vms = await _resolve_vm_list(dispatch_child=dispatch_child, filter_dict=filter_dict)
+    vms = await _resolve_vm_list(
+        connector=connector, target=target, operator=operator, filter_dict=filter_dict
+    )
 
     results: list[dict[str, Any]] = []
     ok_count = 0
@@ -836,26 +900,19 @@ async def vm_power_bulk_composite(
         vm_moid = vm_entry.get("vm")
         if not isinstance(vm_moid, str):
             continue
-        power_result = await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=power_op_id,
-            params={"vm": vm_moid},
-        )
-        if power_result.status == "ok":
-            results.append({"vm": vm_moid, "status": "ok", "error": None})
-            ok_count += 1
-        else:
-            results.append(
-                {
-                    "vm": vm_moid,
-                    "status": "error",
-                    "error": power_result.error or "<no error message>",
-                }
-            )
+        try:
+            gate, _ = await _write_sub_op(connector, target, operator, power_op_id, {"vm": vm_moid})
+        except httpx.HTTPError as exc:
+            results.append({"vm": vm_moid, "status": "error", "error": str(exc)})
             err_count += 1
             if fail_fast:
                 aborted = True
                 break
+            continue
+        if gate is not None:
+            return gate
+        results.append({"vm": vm_moid, "status": "ok", "error": None})
+        ok_count += 1
     return {
         "results": results,
         "summary": {"ok": ok_count, "error": err_count},
@@ -886,23 +943,24 @@ async def host_evacuate_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
+    connector: VmwareRestConnector,
     dispatch_child: DispatchChild,
-) -> dict[str, Any]:
+) -> dict[str, Any] | OperationResult:
     """Migrate every VM off a host (via recursive vm.migrate) then enter maintenance.
 
-    Op-id: ``vmware.composite.host.evacuate``. First production
-    composite that calls another composite via ``dispatch_child``.
+    Op-id: ``vmware.composite.host.evacuate``. First production composite
+    that calls another composite via ``dispatch_child`` -- that recursion
+    into ``vmware.composite.vm.migrate`` stays on the ``dispatch_child`` path
+    (a registrar-guaranteed ``source_kind="composite"`` row, #2248), while
+    the host's own VM listing read and the maintenance-enter write run
+    directly on the injected ``connector`` session.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_HOST_EVACUATE,
-        sub_op_ids=_SUB_OPS_HOST_EVACUATE,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     host_moid = params["host"]
     tolerate_partial = bool(params.get("tolerate_partial_failure", False))
 
-    vms = await _resolve_vm_list(dispatch_child=dispatch_child, filter_dict={"hosts": [host_moid]})
+    vms = await _resolve_vm_list(
+        connector=connector, target=target, operator=operator, filter_dict={"hosts": [host_moid]}
+    )
 
     migrated: list[str] = []
     failed: list[dict[str, str]] = []
@@ -949,13 +1007,11 @@ async def host_evacuate_composite(
                 "maintenance_entered": False,
             }
 
-    _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_host_maintenance_op_id("enter"),
-            params={"host": host_moid},
-        )
+    gate, _ = await _write_sub_op(
+        connector, target, operator, _host_maintenance_op_id("enter"), {"host": host_moid}
     )
+    if gate is not None:
+        return gate
     return {
         "status": "partial" if failed else "evacuated",
         "host": host_moid,
@@ -975,32 +1031,24 @@ async def host_detach_from_vds_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
-) -> dict[str, Any]:
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
     """Migrate host VM NICs off a DVS to a standard switch, then remove host from DVS.
 
     Op-id: ``vmware.composite.host.detach_from_vds``. Refuses the DVS
     detach when any NIC migration failed -- vSphere would reject the
     step-4 detach anyway.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_HOST_DETACH_FROM_VDS,
-        sub_op_ids=_SUB_OPS_HOST_DETACH_FROM_VDS,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     host_moid = params["host"]
     dvs_moid = params["dvs"]
     fallback_network = params["fallback_network"]
 
-    _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_LIST_PORTGROUPS,
-            params={"filter.hosts": [host_moid]},
-        )
+    await _read_sub_op(
+        connector, target, operator, _OP_LIST_PORTGROUPS, {"filter.hosts": [host_moid]}
     )
-    vms = await _resolve_vm_list(dispatch_child=dispatch_child, filter_dict={"hosts": [host_moid]})
+    vms = await _resolve_vm_list(
+        connector=connector, target=target, operator=operator, filter_dict={"hosts": [host_moid]}
+    )
 
     vms_migrated: list[str] = []
     migration_failures: list[dict[str, str]] = []
@@ -1008,17 +1056,20 @@ async def host_detach_from_vds_composite(
         vm_moid = vm_entry.get("vm")
         if not isinstance(vm_moid, str):
             continue
-        nic_result = await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_ATTACH_VM_NIC,
-            params={"vm": vm_moid, "spec": {"network": fallback_network}},
-        )
-        if nic_result.status == "ok":
-            vms_migrated.append(vm_moid)
-        else:
-            migration_failures.append(
-                {"vm": vm_moid, "error": nic_result.error or "<no error message>"}
+        try:
+            gate, _ = await _write_sub_op(
+                connector,
+                target,
+                operator,
+                _OP_ATTACH_VM_NIC,
+                {"vm": vm_moid, "spec": {"network": fallback_network}},
             )
+        except httpx.HTTPError as exc:
+            migration_failures.append({"vm": vm_moid, "error": str(exc)})
+            continue
+        if gate is not None:
+            return gate
+        vms_migrated.append(vm_moid)
 
     if migration_failures:
         return {
@@ -1028,13 +1079,15 @@ async def host_detach_from_vds_composite(
             "vms_migrated": vms_migrated,
         }
 
-    _require_ok(
-        await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=_OP_REMOVE_DVS_HOST,
-            params={"dvs": dvs_moid, "host": host_moid},
-        )
+    gate, _ = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_REMOVE_DVS_HOST,
+        {"dvs": dvs_moid, "host": host_moid},
     )
+    if gate is not None:
+        return gate
     return {
         "status": "detached",
         "host": host_moid,
@@ -1048,10 +1101,9 @@ async def host_detach_from_vds_composite(
 # ===========================================================================
 
 
-# Per-step (step-name, op_id_builder, extra-params-builder) tuples. The op_id
-# builder yields the concrete ``?action=<verb>`` descriptor key per step;
-# extra-params adds the ``method`` body field that ``POST:/vcenter/host/{host}
-# ?action=patch`` consumes (the patch verb has a non-trivial body schema; the
+# Per-step (step-name, op_id) tuples. The op_id yields the concrete
+# ``?action=<verb>`` key per step; the patch step additionally carries a
+# ``method`` body field (the patch verb has a non-trivial body schema; the
 # maintenance verbs do not).
 _CLUSTER_PATCH_STEPS: tuple[tuple[str, str], ...] = (
     ("maintenance_enter", _host_maintenance_op_id("enter")),
@@ -1078,22 +1130,30 @@ def _cluster_patch_step_params(
 
 async def _patch_one_host(
     *,
-    dispatch_child: DispatchChild,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
     host_moid: str,
     patch_method: str,
-) -> str | None:
-    """Sequential maintenance + patch + exit on a single host; return error reason or None."""
+) -> tuple[OperationResult | None, str | None]:
+    """Sequential maintenance + patch + exit on a single host.
+
+    Returns ``(gate, None)`` when a step's governance seam parks/denies the
+    write (the caller returns the :class:`OperationResult` verbatim),
+    ``(None, error_reason)`` when a step's transport fails, or
+    ``(None, None)`` on full success.
+    """
     for step, op_id in _CLUSTER_PATCH_STEPS:
-        step_result = await dispatch_child(
-            connector_id=_CONNECTOR_ID,
-            op_id=op_id,
-            params=_cluster_patch_step_params(
-                step=step, host_moid=host_moid, patch_method=patch_method
-            ),
+        step_params = _cluster_patch_step_params(
+            step=step, host_moid=host_moid, patch_method=patch_method
         )
-        if step_result.status != "ok":
-            return f"{step} on {host_moid!r} failed: {step_result.error or '<no error message>'}"
-    return None
+        try:
+            gate, _ = await _write_sub_op(connector, target, operator, op_id, step_params)
+        except httpx.HTTPError as exc:
+            return None, f"{step} on {host_moid!r} failed: {exc}"
+        if gate is not None:
+            return gate, None
+    return None, None
 
 
 async def cluster_patch_composite(
@@ -1101,24 +1161,20 @@ async def cluster_patch_composite(
     operator: Operator,
     target: Any,
     params: dict[str, Any],
-    dispatch_child: DispatchChild,
-) -> dict[str, Any]:
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
     """Sequentially patch every host in a cluster: maintenance + patch + exit.
 
     Op-id: ``vmware.composite.cluster.patch``. Sequential by design --
     concurrent host patches would force every cluster VM to vMotion
     at once.
     """
-    await preflight_l2_dependencies(
-        composite_op_id=_COMPOSITE_OP_ID_CLUSTER_PATCH,
-        sub_op_ids=_SUB_OPS_CLUSTER_PATCH,
-        connector_id=_CONNECTOR_ID,
-        tenant_id=operator.tenant_id,
-    )
     cluster_moid = params["cluster"]
     patch_method = params.get("patch_method", "default")
 
-    entries = await _resolve_cluster_hosts(dispatch_child=dispatch_child, cluster_moid=cluster_moid)
+    entries = await _resolve_cluster_hosts(
+        connector=connector, target=target, operator=operator, cluster_moid=cluster_moid
+    )
     host_moids: list[str] = []
     for entry in entries:
         host_moid = entry.get("host")
@@ -1127,9 +1183,15 @@ async def cluster_patch_composite(
 
     patched: list[str] = []
     for i, host_moid in enumerate(host_moids):
-        failure_reason = await _patch_one_host(
-            dispatch_child=dispatch_child, host_moid=host_moid, patch_method=patch_method
+        gate, failure_reason = await _patch_one_host(
+            connector=connector,
+            target=target,
+            operator=operator,
+            host_moid=host_moid,
+            patch_method=patch_method,
         )
+        if gate is not None:
+            return gate
         if failure_reason is not None:
             return {
                 "status": "stopped",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -50,17 +50,19 @@ Two preview depths, chosen per composite
 How preview reads execute
 =========================
 
-The handlers receive their ``dispatch_child`` from the dispatcher's
-composite branch; at park time the composite never runs, so the live-read
-builders construct :func:`_read_only_dispatch_child` — an adapter
-satisfying the same :class:`~meho_backplane.operations.composite.DispatchChild`
-protocol (which is what lets the resolution helpers be shared verbatim)
-but executing the sub-op **directly against the resolved connector**
-rather than through :func:`~meho_backplane.operations.dispatcher.dispatch`.
-See the adapter docstring for the three reasons (no policy-gate
-re-entry, no unparented audit rows, GET-only fail-closed guard); the
-k8s.apply dry-run (#1437), the argocd snapshot reads (#1452), and the
-vault capability probe (#1504) all run their preview I/O the same way —
+Post-#2256 the write handlers resolve their live-read helpers
+(:func:`._write._resolve_vm_list` / :func:`._write._resolve_cluster_hosts`)
+**directly on the connector session** rather than through
+``dispatch_child``. The live-read preview builders reuse those same
+helpers verbatim, passing the connector instance the dispatcher already
+resolved into *ctx* (:attr:`PreviewContext.connector_instance`). Because
+the helpers issue a plain ``GET`` on the connector session, the three
+properties the old park-time ``dispatch_child`` adapter enforced hold
+intrinsically: no policy-gate re-entry (a direct session call cannot
+re-enter the dispatcher), no unparented audit rows (a direct read writes
+none), and reads-only (the helpers only ever issue the listing ``GET``).
+The k8s.apply dry-run (#1437), the argocd snapshot reads (#1452), and the
+vault capability probe (#1504) run their preview I/O the same way —
 connector-level, un-dispatched.
 
 Redaction posture
@@ -84,11 +86,9 @@ unknown" from a genuinely small action.
 
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
 from typing import Any
 
-from meho_backplane.connectors import OperationResult
 from meho_backplane.connectors.vmware_rest.composites._write import (
     _resolve_cluster_hosts,
     _resolve_vm_list,
@@ -98,146 +98,12 @@ from meho_backplane.operations._preview import (
     PreviewContext,
     register_preview_builder,
 )
-from meho_backplane.operations.composite import DispatchChild
 
 #: Cap on the ``resolved`` entity list stored in the durable
 #: ``proposed_effect`` row. ``total_resolved`` always carries the uncapped
 #: count, so a reviewer of a 1000-VM bulk op sees the first 20 entities
 #: *and* the true blast-radius number without the row ballooning.
 _PREVIEW_RESOLVED_CAP = 20
-
-#: HTTP-verb prefix every preview sub-op must carry. Canonical L2 op_ids
-#: encode the method (``METHOD:/path``), so the prefix check is a
-#: structural read-only guard that holds for both ``ingested`` and
-#: ``typed`` descriptor rows.
-_READ_OP_ID_PREFIX = "GET:"
-
-
-async def _execute_leaf_read(
-    ctx: PreviewContext,
-    *,
-    connector_id: str,
-    op_id: str,
-    params: dict[str, Any],
-    effective_target: Any,
-) -> Any:
-    """Resolve + execute one leaf read directly via its source-kind branch.
-
-    Mirrors the dispatcher's own steps — resolve the enabled descriptor
-    row for ``(connector_id, op_id)``, then route by ``source_kind``:
-    ``ingested`` rows execute over the connector's HTTP transport,
-    ``typed`` rows import + invoke their module-level handler. Anything
-    else (composite sub-ops, unknown kinds) raises — a preview read must
-    be a leaf. Raises on every fault; the adapter wraps raises into
-    error-shaped :class:`OperationResult` values.
-    """
-    # Local imports keep the connector→operations import graph as thin
-    # as the established preview builders' (mirrors _k8s_apply_preview
-    # and get_dispatch_child's deferred resolution).
-    from meho_backplane.operations._branches import dispatch_ingested, dispatch_typed
-    from meho_backplane.operations._handler_resolve import import_handler
-    from meho_backplane.operations._lookup import lookup_descriptor, parse_connector_id
-
-    product, version, impl_id = parse_connector_id(connector_id)
-    descriptor = await lookup_descriptor(
-        tenant_id=ctx.operator.tenant_id,
-        product=product,
-        version=version,
-        impl_id=impl_id,
-        op_id=op_id,
-    )
-    if descriptor is None:
-        raise RuntimeError(f"unknown_op at preview time: {op_id}")
-
-    if descriptor.source_kind == "ingested":
-        if ctx.connector_instance is None:
-            raise RuntimeError("no connector instance resolved for ingested preview read")
-        return await dispatch_ingested(
-            connector=ctx.connector_instance,
-            descriptor=descriptor,
-            operator=ctx.operator,
-            target=effective_target,
-            params=params,
-        )
-    if descriptor.source_kind == "typed":
-        handler = import_handler(descriptor.handler_ref or "")
-        return await dispatch_typed(
-            handler=handler,
-            operator=ctx.operator,
-            target=effective_target,
-            params=params,
-        )
-    raise RuntimeError(f"preview cannot execute source_kind={descriptor.source_kind!r} sub-op")
-
-
-def _read_only_dispatch_child(ctx: PreviewContext) -> DispatchChild:
-    """Build a read-only ``DispatchChild`` for park-time preview resolution.
-
-    Satisfies the :class:`DispatchChild` protocol so the shared resolution
-    helpers in :mod:`._write` run unchanged, but executes the sub-op
-    directly against the connector resolved into *ctx* (via
-    :func:`_execute_leaf_read`) instead of routing through
-    :func:`~meho_backplane.operations.dispatcher.dispatch`:
-
-    * **No policy-gate re-entry.** A tenant policy that gates *reads*
-      could otherwise park (or deny) the preview's own sub-op from inside
-      the park of its parent — creating approval rows as a side effect of
-      creating an approval row. Direct execution cannot re-enter the gate.
-    * **No unparented audit rows.** At park time the ``approval.request``
-      audit row does not exist yet (it is written after the preview), so
-      a dispatched sub-op would land as a top-level row with no parent
-      linkage and distort the audit tree. The park's own request row
-      remains the audit anchor, exactly as for the k8s/argocd/vault
-      preview I/O.
-    * **Reads only, fail-closed.** Any op_id not carrying the ``GET:``
-      method prefix is refused with an error result before any lookup or
-      I/O — the approval park must never mutate vSphere state, even if a
-      future helper drifts.
-
-    Never raises: every fault returns an error-shaped
-    :class:`OperationResult` (the ``DispatchChild`` contract), which the
-    calling resolution helper surfaces as a raise and
-    :func:`~meho_backplane.operations._preview.build_proposed_effect`
-    swallows fail-soft.
-    """
-
-    async def _dispatch_read(
-        *,
-        connector_id: str,
-        op_id: str,
-        params: dict[str, Any],
-        target: Any = None,
-    ) -> OperationResult:
-        started = time.monotonic()
-
-        def _error(reason: str) -> OperationResult:
-            return OperationResult(
-                status="error",
-                op_id=op_id,
-                error=reason,
-                duration_ms=(time.monotonic() - started) * 1000.0,
-            )
-
-        if not op_id.startswith(_READ_OP_ID_PREFIX):
-            return _error(f"preview refuses non-read sub-op {op_id!r} (GET-only)")
-        try:
-            raw = await _execute_leaf_read(
-                ctx,
-                connector_id=connector_id,
-                op_id=op_id,
-                params=params,
-                effective_target=ctx.target if target is None else target,
-            )
-            return OperationResult(
-                status="ok",
-                op_id=op_id,
-                result=raw,
-                duration_ms=(time.monotonic() - started) * 1000.0,
-            )
-        except Exception as exc:
-            return _error(f"preview read failed: {exc}")
-
-    return _dispatch_read
 
 
 def _vm_identity(row: dict[str, Any]) -> dict[str, Any]:
@@ -275,11 +141,13 @@ async def _vm_power_bulk_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     action would hit. The per-VM power sub-ops never fire here.
     """
     action = ctx.params.get("action")
-    if not isinstance(action, str):
+    if not isinstance(action, str) or ctx.connector_instance is None:
         return None
     filter_dict: dict[str, Any] = dict(ctx.params.get("filter") or {})
     rows = await _resolve_vm_list(
-        dispatch_child=_read_only_dispatch_child(ctx),
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
         filter_dict=filter_dict,
     )
     return {
@@ -296,10 +164,12 @@ async def _host_evacuate_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     ``vm.migrate`` calls and the maintenance-enter never fire here.
     """
     host = ctx.params.get("host")
-    if not isinstance(host, str):
+    if not isinstance(host, str) or ctx.connector_instance is None:
         return None
     rows = await _resolve_vm_list(
-        dispatch_child=_read_only_dispatch_child(ctx),
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
         filter_dict={"hosts": [host]},
     )
     return {
@@ -319,10 +189,12 @@ async def _host_detach_from_vds_preview(ctx: PreviewContext) -> dict[str, Any] |
     host = ctx.params.get("host")
     dvs = ctx.params.get("dvs")
     fallback_network = ctx.params.get("fallback_network")
-    if not isinstance(host, str) or not isinstance(dvs, str):
+    if not isinstance(host, str) or not isinstance(dvs, str) or ctx.connector_instance is None:
         return None
     rows = await _resolve_vm_list(
-        dispatch_child=_read_only_dispatch_child(ctx),
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
         filter_dict={"hosts": [host]},
     )
     return {
@@ -340,10 +212,12 @@ async def _cluster_patch_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     per-host maintenance / patch sub-ops never fire here.
     """
     cluster = ctx.params.get("cluster")
-    if not isinstance(cluster, str):
+    if not isinstance(cluster, str) or ctx.connector_instance is None:
         return None
     rows = await _resolve_cluster_hosts(
-        dispatch_child=_read_only_dispatch_child(ctx),
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
         cluster_moid=cluster,
     )
     return {

--- a/backend/src/meho_backplane/operations/typed_register.py
+++ b/backend/src/meho_backplane/operations/typed_register.py
@@ -130,7 +130,7 @@ import inspect
 import uuid
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
 from sqlalchemy import insert, select
@@ -149,6 +149,9 @@ from meho_backplane.operations.embed import (
 )
 from meho_backplane.retrieval.embedding import EmbeddingService
 from meho_backplane.settings import get_settings
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors import OperationResult
 
 __all__ = [
     "CompositeOpHandler",
@@ -477,8 +480,12 @@ type TypedOpHandler = Callable[..., Awaitable[dict[str, Any]]]
 #: handler exposes a ``dispatch_child`` and/or a ``connector`` parameter
 #: -- the sub-call-capability distinction from typed handlers (#2251
 #: added the direct-session ``connector`` seam alongside
-#: ``dispatch_child``).
-type CompositeOpHandler = Callable[..., Awaitable[dict[str, Any]]]
+#: ``dispatch_child``). The result type widens to ``dict | OperationResult``
+#: (#2256): a migrated write composite may return an ``OperationResult``
+#: verbatim when its direct-session governance seam parks/denies an internal
+#: write, and the dispatcher passes a handler-returned ``OperationResult``
+#: straight through.
+type CompositeOpHandler = Callable[..., Awaitable[dict[str, Any] | OperationResult]]
 
 
 # Bounded enum for ``safety_level`` -- mirrors the DB CHECK constraint
@@ -525,7 +532,7 @@ class HandlerSignatureError(ValueError):
     """
 
 
-def derive_handler_ref(handler: TypedOpHandler) -> str:
+def derive_handler_ref(handler: TypedOpHandler | CompositeOpHandler) -> str:
     """Derive the dotted Python path the dispatcher will import at dispatch time.
 
     Module-level functions resolve to ``f"{module}.{qualname}"`` --

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -654,3 +654,207 @@ async def test_host_vsan_health_over_legacy_mount_routes_to_rest(
     assert result["groups"][0]["group_id"] == "com.vmware.vsan.health.test.network"
     assert result["groups"][0]["tests"][0]["test_health"] == "green"
     assert "read_note" not in result
+
+
+# ---------------------------------------------------------------------------
+# Write composite direct-session dispatch (#2256) — per-op transport + mount
+# parity with ZERO ingested descriptors and the real governance seam
+# ---------------------------------------------------------------------------
+#
+# These exercise the migrated *write* composites end to end against the real
+# connector transport (respx-intercepted): session establish -> mount_op_path
+# -> enforce_subop_policy (auto-executes for the USER operator) -> the direct
+# _post_json write. No ingested endpoint_descriptor rows exist, proving the
+# fresh-boot contract on the write path (Task #2256, Initiative #2249).
+
+
+def _write_operator() -> Operator:
+    """USER operator — enforce_subop_policy auto-executes its dangerous writes.
+
+    The per-sub-op governance seam runs for real here; a human/service
+    principal on a ``requires_approval=False`` sub-op clears the gate
+    synchronously (no DB), so the write proceeds and the parity assertion
+    sees the real wire request.
+    """
+    return Operator(
+        sub="op-write-composite-parity",
+        name="Write Composite Parity",
+        email=None,
+        raw_jwt="<integration-raw-jwt>",
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.mark.asyncio
+async def test_vm_create_composite_over_modern_mount(
+    vcsim_target: _VcsimTarget,
+) -> None:
+    """vm.create runs its folder read + create/NIC/power writes on the /api session.
+
+    Full #2256 direct-session write path end to end against the real connector
+    transport, with the real ``enforce_subop_policy`` seam clearing each write
+    for the USER operator. Zero ingested descriptors.
+    """
+    from meho_backplane.connectors.vmware_rest.composites._write import vm_create_composite
+
+    async def _loader(_target: VsphereTargetLike, _operator: Operator) -> dict[str, str]:
+        return {"username": "user", "password": "pass"}
+
+    connector = VmwareRestConnector(session_loader=_loader)
+
+    async with respx.mock(
+        base_url=VCENTER_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        mock.post("/api/session").respond(200, json=SESSION_TOKEN)
+        mock.get("/api/vcenter/folder").respond(200, json=[{"folder": "group-1", "name": "prod"}])
+        create_route = mock.post("/api/vcenter/vm").respond(200, json="vm-1")
+        nic_route = mock.patch("/api/vcenter/vm/vm-1/network").respond(200, json={})
+        power_route = mock.post("/api/vcenter/vm/vm-1/power").respond(200, json={})
+        mock.delete("/api/session").respond(204)
+        try:
+            out = await vm_create_composite(
+                operator=_write_operator(),
+                target=vcsim_target,
+                params={
+                    "folder_name": "prod",
+                    "name": "web-01",
+                    "guest_os": "UBUNTU_64",
+                    "nics": [{"network": "net-1"}],
+                    "power_on_after_create": True,
+                },
+                connector=connector,
+            )
+        finally:
+            await connector.aclose()
+
+    assert out["status"] == "created"
+    assert out["vm_id"] == "vm-1"
+    assert out["steps_succeeded"] == ["folder_lookup", "create", "nic_attach", "power_on"]
+    # The create/NIC/power writes reached the wire on the modern /api mount.
+    assert create_route.called
+    assert nic_route.called
+    assert power_route.called
+    # The create body carries the spec wrapper the vCenter POST expects.
+    create_body = json.loads(create_route.calls.last.request.content)
+    assert create_body["spec"]["name"] == "web-01"
+    assert create_body["spec"]["placement"]["folder"] == "group-1"
+
+
+@pytest.mark.asyncio
+async def test_cluster_patch_composite_over_legacy_mount_routes_to_rest(
+    vcsim_target: _VcsimTarget,
+) -> None:
+    """A legacy-only target mounts cluster.patch's writes onto /rest.
+
+    The modern ``POST /api/session`` 404s, the connector falls back to the
+    legacy path, and every write sub-op (maintenance enter/exit PATCH, host
+    patch POST) must route through ``/rest`` via ``mount_op_path`` or it 404s
+    — the modern+legacy mount coverage on the #2256 write path.
+    """
+    from meho_backplane.connectors.vmware_rest.composites._write import cluster_patch_composite
+
+    async def _loader(_target: VsphereTargetLike, _operator: Operator) -> dict[str, str]:
+        return {"username": "user", "password": "pass"}
+
+    connector = VmwareRestConnector(session_loader=_loader)
+
+    async with respx.mock(
+        base_url=VCENTER_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        mock.post("/api/session").respond(404)
+        mock.post("/rest/com/vmware/cis/session").respond(200, json=SESSION_TOKEN)
+        mock.get("/rest/vcenter/cluster/domain-c1/host").respond(200, json=[{"host": "host-1"}])
+        enter_route = mock.patch("/rest/vcenter/host/host-1/maintenance").respond(200, json={})
+        patch_route = mock.post("/rest/vcenter/host/host-1").respond(200, json={})
+        mock.delete("/rest/com/vmware/cis/session").respond(204)
+        try:
+            out = await cluster_patch_composite(
+                operator=_write_operator(),
+                target=vcsim_target,
+                params={"cluster": "domain-c1"},
+                connector=connector,
+            )
+        finally:
+            await connector.aclose()
+
+    assert out["status"] == "completed"
+    assert out["patched_hosts"] == ["host-1"]
+    # maintenance enter + exit both hit the same PATCH route; the patch POST hit /rest.
+    assert enter_route.call_count == 2
+    assert patch_route.called
+
+
+@pytest.mark.asyncio
+async def test_host_evacuate_recursion_over_modern_mount(
+    vcsim_target: _VcsimTarget,
+) -> None:
+    """host.evacuate's vm.migrate recursion runs its relocate write on the session.
+
+    Parity for the composite->composite recursion (#2248 carve-out): the
+    ``dispatch_child`` call into ``vmware.composite.vm.migrate`` resolves the
+    same connector and runs the inner DRS read + relocate write on the direct
+    /api session, and host.evacuate then enters maintenance — all against the
+    real transport, zero ingested descriptors.
+    """
+    from meho_backplane.connectors.vmware_rest.composites._write import (
+        host_evacuate_composite,
+        vm_migrate_composite,
+    )
+
+    async def _loader(_target: VsphereTargetLike, _operator: Operator) -> dict[str, str]:
+        return {"username": "user", "password": "pass"}
+
+    connector = VmwareRestConnector(session_loader=_loader)
+    operator = _write_operator()
+
+    async def _recursive_dispatch_child(
+        *, connector_id: str, op_id: str, params: dict[str, Any], target: Any = None
+    ) -> Any:
+        # Mirror the dispatcher's composite->composite recursion: resolve
+        # vm.migrate and run it on the same connector session.
+        from meho_backplane.connectors import OperationResult
+
+        assert op_id == "vmware.composite.vm.migrate"
+        inner = await vm_migrate_composite(
+            operator=operator, target=vcsim_target, params=params, connector=connector
+        )
+        return OperationResult(status="ok", op_id=op_id, result=inner, duration_ms=1.0)
+
+    async with respx.mock(
+        base_url=VCENTER_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        mock.post("/api/session").respond(200, json=SESSION_TOKEN)
+        mock.get("/api/vcenter/vm").respond(200, json=[{"vm": "vm-a", "cluster": "domain-c1"}])
+        mock.get("/api/vcenter/cluster/domain-c1/drs/recommendations").respond(
+            200, json=[{"vm": "vm-a", "target_host": "host-target"}]
+        )
+        relocate_route = mock.post("/api/vcenter/vm/vm-a").respond(200, json={})
+        maintenance_route = mock.patch("/api/vcenter/host/host-1/maintenance").respond(200, json={})
+        mock.delete("/api/session").respond(204)
+        try:
+            out = await host_evacuate_composite(
+                operator=operator,
+                target=vcsim_target,
+                params={"host": "host-1"},
+                connector=connector,
+                dispatch_child=_recursive_dispatch_child,
+            )
+        finally:
+            await connector.aclose()
+
+    assert out["status"] == "evacuated"
+    assert out["migrated_vms"] == ["vm-a"]
+    assert out["maintenance_entered"] is True
+    # The recursion's relocate write and the host maintenance-enter write both
+    # reached the /api session.
+    assert relocate_route.called
+    assert maintenance_route.called
+    relocate_body = json.loads(relocate_route.calls.last.request.content)
+    assert relocate_body["spec"]["placement"]["host"] == "host-target"

--- a/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
@@ -4,36 +4,34 @@
 """End-to-end recursive-composite test via production ``dispatch()``.
 
 The unit tests in
-:mod:`tests.test_connectors_vmware_rest_composites_write` mock
-``dispatch_child`` directly. That proves the handler body wires the
-right sub-op_ids + params, but it does **not** exercise the production
-dispatcher's ``composite`` branch — which is where ``parent_audit_id``
-linkage + the :data:`composite_depth_var` ramp + audit-tree persistence
-actually live.
+:mod:`tests.test_connectors_vmware_rest_composites_write` mock the
+connector session directly. That proves the handler body wires the right
+sub-ops + params, but it does **not** exercise the production dispatcher's
+``composite`` branch -- which is where ``parent_audit_id`` linkage + the
+:data:`composite_depth_var` ramp + audit-tree persistence actually live.
 
 This module closes that gap for the first **production** recursive
-composite, ``vmware.composite.host.evacuate`` (G3.1-T6 / #509):
+composite, ``vmware.composite.host.evacuate`` (G3.1-T6 / #509), under the
+post-#2256 direct-session model:
 
-1. Register a no-op vmware connector class against
-   ``(product="vmware", version="9.0", impl_id="vmware-rest")``.
-2. Register the **real** :func:`register_vmware_composite_operations`
-   runner, which lands all 15 composite rows (including ``vm.migrate``
-   and ``host.evacuate``).
-3. Register the leaf typed sub-ops the recursive chain bottoms out on
-   (``GET:/vcenter/vm`` listing, ``GET:/vcenter/cluster/{cluster}/drs/
-   recommendations``, ``POST:/vcenter/vm/{vm}?action=relocate``,
-   ``PATCH:/vcenter/host/{host}/maintenance?action=enter``) via real
-   :func:`register_typed_operation` calls with stub handlers returning
-   canned payloads.
-4. Dispatch ``vmware.composite.host.evacuate`` against the production
-   :func:`dispatch` entry point.
-5. Assert the 3-level audit tree: ``host.evacuate`` (depth 0) →
-   ``vm.migrate`` (depth 1) → typed leaf ops (depth 2) all share the
-   expected ``parent_audit_id`` linkage, and the
-   :data:`composite_depth_var` reached depth 2 mid-flight.
+* ``host.evacuate`` (depth 0) still recurses into
+  ``vmware.composite.vm.migrate`` via ``dispatch_child`` -- a
+  registrar-guaranteed ``source_kind="composite"`` row, the #2248 carve-out
+  the migration deliberately keeps on the catalog-routed path -- so the
+  recursion produces one ``vm.migrate`` audit row (depth 1) per VM, each
+  parented to the ``host.evacuate`` row.
+* Every **raw-REST leaf** the two composites touch (the VM listing, the DRS
+  read, the relocate write, the maintenance-enter write) now runs
+  **directly on the connector session**, so it writes **no** audit row of
+  its own -- the top-level composite's row is the audit anchor (the
+  documented direct-session behaviour: the per-sub-op child rows disappear).
 
-The test runs against the autouse SQLite migrations harness in
-:mod:`tests.conftest` — no Docker / PG testcontainer required.
+The test therefore asserts the new two-level audit shape (root +
+per-VM ``vm.migrate``), the absence of any leaf-op audit rows, and the
+``composite_depth_var`` ramp 0 -> 1 observed across the direct sub-calls
+(host.evacuate's own reads at depth 0, vm.migrate's reads/writes at
+depth 1). The recording connector is seeded as the dispatcher's resolved
+instance; no Docker / PG testcontainer required.
 """
 
 from __future__ import annotations
@@ -45,16 +43,14 @@ from unittest.mock import AsyncMock
 from uuid import UUID
 
 import pytest
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast import BroadcastEvent
-from meho_backplane.connectors import OperationResult
-from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
-from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.connectors.vmware_rest import VmwareRestConnector
 from meho_backplane.connectors.vmware_rest.composites import (
     register_vmware_composite_operations,
 )
@@ -62,27 +58,22 @@ from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog, EndpointDescriptor
 from meho_backplane.operations import (
     dispatch,
-    register_typed_operation,
     reset_dispatcher_caches,
 )
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
 from meho_backplane.operations.composite import (
     COMPOSITE_DEPTH_TOP_LEVEL,
     composite_depth_var,
 )
 from meho_backplane.settings import get_settings
 
-# The leaf typed sub-ops the recursive chain bottoms out on. Each is
-# registered as a real ``source_kind="typed"`` row pointing at a
-# module-level stub handler below.
+# The raw-REST leaf paths the recursive chain bottoms out on. Post-#2256
+# each runs directly on the connector session (no descriptor row, no audit
+# row) -- the test asserts these paths produce ZERO ``AuditLog`` rows.
 _LEAF_OP_LIST_VMS = "GET:/vcenter/vm"
 _LEAF_OP_GET_DRS_RECS = "GET:/vcenter/cluster/{cluster}/drs/recommendations"
 _LEAF_OP_RELOCATE_VM = "POST:/vcenter/vm/{vm}?action=relocate"
 _LEAF_OP_HOST_MAINTENANCE_ENTER = "PATCH:/vcenter/host/{host}/maintenance?action=enter"
-
-# Captured ``composite_depth_var`` snapshots taken inside each leaf handler.
-# Asserted after the dispatch returns so the test can prove the ramp
-# 0 → 1 → 2 fired during the recursive run.
-_DEPTH_OBSERVATIONS: list[int] = []
 
 
 # ---------------------------------------------------------------------------
@@ -106,11 +97,9 @@ def _reset_module_state() -> Iterator[None]:
     """Reset dispatcher caches + connector registry around every test."""
     reset_dispatcher_caches()
     clear_registry()
-    _DEPTH_OBSERVATIONS.clear()
     yield
     reset_dispatcher_caches()
     clear_registry()
-    _DEPTH_OBSERVATIONS.clear()
 
 
 @pytest.fixture
@@ -125,12 +114,7 @@ def stub_embedding_service() -> AsyncMock:
 
 @pytest.fixture
 def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
-    """Replace :func:`publish_event` with a recording stub.
-
-    Required because the dispatcher's audit path calls ``publish_event``
-    on every audit-log row write; without the stub the real broadcast
-    bus would attempt a write against a missing Postgres instance.
-    """
+    """Replace :func:`publish_event` with a recording stub."""
     events: list[BroadcastEvent] = []
 
     async def _capture(event: BroadcastEvent) -> None:
@@ -175,8 +159,6 @@ class _FakeVmwareTarget:
         self.fingerprint = _FakeFingerprint(version="9.0")
         self.preferred_impl_id: str | None = "vmware-rest"
         self.id: UUID = uuid.uuid4()
-        # Tenant-unique cache key component (#1642/#1672); without it
-        # ``target_cache_key`` raises AttributeError at runtime.
         self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000a2")
         self.name = "test-vcenter"
         self.host = "vcenter.test"
@@ -184,149 +166,52 @@ class _FakeVmwareTarget:
         self.auth_model = "shared_service_account"
 
 
-class _NoOpVmwareConnector(Connector):
-    """Resolver-satisfying connector class — never actually called.
+class _DepthRecordingConnector:
+    """Recording connector double that snapshots the composite depth per call.
 
-    The dispatcher resolves a connector instance only for
-    ``source_kind="ingested"`` rows; ``typed`` and ``composite`` rows
-    skip the instance lookup. The class is here so the registry
-    resolver finds *something* under
-    ``(vmware, 9.0, vmware-rest)`` — never invoked.
+    Seeded as the dispatcher's resolved instance so the migrated composites
+    issue their raw-REST sub-ops on it directly. Each sub-call records the
+    live :data:`composite_depth_var` so the test can prove the ramp: the
+    ``host.evacuate`` frame's own reads run at depth 0, the ``vm.migrate``
+    frame's reads/writes (reached via ``dispatch_child``) at depth 1.
     """
 
-    product = "vmware"
-    version = "9.0"
-    impl_id = "vmware-rest"
+    _MOUNT = "/api"
 
-    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
-        raise NotImplementedError
+    def __init__(self) -> None:
+        self.responses: dict[str, Any] = {}
+        self.calls: list[tuple[str, str]] = []
+        self.depths: list[int] = []
 
-    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
-        raise NotImplementedError
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
 
-    async def execute(  # type: ignore[override]
+    def _spec(self, path: str) -> str:
+        return path[len(self._MOUNT) :] if path.startswith(self._MOUNT) else path
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        self.depths.append(composite_depth_var.get())
+        spec = self._spec(path)
+        self.calls.append(("GET", spec))
+        return self.responses.get(spec, {"value": {}})
+
+    async def _post_json(
         self,
         target: Any,
-        op_id: str,
-        params: dict[str, Any],
-    ) -> OperationResult:
-        raise NotImplementedError
-
-
-# ---------------------------------------------------------------------------
-# Leaf typed-op stub handlers
-# ---------------------------------------------------------------------------
-#
-# Each handler records the live ``composite_depth_var`` so the test can
-# assert the ramp 0 → 1 → 2. They are module-level ``async def`` so
-# ``derive_handler_ref`` accepts them — the same constraint
-# ``register_typed_operation()`` enforces in production.
-
-
-async def _stub_list_vms_handler(
-    target: Any,
-    params: dict[str, Any],
-) -> dict[str, Any]:
-    """Stub for ``GET:/vcenter/vm`` — returns the canned VM listing.
-
-    ``host.evacuate`` calls this at depth 1 (one composite frame above
-    the typed handler).
-    """
-    _DEPTH_OBSERVATIONS.append(composite_depth_var.get())
-    # Two VMs on the host with the same cluster moid — the per-VM
-    # cluster resolution (M1 fix) reads ``cluster`` off each row.
-    return {
-        "value": [
-            {"vm": "vm-aa", "cluster": "cluster-1"},
-            {"vm": "vm-bb", "cluster": "cluster-1"},
-        ]
-    }
-
-
-async def _stub_drs_recs_handler(
-    target: Any,
-    params: dict[str, Any],
-) -> dict[str, Any]:
-    """Stub for ``GET:/vcenter/cluster/{cluster}/drs/recommendations``.
-
-    Recursive composite frames: ``host.evacuate`` (0) →
-    ``vm.migrate`` (1) → this typed leaf (2). Depth observation here
-    pins the ``composite_depth_var == 2`` reached at the bottom of the
-    recursion.
-    """
-    _DEPTH_OBSERVATIONS.append(composite_depth_var.get())
-    return {
-        "value": [
-            {"vm": "vm-aa", "target_host": "host-target"},
-            {"vm": "vm-bb", "target_host": "host-target"},
-        ]
-    }
-
-
-async def _stub_relocate_handler(
-    target: Any,
-    params: dict[str, Any],
-) -> dict[str, Any]:
-    """Stub for ``POST:/vcenter/vm/{vm}?action=relocate`` — succeeds."""
-    _DEPTH_OBSERVATIONS.append(composite_depth_var.get())
-    return {"value": {}}
-
-
-async def _stub_host_maintenance_enter_handler(
-    target: Any,
-    params: dict[str, Any],
-) -> dict[str, Any]:
-    """Stub for ``PATCH:/vcenter/host/{host}/maintenance?action=enter``."""
-    _DEPTH_OBSERVATIONS.append(composite_depth_var.get())
-    return {"value": {}}
-
-
-async def _register_leaf_typed_ops(stub_embedding_service: AsyncMock) -> None:
-    """Land the 4 leaf typed-op descriptor rows the recursive chain hits.
-
-    Each ``register_typed_operation`` call writes one
-    ``source_kind="typed"`` row pointing at the module-level stub above.
-    The descriptor's ``parameter_schema`` is permissive
-    (``additionalProperties=True``) so the composite handlers can pass
-    whatever params they like without per-op schema bookkeeping in this
-    test.
-    """
-    permissive_schema = {"type": "object", "additionalProperties": True}
-    leaf_specs: tuple[tuple[str, Any, str], ...] = (
-        (
-            _LEAF_OP_LIST_VMS,
-            _stub_list_vms_handler,
-            "Stub list-vms typed op for the recursive E2E test.",
-        ),
-        (
-            _LEAF_OP_GET_DRS_RECS,
-            _stub_drs_recs_handler,
-            "Stub DRS-recommendations typed op for the recursive E2E test.",
-        ),
-        (
-            _LEAF_OP_RELOCATE_VM,
-            _stub_relocate_handler,
-            "Stub relocate-VM typed op for the recursive E2E test.",
-        ),
-        (
-            _LEAF_OP_HOST_MAINTENANCE_ENTER,
-            _stub_host_maintenance_enter_handler,
-            "Stub host-maintenance-enter typed op for the recursive E2E test.",
-        ),
-    )
-    for op_id, handler, description in leaf_specs:
-        await register_typed_operation(
-            product="vmware",
-            version="9.0",
-            impl_id="vmware-rest",
-            op_id=op_id,
-            handler=handler,
-            summary=description,
-            description=description,
-            parameter_schema=permissive_schema,
-            when_to_use=None,
-            embedding_service=stub_embedding_service,
-        )
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: Any = None,
+        data: Any = None,
+        extra_headers: Any = None,
+    ) -> Any:
+        self.depths.append(composite_depth_var.get())
+        spec = self._spec(path)
+        self.calls.append((verb, spec))
+        return self.responses.get(spec, {"value": {}})
 
 
 # ---------------------------------------------------------------------------
@@ -335,76 +220,71 @@ async def _register_leaf_typed_ops(stub_embedding_service: AsyncMock) -> None:
 
 
 @pytest.mark.asyncio
-async def test_host_evacuate_e2e_through_production_dispatch_builds_3_level_audit_tree(
+async def test_host_evacuate_e2e_through_production_dispatch_audit_tree(
     stub_embedding_service: AsyncMock,
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """End-to-end: dispatch ``host.evacuate`` and assert the 3-level audit tree.
+    """Dispatch ``host.evacuate`` and assert the post-migration audit shape.
 
-    Acceptance criterion (from #509's review iter-1 M2): the first
-    production recursive composite must be exercised through the real
-    :func:`dispatch` entry point, not just ``dispatch_child`` mocks.
+    * ``host.evacuate`` (root, ``parent_audit_id`` NULL).
+    * one ``vm.migrate`` audit row per VM (depth 1, parent = host.evacuate),
+      produced by the ``dispatch_child`` recursion the migration keeps.
+    * ZERO audit rows for the raw-REST leaves -- they run directly on the
+      session, so the top-level composite's row is the only audit anchor.
 
-    Tree shape under test:
-
-    * ``vmware.composite.host.evacuate`` — depth 0, parent_audit_id NULL.
-    * ``vmware.composite.vm.migrate`` (x 2 — one per listed VM) —
-      depth 1, parent_audit_id = host.evacuate's audit row id.
-    * Leaf typed sub-ops (``GET:/vcenter/vm``,
-      ``GET:/vcenter/cluster/{cluster}/drs/recommendations``,
-      ``POST:/vcenter/vm/{vm}?action=relocate``,
-      ``PATCH:/vcenter/host/{host}/maintenance?action=enter``) —
-      depth 2 where wrapped by vm.migrate, depth 1 where called
-      directly by host.evacuate.
-
-    Also asserts :data:`composite_depth_var` observed values cover the
-    ramp 1 → 2 across leaf-handler invocations.
+    Also asserts the ``composite_depth_var`` ramp 0 -> 1 across the direct
+    sub-calls.
     """
+    recorder = _DepthRecordingConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/vm": {
+                "value": [
+                    {"vm": "vm-aa", "cluster": "cluster-1"},
+                    {"vm": "vm-bb", "cluster": "cluster-1"},
+                ]
+            },
+            "/vcenter/cluster/cluster-1/drs/recommendations": {
+                "value": [
+                    {"vm": "vm-aa", "target_host": "host-target"},
+                    {"vm": "vm-bb", "target_host": "host-target"},
+                ]
+            },
+        }
+    )
+
     register_connector_v2(
         product="vmware",
         version="9.0",
         impl_id="vmware-rest",
-        cls=_NoOpVmwareConnector,
+        cls=VmwareRestConnector,
     )
-    # Register all 15 composite rows (vm.migrate + host.evacuate are
-    # the two the test exercises; the other 13 ride along harmlessly).
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
-    # Register the 4 leaf typed sub-ops the recursive chain bottoms on.
-    await _register_leaf_typed_ops(stub_embedding_service)
-    # Flip ``requires_approval`` off for the two composites under test
-    # — v0.2 doesn't ship the approval workflow, so the production
-    # ``policy_gate`` denies anything carrying ``requires_approval=True``
-    # (see ``_validate.policy_gate``). The acceptance line under test
-    # is the recursive-dispatch + audit-tree shape, not the approval-
-    # gate behaviour itself (G10 territory). The full dangerous /
-    # requires_approval=True posture stays asserted by the row-level
-    # registration suite in
-    # ``test_connectors_vmware_rest_composites_write_register.py``.
+
+    # Flip ``requires_approval`` off for the two composites under test so the
+    # top-level policy gate auto-executes (the recursion + audit-tree shape is
+    # the contract here, not the approval gate). Re-seed the recorder after
+    # the cache reset -- ``reset_dispatcher_caches`` also clears the instance
+    # cache.
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
         await fresh.execute(
             update(EndpointDescriptor)
             .where(
                 EndpointDescriptor.op_id.in_(
-                    {
-                        "vmware.composite.host.evacuate",
-                        "vmware.composite.vm.migrate",
-                    }
+                    {"vmware.composite.host.evacuate", "vmware.composite.vm.migrate"}
                 )
             )
             .values(requires_approval=False)
         )
         await fresh.commit()
-    # Cached descriptor lookups must drop the stale row state after the
-    # UPDATE; otherwise the dispatcher reuses the pre-mutation copy and
-    # the policy gate still denies on the cached ``requires_approval``.
     reset_dispatcher_caches()
+    _CONNECTOR_INSTANCE_CACHE[VmwareRestConnector] = recorder  # type: ignore[assignment]
 
     operator = _make_operator()
     target = _FakeVmwareTarget()
 
-    # Pre-dispatch contextvar invariant: top-level is depth 0.
     assert composite_depth_var.get() == COMPOSITE_DEPTH_TOP_LEVEL
 
     result = await dispatch(
@@ -415,31 +295,24 @@ async def test_host_evacuate_e2e_through_production_dispatch_builds_3_level_audi
         params={"host": "host-source"},
     )
     assert result.status == "ok", result.error
-    # The composite returned the structured envelope with status=evacuated.
     assert isinstance(result.result, dict)
     assert result.result["status"] == "evacuated"
     assert result.result["maintenance_entered"] is True
     assert sorted(result.result["migrated_vms"]) == ["vm-aa", "vm-bb"]
 
-    # Post-dispatch invariant: the contextvar is reset back to depth 0
-    # — composite.get_dispatch_child uses tokens + finally to restore.
+    # Post-dispatch invariant: the contextvar is reset back to depth 0.
     assert composite_depth_var.get() == COMPOSITE_DEPTH_TOP_LEVEL
 
-    # ------------------------------------------------------------------
-    # Depth ramp: leaf handlers were invoked at depths 1 (host.evacuate
-    # frame) and 2 (host.evacuate → vm.migrate frame). The test ramps
-    # 1 → 2 rather than 0 → 1 → 2 because depth is read *inside* the
-    # leaf handler (one composite frame in already).
-    # ------------------------------------------------------------------
-    assert set(_DEPTH_OBSERVATIONS) >= {1, 2}, (
-        f"expected depth ramp covering {{1, 2}}, observed {sorted(set(_DEPTH_OBSERVATIONS))}"
+    # Depth ramp: host.evacuate's own reads/writes ran at depth 0; the
+    # vm.migrate frames (reached via dispatch_child) ran their reads/writes
+    # at depth 1.
+    assert set(recorder.depths) >= {0, 1}, (
+        f"expected depth ramp covering {{0, 1}}, observed {sorted(set(recorder.depths))}"
     )
 
     # ------------------------------------------------------------------
-    # Audit-tree shape: load every audit row produced by the dispatch
-    # and reconstruct the linkage by ``parent_audit_id``.
+    # Audit-tree shape (post-migration): root + per-VM vm.migrate only.
     # ------------------------------------------------------------------
-    sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
         rows = (
             (
@@ -449,10 +322,6 @@ async def test_host_evacuate_e2e_through_production_dispatch_builds_3_level_audi
                             {
                                 "vmware.composite.host.evacuate",
                                 "vmware.composite.vm.migrate",
-                                _LEAF_OP_LIST_VMS,
-                                _LEAF_OP_GET_DRS_RECS,
-                                _LEAF_OP_RELOCATE_VM,
-                                _LEAF_OP_HOST_MAINTENANCE_ENTER,
                             }
                         )
                     )
@@ -466,77 +335,30 @@ async def test_host_evacuate_e2e_through_production_dispatch_builds_3_level_audi
     for row in rows:
         by_path.setdefault(row.path, []).append(row)
 
-    # Parent composite — exactly one row, no parent.
     host_evacuate_rows = by_path["vmware.composite.host.evacuate"]
     assert len(host_evacuate_rows) == 1
     parent = host_evacuate_rows[0]
     assert parent.parent_audit_id is None
 
-    # vm.migrate composite — one row per listed VM (2 VMs in the stub).
     vm_migrate_rows = by_path["vmware.composite.vm.migrate"]
     assert len(vm_migrate_rows) == 2
     for vm_migrate in vm_migrate_rows:
-        # Each vm.migrate row's parent is the host.evacuate row.
         assert vm_migrate.parent_audit_id == parent.id
 
-    vm_migrate_ids = {r.id for r in vm_migrate_rows}
-
-    # Typed leaf ops.
-    list_vms_rows = by_path[_LEAF_OP_LIST_VMS]
-    # host.evacuate calls GET:/vcenter/vm once at depth 1.
-    assert len(list_vms_rows) == 1
-    assert list_vms_rows[0].parent_audit_id == parent.id
-
-    drs_rows = by_path[_LEAF_OP_GET_DRS_RECS]
-    # vm.migrate calls DRS-recs once per VM (no target_host override).
-    assert len(drs_rows) == 2
-    for drs_row in drs_rows:
-        # Each DRS row's parent is a vm.migrate row (depth 2).
-        assert drs_row.parent_audit_id in vm_migrate_ids
-
-    relocate_rows = by_path[_LEAF_OP_RELOCATE_VM]
-    # vm.migrate calls relocate once per VM (after DRS produced a target).
-    assert len(relocate_rows) == 2
-    for relocate_row in relocate_rows:
-        assert relocate_row.parent_audit_id in vm_migrate_ids
-
-    maintenance_rows = by_path[_LEAF_OP_HOST_MAINTENANCE_ENTER]
-    # host.evacuate calls maintenance-enter once at depth 1.
-    assert len(maintenance_rows) == 1
-    assert maintenance_rows[0].parent_audit_id == parent.id
-
-    # ------------------------------------------------------------------
-    # SQL-shape acceptance: a single query against (id, parent_audit_id,
-    # path) round-trips the entire tree the operator-runbook query
-    # uses.
-    # ------------------------------------------------------------------
-    audit_ids = {
-        parent.id,
-        *vm_migrate_ids,
-        *(r.id for r in list_vms_rows),
-        *(r.id for r in drs_rows),
-        *(r.id for r in relocate_rows),
-        *(r.id for r in maintenance_rows),
-    }
+    # The raw-REST leaves ran directly on the session -> no audit rows.
     async with sessionmaker() as fresh:
-        tree_rows = (
-            await fresh.execute(
-                select(
-                    AuditLog.id,
-                    AuditLog.parent_audit_id,
-                    AuditLog.path,
-                ).where(AuditLog.id.in_(audit_ids))
+        leaf_count = await fresh.scalar(
+            select(func.count())
+            .select_from(AuditLog)
+            .where(
+                AuditLog.path.in_(
+                    {
+                        _LEAF_OP_LIST_VMS,
+                        _LEAF_OP_GET_DRS_RECS,
+                        _LEAF_OP_RELOCATE_VM,
+                        _LEAF_OP_HOST_MAINTENANCE_ENTER,
+                    }
+                )
             )
-        ).all()
-    tree = {row.id: row for row in tree_rows}
-    # The reconstructed tree has the right shape: 1 root, 2 depth-1
-    # composites + 2 depth-1 typed leaves, 4 depth-2 typed leaves.
-    roots = [r for r in tree.values() if r.parent_audit_id is None]
-    assert len(roots) == 1
-    assert roots[0].path == "vmware.composite.host.evacuate"
-    depth_1_rows = [r for r in tree.values() if r.parent_audit_id == parent.id]
-    # 2 vm.migrate composites + 1 list_vms typed + 1 maintenance typed = 4.
-    assert len(depth_1_rows) == 4
-    depth_2_rows = [r for r in tree.values() if r.parent_audit_id in vm_migrate_ids]
-    # 2 DRS-recs typed + 2 relocate typed = 4.
-    assert len(depth_2_rows) == 4
+        )
+    assert leaf_count == 0, "direct-session leaf sub-ops must write no audit rows"

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -3,37 +3,49 @@
 
 """Unit tests for the 8 vmware-rest write-composite handler functions.
 
-Coverage matrix (G3.1-T6 / #509 acceptance criteria):
+Post-#2256 the write composites dispatch their sub-ops **directly on the
+connector session** -- ``connector._get_json`` / ``connector._post_json``
+mounted through ``connector.mount_op_path`` -- rather than through the
+catalog-routed ``dispatch_child`` seam, and every mutating sub-call is
+first routed through
+:func:`~meho_backplane.operations.composite.enforce_subop_policy` (the
+#2254 governance seam). These tests therefore:
 
-* Per-composite happy-path test: assert the correct sub-op_ids fire in
-  the expected order with the right ``connector_id`` + ``params``;
-  assert the returned dict shape matches the spec.
-* Per-composite partial-failure test: mocked ``dispatch_child`` raises
-  or returns an error-shaped result on a specific sub-op; assert the
-  composite handles the failure per its documented rollback /
-  partial-result semantics.
-* ``host.evacuate`` recursion: assert the handler dispatches
-  ``vmware.composite.vm.migrate`` per VM (proves the recursive
-  composite pattern).
-* Connector-id contract: every sub-op dispatches against
-  ``vmware-rest-9.0``.
+* stub the connector session with a recording double and assert the
+  call-shape contract: which HTTP verb, against which mounted path, with
+  what query / body, in what order -- plus the aggregation each handler
+  builds from the canned responses (byte-for-byte unchanged by the
+  dispatch-mechanism swap);
+* stub :func:`enforce_subop_policy` with a recorder and assert every
+  *write* sub-op is gated with its declared ``dangerous`` /
+  ``requires_approval=False`` governance and its logical params, while the
+  read sub-ops are never gated;
+* prove the gate short-circuits: when the seam returns an
+  ``awaiting_approval`` result, the handler returns it verbatim and the
+  write is never issued.
 
-Each test mocks ``dispatch_child`` via a recording stub returning
-canned :class:`OperationResult` objects keyed by op_id (or sequenced
-when the same op_id fires multiple times).
+``host.evacuate`` additionally keeps its ``dispatch_child`` recursion into
+``vmware.composite.vm.migrate`` (a registrar-guaranteed composite row,
+out of scope for the ingested-dispatch migration per #2248), so its test
+supplies a recording ``dispatch_child`` alongside the connector.
+
+The end-to-end approval-queue proof against a real DB + real seam lives in
+:mod:`tests.test_connectors_vmware_rest_composites_write_gate`; the
+respx-transport parity proof lives in
+:mod:`tests.integration.test_connectors_vmware_rest_vcsim`.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterator
 from typing import Any
 from uuid import UUID
 
+import httpx
 import pytest
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors import OperationResult
-from meho_backplane.connectors.vmware_rest.composites import _preflight
+from meho_backplane.connectors.vmware_rest.composites import _write
 from meho_backplane.connectors.vmware_rest.composites._write import (
     cluster_patch_composite,
     host_detach_from_vds_composite,
@@ -44,37 +56,6 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_power_bulk_composite,
     vm_snapshot_revert_composite,
 )
-
-
-@pytest.fixture(autouse=True)
-def _prime_preflight_cache() -> Iterator[None]:
-    """Prime the L2 pre-flight cache so handler-direct tests skip the DB walk.
-
-    See the matching fixture in
-    ``test_connectors_vmware_rest_composites_read.py`` for the rationale --
-    the handler-direct tests in this module bypass the dispatcher (and
-    therefore the DB session) but the G0.14-T10 (#1151) pre-flight at
-    the top of each handler would otherwise query
-    :func:`~meho_backplane.operations._lookup.lookup_descriptor`. The
-    dedicated ``test_connectors_vmware_rest_composites_l2_preflight.py``
-    module covers the cache-miss code paths.
-    """
-    _preflight.reset_preflight_cache()
-    _preflight._PREFLIGHT_CACHE.update(
-        {
-            "vmware.composite.vm.create",
-            "vmware.composite.vm.clone",
-            "vmware.composite.vm.snapshot.revert",
-            "vmware.composite.vm.migrate",
-            "vmware.composite.vm.power.bulk",
-            "vmware.composite.host.evacuate",
-            "vmware.composite.host.detach_from_vds",
-            "vmware.composite.cluster.patch",
-        }
-    )
-    yield
-    _preflight.reset_preflight_cache()
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -93,57 +74,143 @@ def _make_operator() -> Operator:
     )
 
 
-def _ok(op_id: str, result: Any) -> OperationResult:
-    """OK :class:`OperationResult` for a sub-op."""
-    return OperationResult(status="ok", op_id=op_id, result=result, duration_ms=1.0)
+class _RecordingConnector:
+    """Stub connector session that records sub-calls and serves canned JSON.
 
-
-def _err(op_id: str, error: str) -> OperationResult:
-    """Error :class:`OperationResult` for partial-failure tests."""
-    return OperationResult(status="error", op_id=op_id, error=error, duration_ms=1.0)
-
-
-class _RecordingDispatchChild:
-    """Records every ``dispatch_child`` call and serves canned results.
-
-    Two modes match :mod:`._read`'s test stub:
-
-    * ``dict`` -- ``op_id -> result``; same op_id served from the same
-      slot every time.
-    * ``list`` -- sequential :class:`OperationResult` values returned
-      in order. Use when the same op_id is dispatched multiple times
-      with different per-call expectations.
+    Stands in for :class:`VmwareRestConnector` on the direct-dispatch path:
+    the handlers call ``mount_op_path`` to resolve the live mount and then
+    ``_get_json`` / ``_post_json`` on the returned path. Every call is
+    recorded as ``{"method", "path", "query", "body"}`` (``method`` is the
+    write verb for ``_post_json``), and a response is served keyed either by
+    the resolved (mounted) path or, in list form, sequentially. A canned
+    value that is an :class:`Exception` is raised -- how the transport-fault
+    partial-failure paths are exercised.
     """
 
-    def __init__(self, responses: dict[str, Any] | list[Any]) -> None:
+    def __init__(
+        self,
+        responses: dict[str, Any] | list[Any],
+        *,
+        mount_prefix: str = "/api",
+    ) -> None:
         self._responses = responses
-        self._sequence_index = 0
+        self._seq_index = 0
+        self._mount_prefix = mount_prefix
         self.calls: list[dict[str, Any]] = []
+        self.mount_calls: list[str] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        self.mount_calls.append(path)
+        return f"{self._mount_prefix}{path}"
+
+    async def _get_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        self.calls.append({"method": "GET", "path": path, "query": params, "body": None})
+        return self._serve(path)
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> Any:
+        self.calls.append({"method": verb, "path": path, "query": None, "body": json})
+        return self._serve(path)
+
+    def _serve(self, path: str) -> Any:
+        if isinstance(self._responses, dict):
+            payload = self._responses[path]
+        else:
+            payload = self._responses[self._seq_index]
+            self._seq_index += 1
+        if isinstance(payload, Exception):
+            raise payload
+        return payload
+
+
+class _GateRecorder:
+    """Recording stub for :func:`enforce_subop_policy`.
+
+    Records every ``(op_id, safety_level, requires_approval, params)`` the
+    handler gates and returns a canned verdict: ``None`` (auto-execute -->
+    the handler proceeds with the direct write) by default, or a
+    per-op_id :class:`OperationResult` (``awaiting_approval`` / ``denied``)
+    when the test wants to prove the gate short-circuits.
+    """
+
+    def __init__(self, gate_for: dict[str, OperationResult] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._gate_for = gate_for or {}
 
     async def __call__(
         self,
         *,
+        operator: Operator,
         connector_id: str,
         op_id: str,
+        safety_level: str,
+        requires_approval: bool,
+        target: Any,
         params: dict[str, Any],
-        target: Any = None,
-    ) -> OperationResult:
+    ) -> OperationResult | None:
         self.calls.append(
             {
-                "connector_id": connector_id,
                 "op_id": op_id,
+                "connector_id": connector_id,
+                "safety_level": safety_level,
+                "requires_approval": requires_approval,
                 "params": dict(params),
-                "target": target,
             }
         )
-        if isinstance(self._responses, dict):
-            payload = self._responses[op_id]
-        else:
-            payload = self._responses[self._sequence_index]
-            self._sequence_index += 1
-        if isinstance(payload, OperationResult):
-            return payload
-        return _ok(op_id, payload)
+        return self._gate_for.get(op_id)
+
+    @property
+    def gated_op_ids(self) -> list[str]:
+        return [c["op_id"] for c in self.calls]
+
+
+@pytest.fixture
+def gate(monkeypatch: pytest.MonkeyPatch) -> _GateRecorder:
+    """Install a default (auto-execute) gate recorder on the ``_write`` module."""
+    recorder = _GateRecorder()
+    monkeypatch.setattr(_write, "enforce_subop_policy", recorder)
+    return recorder
+
+
+def _install_gate(monkeypatch: pytest.MonkeyPatch, recorder: _GateRecorder) -> _GateRecorder:
+    monkeypatch.setattr(_write, "enforce_subop_policy", recorder)
+    return recorder
+
+
+def _awaiting(op_id: str) -> OperationResult:
+    """A canned ``awaiting_approval`` result the gate stub can return."""
+    return OperationResult(
+        status="awaiting_approval",
+        op_id=op_id,
+        result=None,
+        duration_ms=1.0,
+        extras={"approval_request_id": "00000000-0000-0000-0000-0000000000aa"},
+    )
+
+
+def _http_error(status: int, url: str) -> httpx.HTTPStatusError:
+    """Build an ``httpx.HTTPStatusError`` whose ``str`` carries status + URL."""
+    request = httpx.Request("POST", url)
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(
+        f"Client error '{status}' for url '{url}'", request=request, response=response
+    )
 
 
 # ===========================================================================
@@ -152,17 +219,16 @@ class _RecordingDispatchChild:
 
 
 @pytest.mark.asyncio
-async def test_vm_create_happy_path_dispatches_all_steps_in_order() -> None:
-    """Folder lookup -> create -> per-NIC attach -> power-on; returns status=created."""
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok("GET:/vcenter/folder", [{"folder": "folder-7", "name": "Prod"}]),
-            _ok("POST:/vcenter/vm", {"value": "vm-99"}),
-            _ok("PATCH:/vcenter/vm/{vm}/network", {}),
-            _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
-        ]
+async def test_vm_create_happy_path_direct_session(gate: _GateRecorder) -> None:
+    """Folder GET -> create POST -> NIC PATCH -> power POST; every write gated."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
+            "/api/vcenter/vm": {"value": "vm-99"},
+            "/api/vcenter/vm/vm-99/network": {},
+            "/api/vcenter/vm/vm-99/power?action=start": {},
+        }
     )
-
     out = await vm_create_composite(
         operator=_make_operator(),
         target=object(),
@@ -175,19 +241,36 @@ async def test_vm_create_happy_path_dispatches_all_steps_in_order() -> None:
             "nics": [{"network": "net-3"}],
             "power_on_after_create": True,
         },
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
 
-    assert [c["op_id"] for c in dispatch.calls] == [
-        "GET:/vcenter/folder",
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("GET", "/api/vcenter/folder"),
+        ("POST", "/api/vcenter/vm"),
+        ("PATCH", "/api/vcenter/vm/vm-99/network"),
+        ("POST", "/api/vcenter/vm/vm-99/power?action=start"),
+    ]
+    # Folder GET forwards the name filter as a query param.
+    assert conn.calls[0]["query"] == {"filter.names": ["Prod"]}
+    # Create body carries the spec; folder moid resolved in.
+    assert conn.calls[1]["body"]["spec"]["placement"]["folder"] == "folder-7"
+    # NIC PATCH body is the spec; vm rides the path, not the body.
+    assert conn.calls[2]["body"] == {"spec": {"network": "net-3"}}
+    # Power POST carries no body (action rides the path).
+    assert conn.calls[3]["body"] is None
+
+    # Governance: exactly the 3 writes were gated (dangerous / no-approval);
+    # the folder GET was never gated.
+    assert gate.gated_op_ids == [
         "POST:/vcenter/vm",
         "PATCH:/vcenter/vm/{vm}/network",
         "POST:/vcenter/vm/{vm}/power?action=start",
     ]
-    assert dispatch.calls[0]["params"] == {"filter.names": ["Prod"]}
-    assert dispatch.calls[1]["params"]["spec"]["placement"]["folder"] == "folder-7"
-    assert dispatch.calls[2]["params"] == {"vm": "vm-99", "spec": {"network": "net-3"}}
-    assert dispatch.calls[3]["params"] == {"vm": "vm-99"}
+    for call in gate.calls:
+        assert call["safety_level"] == "dangerous"
+        assert call["requires_approval"] is False
+        assert call["connector_id"] == "vmware-rest-9.0"
+
     assert out["status"] == "created"
     assert out["vm_id"] == "vm-99"
     assert out["steps_succeeded"] == ["folder_lookup", "create", "nic_attach", "power_on"]
@@ -195,14 +278,14 @@ async def test_vm_create_happy_path_dispatches_all_steps_in_order() -> None:
 
 
 @pytest.mark.asyncio
-async def test_vm_create_partial_failure_rolls_back_via_delete() -> None:
-    """NIC-attach failure triggers DELETE rollback; returns status=rolled_back."""
-    dispatch = _RecordingDispatchChild(
+async def test_vm_create_nic_failure_rolls_back_via_delete(gate: _GateRecorder) -> None:
+    """A NIC-attach transport error triggers DELETE rollback; status=rolled_back."""
+    conn = _RecordingConnector(
         [
-            _ok("GET:/vcenter/folder", [{"folder": "folder-1", "name": "Prod"}]),
-            _ok("POST:/vcenter/vm", {"value": "vm-77"}),
-            _err("PATCH:/vcenter/vm/{vm}/network", "nic-attach failed"),
-            _ok("DELETE:/vcenter/vm/{vm}", {}),
+            [{"folder": "folder-1", "name": "Prod"}],  # folder GET
+            {"value": "vm-77"},  # create POST
+            _http_error(400, "https://vc/api/vcenter/vm/vm-77/network"),  # NIC PATCH
+            {},  # DELETE rollback
         ]
     )
     out = await vm_create_composite(
@@ -214,12 +297,10 @@ async def test_vm_create_partial_failure_rolls_back_via_delete() -> None:
             "guest_os": "UBUNTU_64",
             "nics": [{"network": "net-x"}],
         },
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
-    # DELETE fires after the NIC error.
-    op_ids_dispatched = [c["op_id"] for c in dispatch.calls]
-    assert "DELETE:/vcenter/vm/{vm}" in op_ids_dispatched
-    assert dispatch.calls[-1]["params"] == {"vm": "vm-77"}
+    verbs = [(c["method"], c["path"]) for c in conn.calls]
+    assert ("DELETE", "/api/vcenter/vm/vm-77") in verbs
     assert out["status"] == "rolled_back"
     assert out["vm_id"] is None
     assert out["failed_step"] == "nic_attach"
@@ -227,18 +308,51 @@ async def test_vm_create_partial_failure_rolls_back_via_delete() -> None:
 
 
 @pytest.mark.asyncio
-async def test_vm_create_folder_lookup_empty_returns_rolled_back_no_create() -> None:
-    """Empty folder match returns rolled_back; POST:/vcenter/vm never fires."""
-    dispatch = _RecordingDispatchChild([_ok("GET:/vcenter/folder", [])])
+async def test_vm_create_folder_lookup_empty_returns_rolled_back_no_create(
+    gate: _GateRecorder,
+) -> None:
+    """Empty folder match returns rolled_back; the create POST never fires."""
+    conn = _RecordingConnector({"/api/vcenter/folder": []})
     out = await vm_create_composite(
         operator=_make_operator(),
         target=object(),
         params={"folder_name": "Missing", "name": "web", "guest_os": "UBUNTU_64"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "rolled_back"
     assert out["failed_step"] == "folder_lookup"
-    assert len(dispatch.calls) == 1
+    assert len(conn.calls) == 1
+    # No write was attempted, so nothing was gated.
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_create_gated_create_returns_awaiting_approval_no_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gated create returns the seam's awaiting_approval verbatim; no create POST fires.
+
+    The unit-level proof of the hard acceptance gate: when
+    :func:`enforce_subop_policy` returns a non-None result for the write
+    sub-op, the composite returns it verbatim (the dispatcher passes a
+    handler-returned OperationResult straight through) and the direct
+    ``_post_json`` is never reached.
+    """
+    _install_gate(
+        monkeypatch, _GateRecorder(gate_for={"POST:/vcenter/vm": _awaiting("POST:/vcenter/vm")})
+    )
+    conn = _RecordingConnector({"/api/vcenter/folder": [{"folder": "f-1", "name": "Prod"}]})
+    out = await vm_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"folder_name": "Prod", "name": "web", "guest_os": "UBUNTU_64"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == "POST:/vcenter/vm"
+    # Only the folder GET hit the session; the create POST was gated off.
+    assert [c["method"] for c in conn.calls] == ["GET"]
 
 
 # ===========================================================================
@@ -247,17 +361,14 @@ async def test_vm_create_folder_lookup_empty_returns_rolled_back_no_create() -> 
 
 
 @pytest.mark.asyncio
-async def test_vm_clone_happy_path_polls_task_to_completion() -> None:
-    """Source-config read -> deploy -> task poll until SUCCEEDED; status=completed."""
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok("GET:/vcenter/vm/{vm}", {"name": "src"}),
-            _ok(
-                "POST:/vcenter/vm-template/library-items?action=deploy",
-                {"task": "task-42"},
-            ),
-            _ok("GET:/cis/tasks/{task}", {"status": "SUCCEEDED", "result": {"vm": "vm-clone-1"}}),
-        ]
+async def test_vm_clone_happy_path_polls_task_to_completion(gate: _GateRecorder) -> None:
+    """Source GET -> deploy POST (gated) -> task-poll GET until SUCCEEDED."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-src": {"name": "src"},
+            "/api/vcenter/vm-template/library-items?action=deploy": {"task": "task-42"},
+            "/api/cis/tasks/task-42": {"status": "SUCCEEDED", "result": {"vm": "vm-clone-1"}},
+        }
     )
     out = await vm_clone_composite(
         operator=_make_operator(),
@@ -268,31 +379,30 @@ async def test_vm_clone_happy_path_polls_task_to_completion() -> None:
             "library_item": "li-7",
             "timeout_seconds": 30,
         },
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "completed"
     assert out["task_id"] == "task-42"
     assert out["vm_id"] == "vm-clone-1"
-    assert [c["op_id"] for c in dispatch.calls] == [
-        "GET:/vcenter/vm/{vm}",
-        "POST:/vcenter/vm-template/library-items?action=deploy",
-        "GET:/cis/tasks/{task}",
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("GET", "/api/vcenter/vm/vm-src"),
+        ("POST", "/api/vcenter/vm-template/library-items?action=deploy"),
+        ("GET", "/api/cis/tasks/task-42"),
     ]
-    # ``action=deploy`` lives on the op_id, not body params.
-    assert "action" not in dispatch.calls[1]["params"]
+    # Deploy body carries library_item + spec (no ``action`` body key).
+    assert conn.calls[1]["body"] == {"library_item": "li-7", "spec": {"name": "vm-clone-1"}}
+    # Only the deploy write was gated.
+    assert gate.gated_op_ids == ["POST:/vcenter/vm-template/library-items?action=deploy"]
 
 
 @pytest.mark.asyncio
-async def test_vm_clone_wait_false_returns_pending_with_task_id() -> None:
-    """wait_for_completion=False returns immediately; no task poll fires."""
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok("GET:/vcenter/vm/{vm}", {"name": "src"}),
-            _ok(
-                "POST:/vcenter/vm-template/library-items?action=deploy",
-                {"task": "task-99"},
-            ),
-        ]
+async def test_vm_clone_wait_false_returns_pending(gate: _GateRecorder) -> None:
+    """wait_for_completion=False returns pending; no task poll fires."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-src": {"name": "src"},
+            "/api/vcenter/vm-template/library-items?action=deploy": {"task": "task-99"},
+        }
     )
     out = await vm_clone_composite(
         operator=_make_operator(),
@@ -303,27 +413,23 @@ async def test_vm_clone_wait_false_returns_pending_with_task_id() -> None:
             "library_item": "li-3",
             "wait_for_completion": False,
         },
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "pending"
     assert out["task_id"] == "task-99"
     assert out["vm_id"] is None
-    # Only 2 calls (no task poll).
-    assert len(dispatch.calls) == 2
+    assert len(conn.calls) == 2
 
 
 @pytest.mark.asyncio
-async def test_vm_clone_task_failed_raises_runtime_error() -> None:
-    """Task returning FAILED status raises -- dispatcher wraps as connector_error."""
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok("GET:/vcenter/vm/{vm}", {}),
-            _ok(
-                "POST:/vcenter/vm-template/library-items?action=deploy",
-                {"task": "task-bad"},
-            ),
-            _ok("GET:/cis/tasks/{task}", {"status": "FAILED", "error": "deploy failed"}),
-        ]
+async def test_vm_clone_task_failed_raises_runtime_error(gate: _GateRecorder) -> None:
+    """A FAILED task raises -- dispatcher wraps as connector_error."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-src": {},
+            "/api/vcenter/vm-template/library-items?action=deploy": {"task": "task-bad"},
+            "/api/cis/tasks/task-bad": {"status": "FAILED", "error": "deploy failed"},
+        }
     )
     with pytest.raises(RuntimeError, match="FAILED"):
         await vm_clone_composite(
@@ -335,7 +441,7 @@ async def test_vm_clone_task_failed_raises_runtime_error() -> None:
                 "library_item": "li-1",
                 "timeout_seconds": 30,
             },
-            dispatch_child=dispatch,
+            connector=conn,  # type: ignore[arg-type]
         )
 
 
@@ -345,71 +451,66 @@ async def test_vm_clone_task_failed_raises_runtime_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_vm_snapshot_revert_happy_path_dispatches_revert() -> None:
-    """List + match + revert; returns status=reverted with snapshot_id."""
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok(
-                "GET:/vcenter/vm/{vm}/snapshot",
-                [{"snapshot": "snap-1", "name": "before-patch"}],
-            ),
-            _ok("POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert", {}),
-        ]
+async def test_vm_snapshot_revert_happy_path(gate: _GateRecorder) -> None:
+    """List GET + match + revert POST (gated); status=reverted."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/snapshot": [{"snapshot": "snap-1", "name": "before-patch"}],
+            "/api/vcenter/vm/vm-1/snapshot/snap-1?action=revert": {},
+        }
     )
     out = await vm_snapshot_revert_composite(
         operator=_make_operator(),
         target=object(),
         params={"vm": "vm-1", "snapshot_name": "before-patch"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "reverted"
     assert out["snapshot_id"] == "snap-1"
-    assert dispatch.calls[1]["op_id"] == "POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert"
-    # ``action=revert`` lives on the op_id, not body params.
-    assert dispatch.calls[1]["params"] == {"vm": "vm-1", "snap": "snap-1"}
+    assert conn.calls[1]["method"] == "POST"
+    assert conn.calls[1]["path"] == "/api/vcenter/vm/vm-1/snapshot/snap-1?action=revert"
+    assert conn.calls[1]["body"] is None
+    assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert"]
 
 
 @pytest.mark.asyncio
-async def test_vm_snapshot_revert_ambiguous_name_does_not_dispatch_revert() -> None:
+async def test_vm_snapshot_revert_ambiguous_no_revert(gate: _GateRecorder) -> None:
     """Multiple snapshots share the name -> status=ambiguous; no revert dispatched."""
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok(
-                "GET:/vcenter/vm/{vm}/snapshot",
-                [
-                    {"snapshot": "snap-1", "name": "x"},
-                    {"snapshot": "snap-2", "name": "x"},
-                ],
-            )
-        ]
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/snapshot": [
+                {"snapshot": "snap-1", "name": "x"},
+                {"snapshot": "snap-2", "name": "x"},
+            ]
+        }
     )
     out = await vm_snapshot_revert_composite(
         operator=_make_operator(),
         target=object(),
         params={"vm": "vm-1", "snapshot_name": "x"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "ambiguous"
-    assert out["snapshot_id"] is None
     assert len(out["candidates"]) == 2
-    # Only the listing call fired -- no revert.
-    assert len(dispatch.calls) == 1
+    assert len(conn.calls) == 1
+    assert gate.calls == []
 
 
 @pytest.mark.asyncio
-async def test_vm_snapshot_revert_not_found_returns_not_found() -> None:
+async def test_vm_snapshot_revert_not_found(gate: _GateRecorder) -> None:
     """Snapshot name not in tree -> status=not_found; no revert dispatched."""
-    dispatch = _RecordingDispatchChild(
-        [_ok("GET:/vcenter/vm/{vm}/snapshot", [{"snapshot": "s-1", "name": "other"}])]
+    conn = _RecordingConnector(
+        {"/api/vcenter/vm/vm-1/snapshot": [{"snapshot": "s-1", "name": "other"}]}
     )
     out = await vm_snapshot_revert_composite(
         operator=_make_operator(),
         target=object(),
         params={"vm": "vm-1", "snapshot_name": "missing"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "not_found"
-    assert len(dispatch.calls) == 1
+    assert len(conn.calls) == 1
+    assert gate.calls == []
 
 
 # ===========================================================================
@@ -418,66 +519,60 @@ async def test_vm_snapshot_revert_not_found_returns_not_found() -> None:
 
 
 @pytest.mark.asyncio
-async def test_vm_migrate_drs_recommendation_dispatches_relocate() -> None:
-    """DRS recommendation -> relocate dispatched against recommended host."""
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok(
-                "GET:/vcenter/cluster/{cluster}/drs/recommendations",
-                [{"vm": "vm-1", "target_host": "host-A"}],
-            ),
-            _ok("POST:/vcenter/vm/{vm}?action=relocate", {}),
-        ]
+async def test_vm_migrate_drs_recommendation_dispatches_relocate(gate: _GateRecorder) -> None:
+    """DRS recommendation GET -> relocate POST (gated) against the recommended host."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/cluster/cluster-7/drs/recommendations": [
+                {"vm": "vm-1", "target_host": "host-A"}
+            ],
+            "/api/vcenter/vm/vm-1?action=relocate": {},
+        }
     )
     out = await vm_migrate_composite(
         operator=_make_operator(),
         target=object(),
         params={"vm": "vm-1", "cluster": "cluster-7"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "migrated"
     assert out["target_host"] == "host-A"
     assert out["source"] == "drs"
-    assert dispatch.calls[1]["op_id"] == "POST:/vcenter/vm/{vm}?action=relocate"
-    assert dispatch.calls[1]["params"]["vm"] == "vm-1"
-    # ``action=relocate`` lives on the op_id, not body params.
-    assert "action" not in dispatch.calls[1]["params"]
+    assert conn.calls[1]["path"] == "/api/vcenter/vm/vm-1?action=relocate"
+    assert conn.calls[1]["body"] == {"spec": {"placement": {"host": "host-A"}}}
+    assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}?action=relocate"]
 
 
 @pytest.mark.asyncio
-async def test_vm_migrate_explicit_target_bypasses_drs_lookup() -> None:
-    """``target_host`` override skips the DRS sub-op; relocate dispatches directly."""
-    dispatch = _RecordingDispatchChild([_ok("POST:/vcenter/vm/{vm}?action=relocate", {})])
+async def test_vm_migrate_explicit_target_bypasses_drs(gate: _GateRecorder) -> None:
+    """``target_host`` override skips the DRS GET; relocate dispatches directly."""
+    conn = _RecordingConnector({"/api/vcenter/vm/vm-2?action=relocate": {}})
     out = await vm_migrate_composite(
         operator=_make_operator(),
         target=object(),
         params={"vm": "vm-2", "cluster": "cluster-9", "target_host": "host-Z"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "migrated"
     assert out["target_host"] == "host-Z"
     assert out["source"] == "operator"
-    assert dispatch.calls[0]["op_id"] == "POST:/vcenter/vm/{vm}?action=relocate"
-    assert len(dispatch.calls) == 1
+    assert len(conn.calls) == 1
 
 
 @pytest.mark.asyncio
-async def test_vm_migrate_no_recommendation_returns_status_no_recommendation() -> None:
-    """DRS returns empty + no target_host override -> status=no_recommendation."""
-    dispatch = _RecordingDispatchChild(
-        [_ok("GET:/vcenter/cluster/{cluster}/drs/recommendations", [])]
-    )
+async def test_vm_migrate_no_recommendation(gate: _GateRecorder) -> None:
+    """DRS returns empty + no override -> status=no_recommendation; no relocate."""
+    conn = _RecordingConnector({"/api/vcenter/cluster/cluster-1/drs/recommendations": []})
     out = await vm_migrate_composite(
         operator=_make_operator(),
         target=object(),
         params={"vm": "vm-3", "cluster": "cluster-1"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "no_recommendation"
-    assert out["target_host"] is None
     assert out["source"] == "none"
-    # Relocate did NOT dispatch.
-    assert len(dispatch.calls) == 1
+    assert len(conn.calls) == 1
+    assert gate.calls == []
 
 
 # ===========================================================================
@@ -486,196 +581,216 @@ async def test_vm_migrate_no_recommendation_returns_status_no_recommendation() -
 
 
 @pytest.mark.asyncio
-async def test_vm_power_bulk_happy_path_aggregates_per_vm_results() -> None:
-    """Filter listing + per-VM power; aggregate results + summary counts."""
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}, {"vm": "vm-3"}]),
-            _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
-            _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
-            _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
-        ]
+async def test_vm_power_bulk_happy_path(gate: _GateRecorder) -> None:
+    """Filter GET + per-VM power POST; aggregate results + summary."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm": [{"vm": "vm-1"}, {"vm": "vm-2"}, {"vm": "vm-3"}],
+            "/api/vcenter/vm/vm-1/power?action=start": {},
+            "/api/vcenter/vm/vm-2/power?action=start": {},
+            "/api/vcenter/vm/vm-3/power?action=start": {},
+        }
     )
     out = await vm_power_bulk_composite(
         operator=_make_operator(),
         target=object(),
         params={"filter": {"power_states": ["POWERED_OFF"]}, "action": "start"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["summary"] == {"ok": 3, "error": 0}
     assert {r["vm"] for r in out["results"]} == {"vm-1", "vm-2", "vm-3"}
-    assert all(r["status"] == "ok" for r in out["results"])
     assert out["aborted_on_failure"] is False
-    # Filter forwarded as filter.power_states.
-    assert dispatch.calls[0]["params"] == {"filter.power_states": ["POWERED_OFF"]}
-    # Every per-VM call targets the ``?action=start`` descriptor row; action
-    # verb lives on the op_id, not body params.
-    for call in dispatch.calls[1:]:
-        assert call["op_id"] == "POST:/vcenter/vm/{vm}/power?action=start"
-        assert "action" not in call["params"]
+    # Filter forwarded as filter.power_states query on the listing GET.
+    assert conn.calls[0]["query"] == {"filter.power_states": ["POWERED_OFF"]}
+    # Every per-VM power write was gated.
+    assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}/power?action=start"] * 3
 
 
 @pytest.mark.asyncio
-async def test_vm_power_bulk_partial_failure_continues_by_default() -> None:
-    """One per-VM failure does not abort; summary reflects mixed outcome."""
-    dispatch = _RecordingDispatchChild(
+async def test_vm_power_bulk_partial_failure_continues(gate: _GateRecorder) -> None:
+    """One per-VM transport error does not abort; summary reflects mixed outcome."""
+    conn = _RecordingConnector(
         [
-            _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}]),
-            _err("POST:/vcenter/vm/{vm}/power?action=stop", "boom"),
-            _ok("POST:/vcenter/vm/{vm}/power?action=stop", {}),
+            [{"vm": "vm-1"}, {"vm": "vm-2"}],  # listing GET
+            _http_error(500, "https://vc/api/vcenter/vm/vm-1/power?action=stop"),
+            {},  # vm-2 ok
         ]
     )
     out = await vm_power_bulk_composite(
         operator=_make_operator(),
         target=object(),
         params={"action": "stop"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["summary"] == {"ok": 1, "error": 1}
     assert out["aborted_on_failure"] is False
-    # Both VMs were attempted.
-    assert len(dispatch.calls) == 3
-    # ``stop`` lives on the op_id.
-    for call in dispatch.calls[1:]:
-        assert call["op_id"] == "POST:/vcenter/vm/{vm}/power?action=stop"
+    assert len(conn.calls) == 3
 
 
 @pytest.mark.asyncio
-async def test_vm_power_bulk_fail_fast_aborts_on_first_failure() -> None:
-    """fail_fast=True -> abort after first error; remaining VMs untouched."""
-    dispatch = _RecordingDispatchChild(
+async def test_vm_power_bulk_fail_fast_aborts(gate: _GateRecorder) -> None:
+    """fail_fast=True -> abort after first transport error; remaining VMs untouched."""
+    conn = _RecordingConnector(
         [
-            _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}, {"vm": "vm-3"}]),
-            _err("POST:/vcenter/vm/{vm}/power?action=stop", "denied"),
+            [{"vm": "vm-1"}, {"vm": "vm-2"}, {"vm": "vm-3"}],
+            _http_error(403, "https://vc/api/vcenter/vm/vm-1/power?action=stop"),
         ]
     )
     out = await vm_power_bulk_composite(
         operator=_make_operator(),
         target=object(),
         params={"action": "stop", "fail_fast": True},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["aborted_on_failure"] is True
     assert out["summary"] == {"ok": 0, "error": 1}
     assert len(out["results"]) == 1
-    # Only listing + first power call fired -- the other two VMs never
-    # got dispatched.
-    assert len(dispatch.calls) == 2
-
-
-# ===========================================================================
-# host.evacuate -- recursive composite
-# ===========================================================================
+    assert len(conn.calls) == 2
 
 
 @pytest.mark.asyncio
-async def test_host_evacuate_dispatches_vm_migrate_per_vm_then_maintenance() -> None:
-    """host.evacuate recursively dispatches vm.migrate, then enters maintenance."""
-    migrate_result = OperationResult(
+async def test_vm_power_bulk_gated_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A denied per-VM power short-circuits the whole batch with the seam's result."""
+    op_id = "POST:/vcenter/vm/{vm}/power?action=start"
+    denied = OperationResult(status="denied", op_id=op_id, error="policy denied", duration_ms=1.0)
+    _install_gate(monkeypatch, _GateRecorder(gate_for={op_id: denied}))
+    conn = _RecordingConnector({"/api/vcenter/vm": [{"vm": "vm-1"}, {"vm": "vm-2"}]})
+    out = await vm_power_bulk_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"action": "start"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    # Only the listing GET hit the session; no power write executed.
+    assert [c["method"] for c in conn.calls] == ["GET"]
+
+
+# ===========================================================================
+# host.evacuate -- recursive composite (dispatch_child kept for vm.migrate)
+# ===========================================================================
+
+
+class _RecordingDispatchChild:
+    """Records ``dispatch_child`` calls; serves canned :class:`OperationResult`s."""
+
+    def __init__(self, results: list[OperationResult]) -> None:
+        self._results = results
+        self._i = 0
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(
+        self,
+        *,
+        connector_id: str,
+        op_id: str,
+        params: dict[str, Any],
+        target: Any = None,
+    ) -> OperationResult:
+        self.calls.append({"connector_id": connector_id, "op_id": op_id, "params": dict(params)})
+        result = self._results[self._i]
+        self._i += 1
+        return result
+
+
+def _migrated() -> OperationResult:
+    return OperationResult(
         status="ok",
         op_id="vmware.composite.vm.migrate",
         result={"status": "migrated", "target_host": "h-2"},
         duration_ms=1.0,
     )
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok(
-                "GET:/vcenter/vm",
-                # Per-VM cluster moids differ so the per-row resolution
-                # gets exercised end to end (vm-a/c-1, vm-b/c-2).
-                [{"vm": "vm-a", "cluster": "c-1"}, {"vm": "vm-b", "cluster": "c-2"}],
-            ),
-            migrate_result,
-            migrate_result,
-            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
-        ]
+
+
+def _no_rec() -> OperationResult:
+    return OperationResult(
+        status="ok",
+        op_id="vmware.composite.vm.migrate",
+        result={"status": "no_recommendation"},
+        duration_ms=1.0,
     )
+
+
+@pytest.mark.asyncio
+async def test_host_evacuate_recurses_then_enters_maintenance(gate: _GateRecorder) -> None:
+    """VM listing GET -> per-VM vm.migrate via dispatch_child -> maintenance-enter write."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm": [
+                {"vm": "vm-a", "cluster": "c-1"},
+                {"vm": "vm-b", "cluster": "c-2"},
+            ],
+            "/api/vcenter/host/host-1/maintenance?action=enter": {},
+        }
+    )
+    dispatch = _RecordingDispatchChild([_migrated(), _migrated()])
     out = await host_evacuate_composite(
         operator=_make_operator(),
         target=object(),
         params={"host": "host-1"},
+        connector=conn,  # type: ignore[arg-type]
         dispatch_child=dispatch,
     )
-    op_ids = [c["op_id"] for c in dispatch.calls]
-    assert op_ids == [
-        "GET:/vcenter/vm",
+    # Recursion routes through dispatch_child (composite->composite), NOT the
+    # direct session -- proving the #2248 carve-out.
+    assert [c["op_id"] for c in dispatch.calls] == [
         "vmware.composite.vm.migrate",
         "vmware.composite.vm.migrate",
-        "PATCH:/vcenter/host/{host}/maintenance?action=enter",
     ]
-    # Each recursive call carries that row's cluster moid — proves per-row
-    # resolution (M1 fix from PR #529 iter-2).
-    assert dispatch.calls[1]["params"] == {"vm": "vm-a", "cluster": "c-1"}
-    assert dispatch.calls[2]["params"] == {"vm": "vm-b", "cluster": "c-2"}
-    # Maintenance enter dispatches against the action-bearing descriptor row;
-    # ``action`` is NOT a body param.
-    assert dispatch.calls[3]["params"] == {"host": "host-1"}
+    assert dispatch.calls[0]["params"] == {"vm": "vm-a", "cluster": "c-1"}
+    assert dispatch.calls[1]["params"] == {"vm": "vm-b", "cluster": "c-2"}
+    assert all(c["connector_id"] == "vmware-rest-9.0" for c in dispatch.calls)
+    # The listing read + the maintenance-enter write are the only direct calls.
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("GET", "/api/vcenter/vm"),
+        ("PATCH", "/api/vcenter/host/host-1/maintenance?action=enter"),
+    ]
+    # Only the maintenance-enter write was gated (the recursion self-gates).
+    assert gate.gated_op_ids == ["PATCH:/vcenter/host/{host}/maintenance?action=enter"]
     assert out["status"] == "evacuated"
     assert out["maintenance_entered"] is True
     assert out["migrated_vms"] == ["vm-a", "vm-b"]
-    assert out["failed_vms"] == []
 
 
 @pytest.mark.asyncio
-async def test_host_evacuate_default_aborts_on_vm_migrate_failure() -> None:
+async def test_host_evacuate_default_aborts_on_migrate_failure(gate: _GateRecorder) -> None:
     """tolerate_partial_failure=False -> a vm.migrate failure aborts before maintenance."""
-    no_rec_result = OperationResult(
-        status="ok",
-        op_id="vmware.composite.vm.migrate",
-        result={"status": "no_recommendation"},
-        duration_ms=1.0,
-    )
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok("GET:/vcenter/vm", [{"vm": "vm-x", "cluster": "c-1"}]),
-            no_rec_result,
-        ]
-    )
+    conn = _RecordingConnector({"/api/vcenter/vm": [{"vm": "vm-x", "cluster": "c-1"}]})
+    dispatch = _RecordingDispatchChild([_no_rec()])
     out = await host_evacuate_composite(
         operator=_make_operator(),
         target=object(),
         params={"host": "host-3"},
+        connector=conn,  # type: ignore[arg-type]
         dispatch_child=dispatch,
     )
     assert out["status"] == "aborted"
     assert out["maintenance_entered"] is False
-    assert out["migrated_vms"] == []
     assert len(out["failed_vms"]) == 1
-    # Maintenance-enter never dispatched.
-    op_ids = [c["op_id"] for c in dispatch.calls]
-    assert "PATCH:/vcenter/host/{host}/maintenance?action=enter" not in op_ids
+    # Maintenance-enter never fired -> the only direct call was the listing GET.
+    assert [c["method"] for c in conn.calls] == ["GET"]
+    assert gate.calls == []
 
 
 @pytest.mark.asyncio
-async def test_host_evacuate_tolerate_partial_failure_still_enters_maintenance() -> None:
+async def test_host_evacuate_tolerate_partial_still_enters_maintenance(gate: _GateRecorder) -> None:
     """tolerate_partial_failure=True -> maintenance enters even with VM failures."""
-    ok_migrate = OperationResult(
-        status="ok",
-        op_id="vmware.composite.vm.migrate",
-        result={"status": "migrated", "target_host": "h-2"},
-        duration_ms=1.0,
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm": [
+                {"vm": "vm-a", "cluster": "c-1"},
+                {"vm": "vm-b", "cluster": "c-1"},
+            ],
+            "/api/vcenter/host/host-2/maintenance?action=enter": {},
+        }
     )
-    err_migrate = OperationResult(
-        status="ok",
-        op_id="vmware.composite.vm.migrate",
-        result={"status": "no_recommendation"},
-        duration_ms=1.0,
-    )
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok(
-                "GET:/vcenter/vm",
-                [{"vm": "vm-a", "cluster": "c-1"}, {"vm": "vm-b", "cluster": "c-1"}],
-            ),
-            ok_migrate,
-            err_migrate,
-            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
-        ]
-    )
+    dispatch = _RecordingDispatchChild([_migrated(), _no_rec()])
     out = await host_evacuate_composite(
         operator=_make_operator(),
         target=object(),
         params={"host": "host-2", "tolerate_partial_failure": True},
+        connector=conn,  # type: ignore[arg-type]
         dispatch_child=dispatch,
     )
     assert out["status"] == "partial"
@@ -690,56 +805,61 @@ async def test_host_evacuate_tolerate_partial_failure_still_enters_maintenance()
 
 
 @pytest.mark.asyncio
-async def test_host_detach_from_vds_happy_path_removes_host_after_nic_migration() -> None:
-    """Discovery + per-VM NIC migration + DVS host-remove; status=detached."""
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok("GET:/vcenter/network/distributed-portgroup", []),
-            _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}]),
-            _ok("PATCH:/vcenter/vm/{vm}/network", {}),
-            _ok("PATCH:/vcenter/vm/{vm}/network", {}),
-            _ok("POST:/vcenter/network/dvs/{dvs}?action=remove_host", {}),
-        ]
+async def test_host_detach_from_vds_happy_path(gate: _GateRecorder) -> None:
+    """Portgroup GET + VM GET + per-VM NIC PATCH + DVS remove POST; status=detached."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/network/distributed-portgroup": [],
+            "/api/vcenter/vm": [{"vm": "vm-1"}, {"vm": "vm-2"}],
+            "/api/vcenter/vm/vm-1/network": {},
+            "/api/vcenter/vm/vm-2/network": {},
+            "/api/vcenter/network/dvs/dvs-1?action=remove_host": {},
+        }
     )
     out = await host_detach_from_vds_composite(
         operator=_make_operator(),
         target=object(),
         params={"host": "host-9", "dvs": "dvs-1", "fallback_network": "standard-net"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "detached"
     assert out["vms_migrated"] == ["vm-1", "vm-2"]
-    assert out["vm_migration_failures"] == []
-    # DVS remove fired against the action-bearing descriptor row.
-    last_call = dispatch.calls[-1]
-    assert last_call["op_id"] == "POST:/vcenter/network/dvs/{dvs}?action=remove_host"
-    # ``action=remove_host`` lives on the op_id, not body params.
-    assert last_call["params"] == {"dvs": "dvs-1", "host": "host-9"}
+    last = conn.calls[-1]
+    assert last["method"] == "POST"
+    assert last["path"] == "/api/vcenter/network/dvs/dvs-1?action=remove_host"
+    assert last["body"] == {"host": "host-9"}
+    # NIC PATCH body carries the fallback network spec.
+    assert conn.calls[2]["body"] == {"spec": {"network": "standard-net"}}
+    # 2 NIC writes + 1 DVS remove write gated; the two reads were not.
+    assert gate.gated_op_ids == [
+        "PATCH:/vcenter/vm/{vm}/network",
+        "PATCH:/vcenter/vm/{vm}/network",
+        "POST:/vcenter/network/dvs/{dvs}?action=remove_host",
+    ]
 
 
 @pytest.mark.asyncio
-async def test_host_detach_from_vds_incomplete_when_nic_migration_fails() -> None:
-    """NIC migration failure -> status=incomplete; DVS remove skipped."""
-    dispatch = _RecordingDispatchChild(
+async def test_host_detach_from_vds_incomplete_on_nic_failure(gate: _GateRecorder) -> None:
+    """A NIC migration transport error -> status=incomplete; DVS remove skipped."""
+    conn = _RecordingConnector(
         [
-            _ok("GET:/vcenter/network/distributed-portgroup", []),
-            _ok("GET:/vcenter/vm", [{"vm": "vm-1"}, {"vm": "vm-2"}]),
-            _ok("PATCH:/vcenter/vm/{vm}/network", {}),
-            _err("PATCH:/vcenter/vm/{vm}/network", "nic move failed"),
+            [],  # portgroup GET
+            [{"vm": "vm-1"}, {"vm": "vm-2"}],  # VM GET
+            {},  # vm-1 NIC ok
+            _http_error(409, "https://vc/api/vcenter/vm/vm-2/network"),  # vm-2 NIC fails
         ]
     )
     out = await host_detach_from_vds_composite(
         operator=_make_operator(),
         target=object(),
         params={"host": "host-9", "dvs": "dvs-1", "fallback_network": "std"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "incomplete"
     assert out["vms_migrated"] == ["vm-1"]
     assert len(out["vm_migration_failures"]) == 1
-    # No DVS remove call.
-    op_ids = [c["op_id"] for c in dispatch.calls]
-    assert "POST:/vcenter/network/dvs/{dvs}?action=remove_host" not in op_ids
+    # No DVS remove call -- the last recorded call is the failed NIC PATCH.
+    assert all("remove_host" not in c["path"] for c in conn.calls)
 
 
 # ===========================================================================
@@ -748,64 +868,56 @@ async def test_host_detach_from_vds_incomplete_when_nic_migration_fails() -> Non
 
 
 @pytest.mark.asyncio
-async def test_cluster_patch_happy_path_dispatches_sequential_maintenance_patch_exit() -> None:
-    """Per-host: maintenance enter -> patch -> maintenance exit; status=completed."""
-    dispatch = _RecordingDispatchChild(
-        [
-            _ok("GET:/vcenter/cluster/{cluster}/host", [{"host": "h1"}, {"host": "h2"}]),
-            # h1: enter -> patch -> exit, action verbs on the op_id.
-            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
-            _ok("POST:/vcenter/host/{host}?action=patch", {}),
-            _ok("PATCH:/vcenter/host/{host}/maintenance?action=exit", {}),
-            # h2
-            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
-            _ok("POST:/vcenter/host/{host}?action=patch", {}),
-            _ok("PATCH:/vcenter/host/{host}/maintenance?action=exit", {}),
-        ]
+async def test_cluster_patch_happy_path(gate: _GateRecorder) -> None:
+    """Per-host: maintenance-enter -> patch -> maintenance-exit; status=completed."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/cluster/c-1/host": [{"host": "h1"}, {"host": "h2"}],
+            "/api/vcenter/host/h1/maintenance?action=enter": {},
+            "/api/vcenter/host/h1?action=patch": {},
+            "/api/vcenter/host/h1/maintenance?action=exit": {},
+            "/api/vcenter/host/h2/maintenance?action=enter": {},
+            "/api/vcenter/host/h2?action=patch": {},
+            "/api/vcenter/host/h2/maintenance?action=exit": {},
+        }
     )
     out = await cluster_patch_composite(
         operator=_make_operator(),
         target=object(),
         params={"cluster": "c-1"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "completed"
     assert out["patched_hosts"] == ["h1", "h2"]
-    assert out["remaining_hosts"] == []
-    # Action sequence per host lives on the op_id (one descriptor row per verb).
-    host_calls = list(dispatch.calls[1:])
-    assert host_calls[0]["op_id"] == "PATCH:/vcenter/host/{host}/maintenance?action=enter"
-    assert host_calls[1]["op_id"] == "POST:/vcenter/host/{host}?action=patch"
-    assert host_calls[2]["op_id"] == "PATCH:/vcenter/host/{host}/maintenance?action=exit"
-    # Body params drop the ``action`` field; patch carries a ``method`` body.
-    assert host_calls[0]["params"] == {"host": "h1"}
-    assert host_calls[1]["params"] == {"host": "h1", "method": "default"}
-    assert host_calls[2]["params"] == {"host": "h1"}
+    # The patch step carries a ``method`` body; the maintenance verbs do not.
+    patch_call = next(c for c in conn.calls if c["path"] == "/api/vcenter/host/h1?action=patch")
+    assert patch_call["body"] == {"method": "default"}
+    enter_call = next(
+        c for c in conn.calls if c["path"] == "/api/vcenter/host/h1/maintenance?action=enter"
+    )
+    assert enter_call["body"] is None
+    # 3 writes per host x 2 hosts were gated.
+    assert len(gate.calls) == 6
 
 
 @pytest.mark.asyncio
-async def test_cluster_patch_per_host_failure_stops_loop() -> None:
-    """A per-host failure stops the loop; status=stopped with remaining_hosts."""
-    dispatch = _RecordingDispatchChild(
+async def test_cluster_patch_per_host_failure_stops_loop(gate: _GateRecorder) -> None:
+    """A per-host transport error stops the loop; status=stopped with remaining_hosts."""
+    conn = _RecordingConnector(
         [
-            _ok(
-                "GET:/vcenter/cluster/{cluster}/host",
-                [{"host": "h1"}, {"host": "h2"}, {"host": "h3"}],
-            ),
-            # h1 completes cleanly.
-            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
-            _ok("POST:/vcenter/host/{host}?action=patch", {}),
-            _ok("PATCH:/vcenter/host/{host}/maintenance?action=exit", {}),
-            # h2 fails on patch.
-            _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
-            _err("POST:/vcenter/host/{host}?action=patch", "vendor patch failed"),
+            [{"host": "h1"}, {"host": "h2"}, {"host": "h3"}],  # host listing GET
+            {},  # h1 enter
+            {},  # h1 patch
+            {},  # h1 exit
+            {},  # h2 enter
+            _http_error(500, "https://vc/api/vcenter/host/h2?action=patch"),  # h2 patch fails
         ]
     )
     out = await cluster_patch_composite(
         operator=_make_operator(),
         target=object(),
         params={"cluster": "c-1"},
-        dispatch_child=dispatch,
+        connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "stopped"
     assert out["patched_hosts"] == ["h1"]
@@ -815,111 +927,34 @@ async def test_cluster_patch_per_host_failure_stops_loop() -> None:
 
 
 # ===========================================================================
-# Connector-id contract
+# Governance contract across every write composite
 # ===========================================================================
 
 
 @pytest.mark.asyncio
-async def test_every_write_composite_uses_vmware_rest_9_0_connector_id() -> None:
-    """Every write composite dispatches sub-ops against ``vmware-rest-9.0`` exclusively.
+async def test_reads_are_never_gated_only_writes(gate: _GateRecorder) -> None:
+    """Resolution GETs never hit the governance seam; only mutating sub-ops do.
 
-    Load-bearing for the issue body's *dispatch_child not direct httpx*
-    contract -- the connector_id is what routes recursive dispatch
-    back to :class:`VmwareRestConnector` for sub-call authentication.
+    Load-bearing for the two-world governance model: a read composite sub-op
+    stays un-gated (it was ``safe`` under ``dispatch_child`` too), while every
+    write is gated with the declared dangerous / no-approval posture.
     """
-    # Every case drives the composite through ALL of its sub-op_ids so the
-    # connector_id contract is asserted on the full dispatch chain — empty
-    # listings would short-circuit before the action-bearing typed ops fire
-    # (M4 from PR #529 iter-2: vm_create_composite was exiting on an empty
-    # folder match before its create / nic / power / rollback sub-ops ran).
-    cases: tuple[tuple[Any, dict[str, Any], list[Any]], ...] = (
-        (
-            vm_create_composite,
-            {
-                "folder_name": "f",
-                "name": "n",
-                "guest_os": "g",
-                "nics": [{"network": "net-a"}],
-                "power_on_after_create": True,
-            },
-            [
-                _ok("GET:/vcenter/folder", [{"folder": "folder-x", "name": "f"}]),
-                _ok("POST:/vcenter/vm", {"value": "vm-x"}),
-                _ok("PATCH:/vcenter/vm/{vm}/network", {}),
-                _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/cluster/c-9/drs/recommendations": [
+                {"vm": "vm-1", "target_host": "host-A"}
             ],
-        ),
-        (
-            vm_clone_composite,
-            {
-                "source_vm": "v",
-                "target_name": "t",
-                "library_item": "l",
-                "wait_for_completion": False,
-            },
-            [
-                _ok("GET:/vcenter/vm/{vm}", {}),
-                _ok("POST:/vcenter/vm-template/library-items?action=deploy", {"task": "t"}),
-            ],
-        ),
-        (
-            vm_snapshot_revert_composite,
-            {"vm": "v", "snapshot_name": "n"},
-            [
-                _ok("GET:/vcenter/vm/{vm}/snapshot", [{"snapshot": "snap-1", "name": "n"}]),
-                _ok("POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert", {}),
-            ],
-        ),
-        (
-            vm_migrate_composite,
-            {"vm": "v", "cluster": "c", "target_host": "h"},
-            [_ok("POST:/vcenter/vm/{vm}?action=relocate", {})],
-        ),
-        (
-            vm_power_bulk_composite,
-            {"action": "start"},
-            [
-                _ok("GET:/vcenter/vm", [{"vm": "vm-x"}]),
-                _ok("POST:/vcenter/vm/{vm}/power?action=start", {}),
-            ],
-        ),
-        (
-            host_evacuate_composite,
-            {"host": "h"},
-            [
-                _ok("GET:/vcenter/vm", []),
-                _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
-            ],
-        ),
-        (
-            host_detach_from_vds_composite,
-            {"host": "h", "dvs": "d", "fallback_network": "f"},
-            [
-                _ok("GET:/vcenter/network/distributed-portgroup", []),
-                _ok("GET:/vcenter/vm", []),
-                _ok("POST:/vcenter/network/dvs/{dvs}?action=remove_host", {}),
-            ],
-        ),
-        (
-            cluster_patch_composite,
-            {"cluster": "c"},
-            [
-                _ok("GET:/vcenter/cluster/{cluster}/host", [{"host": "h1"}]),
-                _ok("PATCH:/vcenter/host/{host}/maintenance?action=enter", {}),
-                _ok("POST:/vcenter/host/{host}?action=patch", {}),
-                _ok("PATCH:/vcenter/host/{host}/maintenance?action=exit", {}),
-            ],
-        ),
+            "/api/vcenter/vm/vm-1?action=relocate": {},
+        }
     )
-    for handler, params, responses in cases:
-        dispatch = _RecordingDispatchChild(list(responses))
-        await handler(
-            operator=_make_operator(),
-            target=object(),
-            params=params,
-            dispatch_child=dispatch,
-        )
-        for call in dispatch.calls:
-            assert call["connector_id"] == "vmware-rest-9.0", (
-                f"{handler.__qualname__} dispatched to {call['connector_id']}"
-            )
+    await vm_migrate_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "cluster": "c-9"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    # The DRS recommendations read fired but was not gated; only the relocate
+    # write was gated.
+    read_paths = [c["path"] for c in conn.calls if c["method"] == "GET"]
+    assert read_paths == ["/api/vcenter/cluster/c-9/drs/recommendations"]
+    assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}?action=relocate"]

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -3,48 +3,35 @@
 
 """End-to-end activation tests for the 8 vmware-rest write composites.
 
-G3.16-T2 (#1415). The unit tests in
-:mod:`tests.test_connectors_vmware_rest_composites_write` mock
-``dispatch_child`` directly and prime the L2 pre-flight cache, so they
-prove handler wiring but never exercise (a) the real
-:func:`~meho_backplane.connectors.vmware_rest.composites._preflight.preflight_l2_dependencies`
-walk against an ingested descriptor set, or (b) the production
-approval-queue path a human principal hits on a
-``requires_approval=True`` composite. T1 (#1414) proved the declared
-``_SUB_OPS_*`` op_ids reconcile with the ingest pipeline's
-``METHOD:/path`` keys; this module proves the same set passes pre-flight
-*through the production* :func:`~meho_backplane.operations.dispatch`
-entry point, and that every write composite dispatches end-to-end behind
-the approval queue.
+Post-#2256 the write composites dispatch every raw-REST sub-op **directly
+on the connector session** (``connector._get_json`` / ``connector._post_json``
+mounted through ``connector.mount_op_path``) rather than through
+``dispatch_child``-routed ingested descriptor rows. This module proves the
+migration holds through the **production**
+:func:`~meho_backplane.operations.dispatch` entry point, with **zero**
+ingested descriptor rows in the catalog (the fresh-boot / two-world DoD):
 
-What this module covers, per #1415 acceptance criteria:
-
-1. **Pre-flight passes for all 8 composites** -- each composite's
-   ``_SUB_OPS_*`` raw-REST op_ids are registered as real
-   ``source_kind="typed"`` descriptor rows; dispatching the composite
-   runs the real pre-flight walk and never returns
-   ``composite_l2_missing``. The leaf typed-op set is derived from the
-   live ``_SUB_OPS_*`` constants (no hardcoded mirror to drift), so the
-   registered descriptor set is exactly what pre-flight queries.
-2. **End-to-end dispatch with sub-op sequence + rollback branch** --
-   each composite is driven through production :func:`dispatch` against
-   stub leaf handlers that record every ``(op_id, params)`` call. The
-   recorded sequence is asserted against the documented orchestration
+1. **Fresh-boot execution** -- each composite dispatched through
+   :func:`dispatch` against a connector whose session is a recording double
+   (seeded into the dispatcher's connector-instance cache) runs to a benign
+   business status; no ``composite_l2_missing`` / ``unknown_op`` can arise
+   because nothing is resolved through the catalog.
+2. **Sub-op sequence + rollback branch** -- each composite's recorded
+   ``(verb, path)`` chain is asserted against the documented orchestration
    workflow; ``vm.create`` additionally exercises the rollback branch
-   (NIC-attach failure → ``DELETE:/vcenter/vm/{vm}``).
+   (NIC-attach transport failure -> ``DELETE:/vcenter/vm/{vm}``).
 3. **The human approval-queue path** -- a USER principal dispatching a
-   ``requires_approval=True`` composite is parked at
-   ``awaiting_approval`` (G11.7-T1 #1401 routing), a distinct human
-   reviewer approves the parked request, and the ``_approved=True``
-   resume re-dispatch executes the composite. At least one composite
-   exercises the full queued → approve → resume cycle; the rest of the
-   8 assert the park half (so every composite is proven approval-gated).
+   ``requires_approval=True`` composite is parked at ``awaiting_approval``
+   (G11.7-T1 #1401 routing) at the **top level**, a distinct human reviewer
+   approves the parked request, and the ``_approved=True`` resume re-dispatch
+   executes the composite. The per-sub-op governance seam
+   (:func:`~meho_backplane.operations.composite.enforce_subop_policy`,
+   ``requires_approval=False``) auto-executes for the approved human on the
+   resume path, so the writes proceed without a second gate.
 
-Determinism: the module registers leaf typed-ops with stub handlers and
-drives them through the in-process SQLite dispatcher (the autouse
-migrations harness in :mod:`tests.conftest`). No vcsim / testcontainer
-required -- the recorded-fixture approach keeps the run deterministic in
-the unit lane.
+Determinism: the recording connector serves canned vSphere REST envelopes
+in-process (no vcsim / testcontainer); the respx-transport parity proof
+lives in :mod:`tests.integration.test_connectors_vmware_rest_vcsim`.
 """
 
 from __future__ import annotations
@@ -55,6 +42,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 from uuid import UUID
 
+import httpx
 import pytest
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -62,23 +50,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.broadcast import BroadcastEvent
-from meho_backplane.connectors import OperationResult
-from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
-from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
-from meho_backplane.connectors.vmware_rest.composites import (
-    _preflight,
-    _write,
-    register_vmware_composite_operations,
-)
+from meho_backplane.connectors.vmware_rest import VmwareRestConnector
+from meho_backplane.connectors.vmware_rest.composites import register_vmware_composite_operations
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus, EndpointDescriptor
 from meho_backplane.db.models import Target as TargetORM
-from meho_backplane.operations import (
-    dispatch,
-    register_typed_operation,
-    reset_dispatcher_caches,
-)
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
 from meho_backplane.operations.approval_queue import approve_request
 from meho_backplane.settings import get_settings
 
@@ -87,7 +66,7 @@ _TENANT_ID = UUID("00000000-0000-0000-0000-00000000a0a3")
 
 
 # ---------------------------------------------------------------------------
-# Fixtures (mirror tests.test_connectors_vmware_rest_composites_recursive_e2e)
+# Fixtures
 # ---------------------------------------------------------------------------
 
 
@@ -104,20 +83,12 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 @pytest.fixture(autouse=True)
 def _reset_module_state() -> Iterator[None]:
-    """Reset dispatcher caches, connector registry, and pre-flight cache.
-
-    The pre-flight cache (:data:`._preflight._PREFLIGHT_CACHE`) is reset
-    so each test exercises the real cache-miss walk against the freshly
-    registered descriptor rows rather than a primed positive carried
-    over from another module's fixture.
-    """
+    """Reset dispatcher caches + connector registry (incl. the instance cache)."""
     reset_dispatcher_caches()
     clear_registry()
-    _preflight.reset_preflight_cache()
     yield
     reset_dispatcher_caches()
     clear_registry()
-    _preflight.reset_preflight_cache()
 
 
 @pytest.fixture
@@ -132,12 +103,7 @@ def stub_embedding_service() -> AsyncMock:
 
 @pytest.fixture
 def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
-    """Replace :func:`publish_event` with a recording stub.
-
-    The dispatcher's audit path publishes a broadcast event on every
-    audit-log row write; without the stub the real bus would attempt a
-    write against a missing Postgres instance.
-    """
+    """Replace :func:`publish_event` with a recording stub."""
     events: list[BroadcastEvent] = []
 
     async def _capture(event: BroadcastEvent) -> None:
@@ -164,8 +130,8 @@ def _make_operator(
     """Synthetic operator scoped to the write-composite E2E tenant.
 
     Defaults to a USER (human) principal — the approval-queue path under
-    test fires for human/service principals on a ``requires_approval``
-    op (G11.7-T1 #1401).
+    test fires for human/service principals on a ``requires_approval`` op
+    (G11.7-T1 #1401).
     """
     return Operator(
         sub=sub,
@@ -193,8 +159,7 @@ class _FakeVmwareTarget:
         self.fingerprint = _FakeFingerprint(version="9.0")
         self.preferred_impl_id: str | None = "vmware-rest"
         self.id: UUID = target_id or uuid.uuid4()
-        # Tenant-unique cache key component (#1642/#1672); without it
-        # ``target_cache_key`` raises AttributeError at runtime.
+        # Tenant-unique cache key component (#1642/#1672).
         self.tenant_id: UUID = _TENANT_ID
         self.name = "test-vcenter"
         self.host = "vcenter.test"
@@ -202,207 +167,123 @@ class _FakeVmwareTarget:
         self.auth_model = "shared_service_account"
 
 
-class _NoOpVmwareConnector(Connector):
-    """Resolver-satisfying connector — never actually invoked.
+# ---------------------------------------------------------------------------
+# Recording connector double (seeded as the dispatcher's resolved instance)
+# ---------------------------------------------------------------------------
 
-    The dispatcher resolves a connector instance only for
-    ``source_kind="ingested"`` rows; ``typed`` and ``composite`` rows
-    skip the instance lookup. The class is here so the registry resolver
-    finds *something* under ``(vmware, 9.0, vmware-rest)``.
+
+def _http_error(status: int, url: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", url)
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(
+        f"Client error '{status}' for url '{url}'", request=request, response=response
+    )
+
+
+class _RecordingVmwareConnector:
+    """Records every direct sub-call the composites issue on the session.
+
+    Stands in for the resolved :class:`VmwareRestConnector` instance the
+    dispatcher injects into a composite handler (#2251). Sub-ops mount their
+    spec-relative path onto ``/api`` via :meth:`mount_op_path`, then read /
+    write it; this double records ``(verb, spec-relative path)`` and serves a
+    canned envelope keyed by that spec path (default ``{"value": {}}``). Spec
+    paths registered in ``failures`` raise :exc:`httpx.HTTPStatusError` to
+    drive the rollback / partial-failure branches. The instance is shared
+    across a composite's recursion (``host.evacuate`` -> ``vm.migrate``
+    resolve the same class), so one call log captures the whole tree.
     """
 
-    product = "vmware"
-    version = "9.0"
-    impl_id = "vmware-rest"
+    _MOUNT = "/api"
 
-    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
-        raise NotImplementedError
+    def __init__(self) -> None:
+        self.responses: dict[str, Any] = {}
+        self.failures: dict[str, str] = {}
+        self.calls: list[tuple[str, str]] = []
 
-    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
-        raise NotImplementedError
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
 
-    async def execute(  # type: ignore[override]
+    def _spec(self, path: str) -> str:
+        return path[len(self._MOUNT) :] if path.startswith(self._MOUNT) else path
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        spec = self._spec(path)
+        self.calls.append(("GET", spec))
+        return self.responses.get(spec, {"value": {}})
+
+    async def _post_json(
         self,
         target: Any,
-        op_id: str,
-        params: dict[str, Any],
-    ) -> OperationResult:
-        raise NotImplementedError
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: Any = None,
+        data: Any = None,
+        extra_headers: Any = None,
+    ) -> Any:
+        spec = self._spec(path)
+        self.calls.append((verb, spec))
+        if spec in self.failures:
+            raise _http_error(500, f"https://vc{self._MOUNT}{spec}")
+        return self.responses.get(spec, {"value": {}})
 
 
-# ---------------------------------------------------------------------------
-# Recording leaf typed-op stubs
-# ---------------------------------------------------------------------------
-#
-# Every raw-REST L2 sub-op the 8 write composites dispatch into is
-# registered as one ``source_kind="typed"`` descriptor row pointing at a
-# single shared recorder. Per-op canned payloads live in a module-level
-# registry the tests populate before dispatch; the recorder appends each
-# ``(op_id, params)`` call so a test can assert the sub-op sequence.
-#
-# Module-level (not closures) because ``derive_handler_ref`` rejects
-# closures — the same constraint ``register_typed_operation`` enforces in
-# production.
+def _seed_connector(recorder: _RecordingVmwareConnector) -> None:
+    """Register the connector class + seed its resolved instance as *recorder*.
 
-#: Ordered record of every leaf op_id dispatched in the current test.
-_CALLS: list[tuple[str, dict[str, Any]]] = []
-
-#: Per-op canned response payload (the vSphere REST envelope shape). A
-#: test sets the payloads it needs before dispatch; absent ops default to
-#: an empty ``{"value": {}}`` success.
-_RESPONSES: dict[str, Any] = {}
-
-#: op_ids whose stub should return a non-ok :class:`OperationResult` (to
-#: drive a rollback / partial-failure branch). Maps op_id → error string.
-_FAILURES: dict[str, str] = {}
+    The dispatcher resolves the ``(vmware, 9.0, vmware-rest)`` class from the
+    target then calls ``get_or_create_connector_instance`` — pre-seeding the
+    cache makes that return the recording double instead of a real
+    Vault-backed connector.
+    """
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=VmwareRestConnector,
+    )
+    _CONNECTOR_INSTANCE_CACHE[VmwareRestConnector] = recorder  # type: ignore[assignment]
 
 
-def _reset_recorder() -> None:
-    """Clear the call log + canned-response/failure registries."""
-    _CALLS.clear()
-    _RESPONSES.clear()
-    _FAILURES.clear()
+async def _bootstrap(
+    recorder: _RecordingVmwareConnector, stub_embedding_service: AsyncMock
+) -> None:
+    """Register the connector + all 13 composites and seed the recorder."""
+    _seed_connector(recorder)
+    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
 
 
-def _record(op_id: str, params: dict[str, Any]) -> dict[str, Any]:
-    """Append a leaf call and resolve its canned payload, raising on failure."""
-    _CALLS.append((op_id, dict(params)))
-    if op_id in _FAILURES:
-        raise RuntimeError(_FAILURES[op_id])
-    return _RESPONSES.get(op_id, {"value": {}})
+async def _clear_requires_approval(op_ids: set[str], recorder: _RecordingVmwareConnector) -> None:
+    """Flip ``requires_approval`` off for *op_ids* and drop stale caches.
 
+    Used by the fresh-boot + sequence tests: the sub-op sequence + rollback
+    branches are the contract there, not the top-level approval gate, so the
+    composites auto-execute. The approval-queue tests keep
+    ``requires_approval=True`` and route through park -> approve -> resume.
 
-# One wrapper per raw-REST leaf op. Each tags its op_id then delegates to
-# ``_record``. ``register_typed_operation`` binds these by dotted path, so
-# they must be module-level ``async def``.
-
-
-async def _h_list_folders(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("GET:/vcenter/folder", params)
-
-
-async def _h_list_vms(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("GET:/vcenter/vm", params)
-
-
-async def _h_get_vm(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("GET:/vcenter/vm/{vm}", params)
-
-
-async def _h_create_vm(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("POST:/vcenter/vm", params)
-
-
-async def _h_delete_vm(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("DELETE:/vcenter/vm/{vm}", params)
-
-
-async def _h_attach_nic(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("PATCH:/vcenter/vm/{vm}/network", params)
-
-
-async def _h_relocate(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("POST:/vcenter/vm/{vm}?action=relocate", params)
-
-
-async def _h_list_snapshots(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("GET:/vcenter/vm/{vm}/snapshot", params)
-
-
-async def _h_revert_snapshot(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert", params)
-
-
-async def _h_list_cluster_hosts(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("GET:/vcenter/cluster/{cluster}/host", params)
-
-
-async def _h_drs_recs(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("GET:/vcenter/cluster/{cluster}/drs/recommendations", params)
-
-
-async def _h_deploy_library_vm(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("POST:/vcenter/vm-template/library-items?action=deploy", params)
-
-
-async def _h_get_task(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("GET:/cis/tasks/{task}", params)
-
-
-async def _h_host_patch(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("POST:/vcenter/host/{host}?action=patch", params)
-
-
-async def _h_list_portgroups(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("GET:/vcenter/network/distributed-portgroup", params)
-
-
-async def _h_remove_dvs_host(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("POST:/vcenter/network/dvs/{dvs}?action=remove_host", params)
-
-
-async def _h_power_start(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("POST:/vcenter/vm/{vm}/power?action=start", params)
-
-
-async def _h_power_stop(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("POST:/vcenter/vm/{vm}/power?action=stop", params)
-
-
-async def _h_power_suspend(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("POST:/vcenter/vm/{vm}/power?action=suspend", params)
-
-
-async def _h_power_reset(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("POST:/vcenter/vm/{vm}/power?action=reset", params)
-
-
-async def _h_maintenance_enter(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("PATCH:/vcenter/host/{host}/maintenance?action=enter", params)
-
-
-async def _h_maintenance_exit(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("PATCH:/vcenter/host/{host}/maintenance?action=exit", params)
-
-
-#: op_id → recording stub handler. Keyed by the canonical ``METHOD:/path``
-#: descriptor key. Covers every raw-REST L2 sub-op across the 8 write
-#: composites; the registration helper below asserts this map is a
-#: superset of the live ``_SUB_OPS_*`` requirement so a future composite
-#: edit that adds a sub-op without a stub fails loudly.
-_LEAF_HANDLERS: dict[str, Any] = {
-    "GET:/vcenter/folder": _h_list_folders,
-    "GET:/vcenter/vm": _h_list_vms,
-    "GET:/vcenter/vm/{vm}": _h_get_vm,
-    "POST:/vcenter/vm": _h_create_vm,
-    "DELETE:/vcenter/vm/{vm}": _h_delete_vm,
-    "PATCH:/vcenter/vm/{vm}/network": _h_attach_nic,
-    "POST:/vcenter/vm/{vm}?action=relocate": _h_relocate,
-    "GET:/vcenter/vm/{vm}/snapshot": _h_list_snapshots,
-    "POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert": _h_revert_snapshot,
-    "GET:/vcenter/cluster/{cluster}/host": _h_list_cluster_hosts,
-    "GET:/vcenter/cluster/{cluster}/drs/recommendations": _h_drs_recs,
-    "POST:/vcenter/vm-template/library-items?action=deploy": _h_deploy_library_vm,
-    "GET:/cis/tasks/{task}": _h_get_task,
-    "POST:/vcenter/host/{host}?action=patch": _h_host_patch,
-    "GET:/vcenter/network/distributed-portgroup": _h_list_portgroups,
-    "POST:/vcenter/network/dvs/{dvs}?action=remove_host": _h_remove_dvs_host,
-    "POST:/vcenter/vm/{vm}/power?action=start": _h_power_start,
-    "POST:/vcenter/vm/{vm}/power?action=stop": _h_power_stop,
-    "POST:/vcenter/vm/{vm}/power?action=suspend": _h_power_suspend,
-    "POST:/vcenter/vm/{vm}/power?action=reset": _h_power_reset,
-    "PATCH:/vcenter/host/{host}/maintenance?action=enter": _h_maintenance_enter,
-    "PATCH:/vcenter/host/{host}/maintenance?action=exit": _h_maintenance_exit,
-}
+    ``reset_dispatcher_caches`` also clears the connector-instance cache, so
+    the seeded recorder is re-activated afterwards or the dispatcher would
+    instantiate a real (Vault-backed) connector on the next resolve.
+    """
+    async with get_sessionmaker()() as fresh:
+        await fresh.execute(
+            update(EndpointDescriptor)
+            .where(EndpointDescriptor.op_id.in_(op_ids))
+            .values(requires_approval=False)
+        )
+        await fresh.commit()
+    reset_dispatcher_caches()
+    _CONNECTOR_INSTANCE_CACHE[VmwareRestConnector] = recorder  # type: ignore[assignment]
 
 
 # ---------------------------------------------------------------------------
 # Composite metadata
 # ---------------------------------------------------------------------------
 
-#: The 8 write composites under test, op_id → human-readable name. Pinned
-#: explicitly so the suite can't silently shrink if a composite is renamed
-#: out of the registrar.
 _WRITE_COMPOSITES: dict[str, str] = {
     "vmware.composite.vm.create": "vm.create",
     "vmware.composite.vm.clone": "vm.clone",
@@ -413,168 +294,6 @@ _WRITE_COMPOSITES: dict[str, str] = {
     "vmware.composite.host.detach_from_vds": "host.detach_from_vds",
     "vmware.composite.cluster.patch": "cluster.patch",
 }
-
-
-def _required_raw_sub_op_ids() -> set[str]:
-    """Union of every raw-REST ``_SUB_OPS_*`` op_id across the 8 composites.
-
-    Excludes composite-to-composite references (``vmware.composite.*``):
-    the pre-flight walk skips those (their own handlers pre-flight). This
-    is the exact set the registered leaf descriptors must cover.
-    """
-    raw: set[str] = set()
-    for name in dir(_write):
-        if not name.startswith("_SUB_OPS_"):
-            continue
-        for op_id in getattr(_write, name):
-            if op_id.startswith("vmware.composite."):
-                continue
-            raw.add(op_id)
-    return raw
-
-
-async def _register_leaf_typed_ops(stub_embedding_service: AsyncMock) -> None:
-    """Register one ``source_kind="typed"`` row per raw-REST leaf op.
-
-    The registered set is exactly :data:`_LEAF_HANDLERS`, asserted to be a
-    superset of the live ``_SUB_OPS_*`` requirement so pre-flight resolves
-    every declared sub-op. ``parameter_schema`` is permissive
-    (``additionalProperties=True``) so the composites pass whatever params
-    they build without per-op schema bookkeeping in this test.
-    """
-    required = _required_raw_sub_op_ids()
-    missing = required - set(_LEAF_HANDLERS)
-    assert not missing, (
-        "the write composites declare raw sub-op_ids this module has no leaf "
-        f"stub for: {sorted(missing)}. Add a stub + map it in _LEAF_HANDLERS."
-    )
-    permissive_schema = {"type": "object", "additionalProperties": True}
-    for op_id, handler in _LEAF_HANDLERS.items():
-        await register_typed_operation(
-            product="vmware",
-            version="9.0",
-            impl_id="vmware-rest",
-            op_id=op_id,
-            handler=handler,
-            summary=f"Stub leaf op {op_id} for the write-composite E2E.",
-            description=f"Stub leaf op {op_id} for the write-composite E2E.",
-            parameter_schema=permissive_schema,
-            when_to_use=None,
-            embedding_service=stub_embedding_service,
-        )
-
-
-async def _bootstrap_registry(stub_embedding_service: AsyncMock) -> None:
-    """Register the connector, all 15 composites, and the leaf typed ops."""
-    register_connector_v2(
-        product="vmware",
-        version="9.0",
-        impl_id="vmware-rest",
-        cls=_NoOpVmwareConnector,
-    )
-    await register_vmware_composite_operations(embedding_service=stub_embedding_service)
-    await _register_leaf_typed_ops(stub_embedding_service)
-    _reset_recorder()
-
-
-async def _clear_requires_approval(op_ids: set[str]) -> None:
-    """Flip ``requires_approval`` off for *op_ids* and drop stale caches.
-
-    Used by the call-sequence E2E half: the sub-op sequence + rollback
-    branches are the contract under test there, not the approval gate, so
-    the composites auto-execute. The approval-queue half keeps
-    ``requires_approval=True`` and routes through park → approve → resume.
-    """
-    sessionmaker = get_sessionmaker()
-    async with sessionmaker() as fresh:
-        await fresh.execute(
-            update(EndpointDescriptor)
-            .where(EndpointDescriptor.op_id.in_(op_ids))
-            .values(requires_approval=False)
-        )
-        await fresh.commit()
-    # The dispatcher caches descriptor rows; drop the stale pre-mutation
-    # copy so the policy gate sees requires_approval=False.
-    reset_dispatcher_caches()
-
-
-def _ops_in_calls() -> list[str]:
-    """The recorded leaf op_ids in dispatch order."""
-    return [op_id for op_id, _ in _CALLS]
-
-
-# ===========================================================================
-# AC1 — pre-flight passes for all 8 write composites
-# ===========================================================================
-
-
-def test_write_composite_set_is_the_expected_eight() -> None:
-    """Guard: the registrar still ships exactly the 8 write composites.
-
-    Pins the op_id set so a renamed / dropped composite can't shrink the
-    parametrised pre-flight + dispatch coverage to a vacuous pass.
-    """
-    registrar_write_op_ids = {f"vmware.composite.{name}" for name in _WRITE_COMPOSITES.values()}
-    assert set(_WRITE_COMPOSITES) == registrar_write_op_ids
-    assert len(_WRITE_COMPOSITES) == 8
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("composite_op_id", sorted(_WRITE_COMPOSITES))
-async def test_write_composite_passes_preflight_through_dispatch(
-    composite_op_id: str,
-    stub_embedding_service: AsyncMock,
-    session: AsyncSession,
-    captured_events: list[BroadcastEvent],
-) -> None:
-    """Each composite's pre-flight walk resolves every declared sub-op (AC1).
-
-    Drives the composite through production :func:`dispatch` against the
-    registered leaf descriptor set with ``requires_approval`` cleared.
-    The assertion is the negative one #1415 cares about: the dispatch
-    never returns the ``composite_l2_missing`` structured error, i.e.
-    :func:`preflight_l2_dependencies` found every ``_SUB_OPS_*`` op_id in
-    ``endpoint_descriptor``. Listing-shaped leaf responses are empty by
-    default, so most composites short-circuit to a benign no-work status
-    — that is fine here; the dispatch-sequence detail is asserted in the
-    dedicated per-composite tests below.
-    """
-    await _bootstrap_registry(stub_embedding_service)
-    await _clear_requires_approval(set(_WRITE_COMPOSITES))
-    for op_id, payload in _benign_responses_for(composite_op_id).items():
-        _RESPONSES[op_id] = payload
-
-    operator = _make_operator()
-    target = _FakeVmwareTarget()
-    params = _benign_params_for(composite_op_id)
-
-    result = await dispatch(
-        operator=operator,
-        connector_id=_CONNECTOR_ID,
-        op_id=composite_op_id,
-        target=target,
-        params=params,
-    )
-
-    # Pre-flight passed: the dispatch never surfaced the
-    # ``composite_l2_missing`` structured error (status='error', error
-    # text prefixed ``composite_l2_missing:`` — see
-    # ``_errors.result_composite_l2_missing``). Any benign business-logic
-    # status (created / no_recommendation / detached / ...) is acceptable
-    # here; the point is the L2 dependency walk resolved every declared
-    # ``_SUB_OPS_*`` op_id against the registered descriptor set.
-    assert "composite_l2_missing" not in (result.error or ""), result.error
-    # AC1 (#1436): a *non*-``composite_l2_missing`` failure would still
-    # satisfy the negative check above — an ``unknown_op`` /
-    # ``invalid_params`` / ``connector_error`` generic error has a
-    # different error text yet is plainly not a passing pre-flight. Pin
-    # the positive outcome too (``status != "error"``) so only a genuine
-    # pre-flight pass through the production dispatch path satisfies the
-    # test. The benign leaf responses above let every composite reach its
-    # no-work business status (``OperationResult.status`` ∈ {ok, pending}),
-    # never a generic execution error.
-    assert result.status != "error", result.error
-    assert result.status in {"ok", "pending"}, (result.status, result.error)
 
 
 def _benign_params_for(composite_op_id: str) -> dict[str, Any]:
@@ -611,50 +330,86 @@ def _benign_params_for(composite_op_id: str) -> dict[str, Any]:
 
 
 def _benign_responses_for(composite_op_id: str) -> dict[str, Any]:
-    """Per-op leaf responses that steer each composite to a no-work status.
+    """Per-op spec-path reads that steer each composite to a no-work status.
 
-    The recorder's default leaf payload is ``{"value": {}}`` (an empty
-    *object* envelope). Composites whose first sub-op is a listing read
-    unwrap ``value`` and expect a *list*; the empty-object default trips
-    their ``isinstance(..., list)`` guard and raises ``RuntimeError`` —
-    surfacing as a generic ``connector_error`` (``status='error'``), which
-    is exactly the non-``composite_l2_missing`` failure AC1 (#1436) now
-    rejects. Returning an empty *list* envelope for those listing ops lets
-    the composite short-circuit to its benign no-work business status
-    (``no_recommendation`` / ``detached`` / ``completed`` / ...) so the
-    strengthened ``status != "error"`` assertion checks a genuine
-    pre-flight pass rather than masking an execution error.
-
-    ``vm.clone`` is fire-and-forget here (``wait_for_completion=False``):
-    it reads the source VM (the empty-object default is a valid non-list
-    payload) then deploys, so it needs a deploy envelope carrying a task
-    id to reach the benign ``pending`` status without a poll.
+    Composites whose first sub-op is a listing read unwrap ``value`` and
+    expect a *list*; an empty *list* envelope lets the composite short-circuit
+    to a benign no-work business status. ``vm.clone`` is fire-and-forget here
+    (``wait_for_completion=False``): it reads the source VM then deploys, so it
+    needs a deploy envelope carrying a task id to reach ``pending``.
     """
-    empty_listing: dict[str, Any] = {"value": []}
+    empty: dict[str, Any] = {"value": []}
     per_composite: dict[str, dict[str, Any]] = {
-        "vmware.composite.vm.create": {"GET:/vcenter/folder": empty_listing},
+        "vmware.composite.vm.create": {"/vcenter/folder": empty},
         "vmware.composite.vm.clone": {
-            "POST:/vcenter/vm-template/library-items?action=deploy": {
-                "value": {"task": "task-benign"}
-            },
+            "/vcenter/vm-template/library-items?action=deploy": {"value": {"task": "task-benign"}},
         },
-        "vmware.composite.vm.snapshot.revert": {"GET:/vcenter/vm/{vm}/snapshot": empty_listing},
-        "vmware.composite.vm.migrate": {
-            "GET:/vcenter/cluster/{cluster}/drs/recommendations": empty_listing,
-        },
-        "vmware.composite.vm.power.bulk": {"GET:/vcenter/vm": empty_listing},
-        "vmware.composite.host.evacuate": {"GET:/vcenter/vm": empty_listing},
+        "vmware.composite.vm.snapshot.revert": {"/vcenter/vm/vm-1/snapshot": empty},
+        "vmware.composite.vm.migrate": {"/vcenter/cluster/domain-c1/drs/recommendations": empty},
+        "vmware.composite.vm.power.bulk": {"/vcenter/vm": empty},
+        "vmware.composite.host.evacuate": {"/vcenter/vm": empty},
         "vmware.composite.host.detach_from_vds": {
-            "GET:/vcenter/network/distributed-portgroup": empty_listing,
-            "GET:/vcenter/vm": empty_listing,
+            "/vcenter/network/distributed-portgroup": empty,
+            "/vcenter/vm": empty,
         },
-        "vmware.composite.cluster.patch": {"GET:/vcenter/cluster/{cluster}/host": empty_listing},
+        "vmware.composite.cluster.patch": {"/vcenter/cluster/domain-c1/host": empty},
     }
     return per_composite[composite_op_id]
 
 
 # ===========================================================================
-# AC2 — end-to-end dispatch: sub-op sequence + rollback branch
+# Guard: the write set is exactly the expected eight
+# ===========================================================================
+
+
+def test_write_composite_set_is_the_expected_eight() -> None:
+    """Pins the op_id set so a renamed / dropped composite can't shrink coverage."""
+    registrar_write_op_ids = {f"vmware.composite.{name}" for name in _WRITE_COMPOSITES.values()}
+    assert set(_WRITE_COMPOSITES) == registrar_write_op_ids
+    assert len(_WRITE_COMPOSITES) == 8
+
+
+# ===========================================================================
+# Fresh-boot: every composite executes through dispatch with ZERO ingested rows
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("composite_op_id", sorted(_WRITE_COMPOSITES))
+async def test_write_composite_executes_through_dispatch_without_ingest(
+    composite_op_id: str,
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """Each composite runs to a benign business status on the direct session.
+
+    No ingested ``endpoint_descriptor`` rows exist in the catalog here — only
+    the 13 composite rows the registrar upserts. Reaching a business status
+    (``created`` / ``no_recommendation`` / ``detached`` / ...) rather than a
+    generic execution error proves every raw-REST sub-op resolved via the
+    connector session, not a catalog lookup (the two-world / fresh-boot DoD).
+    """
+    recorder = _RecordingVmwareConnector()
+    recorder.responses.update(_benign_responses_for(composite_op_id))
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval(set(_WRITE_COMPOSITES), recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=composite_op_id,
+        target=_FakeVmwareTarget(),
+        params=_benign_params_for(composite_op_id),
+    )
+
+    assert "composite_l2_missing" not in (result.error or ""), result.error
+    assert result.status != "error", result.error
+    assert result.status in {"ok", "pending"}, (result.status, result.error)
+
+
+# ===========================================================================
+# Sub-op sequence + rollback branch (through production dispatch)
 # ===========================================================================
 
 
@@ -664,11 +419,16 @@ async def test_vm_create_happy_path_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """vm.create: folder lookup → create → NIC attach → power-on (AC2)."""
-    await _bootstrap_registry(stub_embedding_service)
-    await _clear_requires_approval({"vmware.composite.vm.create"})
-    _RESPONSES["GET:/vcenter/folder"] = {"value": [{"folder": "group-v1"}]}
-    _RESPONSES["POST:/vcenter/vm"] = {"value": "vm-123"}
+    """vm.create: folder GET -> create POST -> NIC PATCH -> power POST."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/folder": {"value": [{"folder": "group-v1"}]},
+            "/vcenter/vm": {"value": "vm-123"},
+        }
+    )
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.create"}, recorder)
 
     result = await dispatch(
         operator=_make_operator(),
@@ -685,14 +445,13 @@ async def test_vm_create_happy_path_sub_op_sequence(
     )
 
     assert result.status == "ok", result.error
-    assert isinstance(result.result, dict)
     assert result.result["status"] == "created"
     assert result.result["vm_id"] == "vm-123"
-    assert _ops_in_calls() == [
-        "GET:/vcenter/folder",
-        "POST:/vcenter/vm",
-        "PATCH:/vcenter/vm/{vm}/network",
-        "POST:/vcenter/vm/{vm}/power?action=start",
+    assert recorder.calls == [
+        ("GET", "/vcenter/folder"),
+        ("POST", "/vcenter/vm"),
+        ("PATCH", "/vcenter/vm/vm-123/network"),
+        ("POST", "/vcenter/vm/vm-123/power?action=start"),
     ]
 
 
@@ -702,12 +461,17 @@ async def test_vm_create_rollback_on_nic_failure(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """vm.create: NIC-attach failure rolls back via DELETE:/vcenter/vm/{vm} (AC2)."""
-    await _bootstrap_registry(stub_embedding_service)
-    await _clear_requires_approval({"vmware.composite.vm.create"})
-    _RESPONSES["GET:/vcenter/folder"] = {"value": [{"folder": "group-v1"}]}
-    _RESPONSES["POST:/vcenter/vm"] = {"value": "vm-123"}
-    _FAILURES["PATCH:/vcenter/vm/{vm}/network"] = "nic backend rejected the attach"
+    """vm.create: a NIC-attach transport error rolls back via DELETE:/vcenter/vm/{vm}."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/folder": {"value": [{"folder": "group-v1"}]},
+            "/vcenter/vm": {"value": "vm-123"},
+        }
+    )
+    recorder.failures["/vcenter/vm/vm-123/network"] = "nic backend rejected the attach"
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.create"}, recorder)
 
     result = await dispatch(
         operator=_make_operator(),
@@ -723,16 +487,14 @@ async def test_vm_create_rollback_on_nic_failure(
     )
 
     assert result.status == "ok", result.error
-    assert isinstance(result.result, dict)
     assert result.result["status"] == "rolled_back"
     assert result.result["failed_step"] == "nic_attach"
     assert result.result["vm_id"] is None
-    # The rollback issued the DELETE after the failed NIC attach.
-    assert _ops_in_calls() == [
-        "GET:/vcenter/folder",
-        "POST:/vcenter/vm",
-        "PATCH:/vcenter/vm/{vm}/network",
-        "DELETE:/vcenter/vm/{vm}",
+    assert recorder.calls == [
+        ("GET", "/vcenter/folder"),
+        ("POST", "/vcenter/vm"),
+        ("PATCH", "/vcenter/vm/vm-123/network"),
+        ("DELETE", "/vcenter/vm/vm-123"),
     ]
 
 
@@ -742,13 +504,16 @@ async def test_vm_clone_pending_path_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """vm.clone (fire-and-forget): source read → deploy → return task id (AC2)."""
-    await _bootstrap_registry(stub_embedding_service)
-    await _clear_requires_approval({"vmware.composite.vm.clone"})
-    _RESPONSES["GET:/vcenter/vm/{vm}"] = {"value": {"name": "src"}}
-    _RESPONSES["POST:/vcenter/vm-template/library-items?action=deploy"] = {
-        "value": {"task": "task-9"}
-    }
+    """vm.clone (fire-and-forget): source read -> deploy -> return task id."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/vm/vm-1": {"value": {"name": "src"}},
+            "/vcenter/vm-template/library-items?action=deploy": {"value": {"task": "task-9"}},
+        }
+    )
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.clone"}, recorder)
 
     result = await dispatch(
         operator=_make_operator(),
@@ -764,13 +529,11 @@ async def test_vm_clone_pending_path_sub_op_sequence(
     )
 
     assert result.status == "ok", result.error
-    assert isinstance(result.result, dict)
     assert result.result["status"] == "pending"
     assert result.result["task_id"] == "task-9"
-    # wait_for_completion=False short-circuits before any task poll.
-    assert _ops_in_calls() == [
-        "GET:/vcenter/vm/{vm}",
-        "POST:/vcenter/vm-template/library-items?action=deploy",
+    assert recorder.calls == [
+        ("GET", "/vcenter/vm/vm-1"),
+        ("POST", "/vcenter/vm-template/library-items?action=deploy"),
     ]
 
 
@@ -780,12 +543,13 @@ async def test_vm_snapshot_revert_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """vm.snapshot.revert: list → match-by-name → revert (AC2)."""
-    await _bootstrap_registry(stub_embedding_service)
-    await _clear_requires_approval({"vmware.composite.vm.snapshot.revert"})
-    _RESPONSES["GET:/vcenter/vm/{vm}/snapshot"] = {
+    """vm.snapshot.revert: list -> match-by-name -> revert."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses["/vcenter/vm/vm-1/snapshot"] = {
         "value": [{"name": "snap-a", "snapshot": "snap-moid-1"}]
     }
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.snapshot.revert"}, recorder)
 
     result = await dispatch(
         operator=_make_operator(),
@@ -796,12 +560,11 @@ async def test_vm_snapshot_revert_sub_op_sequence(
     )
 
     assert result.status == "ok", result.error
-    assert isinstance(result.result, dict)
     assert result.result["status"] == "reverted"
     assert result.result["snapshot_id"] == "snap-moid-1"
-    assert _ops_in_calls() == [
-        "GET:/vcenter/vm/{vm}/snapshot",
-        "POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert",
+    assert recorder.calls == [
+        ("GET", "/vcenter/vm/vm-1/snapshot"),
+        ("POST", "/vcenter/vm/vm-1/snapshot/snap-moid-1?action=revert"),
     ]
 
 
@@ -811,12 +574,13 @@ async def test_vm_migrate_drs_path_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """vm.migrate: DRS recommendation → relocate (AC2)."""
-    await _bootstrap_registry(stub_embedding_service)
-    await _clear_requires_approval({"vmware.composite.vm.migrate"})
-    _RESPONSES["GET:/vcenter/cluster/{cluster}/drs/recommendations"] = {
+    """vm.migrate: DRS recommendation -> relocate."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses["/vcenter/cluster/domain-c1/drs/recommendations"] = {
         "value": [{"vm": "vm-1", "target_host": "host-target"}]
     }
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.migrate"}, recorder)
 
     result = await dispatch(
         operator=_make_operator(),
@@ -827,13 +591,11 @@ async def test_vm_migrate_drs_path_sub_op_sequence(
     )
 
     assert result.status == "ok", result.error
-    assert isinstance(result.result, dict)
     assert result.result["status"] == "migrated"
     assert result.result["target_host"] == "host-target"
-    assert result.result["source"] == "drs"
-    assert _ops_in_calls() == [
-        "GET:/vcenter/cluster/{cluster}/drs/recommendations",
-        "POST:/vcenter/vm/{vm}?action=relocate",
+    assert recorder.calls == [
+        ("GET", "/vcenter/cluster/domain-c1/drs/recommendations"),
+        ("POST", "/vcenter/vm/vm-1?action=relocate"),
     ]
 
 
@@ -843,10 +605,11 @@ async def test_vm_power_bulk_fan_out_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """vm.power.bulk: list → per-VM power action fan-out (AC2)."""
-    await _bootstrap_registry(stub_embedding_service)
-    await _clear_requires_approval({"vmware.composite.vm.power.bulk"})
-    _RESPONSES["GET:/vcenter/vm"] = {"value": [{"vm": "vm-a"}, {"vm": "vm-b"}]}
+    """vm.power.bulk: list -> per-VM power action fan-out."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses["/vcenter/vm"] = {"value": [{"vm": "vm-a"}, {"vm": "vm-b"}]}
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.power.bulk"}, recorder)
 
     result = await dispatch(
         operator=_make_operator(),
@@ -857,13 +620,11 @@ async def test_vm_power_bulk_fan_out_sub_op_sequence(
     )
 
     assert result.status == "ok", result.error
-    assert isinstance(result.result, dict)
     assert result.result["summary"] == {"ok": 2, "error": 0}
-    # One listing then one stop per matched VM (the chosen action verb).
-    assert _ops_in_calls() == [
-        "GET:/vcenter/vm",
-        "POST:/vcenter/vm/{vm}/power?action=stop",
-        "POST:/vcenter/vm/{vm}/power?action=stop",
+    assert recorder.calls == [
+        ("GET", "/vcenter/vm"),
+        ("POST", "/vcenter/vm/vm-a/power?action=stop"),
+        ("POST", "/vcenter/vm/vm-b/power?action=stop"),
     ]
 
 
@@ -873,21 +634,27 @@ async def test_host_evacuate_recursive_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """host.evacuate: list VMs → recursive vm.migrate per VM → maintenance enter (AC2).
+    """host.evacuate: list VMs -> recursive vm.migrate per VM -> maintenance enter.
 
     Exercises the only composite-to-composite recursion in the write set
-    through production dispatch. The recorded leaf sequence proves the
-    recursive vm.migrate frames bottom out on the DRS + relocate leaves
-    before the host enters maintenance.
+    through production dispatch: the recursive ``vm.migrate`` (still routed
+    via ``dispatch_child``, #2248) resolves the same connector instance and
+    runs its DRS read + relocate write on the direct session before the host
+    enters maintenance.
     """
-    await _bootstrap_registry(stub_embedding_service)
-    await _clear_requires_approval(
-        {"vmware.composite.host.evacuate", "vmware.composite.vm.migrate"}
+    recorder = _RecordingVmwareConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/vm": {"value": [{"vm": "vm-a", "cluster": "domain-c1"}]},
+            "/vcenter/cluster/domain-c1/drs/recommendations": {
+                "value": [{"vm": "vm-a", "target_host": "host-target"}]
+            },
+        }
     )
-    _RESPONSES["GET:/vcenter/vm"] = {"value": [{"vm": "vm-a", "cluster": "domain-c1"}]}
-    _RESPONSES["GET:/vcenter/cluster/{cluster}/drs/recommendations"] = {
-        "value": [{"vm": "vm-a", "target_host": "host-target"}]
-    }
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval(
+        {"vmware.composite.host.evacuate", "vmware.composite.vm.migrate"}, recorder
+    )
 
     result = await dispatch(
         operator=_make_operator(),
@@ -898,17 +665,14 @@ async def test_host_evacuate_recursive_sub_op_sequence(
     )
 
     assert result.status == "ok", result.error
-    assert isinstance(result.result, dict)
     assert result.result["status"] == "evacuated"
     assert result.result["maintenance_entered"] is True
     assert result.result["migrated_vms"] == ["vm-a"]
-    # list VMs (host.evacuate) → recursive vm.migrate (DRS → relocate) →
-    # maintenance enter (host.evacuate).
-    assert _ops_in_calls() == [
-        "GET:/vcenter/vm",
-        "GET:/vcenter/cluster/{cluster}/drs/recommendations",
-        "POST:/vcenter/vm/{vm}?action=relocate",
-        "PATCH:/vcenter/host/{host}/maintenance?action=enter",
+    assert recorder.calls == [
+        ("GET", "/vcenter/vm"),
+        ("GET", "/vcenter/cluster/domain-c1/drs/recommendations"),
+        ("POST", "/vcenter/vm/vm-a?action=relocate"),
+        ("PATCH", "/vcenter/host/host-1/maintenance?action=enter"),
     ]
 
 
@@ -918,11 +682,16 @@ async def test_host_detach_from_vds_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """host.detach_from_vds: portgroups → VMs → per-VM NIC migrate → DVS detach (AC2)."""
-    await _bootstrap_registry(stub_embedding_service)
-    await _clear_requires_approval({"vmware.composite.host.detach_from_vds"})
-    _RESPONSES["GET:/vcenter/network/distributed-portgroup"] = {"value": []}
-    _RESPONSES["GET:/vcenter/vm"] = {"value": [{"vm": "vm-a"}]}
+    """host.detach_from_vds: portgroups -> VMs -> per-VM NIC migrate -> DVS detach."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/network/distributed-portgroup": {"value": []},
+            "/vcenter/vm": {"value": [{"vm": "vm-a"}]},
+        }
+    )
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.host.detach_from_vds"}, recorder)
 
     result = await dispatch(
         operator=_make_operator(),
@@ -933,14 +702,13 @@ async def test_host_detach_from_vds_sub_op_sequence(
     )
 
     assert result.status == "ok", result.error
-    assert isinstance(result.result, dict)
     assert result.result["status"] == "detached"
     assert result.result["vms_migrated"] == ["vm-a"]
-    assert _ops_in_calls() == [
-        "GET:/vcenter/network/distributed-portgroup",
-        "GET:/vcenter/vm",
-        "PATCH:/vcenter/vm/{vm}/network",
-        "POST:/vcenter/network/dvs/{dvs}?action=remove_host",
+    assert recorder.calls == [
+        ("GET", "/vcenter/network/distributed-portgroup"),
+        ("GET", "/vcenter/vm"),
+        ("PATCH", "/vcenter/vm/vm-a/network"),
+        ("POST", "/vcenter/network/dvs/dvs-1?action=remove_host"),
     ]
 
 
@@ -950,10 +718,11 @@ async def test_cluster_patch_sequential_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """cluster.patch: list hosts → per-host maintenance enter → patch → exit (AC2)."""
-    await _bootstrap_registry(stub_embedding_service)
-    await _clear_requires_approval({"vmware.composite.cluster.patch"})
-    _RESPONSES["GET:/vcenter/cluster/{cluster}/host"] = {"value": [{"host": "host-1"}]}
+    """cluster.patch: list hosts -> per-host maintenance enter -> patch -> exit."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses["/vcenter/cluster/domain-c1/host"] = {"value": [{"host": "host-1"}]}
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.cluster.patch"}, recorder)
 
     result = await dispatch(
         operator=_make_operator(),
@@ -964,19 +733,18 @@ async def test_cluster_patch_sequential_sub_op_sequence(
     )
 
     assert result.status == "ok", result.error
-    assert isinstance(result.result, dict)
     assert result.result["status"] == "completed"
     assert result.result["patched_hosts"] == ["host-1"]
-    assert _ops_in_calls() == [
-        "GET:/vcenter/cluster/{cluster}/host",
-        "PATCH:/vcenter/host/{host}/maintenance?action=enter",
-        "POST:/vcenter/host/{host}?action=patch",
-        "PATCH:/vcenter/host/{host}/maintenance?action=exit",
+    assert recorder.calls == [
+        ("GET", "/vcenter/cluster/domain-c1/host"),
+        ("PATCH", "/vcenter/host/host-1/maintenance?action=enter"),
+        ("POST", "/vcenter/host/host-1?action=patch"),
+        ("PATCH", "/vcenter/host/host-1/maintenance?action=exit"),
     ]
 
 
 # ===========================================================================
-# AC3 — human approval-queue path (queue → approve → resume → execute)
+# Human approval-queue path (queue -> approve -> resume -> execute)
 # ===========================================================================
 
 
@@ -988,35 +756,37 @@ async def test_write_composite_human_dispatch_parks_for_approval(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """A USER principal dispatching a write composite is parked, not denied (AC3).
+    """A USER principal dispatching a write composite is parked at the top level.
 
-    Every write composite ships ``requires_approval=True``; G11.7-T1
-    (#1401) routes a human/service principal hitting such an op to the
-    approval queue (``awaiting_approval``) rather than the pre-G11.7
-    hard-deny. This proves the park half for all 8 — a durable
-    :class:`ApprovalRequest` row is created and the result carries its id.
+    Every write composite ships ``requires_approval=True``; G11.7-T1 (#1401)
+    routes a human/service principal to the approval queue
+    (``awaiting_approval``) at the top-level gate — before the handler (and
+    thus any sub-op) runs. Proves the park half for all 8; the recorder stays
+    empty because the composite never executed.
     """
-    await _bootstrap_registry(stub_embedding_service)
-
-    operator = _make_operator()
-    target = _FakeVmwareTarget()
+    recorder = _RecordingVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
 
     result = await dispatch(
-        operator=operator,
+        operator=_make_operator(),
         connector_id=_CONNECTOR_ID,
         op_id=composite_op_id,
-        target=target,
+        target=_FakeVmwareTarget(),
         params=_benign_params_for(composite_op_id),
     )
 
     assert result.status == "awaiting_approval", result.error
-    assert result.status != "denied"
     approval_request_id = UUID(result.extras["approval_request_id"])
     async with get_sessionmaker()() as s:
         pending = await s.get(ApprovalRequest, approval_request_id)
     assert pending is not None
     assert pending.status == ApprovalRequestStatus.PENDING.value
     assert pending.op_id == composite_op_id
+    # The composite itself never executed: no *write* hit the session. (The
+    # four fan-out composites' park-time preview builders issue one read-only
+    # listing GET to resolve the blast radius — that is expected, and now
+    # works on a fresh boot via the direct session; only writes are barred.)
+    assert all(verb == "GET" for verb, _ in recorder.calls)
 
 
 @pytest.mark.asyncio
@@ -1025,23 +795,25 @@ async def test_vm_create_full_queue_approve_resume_execute(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """vm.create: full queued → approve → resume → execute cycle (AC3).
+    """vm.create: full queued -> approve -> resume -> execute cycle.
 
-    Drives the complete human write path end-to-end:
-
-    1. A USER principal dispatches the ``requires_approval=True``
-       composite → parked at ``awaiting_approval``; the op does NOT run
-       (no leaf calls recorded yet).
-    2. A distinct human reviewer approves the parked request (self-
-       approval is blocked by the requester != approver guard, so the
-       reviewer is a different ``sub``).
-    3. The ``_approved=True`` resume re-dispatch executes the composite —
-       the gate is bypassed (the approval *is* the authorization), the
-       leaf sub-ops fire, and the composite returns ``status='created'``.
+    1. A USER principal dispatches the ``requires_approval=True`` composite ->
+       parked at ``awaiting_approval`` at the top level; nothing runs.
+    2. A distinct human reviewer approves the parked request.
+    3. The ``_approved=True`` resume re-dispatch executes the composite — the
+       top-level gate is bypassed (the approval *is* the authorization) and
+       the per-sub-op governance seam auto-executes for the approved human, so
+       the create chain runs on the direct session and returns
+       ``status='created'``.
     """
-    await _bootstrap_registry(stub_embedding_service)
-    _RESPONSES["GET:/vcenter/folder"] = {"value": [{"folder": "group-v1"}]}
-    _RESPONSES["POST:/vcenter/vm"] = {"value": "vm-789"}
+    recorder = _RecordingVmwareConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/folder": {"value": [{"folder": "group-v1"}]},
+            "/vcenter/vm": {"value": "vm-789"},
+        }
+    )
+    await _bootstrap(recorder, stub_embedding_service)
 
     # Persist a real Target row so the resume path can re-hydrate it by id.
     target_id = uuid.uuid4()
@@ -1060,13 +832,9 @@ async def test_vm_create_full_queue_approve_resume_execute(
 
     requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
     target = _FakeVmwareTarget(target_id=target_id)
-    params = {
-        "folder_name": "prod",
-        "name": "vm-approved",
-        "guest_os": "UBUNTU_64",
-    }
+    params = {"folder_name": "prod", "name": "vm-approved", "guest_os": "UBUNTU_64"}
 
-    # Step 1: human dispatch → awaiting_approval; the op did not run.
+    # Step 1: human dispatch -> awaiting_approval; the op did not run.
     result1 = await dispatch(
         operator=requester,
         connector_id=_CONNECTOR_ID,
@@ -1075,7 +843,7 @@ async def test_vm_create_full_queue_approve_resume_execute(
         params=params,
     )
     assert result1.status == "awaiting_approval", result1.error
-    assert _CALLS == [], "the composite must not execute before approval"
+    assert recorder.calls == [], "the composite must not execute before approval"
     approval_request_id = UUID(result1.extras["approval_request_id"])
 
     async with get_sessionmaker()() as s:
@@ -1090,7 +858,7 @@ async def test_vm_create_full_queue_approve_resume_execute(
         await s.commit()
     assert row.status == ApprovalRequestStatus.APPROVED.value
 
-    # Step 3: resume re-dispatch with the gate bypass → the op executes.
+    # Step 3: resume re-dispatch with the gate bypass -> the op executes.
     result2 = await dispatch(
         operator=reviewer,
         connector_id=_CONNECTOR_ID,
@@ -1100,8 +868,6 @@ async def test_vm_create_full_queue_approve_resume_execute(
         _approved=True,
     )
     assert result2.status == "ok", result2.error
-    assert isinstance(result2.result, dict)
     assert result2.result["status"] == "created"
     assert result2.result["vm_id"] == "vm-789"
-    # The resume run executed the real sub-op chain.
-    assert _ops_in_calls() == ["GET:/vcenter/folder", "POST:/vcenter/vm"]
+    assert recorder.calls == [("GET", "/vcenter/folder"), ("POST", "/vcenter/vm")]

--- a/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end governance tests for the migrated vmware write composites.
+
+Task #2256 (Initiative #2249, Goal #2247). The hard acceptance gate: a
+write composite that has migrated off ``dispatch_child`` to the direct
+session must keep property 3 of #508's four guarantees -- a now-internal
+write sub-op that is approval-gated (or denied) for the caller still
+**queues** (or is refused) instead of silently executing.
+
+Unlike :mod:`tests.test_connectors_vmware_rest_composites_write` (which
+stubs :func:`enforce_subop_policy`), this module runs the **real**
+:func:`~meho_backplane.operations.composite.enforce_subop_policy` seam
+against the autouse-migrated SQLite engine, driving a composite handler
+with a recording connector double so the assertion is end-to-end:
+
+* an agent principal with a per-op ``needs_approval`` grant on the write
+  sub-op -> the composite returns an ``awaiting_approval`` result, a
+  durable :class:`ApprovalRequest` row exists for the sub-op, and the
+  connector session never issues the write;
+* an agent principal with no grant on a ``dangerous`` write -> the
+  composite returns ``denied`` and the write never runs (governance not
+  lowered);
+* a human operator whose top-level composite was already approved ->
+  the sub-op gate auto-executes (``requires_approval=False`` keeps the
+  top-level composite the single approval gate), so the write proceeds.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.composites._write import (
+    vm_create_composite,
+    vm_migrate_composite,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AgentPermission,
+    ApprovalRequest,
+    ApprovalRequestStatus,
+    PermissionVerdict,
+)
+from meho_backplane.settings import get_settings
+
+_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000025a6")
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Open a session against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _operator(
+    *,
+    principal_kind: PrincipalKind = PrincipalKind.AGENT,
+    sub: str = "agent-write-composite",
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="Write Composite Governance",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_ID,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+async def _grant(*, principal_sub: str, op_pattern: str, verdict: PermissionVerdict) -> None:
+    """Seed one AgentPermission grant for *principal_sub* on *op_pattern*."""
+    async with get_sessionmaker()() as s:
+        s.add(
+            AgentPermission(
+                tenant_id=_TENANT_ID,
+                principal_sub=principal_sub,
+                op_pattern=op_pattern,
+                verdict=verdict.value,
+                target_scope="*",
+                created_by_sub="ops-admin",
+            )
+        )
+        await s.commit()
+
+
+class _RecordingConnector:
+    """Minimal recording connector double for the governance tests.
+
+    Serves canned read payloads and records writes. The governance tests
+    assert on whether a *write* ``_post_json`` ever fires -- the read
+    payloads only need to steer the handler to its first write.
+    """
+
+    def __init__(self, reads: dict[str, Any]) -> None:
+        self._reads = reads
+        self.writes: list[dict[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"/api{path}"
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        return self._reads[path]
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: Any = None,
+        data: Any = None,
+        extra_headers: Any = None,
+    ) -> Any:
+        self.writes.append({"verb": verb, "path": path, "body": json})
+        return {"value": "vm-should-not-exist"}
+
+
+@pytest.mark.asyncio
+async def test_gated_write_subop_queues_for_approval_via_composite(session: AsyncSession) -> None:
+    """An agent-gated create queues for approval via the composite (hard gate).
+
+    The migrated ``vm.create`` composite, driven by an agent principal whose
+    ``POST:/vcenter/vm`` grant is ``needs_approval``, returns an
+    ``awaiting_approval`` result, writes a durable pending
+    :class:`ApprovalRequest` for the sub-op, and never issues the create on
+    the connector session.
+    """
+    await _grant(
+        principal_sub="agent-write-composite",
+        op_pattern="POST:/vcenter/vm",
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _RecordingConnector({"/api/vcenter/folder": [{"folder": "folder-1", "name": "Prod"}]})
+
+    out = await vm_create_composite(
+        operator=_operator(),
+        target=None,
+        params={"folder_name": "Prod", "name": "web-01", "guest_os": "UBUNTU_64"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    # The seam signalled "do not execute" -> the composite returned it verbatim.
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == "POST:/vcenter/vm"
+    request_id = uuid.UUID(out.extras["approval_request_id"])
+
+    # A durable pending approval row exists for the sub-op.
+    row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.op_id == "POST:/vcenter/vm"
+    assert row.connector_id == "vmware-rest-9.0"
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    # The create was never issued on the session.
+    assert conn.writes == []
+
+
+@pytest.mark.asyncio
+async def test_dangerous_write_subop_denied_without_grant(session: AsyncSession) -> None:
+    """An agent with no grant is denied the dangerous relocate write; it never runs."""
+    conn = _RecordingConnector(
+        {"/api/vcenter/cluster/c-1/drs/recommendations": [{"vm": "vm-1", "target_host": "host-A"}]}
+    )
+    out = await vm_migrate_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params={"vm": "vm-1", "cluster": "c-1"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == "POST:/vcenter/vm/{vm}?action=relocate"
+    # No pending row: a deny is not a park.
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+    # The relocate write never fired.
+    assert conn.writes == []
+
+
+@pytest.mark.asyncio
+async def test_human_operator_subop_auto_executes(session: AsyncSession) -> None:
+    """A human operator's already-approved composite auto-executes its writes.
+
+    ``requires_approval=False`` on the sub-op keeps the top-level composite
+    the single approval gate: a human/service operator (whose composite the
+    dispatcher already parked + approved at the top level) clears the sub-op
+    gate and the write proceeds -- no double-gate on the resume path.
+    """
+    conn = _RecordingConnector(
+        {"/api/vcenter/cluster/c-1/drs/recommendations": [{"vm": "vm-1", "target_host": "host-A"}]}
+    )
+    out = await vm_migrate_composite(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        target=None,
+        params={"vm": "vm-1", "cluster": "c-1"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "migrated"
+    # The relocate write executed on the session.
+    assert [w["path"] for w in conn.writes] == ["/api/vcenter/vm/vm-1?action=relocate"]
+    # No approval row -- the sub-op auto-executed.
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -3,7 +3,8 @@
 
 """Park-time ``proposed_effect`` previews for the 8 vmware write composites.
 
-G0.22-T3 (#1608) acceptance criteria:
+G0.22-T3 (#1608) acceptance criteria, under the post-#2256 direct-session
+model:
 
 1. A parked ``vmware.composite.vm.power.bulk`` request's
    ``proposed_effect`` carries the requested ``action``, the ``filter``
@@ -11,24 +12,23 @@ G0.22-T3 (#1608) acceptance criteria:
    — asserted against the durable :class:`ApprovalRequest` row through
    the production :func:`~meho_backplane.operations.dispatch` park path.
 2. The preview path issues **only reads**: the park records exactly one
-   ``GET:/vcenter/vm`` leaf call and no power sub-op; the read-only
-   adapter additionally refuses any non-``GET:`` op_id structurally.
+   listing ``GET`` on the connector session and no mutating sub-op.
 3. The resolution logic is shared, not duplicated — the builders call
    the same :func:`._write._resolve_vm_list` /
-   :func:`._write._resolve_cluster_hosts` helpers the handlers use
-   (asserted via the wiring test + the helpers' single definition site).
+   :func:`._write._resolve_cluster_hosts` helpers the handlers use, now
+   directly on the connector session (no ``dispatch_child``, no ingested
+   descriptor), so the park-time preview works on a fresh boot with zero
+   catalog ingest.
 4. All 8 write composites register a builder (4 live-read + 4 param
    echo); the wiring test pins the full set.
 
 Plus the #1628 follow-up: a *failed* live-read preview parks with the
 identifier fields **and** an explicit ``preview_unavailable`` marker +
-reason (visible through the REST / MCP serialisation helpers), so the
-reviewer can tell "blast-radius unknown" from a genuinely small action.
+reason (visible through the REST / MCP serialisation helpers).
 
-Harness: mirrors :mod:`tests.test_connectors_vmware_rest_composites_write_e2e`
-(recording leaf typed-ops + in-process SQLite dispatcher), trimmed to the
-two listing leaves the park-time previews actually read — at park time
-the composite handler never runs, so no other leaf descriptor is needed.
+Harness: the resolved connector instance the dispatcher hands the preview
+builder is a recording double seeded into the connector-instance cache;
+the park-time listing reads run directly on it.
 """
 
 from __future__ import annotations
@@ -45,20 +45,16 @@ import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.broadcast import BroadcastEvent
 from meho_backplane.connectors import OperationResult
-from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
-from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.connectors.vmware_rest import VmwareRestConnector
 from meho_backplane.connectors.vmware_rest.composites import (
     _write_preview,
     register_vmware_composite_operations,
 )
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus
-from meho_backplane.operations import (
-    dispatch,
-    register_typed_operation,
-    reset_dispatcher_caches,
-)
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
 from meho_backplane.operations._preview import _PREVIEW_BUILDERS, PreviewContext
 from meho_backplane.settings import get_settings
 
@@ -80,7 +76,7 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
 
 
 # ---------------------------------------------------------------------------
-# Fixtures (mirror tests.test_connectors_vmware_rest_composites_write_e2e)
+# Fixtures
 # ---------------------------------------------------------------------------
 
 
@@ -155,8 +151,6 @@ class _FakeVmwareTarget:
         self.fingerprint = _FakeFingerprint(version="9.0")
         self.preferred_impl_id: str | None = "vmware-rest"
         self.id: UUID = target_id or uuid.uuid4()
-        # Tenant-unique cache key component (#1642/#1672); without it
-        # ``target_cache_key`` raises AttributeError at runtime.
         self.tenant_id: UUID = _TENANT_ID
         self.name = "test-vcenter"
         self.host = "vcenter.test"
@@ -164,98 +158,83 @@ class _FakeVmwareTarget:
         self.auth_model = "shared_service_account"
 
 
-class _NoOpVmwareConnector(Connector):
-    """Resolver-satisfying connector — the typed leaf path never invokes it."""
+# ---------------------------------------------------------------------------
+# Recording connector double (seeded as the dispatcher's resolved instance)
+# ---------------------------------------------------------------------------
 
-    product = "vmware"
-    version = "9.0"
-    impl_id = "vmware-rest"
 
-    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
-        raise NotImplementedError
+class _RecordingConnector:
+    """Records the listing reads the park-time preview builders issue.
 
-    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
-        raise NotImplementedError
+    Seeded as the dispatcher's resolved connector instance so the migrated
+    preview builders' shared read helpers (:func:`._write._resolve_vm_list` /
+    :func:`._write._resolve_cluster_hosts`) run directly on it. Records
+    ``(verb, spec-relative path, query)`` and serves a canned envelope keyed
+    by spec path. A spec path registered in ``failures`` raises to drive the
+    #1628 ``preview_unavailable`` fail-soft branch; the message carries the
+    op-id-shaped ``GET:<path>`` string so the reviewer-facing
+    ``preview_error`` names the read that could not resolve.
+    """
 
-    async def execute(  # type: ignore[override]
+    _MOUNT = "/api"
+
+    def __init__(self) -> None:
+        self.responses: dict[str, Any] = {}
+        self.failures: dict[str, str] = {}
+        self.calls: list[tuple[str, str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    def _spec(self, path: str) -> str:
+        return path[len(self._MOUNT) :] if path.startswith(self._MOUNT) else path
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        spec = self._spec(path)
+        self.calls.append(("GET", spec, params))
+        if spec in self.failures:
+            raise RuntimeError(f"GET:{spec} listing failed: {self.failures[spec]}")
+        return self.responses.get(spec, {"value": []})
+
+    async def _post_json(
         self,
         target: Any,
-        op_id: str,
-        params: dict[str, Any],
-    ) -> OperationResult:
-        raise NotImplementedError
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: Any = None,
+        data: Any = None,
+        extra_headers: Any = None,
+    ) -> Any:
+        spec = self._spec(path)
+        self.calls.append((verb, spec, None))
+        return {"value": {}}
+
+    @property
+    def read_calls(self) -> list[tuple[str, Any]]:
+        """(spec-path, query) for every recorded GET."""
+        return [(spec, query) for verb, spec, query in self.calls if verb == "GET"]
+
+    @property
+    def specs(self) -> list[str]:
+        return [spec for _, spec, _ in self.calls]
 
 
-# ---------------------------------------------------------------------------
-# Recording leaf stubs — only the two listing reads the previews issue
-# ---------------------------------------------------------------------------
-
-#: Ordered record of every leaf op_id dispatched in the current test.
-_CALLS: list[tuple[str, dict[str, Any]]] = []
-
-#: Per-op canned response payload (vSphere REST envelope shape).
-_RESPONSES: dict[str, Any] = {}
-
-#: op_ids whose stub should raise (drives the fail-soft branch).
-_FAILURES: dict[str, str] = {}
-
-
-def _record(op_id: str, params: dict[str, Any]) -> dict[str, Any]:
-    """Append a leaf call and resolve its canned payload, raising on failure."""
-    _CALLS.append((op_id, dict(params)))
-    if op_id in _FAILURES:
-        raise RuntimeError(_FAILURES[op_id])
-    return _RESPONSES.get(op_id, {"value": []})
-
-
-async def _h_list_vms(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("GET:/vcenter/vm", params)
-
-
-async def _h_list_cluster_hosts(target: Any, params: dict[str, Any]) -> dict[str, Any]:
-    return _record("GET:/vcenter/cluster/{cluster}/host", params)
-
-
-_LEAF_HANDLERS: dict[str, Any] = {
-    "GET:/vcenter/vm": _h_list_vms,
-    "GET:/vcenter/cluster/{cluster}/host": _h_list_cluster_hosts,
-}
-
-
-def _reset_recorder() -> None:
-    _CALLS.clear()
-    _RESPONSES.clear()
-    _FAILURES.clear()
-
-
-async def _bootstrap_registry(stub_embedding_service: AsyncMock) -> None:
-    """Register the connector, the 15 composites, and the listing leaves."""
+async def _bootstrap_registry(stub_embedding_service: AsyncMock) -> _RecordingConnector:
+    """Register the connector + 13 composites and seed the recording instance."""
     register_connector_v2(
         product="vmware",
         version="9.0",
         impl_id="vmware-rest",
-        cls=_NoOpVmwareConnector,
+        cls=VmwareRestConnector,
     )
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
-    permissive_schema = {"type": "object", "additionalProperties": True}
-    for op_id, handler in _LEAF_HANDLERS.items():
-        await register_typed_operation(
-            product="vmware",
-            version="9.0",
-            impl_id="vmware-rest",
-            op_id=op_id,
-            handler=handler,
-            summary=f"Stub leaf op {op_id} for the write-preview tests.",
-            description=f"Stub leaf op {op_id} for the write-preview tests.",
-            parameter_schema=permissive_schema,
-            when_to_use=None,
-            embedding_service=stub_embedding_service,
-        )
-    _reset_recorder()
-
-
-def _ops_in_calls() -> list[str]:
-    return [op_id for op_id, _ in _CALLS]
+    recorder = _RecordingConnector()
+    _CONNECTOR_INSTANCE_CACHE[VmwareRestConnector] = recorder  # type: ignore[assignment]
+    return recorder
 
 
 async def _park(
@@ -287,44 +266,45 @@ async def _park(
 
 
 def test_all_eight_write_composites_register_a_preview_builder() -> None:
-    """Importing the composites package wires a builder per write composite.
-
-    The side-effect import in ``composites/__init__`` must register every
-    ``requires_approval=True`` composite; a rename or dropped entry would
-    silently regress that op to the identifier-only default.
-    """
+    """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 
 
 # ===========================================================================
-# Read-only adapter — structural GET-only guard (criterion 2, belt)
+# Live-read builders decline without a connector (structural guard)
 # ===========================================================================
 
 
-def _make_preview_ctx(params: dict[str, Any]) -> PreviewContext:
+def _make_preview_ctx(params: dict[str, Any], *, connector_instance: Any = None) -> PreviewContext:
     """A :class:`PreviewContext` for builder-direct unit tests."""
     return PreviewContext(
         descriptor=object(),  # type: ignore[arg-type]  # echo builders ignore it
-        connector_instance=None,
+        connector_instance=connector_instance,
         operator=_make_operator(),
         target=_FakeVmwareTarget(),
         params=params,
     )
 
 
-async def test_read_only_adapter_refuses_non_get_op_ids() -> None:
-    """The adapter rejects any mutating op_id before lookup or I/O fires."""
-    adapter = _write_preview._read_only_dispatch_child(_make_preview_ctx({}))
-    for op_id in (
-        "POST:/vcenter/vm/{vm}/power?action=start",
-        "DELETE:/vcenter/vm/{vm}",
-        "PATCH:/vcenter/vm/{vm}/network",
+async def test_live_read_builders_decline_without_a_connector_instance() -> None:
+    """The four fan-out builders decline (return None) when no connector resolved.
+
+    Post-#2256 the live-read builders resolve their blast radius on the
+    connector session; with ``connector_instance=None`` there is nothing to
+    read, so they decline to the identifier-only default rather than raise.
+    """
+    for builder, params in (
+        (_write_preview._vm_power_bulk_preview, {"action": "stop"}),
+        (_write_preview._host_evacuate_preview, {"host": "host-1"}),
+        (
+            _write_preview._host_detach_from_vds_preview,
+            {"host": "host-1", "dvs": "dvs-1", "fallback_network": "net"},
+        ),
+        (_write_preview._cluster_patch_preview, {"cluster": "domain-c1"}),
     ):
-        result = await adapter(connector_id=_CONNECTOR_ID, op_id=op_id, params={})
-        assert result.status == "error"
-        assert "GET-only" in (result.error or "")
+        assert await builder(_make_preview_ctx(params, connector_instance=None)) is None
 
 
 # ===========================================================================
@@ -437,14 +417,9 @@ async def test_echo_builders_decline_on_malformed_params() -> None:
 async def test_power_bulk_park_carries_action_filter_and_resolved_set(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """The parked row's ``proposed_effect`` names the blast radius (criterion 1).
-
-    The reviewer sees the requested ``action``, the ``filter`` echoed, and
-    the resolved VM identities with the uncapped count — not just
-    ``{op_id, connector_id, target_id}``.
-    """
-    await _bootstrap_registry(stub_embedding_service)
-    _RESPONSES["GET:/vcenter/vm"] = {
+    """The parked row's ``proposed_effect`` names the blast radius (criterion 1)."""
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses["/vcenter/vm"] = {
         "value": [
             {"vm": "vm-a", "name": "web-a", "power_state": "POWERED_ON", "cpu_count": 2},
             {"vm": "vm-b", "name": "web-b", "power_state": "POWERED_OFF", "cpu_count": 4},
@@ -470,32 +445,27 @@ async def test_power_bulk_park_carries_action_filter_and_resolved_set(
         "safety_level": "dangerous",
     }
     # The filter reached the listing read in the handler's wire shape.
-    assert _CALLS == [("GET:/vcenter/vm", {"filter.names": ["web-*"]})]
+    assert recorder.read_calls == [("/vcenter/vm", {"filter.names": ["web-*"]})]
 
 
 async def test_power_bulk_park_issues_only_the_listing_read(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """No power mutation fires on the park path (criterion 2).
-
-    The recorded leaf calls contain exactly the one listing GET — no
-    ``POST:/vcenter/vm/{vm}/power?action=...`` — even though the listing
-    resolved VMs the approved dispatch would act on.
-    """
-    await _bootstrap_registry(stub_embedding_service)
-    _RESPONSES["GET:/vcenter/vm"] = {"value": [{"vm": "vm-a"}, {"vm": "vm-b"}]}
+    """No power mutation fires on the park path (criterion 2)."""
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses["/vcenter/vm"] = {"value": [{"vm": "vm-a"}, {"vm": "vm-b"}]}
 
     await _park("vmware.composite.vm.power.bulk", {"action": "start"})
 
-    assert _ops_in_calls() == ["GET:/vcenter/vm"]
+    assert recorder.specs == ["/vcenter/vm"]
 
 
 async def test_power_bulk_resolved_list_is_capped_with_true_total(
     stub_embedding_service: AsyncMock,
 ) -> None:
     """A wide filter caps ``resolved`` at the preview cap; ``total_resolved`` is uncapped."""
-    await _bootstrap_registry(stub_embedding_service)
-    _RESPONSES["GET:/vcenter/vm"] = {
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses["/vcenter/vm"] = {
         "value": [{"vm": f"vm-{i}", "name": f"node-{i}"} for i in range(25)]
     }
 
@@ -510,18 +480,9 @@ async def test_power_bulk_resolved_list_is_capped_with_true_total(
 async def test_power_bulk_preview_failure_parks_with_unavailable_marker(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """A failing listing read parks with identifiers + an explicit marker (#1628).
-
-    Pre-#1628 the row degraded silently to the bare identifier-only
-    default — indistinguishable from a genuinely small action, defeating
-    the four-eyes purpose of the preview on any deploy where the L2 read
-    can't execute. The park (the safety-relevant action) still proceeds
-    — ``_park`` asserts ``awaiting_approval`` + a PENDING row — but the
-    reviewer now sees "blast-radius unknown" plus the read's failure
-    reason alongside the identifier fields.
-    """
-    await _bootstrap_registry(stub_embedding_service)
-    _FAILURES["GET:/vcenter/vm"] = "vCenter listing unavailable"
+    """A failing listing read parks with identifiers + an explicit marker (#1628)."""
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.failures["/vcenter/vm"] = "vCenter listing unavailable"
 
     target = _FakeVmwareTarget()
     _, row = await _park(
@@ -531,39 +492,25 @@ async def test_power_bulk_preview_failure_parks_with_unavailable_marker(
     )
 
     effect = row.proposed_effect
-    # The identifier fields stay — the marker rides alongside them.
     assert effect["op_id"] == "vmware.composite.vm.power.bulk"
     assert effect["connector_id"] == _CONNECTOR_ID
     assert effect["target_id"] == str(target.id)
     assert effect["op_class"] == "other"
     assert effect["preview_unavailable"] is True
-    # The reason names the failed listing read and its error, not just
-    # "failed" — the reviewer learns *what* could not be resolved.
     assert "GET:/vcenter/vm" in effect["preview_error"]
     assert "vCenter listing unavailable" in effect["preview_error"]
-    # No "preview" envelope key: a failed preview is structurally
-    # distinct from a successful one.
     assert "preview" not in effect
 
 
 async def test_preview_unavailable_marker_reaches_reviewer_surfaces(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """The marker is reviewer-visible on the REST view and the MCP row dict (#1628).
-
-    ``GET /api/v1/approvals[/{id}]`` serialises the row through
-    :func:`meho_backplane.api.v1.approvals._view` and
-    ``meho.approvals.list`` / ``.get`` through
-    :func:`meho_backplane.mcp.tools.approvals._row_to_dict`; both pass
-    ``proposed_effect`` through verbatim. Pinning the passthrough for
-    the marker keeps a future field projection from silently hiding a
-    failed preview from the approval queue.
-    """
+    """The marker is reviewer-visible on the REST view and the MCP row dict (#1628)."""
     from meho_backplane.api.v1.approvals import _view
     from meho_backplane.mcp.tools.approvals import _row_to_dict
 
-    await _bootstrap_registry(stub_embedding_service)
-    _FAILURES["GET:/vcenter/vm"] = "vCenter listing unavailable"
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.failures["/vcenter/vm"] = "vCenter listing unavailable"
 
     _, row = await _park("vmware.composite.vm.power.bulk", {"action": "reset"})
 
@@ -586,8 +533,8 @@ async def test_preview_unavailable_marker_reaches_reviewer_surfaces(
 async def test_host_evacuate_park_resolves_vm_set_on_host(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    await _bootstrap_registry(stub_embedding_service)
-    _RESPONSES["GET:/vcenter/vm"] = {
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses["/vcenter/vm"] = {
         "value": [{"vm": "vm-a", "name": "app-a", "cluster": "domain-c1"}]
     }
 
@@ -604,14 +551,14 @@ async def test_host_evacuate_park_resolves_vm_set_on_host(
         "safety_level": "dangerous",
     }
     # Only the listing read fired — no recursive migrate, no maintenance.
-    assert _CALLS == [("GET:/vcenter/vm", {"filter.hosts": ["host-1"]})]
+    assert recorder.read_calls == [("/vcenter/vm", {"filter.hosts": ["host-1"]})]
 
 
 async def test_host_detach_from_vds_park_resolves_vm_set_on_host(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    await _bootstrap_registry(stub_embedding_service)
-    _RESPONSES["GET:/vcenter/vm"] = {"value": [{"vm": "vm-a", "name": "app-a"}]}
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses["/vcenter/vm"] = {"value": [{"vm": "vm-a", "name": "app-a"}]}
 
     _, row = await _park(
         "vmware.composite.host.detach_from_vds",
@@ -629,14 +576,14 @@ async def test_host_detach_from_vds_park_resolves_vm_set_on_host(
         },
         "safety_level": "dangerous",
     }
-    assert _ops_in_calls() == ["GET:/vcenter/vm"]
+    assert recorder.specs == ["/vcenter/vm"]
 
 
 async def test_cluster_patch_park_resolves_host_set(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    await _bootstrap_registry(stub_embedding_service)
-    _RESPONSES["GET:/vcenter/cluster/{cluster}/host"] = {
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses["/vcenter/cluster/domain-c1/host"] = {
         "value": [
             {"host": "host-1", "name": "esx-1"},
             {"host": "host-2", "name": "esx-2"},
@@ -659,7 +606,7 @@ async def test_cluster_patch_park_resolves_host_set(
         "safety_level": "dangerous",
     }
     # Only the host listing fired — no maintenance / patch sub-ops.
-    assert _ops_in_calls() == ["GET:/vcenter/cluster/{cluster}/host"]
+    assert recorder.specs == ["/vcenter/cluster/domain-c1/host"]
 
 
 # ===========================================================================
@@ -671,7 +618,7 @@ async def test_vm_create_park_carries_echo_preview_without_any_read(
     stub_embedding_service: AsyncMock,
 ) -> None:
     """The echo previews enrich the parked row with zero connector I/O."""
-    await _bootstrap_registry(stub_embedding_service)
+    recorder = await _bootstrap_registry(stub_embedding_service)
 
     _, row = await _park(
         "vmware.composite.vm.create",
@@ -691,4 +638,4 @@ async def test_vm_create_park_carries_echo_preview_without_any_read(
         },
         "safety_level": "dangerous",
     }
-    assert _CALLS == []
+    assert recorder.calls == []

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -44,9 +44,12 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   four `#508` guarantees (bounded recursion, per-sub-op param
   validation) and relocates the other two (audit-tree linkage collapses
   to the top-level composite audit row; per-sub-op policy/broadcast is
-  the top-level op's) — acceptable for **reads**, which is why the
-  write composites keep `dispatch_child` (their sub-ops may be
-  approval-gated). Registered with `safety_level="safe"` +
+  the top-level op's). The two dropped guarantees are acceptable for
+  **reads**; the relocated per-sub-op policy gate is load-bearing for
+  **writes**, so the write composites (`#2256`) re-apply it per governed
+  write sub-call through the reusable
+  `operations.composite.enforce_subop_policy` seam (`#2254`) — see the
+  write-composites bullet. Registered with `safety_level="safe"` +
   `requires_approval=False` — read-only overrides of
   `register_composite_operation()`'s `dangerous` / `True` defaults.
   `host_network_uplinks_composite` (`#2080`) lists hosts via
@@ -68,16 +71,47 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   `async def` handlers (`vm_create_composite`, `vm_clone_composite`,
   `vm_snapshot_revert_composite`, `vm_migrate_composite`,
   `vm_power_bulk_composite`, `host_evacuate_composite`,
-  `host_detach_from_vds_composite`, `cluster_patch_composite`). Same
-  `DispatchChild`-Protocol contract; each orchestrates 2-N sub-ops
-  with documented status enums on the response envelope
-  (`{"status": "created" | "rolled_back" | …}`). Registered with
-  T4's defaults `safety_level="dangerous"` + `requires_approval=True`
-  so the policy gate pops the approval queue on every dispatch.
+  `host_detach_from_vds_composite`, `cluster_patch_composite`). Since
+  `#2256` each accepts `(operator, target, params, connector)` and
+  issues its raw-REST sub-ops **directly on the resolved connector
+  session** — `connector._get_json` (`_read_sub_op`) for the resolution
+  reads, `connector._post_json` (`_write_sub_op`) for the mutating
+  writes, both mounted through `connector.mount_op_path` — with **no**
+  ingested `endpoint_descriptor` lookup and **no** L2 pre-flight, so the
+  write composites also work on a fresh boot with zero catalog ingest.
+  Each orchestrates 2-N sub-ops with documented status enums on the
+  response envelope (`{"status": "created" | "rolled_back" | …}`).
+  Registered with T4's defaults `safety_level="dangerous"` +
+  `requires_approval=True` so the **top-level** composite pops the
+  approval queue on every dispatch — that top-level gate stays the single
+  primary approval decision.
+
+  **Preserving write governance on the direct path.** Because a direct
+  session call bypasses the dispatcher, each mutating sub-call first
+  routes through `operations.composite.enforce_subop_policy` (`#2254`)
+  before `_post_json` fires: the seam re-runs the same `policy_gate`
+  against an in-memory descriptor carrying the sub-op's declared
+  governance (`safety_level="dangerous"`, `requires_approval=False`) and
+  returns an `awaiting_approval` / `denied` `OperationResult` when the
+  gate does not clear. The handler returns that verbatim (the dispatcher
+  passes a handler-returned `OperationResult` straight through), so an
+  internal write **queues** or is **denied** instead of executing
+  un-gated — property 3 of `#508`'s four guarantees preserved. The
+  sub-op posture is `requires_approval=False` on purpose: flooring it to
+  `True` would double-gate the approval-resume path (the resume re-runs
+  the handler with the top-level gate satisfied, but the seam is not
+  resume-aware). A human/service operator whose composite was already
+  approved therefore auto-executes each write; an agent without a grant
+  is denied a `dangerous` sub-op (governance not lowered); an agent with
+  a per-`(principal, op, target)` `needs_approval` grant queues it.
   `host_evacuate_composite` is the first production composite that
   dispatches another composite (`vmware.composite.vm.migrate`) via
-  `dispatch_child` — the recursion-depth contextvar (default cap 8)
-  handles the depth-2 nesting cleanly.
+  `dispatch_child` — that composite→composite recursion is a
+  registrar-guaranteed `source_kind="composite"` row (never an ingested
+  primitive), so it stays on the `dispatch_child` path per `#2248`; the
+  recursion-depth contextvar (default cap 8) handles the depth-1 nesting
+  cleanly, and the resolved `vm.migrate` runs its own relocate write on
+  the direct session under the same governance seam.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
   lifespan startup. Iterates a single `_COMPOSITES` tuple of 15
@@ -92,9 +126,11 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   binds to the resolved connector instance and calls directly — no
   `dispatch_child`, no ingested-descriptor sub-ops, no L2 pre-flight. It
   therefore works on a **fresh boot with zero catalog ingest** — the same
-  direct-session property the 7 read composites now share (`#2253`); only
-  the **write** composites still resolve their `dispatch_child` legs
-  against `endpoint_descriptor` rows that exist post-ingest. The metadata
+  direct-session property the 7 read composites (`#2253`) and, since
+  `#2256`, the 8 write composites now share. The only `dispatch_child`
+  leg left on the whole vmware surface is the `host.evacuate` →
+  `vm.migrate` composite→composite recursion (a registrar-guaranteed
+  `source_kind="composite"` row, not an ingested primitive, `#2248`). The metadata
   lives in a frozen `VmwareTypedOp` dataclass (mirroring
   `argocd/ops.py::ArgoCdOp`); the implementation
   (`host_usage_impl(connector, operator, target, params)`) lists hosts
@@ -247,27 +283,34 @@ rows in `endpoint_descriptor`. At dispatch time:
    parent_target=..., parent_audit_id=..., parent_op_id=...)`.
 2. Handler is resolved via `import_handler(descriptor.handler_ref)`
    to one of the module-level functions in `composites/_read.py` or
-   `composites/_write.py`.
-3. Dispatcher invokes
-   `handler(operator=..., target=..., params=..., dispatch_child=...)`.
-4. Handler issues N `await dispatch_child(connector_id="vmware-rest-9.0",
-   op_id=..., params=...)` calls. Each child dispatch:
-   - Inherits `parent_audit_id` via the contextvar so the child's
-     audit row's `parent_audit_id` column is set automatically.
-   - Increments `composite_depth_var` (bounded at
-     `Settings.composite_max_depth=8`; over-depth raises
-     `CompositeRecursionLimitExceeded` pre-recursion).
-   - Re-enters the dispatcher's same code path -- the child sub-op
-     hits the `source_kind="ingested"` branch which routes through
-     `VmwareRestConnector.execute()` for the actual HTTP call.
+   `composites/_write.py`. The dispatcher also resolves the connector
+   instance for the composite's target (`#2251`).
+3. Dispatcher invokes the handler with the keyword args it declares:
+   `connector` (the resolved instance — every read and write handler)
+   and/or `dispatch_child` (only `host_evacuate_composite`, for its
+   composite→composite recursion).
+4. Handler issues its sub-ops **directly on the connector session**
+   (`connector._get_json` / `connector._post_json` mounted via
+   `connector.mount_op_path`), no `endpoint_descriptor` lookup. Write
+   sub-calls pass through `enforce_subop_policy` first (see the
+   write-composites bullet above). The lone exception is
+   `host.evacuate`'s `await dispatch_child(op_id="vmware.composite.vm.migrate", …)`
+   recursion, which re-enters the dispatcher's `source_kind="composite"`
+   branch, inherits `parent_audit_id` via the contextvar, and increments
+   `composite_depth_var` (bounded at `Settings.composite_max_depth=8`).
 5. Handler aggregates the sub-op responses into a single dict and
    returns; the dispatcher wraps it as an `OperationResult` with
-   `status="ok"` and `result=<aggregated dict>`.
+   `status="ok"` and `result=<aggregated dict>`. A write handler may
+   instead return an `awaiting_approval` / `denied` `OperationResult`
+   (from `enforce_subop_policy`); the dispatcher passes that through
+   verbatim.
 
-The composite handlers go through `dispatch_child` rather than
-calling `_request_json` directly so the audit-tree linkage,
-bounded-recursion guard, policy gate, broadcast publish, and
-parameter-schema validation all run on every sub-call.
+Direct-session sub-calls drop the per-sub-op audit rows (the top-level
+composite row is the audit anchor) and the per-sub-op parameter-schema
+validation; the per-sub-op policy gate is relocated onto
+`enforce_subop_policy` for writes. Only the `host.evacuate` →
+`vm.migrate` recursion still rides `dispatch_child` and keeps its
+audit-tree linkage + bounded-recursion guard.
 
 ### Recursive composite dispatch (`host.evacuate` → `vm.migrate`)
 
@@ -276,36 +319,59 @@ calls another composite via `dispatch_child`. Two-level nesting:
 
 ```text
 host.evacuate                                            # depth 0 (top-level dispatch)
+  ├─ GET:/vcenter/vm                                     # depth 0 (direct session read)
   └─ vmware.composite.vm.migrate (× N)                  # depth 1 (dispatch_child of a composite)
-       ├─ GET:/vcenter/cluster/{c}/drs/recommendations  # depth 2 (typed sub-op)
-       └─ POST:/vcenter/vm/{vm}?action=relocate         # depth 2 (typed sub-op)
-  └─ PATCH:/vcenter/host/{host}/maintenance?action=enter # depth 1 (typed sub-op)
+       ├─ GET:/vcenter/cluster/{c}/drs/recommendations  # depth 1 (direct session read)
+       └─ POST:/vcenter/vm/{vm}?action=relocate         # depth 1 (direct session write, gated)
+  └─ PATCH:/vcenter/host/{host}/maintenance?action=enter # depth 0 (direct session write, gated)
 ```
 
-`composite_depth_var` (default cap 8) handles this naturally. The
-audit log shows a 3-level tree per `host.evacuate` dispatch: one
-parent row, N `vm.migrate` child rows, each with two grandchild rows
-(DRS lookup + relocate). The substrate guard's coverage in
+`composite_depth_var` (default cap 8) handles the one nesting level
+naturally. Post-`#2256` the **audit** tree is two-level, not three:
+one `host.evacuate` parent row and N `vm.migrate` child rows (the
+`dispatch_child` recursion). The raw-REST leaves run directly on the
+session and write **no** audit row of their own — the top-level
+composite's row is the audit anchor. `composite_depth_var` reads inside
+those direct sub-calls ramp 0 (host.evacuate's own reads/writes) → 1
+(the vm.migrate frame's reads/writes). The substrate guard's coverage in
 `tests/test_operations_composite.py` proves the depth-cap behaviour
 holds; this connector's recursive composite is the first production
 caller.
 
-### L1/L2 dispatch contract + pre-flight (G0.14-T10 / #1151)
+### L1/L2 dispatch contract + pre-flight (G0.14-T10 / #1151) — retired-in-place
+
+> **Historical, superseded by the two-world migration (Goal `#2247`).**
+> The section below describes the pre-`#2253`/`#2256` model where every
+> composite fanned out to **ingested** L2 rows via `dispatch_child` and
+> guarded a missing catalog with a pre-flight. All 15 composites now issue
+> their raw-REST sub-ops **directly on the connector session** (reads
+> `#2253`, writes `#2256`), so they no longer touch ingested rows and no
+> longer call `preflight_l2_dependencies`. The `composites/_preflight.py`
+> module and the `CompositeL2Dependency*` exceptions are kept intact but
+> unused pending their removal in `#2259`; the `_SUB_OPS_*` tuples in
+> `_read.py` / `_write.py` are retained as the canonical sub-op-path
+> manifest the ingest-reconcile acceptance guard checks. The
+> platform-wide registration-time invariant
+> (`operations.composite_invariant`, `#2262`) is the replacement safety
+> net: a code-shipped op that declares a sub-op resolving to an
+> `ingested` row fails the boot closed.
 
 The 15 composites are the **L1** surface: hand-authored aggregators
 each connector ships as `source_kind='composite'` descriptors. Every
 composite's body fans out to **L2** raw-REST primitives
 (`GET:/vcenter/datastore`, `POST:/vcenter/vm/{vm}/power?action=start`,
-etc.) via `dispatch_child(...)`. The L2 layer is the ~3,470 ingested
-descriptor rows derived from `vcenter.yaml` + `vi-json.yaml`.
+etc.). Pre-migration these went through `dispatch_child(...)` against the
+~3,470 ingested descriptor rows derived from `vcenter.yaml` +
+`vi-json.yaml`.
 
 The L2 surface is **not** registered by default. Operators bring it in
 by running `meho connector ingest --catalog vmware/9.0`, which posts
 the spec sources from
 `backend/src/meho_backplane/operations/ingest/catalog.yaml` through
 the ingest pipeline. Until that ingest runs, the L2 descriptor rows do
-not exist and any composite that tries to dispatch into them would
-crash mid-call with the dispatcher's generic `unknown_op` error.
+not exist and any composite that tried to dispatch into them would
+crash mid-call with the dispatcher's generic `unknown_op` error — the
+coupling the direct-session migration removed.
 
 Each composite handler runs an explicit pre-flight check
 (`preflight_l2_dependencies` in `composites/_preflight.py`) before any
@@ -514,25 +580,29 @@ does **not** pre-resolve a DRS recommendation (point-in-time output
 would mislead the reviewer — the preview says
 `target_host_source="drs_at_execution"` instead).
 
-At park time the composite handler never runs, so the builders cannot
-receive the dispatcher's `dispatch_child`. They construct a **read-only
-adapter** (`_read_only_dispatch_child`) that satisfies the same
-`DispatchChild` protocol but executes the sub-op directly against the
-resolved connector (descriptor lookup → `dispatch_ingested` /
-`dispatch_typed`), never through `dispatch()`: no policy-gate re-entry
-(a read-gating policy could otherwise park the preview's own sub-op
-from inside the parent's park), no unparented audit rows (the
-`approval.request` row — the audit anchor — is written *after* the
-preview), and a fail-closed `GET:`-prefix guard so the park path can
-never mutate vSphere state. This mirrors how the k8s.apply dry-run
-(#1437), the argocd snapshot reads (#1452), and the vault capability
-probe (#1504) run their preview I/O — connector-level, un-dispatched.
+At park time the composite handler never runs, but the shared
+`_write._resolve_vm_list` / `_write._resolve_cluster_hosts` helpers are
+now direct-session (`#2256`): the live-read builders call them with the
+connector instance the dispatcher resolved into the `PreviewContext`
+(`ctx.connector_instance`), so the one listing `GET` runs straight on the
+session. Because it is a direct read, the three properties the old
+park-time `dispatch_child` adapter enforced hold intrinsically — no
+policy-gate re-entry (a direct call cannot re-enter the dispatcher), no
+unparented audit rows (a direct read writes none), reads-only (the
+helpers only ever issue the listing `GET`). This also fixes the
+fresh-boot gap the pre-`#2256` preview had: the retired adapter resolved
+the sub-op against an **ingested** descriptor row, so on a
+zero-catalog-ingest deploy the live-read preview always degraded to
+`preview_unavailable`; the direct-session read now resolves the entity
+set on a fresh boot. This mirrors how the k8s.apply dry-run (#1437), the
+argocd snapshot reads (#1452), and the vault capability probe (#1504) run
+their preview I/O — connector-level, un-dispatched.
 
 Everything is fail-soft — the park always proceeds — but a decline and
 a failure degrade differently (#1628): a builder that *declines*
-(malformed params) parks with the identifier-only default, while a
-builder that *raises* (vCenter unreachable, listing op not ingested
-yet, the L2 read can't execute on this deploy) parks with the
+(malformed params, or no resolved connector instance) parks with the
+identifier-only default, while a builder that *raises* (vCenter
+unreachable, the listing read errors on this deploy) parks with the
 identifier fields **plus** `preview_unavailable: true` and a
 `preview_error` reason naming the failed read. The marker rides through
 every reviewer surface that renders `proposed_effect` verbatim (REST


### PR DESCRIPTION
## Summary
- Migrates all **8 write** vmware composites (`composites/_write.py`) from `dispatch_child`-through-ingested-`endpoint_descriptor`-rows to **direct connector-session** calls (`mount_op_path` + `_get_json`/`_post_json`), matching the #2253 read migration and using the #2251 `connector`-injection substrate. Composites stay composites (in-place); response schema + aggregation semantics are unchanged.
- **Write governance preserved on the direct path** (#508 property 3): each mutating sub-call routes through `enforce_subop_policy` (#2254) *before* the direct `_post_json`, so an approval-gated write sub-op still **queues** (or is **denied**) instead of executing un-gated. Sub-ops declare `safety_level="dangerous"` / `requires_approval=False` — the **top-level composite** stays the single primary approval gate, avoiding a resume-path double-gate.
- The `host.evacuate` → `vmware.composite.vm.migrate` composite→composite recursion keeps its `dispatch_child` path (registrar-guaranteed `source_kind="composite"` row, out of scope per #2248). It is the **only** `dispatch_child` leg left on the vmware surface.
- `_write_preview` live-read builders now resolve on the connector session (fixes their pre-migration fresh-boot preview gap, which always degraded to `preview_unavailable` without a catalog ingest).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (operations + vmware_rest, 63 files) — clean
- [x] `code-quality.py --diff` — 0 blockers (function-size warnings only, module carries `code-quality-allow: file-size`)
- [x] **Per-op parity** (`tests/integration/test_connectors_vmware_rest_vcsim.py`): `vm.create` (modern /api), `cluster.patch` (legacy /rest mount fallback), and the `host.evacuate`→`vm.migrate` recursion driven over respx against the real connector transport with **zero ingested descriptors** — asserting the real wire request + response semantics.
- [x] **Hard acceptance gate** (`test_..._write_gate.py`): an agent-gated write composite queues a durable `ApprovalRequest` end-to-end via the **real** `enforce_subop_policy` seam + DB and never issues the write; a no-grant agent is denied; a human operator auto-executes.
- [x] Unit wire/governance (`..._write.py`, 25), through-`dispatch()` e2e (`..._write_e2e.py`, 27), recursion audit-tree shape (`..._recursive_e2e.py`), park-time previews (`..._write_preview.py`, 17).
- [x] **Count-lines unchanged**: `..._register.py` (13 total) + `..._write_register.py` (8 write, dangerous/requires_approval=True) pass untouched.
- [x] No vmware write composite dispatches an **ingested** sub-op anymore (grep-verified; composite→composite recursion excepted).
- [x] Broad regression sweep (`-k "composite or typed_register or dispatcher or preview or approval or subop"`): 732 passed, 5 skipped.

## Out of scope
- The `host.evacuate` → `vm.migrate` recursion stays on `dispatch_child` (#2248).
- `composites/_preflight.py` + `CompositeL2Dependency*` kept intact but now unused by writes (retired-in-place pending #2259); `_SUB_OPS_*` tuples retained as the ingest-reconcile manifest.
- Docs note (adjacent): `docs/codebase/connectors-vmware-rest.md` still says "7 read composites" in places — pre-existing #2258 drift, not touched here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2256
