### PR TITLE
feat(ingest): structural OpenAPI 3.x metaschema gate after the version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — structural OpenAPI 3.x metaschema gate on spec ingest (#2292)
+
+- Spec ingest now validates a decoded OpenAPI 3.0/3.1 document against the
+  official OpenAPI metaschema (via `openapi-spec-validator`), immediately
+  after the existing version check. A metaschema-invalid document — `paths`
+  as a list, an operation with a non-object `responses`, a missing required
+  field — is refused with a structured `invalid_spec` error naming the
+  failing JSON path (e.g. `$.paths['/pets'].get.responses`) and a
+  remediation line, on every transport (REST 400, MCP `-32602`, async-job
+  `error`). Because the gate lives at parse, `dry_run` and the real ingest
+  refuse an invalid spec identically, so a structurally broken document can
+  no longer partially ingest into catalog rows of unknown quality.
+  Validation is metaschema-only (no `operationId`/parameter semantic
+  add-ons) so legal vendor specs — and every shipped package-data spec, at
+  boot — keep ingesting; Swagger 2.0 still gets its dedicated conversion
+  remedy, and the parser's tolerant-skip of sub-document junk is unchanged.
+  (#2292)
+
 ### Changed — SDDC Manager auth rebuilt on the `session_login_token` profile scheme (#2290)
 
 - Flip the shipped `sddc_manager_minimal.yaml` profile from the false

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -87,6 +87,12 @@ dependencies = [
     # AsyncMongoClient runs commands off the event loop natively (no
     # ``asyncio.to_thread`` wrapper needed).
     "pymongo>=4.13,<5",
+    # Structural (metaschema) gate on OpenAPI 3.0/3.1 spec ingest (#2292):
+    # validates a decoded document against the official OAS metaschema so a
+    # metaschema-invalid spec is refused at parse (dry-run and effectful
+    # legs alike) instead of partially ingesting. Builds on the existing
+    # ``jsonschema`` dependency; used metaschema-only (no semantic add-ons).
+    "openapi-spec-validator>=0.9.0",
 ]
 
 [dependency-groups]

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -61,6 +61,14 @@ from urllib.parse import urljoin, urlparse
 
 import httpx
 import yaml
+from jsonschema.exceptions import ValidationError as _JsonSchemaValidationError
+from jsonschema.exceptions import best_match as _best_schema_error
+from openapi_spec_validator.schemas import (
+    openapi_v30_schema_validator as _oas30_schema_validator,
+)
+from openapi_spec_validator.schemas import (
+    openapi_v31_schema_validator as _oas31_schema_validator,
+)
 
 from meho_backplane.operations._rfc6570 import split_path_operator
 from meho_backplane.operations.ingest.exceptions import (
@@ -366,9 +374,10 @@ def parse_openapi(
 
     Raises:
         InvalidSpecError: Document is not a mapping, lacks ``paths``,
-            the URI scheme is not ``https``, or the resolved
-            destination is a private/loopback/link-local/reserved
-            address.
+            fails structural (metaschema) validation against the
+            OpenAPI 3.0/3.1 Specification schema, the URI scheme is
+            not ``https``, or the resolved destination is a
+            private/loopback/link-local/reserved address.
         UnsupportedSpecError: Spec version is not 3.0.x / 3.1.x, or the
             document references a cross-document ``$ref``.
         UpstreamNotSpecError: HTTP fetch succeeded (2xx) but the
@@ -386,6 +395,7 @@ def parse_openapi(
     spec_bytes = _load_spec_bytes(spec_path_or_uri, content=content)
     spec = _decode_spec(spec_bytes)
     _validate_openapi_version(spec)
+    _validate_openapi_structure(spec)
 
     paths = spec.get("paths")
     if paths is None:
@@ -743,6 +753,54 @@ def _validate_openapi_version(spec: dict[str, Any]) -> None:
         raise UnsupportedSpecError(
             f"OpenAPI version {raw_version!r} is not supported (expected 3.0.x or 3.1.x)"
         )
+
+
+def _validate_openapi_structure(spec: dict[str, Any]) -> None:
+    """Refuse a 3.x document that violates the official OpenAPI metaschema.
+
+    Runs *after* :func:`_validate_openapi_version`, so the version string
+    is already known to be ``3.0.x`` / ``3.1.x`` and the matching
+    metaschema can be selected (3.1 carries the jsonSchemaDialect-aware
+    2020-12 schema; 3.0 the draft-04-based one). Validation is
+    **metaschema-only**: the document is checked against the JSON Schema
+    that defines a legal OpenAPI object, not the library's optional
+    semantic add-ons (duplicate-operationId, unresolvable-path-parameter,
+    extra-parameter). Those add-ons routinely flag legal-but-untidy vendor
+    specs, and this gate's job is structural validity, not a linter — a
+    published 950-operation spec must not be refused because two operations
+    share a tag or an operation omits an ``operationId``.
+
+    The first (most-relevant) violation is surfaced via
+    :func:`jsonschema.exceptions.best_match` so the operator gets one
+    actionable location instead of a wall of cascading errors, named by
+    its JSON path (e.g. ``$.paths['/pets'].get.responses``). Raised as
+    :class:`InvalidSpecError` — the version-independent structural-fault
+    family — so it flows through the existing ``invalid_spec`` envelope on
+    every transport (REST 400, MCP ``-32602``, async-job ``error``) with
+    no new typed field. Because the gate lives at parse, the ``dry_run``
+    and effectful ingest legs refuse an invalid spec identically.
+
+    The parser's deliberate tolerant-skip of *sub-document* junk
+    (non-dict path items / operations, empty path items) is unaffected:
+    those shapes are still legal per the metaschema and are handled
+    downstream in :func:`_iter_operations`; only genuine metaschema
+    violations (``paths`` as a list, a non-object ``responses``, a missing
+    required field) are refused here.
+    """
+    validator = (
+        _oas31_schema_validator
+        if spec.get("openapi", "").startswith("3.1")
+        else _oas30_schema_validator
+    )
+    error: _JsonSchemaValidationError | None = _best_schema_error(validator.iter_errors(spec))
+    if error is None:
+        return
+    raise InvalidSpecError(
+        f"OpenAPI document fails structural (metaschema) validation at "
+        f"{error.json_path}: {error.message}. Fix the document so it conforms "
+        f"to the OpenAPI Specification schema for its declared version, then "
+        f"re-ingest. See docs/codebase/error-message-shape.md."
+    )
 
 
 def _iter_operations(

--- a/backend/tests/fixtures/openapi/metaschema_invalid_responses_30.yaml
+++ b/backend/tests/fixtures/openapi/metaschema_invalid_responses_30.yaml
@@ -1,0 +1,16 @@
+# A structurally invalid OpenAPI 3.0 document: the operation's
+# ``responses`` is a list, but the OpenAPI metaschema requires a
+# Responses Object (a mapping). Every other part of the document is
+# well-formed, so the only reason to refuse it is the metaschema gate
+# (the version check and the ``paths``-is-a-mapping check both pass).
+openapi: "3.0.3"
+info:
+  title: Metaschema-invalid fixture
+  version: "1.0.0"
+paths:
+  /widgets:
+    get:
+      operationId: listWidgets
+      responses:
+        - "200"
+        - description: ok

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -55,6 +55,7 @@ REQUEST_BODY_REFS_30 = FIXTURES / "request_body_refs_30.yaml"
 HANDAUTHORED_MINIMAL_30 = FIXTURES / "handauthored_minimal_30.yaml"
 TIMESTAMP_EXAMPLES_30 = FIXTURES / "timestamp_examples_30.yaml"
 NONSERIALIZABLE_EXAMPLE_30 = FIXTURES / "nonserializable_example_30.yaml"
+METASCHEMA_INVALID_RESPONSES_30 = FIXTURES / "metaschema_invalid_responses_30.yaml"
 
 # Stable HTTPS URL prefix used by tests that serve fixture content through
 # respx. Using a dedicated subdomain makes it easy to route all fixture
@@ -814,7 +815,20 @@ def test_unsupported_openapi_4_raises() -> None:
 
 
 def test_invalid_spec_missing_paths_raises() -> None:
-    content = b"openapi: '3.1.0'\ninfo: {title: x, version: '1'}\n"
+    """A 3.1 doc that is metaschema-valid but path-less is still refused.
+
+    OpenAPI 3.1 permits a document that declares ``webhooks`` (or
+    ``components``) with no ``paths`` — such a doc passes the structural
+    metaschema gate (#2292) — but meho only ingests path operations, so
+    the bespoke ``no 'paths' key`` check behind the gate still rejects it.
+    This pins the layering: the metaschema gate does not shadow meho's
+    narrower path-required contract for the specs the metaschema allows.
+    """
+    content = (
+        b"openapi: '3.1.0'\ninfo: {title: x, version: '1'}\n"
+        b"webhooks:\n  newPet:\n    post:\n      responses:\n"
+        b"        '200':\n          description: ok\n"
+    )
     with respx.mock(assert_all_called=False) as router:
         url = _mock_yaml_spec(router, "broken.yaml", content)
         with pytest.raises(InvalidSpecError, match="no 'paths' key"):
@@ -827,6 +841,73 @@ def test_invalid_spec_non_mapping_root_raises() -> None:
         url = _mock_yaml_spec(router, "list.yaml", content)
         with pytest.raises(InvalidSpecError, match="must parse to a mapping"):
             parse_openapi(url)
+
+
+def test_metaschema_invalid_spec_refused_naming_pointer() -> None:
+    """A 3.x doc that violates the OpenAPI metaschema is refused (#2292).
+
+    The fixture is well-formed everywhere except its operation's
+    ``responses``, which is a list where the metaschema requires a
+    Responses Object. The version gate and the ``paths``-is-a-mapping
+    check both pass, so the *only* reason to refuse it is the structural
+    metaschema gate. The rejection is actionable: it names the failing
+    JSON path and points at the error-shape convention doc.
+    """
+    content = METASCHEMA_INVALID_RESPONSES_30.read_text()
+    with pytest.raises(InvalidSpecError, match="metaschema") as excinfo:
+        parse_openapi("docs:widgets/spec.yaml", content=content)
+    message = str(excinfo.value)
+    # Names the failing pointer (the operation's responses slot) ...
+    assert "$.paths['/widgets'].get.responses" in message
+    # ... and carries the house remediation anchor.
+    assert "docs/codebase/error-message-shape.md" in message
+
+
+def test_metaschema_invalid_spec_dry_run_and_effectful_refuse_identically() -> None:
+    """The gate lives at parse, so ``dry_run`` and the real run refuse alike.
+
+    ``dry_run`` differs from the effectful ingest only in whether the
+    parsed rows are persisted; both legs call :func:`parse_openapi`. A
+    spec_source tag is threaded on the effectful leg and absent on a bare
+    probe, so exercise both call shapes and assert the same structured
+    refusal — there is no leg on which a metaschema-invalid spec slips
+    through to a partial catalog write.
+    """
+    content = METASCHEMA_INVALID_RESPONSES_30.read_text()
+    with pytest.raises(InvalidSpecError, match="metaschema") as effectful:
+        parse_openapi("docs:widgets/spec.yaml", spec_source="spec:widgets.yaml", content=content)
+    with pytest.raises(InvalidSpecError, match="metaschema") as dry_run:
+        parse_openapi("docs:widgets/spec.yaml", content=content)
+    assert str(effectful.value) == str(dry_run.value)
+
+
+def test_metaschema_valid_path_without_operations_still_tolerated() -> None:
+    """The gate does not disturb the parser's tolerant-skip of empty paths.
+
+    A path item carrying only a ``description`` (no verbs) is legal per
+    the metaschema, so the gate lets it through; the parser then yields no
+    operation for it (existing skip behavior). Guards the boundary that
+    the structural gate refuses *metaschema* violations only, not
+    otherwise-valid specs whose sub-documents the parser deliberately
+    skips.
+    """
+    content = yaml.safe_dump(
+        {
+            "openapi": "3.0.3",
+            "info": {"title": "sparse", "version": "1.0.0"},
+            "paths": {
+                "/described-but-empty": {"description": "no operations here"},
+                "/real": {
+                    "get": {
+                        "operationId": "getReal",
+                        "responses": {"200": {"description": "ok"}},
+                    }
+                },
+            },
+        }
+    )
+    rows = parse_openapi("docs:sparse/spec.yaml", content=content)
+    assert [r.op_id for r in rows] == ["GET:/real"]
 
 
 def test_non_https_scheme_raises_invalid_spec() -> None:
@@ -1389,7 +1470,14 @@ paths:
 
 
 def test_non_list_tags_raises() -> None:
-    """A spec with ``tags: "admin"`` would otherwise iterate as characters."""
+    """A spec with ``tags: "admin"`` is refused by the structural gate.
+
+    ``tags`` must be an array per the OpenAPI metaschema, so the #2292
+    structural gate now catches this scalar-tags mistake at parse with a
+    pointer to ``$.paths['/x'].get.tags`` — earlier than, and superseding,
+    the parser's own defensive ``tags must be a list`` check (which stays
+    as belt-and-suspenders for any input that reaches ``_build_proto``).
+    """
     content = b"""openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
@@ -1402,8 +1490,9 @@ paths:
 """
     with respx.mock(assert_all_called=False) as router:
         url = _mock_yaml_spec(router, "bad_tags.yaml", content)
-        with pytest.raises(InvalidSchemaError, match=r"tags must be a list"):
+        with pytest.raises(InvalidSpecError, match="metaschema") as excinfo:
             parse_openapi(url)
+        assert "$.paths['/x'].get.tags" in str(excinfo.value)
 
 
 def test_openapi_31_boolean_parameter_schema() -> None:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1521,6 +1521,21 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema-path"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
+]
+
+[[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1547,6 +1562,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/45/9e15f4268454636aee32d92ddeaa7128c71100308644bc79685292c1efcc/kubernetes_asyncio-36.1.0.tar.gz", hash = "sha256:6d979d82e5ebe490bea298e7843732a2336173236bae28e200434889443d4443", size = 1426205, upload-time = "2026-06-04T19:42:45.669Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/dc/695601e3a6f08ca3d6035d300a944974c17084050591faec6e1de39e4a4e/kubernetes_asyncio-36.1.0-py3-none-any.whl", hash = "sha256:6d25915d1abff24fceda551a502208d986f674d72586297aa58bc7d55e7feaf3", size = 3044531, upload-time = "2026-06-04T19:42:43.84Z" },
+]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a2/69df9c6ba6d316cfd81fe2381e464db3e6de5db45f8c43c6a23504abf8cb/lazy_object_proxy-1.12.0.tar.gz", hash = "sha256:1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61", size = 43681, upload-time = "2025-08-22T13:50:06.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/1b/b5f5bd6bda26f1e15cd3232b223892e4498e34ec70a7f4f11c401ac969f1/lazy_object_proxy-1.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ee0d6027b760a11cc18281e702c0309dd92da458a74b4c15025d7fc490deede", size = 26746, upload-time = "2025-08-22T13:42:37.572Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/314889b618075c2bfc19293ffa9153ce880ac6153aacfd0a52fcabf21a66/lazy_object_proxy-1.12.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4ab2c584e3cc8be0dfca422e05ad30a9abe3555ce63e9ab7a559f62f8dbc6ff9", size = 71457, upload-time = "2025-08-22T13:42:38.743Z" },
+    { url = "https://files.pythonhosted.org/packages/11/53/857fc2827fc1e13fbdfc0ba2629a7d2579645a06192d5461809540b78913/lazy_object_proxy-1.12.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:14e348185adbd03ec17d051e169ec45686dcd840a3779c9d4c10aabe2ca6e1c0", size = 71036, upload-time = "2025-08-22T13:42:40.184Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/24/e581ffed864cd33c1b445b5763d617448ebb880f48675fc9de0471a95cbc/lazy_object_proxy-1.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c4fcbe74fb85df8ba7825fa05eddca764138da752904b378f0ae5ab33a36c308", size = 69329, upload-time = "2025-08-22T13:42:41.311Z" },
+    { url = "https://files.pythonhosted.org/packages/78/be/15f8f5a0b0b2e668e756a152257d26370132c97f2f1943329b08f057eff0/lazy_object_proxy-1.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:563d2ec8e4d4b68ee7848c5ab4d6057a6d703cb7963b342968bb8758dda33a23", size = 70690, upload-time = "2025-08-22T13:42:42.51Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/aa/f02be9bbfb270e13ee608c2b28b8771f20a5f64356c6d9317b20043c6129/lazy_object_proxy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:53c7fd99eb156bbb82cbc5d5188891d8fdd805ba6c1e3b92b90092da2a837073", size = 26563, upload-time = "2025-08-22T13:42:43.685Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/26/b74c791008841f8ad896c7f293415136c66cc27e7c7577de4ee68040c110/lazy_object_proxy-1.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:86fd61cb2ba249b9f436d789d1356deae69ad3231dc3c0f17293ac535162672e", size = 26745, upload-time = "2025-08-22T13:42:44.982Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/52/641870d309e5d1fb1ea7d462a818ca727e43bfa431d8c34b173eb090348c/lazy_object_proxy-1.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81d1852fb30fab81696f93db1b1e55a5d1ff7940838191062f5f56987d5fcc3e", size = 71537, upload-time = "2025-08-22T13:42:46.141Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b6/919118e99d51c5e76e8bf5a27df406884921c0acf2c7b8a3b38d847ab3e9/lazy_object_proxy-1.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9045646d83f6c2664c1330904b245ae2371b5c57a3195e4028aedc9f999655", size = 71141, upload-time = "2025-08-22T13:42:47.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/47/1d20e626567b41de085cf4d4fb3661a56c159feaa73c825917b3b4d4f806/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:67f07ab742f1adfb3966c40f630baaa7902be4222a17941f3d85fd1dae5565ff", size = 69449, upload-time = "2025-08-22T13:42:48.49Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8d/25c20ff1a1a8426d9af2d0b6f29f6388005fc8cd10d6ee71f48bff86fdd0/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ba769017b944fcacbf6a80c18b2761a1795b03f8899acdad1f1c39db4409be", size = 70744, upload-time = "2025-08-22T13:42:49.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/67/8ec9abe15c4f8a4bcc6e65160a2c667240d025cbb6591b879bea55625263/lazy_object_proxy-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:7b22c2bbfb155706b928ac4d74c1a63ac8552a55ba7fff4445155523ea4067e1", size = 26568, upload-time = "2025-08-22T13:42:57.719Z" },
+    { url = "https://files.pythonhosted.org/packages/23/12/cd2235463f3469fd6c62d41d92b7f120e8134f76e52421413a0ad16d493e/lazy_object_proxy-1.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4a79b909aa16bde8ae606f06e6bbc9d3219d2e57fb3e0076e17879072b742c65", size = 27391, upload-time = "2025-08-22T13:42:50.62Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9e/f1c53e39bbebad2e8609c67d0830cc275f694d0ea23d78e8f6db526c12d3/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:338ab2f132276203e404951205fe80c3fd59429b3a724e7b662b2eb539bb1be9", size = 80552, upload-time = "2025-08-22T13:42:51.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/6c513693448dcb317d9d8c91d91f47addc09553613379e504435b4cc8b3e/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c40b3c9faee2e32bfce0df4ae63f4e73529766893258eca78548bac801c8f66", size = 82857, upload-time = "2025-08-22T13:42:53.225Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1c/d9c4aaa4c75da11eb7c22c43d7c90a53b4fca0e27784a5ab207768debea7/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:717484c309df78cedf48396e420fa57fc8a2b1f06ea889df7248fdd156e58847", size = 80833, upload-time = "2025-08-22T13:42:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ae/29117275aac7d7d78ae4f5a4787f36ff33262499d486ac0bf3e0b97889f6/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a6b7ea5ea1ffe15059eb44bcbcb258f97bcb40e139b88152c40d07b1a1dfc9ac", size = 79516, upload-time = "2025-08-22T13:42:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/19/40/b4e48b2c38c69392ae702ae7afa7b6551e0ca5d38263198b7c79de8b3bdf/lazy_object_proxy-1.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:08c465fb5cd23527512f9bd7b4c7ba6cec33e28aad36fbbe46bf7b858f9f3f7f", size = 27656, upload-time = "2025-08-22T13:42:56.793Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/3a/277857b51ae419a1574557c0b12e0d06bf327b758ba94cafc664cb1e2f66/lazy_object_proxy-1.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c9defba70ab943f1df98a656247966d7729da2fe9c2d5d85346464bf320820a3", size = 26582, upload-time = "2025-08-22T13:49:49.366Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/c5e0fa43535bb9c87880e0ba037cdb1c50e01850b0831e80eb4f4762f270/lazy_object_proxy-1.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6763941dbf97eea6b90f5b06eb4da9418cc088fce0e3883f5816090f9afcde4a", size = 71059, upload-time = "2025-08-22T13:49:50.488Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/7dcad19c685963c652624702f1a968ff10220b16bfcc442257038216bf55/lazy_object_proxy-1.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc70d81235fc586b9e3d1aeef7d1553259b62ecaae9db2167a5d2550dcc391a", size = 71034, upload-time = "2025-08-22T13:49:54.224Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ac/34cbfb433a10e28c7fd830f91c5a348462ba748413cbb950c7f259e67aa7/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0a83c6f7a6b2bfc11ef3ed67f8cbe99f8ff500b05655d8e7df9aab993a6abc95", size = 69529, upload-time = "2025-08-22T13:49:55.29Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
+    { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
 ]
 
 [[package]]
@@ -1767,6 +1814,7 @@ dependencies = [
     { name = "kubernetes-asyncio" },
     { name = "markdown-it-py", extra = ["linkify"] },
     { name = "msgspec" },
+    { name = "openapi-spec-validator" },
     { name = "packaging" },
     { name = "pgvector" },
     { name = "presidio-analyzer" },
@@ -1824,6 +1872,7 @@ requires-dist = [
     { name = "kubernetes-asyncio", specifier = ">=36.1.0,<37" },
     { name = "markdown-it-py", extras = ["linkify"], specifier = ">=4.2.0" },
     { name = "msgspec", specifier = ">=0.20.0" },
+    { name = "openapi-spec-validator", specifier = ">=0.9.0" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pgvector", specifier = ">=0.3,<1.0" },
     { name = "presidio-analyzer", specifier = "==2.2.363" },
@@ -2296,6 +2345,40 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-schema-validator"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/e8/ab3f27dbca54ec645f7fab714b640907d5d36c2ebb07e87eebd30bd5c81b/openapi_schema_validator-0.9.0.tar.gz", hash = "sha256:b72db64315b89d21834cd3ffef37e3e6893bc876327be2d366e8424b1029afd3", size = 24686, upload-time = "2026-04-27T17:31:27.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/c0/5467967d95378b2cfce312e09cbd0c9ab64354a0922379b734f793edd04f/openapi_schema_validator-0.9.0-py3-none-any.whl", hash = "sha256:faa3bbe7c3aa8ca2087ad83f709dc3b7d920283153a570c03e24ea182558aa25", size = 19980, upload-time = "2026-04-27T17:31:25.965Z" },
+]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "lazy-object-proxy" },
+    { name = "openapi-schema-validator" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/d2/640b5149cd5688bc0ad1fdbb4df6a2f7b84a093c8d787c27d566132f8b8b/openapi_spec_validator-0.9.0.tar.gz", hash = "sha256:6d648cff6490ebb799dcfe273792f2941c050158854c721f086599d845da78b8", size = 1756839, upload-time = "2026-05-20T09:23:18.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/d8/321ff889330acca2e3097f3d4f80a40bcc41b6d34d302978ab32c449520b/openapi_spec_validator-0.9.0-py3-none-any.whl", hash = "sha256:222fecffc7714f6d0a6ad62c0e4b66cc2b7dbfafb7b93acfc6c308abbdb51af8", size = 50328, upload-time = "2026-05-20T09:23:17.017Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2314,6 +2397,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
 ]
 
 [[package]]
@@ -2867,6 +2959,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1c/17aab9efff0a37a50fa35d3d69c6c92afe2b602f5885e837dd359ae969c1/pydantic_graph-2.7.0.tar.gz", hash = "sha256:4e5816dba4389c18c799748479754052f624bd3ca613c391c3a418475733cd40", size = 43904, upload-time = "2026-07-09T02:08:40.401Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/d4/c2781175400b40d149179a4ceaaa0279c89bad70f1aa67f255d5d793297b/pydantic_graph-2.7.0-py3-none-any.whl", hash = "sha256:7ce75e8b5533f7af438b10ce6e9dbb51cf26a5a68cb5f5311325adffa75f45da", size = 51644, upload-time = "2026-07-09T02:08:34.388Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1447,7 +1447,9 @@ for the operator-facing framing.
 The only public entry point for the full walk. Resolves the input
 (file path or `http(s)://` URL via `httpx`), sniffs YAML vs JSON via
 `detect_spec_format`, decodes, validates the OpenAPI version
-(3.0.x / 3.1.x), and walks `paths`. Returns a list.
+(3.0.x / 3.1.x), validates the document against the official OpenAPI
+metaschema (`_validate_openapi_structure`), and walks `paths`. Returns a
+list.
 
 The function is synchronous because callers are CLI / one-shot
 ingestion endpoints that have no in-flight event loop concern. It
@@ -1472,6 +1474,41 @@ schema is JSON-serializable at the proto-build boundary both the real and
 say) fails identically — a structured `invalid_schema` 400 at parse time
 — instead of crashing the real INSERT while `dry_run=true` green-lights
 the same spec.
+
+**Structural (metaschema) gate (#2292).** Immediately after the version
+gate, `_validate_openapi_structure` validates the decoded document
+against the official OpenAPI metaschema — the 2020-12-based schema for a
+`3.1.x` document, the draft-04-based schema for `3.0.x` — via
+`openapi-spec-validator`'s pre-built schema validators
+(`openapi_v30_schema_validator` / `openapi_v31_schema_validator`).
+Validation is **metaschema-only**: the library's optional semantic
+add-ons (duplicate-`operationId`, unresolvable-path-parameter,
+extra-parameter) are *not* run, because they routinely flag
+legal-but-untidy vendor specs and this gate judges structure, not style.
+The first (most-relevant) violation is selected with
+`jsonschema.exceptions.best_match` and surfaced as `InvalidSpecError`
+naming the failing JSON path (e.g. `$.paths['/pets'].get.responses`) plus
+the house remediation anchor, so it flows through the existing
+`invalid_spec` envelope on every transport (REST 400, MCP `-32602`,
+async-job `error`) with no new typed field. Because the gate lives at
+parse, a metaschema-invalid document is refused identically on the
+`dry_run` and effectful legs — it can never partially ingest into
+catalog rows of unknown quality. The gate is deliberately narrower than
+"validate everything": the metaschema does not resolve `$ref` targets
+(so cross-document `$ref` rejection stays with the ref resolver
+downstream) and it permits a `3.1` document with `webhooks`/`components`
+but no `paths`, which meho's own `no 'paths' key` check — sitting behind
+the gate — still rejects because meho ingests only path operations. The
+parser's tolerant-skip of sub-document junk (a path item with no verbs,
+a non-dict path item) is unaffected: those shapes are legal per the
+metaschema and are handled in `_iter_operations`.
+
+Boot-time impact: the same gated parser runs in
+`validate_shipped_artifacts` (`catalog.py`, called at `main.py`
+startup), so every shipped package-data spec and catalog `spec_resource`
+must be metaschema-valid or the backplane crashes on start — the guard
+that keeps a malformed shipped artifact from 500-ing the first ingest
+that touches it (Initiative #1966 boot-validation precedent).
 
 `read_spec_info_version(spec_path_or_uri)` is the companion helper
 the G0.9-T8 cross-check uses. It runs the same load / decode /
@@ -1539,6 +1576,7 @@ parse_openapi
 │  └─ _assert_fetchable_remote_url  # https-only SSRF guard; DNS resolve, IP allowlist
 ├─ _decode_spec            # YAML via _SpecYamlLoader (timestamp→str, #2272), stdlib JSON
 ├─ _validate_openapi_version
+├─ _validate_openapi_structure  # metaschema gate: refuse invalid 3.x w/ JSON-pointer (#2292)
 └─ _iter_operations
    └─ _build_proto         # per (method, path) verb under paths
       ├─ _build_parameter_schema


### PR DESCRIPTION
## Summary

- Adds a structural (metaschema) validation gate to OpenAPI spec ingest,
  running immediately after the existing 3.0.x/3.1.x version check in
  `parse_openapi` (`backend/.../ingest/openapi.py`). A metaschema-invalid
  3.x document is refused with the existing `InvalidSpecError`, naming the
  failing JSON path (e.g. `$.paths['/pets'].get.responses`) plus a
  remediation line — so it surfaces through the existing `invalid_spec`
  envelope on every transport (REST 400, MCP `-32602`, async-job `error`).
- Validation is **metaschema-only** (via `openapi-spec-validator`'s
  pre-built `openapi_v30/v31_schema_validator`, `best_match` for one
  actionable error). The library's optional semantic add-ons
  (duplicate-`operationId`, unresolvable-path-parameter, extra-parameter)
  are deliberately **not** run — they routinely flag legal-but-untidy
  vendor specs, and this gate judges structure, not style.
- Because the gate lives at parse, `dry_run` and the effectful ingest
  refuse an invalid spec identically — a structurally broken document can
  no longer partially ingest into catalog rows of unknown quality. The
  same gated parser runs at boot in `validate_shipped_artifacts`, so every
  shipped package-data spec is verified metaschema-valid on start.
- New dependency `openapi-spec-validator>=0.9.0` (builds on the existing
  `jsonschema>=4.26`).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/.../ingest/openapi.py` — clean
- [x] `pytest tests/test_operations_ingest_openapi.py` — 130 passed
- [x] New fixture `metaschema_invalid_responses_30.yaml` is refused with the
      structured error naming `$.paths['/widgets'].get.responses`; dry-run
      and effectful legs refuse identically (new tests).
- [x] All existing openapi fixtures + shipped package-data specs pass the
      gate; `validate_shipped_artifacts()` (boot guard) succeeds.
- [x] Swagger 2.0 still gets its dedicated conversion remediation
      (unchanged, caught at the earlier version gate).
- [x] Tolerant-skip of path-level junk unchanged (empty/verb-less path
      items still yield no ops; new regression test).
- [x] Error-shape is message-only (no new typed field): `make
      snapshot-openapi` produces **zero** delta.
- [x] Code-quality gate: 0 blockers (warnings are pre-existing debt in
      untouched functions).
- [x] Full backend unit sweep (`pytest tests/ --ignore=tests/integration`).

## Notes

- The metaschema does not resolve `$ref` targets, so cross-document `$ref`
  rejection stays with the ref resolver downstream; and it permits a `3.1`
  doc with `webhooks`/`components` but no `paths`, which meho's own
  `no 'paths' key` check (behind the gate) still rejects. Both layered
  cases are pinned by tests.
- Vendor/fleet-lcm integration fixtures are fetched from env-provided URLs
  and skip in the sandbox; the gate is metaschema-only precisely to keep
  those legal specs ingesting. They run in CI where the specs are
  provisioned.

## Out of scope

- Gating `read_spec_info_version` (a lightweight version probe — per the
  task, gating it doubles lint cost for no catalog-integrity gain).
- Linting beyond the OAS metaschema (Spectral rulesets, style rules).

Closes #2292


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structural validation for OpenAPI 3.0 and 3.1 specifications during ingestion.
  - Invalid specifications are rejected with structured errors identifying the failing JSON path and remediation guidance.
  - Validation behaves consistently for dry runs and regular ingestion across supported transports.
  - Valid vendor-specific extensions and path items without operations remain supported.

- **Documentation**
  - Updated specification-ingestion documentation to describe validation behavior and startup checks for malformed packaged specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->