### PR TITLE
feat(connectors): convert vRLI events query to a typed op on VcfLogsConnector's session (#2295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Connectors — vRLI events query converted to a typed op on the connector session (#2295)
+
+- The vRLI (VCF Operations for Logs) events query is now a
+  `source_kind="typed"` op — `vrli.event.query`, a bound method on
+  `VcfLogsConnector` that issues `GET /api/v2/events/<constraints>` (with an
+  optional `limit`) directly on the connector's authenticated session and
+  recovers a 440/401 session expiry with one re-login + retry (the #1909/#1135
+  soak scenario). It works on a fresh boot with **zero catalog ingest**, so
+  the op no longer depends on per-deploy `endpoint_descriptor` state (the
+  #2247 failure class Initiative #2266 retires for the VCF family). The
+  reserved-expansion constraint sub-path (`text/CONTAINS error/...`) is
+  rendered with literal slashes so it reaches the appliance intact
+  (#2003/#2066). `vcf_logs/core_ops.py` no longer flips an ingested row for
+  the events query; the other six curated ops stay ingested (declined from
+  typed conversion — unused in the adopter's real operations, and the
+  ingested canonical spec covers the browse case). First conversion in
+  Initiative #2266; the hand-edited production-overlay retirement is a
+  follow-up RDC-team coordination step. (#2295)
+
 ### Added — persisted spec provenance at ingest (sha256 + origin + operator/timestamp, surfaced in review) (#2291)
 
 - Every accepted spec ingest now writes a durable, non-spoofable

--- a/backend/src/meho_backplane/connectors/vcf_logs/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/__init__.py
@@ -73,6 +73,23 @@ register_connector_v2(
     cls=VcfLogsConnector,
 )
 
+# Queue the typed-op upsert onto the lifespan-driven registrar list (#2295).
+# ``vrli.event.query`` is vRLI's first ``source_kind="typed"`` op -- a
+# bound-method read on the connector session, independent of the
+# generic-ingested catalog path, so it registers via its own registrar the
+# same way vmware's and argocd's typed reads do. Imported after the connector
+# registration above so the registrar's ``getattr(VcfLogsConnector, ...)``
+# handler resolution sees the fully-defined class.
+from meho_backplane.connectors.vcf_logs.typed_ops import (  # noqa: E402
+    VRLI_TYPED_OPS,
+    register_vrli_typed_operations,
+)
+from meho_backplane.operations.typed_register import (  # noqa: E402
+    register_typed_op_registrar,
+)
+
+register_typed_op_registrar(register_vrli_typed_operations)
+
 __all__ = [
     "VRLI_CONNECTOR_ID",
     "VRLI_CORE_GROUPS",
@@ -81,6 +98,7 @@ __all__ = [
     "VRLI_IMPL_ID",
     "VRLI_PATH_RULES",
     "VRLI_PRODUCT",
+    "VRLI_TYPED_OPS",
     "VRLI_VERSION",
     "SessionLoginError",
     "VcfCredentialsLoader",
@@ -91,4 +109,5 @@ __all__ = [
     "apply_vrli_core_curation",
     "classify_vrli_op",
     "load_credentials_from_vault",
+    "register_vrli_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/vcf_logs/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/connector.py
@@ -493,6 +493,35 @@ class VcfLogsConnector(HttpConnector):
                 ) from exc
             raise
 
+    async def event_query(
+        self,
+        operator: Operator,
+        target: VcfLogsTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vrli.event.query`` -- constraint-filtered raw event search (#2295).
+
+        vRLI's first ``source_kind="typed"`` op: a bound method the dispatcher
+        binds to this connector instance and invokes with
+        ``(operator, target, params)`` (see
+        :func:`~meho_backplane.operations._branches.dispatch_typed`). Issues
+        ``GET /api/v2/events/<constraints>`` directly on the connector session
+        through :meth:`_get_json_with_session_retry` -- so it works on a fresh
+        boot with zero catalog ingest and recovers a 440 / 401 session expiry
+        with one re-login + retry (the #1909 / #1135 scenario). Retires the
+        hand-edited production overlay: the two canonical-spec blockers the
+        overlay worked around (#2066 ``{+path}`` render, #1796 ``servers[]``
+        base path) are fixed in v0.20.0.
+
+        Delegates to
+        :func:`~meho_backplane.connectors.vcf_logs.typed_ops.event_query_impl`
+        (imported lazily to keep this module off the typed-ops import at
+        class-load time). Returns ``{"events": [...], "complete": bool}``.
+        """
+        from meho_backplane.connectors.vcf_logs.typed_ops import event_query_impl
+
+        return await event_query_impl(self, operator, target, params)
+
     async def fingerprint(
         self,
         target: VcfLogsTargetLike,

--- a/backend/src/meho_backplane/connectors/vcf_logs/core_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/core_ops.py
@@ -3,10 +3,27 @@
 
 """vRLI 9.x read-only v0.5 core — curated operator-enabled subset.
 
-This module names the **7 read-only vRLI operations** the G3.6 vRLI
+This module names the curated **read-only vRLI operations** the G3.6 vRLI
 v0.5 ship enables out of the much larger ``vcf-logs-9.0/<api-v2>.yaml``
 OpenAPI corpus that the G0.7 spec-ingestion pipeline lands under
-``connector_id="vrli-rest-9.0"``. The curation is two-layered:
+``connector_id="vrli-rest-9.0"``.
+
+Events query moved to a typed op (#2295)
+----------------------------------------
+
+The headline events query (``GET:/api/v2/events/{constraints}``) was the
+one op the adopter's real operations exercise (the hourly sentry cron +
+incident log pulls). #2295 converted it to a ``source_kind="typed"`` op on
+:class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector`
+(:data:`~meho_backplane.connectors.vcf_logs.typed_ops.VRLI_EVENT_QUERY_OP`)
+so it dispatches on the connector's own session with zero catalog ingest,
+and dropped it from :data:`VRLI_CORE_OPS` — this module no longer flips an
+ingested row for it. The other six curated ops stay ingested (declined from
+typed conversion: unused in real operations; the ingested canonical spec
+covers the browse case). This is the first conversion in Initiative #2266;
+curation-apparatus retirement is a later Task.
+
+The curation is two-layered:
 
 * :data:`VRLI_CORE_GROUPS` — the operator-reviewed ``when_to_use``
   hint per LLM-grouping pass output group. Each entry's ``group_key``
@@ -14,7 +31,7 @@ OpenAPI corpus that the G0.7 spec-ingestion pipeline lands under
   ops; the ``when_to_use`` is what the agent reads verbatim through
   :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
   to pick a group to search within.
-* :data:`VRLI_CORE_OPS` — the 7 ``EndpointDescriptor.op_id`` strings
+* :data:`VRLI_CORE_OPS` — the curated ``EndpointDescriptor.op_id`` strings
   that flip to ``is_enabled=True`` at operator-review time, paired
   with the per-op ``llm_instructions`` blob the agent inlines into
   the reasoning context when it sees the op in
@@ -38,38 +55,36 @@ compose a useful query (fields known to the indexer, hosts
 reporting, content packs governing field extraction, alert
 definitions running).
 
-The 7 ops (paths sourced against the vRLI 9.x REST API documented at
+The curated ingested ops (paths sourced against the vRLI 9.x REST API
+documented at
 https://developer.broadcom.com/xapis/vrealize-log-insight-api/latest/
 and the v1 reference at https://vmw-loginsight.github.io/, both of
-which describe the same shape under the ``/api/v2/`` family in 9.x):
+which describe the same shape under the ``/api/v2/`` family in 9.x). The
+events query (``GET:/api/v2/events/{constraints}``) is deliberately absent
+— it is now the ``vrli.event.query`` typed op (#2295, see the module note
+above):
 
 1. ``GET:/api/v2/version`` — ``vrli.about`` — appliance version /
    release-name / build. The same surface :meth:`VcfLogsConnector.fingerprint`
    already consumes; exposing it as an operator-callable op lets the
    agent run a sanity probe before any heavier read.
-2. ``GET:/api/v2/events/{constraints}`` — ``vrli.event.query`` —
-   constraint + time-range filtered raw-event search. Returns a
-   :class:`~meho_backplane.connectors.schemas.ResultHandle` for
-   large result sets -- a bounded inline sample plus a ``fetch_more``
-   envelope -- rather than the full payload inline. To act on more than
-   the sample the agent re-runs with a narrower constraint / time range.
-3. ``GET:/api/v2/aggregated-events/{constraints}`` — ``vrli.aggregated.query``
+2. ``GET:/api/v2/aggregated-events/{constraints}`` — ``vrli.aggregated.query``
    — group-by aggregation over the same constraint set as the event
    query. Useful for "how many events per host / severity / source
    in the last 24h" reductions.
-4. ``GET:/api/v2/fields`` — ``vrli.field.list`` — catalog of fields
+3. ``GET:/api/v2/fields`` — ``vrli.field.list`` — catalog of fields
    the indexer knows about (static + extracted). The agent reads
    this before composing a non-trivial event-query constraint to
    confirm a field name exists.
-5. ``GET:/api/v2/hosts`` — ``vrli.host.list`` — hosts currently
+4. ``GET:/api/v2/hosts`` — ``vrli.host.list`` — hosts currently
    reporting events to this vRLI cluster. Combined with the field
    catalog, this is the minimum agent-side composer-context for a
    useful event query.
-6. ``GET:/api/v2/content/contentpack/list`` — ``vrli.content.pack.list``
+5. ``GET:/api/v2/content/contentpack/list`` — ``vrli.content.pack.list``
    — installed content packs (each governs a set of extracted
    fields, dashboards, and alerts). Read when the operator asks
    "which integrations are configured on this vRLI".
-7. ``GET:/api/v2/alerts`` — ``vrli.alert.list`` — alert definitions
+6. ``GET:/api/v2/alerts`` — ``vrli.alert.list`` — alert definitions
    currently configured. Read-only; create / mutate are intentionally
    excluded from v0.5 per #369 DoD (write ops stay ``staged``).
 
@@ -97,7 +112,7 @@ Curation application
 --------------------
 
 :func:`apply_vrli_core_curation` is the operator-review-time
-substrate call that makes exactly the 7 curated ops dispatchable.
+substrate call that makes exactly the curated ops dispatchable.
 Mirrors :func:`~meho_backplane.connectors.harbor.core_ops.apply_harbor_core_curation`
 verbatim, threading the "enable group but pin non-core ops disabled"
 needle via the audit-log-driven operator-override exclusion. See
@@ -351,9 +366,18 @@ def _instructions(
     }
 
 
-#: The 7 curated read-only vRLI core ops. Each entry carries the
-#: op_id (``GET:/path`` form), the curated group assignment, and the
+#: The curated read-only vRLI core ops (6 after #2295). Each entry carries
+#: the op_id (``GET:/path`` form), the curated group assignment, and the
 #: operator-reviewed ``llm_instructions`` blob.
+#:
+#: The events query (``GET:/api/v2/events/{constraints}``) was converted to a
+#: ``source_kind="typed"`` op on ``VcfLogsConnector`` (#2295,
+#: :data:`~meho_backplane.connectors.vcf_logs.typed_ops.VRLI_EVENT_QUERY_OP`)
+#: and dropped from this curated ingested set: it is the one op the adopter's
+#: real operations run, so it no longer depends on per-deploy catalog state.
+#: The other six ops stay ingested (declined from typed conversion on #2295 —
+#: unused in real operations; the ingested canonical spec covers the browse
+#: case).
 #:
 #: Paths cross-checked against the vRLI 9.x REST API at
 #: https://developer.broadcom.com/xapis/vrealize-log-insight-api/latest/
@@ -380,37 +404,6 @@ VRLI_CORE_OPS: Final[tuple[VrliCoreOp, ...]] = (
                 "the supported range, proceed to vrli.field.list to "
                 "confirm the catalog of queryable fields, then compose "
                 "the event-query constraint."
-            ),
-        ),
-    ),
-    VrliCoreOp(
-        op_id="GET:/api/v2/events/{constraints}",
-        group_key="vrli-events",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to query raw vRLI log events. The {constraints} "
-                "path segment carries the URL-encoded constraint set "
-                "(field/value pairs, time range, limit) — compose it "
-                "with field names obtained from vrli.field.list. The "
-                "headline read surface of vRLI; use when answering "
-                "'show me events where source contains nsx and "
-                "severity is error in the last 1h'."
-            ),
-            output_shape=(
-                "Result-handle-shaped: events[] array of raw event "
-                "rows (each with timestamp, text, fields), plus "
-                "complete (bool) indicating whether the constraint "
-                "exhausted the index or hit the limit. Large result "
-                "sets return a JSONFlux ResultHandle with a bounded "
-                "inline sample plus a ``fetch_more`` envelope; re-run "
-                "with a narrower constraint / time range to act on more "
-                "than the sample."
-            ),
-            next_step=(
-                "If complete=false, surface the truncation to the "
-                "operator. For drill-down, pick an event timestamp + "
-                "host and re-compose a tighter constraint, or switch "
-                "to vrli.aggregated.query for group-by counts."
             ),
         ),
     ),
@@ -548,10 +541,10 @@ async def apply_vrli_core_curation(
     *,
     tenant_id: UUID | None,
 ) -> None:
-    """Apply the curated 7-op read core against an ingested vRLI connector.
+    """Apply the curated read core against an ingested vRLI connector.
 
     Drives the substrate so that, after this call returns, exactly
-    the 7 ops in :data:`VRLI_CORE_OPS` are dispatchable
+    the ops in :data:`VRLI_CORE_OPS` are dispatchable
     (``is_enabled=True``) and every other ingested op stays
     ``is_enabled=False``. The 5 curated groups land
     ``review_status='enabled'`` so the agent's

--- a/backend/src/meho_backplane/connectors/vcf_logs/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/typed_ops.py
@@ -1,0 +1,398 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) read op(s) for :class:`VcfLogsConnector` (#2295).
+
+vRLI shipped its read surface as a **generic-ingested** catalog: the
+``endpoint_descriptor`` rows land via ``meho connector ingest`` against
+``vcf-logs-9.0/openapi.yaml`` and
+:func:`~meho_backplane.connectors.vcf_logs.core_ops.apply_vrli_core_curation`
+flips a curated subset to ``is_enabled=True``. That model makes op
+correctness depend on mutable per-deploy catalog state — the #2247 failure
+class Initiative #2266 retires for the VCF family.
+
+``vrli.event.query`` is vRLI's first **typed** op (``source_kind="typed"``):
+a bound method on :class:`VcfLogsConnector` that issues the events query
+directly on the connector's own authenticated session — no ingested
+descriptor, no ``dispatch_child`` — so it works on a fresh boot with zero
+catalog ingest. It is the one op the adopter's real operations exercise
+(the hourly sentry cron + incident log pulls run exactly the events query),
+which is why it is converted first; the other six curated ops stay ingested
+(declined from typed conversion on #2295: unused in real operations, and the
+ingested canonical spec covers the browse case).
+
+The sibling precedent is
+:mod:`meho_backplane.connectors.vmware_rest.typed_ops` (``vmware.host.usage``,
+#2257) and :mod:`meho_backplane.connectors.argocd.ops`: a metadata dataclass
+here, a thin bound-method handler on the connector, and a module-level
+registrar queued onto
+:func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`.
+
+Why route through ``_get_json_with_session_retry``
+--------------------------------------------------
+
+The events query is a session-token call, and vRLI idle-times out its
+in-memory session (``trait.authenticated.440`` — the #1909 / #1135 soak
+scenario). Dispatching the query through
+:meth:`VcfLogsConnector._get_json_with_session_retry` gives the typed op the
+same one-shot invalidate → re-login → retry-once recovery the connector's
+fingerprint / probe already ride, keyed on the profile's ``{401, 440}``
+``expiry_statuses``. The generic-ingested dispatch path's own #2067 recovery
+seam (:meth:`VcfLogsConnector.invalidate_session`) does not apply here — a
+typed handler owns its transport call, so the retry has to live in the
+handler.
+
+Reserved-expansion constraint path (#2003 / #2066)
+--------------------------------------------------
+
+vRLI encodes the query constraint set as a slash-delimited sub-path
+(``text/CONTAINS error/hostname/CONTAINS vcsa``) after ``/api/v2/events/``.
+Those structural slashes must reach the appliance literal — a ``%2F``-mangled
+URL 400s. :func:`build_event_query_path` renders the constraint with the same
+RFC6570 reserved-expansion safe-set the ingested dispatcher's
+``_substitute_path`` uses for ``{+constraints}``, so structural chars pass
+through while genuinely-unsafe chars (space, control) still percent-encode.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import quote
+
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.vcf_logs.session import VcfLogsTargetLike
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.vcf_logs.connector import VcfLogsConnector
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "VRLI_EVENT_QUERY_OP",
+    "VRLI_TYPED_OPS",
+    "VRLI_TYPED_WHEN_TO_USE_BY_GROUP",
+    "VrliTypedOp",
+    "build_event_query_path",
+    "event_query_impl",
+    "register_vrli_typed_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+# The events read surface. The constraint chain is appended as a
+# reserved-expansion sub-path (see module docstring); the base path with an
+# empty constraint reaches ``/api/v2/events/`` (all events, bounded by limit).
+_EVENTS_PATH_PREFIX = "/api/v2/events/"
+
+# RFC6570 §3.2.3 reserved-expansion safe-set — the gen-delims + sub-delims
+# that stay literal so vRLI's slash-delimited constraint chain reaches the
+# appliance intact. Mirrors the ingested dispatcher's ``_RFC6570_RESERVED_SAFE``
+# (``meho_backplane.operations._branches``); the shared behaviour is pinned by
+# ``test_event_query_path_keeps_reserved_constraint_slashes_literal`` so the
+# typed path and the ingested ``{+constraints}`` path cannot drift (#2003).
+_CONSTRAINTS_RESERVED_SAFE = ":/?#[]@!$&'()*+,;="
+
+# vRLI caps an unbounded events query at the appliance default; the op exposes
+# ``limit`` so the agent can bound the pull explicitly (the adopter's incident
+# pulls do). Sent as a query param, not part of the constraint sub-path.
+_LIMIT_QUERY_KEY = "limit"
+
+_EVENTS_GROUP_KEY = "vrli-events"
+
+
+@dataclass(frozen=True)
+class VrliTypedOp:
+    """Metadata for one vRLI typed op registered at lifespan startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so :func:`register_vrli_typed_operations` can splat the dataclass
+    into the helper without per-op boilerplate. ``handler_attr`` is the
+    attribute name on
+    :class:`~meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector`
+    exposing the async handler; the registrar resolves the bound method against
+    the class so the dispatcher's
+    :func:`~meho_backplane.operations._handler_resolve.import_handler` walk
+    recovers the callable from the persisted ``module.ClassName.method`` path.
+    Mirrors :class:`~meho_backplane.connectors.vmware_rest.typed_ops.VmwareTypedOp`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+def build_event_query_path(constraints: str) -> str:
+    """Render the ``/api/v2/events/<constraints>`` request path.
+
+    *constraints* is vRLI's slash-delimited constraint chain (e.g.
+    ``text/CONTAINS error/hostname/CONTAINS vcsa``); an empty string reaches
+    the base ``/api/v2/events/`` (all events). The value is percent-encoded
+    with the RFC6570 reserved-expansion safe-set so the structural slashes stay
+    literal on the wire while spaces / control chars still encode — identical to
+    how the ingested dispatcher renders a ``{+constraints}`` template (#2003 /
+    #2066).
+    """
+    return _EVENTS_PATH_PREFIX + quote(constraints, safe=_CONSTRAINTS_RESERVED_SAFE)
+
+
+def _coerce_events(payload: Any) -> list[Any]:
+    """Return the ``events`` list from a vRLI events response, or ``[]``.
+
+    vRLI wraps the raw event rows under a top-level ``events`` key. A response
+    that is not a dict, or one missing / mis-typing ``events``, yields an empty
+    list rather than raising — the appliance returning an unexpected shape
+    surfaces as "no events", not a dispatch crash.
+    """
+    if not isinstance(payload, dict):
+        return []
+    events = payload.get("events")
+    return events if isinstance(events, list) else []
+
+
+async def event_query_impl(
+    connector: VcfLogsConnector,
+    operator: Operator,
+    target: VcfLogsTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Implementation of ``vrli.event.query`` — constraint-filtered event search.
+
+    Issues ``GET /api/v2/events/<constraints>`` (optional ``limit`` query
+    param) directly on the connector's authenticated session via
+    :meth:`VcfLogsConnector._get_json_with_session_retry`, which recovers a
+    440 / 401 session expiry with one re-login + retry (the #1909 / #1135
+    scenario). No ingested descriptor, no ``dispatch_child`` — works on a fresh
+    boot with zero catalog ingest.
+
+    Parameters (from *params*):
+
+    * ``constraints`` — the URL-path constraint chain (field/value pairs, time
+      range) composed from field names an agent obtains via the ingested
+      ``vrli.field.list`` browse op. Empty / absent → all events.
+    * ``limit`` — optional cap on the number of event rows returned.
+
+    Returns ``{"events": [...], "complete": bool}``. Large result sets are
+    summarised into a JSONFlux :class:`~meho_backplane.connectors.schemas.ResultHandle`
+    by the dispatcher's connector-agnostic reducer (``events`` is the reduced
+    collection); the handler itself returns the plain envelope.
+    """
+    constraints = params.get("constraints") or ""
+    if not isinstance(constraints, str):
+        raise ValueError(
+            f"vrli.event.query: 'constraints' must be a string; got {type(constraints).__name__}"
+        )
+    path = build_event_query_path(constraints)
+
+    query: dict[str, Any] | None = None
+    limit = params.get("limit")
+    if limit is not None:
+        query = {_LIMIT_QUERY_KEY: limit}
+
+    payload = await connector._get_json_with_session_retry(
+        target, path, operator=operator, params=query
+    )
+    events = _coerce_events(payload)
+    complete = bool(payload.get("complete", True)) if isinstance(payload, dict) else True
+    _log.info(
+        "vrli_event_query_read",
+        target=target.name,
+        constraint_len=len(constraints),
+        event_count=len(events),
+        complete=complete,
+    )
+    return {"events": events, "complete": complete}
+
+
+# ---------------------------------------------------------------------------
+# Op metadata + registrar
+# ---------------------------------------------------------------------------
+
+#: Curated ``when_to_use`` blurb per typed-op group.
+#: :func:`register_typed_operation` requires a non-empty string whenever
+#: ``group_key`` is set (typed_register ``_validate_when_to_use_pairing``).
+#: The ``vrli-events`` group is shared with the ingested ``aggregated-events``
+#: browse op; the blurb covers the headline event-query surface either lands.
+VRLI_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    _EVENTS_GROUP_KEY: (
+        "Use this group to query vRLI log events — the headline read surface of "
+        "vRLI. vrli.event.query returns constraint-filtered, time-range-bounded "
+        "raw log lines directly from the appliance session (works with zero "
+        "catalog ingest). Compose the constraint chain from field names an agent "
+        "confirms via the field catalog, and cap the pull with limit. Large "
+        "result sets come back as a JSONFlux handle (bounded inline sample plus "
+        "a fetch_more envelope); re-run with a narrower constraint / time range "
+        "to act on more than the sample."
+    ),
+}
+
+VRLI_EVENT_QUERY_OP = VrliTypedOp(
+    op_id="vrli.event.query",
+    handler_attr="event_query",
+    summary="Query raw vRLI log events by constraint chain, with an optional limit.",
+    description=(
+        "Queries raw vRLI (VCF Operations for Logs) events via "
+        "GET /api/v2/events/<constraints> issued directly on the connector's "
+        "session — no catalog ingest required. The constraints path segment "
+        "carries the URL-encoded, slash-delimited constraint chain (field/value "
+        "pairs, time range) vRLI's printQuery renders; compose it from field "
+        "names confirmed via the field catalog. Optional limit caps the number "
+        "of event rows. Returns {events: [...], complete: bool}; event rows carry "
+        "timestamp, text, hostname, source, and any extracted fields. The "
+        "headline read surface of vRLI — use for 'show me events where source "
+        "contains nsx and severity is error in the last 1h'. Large result sets "
+        "return a JSONFlux ResultHandle (bounded inline sample plus a fetch_more "
+        "envelope); re-run with a narrower constraint / time range to act on more "
+        "than the sample. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "constraints": {
+                "type": "string",
+                "description": (
+                    "URL-path constraint chain (slash-delimited field/OP value "
+                    "pairs, e.g. 'text/CONTAINS error/hostname/CONTAINS vcsa'). "
+                    "Omit or pass an empty string for all events (bounded by "
+                    "limit). Structural slashes reach the appliance literal."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "description": (
+                    "Optional cap on the number of event rows returned. Omit for "
+                    "the appliance default."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "events": {"type": "array"},
+            "complete": {"type": "boolean"},
+        },
+        "additionalProperties": True,
+    },
+    group_key=_EVENTS_GROUP_KEY,
+    tags=("read-only", "vrli", "vcf-logs", "events", "log-query"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_call": (
+            "Call to query raw vRLI log events. Compose the constraints chain "
+            "from field names obtained from the field catalog; set limit to bound "
+            "the pull. The headline read surface of vRLI — use when answering "
+            "'show me events where source contains nsx and severity is error in "
+            "the last 1h'."
+        ),
+        "parameter_hints": {
+            "constraints": ("Slash-delimited field/OP value chain; omit for all events."),
+            "limit": "Max event rows to return; omit for the appliance default.",
+        },
+        "output_shape": (
+            "{events: [{timestamp, text, hostname, source, ...}, ...], "
+            "complete: bool}. Large result sets return a JSONFlux ResultHandle "
+            "with a bounded inline sample plus a fetch_more envelope; drill via "
+            "result_describe / result_query rather than expecting the full "
+            "payload inline. complete=false means the limit / index truncated the "
+            "set — re-run with a narrower constraint or time range."
+        ),
+        "next_step": (
+            "If complete=false, surface the truncation and re-compose a tighter "
+            "constraint (or lower the time range). For group-by counts, switch to "
+            "the aggregated-events browse op."
+        ),
+    },
+)
+
+#: The typed ops :class:`VcfLogsConnector` registers at lifespan startup. Today
+#: just ``vrli.event.query`` (#2295); the tuple shape lets a future typed vRLI
+#: read join without touching the registrar.
+VRLI_TYPED_OPS: tuple[VrliTypedOp, ...] = (VRLI_EVENT_QUERY_OP,)
+
+
+async def register_vrli_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every op in :data:`VRLI_TYPED_OPS` into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after
+    :func:`~meho_backplane.connectors.registry._eager_import_connectors` has
+    walked every connector subpackage, so the descriptor row lands before the
+    first dispatch. Idempotent across pod restarts (the helper skips the
+    embedding recompute on unchanged summary / description / tags). Mirrors
+    :func:`~meho_backplane.connectors.vmware_rest.typed_ops.register_vmware_typed_operations`
+    and the argocd typed-op registrar.
+
+    The ``embedding_service`` keyword-only parameter is the runner contract:
+    :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar, so
+    each registrar must accept the kwarg. It is forwarded to
+    :func:`register_typed_operation` (which falls back to the process-wide
+    singleton when ``None``).
+    """
+    # Lazy import: the operations package pulls in the embedding pipeline
+    # (ONNX runtime + model), which pure connector/handler unit tests should
+    # not pay. Lifespan callers have it warmed by the time this runs.
+    from meho_backplane.connectors.vcf_logs.connector import VcfLogsConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in VRLI_TYPED_OPS:
+        handler = getattr(VcfLogsConnector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"VcfLogsConnector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = (
+            None if op.group_key is None else VRLI_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        )
+        if op.group_key is not None and when_to_use is None:
+            raise ValueError(
+                f"VcfLogsConnector typed op {op.op_id!r} declares "
+                f"group_key={op.group_key!r} but no curated when_to_use exists for "
+                f"that key. Add an entry to VRLI_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=VcfLogsConnector.product,
+            version=VcfLogsConnector.version,
+            impl_id=VcfLogsConnector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "vrli_typed_operations_registered",
+        count=len(VRLI_TYPED_OPS),
+        product=VcfLogsConnector.product,
+        version=VcfLogsConnector.version,
+        impl_id=VcfLogsConnector.impl_id,
+    )

--- a/backend/tests/acceptance/_vrli_canary_fixtures.py
+++ b/backend/tests/acceptance/_vrli_canary_fixtures.py
@@ -7,11 +7,12 @@ This module is the vRLI sibling of :mod:`tests.acceptance._nsx_canary_fixtures`.
 The acceptance + E2E modules under :mod:`tests` share the same plumbing: a
 registered :class:`~meho_backplane.connectors.vcf_logs.VcfLogsConnector`
 instance with a stub credentials loader (so no Vault read fires), a probed
-:class:`~meho_backplane.db.models.Target` row, the 7 curated
+:class:`~meho_backplane.db.models.Target` row, the curated ingested
 :class:`~meho_backplane.db.models.EndpointDescriptor` rows from
-:data:`~meho_backplane.connectors.vcf_logs.core_ops.VRLI_CORE_OPS`, and a
-:mod:`respx`-mocked vRLI REST surface answering the session-create POST
-plus every read op the connector dispatches against.
+:data:`~meho_backplane.connectors.vcf_logs.core_ops.VRLI_CORE_OPS` plus the
+``vrli.event.query`` typed row (#2295), and a :mod:`respx`-mocked vRLI REST
+surface answering the session-create POST plus every read op the connector
+dispatches against.
 
 The vRLI delta relative to NSX
 -------------------------------
@@ -24,12 +25,14 @@ The vRLI delta relative to NSX
   401 from a downstream call; a second 401 raises ``RuntimeError`` naming
   the target. The contract lives on
   :meth:`VcfLogsConnector._get_json_with_session_retry`.
-* **Path-template ops**: two of the 7 curated ops carry ``{constraints}``
-  in their path — the dispatcher's ``_substitute_path`` fills it via the
-  ``x-meho-param-loc='path'`` extension key on the parameter_schema. The
-  fixture seeds the descriptors with that key + an empty-string default,
-  so dispatch_ingested substitutes an empty trailing segment when the
-  caller passes ``constraints=""``.
+* **Path-template ops**: the ingested ``aggregated-events`` op carries
+  ``{constraints}`` in its path — the dispatcher's ``_substitute_path`` fills
+  it via the ``x-meho-param-loc='path'`` extension key on the
+  parameter_schema. The fixture seeds the descriptor with that key + an
+  empty-string default, so dispatch_ingested substitutes an empty trailing
+  segment when the caller passes ``constraints=""``. The raw events query is
+  the ``vrli.event.query`` typed op since #2295; it builds the constraint
+  sub-path in the handler, not via ``_substitute_path``.
 """
 
 from __future__ import annotations
@@ -58,6 +61,7 @@ from meho_backplane.connectors.vcf_logs import (
     VcfLogsConnector,
 )
 from meho_backplane.connectors.vcf_logs.session import VcfLogsTargetLike
+from meho_backplane.connectors.vcf_logs.typed_ops import VRLI_EVENT_QUERY_OP
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, OperationGroup, Target
 from meho_backplane.operations import reset_dispatcher_caches
@@ -72,6 +76,7 @@ __all__ = [
     "VRLI_CANARY_OPERATOR_TENANT",
     "VRLI_CANARY_SESSION_ID",
     "VRLI_CANARY_SESSION_REFRESH_ID",
+    "VRLI_EVENT_QUERY_HANDLER_REF",
     "VRLI_FORCE_HANDLE_LIST_OP_ID",
     "VRLI_RESERVED_CONSTRAINT_OP_ID",
     "VRLI_RESERVED_CONSTRAINT_VALUE",
@@ -80,6 +85,7 @@ __all__ = [
     "IngestedVrliCanary",
     "_insert_vrli_descriptors",
     "_insert_vrli_reserved_constraint_descriptor",
+    "_insert_vrli_typed_event_query_descriptor",
     "_register_vrli_reserved_constraint_route",
     "_register_vrli_routes",
     "_vrli_credentials_loader",
@@ -130,13 +136,23 @@ VRLI_CANARY_FINGERPRINT: dict[str, object] = FingerprintResult(
     extras={"release_name": "VMware Aria Operations for Logs 9.0", "patch": "0"},
 ).model_dump(mode="json")
 
-#: The list op the JSONFlux force-handle test dispatches. Picked because
-#: events.query is the explicit DoD acceptance criterion ("vcf-logs query
-#: E2E asserts the JSONFlux handle path") — the path is templated so the
-#: param_schema seeding doubles as proof the dispatcher substitutes the
-#: ``{constraints}`` segment correctly even when the caller passes empty
-#: constraints.
-VRLI_FORCE_HANDLE_LIST_OP_ID: str = "GET:/api/v2/events/{constraints}"
+#: The list op the JSONFlux force-handle test dispatches. Since #2295 this is
+#: the ``vrli.event.query`` **typed** op (``source_kind="typed"``): events.query
+#: is the explicit DoD acceptance criterion ("vcf-logs query E2E asserts the
+#: JSONFlux handle path"), and the conversion means the handle path is now
+#: exercised on the typed dispatch surface — the connector-agnostic reducer
+#: wraps the typed handler's ``{events: [...]}`` envelope the same way it wrapped
+#: the ingested row's response.
+VRLI_FORCE_HANDLE_LIST_OP_ID: str = VRLI_EVENT_QUERY_OP.op_id
+
+#: Dotted handler path the seeded typed ``vrli.event.query`` descriptor carries
+#: so the dispatcher's ``import_handler`` walk resolves the bound method and
+#: binds it to the connector instance. Built from the op's ``handler_attr`` so
+#: it can't drift from the real method name.
+VRLI_EVENT_QUERY_HANDLER_REF: str = (
+    f"meho_backplane.connectors.vcf_logs.connector.VcfLogsConnector."
+    f"{VRLI_EVENT_QUERY_OP.handler_attr}"
+)
 
 #: Synthetic event listing — 11 rows so the force-handle reducer sees a
 #: populated set with a sample-row slice. Fields match the vRLI event
@@ -200,28 +216,34 @@ _VRLI_CANARY_ALERTS: dict[str, object] = {
     ],
 }
 
-#: Path-template params for the two events ops whose URLs carry the
+#: Path-template params for the ingested ops whose URLs carry the
 #: ``{constraints}`` placeholder. The dispatcher's ``_substitute_path``
 #: fills it; the respx routes are registered against the substituted
 #: URLs (vRLI accepts an empty trailing path segment as "no extra
-#: constraint", matching the wrapper's posture).
+#: constraint", matching the wrapper's posture). Only aggregated-events
+#: remains ingested here — the raw events query is the ``vrli.event.query``
+#: typed op since #2295 (it takes the same ``constraints`` param).
 VRLI_CONSTRAINT_OP_PARAMS: dict[str, dict[str, object]] = {
-    "GET:/api/v2/events/{constraints}": {"constraints": ""},
     "GET:/api/v2/aggregated-events/{constraints}": {"constraints": ""},
 }
 
 
 async def _insert_vrli_descriptors() -> None:
-    """Seed the 7 curated vRLI core ops + their groups as enabled rows.
+    """Seed the curated vRLI core ops + the typed events op + their groups.
 
     One :class:`OperationGroup` per entry in :data:`VRLI_CORE_GROUPS`
     (``review_status='enabled'``), one :class:`EndpointDescriptor` per
     entry in :data:`VRLI_CORE_OPS` (``is_enabled=True``,
-    ``source_kind='ingested'``, ``handler_ref=None``).
+    ``source_kind='ingested'``, ``handler_ref=None``), plus the
+    ``vrli.event.query`` **typed** row (``source_kind='typed'``,
+    ``handler_ref`` set) so a ``call_operation`` dispatch of the events query
+    resolves to the bound method on the connector (#2295).
 
-    Multiple ops can share the same group (e.g. ``GET:/api/v2/events``
-    and ``GET:/api/v2/aggregated-events`` both map to ``vrli-events``);
-    the helper coalesces shared group_keys into one inserted group row.
+    Multiple ops can share the same group (e.g. the ingested
+    ``aggregated-events`` op and the typed ``vrli.event.query`` op both map to
+    ``vrli-events``); the helper coalesces shared group_keys into one inserted
+    group row. This is the integration double the typed-registration trap warns
+    about: without the typed row the events dispatch would 404 at lookup.
     """
     sessionmaker = get_sessionmaker()
     group_ids: dict[str, UUID] = {}
@@ -265,6 +287,74 @@ async def _insert_vrli_descriptors() -> None:
                 tags=["spec:vcf-logs-9.0/openapi.yaml"],
             )
             session.add(descriptor)
+
+        # The typed events op (#2295). ``method`` / ``path`` are NULL for a
+        # typed row (the handler owns the transport call); the dispatcher
+        # resolves ``handler_ref`` and binds it to the connector instance.
+        session.add(
+            EndpointDescriptor(
+                tenant_id=None,
+                product=VRLI_PRODUCT,
+                version=VRLI_VERSION,
+                impl_id=VRLI_IMPL_ID,
+                op_id=VRLI_EVENT_QUERY_OP.op_id,
+                source_kind="typed",
+                method=None,
+                path=None,
+                handler_ref=VRLI_EVENT_QUERY_HANDLER_REF,
+                group_id=group_ids[VRLI_EVENT_QUERY_OP.group_key],
+                summary=VRLI_EVENT_QUERY_OP.summary,
+                description=VRLI_EVENT_QUERY_OP.description,
+                parameter_schema=VRLI_EVENT_QUERY_OP.parameter_schema,
+                response_schema=VRLI_EVENT_QUERY_OP.response_schema,
+                llm_instructions=VRLI_EVENT_QUERY_OP.llm_instructions,
+                safety_level=VRLI_EVENT_QUERY_OP.safety_level,
+                requires_approval=VRLI_EVENT_QUERY_OP.requires_approval,
+                is_enabled=True,
+                tags=list(VRLI_EVENT_QUERY_OP.tags),
+            )
+        )
+        await session.commit()
+
+
+async def _insert_vrli_typed_event_query_descriptor() -> None:
+    """Seed only the ``vrli.event.query`` typed descriptor (reuses vrli-events).
+
+    For tests that want the typed events op available on top of a setup that
+    seeded the ingested groups some other way. Requires the ``vrli-events``
+    :class:`OperationGroup` to exist already (``_insert_vrli_descriptors``
+    creates it); look it up and attach the typed row.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        group_row = (
+            await session.execute(
+                select(OperationGroup).where(OperationGroup.group_key == "vrli-events")
+            )
+        ).scalar_one()
+        session.add(
+            EndpointDescriptor(
+                tenant_id=None,
+                product=VRLI_PRODUCT,
+                version=VRLI_VERSION,
+                impl_id=VRLI_IMPL_ID,
+                op_id=VRLI_EVENT_QUERY_OP.op_id,
+                source_kind="typed",
+                method=None,
+                path=None,
+                handler_ref=VRLI_EVENT_QUERY_HANDLER_REF,
+                group_id=group_row.id,
+                summary=VRLI_EVENT_QUERY_OP.summary,
+                description=VRLI_EVENT_QUERY_OP.description,
+                parameter_schema=VRLI_EVENT_QUERY_OP.parameter_schema,
+                response_schema=VRLI_EVENT_QUERY_OP.response_schema,
+                llm_instructions=VRLI_EVENT_QUERY_OP.llm_instructions,
+                safety_level=VRLI_EVENT_QUERY_OP.safety_level,
+                requires_approval=VRLI_EVENT_QUERY_OP.requires_approval,
+                is_enabled=True,
+                tags=list(VRLI_EVENT_QUERY_OP.tags),
+            )
+        )
         await session.commit()
 
 
@@ -304,7 +394,7 @@ async def _vrli_credentials_loader(
 
 
 def _register_vrli_routes(mock: respx.MockRouter) -> None:
-    """Register the vRLI session-establish + 7 read-op routes on *mock*.
+    """Register the vRLI session-establish + read-op routes on *mock*.
 
     The session-create route answers with a JSON body carrying
     ``{"sessionId": ..., "ttl": 1800}``; the connector's
@@ -312,11 +402,12 @@ def _register_vrli_routes(mock: respx.MockRouter) -> None:
     subsequent route returns a pre-seeded JSON body matching the rough
     shape vRLI returns for that path family.
 
-    The templated ``{constraints}`` ops register against the empty
-    trailing-segment substitution (``/api/v2/events`` and
-    ``/api/v2/aggregated-events`` — no trailing slash, because the
-    dispatcher's ``_substitute_path`` collapses ``{constraints}`` →
-    ``""`` and strips the leading ``/``).
+    The ingested ``aggregated-events`` op registers against the empty
+    trailing-segment substitution (``/api/v2/aggregated-events`` — no
+    trailing slash, because the dispatcher's ``_substitute_path`` collapses
+    ``{constraints}`` → ``""`` and strips the leading ``/``). The typed
+    ``vrli.event.query`` op builds ``/api/v2/events/`` in the handler for an
+    empty constraint (the trailing slash is the ``_EVENTS_PATH_PREFIX``).
     """
     # Session establish.
     mock.post("/api/v2/sessions").respond(
@@ -332,11 +423,10 @@ def _register_vrli_routes(mock: respx.MockRouter) -> None:
             "buildNumber": "21761695",
         },
     )
-    # vrli.event.query — the dispatcher's ``_substitute_path`` lands the
-    # empty-string ``{constraints}`` value as the trailing path segment,
-    # so the URL on the wire is ``/api/v2/events/`` (with the slash).
-    # vRLI accepts the trailing-slash form as "no extra constraint",
-    # matching the wrapper's posture.
+    # vrli.event.query (typed, #2295) — the handler builds ``/api/v2/events/``
+    # for an empty constraint, so the URL on the wire is ``/api/v2/events/``
+    # (with the slash). vRLI accepts the trailing-slash form as "no extra
+    # constraint", matching the wrapper's posture.
     mock.get("/api/v2/events/").respond(200, json=VRLI_CANARY_EVENTS)
     # vrli.aggregated.query — same trailing-slash shape.
     mock.get("/api/v2/aggregated-events/").respond(200, json=_VRLI_CANARY_AGGREGATED)

--- a/backend/tests/test_connectors_vcf_logs_core_ops.py
+++ b/backend/tests/test_connectors_vcf_logs_core_ops.py
@@ -16,11 +16,12 @@ Covers :mod:`meho_backplane.connectors.vcf_logs.core_ops`:
   non-empty string values.
 * :func:`apply_vrli_core_curation` — the operator-review-time
   substrate call that flips ``review_status='enabled'`` on the 5
-  curated groups, lands ``llm_instructions`` on the 7 curated ops,
+  curated groups, lands ``llm_instructions`` on the curated ops,
   and explicitly disables non-core ops via the audit-log-driven
-  operator-override exclusion. The load-bearing assertion is "7
-  ops dispatchable, every other op in curated groups stays
-  ``is_enabled=False``".
+  operator-override exclusion. The load-bearing assertion is "the
+  curated ingested ops dispatchable, every other op in curated groups
+  stays ``is_enabled=False``". Since #2295 the raw events query is the
+  ``vrli.event.query`` typed op, not one of these ingested rows.
 
 Test harness mirrors :mod:`tests.test_connectors_harbor_core_ops`
 and :mod:`tests.test_connectors_nsx_core_ops`: SQLite via the
@@ -109,7 +110,7 @@ def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
     ids=str,
 )
 def test_classify_vrli_op_returns_correct_group(op_id: str, expected_group: str) -> None:
-    """classify_vrli_op returns the curated group_key for all 7 core ops."""
+    """classify_vrli_op returns the curated group_key for each curated family."""
     assert classify_vrli_op(op_id) == expected_group
 
 
@@ -154,10 +155,35 @@ def test_classify_vrli_op_rejects_write_methods_on_curated_paths() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_vrli_core_ops_has_seven_entries() -> None:
-    """The read-only v0.5 core enables exactly 7 ops per #369 DoD."""
-    assert len(VRLI_CORE_OPS) == 7, (
-        f"VRLI_CORE_OPS should carry 7 entries (v0.5 read core); got {len(VRLI_CORE_OPS)}"
+def test_vrli_core_ops_has_six_entries() -> None:
+    """The curated ingested core carries 6 ops after #2295.
+
+    The read-only v0.5 core was 7 ops; #2295 converted the events query to the
+    ``vrli.event.query`` typed op and dropped it from this ingested curation,
+    leaving 6 (version, aggregated-events, fields, hosts, content-pack-list,
+    alerts). The other six are declined from typed conversion (unused in the
+    adopter's real operations; the ingested canonical spec covers the browse
+    case).
+    """
+    assert len(VRLI_CORE_OPS) == 6, (
+        f"VRLI_CORE_OPS should carry 6 entries (events query moved to a typed "
+        f"op in #2295); got {len(VRLI_CORE_OPS)}"
+    )
+
+
+def test_vrli_core_ops_no_longer_curates_the_events_query_op() -> None:
+    """The raw events query is NOT an ingested-curated row (it's the typed op).
+
+    AC #4 / #2262: ``vcf_logs/core_ops.py`` no longer flips an ingested row
+    for the events query. A grep-equivalent: no VRLI_CORE_OPS entry targets the
+    ``/api/v2/events/`` path (aggregated-events is a distinct path).
+    """
+    events_query_ids = [
+        op.op_id for op in VRLI_CORE_OPS if op.op_id.split(":", 1)[-1].startswith("/api/v2/events/")
+    ]
+    assert not events_query_ids, (
+        f"the events query must not be an ingested-curated op after #2295; "
+        f"found {events_query_ids!r} still in VRLI_CORE_OPS"
     )
 
 
@@ -192,28 +218,19 @@ def test_vrli_core_groups_when_to_use_all_populated() -> None:
         assert group.name and group.name.strip(), f"group {group.group_key!r} has empty name"
 
 
-def test_vrli_core_groups_event_query_op_is_jsonflux_handle_shaped() -> None:
-    """The event-query op's llm_instructions advertise the JSONFlux handle shape.
+def test_vrli_core_ops_events_query_group_still_present() -> None:
+    """The vrli-events group survives the events-query op's move to typed.
 
-    Per #834 acceptance criteria, ``vrli.event.query`` returns a
-    JSONFlux result handle (event result sets are large by nature).
-    The agent learns this from the op's ``output_shape`` /
-    ``next_step`` text — assert the operator-reviewed copy mentions
-    the handle so the LLM knows to drill via
-    ``result_describe`` / ``result_query`` rather than expecting an
-    inline payload.
+    ``aggregated-events`` still classifies to ``vrli-events``, so the group is
+    still carried by both :data:`VRLI_CORE_GROUPS` and at least one ingested
+    core op — the JSONFlux-handle-shape assertion for the raw events query
+    itself now lives with the typed op
+    (``tests.test_connectors_vcf_logs_typed_event_query``).
     """
-    event_query_op = next(
-        op for op in VRLI_CORE_OPS if op.op_id == "GET:/api/v2/events/{constraints}"
-    )
-    output_shape = str(event_query_op.llm_instructions["output_shape"]).lower()
-    next_step = str(event_query_op.llm_instructions["next_step"]).lower()
-    combined = f"{output_shape} {next_step}"
-    assert "handle" in combined or "jsonflux" in combined, (
-        f"vrli.event.query llm_instructions should mention the JSONFlux handle "
-        f"so the agent reads results via result_describe / result_query; "
-        f"got output_shape={event_query_op.llm_instructions['output_shape']!r}, "
-        f"next_step={event_query_op.llm_instructions['next_step']!r}"
+    group_keys_in_core = {op.group_key for op in VRLI_CORE_OPS}
+    assert "vrli-events" in group_keys_in_core, (
+        "vrli-events group must still be covered by an ingested core op "
+        "(aggregated-events) after the events query moved to a typed op"
     )
 
 
@@ -325,8 +342,8 @@ async def _seed_curated_groups_and_ops(
     return group_ids
 
 
-async def test_apply_vrli_core_curation_enables_exactly_7_ops() -> None:
-    """apply_vrli_core_curation enables exactly the 7 core ops."""
+async def test_apply_vrli_core_curation_enables_exactly_the_core_ops() -> None:
+    """apply_vrli_core_curation enables exactly the curated core ops."""
     tenant_id = uuid.uuid4()
     operator = _make_operator(tenant_id=tenant_id)
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)
@@ -387,7 +404,7 @@ async def test_apply_vrli_core_curation_disables_non_core_ops_in_curated_groups(
 
 
 async def test_apply_vrli_core_curation_sets_llm_instructions_on_all_core_ops() -> None:
-    """llm_instructions is populated on all 7 core ops after curation."""
+    """llm_instructions is populated on all curated core ops after curation."""
     tenant_id = uuid.uuid4()
     operator = _make_operator(tenant_id=tenant_id)
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)

--- a/backend/tests/test_connectors_vcf_logs_e2e.py
+++ b/backend/tests/test_connectors_vcf_logs_e2e.py
@@ -507,7 +507,10 @@ async def vrli_e2e_440_persists(
 # ---------------------------------------------------------------------------
 
 _OP_IDS: tuple[str, ...] = tuple(op.op_id for op in VRLI_CORE_OPS)
-assert len(_OP_IDS) == 7, f"Expected 7 curated vRLI ops, got {len(_OP_IDS)}: {_OP_IDS}"
+assert len(_OP_IDS) == 6, (
+    f"Expected 6 curated ingested vRLI ops after #2295 (events query is now the "
+    f"vrli.event.query typed op), got {len(_OP_IDS)}: {_OP_IDS}"
+)
 
 
 @pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
@@ -515,13 +518,15 @@ async def test_vrli_e2e_all_ops_dispatch_ok(
     op_id: str,
     vrli_e2e_canary: _VrliE2EBundle,
 ) -> None:
-    """All 7 vRLI core ops dispatch through the full dispatcher and return status='ok'.
+    """All 6 curated ingested vRLI ops dispatch through the full dispatcher OK.
 
     The first call in the series fires the session-establish POST; subsequent
     calls reuse the cached token. The parametrise reports one CI case per
-    op_id for granular failure attribution. The two ``{constraints}`` ops
-    pass an empty-string constraints value to exercise the path-template
-    substitution + empty-trailing-segment behaviour.
+    op_id for granular failure attribution. The ingested ``aggregated-events``
+    ``{constraints}`` op passes an empty-string constraints value to exercise
+    the path-template substitution + empty-trailing-segment behaviour. The
+    typed ``vrli.event.query`` op is covered separately (its own dispatch-level
+    test module + the JSONFlux handle test below).
     """
     params = VRLI_CONSTRAINT_OP_PARAMS.get(op_id, {})
     result = await call_operation(
@@ -885,13 +890,15 @@ async def test_vrli_e2e_dispatch_writes_audit_row(
 async def test_vrli_e2e_jsonflux_handle_populated_for_event_query(
     vrli_e2e_canary: _VrliE2EBundle,
 ) -> None:
-    """Event query dispatched with the real JsonFluxReducer returns a populated handle.
+    """Typed event query dispatched with the real JsonFluxReducer returns a populated handle.
 
     Exercises acceptance criterion (d) — the issue body's "vcf-logs
     query E2E asserts the JSONFlux handle path (handle →
-    ``result_query`` drills in)". Picks events.query as the canonical
-    list op because the headline read surface of vRLI is event search
-    and large result sets are precisely where the handle path matters.
+    ``result_query`` drills in)". Since #2295 ``vrli.event.query`` is a
+    ``source_kind="typed"`` op, so this also pins that the dispatcher's
+    connector-agnostic reducer wraps a typed handler's ``{events: [...]}``
+    envelope into a handle exactly as it did the ingested row's response —
+    large result sets are precisely where the handle path matters.
     """
     events_payload = VRLI_CANARY_EVENTS["events"]
     assert isinstance(events_payload, list)

--- a/backend/tests/test_connectors_vcf_logs_typed_event_query.py
+++ b/backend/tests/test_connectors_vcf_logs_typed_event_query.py
@@ -1,0 +1,541 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit + dispatch-level tests for the ``vrli.event.query`` typed op (#2295).
+
+``vrli.event.query`` is vRLI's first ``source_kind="typed"`` op: a bound
+method on :class:`VcfLogsConnector` that issues the events query directly on
+the connector's authenticated session (through the retry-once seam
+``_get_json_with_session_retry``), so it works on a fresh boot with **zero
+catalog ingest** — no ingested ``endpoint_descriptor`` row for the events
+query. It replaces the hand-edited production overlay whose two canonical-spec
+blockers (#2066 ``{+path}`` render, #1796 ``servers[]`` base path) are fixed
+in v0.20.0.
+
+Coverage maps to the #2295 acceptance criteria:
+
+* AC #1 — the typed op dispatches as ``source_kind="typed"`` on a fresh boot
+  with zero catalog state, against a respx-mocked vRLI (``call_operation``
+  dispatch level, not helper level).
+* AC #2 — a 440 mid-session recovers via one re-login + retry, pinned on the
+  **typed** dispatch path (the soak-famous #1135 / #1139 scenario).
+* AC #3 — the #2262 registration invariant: the typed events op resolves via a
+  ``source_kind="typed"`` descriptor + ``handler_ref``, never through an
+  ``ingested`` row.
+
+Handler-level unit tests (call shape, path building, limit flow, envelope
+coercion) run against a fake connector so the assertions target the
+request-builder contract without a live transport.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import select
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.vcf_logs import (
+    VRLI_CONNECTOR_ID,
+    VRLI_IMPL_ID,
+    VRLI_TYPED_OPS,
+    VRLI_VERSION,
+    VcfLogsConnector,
+)
+from meho_backplane.connectors.vcf_logs.typed_ops import (
+    VRLI_EVENT_QUERY_OP,
+    build_event_query_path,
+    event_query_impl,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations.meta_tools import call_operation
+from tests.acceptance._vrli_canary_fixtures import (
+    VRLI_CANARY_BASE_URL,
+    VRLI_CANARY_EVENTS,
+    VRLI_CANARY_FINGERPRINT,
+    VRLI_CANARY_OPERATOR_TENANT,
+    VRLI_CANARY_SESSION_ID,
+    VRLI_CANARY_SESSION_REFRESH_ID,
+    VRLI_RESERVED_CONSTRAINT_VALUE,
+    VRLI_RESERVED_CONSTRAINT_WIRE_PATH,
+    _insert_vrli_descriptors,
+    _register_vrli_routes,
+    _vrli_credentials_loader,
+)
+
+_OPERATOR = Operator(
+    sub="vrli-typed-event-query-test",
+    name="vRLI Typed Event Query Test",
+    email=None,
+    raw_jwt="<vrli-typed-raw-jwt>",
+    tenant_id=VRLI_CANARY_OPERATOR_TENANT,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+_TARGET_NAME = "vrli-typed-event-query-target"
+
+
+# ---------------------------------------------------------------------------
+# Handler-level unit tests (fake connector)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Target:
+    name: str = "vrli-unit"
+    host: str = "vrli.test.invalid"
+    port: int | None = 443
+    id: UUID = field(default_factory=lambda: UUID("00000000-0000-0000-0000-0000000000e1"))
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-event-query",
+        name="Event Query Unit",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000b0b0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _FakeConnector:
+    """Records the ``_get_json_with_session_retry`` call ``event_query_impl`` makes."""
+
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    async def _get_json_with_session_retry(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        del target, operator
+        self.calls.append((path, params))
+        return self._payload
+
+
+def test_build_event_query_path_empty_constraint_is_the_base_events_path() -> None:
+    assert build_event_query_path("") == "/api/v2/events/"
+
+
+def test_build_event_query_path_keeps_reserved_constraint_slashes_literal() -> None:
+    """A reserved constraint chain keeps ``/`` literal, encodes spaces (#2003)."""
+    path = build_event_query_path(VRLI_RESERVED_CONSTRAINT_VALUE)
+    assert path == VRLI_RESERVED_CONSTRAINT_WIRE_PATH
+    # Structural slashes survived; only the space was percent-encoded.
+    assert "%2F" not in path
+    assert "%20" in path
+
+
+@pytest.mark.asyncio
+async def test_event_query_impl_builds_path_and_returns_envelope() -> None:
+    conn = _FakeConnector({"events": [{"id": "ev-1"}, {"id": "ev-2"}], "complete": True})
+
+    out = await event_query_impl(conn, _make_operator(), _Target(), {"constraints": ""})
+
+    assert conn.calls == [("/api/v2/events/", None)]
+    assert out == {"events": [{"id": "ev-1"}, {"id": "ev-2"}], "complete": True}
+
+
+@pytest.mark.asyncio
+async def test_event_query_impl_flows_limit_as_query_param() -> None:
+    conn = _FakeConnector({"events": [], "complete": True})
+
+    await event_query_impl(conn, _make_operator(), _Target(), {"constraints": "", "limit": 25})
+
+    (path, params) = conn.calls[0]
+    assert path == "/api/v2/events/"
+    assert params == {"limit": 25}
+
+
+@pytest.mark.asyncio
+async def test_event_query_impl_renders_reserved_constraint_path() -> None:
+    conn = _FakeConnector({"events": [{"id": "ev-1"}], "complete": False})
+
+    await event_query_impl(
+        conn, _make_operator(), _Target(), {"constraints": VRLI_RESERVED_CONSTRAINT_VALUE}
+    )
+
+    assert conn.calls[0][0] == VRLI_RESERVED_CONSTRAINT_WIRE_PATH
+
+
+@pytest.mark.asyncio
+async def test_event_query_impl_defaults_complete_true_and_coerces_missing_events() -> None:
+    """A response missing ``events`` / ``complete`` yields [] and complete=True."""
+    conn = _FakeConnector({"unexpected": "shape"})
+
+    out = await event_query_impl(conn, _make_operator(), _Target(), {})
+
+    assert out == {"events": [], "complete": True}
+
+
+@pytest.mark.asyncio
+async def test_event_query_impl_reads_complete_flag() -> None:
+    conn = _FakeConnector({"events": [{"id": "ev-1"}], "complete": False})
+
+    out = await event_query_impl(conn, _make_operator(), _Target(), {"constraints": ""})
+
+    assert out["complete"] is False
+
+
+@pytest.mark.asyncio
+async def test_event_query_impl_rejects_non_string_constraints() -> None:
+    conn = _FakeConnector({"events": []})
+
+    with pytest.raises(ValueError, match="constraints"):
+        await event_query_impl(conn, _make_operator(), _Target(), {"constraints": ["not", "str"]})
+
+
+# ---------------------------------------------------------------------------
+# Op metadata / registration contract
+# ---------------------------------------------------------------------------
+
+
+def test_event_query_is_a_registered_typed_op() -> None:
+    assert VRLI_EVENT_QUERY_OP in VRLI_TYPED_OPS
+    assert VRLI_EVENT_QUERY_OP.op_id == "vrli.event.query"
+    assert VRLI_EVENT_QUERY_OP.safety_level == "safe"
+    assert VRLI_EVENT_QUERY_OP.requires_approval is False
+
+
+def test_event_query_handler_attr_resolves_to_a_connector_bound_method() -> None:
+    handler = getattr(VcfLogsConnector, VRLI_EVENT_QUERY_OP.handler_attr, None)
+    assert handler is not None
+    assert callable(handler)
+
+
+def test_event_query_handler_signature_is_typed_not_composite() -> None:
+    """Typed handler accepts operator but NOT dispatch_child (else it'd be composite)."""
+    import inspect
+
+    params = inspect.signature(VcfLogsConnector.event_query).parameters
+    assert "operator" in params
+    assert "dispatch_child" not in params
+    assert "connector" not in params
+
+
+def test_event_query_llm_instructions_advertise_the_jsonflux_handle() -> None:
+    """The typed op's copy tells the agent to expect a JSONFlux handle (moved from #834)."""
+    instructions = VRLI_EVENT_QUERY_OP.llm_instructions
+    assert instructions is not None
+    combined = f"{instructions['output_shape']} {instructions['next_step']}".lower()
+    assert "handle" in combined or "jsonflux" in combined
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-level tests (respx-mocked vRLI, fresh-boot zero catalog ingest)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    from meho_backplane.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def _captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    events: list[Any] = []
+
+    async def _capture(event: Any) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+async def _seed_target() -> Any:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            tenant_id=VRLI_CANARY_OPERATOR_TENANT,
+            name=_TARGET_NAME,
+            aliases=[],
+            product=VcfLogsConnector.product,
+            host=VRLI_CANARY_BASE_URL.removeprefix("https://"),
+            port=443,
+            fqdn=None,
+            secret_ref="vrli/vrli-typed",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint=VRLI_CANARY_FINGERPRINT,
+            notes="seeded by test_connectors_vcf_logs_typed_event_query",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _resolve_connector() -> VcfLogsConnector:
+    registry = all_connectors_v2()
+    connector_cls = registry.get((VcfLogsConnector.product, VRLI_VERSION, VRLI_IMPL_ID))
+    assert connector_cls is VcfLogsConnector
+    instance = get_or_create_connector_instance(connector_cls)
+    instance._credentials._loader = _vrli_credentials_loader  # type: ignore[attr-defined]
+    instance._session_tokens.clear()
+    return instance
+
+
+@dataclass(frozen=True)
+class _Bundle:
+    connector_instance: VcfLogsConnector
+    db_target: Any
+
+
+@pytest.fixture
+async def vrli_typed_canary(_captured_events: list[Any]) -> AsyncIterator[_Bundle]:
+    """Dispatcher-ready setup: descriptors (incl. the typed events row) + respx vRLI."""
+    del _captured_events
+    await _insert_vrli_descriptors()
+    seeded_target = await _seed_target()
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=VRLI_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_vrli_routes(mock)
+        try:
+            yield _Bundle(connector_instance=instance, db_target=seeded_target)
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+
+async def test_event_query_dispatches_as_typed_on_fresh_boot(
+    vrli_typed_canary: _Bundle,
+) -> None:
+    """AC #1: vrli.event.query dispatches through the full stack, source_kind=typed."""
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VRLI_CONNECTOR_ID,
+            "op_id": VRLI_EVENT_QUERY_OP.op_id,
+            "target": {"name": _TARGET_NAME},
+            "params": {"constraints": ""},
+        },
+    )
+    assert result["status"] == "ok", f"typed event query did not dispatch ok: {result!r}"
+
+    # The op the dispatcher resolved is a typed row with a handler_ref — never
+    # an ingested descriptor (AC #3 / the #2262 registration invariant).
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == VRLI_EVENT_QUERY_OP.op_id,
+                    EndpointDescriptor.product == "vrli",
+                )
+            )
+        ).scalar_one()
+    assert row.source_kind == "typed", (
+        f"vrli.event.query must resolve through a typed row, not source_kind={row.source_kind!r}"
+    )
+    assert row.handler_ref and row.handler_ref.endswith("VcfLogsConnector.event_query")
+
+
+async def test_no_ingested_events_query_row_exists(vrli_typed_canary: _Bundle) -> None:
+    """AC #3: no ``ingested`` descriptor targets the raw events query path.
+
+    The typed op owns the events surface; the canary's ``_insert_vrli_descriptors``
+    seeds the six ingested core ops (none of them the events query) plus the one
+    typed events row. A ``source_kind='ingested'`` row on ``/api/v2/events/``
+    would mean the curation still flips it — the #2262 violation.
+    """
+    del vrli_typed_canary
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        ingested_events = (
+            (
+                await session.execute(
+                    select(EndpointDescriptor).where(
+                        EndpointDescriptor.product == "vrli",
+                        EndpointDescriptor.source_kind == "ingested",
+                        EndpointDescriptor.path.like("/api/v2/events/%"),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert not ingested_events, (
+        f"no ingested vRLI row may target the raw events path after #2295; "
+        f"found {[r.op_id for r in ingested_events]!r}"
+    )
+
+
+async def test_event_query_limit_flows_to_the_wire(_captured_events: list[Any]) -> None:
+    """A ``limit`` param reaches the appliance as a query param on the events GET.
+
+    Standalone setup (own respx) so the captured events route is the one the
+    dispatch actually hits — nesting a second ``respx.mock`` under the shared
+    happy-path fixture would route the request to the fixture's uncaptured
+    events route instead.
+    """
+    del _captured_events
+    await _insert_vrli_descriptors()
+    await _seed_target()
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=VRLI_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        mock.post("/api/v2/sessions").respond(
+            200, json={"sessionId": VRLI_CANARY_SESSION_ID, "ttl": 1800}
+        )
+        events_route = mock.get("/api/v2/events/").respond(200, json=VRLI_CANARY_EVENTS)
+        try:
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VRLI_CONNECTOR_ID,
+                    "op_id": VRLI_EVENT_QUERY_OP.op_id,
+                    "target": {"name": _TARGET_NAME},
+                    "params": {"constraints": "", "limit": 5},
+                },
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+    assert result["status"] == "ok", f"limited event query did not dispatch ok: {result!r}"
+    assert events_route.called
+    assert dict(events_route.calls.last.request.url.params) == {"limit": "5"}
+
+
+async def test_event_query_reserved_constraint_keeps_slash_literal_on_wire(
+    _captured_events: list[Any],
+) -> None:
+    """The typed path renders a reserved constraint with literal slashes (#2003).
+
+    The overlay existed partly because the ingested ``{+path}`` render was
+    broken; the typed handler builds the sub-path itself. A ``%2F``-mangled URL
+    would miss the literal-slash respx route and 404 against the catch-all.
+    """
+    del _captured_events
+    await _insert_vrli_descriptors()
+    await _seed_target()
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=VRLI_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        mock.post("/api/v2/sessions").respond(
+            200, json={"sessionId": VRLI_CANARY_SESSION_ID, "ttl": 1800}
+        )
+        reserved_route = mock.get(VRLI_RESERVED_CONSTRAINT_WIRE_PATH).respond(
+            200, json=VRLI_CANARY_EVENTS
+        )
+        try:
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VRLI_CONNECTOR_ID,
+                    "op_id": VRLI_EVENT_QUERY_OP.op_id,
+                    "target": {"name": _TARGET_NAME},
+                    "params": {"constraints": VRLI_RESERVED_CONSTRAINT_VALUE},
+                },
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+    assert result["status"] == "ok", f"reserved-constraint dispatch failed: {result!r}"
+    assert reserved_route.called, "the literal-slash wire route was never hit (over-encoded %2F)"
+    assert (
+        reserved_route.calls.last.request.url.path
+        == "/api/v2/events/text/CONTAINS error/hostname/CONTAINS vcsa"
+    )
+
+
+async def test_event_query_440_recovers_on_the_typed_path(
+    _captured_events: list[Any],
+) -> None:
+    """AC #2: a 440 mid-session recovers via one re-login + retry on the typed path.
+
+    The soak-famous #1135 / #1139 scenario, pinned at the dispatch level: the
+    typed handler routes through ``_get_json_with_session_retry``, so a 440 on
+    the events GET invalidates the cached token, re-logs in, and retries once.
+    """
+    del _captured_events
+    await _insert_vrli_descriptors()
+    target = await _seed_target()
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=VRLI_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        session_route = mock.post("/api/v2/sessions")
+        session_route.side_effect = [
+            httpx.Response(200, json={"sessionId": VRLI_CANARY_SESSION_ID, "ttl": 1800}),
+            httpx.Response(200, json={"sessionId": VRLI_CANARY_SESSION_REFRESH_ID, "ttl": 1800}),
+        ]
+        events_route = mock.get("/api/v2/events/")
+        events_route.side_effect = [
+            httpx.Response(440, json={"errorMessage": "Login Timeout"}),
+            httpx.Response(200, json=VRLI_CANARY_EVENTS),
+        ]
+        try:
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VRLI_CONNECTOR_ID,
+                    "op_id": VRLI_EVENT_QUERY_OP.op_id,
+                    "target": {"name": _TARGET_NAME},
+                    "params": {"constraints": ""},
+                },
+            )
+            # Read the token cache before aclose() clears it.
+            cached = instance._session_tokens.get(target_cache_key(target))
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+    assert result["status"] == "ok", f"440 recovery on the typed path failed: {result!r}"
+    assert session_route.call_count == 2, "expected initial + post-440 re-login"
+    assert events_route.call_count == 2, "expected 440 + retry"
+    assert cached == VRLI_CANARY_SESSION_REFRESH_ID, (
+        f"post-retry token should be the refreshed id; got {cached!r}"
+    )

--- a/docs/codebase/connectors-vcf-logs.md
+++ b/docs/codebase/connectors-vcf-logs.md
@@ -17,8 +17,11 @@ spelling resolves this hand-rolled connector rather than an auto-shim
 This is one of the four VCF management-plane connectors landing under
 Initiative #369 (G3.6). The wave is generic-ingested via G0.7 — this
 Task ships only the **skeleton** (auth + fingerprint + probe + the
-G0.6 dispatch shim). Operations arrive in #834 via spec ingestion of
-`vcf-logs-9.0/openapi.yaml`.
+G0.6 dispatch shim). Most operations arrive in #834 via spec ingestion of
+`vcf-logs-9.0/openapi.yaml`; the headline events query is the exception —
+since #2295 it is the `vrli.event.query` **typed** op registered in code
+(see Key types), dispatched on the connector session with zero catalog
+ingest as the first conversion in Initiative #2266.
 
 The connector imports its auth scaffolding from the shared
 `connectors/_shared/vcf_auth.py` module (#841 G3.6-T13) — vRLI is the
@@ -68,13 +71,25 @@ typed and profiled paths is proven in
   model satisfies it structurally once the column lands.
 - **`VRLI_CORE_OPS` / `VRLI_CORE_GROUPS` / `apply_vrli_core_curation`** —
   `connectors/vcf_logs/core_ops.py` (#834 G3.6-T5). The
-  operator-review metadata + driver for the read-only v0.5 core
-  (7 ops across 5 groups: `vrli.about`, `vrli.event.query`,
+  operator-review metadata + driver for the curated ingested read core.
+  Since #2295 this carries **6** ops across 5 groups (`vrli.about`,
   `vrli.aggregated.query`, `vrli.field.list`, `vrli.host.list`,
-  `vrli.content.pack.list`, `vrli.alert.list`). The path-prefix
-  classifier `classify_vrli_op` rejects non-`GET` methods so write
-  ops never land under a curated group — same shape Harbor + NSX
-  use.
+  `vrli.content.pack.list`, `vrli.alert.list`) — the raw events query
+  moved to a typed op (below). The path-prefix classifier
+  `classify_vrli_op` rejects non-`GET` methods so write ops never land
+  under a curated group — same shape Harbor + NSX use.
+- **`VRLI_EVENT_QUERY_OP` / `event_query_impl` / `register_vrli_typed_operations`** —
+  `connectors/vcf_logs/typed_ops.py` (#2295). vRLI's first
+  `source_kind="typed"` op, `vrli.event.query`: a bound method on the
+  connector (`VcfLogsConnector.event_query`) that issues
+  `GET /api/v2/events/<constraints>` (optional `limit`) directly on the
+  connector session via `_get_json_with_session_retry`. Registered at
+  lifespan through the typed-op registrar (queued in the package
+  `__init__`), so it dispatches with **zero catalog ingest** — no
+  `endpoint_descriptor` ingested row. `build_event_query_path` renders the
+  reserved-expansion constraint sub-path with literal slashes (#2003/#2066).
+  Mirrors `vmware_rest/typed_ops.py` (`vmware.host.usage`, #2257) and
+  `argocd/ops.py`.
 - **Re-exports of the shared module**: `VcfCredentialsLoader`,
   `load_credentials_from_vault` (default stub),
   `SessionLoginError` — callers should import these from
@@ -168,6 +183,14 @@ into the dispatcher's auth-class arm: the connector exposes a public
 dispatched vRLI GET recovers the same way a direct
 `_get_json_with_session_retry` call does. The helper is retained for its
 direct callers and shares the one `_invalidate_session` eviction.
+
+Since #2295 the typed `vrli.event.query` op is one of those direct callers:
+its handler routes through `_get_json_with_session_retry`, so it recovers a
+440/401 via the helper's own re-login + retry-once rather than the #2067
+dispatch-path seam (a typed handler owns its transport call, so the
+dispatch-path `invalidate_session` hook does not wrap it). The remaining six
+curated read ops still dispatch as `source_kind='ingested'` and rely on the
+#2067 dispatch-path recovery.
 
 ### Fingerprint + probe
 
@@ -300,8 +323,14 @@ External: `httpx>=0.27` (Bearer header + `AsyncClient`), `structlog`
   [`docs/cross-repo/vcf-logs-onboarding.md`](../cross-repo/vcf-logs-onboarding.md).
 - End-to-end recorded-fixture coverage (G3.6-T6 #838):
   [`backend/tests/test_connectors_vcf_logs_e2e.py`](../../backend/tests/test_connectors_vcf_logs_e2e.py)
-  — exercises all 7 ops through the full dispatcher, the
+  — exercises the 6 ingested ops through the full dispatcher, the
   session-establish + session-expiry retry-once (440 and 401) +
   second-expiry-fails paths via `_get_json_with_session_retry`, the
-  audit-row contract, and the JSONFlux handle path on
+  audit-row contract, and the JSONFlux handle path on the typed
   `vrli.event.query`.
+- Typed events-query coverage (#2295):
+  [`backend/tests/test_connectors_vcf_logs_typed_event_query.py`](../../backend/tests/test_connectors_vcf_logs_typed_event_query.py)
+  — dispatch-level `source_kind="typed"` dispatch on a fresh boot, the
+  440 recovery on the typed path, the reserved-constraint literal-slash
+  wire path, the `limit` query param, and the registration invariant
+  (no ingested events row).


### PR DESCRIPTION
## Summary

- Converts vRLI's headline events query to `vrli.event.query`, a `source_kind="typed"` bound method (`VcfLogsConnector.event_query`) that issues `GET /api/v2/events/<constraints>` (optional `limit`) directly on the connector's authenticated session, so it dispatches on a **fresh boot with zero catalog ingest** — no longer coupled to per-deploy `endpoint_descriptor` state (the #2247 failure class Initiative #2266 retires for the VCF family).
- Routes the query through `_get_json_with_session_retry`, so a 440/401 mid-session recovers via one re-login + retry (the #1909/#1135 soak scenario), and renders the reserved-expansion constraint sub-path with literal slashes (`build_event_query_path`) so it reaches the appliance intact (#2003/#2066).
- Drops the events query from `vcf_logs/core_ops.py`'s ingested curation (`VRLI_CORE_OPS` 7 → 6); the typed op is queued onto the lifespan registrar in the package `__init__`, mirroring the vmware/argocd typed-op mold.
- Updates the integration double (`tests/acceptance/_vrli_canary_fixtures.py`) to seed the typed events descriptor (the known integration-testcontainers trap), plus `docs/codebase/connectors-vcf-logs.md` and a CHANGELOG entry.

### The other six curated ops — declined from typed conversion (per issue scope)

Per the audited scope (#2294), only the events query is converted. The other six curated ops are **declined** from typed conversion — unused in the adopter's real operations (the hourly sentry cron + incident log pulls run only the events query), and the ingested canonical spec covers the browse/compose-context case:

- **`vrli.about`** (`GET /api/v2/version`) — a pre-flight probe already served by `fingerprint()`/`probe()`; not run by the cron.
- **`vrli.aggregated.query`** (`GET /api/v2/aggregated-events/{constraints}`) — group-by aggregation the adopter's raw-line pulls don't use.
- **`vrli.field.list`** (`GET /api/v2/fields`) — agent compose-context (confirm a field name); browse-only, covered by ingested spec.
- **`vrli.host.list`** (`GET /api/v2/hosts`) — compose-context inventory; browse-only.
- **`vrli.content.pack.list`** (`GET /api/v2/content/contentpack/list`) — audit/browse of installed content packs.
- **`vrli.alert.list`** (`GET /api/v2/alerts`) — audit/browse of alert definitions.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on all changed files
- [x] `mypy src/meho_backplane/connectors/vcf_logs/` — clean
- [x] New `tests/test_connectors_vcf_logs_typed_event_query.py` — 17 tests: handler-level builder/limit/coercion + **dispatch-level** (`call_operation`) `source_kind="typed"` on fresh boot (AC #1), 440 recovery on the typed path (AC #2), no-ingested-events-row registration invariant (AC #3 / #2262), `limit` on the wire, reserved-constraint literal-slash wire path
- [x] `test_connectors_vcf_logs_core_ops.py` / `_e2e.py` updated to 6 ingested ops; e2e JSONFlux handle test now drives the typed op — all pass
- [x] `test_connectors_vmware_rest_composites_register.py` (lifespan registrar + two-world sweep) — pass, confirming the vRLI typed registrar boots and its `handler_ref` resolves
- [x] `test_connectors_vrli_profile_parity.py` — pass
- [x] No FastAPI route/schema touched → **no OpenAPI snapshot delta** (AC #7, verified by inspection)

## Out of scope

- **Overlay retirement** (delete the gist overlay, coordinated with the RDC team on `evoila-bosnia/claude-rdc-hetzner-dc#1790`) — a required AC that is purely external coordination on another repo; the code side (typed op + core_ops flip removed) is done here. The canonical-spec blockers the overlay worked around (#2066, #1796) are fixed in v0.20.0.
- Migrating `VcfLogsConnector` to `ProfiledRestConnector` (a #1964-world concern; the profile stays the declared-status source).
- The other five products (T2–T6) and curation-apparatus retirement (T7).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2295
