### PR TITLE
feat(connectors): vROps typed reads on the Basic+auth_source session (#2303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — vROps typed reads (liveness, alerts, resource query) (#2303)
+
+- The vROps (`vcf-operations`) connector's audited read set now dispatches
+  as **typed** ops (`source_kind="typed"`) directly on its hand-rolled HTTP
+  Basic (+ optional `auth-source`) session, so they work on a fresh boot
+  with **zero catalog ingest** (no per-deploy spec ingestion or operator
+  review): `vrops.liveness` (`GET /suite-api/api/versions/current` — the
+  documented reachability surface; the adopter's `casa/health` names a
+  private/undocumented CaSA API), `vrops.alert.list`
+  (`GET /suite-api/api/alerts` alert triage), and `vrops.resource.query`
+  (a body-shaped `POST /suite-api/api/resources/query` with a typed
+  `ResourceQuerySpec` request body). All three are read-only, `safe`, no
+  approval. The two converted GET reads are removed from the `core_ops.py`
+  ingested curation so the ingested twin is never flipped alongside the
+  typed op (the #2262 no-shadow invariant); the remaining 6 ingested-browse
+  ops stay curated as breadth until the Initiative #2266 T7 apparatus
+  retirement. Unconverted curated ops (resource list/get, alert
+  definitions, symptoms, recommendations, super metrics) are declined from
+  typed conversion — not in the adopter's audited operational set. (#2303)
+
 ### Added — persisted spec provenance at ingest (sha256 + origin + operator/timestamp, surfaced in review) (#2291)
 
 - Every accepted spec ingest now writes a durable, non-spoofable

--- a/backend/src/meho_backplane/connectors/vcf_operations/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/__init__.py
@@ -61,6 +61,12 @@ from meho_backplane.connectors.vcf_operations.session import (
     VcfOperationsTargetLike,
     load_credentials_from_vault,
 )
+from meho_backplane.connectors.vcf_operations.typed_ops import (
+    VROPS_TYPED_OPS,
+    VropsTypedOp,
+    register_vcf_operations_typed_operations,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
 
 register_connector_v2(
     product="vrops",
@@ -82,6 +88,12 @@ register_connector_v2(
     cls=VcfOperationsConnector,
 )
 
+# Queue the typed-op upsert (the audited vROps read set, #2303) onto the
+# lifespan-driven registrar list. The runner (``run_typed_op_registrars``)
+# iterates after ``_eager_import_connectors`` so the descriptor rows land
+# before the first dispatch. Mirrors the argocd / vmware registrar wiring.
+register_typed_op_registrar(register_vcf_operations_typed_operations)
+
 __all__ = [
     "VROPS_CONNECTOR_ID",
     "VROPS_CORE_GROUPS",
@@ -89,13 +101,16 @@ __all__ = [
     "VROPS_IMPL_ID",
     "VROPS_PATH_RULES",
     "VROPS_PRODUCT",
+    "VROPS_TYPED_OPS",
     "VROPS_VERSION",
     "VcfOperationsConnector",
     "VcfOperationsCredentialsLoader",
     "VcfOperationsTargetLike",
     "VropsCoreGroup",
     "VropsCoreOp",
+    "VropsTypedOp",
     "apply_vrops_core_curation",
     "classify_vrops_op",
     "load_credentials_from_vault",
+    "register_vcf_operations_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/vcf_operations/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/connector.py
@@ -105,6 +105,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import urlencode
 
 import httpx
 import structlog
@@ -132,6 +133,12 @@ from meho_backplane.connectors.vcf_operations.session import (
 __all__ = ["VcfOperationsConnector"]
 
 _log = structlog.get_logger(__name__)
+
+#: Spec-relative paths the typed read ops (#2303) hit on the connector's
+#: HTTP Basic (+ optional auth-source) session.
+_VERSIONS_CURRENT_PATH = "/suite-api/api/versions/current"
+_ALERTS_PATH = "/suite-api/api/alerts"
+_RESOURCES_QUERY_PATH = "/suite-api/api/resources/query"
 
 
 class VcfOperationsConnector(HttpConnector):
@@ -261,6 +268,49 @@ class VcfOperationsConnector(HttpConnector):
             extra_headers=extra_headers,
         )
 
+    async def _post_json(
+        self,
+        target: VcfOperationsTargetLike,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Thread the auth-source (and caller) query params onto a non-idempotent request.
+
+        The base :meth:`HttpConnector._post_json` neither routes through
+        :meth:`_request_json` (so the auth-source merge there is bypassed)
+        nor accepts a ``params`` mapping. vROps still needs
+        ``?auth-source=<value>`` on **every** authenticated request when the
+        target federates identity, so this override merges the per-target
+        auth-source contribution (:meth:`_auth_query_params`) with any
+        caller-supplied ``params`` and encodes them onto the URL before
+        delegating to the base implementation. Caller params win on a key
+        clash — the same precedence the :meth:`_request_json` override
+        documents. ``doseq=True`` so a list value (a repeated query param)
+        serialises to repeated ``key=a&key=b`` pairs rather than a bracketed
+        string.
+        """
+        merged: dict[str, Any] = dict(self._auth_query_params(target))
+        if params:
+            merged.update({key: value for key, value in params.items() if value is not None})
+        if merged:
+            separator = "&" if "?" in path else "?"
+            path = f"{path}{separator}{urlencode(merged, doseq=True)}"
+        return await super()._post_json(
+            target,
+            path,
+            operator=operator,
+            verb=verb,
+            json=json,
+            data=data,
+            extra_headers=extra_headers,
+        )
+
     async def fingerprint(
         self,
         target: VcfOperationsTargetLike,
@@ -376,6 +426,98 @@ class VcfOperationsConnector(HttpConnector):
             op_id=op_id,
             target=target,
             params=params,
+        )
+
+    # ------------------------------------------------------------------
+    # Typed read ops (Initiative #2266 T3, #2303)
+    #
+    # Each handler is a thin read directly on the connector's HTTP Basic
+    # (+ optional auth-source) session — no dispatch_child, no ingested
+    # descriptor — so the op works on a fresh boot with zero catalog
+    # ingest (the #2262 invariant). The dispatcher binds these bound
+    # methods to the per-process connector instance and threads
+    # ``operator`` / ``target`` / ``params`` by name (see
+    # :func:`~meho_backplane.operations._branches.dispatch_typed`). The op
+    # metadata + registrar live in
+    # :mod:`meho_backplane.connectors.vcf_operations.typed_ops`.
+    # ------------------------------------------------------------------
+
+    async def liveness(
+        self,
+        operator: Operator,
+        target: VcfOperationsTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vrops.liveness`` — ``GET /suite-api/api/versions/current``.
+
+        Reachability + identity probe. Returns the appliance's
+        ``releaseName`` / ``buildNumber`` (and ``humanlyReadableReleaseName``
+        when present) — the same surface :meth:`fingerprint` reads, exposed
+        as an agent-callable typed op. The auth-source query param is merged
+        by the :meth:`_request_json` override.
+        """
+        del params  # schema declares the param object empty
+        return await self._get_json(target, _VERSIONS_CURRENT_PATH, operator=operator)
+
+    async def alert_list(
+        self,
+        operator: Operator,
+        target: VcfOperationsTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vrops.alert.list`` — ``GET /suite-api/api/alerts``.
+
+        Optional ``activeOnly`` / ``alertCriticality`` / ``alertStatus`` /
+        ``resourceId`` filters and ``page`` / ``pageSize`` pagination ride as
+        query params (auth-source merged by the :meth:`_request_json`
+        override). ``resourceId`` is a list — httpx serialises it to repeated
+        ``resourceId=a&resourceId=b`` pairs.
+        """
+        query: dict[str, Any] = {}
+        for key in ("activeOnly", "alertCriticality", "alertStatus", "page", "pageSize"):
+            value = params.get(key)
+            if value is not None:
+                query[key] = value
+        resource_ids = [rid for rid in (params.get("resourceId") or []) if isinstance(rid, str)]
+        if resource_ids:
+            query["resourceId"] = resource_ids
+        return await self._get_json(target, _ALERTS_PATH, operator=operator, params=query or None)
+
+    async def resource_query(
+        self,
+        operator: Operator,
+        target: VcfOperationsTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vrops.resource.query`` — ``POST /suite-api/api/resources/query``.
+
+        A body-shaped POST: the ``ResourceQuerySpec`` fields
+        (:data:`~meho_backplane.connectors.vcf_operations.typed_ops.VROPS_RESOURCE_QUERY_BODY_FIELDS`)
+        form the JSON request body; ``page`` / ``pageSize`` ride as query
+        params. The auth-source query param is merged by the
+        :meth:`_post_json` override (the base ``_post_json`` bypasses the
+        ``_request_json`` auth-source seam).
+        """
+        from meho_backplane.connectors.vcf_operations.typed_ops import (
+            VROPS_RESOURCE_QUERY_BODY_FIELDS,
+        )
+
+        body: dict[str, Any] = {}
+        for key in VROPS_RESOURCE_QUERY_BODY_FIELDS:
+            value = params.get(key)
+            if value is not None:
+                body[key] = value
+        query: dict[str, Any] = {}
+        for key in ("page", "pageSize"):
+            value = params.get(key)
+            if value is not None:
+                query[key] = value
+        return await self._post_json(
+            target,
+            _RESOURCES_QUERY_PATH,
+            operator=operator,
+            json=body,
+            params=query or None,
         )
 
     async def aclose(self) -> None:

--- a/backend/src/meho_backplane/connectors/vcf_operations/core_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/core_ops.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""vROps 9.0 read-only v0.5 core — curated operator-enabled subset.
+"""vROps 9.0 read-only v0.5 core — curated ingested-browse subset.
 
-This module names the **8 read-only vROps operations** the G3.6
-vcf-operations v0.5 ship enables out of the much larger vROps
-``/suite-api`` corpus the G0.7 spec-ingestion pipeline lands under
-``connector_id="vrops-rest-9.0"``. The curation is two-layered:
+This module names the **6 read-only vROps operations** the vcf-operations
+ship keeps as ``is_enabled`` curation over ingested rows out of the much
+larger vROps ``/suite-api`` corpus the G0.7 spec-ingestion pipeline lands
+under ``connector_id="vrops-rest-9.0"``. The curation is two-layered:
 
 * :data:`VROPS_CORE_GROUPS` — the operator-reviewed ``when_to_use``
   hint per LLM-grouping pass output group. Each entry's ``group_key``
@@ -14,7 +14,7 @@ vcf-operations v0.5 ship enables out of the much larger vROps
   ops; the ``when_to_use`` is what the agent reads verbatim through
   :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
   to pick a group to search within.
-* :data:`VROPS_CORE_OPS` — the 8 ``EndpointDescriptor.op_id`` strings
+* :data:`VROPS_CORE_OPS` — the 6 ``EndpointDescriptor.op_id`` strings
   that flip to ``is_enabled=True`` at operator-review time, paired
   with the per-op ``llm_instructions`` blob the agent inlines into
   the reasoning context when it sees the op in
@@ -23,36 +23,40 @@ vcf-operations v0.5 ship enables out of the much larger vROps
   ``is_enabled=False`` (the G0.7 ingestion default for
   ``source_kind='ingested'`` rows).
 
-Per Initiative #369 and CLAUDE.md postulates 1-2, vROps is **fully
-generic-ingested**: the underlying ops are not registered in code,
-they live in the ``endpoint_descriptor`` table. This module only
-carries the **operator-review metadata** the substrate uses at the
-review step — the actual curation is applied through
-:func:`apply_vrops_core_curation` against an existing ingested
-connector.
+Converted to typed ops (Initiative #2266 T3, #2303)
+---------------------------------------------------
 
-The 8 ops (paths cross-checked against the Broadcom vROps suite-api
-docs at https://developer.broadcom.com/xapis/vrealize-operations-manager-api/latest/):
+The adopter's *audited* read set — the appliance liveness probe
+(``GET:/suite-api/api/versions/current``, formerly ``vrops.about``) and
+the alert list (``GET:/suite-api/api/alerts``, formerly ``vrops.alert.list``)
+— is now shipped as **typed** ops (``vrops.liveness`` / ``vrops.alert.list``)
+in :mod:`meho_backplane.connectors.vcf_operations.typed_ops`, dispatched
+directly on the connector's hand-rolled session with zero catalog ingest.
+The audited ``POST:/suite-api/api/resources/query`` lookup lands there too
+as ``vrops.resource.query``. Those two GET rows are therefore **removed
+from this curation** so the ingested twin is never flipped alongside the
+typed op (the #2262 no-shadow invariant). The remaining 6 ops below stay
+ingested-curated so the ingested breadth catalog keeps covering the
+browse case; retiring the whole apparatus is Initiative #2266 T7.
 
-1. ``GET:/suite-api/api/versions/current`` — ``vrops.about`` — appliance
-   version + build (the same surface :meth:`VcfOperationsConnector.fingerprint`
-   already consumes; exposing it as an operator-callable op lets the agent
-   run a sanity probe before any heavier read).
-2. ``GET:/suite-api/api/resources`` — ``vrops.resource.list`` — resource
+The 6 remaining curated ops (paths cross-checked against the Broadcom
+vROps suite-api docs at
+https://developer.broadcom.com/xapis/vrealize-operations-manager-api/latest/):
+
+1. ``GET:/suite-api/api/resources`` — ``vrops.resource.list`` — resource
    inventory filterable by ``resourceKind``, ``name``, or ``adapterKind``.
-3. ``GET:/suite-api/api/resources/{id}`` — ``vrops.resource.get`` — full
+   (The typed ``vrops.resource.query`` POST is the richer counterpart.)
+2. ``GET:/suite-api/api/resources/{id}`` — ``vrops.resource.get`` — full
    detail for one resource by id, including identifiers and credential
    refs (no secret values).
-4. ``GET:/suite-api/api/alerts`` — ``vrops.alert.list`` — current and
-   historical alerts (filter by ``activeOnly``, ``alertCriticality``).
-5. ``GET:/suite-api/api/alertdefinitions`` — ``vrops.alertdefinition.list``
+3. ``GET:/suite-api/api/alertdefinitions`` — ``vrops.alertdefinition.list``
    — the configured alert definitions (the policy surface the alert
    list rolls up against).
-6. ``GET:/suite-api/api/symptoms`` — ``vrops.symptom.list`` — currently
+4. ``GET:/suite-api/api/symptoms`` — ``vrops.symptom.list`` — currently
    firing symptoms; the per-condition signal that rolls up into alerts.
-7. ``GET:/suite-api/api/recommendations`` — ``vrops.recommendation.list``
+5. ``GET:/suite-api/api/recommendations`` — ``vrops.recommendation.list``
    — operator-facing remediation hints attached to alerts / symptoms.
-8. ``GET:/suite-api/api/supermetrics`` — ``vrops.supermetric.list`` —
+6. ``GET:/suite-api/api/supermetrics`` — ``vrops.supermetric.list`` —
    user-defined metric formulae, useful when answering "which metric
    formula was used to compute X".
 
@@ -83,7 +87,7 @@ Curation application
 --------------------
 
 :func:`apply_vrops_core_curation` is the operator-review-time
-substrate call that makes exactly the 8 curated ops dispatchable.
+substrate call that makes exactly the 6 curated ops dispatchable.
 Mirrors :func:`apply_nsx_core_curation` and
 :func:`apply_harbor_core_curation` verbatim, threading the
 "enable group but pin non-core ops disabled" needle via the
@@ -240,21 +244,12 @@ def classify_vrops_op(op_id: str) -> str:
     return "none"
 
 
-#: Operator-reviewed ``when_to_use`` hints for the 7 vROps groups
-#: the read-only v0.5 core spans. Every hint is one complete sentence
+#: Operator-reviewed ``when_to_use`` hints for the 5 vROps groups
+#: the ingested-browse core spans (the liveness + alerts groups moved
+#: to the typed surface in #2303). Every hint is one complete sentence
 #: the agent reads verbatim — vague hints poison
 #: ``search_operations`` ranking, per the ai_engineering pack.
 VROPS_CORE_GROUPS: Final[tuple[VropsCoreGroup, ...]] = (
-    VropsCoreGroup(
-        group_key="vrops-system",
-        name="vROps (system / about)",
-        when_to_use=(
-            "Use this group to read the vROps appliance's own identity — "
-            "release name and build number. The probe surface the agent "
-            "calls before any heavier inventory read, or when confirming "
-            "which vROps instance the target points at."
-        ),
-    ),
     VropsCoreGroup(
         group_key="vrops-resources",
         name="vROps Resources",
@@ -265,17 +260,6 @@ VROPS_CORE_GROUPS: Final[tuple[VropsCoreGroup, ...]] = (
             "any vROps workflow; filter by resourceKind, adapterKind, or "
             "name to narrow large fleets. Drill into one resource by id "
             "for credential references and full identifiers."
-        ),
-    ),
-    VropsCoreGroup(
-        group_key="vrops-alerts",
-        name="vROps Alerts",
-        when_to_use=(
-            "Use this group to list currently firing or recently resolved "
-            "alerts. Filter by activeOnly to focus on the open set, or by "
-            "alertCriticality for severity-scoped views. Each alert ties "
-            "back to an alert definition via alertDefinitionId and to a "
-            "resource via resourceId."
         ),
     ),
     VropsCoreGroup(
@@ -345,36 +329,13 @@ def _instructions(
     }
 
 
-#: The 8 curated read-only vROps core ops. Each entry carries the
+#: The 6 curated read-only vROps ingested-browse ops. Each entry carries the
 #: op_id (``GET:/path`` form), the curated group assignment, and the
 #: operator-reviewed ``llm_instructions`` blob.
 #:
 #: Paths cross-checked against the vROps suite-api docs at
 #: https://developer.broadcom.com/xapis/vrealize-operations-manager-api/latest/.
 VROPS_CORE_OPS: Final[tuple[VropsCoreOp, ...]] = (
-    VropsCoreOp(
-        op_id="GET:/suite-api/api/versions/current",
-        group_key="vrops-system",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to read the vROps appliance identity: release name "
-                "and build number. Useful as a pre-flight probe before "
-                "heavier inventory reads, or to confirm which vROps "
-                "instance the target points at. The same endpoint the "
-                "connector's fingerprint surface consumes."
-            ),
-            output_shape=(
-                "Object with releaseName (e.g. '9.0.0.1.23456789'), "
-                "buildNumber (int), and optionally "
-                "humanlyReadableReleaseName when the appliance emits it."
-            ),
-            next_step=(
-                "If the version looks healthy, proceed to "
-                "vrops.resource.list for the inventory entry point, or "
-                "vrops.alert.list for the operational signal surface."
-            ),
-        ),
-    ),
     VropsCoreOp(
         op_id="GET:/suite-api/api/resources",
         group_key="vrops-resources",
@@ -427,35 +388,6 @@ VROPS_CORE_OPS: Final[tuple[VropsCoreOp, ...]] = (
                 "vrops.alert.list (?resourceId=<uuid>) to find "
                 "alerts firing on it, or with vrops.symptom.list to "
                 "see the underlying signal layer."
-            ),
-        ),
-    ),
-    VropsCoreOp(
-        op_id="GET:/suite-api/api/alerts",
-        group_key="vrops-alerts",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to list currently firing or recently resolved "
-                "alerts. Accepts activeOnly (bool, default false), "
-                "alertCriticality (CRITICAL / IMMEDIATE / WARNING / "
-                "INFORMATION / UNKNOWN), alertStatus (ACTIVE / CANCELED "
-                "/ SUSPENDED / UPDATED), and resourceId (UUID) query "
-                "parameters. Supports pagination via page + pageSize; "
-                "large alert sets return a JSONFlux handle."
-            ),
-            output_shape=(
-                "Object with alerts[]; each entry carries alertId (UUID), "
-                "alertDefinitionId, alertDefinitionName, alertLevel "
-                "(0..5), alertImpact, resourceId, startTimeUTC, "
-                "cancelTimeUTC, status, and controlState. Also returns "
-                "pageInfo and links."
-            ),
-            next_step=(
-                "Surface the high-criticality alerts to the operator; "
-                "cross-reference alertDefinitionId with "
-                "vrops.alertdefinition.list for policy context, "
-                "resourceId with vrops.resource.get for affected-object "
-                "detail."
             ),
         ),
     ),
@@ -565,51 +497,34 @@ async def apply_vrops_core_curation(
     *,
     tenant_id: UUID | None,
 ) -> None:
-    """Apply the curated 8-op read core against an ingested vROps connector.
+    """Apply the curated 6-op read core against an ingested vROps connector.
 
     Drives the substrate so that, after this call returns, exactly
-    the 8 ops in :data:`VROPS_CORE_OPS` are dispatchable
+    the 6 ops in :data:`VROPS_CORE_OPS` are dispatchable
     (``is_enabled=True``) and every other ingested op stays
-    ``is_enabled=False``. The 7 curated groups land
-    ``review_status='enabled'`` so the agent's
-    :func:`~meho_backplane.operations.meta_tools.search_operations`
-    surfaces the core ops; non-curated groups are left untouched
-    (``review_status='staged'`` from the G0.7 ingest default).
+    ``is_enabled=False``. The 5 curated groups land
+    ``review_status='enabled'`` so the agent's ``search_operations``
+    surfaces them; non-curated groups stay ``review_status='staged'``.
 
-    The substrate doesn't expose "enable only ops X, Y, Z under
-    group G": :meth:`ReviewService.enable_group`'s cascade flips
-    ``is_enabled=True`` on every child op in the group. The helper
-    works around this via the audit-log-driven operator-override
-    exclusion — the same mechanism
-    :func:`~meho_backplane.connectors.nsx.core_ops.apply_nsx_core_curation`
-    and :func:`~meho_backplane.connectors.harbor.core_ops.apply_harbor_core_curation`
-    established:
+    The substrate doesn't expose "enable only ops X, Y, Z under group
+    G": :meth:`ReviewService.enable_group`'s cascade flips
+    ``is_enabled=True`` on every child op in the group. The helper works
+    around this via the audit-log-driven operator-override exclusion —
+    the same mechanism ``apply_nsx_core_curation`` /
+    ``apply_harbor_core_curation`` established: (1) load the review
+    payload; (2) ``edit_op(is_enabled=False)`` every non-core child of a
+    curated group (writing the override audit row the cascade then
+    skips); (3) ``edit_group`` lands each group's ``name`` +
+    ``when_to_use``; (4) ``enable_group`` cascades ``is_enabled=True`` to
+    the curated children; (5) ``edit_op`` lands each core op's
+    ``llm_instructions``.
 
-    1. :meth:`ReviewService.get_review_payload` loads the current
-       state of every curated group and its child ops.
-    2. For each child op in a curated group that **isn't** in the
-       :data:`VROPS_CORE_OPS` allow-list,
-       :meth:`ReviewService.edit_op` with ``is_enabled=False``
-       writes the operator-override audit row. The follow-on
-       :meth:`enable_group` cascade detects these rows and skips
-       them.
-    3. :meth:`ReviewService.edit_group` lands the operator-reviewed
-       ``name`` + ``when_to_use`` on each curated group.
-    4. :meth:`ReviewService.enable_group` flips
-       ``review_status='enabled'`` and cascades ``is_enabled=True``
-       to the curated child ops (operator-overridden non-core ops
-       are skipped).
-    5. :meth:`ReviewService.edit_op` lands the curated
-       ``llm_instructions`` blob per entry in :data:`VROPS_CORE_OPS`.
-
-    Re-running is safe but not idempotent at the audit layer.
-    :meth:`enable_group` short-circuits on groups already in
-    ``review_status='enabled'`` (no audit row), but
-    :meth:`edit_group` and :meth:`edit_op` always emit one audit
-    row per call — even when the incoming value equals the
-    persisted one. The intended posture is a one-shot curation step
-    after ingest; re-runs produce redundant
-    ``meho.connector.edit_*`` audit rows but never corrupt state.
+    Re-running is safe but not idempotent at the audit layer:
+    ``enable_group`` short-circuits on already-enabled groups, but
+    ``edit_group`` / ``edit_op`` emit an audit row per call even when the
+    value is unchanged. The intended posture is a one-shot curation step
+    after ingest; re-runs produce redundant audit rows but never corrupt
+    state.
 
     Raises :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError`
     if no groups exist for ``vrops-rest-9.0`` under *tenant_id* (the

--- a/backend/src/meho_backplane/connectors/vcf_operations/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/typed_ops.py
@@ -1,0 +1,512 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) read ops for :class:`VcfOperationsConnector`.
+
+Initiative #2266 (T3, #2303) converts the vROps *audited* read set —
+the ops the adopter actually runs (audit #2294) — from ``is_enabled``
+curation over ingested ``endpoint_descriptor`` rows to **typed** ops
+(``source_kind="typed"``) dispatched directly on the connector's
+existing hand-rolled HTTP Basic (+ optional ``auth-source``) session.
+A typed op works on a fresh boot with **zero catalog ingest**: the
+dispatcher resolves its ``handler_ref`` (a bound method on
+:class:`~meho_backplane.connectors.vcf_operations.connector.VcfOperationsConnector`)
+and calls it directly, never touching an ingested descriptor row (the
+#2262 registration invariant).
+
+The audited set (three ops):
+
+* ``vrops.liveness`` — appliance liveness + identity. Reads
+  ``GET /suite-api/api/versions/current`` — the same surface
+  :meth:`VcfOperationsConnector.probe` / :meth:`fingerprint` already
+  use as vROps' reachability check. The adopter's audit named the
+  probe ``casa/health``, but the CaSA (Cluster and Slice
+  Administration) API is a **private, undocumented** surface; vROps
+  exposes no public dedicated health endpoint distinct from the
+  version surface (see the connector's "Probe" docstring). The
+  documented ``versions/current`` probe is therefore the grounded
+  liveness op. Supersedes the curated ``vrops.about``.
+* ``vrops.alert.list`` — alert triage. Reads ``GET /suite-api/api/alerts``
+  with the vROps alert filters. Supersedes the curated
+  ``GET:/suite-api/api/alerts`` ingested row.
+* ``vrops.resource.query`` — resource lookup. A **body-shaped POST**
+  to ``POST /suite-api/api/resources/query`` carrying a typed
+  ``ResourceQuerySpec`` request body (a richer query surface than the
+  ``GET /suite-api/api/resources`` list the ingested curation still
+  browses).
+
+Sibling precedent for the dataclass + registrar shape:
+:mod:`meho_backplane.connectors.argocd.ops` (metadata dataclasses here,
+thin bound-method handlers on the connector, a module-level registrar
+queued onto :func:`register_typed_op_registrar`) and
+:mod:`meho_backplane.connectors.vmware_rest.typed_ops`.
+
+Unconverted curated ops (resource list/get, alert definitions, symptoms,
+recommendations, super metrics) are **declined** from typed conversion —
+they are not in the adopter's audited operational set; the ingested
+breadth catalog still covers the browse case, and their ``is_enabled``
+curation stays in :mod:`.core_ops` until T7 retires the apparatus.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+
+if TYPE_CHECKING:
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "VROPS_ALERT_LIST_OP",
+    "VROPS_LIVENESS_OP",
+    "VROPS_RESOURCE_QUERY_BODY_FIELDS",
+    "VROPS_RESOURCE_QUERY_OP",
+    "VROPS_TYPED_OPS",
+    "VROPS_TYPED_WHEN_TO_USE_BY_GROUP",
+    "VropsTypedOp",
+    "register_vcf_operations_typed_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Group keys for the typed read surface. Chosen distinct from the
+#: ingested classifier slugs in
+#: :data:`~meho_backplane.connectors.vcf_operations.core_ops.VROPS_PATH_RULES`
+#: (``vrops-system`` / ``vrops-alerts`` / ``vrops-resources`` / ...) so
+#: the typed OperationGroup rows never share a row with the ingested
+#: browse groups and their curated ``when_to_use`` blurbs can't tug
+#: against each other.
+_LIVENESS_GROUP_KEY = "vrops-liveness"
+_ALERT_TRIAGE_GROUP_KEY = "vrops-alert-triage"
+_RESOURCE_QUERY_GROUP_KEY = "vrops-resource-query"
+
+#: Top-level ``ResourceQuerySpec`` body fields ``vrops.resource.query``
+#: forwards (a curated subset of the full spec). ``page`` / ``pageSize``
+#: are pagination *query* params, not body fields, so they are excluded
+#: here and threaded onto the URL by the handler.
+VROPS_RESOURCE_QUERY_BODY_FIELDS: tuple[str, ...] = (
+    "resourceId",
+    "name",
+    "regex",
+    "adapterKind",
+    "resourceKind",
+    "resourceState",
+    "resourceStatus",
+    "resourceHealth",
+    "parentId",
+    "statKey",
+)
+
+
+@dataclass(frozen=True)
+class VropsTypedOp:
+    """Metadata for one vROps typed op registered at lifespan startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so :func:`register_vcf_operations_typed_operations` can splat
+    the dataclass into the helper without per-op boilerplate.
+    ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.vcf_operations.connector.VcfOperationsConnector`
+    exposing the async handler; the registrar resolves the bound method
+    against the class so the dispatcher's
+    :func:`~meho_backplane.operations._handler_resolve.import_handler`
+    walk recovers the callable from the persisted ``module.ClassName.method``
+    path. Mirrors
+    :class:`~meho_backplane.connectors.argocd.ops.ArgoCdOp`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurb per typed-op group.
+#: :func:`register_typed_operation` requires a non-empty string whenever
+#: ``group_key`` is set (typed_register ``_validate_when_to_use_pairing``).
+VROPS_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    _LIVENESS_GROUP_KEY: (
+        "Use to check that a vROps (VMware Aria Operations) appliance is "
+        "reachable and to read its identity — release name and build "
+        "number. The cheap pre-flight probe to run before any heavier "
+        "alert or resource read, or when confirming which vROps instance a "
+        "target points at. Read-only."
+    ),
+    _ALERT_TRIAGE_GROUP_KEY: (
+        "Use to triage vROps alerts: list currently firing or recently "
+        "resolved alerts, filtered by whether they are still active, by "
+        "criticality, by status, or scoped to a specific resource. The "
+        "right group when the question is 'what is alerting right now?', "
+        "'show me the critical alerts', or 'what is firing on this "
+        "resource?'. Read-only."
+    ),
+    _RESOURCE_QUERY_GROUP_KEY: (
+        "Use to look up vROps-monitored resources (VMs, hosts, datastores, "
+        "cloud objects) by a structured query — match on name, regex, "
+        "adapter kind, resource kind, state, status, health, or parent — "
+        "with pagination. The right group when the question is 'find the "
+        "resource(s) matching X' or 'which monitored objects are in state "
+        "Y?'. Read-only."
+    ),
+}
+
+
+VROPS_LIVENESS_OP = VropsTypedOp(
+    op_id="vrops.liveness",
+    handler_attr="liveness",
+    summary="vROps appliance liveness and identity (release name + build number).",
+    description=(
+        "Reads GET /suite-api/api/versions/current directly on the "
+        "connector's HTTP Basic (+ optional auth-source) session — the same "
+        "surface the connector's reachability probe uses — so it works with "
+        "zero catalog ingest. Returns the appliance's releaseName and "
+        "buildNumber (and humanlyReadableReleaseName when the build emits "
+        "it). The cheap pre-flight liveness/identity probe before any "
+        "heavier vROps read. vROps exposes no public dedicated health "
+        "endpoint distinct from the version surface (the CaSA API is "
+        "private/undocumented), so this documented endpoint is the "
+        "liveness check. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "releaseName": {"type": ["string", "null"]},
+            "buildNumber": {"type": ["integer", "string", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key=_LIVENESS_GROUP_KEY,
+    tags=("read-only", "vrops", "vmware", "liveness", "probe"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call first to confirm a vROps appliance is reachable and to "
+            "read which version/build it runs, before any alert or resource "
+            "query. Supersedes the older vrops.about op."
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "{releaseName: '9.0.0.1.23456789', buildNumber: 23456789, "
+            "humanlyReadableReleaseName?: '...'}. A returned payload means "
+            "the appliance answered; the dispatcher surfaces transport "
+            "failures as a connector_error instead."
+        ),
+    },
+)
+
+
+VROPS_ALERT_LIST_OP = VropsTypedOp(
+    op_id="vrops.alert.list",
+    handler_attr="alert_list",
+    summary="List vROps alerts (currently firing or recently resolved) for triage.",
+    description=(
+        "Reads GET /suite-api/api/alerts directly on the connector session "
+        "(no catalog ingest). Optional filters: activeOnly (bool, default "
+        "false — server-side false lists resolved alerts too), "
+        "alertCriticality (CRITICAL / IMMEDIATE / WARNING / INFORMATION / "
+        "UNKNOWN), alertStatus (ACTIVE / CANCELED / SUSPENDED / UPDATED), "
+        "resourceId (one or more resource UUIDs to scope to), and page / "
+        "pageSize pagination. Each alert carries alertId, "
+        "alertDefinitionId, alertDefinitionName, alertLevel, alertImpact, "
+        "resourceId, startTimeUTC, cancelTimeUTC, status and controlState. "
+        "Large alert sets are reduced to a JSONFlux handle with a bounded "
+        "inline sample. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "activeOnly": {
+                "type": "boolean",
+                "description": (
+                    "When true, list only alerts that are still active; "
+                    "omit or false to include recently resolved alerts."
+                ),
+            },
+            "alertCriticality": {
+                "type": "string",
+                "enum": ["CRITICAL", "IMMEDIATE", "WARNING", "INFORMATION", "UNKNOWN"],
+                "description": "Scope to a single alert criticality level.",
+            },
+            "alertStatus": {
+                "type": "string",
+                "enum": ["ACTIVE", "CANCELED", "SUSPENDED", "UPDATED"],
+                "description": "Scope to a single alert status.",
+            },
+            "resourceId": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": (
+                    "Optional list of resource UUIDs to scope the alert "
+                    "listing to (from vrops.resource.query)."
+                ),
+            },
+            "page": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "0-based page number (pagination).",
+            },
+            "pageSize": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Number of alerts per page (pagination).",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "alerts": {"type": "array"},
+            "pageInfo": {"type": "object"},
+        },
+        "additionalProperties": True,
+    },
+    group_key=_ALERT_TRIAGE_GROUP_KEY,
+    tags=("read-only", "vrops", "vmware", "alerts"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator asks what is alerting in vROps, wants "
+            "the critical/active alerts, or wants alerts firing on a "
+            "specific resource. Filter with activeOnly / alertCriticality / "
+            "alertStatus / resourceId to narrow large sets."
+        ),
+        "parameter_hints": {
+            "activeOnly": "true to hide resolved alerts; omit for all.",
+            "alertCriticality": "e.g. 'CRITICAL' to see only critical alerts.",
+            "resourceId": "List of resource UUIDs to scope to; omit for all.",
+        },
+        "output_shape": (
+            "{alerts: [{alertId, alertDefinitionId, alertDefinitionName, "
+            "alertLevel, alertImpact, resourceId, startTimeUTC, "
+            "cancelTimeUTC, status, controlState}, ...], pageInfo, links}. "
+            "Cross-reference resourceId with vrops.resource.query for "
+            "affected-object detail. Large sets return a JSONFlux handle."
+        ),
+    },
+)
+
+
+VROPS_RESOURCE_QUERY_OP = VropsTypedOp(
+    op_id="vrops.resource.query",
+    handler_attr="resource_query",
+    summary="Look up vROps-monitored resources by a structured query (body POST).",
+    description=(
+        "Issues POST /suite-api/api/resources/query with a typed "
+        "ResourceQuerySpec request body directly on the connector session "
+        "(no catalog ingest). Match resources by any combination of: "
+        "resourceId (UUIDs), name, regex, adapterKind (e.g. 'VMWARE'), "
+        "resourceKind (e.g. 'VirtualMachine', 'HostSystem', 'Datastore'), "
+        "resourceState, resourceStatus, resourceHealth, parentId, and "
+        "statKey; page / pageSize paginate. The POST query surface is the "
+        "richer counterpart of the GET /suite-api/api/resources list (each "
+        "array field is OR-matched within, AND-matched across fields). "
+        "Returns resourceList[] with identifier (UUID), resourceKey (name "
+        "+ resourceKindKey + adapterKindKey + resourceIdentifiers[]), "
+        "resourceStatusStates[], plus pageInfo. Large sets are reduced to "
+        "a JSONFlux handle. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "resourceId": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": "Match specific resource UUIDs.",
+            },
+            "name": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": "Match resources whose name equals any listed value.",
+            },
+            "regex": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": "Match resource names against any listed regex.",
+            },
+            "adapterKind": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": "Match by adapter kind key (e.g. 'VMWARE').",
+            },
+            "resourceKind": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": (
+                    "Match by resource kind key (e.g. 'VirtualMachine', 'HostSystem', 'Datastore')."
+                ),
+            },
+            "resourceState": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": "Match by resource state (e.g. 'STARTED', 'STOPPED').",
+            },
+            "resourceStatus": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": "Match by resource status (e.g. 'DATA_RECEIVING').",
+            },
+            "resourceHealth": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": "Match by health (e.g. 'GREEN', 'YELLOW', 'RED').",
+            },
+            "parentId": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": "Match resources whose parent is any listed UUID.",
+            },
+            "statKey": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Restrict to resources that report this stat key.",
+            },
+            "page": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "0-based page number (pagination).",
+            },
+            "pageSize": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Number of resources per page (pagination).",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "resourceList": {"type": "array"},
+            "pageInfo": {"type": "object"},
+        },
+        "additionalProperties": True,
+    },
+    group_key=_RESOURCE_QUERY_GROUP_KEY,
+    tags=("read-only", "vrops", "vmware", "resources", "query"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to find vROps-monitored resources matching a structured "
+            "query — by name/regex, adapterKind, resourceKind, state, "
+            "status, health, or parent. Prefer this over browsing the "
+            "ingested resource list when the operator names concrete match "
+            "criteria."
+        ),
+        "parameter_hints": {
+            "resourceKind": "e.g. 'VirtualMachine' / 'HostSystem' / 'Datastore'.",
+            "name": "Exact-name matches (list); use regex for patterns.",
+            "adapterKind": "e.g. 'VMWARE'.",
+        },
+        "output_shape": (
+            "{resourceList: [{identifier, resourceKey: {name, "
+            "resourceKindKey, adapterKindKey, resourceIdentifiers}, "
+            "resourceStatusStates, creationTime}, ...], pageInfo, links}. "
+            "Feed identifier UUIDs into vrops.alert.list(resourceId=...) to "
+            "find alerts on a matched resource. Large sets return a "
+            "JSONFlux handle."
+        ),
+    },
+)
+
+
+#: The typed ops :class:`VcfOperationsConnector` registers at lifespan
+#: startup — the audited vROps read set (#2303). The tuple shape lets a
+#: future typed read join without touching the registrar.
+VROPS_TYPED_OPS: tuple[VropsTypedOp, ...] = (
+    VROPS_LIVENESS_OP,
+    VROPS_ALERT_LIST_OP,
+    VROPS_RESOURCE_QUERY_OP,
+)
+
+
+async def register_vcf_operations_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every op in :data:`VROPS_TYPED_OPS` into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after
+    :func:`~meho_backplane.connectors.registry._eager_import_connectors`
+    has walked every connector subpackage, so the descriptor rows land
+    before the first dispatch. Idempotent across pod restarts (the helper
+    skips the embedding recompute on unchanged summary / description /
+    tags). Mirrors :func:`register_argocd_typed_operations` and the
+    vmware typed-op registrar.
+
+    The ``embedding_service`` keyword-only parameter is the runner
+    contract: :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar,
+    so each registrar must accept the kwarg. It is forwarded to
+    :func:`register_typed_operation` (which falls back to the process-wide
+    singleton when ``None``).
+    """
+    # Lazy import: the operations package pulls in the embedding pipeline
+    # (ONNX runtime + model), which pure connector/handler unit tests
+    # should not pay. Lifespan callers have it warmed by the time this runs.
+    from meho_backplane.connectors.vcf_operations.connector import VcfOperationsConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in VROPS_TYPED_OPS:
+        handler = getattr(VcfOperationsConnector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"VcfOperationsConnector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = (
+            None if op.group_key is None else VROPS_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        )
+        if op.group_key is not None and when_to_use is None:
+            raise ValueError(
+                f"VcfOperationsConnector typed op {op.op_id!r} declares "
+                f"group_key={op.group_key!r} but no curated when_to_use exists for "
+                f"that key. Add an entry to VROPS_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=VcfOperationsConnector.product,
+            version=VcfOperationsConnector.version,
+            impl_id=VcfOperationsConnector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "vcf_operations_typed_operations_registered",
+        count=len(VROPS_TYPED_OPS),
+        product=VcfOperationsConnector.product,
+        version=VcfOperationsConnector.version,
+        impl_id=VcfOperationsConnector.impl_id,
+    )

--- a/backend/tests/test_connectors_vcf_operations_core_ops.py
+++ b/backend/tests/test_connectors_vcf_operations_core_ops.py
@@ -13,12 +13,14 @@ Covers :mod:`meho_backplane.connectors.vcf_operations.core_ops`:
   carries non-placeholder ``llm_instructions`` / ``when_to_use`` text
   (the AC's "non-empty reviewed text" gate).
 * :func:`apply_vrops_core_curation` — the operator-review-time
-  substrate call that flips ``review_status='enabled'`` on the 7
-  curated groups, lands ``llm_instructions`` on the 8 curated ops,
+  substrate call that flips ``review_status='enabled'`` on the 5
+  curated groups, lands ``llm_instructions`` on the 6 curated ops,
   and explicitly disables non-core ops via the audit-log-driven
-  operator-override exclusion. The load-bearing assertion is "8 ops
+  operator-override exclusion. The load-bearing assertion is "6 ops
   dispatchable, every other op in curated groups stays
-  ``is_enabled=False``".
+  ``is_enabled=False``". The audited liveness / alerts /
+  resources-query reads moved to the typed surface (#2303) and are
+  covered by :mod:`tests.test_connectors_vcf_operations_typed_reads`.
 
 Test harness mirrors :mod:`tests.test_connectors_harbor_core_ops`:
 SQLite via the autouse ``_default_database_url`` fixture, hand-rolled
@@ -140,21 +142,31 @@ def test_classify_vrops_op_all_core_ops_are_classified() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_vrops_core_ops_count_is_eight_and_read_only() -> None:
-    """VROPS_CORE_OPS ships exactly the 8 read-only core ops per #833."""
-    assert len(VROPS_CORE_OPS) == 8, (
-        f"expected exactly 8 vROps core ops per #833 AC; got {len(VROPS_CORE_OPS)}"
+def test_vrops_core_ops_count_is_six_and_read_only() -> None:
+    """VROPS_CORE_OPS ships exactly the 6 ingested-browse ops.
+
+    The audited liveness / alerts / resources-query reads converted to
+    typed ops in #2303 (Initiative #2266 T3); the remaining ingested
+    curation is the browse breadth kept until the T7 apparatus retirement.
+    """
+    assert len(VROPS_CORE_OPS) == 6, (
+        f"expected exactly 6 vROps ingested-browse core ops after #2303; got {len(VROPS_CORE_OPS)}"
     )
     for op in VROPS_CORE_OPS:
         assert op.op_id.startswith("GET:"), (
-            f"vROps core op {op.op_id!r} must be a GET (v0.5 read-only core)"
+            f"vROps core op {op.op_id!r} must be a GET (read-only browse core)"
         )
+    # The two converted reads must no longer flip their ingested twin
+    # (the #2262 no-shadow invariant): they are typed ops now.
+    op_ids = {op.op_id for op in VROPS_CORE_OPS}
+    assert "GET:/suite-api/api/versions/current" not in op_ids
+    assert "GET:/suite-api/api/alerts" not in op_ids
 
 
-def test_vrops_core_groups_count_is_seven_and_unique() -> None:
-    """VROPS_CORE_GROUPS spans the 7 vROps groups the 8 ops fall into."""
-    assert len(VROPS_CORE_GROUPS) == 7, (
-        f"expected exactly 7 vROps core groups; got {len(VROPS_CORE_GROUPS)}"
+def test_vrops_core_groups_count_is_five_and_unique() -> None:
+    """VROPS_CORE_GROUPS spans the 5 vROps groups the 6 ops fall into."""
+    assert len(VROPS_CORE_GROUPS) == 5, (
+        f"expected exactly 5 vROps core groups; got {len(VROPS_CORE_GROUPS)}"
     )
     group_keys = [g.group_key for g in VROPS_CORE_GROUPS]
     assert len(set(group_keys)) == len(group_keys), (
@@ -307,8 +319,8 @@ async def _seed_curated_groups_and_ops(
     return group_ids
 
 
-async def test_apply_vrops_core_curation_enables_exactly_8_ops() -> None:
-    """apply_vrops_core_curation enables exactly the 8 core ops."""
+async def test_apply_vrops_core_curation_enables_exactly_6_ops() -> None:
+    """apply_vrops_core_curation enables exactly the 6 core ops."""
     tenant_id = uuid.uuid4()
     operator = _make_operator(tenant_id=tenant_id)
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)
@@ -369,7 +381,7 @@ async def test_apply_vrops_core_curation_disables_non_core_ops_in_curated_groups
 
 
 async def test_apply_vrops_core_curation_sets_llm_instructions_on_all_core_ops() -> None:
-    """llm_instructions is populated on all 8 core ops after curation."""
+    """llm_instructions is populated on all 6 core ops after curation."""
     tenant_id = uuid.uuid4()
     operator = _make_operator(tenant_id=tenant_id)
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)
@@ -396,8 +408,8 @@ async def test_apply_vrops_core_curation_sets_llm_instructions_on_all_core_ops()
         )
 
 
-async def test_apply_vrops_core_curation_enables_all_7_curated_groups() -> None:
-    """All 7 curated groups land review_status='enabled' after curation."""
+async def test_apply_vrops_core_curation_enables_all_5_curated_groups() -> None:
+    """All 5 curated groups land review_status='enabled' after curation."""
     tenant_id = uuid.uuid4()
     operator = _make_operator(tenant_id=tenant_id)
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)

--- a/backend/tests/test_connectors_vcf_operations_e2e.py
+++ b/backend/tests/test_connectors_vcf_operations_e2e.py
@@ -258,7 +258,9 @@ async def vcf_operations_e2e_canary(captured_events: list[Any]) -> AsyncIterator
 # ---------------------------------------------------------------------------
 
 _OP_IDS: tuple[str, ...] = tuple(op.op_id for op in VROPS_CORE_OPS)
-assert len(_OP_IDS) == 8, f"Expected 8 curated vROps ops, got {len(_OP_IDS)}: {_OP_IDS}"
+# 6 ingested-browse ops after #2303 moved liveness/alerts/resources-query to
+# the typed surface (tests/test_connectors_vcf_operations_typed_reads.py).
+assert len(_OP_IDS) == 6, f"Expected 6 curated vROps ops, got {len(_OP_IDS)}: {_OP_IDS}"
 
 
 @pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
@@ -322,7 +324,10 @@ async def test_vcf_operations_e2e_credentials_cached_after_first_dispatch(
         _OPERATOR,
         {
             "connector_id": VROPS_CONNECTOR_ID,
-            "op_id": "GET:/suite-api/api/versions/current",
+            # versions/current + alerts moved to the typed surface (#2303),
+            # so they are no longer seeded as ingested rows here; use another
+            # curated ingested op to exercise the cold credential load.
+            "op_id": "GET:/suite-api/api/alertdefinitions",
             "target": {"name": target_name},
             "params": {},
         },

--- a/backend/tests/test_connectors_vcf_operations_typed_reads.py
+++ b/backend/tests/test_connectors_vcf_operations_typed_reads.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the vROps typed read surface (Initiative #2266 T3, #2303).
+
+Covers the audited read set converted from ingested-row curation to
+**typed** ops (``source_kind="typed"``) on the connector's hand-rolled
+HTTP Basic (+ optional ``auth-source``) session:
+
+* ``vrops.liveness`` — ``GET /suite-api/api/versions/current`` (appliance
+  liveness + identity; the documented reachability surface — vROps'
+  CaSA ``/casa/health`` is a private, undocumented API).
+* ``vrops.alert.list`` — ``GET /suite-api/api/alerts`` (alert triage).
+* ``vrops.resource.query`` — ``POST /suite-api/api/resources/query`` (a
+  body-shaped POST carrying a typed ``ResourceQuerySpec``).
+
+Coverage matrix (per #2303 acceptance criteria):
+
+* **Each op dispatches live** through :func:`~meho_backplane.operations.dispatch`
+  against a respx-mocked vROps appliance and returns ``status="ok"`` with
+  the payload — with **zero catalog ingest** (the descriptor rows come only
+  from the typed registrar, never from an ingested spec). The in-process
+  Vault fake exercises the real default credential loader (Basic auth).
+* **`source_kind="typed"`** — the registered descriptor rows carry
+  ``source_kind="typed"`` with a resolvable ``handler_ref`` (the #2262
+  invariant: the dispatch path never touches an ingested descriptor row).
+* **The query op is a body POST** — ``vrops.resource.query`` sends the
+  ``ResourceQuerySpec`` body and paginates via query params.
+* **auth-source rides every request** — both the GET (``_request_json``
+  override) and the body POST (``_post_json`` override) carry
+  ``?auth-source=<value>`` when the target federates identity, and omit it
+  otherwise.
+* **Metadata shape** — all three are ``safety_level="safe"``,
+  ``requires_approval=False``, tagged ``read-only``, with
+  ``additionalProperties=False`` parameter schemas and non-empty
+  ``llm_instructions``; no write op is registered.
+
+Mirrors :mod:`tests.test_connectors_vcf_operations_credread` for the
+dispatch/Vault-fake lifecycle and :mod:`tests.test_connectors_argocd_reads`
+for the typed-op registration + metadata invariants.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vcf_operations import (
+    VROPS_TYPED_OPS,
+    VcfOperationsConnector,
+    register_vcf_operations_typed_operations,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import import_handler, reset_handler_cache
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+_CANARY_USERNAME = "svc-vrops-typed-canary"
+_CANARY_PASSWORD = "p4ss-canary-must-not-leak-typed-reads-vrops"
+
+_PRODUCT = "vrops"
+_VERSION = "9.0"
+_IMPL_ID = "vrops-rest"
+_CONNECTOR_ID = "vrops-rest-9.0"
+
+_VROPS_HOST = "vrops-typed-reads.test.invalid"
+_VROPS_BASE_URL = f"https://{_VROPS_HOST}"
+
+_LIVENESS_PATH = "/suite-api/api/versions/current"
+_ALERTS_PATH = "/suite-api/api/alerts"
+_RESOURCES_QUERY_PATH = "/suite-api/api/resources/query"
+
+_LIVENESS_RESPONSE: dict[str, Any] = {"releaseName": "9.0.0", "buildNumber": 23456789}
+_ALERTS_RESPONSE: dict[str, Any] = {
+    "alerts": [
+        {"alertId": "a-1", "alertLevel": 5, "status": "ACTIVE", "resourceId": "r-1"},
+    ],
+    "pageInfo": {"page": 0, "pageSize": 1000, "totalCount": 1},
+}
+_RESOURCES_QUERY_RESPONSE: dict[str, Any] = {
+    "resourceList": [
+        {
+            "identifier": "r-1",
+            "resourceKey": {"name": "vm-01", "resourceKindKey": "VirtualMachine"},
+        },
+    ],
+    "pageInfo": {"page": 0, "pageSize": 1000, "totalCount": 1},
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=VcfOperationsConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _TypedReadTarget:
+    """Target satisfying both ``VcfOperationsTargetLike`` and the resolver shape."""
+
+    def __init__(self, *, auth_source: str | None = None) -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": _VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = UUID("00000000-0000-0000-0000-00000000a0b2")
+        self.name = "vrops-typed-reads"
+        self.host = _VROPS_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-typed/vrops-typed-reads"
+        self.auth_model = "shared_service_account"
+        self.auth_source: str | None = auth_source
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-typed-vrops",
+        name="Typed Reads vROps Operator",
+        email=None,
+        raw_jwt="op.typed.vrops.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0b2"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _register_typed_ops(stub: AsyncMock) -> None:
+    """Upsert VROPS_TYPED_OPS into the test DB via the real registrar."""
+    await register_vcf_operations_typed_operations(embedding_service=stub)
+
+
+# ---------------------------------------------------------------------------
+# Live dispatch — each typed op hits the right path on a fresh (zero-catalog) DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("op_id", "params", "method", "path", "payload"),
+    [
+        ("vrops.liveness", {}, "GET", _LIVENESS_PATH, _LIVENESS_RESPONSE),
+        ("vrops.alert.list", {"activeOnly": True}, "GET", _ALERTS_PATH, _ALERTS_RESPONSE),
+        (
+            "vrops.resource.query",
+            {"resourceKind": ["VirtualMachine"]},
+            "POST",
+            _RESOURCES_QUERY_PATH,
+            _RESOURCES_QUERY_RESPONSE,
+        ),
+    ],
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+@pytest.mark.asyncio
+async def test_each_typed_read_dispatches_live_and_returns_payload(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    op_id: str,
+    params: dict[str, Any],
+    method: str,
+    path: str,
+    payload: dict[str, Any],
+) -> None:
+    """Each audited read dispatches end to end on a zero-catalog DB and returns the payload."""
+    await _register_typed_ops(_stub_embedding)
+    install_fake_client(
+        monkeypatch, secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    )
+
+    target = _TypedReadTarget()
+    operator = _make_operator()
+
+    async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        route = mock.request(method, path).respond(200, json=payload)
+        result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == payload
+    assert route.called and route.call_count == 1
+    sent_auth = route.calls[0].request.headers.get("authorization")
+    assert sent_auth is not None and sent_auth.startswith("Basic ")
+
+
+@pytest.mark.asyncio
+async def test_typed_ops_registered_with_source_kind_typed(
+    _stub_embedding: AsyncMock, session: AsyncSession
+) -> None:
+    """The audited reads register as source_kind='typed' with resolvable handlers.
+
+    Proves the #2262 invariant: a typed op's dispatch resolves its
+    ``handler_ref`` (a bound method), never an ingested descriptor row.
+    """
+    await _register_typed_ops(_stub_embedding)
+
+    expected = {"vrops.liveness", "vrops.alert.list", "vrops.resource.query"}
+    rows = (
+        (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == _PRODUCT,
+                    EndpointDescriptor.version == _VERSION,
+                    EndpointDescriptor.impl_id == _IMPL_ID,
+                    EndpointDescriptor.op_id.in_(list(expected)),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert {r.op_id for r in rows} == expected
+    for row in rows:
+        assert row.source_kind == "typed", f"{row.op_id} is {row.source_kind}, want typed"
+        assert row.handler_ref, f"{row.op_id} has no handler_ref"
+        assert row.requires_approval is False
+        assert row.safety_level == "safe"
+        # The dotted handler_ref resolves to a callable (dispatch would too).
+        assert callable(import_handler(row.handler_ref))
+
+
+@pytest.mark.asyncio
+async def test_resource_query_sends_body_and_paginates(
+    _stub_embedding: AsyncMock, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """vrops.resource.query POSTs a ResourceQuerySpec body and paginates via query params."""
+    await _register_typed_ops(_stub_embedding)
+    install_fake_client(
+        monkeypatch, secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    )
+
+    params = {
+        "resourceKind": ["VirtualMachine", "HostSystem"],
+        "name": ["vm-01"],
+        "statKey": "cpu|usage_average",
+        "page": 0,
+        "pageSize": 100,
+    }
+    async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        route = mock.post(_RESOURCES_QUERY_PATH).respond(200, json=_RESOURCES_QUERY_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="vrops.resource.query",
+            target=_TypedReadTarget(),
+            params=params,
+        )
+
+    assert result.status == "ok", result.error
+    request = route.calls[0].request
+    body = json.loads(request.content)
+    # Body carries the ResourceQuerySpec match fields, not the pagination.
+    assert body == {
+        "resourceKind": ["VirtualMachine", "HostSystem"],
+        "name": ["vm-01"],
+        "statKey": "cpu|usage_average",
+    }
+    # Pagination rides as query params.
+    assert request.url.params["page"] == "0"
+    assert request.url.params["pageSize"] == "100"
+
+
+@pytest.mark.asyncio
+async def test_auth_source_threads_on_get_and_post(
+    _stub_embedding: AsyncMock, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A federated target's auth-source rides both the GET and the body-POST reads."""
+    await _register_typed_ops(_stub_embedding)
+    install_fake_client(
+        monkeypatch, secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    )
+    target = _TypedReadTarget(auth_source="vIDM")
+
+    async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        alerts_route = mock.get(_ALERTS_PATH).respond(200, json=_ALERTS_RESPONSE)
+        query_route = mock.post(_RESOURCES_QUERY_PATH).respond(200, json=_RESOURCES_QUERY_RESPONSE)
+
+        alerts_result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="vrops.alert.list",
+            target=target,
+            params={"alertCriticality": "CRITICAL", "resourceId": ["r-1", "r-2"]},
+        )
+        query_result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="vrops.resource.query",
+            target=target,
+            params={"name": ["vm-01"]},
+        )
+
+    assert alerts_result.status == "ok", alerts_result.error
+    assert query_result.status == "ok", query_result.error
+
+    # GET path — auth-source merged by the _request_json override, plus the filters.
+    alerts_params = alerts_route.calls[0].request.url.params
+    assert alerts_params["auth-source"] == "vIDM"
+    assert alerts_params["alertCriticality"] == "CRITICAL"
+    resource_ids = [value for key, value in alerts_params.multi_items() if key == "resourceId"]
+    assert resource_ids == ["r-1", "r-2"]
+
+    # POST path — auth-source merged by the _post_json override.
+    assert query_route.calls[0].request.url.params["auth-source"] == "vIDM"
+
+
+@pytest.mark.asyncio
+async def test_auth_source_omitted_when_unset(
+    _stub_embedding: AsyncMock, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no auth_source, the reads omit ?auth-source= (vROps' default local realm)."""
+    await _register_typed_ops(_stub_embedding)
+    install_fake_client(
+        monkeypatch, secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    )
+
+    async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        route = mock.post(_RESOURCES_QUERY_PATH).respond(200, json=_RESOURCES_QUERY_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="vrops.resource.query",
+            target=_TypedReadTarget(auth_source=None),
+            params={"name": ["vm-01"]},
+        )
+
+    assert result.status == "ok", result.error
+    assert "auth-source" not in route.calls[0].request.url.params
+
+
+# ---------------------------------------------------------------------------
+# Metadata invariants
+# ---------------------------------------------------------------------------
+
+
+def test_typed_ops_are_read_only_and_well_formed() -> None:
+    """Every typed op is safe/no-approval/read-only with a closed parameter schema."""
+    assert {op.op_id for op in VROPS_TYPED_OPS} == {
+        "vrops.liveness",
+        "vrops.alert.list",
+        "vrops.resource.query",
+    }
+    for op in VROPS_TYPED_OPS:
+        assert op.safety_level == "safe", f"{op.op_id} must be safe (read-only surface)"
+        assert op.requires_approval is False, f"{op.op_id} must not require approval"
+        assert "read-only" in op.tags, f"{op.op_id} missing read-only tag"
+        assert op.parameter_schema.get("additionalProperties") is False, (
+            f"{op.op_id} parameter_schema must set additionalProperties=False"
+        )
+        assert op.group_key, f"{op.op_id} must declare a group_key"
+        assert op.llm_instructions, f"{op.op_id} must carry llm_instructions"
+        assert op.llm_instructions.get("when_to_use", "").strip(), (
+            f"{op.op_id} llm_instructions.when_to_use must be non-empty"
+        )

--- a/docs/codebase/connectors-vcf-operations.md
+++ b/docs/codebase/connectors-vcf-operations.md
@@ -165,11 +165,47 @@ dispatcher through this shim; post-G0.6 callers (the
 `meho vcf-operations …` CLI verbs added in #837) construct a real
 `Operator` and call `dispatch` themselves.
 
-Until G3.6-T2 (#833) ingests the vROps OpenAPI spec, no operations exist
-in the `endpoint_descriptor` table for the `vrops-rest-9.0` connector_id
-— every `execute(..., op_id, ...)` call resolves to "unknown operation"
-at the dispatcher layer. This is the correct behaviour for a
-registered-but-empty connector at this Task's stage.
+The connector exposes two operation surfaces: a **typed** read set
+(below) that works with zero catalog ingest, plus the **ingested**
+`/suite-api` breadth catalog curated in `core_ops.py`.
+
+### Typed read operations (#2303, Initiative #2266 T3)
+
+The adopter's *audited* vROps read set (audit #2294) ships as **typed**
+ops (`source_kind="typed"`) in `typed_ops.py`, dispatched directly on the
+connector's Basic (+ `auth-source`) session — no ingested descriptor row,
+so they work on a fresh boot with zero catalog ingest (the #2262
+no-shadow invariant). Handlers are bound methods on
+`VcfOperationsConnector`; a module-level `register_vcf_operations_typed_operations`
+registrar is queued via `register_typed_op_registrar` in the package
+`__init__` and run by the lifespan.
+
+- **`vrops.liveness`** — `GET /suite-api/api/versions/current`. Appliance
+  liveness + identity (release/build); the same surface `probe()` uses.
+  The adopter named the probe `casa/health`, but the CaSA API is
+  private/undocumented, so the documented version surface is the grounded
+  liveness op. Supersedes the former curated `vrops.about`.
+- **`vrops.alert.list`** — `GET /suite-api/api/alerts`. Alert triage,
+  filtered by `activeOnly` / `alertCriticality` / `alertStatus` /
+  `resourceId` with pagination. Supersedes the curated
+  `GET:/suite-api/api/alerts` ingested row.
+- **`vrops.resource.query`** — `POST /suite-api/api/resources/query`. A
+  body-shaped POST carrying a typed `ResourceQuerySpec` subset (match on
+  `resourceKind` / `name` / `regex` / `adapterKind` / state / status /
+  health / parent / `statKey`), paginated via `page` / `pageSize` query
+  params.
+
+All three are `safety_level="safe"`, `requires_approval=False`,
+read-only. The `auth-source` query param rides both the GET path (the
+`_request_json` override) and the body POST (a `_post_json` override that
+threads auth-source + pagination onto the URL, since the base
+`_post_json` bypasses the `_request_json` seam and takes no params).
+
+The two converted GET reads are **removed** from the `core_ops.py`
+ingested curation so their ingested twin is never flipped alongside the
+typed op; the remaining 6 ingested-browse ops (resource list/get, alert
+definitions, symptoms, recommendations, super metrics) stay curated as
+browse breadth until Initiative #2266 T7 retires the apparatus.
 
 ### Shutdown
 
@@ -216,10 +252,11 @@ client.
   `CredentialsCache.invalidate(target)`. Until the admin endpoint for
   rotation lands, the workaround is to restart the backplane process
   (which clears the cache on `aclose`).
-- **No operations yet** — the connector is registered but no
-  `endpoint_descriptor` rows exist; dispatch against any `op_id`
-  resolves to "unknown operation" until G3.6-T2 (#833) ingests the
-  vROps `/suite-api` OpenAPI spec.
+- **Ingested-curation retirement pending** — the 6 remaining
+  `core_ops.py` ingested-browse ops still depend on per-deploy catalog
+  state (an ingest of the vROps `/suite-api` spec + operator review); the
+  typed reads above do not. Retiring the whole ingested-curation
+  apparatus is Initiative #2266 T7.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Converts the vROps (`vcf-operations`) **audited** read set (audit #2294) from `is_enabled` curation over ingested `endpoint_descriptor` rows to **typed** ops (`source_kind="typed"`) dispatched directly on the connector's existing hand-rolled HTTP Basic (+ optional `auth-source`) session — so they work on a fresh boot with **zero catalog ingest** (the #2262 no-shadow invariant). No write ops (none wanted).
- New ops: `vrops.liveness` (`GET /suite-api/api/versions/current`), `vrops.alert.list` (`GET /suite-api/api/alerts`), `vrops.resource.query` (a body-shaped `POST /suite-api/api/resources/query` with a typed `ResourceQuerySpec` request body). All read-only, `safety_level="safe"`, no approval.
- The two converted GET reads are **removed** from `core_ops.py` so the ingested twin is never flipped alongside the typed op; the remaining 6 ingested-browse ops stay curated as breadth until the Initiative #2266 **T7** apparatus retirement.

## Design notes / Phase-4 decision

- **Liveness endpoint.** The T0 audit named the vROps liveness probe `casa/health`. The CaSA (Cluster and Slice Administration) API is a **private, undocumented** surface (I could not ground the exact path/response, and it may need different auth/port), so per the no-guessing-on-APIs rule I implemented `vrops.liveness` against `GET /suite-api/api/versions/current` — the **documented** endpoint the connector already uses as its `probe()`/`fingerprint()` reachability check. This forced removing the curated `vrops.about` (same endpoint) to avoid double-surfacing. A disposition comment covering this and the declined ops is posted on #2303.
- **auth-source on the POST.** The base `HttpConnector._post_json` bypasses the connector's `_request_json` auth-source seam and accepts no `params`. A `_post_json` override threads `?auth-source=<value>` + pagination onto the URL (caller params win on clash), so the federated-identity routing rides the body POST exactly as it rides the GET reads.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/.../vcf_operations` — clean (5 files)
- [x] `code-quality.py --diff` — 0 blockers
- [x] New `tests/test_connectors_vcf_operations_typed_reads.py` (11 cases): each op dispatches live over respx on a **zero-catalog** DB and returns its payload; the descriptors register as `source_kind="typed"` with resolvable `handler_ref`; the query op sends the `ResourceQuerySpec` body + paginates via query params; `auth-source` rides both the GET and the body-POST reads and is omitted when unset; metadata shape (safe / no-approval / read-only / closed schema).
- [x] Updated `core_ops` + `e2e` tests for the 6-op / 5-group curation; full vcf_operations suite green (69 passed).
- [x] Cross-cutting sweeps green: broadcast-classifier-coverage, typed-connectors-metadata, registry-v2, secret-leak-checks, resolver-shadowing, mcp-tools-operations, api-health (162 + 88 passed).
- [x] OpenAPI snapshot: no delta (no FastAPI route/schema touched — verified `make snapshot-openapi` produces no diff).
- [x] `docs/codebase/connectors-vcf-operations.md` updated (typed read surface + "no operations yet" known-issue corrected).

## Out of scope

- Unconverted curated ops (resource list/get, alert definitions, symptoms, recommendations, super metrics) — declined from typed conversion (not in the adopter's audited operational set); ingested breadth still browses them; declined with reasons on #2303.
- T7 ingested-curation-apparatus retirement (Initiative #2266).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2303
