### PR TITLE
feat(connectors): operator-selectable auth scheme on non-catalog ingest (#2289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — operator-selectable auth scheme on non-catalog ingest (#2289)
+
+- `meho connector ingest --auth-scheme <name>` (and the REST
+  `IngestRequest.auth_scheme` / MCP `meho.connector.ingest` fields) let an
+  operator select a named auth scheme from the **closed** catalog (`basic`,
+  `static_header`, `session_login`, `session_login_basic`,
+  `session_login_token`, `oauth2_mint`) when ingesting an arbitrary spec. The
+  register phase then synthesises a minimal `ExecutionProfile` and stamps a
+  **dispatchable** `ProfiledRestConnector` instead of the non-dispatchable
+  bare shim — staged behind the normal review/enable gate (#1971), never
+  auto-enabled. Optional `--auth-secret-field` overrides the secret-field
+  NAMES the scheme reads at dispatch; values stay in the target's
+  `secret_ref` and never ride the request. Selection only — no free-form auth
+  config (login URL / template / token path), and reserved typed-only schemes
+  are rejected at the API boundary with a closed-set 422. Omitting the flag
+  keeps today's bare-shim behaviour unchanged. (#2271 / #2289)
+
 ### Added — profiled-connector boot registration (shipped ExecutionProfiles become dispatchable at boot) (#2288)
 
 - Wire `record_profile_stamp` into production: at boot, immediately after

--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -649,6 +649,12 @@ async def _spawn_async_ingest(
             tenant_id=resolved.tenant_id,
             dry_run=False,
             spec_info_versions_compatible=spec_info_versions_compatible,
+            auth_scheme=resolved.auth_scheme,
+            auth_secret_fields=(
+                tuple(resolved.auth_secret_fields)
+                if resolved.auth_secret_fields is not None
+                else None
+            ),
         )
 
     # ``asyncio.create_task`` (not ``BackgroundTasks``) so the work
@@ -1131,6 +1137,10 @@ async def _run_ingest_with_http_mapping(
             tenant_id=body.tenant_id,
             dry_run=body.dry_run,
             spec_info_versions_compatible=spec_info_versions_compatible,
+            auth_scheme=body.auth_scheme,
+            auth_secret_fields=(
+                tuple(body.auth_secret_fields) if body.auth_secret_fields is not None else None
+            ),
         )
     except Exception as exc:
         _raise_ingest_http_error(exc, catalog_entry=catalog_entry)

--- a/backend/src/meho_backplane/mcp/tools/connector_ingest.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_ingest.py
@@ -108,6 +108,7 @@ import structlog
 
 from meho_backplane.api.v1.connectors_ingest import get_llm_client_factory
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.profile import NAMED_AUTH_SCHEMES
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.mcp.tools._connector_shared import (
@@ -171,6 +172,13 @@ def _build_ingest_request(arguments: dict[str, Any]) -> IngestRequest:
         specs=[SpecSource(uri=spec["uri"]) for spec in arguments["specs"]],
         base_url=arguments.get("base_url"),
         dry_run=bool(arguments.get("dry_run", False)),
+        # #2289: an operator-selected named auth scheme (+ optional secret-field
+        # NAMES) stamps a dispatchable profiled connector instead of the bare
+        # shim. Left unset (the common path) keeps the bare-shim behaviour. The
+        # closed-set / reserved-scheme rejection happens in the IngestRequest
+        # Literal below, surfacing as a -32602 invalid_params on a bad value.
+        auth_scheme=arguments.get("auth_scheme"),
+        auth_secret_fields=arguments.get("auth_secret_fields"),
     )
     assert request.product is not None
     assert request.version is not None
@@ -305,6 +313,12 @@ async def _run_inline_ingest(
             base_url=request.base_url,
             tenant_id=tenant_id,
             dry_run=request.dry_run,
+            auth_scheme=request.auth_scheme,
+            auth_secret_fields=(
+                tuple(request.auth_secret_fields)
+                if request.auth_secret_fields is not None
+                else None
+            ),
         )
     except SPEC_ERROR_TYPES as exc:
         # The whole typed SpecError sibling set maps onto JSON-RPC -32602
@@ -384,6 +398,12 @@ async def _spawn_async_ingest(
             base_url=request.base_url,
             tenant_id=tenant_id,
             dry_run=False,
+            auth_scheme=request.auth_scheme,
+            auth_secret_fields=(
+                tuple(request.auth_secret_fields)
+                if request.auth_secret_fields is not None
+                else None
+            ),
         )
 
     # ``asyncio.create_task`` (not the request itself) so the work
@@ -554,6 +574,31 @@ register_mcp_tool(
                     },
                 },
                 "base_url": {"type": ["string", "null"], "maxLength": 2048},
+                "auth_scheme": {
+                    "type": ["string", "null"],
+                    "enum": [*sorted(NAMED_AUTH_SCHEMES), None],
+                    "description": (
+                        "Optional named auth scheme (closed catalog) for a "
+                        "non-catalog ingest. When set, the connector is stamped "
+                        "as a dispatchable profiled connector — staged behind "
+                        "the review/enable gate, never auto-enabled — instead of "
+                        "a non-dispatchable bare shim. Selection only: there is "
+                        "no free-form auth config, and reserved typed-only "
+                        "schemes are not selectable. Omit for the historical "
+                        "bare-shim behaviour."
+                    ),
+                },
+                "auth_secret_fields": {
+                    "type": ["array", "null"],
+                    "maxItems": 8,
+                    "items": {"type": "string", "minLength": 1},
+                    "description": (
+                        "Optional override of the secret-field NAMES the "
+                        "auth_scheme reads at dispatch (never the values — those "
+                        "stay in the target's secret_ref). Omit for the "
+                        "per-scheme defaults. Requires auth_scheme."
+                    ),
+                },
                 "dry_run": {"type": "boolean", "default": False},
                 "async": {
                     "type": "boolean",

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -60,6 +60,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from meho_backplane.connectors.profile import AuthSchemeName
 from meho_backplane.operations.ingest.catalog import _compatibility_pattern_to_specifier
 
 __all__ = [
@@ -242,6 +243,54 @@ class IngestRequest(BaseModel):
         default=None,
         max_length=16,
     )
+    #: Operator-selected named auth scheme for a **non-catalog** ingest
+    #: (#2289). When set, the register phase synthesises a minimal
+    #: :class:`~meho_backplane.connectors.profile.ExecutionProfile` (this
+    #: scheme + secret-field names + scheme defaults) and stamps a
+    #: dispatchable
+    #: :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector`
+    #: instead of the non-dispatchable bare
+    #: :class:`~meho_backplane.operations.ingest.connector_registration.GenericRestConnector`
+    #: shim — staged behind the normal review/enable gate (#1971), never
+    #: auto-enabled. Left ``None`` (the default) keeps the historical bare-shim
+    #: behaviour byte-identical.
+    #:
+    #: A member of the closed
+    #: :data:`~meho_backplane.connectors.profile.AuthSchemeName` catalog; the
+    #: ``Literal`` rejects an unknown value **and every reserved typed-only
+    #: shape** with a 422 closed-set error naming the allowed members. There is
+    #: no free-form auth config (login URL / body template / token path) — that
+    #: is the rejected-DSL door (#1177 / Goal #1964 Non-goals). Mutually
+    #: exclusive with ``catalog_entry`` (catalog rows bind their profile via
+    #: ``profile_resource`` + boot stamping, #2288).
+    auth_scheme: AuthSchemeName | None = Field(
+        default=None,
+        description=(
+            "Named auth scheme (closed catalog) for a non-catalog ingest. When "
+            "set, the connector is stamped as a dispatchable profiled connector "
+            "(staged behind review, never auto-enabled) instead of a "
+            "non-dispatchable bare shim. Unknown / reserved schemes are rejected "
+            "(422). No free-form auth config — selection only. Mutually exclusive "
+            "with catalog_entry."
+        ),
+    )
+    #: Optional override of the secret-bundle key **names** the selected
+    #: ``auth_scheme``'s extractor reads at dispatch (e.g. ``["username",
+    #: "password"]``). NAMES only — credential *values* are never carried in
+    #: the request; they are resolved from the target's ``secret_ref`` at
+    #: dispatch. Omitted → the per-scheme defaults
+    #: (:data:`~meho_backplane.operations.ingest.ingest_profile.DEFAULT_SECRET_FIELDS`).
+    #: Requires ``auth_scheme`` to be set (naming fields without selecting a
+    #: scheme is a caller-side bug worth a 422).
+    auth_secret_fields: list[str] | None = Field(
+        default=None,
+        max_length=8,
+        description=(
+            "Optional override of the secret-field NAMES the auth_scheme reads "
+            "at dispatch (never the values — those stay in the target's "
+            "secret_ref). Omit for the per-scheme defaults. Requires auth_scheme."
+        ),
+    )
     dry_run: bool = False
     #: Background-mode opt-out. ``True`` (default) fires the
     #: pipeline off the request thread and returns
@@ -319,6 +368,25 @@ class IngestRequest(BaseModel):
                 "(explicit-quadruple shape). "
                 "See docs/codebase/error-message-shape.md.",
             )
+        if catalog_set and self.auth_scheme is not None:
+            # A catalog row binds its profile via ``profile_resource`` + boot
+            # stamping (#2288); an operator-selected ``auth_scheme`` is the
+            # non-catalog on-ramp (#2289). Mixing them would silently discard
+            # the selection during catalog resolution, so reject it loudly.
+            raise ValueError(
+                "catalog_entry_conflict: 'auth_scheme' is the non-catalog "
+                "ingest on-ramp; a catalog row binds its own profile via "
+                "profile_resource. Drop 'auth_scheme' when using "
+                "'catalog_entry'. See docs/codebase/error-message-shape.md.",
+            )
+        if self.auth_secret_fields is not None and self.auth_scheme is None:
+            # Naming the secret fields without selecting a scheme is a
+            # caller-side bug: there is no extractor to read them.
+            raise ValueError(
+                "ingest_request_underspecified: 'auth_secret_fields' names the "
+                "secret keys the selected auth scheme reads, so it requires "
+                "'auth_scheme' to be set. See docs/codebase/error-message-shape.md.",
+            )
         if not catalog_set:
             # Explicit-quadruple shape — every quadruple field must
             # be set. Partial-quadruple bodies (e.g. impl_id missing)
@@ -343,6 +411,28 @@ class IngestRequest(BaseModel):
                     "See docs/codebase/error-message-shape.md.",
                 )
         return self
+
+    @field_validator("auth_secret_fields")
+    @classmethod
+    def _auth_secret_fields_nonblank(cls, value: list[str] | None) -> list[str] | None:
+        """Reject an empty list or a blank secret-field name.
+
+        Mirrors :meth:`AuthSpec._secret_fields_nonempty`: naming zero fields
+        (or a blank one) is a malformed selection, not a credential-less auth
+        shape. ``None`` (use the per-scheme defaults) is the common path and
+        passes untouched. The values are field *names* only — the credential
+        values are resolved from the target's ``secret_ref`` at dispatch and
+        never ride this request.
+        """
+        if value is None:
+            return value
+        if not value:
+            raise ValueError(
+                "auth_secret_fields must be null (scheme defaults) or a non-empty list"
+            )
+        if any(not field.strip() for field in value):
+            raise ValueError("auth_secret_fields entries must be non-blank")
+        return value
 
     @field_validator("spec_info_versions_compatible")
     @classmethod

--- a/backend/src/meho_backplane/operations/ingest/ingest_profile.py
+++ b/backend/src/meho_backplane/operations/ingest/ingest_profile.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Synthesise a minimal :class:`ExecutionProfile` from an operator's auth selection.
+
+Initiative #2271 / Goal #221, Task #2289. The boot-time stamping path
+(:mod:`meho_backplane.operations.ingest.boot_stamp`, #2288) turns a
+*shipped* profile-backed catalog row into a dispatchable
+:class:`~meho_backplane.connectors.profiled.ProfiledRestConnector`. This
+module is the **non-catalog on-ramp**: when an operator ingests an arbitrary
+spec and *selects* a named auth scheme (``meho connector ingest --auth-scheme
+session_login_token``), the ingest pipeline synthesises a minimal
+:class:`ExecutionProfile` here and stamps the same profiled connector — so a
+hand-authored spec becomes dispatchable without a hand-coded connector class.
+
+The boundary (Initiative #2271, grounded in #1177 / Goal #1964 Non-goals) is
+strict: the operator selects a **named scheme from the closed catalog**
+(:data:`~meho_backplane.connectors.profile.AuthSchemeName`) plus, optionally,
+the **names** of the secret-bundle keys the scheme reads. There is **no**
+free-form auth config — no login URL, body template, token JSONPath, or header
+name. Those are the rejected-DSL / credential-forwarding door. The login path,
+request body shape, and token extractor for each scheme are vetted Python
+selected by the scheme name in
+:data:`~meho_backplane.connectors._shared.profile_auth.SESSION_SCHEME_SPECS`;
+the operator picks *which* vetted shape, never authors one.
+
+Two knobs the profile schema needs but the operator does not supply are
+defaulted here:
+
+* **secret-field names** — :data:`DEFAULT_SECRET_FIELDS` maps each named
+  scheme to the field names its vetted extractor reads (e.g.
+  ``(username, password)`` for the session schemes, ``(client_id,
+  client_secret)`` for ``oauth2_mint``). An operator who stores the
+  credential under different key names overrides them via
+  ``auth_secret_fields``; the values are always resolved from the target's
+  ``secret_ref`` at dispatch, never carried in the ingest request.
+* **fingerprint / probe / pagination** — a non-catalog ingest carries no
+  fingerprint recipe (the operator selected auth, not a version endpoint), so
+  :func:`build_ingest_execution_profile` fills these with the conservative
+  :data:`_DEFAULT_FINGERPRINT` / ``"delegate"`` / :data:`_DEFAULT_PAGINATION`
+  defaults. They keep the profile schema-valid without inventing a per-spec
+  recipe: op dispatch runs off the ``EndpointDescriptor`` row through
+  ``dispatch_ingested`` (auth + the op path), and the ``strategy="none"``
+  pagination default never unwraps ``items_key`` (only the ``cursor_token``
+  loop reads it). The fingerprint/probe defaults are exercised only by an
+  explicit ``fingerprint`` / ``probe`` call, which the auth-only on-ramp does
+  not wire; a connector that needs a real fingerprint recipe ships as a
+  profile-backed catalog row (#2288), not this on-ramp.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.profile import (
+    NAMED_AUTH_SCHEMES,
+    AuthSchemeName,
+    AuthSpec,
+    ExecutionProfile,
+    FingerprintSpec,
+    PaginationSpec,
+    StaticHeaderValueKind,
+)
+
+__all__ = [
+    "DEFAULT_SECRET_FIELDS",
+    "DEFAULT_STATIC_HEADER_VALUE_KIND",
+    "build_ingest_execution_profile",
+]
+
+#: Per-scheme default secret-field **names** the vetted extractor reads at
+#: dispatch. The values are the field names each scheme's ``build_*`` /
+#: ``build_static_headers`` helper looks up in the resolved secret bundle
+#: (see :mod:`meho_backplane.connectors._shared.profile_auth`): the session
+#: schemes and ``basic`` read ``username`` / ``password``, ``static_header``
+#: reads a single ``token`` field, and ``oauth2_mint`` reads ``client_id`` /
+#: ``client_secret``. Names only — the credential *values* live in the
+#: target's ``secret_ref`` and are resolved by the broker at dispatch.
+#:
+#: Every member of :data:`~meho_backplane.connectors.profile.NAMED_AUTH_SCHEMES`
+#: must have an entry (asserted below and pinned by a test) so a scheme added
+#: to the closed catalog cannot silently reach this on-ramp without a
+#: reviewed default.
+DEFAULT_SECRET_FIELDS: dict[str, tuple[str, ...]] = {
+    "basic": ("username", "password"),
+    "static_header": ("token",),
+    "session_login": ("username", "password"),
+    "session_login_basic": ("username", "password"),
+    "session_login_token": ("username", "password"),
+    "oauth2_mint": ("client_id", "client_secret"),
+}
+
+#: ``static_header`` is the one scheme whose :class:`AuthSpec` requires a
+#: ``value_kind``; the auth-only on-ramp exposes no knob for it, so it defaults
+#: to bearer-wrapping (argocd's shape). An operator needing raw placement in a
+#: custom header authors a profile-backed catalog row instead.
+DEFAULT_STATIC_HEADER_VALUE_KIND: StaticHeaderValueKind = "bearer"
+
+# Every named scheme must carry a default secret-field set — a scheme in the
+# closed catalog with no entry here would raise a KeyError at ingest rather
+# than surfacing at review, which the missing-default is: a reviewer forgot to
+# extend this map when adding the scheme.
+assert set(DEFAULT_SECRET_FIELDS) == NAMED_AUTH_SCHEMES, (
+    "DEFAULT_SECRET_FIELDS must cover exactly NAMED_AUTH_SCHEMES; drift: "
+    f"missing={NAMED_AUTH_SCHEMES - set(DEFAULT_SECRET_FIELDS)}, "
+    f"extra={set(DEFAULT_SECRET_FIELDS) - NAMED_AUTH_SCHEMES}"
+)
+
+#: Conservative fingerprint recipe for an auth-only on-ramp profile. A
+#: non-catalog ingest names no version endpoint, so the default reads a
+#: top-level ``version`` key off ``/`` verbatim. Schema-valid and never
+#: reached by op dispatch (only an explicit ``fingerprint`` call uses it).
+_DEFAULT_FINGERPRINT = FingerprintSpec(path="/", version_key="version", version_splitter="none")
+
+#: Single-request pagination default: ``strategy="none"`` means the dispatch
+#: loop issues one request and never unwraps ``items_key`` (only the
+#: ``cursor_token`` loop reads it), so the placeholder key is inert.
+_DEFAULT_PAGINATION = PaginationSpec(strategy="none", items_key="value")
+
+
+def build_ingest_execution_profile(
+    *,
+    product: str,
+    version: str,
+    auth_scheme: AuthSchemeName,
+    secret_fields: tuple[str, ...] | None = None,
+) -> ExecutionProfile:
+    """Synthesise a minimal :class:`ExecutionProfile` from an auth selection.
+
+    Builds the profile the ingest pipeline stamps onto a non-catalog
+    connector: the operator-selected *auth_scheme* plus its secret-field
+    names (the operator's *secret_fields*, or :data:`DEFAULT_SECRET_FIELDS`
+    for the scheme when ``None``), with the conservative fingerprint / probe /
+    pagination defaults this module documents.
+
+    *auth_scheme* is already validated against the closed
+    :data:`~meho_backplane.connectors.profile.AuthSchemeName` catalog at the
+    API boundary (the request schema's ``Literal`` rejects unknown / reserved
+    values with a closed-set 422); the :class:`AuthSpec` constructed here
+    re-asserts it. ``static_header`` gets :data:`DEFAULT_STATIC_HEADER_VALUE_KIND`
+    since the on-ramp exposes no ``value_kind`` knob; every other scheme leaves
+    ``value_kind`` unset (the schema forbids it off ``static_header``).
+
+    Raises :class:`pydantic.ValidationError` when *secret_fields* is empty or
+    carries a blank name — the same fail-loud contract :class:`AuthSpec`
+    enforces for a hand-authored profile.
+    """
+    fields = secret_fields if secret_fields is not None else DEFAULT_SECRET_FIELDS[auth_scheme]
+    value_kind: StaticHeaderValueKind | None = (
+        DEFAULT_STATIC_HEADER_VALUE_KIND if auth_scheme == "static_header" else None
+    )
+    auth = AuthSpec(scheme=auth_scheme, secret_fields=tuple(fields), value_kind=value_kind)
+    return ExecutionProfile(
+        product=product,
+        version=version,
+        auth=auth,
+        fingerprint=_DEFAULT_FINGERPRINT,
+        probe="delegate",
+        pagination=_DEFAULT_PAGINATION,
+    )

--- a/backend/src/meho_backplane/operations/ingest/pipeline.py
+++ b/backend/src/meho_backplane/operations/ingest/pipeline.py
@@ -83,6 +83,7 @@ from packaging.version import InvalidVersion, Version
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.profile import AuthSchemeName, ExecutionProfile
 from meho_backplane.connectors.registry import product_impl_id_round_trips
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.operations.ingest._llm_grouping_internals import (
@@ -102,11 +103,13 @@ from meho_backplane.operations.ingest.catalog import (
 )
 from meho_backplane.operations.ingest.connector_registration import (
     check_version_covered_by_registered_class,
+    synthesise_profiled_class,
 )
 from meho_backplane.operations.ingest.exceptions import (
     ProductImplIdMismatch,
     VersionMismatchError,
 )
+from meho_backplane.operations.ingest.ingest_profile import build_ingest_execution_profile
 from meho_backplane.operations.ingest.llm_groups import (
     GroupingResult,
     run_llm_grouping,
@@ -119,6 +122,7 @@ from meho_backplane.operations.ingest.register_ingested import (
     IngestionResult,
     register_ingested_operations,
 )
+from meho_backplane.operations.ingest.service import ReviewService
 from meho_backplane.retrieval.embedding import EmbeddingService
 
 __all__ = [
@@ -589,6 +593,8 @@ class IngestionPipelineService:
         tenant_id: UUID | None = None,
         dry_run: bool = False,
         spec_info_versions_compatible: tuple[str, ...] | None = None,
+        auth_scheme: AuthSchemeName | None = None,
+        auth_secret_fields: tuple[str, ...] | None = None,
     ) -> IngestionPipelineResult:
         """Run the full pipeline (parse → register → group) for one connector.
 
@@ -615,6 +621,17 @@ class IngestionPipelineService:
         the spec-vs-label cross-check accepts ``info.version`` values
         inside the declared band even if they differ from the
         operator's ``version`` label.
+
+        ``auth_scheme`` (#2289) is the operator-selected named auth scheme
+        for a non-catalog ingest. When set, the register phase synthesises a
+        minimal :class:`~meho_backplane.connectors.profile.ExecutionProfile`
+        (scheme + ``auth_secret_fields`` names, or the per-scheme defaults)
+        and stamps a dispatchable
+        :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector`
+        under the triple instead of the bare non-dispatchable shim — staged
+        behind the #1971 review gate, never auto-enabled. ``None`` keeps the
+        historical bare-shim behaviour. Ignored on the ``dry_run`` path (which
+        registers nothing).
         """
         self.authorize_scope(tenant_id)
         # Round-trip guard runs first — before the spec-vs-label
@@ -654,6 +671,17 @@ class IngestionPipelineService:
                 log=log,
             )
 
+        execution_profile = (
+            build_ingest_execution_profile(
+                product=product,
+                version=version,
+                auth_scheme=auth_scheme,
+                secret_fields=auth_secret_fields,
+            )
+            if auth_scheme is not None
+            else None
+        )
+
         return await self._dispatch_real_run(
             product=product,
             version=version,
@@ -663,6 +691,7 @@ class IngestionPipelineService:
             tenant_id=tenant_id,
             connector_id=connector_id,
             log=log,
+            execution_profile=execution_profile,
         )
 
     # ----- private helpers ------------------------------------------------
@@ -762,12 +791,17 @@ class IngestionPipelineService:
         tenant_id: UUID | None,
         connector_id: str,
         log: structlog.stdlib.BoundLogger,
+        execution_profile: ExecutionProfile | None = None,
     ) -> IngestionPipelineResult:
         """Drive the register → group phases for a non-dry-run ingest.
 
         Extracted from :meth:`ingest` so the public method stays at
         the "validate, dispatch" abstraction level; the per-phase
         log binding + result aggregation lives here.
+
+        ``execution_profile`` (#2289), when set, makes the register phase
+        stamp a dispatchable profiled connector under the triple instead of
+        the bare shim (see :meth:`_run_register_phase`).
         """
         log.info("ingestion_pipeline_start")
         sessionmaker = self._sessionmaker()
@@ -778,7 +812,9 @@ class IngestionPipelineService:
             specs=specs,
             base_url=base_url,
             tenant_id=tenant_id,
+            connector_id=connector_id,
             sessionmaker=sessionmaker,
+            execution_profile=execution_profile,
         )
         log.info(
             "ingestion_pipeline_register_complete",
@@ -871,7 +907,9 @@ class IngestionPipelineService:
         specs: Sequence[SpecSource],
         base_url: str | None,
         tenant_id: UUID | None,
+        connector_id: str,
         sessionmaker: async_sessionmaker[AsyncSession],
+        execution_profile: ExecutionProfile | None = None,
     ) -> IngestionResult:
         """Parse + register every spec under the same connector triple.
 
@@ -882,7 +920,19 @@ class IngestionPipelineService:
         ``True`` when ANY spec triggered the auto-shim registration —
         on a fresh connector the first spec flips it, subsequent
         specs see it already there.
+
+        When ``execution_profile`` is set (#2289 — the operator selected a
+        named ``auth_scheme``), the per-spec calls skip the bare-shim
+        registration (``register_shim=False``) and, after every spec's rows
+        land, a dispatchable
+        :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector`
+        synthesised from the profile is stamped under the triple via
+        :meth:`ReviewService.record_profile_stamp`. Stamping registers the
+        class but never enables an op — the ``review_status='staged'`` gate
+        (#1971) stays the interlock. ``connector_registered`` then reflects
+        the stamp (``True`` on the first stamp of a fresh triple).
         """
+        register_shim = execution_profile is None
         aggregated_inserted = 0
         aggregated_updated = 0
         aggregated_skipped = 0
@@ -908,11 +958,25 @@ class IngestionPipelineService:
                 base_url=base_url,
                 tenant_id=tenant_id,
                 embedding_service=self._embedding_service,
+                register_shim=register_shim,
             )
             aggregated_inserted += partial.inserted_count
             aggregated_updated += partial.updated_count
             aggregated_skipped += partial.skipped_count
             connector_registered = connector_registered or partial.connector_registered
+
+        if execution_profile is not None:
+            connector_registered = (
+                await self._stamp_profiled_connector(
+                    product=product,
+                    version=version,
+                    impl_id=impl_id,
+                    connector_id=connector_id,
+                    tenant_id=tenant_id,
+                    execution_profile=execution_profile,
+                )
+                or connector_registered
+            )
 
         return IngestionResult(
             inserted_count=aggregated_inserted,
@@ -920,6 +984,38 @@ class IngestionPipelineService:
             skipped_count=aggregated_skipped,
             connector_registered=connector_registered,
             operations_grouped=False,
+        )
+
+    async def _stamp_profiled_connector(
+        self,
+        *,
+        product: str,
+        version: str,
+        impl_id: str,
+        connector_id: str,
+        tenant_id: UUID | None,
+        execution_profile: ExecutionProfile,
+    ) -> bool:
+        """Stamp a profiled connector synthesised from *execution_profile*.
+
+        The non-catalog on-ramp (#2289) sibling of
+        :func:`~meho_backplane.operations.ingest.boot_stamp.stamp_catalog_profiled_connectors`:
+        synthesises a
+        :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector`
+        subclass carrying the profile and registers it under the triple via
+        the review-gate-preserving
+        :meth:`ReviewService.record_profile_stamp` seam. Returns ``True`` when
+        a new profiled class was registered, ``False`` on the idempotent
+        no-op (the triple is already served by a stamped / hand-coded class).
+        The stamp writes a ``meho.connector.profile_stamp`` audit row under
+        the ingesting operator and never enables an op (#1971).
+        """
+        connector_class = synthesise_profiled_class(
+            product=product, version=version, impl_id=impl_id, profile=execution_profile
+        )
+        review_service = ReviewService(self._operator)
+        return await review_service.record_profile_stamp(
+            connector_id, tenant_id=tenant_id, connector_class=connector_class
         )
 
     async def _run_grouping_phase(

--- a/backend/src/meho_backplane/operations/ingest/register_ingested.py
+++ b/backend/src/meho_backplane/operations/ingest/register_ingested.py
@@ -271,6 +271,7 @@ async def register_ingested_operations(
     tenant_id: UUID | None = None,
     session: AsyncSession | None = None,
     embedding_service: EmbeddingService | None = None,
+    register_shim: bool = True,
 ) -> IngestionResult:
     """Bulk-upsert parsed operations into ``endpoint_descriptor``.
 
@@ -303,6 +304,12 @@ async def register_ingested_operations(
             mid-batch rolls back to zero rows).
         embedding_service: Test seam; production callers leave
             ``None`` to resolve the process-wide singleton.
+        register_shim: ``True`` (default) auto-registers a bare
+            :class:`GenericRestConnector` shim for the triple on first
+            ingest. ``False`` (#2289) skips it because the caller will
+            stamp a dispatchable ``ProfiledRestConnector`` under the same
+            triple from an operator-selected ``auth_scheme``; a bare shim
+            would occupy the triple and make that stamp a no-op.
 
     Returns:
         :class:`IngestionResult` with per-action counts +
@@ -329,6 +336,7 @@ async def register_ingested_operations(
         version=version,
         impl_id=impl_id,
         base_url=base_url,
+        register_shim=register_shim,
     )
     coords = _BatchCoordinates(
         tenant_id=tenant_id,
@@ -358,6 +366,7 @@ def _preflight_and_register_class(
     version: str,
     impl_id: str,
     base_url: str | None,
+    register_shim: bool = True,
 ) -> bool:
     """Run the version-coverage pre-flight, then ensure the v2 class exists.
 
@@ -378,6 +387,16 @@ def _preflight_and_register_class(
     under. So the coverage check finds the real registered class and the
     auto-shim, when synthesised, lands in the dispatchable namespace.
 
+    ``register_shim`` is ``False`` for a profiled ingest (#2289): the
+    operator selected a named ``auth_scheme``, so the pipeline stamps a
+    dispatchable
+    :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector`
+    under the triple *after* this register phase. Synthesising a bare shim
+    here would occupy the triple and make that stamp a no-op, leaving the
+    connector non-dispatchable — so the shim is skipped and this returns
+    ``False`` (the profiled stamp is the registration). The version-coverage
+    pre-flight still runs (a divergent label is caught regardless of tier).
+
     Returns the ``connector_registered`` flag (``True`` when a fresh
     auto-shim was registered).
     """
@@ -386,6 +405,8 @@ def _preflight_and_register_class(
         version=version,
         impl_id=impl_id,
     )
+    if not register_shim:
+        return False
     return ensure_connector_class_registered(
         product=product,
         version=version,

--- a/backend/tests/test_mcp_tools_connector_ingest.py
+++ b/backend/tests/test_mcp_tools_connector_ingest.py
@@ -305,6 +305,57 @@ def test_ingest_tool_schemas_are_strict_and_describe_async(
 
 @pytest.mark.parametrize(
     "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_ingest_schema_exposes_closed_auth_scheme_selector(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The ingest tool schema advertises auth_scheme as a closed enum + names only (#2289)."""
+    from meho_backplane.connectors.profile import NAMED_AUTH_SCHEMES
+
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    tools = {t["name"]: t for t in response.json()["result"]["tools"]}
+    props = tools[_INGEST_TOOL]["inputSchema"]["properties"]
+
+    # auth_scheme is a closed enum covering exactly the named catalog (+ null).
+    scheme_enum = set(props["auth_scheme"]["enum"]) - {None}
+    assert scheme_enum == NAMED_AUTH_SCHEMES
+    # auth_secret_fields carries NAMES only — an array of strings, no value field.
+    assert props["auth_secret_fields"]["items"]["type"] == "string"
+    assert "auth_secret" not in {k for k in props if "value" in k}
+
+
+async def test_inline_ingest_threads_auth_scheme_to_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A selected auth_scheme + secret-field names reach the pipeline (#2289)."""
+    fake = _FakeIngestionPipelineService()
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", fake)
+    op = build_operator(TenantRole.TENANT_ADMIN)
+
+    await ci_mod._ingest_handler(
+        op,
+        {
+            "product": "acme",
+            "version": "1.2",
+            "impl_id": "acme-rest",
+            "specs": [{"uri": "docs:acme-1.2/acme.yaml"}],
+            "auth_scheme": "session_login_token",
+            "auth_secret_fields": ["username", "password"],
+            "async": False,
+            "tenant_id": str(OPERATOR_TENANT_ID),
+        },
+    )
+
+    [call] = fake.ingest_calls
+    assert call["auth_scheme"] == "session_login_token"
+    assert call["auth_secret_fields"] == ("username", "password")
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
     [TenantRole.OPERATOR],
     indirect=True,
 )

--- a/backend/tests/test_operations_ingest_auth_scheme.py
+++ b/backend/tests/test_operations_ingest_auth_scheme.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Operator-selectable auth scheme on non-catalog ingest (#2289).
+
+Initiative #2271 / Goal #221. An operator ingesting an arbitrary spec may
+*select* a named auth scheme from the closed catalog (plus, optionally, the
+secret-field NAMES it reads). When they do, the register phase synthesises a
+minimal :class:`ExecutionProfile` and stamps a dispatchable
+:class:`ProfiledRestConnector` under the triple — staged behind the #1971
+review gate — instead of the non-dispatchable bare
+:class:`GenericRestConnector` shim. When they don't, the historical bare-shim
+behaviour is byte-identical.
+
+The tests pin the task's acceptance criteria:
+
+* **Dispatchability contrast** — ingest *with* ``auth_scheme`` yields a
+  profiled connector whose ``auth_headers`` mint a Bearer token against a
+  mocked upstream login (dispatchable); the same ingest *without* the flag
+  yields the non-dispatchable bare shim.
+* **Closed-set rejection** — an unknown / reserved scheme is rejected at the
+  API boundary (the request schema) with a closed-set error naming the
+  allowed members; reserved typed-only shapes are not selectable.
+* **Secrets by reference** — the request carries secret-field *names* only;
+  no credential-value field exists on the schema.
+* **Review gate (#1971)** — the stamped connector's ops stay
+  ``is_enabled=False`` / ``review_status='staged'``; stamping never
+  auto-enables dispatch.
+
+The DB-backed tests run against ``sqlite+aiosqlite`` via the autouse
+``_default_database_url`` fixture in :mod:`tests.conftest`; each clears the
+process-global v2 registry around itself.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+import respx
+from pydantic import ValidationError
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.base import shim_kind
+from meho_backplane.connectors.profile import NAMED_AUTH_SCHEMES, AuthSchemeName
+from meho_backplane.connectors.profiled import ProfiledRestConnector
+from meho_backplane.connectors.registry import all_connectors_v2, clear_registry
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations.ingest.api_schemas import IngestRequest, SpecSource
+from meho_backplane.operations.ingest.connector_registration import (
+    GenericRestConnector,
+    resolve_authoring_kind,
+)
+from meho_backplane.operations.ingest.ingest_profile import (
+    DEFAULT_SECRET_FIELDS,
+    DEFAULT_STATIC_HEADER_VALUE_KIND,
+    build_ingest_execution_profile,
+)
+from meho_backplane.operations.ingest.llm_groups import GroupingResult
+from meho_backplane.operations.ingest.pipeline import IngestionPipelineService
+
+_PRODUCT = "acme"
+_VERSION = "1.2"
+_IMPL_ID = "acme-rest"
+_CONNECTOR_ID = "acme-rest-1.2"
+
+_SPEC_YAML = """
+openapi: "3.1.0"
+info:
+  title: Acme fixture
+  version: "1.2.0"
+paths:
+  /things:
+    get:
+      operationId: listThings
+      summary: List things
+      responses:
+        "200":
+          description: A list of things.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Unit: profile synthesis + secret-field defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_secret_fields_cover_named_schemes() -> None:
+    """Every named scheme in the closed catalog has a reviewed secret-field default."""
+    assert set(DEFAULT_SECRET_FIELDS) == NAMED_AUTH_SCHEMES
+
+
+@pytest.mark.parametrize("scheme", sorted(NAMED_AUTH_SCHEMES))
+def test_build_profile_is_valid_for_every_named_scheme(scheme: str) -> None:
+    """A minimal profile synthesises + validates for every selectable scheme."""
+    profile = build_ingest_execution_profile(
+        product=_PRODUCT,
+        version=_VERSION,
+        auth_scheme=scheme,  # type: ignore[arg-type]
+    )
+    assert profile.product == _PRODUCT
+    assert profile.version == _VERSION
+    assert profile.auth.scheme == scheme
+    assert profile.auth.secret_fields == DEFAULT_SECRET_FIELDS[scheme]
+    # value_kind is bound to static_header only (AuthSpec enforces it).
+    if scheme == "static_header":
+        assert profile.auth.value_kind == DEFAULT_STATIC_HEADER_VALUE_KIND
+    else:
+        assert profile.auth.value_kind is None
+
+
+def test_build_profile_honours_secret_fields_override() -> None:
+    """An explicit secret-field name list overrides the per-scheme default."""
+    profile = build_ingest_execution_profile(
+        product=_PRODUCT,
+        version=_VERSION,
+        auth_scheme="static_header",
+        secret_fields=("api_key",),
+    )
+    assert profile.auth.secret_fields == ("api_key",)
+
+
+def test_build_profile_rejects_empty_secret_fields() -> None:
+    """An empty override is a malformed selection (AuthSpec fails closed)."""
+    with pytest.raises(ValidationError):
+        build_ingest_execution_profile(
+            product=_PRODUCT,
+            version=_VERSION,
+            auth_scheme="basic",
+            secret_fields=(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit: API-boundary schema contract
+# ---------------------------------------------------------------------------
+
+
+def _base_request_kwargs() -> dict[str, Any]:
+    return {
+        "product": _PRODUCT,
+        "version": _VERSION,
+        "impl_id": _IMPL_ID,
+        "specs": [SpecSource(uri="https://acme.test/spec.yaml")],
+    }
+
+
+def test_unknown_or_reserved_scheme_rejected_naming_allowed_members() -> None:
+    """A reserved typed-only scheme is rejected at the boundary, naming the closed set."""
+    with pytest.raises(ValidationError) as exc:
+        IngestRequest(**_base_request_kwargs(), auth_scheme="github_app_jwt")
+    message = str(exc.value)
+    # The closed-set error names the allowed members (pydantic Literal error).
+    assert "session_login_token" in message
+    assert "github_app_jwt" in message
+
+
+def test_auth_secret_fields_requires_a_scheme() -> None:
+    """Naming secret fields without selecting a scheme is a 422."""
+    with pytest.raises(ValidationError) as exc:
+        IngestRequest(**_base_request_kwargs(), auth_secret_fields=["username"])
+    assert "requires 'auth_scheme'" in str(exc.value)
+
+
+def test_auth_scheme_mutually_exclusive_with_catalog_entry() -> None:
+    """auth_scheme is the non-catalog on-ramp; a catalog row binds its own profile."""
+    with pytest.raises(ValidationError) as exc:
+        IngestRequest(catalog_entry="acme/1.2", auth_scheme="basic")
+    assert "catalog_entry_conflict" in str(exc.value)
+
+
+def test_no_credential_value_field_on_the_schema() -> None:
+    """The request carries field NAMES only — never a credential-value field."""
+    fields = set(IngestRequest.model_fields)
+    # The only auth fields are the scheme selector and the secret-field NAMES.
+    assert "auth_scheme" in fields
+    assert "auth_secret_fields" in fields
+    # No field that would carry credential values.
+    for banned in ("password", "secret", "secrets", "credentials", "token", "api_key"):
+        assert banned not in fields
+
+
+# ---------------------------------------------------------------------------
+# DB-backed: ingest register phase stamps a dispatchable profiled connector
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env vars engine / Operator construction depend on transitively."""
+    from meho_backplane.settings import get_settings
+
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_registry()
+    yield
+    clear_registry()
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None = 443
+    secret_ref: str | None = "p/secret"
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+def _operator() -> Operator:
+    return Operator(
+        sub=f"test-operator-{uuid.uuid4()}",
+        name="Test Operator",
+        email=None,
+        raw_jwt="header.payload.signature",
+        tenant_id=uuid.uuid4(),
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+def _stub_embedding() -> Any:
+    from unittest.mock import AsyncMock
+
+    service = AsyncMock()
+    service.encode_one.return_value = [0.25] * 384
+    service.encode.return_value = [[0.25] * 384]
+    service.dimension = 384
+    return service
+
+
+async def _run_ingest(
+    *,
+    auth_scheme: AuthSchemeName | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drive the full pipeline for the acme fixture, stubbing only grouping.
+
+    Grouping needs an LLM; the register + stamp phases (the #2289 surface) do
+    not, so the grouping phase is stubbed to an empty result while the real
+    register phase — including the profile stamp — runs against sqlite.
+    """
+    service = IngestionPipelineService(
+        _operator(),
+        sessionmaker=get_sessionmaker(),
+        embedding_service=_stub_embedding(),
+    )
+
+    async def _no_grouping(**_kwargs: Any) -> GroupingResult:
+        return GroupingResult(
+            connector_id=_CONNECTOR_ID,
+            groups_created=0,
+            operations_assigned=0,
+            operations_unassigned=1,
+            llm_call_count=0,
+            llm_duration_ms=0.0,
+        )
+
+    monkeypatch.setattr(service, "_run_grouping_phase", _no_grouping)
+
+    await service.ingest(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        specs=[SpecSource(uri="fixture://acme/spec.yaml", content=_SPEC_YAML)],
+        tenant_id=None,
+        dry_run=False,
+        auth_scheme=auth_scheme,
+    )
+
+
+async def _descriptor_states() -> dict[str, bool]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.product == _PRODUCT)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        return {r.op_id: r.is_enabled for r in rows}
+
+
+@pytest.mark.asyncio
+async def test_ingest_with_auth_scheme_stamps_dispatchable_profiled_connector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ingest with --auth-scheme yields a dispatchable, review-gated profiled connector."""
+    await _run_ingest(auth_scheme="session_login_token", monkeypatch=monkeypatch)
+
+    # The triple resolves to a ProfiledRestConnector carrying the synthesised
+    # profile — the dispatchable ("profiled") tier, not the bare shim.
+    registered = all_connectors_v2()[(_PRODUCT, _VERSION, _IMPL_ID)]
+    assert issubclass(registered, ProfiledRestConnector)
+    assert shim_kind(registered) == "profiled"
+    assert registered.profile is not None
+    assert registered.profile.auth.scheme == "session_login_token"
+    assert registered.profile.auth.secret_fields == ("username", "password")
+
+    # #1971: stamping did NOT clear the review gate — the op stays staged.
+    states = await _descriptor_states()
+    assert states, "expected the ingested op to be persisted"
+    assert all(enabled is False for enabled in states.values())
+    # The read-surface projection reports it as dispatchable-but-unreviewed
+    # (not yet dispatchable until an operator enables an op).
+    assert resolve_authoring_kind(
+        product=_PRODUCT, version=_VERSION, enabled_operation_count=0
+    ) == ("profiled-but-unreviewed", False)
+
+    # Dispatch proof: the stamped connector authenticates against a mocked
+    # upstream login (SDDC-shape token mint -> Bearer). Instantiate the
+    # registered class with a stub credentials loader (no Vault) — the profile
+    # rides as a class attribute.
+    async def _loader(_target: object, _operator: Operator) -> dict[str, str]:
+        return {"username": "svc", "password": "pw"}
+
+    connector = registered(credentials_loader=_loader)
+    target = _StubTarget(name="sddc", host="sddc.invalid")
+    async with respx.mock(base_url="https://sddc.invalid") as mock:
+        route = mock.post("/v1/tokens").respond(200, json={"accessToken": "acc-xyz"})
+        headers = await connector.auth_headers(target, operator=_operator())
+    assert headers == {"Authorization": "Bearer acc-xyz"}
+    # Only field names ride the login body — the values come from the loader.
+    assert json.loads(route.calls[0].request.read().decode()) == {
+        "username": "svc",
+        "password": "pw",
+    }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_ingest_without_auth_scheme_registers_non_dispatchable_bare_shim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The same ingest without the flag yields today's non-dispatchable bare shim."""
+    await _run_ingest(auth_scheme=None, monkeypatch=monkeypatch)
+
+    registered = all_connectors_v2()[(_PRODUCT, _VERSION, _IMPL_ID)]
+    assert issubclass(registered, GenericRestConnector)
+    assert shim_kind(registered) == "bare"
+    assert resolve_authoring_kind(
+        product=_PRODUCT, version=_VERSION, enabled_operation_count=0
+    ) == ("ingested-shim", False)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -22888,6 +22888,30 @@
             "nullable": true,
             "title": "Spec Info Versions Compatible"
           },
+          "auth_scheme": {
+            "type": "string",
+            "enum": [
+              "basic",
+              "static_header",
+              "session_login",
+              "session_login_basic",
+              "session_login_token",
+              "oauth2_mint"
+            ],
+            "nullable": true,
+            "title": "Auth Scheme",
+            "description": "Named auth scheme (closed catalog) for a non-catalog ingest. When set, the connector is stamped as a dispatchable profiled connector (staged behind review, never auto-enabled) instead of a non-dispatchable bare shim. Unknown / reserved schemes are rejected (422). No free-form auth config \u2014 selection only. Mutually exclusive with catalog_entry."
+          },
+          "auth_secret_fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "maxItems": 8,
+            "nullable": true,
+            "title": "Auth Secret Fields",
+            "description": "Optional override of the secret-field NAMES the auth_scheme reads at dispatch (never the values \u2014 those stay in the target's secret_ref). Omit for the per-scheme defaults. Requires auth_scheme."
+          },
           "dry_run": {
             "type": "boolean",
             "title": "Dry Run",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -186,6 +186,16 @@ const (
 	IngestJobStatusResponseStatusSucceeded IngestJobStatusResponseStatus = "succeeded"
 )
 
+// Defines values for IngestRequestAuthScheme.
+const (
+	Basic             IngestRequestAuthScheme = "basic"
+	Oauth2Mint        IngestRequestAuthScheme = "oauth2_mint"
+	SessionLogin      IngestRequestAuthScheme = "session_login"
+	SessionLoginBasic IngestRequestAuthScheme = "session_login_basic"
+	SessionLoginToken IngestRequestAuthScheme = "session_login_token"
+	StaticHeader      IngestRequestAuthScheme = "static_header"
+)
+
 // Defines values for KindFilterValue.
 const (
 	KindFilterValueCron   KindFilterValue = "cron"
@@ -3795,7 +3805,13 @@ type IngestKbRequest struct {
 // and the operator only finds out at review-time.
 type IngestRequest struct {
 	// Async Run the pipeline off the request thread (202 + job handle); set to false for the legacy blocking response. Ignored when dry_run=true.
-	Async                      *bool         `json:"async,omitempty"`
+	Async *bool `json:"async,omitempty"`
+
+	// AuthScheme Named auth scheme (closed catalog) for a non-catalog ingest. When set, the connector is stamped as a dispatchable profiled connector (staged behind review, never auto-enabled) instead of a non-dispatchable bare shim. Unknown / reserved schemes are rejected (422). No free-form auth config — selection only. Mutually exclusive with catalog_entry.
+	AuthScheme *IngestRequestAuthScheme `json:"auth_scheme"`
+
+	// AuthSecretFields Optional override of the secret-field NAMES the auth_scheme reads at dispatch (never the values — those stay in the target's secret_ref). Omit for the per-scheme defaults. Requires auth_scheme.
+	AuthSecretFields           *[]string     `json:"auth_secret_fields"`
 	BaseUrl                    *string       `json:"base_url"`
 	CatalogEntry               *string       `json:"catalog_entry"`
 	DryRun                     *bool         `json:"dry_run,omitempty"`
@@ -3808,6 +3824,9 @@ type IngestRequest struct {
 	TenantId *openapi_types.UUID `json:"tenant_id"`
 	Version  *string             `json:"version"`
 }
+
+// IngestRequestAuthScheme Named auth scheme (closed catalog) for a non-catalog ingest. When set, the connector is stamped as a dispatchable profiled connector (staged behind review, never auto-enabled) instead of a non-dispatchable bare shim. Unknown / reserved schemes are rejected (422). No free-form auth config — selection only. Mutually exclusive with catalog_entry.
+type IngestRequestAuthScheme string
 
 // IngestResponse Response shape for “POST /api/v1/connectors/ingest“.
 //

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -388,6 +388,17 @@ func TestValidateIngestModeTable(t *testing.T) {
 		{"no-wait alone is fine", ingestOptions{
 			Catalog: "vmware/9.0", NoWait: true,
 		}, ""},
+		{"auth-scheme in manual mode is fine", ingestOptions{
+			Product: "acme", Version: "1.2", ImplID: "acme-rest",
+			Specs: []string{"file:///x.yaml"}, AuthScheme: "session_login_token",
+		}, ""},
+		{"auth-scheme + catalog", ingestOptions{
+			Catalog: "vmware/9.0", AuthScheme: "basic",
+		}, "--auth-scheme cannot be combined with --catalog"},
+		{"auth-secret-field without scheme", ingestOptions{
+			Product: "acme", Version: "1.2", ImplID: "acme-rest",
+			Specs: []string{"file:///x.yaml"}, AuthSecretFields: []string{"username"},
+		}, "--auth-secret-field requires --auth-scheme"},
 	}
 	for _, c := range cases {
 		err := validateIngestMode(c.opts)
@@ -458,6 +469,68 @@ func TestBuildIngestRequestSpecInfoVersionsCompatible(t *testing.T) {
 		}
 		if body.SpecInfoVersionsCompatible != nil {
 			t.Errorf("SpecInfoVersionsCompatible = %v, want nil", *body.SpecInfoVersionsCompatible)
+		}
+	})
+}
+
+// TestBuildIngestRequestAuthScheme — the manual-mode --auth-scheme /
+// --auth-secret-field flags (#2289) thread onto the request body so the
+// backend stamps a dispatchable profiled connector instead of a bare
+// shim; catalog mode and an unset flag both leave the fields nil, and
+// the secret fields carry NAMES only.
+func TestBuildIngestRequestAuthScheme(t *testing.T) {
+	t.Run("manual sets scheme + secret-field names", func(t *testing.T) {
+		body, err := buildIngestRequest(ingestOptions{
+			Product:          "acme",
+			Version:          "1.2",
+			ImplID:           "acme-rest",
+			Specs:            []string{"https://specs.example.test/acme.yaml"},
+			AuthScheme:       "session_login_token",
+			AuthSecretFields: []string{"username", "password"},
+		})
+		if err != nil {
+			t.Fatalf("buildIngestRequest: %v", err)
+		}
+		if body.AuthScheme == nil || *body.AuthScheme != api.SessionLoginToken {
+			t.Fatalf("AuthScheme = %v, want session_login_token", body.AuthScheme)
+		}
+		if body.AuthSecretFields == nil {
+			t.Fatal("AuthSecretFields: want populated, got nil")
+		}
+		got := *body.AuthSecretFields
+		if len(got) != 2 || got[0] != "username" || got[1] != "password" {
+			t.Errorf("AuthSecretFields = %v, want [username password]", got)
+		}
+	})
+
+	t.Run("unset leaves both fields nil", func(t *testing.T) {
+		body, err := buildIngestRequest(ingestOptions{
+			Product: "acme",
+			Version: "1.2",
+			ImplID:  "acme-rest",
+			Specs:   []string{"https://specs.example.test/acme.yaml"},
+		})
+		if err != nil {
+			t.Fatalf("buildIngestRequest: %v", err)
+		}
+		if body.AuthScheme != nil {
+			t.Errorf("AuthScheme = %v, want nil", *body.AuthScheme)
+		}
+		if body.AuthSecretFields != nil {
+			t.Errorf("AuthSecretFields = %v, want nil", *body.AuthSecretFields)
+		}
+	})
+
+	t.Run("catalog mode never carries the scheme", func(t *testing.T) {
+		body, err := buildIngestRequest(ingestOptions{
+			Catalog:    "vmware/9.0",
+			AuthScheme: "basic",
+		})
+		if err != nil {
+			t.Fatalf("buildIngestRequest: %v", err)
+		}
+		if body.AuthScheme != nil {
+			t.Errorf("AuthScheme = %v, want nil", *body.AuthScheme)
 		}
 	})
 }

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -54,6 +54,8 @@ func newIngestCmd() *cobra.Command {
 		compatible        []string
 		catalog           string
 		tenantID          string
+		authScheme        string
+		authSecretFields  []string
 		dryRun            bool
 		noWait            bool
 		jsonOut           bool
@@ -104,7 +106,18 @@ func newIngestCmd() *cobra.Command {
 			"tenant) — the request then leaves tenant_id unset, the\n" +
 			"omit-equals-global semantics the REST and MCP surfaces share.\n" +
 			"Pass your OWN tenant UUID for a tenant-curated ingest; the\n" +
-			"backplane rejects any other tenant's UUID with HTTP 403.",
+			"backplane rejects any other tenant's UUID with HTTP 403.\n\n" +
+			"--auth-scheme (manual mode) selects a named auth scheme from the\n" +
+			"closed catalog so the connector is stamped DISPATCHABLE (a profiled\n" +
+			"connector), still staged behind review/enable — never auto-enabled.\n" +
+			"Without it, an arbitrary spec ingests a non-dispatchable shim. The\n" +
+			"allowed values are: basic, static_header, session_login,\n" +
+			"session_login_basic, session_login_token, oauth2_mint. There is no\n" +
+			"free-form auth config (no login URL/template/token path) — selection\n" +
+			"only. --auth-secret-field overrides the secret-field NAMES the scheme\n" +
+			"reads at dispatch (never the values — those stay in the target's\n" +
+			"secret_ref); omit for the per-scheme defaults. Both are mutually\n" +
+			"exclusive with --catalog (a catalog row binds its own profile).",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -117,6 +130,8 @@ func newIngestCmd() *cobra.Command {
 				Compatible:        compatible,
 				Catalog:           catalog,
 				TenantID:          tenantID,
+				AuthScheme:        authScheme,
+				AuthSecretFields:  authSecretFields,
 				DryRun:            dryRun,
 				NoWait:            noWait,
 				JSONOut:           jsonOut,
@@ -145,6 +160,16 @@ func newIngestCmd() *cobra.Command {
 		"write scope for the ingested rows (works with both modes): omit for the built-in / "+
 			"global scope (tenant_id left unset — visible to every tenant); pass your own "+
 			"tenant UUID for a tenant-curated ingest (another tenant's UUID is rejected with HTTP 403)")
+	cmd.Flags().StringVar(&authScheme, "auth-scheme", "",
+		"manual mode: select a named auth scheme (closed catalog) so the connector is stamped "+
+			"DISPATCHABLE (a profiled connector, still staged behind review) instead of a "+
+			"non-dispatchable shim. One of: basic, static_header, session_login, session_login_basic, "+
+			"session_login_token, oauth2_mint. Selection only — no free-form auth config. Mutually "+
+			"exclusive with --catalog")
+	cmd.Flags().StringArrayVar(&authSecretFields, "auth-secret-field", nil,
+		"manual mode: override a secret-field NAME the --auth-scheme reads at dispatch (never the "+
+			"value — that stays in the target's secret_ref); repeat for multiple. Omit for the "+
+			"per-scheme defaults. Requires --auth-scheme")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
 		"parse and plan without writing to the DB; the response carries an IngestionResult with counts but no GroupingResult")
 	cmd.Flags().BoolVar(&noWait, "no-wait", false,
@@ -165,6 +190,8 @@ type ingestOptions struct {
 	Compatible        []string
 	Catalog           string
 	TenantID          string
+	AuthScheme        string
+	AuthSecretFields  []string
 	DryRun            bool
 	NoWait            bool
 	JSONOut           bool
@@ -282,6 +309,22 @@ func buildIngestRequest(opts ingestOptions) (api.IngestRequest, error) {
 		compatible := append([]string(nil), opts.Compatible...)
 		body.SpecInfoVersionsCompatible = &compatible
 	}
+	if opts.AuthScheme != "" {
+		// Non-catalog on-ramp (#2289): selecting a named auth scheme stamps
+		// a dispatchable profiled connector (still review-gated) instead of a
+		// bare shim. Catalog mode returns above, so this only rides the
+		// manual shape. The closed-set / reserved-scheme rejection is the
+		// backend's (a 422 naming the allowed members) — the CLI forwards the
+		// operator's selection verbatim as the typed enum.
+		scheme := api.IngestRequestAuthScheme(opts.AuthScheme)
+		body.AuthScheme = &scheme
+	}
+	if len(opts.AuthSecretFields) > 0 {
+		// NAMES only — the credential values are resolved from the target's
+		// secret_ref at dispatch, never carried in the request.
+		fields := append([]string(nil), opts.AuthSecretFields...)
+		body.AuthSecretFields = &fields
+	}
 	return body, nil
 }
 
@@ -299,12 +342,24 @@ func validateIngestMode(opts ingestOptions) error {
 			"--no-wait cannot be combined with --dry-run: dry runs always execute " +
 				"synchronously (the backplane returns the parse plan inline)")
 	}
+	if len(opts.AuthSecretFields) > 0 && opts.AuthScheme == "" {
+		// Naming the secret fields without selecting a scheme is a caller-side
+		// bug — there is no extractor to read them (mirrors the backend 422).
+		return errors.New(
+			"--auth-secret-field requires --auth-scheme (the field names are read " +
+				"by the selected scheme's extractor)")
+	}
 	manualSet := opts.Product != "" || opts.Version != "" || opts.ImplID != "" || len(opts.Specs) > 0
 	if opts.Catalog != "" {
 		if manualSet {
 			return errors.New(
 				"--catalog cannot be combined with --product/--version/--impl/--spec; " +
 					"use catalog mode OR manual mode, not both")
+		}
+		if opts.AuthScheme != "" {
+			return errors.New(
+				"--auth-scheme cannot be combined with --catalog; a catalog row binds its " +
+					"own profile (use --auth-scheme only with the manual --product/--version/--impl/--spec shape)")
 		}
 		return nil
 	}

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -656,6 +656,55 @@ product does not round-trip (the `_fixture` mechanism row parses to
 `validate_shipped_artifacts()`; the stamp path re-parses with the same
 model, so it stays fail-closed as a second line of defence.
 
+### Operator-selectable auth scheme on a non-catalog ingest (#2289)
+
+Boot stamping (above) makes a *shipped* profile-backed catalog row
+dispatchable. `#2289` is the **non-catalog on-ramp**: an operator ingesting an
+arbitrary spec may *select* a named auth scheme at creation time, and the
+register phase synthesises a minimal `ExecutionProfile` and stamps the same
+`ProfiledRestConnector` under the triple — so a hand-authored spec becomes
+dispatchable without a hand-coded connector class.
+
+The selection is exposed on all three surfaces as two optional fields:
+
+* REST — `IngestRequest.auth_scheme` (+ `auth_secret_fields`) in
+  `ingest/api_schemas.py`.
+* MCP — the `auth_scheme` / `auth_secret_fields` properties on the
+  `meho.connector.ingest` tool schema (`mcp/tools/connector_ingest.py`).
+* CLI — `meho connector ingest --auth-scheme <name> [--auth-secret-field
+  <name> ...]` (`cli/internal/cmd/connector/ingest.go`).
+
+`auth_scheme` is a member of the **closed** `AuthSchemeName` catalog
+(`connectors/profile.py`): `basic`, `static_header`, `session_login`,
+`session_login_basic`, `session_login_token`, `oauth2_mint`. The Pydantic
+`Literal` rejects an unknown value **and every reserved typed-only shape**
+(`github_app_jwt`, `kubeconfig`, `cookie_jar_session`, …) with a 422 closed-set
+error naming the allowed members, at the API boundary.
+
+**The boundary (Initiative #2271, grounded in #1177 / Goal #1964 Non-goals) is
+selection only.** The operator picks *which* vetted scheme (and optionally the
+NAMES of the secret-bundle keys it reads); there is **no** free-form auth
+config — no login URL, body template, token JSONPath, or header name. The login
+path, request body shape, and token extractor for each scheme are vetted Python
+selected by the scheme name in `_shared/profile_auth.py::SESSION_SCHEME_SPECS`.
+Adding a new auth shape is a scheme PR (a new `Literal` member + a reviewed
+extractor + coverage-trace update), never a request knob. The secret *values*
+are never carried in the ingest request — `auth_secret_fields` is field NAMES
+only, resolved from the target's `secret_ref` by the broker at dispatch.
+
+Wiring: `IngestionPipelineService.ingest(auth_scheme=…, auth_secret_fields=…)`
+builds the profile via `ingest/ingest_profile.py::build_ingest_execution_profile`
+(per-scheme secret-field defaults in `DEFAULT_SECRET_FIELDS`; conservative
+fingerprint/`delegate`-probe/`none`-pagination defaults, since a non-catalog
+ingest names no version endpoint). The register phase then skips the bare shim
+(`register_ingested_operations(register_shim=False)`) so the triple is free, and
+`_stamp_profiled_connector` stamps the synthesised class through the same
+`record_profile_stamp` seam boot stamping uses. **Stamping never enables an
+op** — the `review_status='staged'` gate (#1971) stays the interlock, so the
+connector lands dispatchable-but-unreviewed (`kind="profiled-but-unreviewed"`)
+and the operator clears the gate per-op via the normal review/enable flow.
+Omitting `auth_scheme` keeps the historical bare-shim behaviour byte-identical.
+
 ### Authoring-mode `kind` on the list / review surfaces (G0.28-T6 #1979)
 
 The enable-time advisory above surfaces the connector tier only at the


### PR DESCRIPTION
## Summary

- Give **non-catalog** spec ingest a creation-time auth selection: an optional `auth_scheme` (a member of the closed `AuthSchemeName` catalog) plus optional `auth_secret_fields` (names only) on the ingest request across REST + MCP + CLI. When set, the register phase synthesises a minimal `ExecutionProfile` and stamps a dispatchable `ProfiledRestConnector` under the triple — via the same `record_profile_stamp` seam boot stamping (#2288) uses — instead of the non-dispatchable bare `GenericRestConnector` shim.
- **Selection only** (Initiative #2271 boundary, #1177 / Goal #1964 Non-goals): the operator picks a vetted scheme from the closed set and, optionally, the secret-field *names* it reads. No free-form auth config (login URL / body template / token path / header name), and reserved typed-only shapes are rejected at the API boundary with a closed-set 422.
- **Never auto-enabled**: stamping registers the class but leaves every op `is_enabled=False` / `review_status='staged'`; the #1971 review gate stays the interlock. Omitting `auth_scheme` keeps the historical bare-shim behaviour byte-identical.
- Secrets never ride the request — `auth_secret_fields` is field *names*; credential values resolve from the target's `secret_ref` at dispatch.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — Success, no issues (599 files)
- [x] New `backend/tests/test_operations_ingest_auth_scheme.py` (15 tests): profile synthesis for every named scheme, secret-field defaults cover `NAMED_AUTH_SCHEMES`, closed-set/reserved rejection naming allowed members, `auth_secret_fields`-requires-scheme, catalog mutual-exclusion, no-credential-value-field assertion, **ingest-with-scheme stamps a dispatchable profiled connector whose `auth_headers` mint a Bearer token against a mocked SDDC login**, ingest-without-scheme yields the bare shim, and the #1971 gate (ops stay staged).
- [x] MCP: schema exposes `auth_scheme` as a closed enum + `auth_secret_fields` (names only); handler threads both to `service.ingest`.
- [x] CLI: `--auth-scheme` / `--auth-secret-field` flags + validation (`go test ./...` green); `make snapshot-openapi && make generate` regenerated `cli/api/openapi.json` + the generated client.
- [x] Full backend unit suite (`pytest -n 4 --dist loadscope --ignore=tests/integration --ignore=tests/migrations tests/`)

## Out of scope

- Any free-form auth parameter (login URL, body template, token path, header name) — rejected design.
- Editing a connector's scheme after ingest (re-ingest is the path); an operator-editable profile store stays rejected.
- Catalog-row products (they bind profiles via `profile_resource` + boot stamping, #2288).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2289


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--auth-scheme` support for selecting a named authentication scheme during non-catalog ingest.
  * Added optional `--auth-secret-field` overrides for specifying secret-field names.
  * Added equivalent authentication options to the connector ingest API and MCP tool.
  * Authenticated ingests now produce dispatchable, review-gated connectors.

* **Bug Fixes**
  * Added validation preventing incompatible catalog, authentication scheme, and secret-field combinations.

* **Documentation**
  * Documented authentication scheme selection, validation, and review-gating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->