### PR TITLE
fix(ui): guard shared modal controller against htmx's detached pre-swap target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — shared modal controller ignores htmx's detached pre-swap target
+
+- **The app-shell modal controller no longer calls ``showModal()`` on a
+  disconnected dialog after an ``outerHTML`` swap** (#2242). htmx 2.0.9
+  dispatches ``htmx:afterSwap`` with ``detail.target`` still pointing at the
+  PRE-swap element, which an ``outerHTML`` swap already detached — the runbook
+  run driver's abort / reassign / advance forms target ``#runbook-run-step``
+  with ``hx-swap="outerHTML"``. The shared controller scanned that stale
+  subtree and reopened the old, closed descendant dialog (the admin-only
+  reassign dialog on the abort repro; the assignee's advance dialog on every
+  Advance click), throwing an uncaught ``InvalidStateError`` into the console.
+  A one-line ``isConnected`` guard on the scan root skips a detached root and
+  is behaviour-preserving for the console's ``innerHTML``-into-a-stable-
+  container auto-open pattern, which always delivers a connected root. Console
+  noise only; the abort / advance actions were always functional.
+
 ### Fixed — exactly-one-resumer claim for run-bound approvals (#2293)
 
 - **A run-bound approval now executes its gated op exactly once — no silent

--- a/backend/src/meho_backplane/ui/static/src/app/modal-dialogs.js
+++ b/backend/src/meho_backplane/ui/static/src/app/modal-dialogs.js
@@ -79,7 +79,24 @@
   // descendant of a container target and we must not double-drive it.
   document.body.addEventListener("htmx:afterSwap", function (event) {
     var root = (event.detail && event.detail.target) || event.target;
-    if (!root || typeof root.querySelectorAll !== "function") {
+    // htmx 2.0.9 dispatches ``htmx:afterSwap`` with ``detail.target`` still
+    // referencing the PRE-swap element. An ``outerHTML`` swap (e.g. the
+    // runbook run driver's abort / reassign / advance forms, which target
+    // ``#runbook-run-step`` with ``hx-swap="outerHTML"``) has already replaced
+    // and DETACHED that element, so ``detail.target`` is now disconnected from
+    // the document. Scanning its stale subtree would find the old, closed
+    // descendant dialogs and call ``showModal()`` on a dialog that is no longer
+    // connected -- which throws ``InvalidStateError``. Bail on a detached root:
+    // the freshly swapped-in replacement ships its own dialogs closed and
+    // button-driven, so there is nothing here to auto-open. This handler's
+    // auto-open pattern always swaps modal fragments via ``innerHTML`` into a
+    // STABLE container, whose ``detail.target`` stays connected, so the
+    // ``isConnected`` check is a no-op for it.
+    if (
+      !root ||
+      typeof root.querySelectorAll !== "function" ||
+      !root.isConnected
+    ) {
       return;
     }
     var dialogs = root.querySelectorAll("dialog.modal");

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -382,6 +382,31 @@ def test_modal_controller_script_opens_injected_dialog_on_swap() -> None:
     )
 
 
+def test_modal_controller_script_guards_detached_swap_target() -> None:
+    """The controller skips a detached scan root (htmx 2.0.9 pre-swap target).
+
+    ``htmx:afterSwap`` fires with ``detail.target`` still pointing at the
+    PRE-swap element. An ``outerHTML`` swap (the runbook run driver's
+    abort / reassign / advance forms target ``#runbook-run-step`` with
+    ``hx-swap="outerHTML"``) has already detached that element, so scanning its
+    stale subtree and calling ``showModal()`` on a now-disconnected dialog
+    throws ``InvalidStateError``. An ``isConnected`` guard on the scan root
+    suppresses that while leaving the connected-container auto-open path
+    untouched (#2242).
+    """
+    script = (static_src_dir() / "app" / "modal-dialogs.js").read_text(encoding="utf-8")
+    assert "isConnected" in script, (
+        "the controller must skip a detached scan root so an outerHTML swap "
+        "cannot showModal() a disconnected dialog (InvalidStateError)"
+    )
+    # The guard belongs on the afterSwap scan-root early return, in the same
+    # condition as the existing querySelectorAll capability check.
+    assert re.search(r"querySelectorAll[^)]*isConnected", script), (
+        "isConnected must gate the htmx:afterSwap scan-root early return, "
+        "alongside the querySelectorAll check"
+    )
+
+
 def test_base_template_loads_modal_controller_outside_component_scripts() -> None:
     """``base.html`` ships the modal controller on every page (#1803).
 


### PR DESCRIPTION
## Summary

- htmx 2.0.9 dispatches `htmx:afterSwap` with `detail.target` still pointing at
  the **pre-swap** element; an `outerHTML` swap has already detached it. The
  shared app-shell modal controller (`app/modal-dialogs.js`) re-queries dialogs
  on every swap and scanned that stale, disconnected subtree, calling
  `showModal()` on the old closed descendant dialog — throwing an uncaught
  `InvalidStateError` into the console.
- The thrower on the abort repro is the admin-only **reassign** dialog (closed
  sibling; the still-`open` abort dialog is skipped by the existing `!dialog.open`
  guard). The same error is code-predicted for the run's **assignee on every
  Advance click**, and on account-sessions revoke with ≥2 sessions.
- Fix: a one-line `isConnected` guard on the `htmx:afterSwap` scan-root early
  return, so a detached root is skipped. Behaviour-preserving for the console's
  `innerHTML`-into-a-stable-container auto-open pattern (always a connected
  root); only the `outerHTML` self-detaching swap zones are newly skipped, and
  their freshly swapped-in replacements ship dialogs closed + button-driven.
- Console noise only — the abort / advance actions were always functional.

## Why `isConnected` (verified against the vendored htmx 2.0.9 source)

- `Me()` (the `outerHTML` swap) filters the old target out of `settleInfo.elts`,
  inserts the new nodes, then `t.remove()` **detaches** the old target.
- `afterSwap` is dispatched on the new elements but carries a shared `detail`
  (`eventInfo`); `responseInfo.target` (`= detail.target`) is pinned to the
  **pre-swap** resolved target and is never reassigned post-swap.
- So `detail.target` is the detached `#runbook-run-step`. A detached element
  still exposes `querySelectorAll`, which is exactly why the existing capability
  check missed it; `isConnected` is the precise still-attached test (the modern
  form of the report's Option A `document.contains`).

## Test plan

- [x] `uv run pytest tests/test_ui_templates.py` — 36 passed (adds
  `test_modal_controller_script_guards_detached_swap_target`, a source-text
  assertion pinning the guard, matching the existing `#1803` showModal wiring
  asserts).
- [x] `uv run mypy src/` — clean (592 files).
- [x] `uv run ruff check src/ tests/` + `ruff format --check` — clean.
- [x] `.claude/hooks/code-quality.py --diff` — pass.
- [x] No route/model touched → **no OpenAPI snapshot delta** (AC #4).
- [ ] **Manual/browser spot-check (AC #3 — needs a running console + tenant_admin + an active run):**
  1. As a tenant_admin, open a runbook run; open the DevTools console.
  2. Click **Abort run**, enter a reason, submit. Expect: the step re-renders
     (`#runbook-run-step` `outerHTML` swap), the abort modal closes, and **no
     `InvalidStateError`** is logged (previously the closed reassign sibling
     threw).
  3. As the run's **assignee**, click **Advance**. Expect the step to advance
     with **no `InvalidStateError`** (the code-predicted steady-state noise).

## Out of scope

- Restructuring run-driver swap targets / hoisting dialogs (report Options B/C).
- The Alpine-pattern dialogs (Deprecate / Delete / Publish) — different
  mechanism, no defect.
- Upgrading vendored htmx (the pre-swap `detail.target` behaviour is upstream
  semantics this guard accommodates).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2242
