### PR TITLE
feat(ingest): persist spec provenance at ingest — sha256 + origin + operator/timestamp, surfaced in review/status (#2291)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,27 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — persisted spec provenance at ingest (sha256 + origin + operator/timestamp, surfaced in review) (#2291)
+
+- Every accepted spec ingest now writes a durable, non-spoofable
+  provenance row to a new `spec_provenance` table (Alembic `0056`): the
+  `sha256` over the **raw spec bytes** (hashed at the fetch/upload trust
+  boundary before any decode), the audit `uri` as presented, the
+  `origin` (`fetched` https GET · `inline` operator upload · `shipped`
+  MEHO-authored catalog data), the ingesting operator, and a timestamp,
+  scoped like the descriptor rows (`tenant_id IS NULL` = global). Before
+  this, the only provenance was a spoofable `spec:<uri>` tag — an
+  operator's hand-mutated inline upload labelled with a vendor's https
+  URL persisted identically to a genuine fetch of that URL, and the
+  fetched-vs-inline bit was never persisted. Re-ingesting the same spec
+  updates the row in place (new `sha256` + timestamp), so different
+  content under the same label is detectable. Provenance is surfaced on
+  the connector review REST payload (`ConnectorReviewPayload.provenance`)
+  and rendered by `meho connector review`; connectors ingested before
+  this landed read as "unknown (pre-provenance)". Record-and-surface
+  only — no refusal policy, and the `file:///` / `docs:` inline on-ramp
+  stays fully functional. (#2270 / #2291)
+
 ### Changed — SDDC Manager auth rebuilt on the `session_login_token` profile scheme (#2290)
 
 - Flip the shipped `sddc_manager_minimal.yaml` profile from the false

--- a/backend/alembic/versions/0056_create_spec_provenance.py
+++ b/backend/alembic/versions/0056_create_spec_provenance.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``spec_provenance`` table (#2291).
+
+Revision ID: 0056
+Revises: 0055
+Create Date: 2026-07-10
+
+Initiative #2270 (ingest spec hygiene), Task #2291. Persists durable,
+non-spoofable provenance for every accepted spec ingest so downstream
+reasoning (dispatch debugging, re-ingest, upgrade reconciliation) can
+tell a vendor artifact from a hand-mutated one.
+
+Before this table the only per-row provenance was the spoofable
+``spec:<uri>`` tag on ``endpoint_descriptor``: an operator's
+hand-mutated inline upload labelled with a vendor's ``https`` URL
+persisted identically to a genuine fetch of that URL, and the
+fetched-vs-inline bit was never persisted anywhere. A single spec fans
+out to hundreds of descriptor rows, so provenance is a spec-level table,
+not per-descriptor columns.
+
+Columns
+-------
+
+* ``uri`` — the audit label exactly as presented (``spec:`` /
+  ``https://`` / ``file:///`` / ``docs:`` form preserved).
+* ``sha256`` — hex digest over the raw spec bytes (fetched body or
+  uploaded content), computed at the ``_load_spec_bytes`` trust boundary
+  before any decode.
+* ``origin`` — ``fetched`` | ``inline`` | ``shipped`` (bounded via a
+  portable ``CHECK`` constraint, same discipline as
+  ``ck_endpoint_descriptor_source_kind`` in ``0005``).
+* ``operator_sub`` — the ingesting operator's subject claim; nullable
+  for boot-time shipped ingests with no operator.
+* ``ingested_at`` — UTC time the row was last written; refreshed on
+  re-ingest.
+
+Unique-constraint shape — partial unique indexes
+------------------------------------------------
+
+The natural key is ``(tenant_id, product, version, impl_id, uri)`` with
+``tenant_id IS NULL`` for built-in/global ingests. A single
+``UNIQUE (tenant_id, ...)`` would not enforce "two global ingests of the
+same spec collide" — NULL != NULL under SQL UNIQUE. Mirrors
+``0005``'s ``endpoint_descriptor`` split: two partial unique indexes,
+one ``WHERE tenant_id IS NULL`` and one ``WHERE tenant_id IS NOT NULL``.
+SQLite has supported partial indexes since 3.8.0 (we're on 3.45+);
+SQLAlchemy emits the ``WHERE`` for both dialects via the
+``postgresql_where`` / ``sqlite_where`` pair.
+
+Dialect-portability decisions
+-----------------------------
+
+Mirrors ``0005``. ``id`` gets a ``gen_random_uuid()`` server default on
+PG (SQLite leaves it to the ORM ``default=uuid.uuid4``); ``ingested_at``
+gets ``now()`` on PG (SQLite leaves it to the ORM default). No JSON,
+vector, or PG-only index — the table is plain text + timestamp columns,
+so the migration is symmetric on both dialects.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the two partial indexes explicitly (SQLite does
+not always cascade indexes on ``drop_table``) then the table. Purely
+additive on the way up (no ``DROP`` / destructive DDL in ``upgrade()``),
+so the migration-compat CI guard passes.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0056"
+down_revision: str | None = "0055"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``spec_provenance`` table + its two partial unique indexes."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.create_table(
+        "spec_provenance",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        # tenant_id NULL → built-in/global ingest; non-null → tenant-scoped.
+        # Soft-FK discipline (no FK to tenant.id), same as 0002/0005.
+        sa.Column("tenant_id", sa.Uuid(), nullable=True),
+        sa.Column("product", sa.Text(), nullable=False),
+        sa.Column("version", sa.Text(), nullable=False),
+        sa.Column("impl_id", sa.Text(), nullable=False),
+        sa.Column("uri", sa.Text(), nullable=False),
+        sa.Column("sha256", sa.Text(), nullable=False),
+        sa.Column("origin", sa.Text(), nullable=False),
+        sa.Column("operator_sub", sa.Text(), nullable=True),
+        sa.Column(
+            "ingested_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.CheckConstraint(
+            "origin IN ('fetched', 'inline', 'shipped')",
+            name="ck_spec_provenance_origin",
+        ),
+    )
+
+    # Partial unique indexes — see module docstring (NULL != NULL under
+    # SQL UNIQUE; global and tenant rows need separate scopes).
+    op.create_index(
+        "spec_provenance_global_idx",
+        "spec_provenance",
+        ["product", "version", "impl_id", "uri"],
+        unique=True,
+        postgresql_where=sa.text("tenant_id IS NULL"),
+        sqlite_where=sa.text("tenant_id IS NULL"),
+    )
+    op.create_index(
+        "spec_provenance_tenant_idx",
+        "spec_provenance",
+        ["tenant_id", "product", "version", "impl_id", "uri"],
+        unique=True,
+        postgresql_where=sa.text("tenant_id IS NOT NULL"),
+        sqlite_where=sa.text("tenant_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the ``spec_provenance`` indexes then the table (reverse order)."""
+    op.drop_index("spec_provenance_tenant_idx", table_name="spec_provenance")
+    op.drop_index("spec_provenance_global_idx", table_name="spec_provenance")
+    op.drop_table("spec_provenance")

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -282,6 +282,7 @@ __all__ = [
     "RunbookRun",
     "RunbookRunStepState",
     "RunbookTemplate",
+    "SpecProvenance",
     "Target",
     "Tenant",
     "TenantConvention",
@@ -1565,6 +1566,101 @@ class EndpointDescriptor(Base):
         sa.CheckConstraint(
             "safety_level IN ('safe', 'caution', 'dangerous')",
             name="ck_endpoint_descriptor_safety_level",
+        ),
+    )
+
+
+class SpecProvenance(Base):
+    """One row per accepted spec ingest — durable, non-spoofable provenance.
+
+    A single spec fans out to hundreds of :class:`EndpointDescriptor`
+    rows, so provenance lives at the spec level rather than as per-row
+    columns (#2291). Before this table the only per-row provenance was
+    the spoofable ``spec:<uri>`` tag: an operator's hand-mutated inline
+    upload labelled with a vendor's ``https`` URL persisted identically
+    to a genuine fetch of that URL, so nothing downstream could tell a
+    vendor artifact from a mutation.
+
+    Columns:
+
+    * ``uri`` — the audit label exactly as the operator presented it
+      (``spec:`` / ``https://`` / ``file:///`` / ``docs:`` form
+      preserved). It is *not* a trust signal on its own; ``origin`` +
+      ``sha256`` are.
+    * ``sha256`` — hex digest over the **raw spec bytes** (fetched body
+      or uploaded content), computed at the ``_load_spec_bytes`` trust
+      boundary before any YAML/JSON decode. Different content under the
+      same ``uri`` changes this digest.
+    * ``origin`` — how the bytes reached the backplane:
+      ``fetched`` (https GET), ``inline`` (operator-uploaded content),
+      or ``shipped`` (MEHO-authored catalog package data). This is the
+      fetched-vs-inline bit that was never persisted before.
+    * ``operator_sub`` — the ingesting operator's subject claim
+      (nullable for boot-time shipped ingests with no operator).
+    * ``ingested_at`` — UTC time the provenance row was last written;
+      refreshed on re-ingest so it tracks the latest accepted ingest.
+
+    Scope mirrors :class:`EndpointDescriptor`: ``tenant_id IS NULL`` is
+    a built-in/global ingest, non-null is tenant-scoped. The natural key
+    is ``(tenant_id, product, version, impl_id, uri)`` enforced by two
+    partial unique indexes (NULL != NULL under SQL UNIQUE, so global and
+    tenant rows need separate partial indexes — same shape the
+    descriptor table uses). Re-ingesting the same spec under the same
+    key updates the row in place (new ``sha256`` + ``ingested_at``)
+    rather than accumulating duplicates.
+    """
+
+    __tablename__ = "spec_provenance"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    tenant_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(),
+        nullable=True,
+        default=None,
+    )
+    product: Mapped[str] = mapped_column(Text, nullable=False)
+    version: Mapped[str] = mapped_column(Text, nullable=False)
+    impl_id: Mapped[str] = mapped_column(Text, nullable=False)
+    uri: Mapped[str] = mapped_column(Text, nullable=False)
+    sha256: Mapped[str] = mapped_column(Text, nullable=False)
+    origin: Mapped[str] = mapped_column(Text, nullable=False)
+    operator_sub: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    ingested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        Index(
+            "spec_provenance_global_idx",
+            "product",
+            "version",
+            "impl_id",
+            "uri",
+            unique=True,
+            postgresql_where=sa.text("tenant_id IS NULL"),
+            sqlite_where=sa.text("tenant_id IS NULL"),
+        ),
+        Index(
+            "spec_provenance_tenant_idx",
+            "tenant_id",
+            "product",
+            "version",
+            "impl_id",
+            "uri",
+            unique=True,
+            postgresql_where=sa.text("tenant_id IS NOT NULL"),
+            sqlite_where=sa.text("tenant_id IS NOT NULL"),
+        ),
+        sa.CheckConstraint(
+            "origin IN ('fetched', 'inline', 'shipped')",
+            name="ck_spec_provenance_origin",
         ),
     )
 

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -125,6 +125,7 @@ from meho_backplane.operations.ingest.payload import (
     ConnectorReviewGroup,
     ConnectorReviewOp,
     ConnectorReviewPayload,
+    ConnectorReviewProvenance,
 )
 from meho_backplane.operations.ingest.pipeline import (
     IngestionPipelineResult,
@@ -155,6 +156,7 @@ __all__ = [
     "ConnectorReviewGroup",
     "ConnectorReviewOp",
     "ConnectorReviewPayload",
+    "ConnectorReviewProvenance",
     "ConnectorScopeCandidate",
     "ConnectorSpecCatalog",
     "ConnectorSpecEntry",

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -50,12 +50,14 @@ collision; T1 produces what the spec literally says.
 
 from __future__ import annotations
 
+import hashlib
 import io
 import ipaddress
 import json
 import re
 import socket
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any, cast
 from urllib.parse import urljoin, urlparse
 
@@ -86,12 +88,71 @@ from meho_backplane.operations.ingest.schemas import (
 __all__ = [
     "InvalidSchemaError",
     "InvalidSpecError",
+    "ParsedSpecProvenance",
     "UnsupportedSpecError",
     "UpstreamNotSpecError",
+    "classify_spec_origin",
     "detect_spec_format",
     "parse_openapi",
+    "parse_openapi_with_provenance",
     "read_spec_info_version",
 ]
+
+#: Prefix of the audit label the catalog shipped-spec on-ramp assigns
+#: (``spec:<resource>``, #1975). Combined with the presence of inline
+#: ``content`` it distinguishes a MEHO-authored shipped ingest from an
+#: operator's inline upload — see :func:`classify_spec_origin`.
+_SHIPPED_SPEC_URI_PREFIX = "spec:"
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedSpecProvenance:
+    """Provenance facts captured while a spec's raw bytes are loaded.
+
+    Emitted by :func:`parse_openapi_with_provenance` so the ingest
+    pipeline can persist a durable, non-spoofable record of what was
+    ingested (#2291):
+
+    * ``uri`` — the audit label exactly as presented (the value passed
+      as ``spec_path_or_uri``); ``spec:`` / ``https://`` / ``file:///``
+      / ``docs:`` form preserved.
+    * ``sha256`` — hex digest over the raw spec bytes (fetched body or
+      uploaded content), computed before any decode so a hand-mutated
+      upload and a genuine fetch of the same label are distinguishable.
+    * ``origin`` — ``fetched`` | ``inline`` | ``shipped`` per
+      :func:`classify_spec_origin`.
+    """
+
+    uri: str
+    sha256: str
+    origin: str
+
+
+def classify_spec_origin(spec_path_or_uri: str, content: str | None) -> str:
+    """Classify how a spec's bytes reached the backplane.
+
+    Three origins, derived from what the ingest request already carries
+    (no extra threading from the REST/MCP/CLI entry points):
+
+    * ``fetched`` — no inline ``content``; the bytes came from the
+      ``https`` GET in :func:`_fetch_spec_bytes`.
+    * ``shipped`` — inline ``content`` **and** a ``spec:`` audit label:
+      the MEHO-authored catalog on-ramp uploads shipped package data
+      under ``uri=f"spec:{resource}"`` (#1975), which is categorically
+      different from an operator's hand-mutated upload.
+    * ``inline`` — inline ``content`` under any other label
+      (``file:///`` / ``docs:`` / a vendor ``https`` URL reused as the
+      label): an operator-uploaded spec.
+
+    The ``spec:`` label is a MEHO-internal convention the catalog route
+    assigns, not operator input on the inline on-ramp, so it is a sound
+    discriminator for record-and-surface provenance.
+    """
+    if content is None:
+        return "fetched"
+    if spec_path_or_uri.startswith(_SHIPPED_SPEC_URI_PREFIX):
+        return "shipped"
+    return "inline"
 
 
 try:
@@ -384,6 +445,52 @@ def parse_openapi(
         httpx.HTTPError: HTTP fetch failure for URL inputs.
     """
     spec_bytes = _load_spec_bytes(spec_path_or_uri, content=content)
+    return _project_spec_bytes_to_protos(spec_bytes, spec_source=spec_source)
+
+
+def parse_openapi_with_provenance(
+    spec_path_or_uri: str,
+    *,
+    spec_source: str | None = None,
+    content: str | None = None,
+) -> tuple[list[EndpointDescriptorProto], ParsedSpecProvenance]:
+    """Parse a spec and return its operations **plus** its provenance.
+
+    Same contract as :func:`parse_openapi` for the operations list; the
+    second return value is a :class:`ParsedSpecProvenance` capturing the
+    audit label, the ``sha256`` over the **raw bytes** (hashed at the
+    trust boundary before any YAML/JSON decode, so it reflects exactly
+    what arrived), and the ``fetched`` / ``inline`` / ``shipped`` origin.
+
+    The register phase (#2291) calls this instead of :func:`parse_openapi`
+    so it can persist a durable provenance row alongside the descriptor
+    upserts. The bytes are loaded exactly once — no second fetch — so a
+    remote spec is not pulled twice.
+
+    Raises the same exceptions as :func:`parse_openapi`.
+    """
+    spec_bytes = _load_spec_bytes(spec_path_or_uri, content=content)
+    provenance = ParsedSpecProvenance(
+        uri=spec_path_or_uri,
+        sha256=hashlib.sha256(spec_bytes).hexdigest(),
+        origin=classify_spec_origin(spec_path_or_uri, content),
+    )
+    protos = _project_spec_bytes_to_protos(spec_bytes, spec_source=spec_source)
+    return protos, provenance
+
+
+def _project_spec_bytes_to_protos(
+    spec_bytes: bytes,
+    *,
+    spec_source: str | None,
+) -> list[EndpointDescriptorProto]:
+    """Decode + validate + project raw spec bytes into descriptor protos.
+
+    The shared core of :func:`parse_openapi` and
+    :func:`parse_openapi_with_provenance`: everything after the raw
+    bytes are in hand (so the sha256 can be taken over those same bytes
+    before this runs).
+    """
     spec = _decode_spec(spec_bytes)
     _validate_openapi_version(spec)
 

--- a/backend/src/meho_backplane/operations/ingest/payload.py
+++ b/backend/src/meho_backplane/operations/ingest/payload.py
@@ -18,6 +18,7 @@ would be a programming bug, not a feature.
 
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
@@ -28,7 +29,42 @@ __all__ = [
     "ConnectorReviewGroup",
     "ConnectorReviewOp",
     "ConnectorReviewPayload",
+    "ConnectorReviewProvenance",
 ]
+
+
+class ConnectorReviewProvenance(BaseModel):
+    """Provenance for one spec ingested under this connector (#2291).
+
+    Surfaces the durable
+    :class:`~meho_backplane.db.models.SpecProvenance` record so an
+    operator reviewing a connector can tell a vendor artifact from a
+    hand-mutated one before enabling reads:
+
+    * ``uri`` — the audit label as presented at ingest
+      (``spec:`` / ``https://`` / ``file:///`` / ``docs:`` form).
+    * ``sha256`` — hex digest over the raw spec bytes. Two ingests of
+      the *same* label with different digests mean the content changed.
+    * ``origin`` — ``fetched`` (https GET) vs ``inline`` (operator
+      upload) vs ``shipped`` (MEHO-authored catalog data). An inline
+      upload labelled with a vendor URL is thus distinguishable from a
+      genuine fetch of that URL.
+    * ``operator_sub`` — who ingested it (``None`` for boot-time
+      shipped ingests with no operator).
+    * ``ingested_at`` — when the provenance row was last written.
+
+    Connectors ingested before this table landed have no provenance
+    rows; the surfaces render that as "unknown (pre-provenance)" rather
+    than a fabricated record.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    uri: str
+    sha256: str
+    origin: str
+    operator_sub: str | None
+    ingested_at: datetime
 
 
 class ConnectorReviewOp(BaseModel):
@@ -131,3 +167,9 @@ class ConnectorReviewPayload(BaseModel):
     ungrouped_op_count: int = 0
     kind: ConnectorAuthoringKind = "ingested-shim"
     dispatchable: bool = False
+    # #2291: one entry per spec ingested under this connector scope,
+    # ordered by ``uri``. Empty for connectors ingested before the
+    # provenance table landed (surfaces render "unknown (pre-provenance)").
+    # Additive with a default so existing construction call sites keep
+    # working; the service always sets it from the persisted rows.
+    provenance: list[ConnectorReviewProvenance] = []

--- a/backend/src/meho_backplane/operations/ingest/pipeline.py
+++ b/backend/src/meho_backplane/operations/ingest/pipeline.py
@@ -116,6 +116,7 @@ from meho_backplane.operations.ingest.llm_groups import (
 )
 from meho_backplane.operations.ingest.openapi import (
     parse_openapi,
+    parse_openapi_with_provenance,
     read_spec_info_version,
 )
 from meho_backplane.operations.ingest.register_ingested import (
@@ -123,6 +124,7 @@ from meho_backplane.operations.ingest.register_ingested import (
     register_ingested_operations,
 )
 from meho_backplane.operations.ingest.service import ReviewService
+from meho_backplane.operations.ingest.spec_provenance import upsert_spec_provenance
 from meho_backplane.retrieval.embedding import EmbeddingService
 
 __all__ = [
@@ -915,7 +917,12 @@ class IngestionPipelineService:
 
         Each spec is parsed and registered separately so the per-spec
         :func:`register_ingested_operations` call attaches its own
-        ``spec:<uri>`` tag to the row. The aggregated counts roll up
+        ``spec:<uri>`` tag to the row. After a spec's descriptor rows
+        land, its durable provenance (#2291) — sha256 over the raw
+        bytes, ``fetched`` / ``inline`` / ``shipped`` origin, operator,
+        timestamp — is upserted via :func:`upsert_spec_provenance`,
+        keyed on ``(triple, uri, scope)`` so a re-ingest updates the row
+        rather than duplicating it. The aggregated counts roll up
         every spec's individual result. ``connector_registered`` is
         ``True`` when ANY spec triggered the auto-shim registration —
         on a fresh connector the first spec flips it, subsequent
@@ -939,25 +946,14 @@ class IngestionPipelineService:
         connector_registered = False
 
         for spec in specs:
-            # G0.16-T1 (#1303): same thread-pool offload as the
-            # dry-run path -- the synchronous parser is the worst
-            # event-loop-blocking offender on real vendor specs
-            # (vmware/9.0 ingest blocked the loop for ~30 s before
-            # this hop). ``register_ingested_operations`` is already
-            # an async coroutine that yields on every DB write so
-            # it doesn't need the same treatment.
-            protos = await asyncio.to_thread(
-                parse_openapi, spec.uri, spec_source=spec.uri, content=spec.content
-            )
-            partial = await register_ingested_operations(
+            partial = await self._register_one_spec(
+                spec,
                 product=product,
                 version=version,
                 impl_id=impl_id,
-                spec_source=spec.uri,
-                operations=protos,
                 base_url=base_url,
                 tenant_id=tenant_id,
-                embedding_service=self._embedding_service,
+                sessionmaker=sessionmaker,
                 register_shim=register_shim,
             )
             aggregated_inserted += partial.inserted_count
@@ -985,6 +981,64 @@ class IngestionPipelineService:
             connector_registered=connector_registered,
             operations_grouped=False,
         )
+
+    async def _register_one_spec(
+        self,
+        spec: SpecSource,
+        *,
+        product: str,
+        version: str,
+        impl_id: str,
+        base_url: str | None,
+        tenant_id: UUID | None,
+        sessionmaker: async_sessionmaker[AsyncSession],
+        register_shim: bool,
+    ) -> IngestionResult:
+        """Parse one spec, upsert its descriptor rows, persist its provenance.
+
+        G0.16-T1 (#1303): the synchronous parser is offloaded to a
+        thread pool -- it is the worst event-loop-blocking offender on
+        real vendor specs (vmware/9.0 ingest blocked the loop for ~30 s
+        before this hop). ``register_ingested_operations`` is already an
+        async coroutine that yields on every DB write, so it needs no
+        such treatment.
+
+        After the descriptor rows land, the spec's durable provenance
+        (#2291) — sha256 over the raw bytes + ``fetched`` / ``inline`` /
+        ``shipped`` origin + operator + timestamp — is upserted in its
+        own transaction (keyed on ``(triple, uri, scope)``). Provenance
+        is record-and-surface metadata and must not roll back the
+        operations it describes, hence the separate write.
+        """
+        protos, provenance = await asyncio.to_thread(
+            parse_openapi_with_provenance,
+            spec.uri,
+            spec_source=spec.uri,
+            content=spec.content,
+        )
+        partial = await register_ingested_operations(
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            spec_source=spec.uri,
+            operations=protos,
+            base_url=base_url,
+            tenant_id=tenant_id,
+            embedding_service=self._embedding_service,
+            register_shim=register_shim,
+        )
+        await upsert_spec_provenance(
+            sessionmaker,
+            tenant_id=tenant_id,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            uri=provenance.uri,
+            sha256=provenance.sha256,
+            origin=provenance.origin,
+            operator_sub=self._operator.sub,
+        )
+        return partial
 
     async def _stamp_profiled_connector(
         self,

--- a/backend/src/meho_backplane/operations/ingest/service.py
+++ b/backend/src/meho_backplane/operations/ingest/service.py
@@ -123,7 +123,9 @@ from meho_backplane.operations.ingest.payload import (
     ConnectorReviewGroup,
     ConnectorReviewOp,
     ConnectorReviewPayload,
+    ConnectorReviewProvenance,
 )
+from meho_backplane.operations.ingest.spec_provenance import load_spec_provenance
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.base import Connector
@@ -511,6 +513,17 @@ class ReviewService:
         # ``ungrouped_op_count`` is the reconciling remainder:
         # ``total_op_count + ungrouped_op_count == listing.operation_count``.
         all_op_count = await count_ops_in_scope(session, scope)
+        # #2291: durable per-spec provenance for this connector scope,
+        # ordered by ``uri``. Empty for connectors ingested before the
+        # provenance table landed — the surfaces render that gap rather
+        # than fabricating a record.
+        provenance_rows = await load_spec_provenance(
+            session,
+            tenant_id=scope.tenant_id,
+            product=scope.product,
+            version=scope.version,
+            impl_id=scope.impl_id,
+        )
         return ConnectorReviewPayload(
             connector_id=connector_id,
             product=scope.product,
@@ -522,6 +535,16 @@ class ReviewService:
             ungrouped_op_count=max(all_op_count - grouped_op_count, 0),
             kind=kind,
             dispatchable=dispatchable,
+            provenance=[
+                ConnectorReviewProvenance(
+                    uri=row.uri,
+                    sha256=row.sha256,
+                    origin=row.origin,
+                    operator_sub=row.operator_sub,
+                    ingested_at=row.ingested_at,
+                )
+                for row in provenance_rows
+            ],
         )
 
     # -- public write API: edits ------------------------------------------

--- a/backend/src/meho_backplane/operations/ingest/spec_provenance.py
+++ b/backend/src/meho_backplane/operations/ingest/spec_provenance.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Persist + read durable spec-ingest provenance (#2291).
+
+One :class:`~meho_backplane.db.models.SpecProvenance` row per accepted
+spec ingest, keyed on the connector triple + audit ``uri`` within a
+tenant scope. The register phase
+(:meth:`~meho_backplane.operations.ingest.pipeline.IngestionPipeline._run_register_phase`)
+writes a row per spec after its descriptor rows land; the review
+service reads them back to surface provenance on
+:class:`~meho_backplane.operations.ingest.payload.ConnectorReviewPayload`.
+
+Provenance is deliberately its own transaction, independent of the
+descriptor upsert: it is record-and-surface metadata, not a
+dispatch-time invariant, so a provenance write must never roll back the
+operations it describes (and vice versa). Re-ingesting the same spec
+updates the existing row in place (new ``sha256`` + ``ingested_at``)
+rather than accumulating duplicates — the ``(scope, uri)`` natural key
+is the dedup axis.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from meho_backplane.db.models import SpecProvenance
+
+__all__ = [
+    "load_spec_provenance",
+    "upsert_spec_provenance",
+]
+
+
+async def upsert_spec_provenance(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    version: str,
+    impl_id: str,
+    uri: str,
+    sha256: str,
+    origin: str,
+    operator_sub: str | None,
+) -> None:
+    """Insert or update the provenance row for one accepted spec ingest.
+
+    Keyed on ``(tenant_id, product, version, impl_id, uri)`` — the same
+    scope discipline the descriptor upsert uses (``tenant_id IS NULL``
+    for built-in/global rows). A first ingest inserts; a re-ingest of the
+    same spec under the same key updates ``sha256`` / ``origin`` /
+    ``operator_sub`` and refreshes ``ingested_at`` so the row always
+    reflects the latest accepted ingest. Different content under the same
+    ``uri`` changes the stored ``sha256`` in place.
+
+    Owns its own session + commit (see the module docstring): a
+    provenance write is decoupled from the descriptor transaction.
+    """
+    async with sessionmaker() as session:
+        existing = await _lookup_provenance(
+            session,
+            tenant_id=tenant_id,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            uri=uri,
+        )
+        if existing is None:
+            session.add(
+                SpecProvenance(
+                    tenant_id=tenant_id,
+                    product=product,
+                    version=version,
+                    impl_id=impl_id,
+                    uri=uri,
+                    sha256=sha256,
+                    origin=origin,
+                    operator_sub=operator_sub,
+                    ingested_at=datetime.now(UTC),
+                )
+            )
+        else:
+            existing.sha256 = sha256
+            existing.origin = origin
+            existing.operator_sub = operator_sub
+            existing.ingested_at = datetime.now(UTC)
+        await session.commit()
+
+
+async def load_spec_provenance(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> list[SpecProvenance]:
+    """Return every provenance row for a connector scope, ordered by ``uri``.
+
+    Scoped exactly like the resolved review scope: ``tenant_id IS NULL``
+    reads the built-in/global rows, a tenant UUID reads that tenant's
+    rows. Deterministic ``uri`` ordering keeps the review payload stable
+    across calls. Runs on the caller-owned session so it shares the
+    review render's transaction snapshot.
+    """
+    stmt = select(SpecProvenance).where(
+        SpecProvenance.product == product,
+        SpecProvenance.version == version,
+        SpecProvenance.impl_id == impl_id,
+    )
+    if tenant_id is None:
+        stmt = stmt.where(SpecProvenance.tenant_id.is_(None))
+    else:
+        stmt = stmt.where(SpecProvenance.tenant_id == tenant_id)
+    stmt = stmt.order_by(SpecProvenance.uri)
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def _lookup_provenance(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID | None,
+    product: str,
+    version: str,
+    impl_id: str,
+    uri: str,
+) -> SpecProvenance | None:
+    """Find the provenance row matching the natural key within its scope."""
+    stmt = select(SpecProvenance).where(
+        SpecProvenance.product == product,
+        SpecProvenance.version == version,
+        SpecProvenance.impl_id == impl_id,
+        SpecProvenance.uri == uri,
+    )
+    if tenant_id is None:
+        stmt = stmt.where(SpecProvenance.tenant_id.is_(None))
+    else:
+        stmt = stmt.where(SpecProvenance.tenant_id == tenant_id)
+    return (await session.execute(stmt)).scalar_one_or_none()

--- a/backend/tests/migrations/test_migration_0056_create_spec_provenance.py
+++ b/backend/tests/migrations/test_migration_0056_create_spec_provenance.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0056_create_spec_provenance``.
+
+Initiative #2270 (ingest spec hygiene), Task #2291. Creates the
+``spec_provenance`` table — one durable, non-spoofable provenance row
+per accepted spec ingest (sha256 over raw bytes, fetched/inline/shipped
+origin, operator, timestamp) keyed on the connector triple + audit uri
+within a tenant scope.
+
+Asserts the table + its columns land, both partial unique indexes exist,
+the ``origin`` CHECK constraint rejects an out-of-vocabulary value, and
+the migration round-trips (downgrade drops it, re-upgrade recreates it).
+
+**Idempotency pinning (0049/0050/0053/0055 footgun).** Every forward /
+round-trip step targets this migration's **own** revision (``0056``) and
+its ``down_revision`` (``0055``), never ``head`` — so a future head
+migration cannot make ``upgrade("head")`` re-run this ``create_table`` on
+a schema that already has it (the "table already exists" stamp-replay
+footgun). SQLite is the test driver and the migration uses only generic
+DDL + partial indexes (SQLite 3.8.0+), so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0056"
+_DOWN_REVISION = "0055"
+_TABLE = "spec_provenance"
+_EXPECTED_COLUMNS = {
+    "id",
+    "tenant_id",
+    "product",
+    "version",
+    "impl_id",
+    "uri",
+    "sha256",
+    "origin",
+    "operator_sub",
+    "ingested_at",
+}
+_EXPECTED_INDEXES = {"spec_provenance_global_idx", "spec_provenance_tenant_idx"}
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0056.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _table_names(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type = 'table'")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def _columns(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({_TABLE})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _index_names(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type = 'index'")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def test_upgrade_creates_table_columns_and_indexes(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0056`` creates ``spec_provenance`` with its columns + indexes."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    assert _TABLE in _table_names(sync_url)
+    assert _columns(sync_url) >= _EXPECTED_COLUMNS
+    assert _index_names(sync_url) >= _EXPECTED_INDEXES
+
+
+def test_origin_check_constraint_rejects_unknown_value(alembic_cfg: tuple[Config, str]) -> None:
+    """The ``origin`` CHECK constraint bounds the enum to the three known values."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(text("PRAGMA foreign_keys = ON"))
+            with pytest.raises(IntegrityError):
+                conn.execute(
+                    text(
+                        "INSERT INTO spec_provenance "
+                        "(id, product, version, impl_id, uri, sha256, origin, ingested_at) "
+                        "VALUES ('id-1', 'p', 'v', 'i', 'u', 'sha', 'bogus', '2026-07-10')"
+                    )
+                )
+    finally:
+        sync_eng.dispose()
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0055"`` drops the table; ``upgrade "0056"`` recreates it.
+
+    Pinned to this migration's own revision on both legs (never ``head``)
+    so a future head migration cannot break the round-trip.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _TABLE in _table_names(sync_url)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert _TABLE not in _table_names(sync_url), "downgrade must drop spec_provenance"
+    assert not (_EXPECTED_INDEXES & _index_names(sync_url)), (
+        "downgrade must drop the partial unique indexes too"
+    )
+
+    command.upgrade(cfg, _REVISION)
+    assert _TABLE in _table_names(sync_url)

--- a/backend/tests/test_operations_spec_provenance.py
+++ b/backend/tests/test_operations_spec_provenance.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for persisted spec-ingest provenance (#2291).
+
+Coverage matrix (Task #2291 acceptance criteria):
+
+* ``classify_spec_origin`` maps ``(uri, content)`` to
+  ``fetched`` / ``inline`` / ``shipped``.
+* ``parse_openapi_with_provenance`` hashes the **raw bytes** (fetched
+  body or uploaded content) — a fetched https spec records
+  ``origin=fetched`` with ``sha256 == sha256(raw body)``; an inline
+  upload records ``origin=inline``; a ``spec:``-labelled inline upload
+  (the catalog shipped on-ramp) records ``origin=shipped``.
+* ``upsert_spec_provenance`` / ``load_spec_provenance`` — a first ingest
+  inserts, a re-ingest of the same ``(triple, uri, scope)`` updates the
+  row in place (new sha256, no duplicate), and tenant-scoped + global
+  ingests write correctly-scoped rows that coexist (mirrors the
+  descriptor scope tests).
+* The connector review payload surfaces the provenance rows for its
+  scope, and renders an empty list for a connector ingested before the
+  table landed.
+
+The fetch path is served through respx with a patched ``getaddrinfo``
+so the SSRF destination guard passes without real DNS — the same shape
+``test_operations_ingest_openapi`` uses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import socket
+import uuid
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup, SpecProvenance
+from meho_backplane.operations.ingest.openapi import (
+    classify_spec_origin,
+    parse_openapi_with_provenance,
+)
+from meho_backplane.operations.ingest.service import ReviewService
+from meho_backplane.operations.ingest.spec_provenance import (
+    load_spec_provenance,
+    upsert_spec_provenance,
+)
+from meho_backplane.settings import get_settings
+
+FIXTURES = Path(__file__).parent / "fixtures" / "openapi"
+PETSTORE_30 = FIXTURES / "petstore_30.yaml"
+
+_FIXTURE_HOST = "https://specs.example.test"
+_PUBLIC_TEST_IP = "93.184.216.34"
+_TEST_HOSTS = frozenset({"specs.example.test"})
+
+_PRODUCT = "vmware"
+_VERSION = "9.0"
+_IMPL_ID = "vmware-rest"
+_CONNECTOR_ID = "vmware-rest-9.0"
+_FAKE_JWT = "header.payload.signature"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _getaddrinfo_for_tests(
+    host: str, port: object, **kwargs: object
+) -> list[tuple[int, int, int, str, tuple[str, int]]]:
+    """Resolve known test hosts to a public IP so the SSRF guard passes."""
+    if host in _TEST_HOSTS:
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (_PUBLIC_TEST_IP, 443))]
+    return socket.getaddrinfo(host, port, **kwargs)  # type: ignore[arg-type]
+
+
+@pytest.fixture(autouse=True)
+def _mock_getaddrinfo_for_test_hosts() -> Generator[None, None, None]:
+    """Patch ``getaddrinfo`` for the SSRF guard so test HTTPS URLs resolve public."""
+    with patch(
+        "meho_backplane.operations.ingest.openapi.socket.getaddrinfo",
+        side_effect=_getaddrinfo_for_tests,
+    ):
+        yield
+
+
+def _make_operator(*, tenant_id: uuid.UUID, sub: str = "user:alice") -> Operator:
+    """Build a frozen :class:`Operator` with default test fields."""
+    return Operator(
+        sub=sub,
+        name="Test Operator",
+        email=None,
+        raw_jwt=_FAKE_JWT,
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# classify_spec_origin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("uri", "content", "expected"),
+    [
+        ("https://vendor.example/openapi.yaml", None, "fetched"),
+        ("file:///home/op/internal.yaml", "openapi: 3.0.0", "inline"),
+        ("https://vendor.example/openapi.yaml", "openapi: 3.0.0", "inline"),
+        ("docs:vcenter/vcenter.yaml", "openapi: 3.0.0", "inline"),
+        ("spec:vcenter.yaml", "openapi: 3.0.0", "shipped"),
+    ],
+)
+def test_classify_spec_origin(uri: str, content: str | None, expected: str) -> None:
+    """Origin is derived from the fetched-vs-inline bit + the shipped label."""
+    assert classify_spec_origin(uri, content) == expected
+
+
+# ---------------------------------------------------------------------------
+# parse_openapi_with_provenance — hash over raw bytes
+# ---------------------------------------------------------------------------
+
+
+def test_parse_with_provenance_inline_hashes_uploaded_content() -> None:
+    """An inline upload records origin=inline + sha256 over the raw content bytes."""
+    text = PETSTORE_30.read_text(encoding="utf-8")
+    protos, provenance = parse_openapi_with_provenance(
+        "file:///uploads/petstore.yaml", spec_source="petstore.yaml", content=text
+    )
+    assert protos, "expected at least one parsed operation"
+    assert provenance.uri == "file:///uploads/petstore.yaml"
+    assert provenance.origin == "inline"
+    assert provenance.sha256 == hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def test_parse_with_provenance_shipped_label_records_shipped_origin() -> None:
+    """A ``spec:``-labelled inline upload (catalog on-ramp) records origin=shipped."""
+    text = PETSTORE_30.read_text(encoding="utf-8")
+    _protos, provenance = parse_openapi_with_provenance(
+        "spec:petstore.yaml", spec_source="spec:petstore.yaml", content=text
+    )
+    assert provenance.origin == "shipped"
+    assert provenance.sha256 == hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def test_parse_with_provenance_fetched_hashes_response_body() -> None:
+    """A fetched https spec records origin=fetched + sha256 over the raw body."""
+    body = PETSTORE_30.read_bytes()
+    url = f"{_FIXTURE_HOST}/petstore_30.yaml"
+    with respx.mock(assert_all_called=False) as router:
+        router.get(url).mock(
+            return_value=httpx.Response(
+                200, content=body, headers={"content-type": "application/yaml"}
+            )
+        )
+        _protos, provenance = parse_openapi_with_provenance(
+            url, spec_source="spec:petstore_30.yaml"
+        )
+    assert provenance.uri == url
+    assert provenance.origin == "fetched"
+    assert provenance.sha256 == hashlib.sha256(body).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# upsert_spec_provenance / load_spec_provenance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_inserts_then_load_returns_global_row() -> None:
+    """A first global ingest inserts a row load_spec_provenance reads back."""
+    sessionmaker = get_sessionmaker()
+    await upsert_spec_provenance(
+        sessionmaker,
+        tenant_id=None,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        uri="https://vendor.example/openapi.yaml",
+        sha256="a" * 64,
+        origin="fetched",
+        operator_sub="user:alice",
+    )
+    async with sessionmaker() as session:
+        rows = await load_spec_provenance(
+            session,
+            tenant_id=None,
+            product=_PRODUCT,
+            version=_VERSION,
+            impl_id=_IMPL_ID,
+        )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.uri == "https://vendor.example/openapi.yaml"
+    assert row.sha256 == "a" * 64
+    assert row.origin == "fetched"
+    assert row.operator_sub == "user:alice"
+    assert row.tenant_id is None
+
+
+@pytest.mark.asyncio
+async def test_reingest_same_key_updates_in_place_without_duplicate() -> None:
+    """Re-ingesting the same (triple, uri, scope) updates the row, no duplicate."""
+    sessionmaker = get_sessionmaker()
+    common: dict[str, object] = {
+        "tenant_id": None,
+        "product": _PRODUCT,
+        "version": _VERSION,
+        "impl_id": _IMPL_ID,
+        "uri": "https://vendor.example/openapi.yaml",
+        "origin": "fetched",
+        "operator_sub": "user:alice",
+    }
+    await upsert_spec_provenance(sessionmaker, sha256="1" * 64, **common)  # type: ignore[arg-type]
+    await upsert_spec_provenance(sessionmaker, sha256="2" * 64, **common)  # type: ignore[arg-type]
+
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(SpecProvenance).where(
+                        SpecProvenance.product == _PRODUCT,
+                        SpecProvenance.uri == "https://vendor.example/openapi.yaml",
+                        SpecProvenance.tenant_id.is_(None),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1, "re-ingest must update in place, not accumulate duplicates"
+    assert rows[0].sha256 == "2" * 64, "the stored digest must track the latest content"
+
+
+@pytest.mark.asyncio
+async def test_tenant_and_global_scopes_write_distinct_rows() -> None:
+    """A tenant-scoped ingest and a global ingest of the same uri coexist."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    shared: dict[str, object] = {
+        "product": _PRODUCT,
+        "version": _VERSION,
+        "impl_id": _IMPL_ID,
+        "uri": "https://vendor.example/openapi.yaml",
+        "sha256": "b" * 64,
+        "origin": "fetched",
+        "operator_sub": "user:alice",
+    }
+    await upsert_spec_provenance(sessionmaker, tenant_id=None, **shared)  # type: ignore[arg-type]
+    await upsert_spec_provenance(sessionmaker, tenant_id=tenant_id, **shared)  # type: ignore[arg-type]
+
+    async with sessionmaker() as session:
+        global_rows = await load_spec_provenance(
+            session, tenant_id=None, product=_PRODUCT, version=_VERSION, impl_id=_IMPL_ID
+        )
+        tenant_rows = await load_spec_provenance(
+            session, tenant_id=tenant_id, product=_PRODUCT, version=_VERSION, impl_id=_IMPL_ID
+        )
+    assert len(global_rows) == 1
+    assert global_rows[0].tenant_id is None
+    assert len(tenant_rows) == 1
+    assert tenant_rows[0].tenant_id == tenant_id
+
+
+# ---------------------------------------------------------------------------
+# review payload surfacing
+# ---------------------------------------------------------------------------
+
+
+async def _seed_group_and_op(*, tenant_id: uuid.UUID) -> None:
+    """Insert one group + one op so get_review_payload resolves the scope."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        group_id = uuid.uuid4()
+        session.add(
+            OperationGroup(
+                id=group_id,
+                tenant_id=tenant_id,
+                product=_PRODUCT,
+                version=_VERSION,
+                impl_id=_IMPL_ID,
+                group_key="group-0",
+                name="Group 0",
+                when_to_use="Use group 0.",
+                review_status="staged",
+            )
+        )
+        session.add(
+            EndpointDescriptor(
+                tenant_id=tenant_id,
+                product=_PRODUCT,
+                version=_VERSION,
+                impl_id=_IMPL_ID,
+                op_id="GET:/api/v1/group-0/0",
+                source_kind="ingested",
+                method="GET",
+                path="/api/v1/group-0/0",
+                group_id=group_id,
+                summary="Op 0",
+                is_enabled=False,
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_review_payload_surfaces_provenance_rows() -> None:
+    """get_review_payload returns the scope's provenance, ordered by uri."""
+    tenant_id = uuid.uuid4()
+    await _seed_group_and_op(tenant_id=tenant_id)
+    sessionmaker = get_sessionmaker()
+    await upsert_spec_provenance(
+        sessionmaker,
+        tenant_id=tenant_id,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        uri="https://vendor.example/openapi.yaml",
+        sha256="c" * 64,
+        origin="fetched",
+        operator_sub="user:alice",
+    )
+
+    service = ReviewService(_make_operator(tenant_id=tenant_id))
+    payload = await service.get_review_payload(_CONNECTOR_ID, tenant_id)
+
+    assert len(payload.provenance) == 1
+    prov = payload.provenance[0]
+    assert prov.uri == "https://vendor.example/openapi.yaml"
+    assert prov.sha256 == "c" * 64
+    assert prov.origin == "fetched"
+    assert prov.operator_sub == "user:alice"
+
+
+@pytest.mark.asyncio
+async def test_review_payload_empty_provenance_for_pre_provenance_connector() -> None:
+    """A connector with no provenance rows renders an empty provenance list."""
+    tenant_id = uuid.uuid4()
+    await _seed_group_and_op(tenant_id=tenant_id)
+
+    service = ReviewService(_make_operator(tenant_id=tenant_id))
+    payload = await service.get_review_payload(_CONNECTOR_ID, tenant_id)
+
+    assert payload.provenance == []

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -21286,6 +21286,14 @@
             "type": "boolean",
             "title": "Dispatchable",
             "default": false
+          },
+          "provenance": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorReviewProvenance"
+            },
+            "type": "array",
+            "title": "Provenance",
+            "default": []
           }
         },
         "type": "object",
@@ -21300,6 +21308,42 @@
         ],
         "title": "ConnectorReviewPayload",
         "description": "Top-level review payload returned by :meth:`ReviewService.get_review_payload`.\n\n``connector_id`` is the operator-facing string the request\ntargeted (echoed back verbatim for round-trip clarity).\n``product`` / ``version`` / ``impl_id`` are the parsed triple\nderived via\n:func:`~meho_backplane.operations.ingest.parser.parse_connector_id`;\nthe CLI / API layers surface them in operator output so the\nconvention is self-documenting. ``tenant_id`` is the scope the\npayload was queried under (``None`` for built-in).\n\n``kind`` (G0.28-T6 / #1979) is the authoring-mode discriminator \u2014\ntyped / ingested-shim / profiled / profiled-but-unreviewed \u2014\nprojected from the v2 resolver's\n:data:`~meho_backplane.connectors.base.ShimKind` tier for this\nconnector's ``(product, version)`` crossed with the review-gate\nstate, and ``dispatchable`` is its boolean roll-up (``True`` for\ntyped / profiled). They mirror the same-named fields on\n:class:`~meho_backplane.operations.ingest.api_schemas.ConnectorListItem`\nso the list and review surfaces agree on how a connector reads.\nBoth default to the bare-shim reading\n(``kind=\"ingested-shim\"``, ``dispatchable=False``) so existing\nconstruction call sites keep working; the service always sets them\nexplicitly. The per-scheme auth detail is deliberately **not**\nsurfaced here yet \u2014 deferred until #1969 freezes the\n:class:`~meho_backplane.connectors.schemas.ExecutionProfile` schema\n(the Goal flags secret-handling sensitivity). See\n:data:`~meho_backplane.operations.ingest.api_schemas.ConnectorAuthoringKind`."
+      },
+      "ConnectorReviewProvenance": {
+        "properties": {
+          "uri": {
+            "type": "string",
+            "title": "Uri"
+          },
+          "sha256": {
+            "type": "string",
+            "title": "Sha256"
+          },
+          "origin": {
+            "type": "string",
+            "title": "Origin"
+          },
+          "operator_sub": {
+            "type": "string",
+            "nullable": true,
+            "title": "Operator Sub"
+          },
+          "ingested_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Ingested At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "uri",
+          "sha256",
+          "origin",
+          "operator_sub",
+          "ingested_at"
+        ],
+        "title": "ConnectorReviewProvenance",
+        "description": "Provenance for one spec ingested under this connector (#2291).\n\nSurfaces the durable\n:class:`~meho_backplane.db.models.SpecProvenance` record so an\noperator reviewing a connector can tell a vendor artifact from a\nhand-mutated one before enabling reads:\n\n* ``uri`` \u2014 the audit label as presented at ingest\n  (``spec:`` / ``https://`` / ``file:///`` / ``docs:`` form).\n* ``sha256`` \u2014 hex digest over the raw spec bytes. Two ingests of\n  the *same* label with different digests mean the content changed.\n* ``origin`` \u2014 ``fetched`` (https GET) vs ``inline`` (operator\n  upload) vs ``shipped`` (MEHO-authored catalog data). An inline\n  upload labelled with a vendor URL is thus distinguishable from a\n  genuine fetch of that URL.\n* ``operator_sub`` \u2014 who ingested it (``None`` for boot-time\n  shipped ingests with no operator).\n* ``ingested_at`` \u2014 when the provenance row was last written.\n\nConnectors ingested before this table landed have no provenance\nrows; the surfaces render that as \"unknown (pre-provenance)\" rather\nthan a fabricated record."
       },
       "ConnectorSpecEntry": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2571,20 +2571,51 @@ type ConnectorReviewOp struct {
 // (the Goal flags secret-handling sensitivity). See
 // :data:`~meho_backplane.operations.ingest.api_schemas.ConnectorAuthoringKind`.
 type ConnectorReviewPayload struct {
-	ConnectorId      string                      `json:"connector_id"`
-	Dispatchable     *bool                       `json:"dispatchable,omitempty"`
-	Groups           []ConnectorReviewGroup      `json:"groups"`
-	ImplId           string                      `json:"impl_id"`
-	Kind             *ConnectorReviewPayloadKind `json:"kind,omitempty"`
-	Product          string                      `json:"product"`
-	TenantId         *openapi_types.UUID         `json:"tenant_id"`
-	TotalOpCount     int                         `json:"total_op_count"`
-	UngroupedOpCount *int                        `json:"ungrouped_op_count,omitempty"`
-	Version          string                      `json:"version"`
+	ConnectorId      string                       `json:"connector_id"`
+	Dispatchable     *bool                        `json:"dispatchable,omitempty"`
+	Groups           []ConnectorReviewGroup       `json:"groups"`
+	ImplId           string                       `json:"impl_id"`
+	Kind             *ConnectorReviewPayloadKind  `json:"kind,omitempty"`
+	Product          string                       `json:"product"`
+	Provenance       *[]ConnectorReviewProvenance `json:"provenance,omitempty"`
+	TenantId         *openapi_types.UUID          `json:"tenant_id"`
+	TotalOpCount     int                          `json:"total_op_count"`
+	UngroupedOpCount *int                         `json:"ungrouped_op_count,omitempty"`
+	Version          string                       `json:"version"`
 }
 
 // ConnectorReviewPayloadKind defines model for ConnectorReviewPayload.Kind.
 type ConnectorReviewPayloadKind string
+
+// ConnectorReviewProvenance Provenance for one spec ingested under this connector (#2291).
+//
+// Surfaces the durable
+// :class:`~meho_backplane.db.models.SpecProvenance` record so an
+// operator reviewing a connector can tell a vendor artifact from a
+// hand-mutated one before enabling reads:
+//
+//   - “uri“ — the audit label as presented at ingest
+//     (“spec:“ / “https://“ / “file:///“ / “docs:“ form).
+//   - “sha256“ — hex digest over the raw spec bytes. Two ingests of
+//     the *same* label with different digests mean the content changed.
+//   - “origin“ — “fetched“ (https GET) vs “inline“ (operator
+//     upload) vs “shipped“ (MEHO-authored catalog data). An inline
+//     upload labelled with a vendor URL is thus distinguishable from a
+//     genuine fetch of that URL.
+//   - “operator_sub“ — who ingested it (“None“ for boot-time
+//     shipped ingests with no operator).
+//   - “ingested_at“ — when the provenance row was last written.
+//
+// Connectors ingested before this table landed have no provenance
+// rows; the surfaces render that as "unknown (pre-provenance)" rather
+// than a fabricated record.
+type ConnectorReviewProvenance struct {
+	IngestedAt  time.Time `json:"ingested_at"`
+	OperatorSub *string   `json:"operator_sub"`
+	Origin      string    `json:"origin"`
+	Sha256      string    `json:"sha256"`
+	Uri         string    `json:"uri"`
+}
 
 // ConnectorSpecEntry One curated “(product, version)“ -> spec-source mapping.
 //

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -1138,6 +1138,48 @@ func TestPrintReviewTableHappyPath(t *testing.T) {
 	}
 }
 
+// TestPrintReviewTableRendersProvenance — the review render surfaces
+// per-spec provenance (#2291): the fetched/inline/shipped origin, the
+// audit uri, a sha256 prefix, and the operator, so an operator can tell
+// a vendor artifact from a hand-mutated one before enabling reads.
+func TestPrintReviewTableRendersProvenance(t *testing.T) {
+	operator := "user:alice"
+	r := &api.ConnectorReviewPayload{
+		ConnectorId: "vmware-rest-9.0",
+		Product:     "vmware",
+		Version:     "9.0",
+		ImplId:      "vmware-rest",
+		Provenance: &[]api.ConnectorReviewProvenance{
+			{
+				Uri:         "https://developer.broadcom.com/vcenter.yaml",
+				Sha256:      "deadbeefdeadbeefdeadbeefdeadbeef",
+				Origin:      "fetched",
+				OperatorSub: &operator,
+			},
+		},
+	}
+	var buf bytes.Buffer
+	printReviewTable(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"provenance", "fetched", "deadbeef", "user:alice", "vcenter.yaml"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("review render missing provenance token %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintReviewTableProvenanceUnknown — a connector ingested before
+// the provenance table landed (nil/empty Provenance) says so explicitly
+// rather than rendering a blank section.
+func TestPrintReviewTableProvenanceUnknown(t *testing.T) {
+	r := &api.ConnectorReviewPayload{ConnectorId: "k8s-1.x", Provenance: nil}
+	var buf bytes.Buffer
+	printReviewTable(&buf, r)
+	if !strings.Contains(buf.String(), "pre-provenance") {
+		t.Errorf("expected pre-provenance note; got:\n%s", buf.String())
+	}
+}
+
 // TestPrintReviewTableEmptyGroups — zero-group connector renders
 // the explanation line and shows "(empty)" rollup.
 func TestPrintReviewTableEmptyGroups(t *testing.T) {

--- a/cli/internal/cmd/connector/review.go
+++ b/cli/internal/cmd/connector/review.go
@@ -135,6 +135,7 @@ func printReviewTable(w io.Writer, r *api.ConnectorReviewPayload) {
 		rollup, kindCell(kind, dispatchable),
 		len(r.Groups), r.TotalOpCount,
 	)
+	printProvenance(w, r.Provenance)
 	if len(r.Groups) == 0 {
 		fmt.Fprintln(w, "(no groups; the connector has no operations or the grouping pass produced no buckets)")
 		return
@@ -165,6 +166,33 @@ func printReviewTable(w io.Writer, r *api.ConnectorReviewPayload) {
 				truncate(strDeref(op.Summary), 70),
 			)
 		}
+	}
+}
+
+// printProvenance renders the per-spec ingest provenance (#2291) so an
+// operator can tell a vendor artifact from a hand-mutated one before
+// enabling reads: the fetched/inline/shipped origin, the audit uri, a
+// short sha256 prefix over the raw bytes, who ingested it, and when. A
+// connector ingested before the provenance table landed carries no
+// rows; we say so explicitly rather than render a blank section.
+func printProvenance(w io.Writer, provenance *[]api.ConnectorReviewProvenance) {
+	if provenance == nil || len(*provenance) == 0 {
+		fmt.Fprintln(w, "  provenance: unknown (pre-provenance) — ingested before provenance was recorded")
+		return
+	}
+	fmt.Fprintf(w, "\nprovenance — %d spec(s):\n", len(*provenance))
+	fmt.Fprintf(w, "  %-8s %-19s %-14s %s\n", "origin", "sha256", "operator", "uri")
+	for _, p := range *provenance {
+		operator := "—"
+		if p.OperatorSub != nil && *p.OperatorSub != "" {
+			operator = *p.OperatorSub
+		}
+		fmt.Fprintf(w, "  %-8s %-19s %-14s %s\n",
+			p.Origin,
+			truncate(p.Sha256, 19),
+			truncate(operator, 14),
+			p.Uri,
+		)
 	}
 }
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -1480,6 +1480,47 @@ version-gate steps but returns the spec's `info.version` string
 pipeline can fail the spec-vs-label check in milliseconds rather
 than after spending CPU on a 2,000-op spec walk.
 
+### Spec provenance persistence (#2291)
+
+`parse_openapi_with_provenance(spec_path_or_uri, *, spec_source=None,
+content=None)` is the register phase's variant of `parse_openapi`: it
+returns the same proto list **plus** a `ParsedSpecProvenance` (a frozen
+dataclass with `uri`, `sha256`, `origin`). The bytes are loaded exactly
+once — the `sha256` is taken over the **raw bytes** (fetched body or
+uploaded content) at the `_load_spec_bytes` trust boundary, before any
+YAML/JSON decode, so it reflects exactly what arrived rather than a
+re-serialised dict. `classify_spec_origin(uri, content)` derives the
+origin from what the ingest request already carries — no threading from
+the REST/MCP/CLI entry points:
+
+- `content is None` → `fetched` (the https GET path).
+- `content` set **and** `uri` starts with `spec:` → `shipped` (the
+  catalog on-ramp uploads MEHO-authored package data under
+  `uri="spec:<resource>"`, #1975).
+- `content` set under any other label → `inline` (an operator upload).
+
+The register phase (`IngestionPipeline._register_one_spec`) upserts one
+`spec_provenance` row per accepted spec after its descriptor rows land —
+in its **own** transaction, because provenance is record-and-surface
+metadata and must not roll back the operations it describes. The row is
+keyed on `(tenant_id, product, version, impl_id, uri)` (two partial
+unique indexes, `tenant_id IS NULL` = global, mirroring the descriptor
+scope split), so re-ingesting the same spec updates the row in place
+(new `sha256` + `ingested_at`, no duplicate) and different content under
+the same label changes the stored digest. `upsert_spec_provenance` /
+`load_spec_provenance` live in `ingest/spec_provenance.py`; the
+`SpecProvenance` model is in `db/models.py` (Alembic `0056`).
+
+The review service reads the rows back via `load_spec_provenance` and
+attaches them to `ConnectorReviewPayload.provenance` (a list of
+`ConnectorReviewProvenance`), which `GET
+/api/v1/connectors/{id}/review`, `meho connector review`, and the review
+drawer surface. A connector ingested before the table landed has no
+rows; the surfaces render that as "unknown (pre-provenance)" rather than
+fabricating a record. This is a spec-level table by design: a single
+spec fans out to hundreds of descriptor rows, so per-descriptor
+provenance columns would be the wrong shape.
+
 ## Security: SSRF and local-file guard (G0.16-T8, #95)
 
 `_load_spec_bytes` (the fetch sink shared by `parse_openapi` and


### PR DESCRIPTION
## Summary

- Persists durable, non-spoofable **spec provenance** for every accepted ingest in a new `spec_provenance` table (Alembic `0056`): `sha256` over the **raw bytes** (hashed at the fetch/upload trust boundary before any decode), the audit `uri`, the `origin` (`fetched` https GET · `inline` operator upload · `shipped` MEHO-authored catalog data), the operator, and a timestamp — scoped like the descriptor rows (`tenant_id IS NULL` = global).
- Closes the spoofability gap: before this, the only provenance was a `spec:<uri>` tag, so a hand-mutated inline upload labelled with a vendor's https URL persisted identically to a genuine fetch of that URL, and the fetched-vs-inline bit was never persisted.
- Hash + origin are computed in `openapi.parse_openapi_with_provenance` (bytes loaded once, no second fetch) and threaded through the register phase, which upserts one row per spec after its descriptor rows land — in its own transaction, keyed on `(tenant_id, product, version, impl_id, uri)` so a re-ingest updates in place rather than duplicating. `classify_spec_origin` derives origin from what the request already carries (the `spec:` label = shipped catalog on-ramp), so no new threading from the REST/MCP/CLI entry points.
- Surfaced on `ConnectorReviewPayload.provenance` and rendered by `meho connector review`; pre-existing connectors read as "unknown (pre-provenance)". Record-and-surface only — no refusal policy; the `file:///` / `docs:` inline on-ramp stays fully functional.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean on all changed files
- [x] `mypy` — clean on changed backend modules
- [x] `pytest tests/test_operations_spec_provenance.py tests/migrations/test_migration_0056_create_spec_provenance.py` — 16 passed
- [x] Broad ingest + migration + db-model sweep — passing (9 unrelated `test_operations_ingest_jobs` failures are a pre-existing cross-test structlog/env ordering artifact only under a combined `-k` run; the file passes in isolation and CI's xdist isolation avoids it)
- [x] **AC — fetched**: `parse_openapi_with_provenance` over a mocked https fetch records `origin=fetched` + `sha256 == sha256(raw body)`
- [x] **AC — inline / shipped**: inline upload records `origin=inline`; a `spec:`-labelled upload records `origin=shipped`
- [x] **AC — re-ingest**: same `(triple, uri, scope)` updates the row (new sha256, no duplicate); tenant + global scopes coexist
- [x] **AC — surface**: `get_review_payload` returns provenance; `meho connector review` renders it (Go tests)
- [x] **AC — migration hygiene**: the `0056` idempotency test pins to its own revision (`0056`/`0055`), never `head`; `origin` CHECK constraint asserted
- [x] **AC — snapshot**: `cli/api/openapi.json` + generated Go client regenerated (`make snapshot-openapi && make generate`); `go build ./...` + connector tests green

## Out of scope (per #2270 / issue)

- Refusal policies keyed on provenance (record-and-surface only)
- Enforcing the catalog's advisory `sha256` for shipped entries (natural follow-up)
- Backfilling provenance for pre-existing rows (they render "unknown (pre-provenance)")

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2291
