### PR TITLE
feat(connectors): Fleet typed reads on the LCM-local Basic session (#2304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — Fleet typed reads on the LCM-local Basic session (#2304)
+
+- VCF Fleet's audited read set — the **about/health probe** (`fleet.about`)
+  and the **component inventory** ("what's deployed", `fleet.environment.list`)
+  — now dispatches as `source_kind="typed"` off the connector's existing
+  HTTP Basic (LCM-local) session, registered in code at lifespan startup.
+  These ops work on a fresh boot with **zero catalog ingest**, removing the
+  Fleet operational surface's dependence on ingesting the crash-prone
+  vRSLCM-derived Fleet OpenAPI spec (the #2272 datetime-crash artifact). The
+  remaining six curated ops (datacenter/vcenter list, environment detail,
+  product list, request list/detail) are declined from typed conversion —
+  outside the adopter's audited set — and stay as browsable ingested breadth
+  until the curation apparatus is retired (T7); their ingested `/about` and
+  `/environments` duplicates no longer curate, so they cannot shadow the
+  typed ops. (#2304)
+
 ### Added — structural OpenAPI 3.x metaschema gate on spec ingest (#2292)
 
 - Spec ingest now validates a decoded OpenAPI 3.0/3.1 document against the

--- a/backend/src/meho_backplane/connectors/vcf_fleet/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/__init__.py
@@ -48,6 +48,42 @@ from meho_backplane.connectors.vcf_fleet.session import (
     VcfFleetTargetLike,
     load_credentials_from_vault,
 )
+from meho_backplane.connectors.vcf_fleet.typed_ops import (
+    FLEET_TYPED_OPS,
+    FLEET_TYPED_WHEN_TO_USE_BY_GROUP,
+    FleetTypedOp,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_fleet_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``VcfFleetConnector.register_operations``.
+
+    The canonical typed-op registration pattern is a module-level
+    ``async def register_xxx_typed_operations`` queued onto
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+    via :func:`register_typed_op_registrar`. Fleet implements the op walk
+    as a classmethod on :class:`VcfFleetConnector` (so the test suite can
+    exercise it without lifespan plumbing); this wrapper is the seam that
+    lets the standard registrar mechanism drive it.
+
+    The ``embedding_service`` keyword-only parameter mirrors the argocd /
+    bind9 sibling contract: :func:`run_typed_op_registrars` passes the
+    process-wide :class:`EmbeddingService` (or a chassis-test stub) to
+    every registrar, so each registrar **must** accept the kwarg or the
+    lifespan crashes with :class:`TypeError`. The wrapper
+    accepts-and-discards it because
+    :meth:`VcfFleetConnector.register_operations` resolves the embedding
+    service via ``register_typed_operation``'s process-wide singleton
+    fallback.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await VcfFleetConnector.register_operations()
+
 
 register_connector_v2(
     product="fleet",
@@ -69,6 +105,13 @@ register_connector_v2(
     cls=VcfFleetConnector,
 )
 
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The
+# runner (``run_typed_op_registrars``) iterates after
+# ``_eager_import_connectors`` so the typed descriptor rows land before the
+# first dispatch — the audited read set dispatches on a fresh boot with
+# zero catalog ingest (T4 · #2304).
+register_typed_op_registrar(register_fleet_typed_operations)
+
 __all__ = [
     "FLEET_CONNECTOR_ID",
     "FLEET_CORE_GROUPS",
@@ -76,9 +119,12 @@ __all__ = [
     "FLEET_IMPL_ID",
     "FLEET_PATH_RULES",
     "FLEET_PRODUCT",
+    "FLEET_TYPED_OPS",
+    "FLEET_TYPED_WHEN_TO_USE_BY_GROUP",
     "FLEET_VERSION",
     "FleetCoreGroup",
     "FleetCoreOp",
+    "FleetTypedOp",
     "SessionCredentials",
     "VcfFleetConnector",
     "VcfFleetCredentialsLoader",
@@ -86,4 +132,5 @@ __all__ = [
     "apply_fleet_core_curation",
     "classify_fleet_op",
     "load_credentials_from_vault",
+    "register_fleet_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/vcf_fleet/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/connector.py
@@ -162,6 +162,14 @@ _FLEET_PROBE_METHOD = (
 )
 _FLEET_LCM_API_VERSION_HEADER = "Lcm-API-Version"
 
+# Typed read-op endpoint paths (T4 · #2304). The audited read set — the
+# about/health probe + the component-inventory ("what's deployed") list —
+# dispatches off these paths as ``source_kind="typed"`` on the connector's
+# existing HTTP Basic session, with no dependence on ingesting the
+# crash-prone Fleet LCM spec.
+_FLEET_ABOUT_PATH = "/lcm/lcops/api/v2/about"
+_FLEET_ENVIRONMENTS_PATH = "/lcm/lcops/api/v2/environments"
+
 
 class VcfFleetConnector(HttpConnector):
     """VCF Fleet 9.0 REST connector with HTTP Basic auth.
@@ -373,6 +381,131 @@ class VcfFleetConnector(HttpConnector):
             op_id=op_id,
             target=target,
             params=params,
+        )
+
+    # ------------------------------------------------------------------
+    # Typed read ops (T4 · #2304, Initiative #2266)
+    #
+    # The audited Fleet read set — about/health probe + component
+    # inventory — dispatched off the connector's existing HTTP Basic
+    # session as ``source_kind="typed"`` (no ingested endpoint_descriptor
+    # rows, no Fleet-LCM spec dependency). The dispatcher rebinds these
+    # bound methods to the per-process connector instance and threads
+    # ``operator`` by name (see ``dispatch_typed``); ``operator`` is
+    # forwarded to ``_get_json`` so the credential loader reads the
+    # per-target Basic credentials under the operator's identity. Both are
+    # read-only — no write op ships here (writes are out of #2266 scope).
+    # ------------------------------------------------------------------
+
+    async def about(
+        self,
+        operator: Operator,
+        target: VcfFleetTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``fleet.about`` — ``GET /lcm/lcops/api/v2/about``.
+
+        Returns the appliance identity payload (``apiVersion`` /
+        ``productVersion`` / ``buildNumber`` / ``releaseDate``). KNOWN
+        REGRESSION: in VCF 9.0 builds this endpoint returns HTTP 500 — the
+        dispatcher records that as a ``connector_error`` result; the
+        curated ``llm_instructions`` tell the agent the appliance is still
+        reachable (the connector probe confirms it off the datacenters
+        surface) and to cross-source the product version from SDDC Manager.
+        """
+        del params  # schema declares the param object empty
+        return await self._get_json(target, _FLEET_ABOUT_PATH, operator=operator)
+
+    async def environment_list(
+        self,
+        operator: Operator,
+        target: VcfFleetTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``fleet.environment.list`` — ``GET /lcm/lcops/api/v2/environments``.
+
+        The component inventory ("what's deployed"). Fleet returns a bare
+        JSON array of Environment objects; the handler wraps it under an
+        ``environments`` key so the typed result is a stable object
+        envelope (mirrors the vSphere typed reads' ``{"hosts": [...]}``
+        shape). Each environment carries its status and an inline
+        ``products[]`` summary.
+        """
+        del params  # schema declares the param object empty
+        environments: Any = await self._get_json(
+            target, _FLEET_ENVIRONMENTS_PATH, operator=operator
+        )
+        return {"environments": environments}
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`FLEET_TYPED_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan (via the registrar queued in
+        :mod:`meho_backplane.connectors.vcf_fleet.__init__`) after the
+        registry has eager-imported every connector module. Walks
+        :data:`~meho_backplane.connectors.vcf_fleet.typed_ops.FLEET_TYPED_OPS`,
+        resolves each op's ``handler_attr`` to the class-visible handler,
+        looks the group's curated ``when_to_use`` up in
+        :data:`~meho_backplane.connectors.vcf_fleet.typed_ops.FLEET_TYPED_WHEN_TO_USE_BY_GROUP`,
+        and routes each row through
+        :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+        (``source_kind="typed"``). Idempotent across restarts (the helper
+        skips the embedding recompute on unchanged text). Mirrors the
+        argocd / bind9 / vmware_rest ``register_operations`` shape.
+        """
+        # Lazy import: the operations package pulls in the embedding
+        # pipeline (ONNX runtime + model), which pure fingerprint/probe
+        # unit tests should not pay. Lifespan callers have it warmed by the
+        # time this runs.
+        from meho_backplane.connectors.vcf_fleet.typed_ops import (
+            FLEET_TYPED_OPS,
+            FLEET_TYPED_WHEN_TO_USE_BY_GROUP,
+        )
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        for op in FLEET_TYPED_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"VcfFleetConnector op {op.op_id!r} declares "
+                    f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+                )
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = FLEET_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"VcfFleetConnector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated when_to_use exists "
+                        f"for that key. Add an entry to "
+                        f"FLEET_TYPED_WHEN_TO_USE_BY_GROUP (typed_ops.py)."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "fleet_typed_operations_registered",
+            count=len(FLEET_TYPED_OPS),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
         )
 
     async def aclose(self) -> None:

--- a/backend/src/meho_backplane/connectors/vcf_fleet/core_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/core_ops.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""VCF Fleet 9.0 (vRSLCM-derived) read-only v0.5 core — curated subset.
+"""VCF Fleet 9.0 (vRSLCM-derived) read-only core — ingested-curation subset.
 
-This module names the **8 read-only Fleet operations** the G3.6 v0.5 ship
-enables out of the much larger vRSLCM LCM REST corpus the G0.7
-spec-ingestion pipeline lands under ``connector_id="fleet-rest-9.0"``.
-The curation is two-layered:
+This module names the **6 read-only Fleet operations** that stay as
+``is_enabled`` curation over **ingested** ``endpoint_descriptor`` rows
+(the G0.7 spec-ingestion pipeline lands them under
+``connector_id="fleet-rest-9.0"``). The curation is two-layered:
 
 * :data:`FLEET_CORE_GROUPS` — the operator-reviewed ``when_to_use``
   hint per LLM-grouping pass output group. Each entry's ``group_key``
@@ -14,7 +14,7 @@ The curation is two-layered:
   ops; the ``when_to_use`` is what the agent reads verbatim through
   :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
   to pick a group to search within.
-* :data:`FLEET_CORE_OPS` — the 8 ``EndpointDescriptor.op_id`` strings
+* :data:`FLEET_CORE_OPS` — the 6 ``EndpointDescriptor.op_id`` strings
   that flip to ``is_enabled=True`` at operator-review time, paired
   with the per-op ``llm_instructions`` blob the agent inlines into
   the reasoning context when it sees the op in
@@ -23,43 +23,45 @@ The curation is two-layered:
   ``is_enabled=False`` (the G0.7 ingestion default for
   ``source_kind='ingested'`` rows).
 
-Per Initiative #369 and CLAUDE.md postulates 1-2, Fleet is **fully
-generic-ingested**: the underlying ops are not registered in code,
-they live in the ``endpoint_descriptor`` table. This module only
-carries the **operator-review metadata** the substrate uses at the
-review step — the actual curation is applied through
-:func:`apply_fleet_core_curation` against an existing ingested
-connector.
+Typed conversion (T4 · #2304, Initiative #2266)
+-----------------------------------------------
 
-The 8 ops (paths cross-checked against vRSLCM REST API 1.3.0 at
+The G3.6 ship curated **8** ops; the adopter's #2294 audit (row 21)
+found only two of Fleet's ops in real use — the **about/health probe**
+and the **component inventory read ("what's deployed")**. Those two
+were converted to **typed** ops (``source_kind="typed"``) in
+:mod:`meho_backplane.connectors.vcf_fleet.typed_ops`, so they dispatch
+off the connector's hand-rolled HTTP Basic session with no dependence on
+ingesting the crash-prone Fleet LCM spec (the #2272 datetime-crash
+artifact). They are therefore **removed** from :data:`FLEET_CORE_OPS`
+here — the ingested duplicate must not shadow the typed op. The
+``fleet-about`` curation group is gone entirely (its only op moved to
+typed); ``fleet-environment`` stays because ``fleet.environment.get``
+(declined from typed conversion, not in the audited set) still lives
+there. The remaining six ops below are the **declined** set — outside
+the audited surface, kept as ingested breadth until T7 retires the
+curation apparatus. See #2304 for the per-op decline rationale.
+
+The 6 remaining ingested-curated ops (paths cross-checked against
+vRSLCM REST API 1.3.0 at
 https://developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager/latest/):
 
-1. ``GET:/lcm/lcops/api/v2/about`` — ``fleet.about`` — vRSLCM
-   appliance identity. **Note:** Fleet's first-party ``/about``
-   endpoint returns HTTP 500 in VCF 9.0 builds (see the
-   :class:`~meho_backplane.connectors.vcf_fleet.connector.VcfFleetConnector`
-   docstring for the known-issue inventory). The op is curated for
-   parity with the spec; the ``llm_instructions.next_step`` tells
-   the agent to fall back to ``fleet.datacenter.list`` as the
-   reachability probe in 9.0.
-2. ``GET:/lcm/lcops/api/v2/datacenters`` — ``fleet.datacenter.list``
+1. ``GET:/lcm/lcops/api/v2/datacenters`` — ``fleet.datacenter.list``
    — datacenter inventory. The wrapper-verified probe endpoint;
    guaranteed to work in 9.0 because the connector's own probe uses
-   it.
-3. ``GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters``
+   it (so no agent-facing typed probe duplicate is warranted).
+2. ``GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters``
    — ``fleet.vcenter.list`` — vCenters registered under a datacenter.
-4. ``GET:/lcm/lcops/api/v2/environments`` — ``fleet.environment.list``
-   — environment inventory (the primary Fleet entry point — every
-   product deploy lives under an environment).
-5. ``GET:/lcm/lcops/api/v2/environments/{environmentId}`` —
+3. ``GET:/lcm/lcops/api/v2/environments/{environmentId}`` —
    ``fleet.environment.get`` — per-environment detail including
-   products, status, and metadata.
-6. ``GET:/lcm/lcops/api/v2/environments/{environmentId}/products`` —
+   products, status, and metadata (``fleet.environment.list`` is now
+   typed; the deep per-environment read stays ingested breadth).
+4. ``GET:/lcm/lcops/api/v2/environments/{environmentId}/products`` —
    ``fleet.product.list`` — products deployed under an environment.
-7. ``GET:/lcm/request/api/v2/requests`` — ``fleet.request.list`` —
+5. ``GET:/lcm/request/api/v2/requests`` — ``fleet.request.list`` —
    lifecycle requests (deploy / patch / upgrade) the appliance has
    processed; the LCM workflow-status surface.
-8. ``GET:/lcm/request/api/v2/requests/{requestId}`` —
+6. ``GET:/lcm/request/api/v2/requests/{requestId}`` —
    ``fleet.request.get`` — per-request detail including state
    (``INPROGRESS`` / ``COMPLETED`` / ``FAILED``), output map, and
    error cause.
@@ -85,7 +87,7 @@ Curation application
 --------------------
 
 :func:`apply_fleet_core_curation` is the operator-review-time
-substrate call that makes exactly the 8 curated ops dispatchable.
+substrate call that makes exactly the 6 curated ops dispatchable.
 Mirrors :func:`~meho_backplane.connectors.harbor.core_ops.apply_harbor_core_curation`
 verbatim, threading the "enable group but pin non-core ops
 disabled" needle via the audit-log-driven operator-override
@@ -217,7 +219,9 @@ class FleetCoreOp:
 #: ingested op_ids (which also carry the literal template var names)
 #: resolve correctly.
 FLEET_PATH_RULES: Final[tuple[tuple[str, str], ...]] = (
-    ("/lcm/lcops/api/v2/about", "fleet-about"),
+    # ``/about`` is no longer classified — ``fleet.about`` was converted
+    # to a typed op (T4 · #2304), so an ingested ``/about`` row classifies
+    # to ``"none"`` and stays disabled (it must not shadow the typed op).
     # Deeper paths under datacenters must precede the datacenters root.
     (
         "/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters",
@@ -266,23 +270,14 @@ def classify_fleet_op(op_id: str) -> str:
     return "none"
 
 
-#: Operator-reviewed ``when_to_use`` hints for the 6 Fleet groups
-#: the read-only v0.5 core spans. Every hint is one complete sentence
-#: the agent reads verbatim — vague hints poison
-#: ``search_operations`` ranking.
+#: Operator-reviewed ``when_to_use`` hints for the 5 Fleet groups
+#: the ingested-curation core spans (``fleet-about`` moved to typed).
+#: Every hint is one complete sentence the agent reads verbatim —
+#: vague hints poison ``search_operations`` ranking.
 FLEET_CORE_GROUPS: Final[tuple[FleetCoreGroup, ...]] = (
-    FleetCoreGroup(
-        group_key="fleet-about",
-        name="VCF Fleet (about)",
-        when_to_use=(
-            "Use this group to read the VCF Fleet (vRSLCM) appliance's "
-            "identity: API version, build, product version. WARNING: in "
-            "VCF 9.0 builds the /about endpoint returns HTTP 500 — use "
-            "fleet.datacenter.list as the reachability probe instead, "
-            "and cross-source the product version from SDDC Manager's "
-            "/v1/vcf-services entry until the 9.0 regression is fixed."
-        ),
-    ),
+    # ``fleet-about`` was removed — its only op (``fleet.about``) was
+    # converted to a typed op (T4 · #2304); the appliance-identity
+    # ``when_to_use`` now lives in ``FLEET_TYPED_WHEN_TO_USE_BY_GROUP``.
     FleetCoreGroup(
         group_key="fleet-datacenter",
         name="VCF Fleet Datacenters",
@@ -364,43 +359,19 @@ def _instructions(
     }
 
 
-#: The 8 curated read-only Fleet core ops. Each entry carries the
-#: op_id (``GET:/path`` form), the curated group assignment, and the
-#: operator-reviewed ``llm_instructions`` blob.
+#: The 6 curated read-only Fleet core ops (the declined set — outside
+#: the #2304 audited surface; ``fleet.about`` + ``fleet.environment.list``
+#: are now typed). Each entry carries the op_id (``GET:/path`` form), the
+#: curated group assignment, and the operator-reviewed
+#: ``llm_instructions`` blob.
 #:
 #: Paths cross-checked against vRSLCM REST API 1.3.0 at
 #: https://developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager/latest/.
 FLEET_CORE_OPS: Final[tuple[FleetCoreOp, ...]] = (
-    FleetCoreOp(
-        op_id="GET:/lcm/lcops/api/v2/about",
-        group_key="fleet-about",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to read the vRSLCM appliance's identity — API "
-                "version, build, product version — when confirming "
-                "which Fleet instance the target points at. KNOWN "
-                "REGRESSION: in VCF 9.0 builds this endpoint returns "
-                "HTTP 500. When the call fails with a 500, do not "
-                "retry; fall back to fleet.datacenter.list as the "
-                "appliance reachability probe."
-            ),
-            output_shape=(
-                "On success: object with apiVersion, productVersion, "
-                "buildNumber, releaseDate keys. On 500 (the 9.0 "
-                "regression): a connector_error OperationResult with "
-                "the response body's `errorCode` and `errorMessage` "
-                "fields surfaced in extras."
-            ),
-            next_step=(
-                "If the call returned 200, proceed with the intended "
-                "Fleet operation. If it returned 500 (VCF 9.0), call "
-                "fleet.datacenter.list — it doubles as a reachability "
-                "probe and exposes the Lcm-API-Version response header "
-                "(read via fingerprint, not call_operation, in the "
-                "current substrate)."
-            ),
-        ),
-    ),
+    # ``GET:/lcm/lcops/api/v2/about`` (fleet.about) and
+    # ``GET:/lcm/lcops/api/v2/environments`` (fleet.environment.list) were
+    # converted to typed ops (T4 · #2304) and are intentionally absent from
+    # the ingested-curation set so the ingested rows never shadow them.
     FleetCoreOp(
         op_id="GET:/lcm/lcops/api/v2/datacenters",
         group_key="fleet-datacenter",
@@ -459,36 +430,6 @@ FLEET_CORE_OPS: Final[tuple[FleetCoreOp, ...]] = (
                 "may need to add it. Use the vCenter's vmid for any "
                 "follow-up data-collection trigger (POST surface — "
                 "out of v0.5 scope)."
-            ),
-        ),
-    ),
-    FleetCoreOp(
-        op_id="GET:/lcm/lcops/api/v2/environments",
-        group_key="fleet-environment",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to list all Fleet-managed environments. An "
-                "environment is the unit Fleet uses to group one or "
-                "more product deployments (e.g. a vRA environment with "
-                "vRA + vIDM + Postgres nodes). The primary entry point "
-                "for any Fleet inventory workflow. Large appliances "
-                "managing many environments return a JSONFlux handle "
-                "carrying a bounded inline sample plus a ``fetch_more`` "
-                "envelope (no handle read-back tool exists in this version)."
-            ),
-            output_shape=(
-                "Array of Environment objects; each carries "
-                "environmentId, environmentName, environmentDescription, "
-                "environmentStatus (DEPLOY_SUCCESSFUL / DEPLOY_FAILED / "
-                "...), and a products[] sub-array with product summaries."
-            ),
-            next_step=(
-                "Pick an environmentId and pass it to "
-                "fleet.environment.get for the full per-environment "
-                "detail, or to fleet.product.list to enumerate its "
-                "products and their versions. Cross-reference status "
-                "against the fleet-request surface when an environment "
-                "looks stuck (open requests against it may explain why)."
             ),
         ),
     ),
@@ -623,55 +564,34 @@ async def apply_fleet_core_curation(
     *,
     tenant_id: UUID | None,
 ) -> None:
-    """Apply the curated 8-op read core against an ingested Fleet connector.
+    """Apply the curated 6-op read core against an ingested Fleet connector.
 
     Drives the substrate so that, after this call returns, exactly
-    the 8 ops in :data:`FLEET_CORE_OPS` are dispatchable
+    the 6 ops in :data:`FLEET_CORE_OPS` are dispatchable
     (``is_enabled=True``) and every other ingested op stays
-    ``is_enabled=False``. The 6 curated groups land
+    ``is_enabled=False``; the 5 curated groups land
     ``review_status='enabled'`` so the agent's
     :func:`~meho_backplane.operations.meta_tools.search_operations`
-    surfaces the core ops; non-curated groups are left untouched
-    (``review_status='staged'`` from the G0.7 ingest default).
+    surfaces the core ops (non-curated groups stay ``'staged'``).
 
-    The substrate doesn't expose "enable only ops X, Y, Z under
-    group G": :meth:`ReviewService.enable_group`'s cascade flips
-    ``is_enabled=True`` on every child op in the group. The helper
-    works around this via the audit-log-driven operator-override
-    exclusion — the same mechanism
+    :meth:`ReviewService.enable_group`'s cascade would enable *every*
+    child op in a group, so the helper first writes an
+    ``is_enabled=False`` operator-override audit row (via
+    :meth:`ReviewService.edit_op`) for each non-core op — the cascade
+    then skips those — before landing each group's reviewed ``name`` +
+    ``when_to_use`` (:meth:`edit_group`), enabling the group
+    (:meth:`enable_group`), and landing the per-op ``llm_instructions``
+    (:meth:`edit_op`). Same mechanism as
     :func:`~meho_backplane.connectors.harbor.core_ops.apply_harbor_core_curation`
-    and :func:`~meho_backplane.connectors.nsx.core_ops.apply_nsx_core_curation`
-    established:
+    and :func:`~meho_backplane.connectors.nsx.core_ops.apply_nsx_core_curation`.
 
-    1. :meth:`ReviewService.get_review_payload` loads the current
-       state of every curated group and its child ops.
-    2. For each child op in a curated group that **isn't** in the
-       :data:`FLEET_CORE_OPS` allow-list,
-       :meth:`ReviewService.edit_op` with ``is_enabled=False``
-       writes the operator-override audit row. The follow-on
-       :meth:`enable_group` cascade detects these rows and skips
-       them.
-    3. :meth:`ReviewService.edit_group` lands the operator-reviewed
-       ``name`` + ``when_to_use`` on each curated group.
-    4. :meth:`ReviewService.enable_group` flips
-       ``review_status='enabled'`` and cascades ``is_enabled=True``
-       to the curated child ops (operator-overridden non-core ops
-       are skipped).
-    5. :meth:`ReviewService.edit_op` lands the curated
-       ``llm_instructions`` blob per entry in :data:`FLEET_CORE_OPS`.
-
-    Re-running is safe but not idempotent at the audit layer:
-    :meth:`enable_group` short-circuits on groups already in
-    ``review_status='enabled'`` (no audit row), but
-    :meth:`edit_group` and :meth:`edit_op` always emit one audit
-    row per call. The intended posture is a one-shot curation step
-    after ingest; re-runs produce redundant ``meho.connector.edit_*``
-    audit rows but never corrupt state.
-
-    Raises :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError`
-    if no groups exist for ``fleet-rest-9.0`` under *tenant_id* (the
-    operator must run ``meho connector ingest`` against the Fleet
-    LCM spec before this helper applies).
+    Re-running is safe but emits redundant ``meho.connector.edit_*``
+    audit rows (``edit_group`` / ``edit_op`` always audit; only
+    ``enable_group`` short-circuits on an already-enabled group) — the
+    intended posture is a one-shot curation step after ingest. Raises
+    :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError` if
+    no groups exist for ``fleet-rest-9.0`` under *tenant_id* (the
+    operator must ``meho connector ingest`` the Fleet LCM spec first).
     """
     payload = await review_service.get_review_payload(
         FLEET_CONNECTOR_ID,

--- a/backend/src/meho_backplane/connectors/vcf_fleet/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/typed_ops.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed read ops for :class:`VcfFleetConnector` (T4 · #2304, Initiative #2266).
+
+The G3.6 v0.5 core (:mod:`meho_backplane.connectors.vcf_fleet.core_ops`)
+exposed the Fleet operational surface as ``is_enabled`` curation over
+**ingested** ``endpoint_descriptor`` rows — the operator had to ingest
+the vRSLCM-derived Fleet OpenAPI spec before any op could dispatch. That
+spec is the #2272 datetime-crash artifact, so the operational surface was
+hostage to a crash-prone ingest.
+
+This module converts the **audited read set** (the adopter's real Fleet
+usage from the #2294 T0 audit, row 21: *"about/health probe; component
+inventory read ('what's deployed')"*) to **typed** ops that dispatch as
+``source_kind="typed"`` off the connector's existing hand-rolled HTTP
+Basic session against the LCM-local user store — no catalog ingest, no
+spec dependency.
+
+Two ops ship here, one per audited bucket:
+
+* ``fleet.about`` — ``GET /lcm/lcops/api/v2/about`` — the appliance
+  identity / health probe. **Known regression:** this endpoint returns
+  HTTP 500 in VCF 9.0 builds (the connector's own probe therefore reads
+  ``Lcm-API-Version`` off ``/lcm/lcops/api/v2/datacenters`` instead — see
+  :class:`~meho_backplane.connectors.vcf_fleet.connector.VcfFleetConnector`).
+  The op is converted for parity with the audited "about/health probe"
+  ask; its ``llm_instructions`` carry the 9.0-500 warning and the
+  reachability-probe fallback so the agent degrades gracefully.
+* ``fleet.environment.list`` — ``GET /lcm/lcops/api/v2/environments`` —
+  the component inventory ("what's deployed"). Every product deployment
+  (vRA / vROps / vRLI / vIDM / …) lives under a Fleet environment, and
+  each environment carries a ``products[]`` summary inline, so a single
+  no-argument call answers "what has Fleet provisioned" — the audited
+  lab-bookkeeping surface.
+
+The remaining six curated ops (datacenter/vcenter list, environment
+detail, product list, request list/detail) are **declined** from typed
+conversion — they are outside the adopter's audited set. The decline
+rationale is posted on #2304; the ingested breadth catalog still covers
+their browse case until T7 retires the curation apparatus.
+
+Mold
+----
+
+The dataclass + tuple + ``register_operations`` walk mirrors the
+argocd read core (:mod:`meho_backplane.connectors.argocd.ops`) and the
+vSphere typed reads (:mod:`meho_backplane.connectors.vmware_rest.typed_ops`):
+each op names a ``handler_attr`` resolved against
+:class:`VcfFleetConnector` at registration time, so the persisted
+``handler_ref`` round-trips through the dispatcher's
+:func:`~meho_backplane.operations._handler_resolve.import_handler` walk as
+a ``module.ClassName.method`` dotted path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+__all__ = [
+    "FLEET_TYPED_OPS",
+    "FLEET_TYPED_WHEN_TO_USE_BY_GROUP",
+    "FleetTypedOp",
+]
+
+
+@dataclass(frozen=True)
+class FleetTypedOp:
+    """Metadata for one typed Fleet op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the registrar can splat the dataclass into the helper
+    without per-op boilerplate. ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.vcf_fleet.connector.VcfFleetConnector`
+    exposing the async handler; the registrar resolves the bound method
+    against the class at registration time so the dispatcher can recover
+    the callable from the persisted ``module.ClassName.method`` path.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurbs per typed group. ``register_typed_operation``
+#: requires a non-empty string whenever ``group_key`` is set; the registrar
+#: looks each op's ``group_key`` up here.
+FLEET_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "fleet-about": (
+        "Use to read the VCF Fleet (vRSLCM) appliance's identity / health via "
+        "fleet.about — API version, product version, build. WARNING: in VCF "
+        "9.0 builds the /about endpoint returns HTTP 500; when that happens the "
+        "appliance is still reachable — the connector's probe reads the "
+        "Lcm-API-Version header off the datacenters surface, and the product "
+        "version is cross-sourced from SDDC Manager's /v1/vcf-services entry. "
+        "The right group to confirm which Fleet instance a target points at."
+    ),
+    "fleet-inventory": (
+        "Use to read the Fleet component inventory — what products Fleet has "
+        "deployed — via fleet.environment.list. Every product deployment (vRA, "
+        "vROps, vRLI, vIDM, …) lives under a Fleet environment; the call "
+        "returns every environment with its deployment status and an inline "
+        "products[] summary, so one no-argument call answers 'what has Fleet "
+        "provisioned' for lab bookkeeping and inventory snapshots."
+    ),
+}
+
+
+_ABOUT = FleetTypedOp(
+    op_id="fleet.about",
+    handler_attr="about",
+    summary="Read the VCF Fleet appliance identity / health (about probe).",
+    description=(
+        "Reads the vRSLCM appliance identity via GET /lcm/lcops/api/v2/about — "
+        "API version, product version, build number, release date. KNOWN "
+        "REGRESSION: in VCF 9.0 builds this endpoint returns HTTP 500; the call "
+        "then surfaces as a connector_error and the caller should treat the "
+        "appliance as reachable-but-about-broken (the connector's own probe "
+        "confirms reachability off the datacenters surface). safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "apiVersion": {"type": "string"},
+            "productVersion": {"type": "string"},
+            "buildNumber": {"type": "string"},
+            "releaseDate": {"type": "string"},
+        },
+        "additionalProperties": True,
+    },
+    group_key="fleet-about",
+    tags=("read-only", "fleet", "vcf", "probe"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_call": (
+            "Call to confirm which Fleet instance a target points at — API "
+            "version, product version, build. KNOWN REGRESSION: in VCF 9.0 "
+            "builds this endpoint returns HTTP 500. When the call fails with a "
+            "500, do not retry; the appliance is still reachable — the "
+            "connector's probe reads the Lcm-API-Version header off the "
+            "datacenters surface, and the product version cross-sources from "
+            "SDDC Manager's /v1/vcf-services entry."
+        ),
+        "output_shape": (
+            "On success: {apiVersion, productVersion, buildNumber, releaseDate}. "
+            "On the 9.0 HTTP 500 regression: a connector_error result carrying "
+            "the appliance's errorCode / errorMessage."
+        ),
+        "next_step": (
+            "If 200, proceed with the intended Fleet workflow. If 500 (VCF 9.0), "
+            "rely on the connector fingerprint/probe for reachability and "
+            "cross-source the product version from SDDC Manager rather than "
+            "retrying fleet.about."
+        ),
+    },
+)
+
+
+_ENVIRONMENT_LIST = FleetTypedOp(
+    op_id="fleet.environment.list",
+    handler_attr="environment_list",
+    summary="List Fleet environments with their deployed products (inventory).",
+    description=(
+        "Lists every Fleet-managed environment via GET "
+        "/lcm/lcops/api/v2/environments — the component inventory of what "
+        "Fleet has deployed. An environment is the unit Fleet uses to group "
+        "one or more product deployments (vRA, vROps, vRLI, vIDM, …); each "
+        "entry carries environmentId, environmentName, environmentStatus "
+        "(DEPLOY_SUCCESSFUL / DEPLOY_FAILED / …) and an inline products[] "
+        "summary. Returns the array under an 'environments' key. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "environments": {"type": "array"},
+        },
+        "additionalProperties": True,
+    },
+    group_key="fleet-inventory",
+    tags=("read-only", "fleet", "vcf", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_call": (
+            "Call to answer 'what has Fleet deployed' / 'what environments has "
+            "Fleet provisioned' — the primary component-inventory read. No "
+            "arguments; returns every environment with its status and an inline "
+            "products[] summary."
+        ),
+        "output_shape": (
+            "{environments: [Environment, ...]}. Each Environment carries "
+            "environmentId, environmentName, environmentStatus, and a "
+            "products[] sub-array with per-product id/version summaries."
+        ),
+        "next_step": (
+            "Surface each environment's products[] versions for the inventory "
+            "snapshot. For a DEPLOY_FAILED environment, the deeper per-request "
+            "diagnostics remain on the ingested breadth catalog (not part of "
+            "the typed audited set)."
+        ),
+    },
+)
+
+
+#: The typed read ops :class:`VcfFleetConnector` registers at lifespan
+#: startup — the #2304 audited set (about/health probe + component
+#: inventory). Ordered probe → inventory to match the operator's typical
+#: "is it up, and what's on it" drill path.
+FLEET_TYPED_OPS: tuple[FleetTypedOp, ...] = (
+    _ABOUT,
+    _ENVIRONMENT_LIST,
+)

--- a/backend/tests/acceptance/_vcf_fleet_canary_fixtures.py
+++ b/backend/tests/acceptance/_vcf_fleet_canary_fixtures.py
@@ -6,11 +6,12 @@
 The E2E module (:mod:`tests.test_connectors_vcf_fleet_e2e`) needs a
 registered :class:`~meho_backplane.connectors.vcf_fleet.VcfFleetConnector`
 instance with a stub credentials loader (so no Vault read fires), a
-probed :class:`~meho_backplane.db.models.Target`, the 8 curated
+probed :class:`~meho_backplane.db.models.Target`, the curated
 :class:`~meho_backplane.db.models.EndpointDescriptor` rows from
-:data:`~meho_backplane.connectors.vcf_fleet.core_ops.FLEET_CORE_OPS`,
-and a :mod:`respx`-mocked Fleet REST surface answering each of the 8
-curated read ops.
+:data:`~meho_backplane.connectors.vcf_fleet.core_ops.FLEET_CORE_OPS`
+(the declined ingested set — the audited about/inventory ops are typed
+now, T4 · #2304), and a :mod:`respx`-mocked Fleet REST surface
+answering each curated read op.
 
 Fleet uses HTTP Basic auth against the local LCM user store on every
 request — no session-establish call, no XSRF-token dance, no 401-retry
@@ -24,7 +25,7 @@ Why a minimal direct-insert path (not full G0.7 canary ingest)
 VCF Fleet has no public CI simulator (Initiative #369 DoD), and the
 full vRSLCM OpenAPI ingest needs the spec file reachable on the runner.
 Until the spec-shelf is wired to the meho-runners pool, the dispatch
-leg is exercised against a direct-insert path that seeds the 8 curated
+leg is exercised against a direct-insert path that seeds the curated
 endpoint_descriptor rows by hand. Same pattern :mod:`tests.acceptance._nsx_canary_fixtures`
 and :mod:`tests.acceptance._sddc_canary_fixtures` established for the
 other no-public-simulator connectors.
@@ -105,12 +106,14 @@ FLEET_TARGET_NAME: str = "fleet-acceptance"
 #: client URL exactly.
 FLEET_CANARY_BASE_URL: str = "https://fleet-canary.test.invalid"
 
-#: The list op the JSONFlux force-handle test dispatches. Environment
-#: listing is the largest curated Fleet read surface in real
-#: deployments — every vRA / vROps / vRLI / vIDM deploy on the appliance
-#: lives under an environment, and busy Fleets manage dozens. Mirrors
-#: the NSX (segment list) and SDDC Manager (host list) choices.
-FLEET_FORCE_HANDLE_LIST_OP_ID: str = "GET:/lcm/lcops/api/v2/environments"
+#: The ingested list op the JSONFlux force-handle test dispatches.
+#: Lifecycle-request listing is the largest *ingested-curated* Fleet read
+#: surface in real deployments — busy appliances accumulate thousands of
+#: historical requests. (Environment listing, formerly used here, is now a
+#: typed op — T4 · #2304 — so it no longer dispatches via the ingested
+#: path this fixture exercises.) Mirrors the NSX (segment list) and SDDC
+#: Manager (host list) choices.
+FLEET_FORCE_HANDLE_LIST_OP_ID: str = "GET:/lcm/request/api/v2/requests"
 
 #: Persisted as ``Target.fingerprint`` so the resolver binds
 #: :class:`VcfFleetConnector` (``supported_version_range=">=9.0,<10.0"``).
@@ -330,14 +333,15 @@ def _param_schema_for(path: str) -> dict[str, object]:
 
 
 async def _insert_fleet_descriptors() -> None:
-    """Seed the 8 curated Fleet core ops + their groups as enabled rows.
+    """Seed the curated Fleet core ops + their groups as enabled rows.
 
     One :class:`OperationGroup` per entry in
     :data:`~meho_backplane.connectors.vcf_fleet.FLEET_CORE_GROUPS`
     (``review_status='enabled'``), one :class:`EndpointDescriptor` per
     entry in :data:`~meho_backplane.connectors.vcf_fleet.FLEET_CORE_OPS`
     (``is_enabled=True``, ``source_kind='ingested'``,
-    ``handler_ref=None``).
+    ``handler_ref=None``). This is the *declined* ingested set — the
+    audited about/inventory ops dispatch typed (T4 · #2304).
 
     Rows use ``product=FLEET_PRODUCT="fleet"`` (from
     :func:`parse_connector_id("fleet-rest-9.0")`), not the connector
@@ -345,10 +349,9 @@ async def _insert_fleet_descriptors() -> None:
     ``product="fleet"`` so the resolver finds
     :class:`VcfFleetConnector`.
 
-    Multiple ops can reference the same ``group_key`` — environments
-    has two ops (list + info), requests has two ops (list + info) — so
-    the helper coalesces group inserts via the ``group_ids`` dict and
-    skips re-inserting on the second op encounter.
+    Multiple ops can reference the same ``group_key`` — requests has two
+    ops (list + info) — so the helper coalesces group inserts via the
+    ``group_ids`` dict and skips re-inserting on the second op encounter.
     """
     sessionmaker = get_sessionmaker()
     group_ids: dict[str, UUID] = {}
@@ -406,7 +409,12 @@ async def _fleet_credentials_loader(_target: object, _operator: Operator) -> dic
 
 
 def _register_fleet_routes(mock: respx.MockRouter) -> None:
-    """Register the 8 Fleet read-op routes on *mock*.
+    """Register the Fleet read-op routes on *mock*.
+
+    Covers the full read surface (including the now-typed /about and
+    /environments paths, kept here so a typed-op smoke can reuse this
+    router); the ingested E2E only dispatches the curated FLEET_CORE_OPS
+    subset. ``assert_all_called=False`` tolerates the unhit routes.
 
     Fleet uses HTTP Basic on every request — no session-establish call.
     Each route returns a pre-seeded JSON body matching the rough shape

--- a/backend/tests/test_connectors_vcf_fleet_core_ops.py
+++ b/backend/tests/test_connectors_vcf_fleet_core_ops.py
@@ -17,12 +17,13 @@ Covers :mod:`meho_backplane.connectors.vcf_fleet.core_ops`:
   (``when_to_call`` / ``output_shape`` / ``next_step`` per op,
   ``name`` + ``when_to_use`` per group).
 * :func:`apply_fleet_core_curation` — the operator-review-time
-  substrate call that flips ``review_status='enabled'`` on the 6
-  curated groups, lands ``llm_instructions`` on the 8 curated ops,
+  substrate call that flips ``review_status='enabled'`` on the 5
+  curated groups, lands ``llm_instructions`` on the 6 curated ops,
   and explicitly disables non-core ops via the audit-log-driven
-  operator-override exclusion. The load-bearing assertion is "8 ops
-  dispatchable, every other op in curated groups stays
-  ``is_enabled=False``".
+  operator-override exclusion. The load-bearing assertion is "the
+  FLEET_CORE_OPS set is dispatchable, every other op in curated groups
+  stays ``is_enabled=False``". fleet.about + fleet.environment.list are
+  now typed (see tests.test_connectors_vcf_fleet_typed_reads).
 
 Test harness mirrors :mod:`tests.test_connectors_harbor_core_ops`:
 SQLite via the autouse ``_default_database_url`` fixture, hand-rolled
@@ -89,7 +90,9 @@ def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
 @pytest.mark.parametrize(
     "op_id,expected_group",
     [
-        ("GET:/lcm/lcops/api/v2/about", "fleet-about"),
+        # fleet.about was converted to a typed op (T4 · #2304); the /about
+        # rule was removed from FLEET_PATH_RULES, so it now classifies "none".
+        ("GET:/lcm/lcops/api/v2/about", "none"),
         ("GET:/lcm/lcops/api/v2/datacenters", "fleet-datacenter"),
         (
             "GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters",
@@ -118,7 +121,7 @@ def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
     ids=str,
 )
 def test_classify_fleet_op_returns_correct_group(op_id: str, expected_group: str) -> None:
-    """classify_fleet_op returns the curated group_key for all 8 core ops."""
+    """classify_fleet_op returns the curated group_key for each core op path."""
     assert classify_fleet_op(op_id) == expected_group
 
 
@@ -164,26 +167,48 @@ def test_classify_fleet_op_all_core_ops_are_classified() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_fleet_core_ops_has_exactly_eight_ops() -> None:
-    """FLEET_CORE_OPS carries exactly 8 entries — the v0.5 read core per #835."""
-    assert len(FLEET_CORE_OPS) == 8, (
-        f"v0.5 Fleet read core must have exactly 8 ops; "
-        f"got {len(FLEET_CORE_OPS)}: {[op.op_id for op in FLEET_CORE_OPS]}"
+def test_fleet_core_ops_has_exactly_six_ops() -> None:
+    """FLEET_CORE_OPS carries exactly 6 entries — the declined ingested set.
+
+    The G3.6 ship curated 8; the #2304 audited set (fleet.about +
+    fleet.environment.list) was converted to typed ops and removed from
+    the ingested curation, leaving the 6 declined ops.
+    """
+    assert len(FLEET_CORE_OPS) == 6, (
+        f"Fleet ingested-curation core must have exactly 6 ops after the "
+        f"#2304 typed conversion; got {len(FLEET_CORE_OPS)}: "
+        f"{[op.op_id for op in FLEET_CORE_OPS]}"
     )
 
 
-def test_fleet_core_groups_has_exactly_six_groups() -> None:
-    """FLEET_CORE_GROUPS carries exactly 6 entries spanning the v0.5 core.
+def test_fleet_core_groups_has_exactly_five_groups() -> None:
+    """FLEET_CORE_GROUPS carries exactly 5 entries after the #2304 conversion.
 
-    The 8 ops distribute across 6 groups: fleet-about, fleet-datacenter,
-    fleet-vcenter, fleet-environment (carries env.list + env.get),
-    fleet-product, fleet-request (carries req.list + req.get).
+    The 6 remaining ops distribute across 5 groups: fleet-datacenter,
+    fleet-vcenter, fleet-environment (carries env.get), fleet-product,
+    fleet-request (carries req.list + req.get). fleet-about was removed —
+    its only op (fleet.about) is now typed.
     """
-    assert len(FLEET_CORE_GROUPS) == 6, (
-        f"v0.5 Fleet read core must have exactly 6 groups; "
-        f"got {len(FLEET_CORE_GROUPS)}: "
+    assert len(FLEET_CORE_GROUPS) == 5, (
+        f"Fleet ingested-curation core must have exactly 5 groups after the "
+        f"#2304 typed conversion; got {len(FLEET_CORE_GROUPS)}: "
         f"{[g.group_key for g in FLEET_CORE_GROUPS]}"
     )
+
+
+def test_fleet_about_and_environment_list_not_in_ingested_curation() -> None:
+    """The two typed-converted ops are absent from the ingested curation.
+
+    fleet.about (GET:/lcm/lcops/api/v2/about) and fleet.environment.list
+    (GET:/lcm/lcops/api/v2/environments) dispatch as source_kind="typed"
+    (see tests.test_connectors_vcf_fleet_typed_reads); their ingested
+    duplicates must not be curated, or they would shadow the typed ops.
+    """
+    ingested_op_ids = {op.op_id for op in FLEET_CORE_OPS}
+    assert "GET:/lcm/lcops/api/v2/about" not in ingested_op_ids
+    assert "GET:/lcm/lcops/api/v2/environments" not in ingested_op_ids
+    ingested_group_keys = {g.group_key for g in FLEET_CORE_GROUPS}
+    assert "fleet-about" not in ingested_group_keys
 
 
 def test_fleet_core_ops_are_all_get() -> None:
@@ -258,28 +283,9 @@ def test_fleet_core_groups_when_to_use_is_not_placeholder() -> None:
         )
 
 
-def test_fleet_about_llm_instructions_flag_the_9_0_regression() -> None:
-    """fleet.about's llm_instructions must warn the agent about the 9.0 HTTP 500.
-
-    The wrapper-verified known issue is that ``/lcm/lcops/api/v2/about``
-    returns HTTP 500 in VCF 9.0 builds — the connector's probe falls
-    back to ``/lcm/lcops/api/v2/datacenters``, and the agent needs the
-    same fallback guidance in its reasoning context.
-    """
-    about_ops = [op for op in FLEET_CORE_OPS if op.op_id.endswith(":/lcm/lcops/api/v2/about")]
-    assert len(about_ops) == 1, (
-        f"expected exactly 1 fleet.about op; got {[op.op_id for op in about_ops]}"
-    )
-    about_op = about_ops[0]
-    combined = " ".join(str(v) for v in about_op.llm_instructions.values()).lower()
-    assert "500" in combined, (
-        f"fleet.about llm_instructions must mention the HTTP 500 regression in VCF 9.0; "
-        f"got: {about_op.llm_instructions!r}"
-    )
-    assert "datacenter" in combined, (
-        f"fleet.about llm_instructions must point the agent at "
-        f"fleet.datacenter.list as the fallback; got: {about_op.llm_instructions!r}"
-    )
+# The fleet.about 9.0-HTTP-500 llm_instructions guidance moved with the op
+# to the typed surface; it is asserted in
+# tests.test_connectors_vcf_fleet_typed_reads now.
 
 
 # ---------------------------------------------------------------------------
@@ -380,8 +386,8 @@ async def _seed_curated_groups_and_ops(
     return group_ids
 
 
-async def test_apply_fleet_core_curation_enables_exactly_8_ops() -> None:
-    """apply_fleet_core_curation enables exactly the 8 core ops."""
+async def test_apply_fleet_core_curation_enables_exactly_the_core_ops() -> None:
+    """apply_fleet_core_curation enables exactly the FLEET_CORE_OPS set."""
     tenant_id = uuid.uuid4()
     operator = _make_operator(tenant_id=tenant_id)
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)
@@ -442,7 +448,7 @@ async def test_apply_fleet_core_curation_disables_non_core_ops_in_curated_groups
 
 
 async def test_apply_fleet_core_curation_sets_llm_instructions_on_all_core_ops() -> None:
-    """llm_instructions is populated on all 8 core ops after curation."""
+    """llm_instructions is populated on all curated core ops after curation."""
     tenant_id = uuid.uuid4()
     operator = _make_operator(tenant_id=tenant_id)
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)

--- a/backend/tests/test_connectors_vcf_fleet_e2e.py
+++ b/backend/tests/test_connectors_vcf_fleet_e2e.py
@@ -67,9 +67,9 @@ from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._vcf_fleet_canary_fixtures import (
     FLEET_CANARY_BASE_URL,
-    FLEET_CANARY_ENVIRONMENTS,
     FLEET_CANARY_FINGERPRINT,
     FLEET_CANARY_OPERATOR_TENANT,
+    FLEET_CANARY_REQUESTS,
     FLEET_FORCE_HANDLE_LIST_OP_ID,
     FLEET_TARGET_NAME,
     _fleet_credentials_loader,
@@ -227,7 +227,7 @@ async def fleet_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_FleetE2
     3. Resolve + cache the connector instance; replace its
        :class:`CredentialsCache` so no Vault read fires.
     4. Activate a respx router for :data:`FLEET_CANARY_BASE_URL` and
-       register the 8 read-op routes.
+       register the Fleet read-op routes.
     """
     await _insert_fleet_descriptors()
     seeded_target = await _seed_target()
@@ -255,7 +255,7 @@ async def fleet_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_FleetE2
 # ---------------------------------------------------------------------------
 
 _OP_IDS: tuple[str, ...] = tuple(op.op_id for op in FLEET_CORE_OPS)
-assert len(_OP_IDS) == 8, f"Expected 8 curated Fleet ops, got {len(_OP_IDS)}: {_OP_IDS}"
+assert len(_OP_IDS) == 6, f"Expected 6 curated Fleet ops, got {len(_OP_IDS)}: {_OP_IDS}"
 
 
 @pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
@@ -263,7 +263,7 @@ async def test_fleet_e2e_all_ops_dispatch_ok(
     op_id: str,
     fleet_e2e_canary: _FleetE2EBundle,
 ) -> None:
-    """All 8 Fleet core ops dispatch through the full dispatcher and return status='ok'.
+    """All ingested Fleet core ops dispatch through the full dispatcher, status='ok'.
 
     HTTP Basic auth is computed by the connector's stub credentials
     loader on first dispatch (then cached); no session-establish step
@@ -327,12 +327,14 @@ async def test_fleet_e2e_credentials_cached_after_first_dispatch(
     )
 
     # Second dispatch must NOT reload credentials — cache entry survives.
+    # Uses a still-ingested op (request list); environments moved to the
+    # typed surface (T4 · #2304) and no longer dispatches via this path.
     creds_before = dict(instance._creds._cache)  # type: ignore[attr-defined]
     result2 = await call_operation(
         _OPERATOR,
         {
             "connector_id": FLEET_CONNECTOR_ID,
-            "op_id": "GET:/lcm/lcops/api/v2/environments",
+            "op_id": "GET:/lcm/request/api/v2/requests",
             "target": {"name": target_name},
             "params": {},
         },
@@ -414,27 +416,29 @@ async def test_fleet_e2e_dispatch_writes_audit_row(
     )
 
 
-async def test_fleet_e2e_jsonflux_handle_populated_for_environment_list(
+async def test_fleet_e2e_jsonflux_handle_populated_for_request_list(
     fleet_e2e_canary: _FleetE2EBundle,
 ) -> None:
-    """Environment list dispatched with the real JsonFluxReducer returns a populated handle.
+    """Request list dispatched with the real JsonFluxReducer returns a populated handle.
 
     Exercises acceptance criterion (c): the JSONFlux dispatcher seam
     threads the reducer's :class:`ResultHandle` onto
-    :class:`OperationResult`. Environment listing is the largest Fleet
-    read surface in real deployments — busy appliances commonly manage
-    dozens of environments — so the handle-path coverage lands here.
+    :class:`OperationResult`. Lifecycle-request listing is the largest
+    *ingested* Fleet read surface in real deployments — busy appliances
+    accumulate thousands of historical requests — so the ingested-path
+    handle coverage lands here. (Environment listing, formerly used here,
+    is a typed op now — T4 · #2304.)
 
     Assertions mirror the NSX / SDDC Manager JSONFlux handle tests:
 
     * ``status == 'ok'``.
     * ``handle`` is non-None and carries a valid UUID4 ``handle_id``.
-    * ``handle.total_rows`` matches the seeded environment count.
+    * ``handle.total_rows`` matches the seeded request count.
     * ``handle.sample_rows`` is populated (≥1 row).
     * ``result['row_count']`` equals ``handle.total_rows`` (the
       reducer's summary inlined on the envelope).
     """
-    expected_rows = len(FLEET_CANARY_ENVIRONMENTS)
+    expected_rows = len(FLEET_CANARY_REQUESTS)
 
     set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
@@ -463,13 +467,13 @@ async def test_fleet_e2e_jsonflux_handle_populated_for_environment_list(
     uuid.UUID(handle["handle_id"])
 
     assert handle["total_rows"] == expected_rows, (
-        f"Expected {expected_rows} environment rows from FLEET_CANARY_ENVIRONMENTS; "
+        f"Expected {expected_rows} request rows from FLEET_CANARY_REQUESTS; "
         f"got handle.total_rows={handle['total_rows']}"
     )
 
     sample_rows = handle.get("sample_rows")
     assert sample_rows, (
-        f"Expected ≥1 sample row from the seeded Fleet environment list; "
+        f"Expected ≥1 sample row from the seeded Fleet request list; "
         f"got sample_rows={sample_rows!r}"
     )
 

--- a/backend/tests/test_connectors_vcf_fleet_typed_reads.py
+++ b/backend/tests/test_connectors_vcf_fleet_typed_reads.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the VCF Fleet typed read core (T4 · #2304, Initiative #2266).
+
+Covers the audited Fleet read set converted from ingested-row curation to
+typed ops on the connector's existing HTTP Basic (LCM-local) session:
+
+* ``fleet.about`` — the about/health probe.
+* ``fleet.environment.list`` — the component inventory ("what's deployed").
+
+Coverage matrix (per #2304 acceptance criteria):
+
+* **Both ops dispatch as ``source_kind="typed"`` on a fresh boot with
+  zero catalog state** — the persisted ``endpoint_descriptor`` rows carry
+  ``source_kind="typed"`` after ``register_operations`` runs against an
+  empty DB, and each dispatches end-to-end through
+  :func:`~meho_backplane.operations.dispatch` against a respx-mocked
+  appliance, returning ``status="ok"`` with the payload in
+  ``OperationResult.result``. No ingested row is involved.
+* **``fleet.environment.list`` wraps the bare Fleet array** under an
+  ``environments`` key (the vSphere typed-reads envelope shape).
+* **``fleet.about`` carries the 9.0 HTTP-500 fallback guidance** in its
+  ``llm_instructions`` (the regression warning that moved off the
+  ingested curation with the op).
+* **Registration shape** — both are ``safety_level="safe"``,
+  ``requires_approval=False``, read-only. No write op is registered.
+
+Mirrors :mod:`tests.test_connectors_argocd_reads` for the typed dispatch
+lifecycle; injects a stub credentials loader on the resolved connector
+instance (the :mod:`tests.test_connectors_vcf_fleet_e2e` pattern) so no
+Vault read fires — Fleet auth is HTTP Basic, not a bearer token.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vcf_fleet import (
+    FLEET_CONNECTOR_ID,
+    FLEET_TYPED_OPS,
+    VcfFleetConnector,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import (
+    get_or_create_connector_instance,
+    reset_handler_cache,
+)
+from meho_backplane.settings import get_settings
+
+_PRODUCT = "fleet"
+_VERSION = "9.0"
+_IMPL_ID = "fleet-rest"
+
+_FLEET_HOST = "fleet-typed.test.invalid"
+_FLEET_BASE_URL = f"https://{_FLEET_HOST}"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Operator + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=VcfFleetConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _FleetTarget:
+    """Target satisfying both ``VcfFleetTargetLike`` and the resolver shape."""
+
+    def __init__(self) -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": _VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000fe")
+        self.name = "fleet-typed"
+        self.host = _FLEET_HOST
+        self.port = 443
+        self.secret_ref = "targets/fleet/fleet-typed"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-typed-fleet",
+        name="Fleet Typed Reads Operator",
+        email=None,
+        raw_jwt="op.typed.fleet.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000ab"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _fleet_stub_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Stub HTTP Basic credentials — bypasses the Vault read."""
+    return {"username": "admin@local", "password": "fleet-typed-pw"}
+
+
+async def _register_and_bind() -> VcfFleetConnector:
+    """Register the typed ops + resolve the connector with a stub creds loader.
+
+    Resolving the instance via :func:`get_or_create_connector_instance`
+    before dispatch populates the dispatcher's instance cache, so the
+    stub-loader injection lands on the same instance the dispatch reuses.
+    """
+    await VcfFleetConnector.register_operations()
+    instance = get_or_create_connector_instance(VcfFleetConnector)
+    instance._creds = type(instance._creds)(  # type: ignore[attr-defined]
+        _fleet_stub_loader,
+        product_label="fleet",
+    )
+    return instance
+
+
+_ABOUT_PAYLOAD: dict[str, Any] = {
+    "apiVersion": "8.0",
+    "productVersion": "9.0.0.0",
+    "buildNumber": "24123456",
+    "releaseDate": "2026-04-01",
+}
+_ENVIRONMENTS_PAYLOAD: list[dict[str, Any]] = [
+    {
+        "environmentId": "env-typed-000",
+        "environmentName": "env-typed-000",
+        "environmentStatus": "DEPLOY_SUCCESSFUL",
+        "products": [{"productId": "vrops", "version": "9.0.0"}],
+    },
+    {
+        "environmentId": "env-typed-001",
+        "environmentName": "env-typed-001",
+        "environmentStatus": "DEPLOY_SUCCESSFUL",
+        "products": [{"productId": "vrli", "version": "9.0.0"}],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# AC #1 — typed dispatch on a fresh boot with zero catalog state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_about_dispatches_typed_on_fresh_boot(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """fleet.about dispatches as source_kind='typed' against a mocked appliance."""
+    instance = await _register_and_bind()
+    try:
+        target = _FleetTarget()
+        operator = _make_operator()
+        async with respx.mock(base_url=_FLEET_BASE_URL, assert_all_called=False) as mock:
+            route = mock.get("/lcm/lcops/api/v2/about").respond(200, json=_ABOUT_PAYLOAD)
+            result = await dispatch(
+                operator=operator,
+                connector_id=FLEET_CONNECTOR_ID,
+                op_id="fleet.about",
+                target=target,
+                params={},
+            )
+        assert result.status == "ok", result.error
+        assert result.result == _ABOUT_PAYLOAD
+        assert route.called and route.call_count == 1
+        sent_auth = route.calls[0].request.headers.get("authorization")
+        assert sent_auth is not None and sent_auth.startswith("Basic ")
+    finally:
+        await instance.aclose()
+
+    descriptor = (
+        await session.execute(
+            select(EndpointDescriptor).where(EndpointDescriptor.op_id == "fleet.about")
+        )
+    ).scalar_one()
+    assert descriptor.source_kind == "typed"
+    assert descriptor.tenant_id is None
+
+
+@pytest.mark.asyncio
+async def test_environment_list_dispatches_typed_and_wraps_array(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """fleet.environment.list dispatches typed and wraps the bare array."""
+    instance = await _register_and_bind()
+    try:
+        target = _FleetTarget()
+        operator = _make_operator()
+        async with respx.mock(base_url=_FLEET_BASE_URL, assert_all_called=False) as mock:
+            route = mock.get("/lcm/lcops/api/v2/environments").respond(
+                200, json=_ENVIRONMENTS_PAYLOAD
+            )
+            result = await dispatch(
+                operator=operator,
+                connector_id=FLEET_CONNECTOR_ID,
+                op_id="fleet.environment.list",
+                target=target,
+                params={},
+            )
+        assert result.status == "ok", result.error
+        assert result.result == {"environments": _ENVIRONMENTS_PAYLOAD}
+        assert route.called and route.call_count == 1
+    finally:
+        await instance.aclose()
+
+    descriptor = (
+        await session.execute(
+            select(EndpointDescriptor).where(EndpointDescriptor.op_id == "fleet.environment.list")
+        )
+    ).scalar_one()
+    assert descriptor.source_kind == "typed"
+
+
+@pytest.mark.asyncio
+async def test_typed_ops_registered_with_no_ingested_rows(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """A fresh boot registers exactly the typed ops — no ingested descriptors.
+
+    Proves the "zero catalog state" half of AC #1: after
+    ``register_operations`` runs against an empty DB, the only Fleet
+    ``endpoint_descriptor`` rows are the typed ops (no spec was ingested).
+    """
+    await VcfFleetConnector.register_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(EndpointDescriptor).where(EndpointDescriptor.product == _PRODUCT)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    op_ids = {r.op_id for r in rows}
+    assert op_ids == {"fleet.about", "fleet.environment.list"}
+    assert all(r.source_kind == "typed" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Registration shape
+# ---------------------------------------------------------------------------
+
+
+def test_typed_ops_are_read_only_and_ungated() -> None:
+    """Both typed ops are safe, read-only, and require no approval."""
+    assert {op.op_id for op in FLEET_TYPED_OPS} == {
+        "fleet.about",
+        "fleet.environment.list",
+    }
+    for op in FLEET_TYPED_OPS:
+        assert op.safety_level == "safe", op.op_id
+        assert op.requires_approval is False, op.op_id
+        assert "read-only" in op.tags, op.op_id
+
+
+def test_about_llm_instructions_flag_the_9_0_regression() -> None:
+    """fleet.about's llm_instructions warn about the VCF 9.0 HTTP 500 + fallback."""
+    about = next(op for op in FLEET_TYPED_OPS if op.op_id == "fleet.about")
+    assert about.llm_instructions is not None
+    combined = " ".join(str(v) for v in about.llm_instructions.values()).lower()
+    assert "500" in combined, about.llm_instructions
+    assert "datacenter" in combined, about.llm_instructions

--- a/docs/codebase/connectors-vcf-fleet.md
+++ b/docs/codebase/connectors-vcf-fleet.md
@@ -8,9 +8,12 @@ dispatches VCF Fleet REST operations under the
 G3.6-T7 (#831) shipped the skeleton — HTTP Basic auth against the LCM-local
 user store, the wrapper-verified fingerprint/probe call, and the G0.6
 dispatch shim. G3.6-T8 (#835) added the operator-review curation surface —
-`FLEET_CORE_GROUPS` + `FLEET_CORE_OPS` + `apply_fleet_core_curation` — the
-v0.5 read core (8 ops across 6 groups). G3.6-T9 (#839) will ship the CLI
-verb tree + recorded-fixture E2E.
+`FLEET_CORE_GROUPS` + `FLEET_CORE_OPS` + `apply_fleet_core_curation`. T4
+(#2304, Initiative #2266) then converted the audited read set (about/health
+probe + component inventory) to **typed** ops in `typed_ops.py`, trimming
+the ingested curation to the 6 declined ops (5 groups) and removing the
+Fleet-LCM-spec ingest dependency for the operational surface. G3.6-T9
+(#839) shipped the CLI verb tree + recorded-fixture E2E.
 
 Source: `backend/src/meho_backplane/connectors/vcf_fleet/`.
 
@@ -132,34 +135,65 @@ delegation pattern as `vcf_automation`, `sddc_manager`, `nsx`).
 
 ### Dispatch
 
-Operations are **generic-ingested** (#835) under the same dispatcher path
-the other tier-3 VCF connectors use: G0.7 ingests the Fleet OpenAPI spec
-into `endpoint_descriptor`, the operator reviews and enables the curated
-op_ids, and `POST /api/v1/operations/call` (or MCP `call_operation`)
-dispatches them through `meho_backplane.operations.dispatch`. The
-connector's `execute()` is the G0.6 ABC-compatibility shim that builds a
-synthetic `Operator` and forwards to the dispatcher; post-G0.6 callers
-construct a real `Operator` and invoke `dispatch` directly.
+The audited read set dispatches as **typed** ops (`source_kind="typed"`)
+off the connector's hand-rolled HTTP Basic session; the declined breadth
+stays **generic-ingested**. Typed ops need no catalog ingest — they are
+registered in code at lifespan startup and dispatch on a fresh boot with
+zero catalog state. Ingested ops still take the G0.7 path: the operator
+ingests the Fleet OpenAPI spec into `endpoint_descriptor`, reviews and
+enables the curated op_ids, then dispatches. Both paths route through
+`meho_backplane.operations.dispatch` via `POST /api/v1/operations/call`
+(or MCP `call_operation`). The connector's `execute()` is the G0.6
+ABC-compatibility shim that builds a synthetic `Operator` and forwards to
+the dispatcher; post-G0.6 callers construct a real `Operator` and invoke
+`dispatch` directly.
 
-### Curated read-core (G3.6-T8 #835)
+### Typed read set (T4 · #2304, Initiative #2266)
 
-`core_ops.py` carries the operator-review metadata for the v0.5 read core:
+`typed_ops.py` + `VcfFleetConnector.register_operations()` carry the
+**audited** read set — the two ops the adopter actually uses (#2294 T0
+audit, row 21) — converted from ingested-row curation to typed ops so the
+operational surface no longer depends on ingesting the crash-prone Fleet
+LCM spec (the #2272 datetime-crash artifact):
 
-- **`FLEET_CORE_GROUPS`** — 6 `FleetCoreGroup` entries: `fleet-about`,
-  `fleet-datacenter`, `fleet-vcenter`, `fleet-environment`, `fleet-product`,
-  `fleet-request`. Each carries the operator-reviewed `name` +
-  `when_to_use` blurb the agent reads through `list_operation_groups`.
-- **`FLEET_CORE_OPS`** — 8 `FleetCoreOp` entries (all `GET:` — the v0.5
-  core is read-only): `fleet.about` (`/lcm/lcops/api/v2/about` — see
-  known-issue below), `fleet.datacenter.list`, `fleet.vcenter.list`,
-  `fleet.environment.list`, `fleet.environment.get`, `fleet.product.list`,
-  `fleet.request.list`, `fleet.request.get`. Each carries a
-  `when_to_call` / `output_shape` / `next_step` `llm_instructions` blob
-  matching the bind9 / NSX / Harbor convention.
+- **`fleet.about`** (`GET /lcm/lcops/api/v2/about`, group `fleet-about`) —
+  the about/health probe. Returns HTTP 500 in VCF 9.0 (see known-issue
+  below); the `llm_instructions` carry the 500 warning + reachability
+  fallback that moved with the op.
+- **`fleet.environment.list`** (`GET /lcm/lcops/api/v2/environments`,
+  group `fleet-inventory`) — the component inventory ("what's deployed").
+  Wraps Fleet's bare environments array under an `environments` key
+  (the vSphere typed-reads envelope shape).
+
+`register_operations` walks `FLEET_TYPED_OPS`, resolves each op's
+`handler_attr` to the bound method on the connector, and routes it through
+`register_typed_operation` — the argocd / bind9 / vmware_rest mold. The
+module-level `register_fleet_typed_operations` wrapper is queued via
+`register_typed_op_registrar` in `__init__.py` so the rows land before the
+first dispatch.
+
+### Declined ingested read-core (G3.6-T8 #835, trimmed by #2304)
+
+`core_ops.py` carries the operator-review metadata for the **declined**
+ingested read core — the six ops outside the audited set (kept as
+browsable ingested breadth until T7 retires the curation apparatus):
+
+- **`FLEET_CORE_GROUPS`** — 5 `FleetCoreGroup` entries: `fleet-datacenter`,
+  `fleet-vcenter`, `fleet-environment` (now carries only
+  `fleet.environment.get`), `fleet-product`, `fleet-request`.
+  (`fleet-about` was removed — its op is typed now.)
+- **`FLEET_CORE_OPS`** — 6 `FleetCoreOp` entries (all `GET:`, read-only):
+  `fleet.datacenter.list`, `fleet.vcenter.list`, `fleet.environment.get`,
+  `fleet.product.list`, `fleet.request.list`, `fleet.request.get`.
+  `fleet.about` + `fleet.environment.list` are intentionally absent —
+  they are typed now, and the ingested duplicate must not shadow the typed
+  op.
 - **`FLEET_PATH_RULES` + `classify_fleet_op`** — deterministic path-prefix
-  classifier feeding the curated `group_key` per op_id. Rule ordering is
-  load-bearing (vcenters before datacenters; products before environments;
-  request paths under `/lcm/request/` independent of LCM-ops paths under
+  classifier feeding the curated `group_key` per op_id. The `/about` rule
+  was removed with the typed conversion (an ingested `/about` row now
+  classifies `none` and stays disabled). Rule ordering is load-bearing
+  (vcenters before datacenters; products before environments; request
+  paths under `/lcm/request/` independent of LCM-ops paths under
   `/lcm/lcops/`).
 - **`apply_fleet_core_curation`** — operator-review-time substrate call
   that runs against an already-ingested connector: disables non-core ops


### PR DESCRIPTION
## Summary

- Convert VCF Fleet's **audited read set** — the about/health probe
  (`fleet.about`) and the component inventory "what's deployed"
  (`fleet.environment.list`) — from `is_enabled` curation over ingested
  `endpoint_descriptor` rows to **typed** ops (`source_kind="typed"`) that
  dispatch off the connector's existing hand-rolled HTTP Basic (LCM-local)
  session. They register in code at lifespan startup (argocd-style
  registrar mold), so they work on a **fresh boot with zero catalog
  ingest** — removing the Fleet operational surface's dependence on
  ingesting the crash-prone vRSLCM-derived Fleet OpenAPI spec (the #2272
  datetime-crash artifact).
- The two converted ops are removed from `FLEET_CORE_OPS` (empty
  `fleet-about` group + its `/about` path rule dropped) so the ingested
  duplicates cannot shadow the typed ops (the #2262 registration
  invariant). The remaining six curated ops are **declined** from typed
  conversion — outside the #2294 audit — and stay as browsable ingested
  breadth until T7 retires the curation apparatus. Per-op decline
  rationale posted on #2304.
- Reads only; no writes (out of #2266 scope).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy backend/src/.../vcf_fleet/` — clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] **AC #1** — new `tests/test_connectors_vcf_fleet_typed_reads.py`:
      `fleet.about` + `fleet.environment.list` dispatch as
      `source_kind="typed"` on a fresh boot with zero catalog state,
      against a respx-mocked appliance (the only Fleet
      `endpoint_descriptor` rows are the two typed ops).
- [x] **AC #2** — `core_ops.py` no longer curates the converted ops'
      ingested rows; unconverted ops declined (reasons on #2304);
      canary fixtures + e2e ingested-path tests repointed
      (`test_connectors_vcf_fleet_core_ops`, `_e2e`).
- [x] **AC #3** — `cd cli && make snapshot-openapi` produced **no delta**
      (no FastAPI route/schema touched).
- [x] Broad unit sweep (`-k "fleet or typed_register or registry or
      resolver or catalog or redaction or health or mcp_tools_operations
      or eval_corpus"`) — 851 passed, 20 skipped.

## Out of scope

- Writes (none wanted); T7 curation-apparatus retirement; the #2272
  loader fix (G0.30).
- The declined six curated ops stay as ingested breadth (browse case).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2304


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed Fleet read operations for appliance details and deployed environments.
  * Fleet reads now use the existing secure session and remain available without Fleet API specification ingestion.
  * Added guidance for handling a known VCF 9.0 appliance-details error.

* **Bug Fixes**
  * Prevented typed Fleet operations from being duplicated or overridden by ingested results.
  * Retained broader Fleet operations through the existing browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->