### PR TITLE
feat(connectors): read-only MongoDB wire-protocol connector via pymongo async

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -78,6 +78,15 @@ dependencies = [
     # so a slim wheel install doesn't fail at first ``encode`` call).
     # No stdlib alternative exists for RS256 signing.
     "pyjwt[crypto]>=2.13.0,<3",
+    # MongoDB wire-protocol driver for the read-only ``mongodb`` connector
+    # (#2237). Uses PyMongo's **native async API** (``AsyncMongoClient``,
+    # GA since PyMongo 4.13) rather than Motor: MongoDB deprecated Motor on
+    # 2025-05-14 in favour of the PyMongo Async API (Motor reaches
+    # end-of-life 2026-05-14), so a brand-new connector adopts the
+    # unified async client directly and pulls no separate ``motor`` dep.
+    # AsyncMongoClient runs commands off the event loop natively (no
+    # ``asyncio.to_thread`` wrapper needed).
+    "pymongo>=4.13,<5",
 ]
 
 [dependency-groups]

--- a/backend/src/meho_backplane/connectors/mongodb/__init__.py
+++ b/backend/src/meho_backplane/connectors/mongodb/__init__.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.mongodb -- MongoDbConnector package (#2237).
+
+MEHO's second wire-protocol (non-HTTP) connector, following the DB-connector
+shape the postgres connector (#2236) established. Importing this package
+registers :class:`MongoDbConnector` against the v2 connector registry under the
+natural key ``(product="mongodb", version="7", impl_id="mongodb-wire")`` **and**
+the ``(product="mongodb", version="", impl_id="")`` wildcard fallback -- dual
+registration from day one per G0.15-T6 (#1215).
+
+Two-phase registration, the same shape as
+:mod:`meho_backplane.connectors.postgres.__init__` /
+:mod:`meho_backplane.connectors.loki.__init__`:
+
+* **Synchronous (import time)** -- the v2 registry entries land via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2` below, so the
+  lookup tables are populated before the lifespan begins and a probe firing
+  during startup sees a fully-populated registry.
+  :func:`~meho_backplane.connectors.registry._eager_import_connectors` discovers
+  this subpackage by directory name, so no manual import-list edit is needed
+  elsewhere.
+
+* **Asynchronous (lifespan startup)** --
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`register_mongodb_typed_operations`, which delegates to
+  :meth:`MongoDbConnector.register_operations` to upsert the eight read-only
+  descriptors. Idempotent on re-call with unchanged op text.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry point
+is intentionally **not** called: mongodb has no v1 chassis history, and the v1
+entry would land as ``("mongodb", "", "")`` and confuse the resolver tie-break
+ladder -- the same decision postgres, loki, bind9, and pfSense made.
+"""
+
+from meho_backplane.connectors.mongodb.connector import MongoDbConnector
+from meho_backplane.connectors.mongodb.ops import (
+    MONGO_OPS,
+    MONGO_WHEN_TO_USE_BY_GROUP,
+    MongoOp,
+)
+from meho_backplane.connectors.mongodb.session import (
+    MONGO_READ_COMMANDS,
+    MongoReadOnlyError,
+    assert_read_command,
+)
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_mongodb_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``MongoDbConnector.register_operations``.
+
+    The canonical typed-op registration pattern (G0.6-T-Refactor-Vault #390) is a
+    module-level ``async def register_xxx_typed_operations`` queued onto
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`.
+    MongoDB implements the op walk as a classmethod on
+    :class:`MongoDbConnector` so the test suite can exercise it without lifespan
+    plumbing; this wrapper is the seam that lets the standard registrar mechanism
+    drive it.
+
+    The ``embedding_service`` keyword-only parameter mirrors the postgres / loki
+    contract: :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar, so
+    each registrar **must** accept the kwarg or the lifespan crashes with
+    :class:`TypeError`. The wrapper accepts-and-discards it because
+    :meth:`MongoDbConnector.register_operations` resolves the embedding service
+    via ``register_typed_operation``'s process-wide singleton fallback.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await MongoDbConnector.register_operations()
+
+
+# v2 entry -- the canonical resolver key. The versioned triple always wins the
+# resolver tie-break when both it and the wildcard are present.
+register_connector_v2(
+    product="mongodb",
+    version="7",
+    impl_id="mongodb-wire",
+    cls=MongoDbConnector,
+)
+
+# G0.15-T6 (#1215) wildcard fallback -- a target with ``version=None`` (fresh,
+# unfingerprinted, no operator-asserted version yet) resolves to this connector
+# through the resolver's ``versioned_over_wildcard`` step rather than 501-ing
+# with ``no_connector``.
+register_connector_v2(
+    product="mongodb",
+    version="",
+    impl_id="",
+    cls=MongoDbConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The runner
+# (``run_typed_op_registrars``) iterates after ``_eager_import_connectors`` so the
+# descriptor rows land before the first dispatch.
+register_typed_op_registrar(register_mongodb_typed_operations)
+
+__all__ = [
+    "MONGO_OPS",
+    "MONGO_READ_COMMANDS",
+    "MONGO_WHEN_TO_USE_BY_GROUP",
+    "MongoDbConnector",
+    "MongoOp",
+    "MongoReadOnlyError",
+    "assert_read_command",
+    "register_mongodb_typed_operations",
+]

--- a/backend/src/meho_backplane/connectors/mongodb/connector.py
+++ b/backend/src/meho_backplane/connectors/mongodb/connector.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""MongoDbConnector -- read-only wire-protocol connector for MongoDB (#2237).
+
+MEHO's **second wire-protocol (non-HTTP) connector**, following the DB-connector
+shape the postgres connector (#2236) established: it subclasses the generic
+:class:`~meho_backplane.connectors.base.Connector` ABC (not
+:class:`~meho_backplane.connectors.adapters.http.HttpConnector`) and drives a
+:class:`~pymongo.AsyncMongoClient` over the MongoDB wire protocol (default port
+27017). Registry v2 triple ``("mongodb", "7", "mongodb-wire")``.
+
+Design
+------
+
+* **Read-only by construction.** The connector registers a fixed set of read
+  ops, each of which issues exactly one command from
+  :data:`~meho_backplane.connectors.mongodb.session.MONGO_READ_COMMANDS`. There
+  is no free-form command / ``eval`` / ``$where`` / aggregation-with-``$out``
+  op, so read-only is guaranteed by the closed command set rather than a runtime
+  gate. :func:`~meho_backplane.connectors.mongodb.session.assert_read_command`
+  is the belt-and-suspenders check the query layer runs before every command.
+
+* **Optional auth.** A target with ``secret_ref=None`` is a no-auth instance and
+  connects with no credentials; a target with a ``secret_ref`` resolves
+  ``{username, password}`` under the operator's identity and authenticates
+  against the ``admin`` database. The password flows only into the client's
+  connection params -- never a log line or an :class:`OperationResult`. See
+  :func:`~meho_backplane.connectors.mongodb.session.connect_client`.
+
+* **The DB-connector shape.** The package split (``session.py`` = wire +
+  read-command allowlist, ``queries.py`` = command text + document shaping,
+  ``ops.py`` = op metadata, ``connector.py`` = the thin op surface) is the same
+  four-module split the postgres sibling uses, so the two wire connectors read
+  in parallel.
+
+Fingerprint reads ``buildInfo`` / ``hello`` / ``serverStatus``; probe is a
+``hello`` handshake with structured failure reasons.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from pymongo import AsyncMongoClient
+from pymongo.errors import ConnectionFailure, OperationFailure, PyMongoError
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.mongodb import queries
+from meho_backplane.connectors.mongodb.ops import MONGO_OPS, MONGO_WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.mongodb.session import connect_client
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["MongoDbConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Forward declaration -- replaced with `from meho_backplane.targets import Target`
+# once G0.3's Target model rollout lands, mirroring the sibling connectors.
+type Target = Any
+
+#: MongoDB auth error codes: Unauthorized (13) and AuthenticationFailed (18).
+_AUTH_ERROR_CODES = frozenset({13, 18})
+
+
+class MongoDbConnector(Connector):
+    """Read-only MongoDB connector over the wire protocol via ``pymongo``.
+
+    Registry v2 triple ``("mongodb", "7", "mongodb-wire")``. ``priority`` is
+    ``1`` so a future ``GenericRestConnector`` auto-shim registering the same
+    product loses the resolver tie-break. ``supported_version_range`` covers the
+    maintained MongoDB releases; the diagnostic commands this connector reads
+    are stable across them.
+    """
+
+    product = "mongodb"
+    version = "7"
+    impl_id = "mongodb-wire"
+    supported_version_range = ">=5,<9"
+    priority = 1
+
+    # ------------------------------------------------------------------
+    # Connection lifecycle
+    # ------------------------------------------------------------------
+
+    @asynccontextmanager
+    async def _client(
+        self, target: Target, operator: Operator | None
+    ) -> AsyncIterator[AsyncMongoClient[dict[str, Any]]]:
+        """Yield an ``AsyncMongoClient``, always closed on exit.
+
+        Thin wrapper over
+        :func:`~meho_backplane.connectors.mongodb.session.connect_client` so
+        every op shares the connect (optional auth) and teardown path.
+        """
+        client = await connect_client(target, operator)
+        try:
+            yield client
+        finally:
+            await client.close()
+
+    # ------------------------------------------------------------------
+    # Curated read ops -- each threads ``operator`` for the (optional) auth read
+    # ------------------------------------------------------------------
+
+    async def list_databases(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mongodb.databases`` -- databases with on-disk sizes."""
+        del params  # declared empty in schema
+        async with self._client(target, operator) as client:
+            return await queries.fetch_databases(client)
+
+    async def list_collections(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mongodb.collections`` -- collections in a database."""
+        async with self._client(target, operator) as client:
+            return await queries.fetch_collections(client, params["database"])
+
+    async def db_stats(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mongodb.db_stats`` -- storage statistics for a database."""
+        async with self._client(target, operator) as client:
+            return await queries.fetch_db_stats(client, params["database"])
+
+    async def collection_stats(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mongodb.collection_stats`` -- storage statistics for a collection."""
+        async with self._client(target, operator) as client:
+            return await queries.fetch_collection_stats(
+                client, params["database"], params["collection"]
+            )
+
+    async def list_indexes(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mongodb.indexes`` -- indexes for a collection, incl. TTL config."""
+        async with self._client(target, operator) as client:
+            return await queries.fetch_indexes(client, params["database"], params["collection"])
+
+    async def estimated_count(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mongodb.count`` -- fast metadata document count."""
+        async with self._client(target, operator) as client:
+            return await queries.fetch_estimated_count(
+                client, params["database"], params["collection"]
+            )
+
+    async def server_status(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mongodb.server_status`` -- slim ``serverStatus`` projection."""
+        del params  # declared empty in schema
+        async with self._client(target, operator) as client:
+            return await queries.fetch_server_status(client)
+
+    async def replica_status(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mongodb.replica_status`` -- replica-set health + member roles."""
+        del params  # declared empty in schema
+        async with self._client(target, operator) as client:
+            return await queries.fetch_replica_status(client)
+
+    # ------------------------------------------------------------------
+    # Fingerprint / probe
+    # ------------------------------------------------------------------
+
+    async def fingerprint(
+        self, target: Target, operator: Operator | None = None
+    ) -> FingerprintResult:
+        """Canonical fingerprint: version, gitVersion, edition, wire version, topology.
+
+        Connects and reads ``buildInfo`` / ``hello`` / ``serverStatus``. A
+        no-auth target fingerprints with no operator; a credentialled target
+        reads its secret under *operator* (``None`` fails closed inside the
+        loader). Any connection or credential failure maps to ``reachable=False``
+        with the error under ``extras`` rather than raising (#986 discipline).
+        """
+        probed_at = datetime.now(UTC)
+        auth_mode = "scram" if getattr(target, "secret_ref", None) else "none"
+        try:
+            async with self._client(target, operator) as client:
+                identity = await queries.fetch_fingerprint(client, auth_mode=auth_mode)
+        except (OSError, PyMongoError, VaultCredentialsReadError, ValueError) as exc:
+            _log.warning(
+                "mongodb_fingerprint_unreachable",
+                target=getattr(target, "name", None),
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            return FingerprintResult(
+                vendor="mongodb",
+                product="mongodb",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="pymongo: buildInfo/hello",
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+
+        version = identity.pop("server_version", None)
+        build = identity.pop("git_version", None)
+        edition = identity.pop("edition", None)
+        return FingerprintResult(
+            vendor="mongodb",
+            product="mongodb",
+            version=version,
+            build=build,
+            edition=edition,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method="pymongo: buildInfo/hello",
+            extras=identity,
+        )
+
+    async def probe(self, target: Target) -> ProbeResult:
+        """Reachability check via a ``hello`` handshake.
+
+        Distinct ``reason`` values on failure:
+
+        * ``auth_failed`` -- the credential could not be resolved
+          (:class:`VaultCredentialsReadError` / :exc:`ValueError` -- a
+          credentialled target on an operator-less probe) or the server rejected
+          it (:exc:`~pymongo.errors.OperationFailure` with an auth error code).
+        * ``tcp_unreachable`` -- server selection / TCP connect failed (host
+          down, firewall, wrong port; :exc:`~pymongo.errors.ConnectionFailure`,
+          which covers :exc:`~pymongo.errors.ServerSelectionTimeoutError`).
+        * ``connect_failed`` -- another server-side failure
+          (:exc:`~pymongo.errors.PyMongoError`).
+
+        ``probe`` carries no operator, so a credentialled target's secret read
+        runs without an authenticated operator and fails closed to
+        ``auth_failed`` -- reachability of a credentialled target is confirmed on
+        the operator-carrying fingerprint / op path.
+        """
+        start = time.monotonic()
+        probed_at = datetime.now(UTC)
+
+        def _result(ok: bool, reason: str | None) -> ProbeResult:
+            return ProbeResult(
+                ok=ok,
+                reason=reason,
+                latency_ms=(time.monotonic() - start) * 1000.0,
+                probed_at=probed_at,
+            )
+
+        try:
+            async with self._client(target, None) as client:
+                await client.get_database("admin").command("hello")
+        except (VaultCredentialsReadError, ValueError):
+            return _result(False, "auth_failed")
+        except OperationFailure as exc:
+            reason = "auth_failed" if exc.code in _AUTH_ERROR_CODES else "connect_failed"
+            return _result(False, reason)
+        except ConnectionFailure:
+            return _result(False, "tcp_unreachable")
+        except PyMongoError:
+            return _result(False, "connect_failed")
+        return _result(True, None)
+
+    # ------------------------------------------------------------------
+    # Registration + dispatch shim
+    # ------------------------------------------------------------------
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`MONGO_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan (via the registrar queued in
+        :mod:`meho_backplane.connectors.mongodb.__init__`) after the registry has
+        eager-imported every connector module. Idempotent across pod restarts,
+        mirroring the postgres / loki shape.
+        """
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        for op in MONGO_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"MongoDbConnector op {op.op_id!r} declares handler_attr="
+                    f"{op.handler_attr!r} but the class has no such attribute"
+                )
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = MONGO_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"MongoDbConnector op {op.op_id!r} declares group_key="
+                        f"{op.group_key!r} but no curated when_to_use exists for that key. "
+                        "Add an entry to MONGO_WHEN_TO_USE_BY_GROUP in mongodb/ops.py."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "mongodb_operations_registered",
+            count=len(MONGO_OPS),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+        )
+
+    async def execute(self, target: Target, op_id: str, params: dict[str, Any]) -> OperationResult:
+        """Legacy shim -- delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`PostgresConnector.execute`. Post-G0.6 callers
+        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI verbs)
+        construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly. The connector's
+        natural key encodes as ``"mongodb-wire-7"`` per ``parse_connector_id``.
+        The synthetic operator carries ``raw_jwt=""``, so a credentialled target
+        reached through this shim fails closed in the credential loader -- the
+        operator-context path is the real dispatch surface.
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:mongodb-wire-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )

--- a/backend/src/meho_backplane/connectors/mongodb/ops.py
+++ b/backend/src/meho_backplane/connectors/mongodb/ops.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Curated read ops exposed by :class:`MongoDbConnector` (#2237).
+
+The read core an operator needs to triage a self-hosted MongoDB instance
+through the same dispatch -> policy-gate -> audit seam every other connector
+uses, without reaching for ``mongosh`` against ``:27017``:
+
+* ``mongodb.databases`` -- databases with on-disk sizes (``listDatabases``).
+* ``mongodb.collections`` -- collections in a database (``listCollections``).
+* ``mongodb.db_stats`` -- storage statistics for a database (``dbStats``).
+* ``mongodb.collection_stats`` -- storage statistics for a collection (``collStats``).
+* ``mongodb.indexes`` -- indexes for a collection, incl. TTL ``expireAfterSeconds``
+  (``listIndexes``).
+* ``mongodb.count`` -- fast metadata document count (``estimatedDocumentCount``).
+* ``mongodb.server_status`` -- slim ``serverStatus`` projection.
+* ``mongodb.replica_status`` -- replica-set health (``hello`` + ``replSetGetStatus``).
+
+Every op is ``safety_level="safe"`` + ``requires_approval=False`` and carries a
+``read-only`` tag. Read-only is guaranteed by the **fixed command set**: each op
+issues exactly one command from
+:data:`~meho_backplane.connectors.mongodb.session.MONGO_READ_COMMANDS`, and the
+connector exposes **no** arbitrary-command / ``eval`` / ``$where`` /
+aggregation-with-``$out`` op. The dataclass + tuple shape mirrors the postgres
+(#2236) and loki (#2235) siblings so the registration walk reads identically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+__all__ = ["MONGO_OPS", "MONGO_WHEN_TO_USE_BY_GROUP", "MongoOp"]
+
+
+@dataclass(frozen=True)
+class MongoOp:
+    """Metadata for one MongoDB op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the registrar can splat the dataclass into the helper.
+    ``handler_attr`` is the async-handler attribute name on
+    :class:`~meho_backplane.connectors.mongodb.connector.MongoDbConnector`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurbs per group. ``register_typed_operation``
+#: requires a non-empty string whenever ``group_key`` is set; the registrar
+#: looks each op's ``group_key`` up here.
+MONGO_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "mongodb-inventory": (
+        "Use to inventory a MongoDB instance's logical layout: list databases "
+        "with their on-disk size (mongodb.databases), the collections in a "
+        "database (mongodb.collections), the indexes on a collection including "
+        "any TTL expiry (mongodb.indexes), or a collection's fast estimated "
+        "document count (mongodb.count). The right group for 'what databases / "
+        "collections exist?', 'which collection has a TTL index and after how "
+        "long does it expire?', or 'roughly how many documents are in this "
+        "collection?'. Read-only."
+    ),
+    "mongodb-stats": (
+        "Use to read a MongoDB instance's storage statistics: a database's data "
+        "/ storage / index sizes and object count (mongodb.db_stats) or the same "
+        "for a single collection (mongodb.collection_stats). The right group for "
+        "'why is this database so large?' or 'which collection / its indexes "
+        "dominate disk?'. Read-only."
+    ),
+    "mongodb-runtime": (
+        "Use to inspect a MongoDB instance's live runtime: a slim serverStatus "
+        "projection covering connections, network, opcounters, memory, and the "
+        "storage engine (mongodb.server_status), or replica-set health with each "
+        "member's role and state (mongodb.replica_status). The right group for "
+        "'is this instance under connection pressure?', 'what is the opcounter "
+        "mix?', or 'is the replica set healthy and who is primary?'. Read-only."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared parameter-schema fragments
+# ---------------------------------------------------------------------------
+
+_DATABASE_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "The database to inspect (e.g. 'app', 'admin').",
+}
+
+_COLLECTION_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "The collection to inspect within the database.",
+}
+
+_EMPTY_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+_DATABASE_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {"database": _DATABASE_PROPERTY},
+    "required": ["database"],
+    "additionalProperties": False,
+}
+
+_DATABASE_COLLECTION_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {"database": _DATABASE_PROPERTY, "collection": _COLLECTION_PROPERTY},
+    "required": ["database", "collection"],
+    "additionalProperties": False,
+}
+
+_OBJECT_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": True,
+}
+
+
+_DATABASES = MongoOp(
+    op_id="mongodb.databases",
+    handler_attr="list_databases",
+    summary="List databases with their on-disk sizes.",
+    description=(
+        "Lists every database on the instance with its on-disk size in bytes and "
+        "whether it holds data (listDatabases), plus the cluster total size. The "
+        "starting point for 'what databases exist and which is using the disk?'. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema=_EMPTY_PARAMS,
+    response_schema=_OBJECT_RESPONSE_SCHEMA,
+    group_key="mongodb-inventory",
+    tags=("read-only", "mongodb", "inventory", "databases"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call first to see the databases on a MongoDB instance and their "
+            "sizes before drilling into collections of a specific one."
+        ),
+        "parameter_hints": {},
+        "output_shape": ("{databases:[{name, sizeOnDisk, empty}], total_size_bytes}."),
+    },
+)
+
+
+_COLLECTIONS = MongoOp(
+    op_id="mongodb.collections",
+    handler_attr="list_collections",
+    summary="List the collections in a database.",
+    description=(
+        "Lists the collections (and views) in a database with their type and "
+        "creation options (listCollections). Pass 'database'. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema=_DATABASE_PARAMS,
+    response_schema=_OBJECT_RESPONSE_SCHEMA,
+    group_key="mongodb-inventory",
+    tags=("read-only", "mongodb", "inventory", "collections"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to enumerate the collections in a database before reading their stats/indexes."
+        ),
+        "parameter_hints": {"database": "The database to inspect."},
+        "output_shape": "{database, collections:[{name, type, options, info}]}.",
+    },
+)
+
+
+_DB_STATS = MongoOp(
+    op_id="mongodb.db_stats",
+    handler_attr="db_stats",
+    summary="Return storage statistics for a database.",
+    description=(
+        "Returns a database's storage statistics (dbStats): collection count, "
+        "object count, data size, storage size, index count and size, and total "
+        "size. The op for 'why is this database so large?'. Pass 'database'. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema=_DATABASE_PARAMS,
+    response_schema=_OBJECT_RESPONSE_SCHEMA,
+    group_key="mongodb-stats",
+    tags=("read-only", "mongodb", "stats", "storage"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": "Call to see a database's data/storage/index sizes and object counts.",
+        "parameter_hints": {"database": "The database to inspect."},
+        "output_shape": (
+            "{database, stats:{collections, objects, dataSize, storageSize, "
+            "indexes, indexSize, totalSize}}."
+        ),
+    },
+)
+
+
+_COLLECTION_STATS = MongoOp(
+    op_id="mongodb.collection_stats",
+    handler_attr="collection_stats",
+    summary="Return storage statistics for a collection.",
+    description=(
+        "Returns a collection's storage statistics (collStats): document count, "
+        "average object size, data / storage size, and per-index sizes. The op "
+        "for 'which collection or its indexes dominate disk?'. Pass 'database' "
+        "and 'collection'. safety_level=safe, read-only."
+    ),
+    parameter_schema=_DATABASE_COLLECTION_PARAMS,
+    response_schema=_OBJECT_RESPONSE_SCHEMA,
+    group_key="mongodb-stats",
+    tags=("read-only", "mongodb", "stats", "storage"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": "Call to see a single collection's size, storage, and per-index sizes.",
+        "parameter_hints": {
+            "database": "The database holding the collection.",
+            "collection": "The collection to inspect.",
+        },
+        "output_shape": (
+            "{database, collection, stats:{count, size, storageSize, avgObjSize, "
+            "totalIndexSize, indexSizes}}."
+        ),
+    },
+)
+
+
+_INDEXES = MongoOp(
+    op_id="mongodb.indexes",
+    handler_attr="list_indexes",
+    summary="List a collection's indexes, including TTL expiry.",
+    description=(
+        "Lists the indexes on a collection (listIndexes) with each index's key "
+        "spec, name, uniqueness, and — for a TTL index — its "
+        "'expireAfterSeconds'. The op for 'which indexes exist / which collection "
+        "expires documents and after how long?'. Pass 'database' and "
+        "'collection'. safety_level=safe, read-only."
+    ),
+    parameter_schema=_DATABASE_COLLECTION_PARAMS,
+    response_schema=_OBJECT_RESPONSE_SCHEMA,
+    group_key="mongodb-inventory",
+    tags=("read-only", "mongodb", "inventory", "indexes", "ttl"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to inspect a collection's indexes, including TTL 'expireAfterSeconds'."
+        ),
+        "parameter_hints": {
+            "database": "The database holding the collection.",
+            "collection": "The collection to inspect.",
+        },
+        "output_shape": (
+            "{database, collection, indexes:[{name, key, unique, expireAfterSeconds}]}."
+        ),
+    },
+)
+
+
+_COUNT = MongoOp(
+    op_id="mongodb.count",
+    handler_attr="estimated_count",
+    summary="Return a collection's fast estimated document count.",
+    description=(
+        "Returns a collection's document count from collection metadata "
+        "(estimatedDocumentCount) — O(1) and safe on a large collection, unlike "
+        "a full-scan count. Pass 'database' and 'collection'. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema=_DATABASE_COLLECTION_PARAMS,
+    response_schema=_OBJECT_RESPONSE_SCHEMA,
+    group_key="mongodb-inventory",
+    tags=("read-only", "mongodb", "inventory", "count"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": "Call for a fast, metadata-based document count (not a full scan).",
+        "parameter_hints": {
+            "database": "The database holding the collection.",
+            "collection": "The collection to count.",
+        },
+        "output_shape": "{database, collection, estimated_count}.",
+    },
+)
+
+
+_SERVER_STATUS = MongoOp(
+    op_id="mongodb.server_status",
+    handler_attr="server_status",
+    summary="Return a slim serverStatus projection.",
+    description=(
+        "Returns a slim serverStatus projection: host, version, process, uptime, "
+        "connections, network, opcounters, memory, storage engine, and the "
+        "replication summary. Heavy internal sections (wiredTiger, metrics, "
+        "locks, transactions) are suppressed so the payload stays a triage-sized "
+        "summary. The op for 'is this instance under connection pressure / what "
+        "is the opcounter mix?'. safety_level=safe, read-only."
+    ),
+    parameter_schema=_EMPTY_PARAMS,
+    response_schema=_OBJECT_RESPONSE_SCHEMA,
+    group_key="mongodb-runtime",
+    tags=("read-only", "mongodb", "runtime", "server-status"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to triage live server health: connections, opcounters, memory, storage engine."
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "{server_status:{host, version, connections, network, opcounters, mem, "
+            "storageEngine, repl}}."
+        ),
+    },
+)
+
+
+_REPLICA_STATUS = MongoOp(
+    op_id="mongodb.replica_status",
+    handler_attr="replica_status",
+    summary="Return replica-set health and member roles.",
+    description=(
+        "Returns replica-set health from the hello handshake plus "
+        "replSetGetStatus: set name, current primary, each member's role, and "
+        "(when available) each member's live state / health / uptime. On a "
+        "standalone it reports is_replica_set=false rather than erroring. The op "
+        "for 'is the replica set healthy and who is primary?'. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema=_EMPTY_PARAMS,
+    response_schema=_OBJECT_RESPONSE_SCHEMA,
+    group_key="mongodb-runtime",
+    tags=("read-only", "mongodb", "runtime", "replica-set"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": "Call to check replica-set health, membership, and which member is primary.",
+        "parameter_hints": {},
+        "output_shape": (
+            "{is_replica_set, set_name, primary, me, members:[{host, role}], "
+            "repl_set_status:{set, members:[{name, state, health, uptime}]}}."
+        ),
+    },
+)
+
+
+#: The ops :class:`MongoDbConnector` registers at lifespan startup.
+MONGO_OPS: tuple[MongoOp, ...] = (
+    _DATABASES,
+    _COLLECTIONS,
+    _DB_STATS,
+    _COLLECTION_STATS,
+    _INDEXES,
+    _COUNT,
+    _SERVER_STATUS,
+    _REPLICA_STATUS,
+)

--- a/backend/src/meho_backplane/connectors/mongodb/queries.py
+++ b/backend/src/meho_backplane/connectors/mongodb/queries.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Command text + document-shaping for the read-only MongoDB connector (#2237).
+
+Every function here issues one fixed read command (from
+:data:`~meho_backplane.connectors.mongodb.session.MONGO_READ_COMMANDS`) against
+an already-open :class:`~pymongo.AsyncMongoClient`, and returns a
+JSON-serialisable dict — the connector methods own the connect/close lifecycle
+so this module stays a pure command surface (easy to read against the MongoDB
+command reference and to unit-test with a fake client).
+
+Command facts are pinned to the MongoDB manual:
+``listDatabases`` / ``listCollections`` / ``dbStats`` / ``collStats`` /
+``listIndexes`` / ``serverStatus`` / ``buildInfo`` / ``hello`` /
+``replSetGetStatus`` (https://www.mongodb.com/docs/manual/reference/command/).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from collections.abc import Mapping
+from typing import Any
+
+from bson import Binary, Decimal128, ObjectId, Timestamp
+from pymongo import AsyncMongoClient
+from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.errors import OperationFailure
+
+from meho_backplane.connectors.mongodb.session import DEFAULT_AUTH_SOURCE, assert_read_command
+
+__all__ = [
+    "NO_REPLICATION_ENABLED_CODE",
+    "SERVER_STATUS_SLIM_FIELDS",
+    "SERVER_STATUS_SUPPRESSED_SECTIONS",
+    "fetch_collection_stats",
+    "fetch_collections",
+    "fetch_databases",
+    "fetch_db_stats",
+    "fetch_estimated_count",
+    "fetch_fingerprint",
+    "fetch_indexes",
+    "fetch_replica_status",
+    "fetch_server_status",
+]
+
+#: ``replSetGetStatus`` returns this error code on a standalone (non-replica-set)
+#: server. Treated as "not a replica set" rather than an error.
+NO_REPLICATION_ENABLED_CODE = 76
+
+#: Heavy ``serverStatus`` sections suppressed over the wire. Passing a top-level
+#: section name with value ``0`` tells the server to omit it, so the response
+#: stays a slim triage payload instead of the multi-hundred-KB full document
+#: (the ``wiredTiger`` and ``metrics`` sections dominate the size). Unknown
+#: section names are ignored by the server, so this is version-tolerant.
+SERVER_STATUS_SUPPRESSED_SECTIONS: tuple[str, ...] = (
+    "wiredTiger",
+    "metrics",
+    "tcmalloc",
+    "locks",
+    "transactions",
+    "electionMetrics",
+    "mirroredReads",
+    "latchAnalysis",
+)
+
+#: The curated top-level ``serverStatus`` fields the slim projection keeps — the
+#: ones an operator reaches for first when triaging a Mongo instance.
+SERVER_STATUS_SLIM_FIELDS: tuple[str, ...] = (
+    "host",
+    "version",
+    "process",
+    "pid",
+    "uptime",
+    "uptimeMillis",
+    "localTime",
+    "connections",
+    "network",
+    "opcounters",
+    "opcountersRepl",
+    "mem",
+    "storageEngine",
+    "repl",
+    "ok",
+)
+
+
+def _jsonable(value: Any) -> Any:
+    """Coerce a BSON scalar to a JSON-serialisable primitive.
+
+    pymongo maps BSON types to rich Python objects (``ObjectId``, ``datetime``,
+    ``Decimal128``, ``Timestamp``, ``Binary``/``bytes``, ``UUID``). The
+    dispatcher wraps a handler's return value into an :class:`OperationResult`
+    whose ``result`` must be JSON-serialisable, so this normaliser runs over
+    every document value: temporals become ISO-8601 strings, ``Decimal128``
+    becomes its string form, and the remaining rich types become their
+    canonical string.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (_dt.datetime, _dt.date, _dt.time)):
+        return value.isoformat()
+    if isinstance(value, _dt.timedelta):
+        return value.total_seconds()
+    if isinstance(value, Decimal128):
+        return str(value.to_decimal())
+    if isinstance(value, Timestamp):
+        return {"t": value.time, "i": value.inc}
+    if isinstance(value, (ObjectId, uuid.UUID)):
+        return str(value)
+    if isinstance(value, (bytes, bytearray, memoryview, Binary)):
+        return bytes(value).hex()
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    return str(value)
+
+
+def _doc(document: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalise a whole BSON document to a JSON-serialisable dict."""
+    return {str(key): _jsonable(val) for key, val in document.items()}
+
+
+def _admin(client: AsyncMongoClient[dict[str, Any]]) -> AsyncDatabase[dict[str, Any]]:
+    """Return the ``admin`` database handle (cluster-wide commands run here)."""
+    return client.get_database(DEFAULT_AUTH_SOURCE)
+
+
+async def fetch_databases(client: AsyncMongoClient[dict[str, Any]]) -> dict[str, Any]:
+    """List databases with on-disk sizes via ``listDatabases``."""
+    assert_read_command("listDatabases")
+    result = await _admin(client).command({"listDatabases": 1})
+    return {
+        "databases": [_doc(db) for db in result.get("databases", [])],
+        "total_size_bytes": _jsonable(result.get("totalSize")),
+    }
+
+
+async def fetch_collections(
+    client: AsyncMongoClient[dict[str, Any]], database: str
+) -> dict[str, Any]:
+    """List collections in *database* with type + options via ``listCollections``."""
+    assert_read_command("listCollections")
+    cursor = await client.get_database(database).list_collections()
+    collections = [_doc(info) async for info in cursor]
+    return {"database": database, "collections": collections}
+
+
+async def fetch_db_stats(client: AsyncMongoClient[dict[str, Any]], database: str) -> dict[str, Any]:
+    """Return storage statistics for *database* via ``dbStats``."""
+    assert_read_command("dbStats")
+    stats = await client.get_database(database).command("dbStats")
+    return {"database": database, "stats": _doc(stats)}
+
+
+async def fetch_collection_stats(
+    client: AsyncMongoClient[dict[str, Any]], database: str, collection: str
+) -> dict[str, Any]:
+    """Return storage statistics for *collection* via ``collStats``.
+
+    ``collStats`` is deprecated as a diagnostic command since MongoDB 6.2 but is
+    still served through MongoDB 8.x; it is the single-round-trip way to read a
+    collection's size / storage-size / index sizes without the ``$collStats``
+    aggregation stage's extra shaping.
+    """
+    assert_read_command("collStats")
+    stats = await client.get_database(database).command("collStats", collection)
+    return {"database": database, "collection": collection, "stats": _doc(stats)}
+
+
+async def fetch_indexes(
+    client: AsyncMongoClient[dict[str, Any]], database: str, collection: str
+) -> dict[str, Any]:
+    """List indexes for *collection* via ``listIndexes``, surfacing TTL config.
+
+    Each index document carries its ``key`` spec, ``name``, uniqueness, and —
+    for a TTL index — the ``expireAfterSeconds`` value, so an operator can see
+    which collections expire documents and after how long.
+    """
+    assert_read_command("listIndexes")
+    cursor = await client.get_database(database).get_collection(collection).list_indexes()
+    indexes = [_doc(index) async for index in cursor]
+    return {"database": database, "collection": collection, "indexes": indexes}
+
+
+async def fetch_estimated_count(
+    client: AsyncMongoClient[dict[str, Any]], database: str, collection: str
+) -> dict[str, Any]:
+    """Return the fast metadata-based document count via ``estimatedDocumentCount``.
+
+    Uses the collection's metadata (the ``count`` command) rather than a full
+    scan, so it is O(1) on WiredTiger and safe to run on a large collection.
+    """
+    assert_read_command("count")
+    count = (
+        await client.get_database(database).get_collection(collection).estimated_document_count()
+    )
+    return {"database": database, "collection": collection, "estimated_count": int(count)}
+
+
+async def fetch_server_status(client: AsyncMongoClient[dict[str, Any]]) -> dict[str, Any]:
+    """Return a slim ``serverStatus`` projection.
+
+    Heavy sections (:data:`SERVER_STATUS_SUPPRESSED_SECTIONS`) are suppressed
+    over the wire, then the response is projected down to
+    :data:`SERVER_STATUS_SLIM_FIELDS` — the connections / network / opcounters /
+    memory / storage-engine / replication summary an operator triages first,
+    without the multi-hundred-KB internal-metrics payload.
+    """
+    assert_read_command("serverStatus")
+    command: dict[str, Any] = {"serverStatus": 1}
+    for section in SERVER_STATUS_SUPPRESSED_SECTIONS:
+        command[section] = 0
+    status = await _admin(client).command(command)
+    slim = {
+        field: _jsonable(status[field]) for field in SERVER_STATUS_SLIM_FIELDS if field in status
+    }
+    return {"server_status": slim}
+
+
+async def _hello(client: AsyncMongoClient[dict[str, Any]]) -> dict[str, Any]:
+    """Run the ``hello`` handshake command (the modern ``isMaster`` replacement)."""
+    assert_read_command("hello")
+    return await _admin(client).command("hello")
+
+
+def _members_from_hello(hello: dict[str, Any]) -> list[dict[str, str]]:
+    """Derive per-host member roles from a ``hello`` response.
+
+    ``hello`` reports the replica-set membership as ``hosts`` (voting
+    data-bearing members), ``passives`` (priority-0 data-bearing members), and
+    ``arbiters``, plus the current ``primary``. Classify each host into its role
+    so ``fingerprint`` can surface member roles without the elevated
+    ``replSetGetStatus`` privilege.
+    """
+    primary = hello.get("primary")
+    members: list[dict[str, str]] = []
+    for host in hello.get("hosts", []) or []:
+        members.append({"host": host, "role": "primary" if host == primary else "secondary"})
+    for host in hello.get("passives", []) or []:
+        members.append({"host": host, "role": "passive"})
+    for host in hello.get("arbiters", []) or []:
+        members.append({"host": host, "role": "arbiter"})
+    return members
+
+
+async def fetch_replica_status(client: AsyncMongoClient[dict[str, Any]]) -> dict[str, Any]:
+    """Return replica-set health from ``hello`` + ``replSetGetStatus``.
+
+    ``hello`` always answers (it needs no auth and works on a standalone), so it
+    is the reachable baseline: set name, primary, and derived member roles.
+    ``replSetGetStatus`` adds each member's live ``stateStr`` / health /
+    replication lag, but is only meaningful on a replica set and requires the
+    ``clusterMonitor`` privilege; on a standalone it raises
+    :data:`NO_REPLICATION_ENABLED_CODE` and the connector reports
+    ``is_replica_set=False`` rather than surfacing an error.
+    """
+    hello = await _hello(client)
+    set_name = hello.get("setName")
+    payload: dict[str, Any] = {
+        "is_replica_set": set_name is not None,
+        "set_name": set_name,
+        "primary": hello.get("primary"),
+        "me": hello.get("me"),
+        "members": _members_from_hello(hello),
+        "repl_set_status": None,
+    }
+    if set_name is None:
+        return payload
+
+    assert_read_command("replSetGetStatus")
+    try:
+        status = await _admin(client).command("replSetGetStatus")
+    except OperationFailure as exc:
+        if exc.code == NO_REPLICATION_ENABLED_CODE:
+            payload["is_replica_set"] = False
+            return payload
+        raise
+    payload["repl_set_status"] = {
+        "set": status.get("set"),
+        "members": [
+            {
+                "name": member.get("name"),
+                "state": member.get("stateStr"),
+                "health": member.get("health"),
+                "uptime": member.get("uptime"),
+            }
+            for member in status.get("members", [])
+        ],
+    }
+    return payload
+
+
+async def fetch_fingerprint(
+    client: AsyncMongoClient[dict[str, Any]], *, auth_mode: str
+) -> dict[str, Any]:
+    """Return the canonical fingerprint fields.
+
+    Reads ``buildInfo`` (version, gitVersion, edition), ``hello`` (wire-protocol
+    version range, replica-set name + primary + member roles), and the slim
+    ``serverStatus`` (storage engine). *auth_mode* is derived by the caller from
+    whether the target carries a ``secret_ref``.
+    """
+    assert_read_command("buildInfo")
+    build = await _admin(client).command("buildInfo")
+    hello = await _hello(client)
+    server_status = await fetch_server_status(client)
+    storage = server_status["server_status"].get("storageEngine") or {}
+
+    modules = build.get("modules", []) or []
+    edition = "enterprise" if "enterprise" in modules else "community"
+
+    return {
+        "server_version": build.get("version"),
+        "git_version": build.get("gitVersion"),
+        "edition": edition,
+        "max_wire_version": hello.get("maxWireVersion"),
+        "min_wire_version": hello.get("minWireVersion"),
+        "auth_mode": auth_mode,
+        "storage_engine": storage.get("name") if isinstance(storage, dict) else None,
+        "replica_set": hello.get("setName"),
+        "primary": hello.get("primary"),
+        "members": _members_from_hello(hello),
+    }

--- a/backend/src/meho_backplane/connectors/mongodb/session.py
+++ b/backend/src/meho_backplane/connectors/mongodb/session.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Wire-session plumbing + read-command allowlist for the MongoDB connector (#2237).
+
+MEHO's second wire-protocol (non-HTTP) connector, mirroring the postgres shape
+(#2236). This module owns the two concerns that keep the connector safe by
+construction, kept out of ``connector.py`` so the connector body stays a thin
+op surface:
+
+* **The read-command allowlist** — :data:`MONGO_READ_COMMANDS` is the closed set
+  of MongoDB database commands the connector will ever issue. Unlike a SQL
+  database there is no free-form query surface here at all: every op maps to
+  exactly one fixed read command (``listDatabases`` / ``listCollections`` /
+  ``dbStats`` / ``collStats`` / ``listIndexes`` / ``count`` / ``serverStatus`` /
+  ``buildInfo`` / ``hello`` / ``replSetGetStatus``). There is **no**
+  arbitrary-command / ``eval`` / ``$where`` / aggregation passthrough, so
+  read-only is guaranteed by the fixed command set rather than by a runtime gate.
+  :func:`assert_read_command` is the belt-and-suspenders check the query layer
+  runs before dispatching any command name to the wire.
+
+* **The client factory** — :func:`connect_client` opens an
+  :class:`~pymongo.AsyncMongoClient` with ``directConnection=True`` (a single
+  node is triaged directly, not resolved into a replica-set topology) and a
+  bounded server-selection timeout. Auth is optional: a ``secret_ref=None``
+  target connects with no credentials (a no-auth instance); a target with a
+  ``secret_ref`` resolves ``{username, password}`` from the operator-context
+  credential broker and authenticates against the ``admin`` database. The
+  resolved password flows only into the client's connection params — never a
+  log line or an :class:`OperationResult`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pymongo import AsyncMongoClient
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
+
+__all__ = [
+    "APP_NAME",
+    "DEFAULT_AUTH_SOURCE",
+    "DEFAULT_PORT",
+    "DEFAULT_SERVER_SELECTION_TIMEOUT_MS",
+    "MONGO_READ_COMMANDS",
+    "MongoReadOnlyError",
+    "assert_read_command",
+    "connect_client",
+]
+
+#: The MongoDB wire-protocol default port.
+DEFAULT_PORT = 27017
+
+#: The database a credentialled target authenticates against. MongoDB stores
+#: SCRAM users under the ``admin`` database by convention (and a target model
+#: carries no per-target auth-source field), so a credentialled Mongo target
+#: authenticates there. An operator whose user lives in another auth database
+#: is out of scope for this read-only connector.
+DEFAULT_AUTH_SOURCE = "admin"
+
+#: Server-selection + connect timeout (milliseconds) — bounds a hung topology
+#: scan / TCP handshake so a probe or op fails fast rather than hanging the
+#: dispatcher. pymongo's default is 30 s, which is too long for an interactive
+#: triage surface.
+DEFAULT_SERVER_SELECTION_TIMEOUT_MS = 5000
+
+#: ``appname`` sent on the connection handshake — surfaces in the server's
+#: ``currentOp`` / log lines so an operator can attribute MEHO's reads.
+APP_NAME = "meho-backplane"
+
+#: The closed set of MongoDB database commands this connector issues. Every op
+#: maps to exactly one of these fixed reads; there is no generic
+#: command / eval / aggregation passthrough, so read-only is guaranteed by the
+#: command set itself. ``$where`` and aggregation-with-``$out`` never appear
+#: because no op accepts a caller-supplied command name or pipeline.
+MONGO_READ_COMMANDS: frozenset[str] = frozenset(
+    {
+        "listDatabases",
+        "listCollections",
+        "dbStats",
+        "collStats",
+        "listIndexes",
+        "count",
+        "serverStatus",
+        "buildInfo",
+        "hello",
+        "replSetGetStatus",
+    }
+)
+
+
+class MongoReadOnlyError(ValueError):
+    """A command name outside :data:`MONGO_READ_COMMANDS` was about to be issued.
+
+    Raised by :func:`assert_read_command`. In normal operation this is
+    unreachable — the connector never routes a caller-supplied command name to
+    the wire — so the exception is a defensive invariant guarding against a
+    future op wiring a command that is not on the read allowlist. Subclasses
+    :class:`ValueError` so the dispatcher's ``connector_error`` branch renders
+    the message verbatim.
+    """
+
+
+def assert_read_command(command: str) -> None:
+    """Raise :class:`MongoReadOnlyError` unless *command* is on the read allowlist.
+
+    The belt-and-suspenders half of the read-only guarantee: the closed op set
+    already prevents an arbitrary command from being dispatched, and this check
+    fails closed if a future op is wired to a command not in
+    :data:`MONGO_READ_COMMANDS`.
+    """
+    if command not in MONGO_READ_COMMANDS:
+        allowed = ", ".join(sorted(MONGO_READ_COMMANDS))
+        raise MongoReadOnlyError(
+            f"mongodb connector is read-only: command {command!r} is not on the "
+            f"read allowlist ({allowed}). This connector issues only fixed read "
+            "commands; there is no arbitrary-command / eval passthrough."
+        )
+
+
+async def connect_client(
+    target: Any,
+    operator: Operator | None,
+    *,
+    timeout_ms: int = DEFAULT_SERVER_SELECTION_TIMEOUT_MS,
+) -> AsyncMongoClient[dict[str, Any]]:
+    """Open an :class:`~pymongo.AsyncMongoClient` to *target*.
+
+    ``directConnection=True`` triages the single addressed node rather than
+    resolving a replica-set topology from it, so a read is served by exactly the
+    member the operator named (a secondary is not silently redirected to the
+    primary). The client is lazy — no I/O happens until the first command — so
+    the credential read is the only awaited work here.
+
+    Auth is optional:
+
+    * ``target.secret_ref is None`` — a no-auth instance. Connect with no
+      credentials. This is the net-new "execute without a secret_ref" branch;
+      every other execute path fails closed on an unresolved credential.
+    * ``target.secret_ref`` set — resolve ``{username, password}`` from the
+      operator-context credential broker
+      (:func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`),
+      which reads the secret under *operator*'s identity, and authenticate
+      against :data:`DEFAULT_AUTH_SOURCE`. A credentialled target dispatched
+      without an authenticated operator (``operator is None`` or
+      ``operator.raw_jwt == ""``) fails closed inside the loader.
+
+    The resolved password is passed only to the client constructor; it is never
+    logged, returned, or placed on an :class:`OperationResult`.
+    """
+    connect_kwargs: dict[str, Any] = {
+        "host": target.host,
+        "port": getattr(target, "port", None) or DEFAULT_PORT,
+        "serverSelectionTimeoutMS": timeout_ms,
+        "connectTimeoutMS": timeout_ms,
+        "directConnection": True,
+        "appname": APP_NAME,
+    }
+
+    if getattr(target, "secret_ref", None):
+        if operator is None:
+            # Mirror the loader's fail-closed contract with a message naming the
+            # operator-context requirement rather than raising a bare
+            # AttributeError deep in the loader.
+            raise ValueError(
+                f"mongodb target {getattr(target, 'name', target)!r} has a secret_ref "
+                "but no authenticated operator was supplied; a credentialled target "
+                "cannot be reached on an operator-less dispatch path"
+            )
+        creds = await load_basic_credentials(target, operator)
+        connect_kwargs["username"] = creds["username"]
+        connect_kwargs["password"] = creds["password"]
+        connect_kwargs["authSource"] = DEFAULT_AUTH_SOURCE
+
+    return AsyncMongoClient(**connect_kwargs)

--- a/backend/tests/integration/test_connectors_mongodb_container.py
+++ b/backend/tests/integration/test_connectors_mongodb_container.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration smoke test for :class:`MongoDbConnector` against a real MongoDB.
+
+Boots a stock ``mongo`` container (root auth enabled) and exercises the
+connector's :meth:`fingerprint`, curated read ops, and the credentialled auth
+path end-to-end over the real pymongo wire path:
+
+* ``fingerprint`` returns ``version`` / wire-version / storage engine / auth
+  mode against a live standalone (Task #2237 AC).
+* ``mongodb.databases`` / ``mongodb.collections`` see a seeded database +
+  collection.
+* ``mongodb.indexes`` surfaces a TTL index's ``expireAfterSeconds`` (Task #2237
+  AC).
+* ``mongodb.replica_status`` reports ``is_replica_set=False`` on a standalone
+  (the ``replSetGetStatus`` code-76 carve-out) -- member roles on a real
+  replica set are covered by the recorded-fixture unit test, per the AC's "or
+  recorded fixture" allowance.
+
+The credential loader is exercised through the in-process Vault fake (there is
+no real Vault in this lane), which returns the container's own root credentials
+so the connector's operator-context read path runs for real.
+
+Skip conditions mirror ``tests/integration/conftest.py``: no Docker socket ->
+skip (agent sandbox); CI provisions Docker so the test runs there. A Docker Hub
+pull rate-limit is converted to a skip so the suite's pass/fail signal stays
+meaningful.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.mongodb import MongoDbConnector
+from meho_backplane.settings import get_settings
+
+from .._vault_fakes import install_fake_client
+
+
+def _docker_socket_present() -> bool:
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+DOCKER_AVAILABLE: bool = _docker_socket_present()
+SKIP_REASON: str = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+pytestmark = pytest.mark.skipif(not DOCKER_AVAILABLE, reason=SKIP_REASON)
+
+
+@dataclass
+class _MongoLiveTarget:
+    """Target double carrying the container's connection coordinates.
+
+    ``secret_ref`` is set so the connector resolves credentials through the
+    operator-context loader (fed by the Vault fake); the integration-double
+    ``id`` / ``tenant_id`` / ``product`` / ``version`` fields stay present so
+    nothing downstream trips on a missing attribute (the integration-double
+    trap).
+    """
+
+    host: str
+    port: int
+    secret_ref: str = "targets/mongo-live"
+    name: str = "mongo-live"
+    id: str = "00000000-0000-0000-0000-0000000000f0"
+    tenant_id: str = "00000000-0000-0000-0000-000000000000"
+    product: str = "mongodb"
+    version: str | None = "7"
+    extras: dict[str, object] = field(default_factory=dict)
+
+
+def _operator() -> Operator:
+    return Operator(
+        sub="op-mongo-live",
+        name="Mongo Live Operator",
+        email=None,
+        raw_jwt="op.mongo.live.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000f4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@dataclass
+class _Container:
+    host: str
+    port: int
+    user: str
+    password: str
+
+
+@pytest.fixture(scope="module")
+def mongo_container() -> Iterator[_Container]:
+    """Boot a stock Mongo (root auth), seed a collection + TTL index, yield coords."""
+    from docker.errors import APIError as _DockerAPIError
+    from testcontainers.mongodb import MongoDbContainer
+
+    image = os.environ.get("MEHO_TEST_MONGODB_IMAGE", "mongo:7")
+    mongo = MongoDbContainer(image)
+    try:
+        mongo.start()
+    except _DockerAPIError as exc:
+        msg = str(exc).lower()
+        if "rate limit" in msg or "too many requests" in msg or "429" in msg:
+            pytest.skip(f"Docker Hub pull rate-limited for {image!r}; set MEHO_TEST_MONGODB_IMAGE")
+        raise
+    try:
+        coords = _Container(
+            host=mongo.get_container_host_ip(),
+            port=int(mongo.get_exposed_port(27017)),
+            user=mongo.username,
+            password=mongo.password,
+        )
+        _seed(coords)
+        yield coords
+    finally:
+        mongo.stop()
+
+
+def _seed(c: _Container) -> None:
+    """Create a database + collection with a TTL index so listIndexes has one."""
+    from pymongo import MongoClient
+
+    client: MongoClient[dict[str, object]] = MongoClient(
+        host=c.host, port=c.port, username=c.user, password=c.password, authSource="admin"
+    )
+    try:
+        events = client.get_database("app").get_collection("events")
+        events.insert_many([{"n": i} for i in range(10)])
+        events.create_index("createdAt", expireAfterSeconds=3600, name="ttl_idx")
+    finally:
+        client.close()
+
+
+@pytest.fixture
+def _vault(monkeypatch: pytest.MonkeyPatch, mongo_container: _Container) -> None:
+    """Route the credential loader at the container's own root credentials."""
+    get_settings.cache_clear()
+    install_fake_client(
+        monkeypatch,
+        secret={"username": mongo_container.user, "password": mongo_container.password},
+    )
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_returns_identity_fields(
+    mongo_container: _Container, _vault: None
+) -> None:
+    """AC: fingerprint returns version / wire version / storage engine / auth mode."""
+    target = _MongoLiveTarget(host=mongo_container.host, port=mongo_container.port)
+    fp = await MongoDbConnector().fingerprint(target, _operator())
+
+    assert fp.reachable is True, fp.extras
+    assert fp.vendor == "mongodb"
+    assert fp.version is not None and fp.version.startswith("7")
+    assert fp.edition in {"community", "enterprise"}
+    assert isinstance(fp.extras["max_wire_version"], int)
+    assert fp.extras["auth_mode"] == "scram"
+    assert fp.extras["storage_engine"]  # e.g. "wiredTiger"
+
+
+@pytest.mark.asyncio
+async def test_databases_and_collections(mongo_container: _Container, _vault: None) -> None:
+    """AC: a curated op dispatches; the seeded database + collection are visible."""
+    target = _MongoLiveTarget(host=mongo_container.host, port=mongo_container.port)
+    connector = MongoDbConnector()
+
+    dbs = await connector.list_databases(_operator(), target, {})
+    assert any(d["name"] == "app" for d in dbs["databases"])
+
+    colls = await connector.list_collections(_operator(), target, {"database": "app"})
+    assert any(c["name"] == "events" for c in colls["collections"])
+
+
+@pytest.mark.asyncio
+async def test_indexes_surface_ttl_expire_after_seconds(
+    mongo_container: _Container, _vault: None
+) -> None:
+    """AC: getIndexes surfaces TTL expireAfterSeconds against a live Mongo."""
+    target = _MongoLiveTarget(host=mongo_container.host, port=mongo_container.port)
+    result = await MongoDbConnector().list_indexes(
+        _operator(), target, {"database": "app", "collection": "events"}
+    )
+    ttl = next((i for i in result["indexes"] if i["name"] == "ttl_idx"), None)
+    assert ttl is not None, result["indexes"]
+    assert ttl["expireAfterSeconds"] == 3600
+
+
+@pytest.mark.asyncio
+async def test_replica_status_standalone(mongo_container: _Container, _vault: None) -> None:
+    """AC: replica_status reports is_replica_set=False on a standalone (code-76 carve-out)."""
+    target = _MongoLiveTarget(host=mongo_container.host, port=mongo_container.port)
+    result = await MongoDbConnector().replica_status(_operator(), target, {})
+    assert result["is_replica_set"] is False
+    assert result["repl_set_status"] is None

--- a/backend/tests/test_connectors_mongodb.py
+++ b/backend/tests/test_connectors_mongodb.py
@@ -1,0 +1,684 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the read-only MongoDB wire-protocol connector (#2237).
+
+Coverage matrix (per Task #2237 acceptance criteria):
+
+* **Registration** -- ``mongodb`` resolves via ``register_connector_v2``
+  (versioned triple + wildcard), appears in ``all_connectors_v2()`` and
+  ``registered_product_tokens()``; every op is safe/read-only/no-approval with a
+  closed schema.
+* **Fixed command set** -- the connector issues only commands from
+  ``MONGO_READ_COMMANDS``; there is no arbitrary-command / eval op, and
+  :func:`assert_read_command` rejects any command off the allowlist.
+* **Optional auth** -- a ``secret_ref=None`` (no-auth) target connects with no
+  credentials; a credentialled target passes the password to the client and it
+  never appears in logs (``capture_logs`` assertion).
+* **Op payloads** -- ``list_indexes`` surfaces TTL ``expireAfterSeconds``;
+  ``fingerprint`` returns version/edition/wire-version/storage-engine plus
+  replica-set name + member roles (recorded fixture).
+* **Live dispatch** -- the connector registers, an unknown op returns the
+  ``unknown_op`` envelope, a curated op dispatches end-to-end, and a missing
+  required param returns ``invalid_params``.
+
+The wire is faked with an in-memory client double; the in-process Vault fake
+exercises the real credential loader. Mirrors
+:mod:`tests.test_connectors_postgres`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import pytest
+import structlog
+from pymongo.errors import (
+    ConnectionFailure,
+    OperationFailure,
+    ServerSelectionTimeoutError,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.mongodb import (
+    MONGO_OPS,
+    MONGO_READ_COMMANDS,
+    MongoDbConnector,
+    MongoReadOnlyError,
+    assert_read_command,
+)
+from meho_backplane.connectors.mongodb import connector as connector_module
+from meho_backplane.connectors.mongodb import session as session_module
+from meho_backplane.connectors.mongodb.session import (
+    DEFAULT_AUTH_SOURCE,
+    DEFAULT_PORT,
+    connect_client,
+)
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+    registered_product_tokens,
+)
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import reset_handler_cache
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+_PRODUCT = "mongodb"
+_VERSION = "7"
+_IMPL_ID = "mongodb-wire"
+_CONNECTOR_ID = "mongodb-wire-7"
+
+_MONGO_HOST = "mongo.test.invalid"
+_MONGO_PORT = 27017
+
+#: A clearly-fake password that must never reach a log line.
+_CANARY_PASSWORD = "mongo-canary-must-not-leak-12345"  # trufflehog:ignore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT, version=_VERSION, impl_id=_IMPL_ID, cls=MongoDbConnector
+    )
+    register_connector_v2(product=_PRODUCT, version="", impl_id="", cls=MongoDbConnector)
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    return AsyncMock()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _MongoTarget:
+    """Target satisfying both the connector shape and the resolver shape."""
+
+    def __init__(
+        self,
+        *,
+        secret_ref: str | None = None,
+        host: str = _MONGO_HOST,
+        port: int | None = _MONGO_PORT,
+    ) -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": _VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000e0")
+        self.name = "mongo-reads"
+        self.host = host
+        self.port = port
+        self.secret_ref = secret_ref
+        self.auth_model = None
+        self.verify_tls = True
+        self.tls_ca_pin = None
+        self.tls_server_name = None
+        self.extras: dict[str, Any] = {}
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-reads-mongo",
+        name="Mongo Reads Operator",
+        email=None,
+        raw_jwt="op.reads.mongo.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000e4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _AsyncCursor:
+    """Minimal async-iterable stand-in for pymongo's AsyncCommandCursor."""
+
+    def __init__(self, docs: list[dict[str, Any]]) -> None:
+        self._docs = docs
+
+    async def __aiter__(self) -> AsyncIterator[dict[str, Any]]:
+        for doc in self._docs:
+            yield doc
+
+
+class _FakeCollection:
+    def __init__(self, *, indexes: list[dict[str, Any]] | None = None, count: int = 0) -> None:
+        self._indexes = indexes or []
+        self._count = count
+
+    async def list_indexes(self) -> _AsyncCursor:
+        return _AsyncCursor(self._indexes)
+
+    async def estimated_document_count(self) -> int:
+        return self._count
+
+
+class _FakeDb:
+    """Minimal AsyncDatabase double: canned command responses + a collection."""
+
+    def __init__(
+        self,
+        *,
+        command_responses: dict[str, Any] | None = None,
+        collections: list[dict[str, Any]] | None = None,
+        collection: _FakeCollection | None = None,
+    ) -> None:
+        self._responses = command_responses or {}
+        self._collections = collections or []
+        self._collection = collection or _FakeCollection()
+        self.commands: list[str] = []
+
+    async def command(self, command: Any, value: Any = 1, **kwargs: Any) -> dict[str, Any]:
+        name = command if isinstance(command, str) else next(iter(command))
+        self.commands.append(name)
+        resp = self._responses.get(name)
+        if isinstance(resp, Exception):
+            raise resp
+        if resp is None:
+            return {"ok": 1.0}
+        return resp
+
+    async def list_collections(self) -> _AsyncCursor:
+        return _AsyncCursor(self._collections)
+
+    def get_collection(self, name: str) -> _FakeCollection:
+        return self._collection
+
+
+class _FakeClient:
+    """Minimal AsyncMongoClient double routing get_database to fake dbs."""
+
+    def __init__(
+        self, *, databases: dict[str, _FakeDb] | None = None, default: _FakeDb | None = None
+    ) -> None:
+        self._databases = databases or {}
+        self._default = default or _FakeDb()
+        self.closed = False
+
+    def get_database(self, name: str) -> _FakeDb:
+        return self._databases.get(name, self._default)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, client: _FakeClient) -> AsyncMock:
+    """Patch the connector's ``connect_client`` to yield *client*."""
+    mock = AsyncMock(return_value=client)
+    monkeypatch.setattr(connector_module, "connect_client", mock)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_mongodb_resolves_versioned_and_wildcard_and_appears_in_registry() -> None:
+    """AC: mongodb resolves via register_connector_v2 (versioned + wildcard)."""
+    registry = all_connectors_v2()
+    assert registry[("mongodb", "7", "mongodb-wire")] is MongoDbConnector
+    assert registry[("mongodb", "", "")] is MongoDbConnector
+    assert "mongodb" in registered_product_tokens()
+
+    assert resolve_connector(_MongoTarget()) is MongoDbConnector
+    fresh = _MongoTarget()
+    fresh.fingerprint = type("_FP", (), {"version": None})()
+    assert resolve_connector(fresh) is MongoDbConnector
+
+
+def test_every_op_is_safe_read_only_with_closed_schema() -> None:
+    """AC: no write op -- every registered op is safe/read-only/no-approval."""
+    assert {op.op_id for op in MONGO_OPS} == {
+        "mongodb.databases",
+        "mongodb.collections",
+        "mongodb.db_stats",
+        "mongodb.collection_stats",
+        "mongodb.indexes",
+        "mongodb.count",
+        "mongodb.server_status",
+        "mongodb.replica_status",
+    }
+    for op in MONGO_OPS:
+        assert op.safety_level == "safe", op.op_id
+        assert op.requires_approval is False, op.op_id
+        assert "read-only" in op.tags, op.op_id
+        assert op.parameter_schema.get("additionalProperties") is False, op.op_id
+
+
+# ---------------------------------------------------------------------------
+# Fixed command set -- read-only by construction (AC #3)
+# ---------------------------------------------------------------------------
+
+
+def test_read_command_allowlist_is_the_closed_fixed_set() -> None:
+    """AC: only the fixed command set is dispatchable (assert the allowlist)."""
+    assert (
+        frozenset(
+            {
+                "listDatabases",
+                "listCollections",
+                "dbStats",
+                "collStats",
+                "listIndexes",
+                "count",
+                "serverStatus",
+                "buildInfo",
+                "hello",
+                "replSetGetStatus",
+            }
+        )
+        == MONGO_READ_COMMANDS
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    ["eval", "aggregate", "find", "insert", "update", "delete", "$where", "mapReduce", ""],
+)
+def test_assert_read_command_rejects_off_allowlist(command: str) -> None:
+    """A command outside the read allowlist (incl. eval/aggregate) is refused."""
+    with pytest.raises(MongoReadOnlyError):
+        assert_read_command(command)
+
+
+def test_no_op_exposes_a_free_form_command_or_pipeline_param() -> None:
+    """AC: there is no arbitrary-command / eval op.
+
+    No op's parameter schema accepts a caller-supplied command name, aggregation
+    pipeline, filter, or eval body -- the only params are database / collection
+    selectors, so read-only cannot be subverted through op params.
+    """
+    forbidden = {"command", "pipeline", "filter", "query", "eval", "code", "$where", "aggregate"}
+    for op in MONGO_OPS:
+        props = set(op.parameter_schema.get("properties", {}))
+        assert props <= {"database", "collection"}, op.op_id
+        assert not (props & forbidden), op.op_id
+
+
+# ---------------------------------------------------------------------------
+# Optional auth (connect_client)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_no_auth_sends_no_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: a secret_ref=None (no-auth) target connects with no credentials."""
+    fake_ctor = MagicMock(return_value=_FakeClient())
+    monkeypatch.setattr(session_module, "AsyncMongoClient", fake_ctor)
+
+    await connect_client(_MongoTarget(secret_ref=None), None)
+
+    kwargs = fake_ctor.call_args.kwargs
+    assert "username" not in kwargs
+    assert "password" not in kwargs
+    assert kwargs["port"] == DEFAULT_PORT
+    assert kwargs["directConnection"] is True
+
+
+@pytest.mark.asyncio
+async def test_connect_credentialled_passes_password_and_never_logs_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: a credentialled target passes the password to the client, unlogged."""
+    fake_ctor = MagicMock(return_value=_FakeClient())
+    monkeypatch.setattr(session_module, "AsyncMongoClient", fake_ctor)
+    install_fake_client(monkeypatch, secret={"username": "mongo_ro", "password": _CANARY_PASSWORD})
+
+    with structlog.testing.capture_logs() as logs:
+        await connect_client(_MongoTarget(secret_ref="targets/op-reads/mongo"), _make_operator())
+
+    kwargs = fake_ctor.call_args.kwargs
+    assert kwargs["username"] == "mongo_ro"
+    assert kwargs["password"] == _CANARY_PASSWORD
+    assert kwargs["authSource"] == DEFAULT_AUTH_SOURCE
+
+    # The password must not appear anywhere in the captured structured logs.
+    assert _CANARY_PASSWORD not in repr(logs)
+
+
+@pytest.mark.asyncio
+async def test_connect_credentialled_without_operator_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A credentialled target on an operator-less path fails closed (no connect)."""
+    fake_ctor = MagicMock(return_value=_FakeClient())
+    monkeypatch.setattr(session_module, "AsyncMongoClient", fake_ctor)
+
+    with pytest.raises(ValueError, match="no authenticated operator"):
+        await connect_client(_MongoTarget(secret_ref="targets/x/mongo"), None)
+    fake_ctor.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Op payloads -- document shaping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_indexes_surfaces_ttl_expire_after_seconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: getIndexes surfaces TTL expireAfterSeconds."""
+    coll = _FakeCollection(
+        indexes=[
+            {"v": 2, "key": {"_id": 1}, "name": "_id_"},
+            {"v": 2, "key": {"createdAt": 1}, "name": "ttl_idx", "expireAfterSeconds": 3600},
+        ]
+    )
+    client = _FakeClient(databases={"app": _FakeDb(collection=coll)})
+    _patch_client(monkeypatch, client)
+
+    result = await MongoDbConnector().list_indexes(
+        _make_operator(), _MongoTarget(), {"database": "app", "collection": "events"}
+    )
+    ttl = next(i for i in result["indexes"] if i["name"] == "ttl_idx")
+    assert ttl["expireAfterSeconds"] == 3600
+    assert result["collection"] == "events"
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_server_status_is_slim_projection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """serverStatus returns only the curated slim fields, not heavy sections."""
+    admin = _FakeDb(
+        command_responses={
+            "serverStatus": {
+                "host": "mongo1:27017",
+                "version": "7.0.5",
+                "connections": {"current": 3, "available": 997},
+                "opcounters": {"query": 100, "insert": 0},
+                "wiredTiger": {"huge": "x" * 1000},  # must be dropped
+                "ok": 1.0,
+            }
+        }
+    )
+    client = _FakeClient(default=admin)
+    _patch_client(monkeypatch, client)
+
+    result = await MongoDbConnector().server_status(_make_operator(), _MongoTarget(), {})
+    slim = result["server_status"]
+    assert slim["version"] == "7.0.5"
+    assert slim["connections"]["current"] == 3
+    assert "wiredTiger" not in slim
+
+
+@pytest.mark.asyncio
+async def test_replica_status_standalone_reports_not_replica_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a standalone (no setName), hello alone reports is_replica_set=False."""
+    admin = _FakeDb(command_responses={"hello": {"isWritablePrimary": True, "ok": 1.0}})
+    client = _FakeClient(default=admin)
+    _patch_client(monkeypatch, client)
+
+    result = await MongoDbConnector().replica_status(_make_operator(), _MongoTarget(), {})
+    assert result["is_replica_set"] is False
+    assert result["set_name"] is None
+    assert result["repl_set_status"] is None
+    # replSetGetStatus is not issued on a standalone.
+    assert "replSetGetStatus" not in admin.commands
+
+
+@pytest.mark.asyncio
+async def test_replica_status_replica_set_returns_member_roles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A replica set surfaces member roles from hello + replSetGetStatus."""
+    admin = _FakeDb(
+        command_responses={
+            "hello": {
+                "isWritablePrimary": True,
+                "setName": "rs0",
+                "primary": "m1:27017",
+                "me": "m1:27017",
+                "hosts": ["m1:27017", "m2:27017"],
+            },
+            "replSetGetStatus": {
+                "set": "rs0",
+                "members": [
+                    {"name": "m1:27017", "stateStr": "PRIMARY", "health": 1, "uptime": 500},
+                    {"name": "m2:27017", "stateStr": "SECONDARY", "health": 1, "uptime": 490},
+                ],
+            },
+        }
+    )
+    client = _FakeClient(default=admin)
+    _patch_client(monkeypatch, client)
+
+    result = await MongoDbConnector().replica_status(_make_operator(), _MongoTarget(), {})
+    assert result["is_replica_set"] is True
+    assert result["set_name"] == "rs0"
+    assert result["primary"] == "m1:27017"
+    roles = {m["host"]: m["role"] for m in result["members"]}
+    assert roles == {"m1:27017": "primary", "m2:27017": "secondary"}
+    assert result["repl_set_status"]["members"][0]["state"] == "PRIMARY"
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_returns_identity_and_member_roles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: fingerprint returns version/edition/wire + replica-set member roles."""
+    admin = _FakeDb(
+        command_responses={
+            "buildInfo": {
+                "version": "7.0.5",
+                "gitVersion": "abc123",
+                "modules": ["enterprise"],
+            },
+            "hello": {
+                "maxWireVersion": 21,
+                "minWireVersion": 0,
+                "setName": "rs0",
+                "primary": "m1:27017",
+                "hosts": ["m1:27017", "m2:27017"],
+            },
+            "serverStatus": {"storageEngine": {"name": "wiredTiger"}, "ok": 1.0},
+        }
+    )
+    client = _FakeClient(default=admin)
+    _patch_client(monkeypatch, client)
+
+    fp = await MongoDbConnector().fingerprint(
+        _MongoTarget(secret_ref="targets/x"), _make_operator()
+    )
+    assert fp.reachable is True
+    assert fp.vendor == "mongodb"
+    assert fp.product == "mongodb"
+    assert fp.version == "7.0.5"
+    assert fp.build == "abc123"
+    assert fp.edition == "enterprise"
+    assert fp.extras["max_wire_version"] == 21
+    assert fp.extras["auth_mode"] == "scram"
+    assert fp.extras["storage_engine"] == "wiredTiger"
+    assert fp.extras["replica_set"] == "rs0"
+    roles = {m["host"]: m["role"] for m in fp.extras["members"]}
+    assert roles == {"m1:27017": "primary", "m2:27017": "secondary"}
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_maps_to_not_reachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connect failure maps to reachable=False with the error under extras."""
+    monkeypatch.setattr(
+        connector_module,
+        "connect_client",
+        AsyncMock(side_effect=ServerSelectionTimeoutError("no server")),
+    )
+    fp = await MongoDbConnector().fingerprint(_MongoTarget(), _make_operator())
+    assert fp.reachable is False
+    assert "error" in fp.extras
+
+
+# ---------------------------------------------------------------------------
+# Probe reasons
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A reachable no-auth target with a working hello probes ok."""
+    admin = _FakeDb(command_responses={"hello": {"isWritablePrimary": True, "ok": 1.0}})
+    _patch_client(monkeypatch, _FakeClient(default=admin))
+    result = await MongoDbConnector().probe(_MongoTarget(secret_ref=None))
+    assert result.ok is True
+    assert result.reason is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("exc", "reason"),
+    [
+        (OperationFailure("auth", code=18), "auth_failed"),
+        (ServerSelectionTimeoutError("no route"), "tcp_unreachable"),
+        (ConnectionFailure("reset"), "tcp_unreachable"),
+        (OperationFailure("boom", code=999), "connect_failed"),
+    ],
+)
+async def test_probe_failure_reasons(
+    monkeypatch: pytest.MonkeyPatch, exc: Exception, reason: str
+) -> None:
+    """Each connect/command failure maps to its distinct probe reason."""
+    monkeypatch.setattr(connector_module, "connect_client", AsyncMock(side_effect=exc))
+    result = await MongoDbConnector().probe(_MongoTarget(secret_ref=None))
+    assert result.ok is False
+    assert result.reason == reason
+
+
+@pytest.mark.asyncio
+async def test_probe_credentialled_without_operator_is_auth_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A credentialled target on the operator-less probe path fails auth_failed."""
+
+    async def _raise(target: Any, operator: Any, **_kw: Any) -> Any:
+        raise ValueError("no authenticated operator was supplied")
+
+    monkeypatch.setattr(connector_module, "connect_client", _raise)
+    result = await MongoDbConnector().probe(_MongoTarget(secret_ref="targets/x"))
+    assert result.ok is False
+    assert result.reason == "auth_failed"
+
+
+# ---------------------------------------------------------------------------
+# Live dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_op_returns_unknown_op_envelope(
+    _stub_embedding: AsyncMock, session: AsyncSession
+) -> None:
+    """After registration, an unknown op_id returns the unknown_op envelope."""
+    await MongoDbConnector.register_operations()
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="mongodb.nonexistent",
+        target=_MongoTarget(secret_ref=None),
+        params={},
+    )
+    assert result.status == "error"
+    assert result.error.startswith("unknown_op")
+
+
+@pytest.mark.asyncio
+async def test_databases_op_dispatches_live_and_returns_payload(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: a curated op dispatches end-to-end and returns its payload."""
+    await MongoDbConnector.register_operations()
+    admin = _FakeDb(
+        command_responses={
+            "listDatabases": {
+                "databases": [{"name": "app", "sizeOnDisk": 999, "empty": False}],
+                "totalSize": 999,
+            }
+        }
+    )
+    client = _FakeClient(default=admin)
+    _patch_client(monkeypatch, client)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="mongodb.databases",
+        target=_MongoTarget(secret_ref=None),
+        params={},
+    )
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "databases": [{"name": "app", "sizeOnDisk": 999, "empty": False}],
+        "total_size_bytes": 999,
+    }
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_collections_op_missing_database_returns_invalid_params(
+    _stub_embedding: AsyncMock, session: AsyncSession
+) -> None:
+    """mongodb.collections without the required 'database' param is rejected."""
+    await MongoDbConnector.register_operations()
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="mongodb.collections",
+        target=_MongoTarget(secret_ref=None),
+        params={},
+    )
+    assert result.status == "error"
+    assert result.error.startswith("invalid_params")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1777,6 +1777,7 @@ dependencies = [
     { name = "pydantic-ai-slim", extra = ["anthropic", "bedrock", "openai"] },
     { name = "pygments" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pymongo" },
     { name = "python-frontmatter" },
     { name = "python-multipart" },
     { name = "redis" },
@@ -1833,6 +1834,7 @@ requires-dist = [
     { name = "pydantic-ai-slim", extras = ["anthropic", "bedrock", "openai"], specifier = ">=2.7.0" },
     { name = "pygments", specifier = ">=2.18" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0,<3" },
+    { name = "pymongo", specifier = ">=4.13,<5" },
     { name = "python-frontmatter", specifier = ">=1.3.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
     { name = "redis", specifier = ">=8.0.1,<9" },
@@ -2888,6 +2890,57 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pymongo"
+version = "4.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/64/50be6fbac9c79fe2e4c17401a467da2d8764d82833d83cec325afe5cab32/pymongo-4.17.0.tar.gz", hash = "sha256:70ffa08ba641468cc068cf46c06b34f01a8ce3489f6411309fcb5ceabe6b2fc0", size = 2523370, upload-time = "2026-04-20T16:39:53.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/90/60bcb508840135d5ee46b51b1a950f548338aa8145a8366dbe6639ae51ac/pymongo-4.17.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53ffa94b2340dbf6b055e09a0090618c60482c158ecfc9565642fc996bf0944", size = 930529, upload-time = "2026-04-20T16:38:00.936Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/e9/313840f1e52c6dfac47f704428cbfbce59956ebe7633bffc92b03f74f0ad/pymongo-4.17.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6fe0de9d0f6791abce3471230b32b4817bf89d27b1182b6a550e1ec0fa72aa9a", size = 930665, upload-time = "2026-04-20T16:38:02.915Z" },
+    { url = "https://files.pythonhosted.org/packages/78/35/9d3565ea45b1606f635c1e2cd2563c28d66caafdc50f7ad7d979fcd1b363/pymongo-4.17.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e537e95514dae1aaa718f481ec03151a0f0394bcd05f1322896d8fc1330cb729", size = 1762369, upload-time = "2026-04-20T16:38:05.375Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ee/149b0d4b1a11c38bff6f14c23d5814c9b0843fd6dc38ad40596bdb1a62d2/pymongo-4.17.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:37a8385c29881b43eab31f584100fa0eaddedd5607adf010147ba1810118be90", size = 1798044, upload-time = "2026-04-20T16:38:07.195Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d4/4cee4a7b8d8f6f0550ef6cd2fea42455c5ed619a220cb6ba4fb40d6a5bc8/pymongo-4.17.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f3ee3d241ed77a4fc99ce3cff3b289c3ebce37f61fdd7349d3592c23b82c8784", size = 1878567, upload-time = "2026-04-20T16:38:09.121Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ef/7fe366c84952619ee2f69973566c214775e083dd4df465751912153e4b72/pymongo-4.17.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9eb5d63a3c518cb0804ed678f5e2b875af032d89a7cf57a57360322cf6a4d222", size = 1864881, upload-time = "2026-04-20T16:38:10.896Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/35/b577d82c6d1be7aee7ac7e249bc86f7847998345042e5f8360de238e177b/pymongo-4.17.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e97e03fa13327c87e3fdc5656acd01e71817f0c1dc3221cd8f30de136bf4ec3", size = 1800349, upload-time = "2026-04-20T16:38:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/69/dafcf04f66e130ddd91aeb92e7a692480eda46dcd04ec1dbe82c06619e10/pymongo-4.17.0-cp312-cp312-win32.whl", hash = "sha256:6877214bff5f06f6884a9fc8d9016a4a7a5f51f537f5c51ac3a576f93e7dfb32", size = 900518, upload-time = "2026-04-20T16:38:15.541Z" },
+    { url = "https://files.pythonhosted.org/packages/11/35/5c9262a459f988b4eb2605f70815240b77a0d4131136c4326d18f1822b89/pymongo-4.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:9828485f72f63c7d802e0ec41f71906f633c2692621ab3af55ca990186b091b1", size = 920335, upload-time = "2026-04-20T16:38:17.665Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/e9c7265ee176faccf4e52c4797837e794d93569a1046f6b19a4acc36e5ad/pymongo-4.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:1195370a77baf003b59b10e91ecc4706297197f0dd9d29c840cc556dc08f7cee", size = 903289, upload-time = "2026-04-20T16:38:19.33Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6b/c1206879708b94e82fcd8b9653440ec271f79a3674d122192df383047f5a/pymongo-4.17.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:809ec74de3b9148ae43fa8df9faf53470f511c8d384f13b99d6f671f2a379f15", size = 985829, upload-time = "2026-04-20T16:38:21.031Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/bb044ed85160e5c40f568c7c4f4e8ea16f40764ff5d302e5befbe8f6f814/pymongo-4.17.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a431b737816bf4cddd4fa0fcef04e424ad36b7692734a64150f872fb8f3208be", size = 985899, upload-time = "2026-04-20T16:38:23.409Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0a/f6dfd5ea3901e5d6888da8de8ba728971a1d447debab681cfc56f90d1208/pymongo-4.17.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e4fab10f8403169ce92f3cea921609d9ee81107306caae06c08f592d4b8ad2b5", size = 2028569, upload-time = "2026-04-20T16:38:25.343Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c5/081f59a1c02ae8c0dc73ae58e563838c44eec81aeafa7d0b93a637841c9b/pymongo-4.17.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20323b0b1c1d33770ad1fc68d429c757734ce9ad3594421c3d6618f10572b1b9", size = 2072916, upload-time = "2026-04-20T16:38:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/31/42/6e41d434297ffe8b30d9c3717916591a4a7be9075a0dcc2fafdfaaaa62ed/pymongo-4.17.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5a5de048e6da5c18e27cc2437e8c15b3b0cdc8385c15b41178b0caa3322a09c2", size = 2173234, upload-time = "2026-04-20T16:38:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/cf/1e4a7db352ef9485831c7268dfe8402f0117b32a9ad54b16e810699e3617/pymongo-4.17.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dff3de1294fbbc1db0ba6b511f77b8e540601d092538a31312e99c8a91a78b1e", size = 2156784, upload-time = "2026-04-20T16:38:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/12/10/6195be29962a61ebb5f4bd9e4c7519890b172f7968a0a0d880398c6ddb02/pymongo-4.17.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faf03e4c2aafd6de626dbd30ba246d369ae33f47f10629d1bbe40f72115027a6", size = 2074446, upload-time = "2026-04-20T16:38:34.004Z" },
+    { url = "https://files.pythonhosted.org/packages/37/48/33410b8819837ed370c738587306bdf060b59cef11823be212f4a07703c5/pymongo-4.17.0-cp313-cp313-win32.whl", hash = "sha256:c9786665926a09630c5d420c79762cfadbff35a9438bcbc4c81a9fb5ab9228b7", size = 948435, upload-time = "2026-04-20T16:38:35.922Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/77/c0ed522f798a286b99acaa7914ed8d9c80ab091f97f57c59ffed72906e5e/pymongo-4.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:5960519b4d7168f1ecdd3ea10c81b2aedeb9423651aca953cfbc8e76705d3b38", size = 972847, upload-time = "2026-04-20T16:38:37.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f0/c39480a2db385fde23861d0c8acda41cdaf1d43e46579db72c5c013a2e81/pymongo-4.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:0ff6bd2f735ab5356541e3e57d5b7dbfbc3f2ee1ccb10b6b0f82d58af69d1d8e", size = 951575, upload-time = "2026-04-20T16:38:40.544Z" },
+    { url = "https://files.pythonhosted.org/packages/da/49/2b0250762a89737ed6f9cea238331baca061b89a8ddd10dd17fee52c3970/pymongo-4.17.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ff5aa3f1c7e3f08eb0e7a016c91ba468b1850ccfd63d9b1f12f56350f4974cef", size = 1040945, upload-time = "2026-04-20T16:38:42.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1c/7a9b5447a08be20e84b6e5b17330917e8d6d9507daa3cd099a9309f11ad7/pymongo-4.17.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e816db649ba5d7de0568cf3a9f287a9dc9aad21cf0ca667ab156a7ef47fca0b0", size = 1041187, upload-time = "2026-04-20T16:38:45.358Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a1/71704f61632dfc90407a5834fe5f6132854937c4a3648f6c05c351d85a45/pymongo-4.17.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c4fded3a9f1d6a687e36ebd384ac6d00b9b00de1969aa74048e7051ec2a713", size = 2294806, upload-time = "2026-04-20T16:38:47.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b9/aff42be75108b96c2469b1d9329b912c15108f3e7ef32fdc86da8423c330/pymongo-4.17.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2db66aa8dd253a0fc1fad3b0d23d5b3993f7ebde02fbbd7727128debf2853675", size = 2348231, upload-time = "2026-04-20T16:38:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/30/44c115b8ba1479942c15fd9480eb29a7da0ba68acd56983423ba0deb4a94/pymongo-4.17.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3987e96e7c7be4083d42e8ac2cc6c0d5b78db9973c90fce42ae800b616ca6b20", size = 2467614, upload-time = "2026-04-20T16:38:52.665Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/84/21ee95c8bf0ca7acae7ec7eb365d740bf8fc0156c194baf2c3bdfcb85ec0/pymongo-4.17.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cee36b3c0d0354f880fa7a7fdcdaf2bb5e542c2281e25c1bfadf8cfe21eba7d2", size = 2445970, upload-time = "2026-04-20T16:38:55.175Z" },
+    { url = "https://files.pythonhosted.org/packages/06/89/081d7f1809d5ca09d1e47e49f2111b245f5694de3a7af32cd3a353a6f43f/pymongo-4.17.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:320b34457b20bbcc79997801f95d25ce00472915ca5241167242b42c4359e027", size = 2348605, upload-time = "2026-04-20T16:38:57.557Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c3/0d949f9d3f2a341c1f635c398c16615e96f89f51ff424ed81e914cf1a4de/pymongo-4.17.0-cp314-cp314-win32.whl", hash = "sha256:df4a644af9ae132d4bfdb2e9516ea51a615fd881caddfbfbd071cf1354844479", size = 1004119, upload-time = "2026-04-20T16:39:00.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/55/5c3a3db1048054c695c75c5964cc8bedc2247fdb5a75ef6fab4ec8bb013e/pymongo-4.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:c797f8a80957134f6dd9690367a0f8f5906d672119af2c6aa55f0c527b656bed", size = 1032314, upload-time = "2026-04-20T16:39:02.665Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/19/e235f39906134cb0ffd5574c5a59c355ef5380f0499644ab94994afbb109/pymongo-4.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:68fca71e05ee5da23a8d73cee8379dfb3d26e609a377cae731d742771ed96946", size = 1007627, upload-time = "2026-04-20T16:39:04.678Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e0/c4c1a86791415b14c684fa0908f9da96de91594a3fd1fa1b8dc689fbb800/pymongo-4.17.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b4384700cffc3f1dd98e088bc0072dedf6d7d68a230bb4b972665cf69c071c1e", size = 1099151, upload-time = "2026-04-20T16:39:06.969Z" },
+    { url = "https://files.pythonhosted.org/packages/81/4b/69c67f3e23fd9b23b9bedc7ebd23754881cc9d5c5d5b2a9811e96b07f475/pymongo-4.17.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:93641192644fa1ee0f34030e774fd31022a27ad11ba22cb1716142231524f8bd", size = 1099346, upload-time = "2026-04-20T16:39:08.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/19/a5208f62f9508a26d73acc69bd3821b8c8adae253679a3c26d2f9652f0d5/pymongo-4.17.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:75bc3aa5b94fdb7138d357ec6ca61cd97e0c79f4f7f0bd3efe9639b15cc50942", size = 2619034, upload-time = "2026-04-20T16:39:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/77/27/426cba1ec5973082a56d4150798529bfdf4151c31391ed1fbbecb23ef2ac/pymongo-4.17.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e8f8e23c6df7c6d6929f5e734980b227706e73ee847517c9ba5af90f7fc466", size = 2689939, upload-time = "2026-04-20T16:39:13.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/2e/f70993d1255e33f6ee59a4ec4371cc65bff7a7e3fda7d55c3386f25287e8/pymongo-4.17.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:15d3f3d732aecac1f8d481bde4029755615639bd3076f258a2147210aec8515a", size = 2824994, upload-time = "2026-04-20T16:39:16.057Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/eb/87b0e988ba889e1fcc3430c2cfc166b251872c813e92b43174298bee17ff/pymongo-4.17.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c5f62862d0f87be481fa1fe8cb811994486773c94a2b61e509285e3f2890763", size = 2801745, upload-time = "2026-04-20T16:39:18.476Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4c/3f83412d086f682d4d468761d66ddc49cf161e786ea74073045eb4491c60/pymongo-4.17.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64837adbbd72073301af51bb0fc80e3d7707fe5527cea1033ba0320f0b2f881b", size = 2684636, upload-time = "2026-04-20T16:39:20.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d8/b75f6f4ab6c8beb50b0270a4f1e2530b5774f5e116563440e1677ca1820f/pymongo-4.17.0-cp314-cp314t-win32.whl", hash = "sha256:b93b22eedc62598cf5ee9d8c8007a8e9121c50fd88137012d8985500e9dc3151", size = 1056356, upload-time = "2026-04-20T16:39:22.996Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5e/648c8a238eef18a25ed8a169ea6542d4a860bbec3e95b3d9badac2935c71/pymongo-4.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3689ea34f6b647c7d1e7bdc60fcfb214b2789ed1359a7fb96569c69f50e5f18f", size = 1090964, upload-time = "2026-04-20T16:39:24.989Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cb/d9780b66939c4fc1f024bcc7be23a2abcfe06a9745ca8fa76dc73395482e/pymongo-4.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9543d8f84c2e5608565c08ac679774811e6730770d8a645439b073422a4276fb", size = 1058526, upload-time = "2026-04-20T16:39:27.924Z" },
 ]
 
 [[package]]

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -25387,6 +25387,7 @@
               "k8s",
               "keycloak",
               "loki",
+              "mongodb",
               "nsx",
               "pfsense",
               "postgres",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -333,6 +333,7 @@ const (
 	K8s        TargetCreateProduct = "k8s"
 	Keycloak   TargetCreateProduct = "keycloak"
 	Loki       TargetCreateProduct = "loki"
+	Mongodb    TargetCreateProduct = "mongodb"
 	Nsx        TargetCreateProduct = "nsx"
 	Pfsense    TargetCreateProduct = "pfsense"
 	Postgres   TargetCreateProduct = "postgres"

--- a/docs/codebase/connectors-mongodb.md
+++ b/docs/codebase/connectors-mongodb.md
@@ -1,0 +1,170 @@
+# Connector: mongodb (MongoDB 5–8, read-only)
+
+## Overview
+
+The `mongodb` connector is MEHO's **second wire-protocol (non-HTTP) connector**,
+following the DB-connector shape the postgres connector (#2236) established. It
+subclasses the generic `Connector` ABC (not `HttpConnector`) and drives a
+`pymongo.AsyncMongoClient` over the MongoDB wire protocol (default port 27017),
+under the `(product="mongodb", version="7", impl_id="mongodb-wire")` registry
+triple plus the `("mongodb", "", "")` wildcard fallback. It brings a self-hosted
+MongoDB instance inside the MEHO dispatch → policy-gate → audit seam, so an
+operator can triage replica-set health, index/TTL config, and collection storage
+through the same governed surface every other connector uses (#2237, under
+Initiative #2228).
+
+The connector is **read-only by construction**: it registers a fixed set of read
+ops, each issuing exactly one command from a closed allowlist. There is **no**
+free-form command / `eval` / `$where` / aggregation-with-`$out` op, so read-only
+is guaranteed by the command set itself rather than a runtime SQL-style gate.
+Auth is **optional** — a no-auth instance (no `secret_ref`) connects with no
+credentials.
+
+Source: `backend/src/meho_backplane/connectors/mongodb/`.
+
+## Driver choice: PyMongo native async, not Motor
+
+The connector uses PyMongo's **native async API** (`AsyncMongoClient`, GA since
+PyMongo 4.13), not the Motor driver the task originally suggested. MongoDB
+deprecated Motor on 2025-05-14 in favour of the unified PyMongo Async API and
+set Motor's end-of-life at 2026-05-14, so a brand-new connector adopts the
+supported client directly and pulls **no separate `motor` dependency**.
+`AsyncMongoClient` runs commands natively on the event loop, so no
+`asyncio.to_thread` wrapper is needed (unlike the synchronous `hvac` precedent).
+
+## Key types
+
+- **`MongoDbConnector`** (`connector.py`) — `Connector` subclass. Class
+  attributes: `product="mongodb"`, `version="7"`, `impl_id="mongodb-wire"`,
+  `supported_version_range=">=5,<9"`, `priority=1` (outranks a
+  `GenericRestConnector` auto-shim). Owns the connect/close lifecycle
+  (`_client` async context manager), `fingerprint`, `probe`, the eight op
+  handlers, `register_operations`, and the `execute` dispatcher shim.
+- **`MongoOp`** (`ops.py`) — frozen dataclass carrying one op's registration
+  metadata. `MONGO_OPS` is the tuple the registrar walks;
+  `MONGO_WHEN_TO_USE_BY_GROUP` supplies the per-group `when_to_use` blurb.
+- **`connect_client` / `MONGO_READ_COMMANDS` / `assert_read_command` /
+  `MongoReadOnlyError`** (`session.py`) — the client factory (with the
+  optional-auth branch) and the closed read-command allowlist + its
+  belt-and-suspenders check and violation type.
+- **`queries.py`** — the command runners, document row-shaping, and the
+  `_jsonable` normaliser that coerces BSON types (`ObjectId`, `datetime`,
+  `Decimal128`, `Timestamp`, `Binary`) to JSON-serialisable primitives.
+
+## Control flow
+
+### Registration (two-phase, mirrors postgres/loki)
+
+- **Import time** — `mongodb/__init__.py` calls `register_connector_v2` twice
+  (versioned triple + wildcard). `_eager_import_connectors` discovers the
+  subpackage by directory name. The `product="mongodb"` token enters the
+  `TargetCreate.product` OpenAPI enum via `registered_product_tokens()`
+  (regenerated CLI snapshot at `cli/api/openapi.json`).
+- **Lifespan** — `register_mongodb_typed_operations` (queued via
+  `register_typed_op_registrar`) delegates to
+  `MongoDbConnector.register_operations`, which upserts the eight descriptors
+  into `endpoint_descriptor`. Idempotent across restarts.
+
+### Dispatch
+
+An op dispatches through `meho_backplane.operations.dispatch`, which resolves the
+connector, runs the policy gate, validates params, and invokes the bound handler
+`(operator, target, params)`. Each handler opens a client via
+`self._client(...)` (which delegates to `connect_client`), runs one command
+function from `queries.py`, shapes the documents, and closes the client.
+
+Ops:
+
+| op | command | notes |
+|----|---------|-------|
+| `mongodb.databases` | `listDatabases` | databases + on-disk sizes + cluster total |
+| `mongodb.collections` | `listCollections` | collections/views in a database (`database` required) |
+| `mongodb.db_stats` | `dbStats` | database storage stats (`database` required) |
+| `mongodb.collection_stats` | `collStats` | collection storage + per-index sizes (`database`, `collection`) |
+| `mongodb.indexes` | `listIndexes` | indexes incl. TTL `expireAfterSeconds` (`database`, `collection`) |
+| `mongodb.count` | `estimatedDocumentCount` | fast metadata count, O(1) (`database`, `collection`) |
+| `mongodb.server_status` | `serverStatus` | slim projection (heavy sections suppressed) |
+| `mongodb.replica_status` | `hello` + `replSetGetStatus` | replica-set health + member roles |
+
+### Read-only enforcement (fixed command set)
+
+Unlike a SQL database there is no free-form query surface at all. Every op maps
+to exactly one command in `MONGO_READ_COMMANDS` (`listDatabases`,
+`listCollections`, `dbStats`, `collStats`, `listIndexes`, `count`,
+`serverStatus`, `buildInfo`, `hello`, `replSetGetStatus`), and no op's parameter
+schema accepts a caller-supplied command name, aggregation pipeline, filter, or
+`eval` body — the only params are `database` / `collection` selectors. Read-only
+is therefore a property of the closed command set. `assert_read_command` is a
+belt-and-suspenders check the query layer runs before every command, so a future
+op wired to a command off the allowlist fails closed.
+
+### Auth (optional)
+
+`connect_client` branches on `target.secret_ref`:
+
+- **`None`** — a no-auth instance. Connects with no credentials
+  (`directConnection=True`, bounded server-selection timeout). This is the
+  net-new "execute without a `secret_ref`" branch — every other execute path
+  fails closed on an unresolved credential.
+- **set** — resolves `{username, password}` via `load_basic_credentials`
+  (operator-context Vault read) and authenticates against the `admin` database
+  (`DEFAULT_AUTH_SOURCE`). The password flows only into the client's connection
+  params; it never enters a log line or an `OperationResult`. A credentialled
+  target reached without an authenticated operator (the operator-less `execute`
+  shim / `probe`) fails closed inside the loader.
+
+### Fingerprint / probe
+
+`fingerprint()` reads `buildInfo` (version, gitVersion, edition), `hello`
+(wire-protocol version range, replica-set name + primary + derived member
+roles), and the slim `serverStatus` (storage engine); any connect/credential
+failure maps to `reachable=False` with the error under `extras` (never raises).
+`probe()` is a `hello` handshake carrying no operator, so its failure reasons are
+`auth_failed` (bad/unresolvable credential, or a MongoDB auth error code 13/18 —
+a credentialled target on the operator-less probe path resolves here),
+`tcp_unreachable` (`ConnectionFailure` / `ServerSelectionTimeoutError`), and
+`connect_failed` (other `PyMongoError`).
+
+Member roles are derived from `hello` (`hosts`/`passives`/`arbiters` + `primary`)
+so the fingerprint does not need the elevated `clusterMonitor` privilege
+`replSetGetStatus` requires; `mongodb.replica_status` additionally calls
+`replSetGetStatus` for each member's live `stateStr`/health, and treats the
+standalone code-76 (`NoReplicationEnabled`) as `is_replica_set=False`.
+
+## Dependencies
+
+- `pymongo` (>=4.13, added for this connector) — the async wire client
+  (`AsyncMongoClient`) + BSON types. Native async replaces Motor (deprecated).
+- `_shared/vault_creds.py` — `load_basic_credentials` for the optional
+  operator-context credential read.
+- `operations/typed_register.py` — `register_typed_operation` and the registrar
+  queue.
+- `operations.dispatch` — the `execute` shim delegates to it.
+
+## Known issues / scope
+
+- **TLS is not yet wired.** `connect_client` passes no TLS argument, so it
+  connects unencrypted (fine for a no-auth port-forward or an in-cluster
+  instance). A `verify_tls` / SNI-aware TLS path is a follow-up when a
+  TLS-required target is registered.
+- **`collStats` is deprecated** as a diagnostic command since MongoDB 6.2 but is
+  still served through 8.x; if a future server removes it, `mongodb.collection_stats`
+  moves to the `$collStats` aggregation stage.
+- `serverStatus` is projected to a curated slim subset; the full internal
+  metrics (`wiredTiger`, `metrics`, `locks`, `transactions`) are suppressed over
+  the wire, not just dropped in code.
+- Member roles in `fingerprint` come from `hello`; a live replica set's detailed
+  per-member state is on `mongodb.replica_status`.
+
+## References
+
+- PyMongo async API: <https://pymongo.readthedocs.io/en/stable/api/pymongo/asynchronous/index.html>
+- Motor deprecation / migrate to PyMongo async:
+  <https://www.mongodb.com/docs/languages/python/pymongo-driver/current/reference/migration/>
+- MongoDB database commands:
+  <https://www.mongodb.com/docs/manual/reference/command/>
+- `replSetGetStatus`:
+  <https://www.mongodb.com/docs/manual/reference/command/replSetGetStatus/>
+- Sibling wire-protocol connector: `docs/codebase/connectors-postgres.md`.
+- Task #2237; Initiative #2228 (data-tier + hypervisor connector coverage);
+  reuses the DB-connector shape from postgres (#2236).


### PR DESCRIPTION
## Summary

- Adds `MongoDbConnector` (`backend/src/meho_backplane/connectors/mongodb/`) — MEHO's second wire-protocol (non-HTTP) connector, reusing the DB-connector shape the postgres connector (#2236) established: subclasses the generic `Connector` ABC, drives a wire client, dual v2 registration (versioned triple `("mongodb","7","mongodb-wire")` + wildcard) + typed-op registrar + `fingerprint()`/`probe()`. Read-only over the MongoDB wire protocol (:27017).
- **Read-only by construction:** eight fixed read ops (`databases` / `collections` / `db_stats` / `collection_stats` / `indexes` / `count` / `server_status` / `replica_status`), each issuing exactly one command from a closed allowlist (`MONGO_READ_COMMANDS`). There is **no** free-form command / `eval` / `$where` / aggregation-with-`$out` op — read-only is a property of the command set, not a runtime gate.
- **Optional auth:** a `secret_ref=None` target connects with no credentials (no-auth instance); a credentialled target resolves `{username, password}` under the operator's identity and authenticates against `admin`. The password flows only into the client's connection params — never a log line or an `OperationResult`.
- **Driver deviation (documented):** the task suggested `motor`, but MongoDB **deprecated Motor on 2025-05-14 (EOL 2026-05-14)** in favour of PyMongo's native async API. This connector uses `pymongo.AsyncMongoClient` (GA since PyMongo 4.13) — async/off-loop natively, one dependency (`pymongo`, no separate `motor`), and not EOL in five weeks. Satisfies every acceptance criterion; see the "Driver choice" section of `docs/codebase/connectors-mongodb.md`.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/` (strict, **no** `--ignore-missing-imports`) — clean, 591 files. pymongo/bson ship `py.typed`, so **no mypy override was needed** (unlike the asyncpg/hvac stubless deps); types resolve natively.
- [x] `pytest tests/test_connectors_mongodb.py` — 31 passed (registration, closed-command-set allowlist assertion, optional-auth + no-secret-in-logs, TTL `expireAfterSeconds`, fingerprint replica-set member roles via recorded fixture, probe reasons, live dispatch)
- [x] Product enum: `mongodb` auto-derives into `TargetCreate.product`; `cli/api/openapi.json` + `cli/internal/api/client.gen.go` regenerated (`grep -c '"mongodb"' cli/api/openapi.json` = 1). `test_openapi_target_product_enum.py` green.
- [x] `code-quality.py --diff` — 0 blockers (1 non-blocking PLR0911 warning on the `_jsonable` BSON type-dispatch normaliser, same shape as postgres's `_jsonable`).
- [ ] Integration testcontainers lane (`tests/integration/test_connectors_mongodb_container.py`) — `skipped-in-sandbox` (no Docker socket); runs in CI. Covers live fingerprint identity, seeded db/collection, TTL index `expireAfterSeconds`, and standalone `replSetGetStatus` code-76 carve-out. Integration-double target carries `id`/`tenant_id`/`product`/`version`.

## Out of scope

- TLS to the Mongo target is not yet wired (no TLS-required target registered yet) — noted in the connector doc's Known issues.
- `_jsonable` PLR0911 (10 returns) — a type-dispatch normaliser; mirrors the postgres sibling verbatim, left as-is.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2237
