### PR TITLE
feat(charts): first-class MEHO_TARGET_SSRF_ALLOWLIST chart value (#2240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — first-class Helm chart value for the target-SSRF allowlist (#2240)
+
+- **The target-destination SSRF allowlist is now a typed Helm chart
+  value** (#2240). v0.20.0 shipped the default-deny target-destination
+  SSRF guard whose only opt-out is the `MEHO_TARGET_SSRF_ALLOWLIST` env
+  var ("Deployment impact — action likely required"), but the chart had
+  no surface for it: operators had to reach for the untyped `extraEnv`
+  escape hatch, which `values.schema.json` does not validate and
+  `helm show values` does not surface. A new `config.targetSsrfAllowlist`
+  value (schema-typed optional string, default `""`) now renders into
+  `MEHO_TARGET_SSRF_ALLOWLIST` on the backplane ConfigMap — injected
+  into the container via the existing `envFrom.configMapRef` — so a
+  scoped allowlist (e.g. `"10.0.0.0/8,192.168.0.0/16"` for a deploy that
+  registers on-prem appliances on RFC 1918 space) is a first-class,
+  `helm show values`-discoverable setting. The default `""` is a genuine
+  no-op that keeps the guard fully on (default-deny), so existing
+  installs are unchanged. Chart-only — the guard itself is untouched.
+  (#2240)
+
 ### Changed — scheduler `fire_at` tick-quantization latency documented on the API schema (#2245)
 
 - **The scheduler's fire-time latency window is now part of the API contract,

--- a/deploy/charts/meho/templates/configmap.yaml
+++ b/deploy/charts/meho/templates/configmap.yaml
@@ -105,6 +105,17 @@ data:
   # `docs/cross-repo/reverse-proxy-contract.md` for the trust
   # contract.
   FORWARDED_ALLOW_IPS: {{ .Values.config.forwardedAllowIps | quote }}
+  # v0.20.0 (PR #2191) target-destination SSRF guard. The backplane
+  # refuses to register or dial a target that resolves to a non-public
+  # address; this env var is the operator's scoped opt-out. Read per
+  # request from the environment by
+  # `backend/src/meho_backplane/targets/ssrf_guard.py`
+  # (`TARGET_SSRF_ALLOWLIST_ENV`) — NOT via settings.py. Rendered
+  # unconditionally: the default `""` is a genuine no-op (the guard
+  # stays default-deny). Comma-separated CIDRs / bare IPs / hostname
+  # literals. See `deploy/charts/meho/values.yaml`
+  # (`config.targetSsrfAllowlist`) and `docs/codebase/target-ssrf-guard.md`.
+  MEHO_TARGET_SSRF_ALLOWLIST: {{ .Values.config.targetSsrfAllowlist | quote }}
   # G0.8-T4 (#633) — the /mcp router is mounted unconditionally; an MCP
   # request's Bearer token must carry `aud == MCP_RESOURCE_URI`. The
   # documented default is `${BACKPLANE_URL}/mcp`, but on a deploy that

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -261,6 +261,10 @@
           "type": "string",
           "minLength": 1,
           "description": "Comma-separated IPs / CIDRs uvicorn trusts as upstream proxies for `X-Forwarded-Proto` / `X-Forwarded-For` parsing (rendered into the `FORWARDED_ALLOW_IPS` env var; uvicorn reads it natively). Fixes the HTTPS→HTTP redirect downgrade behind a TLS-terminating Ingress (Issue #730, Signal #3, RDC dogfood 2026-05-20). Default `127.0.0.1` matches uvicorn's secure default and fails-closed in-cluster (the Ingress controller's pod IP is never the loopback). Operators MUST override for production with the Ingress controller's pod CIDR (e.g. `10.42.0.0/16` for the RKE2 default). `*` disables the allow-list and is acceptable only for ephemeral CI / single-tenant labs where every connecting peer is the cluster's own proxy. See `docs/cross-repo/reverse-proxy-contract.md`."
+        },
+        "targetSsrfAllowlist": {
+          "type": "string",
+          "description": "Target-destination SSRF allowlist exemptions, rendered into the `MEHO_TARGET_SSRF_ALLOWLIST` env var the backplane guard reads per request (`backend/src/meho_backplane/targets/ssrf_guard.py`; v0.20.0, PR #2191). Comma-separated CIDR ranges (`10.0.0.0/8`), bare IPs (`192.168.7.10`), and/or hostname literals (`vcenter.lab.internal`); whitespace around commas is ignored. Default `\"\"` keeps the default-deny guard fully on — deliberately absent from `config.required` and carrying no `minLength` so the empty default validates on every install (copying the adjacent `forwardedAllowIps` `minLength: 1` would break it). MEHO is on-prem, so a deploy that registers appliances on RFC 1918 space MUST allowlist those ranges (e.g. `10.0.0.0/8,192.168.0.0/16`); a scoped opt-in, never a global off-switch. Value shape is validated at the backend — a malformed CIDR fails loudly at runtime naming the offending token. See CHANGELOG v0.20.0 (\"Deployment impact — action likely required\") and `docs/codebase/target-ssrf-guard.md`."
         }
       }
     },

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -282,6 +282,28 @@ config:
   # `docs/cross-repo/reverse-proxy-contract.md` for the operator-
   # side trust contract.
   forwardedAllowIps: "127.0.0.1"
+  # -- Target-destination SSRF allowlist (v0.20.0, PR #2191). The
+  # backplane refuses to register or dial a target whose host is (or
+  # resolves to) a non-public address — loopback, RFC 1918, link-local,
+  # `169.254.169.254` (cloud metadata), CGNAT, the IPv6 analogues —
+  # classic server-side request forgery protection. This value is the
+  # operator's scoped opt-out: it renders into the
+  # `MEHO_TARGET_SSRF_ALLOWLIST` env var the guard reads per request
+  # (`backend/src/meho_backplane/targets/ssrf_guard.py`), NOT via
+  # settings.py. Comma-separated exemptions: CIDR ranges (`10.0.0.0/8`),
+  # bare IPs (`192.168.7.10`), and/or hostname literals
+  # (`vcenter.lab.internal`); whitespace around commas is ignored.
+  #
+  # Default `""` keeps the guard fully on (default-deny) — a genuine
+  # no-op render. MEHO is on-prem: registering appliances on private
+  # space is the normal case, so a deploy that manages LAN targets MUST
+  # allowlist the ranges those appliances live on, e.g.
+  # `"10.0.0.0/8,192.168.0.0/16"`. A scoped opt-in is the intended
+  # posture, never a global off-switch; a malformed CIDR fails loudly at
+  # runtime naming the offending token. See CHANGELOG v0.20.0
+  # ("Deployment impact — action likely required") and
+  # `docs/codebase/target-ssrf-guard.md`.
+  targetSsrfAllowlist: ""
 
 # Memory layer (G5.2 #374). The backplane ships an in-process
 # memory-expiry sweeper that runs in the FastAPI lifespan and removes

--- a/deploy/values-examples/values-rdc-example.yaml
+++ b/deploy/values-examples/values-rdc-example.yaml
@@ -141,6 +141,15 @@ config:
   # `docs/cross-repo/reverse-proxy-contract.md` for the per-cluster
   # recommended values and the diagnostic walk.
   forwardedAllowIps: "10.42.0.0/16"
+  # Target-destination SSRF allowlist (v0.20.0, PR #2191). The default-
+  # deny guard refuses to register or dial a target on non-public space,
+  # but the RDC lab registers on-prem appliances on RFC 1918 ranges as a
+  # matter of course — so scope-open the guard to those ranges or every
+  # target create / dispatch is refused. Comma-separated CIDRs / bare
+  # IPs / hostname literals; a malformed CIDR fails loudly at runtime.
+  # Leave `""` on a chassis-only lab that dials no private-range targets.
+  # See `docs/codebase/target-ssrf-guard.md`.
+  targetSsrfAllowlist: "10.0.0.0/8,192.168.0.0/16"
 
 postgres:
   # Cluster-internal Postgres on rke2-infra (per Goal #11 cross-repo deps).

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -20,7 +20,10 @@ resources that make up a running backplane:
 - Service — ClusterIP front-door for the Deployment, target port `http`.
 - Ingress — TLS-enabled external entry with cert-manager annotations.
 - ConfigMap — non-secret env (Keycloak URLs, Vault address, pool sizes,
-  `FORWARDED_ALLOW_IPS` for the uvicorn proxy-header trust list).
+  `FORWARDED_ALLOW_IPS` for the uvicorn proxy-header trust list, and
+  `MEHO_TARGET_SSRF_ALLOWLIST` — the operator-scoped opt-out for the
+  target-destination SSRF guard, set via `config.targetSsrfAllowlist`
+  (v0.20.0; see `docs/codebase/target-ssrf-guard.md`)).
 - ServiceAccount — Pod identity, `automountServiceAccountToken: false`.
 - NetworkPolicy — default-deny ingress + explicit egress allow-list to
   Postgres, Vault, Keycloak, the broadcast subchart, and CoreDNS only.

--- a/docs/codebase/target-ssrf-guard.md
+++ b/docs/codebase/target-ssrf-guard.md
@@ -115,6 +115,23 @@ Design choices:
   connector, GitHub App session client) are separate sinks outside this
   guard.
 
+## Deployment surface
+
+The allowlist env var is a first-class Helm chart value:
+`config.targetSsrfAllowlist` in `deploy/charts/meho/values.yaml` renders
+into `MEHO_TARGET_SSRF_ALLOWLIST` on the backplane ConfigMap
+(`templates/configmap.yaml`), which the Deployment injects into the
+container via `envFrom.configMapRef` — so a populated value reaches the
+guard with no `extraEnv` escape hatch. It is schema-typed in
+`values.schema.json` as a plain optional string: deliberately absent
+from `config.required` and carrying no `minLength`, so the safe default
+`""` validates on every install (and surfaces under `helm show values`).
+That default renders `MEHO_TARGET_SSRF_ALLOWLIST: ""`, a genuine no-op
+that keeps the guard fully on. See CHANGELOG v0.20.0 ("Deployment
+impact — action likely required") and
+`deploy/values-examples/values-rdc-example.yaml` for a populated
+private-range example.
+
 ## References
 
 - Task: evoila-bosnia/meho-internal#153 (parent backlog #101, goal #87)


### PR DESCRIPTION
## Summary

- v0.20.0 shipped the default-deny **target-destination SSRF guard** (PR #2191) whose only opt-out is the `MEHO_TARGET_SSRF_ALLOWLIST` env var — the release note flags **"Deployment impact (action likely required)"** — but the Helm chart had **zero surface** for it (no values key, no schema property, no ConfigMap line). Operators had to use the untyped `extraEnv` escape hatch, which `values.schema.json` does not validate and `helm show values` does not surface.
- Adds a first-class **`config.targetSsrfAllowlist`** value → schema property → `MEHO_TARGET_SSRF_ALLOWLIST` on the backplane ConfigMap. The Deployment already injects that ConfigMap via `envFrom.configMapRef`, so a populated value reaches the guard the backend reads per request (`backend/src/meho_backplane/targets/ssrf_guard.py`).
- Mirrors the adjacent **`forwardedAllowIps`** precedent (same value shape, same ConfigMap→env path) **minus** its `required` membership and `minLength: 1` — a plain optional string with default `""`, so the empty default (a genuine no-op that keeps the guard fully on / default-deny) validates on every install.
- **Chart-only** — the guard itself is untouched; the backend already parses `MEHO_TARGET_SSRF_ALLOWLIST`. No backend change, no OpenAPI snapshot delta.

## Files

- `deploy/charts/meho/values.yaml` — `config.targetSsrfAllowlist: ""` after `forwardedAllowIps`, comment mirroring house style.
- `deploy/charts/meho/values.schema.json` — `targetSsrfAllowlist` under `config.properties` (plain `string` + description; **not** in `config.required`, **no** `minLength`).
- `deploy/charts/meho/templates/configmap.yaml` — `MEHO_TARGET_SSRF_ALLOWLIST: {{ .Values.config.targetSsrfAllowlist | quote }}` after `FORWARDED_ALLOW_IPS`, comment citing `targets/ssrf_guard.py` (not settings.py).
- `deploy/values-examples/values-rdc-example.yaml` — populated example (`"10.0.0.0/8,192.168.0.0/16"` — the RDC lab registers RFC-1918 appliances).
- `docs/codebase/target-ssrf-guard.md` — new "Deployment surface" section naming the chart key.
- `docs/codebase/devops.md` — ConfigMap env catalogue mentions the new var.
- `CHANGELOG.md` — `[Unreleased]` entry under a unique `### Added —` header.

## Test plan

Verified locally with Helm (CI pins v3.16.4; JSON-Schema draft-07 validation behaves identically):

- [x] **`helm lint`** with the CI override set — `1 chart(s) linted, 0 chart(s) failed` (the new schema key is accepted under `config`'s `additionalProperties: false`).
- [x] **AC1 — default is an empty no-op:** `helm template` (defaults) renders `MEHO_TARGET_SSRF_ALLOWLIST: ""`; `helm show values` surfaces `config.targetSsrfAllowlist: ""`.
- [x] **AC2 — populated value reaches the backplane env:** `helm template -f <overlay with targetSsrfAllowlist: "10.0.0.0/8,192.168.0.0/16">` renders `MEHO_TARGET_SSRF_ALLOWLIST: "10.0.0.0/8,192.168.0.0/16"` on ConfigMap `test-meho-config`, which the Deployment consumes via `envFrom.configMapRef.name: test-meho-config` (envFrom→configMapRef path). `docs/codebase/target-ssrf-guard.md` already covers the create + dispatch honoring.
- [x] **AC3 — schema:** setting the key passes validation; the key is absent from `config.required`; an install with no key still passes (default `""` validates; `additionalProperties` unaffected).
- [x] **AC4 — chart CI non-regression:** rendered manifests parse as valid multi-doc YAML (kubeconform substitute — kubeconform runs in CI); the existing chart.yml grep gates still hold (`BACKPLANE_URL: "https://meho.test"`, `MCP_RESOURCE_URI: "https://meho.test/mcp"` still derive). No OpenAPI snapshot involvement.
- [x] **AC5 — values-rdc-example** carries the populated example.
- [x] `git diff --check` clean; pre-commit hooks (trailing-whitespace / EOF / check-yaml / check-json / gitleaks / Conventional Commit) all pass; commit DCO-signed.

Note: `--set config.targetSsrfAllowlist=10.0.0.0/8,192.168.0.0/16` fails because Helm's `--set` splits on commas — use `--set-string`/escaped commas or a values file (the real operator path, as in `values-rdc-example.yaml`). This is a CLI-quoting artifact, not a chart issue.

## Out of scope

- Any change to the guard itself (working as documented; default-deny preserved).
- A `NOTES.txt` post-install warning for an empty allowlist on private-range deploys (beyond the binary config-surface ask; file separately if ops want a deploy-time signal).
- Sibling #2275's watchdog/timeout env var — a different setting, not added here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2240


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm configuration for an SSRF target allowlist using `config.targetSsrfAllowlist`.
  * Supports comma-separated IPs, CIDR ranges, and hostname literals.
  * Defaults to an empty value, preserving default-deny SSRF protection.

* **Documentation**
  * Updated deployment guidance, schema descriptions, example values, and the changelog with configuration details and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->