### PR TITLE
fix(ingest): watchdog async ingest jobs to a terminal state + bound LLM client + job-id log binding (#2275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,36 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — async ingest jobs always reach a terminal state (watchdog + bounded LLM client + job-id log binding) (#2275)
+
+- **A wedged async connector ingest can no longer sit at `status=running`
+  forever** (#2275). An ingest job whose pipeline hit a *never-completing
+  await* — a starved `to_thread` executor, a DB connection that never
+  acquires, or a grouping LLM call pending on the Anthropic SDK's default
+  10-min-read × 2-retry ceiling (~30 min wall-clock) — was stranded at
+  `running` until a pod restart cleared the in-memory registry, even
+  though the identical *sync* request returned a clean 400. (The
+  exception boundary was already maximal — an `OpIdCollision`-raising
+  pipeline does flip to `failed` — so the earlier "widen the try/except"
+  framing was a no-op; the real defect was the missing watchdog.)
+  `run_ingest_job` now time-boxes the whole job body — the pipeline call
+  **and** the post-run dispatchability probe — inside
+  `asyncio.timeout`; at the deadline the job flips to `failed` with
+  `error_class="TimeoutError"`. The budget defaults to 30 min and is
+  env-overridable via `INGEST_JOB_TIMEOUT_SECONDS`. Cancellation cannot
+  interrupt an already-running `to_thread` OS thread, so the guarantee is
+  job-state terminality, not thread reclamation.
+- **The grouping LLM client is now constructed with an explicit request
+  timeout + retry ceiling** (120 s × 1 retry) instead of the SDK
+  defaults, so a hung grouping call fails fast rather than consuming the
+  watchdog budget; the fail-closed 503 contract for a missing
+  `ANTHROPIC_API_KEY` (#1386) is unchanged.
+- **Pipeline log events now carry `ingest_job_id`.** The job id is bound
+  via structlog `contextvars` (not just the job coroutine's own logger),
+  so the configured `merge_contextvars` processor stamps it onto pipeline
+  events (`ingestion_pipeline_start` &c.) — a job-id-filtered log grep is
+  no longer blind to the pipeline. No schema or route change. (#2275)
+
 ### Changed — scheduler `fire_at` tick-quantization latency documented on the API schema (#2245)
 
 - **The scheduler's fire-time latency window is now part of the API contract,

--- a/backend/src/meho_backplane/operations/ingest/anthropic_client.py
+++ b/backend/src/meho_backplane/operations/ingest/anthropic_client.py
@@ -40,7 +40,7 @@ tenant + egress story the build-time grouping pass does not have today).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Final
 
 import structlog
 
@@ -59,6 +59,23 @@ __all__ = [
 
 _log = structlog.get_logger(__name__)
 
+#: Per-request transport timeout (seconds) for the grouping-pass client.
+#: The Anthropic SDK's default is a 10-min *read* timeout, and with the
+#: default ``max_retries`` a timed-out request is retried, so a hung
+#: grouping call can pend on the order of ~30 min wall-clock -- long
+#: enough to outlive the ingest-job watchdog's default budget and the
+#: single wedge candidate that inherently spans "10+ minutes with the
+#: event loop responsive". Pin it well below the watchdog so a stuck LLM
+#: call fails the grouping request (surfaced as the job's failure) rather
+#: than silently consuming the whole watchdog budget.
+_INGEST_LLM_TIMEOUT_SECONDS: Final[float] = 120.0
+
+#: Retry ceiling for the grouping-pass client. One retry (vs the SDK
+#: default of 2) keeps a transient 429/5xx recoverable while bounding the
+#: worst-case wall-clock at ``_INGEST_LLM_TIMEOUT_SECONDS * (1 + retries)``
+#: rather than the SDK default's ~30 min.
+_INGEST_LLM_MAX_RETRIES: Final[int] = 1
+
 
 class AnthropicMessagesLlmClient:
     """:class:`LlmClient` backed by the Anthropic Messages API.
@@ -70,9 +87,13 @@ class AnthropicMessagesLlmClient:
     Protocol the ``ask_docs`` answer legs use (``generate_structured_json``
     -> text + ``stop_reason``, with optional schema-forced output). Retry/
     backoff and transport timeouts are owned by the injected
-    :class:`anthropic.AsyncAnthropic` client (the SDK retries 429 /
-    5xx / connection errors with exponential backoff by default), so
-    this adapter holds no retry state of its own.
+    :class:`anthropic.AsyncAnthropic` client, so this adapter holds no
+    retry state of its own. :func:`build_anthropic_ingest_llm_client`
+    constructs that client with an **explicit** request timeout +
+    retry ceiling (:data:`_INGEST_LLM_TIMEOUT_SECONDS` /
+    :data:`_INGEST_LLM_MAX_RETRIES`) rather than the SDK defaults, whose
+    10-min read timeout with retried requests let a hung grouping call
+    pend ~30 min and outlive the ingest-job watchdog.
 
     One instance wraps one SDK client + one resolved model id; the
     grouping pipeline builds a fresh instance per ingest run (see
@@ -195,4 +216,15 @@ def build_anthropic_ingest_llm_client() -> LlmClient:
         )
     _, model = _split_model_id(settings.agent_default_model)
     _log.info("ingest_llm_client_built", model=model)
-    return AnthropicMessagesLlmClient(client=AsyncAnthropic(api_key=api_key), model=model)
+    # Pin an explicit request timeout + retry ceiling: the SDK defaults
+    # (10-min read timeout, retried) let a hung grouping call pend ~30 min
+    # and silently consume the ingest-job watchdog budget. Bounding them
+    # here fails the grouping request fast instead.
+    return AnthropicMessagesLlmClient(
+        client=AsyncAnthropic(
+            api_key=api_key,
+            timeout=_INGEST_LLM_TIMEOUT_SECONDS,
+            max_retries=_INGEST_LLM_MAX_RETRIES,
+        ),
+        model=model,
+    )

--- a/backend/src/meho_backplane/operations/ingest/jobs.py
+++ b/backend/src/meho_backplane/operations/ingest/jobs.py
@@ -42,12 +42,13 @@ enough scrollback.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 import uuid
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Final, Literal
 from uuid import UUID
 
 import structlog
@@ -71,6 +72,56 @@ _log = structlog.get_logger(__name__)
 #: (~handful of ingests per release window) while keeping the
 #: per-pod memory footprint trivial.
 _MAX_JOBS_RETAINED = 256
+
+#: Fallback wall-clock watchdog budget (seconds) for a single async
+#: ingest job. Matches the Anthropic-family agent-approval wait default
+#: (30 min): comfortably longer than a legitimate large-spec run (a
+#: 7.5 MB / 1275-op vmware spec is tens of seconds of CPU + DB) yet an
+#: order of magnitude below the ~30 min wall-clock a hung grouping call
+#: could otherwise reach on the Anthropic SDK's default 10-min-read,
+#: 2-retry ceiling. Past this budget the job body is cancelled and the
+#: row flips to ``failed`` (``error_class="TimeoutError"``) rather than
+#: sitting at ``running`` until a pod restart clears it.
+_DEFAULT_INGEST_JOB_TIMEOUT_SECONDS: Final[float] = 1800.0
+
+
+def _load_ingest_job_timeout_seconds() -> float:
+    """Read the watchdog budget from ``INGEST_JOB_TIMEOUT_SECONDS``.
+
+    Env-overridable (a slow shared executor / very large fleet of specs
+    may want a longer ceiling) with a sane default. Parsed defensively —
+    a malformed or non-positive value falls back to
+    :data:`_DEFAULT_INGEST_JOB_TIMEOUT_SECONDS` with a warning rather
+    than crashing the ingest package at import, because a timeout typo
+    should not take the whole backplane down on boot.
+    """
+    raw = os.environ.get("INGEST_JOB_TIMEOUT_SECONDS")
+    if raw is None:
+        return _DEFAULT_INGEST_JOB_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        _log.warning(
+            "ingest_job_timeout_env_invalid",
+            raw=raw,
+            fallback_seconds=_DEFAULT_INGEST_JOB_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_INGEST_JOB_TIMEOUT_SECONDS
+    if value <= 0:
+        _log.warning(
+            "ingest_job_timeout_env_non_positive",
+            value=value,
+            fallback_seconds=_DEFAULT_INGEST_JOB_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_INGEST_JOB_TIMEOUT_SECONDS
+    return value
+
+
+#: Resolved watchdog budget, read once at import from the environment.
+#: ``run_ingest_job`` reads this module global at call time (not as a
+#: default-arg snapshot) so a test can shrink it via the ``timeout_s``
+#: parameter without monkeypatching import-time state.
+_INGEST_JOB_TIMEOUT_SECONDS: float = _load_ingest_job_timeout_seconds()
 
 #: Snapshot of an ingest run's lifecycle. The status enum lives at
 #: module scope so the route layer + tests share one source of truth
@@ -397,79 +448,107 @@ async def run_ingest_job(
     pipeline_call: Callable[[], Awaitable[IngestionPipelineResult]],
     registry: IngestJobRegistry | None = None,
     dispatchability_check: DispatchabilityCheck | None = None,
+    timeout_s: float | None = None,
 ) -> None:
     """Drive *pipeline_call* off the request thread and reconcile the job row.
 
     Background-coroutine body for the fire-and-forget shape the
-    ``POST /api/v1/connectors/ingest`` route uses. The route
-    constructs the pipeline-invocation closure (so this helper stays
-    framework-agnostic), kicks the coroutine off with
-    :func:`asyncio.create_task`, and immediately returns the 202 + job
-    handle. This helper:
+    ``POST /api/v1/connectors/ingest`` route (and the MCP ingest tool)
+    use: the caller builds the pipeline closure, kicks this off with
+    :func:`asyncio.create_task`, and immediately returns 202 + a job
+    handle. This helper reconciles the run into the in-memory job row as
+    ``succeeded`` / ``degraded`` (see :func:`_reconcile_returned_result`)
+    or ``failed`` -- the latter on any exception, including the watchdog's
+    ``TimeoutError``. The exception is swallowed (no re-raise) except
+    ``SystemExit`` / ``KeyboardInterrupt``: the 202 already went out, so
+    re-raising would only log a noisy traceback for a routine
+    operator-facing failure.
 
-    1. Runs the closure under a structlog binding tagged with
-       ``ingest_job_id`` so the log output during the long-running
-       pass is correlatable with the polling responses.
-    2. On success, applies the dispatchability postcondition (see
-       below) and flips the job to ``succeeded`` (with the structured
-       :class:`IngestionPipelineResult`) only when it holds; otherwise
-       to ``degraded``.
-    3. On any exception, flips the job to ``failed`` and records the
-       exception class + capped message. The exception is swallowed
-       (no re-raise) -- the request that started the job has already
-       returned 202, and re-raising into the asyncio default exception
-       handler would log a noisy traceback for what is now a routine
-       operator-facing failure mode.
+    Terminal-state guarantee (#2275): an exception handler alone does not
+    cover a *never-completing await* -- a starved ``to_thread`` executor,
+    a DB acquire that never returns, or a grouping LLM call pending on the
+    SDK's default ~30-min ceiling -- which would strand the job at
+    ``running`` until a pod restart clears the in-memory registry. The
+    whole body (the pipeline call **and** the post-run dispatchability
+    probe, whose own hang would otherwise strand the job) runs inside
+    ``asyncio.timeout``, budget *timeout_s* or the module default
+    :data:`_INGEST_JOB_TIMEOUT_SECONDS` (env
+    ``INGEST_JOB_TIMEOUT_SECONDS``). At the deadline the body is cancelled
+    and re-raised as ``TimeoutError`` -> ``failed``. The guarantee is
+    job-state terminality, not thread reclamation: an already-running
+    ``to_thread`` OS thread cannot be cancelled and may linger.
 
-    Dispatchability postcondition (claude-rdc-hetzner-dc#1136)
-    ---------------------------------------------------------
-
-    A pipeline coroutine that returns without raising is **not**
-    sufficient evidence the ingest succeeded: an async ``--spec`` run
-    can persist rows under a product key the dispatch surface never
-    queries (the VCF-family long↔short split, now reconciled at
-    register-time) or skip every op against a prior run, leaving the
-    catalog row ``registered, 0 ops`` and ``search_operations`` returning
-    ``connector_not_ingested``. Flipping such a job to ``succeeded``
-    reports a green run that produced nothing callable.
-
-    The postcondition is: ``inserted_count > 0`` **and**
-    *dispatchability_check* (the route's ``connector_exists`` probe under
-    the parser-derived natural key) returns ``True``. When it fails the
-    job ends ``degraded`` carrying ``error_class=
-    "ingested_not_dispatchable"``, never a bare ``succeeded``.
-    *dispatchability_check* is ``None`` only for legacy callers / tests
-    that opt out of the probe; the production route always supplies one.
-
-    The structured failure logged at :func:`structlog.get_logger`
-    INFO level preserves the diagnostic for ops dashboards even
-    though the exception itself is swallowed.
+    ``ingest_job_id`` is bound into structlog *contextvars* for the run so
+    the configured ``merge_contextvars`` processor stamps it onto every
+    event emitted under the pipeline call -- the pipeline binds only its
+    own ``connector_id`` logger, so a plain ``_log.bind`` here would leave
+    a job-id-filtered grep blind to every pipeline event. See
+    ``docs/codebase/spec-ingestion.md`` for the full narrative.
     """
     if registry is None:
         registry = get_job_registry()
-    log = _log.bind(ingest_job_id=str(job_id))
-    try:
-        result = await pipeline_call()
-    except BaseException as exc:
-        log.info(
-            "ingest_job_failed",
-            error_class=type(exc).__name__,
-            error_message=str(exc)[:512],
-        )
-        await registry.fail(job_id, error=exc)
-        # Re-raise system-exit / keyboard-interrupt class exceptions
-        # so they aren't silently swallowed -- the rest are
-        # operator-facing failure modes routed via the registry above.
-        if isinstance(exc, (SystemExit, KeyboardInterrupt)):
-            raise
-        return
+    timeout_seconds = _INGEST_JOB_TIMEOUT_SECONDS if timeout_s is None else timeout_s
+    with structlog.contextvars.bound_contextvars(ingest_job_id=str(job_id)):
+        try:
+            # Watchdog: time-box the whole body -- the pipeline call AND
+            # the post-run dispatchability probe (a real DB read whose own
+            # hang would strand the job) -- so the row always reaches a
+            # terminal state. ``asyncio.timeout`` cancels a wedged await at
+            # the deadline and re-raises it as ``TimeoutError``, which the
+            # ``except`` below routes to ``failed``.
+            async with asyncio.timeout(timeout_seconds):
+                result = await pipeline_call()
+                await _reconcile_returned_result(
+                    job_id,
+                    result=result,
+                    registry=registry,
+                    dispatchability_check=dispatchability_check,
+                )
+        except BaseException as exc:
+            _log.info(
+                "ingest_job_failed",
+                error_class=type(exc).__name__,
+                error_message=str(exc)[:512],
+            )
+            await registry.fail(job_id, error=exc)
+            # Re-raise system-exit / keyboard-interrupt class exceptions
+            # so they aren't silently swallowed -- the rest (including the
+            # watchdog ``TimeoutError``) are operator-facing failure modes
+            # routed via the registry above.
+            if isinstance(exc, (SystemExit, KeyboardInterrupt)):
+                raise
+            return
 
+
+async def _reconcile_returned_result(
+    job_id: UUID,
+    *,
+    result: IngestionPipelineResult,
+    registry: IngestJobRegistry,
+    dispatchability_check: DispatchabilityCheck | None,
+) -> None:
+    """Flip a *returned* pipeline result to ``succeeded`` or ``degraded``.
+
+    Applies the dispatchability postcondition
+    (claude-rdc-hetzner-dc#1136): a coroutine that returned without
+    raising is **not** sufficient evidence the ingest is dispatchable --
+    an async ``--spec`` run can persist rows under a product key the
+    dispatch surface never queries (the VCF-family long<->short split,
+    reconciled at register-time) or skip every op against a prior run,
+    leaving the catalog row ``registered, 0 ops``. The job ends
+    ``succeeded`` only when ``inserted_count > 0`` **and**
+    *dispatchability_check* resolves the connector (or a benign idempotent
+    zero-insert re-run); otherwise ``degraded`` carrying
+    ``error_class="ingested_not_dispatchable"`` and the counts that (did
+    not) land. *dispatchability_check* is ``None`` only for legacy callers
+    / tests that opt out; the production route always supplies one.
+    """
     degraded_reason = await _dispatchability_failure_reason(
         result=result,
         dispatchability_check=dispatchability_check,
     )
     if degraded_reason is not None:
-        log.warning(
+        _log.warning(
             "ingest_job_degraded",
             connector_id=result.connector_id,
             inserted_count=result.ingestion.inserted_count,
@@ -483,8 +562,7 @@ async def run_ingest_job(
             error=degraded_reason,
         )
         return
-
-    log.info(
+    _log.info(
         "ingest_job_succeeded",
         connector_id=result.connector_id,
         inserted_count=result.ingestion.inserted_count,

--- a/backend/tests/test_operations_ingest_anthropic_client.py
+++ b/backend/tests/test_operations_ingest_anthropic_client.py
@@ -90,6 +90,46 @@ def test_factory_accepts_bare_model_id(monkeypatch: pytest.MonkeyPatch) -> None:
     assert client._model == "claude-haiku-4-5"
 
 
+def test_factory_constructs_client_with_explicit_timeout_and_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The grouping-pass ``AsyncAnthropic`` is built with explicit bounds (#2275).
+
+    The SDK defaults (10-min read timeout, retried) let a hung grouping
+    call pend ~30 min and outlive the ingest-job watchdog. The factory
+    must pass explicit ``timeout`` + ``max_retries`` so a stuck LLM call
+    fails fast instead of silently consuming the watchdog budget. Patch
+    the SDK constructor (function-local ``from anthropic import
+    AsyncAnthropic``) and assert the kwargs.
+    """
+    import anthropic
+
+    from meho_backplane.operations.ingest.anthropic_client import (
+        _INGEST_LLM_MAX_RETRIES,
+        _INGEST_LLM_TIMEOUT_SECONDS,
+    )
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-key-for-ingest-test")
+    get_settings.cache_clear()
+
+    captured: dict[str, object] = {}
+
+    class _FakeAsyncAnthropic:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(anthropic, "AsyncAnthropic", _FakeAsyncAnthropic)
+
+    client = build_anthropic_ingest_llm_client()
+
+    assert isinstance(client, AnthropicMessagesLlmClient)
+    # Explicit bounds pinned to the module constants (not the SDK defaults).
+    assert captured["timeout"] == _INGEST_LLM_TIMEOUT_SECONDS
+    assert captured["max_retries"] == _INGEST_LLM_MAX_RETRIES
+    # The fail-closed key contract is unchanged: the key is still forwarded.
+    assert captured["api_key"] == "fake-key-for-ingest-test"
+
+
 # ---------------------------------------------------------------------------
 # Adapter: generate_json -> Messages API
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_ingest_jobs.py
+++ b/backend/tests/test_operations_ingest_jobs.py
@@ -29,7 +29,12 @@ side of the same task).
 
 from __future__ import annotations
 
+import asyncio
+import time
+
 import pytest
+import structlog
+from structlog.testing import capture_logs
 
 from meho_backplane.operations.ingest import (
     IngestionPipelineResult,
@@ -245,6 +250,124 @@ async def test_raising_pipeline_still_fails() -> None:
     assert stored.error is not None and "spec parse blew up" in stored.error
     assert stored.result is None
     assert probe_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_wedged_pipeline_times_out_to_failed() -> None:
+    """A never-returning ``pipeline_call`` is watchdog-failed, not left ``running``.
+
+    The terminal-state guarantee (#2275): an await that never resolves
+    (a starved ``to_thread`` executor, a hung DB acquire, a grouping LLM
+    call pending on the SDK's ~30-min ceiling) must not strand the job at
+    ``running`` until a pod restart clears the in-memory registry. With a
+    test-shrunk budget the job flips to ``failed`` carrying
+    ``error_class="TimeoutError"`` well within the budget.
+    """
+    registry = IngestJobRegistry()
+    job = await _create_running_job(registry)
+
+    async def _never_returns() -> IngestionPipelineResult:
+        await asyncio.Event().wait()  # blocks forever until cancelled
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    started = time.monotonic()
+    await run_ingest_job(
+        job.job_id,
+        pipeline_call=_never_returns,
+        registry=registry,
+        timeout_s=0.05,
+    )
+    elapsed = time.monotonic() - started
+
+    stored = await registry.get(job.job_id, tenant_id=None, is_tenant_admin=True)
+    assert stored.status == "failed"
+    assert stored.error_class == "TimeoutError"
+    assert stored.ended_at is not None
+    assert stored.result is None
+    # Terminated promptly on the shrunk budget -- nowhere near the 30-min default.
+    assert elapsed < 5.0
+
+
+@pytest.mark.asyncio
+async def test_wedged_dispatchability_probe_times_out_to_failed() -> None:
+    """A hang in the *post-run* dispatchability probe also terminates the job.
+
+    The watchdog wraps the whole body, not just ``pipeline_call``: the
+    dispatchability probe is a real DB read (``connector_exists``) whose
+    own hang would strand the job if only the pipeline call were guarded.
+    A probe that never returns flips the job to ``failed`` /
+    ``TimeoutError``. Note the probe *hangs* rather than raises, so
+    ``_dispatchability_failure_reason``'s fail-open ``except Exception``
+    does not swallow the cancellation (``CancelledError`` is a
+    ``BaseException``, outside ``Exception``).
+    """
+    registry = IngestJobRegistry()
+    job = await _create_running_job(registry)
+    result = _pipeline_result(inserted_count=5)
+
+    async def _hanging_probe(_result: IngestionPipelineResult) -> bool:
+        await asyncio.Event().wait()  # blocks forever until cancelled
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    started = time.monotonic()
+    await run_ingest_job(
+        job.job_id,
+        pipeline_call=lambda: _async_return(result),
+        registry=registry,
+        dispatchability_check=_hanging_probe,
+        timeout_s=0.05,
+    )
+    elapsed = time.monotonic() - started
+
+    stored = await registry.get(job.job_id, tenant_id=None, is_tenant_admin=True)
+    assert stored.status == "failed"
+    assert stored.error_class == "TimeoutError"
+    # The pipeline returned, but the job is failed (not succeeded/degraded)
+    # because the probe never produced a dispatchability verdict.
+    assert stored.result is None
+    assert elapsed < 5.0
+
+
+@pytest.mark.asyncio
+async def test_pipeline_log_event_carries_ingest_job_id() -> None:
+    """A pipeline log event carries ``ingest_job_id`` via the contextvar binding.
+
+    ``run_ingest_job`` binds the job id into structlog contextvars, so the
+    configured ``merge_contextvars`` processor stamps it onto events
+    emitted by *other* loggers under the pipeline call -- not just
+    jobs.py's own lines. This is what lets a job-id-filtered log grep see
+    ``ingestion_pipeline_start`` &c. ``capture_logs`` clears the configured
+    processor chain, so ``merge_contextvars`` is re-supplied to mirror the
+    production chain (``logging.py``).
+    """
+    registry = IngestJobRegistry()
+    job = await _create_running_job(registry)
+    result = _pipeline_result(inserted_count=5)
+
+    async def _pipeline_that_logs() -> IngestionPipelineResult:
+        # Mirror the real pipeline: emit from a freshly-bound logger that
+        # carries ``connector_id`` but has never seen the job id.
+        structlog.get_logger("test.pipeline").bind(connector_id="vrli-rest-9.0").info(
+            "ingestion_pipeline_start",
+        )
+        return result
+
+    async def _check(_result: IngestionPipelineResult) -> bool:
+        return True
+
+    with capture_logs(processors=[structlog.contextvars.merge_contextvars]) as logs:
+        await run_ingest_job(
+            job.job_id,
+            pipeline_call=_pipeline_that_logs,
+            registry=registry,
+            dispatchability_check=_check,
+        )
+
+    starts = [entry for entry in logs if entry.get("event") == "ingestion_pipeline_start"]
+    assert starts, "pipeline start event was not captured"
+    assert starts[0]["ingest_job_id"] == str(job.job_id)
+    # The binding must not leak past the run: the contextvar is unbound.
+    assert "ingest_job_id" not in structlog.contextvars.get_contextvars()
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1109,6 +1109,56 @@ open to `succeeded` (a transient DB blip must not strand or degrade a
 completed pipeline). Regression coverage:
 `tests/test_operations_ingest_jobs.py`.
 
+#### Watchdog: a job always reaches a terminal state (#2275)
+
+The dispatchability postcondition and the `except BaseException`
+boundary only guarantee terminality for a pipeline that *returns or
+raises*. A pipeline that **never completes an await** — a starved
+`asyncio.to_thread` executor, a DB connection that never acquires, or a
+grouping LLM call pending on the Anthropic SDK's default 10-min-read ×
+2-retry ceiling (~30 min wall-clock) — left the job at `running` until a
+pod restart cleared the in-memory registry, while the identical *sync*
+request returned a clean 4xx. `run_ingest_job` now time-boxes the whole
+body — the pipeline call **and** the post-run dispatchability probe (a
+real `connector_exists` DB read whose own hang would strand the job if
+only the pipeline call were wrapped) — inside
+`async with asyncio.timeout(_INGEST_JOB_TIMEOUT_SECONDS)`. At the
+deadline the body is cancelled and `asyncio.timeout` re-raises
+`TimeoutError`, which the existing `except` routes to `failed`
+(`error_class="TimeoutError"`). The budget defaults to 30 min and is
+env-overridable via `INGEST_JOB_TIMEOUT_SECONDS` (parsed defensively — a
+malformed value falls back to the default with a warning rather than
+crashing the package at import). The guarantee is scoped precisely to
+the *job leg*: cancellation cannot interrupt an already-running
+`to_thread` OS thread (Python exposes no thread cancellation), so the
+status flips but that thread may linger until it returns.
+
+Two supporting bounds close the same wedge:
+
+* **LLM client bounds.** `build_anthropic_ingest_llm_client`
+  (`ingest/anthropic_client.py`) constructs the grouping
+  `AsyncAnthropic` with an explicit `timeout` + `max_retries`
+  (`_INGEST_LLM_TIMEOUT_SECONDS` = 120 s, `_INGEST_LLM_MAX_RETRIES` = 1)
+  instead of the SDK defaults, so a hung grouping call fails the request
+  fast rather than silently consuming the watchdog budget. The
+  fail-closed 503 contract for a missing key (#1386) is unchanged.
+* **Job-id log correlation.** `run_ingest_job` binds `ingest_job_id`
+  into structlog *contextvars* (`bound_contextvars`), not just a local
+  `_log.bind`. The pipeline binds its own `connector_id` logger and never
+  sees the job id, so before this a job-id-filtered log grep was
+  structurally blind to every pipeline event; the configured
+  `merge_contextvars` processor (`logging.py`) now stamps `ingest_job_id`
+  onto `ingestion_pipeline_start` &c. A future wedge is diagnosable from
+  those events plus a `py-spy` dump against the named
+  `ingest-job-<uuid>` task.
+
+Regression coverage: `tests/test_operations_ingest_jobs.py`
+(`test_wedged_pipeline_times_out_to_failed`,
+`test_wedged_dispatchability_probe_times_out_to_failed`,
+`test_pipeline_log_event_carries_ingest_job_id`) and
+`tests/test_operations_ingest_anthropic_client.py`
+(`test_factory_constructs_client_with_explicit_timeout_and_retries`).
+
 If `load_catalog()` raises `CatalogError` at listing time (only
 possible mid-test-monkeypatch or mid-reload — startup parse failures
 crash the lifespan), the helper degrades to the manual-mode


### PR DESCRIPTION
## Summary

- **Watchdog: an async ingest job now always reaches a terminal state.** A wedged pipeline could sit at `status=running` forever (surviving until a pod restart cleared the in-memory registry) while the identical sync request returned a clean 400. Per the issue's re-diagnosis, the `except BaseException` boundary was already maximal — an `OpIdCollision`-raising pipeline provably flips the job to `failed` — so the earlier "widen the try/except" framing was a no-op; the real defect was a **never-completing await with no watchdog**. `run_ingest_job` now time-boxes the whole job body (the pipeline call **and** the post-run dispatchability probe, whose own hang would otherwise strand the job) inside `asyncio.timeout`; at the deadline the job flips to `failed` with `error_class="TimeoutError"`. Budget defaults to 30 min, env-overridable via `INGEST_JOB_TIMEOUT_SECONDS` (parsed defensively — a malformed value falls back with a warning rather than crashing the package at import).
- **Explicit LLM-client bounds.** The grouping `AsyncAnthropic` is now constructed with an explicit `timeout` (120 s) + `max_retries` (1) instead of the SDK defaults, whose 10-min read timeout with retried requests let a hung grouping call pend ~30 min — the one wedge candidate that inherently spans "10+ minutes with the event loop responsive". The fail-closed 503 contract for a missing `ANTHROPIC_API_KEY` (#1386) is unchanged.
- **Job-id log binding via contextvars.** `ingest_job_id` is now bound through `structlog.contextvars` (not just the job coroutine's own logger), so the configured `merge_contextvars` processor stamps it onto pipeline events (`ingestion_pipeline_start` &c.). A job-id-filtered log grep is no longer structurally blind to the pipeline — the "zero pipeline log events" observation was this artifact.

`run_ingest_job`'s succeeded/degraded reconciliation was extracted into `_reconcile_returned_result` to stay within the function-size budget; behavior is unchanged.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` — clean
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers
- [x] AC1 — a never-returning `pipeline_call` flips to `failed` / `TimeoutError` within a test-shrunk budget: `test_wedged_pipeline_times_out_to_failed`
- [x] AC2 — an `OpIdCollision` through the async path yields `status=failed` with the structured collision error (regression pin; the "async swallows collisions" premise stays dead): existing `test_op_id_collision_job_error_names_remediation`
- [x] AC3 — a hang in the dispatchability leg also terminates the job (`CancelledError` is `BaseException`, so the probe's fail-open `except Exception` does not swallow it): `test_wedged_dispatchability_probe_times_out_to_failed`
- [x] AC4 — the grouping Anthropic client is constructed with explicit `timeout` + `max_retries`: `test_factory_constructs_client_with_explicit_timeout_and_retries`
- [x] AC5 — a job-id-filtered log capture during a pipeline run includes `ingestion_pipeline_start` carrying `ingest_job_id`: `test_pipeline_log_event_carries_ingest_job_id`
- [x] AC6 — no route/schema change → **OpenAPI snapshot regenerated with zero delta**
- [x] Broader sweep — `pytest -k "ingest or connector_ingest"`: 601 passed, 11 skipped

## Out of scope

- **Helm chart value for `INGEST_JOB_TIMEOUT_SECONDS`.** The watchdog budget is env-configurable and may want a chart surface; sibling **#2240** is doing a chart-value task separately, so chart files are deliberately untouched here.
- Persisting the job registry across restarts (in-memory-by-design, #1323); interrupting wedged `to_thread` workers (Python has no thread cancellation — the guarantee is job-state terminality, not thread reclamation); root-causing which await wedged on the RDC pod (unrecoverable post-restart — a future wedge is now diagnosable via the job-id-bound pipeline events + a `py-spy` dump against the named `ingest-job-<uuid>` task).
- **Adjacent finding (recorded, not addressed):** `ingest/jobs.py` is now 655 lines (soft file-size warning, >600); a responsibility-based module split is a larger refactor beyond this task's scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2275
