### PR TITLE
feat(connectors): NSX audited reads as typed ops on the cookie+XSRF session (#2302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,30 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — NSX typed reads on the cookie+XSRF session (audited set) (#2302)
+
+- The audited NSX operational read set is now first-class **typed** ops
+  (`source_kind="typed"`) that dispatch on a fresh boot with **zero
+  catalog ingest** (no per-deploy curation state, the #2247 failure
+  class): `nsx.node.status` + `nsx.cluster.status` (manager/cluster
+  status+version), `nsx.backup.config` + `nsx.backup.status`,
+  `nsx.transport_zone.list`, `nsx.tier1.list`, and `nsx.alarm.list`
+  (optional status/feature/severity filters). `nsx.backup.config` is
+  first-class for the backup disk-fill incident class (Broadcom KB 442696
+  shape): it surfaces `backup_enabled`, `passphrase_configured`, and the
+  retention-relevant `backup_schedule` / `remote_file_server` fields, and
+  scrubs the backup passphrase + any nested SFTP credential at the
+  connector boundary (the default redaction policy masks
+  `password`/`secret` but not `passphrase`). These reads recover from
+  session expiry through the #2067 dispatcher seam — `NsxConnector` now
+  exposes the public `invalidate_session` hook, so a 401 evicts the cached
+  cookie+XSRF session and re-dispatches once, no restart. The remaining
+  reads (transport-node listing, segments, tier-0 gateways,
+  distributed-firewall policies + rules) stay as ingested-row curation in
+  `core_ops.py` so the wider ingested breadth is still browsable; the
+  converted ops are no longer flipped by `apply_nsx_core_curation`. `tier-1
+  gateway create` (a write) is out of scope. (#2302)
+
 ### Added — persisted spec provenance at ingest (sha256 + origin + operator/timestamp, surfaced in review) (#2291)
 
 - Every accepted spec ingest now writes a durable, non-spoofable

--- a/backend/src/meho_backplane/connectors/nsx/__init__.py
+++ b/backend/src/meho_backplane/connectors/nsx/__init__.py
@@ -60,7 +60,13 @@ from meho_backplane.connectors.nsx.session import (
     SessionCredentials,
     load_session_credentials_from_vault,
 )
+from meho_backplane.connectors.nsx.typed_ops import (
+    NSX_TYPED_OPS,
+    NsxTypedOp,
+    register_nsx_typed_operations,
+)
 from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
 
 register_connector_v2(
     product="nsx",
@@ -82,6 +88,12 @@ register_connector_v2(
     cls=NsxConnector,
 )
 
+# Queue the audited-read typed-op upsert (#2302) onto the lifespan-driven
+# registrar list. The runner (``run_typed_op_registrars``) iterates after
+# ``_eager_import_connectors`` so the ``source_kind='typed'`` descriptor
+# rows land before the first dispatch -- no catalog ingest required.
+register_typed_op_registrar(register_nsx_typed_operations)
+
 __all__ = [
     "NSX_CONNECTOR_ID",
     "NSX_CORE_GROUPS",
@@ -89,14 +101,17 @@ __all__ = [
     "NSX_IMPL_ID",
     "NSX_PATH_RULES",
     "NSX_PRODUCT",
+    "NSX_TYPED_OPS",
     "NSX_VERSION",
     "NsxConnector",
     "NsxCoreGroup",
     "NsxCoreOp",
     "NsxSessionLoader",
     "NsxTargetLike",
+    "NsxTypedOp",
     "SessionCredentials",
     "apply_nsx_core_curation",
     "classify_nsx_op",
     "load_session_credentials_from_vault",
+    "register_nsx_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -96,13 +96,13 @@ for proactive refresh: revoke-on-close is v0.2.next.
 Operations
 ----------
 
-This module ships zero operations -- the G0.6 dispatch shim
-:meth:`execute` exists for ABC compatibility but operations land in
-the ``endpoint_descriptor`` table via #614's spec ingestion. Until
-then, the connector is registered and discoverable but
-``execute(target, op_id, ...)`` against any ``op_id`` will resolve to
-"unknown operation" at the dispatcher layer -- which is the correct
-behaviour for a registered-but-empty connector at this Task's stage.
+The audited read set (#2302) ships as **typed** ops
+(``source_kind="typed"``) via the bound-method shims below, registered
+through :mod:`meho_backplane.connectors.nsx.typed_ops`; they dispatch on
+a fresh boot with zero catalog ingest. The remaining curated reads stay
+as ingested-row curation in
+:mod:`meho_backplane.connectors.nsx.core_ops`. The G0.6 :meth:`execute`
+shim remains for ABC compatibility.
 """
 
 from __future__ import annotations
@@ -320,11 +320,22 @@ class NsxConnector(HttpConnector):
             )
             return xsrf
 
+    async def invalidate_session(self, target: NsxTargetLike) -> None:
+        """Public duck-typed session-eviction hook for the dispatch path.
+
+        The seam the generic dispatch path calls on an auth-class status
+        (NSX's 401) before re-dispatching once (G0.29-T2 #2067) -- the path
+        the typed read ops (#2302) traverse. Delegates to
+        :meth:`_invalidate_session`, mirroring the vmware-rest / vcf-logs seam.
+        """
+        await self._invalidate_session(target)
+
     async def _invalidate_session(self, target: NsxTargetLike) -> None:
         """Drop the cached XSRF token + clear the client cookie jar for *target*.
 
         Called by :meth:`_get_json_with_session_retry` on 401 from a
-        downstream call so the subsequent :meth:`_session_token`
+        downstream call, and by the public :meth:`invalidate_session`
+        dispatch-path hook (#2067), so the subsequent :meth:`_session_token`
         re-issues ``POST /api/session/create`` from a clean state.
         Holds the lock so a concurrent re-establish doesn't race with
         the invalidation.
@@ -511,6 +522,67 @@ class NsxConnector(HttpConnector):
             target=target,
             params=params,
         )
+
+    # Typed read ops (#2302): thin bound-method shims delegating to
+    # ``nsx.typed_reads`` bodies (kept in a sibling module for the
+    # file-length budget). All read-only; a raw 401 propagates to the
+    # dispatcher's #2067 arm (see :meth:`invalidate_session`).
+
+    async def node_status(
+        self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``nsx.node.status`` shim (#2302)."""
+        from meho_backplane.connectors.nsx.typed_reads import nsx_node_status_impl
+
+        return await nsx_node_status_impl(self, operator, target, params)
+
+    async def cluster_status(
+        self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``nsx.cluster.status`` shim (#2302)."""
+        from meho_backplane.connectors.nsx.typed_reads import nsx_cluster_status_impl
+
+        return await nsx_cluster_status_impl(self, operator, target, params)
+
+    async def backup_config(
+        self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``nsx.backup.config`` shim (#2302)."""
+        from meho_backplane.connectors.nsx.typed_reads import nsx_backup_config_impl
+
+        return await nsx_backup_config_impl(self, operator, target, params)
+
+    async def backup_status(
+        self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``nsx.backup.status`` shim (#2302)."""
+        from meho_backplane.connectors.nsx.typed_reads import nsx_backup_status_impl
+
+        return await nsx_backup_status_impl(self, operator, target, params)
+
+    async def transport_zone_list(
+        self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``nsx.transport_zone.list`` shim (#2302)."""
+        from meho_backplane.connectors.nsx.typed_reads import nsx_transport_zone_list_impl
+
+        return await nsx_transport_zone_list_impl(self, operator, target, params)
+
+    async def tier1_list(
+        self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``nsx.tier1.list`` shim (#2302)."""
+        from meho_backplane.connectors.nsx.typed_reads import nsx_tier1_list_impl
+
+        return await nsx_tier1_list_impl(self, operator, target, params)
+
+    async def alarm_list(
+        self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``nsx.alarm.list`` shim (#2302)."""
+        from meho_backplane.connectors.nsx.typed_reads import nsx_alarm_list_impl
+
+        return await nsx_alarm_list_impl(self, operator, target, params)
 
     async def aclose(self) -> None:
         """Clear cached XSRF tokens, then tear down the httpx pool.

--- a/backend/src/meho_backplane/connectors/nsx/core_ops.py
+++ b/backend/src/meho_backplane/connectors/nsx/core_ops.py
@@ -1,12 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""NSX read-only v0.2 core — curated operator-enabled subset.
+"""NSX read-only core — curated operator-enabled subset (browse breadth).
 
-This module names the **9 read-only NSX operations** the G3.5 NSX
-v0.2 ship enables out of the much larger ``policy.yaml`` +
-``manager.yaml`` corpus that the G0.7 spec-ingestion pipeline lands
-under the NSX connector triple. NSX-T 4.x was renumbered onto the
+This module names the **5 read-only NSX operations** left as ingested-row
+curation after the audited operational read set (node/cluster status,
+backup config/status, transport-zones, tier-1 list, alarms) was promoted
+to first-class **typed** ops in
+:mod:`meho_backplane.connectors.nsx.typed_ops` (#2302). The curated set
+here keeps the wider ingested breadth browsable (transport-node listing,
+segments, tier-0 gateways, distributed-firewall policies + rules) out of
+the much larger ``policy.yaml`` + ``manager.yaml`` corpus that the G0.7
+spec-ingestion pipeline lands under the NSX connector triple. NSX-T 4.x
+was renumbered onto the
 VCF train at VCF 9.0 (#1530), so :data:`NSX_VERSION` tracks the
 VCF-9-aligned ``"9.0"`` line and :data:`NSX_CONNECTOR_ID` is the
 default ``"nsx-rest-9.0"`` slug; :func:`apply_nsx_core_curation`
@@ -22,7 +28,7 @@ two-layered:
   ``when_to_use`` is what the agent reads verbatim through
   :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
   to pick a group to search within.
-* :data:`NSX_CORE_OPS` — the 9 ``EndpointDescriptor.op_id`` strings
+* :data:`NSX_CORE_OPS` — the 5 ``EndpointDescriptor.op_id`` strings
   that flip to ``is_enabled=True`` at operator-review time, paired
   with the per-op ``llm_instructions`` blob the agent inlines into
   the reasoning context when it sees the op in
@@ -39,38 +45,35 @@ review step — the actual curation is applied through
 :func:`apply_nsx_core_curation` against an existing ingested
 connector.
 
-The 9 ops (paths cross-checked against the NSX REST API guide,
+The 5 ops (paths cross-checked against the NSX REST API guide,
 2026-04 snapshot at https://developer.broadcom.com/xapis/nsx-data-center-rest-api/latest/;
 the manager (``/api/v1/...``) and policy (``/policy/api/v1/...``)
 path families are stable across the 4.x and VCF-9-aligned 9.x lines):
 
-1. ``GET:/api/v1/node`` — ``nsx.about`` — manager version / build /
-   node UUID (the same surface :meth:`NsxConnector.fingerprint`
-   already consumes; exposing it as an operator-callable op lets
-   the agent run a sanity probe before any heavier read).
-2. ``GET:/api/v1/transport-nodes`` — ``nsx.node.list`` — list of
+1. ``GET:/api/v1/transport-nodes`` — ``nsx.node.list`` — list of
    transport nodes (ESXi / edge) the NSX manager is aware of.
-3. ``GET:/api/v1/cluster/status`` — ``nsx.cluster.status`` —
-   manager cluster mode + node membership; mirrors the connector's
-   probe target.
-4. ``GET:/policy/api/v1/infra/segments`` — ``nsx.segment.list`` —
+2. ``GET:/policy/api/v1/infra/segments`` — ``nsx.segment.list`` —
    policy-API segments (logical-port + DVS-backed portgroup
    surface).
-5. ``GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones``
-   — ``nsx.transport_zone.list`` — transport-zone inventory under
-   the default enforcement point.
-6. ``GET:/policy/api/v1/infra/tier-0s`` — ``nsx.tier0.list`` —
+3. ``GET:/policy/api/v1/infra/tier-0s`` — ``nsx.tier0.list`` —
    policy-API tier-0 gateway inventory (BGP / NAT summaries via
    nested ``children`` field when present).
-7. ``GET:/policy/api/v1/infra/tier-1s`` — ``nsx.tier1.list`` —
-   tier-1 gateway inventory (the per-tenant routing surface).
-8. ``GET:/policy/api/v1/infra/domains/{domain-id}/security-policies``
+4. ``GET:/policy/api/v1/infra/domains/{domain-id}/security-policies``
    — ``nsx.firewall.policy.list`` — distributed-firewall policy
    listing scoped by domain (``--scope <domain>`` in the CLI verb,
    default ``default``).
-9. ``GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules``
+5. ``GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules``
    — ``nsx.firewall.rule.list`` — per-policy rule listing; the
    final-grain firewall inspection surface.
+
+The audited operational reads — node/cluster status+version, backup
+config+status, transport-zones list, tier-1 list, and alarms — are **not**
+curated here: #2302 promoted them to first-class typed ops
+(``source_kind="typed"``, :mod:`meho_backplane.connectors.nsx.typed_ops`)
+that dispatch on a fresh boot with zero catalog state. Their ingested rows
+still exist and stay browsable; this module simply no longer flips them to
+``is_enabled=True``. :data:`NSX_PATH_RULES` retains the full manager/policy
+taxonomy so the ingested breadth keeps its group organisation.
 
 Path families and group_keys
 ----------------------------
@@ -91,7 +94,7 @@ Curation application
 --------------------
 
 :func:`apply_nsx_core_curation` is the operator-review-time
-substrate call that makes exactly the 9 curated ops dispatchable
+substrate call that makes exactly the 5 curated ops dispatchable
 and leaves every other ingested op disabled. The substrate has no
 "enable only ops X, Y, Z under group G" verb —
 :meth:`ReviewService.enable_group` cascades ``is_enabled=True`` to
@@ -259,32 +262,13 @@ def classify_nsx_op(op_id: str) -> str:
     return "none"
 
 
-#: Operator-reviewed ``when_to_use`` hints for the seven NSX groups
-#: the read-only v0.2 core spans. Two groups carry one op each
-#: (``manager-node`` for nsx.about, ``manager-cluster`` for
-#: nsx.cluster.status); the rest carry one or two. Every hint is
-#: one complete sentence the agent reads verbatim — vague hints
-#: poison ``search_operations`` ranking, per the ai_engineering pack.
+#: Operator-reviewed ``when_to_use`` hints for the four NSX groups the
+#: browse-breadth curated core spans (the audited operational groups moved
+#: to typed ops in #2302). ``policy-firewall`` carries two ops; the rest
+#: carry one. Every hint is one complete sentence the agent reads verbatim
+#: — vague hints poison ``search_operations`` ranking, per the
+#: ai_engineering pack.
 NSX_CORE_GROUPS: Final[tuple[NsxCoreGroup, ...]] = (
-    NsxCoreGroup(
-        group_key="manager-node",
-        name="NSX Manager (node)",
-        when_to_use=(
-            "Use this group to read the NSX Manager's own identity — "
-            "build, version, node UUID, hostname. The probe / sanity "
-            "surface the agent calls before any heavier inventory "
-            "read."
-        ),
-    ),
-    NsxCoreGroup(
-        group_key="manager-cluster",
-        name="NSX Manager (cluster)",
-        when_to_use=(
-            "Use this group to check whether the NSX management plane "
-            "is healthy — cluster mode (1-node / 3-node), per-member "
-            "status, control-plane availability."
-        ),
-    ),
     NsxCoreGroup(
         group_key="manager-transport-nodes",
         name="NSX Transport Nodes",
@@ -304,28 +288,11 @@ NSX_CORE_GROUPS: Final[tuple[NsxCoreGroup, ...]] = (
         ),
     ),
     NsxCoreGroup(
-        group_key="policy-transport-zones",
-        name="NSX Transport Zones",
-        when_to_use=(
-            "Use this group to list the transport zones segments and "
-            "tier-routers attach to. Read-only inventory under the "
-            "default enforcement point."
-        ),
-    ),
-    NsxCoreGroup(
         group_key="policy-tier0",
         name="NSX Tier-0 Gateways",
         when_to_use=(
             "Use this group to inspect provider tier-0 gateways — "
             "north-south edge routing, BGP peers, NAT summaries."
-        ),
-    ),
-    NsxCoreGroup(
-        group_key="policy-tier1",
-        name="NSX Tier-1 Gateways",
-        when_to_use=(
-            "Use this group to inspect per-tenant tier-1 gateways — "
-            "the east-west routing surface attached under a tier-0."
         ),
     ),
     NsxCoreGroup(
@@ -372,24 +339,6 @@ def _instructions(
 #: (path families unchanged across 4.x and the VCF-9-aligned 9.x line).
 NSX_CORE_OPS: Final[tuple[NsxCoreOp, ...]] = (
     NsxCoreOp(
-        op_id="GET:/api/v1/node",
-        group_key="manager-node",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to identify the NSX Manager — its build, version, "
-                "node UUID, hostname. Useful as a probe before heavier "
-                "policy reads, or to confirm which NSX cluster the "
-                "target points at."
-            ),
-            output_shape=(
-                "Object with node_version, kernel_version, node_uuid, hostname, external_id keys."
-            ),
-            next_step=(
-                "If the manager looks healthy, move on to cluster-status or transport-node listing."
-            ),
-        ),
-    ),
-    NsxCoreOp(
         op_id="GET:/api/v1/transport-nodes",
         group_key="manager-transport-nodes",
         llm_instructions=_instructions(
@@ -407,26 +356,6 @@ NSX_CORE_OPS: Final[tuple[NsxCoreOp, ...]] = (
             next_step=(
                 "Drill into a specific node by id when you need its "
                 "uplink configuration or tunnel state."
-            ),
-        ),
-    ),
-    NsxCoreOp(
-        op_id="GET:/api/v1/cluster/status",
-        group_key="manager-cluster",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to confirm whether the NSX management plane is "
-                "healthy and which members make up the cluster. "
-                "Useful when an operator suspects a control-plane "
-                "outage."
-            ),
-            output_shape=(
-                "Object with mgmt_cluster_status (overall health), "
-                "control_cluster_status, and per-member detail."
-            ),
-            next_step=(
-                "If unhealthy, surface the failing member's id; "
-                "otherwise proceed to the inventory / policy reads."
             ),
         ),
     ),
@@ -456,27 +385,6 @@ NSX_CORE_OPS: Final[tuple[NsxCoreOp, ...]] = (
         ),
     ),
     NsxCoreOp(
-        op_id=("GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones"),
-        group_key="policy-transport-zones",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to list transport zones under the default "
-                "enforcement point — the scope segments and "
-                "tier-gateways attach to. Read-only inventory."
-            ),
-            output_shape=(
-                "Object with a `results` array of transport-zone "
-                "entries; each carries id, display_name, tz_type "
-                "(OVERLAY / VLAN), and host_switch_name."
-            ),
-            next_step=(
-                "Cross-reference a zone's id when answering 'where "
-                "does this segment live' or 'what zones does this "
-                "edge see'."
-            ),
-        ),
-    ),
-    NsxCoreOp(
         op_id="GET:/policy/api/v1/infra/tier-0s",
         group_key="policy-tier0",
         llm_instructions=_instructions(
@@ -497,28 +405,6 @@ NSX_CORE_OPS: Final[tuple[NsxCoreOp, ...]] = (
                 "Drill into a tier-0 by id for its locale-services / "
                 "interfaces, or follow up with tier-1 listing for "
                 "downstream consumers."
-            ),
-        ),
-    ),
-    NsxCoreOp(
-        op_id="GET:/policy/api/v1/infra/tier-1s",
-        group_key="policy-tier1",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to inspect per-tenant tier-1 gateways — the "
-                "east-west routing surface attached under a tier-0. "
-                "Useful when mapping which tier-1 fronts a given "
-                "segment."
-            ),
-            output_shape=(
-                "Object with a `results` array; each tier-1 carries "
-                "id, display_name, tier0_path (its parent), "
-                "route_advertisement_types, and ha_mode."
-            ),
-            next_step=(
-                "Cross-reference tier0_path against the tier-0 "
-                "listing, or drill into a tier-1 for its segment "
-                "attachments."
             ),
         ),
     ),
@@ -580,12 +466,12 @@ async def apply_nsx_core_curation(
     tenant_id: UUID | None,
     connector_id: str = NSX_CONNECTOR_ID,
 ) -> None:
-    """Apply the curated 9-op read core against an ingested NSX connector.
+    """Apply the curated 5-op read core against an ingested NSX connector.
 
     Drives the substrate so that, after this call returns, exactly
-    the 9 ops in :data:`NSX_CORE_OPS` are dispatchable
+    the 5 ops in :data:`NSX_CORE_OPS` are dispatchable
     (``is_enabled=True``) and every other ingested op stays
-    ``is_enabled=False``. The 8 curated groups land
+    ``is_enabled=False``. The 4 curated groups land
     ``review_status='enabled'`` so the agent's
     :func:`~meho_backplane.operations.meta_tools.search_operations`
     surfaces the core ops; non-curated groups are left untouched

--- a/backend/src/meho_backplane/connectors/nsx/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/nsx/typed_ops.py
@@ -1,0 +1,516 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed-op metadata + registrar for :class:`NsxConnector` (#2302).
+
+The audited NSX read set is registered as typed ops
+(``source_kind="typed"``) so it dispatches on a fresh boot with **zero
+catalog ingest** -- the #2247 failure class the ingested-row curation in
+:mod:`meho_backplane.connectors.nsx.core_ops` was subject to (per-deploy
+catalog state). The op bodies live in
+:mod:`meho_backplane.connectors.nsx.typed_reads`; thin bound-method shims
+on :class:`~meho_backplane.connectors.nsx.connector.NsxConnector` expose
+them under the ``handler_attr`` names below so the dispatcher's
+:func:`~meho_backplane.operations._handler_resolve.import_handler` walk
+recovers each callable from its persisted ``module.ClassName.method``
+path.
+
+The dataclass + tuple + module-level registrar shape mirrors
+:mod:`meho_backplane.connectors.argocd.ops` and
+:mod:`meho_backplane.connectors.vmware_rest.typed_ops`.
+
+Curated ops NOT in the audited set (transport-node listing, segment
+listing, tier-0 gateways, distributed-firewall policies + rules) stay as
+``core_ops.py`` curation over ingested rows -- the ingested breadth
+remains browsable; only the audited operational reads are promoted to
+first-class typed ops. ``tier-1 gateway create`` (a write) is out of
+scope: the first write on a read-only connector is its own approval-gated
+G3.x write-surface initiative.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+
+if TYPE_CHECKING:
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "NSX_TYPED_OPS",
+    "NSX_TYPED_WHEN_TO_USE_BY_GROUP",
+    "NsxTypedOp",
+    "register_nsx_typed_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+# Typed-op group keys. Each groups the audited reads by the operator
+# question they answer; the ``when_to_use`` blurbs below are what the
+# agent reads verbatim through ``list_operation_groups`` to pick a group.
+_GROUP_HEALTH = "nsx-health"
+_GROUP_BACKUP = "nsx-backup"
+_GROUP_INVENTORY = "nsx-inventory"
+_GROUP_ALARMS = "nsx-alarms"
+
+
+@dataclass(frozen=True)
+class NsxTypedOp:
+    """Metadata for one NSX typed op registered at lifespan startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so :func:`register_nsx_typed_operations` can splat the
+    dataclass into the helper without per-op boilerplate. ``handler_attr``
+    is the attribute name on
+    :class:`~meho_backplane.connectors.nsx.connector.NsxConnector`
+    exposing the async handler; the registrar resolves the bound method
+    against the class at registration time. Mirrors
+    :class:`~meho_backplane.connectors.argocd.ops.ArgoCdOp`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurb per typed-op group.
+#: ``register_typed_operation`` requires a non-empty string whenever
+#: ``group_key`` is set (typed_register ``_validate_when_to_use_pairing``).
+NSX_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    _GROUP_HEALTH: (
+        "Use to read the NSX management plane's health and version: the "
+        "manager node's build/version/UUID (nsx.node.status) and the "
+        "management + control cluster status (nsx.cluster.status). The "
+        "right group for the probe / incident-triage question 'which NSX "
+        "build is this and is the manager cluster healthy?'. Read-only."
+    ),
+    _GROUP_BACKUP: (
+        "Use to inspect NSX Manager backup: the backup configuration and "
+        "schedule (nsx.backup.config -- whether automated backup is "
+        "enabled, how often it runs, and which remote file server it "
+        "writes to) and the current backup operation status "
+        "(nsx.backup.status). The right group when diagnosing a backup "
+        "gap or a retention/schedule misconfiguration that risks filling "
+        "the remote server's disk. Read-only; the backup passphrase is "
+        "never returned."
+    ),
+    _GROUP_INVENTORY: (
+        "Use to list the NSX routing/overlay inventory the operator asks "
+        "about most: transport zones under the default enforcement point "
+        "(nsx.transport_zone.list) and per-tenant tier-1 gateways "
+        "(nsx.tier1.list). Read-only."
+    ),
+    _GROUP_ALARMS: (
+        "Use to read NSX system alarms (nsx.alarm.list) -- open faults and "
+        "capacity/health events across the manager, with optional filters "
+        "by status, feature, and severity. The right group when the "
+        "question is 'what is NSX complaining about right now?'. Read-only."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared parameter-schema fragments
+# ---------------------------------------------------------------------------
+
+#: The empty parameter object shared by the no-argument reads.
+_NO_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# nsx.node.status
+# ---------------------------------------------------------------------------
+
+_NODE_STATUS = NsxTypedOp(
+    op_id="nsx.node.status",
+    handler_attr="node_status",
+    summary="NSX Manager node identity, version, and build.",
+    description=(
+        "Returns the NSX Manager node's identity and version via "
+        "GET /api/v1/node: node_version (the NSX build the manager runs), "
+        "kernel_version, node_uuid, hostname, and external_id. The probe / "
+        "sanity read to confirm which NSX build a target points at and that "
+        "the manager answers before any heavier policy read. Works with "
+        "zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_HEALTH,
+    tags=("read-only", "nsx", "manager", "version"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to identify the NSX Manager -- its build, version, node "
+            "UUID, hostname -- as a probe before heavier reads or to confirm "
+            "which NSX cluster the target points at."
+        ),
+        "output_shape": ("{node_version, kernel_version, node_uuid, hostname, external_id}."),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# nsx.cluster.status
+# ---------------------------------------------------------------------------
+
+_CLUSTER_STATUS = NsxTypedOp(
+    op_id="nsx.cluster.status",
+    handler_attr="cluster_status",
+    summary="NSX management + control cluster health.",
+    description=(
+        "Returns the NSX management-plane health via "
+        "GET /api/v1/cluster/status: mgmt_cluster_status (overall "
+        "management cluster state), control_cluster_status, and per-member "
+        "detail. The read an operator runs when a control-plane outage is "
+        "suspected. Works with zero catalog ingest. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_HEALTH,
+    tags=("read-only", "nsx", "manager", "cluster"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to confirm whether the NSX management plane is healthy and "
+            "which members make up the cluster, e.g. when a control-plane "
+            "outage is suspected."
+        ),
+        "output_shape": (
+            "{mgmt_cluster_status, control_cluster_status, detail: [...]}. "
+            "If unhealthy, surface the failing member's id."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# nsx.backup.config
+# ---------------------------------------------------------------------------
+
+_BACKUP_CONFIG = NsxTypedOp(
+    op_id="nsx.backup.config",
+    handler_attr="backup_config",
+    summary="NSX Manager automated-backup configuration (retention-relevant fields surfaced).",
+    description=(
+        "Returns the NSX Manager automated-backup configuration via "
+        "GET /api/v1/cluster/backups/config, with the retention-relevant "
+        "fields surfaced and secret material scrubbed. backup_enabled is "
+        "hoisted for the at-a-glance answer; passphrase_configured reports "
+        "whether an encryption passphrase is set without returning it; the "
+        "config object preserves backup_schedule (the accumulation rate -- "
+        "a WeeklyBackupSchedule or IntervalBackupSchedule) and "
+        "remote_file_server (server / port / directory_path / protocol -- "
+        "where backups accumulate, with credentials masked), plus "
+        "inventory_summary_interval and after_inventory_update_interval. "
+        "The read for the disk-fill class of incident (Broadcom KB 442696 "
+        "shape) where a frequent schedule against a bounded remote server "
+        "fills the disk. Works with zero catalog ingest. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={
+        "type": "object",
+        "properties": {
+            "backup_enabled": {"type": ["boolean", "null"]},
+            "passphrase_configured": {"type": "boolean"},
+            "config": {"type": "object"},
+        },
+        "additionalProperties": True,
+    },
+    group_key=_GROUP_BACKUP,
+    tags=("read-only", "nsx", "manager", "backup", "retention"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to check whether NSX Manager backups are configured and how "
+            "often they run, and to which remote server -- e.g. when "
+            "diagnosing a missing-backup gap or a retention/schedule "
+            "misconfiguration that risks filling the remote server's disk."
+        ),
+        "output_shape": (
+            "{backup_enabled, passphrase_configured, config: {backup_schedule, "
+            "remote_file_server, inventory_summary_interval, "
+            "after_inventory_update_interval, ...}}. The passphrase and any "
+            "nested SFTP credential are masked as ***REDACTED***; read "
+            "config.backup_schedule (frequency) against "
+            "config.remote_file_server.directory_path for the disk-fill risk."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# nsx.backup.status
+# ---------------------------------------------------------------------------
+
+_BACKUP_STATUS = NsxTypedOp(
+    op_id="nsx.backup.status",
+    handler_attr="backup_status",
+    summary="NSX Manager current backup operation status.",
+    description=(
+        "Returns the current NSX Manager backup operation status via "
+        "GET /api/v1/cluster/backups/status: whether a backup is running, "
+        "the last operation's success/failure, and its timing "
+        "(current_backup_operation_status). Pairs with nsx.backup.config so "
+        "the operator sees both 'is backup configured (and how often)' and "
+        "'did the last backup actually succeed'. Works with zero catalog "
+        "ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_BACKUP,
+    tags=("read-only", "nsx", "manager", "backup"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to confirm whether the last NSX Manager backup succeeded "
+            "and when, or whether one is running now -- alongside "
+            "nsx.backup.config for the schedule."
+        ),
+        "output_shape": (
+            "{current_backup_operation_status: {...}}. Surface the last "
+            "operation's success flag and timing."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# nsx.transport_zone.list
+# ---------------------------------------------------------------------------
+
+_TRANSPORT_ZONE_LIST = NsxTypedOp(
+    op_id="nsx.transport_zone.list",
+    handler_attr="transport_zone_list",
+    summary="NSX transport zones under the default enforcement point.",
+    description=(
+        "Lists NSX transport zones via "
+        "GET /policy/api/v1/infra/sites/default/enforcement-points/default/"
+        "transport-zones -- the scope segments and tier-gateways attach to. "
+        "Returns {results: [...]} where each zone carries id, display_name, "
+        "tz_type (OVERLAY / VLAN), and host_switch_name. Works with zero "
+        "catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "nsx", "policy", "transport-zone"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to list transport zones under the default enforcement "
+            "point -- the scope segments and tier-gateways attach to."
+        ),
+        "output_shape": ("{results: [{id, display_name, tz_type, host_switch_name}, ...]}."),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# nsx.tier1.list
+# ---------------------------------------------------------------------------
+
+_TIER1_LIST = NsxTypedOp(
+    op_id="nsx.tier1.list",
+    handler_attr="tier1_list",
+    summary="NSX per-tenant tier-1 gateway inventory.",
+    description=(
+        "Lists NSX tier-1 gateways via GET /policy/api/v1/infra/tier-1s -- "
+        "the per-tenant east-west routing surface attached under a tier-0. "
+        "Returns {results: [...]} where each tier-1 carries id, "
+        "display_name, tier0_path (its parent), route_advertisement_types, "
+        "and ha_mode. Read-only inventory: tier-1 gateway *create* is a "
+        "separate approval-gated write and is not registered here. Works "
+        "with zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "nsx", "policy", "tier1"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to inspect per-tenant tier-1 gateways -- useful when "
+            "mapping which tier-1 fronts a given segment or cross-referencing "
+            "tier0_path against the tier-0 listing."
+        ),
+        "output_shape": (
+            "{results: [{id, display_name, tier0_path, route_advertisement_types, ha_mode}, ...]}."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# nsx.alarm.list
+# ---------------------------------------------------------------------------
+
+_ALARM_LIST = NsxTypedOp(
+    op_id="nsx.alarm.list",
+    handler_attr="alarm_list",
+    summary="NSX system alarms, optionally filtered by status/feature/severity.",
+    description=(
+        "Lists NSX system alarms via GET /api/v1/alarms -- open faults and "
+        "capacity/health events across the manager. Optional status (OPEN / "
+        "ACKNOWLEDGED / SUPPRESSED / RESOLVED), feature_name (e.g. "
+        "manager_health), and severity (CRITICAL / HIGH / MEDIUM / LOW) "
+        "narrow the result to the actionable set. Returns {results: [...]} "
+        "where each alarm carries id, status, severity, feature_name, "
+        "event_type, node_id, last_reported_time, and description. Works "
+        "with zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "string",
+                "enum": ["OPEN", "ACKNOWLEDGED", "SUPPRESSED", "RESOLVED"],
+                "description": "Optional alarm status filter. Omit for all statuses.",
+            },
+            "feature_name": {
+                "type": "string",
+                "minLength": 1,
+                "description": (
+                    "Optional NSX feature filter (e.g. 'manager_health'). Omit for all features."
+                ),
+            },
+            "severity": {
+                "type": "string",
+                "enum": ["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+                "description": "Optional severity filter. Omit for all severities.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_ALARMS,
+    tags=("read-only", "nsx", "manager", "alarms"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the question is 'what is NSX complaining about right "
+            "now?'. Narrow with status='OPEN' for active faults, or by "
+            "feature_name / severity when the operator named one."
+        ),
+        "parameter_hints": {
+            "status": "OPEN / ACKNOWLEDGED / SUPPRESSED / RESOLVED; omit for all.",
+            "feature_name": "NSX feature id (e.g. manager_health); omit for all.",
+            "severity": "CRITICAL / HIGH / MEDIUM / LOW; omit for all.",
+        },
+        "output_shape": (
+            "{results: [{id, status, severity, feature_name, event_type, "
+            "node_id, last_reported_time, description}, ...]}."
+        ),
+    },
+)
+
+
+#: The typed ops :class:`NsxConnector` registers at lifespan startup --
+#: the audited read set (#2302). Ordered health -> backup -> inventory ->
+#: alarms to match the operator's typical triage path.
+NSX_TYPED_OPS: tuple[NsxTypedOp, ...] = (
+    _NODE_STATUS,
+    _CLUSTER_STATUS,
+    _BACKUP_CONFIG,
+    _BACKUP_STATUS,
+    _TRANSPORT_ZONE_LIST,
+    _TIER1_LIST,
+    _ALARM_LIST,
+)
+
+
+async def register_nsx_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every op in :data:`NSX_TYPED_OPS` into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after
+    :func:`~meho_backplane.connectors.registry._eager_import_connectors`
+    has walked every connector subpackage, so the descriptor rows land
+    before the first dispatch. Idempotent across pod restarts (the helper
+    skips the embedding recompute on unchanged summary / description /
+    tags). Mirrors :func:`register_vmware_typed_operations` and the argocd
+    typed-op registrar.
+
+    The ``embedding_service`` keyword-only parameter is the runner
+    contract: :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar,
+    so each registrar must accept the kwarg. It is forwarded to
+    :func:`register_typed_operation` (which falls back to the process-wide
+    singleton when ``None``).
+    """
+    # Lazy imports: the operations package pulls in the embedding pipeline
+    # (ONNX runtime + model), which pure connector/handler unit tests
+    # should not pay. Lifespan callers have it warmed by the time this runs.
+    from meho_backplane.connectors.nsx.connector import NsxConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in NSX_TYPED_OPS:
+        handler = getattr(NsxConnector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"NsxConnector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = (
+            None if op.group_key is None else NSX_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        )
+        if op.group_key is not None and when_to_use is None:
+            raise ValueError(
+                f"NsxConnector typed op {op.op_id!r} declares "
+                f"group_key={op.group_key!r} but no curated when_to_use exists for "
+                f"that key. Add an entry to NSX_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=NsxConnector.product,
+            version=NsxConnector.version,
+            impl_id=NsxConnector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "nsx_typed_operations_registered",
+        count=len(NSX_TYPED_OPS),
+        product=NsxConnector.product,
+        version=NsxConnector.version,
+        impl_id=NsxConnector.impl_id,
+    )

--- a/backend/src/meho_backplane/connectors/nsx/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/nsx/typed_reads.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) read implementations for :class:`NsxConnector`.
+
+The audited NSX read set (#2302) is converted from the ingested-row
+curation in :mod:`meho_backplane.connectors.nsx.core_ops` to typed ops
+(``source_kind="typed"``) so it dispatches on a fresh boot with **zero
+catalog state**. Each function here is the body a thin bound-method shim
+on :class:`~meho_backplane.connectors.nsx.connector.NsxConnector`
+delegates to; the metadata + registrar live in
+:mod:`meho_backplane.connectors.nsx.typed_ops`.
+
+Every read is issued directly on the connector's own authenticated
+session via :meth:`HttpConnector._get_json` -- no ``dispatch_child``, no
+ingested descriptor. A raw ``401`` from a downstream call propagates as
+:class:`httpx.HTTPStatusError` up to the dispatcher's G0.29-T2 (#2067)
+recovery arm, which evicts the cached session via the connector's public
+:meth:`NsxConnector.invalidate_session` hook and re-dispatches once. The
+handlers therefore do **not** wrap calls in the connector's internal
+``_get_json_with_session_retry`` helper (that helper serves the
+fingerprint/probe path, which the dispatcher does not drive).
+
+The audited set:
+
+* ``nsx.node.status`` -- ``GET /api/v1/node`` (manager identity: version,
+  build, node UUID).
+* ``nsx.cluster.status`` -- ``GET /api/v1/cluster/status`` (management +
+  control cluster health).
+* ``nsx.backup.config`` -- ``GET /api/v1/cluster/backups/config``, the
+  first-class backup read the adopter flagged (a retention/schedule
+  misconfig of the Broadcom KB 442696 class filled a router disk and took
+  a lab's DNS down). Secret material (the backup ``passphrase`` and any
+  nested SFTP credential) is scrubbed at this boundary -- the default
+  connector-boundary redaction policy masks ``password`` / ``secret`` but
+  not ``passphrase``, so the scrub happens here (the same
+  secret-is-incidental posture the keycloak read ops take).
+* ``nsx.backup.status`` -- ``GET /api/v1/cluster/backups/status`` (the
+  current backup operation status).
+* ``nsx.transport_zone.list`` -- policy-API transport zones under the
+  default enforcement point.
+* ``nsx.tier1.list`` -- ``GET /policy/api/v1/infra/tier-1s`` (the
+  per-tenant east-west routing surface).
+* ``nsx.alarm.list`` -- ``GET /api/v1/alarms`` with optional
+  ``status`` / ``feature_name`` / ``severity`` filters.
+
+Field names are pinned to the NSX-T Data Center REST API guide
+(https://developer.broadcom.com/xapis/nsx-t-data-center-rest-api/latest/);
+the ``/api/v1/...`` manager and ``/policy/api/v1/...`` policy path
+families are stable across the standalone NSX-T 4.x line and the
+VCF-9-aligned 9.x line (#1530).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.nsx.session import NsxTargetLike
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.nsx.connector import NsxConnector
+
+__all__ = [
+    "REDACTED",
+    "nsx_alarm_list_impl",
+    "nsx_backup_config_impl",
+    "nsx_backup_status_impl",
+    "nsx_cluster_status_impl",
+    "nsx_node_status_impl",
+    "nsx_tier1_list_impl",
+    "nsx_transport_zone_list_impl",
+]
+
+_log = structlog.get_logger(__name__)
+
+# Spec-relative NSX endpoints. The manager API lives under ``/api/v1``;
+# the policy API under ``/policy/api/v1``. Both are reached through the
+# connector's pooled per-target client, which carries the JSESSIONID
+# cookie + X-XSRF-TOKEN the session establish primed.
+_NODE_PATH = "/api/v1/node"
+_CLUSTER_STATUS_PATH = "/api/v1/cluster/status"
+_BACKUP_CONFIG_PATH = "/api/v1/cluster/backups/config"
+_BACKUP_STATUS_PATH = "/api/v1/cluster/backups/status"
+_TRANSPORT_ZONES_PATH = (
+    "/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones"
+)
+_TIER1S_PATH = "/policy/api/v1/infra/tier-1s"
+_ALARMS_PATH = "/api/v1/alarms"
+
+#: Sentinel written in place of a scrubbed secret value. A non-empty
+#: marker (rather than dropping the key) keeps the shape stable so the
+#: agent can see a secret *existed* without learning its value. Same
+#: convention :mod:`meho_backplane.connectors.keycloak.redaction` uses.
+REDACTED = "***REDACTED***"
+
+#: Key names (matched case-insensitively) whose value -- scalar or
+#: subtree -- is secret material scrubbed wherever it appears in the
+#: backup configuration. ``passphrase`` is the NSX-specific addition the
+#: generic boundary policy does not cover; the rest mirror the well-known
+#: credential spellings so a nested SFTP ``password`` under
+#: ``remote_file_server.protocol.authentication_scheme`` never leaks.
+_SECRET_FIELDS: frozenset[str] = frozenset(
+    {
+        "passphrase",
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "client_secret",
+        "token",
+        "private_key",
+    }
+)
+
+
+def _redact_secrets(value: Any) -> Any:
+    """Return *value* with secret-keyed material scrubbed, recursively.
+
+    Walks dicts and lists. A key matching :data:`_SECRET_FIELDS`
+    (case-insensitively) has its whole value replaced with
+    :data:`REDACTED`; every other value is walked so a credential nested
+    inside ``remote_file_server`` is still caught. Scalars pass through
+    unchanged. The input is not mutated -- a new structure is returned.
+    """
+    if isinstance(value, dict):
+        return {
+            key: (
+                REDACTED
+                if isinstance(key, str) and key.lower() in _SECRET_FIELDS
+                else _redact_secrets(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_secrets(item) for item in value]
+    return value
+
+
+async def nsx_node_status_impl(
+    connector: NsxConnector,
+    operator: Operator,
+    target: NsxTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``nsx.node.status`` -- ``GET /api/v1/node``.
+
+    Returns the NSX Manager node's identity + version: ``node_version``,
+    ``kernel_version`` (build), ``node_uuid``, ``hostname``,
+    ``external_id``. The same surface :meth:`NsxConnector.fingerprint`
+    reads, exposed as an operator-callable typed op for the probe /
+    incident-triage question "which NSX build is this and is the manager
+    up?".
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _NODE_PATH, operator=operator)
+
+
+async def nsx_cluster_status_impl(
+    connector: NsxConnector,
+    operator: Operator,
+    target: NsxTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``nsx.cluster.status`` -- ``GET /api/v1/cluster/status``.
+
+    Returns the management-plane health: ``mgmt_cluster_status`` (overall
+    management cluster state), ``control_cluster_status``, and per-member
+    ``detail``. The read an operator runs when a control-plane outage is
+    suspected.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _CLUSTER_STATUS_PATH, operator=operator)
+
+
+async def nsx_backup_config_impl(
+    connector: NsxConnector,
+    operator: Operator,
+    target: NsxTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``nsx.backup.config`` -- ``GET /api/v1/cluster/backups/config``.
+
+    Returns the automated-backup configuration with the retention-relevant
+    fields surfaced and secret material scrubbed. NSX's
+    ``BackupConfiguration`` carries ``backup_enabled``, ``backup_schedule``
+    (the accumulation rate -- a WeeklyBackupSchedule or an
+    IntervalBackupSchedule), ``remote_file_server`` (where backups
+    accumulate: ``server`` / ``port`` / ``directory_path`` /
+    ``protocol``), ``inventory_summary_interval``,
+    ``after_inventory_update_interval``, and a ``passphrase``.
+
+    The disk-fill incident the adopter flagged (Broadcom KB 442696 class)
+    is a function of the schedule frequency against the remote server's
+    free space, so the returned ``config`` preserves ``backup_schedule``
+    and ``remote_file_server`` verbatim (creds masked). ``backup_enabled``
+    is hoisted for the at-a-glance answer and ``passphrase_configured``
+    reports whether an encryption passphrase is set without returning it.
+    """
+    del params  # schema declares the param object empty
+    raw = await connector._get_json(target, _BACKUP_CONFIG_PATH, operator=operator)
+    passphrase = raw.get("passphrase") if isinstance(raw, dict) else None
+    _log.info("nsx_backup_config_read", target=target.name)
+    return {
+        "backup_enabled": raw.get("backup_enabled") if isinstance(raw, dict) else None,
+        "passphrase_configured": isinstance(passphrase, str) and bool(passphrase),
+        "config": _redact_secrets(raw),
+    }
+
+
+async def nsx_backup_status_impl(
+    connector: NsxConnector,
+    operator: Operator,
+    target: NsxTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``nsx.backup.status`` -- ``GET /api/v1/cluster/backups/status``.
+
+    Returns the current backup operation status
+    (``current_backup_operation_status``): whether a backup is running,
+    the last operation's success/failure, and its timing. Pairs with
+    ``nsx.backup.config`` so the operator sees both "is backup configured
+    (and how often)" and "did the last backup actually succeed".
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _BACKUP_STATUS_PATH, operator=operator)
+
+
+async def nsx_transport_zone_list_impl(
+    connector: NsxConnector,
+    operator: Operator,
+    target: NsxTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``nsx.transport_zone.list`` -- policy-API transport zones.
+
+    ``GET /policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones``
+    -- the transport-zone inventory under the default enforcement point.
+    Returns ``{"results": [...]}`` where each zone carries ``id``,
+    ``display_name``, ``tz_type`` (OVERLAY / VLAN), and
+    ``host_switch_name``.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _TRANSPORT_ZONES_PATH, operator=operator)
+
+
+async def nsx_tier1_list_impl(
+    connector: NsxConnector,
+    operator: Operator,
+    target: NsxTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``nsx.tier1.list`` -- ``GET /policy/api/v1/infra/tier-1s``.
+
+    Returns the per-tenant tier-1 gateway inventory (the east-west routing
+    surface attached under a tier-0). ``{"results": [...]}`` where each
+    tier-1 carries ``id``, ``display_name``, ``tier0_path`` (its parent),
+    ``route_advertisement_types``, and ``ha_mode``.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _TIER1S_PATH, operator=operator)
+
+
+async def nsx_alarm_list_impl(
+    connector: NsxConnector,
+    operator: Operator,
+    target: NsxTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``nsx.alarm.list`` -- ``GET /api/v1/alarms``.
+
+    Returns the NSX system alarms. Optional ``status`` (OPEN / ACKNOWLEDGED
+    / SUPPRESSED / RESOLVED), ``feature_name`` (e.g. ``manager_health``),
+    and ``severity`` (CRITICAL / HIGH / MEDIUM / LOW) narrow the result to
+    the actionable set. ``{"results": [...]}`` where each alarm carries
+    ``id``, ``status``, ``severity``, ``feature_name``, ``event_type``,
+    ``node_id``, ``last_reported_time``, and ``description``.
+    """
+    query: dict[str, Any] = {}
+    for key in ("status", "feature_name", "severity"):
+        value = params.get(key)
+        if value:
+            query[key] = value
+    return await connector._get_json(target, _ALARMS_PATH, operator=operator, params=query or None)

--- a/backend/tests/acceptance/_nsx_canary_fixtures.py
+++ b/backend/tests/acceptance/_nsx_canary_fixtures.py
@@ -7,7 +7,7 @@ Two NSX acceptance modules (dispatch smoke + JSONFlux force-handle)
 share the same plumbing: a registered
 :class:`~meho_backplane.connectors.nsx.NsxConnector` instance with a
 stub session loader (so no Vault read is required), a probed
-:class:`~meho_backplane.db.models.Target` row, the 9 curated
+:class:`~meho_backplane.db.models.Target` row, the curated
 :class:`~meho_backplane.db.models.EndpointDescriptor` rows from
 :data:`~meho_backplane.connectors.nsx.core_ops.NSX_CORE_OPS`, and a
 :mod:`respx`-mocked NSX REST surface answering both the session-
@@ -25,7 +25,7 @@ PR body for #614); until the NSX specs are wired to the meho-runners
 pool, the dispatch leg can still be exercised against a minimal
 direct-insert path.
 
-This module inserts the 9 curated NSX-core
+This module inserts the curated NSX-core
 :class:`EndpointDescriptor` rows with hand-authored ``method`` /
 ``path`` triples (sourced from :mod:`meho_backplane.connectors.nsx.core_ops`),
 seeds one enabled :class:`OperationGroup` per curated group_key,
@@ -217,7 +217,7 @@ class IngestedNsxCanary:
 
 
 async def _insert_nsx_descriptors() -> None:
-    """Seed the 9 curated NSX core ops + their groups as enabled rows.
+    """Seed the curated NSX core ops + their groups as enabled rows.
 
     One :class:`OperationGroup` per entry in
     :data:`~meho_backplane.connectors.nsx.core_ops.NSX_CORE_GROUPS`
@@ -483,7 +483,7 @@ async def ingested_nsx_canary(
     Setup steps mirror :func:`tests.acceptance._canary_fixtures.ingested_canary_vcsim`:
 
     1. Insert built-in :class:`OperationGroup` + :class:`EndpointDescriptor`
-       rows for the 9 curated NSX core ops.
+       rows for the curated NSX core ops.
     2. Seed a :class:`Target` carrying the :data:`NSX_CANARY_FINGERPRINT`
        so the resolver binds :class:`NsxConnector` (version 9.0 fits
        its ``">=4.0,<10.0"`` advertisement).

--- a/backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""G3.5-T2 dispatch smoke — the 9 curated NSX read ops over respx.
+"""G3.5-T2 dispatch smoke — the curated NSX read ops over respx.
 
 Closes the substrate-proves-out half of the NSX v0.2 ship for
 Initiative #368: each entry in

--- a/backend/tests/test_connectors_nsx_e2e.py
+++ b/backend/tests/test_connectors_nsx_e2e.py
@@ -322,7 +322,9 @@ async def nsx_e2e_401_canary(
 # ---------------------------------------------------------------------------
 
 _OP_IDS: tuple[str, ...] = tuple(op.op_id for op in NSX_CORE_OPS)
-assert len(_OP_IDS) == 9, f"Expected 9 curated NSX ops, got {len(_OP_IDS)}: {_OP_IDS}"
+# The audited operational reads moved to typed ops in #2302; the ingested
+# curation now covers the 5 browse-breadth reads.
+assert len(_OP_IDS) == 5, f"Expected 5 curated NSX ops, got {len(_OP_IDS)}: {_OP_IDS}"
 
 
 @pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
@@ -377,7 +379,9 @@ async def test_nsx_e2e_session_establishes_on_first_dispatch(
         _OPERATOR,
         {
             "connector_id": NSX_CONNECTOR_ID,
-            "op_id": "GET:/api/v1/node",
+            # node/cluster moved to typed ops (#2302); dispatch a still-ingested
+            # curated op to exercise the ingested-path session establish.
+            "op_id": "GET:/api/v1/transport-nodes",
             "target": {"name": target_name},
             "params": {},
         },
@@ -452,7 +456,8 @@ async def test_nsx_e2e_dispatch_writes_audit_row(
     * ``row.payload["op_id"]`` equals the dispatched ``op_id``.
     * ``row.payload["params_hash"]`` is present (non-None string).
     """
-    op_id = "GET:/api/v1/node"
+    # node/cluster moved to typed ops (#2302); use a still-ingested op.
+    op_id = "GET:/api/v1/transport-nodes"
     sessionmaker = get_sessionmaker()
 
     async def _count_dispatch_rows() -> int:

--- a/backend/tests/test_connectors_nsx_typed_reads.py
+++ b/backend/tests/test_connectors_nsx_typed_reads.py
@@ -1,0 +1,498 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the NSX audited-read typed ops (#2302).
+
+Coverage matrix (per Task #2302 acceptance criteria):
+
+* **Zero-catalog typed dispatch (AC #1).** Each audited read
+  (nsx.node.status / nsx.cluster.status / nsx.backup.config /
+  nsx.backup.status / nsx.transport_zone.list / nsx.tier1.list /
+  nsx.alarm.list) dispatches through :func:`~meho_backplane.operations.dispatch`
+  against a respx-mocked NSX manager with **only** the typed registrar
+  run -- no ingested descriptor rows -- and returns ``status="ok"``. The
+  persisted descriptor carries ``source_kind="typed"``.
+* **Backup config is first-class with retention fields surfaced, secrets
+  scrubbed (AC #2).** nsx.backup.config surfaces backup_enabled +
+  passphrase_configured + the backup_schedule / remote_file_server the
+  disk-fill class hinges on, and never returns the passphrase or a nested
+  SFTP credential.
+* **Session recovery via the #2067 seam (AC #3).** A 401 on the first
+  downstream GET is recovered by the dispatcher's auth-class arm calling
+  the connector's public ``invalidate_session`` hook and re-dispatching
+  once; the op returns ``status="ok"``.
+* **Registration-shape invariants.** All seven carry
+  ``safety_level="safe"``, ``requires_approval=False``, a ``read-only``
+  tag, ``additionalProperties=False`` on the parameter schema, and
+  non-empty llm_instructions. No write op is registered.
+
+Mirrors :mod:`tests.test_connectors_argocd_reads` for the dispatch
+lifecycle + embedding stub and :mod:`tests.test_connectors_nsx_e2e` for
+the NSX session-establish + session-loader stub.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.nsx import (
+    NSX_CONNECTOR_ID,
+    NSX_IMPL_ID,
+    NSX_PRODUCT,
+    NSX_TYPED_OPS,
+    NSX_VERSION,
+    NsxConnector,
+    register_nsx_typed_operations,
+)
+from meho_backplane.connectors.nsx.typed_reads import REDACTED
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import (
+    get_or_create_connector_instance,
+    reset_handler_cache,
+)
+from meho_backplane.operations.meta_tools import search_operations
+from meho_backplane.settings import get_settings
+
+_NSX_HOST = "nsx-typed.test.invalid"
+_NSX_BASE_URL = f"https://{_NSX_HOST}"
+
+_XSRF_HEADERS = {
+    "X-XSRF-TOKEN": "typed-xsrf-token",
+    "Set-Cookie": "JSESSIONID=typed-session-id; Path=/; HttpOnly",
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=NSX_PRODUCT,
+        version=NSX_VERSION,
+        impl_id=NSX_IMPL_ID,
+        cls=NsxConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration/search don't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.operations._search.get_embedding_service",
+        lambda: service,
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _NsxReadTarget:
+    """Target satisfying both ``NsxTargetLike`` and the resolver shape."""
+
+    def __init__(self) -> None:
+        self.product = NSX_PRODUCT
+        self.fingerprint = type("_FP", (), {"version": NSX_VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000b0")
+        self.name = "nsx-typed"
+        self.host = _NSX_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-reads/nsx-typed"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-reads-nsx",
+        name="NSX Reads Operator",
+        email=None,
+        raw_jwt="op.reads.nsx.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000b4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _nsx_session_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Static session loader -- bypasses the live operator-context Vault read."""
+    return {"username": "nsx-typed-svc", "password": "nsx-typed-pw"}
+
+
+async def _register_and_resolve(_stub_embedding: AsyncMock) -> NsxConnector:
+    """Run the typed registrar (only) and return the session-stubbed instance."""
+    await register_nsx_typed_operations()
+    instance = get_or_create_connector_instance(NsxConnector)
+    instance._session_loader = _nsx_session_loader  # type: ignore[attr-defined]
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# AC #1 -- zero-catalog typed dispatch
+# ---------------------------------------------------------------------------
+
+_NODE_PAYLOAD: dict[str, Any] = {
+    "node_version": NSX_VERSION,
+    "kernel_version": "9.0.2.0.0",
+    "node_uuid": "deadbeef-typed",
+    "hostname": "nsxmgr-typed",
+    "external_id": "typed-external-id",
+}
+_CLUSTER_PAYLOAD: dict[str, Any] = {
+    "mgmt_cluster_status": {"status": "STABLE"},
+    "control_cluster_status": {"status": "STABLE"},
+    "detail": [{"member_uuid": "m1", "status": "CONNECTED"}],
+}
+_BACKUP_STATUS_PAYLOAD: dict[str, Any] = {
+    "current_backup_operation_status": {"backup_id": "b-1", "success": True}
+}
+_TZ_PAYLOAD: dict[str, Any] = {
+    "results": [{"id": "tz-overlay", "display_name": "overlay", "tz_type": "OVERLAY"}]
+}
+_TIER1_PAYLOAD: dict[str, Any] = {
+    "results": [{"id": "t1-a", "display_name": "tenant-a", "tier0_path": "/infra/tier-0s/t0"}]
+}
+_ALARM_PAYLOAD: dict[str, Any] = {
+    "results": [
+        {
+            "id": "alarm-1",
+            "status": "OPEN",
+            "severity": "CRITICAL",
+            "feature_name": "manager_health",
+            "event_type": "manager_cpu_usage_high",
+        }
+    ]
+}
+
+
+@pytest.mark.parametrize(
+    ("op_id", "params", "method", "path", "payload"),
+    [
+        ("nsx.node.status", {}, "GET", "/api/v1/node", _NODE_PAYLOAD),
+        ("nsx.cluster.status", {}, "GET", "/api/v1/cluster/status", _CLUSTER_PAYLOAD),
+        (
+            "nsx.backup.status",
+            {},
+            "GET",
+            "/api/v1/cluster/backups/status",
+            _BACKUP_STATUS_PAYLOAD,
+        ),
+        (
+            "nsx.transport_zone.list",
+            {},
+            "GET",
+            "/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones",
+            _TZ_PAYLOAD,
+        ),
+        ("nsx.tier1.list", {}, "GET", "/policy/api/v1/infra/tier-1s", _TIER1_PAYLOAD),
+        ("nsx.alarm.list", {}, "GET", "/api/v1/alarms", _ALARM_PAYLOAD),
+    ],
+)
+@pytest.mark.asyncio
+async def test_each_typed_op_dispatches_zero_catalog(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    op_id: str,
+    params: dict[str, Any],
+    method: str,
+    path: str,
+    payload: dict[str, Any],
+) -> None:
+    """AC #1: each audited read dispatches typed with zero ingested catalog state."""
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_NSX_BASE_URL, assert_all_called=False) as mock:
+        mock.post("/api/session/create").respond(200, headers=_XSRF_HEADERS)
+        route = mock.request(method, path).respond(200, json=payload)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=NSX_CONNECTOR_ID,
+            op_id=op_id,
+            target=_NsxReadTarget(),
+            params=params,
+        )
+
+    assert result.status == "ok", result.error
+    assert route.called and route.call_count == 1
+    # The XSRF token the session establish primed rides on the read.
+    assert route.calls[0].request.headers.get("X-XSRF-TOKEN") == "typed-xsrf-token"
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_source_kind_typed(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """AC #1: the persisted descriptor rows carry ``source_kind='typed'``."""
+    await register_nsx_typed_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == NSX_PRODUCT,
+                    EndpointDescriptor.impl_id == NSX_IMPL_ID,
+                    EndpointDescriptor.op_id.in_([op.op_id for op in NSX_TYPED_OPS]),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {r.op_id for r in rows} == {op.op_id for op in NSX_TYPED_OPS}
+    assert all(r.source_kind == "typed" for r in rows)
+    assert all(r.handler_ref is not None for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_alarm_list_forwards_filters(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """nsx.alarm.list forwards status / feature_name / severity as query params."""
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_NSX_BASE_URL, assert_all_called=False) as mock:
+        mock.post("/api/session/create").respond(200, headers=_XSRF_HEADERS)
+        route = mock.get("/api/v1/alarms").respond(200, json=_ALARM_PAYLOAD)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=NSX_CONNECTOR_ID,
+            op_id="nsx.alarm.list",
+            target=_NsxReadTarget(),
+            params={"status": "OPEN", "feature_name": "manager_health", "severity": "CRITICAL"},
+        )
+
+    assert result.status == "ok", result.error
+    sent = route.calls[0].request.url
+    assert sent.params.get("status") == "OPEN"
+    assert sent.params.get("feature_name") == "manager_health"
+    assert sent.params.get("severity") == "CRITICAL"
+
+
+# ---------------------------------------------------------------------------
+# AC #2 -- backup config first-class + retention surfaced + secrets scrubbed
+# ---------------------------------------------------------------------------
+
+_BACKUP_CONFIG_PAYLOAD: dict[str, Any] = {
+    "backup_enabled": True,
+    "passphrase": "super-secret-passphrase",
+    "backup_schedule": {
+        "resource_type": "WeeklyBackupSchedule",
+        "days_of_week": [0],
+        "hour_of_day": 2,
+    },
+    "remote_file_server": {
+        "server": "sftp.backup.invalid",
+        "port": 22,
+        "directory_path": "/backups/nsx",
+        "protocol": {
+            "protocol_name": "sftp",
+            "authentication_scheme": {"scheme_name": "PASSWORD", "password": "sftp-pw"},
+        },
+    },
+    "inventory_summary_interval": 240,
+    "after_inventory_update_interval": 300,
+}
+
+
+@pytest.mark.asyncio
+async def test_backup_config_surfaces_retention_and_scrubs_secrets(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """AC #2: retention fields surfaced; passphrase + nested SFTP creds never returned."""
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_NSX_BASE_URL, assert_all_called=False) as mock:
+        mock.post("/api/session/create").respond(200, headers=_XSRF_HEADERS)
+        mock.get("/api/v1/cluster/backups/config").respond(200, json=_BACKUP_CONFIG_PAYLOAD)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=NSX_CONNECTOR_ID,
+            op_id="nsx.backup.config",
+            target=_NsxReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    body = result.result
+    assert isinstance(body, dict)
+    # Retention-relevant fields are first-class / preserved.
+    assert body["backup_enabled"] is True
+    assert body["passphrase_configured"] is True
+    config = body["config"]
+    assert config["backup_schedule"]["resource_type"] == "WeeklyBackupSchedule"
+    assert config["remote_file_server"]["directory_path"] == "/backups/nsx"
+    assert config["inventory_summary_interval"] == 240
+    # Secrets are scrubbed at the boundary -- top-level passphrase + nested
+    # SFTP password both masked, and the raw values appear nowhere.
+    assert config["passphrase"] == REDACTED
+    assert config["remote_file_server"]["protocol"]["authentication_scheme"]["password"] == REDACTED
+    serialised = repr(result.result)
+    assert "super-secret-passphrase" not in serialised
+    assert "sftp-pw" not in serialised
+
+
+# ---------------------------------------------------------------------------
+# AC #3 -- session recovery via the #2067 dispatch-path seam
+# ---------------------------------------------------------------------------
+
+
+def test_connector_advertises_public_invalidate_session() -> None:
+    """AC #3: the #2067 duck-typed hook is present (was private-only before #2302)."""
+    hook = getattr(NsxConnector, "invalidate_session", None)
+    assert callable(hook)
+
+
+@pytest.mark.asyncio
+async def test_typed_dispatch_recovers_from_session_expiry(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """AC #3: a 401 on the first read is recovered via invalidate_session + re-dispatch."""
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_NSX_BASE_URL, assert_all_called=False) as mock:
+        session_route = mock.post("/api/session/create")
+        session_route.side_effect = [
+            httpx.Response(200, headers=_XSRF_HEADERS),
+            httpx.Response(
+                200,
+                headers={
+                    "X-XSRF-TOKEN": "typed-xsrf-token-2",
+                    "Set-Cookie": "JSESSIONID=typed-session-id-2; Path=/; HttpOnly",
+                },
+            ),
+        ]
+        node_route = mock.get("/api/v1/node")
+        node_route.side_effect = [
+            httpx.Response(401),
+            httpx.Response(200, json=_NODE_PAYLOAD),
+        ]
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=NSX_CONNECTOR_ID,
+            op_id="nsx.node.status",
+            target=_NsxReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == _NODE_PAYLOAD
+    # One 401 + one recovered 200 = two node calls; two session establishes.
+    assert node_route.call_count == 2
+    assert session_route.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# search_operations visibility + registration-shape invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_visible_to_search_operations(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The registered typed ops are retrievable via search_operations."""
+    await register_nsx_typed_operations()
+
+    result = await search_operations(
+        _make_operator(),
+        {"connector_id": NSX_CONNECTOR_ID, "query": "nsx backup cluster alarms", "limit": 25},
+    )
+    found = {hit["op_id"] for hit in result["hits"]}
+    expected = {op.op_id for op in NSX_TYPED_OPS}
+    assert expected <= found, f"missing from search: {expected - found}"
+
+
+_EXPECTED_OP_IDS = {
+    "nsx.node.status",
+    "nsx.cluster.status",
+    "nsx.backup.config",
+    "nsx.backup.status",
+    "nsx.transport_zone.list",
+    "nsx.tier1.list",
+    "nsx.alarm.list",
+}
+
+
+def test_typed_ops_table_is_exactly_the_audited_read_set() -> None:
+    assert {op.op_id for op in NSX_TYPED_OPS} == _EXPECTED_OP_IDS
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_is_safe_no_approval_and_read_only(op_id: str) -> None:
+    op = next(o for o in NSX_TYPED_OPS if o.op_id == op_id)
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert "read-only" in op.tags
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_parameter_schema_disallows_additional_properties(op_id: str) -> None:
+    op = next(o for o in NSX_TYPED_OPS if o.op_id == op_id)
+    assert op.parameter_schema.get("additionalProperties") is False
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_has_llm_instructions_with_when_to_use_and_output_shape(op_id: str) -> None:
+    op = next(o for o in NSX_TYPED_OPS if o.op_id == op_id)
+    assert op.llm_instructions is not None
+    assert op.llm_instructions.get("when_to_use", "").strip() != ""
+    assert "output_shape" in op.llm_instructions
+
+
+def test_no_write_or_mutating_op_is_registered() -> None:
+    """Read-only Task: no create/write op ships (tier-1 create is out of scope)."""
+    for op in NSX_TYPED_OPS:
+        assert op.safety_level == "safe"
+        assert not any(token in op.op_id for token in (".create", ".delete", ".update", ".set"))
+        assert "write" not in op.tags

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -3,15 +3,43 @@
 ## Overview
 
 The `nsx` connector is the hand-rolled `HttpConnector` subclass that
-dispatches ingested NSX REST operations under the
+dispatches NSX REST operations under the
 `(product="nsx", version="9.0", impl_id="nsx-rest")` registry triple.
 G3.5-T1 (#613) shipped the skeleton -- session-cookie / XSRF auth,
-fingerprint, probe, and the G0.6 dispatch shim. G3.5-T2 (#614) adds
-the **operator-review curation substrate**: the 9 read-only core
-ops + per-op `llm_instructions` blobs + group-level `when_to_use`
-hints + the `apply_nsx_core_curation` helper that the operator
-review step calls against the G0.7-ingested connector. CLI verbs +
-MCP review + recorded-fixture E2E arrive in G3.5-T3 (#615).
+fingerprint, probe, and the G0.6 dispatch shim. G3.5-T2 (#614) added
+the **operator-review curation substrate**: per-op `llm_instructions`
+blobs + group-level `when_to_use` hints + the `apply_nsx_core_curation`
+helper that the operator review step calls against the G0.7-ingested
+connector. CLI verbs + MCP review + recorded-fixture E2E arrive in
+G3.5-T3 (#615).
+
+**Audited reads are typed ops (#2302).** The audited operational read
+set -- node/cluster status+version, backup config+status,
+transport-zones list, tier-1 list, and alarms -- is registered as
+**typed** ops (`source_kind="typed"`, `typed_ops.py` metadata +
+`typed_reads.py` bodies + bound-method shims on `NsxConnector`), so it
+dispatches on a fresh boot with **zero catalog ingest** (avoiding the
+#2247 per-deploy catalog-state failure class). The remaining reads
+(transport-node listing, segments, tier-0 gateways, distributed-firewall
+policies + rules) stay as ingested-row curation in `core_ops.py` so the
+wider ingested breadth remains browsable. `nsx.backup.config` is
+first-class for the disk-fill incident class (Broadcom KB 442696 shape):
+it surfaces `backup_enabled` + `passphrase_configured` + the
+`backup_schedule` / `remote_file_server` retention-relevant fields, and
+scrubs the backup passphrase + any nested SFTP credential at the boundary
+(the default redaction policy masks `password`/`secret` but not
+`passphrase`). `tier-1 gateway create` (a write) is out of scope -- the
+first write on a read-only connector is its own approval-gated G3.x
+write-surface initiative.
+
+**Session recovery (#2067).** `NsxConnector.invalidate_session(target)`
+is the public duck-typed hook the generic dispatch path calls on an
+auth-class status (NSX's 401) before re-dispatching once. The typed reads
+issue `_get_json` directly, so a raw 401 propagates to the dispatcher's
+#2067 recovery arm, which evicts the cached session and re-dispatches --
+the same seam the vmware-rest / vcf-logs connectors expose. The internal
+`_get_json_with_session_retry` helper still serves the fingerprint /
+probe path (which the dispatcher does not drive).
 
 **VCF-9 version renumber (#1530).** NSX-T 4.x was renumbered onto the
 VCF train at VCF 9.0 -- a live VCF-9 appliance reports NSX 9.0.x and


### PR DESCRIPTION
## Summary

- Promote the **audited NSX operational read set** to first-class **typed** ops (`source_kind="typed"`) that dispatch on a **fresh boot with zero catalog ingest**, off the existing hand-rolled cookie+XSRF session — removing the per-deploy curation-state dependency (the #2247 failure class) for these reads.
- The set: `nsx.node.status` + `nsx.cluster.status` (manager/cluster status+version), `nsx.backup.config` + `nsx.backup.status`, `nsx.transport_zone.list`, `nsx.tier1.list`, `nsx.alarm.list` (optional status/feature/severity filters). Metadata + registrar in `typed_ops.py`; read bodies in `typed_reads.py` behind thin bound-method shims on `NsxConnector`; `__init__` queues the registrar onto the lifespan runner.
- **`nsx.backup.config` is first-class** for the backup disk-fill incident class (Broadcom KB 442696 shape): surfaces `backup_enabled`, `passphrase_configured`, and the retention-relevant `backup_schedule` / `remote_file_server` fields, and **scrubs the backup passphrase + any nested SFTP credential** at the connector boundary (the default redaction policy masks `password`/`secret` but not `passphrase`).
- **Session-expiry recovery via the #2067 seam**: `NsxConnector` now exposes the public `invalidate_session` hook (was private only), so a 401 from a typed read evicts the cached cookie+XSRF session and re-dispatches once — the same seam vmware-rest / vcf-logs expose.
- `core_ops.py` no longer flips the converted ops' ingested rows; the wider ingested breadth stays browsable as curation. **No OpenAPI snapshot delta.**

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (nsx package + tests)
- [x] `mypy src/meho_backplane/connectors/nsx/` — clean
- [x] `pytest -k nsx` — 102 passed, 6 skipped (Postgres-gated acceptance, run in CI)
- [x] `pytest tests/test_operations_typed_register.py tests/test_connectors_registry.py tests/test_mcp_tools_operations.py tests/test_api_v1_health.py` — 77 passed
- [x] `code-quality.py --diff` — 0 blockers
- [x] `make snapshot-openapi` — **zero delta** (no FastAPI route/schema touched)
- [x] **AC #1** — each audited read dispatches `source_kind="typed"` on a fresh boot with zero ingested catalog rows against a respx-mocked NSX (`test_each_typed_op_dispatches_zero_catalog`, `test_registered_ops_are_source_kind_typed`)
- [x] **AC #2** — `nsx.backup.config` surfaces retention fields and never returns the passphrase or nested SFTP creds (`test_backup_config_surfaces_retention_and_scrubs_secrets`)
- [x] **AC #3** — session expiry recovers via `invalidate_session` + re-dispatch (`test_typed_dispatch_recovers_from_session_expiry`, `test_connector_advertises_public_invalidate_session`)
- [x] **AC #4** — `core_ops.py` no longer flips converted ops; ingested breadth browsable; integration doubles/fixtures updated (NSX e2e + acceptance fixtures data-driven off `NSX_CORE_OPS`)

## Declined curated ops (AC #5 — not in the audited set; kept as ingested browse breadth)

These stay as `core_ops.py` ingested-row curation rather than typed ops — the ingested breadth covers browse, and none is in the adopter's audited operational read set:

- **`nsx.node.list`** (`GET /api/v1/transport-nodes`) — transport-node inventory is a browse/enumeration surface, not an audited operational read.
- **`nsx.segment.list`** (`GET /policy/api/v1/infra/segments`) — large browse surface (hundreds of rows in real deployments); ingested + JSONFlux handle already covers it.
- **`nsx.tier0.list`** (`GET /policy/api/v1/infra/tier-0s`) — provider tier-0 gateways; the audited per-tenant routing read is **tier-1** (converted), tier-0 stays browse.
- **`nsx.firewall.policy.list`** + **`nsx.firewall.rule.list`** (DFW security-policies + rules) — deep firewall inspection, not in the audited set; ingested browse covers it.

## Out of scope

- **`tier-1 gateway create`** (a write) — the first write on a read-only connector is its own approval-gated G3.x write-surface initiative (Goal #214 mold).
- Curation-apparatus retirement (T7).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2302


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seven typed NSX read operations for health, backup, inventory, and alarm information.
  * These reads can run immediately on fresh installations without catalog ingestion.
  * Added automatic recovery when an NSX session expires.
  * Backup configuration responses now redact passphrases and nested credentials while preserving useful status details.

* **Documentation**
  * Updated NSX connector documentation and release notes to describe typed reads, curation scope, and session recovery.

* **Tests**
  * Added end-to-end coverage for dispatch, redaction, parameter handling, registration, and session recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->