### PR TITLE
feat(connectors): rebuild SDDC Manager auth on session_login_token profile (#2290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — SDDC Manager auth rebuilt on the `session_login_token` profile scheme (#2290)
+
+- Flip the shipped `sddc_manager_minimal.yaml` profile from the false
+  `basic` scheme to `session_login_token`, and rebuild `SddcManagerConnector`
+  auth atop it: the connector now establishes a session at
+  `POST /v1/tokens` (JSON `{username, password}` → `accessToken`) and sends
+  `Authorization: Bearer <accessToken>` on every request — SDDC Manager
+  rejects HTTP Basic outright (live 401; Broadcom KBs 435716/387124/372387),
+  so the ingested sddc catalog was never dispatchable before. Session
+  mechanics are derived from the shared `session_login_token` scheme spec
+  (single source with a profile-stamped connector), with per-`(tenant_id,
+  target.id)` token isolation, single-flight establish, and one-shot 401
+  recovery through the #2067 dispatcher seam (`invalidate_session` hook) —
+  no restart. The hand-rolled class stays the resolution winner, preserving
+  the #1750/#1798 product-shadowing invariant. Removed the false
+  `username@sso_realm` Basic decoration. (#2271 / #2290)
+
 ### Added — profiled-connector boot registration (shipped ExecutionProfiles become dispatchable at boot) (#2288)
 
 - Wire `record_profile_stamp` into production: at boot, immediately after

--- a/backend/src/meho_backplane/connectors/profiles/sddc_manager_minimal.yaml
+++ b/backend/src/meho_backplane/connectors/profiles/sddc_manager_minimal.yaml
@@ -4,11 +4,16 @@
 # ExecutionProfile for the `sddc/9.0` profile-backed catalog row
 # (#1964 T2 #1976). Pairs with operations/ingest/specs/sddc_manager_minimal.yaml.
 #
-# AUTH. `basic` — the SDDC Manager API authenticates with HTTP Basic
-# (username/password from the per-target secret bundle), matching the
-# vetted classification in docs/codebase/connector-auth-coverage.md and the
-# typed SddcManagerConnector.auth_headers. No DSL: the scheme names a vetted
-# extractor (#1969); the profile carries only the secret-field names.
+# AUTH. `session_login_token` — the SDDC Manager API is token-only: it
+# authenticates by POSTing the `{username, password}` JSON credential body to
+# `/v1/tokens`, reading `accessToken` out of the response, and sending it as
+# `Authorization: Bearer <accessToken>` on every subsequent request. The
+# appliance rejects HTTP Basic outright (live 401; Broadcom KBs
+# 435716/387124/372387). This matches the vetted classification in
+# docs/codebase/connector-auth-coverage.md and the typed
+# SddcManagerConnector, which derives its session from this same scheme
+# (#2290). No DSL: the scheme names a vetted extractor (#1969/#2287); the
+# profile carries only the secret-field names.
 #
 # FINGERPRINT. `/v1/releases/system` returns a top-level `version` string,
 # so it satisfies the FingerprintSpec literal-top-level-key constraint
@@ -30,7 +35,7 @@
 product: sddc
 version: "9.0"
 auth:
-  scheme: basic
+  scheme: session_login_token
   secret_fields:
     - username
     - password

--- a/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
@@ -45,6 +45,7 @@ from meho_backplane.connectors.sddc_manager.core_ops import (
     apply_sddc_core_curation,
     classify_sddc_op,
 )
+from meho_backplane.connectors.sddc_manager.profile import SDDC_EXECUTION_PROFILE
 from meho_backplane.connectors.sddc_manager.session import (
     SddcCredentialsLoader,
     SddcTargetLike,
@@ -76,6 +77,7 @@ __all__ = [
     "SDDC_CONNECTOR_ID",
     "SDDC_CORE_GROUPS",
     "SDDC_CORE_OPS",
+    "SDDC_EXECUTION_PROFILE",
     "SDDC_IMPL_ID",
     "SDDC_PATH_RULES",
     "SDDC_PRODUCT",

--- a/backend/src/meho_backplane/connectors/sddc_manager/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/connector.py
@@ -3,34 +3,47 @@
 
 """SddcManagerConnector — hand-rolled HttpConnector subclass for SDDC Manager 9.0.
 
-Skeleton-only — auth + fingerprint + probe + the G0.6 dispatch shim.
-Operations arrive in #617 via G0.7 spec ingestion against the VCF API
-spec for SDDC Manager.
+Auth + fingerprint + probe + the G0.6 dispatch shim. Ingested operations
+dispatch through the same transport + ``auth_headers`` seam.
 
 Registered against the v2 registry at module-import time via
 :func:`~meho_backplane.connectors.registry.register_connector_v2` in
-:mod:`meho_backplane.connectors.sddc_manager.__init__`. The G0.7 auto-shim's
-idempotency check (in
-:func:`~meho_backplane.operations.ingest.connector_registration.ensure_connector_class_registered`
-once #408's pipeline lands in main) no-ops on subsequent ingests against the
-same ``(product="sddc", version="9.0", impl_id="sddc-rest")`` triple.
+:mod:`meho_backplane.connectors.sddc_manager.__init__`. The connector *occupies*
+the ``(product="sddc", version="9.0", impl_id="sddc-rest")`` triple, so the
+boot-time profile stamp (#2288/#2320) no-ops on it — the typed class stays the
+resolution winner, preserving the #1750/#1798 product-shadowing invariant while
+its session auth is derived from the shipped profile.
 
-Auth divergence from the NSX/vSphere precedents
-------------------------------------------------
+Auth — token session derived from the shipped ExecutionProfile
+--------------------------------------------------------------
 
-SDDC Manager uses HTTP Basic auth sent on every request — no session cookie
-or XSRF token is established. The connector caches the raw service-account
-credentials (loaded once from Vault via an injectable loader) and computes
-the ``Authorization: Basic`` header on each :meth:`auth_headers` call from
-the cached values. The username is formatted as ``username@sso_realm`` where
-``sso_realm`` defaults to ``"vsphere.local"`` per the consumer wrapper
-contract; operators managing a custom SSO domain override this via
-``target.sso_realm``.
+SDDC Manager is **token-only**: it rejects HTTP Basic outright (live 401;
+Broadcom KBs 435716/387124/372387). The real flow is a JSON credential login —
+``POST /v1/tokens`` with a ``{username, password}`` body — that returns
+``accessToken``, sent as ``Authorization: Bearer <accessToken>`` on every
+subsequent request.
 
-Because HTTP Basic credentials are stateless server-side (no session to
-revoke or expire), no 401-driven re-login loop is needed. A 401 from a
-downstream call propagates directly to the caller — it means wrong
-credentials, not an expired session.
+That flow is the ``session_login_token`` named scheme (#2287). The connector
+derives its session-login path, request headers, and session-expiry status set
+from the reviewed
+:data:`~meho_backplane.connectors.sddc_manager.profile.SDDC_EXECUTION_PROFILE`
+via that scheme's
+:class:`~meho_backplane.connectors._shared.profile_auth.SessionSchemeSpec`, so
+the typed connector and a profile-stamped
+:class:`~meho_backplane.connectors.profiled.ProfiledRestConnector` share one
+declaration of the login mechanics rather than two literals that could drift —
+the same posture :class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector`
+takes against ``VRLI_EXECUTION_PROFILE`` (#1974).
+
+The per-target session token is cached (single-flight under a lock). On a
+downstream session-expiry status (:data:`_SESSION_EXPIRED_STATUSES` — ``401``,
+the SDDC Manager expired-token signal) the cached token is evicted and the
+login re-run once: the helper-level :meth:`_get_json_with_session_retry` covers
+the fingerprint/probe round-trip, and the public duck-typed
+:meth:`invalidate_session` hook is the seam the generic-ingested dispatch path
+calls (#2067) before re-dispatching the op once. Credentials themselves are
+loaded once per target from Vault (a ``401`` means the *token* expired, not the
+credential, so the credential cache is left intact across an eviction).
 
 Auth model gating
 -----------------
@@ -50,24 +63,15 @@ Fingerprint
 singleton appliance). ``version`` carries the full version string (e.g.
 ``"5.2.0.0-24276214"``); ``build`` is extracted from a separate ``build``
 field when present (VCF 9.x may surface it explicitly), otherwise ``None``.
-``extras["management_domain"]`` carries the management domain name.
-
-Operations
-----------
-
-This module ships zero operations — the G0.6 dispatch shim :meth:`execute`
-exists for ABC compatibility but operations land in the
-``endpoint_descriptor`` table via #617's spec ingestion. Until then, the
-connector is registered and discoverable but ``execute(target, op_id, ...)``
-against any ``op_id`` resolves to "unknown operation" at the dispatcher
-layer — which is the correct behaviour for a registered-but-empty connector
-at this Task's stage.
+``extras["management_domain"]`` carries the management domain name. The
+fingerprint GET authenticates via the token session (SDDC Manager has no
+unauthenticated version endpoint), so it goes through
+:meth:`_get_json_with_session_retry`.
 """
 
 from __future__ import annotations
 
 import asyncio
-import base64
 from datetime import UTC, datetime
 from typing import Any
 
@@ -76,10 +80,12 @@ import structlog
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors._shared.profile_auth import SESSION_SCHEME_SPECS
 from meho_backplane.connectors._shared.system_operator import (
     is_system_operator,
     synthesise_system_operator,
 )
+from meho_backplane.connectors._shared.vcf_auth import SessionLoginError, vcf_session_login
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.schemas import (
     AuthModel,
@@ -87,17 +93,39 @@ from meho_backplane.connectors.schemas import (
     OperationResult,
     ProbeResult,
 )
+from meho_backplane.connectors.sddc_manager.profile import SDDC_EXECUTION_PROFILE
 from meho_backplane.connectors.sddc_manager.session import (
     SddcCredentialsLoader,
     SddcTargetLike,
     load_credentials_from_vault,
 )
 
-__all__ = ["SddcManagerConnector"]
+# Re-export ``SessionLoginError`` so callers that catch the login helper's
+# structured failure don't have to reach into the shared module.
+__all__ = ["SddcManagerConnector", "SessionLoginError"]
 
 _log = structlog.get_logger(__name__)
 
-_DEFAULT_SSO_REALM = "vsphere.local"
+# The ``session_login_token`` scheme spec (#2287), selected by the shipped
+# profile. Supplies the login path, request headers, credential-body builder,
+# and token extractor — the single declaration the typed connector and a
+# profiled SDDC connector both read, so the login mechanics cannot drift.
+_SESSION_SPEC = SESSION_SCHEME_SPECS[SDDC_EXECUTION_PROFILE.auth.scheme]
+
+# ``POST /v1/tokens`` — the SDDC Manager token-issue endpoint, sourced from the
+# scheme spec's login-path builder rather than a bare literal.
+_SESSION_CREATE_PATH = _SESSION_SPEC.login_path(SDDC_EXECUTION_PROFILE.auth)
+
+# Static headers the login POST carries (``Content-Type`` / ``Accept`` JSON).
+_SESSION_REQUEST_HEADERS: dict[str, str] = dict(_SESSION_SPEC.request_headers)
+
+# Downstream statuses meaning "the cached session token is no longer accepted;
+# re-login and retry once". SDDC Manager signals an expired token with a plain
+# ``401`` (no vendor-specific expiry code — the refresh-token leg is an
+# initiative Non-goal), so this is the profile's default ``{401}``. Sourced
+# from the profile's ``expiry_statuses`` so the helper retry layer and the
+# dispatcher's auth-class arm narrow the same closed set from one declaration.
+_SESSION_EXPIRED_STATUSES: frozenset[int] = SDDC_EXECUTION_PROFILE.expiry_statuses
 
 
 def _is_acceptable_auth_model(value: Any) -> bool:
@@ -116,23 +144,56 @@ def _is_acceptable_auth_model(value: Any) -> bool:
     return bool(value == AuthModel.SHARED_SERVICE_ACCOUNT.value)
 
 
-def _basic_auth_header(username: str, password: str) -> str:
-    """Compute the ``Authorization: Basic`` header value for *username*:*password*."""
-    encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
-    return f"Basic {encoded}"
+def _sddc_login_body(username: str, password: str) -> dict[str, Any]:
+    """Build SDDC Manager's ``{username, password}`` login body.
+
+    Delegates to the ``session_login_token`` scheme spec's body builder so the
+    wire-key contract lives in one place (``profile_auth``), shared with a
+    profiled SDDC connector. The shared :func:`vcf_session_login` helper's
+    ``payload_builder`` contract is ``(username, password) -> dict``; the scheme
+    spec's builder reads them out of a secret bundle, so this closure bridges
+    the two shapes.
+    """
+    return dict(
+        _SESSION_SPEC.build_body(
+            SDDC_EXECUTION_PROFILE.auth,
+            {"username": username, "password": password},
+        )
+    )
+
+
+def _extract_access_token(resp: httpx.Response) -> str | None:
+    """Pull ``accessToken`` out of the SDDC Manager token-response body.
+
+    Delegates to the scheme spec's vetted token extractor so the connector and
+    a profiled SDDC connector read the same response field. Returns ``None`` for
+    a missing / non-string / empty token (or a non-JSON body); the shared
+    :func:`vcf_session_login` helper then raises the consistent target-named
+    :class:`SessionLoginError`.
+    """
+    try:
+        payload = resp.json()
+    except ValueError:
+        return None
+    token = _SESSION_SPEC.extract_token(payload)
+    return token.token if token is not None else None
 
 
 class SddcManagerConnector(HttpConnector):
-    """SDDC Manager 9.0 REST connector with HTTP Basic auth.
+    """SDDC Manager 9.0 REST connector with profile-derived token-session auth.
 
-    Per-target credentials cached in :attr:`_creds_cache` (loaded once via
-    the injectable :class:`SddcCredentialsLoader`). HTTP Basic auth is sent
-    on every request via ``Authorization: Basic <base64>`` — no session
-    token is established and no 401-driven re-login is needed.
+    Per-target credentials cached in :attr:`_creds_cache` (loaded once via the
+    injectable :class:`SddcCredentialsLoader`); the per-target session token
+    minted from them cached in :attr:`_session_tokens`. Auth is the
+    ``session_login_token`` scheme derived from
+    :data:`~meho_backplane.connectors.sddc_manager.profile.SDDC_EXECUTION_PROFILE`
+    — ``POST /v1/tokens`` → ``accessToken`` → ``Authorization: Bearer`` — with
+    a single re-login on a downstream ``401`` (SDDC Manager rejects HTTP Basic;
+    the token is the only path that dispatches).
 
-    The :attr:`priority` is set to ``1`` so a future
-    ``GenericRestConnector`` auto-shim that somehow registers for the same
-    triple loses the registry's tie-break ladder.
+    The :attr:`priority` is set to ``1`` so a future ``GenericRestConnector``
+    auto-shim that somehow registers for the same triple loses the registry's
+    tie-break ladder.
     """
 
     # G0.6 v2 registry metadata. The (product, version, impl_id) triple
@@ -152,29 +213,27 @@ class SddcManagerConnector(HttpConnector):
         super().__init__()
         self._creds_cache: dict[tuple[str, str], dict[str, str]] = {}
         self._creds_lock = asyncio.Lock()
+        self._session_tokens: dict[tuple[str, str], str] = {}
+        self._session_lock = asyncio.Lock()
         self._credentials_loader: SddcCredentialsLoader = (
             credentials_loader if credentials_loader is not None else load_credentials_from_vault
         )
 
     async def auth_headers(self, target: SddcTargetLike, operator: Operator) -> dict[str, str]:
-        """Return ``{"Authorization": "Basic ..."}`` for the request.
+        """Return ``{"Authorization": "Bearer <accessToken>"}`` for the request.
 
-        Loads credentials from Vault on first call against *target*, caches
-        them, and reuses the cached values on subsequent calls. The full
-        ``operator`` is forwarded to :meth:`_load_credentials` so the live
-        default loader (G3.10-T1 #945) reads the per-target Vault secret
-        under the operator's identity (``vault_client_for_operator(operator)``).
+        Lazily establishes the session on first call against *target*
+        (``POST /v1/tokens``); subsequent calls reuse the cached token. The
+        full ``operator`` is threaded into :meth:`_session_token` →
+        :meth:`_load_credentials` so the live default loader (G3.10-T1 #945)
+        reads the per-target Vault secret under the operator's identity
+        (``vault_client_for_operator(operator)``).
         :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` selects the Vault-sourced
-        service account once the loader has resolved it; the operator's
-        JWT only authenticates the read, not the SDDC Manager request
-        itself.
+        service account once the loader has resolved it; the operator's JWT
+        only authenticates the read, not the SDDC Manager request itself.
 
-        The Basic auth username is ``{creds['username']}@{target.sso_realm}``
-        where ``sso_realm`` defaults to ``"vsphere.local"`` when unset or
-        empty.
-
-        Raises :exc:`NotImplementedError` if ``target.auth_model`` is
-        anything other than ``shared_service_account`` or ``None``.
+        Raises :exc:`NotImplementedError` if ``target.auth_model`` is anything
+        other than ``shared_service_account`` or ``None``.
         """
         auth_model = getattr(target, "auth_model", None)
         if not _is_acceptable_auth_model(auth_model):
@@ -183,10 +242,112 @@ class SddcManagerConnector(HttpConnector):
                 f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
                 f"{target.name!r} requested auth_model={auth_model!r}"
             )
-        creds = await self._load_credentials(target, operator)
-        sso_realm = getattr(target, "sso_realm", None) or _DEFAULT_SSO_REALM
-        auth_username = f"{creds['username']}@{sso_realm}"
-        return {"Authorization": _basic_auth_header(auth_username, creds["password"])}
+        token = await self._session_token(target, operator)
+        return {"Authorization": f"Bearer {token}"}
+
+    async def _session_token(self, target: SddcTargetLike, operator: Operator) -> str:
+        """Return the cached session token for *target*, establishing on first use.
+
+        The lock serialises concurrent first-use callers for one target so two
+        first-use callers don't both pay the ``POST /v1/tokens`` round-trip.
+        Credentials are sourced from :meth:`_load_credentials` (its own lock,
+        cache, and fail-closed loader); the login round-trip delegates to the
+        shared :func:`vcf_session_login` helper, which wraps a non-2xx or a
+        token-less 2xx in :exc:`SessionLoginError` naming the target.
+
+        The cache fast-path is closed to the synthesised system operator
+        (``is_system_operator``): a system/operator-less caller always
+        re-establishes (its :meth:`_load_credentials` re-runs the loader so the
+        fail-closed guard applies), and its minted token is never written to the
+        shared cache — it can neither be served a warm token a real operator
+        primed nor poison the cache for one (#1008).
+        """
+        cache_key = target_cache_key(target)
+        async with self._session_lock:
+            cached = self._session_tokens.get(cache_key)
+            if cached is not None and not is_system_operator(operator):
+                return cached
+            creds = await self._load_credentials(target, operator)
+            client = await self._http_client(target)
+            token = await vcf_session_login(
+                client,
+                _SESSION_CREATE_PATH,
+                username=creds["username"],
+                password=creds["password"],
+                target_name=target.name,
+                payload_builder=_sddc_login_body,
+                token_extractor=_extract_access_token,
+                request_headers=dict(_SESSION_REQUEST_HEADERS),
+            )
+            if not is_system_operator(operator):
+                self._session_tokens[cache_key] = token
+            _log.info(
+                "sddc_manager_session_established",
+                target=target.name,
+                host=target.host,
+            )
+            return token
+
+    async def invalidate_session(self, target: SddcTargetLike) -> None:
+        """Public duck-typed session-eviction hook for the dispatch path.
+
+        The seam the generic-ingested dispatch path calls on an auth-class
+        status (SDDC Manager's ``401``) before re-dispatching the op once
+        (#2067) — the path an ingested sddc op actually traverses. Delegates to
+        :meth:`_invalidate_session` so the dispatch-path recovery and the
+        helper's internal retry share one eviction implementation.
+        """
+        await self._invalidate_session(target)
+
+    async def _invalidate_session(self, target: SddcTargetLike) -> None:
+        """Drop the cached session token for *target*.
+
+        Called by :meth:`_get_json_with_session_retry` on a session-expiry
+        status from a downstream call, and by the public
+        :meth:`invalidate_session` dispatch-path hook (#2067), so the
+        subsequent :meth:`_session_token` re-issues ``POST /v1/tokens`` from a
+        clean state. Holds the lock so a concurrent re-establish doesn't race
+        with the invalidation. The credential cache is left intact — a ``401``
+        means the *session token* expired, not that the credentials are wrong.
+        """
+        async with self._session_lock:
+            self._session_tokens.pop(target_cache_key(target), None)
+
+    async def _get_json_with_session_retry(
+        self,
+        target: SddcTargetLike,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """GET *path* with single session-expiry -> re-login -> retry-once recovery.
+
+        Wraps the inherited :meth:`HttpConnector._get_json` (which carries
+        tenacity's connection-error + 5xx retry decorator). On a session-expiry
+        status (:data:`_SESSION_EXPIRED_STATUSES` — SDDC Manager's ``401``) from
+        the inherited call, invalidates the cached token and retries once: the
+        cached token is stale, not the credential, so a re-login recovers it. A
+        second session-expiry status raises :exc:`RuntimeError` naming the
+        target — re-login once on expiry, not a retry loop. Same shape the
+        vRLI / NSX precedents established.
+        """
+        try:
+            return await self._get_json(target, path, operator=operator, params=params)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code not in _SESSION_EXPIRED_STATUSES:
+                raise
+            await self._invalidate_session(target)
+        try:
+            return await self._get_json(target, path, operator=operator, params=params)
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            if status_code in _SESSION_EXPIRED_STATUSES:
+                raise RuntimeError(
+                    f"sddc-manager session re-login failed for target {target.name!r}: "
+                    f"GET {path} returned HTTP {status_code} after refresh"
+                ) from exc
+            raise
 
     async def _load_credentials(self, target: SddcTargetLike, operator: Operator) -> dict[str, str]:
         """Return the cached credentials for *target*, loading from Vault on first use.
@@ -242,10 +403,14 @@ class SddcManagerConnector(HttpConnector):
     ) -> FingerprintResult:
         """Canonical fingerprint built from ``GET /v1/sddc-managers``.
 
-        Reads ``elements[0]`` from the pagination envelope. On transport or
-        status failure, returns a non-reachable :class:`FingerprintResult`
-        whose ``extras["error"]`` carries the exception class + message —
-        same pattern the NSX and vSphere connectors established.
+        Reads ``elements[0]`` from the pagination envelope. The GET
+        authenticates via the token session and goes through
+        :meth:`_get_json_with_session_retry`, so an idle-expired token is
+        recovered with one re-login rather than surfacing as unreachable. On
+        transport or status failure (including a re-login that still fails),
+        returns a non-reachable :class:`FingerprintResult` whose
+        ``extras["error"]`` carries the exception class + message — same pattern
+        the NSX and vSphere connectors established.
 
         ``operator`` (optional) is the request-scoped operator forwarded
         from the probe routes. When provided, the credentials loader
@@ -261,7 +426,9 @@ class SddcManagerConnector(HttpConnector):
         probed_at = datetime.now(UTC)
         eff_operator = operator if operator is not None else synthesise_system_operator()
         try:
-            payload = await self._get_json(target, "/v1/sddc-managers", operator=eff_operator)
+            payload = await self._get_json_with_session_retry(
+                target, "/v1/sddc-managers", operator=eff_operator
+            )
         except (httpx.HTTPError, OSError, RuntimeError) as exc:
             return FingerprintResult(
                 vendor="vmware",
@@ -348,13 +515,18 @@ class SddcManagerConnector(HttpConnector):
         )
 
     async def aclose(self) -> None:
-        """Clear cached credentials, then tear down the httpx pool.
+        """Clear cached session tokens + credentials, then tear down the httpx pool.
 
-        No server-side session to revoke — HTTP Basic is stateless.
-        The credential cache is cleared so a post-aclose reuse of the same
-        connector instance (e.g. a test that builds one connector across two
-        contexts) starts clean.
+        No DELETE-revoke is issued for the token — SDDC Manager's session has a
+        server-side lifetime and a per-target network call during lifespan
+        shutdown is more risk than benefit (same posture the vRLI / NSX
+        precedents established). Both caches are cleared so a post-aclose reuse
+        of the same connector instance (e.g. a test that builds one connector
+        across two contexts) starts clean and secrets don't outlive the
+        instance.
         """
+        async with self._session_lock:
+            self._session_tokens.clear()
         async with self._creds_lock:
             self._creds_cache.clear()
         await super().aclose()

--- a/backend/src/meho_backplane/connectors/sddc_manager/profile.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/profile.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The reviewed ``sddc`` ExecutionProfile for the SDDC Manager connector.
+
+T4 of Initiative #2271 (#2290) — the declarative source of truth the typed
+:class:`~meho_backplane.connectors.sddc_manager.connector.SddcManagerConnector`
+now derives its session auth from, mirroring the
+:data:`~meho_backplane.connectors.vcf_logs.profile.VRLI_EXECUTION_PROFILE`
+capstone (#1974).
+
+Single source, two consumers
+============================
+
+This constant is the byte-for-byte equivalent of the shipped catalog profile
+``connectors/profiles/sddc_manager_minimal.yaml`` (a parity test pins them
+together). The two consumers read the *same* declarative auth block:
+
+* the **boot-stamp** path parses the shipped YAML and — on an *unoccupied*
+  ``(sddc, 9.0, sddc-rest)`` triple — synthesises a
+  :class:`~meho_backplane.connectors.profiled.ProfiledRestConnector` from it;
+* the **typed** :class:`SddcManagerConnector` (which *does* occupy that triple,
+  so the boot-stamp no-ops on it — preserving the #1750/#1798 product-shadowing
+  invariant) imports this constant and derives its session-login path,
+  request headers, and session-expiry status set from the named
+  ``session_login_token`` scheme (#2287).
+
+What the profile drives on the typed connector
+==============================================
+
+Only the **auth** block is load-bearing for the typed connector: the
+``session_login_token`` scheme fixes SDDC Manager's real flow —
+``POST /v1/tokens`` with a ``{username, password}`` JSON body, read
+``accessToken`` out of the response, send it as ``Authorization: Bearer
+<accessToken>``. The appliance rejects HTTP Basic outright (live 401;
+Broadcom KBs 435716/387124/372387), so the token flow is the only path that
+dispatches.
+
+The ``fingerprint`` recipe here (``/v1/releases/system`` → literal
+top-level ``version``) is the *declarative* version source a profiled
+connector would use; the typed connector keeps its bespoke
+``elements[0]``-off-``/v1/sddc-managers`` fingerprint (nested, not
+expressible as a literal top-level key), so it does not derive its
+fingerprint from this profile — the same split vRLI takes. ``expiry_statuses``
+defaults to ``{401}``: SDDC Manager signals an expired token with a plain
+``401`` and there is no vendor-specific expiry code (the refresh-token leg is
+an initiative Non-goal).
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.profile import (
+    AuthSpec,
+    ExecutionProfile,
+    FingerprintSpec,
+    PaginationSpec,
+)
+
+__all__ = ["SDDC_EXECUTION_PROFILE"]
+
+
+#: The reviewed declarative profile for SDDC Manager 9.x. The single source
+#: of truth for the connector's auth scheme; the typed
+#: :class:`SddcManagerConnector` derives its session-login path, request
+#: headers, and session-expiry status set from the named
+#: ``session_login_token`` scheme this profile selects. Kept in lock-step
+#: with the shipped ``sddc_manager_minimal.yaml`` catalog profile by a parity
+#: test.
+SDDC_EXECUTION_PROFILE = ExecutionProfile(
+    product="sddc",
+    version="9.0",
+    auth=AuthSpec(scheme="session_login_token", secret_fields=("username", "password")),
+    fingerprint=FingerprintSpec(
+        path="/v1/releases/system",
+        authenticated=True,
+        version_key="version",
+        version_splitter="none",
+    ),
+    probe="delegate",
+    pagination=PaginationSpec(strategy="none", items_key="elements"),
+)

--- a/backend/src/meho_backplane/connectors/sddc_manager/session.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/session.py
@@ -4,10 +4,10 @@
 """Credential loading for the sddc-manager connector.
 
 The hand-rolled :class:`~meho_backplane.connectors.sddc_manager.connector.SddcManagerConnector`
-reads service-account credentials from the target's Vault path and sends
-them as HTTP Basic auth on every request — no session token is established;
-the ``Authorization: Basic`` header is recomputed from the cached credentials
-on each call.
+reads service-account credentials from the target's Vault path and exchanges
+them for a session token at ``POST /v1/tokens`` (the ``session_login_token``
+scheme), sending it as ``Authorization: Bearer <accessToken>`` on every
+subsequent request — SDDC Manager rejects HTTP Basic outright.
 
 The credential fetch (Vault path → ``{"username": ..., "password": ...}``
 dict) is split out behind a narrow :class:`SddcCredentialsLoader` callable
@@ -30,11 +30,9 @@ This is the rubric **State 2** wiring (`shared_service_account` only) per
 The :class:`SddcTargetLike` Protocol captures the minimum target shape the
 connector reads: ``name`` (for the per-target credential cache key), ``host``,
 ``port`` (forwarded to :meth:`HttpConnector._base_url`), ``secret_ref`` (the
-Vault path the loader resolves), ``auth_model`` (checked at the boundary),
-and ``sso_realm`` (the SSO domain appended to the username in the Basic auth
-header, defaulting to ``"vsphere.local"``). The concrete ``Target`` model in
-:mod:`meho_backplane.targets` (G0.3 #224 — closed) satisfies this Protocol
-structurally; no edits here.
+Vault path the loader resolves), and ``auth_model`` (checked at the boundary).
+The concrete ``Target`` model in :mod:`meho_backplane.targets` (G0.3 #224 —
+closed) satisfies this Protocol structurally; no edits here.
 """
 
 from __future__ import annotations
@@ -57,9 +55,8 @@ class SessionCredentials(Protocol):
     """The dict shape :class:`SddcCredentialsLoader` returns.
 
     Captured as a Protocol so the type checker can flag a loader that
-    forgets a key. The two values map to the Basic auth components the
-    connector sends on every SDDC Manager API request; nothing else is
-    read.
+    forgets a key. The two values are the credential pair the connector POSTs
+    to ``/v1/tokens`` to establish the session token; nothing else is read.
     """
 
     username: str
@@ -86,11 +83,6 @@ class SddcTargetLike(Protocol):
     443 and :meth:`HttpConnector._base_url` already handles the
     ``port is None or 443`` case correctly.
 
-    ``sso_realm`` is the vSphere SSO domain appended to ``username`` when
-    constructing the Basic auth header (``username@sso_realm``). Defaults
-    to ``"vsphere.local"`` per the consumer wrapper contract; operators
-    managing a custom domain override this at the target level.
-
     ``id`` / ``tenant_id`` form the tenant-unique ``(tenant_id, id)``
     cache key (:func:`~meho_backplane.connectors._shared.cache_key.target_cache_key`)
     the credential + HTTP-client caches use, so two same-named targets in
@@ -104,7 +96,6 @@ class SddcTargetLike(Protocol):
     port: int | None
     secret_ref: str | None
     auth_model: str | None
-    sso_realm: str
 
 
 SddcCredentialsLoader = Callable[[SddcTargetLike, Operator], Awaitable[dict[str, str]]]
@@ -112,8 +103,9 @@ SddcCredentialsLoader = Callable[[SddcTargetLike, Operator], Awaitable[dict[str,
 
 Returns ``{"username": ..., "password": ...}``. The connector's
 :meth:`SddcManagerConnector._load_credentials` invokes the loader
-exactly once per target (first-use), caching the resulting dict under
-``target.name``. The return type is the looser ``dict[str, str]`` (not
+exactly once per target (first-use), caching the resulting dict under the
+tenant-unique ``(tenant_id, id)`` key (#1642). The return type is the looser
+``dict[str, str]`` (not
 :class:`SessionCredentials`) because Python :class:`Protocol` instances
 aren't runtime-constructible without a matching class — production code
 returns a plain dict and the connector reads ``creds["username"]`` /
@@ -136,8 +128,9 @@ async def load_credentials_from_vault(
     Reads ``target.secret_ref`` as a KV-v2 secret **under the operator's
     identity** (the operator's validated Keycloak JWT is forwarded to
     Vault's JWT/OIDC auth method) and returns the service-account
-    ``{"username": ..., "password": ...}`` pair the connector sends as
-    HTTP Basic auth on every SDDC Manager API call. Delegates to the
+    ``{"username": ..., "password": ...}`` pair the connector exchanges for a
+    session token at ``POST /v1/tokens`` (the ``session_login_token`` scheme).
+    Delegates to the
     shared
     :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
     helper (G3.9-T2 #941) so the read, the no-secret-in-logs discipline,

--- a/backend/tests/acceptance/_sddc_canary_fixtures.py
+++ b/backend/tests/acceptance/_sddc_canary_fixtures.py
@@ -13,9 +13,11 @@ with a stub credentials loader (so no Vault read is required), a probed
 :mod:`respx`-mocked SDDC Manager REST surface answering each of the 9 curated
 read ops.
 
-SDDC Manager uses HTTP Basic auth on every request — no session establish
-or XSRF-token dance is needed. The stub credentials loader bypasses the
-Vault-backed loader; the respx router matches requests by path (Basic auth
+SDDC Manager is token-only: the connector establishes a session at
+``POST /v1/tokens`` (the ``session_login_token`` scheme, #2290) and sends the
+minted ``accessToken`` as ``Authorization: Bearer`` on every subsequent
+request. The stub credentials loader bypasses the Vault-backed loader; the
+respx router registers the token-mint route plus each op path (the Bearer
 header is not asserted by default).
 
 Why a minimal direct-insert path (not full G0.7 canary ingest)
@@ -373,16 +375,25 @@ async def _sddc_credentials_loader(_target: object, _operator: Operator) -> dict
     return {"username": "sddc-canary-svc", "password": "sddc-canary-pw"}
 
 
-def _register_sddc_routes(mock: respx.MockRouter) -> None:
-    """Register the 9 SDDC Manager read-op routes on *mock*.
+#: The synthetic ``accessToken`` the mocked ``POST /v1/tokens`` mints. Opaque
+#: to the dispatch leg — the tests assert only that requests carry a Bearer
+#: header, not the token value.
+SDDC_CANARY_ACCESS_TOKEN: str = "sddc-canary-access-token"
 
-    SDDC Manager uses HTTP Basic on every request — no session establish
-    call is needed. Each route returns a pre-seeded JSON body matching
-    the rough shape SDDC Manager returns for that path family.
+
+def _register_sddc_routes(mock: respx.MockRouter) -> None:
+    """Register the session-mint route + the 9 SDDC Manager read-op routes on *mock*.
+
+    SDDC Manager is token-only: the connector first POSTs ``/v1/tokens`` to
+    mint an ``accessToken`` (the ``session_login_token`` scheme, #2290), then
+    sends it as ``Authorization: Bearer`` on each op request. Each route returns
+    a pre-seeded JSON body matching the rough shape SDDC Manager returns for
+    that path family.
 
     The ``GET:/v1/domains/{id}`` route is registered for the specific
     ``domain-mgmt`` id the dispatch smoke test uses as its path parameter.
     """
+    mock.post("/v1/tokens").respond(200, json={"accessToken": SDDC_CANARY_ACCESS_TOKEN})
     mock.get("/v1/releases/system").respond(200, json=SDDC_CANARY_RELEASE)
     mock.get("/v1/sddc-managers").respond(200, json=SDDC_CANARY_MANAGERS)
     mock.get("/v1/domains").respond(200, json=SDDC_CANARY_DOMAINS)

--- a/backend/tests/acceptance/test_g35_sddc_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_g35_sddc_dispatch_smoke.py
@@ -47,11 +47,11 @@ async def test_dispatch_smoke_sddc_core_op_returns_ok(
 ) -> None:
     """Each curated SDDC Manager core op dispatches over respx and returns ``status='ok'``.
 
-    HTTP Basic auth is computed by the connector on each request (no
-    session establish); the connector's stub credentials loader returns a
-    static pair. Asserting only ``status='ok'`` keeps the smoke focused
-    on the dispatch leg — payload shape is the JSONFlux force-handle
-    test's job.
+    The connector mints a session token at ``POST /v1/tokens`` (the
+    ``session_login_token`` scheme) and sends it as ``Authorization: Bearer``
+    on each request; the connector's stub credentials loader returns a static
+    pair. Asserting only ``status='ok'`` keeps the smoke focused on the
+    dispatch leg — payload shape is the JSONFlux force-handle test's job.
     """
     params = SMOKE_PARAMS.get(op_id, {})
     result = await call_operation(

--- a/backend/tests/test_connectors_sddc_manager_auth.py
+++ b/backend/tests/test_connectors_sddc_manager_auth.py
@@ -1,26 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Unit tests for :class:`SddcManagerConnector` auth + fingerprint/probe (G3.5-T4 #616).
+"""Unit tests for :class:`SddcManagerConnector` auth + fingerprint/probe.
 
-Exercises HTTP Basic auth with sso_realm handling (default + override),
-per-target credential isolation, the auth_model boundary gate, and the
-fingerprint/probe shape against a mocked ``GET /v1/sddc-managers`` endpoint.
-
-Auth divergence from the NSX/vSphere precedents: no session token is
-established — HTTP Basic is sent on every request via
-``Authorization: Basic <base64(username@realm:password)>``. Credentials are
-cached per target so Vault is only queried once per target per connector
-instance lifetime.
+Exercises the ``session_login_token`` auth flow (#2290): the connector
+POSTs ``{username, password}`` to ``/v1/tokens``, reads ``accessToken`` out
+of the response, and sends it as ``Authorization: Bearer <accessToken>`` on
+every subsequent request — SDDC Manager rejects HTTP Basic outright. Covers
+per-target credential + token isolation, the system-operator cache bypass
+(#1008), the auth_model boundary gate, single re-login on a downstream 401,
+and the fingerprint/probe shape against a mocked ``GET /v1/sddc-managers``.
 """
 
 from __future__ import annotations
 
-import base64
-from collections.abc import Iterator
+import json
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from uuid import UUID, uuid4
 
+import httpx
 import pytest
 import respx
 
@@ -31,6 +30,7 @@ from meho_backplane.connectors._shared.system_operator import (
     synthesise_system_operator,
 )
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors._shared.vcf_auth import SessionLoginError
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.registry import (
     clear_registry,
@@ -41,6 +41,8 @@ from meho_backplane.connectors.sddc_manager import (
     SddcManagerConnector,
     SddcTargetLike,
 )
+
+_TOKEN_PATH = "/v1/tokens"
 
 
 def _make_operator(raw_jwt: str = "") -> Operator:
@@ -77,7 +79,6 @@ def _clean_sddc_registry() -> Iterator[None]:
 
 # ---------------------------------------------------------------------------
 # Target stub — satisfies SddcTargetLike Protocol structurally.
-# Replaced by the real Target model when G0.3 (#224) lands.
 # ---------------------------------------------------------------------------
 
 
@@ -88,7 +89,6 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
-    sso_realm: str = field(default="vsphere.local")
     # Tenant-unique cache key components (#1642). Distinct ``id`` per
     # instance so two stub targets never collapse onto one cache entry.
     id: UUID = field(default_factory=uuid4)
@@ -119,12 +119,21 @@ def _make_connector() -> SddcManagerConnector:
     return SddcManagerConnector(credentials_loader=_stub_loader)
 
 
-def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
-    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
-    assert authorization_header.startswith("Basic ")
-    decoded = base64.b64decode(authorization_header[6:]).decode()
-    username, _, password = decoded.partition(":")
-    return username, password
+def _mint_from_username(
+    token_prefix: str = "tok",
+) -> Callable[[httpx.Request], httpx.Response]:
+    """respx side-effect minting ``<prefix>-<login-body-username>`` as the token.
+
+    Lets a single ``/v1/tokens`` route return a token that varies with the
+    posted credential body, so per-target / per-tenant token distinctness can
+    be asserted from one router.
+    """
+
+    def _mint(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        return httpx.Response(200, json={"accessToken": f"{token_prefix}-{body['username']}"})
+
+    return _mint
 
 
 # ---------------------------------------------------------------------------
@@ -163,7 +172,6 @@ def test_default_credentials_loader_delegates_to_shared_basic_loader() -> None:
     """
     import asyncio
 
-    from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
     from meho_backplane.connectors.sddc_manager.session import load_credentials_from_vault
 
     async def _check() -> None:
@@ -175,52 +183,36 @@ def test_default_credentials_loader_delegates_to_shared_basic_loader() -> None:
 
 
 # ---------------------------------------------------------------------------
-# HTTP Basic auth — happy paths
+# session_login_token auth — happy paths
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_auth_headers_sends_basic_auth_with_default_sso_realm() -> None:
-    """auth_headers() produces Authorization: Basic with sso_realm=vsphere.local default.
+async def test_auth_headers_mints_and_sends_bearer_token() -> None:
+    """auth_headers() POSTs /v1/tokens and returns Authorization: Bearer <accessToken>.
 
-    The username in the Basic auth header must be ``svc-meho@vsphere.local``,
-    not bare ``svc-meho``. This is the load-bearing sso_realm contract.
-
-    auth_headers() does not make any HTTP calls — it computes the header from
-    cached credentials — so no respx mock is needed here.
+    No request ever carries HTTP Basic — the appliance rejects it.
     """
     connector = _make_connector()
-    headers = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        headers = await connector.auth_headers(_TARGET_A, operator=_make_operator())
 
-    assert "Authorization" in headers
-    assert headers["Authorization"].startswith("Basic ")
-    username, password = _decode_basic_auth(headers["Authorization"])
-    assert username == "svc-meho@vsphere.local"
-    assert password == "stub-password"
+    assert headers == {"Authorization": "Bearer tok-abc"}
+    assert token_route.call_count == 1
+    # The login POST carried the JSON credential body — no Basic header.
+    login_request = token_route.calls[0].request
+    assert login_request.headers.get("authorization") is None
+    assert json.loads(login_request.content) == {
+        "username": "svc-meho",
+        "password": "stub-password",
+    }
     await connector.aclose()
 
 
 @pytest.mark.asyncio
-async def test_auth_headers_honors_explicit_sso_realm_override() -> None:
-    """A target with a custom sso_realm has that realm reflected in the Basic auth header."""
-    target = _StubTarget(
-        name="sddc-custom",
-        host="sddc-custom.test.invalid",
-        port=443,
-        secret_ref="sddc/custom",
-        sso_realm="corp.example.com",
-    )
-    connector = _make_connector()
-
-    headers = await connector.auth_headers(target, operator=_make_operator())
-    username, _ = _decode_basic_auth(headers["Authorization"])
-    assert username == "svc-meho@corp.example.com"
-    await connector.aclose()
-
-
-@pytest.mark.asyncio
-async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
-    """Second auth_headers call against the same target does NOT re-invoke the loader."""
+async def test_auth_headers_reuses_cached_token_across_calls() -> None:
+    """Second auth_headers call reuses the cached token — no re-mint, no re-load."""
     call_count = 0
 
     async def _counting_loader(_target: SddcTargetLike, _operator: Operator) -> dict[str, str]:
@@ -229,11 +221,14 @@ async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
         return {"username": "svc-meho", "password": "stub-password"}
 
     connector = SddcManagerConnector(credentials_loader=_counting_loader)
-    h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
-    h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
 
-    assert h1 == h2
+    assert h1 == h2 == {"Authorization": "Bearer tok-abc"}
     assert call_count == 1
+    assert token_route.call_count == 1
     await connector.aclose()
 
 
@@ -244,11 +239,11 @@ async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
 
 @pytest.mark.asyncio
 async def test_warm_cache_not_served_to_system_operator_runs_loader() -> None:
-    """A warm cache primed by a real operator is NOT served to the system operator.
+    """A warm session primed by a real operator is NOT served to the system operator.
 
     The system/operator-less caller (``synthesise_system_operator``) must
     re-run the loader so its fail-closed behaviour applies — it can never
-    borrow warm credentials a real operator resolved (#1008). Keyed off
+    borrow a warm credential/token a real operator resolved (#1008). Keyed off
     ``SYSTEM_OPERATOR_SUB``, not ``raw_jwt`` (the system operator carries a
     non-empty placeholder JWT since #980).
     """
@@ -259,10 +254,12 @@ async def test_warm_cache_not_served_to_system_operator_runs_loader() -> None:
         return {"username": "svc-meho", "password": "stub-password"}
 
     connector = SddcManagerConnector(credentials_loader=_counting_loader)
-    # Real operator warms the cache (cold load).
-    await connector.auth_headers(_TARGET_A, operator=_make_operator())
-    # System operator must re-run the loader rather than reuse the warm cache.
-    await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        # Real operator warms the cache (cold load + mint).
+        await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        # System operator must re-run the loader rather than reuse the warm cache.
+        await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())
 
     assert call_log == ["test-operator", SYSTEM_OPERATOR_SUB]
     await connector.aclose()
@@ -288,9 +285,11 @@ async def test_system_operator_fails_closed_against_warm_cache() -> None:
         return {"username": "svc-meho", "password": "stub-password"}
 
     connector = SddcManagerConnector(credentials_loader=_failing_for_system_loader)
-    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # warm the cache
-    with pytest.raises(VaultCredentialsReadError, match=r"system-initiated"):
-        await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        await connector.auth_headers(_TARGET_A, operator=_make_operator())  # warm the cache
+        with pytest.raises(VaultCredentialsReadError, match=r"system-initiated"):
+            await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())
     await connector.aclose()
 
 
@@ -311,17 +310,19 @@ async def test_real_operator_reuse_unchanged_after_system_operator_call() -> Non
         return {"username": "svc-meho", "password": "stub-password"}
 
     connector = SddcManagerConnector(credentials_loader=_counting_loader)
-    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # cold real load
-    await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())  # bypass
-    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # warm real reuse
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        await connector.auth_headers(_TARGET_A, operator=_make_operator())  # cold real load
+        await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())  # bypass
+        await connector.auth_headers(_TARGET_A, operator=_make_operator())  # warm real reuse
 
     assert real_calls == 1
     await connector.aclose()
 
 
 @pytest.mark.asyncio
-async def test_per_target_isolation_keeps_credentials_separate() -> None:
-    """Two targets get two distinct credential cache entries; no cross-target leakage."""
+async def test_per_target_isolation_keeps_tokens_separate() -> None:
+    """Two targets get two distinct credential + token cache entries; no leakage."""
     call_log: list[str] = []
 
     async def _tracking_loader(target: SddcTargetLike, _operator: Operator) -> dict[str, str]:
@@ -329,27 +330,27 @@ async def test_per_target_isolation_keeps_credentials_separate() -> None:
         return {"username": f"svc-{target.name}", "password": "pass"}
 
     connector = SddcManagerConnector(credentials_loader=_tracking_loader)
-    h_a = await connector.auth_headers(_TARGET_A, operator=_make_operator())
-    h_b = await connector.auth_headers(_TARGET_B, operator=_make_operator())
+    async with respx.mock(assert_all_called=False) as mock:
+        mock.post("https://sddc-a.test.invalid/v1/tokens").mock(side_effect=_mint_from_username())
+        mock.post("https://sddc-b.test.invalid/v1/tokens").mock(side_effect=_mint_from_username())
+        h_a = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        h_b = await connector.auth_headers(_TARGET_B, operator=_make_operator())
 
-    username_a, _ = _decode_basic_auth(h_a["Authorization"])
-    username_b, _ = _decode_basic_auth(h_b["Authorization"])
-    assert username_a == "svc-sddc-a@vsphere.local"
-    assert username_b == "svc-sddc-b@vsphere.local"
+    assert h_a == {"Authorization": "Bearer tok-svc-sddc-a"}
+    assert h_b == {"Authorization": "Bearer tok-svc-sddc-b"}
     # Loader called exactly once per distinct target.
     assert call_log == ["sddc-a", "sddc-b"]
     await connector.aclose()
 
 
 @pytest.mark.asyncio
-async def test_same_name_targets_in_different_tenants_get_distinct_credentials() -> None:
-    """Same-named targets in DIFFERENT tenants never share a cached credential.
+async def test_same_name_targets_in_different_tenants_get_distinct_tokens() -> None:
+    """Same-named targets in DIFFERENT tenants never share a cached credential/token.
 
-    Regression guard for #1642: the credential cache used to key on
-    ``target.name`` alone, so two same-named targets in different tenants
-    collapsed onto one entry and one tenant could be served another
-    tenant's cached credential. The cache keys on the tenant-unique
-    ``(tenant_id, id)`` tuple instead.
+    Regression guard for #1642/#1672/#1684: the caches key on the
+    tenant-unique ``(tenant_id, id)`` tuple, so two same-named targets in
+    different tenants get distinct credential + token entries and one tenant
+    can never be served another tenant's cached token.
     """
     load_count = 0
 
@@ -376,30 +377,61 @@ async def test_same_name_targets_in_different_tenants_get_distinct_credentials()
     )
 
     connector = SddcManagerConnector(credentials_loader=_counting_loader)
-    h_one = await connector.auth_headers(tenant_one, operator=_make_operator())
-    h_two = await connector.auth_headers(tenant_two, operator=_make_operator())
+    async with respx.mock(base_url="https://sddc-shared.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).mock(side_effect=_mint_from_username())
+        h_one = await connector.auth_headers(tenant_one, operator=_make_operator())
+        h_two = await connector.auth_headers(tenant_two, operator=_make_operator())
 
-    user_one, _ = _decode_basic_auth(h_one["Authorization"])
-    user_two, _ = _decode_basic_auth(h_two["Authorization"])
-    # Each tenant triggered its own load -- no cross-tenant cache hit.
-    assert load_count == 2
-    assert user_one == f"svc-{tenant_one.tenant_id}@vsphere.local"
-    assert user_two == f"svc-{tenant_two.tenant_id}@vsphere.local"
-    assert user_one != user_two
-    assert connector._creds_cache.keys() == {
-        target_cache_key(tenant_one),
-        target_cache_key(tenant_two),
-    }
+        # Each tenant triggered its own load + mint — no cross-tenant cache hit.
+        assert load_count == 2
+        assert h_one == {"Authorization": f"Bearer tok-svc-{tenant_one.tenant_id}"}
+        assert h_two == {"Authorization": f"Bearer tok-svc-{tenant_two.tenant_id}"}
+        assert h_one != h_two
+        assert connector._creds_cache.keys() == {
+            target_cache_key(tenant_one),
+            target_cache_key(tenant_two),
+        }
+        assert connector._session_tokens.keys() == {
+            target_cache_key(tenant_one),
+            target_cache_key(tenant_two),
+        }
 
-    # Same-tenant re-fetch is a cache HIT -- behaviour unchanged.
-    h_one_again = await connector.auth_headers(tenant_one, operator=_make_operator())
-    assert h_one_again == h_one
-    assert load_count == 2
+        # Same-tenant re-fetch is a cache HIT — behaviour unchanged.
+        h_one_again = await connector.auth_headers(tenant_one, operator=_make_operator())
+        assert h_one_again == h_one
+        assert load_count == 2
     await connector.aclose()
 
 
 # ---------------------------------------------------------------------------
-# Credential loading failure modes
+# Session-login failure modes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_non_2xx_raises_session_login_error_naming_target() -> None:
+    """A non-2xx from /v1/tokens surfaces a SessionLoginError naming the target."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(401, json={"message": "bad credentials"})
+        with pytest.raises(SessionLoginError, match=r"sddc-a"):
+            await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_login_without_access_token_raises_session_login_error() -> None:
+    """A 2xx body carrying no accessToken surfaces a SessionLoginError."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"refreshToken": {"id": "r"}})
+        with pytest.raises(SessionLoginError, match=r"sddc-a"):
+            await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Credential loading failure modes (raised before the login POST)
 # ---------------------------------------------------------------------------
 
 
@@ -434,7 +466,7 @@ async def test_loader_missing_username_key_raises_runtime_error_naming_target() 
 
 
 # ---------------------------------------------------------------------------
-# Auth model gating
+# Auth model gating (rejected before any login POST fires)
 # ---------------------------------------------------------------------------
 
 
@@ -473,8 +505,10 @@ async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> Non
         auth_model=None,
     )
     connector = _make_connector()
-    headers = await connector.auth_headers(target, operator=_make_operator())
-    assert headers["Authorization"].startswith("Basic ")
+    async with respx.mock(base_url="https://sddc.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        headers = await connector.auth_headers(target, operator=_make_operator())
+    assert headers == {"Authorization": "Bearer tok-abc"}
     await connector.aclose()
 
 
@@ -489,8 +523,33 @@ async def test_auth_headers_accepts_enum_member_for_auth_model() -> None:
     )
     target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
     connector = _make_connector()
-    headers = await connector.auth_headers(target, operator=_make_operator())
-    assert headers["Authorization"].startswith("Basic ")
+    async with respx.mock(base_url="https://sddc.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        headers = await connector.auth_headers(target, operator=_make_operator())
+    assert headers == {"Authorization": "Bearer tok-abc"}
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# invalidate_session — the #2067 dispatch-path seam
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_session_evicts_token_and_re_mints_on_next_call() -> None:
+    """invalidate_session drops the cached token; the next call re-establishes it."""
+    connector = _make_connector()
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        assert target_cache_key(_TARGET_A) in connector._session_tokens
+        assert token_route.call_count == 1
+
+        await connector.invalidate_session(_TARGET_A)
+        assert target_cache_key(_TARGET_A) not in connector._session_tokens
+
+        await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        assert token_route.call_count == 2
     await connector.aclose()
 
 
@@ -501,11 +560,12 @@ async def test_auth_headers_accepts_enum_member_for_auth_model() -> None:
 
 @pytest.mark.asyncio
 async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
-    """fingerprint() against a respx-mocked GET /v1/sddc-managers returns canonical shape."""
+    """fingerprint() authenticates via the token flow then reads GET /v1/sddc-managers."""
     connector = _make_connector()
 
     async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
-        mock.get("/v1/sddc-managers").respond(
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        managers_route = mock.get("/v1/sddc-managers").respond(
             200,
             json={
                 "elements": [
@@ -532,24 +592,64 @@ async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
     assert fp.extras["management_domain_id"] == "domain-uuid-1"
     assert fp.extras["id"] == "sddc-uuid-1"
     assert fp.extras["fqdn"] == "sddc-a.test.invalid"
+    # The inventory GET carried the minted Bearer token — never HTTP Basic.
+    inv_auth = managers_route.calls[0].request.headers.get("authorization")
+    assert inv_auth == "Bearer tok-abc"
     await connector.aclose()
 
 
 @pytest.mark.asyncio
-async def test_fingerprint_unreachable_returns_reachable_false_with_structured_error() -> None:
-    """Transport/status failure returns reachable=False with extras['error']."""
+async def test_fingerprint_recovers_once_from_a_401_then_reports_reachable() -> None:
+    """A single 401 on the inventory GET recovers via one re-login; a second 401 fails.
+
+    The helper-level ``_get_json_with_session_retry`` evicts the token, re-mints,
+    and retries the GET once. Here the retry succeeds, so the fingerprint is
+    reachable.
+    """
+    connector = _make_connector()
+    inventory = {
+        "elements": [
+            {
+                "id": "x",
+                "fqdn": "sddc-a.test.invalid",
+                "version": "9.0.0.0",
+                "domain": {"name": "M"},
+            }
+        ]
+    }
+    calls = {"n": 0}
+
+    def _inv(_request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(401, json={"message": "token expired"})
+        return httpx.Response(200, json=inventory)
+
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        mock.get("/v1/sddc-managers").mock(side_effect=_inv)
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is True
+    assert fp.version == "9.0.0.0"
+    # One initial mint + one re-mint after the 401 eviction.
+    assert token_route.call_count == 2
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_returns_reachable_false_on_persistent_401() -> None:
+    """A persistent 401 (re-login also 401s) returns reachable=False with a structured error."""
     connector = _make_connector()
 
     async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
         mock.get("/v1/sddc-managers").respond(401, json={"message": "Unauthorized"})
         fp = await connector.fingerprint(_TARGET_A)
 
-    assert fp.vendor == "vmware"
-    assert fp.product == "sddc"
     assert fp.reachable is False
     assert fp.probe_method == "GET /v1/sddc-managers"
-    error = fp.extras["error"]
-    assert "HTTPStatusError" in error or "401" in error
+    assert "401" in fp.extras["error"]
     await connector.aclose()
 
 
@@ -559,6 +659,7 @@ async def test_fingerprint_empty_elements_returns_reachable_true_with_no_version
     connector = _make_connector()
 
     async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
         mock.get("/v1/sddc-managers").respond(
             200,
             json={"elements": [], "pageMetadata": {"totalElements": 0}},
@@ -577,6 +678,7 @@ async def test_probe_returns_ok_true_when_reachable() -> None:
     connector = _make_connector()
 
     async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
         mock.get("/v1/sddc-managers").respond(
             200,
             json={
@@ -603,6 +705,7 @@ async def test_probe_returns_ok_false_with_reason_when_unreachable() -> None:
     connector = _make_connector()
 
     async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
         mock.get("/v1/sddc-managers").respond(401)
         result = await connector.probe(_TARGET_A)
 
@@ -612,28 +715,33 @@ async def test_probe_returns_ok_false_with_reason_when_unreachable() -> None:
 
 
 # ---------------------------------------------------------------------------
-# aclose — credential cache clear + pool tear-down
+# aclose — credential + token cache clear + pool tear-down
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_aclose_clears_credential_cache_and_pool() -> None:
-    """aclose() clears the in-memory credential cache and tears down the httpx pool."""
+async def test_aclose_clears_caches_and_pool() -> None:
+    """aclose() clears the in-memory credential + token caches and tears down the pool."""
     connector = _make_connector()
-    await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        await connector.auth_headers(_TARGET_A, operator=_make_operator())
     assert target_cache_key(_TARGET_A) in connector._creds_cache
+    assert target_cache_key(_TARGET_A) in connector._session_tokens
     await connector.aclose()
     assert connector._creds_cache == {}
+    assert connector._session_tokens == {}
     assert connector._clients == {}
 
 
 @pytest.mark.asyncio
-async def test_aclose_with_no_cached_credentials_is_a_noop() -> None:
-    """A fresh connector with no credentials established closes cleanly."""
+async def test_aclose_with_no_cached_state_is_a_noop() -> None:
+    """A fresh connector with no session established closes cleanly."""
     connector = _make_connector()
     await connector.aclose()
     assert connector._clients == {}
     assert connector._creds_cache == {}
+    assert connector._session_tokens == {}
 
 
 # ---------------------------------------------------------------------------
@@ -645,18 +753,10 @@ async def test_aclose_with_no_cached_credentials_is_a_noop() -> None:
 async def test_fingerprint_forwards_route_operator_to_credentials_loader() -> None:
     """G0.16-T4 (#1306) probe-vs-dispatch convergence regression for sddc-manager.
 
-    Pre-#1306 the probe route called ``cls().fingerprint(target)``
-    without an operator; the connector synthesised a system operator
-    whose placeholder ``raw_jwt`` is not a compact-JWS. Vault's
-    JWT/OIDC auth method rejected it before the per-target read,
-    surfacing as ``vault OIDC malformed jwt: must have three parts``
-    on the v0.8.0 dogfood's ``vcf9-sddc`` probe.
-
-    Post-#1306 the probe route forwards its operator — the same code
-    path the dispatch surface uses. Test pins:
+    Post-#1306 the probe route forwards its operator — the same code path the
+    dispatch surface uses. Test pins:
     1. The credentials loader receives the route operator.
-    2. The forwarded JWT has the compact-JWS shape (≥3 dot-separated
-       parts).
+    2. The forwarded JWT has the compact-JWS shape (≥3 dot-separated parts).
     """
     captured: list[Operator] = []
 
@@ -679,6 +779,7 @@ async def test_fingerprint_forwards_route_operator_to_credentials_loader() -> No
     )
 
     async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
         mock.get("/v1/sddc-managers").respond(
             200,
             json={
@@ -707,9 +808,7 @@ async def test_fingerprint_forwards_route_operator_to_credentials_loader() -> No
 
 @pytest.mark.asyncio
 async def test_fingerprint_without_operator_falls_back_to_system_operator() -> None:
-    """``fingerprint(target)`` without ``operator`` synthesises the
-    system operator (the system-call carve-out).
-    """
+    """``fingerprint(target)`` without ``operator`` synthesises the system operator."""
     captured: list[Operator] = []
 
     async def _capturing_loader(
@@ -722,6 +821,7 @@ async def test_fingerprint_without_operator_falls_back_to_system_operator() -> N
     connector = SddcManagerConnector(credentials_loader=_capturing_loader)
 
     async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
         mock.get("/v1/sddc-managers").respond(
             200,
             json={"elements": [], "pageMetadata": {}},

--- a/backend/tests/test_connectors_sddc_manager_credread.py
+++ b/backend/tests/test_connectors_sddc_manager_credread.py
@@ -9,17 +9,17 @@ non-injected) credential loader:
     dispatch(...)
       -> _resolve_connector_instance -> SddcManagerConnector()   # default loader
       -> dispatch_ingested -> _request_json -> auth_headers
-      -> _load_credentials -> load_credentials_from_vault        # the live loader
+      -> _session_token -> _load_credentials -> load_credentials_from_vault
       -> load_basic_credentials (#941)                           # operator-context Vault read
-      -> GET <op path> (HTTP Basic auth w/ username@sso_realm)
+      -> POST /v1/tokens (session mint) -> GET <op path> (Bearer accessToken)
       -> OperationResult(status="ok")
 
-SDDC Manager differs from nsx/vmware in that there is no session
-establish call — HTTP Basic auth rides every request. The username is
-formatted as ``username@sso_realm`` (default ``vsphere.local``) before
-the base64 encode; the password is the Vault-read value verbatim. The
-credential read still goes through the shared operator-context Vault
-helper.
+SDDC Manager is token-only (#2290): the connector exchanges the
+Vault-read credential pair for a session token at ``POST /v1/tokens``
+(the ``session_login_token`` scheme) and sends it as
+``Authorization: Bearer <accessToken>`` on the op request — the
+appliance rejects HTTP Basic. The credential read still goes through the
+shared operator-context Vault helper.
 
 The two "real" leaves are stubbed at their boundaries so the gate runs
 in the **secret-free unit lane** (``pytest -n auto`` /
@@ -189,7 +189,6 @@ class _CredReadTarget:
         self.port = 443
         self.secret_ref = "targets/op-credread/sddc-credread"
         self.auth_model = "shared_service_account"
-        self.sso_realm = "vsphere.local"
 
 
 def _make_operator() -> Operator:
@@ -261,6 +260,7 @@ async def test_dispatch_executes_full_credread_chain_returns_ok(
     operator = _make_operator()
 
     async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        token_route = mock.post("/v1/tokens").respond(200, json={"accessToken": "credread-tok"})
         op_route = mock.get("/v1/sddc-managers").respond(200, json=_OP_RESPONSE)
 
         result = await dispatch(
@@ -279,10 +279,12 @@ async def test_dispatch_executes_full_credread_chain_returns_ok(
     # The default loader actually read Vault under the operator's identity.
     assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.credread.sddc.jwt"
     assert fake.secrets.kv.v2.read_calls[-1]["path"] == target.secret_ref
-    # The read op hit the mocked SDDC Manager with HTTP Basic auth.
+    # The connector minted a session token, then the read op hit SDDC Manager
+    # with the Bearer token — never HTTP Basic.
+    assert token_route.called and token_route.call_count == 1
     assert op_route.called and op_route.call_count == 1
     sent_auth = op_route.calls[0].request.headers.get("authorization")
-    assert sent_auth is not None and sent_auth.startswith("Basic ")
+    assert sent_auth == "Bearer credread-tok"
     # One audit + one broadcast for the dispatched op.
     assert len(captured_events) == 1
 
@@ -307,6 +309,7 @@ async def test_credread_chain_never_leaks_credential_in_result_or_logs(
 
     with capture_logs() as captured:
         async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+            mock.post("/v1/tokens").respond(200, json={"accessToken": "credread-tok"})
             mock.get("/v1/sddc-managers").respond(200, json=_OP_RESPONSE)
 
             result = await dispatch(

--- a/backend/tests/test_connectors_sddc_manager_e2e.py
+++ b/backend/tests/test_connectors_sddc_manager_e2e.py
@@ -8,9 +8,10 @@ Covers all four acceptance criteria from Issue #618:
 (a) All 9 curated SDDC Manager read ops dispatch through the full
     ``call_operation`` stack against a respx-mocked SDDC Manager
     appliance and return ``status='ok'``.
-(b) HTTP Basic auth path: no 401-retry for SDDC Manager — Basic
-    credentials are stateless. The connector's stub credentials loader
-    is verified to be called (once, then cached) on the first dispatch.
+(b) Token-session auth path: the connector mints a session token at
+    ``POST /v1/tokens`` and reuses it. The connector's stub credentials
+    loader is verified to be called (once, then cached) on the first
+    dispatch.
 (c) Audit rows: each dispatch inserts an ``AuditLog`` row carrying
     ``method='DISPATCH'``, a non-null ``target_id``, and a
     ``payload["params_hash"]`` key.
@@ -230,9 +231,9 @@ async def test_sddc_e2e_all_ops_dispatch_ok(
 ) -> None:
     """All 9 SDDC Manager core ops dispatch through the full dispatcher and return status='ok'.
 
-    HTTP Basic auth is computed by the connector's stub credentials loader on
-    first dispatch (then cached); no session-establish step is needed because
-    Basic auth is stateless on the SDDC Manager side.
+    The connector mints a session token at ``POST /v1/tokens`` from the stub
+    credentials loader on first dispatch (then caches both the credentials and
+    the token), and sends it as ``Authorization: Bearer`` on each op request.
     """
     params = _DOMAIN_INFO_OP_PARAMS.get(op_id, {})
     result = await call_operation(
@@ -257,8 +258,9 @@ async def test_sddc_e2e_credentials_cached_after_first_dispatch(
 
     Verifies acceptance criterion (b): the SDDC Manager connector's per-target
     credential cache starts empty, gets populated on the first dispatch, and is
-    not re-filled on the second dispatch to the same target. HTTP Basic is
-    stateless server-side — no session revoke or re-login needed.
+    not re-filled on the second dispatch to the same target (the minted session
+    token is likewise cached, so the second dispatch neither re-loads
+    credentials nor re-mints the token).
     """
     instance = sddc_e2e_canary.connector_instance
     target_name = sddc_e2e_canary.target_name

--- a/backend/tests/test_connectors_sddc_manager_session_dispatch.py
+++ b/backend/tests/test_connectors_sddc_manager_session_dispatch.py
@@ -1,0 +1,362 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Dispatch-level proof of the SDDC Manager token session (#2290).
+
+Seeds a ``source_kind='ingested'`` :class:`EndpointDescriptor` for the sddc
+triple and dispatches it against a respx-mocked SDDC Manager, proving the
+ingested catalog is dispatchable end to end on the ``session_login_token``
+flow:
+
+* cold dispatch mints a token at ``POST /v1/tokens`` (JSON body), and every
+  op request carries ``Authorization: Bearer <accessToken>`` — never HTTP
+  Basic;
+* a mid-session ``401`` recovers via exactly one invalidate + re-login + retry
+  through the #2067 dispatcher seam, with no restart;
+* a second consecutive ``401`` resolves to ``connector_auth_failed`` with no
+  retry loop;
+* two same-named targets in different tenants never share a token (#1642).
+
+Also pins the module-constant ``SDDC_EXECUTION_PROFILE`` to the shipped
+``sddc_manager_minimal.yaml`` catalog profile so the two declarations of the
+auth scheme cannot drift.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.sddc_manager import (
+    SDDC_EXECUTION_PROFILE,
+    SddcManagerConnector,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.settings import get_settings
+
+_PRODUCT = "sddc"
+_VERSION = "9.0"
+_IMPL_ID = "sddc-rest"
+_CONNECTOR_ID = "sddc-rest-9.0"
+
+_OP_ID = "GET:/v1/sddc-managers"
+_OP_PATH = "/v1/sddc-managers"
+_TOKEN_PATH = "/v1/tokens"
+
+_SDDC_HOST = "sddc-session.test.invalid"
+_SDDC_BASE_URL = f"https://{_SDDC_HOST}"
+
+_OP_RESPONSE: dict[str, object] = {
+    "elements": [
+        {
+            "id": "sddc-session-id",
+            "fqdn": _SDDC_HOST,
+            "version": "9.0.0.0",
+            "domain": {"id": "mgmt-dom", "name": "mgmt"},
+        }
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT, version=_VERSION, impl_id=_IMPL_ID, cls=SddcManagerConnector
+    )
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _SessionTarget:
+    """Duck-typed target satisfying both ``SddcTargetLike`` and the resolver shape."""
+
+    def __init__(
+        self,
+        *,
+        name: str = "sddc-session",
+        host: str = _SDDC_HOST,
+        tenant_id: UUID | None = None,
+        target_id: UUID | None = None,
+    ) -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": _VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = target_id or uuid.uuid4()
+        self.tenant_id: UUID = tenant_id or UUID("00000000-0000-0000-0000-00000000b0b0")
+        self.name = name
+        self.host = host
+        self.port = 443
+        self.secret_ref = f"targets/{name}"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator(tenant_id: UUID) -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-sddc-session",
+        name="SDDC Session Operator",
+        email=None,
+        raw_jwt="op.sddc.session.jwt",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_descriptor(session: AsyncSession) -> None:
+    """Insert one enabled ingested GET descriptor for the read op."""
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id=_OP_ID,
+        source_kind="ingested",
+        method="GET",
+        path=_OP_PATH,
+        handler_ref=None,
+        summary="Read SDDC Manager inventory",
+        description="Return the SDDC Manager appliance(s) under management.",
+        tags=["readiness"],
+        parameter_schema={"type": "object", "properties": {}},
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=[0.1] * 384,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+
+def _install_stub_loader(username: str = "svc-sddc", password: str = "pw") -> SddcManagerConnector:
+    """Resolve + cache the dispatcher's connector instance with a stub loader.
+
+    The dispatcher resolves the class via ``get_or_create_connector_instance``;
+    pre-resolving here and patching the loader means the dispatched op uses this
+    exact instance (whose token cache we can then inspect) without a Vault read.
+    """
+
+    async def _loader(_target: object, _operator: Operator) -> dict[str, str]:
+        return {"username": username, "password": password}
+
+    registry = all_connectors_v2()
+    instance = get_or_create_connector_instance(registry[(_PRODUCT, _VERSION, _IMPL_ID)])
+    instance._credentials_loader = _loader  # type: ignore[attr-defined]
+    return instance
+
+
+@pytest.mark.asyncio
+async def test_cold_dispatch_mints_token_then_sends_bearer_never_basic(
+    session: AsyncSession,
+) -> None:
+    """Cold dispatch POSTs /v1/tokens (JSON body) then GETs with Bearer — never Basic."""
+    await _seed_descriptor(session)
+    instance = _install_stub_loader()
+    target = _SessionTarget()
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "sess-tok"})
+        op_route = mock.get(_OP_PATH).respond(200, json=_OP_RESPONSE)
+
+        result = await dispatch(
+            operator=_make_operator(target.tenant_id),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    # Session mint carried the JSON credential body, no Basic on the login POST.
+    assert token_route.call_count == 1
+    login_request = token_route.calls[0].request
+    assert login_request.headers.get("authorization") is None
+    assert json.loads(login_request.content) == {"username": "svc-sddc", "password": "pw"}
+    # The op request carried the minted Bearer token — and no request ever Basic.
+    assert op_route.call_count == 1
+    assert op_route.calls[0].request.headers.get("authorization") == "Bearer sess-tok"
+    for call in [*token_route.calls, *op_route.calls]:
+        auth = call.request.headers.get("authorization")
+        assert auth is None or not auth.startswith("Basic ")
+    await instance.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_recovers_once_from_mid_session_401(session: AsyncSession) -> None:
+    """A mid-session 401 recovers via one invalidate + re-login + retry (#2067 seam)."""
+    await _seed_descriptor(session)
+    instance = _install_stub_loader()
+    target = _SessionTarget()
+
+    op_calls = {"n": 0}
+
+    def _op(_request: httpx.Request) -> httpx.Response:
+        op_calls["n"] += 1
+        if op_calls["n"] == 1:
+            return httpx.Response(401, json={"message": "token expired"})
+        return httpx.Response(200, json=_OP_RESPONSE)
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "sess-tok"})
+        op_route = mock.get(_OP_PATH).mock(side_effect=_op)
+
+        result = await dispatch(
+            operator=_make_operator(target.tenant_id),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == _OP_RESPONSE
+    # Exactly one retry: two op attempts, two mints (initial + post-invalidation).
+    assert op_route.call_count == 2
+    assert token_route.call_count == 2
+    await instance.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_second_consecutive_401_is_connector_auth_failed_no_loop(
+    session: AsyncSession,
+) -> None:
+    """A persistent 401 (re-login also 401s) resolves to connector_auth_failed, no loop."""
+    await _seed_descriptor(session)
+    instance = _install_stub_loader()
+    target = _SessionTarget()
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "sess-tok"})
+        op_route = mock.get(_OP_PATH).respond(401, json={"message": "still bad"})
+
+        result = await dispatch(
+            operator=_make_operator(target.tenant_id),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    assert result.status == "error"
+    assert result.extras is not None
+    assert result.extras.get("error_code") == "connector_auth_failed"
+    # Exactly one retry — the op was attempted twice, never in a loop.
+    assert op_route.call_count == 2
+    await instance.aclose()
+
+
+@pytest.mark.asyncio
+async def test_same_name_targets_in_different_tenants_never_share_token(
+    session: AsyncSession,
+) -> None:
+    """Two same-named targets in different tenants dispatch with distinct tokens (#1642)."""
+    await _seed_descriptor(session)
+
+    # Loader returns a tenant-specific username; the mock derives the token from
+    # it, so a shared token would collapse the two into one string.
+    async def _loader(target: _SessionTarget, _operator: Operator) -> dict[str, str]:
+        return {"username": f"svc-{target.tenant_id}", "password": "pw"}
+
+    registry = all_connectors_v2()
+    instance = get_or_create_connector_instance(registry[(_PRODUCT, _VERSION, _IMPL_ID)])
+    instance._credentials_loader = _loader  # type: ignore[attr-defined]
+
+    def _mint(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        return httpx.Response(200, json={"accessToken": f"tok-{body['username']}"})
+
+    tenant_a = UUID("00000000-0000-0000-0000-0000000000a1")
+    tenant_b = UUID("00000000-0000-0000-0000-0000000000b2")
+    target_a = _SessionTarget(name="sddc-shared", tenant_id=tenant_a)
+    target_b = _SessionTarget(name="sddc-shared", tenant_id=tenant_b)
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).mock(side_effect=_mint)
+        op_route = mock.get(_OP_PATH).respond(200, json=_OP_RESPONSE)
+
+        result_a = await dispatch(
+            operator=_make_operator(tenant_a),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target_a,
+            params={},
+        )
+        result_b = await dispatch(
+            operator=_make_operator(tenant_b),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target_b,
+            params={},
+        )
+
+    assert result_a.status == "ok" and result_b.status == "ok"
+    auth_a = op_route.calls[0].request.headers.get("authorization")
+    auth_b = op_route.calls[1].request.headers.get("authorization")
+    assert auth_a == f"Bearer tok-svc-{tenant_a}"
+    assert auth_b == f"Bearer tok-svc-{tenant_b}"
+    assert auth_a != auth_b
+    await instance.aclose()
+
+
+def test_module_profile_matches_shipped_yaml() -> None:
+    """The typed connector's ``SDDC_EXECUTION_PROFILE`` equals the shipped catalog profile.
+
+    Guards against the two declarations of the auth scheme drifting: the boot
+    stamp reads the YAML, the typed connector reads this constant, and they must
+    agree on the ``session_login_token`` scheme.
+    """
+    import yaml
+
+    from meho_backplane.connectors.profile import ExecutionProfile
+    from meho_backplane.operations.ingest import load_profile_resource
+
+    raw = yaml.safe_load(load_profile_resource("sddc_manager_minimal.yaml"))
+    shipped = ExecutionProfile.model_validate(raw)
+    assert shipped == SDDC_EXECUTION_PROFILE
+    assert SDDC_EXECUTION_PROFILE.auth.scheme == "session_login_token"

--- a/backend/tests/test_operations_boot_stamp.py
+++ b/backend/tests/test_operations_boot_stamp.py
@@ -185,7 +185,7 @@ async def test_boot_stamp_shipped_catalog_registers_every_profile_row() -> None:
 
     Runs the real ``load_profile_resource`` + ``ExecutionProfile`` parse +
     class synthesis for the shipped vmware (``session_login_basic``), sddc
-    (``basic``) and fixture (``basic``) profiles. With a cleared registry no
+    (``session_login_token``) and fixture (``basic``) profiles. With a cleared registry no
     triple is occupied, so every profile row registers a profiled class.
     """
     expected = sum(1 for e in load_catalog().entries if e.profile_resource is not None)

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -478,7 +478,13 @@ def test_validate_shipped_artifacts_passes_for_shipped_catalog() -> None:
             "session_login_basic",
             9,
         ),
-        ("sddc", "sddc_manager_minimal.yaml", "sddc_manager_minimal.yaml", "basic", 9),
+        (
+            "sddc",
+            "sddc_manager_minimal.yaml",
+            "sddc_manager_minimal.yaml",
+            "session_login_token",
+            9,
+        ),
     ],
 )
 def test_shipped_vmware_sddc_rows_are_profile_backed(
@@ -537,7 +543,7 @@ def test_shipped_vmware_sddc_specs_parse_with_the_ingest_parser(
     ("profile_resource", "expected_scheme"),
     [
         ("vmware_rest_minimal.yaml", "session_login_basic"),
-        ("sddc_manager_minimal.yaml", "basic"),
+        ("sddc_manager_minimal.yaml", "session_login_token"),
     ],
 )
 def test_shipped_vmware_sddc_profiles_validate_with_named_scheme(

--- a/docs/codebase/connector-auth-coverage.md
+++ b/docs/codebase/connector-auth-coverage.md
@@ -26,7 +26,7 @@ naming one raises `ReservedAuthSchemeError` ("author a typed connector").
 | # | Connector | File (auth method) | Mechanism | Secret field names | Returns | Catalog verdict |
 |---|-----------|--------------------|-----------|--------------------|---------|-----------------|
 | 1 | harbor | `harbor/connector.py` `auth_headers` | HTTP Basic `base64(user:pass)` → `Authorization: Basic` | `username`, `password` | `dict[str,str]` | **`basic`** |
-| 2 | sddc_manager | `sddc_manager/connector.py` `auth_headers` | HTTP Basic `base64(user@sso_realm:pass)` | `username`, `password` | `dict[str,str]` | **`basic`** |
+| 2 | sddc_manager | `sddc_manager/connector.py` `auth_headers` | Session login `POST /v1/tokens` (JSON `{username,password}`) → `accessToken` → cached Bearer; re-login once on `401` (HTTP Basic rejected by the appliance) | `username`, `password` | `dict[str,str]` (Bearer) | **`session_login_token`** |
 | 3 | vcf_fleet | `vcf_fleet/connector.py` (`_shared/vcf_auth.basic_auth_header`) | HTTP Basic (shared helper) | `username`, `password` | `dict[str,str]` | **`basic`** |
 | 4 | vcf_operations | `vcf_operations/connector.py` `auth_headers` | HTTP Basic + optional `?auth-source=` query | `username`, `password` | `dict[str,str]` | **`basic`** |
 | 5 | hetzner_robot | `hetzner_robot/connector.py` `_basic_auth_header` | HTTP Basic (hard-fail on first 401, IP-block guard) | `username`, `password` | `dict[str,str]` | **`basic`** |
@@ -52,19 +52,20 @@ naming one raises `ReservedAuthSchemeError` ("author a typed connector").
 Six connectors (five if `vcf_operations`'s query-param merge is counted as
 `basic` with a transport quirk) fit a named scheme:
 
-- **`basic`** — harbor, sddc_manager, vcf_fleet, vcf_operations, hetzner_robot
+- **`basic`** — harbor, vcf_fleet, vcf_operations, hetzner_robot
 - **`static_header`** — argocd
 - **`oauth2_mint`** — keycloak
 - **`session_login`** — vcf_logs (vRLI: JSON creds body → `sessionId` → Bearer)
 - **`session_login_basic`** — vmware_rest (vCenter: HTTP Basic login, no body
   → token from a raw JSON-string body or the legacy `{"value": "<tok>"}`
   object body → `vmware-api-session-id` header; #2025, legacy shape #2047)
-- **`session_login_token`** — SDDC Manager shape (JSON creds body
+- **`session_login_token`** — sddc_manager (SDDC Manager: JSON creds body
   `{username, password}` → response-body `accessToken` field → Bearer). First
   member of this shape; the appliance's HTTP Basic surface is rejected —
-  token-only. Grounded in `POST /v1/tokens` live evidence (#2287). No shipped
-  profile selects it yet: `sddc_manager` still ships `basic` (row 2 above), and
-  flipping it onto this scheme is a separate task.
+  token-only. Grounded in `POST /v1/tokens` live evidence (#2287). The shipped
+  `sddc_manager_minimal.yaml` profile selects it and the typed
+  `SddcManagerConnector` derives its session from the same scheme (#2290, row 2
+  above).
 
 Eight stay **reserved/typed** — github, gcloud, vault, kubernetes, nsx,
 vcf_automation — because their auth is stateful, asymmetric-crypto, or


### PR DESCRIPTION
## Summary

- **Flip the shipped `sddc_manager_minimal.yaml` profile** from the false `scheme: basic` to `session_login_token`, and **rebuild `SddcManagerConnector` auth atop it.** SDDC Manager is token-only — it rejects HTTP Basic outright (live 401; Broadcom KBs 435716/387124/372387), so every ingested sddc op previously rode the hand-rolled connector's Basic-only `auth_headers` and the catalog was never dispatchable.
- The connector now establishes a session at `POST /v1/tokens` (JSON `{username, password}` → `accessToken`) and sends `Authorization: Bearer <accessToken>` on every request, **deriving the login path / request headers / expiry set from the shared `session_login_token` scheme spec (#2287)** via a module-constant `SDDC_EXECUTION_PROFILE` — one declaration shared with a profile-stamped `ProfiledRestConnector` (the vRLI `VRLI_EXECUTION_PROFILE` posture, #1974). Per-`(tenant_id, target.id)` token isolation, single-flight establish, and **one-shot mid-session 401 recovery through the #2067 dispatcher seam** (public duck-typed `invalidate_session` hook) — no restart.
- **Precedence resolved by rebuilding, not racing:** the hand-rolled class stays the resolution winner and keeps occupying the `(sddc, 9.0, sddc-rest)` triple, so the boot-time profile stamp (#2288/#2320) no-ops on it — the **#1750/#1798 product-shadowing invariant is preserved**. Removed the false `username@sso_realm` Basic decoration (`sso_realm` was never a real `Target` column).
- Corrected `docs/codebase/connector-auth-coverage.md` (row 2 + scheme lists), reconciling with #2287's partial update.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/` — clean (Success, 5 sddc source files)
- [x] **Full backend unit suite** — `9675 passed, 192 skipped, 0 failed`
- [x] New **dispatch-level** test (`test_connectors_sddc_manager_session_dispatch.py`, seeded `source_kind='ingested'` descriptor + mocked SDDC API): cold dispatch performs `POST /v1/tokens` with a JSON body, subsequent requests carry `Authorization: Bearer <accessToken>`, **no request ever carries Basic**; a mid-session 401 recovers via exactly one invalidate + re-login + retry through the #2067 seam; a second consecutive 401 resolves to `connector_auth_failed` with no retry loop; two same-named targets in different tenants get distinct tokens (#1642).
- [x] Rewrote the auth unit suite for the token flow (Bearer, token cache, #1008 system-operator bypass, session-login failure modes, `invalidate_session`, `fingerprint`/`probe` via the token session + single 401 recovery).
- [x] `fingerprint()` succeeds via the token flow against the mock.
- [x] **#1750/#1798 shadowing tests stay green** (`test_connectors_resolver_shim_shadowing.py`, `test_operations_boot_stamp.py`, `test_connectors_registry_v2.py`).
- [x] Integration-double dispatch sites grepped (`tests/integration/` has no sddc auth double); shared `tests/acceptance/_sddc_canary_fixtures.py` updated to register the `POST /v1/tokens` route (covers e2e + smoke + force-handle).
- [x] Module-constant `SDDC_EXECUTION_PROFILE` pinned to the shipped YAML by a parity guard.
- [x] No FastAPI route/schema touched → no OpenAPI snapshot delta.

## Out of scope

- Refresh-token leg (`/v1/tokens/access-token`) — expiry re-login covers recovery (initiative Non-goal).
- A typed curated SDDC op surface (#2266 / Goal #2247) — this makes the *ingested* catalog dispatch.
- Live-SDDC soak — handed to the RDC team once merged.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2290
