### PR TITLE
fix(ingest): normalize spec: prefix in spec_source dedup so catalog re-ingest is idempotent (#2274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — catalog re-ingest is idempotent instead of colliding with its own rows
+
+- **A second `meho connector ingest --catalog <product>/<version>` on the
+  same deploy now returns an idempotent skip instead of a 400
+  `op_id_collision` against the rows the first ingest just wrote** (#2274).
+  The catalog shipped-spec on-ramp labels its source `spec:<resource>`;
+  the parser then persists that label verbatim as a row tag while the
+  upsert appends its own `spec:<spec_source>` marker, so a catalog row
+  carries two `spec:` tags. The cross-source collision guard recovered the
+  persisted source from the *first* matching tag — the verbatim one, one
+  `spec:` layer short of the real source — so every re-ingest mismatched
+  its own rows and aborted the batch, making the unbacked-composite
+  remediation loop (which prints exactly that command) circular. The guard
+  now reads the authoritative *last* (marker) tag and compares on the
+  prefix-normalized logical spec identity; genuine cross-source `op_id`
+  clashes (`file:///a.yaml` vs `spec:b.yaml`) still fire, and the
+  structured exception still carries the raw persisted/incoming labels for
+  diagnostics. Compare-time fix only — no data migration, no schema
+  change. (#2274)
+
 ### Fixed — vendor YAML date/timestamp `example:` values no longer crash spec ingest
 
 - **Ingesting a YAML OpenAPI spec whose schema `example:` fields carry

--- a/backend/src/meho_backplane/operations/ingest/_upsert.py
+++ b/backend/src/meho_backplane/operations/ingest/_upsert.py
@@ -110,20 +110,81 @@ def build_upsert_context(
     )
 
 
+def _normalize_spec_source(spec_source: str) -> str:
+    """Reduce a ``spec_source`` label to its prefix-free logical identity.
+
+    Cross-call dedup keys on the *logical* spec a row came from, not on
+    the exact rendering of its audit label. The catalog shipped-spec
+    on-ramp labels its source ``spec:<resource>`` (#1975), so the same
+    logical spec can reach the comparison carrying a different number of
+    leading ``spec:`` prefixes on each side -- e.g. a persisted marker
+    that round-trips ``spec:<resource>`` versus an incoming
+    ``spec:<resource>`` re-submission. Stripping the leading ``spec:``
+    layers off both sides makes those compare equal (idempotent
+    re-ingest) while leaving genuinely distinct sources apart:
+    ``file:///a.yaml`` never normalizes onto ``spec:b.yaml``.
+    """
+    while spec_source.startswith(_SPEC_TAG_PREFIX):
+        spec_source = spec_source[len(_SPEC_TAG_PREFIX) :]
+    return spec_source
+
+
 def _extract_persisted_spec_source(existing: EndpointDescriptor) -> str | None:
     """Recover the ``spec_source`` of an already-persisted row.
 
-    The synthetic ``f"spec:{spec_source}"`` marker is appended once
-    per row at first-register (and re-applied on the re-embed path),
-    so a well-formed row carries exactly one ``spec:`` tag. If the
-    tag is missing (older rows, hand-edited fixtures), return
-    ``None`` and let the caller skip the cross-call check rather
-    than raise a spurious collision.
+    ``build_upsert_context`` appends the synthetic ``f"spec:{spec_source}"``
+    marker as the row's **last** tag, so the marker is the authoritative
+    record of the source. The parser also persists the raw ``spec_source``
+    verbatim as a tag (:func:`parse_openapi`); for a catalog shipped-spec
+    source -- already ``spec:<resource>`` -- that verbatim tag is itself
+    ``spec:``-prefixed and sits *before* the marker. Scanning from the
+    end returns the marker instead of letting the verbatim tag shadow it:
+    a first-match scan recovered the verbatim tag's payload, one ``spec:``
+    layer short of the real source, so every catalog re-ingest then
+    collided with its own rows (#2274). If no ``spec:`` tag is present
+    (older rows, hand-edited fixtures) return ``None`` and let the caller
+    skip the cross-call check rather than raise a spurious collision.
     """
-    for tag in existing.tags or []:
+    for tag in reversed(existing.tags or []):
         if tag.startswith(_SPEC_TAG_PREFIX):
             return tag[len(_SPEC_TAG_PREFIX) :]
     return None
+
+
+def _check_cross_source_collision(existing: EndpointDescriptor, ctx: UpsertContext) -> None:
+    """Raise :exc:`OpIdCollision` when a persisted row came from a *different* spec.
+
+    A row already exists under this ``(product, version, impl_id, op_id)``
+    natural key. If a prior ingest wrote it under a different
+    ``spec_source``, silently re-embedding would overwrite that spec's
+    method / path / summary / schemas with this call's payload -- never
+    what the operator wants. Per Task #403 they must instead see a
+    structured exception naming both sources so they can rename one
+    ``op_id`` or skip the offending spec.
+
+    The equality keys on the *logical* spec identity, not the rendered
+    audit label. The catalog shipped-spec on-ramp labels its source
+    ``spec:<resource>`` (#1975), so the same spec can reach this guard
+    carrying a different number of leading ``spec:`` prefixes on each
+    side; :func:`_normalize_spec_source` collapses them so a same-spec
+    re-ingest stays a no-op instead of colliding with its own rows
+    (#2274). A missing marker (older rows, hand-edited fixtures) skips
+    the check. The raised exception carries the *raw* labels for
+    diagnostics.
+    """
+    existing_spec_source = _extract_persisted_spec_source(existing)
+    if existing_spec_source is None:
+        return
+    if _normalize_spec_source(existing_spec_source) == _normalize_spec_source(ctx.spec_source):
+        return
+    raise OpIdCollision(
+        op_ids=[ctx.proto.op_id],
+        product=ctx.product,
+        version=ctx.version,
+        impl_id=ctx.impl_id,
+        existing_spec_source=existing_spec_source,
+        incoming_spec_source=ctx.spec_source,
+    )
 
 
 async def _lookup_existing_descriptor(
@@ -230,26 +291,10 @@ async def upsert_one_operation(
     existing = await _lookup_existing_descriptor(session, ctx)
 
     if existing is not None:
-        # Cross-call op_id collision: the existing row was written by a
-        # prior register_ingested_operations() call under a *different*
-        # spec_source. Silently re-embedding would replace the prior
-        # spec's method / path / summary / description / schemas with
-        # this call's payload — never what the operator wants.
-        # Per Task #403 the operator must see a structured exception
-        # naming both spec sources so they can decide whether to rename
-        # one op_id or skip the offending spec. Same-spec_source
-        # re-ingest stays on the existing skip-re-embed / re-embed
-        # branches below; only a true spec_source mismatch fires.
-        existing_spec_source = _extract_persisted_spec_source(existing)
-        if existing_spec_source is not None and existing_spec_source != ctx.spec_source:
-            raise OpIdCollision(
-                op_ids=[ctx.proto.op_id],
-                product=ctx.product,
-                version=ctx.version,
-                impl_id=ctx.impl_id,
-                existing_spec_source=existing_spec_source,
-                incoming_spec_source=ctx.spec_source,
-            )
+        # Same-spec re-ingest falls through to the skip-re-embed /
+        # re-embed branches below; only a genuine cross-source op_id
+        # clash raises (see the helper for the normalization rationale).
+        _check_cross_source_collision(existing, ctx)
 
         existing_text = build_embedding_text(
             summary=existing.summary or "",

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -3639,6 +3639,78 @@ def test_ingest_catalog_entry_shipped_spec_loads_content_and_ingests(
     assert body["ingestion"]["connector_id"] == "shippedt1-rest-1.0"
 
 
+def test_ingest_catalog_entry_shipped_spec_reingest_is_idempotent(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2274: a second non-dry-run catalog ingest skips its own rows, not 400.
+
+    The catalog shipped-spec route labels its source ``spec:<resource>``;
+    the parser persists that verbatim as a tag and the upsert appends its
+    own ``spec:<spec_source>`` marker, so the row carries two ``spec:``
+    tags. A first-match extractor recovered the shadowing verbatim tag
+    (one ``spec:`` layer short of the real source) and the second ingest
+    of the same catalog entry collided with its own rows -- a 400
+    ``op_id_collision`` that made the unbacked-composite remediation loop
+    (which prints exactly this command) circular. The persisted-then-
+    re-ingested, non-dry-run catalog leg is the path CI never covered.
+    """
+    _patch_catalog(
+        monkeypatch,
+        entries=[
+            {
+                "product": "shippedt1",
+                "version": "1.0",
+                "impl_id": "shippedt1-rest",
+                "requires_connector_class": "ProfiledRestConnector_shippedt1",
+                "upstream": None,
+                "spec_resource": "_fixture_minimal.yaml",
+                "profile_resource": "_fixture_minimal.yaml",
+            },
+        ],
+    )
+    # _fixture_minimal.yaml carries exactly one op (``GET /things``); the
+    # deterministic grouping stub only needs to place that one op.
+    set_llm_client_factory(
+        lambda: _StubLlmClient(
+            propose_response=(
+                '[{"group_key": "things", "name": "Things", '
+                '"when_to_use": "Use these operations to work with things."}]'
+            ),
+            assign_response='{"GET:/things": "things"}',
+        ),
+    )
+    key, token = _admin_token()
+    with (
+        respx.mock as mock_router,
+        patch(
+            "meho_backplane.operations.ingest._upsert.encode_endpoint_text",
+            AsyncMock(return_value=[0.25] * 384),
+        ),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        # No upstream mock — the shipped spec is served inline from
+        # package data; any fetch attempt would raise an unmocked request.
+        first = client.post(
+            "/api/v1/connectors/ingest",
+            json={"catalog_entry": "shippedt1/1.0", "async": False},
+            headers=_authed(token),
+        )
+        second = client.post(
+            "/api/v1/connectors/ingest",
+            json={"catalog_entry": "shippedt1/1.0", "async": False},
+            headers=_authed(token),
+        )
+    assert first.status_code == 200, first.text
+    assert first.json()["ingestion"]["inserted_count"] == 1
+    # The re-ingest is idempotent: success with nothing inserted, not a
+    # 400 op_id_collision against the rows the first call just wrote.
+    assert second.status_code == 200, second.text
+    second_ingestion = second.json()["ingestion"]
+    assert second_ingestion["inserted_count"] == 0
+    assert second_ingestion["skipped_count"] == 1
+
+
 def test_ingest_catalog_entry_unknown_returns_structured_422(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -760,6 +760,67 @@ async def test_end_to_end_with_real_parsed_spec(
     assert ("petstore", "3.0", "petstore-rest") in all_connectors_v2()
 
 
+@pytest.mark.asyncio
+async def test_reingest_with_spec_prefixed_source_is_idempotent(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Re-ingesting a ``spec:``-labelled source through the parser skips, not collides (#2274).
+
+    The catalog shipped-spec on-ramp labels its source
+    ``spec:<resource>`` (#1975). The parser persists that label verbatim
+    as a row tag, and the upsert appends its own ``spec:<spec_source>``
+    marker on top -- so a catalog row ends up carrying *two* ``spec:``
+    tags. A first-match extractor read the verbatim tag (one ``spec:``
+    layer short of the real source) and every re-ingest then collided
+    with its own rows. The proto **must** come from :func:`parse_openapi`
+    *with* the ``spec:``-prefixed ``spec_source`` (the exact shape
+    ``IngestionPipelineService`` feeds it for a shipped spec): a
+    hand-built proto -- or a parse without ``spec_source`` -- lacks the
+    verbatim ``spec:<resource>`` tag and would not reproduce the shadow.
+    """
+    _fixtures = Path(__file__).parent / "fixtures" / "openapi"
+    _petstore_text = (_fixtures / "petstore_30.yaml").read_text()
+    # Mirror pipeline.py's parse call for a shipped spec: the uri *is* the
+    # ``spec:``-prefixed label, and the content is passed inline (no fetch).
+    _spec_uri = "spec:petstore_30.yaml"
+    operations = parse_openapi(_spec_uri, spec_source=_spec_uri, content=_petstore_text)
+
+    common_kwargs: dict[str, Any] = {
+        "product": "petstore",
+        "version": "3.0",
+        "impl_id": "petstore-rest",
+        "spec_source": _spec_uri,
+        "operations": operations,
+        "embedding_service": stub_embedding_service,
+    }
+
+    first_result = await register_ingested_operations(**common_kwargs)
+    assert first_result.inserted_count == len(operations) > 0
+
+    # The persisted row carries the doubled marker -- the exact condition
+    # that shadowed the first-match extractor. Assert it so this test
+    # stays anchored to the real bug regime if the persist path changes.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.product == "petstore")
+                )
+            )
+            .scalars()
+            .first()
+        )
+    assert row is not None
+    assert "spec:petstore_30.yaml" in row.tags  # verbatim parser tag
+    assert "spec:spec:petstore_30.yaml" in row.tags  # upsert marker
+
+    # Second ingest of the same catalog source is a no-op, not a 400.
+    second_result = await register_ingested_operations(**common_kwargs)
+    assert second_result.inserted_count == 0
+    assert second_result.skipped_count == len(operations)
+
+
 # ---------------------------------------------------------------------------
 # Caller-owned session
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Fixes non-idempotent catalog re-ingest (#2274).** A second
  `meho connector ingest --catalog <product>/<version>` on the same deploy
  400'd with `op_id_collision` against the rows the *first* ingest just
  wrote, which made the unbacked-composite remediation loop (it prints
  exactly that command) circular.
- **Root cause is extractor tag-shadowing, not old-vs-new row labels.**
  The catalog shipped-spec on-ramp labels its source `spec:<resource>`
  (#1975); the parser persists that verbatim as a row tag and the upsert
  appends its own `spec:<spec_source>` marker, so a catalog row carries
  *two* `spec:` tags. `_extract_persisted_spec_source` returned the
  **first** matching tag — the verbatim one, one `spec:` layer short of
  the real source — so the cross-source collision guard mismatched a row
  against itself.
- **Compare-time fix, zero data migration.** The extractor now reads the
  authoritative **last** (marker) tag, and the guard compares on the
  prefix-normalized *logical* spec identity (`_normalize_spec_source`).
  The guard was extracted into `_check_cross_source_collision` to keep
  `upsert_one_operation` small.
- **Invariants preserved.** Genuine cross-source `op_id` clashes
  (`file:///a.yaml` vs `spec:b.yaml`) still fire; the `OpIdCollision`
  payload still carries the *raw* persisted/incoming labels for
  diagnostics. No route/schema change — the OpenAPI snapshot is unchanged.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/.../ingest/_upsert.py` — clean
- [x] `code-quality.py --diff` — 0 blockers (the one remaining warning,
  `build_upsert_context` 7-args, is pre-existing debt not touched here)
- [x] **AC1 — e2e non-dry-run, twice:** new
  `test_ingest_catalog_entry_shipped_spec_reingest_is_idempotent` POSTs a
  shipped-spec catalog ingest twice without `dry_run`; the second returns
  `200` with `inserted_count == 0` (`skipped_count == 1`), not `400`.
- [x] **AC2 — parser-based unit:** new
  `test_reingest_with_spec_prefixed_source_is_idempotent` parses the
  petstore fixture through `parse_openapi` with a `spec:`-prefixed source
  (a hand-built proto would not reproduce the shadow) and re-registers;
  the second call skips. Asserts both `spec:petstore_30.yaml` (verbatim)
  and `spec:spec:petstore_30.yaml` (marker) tags exist to stay anchored
  to the real bug regime.
- [x] **AC3 — cross-source still collides:**
  `test_op_id_collision_across_calls_with_different_spec_sources_raises`
  stays green (asserts `existing_spec_source == "petstore.yaml"`).
- [x] **AC4 — MCP shared seam:** the `meho.connector.ingest` MCP tool
  calls the same `IngestionPipelineService.ingest` →
  `register_ingested_operations` → `upsert_one_operation` seam the fix
  lives at (`mcp/tools/connector_ingest.py:300`). The MCP test suite
  mocks the pipeline boundary (canned results), so the behavioral proof
  is the REST e2e + register-level unit test; `test_mcp_tools_connector_ingest.py`
  stays green (144 + 1 new).
- [x] **AC5 — raw labels:** `OpIdCollision` still receives the raw
  extracted + raw incoming labels (verified: reverting only `_upsert.py`
  reproduces `existing_spec_source:"_fixture_minimal.yaml"` /
  `incoming_spec_source:"spec:_fixture_minimal.yaml"` in the 400 body).
- [x] **AC6 — no OpenAPI delta:** `make snapshot-openapi` produced no diff
  on `cli/api/openapi.json`.
- [x] Regression sweep: `test_operations_register_ingested.py`,
  `test_api_v1_connectors_ingest.py`, `test_mcp_tools_connector_ingest.py`
  (145 passed) + ingest/catalog/parser/pipeline/registration files
  (309 passed, 1 skipped). Integration ingest tests skip in-sandbox
  (Docker/testcontainers; run in CI).

## Out of scope

- Healing the cosmetic `spec:spec:<resource>` double tag on existing rows
  (baked into embedding text; rewriting forces a re-embed) — the skip
  path leaves tags untouched.
- Same-file-different-source refresh semantics (a `file:///` re-host
  taking over `spec:`-labeled rows) — a deliberate collision per #403;
  needs a supersede/`--replace` story if ever wanted.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2274
