### PR TITLE
feat(connectors): VCFA typed reads on the dual-plane session (#2305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Connectors — VCFA typed reads on the dual-plane session (#2305)
+
+- The audited VCF Automation read set — provider org list / region list /
+  health (`/cloudapi/1.0.0/site`) and tenant `/iaas/api/projects` + `about`
+  — is now served by first-class `source_kind="typed"` operations
+  (`vcfa.provider.org.list` / `region.list` / `health`,
+  `vcfa.tenant.project.list` / `about`) that dispatch through the
+  connector's own dual-plane session with **zero catalog state**. VCFA
+  ships no vendor OpenAPI spec, so the prior ingested-curation path was
+  dispatch-inert on a real deploy; typed conversion is the only working
+  read surface. Each op declares the auth plane it rides (provider vs
+  tenant), cross-checked against the request path at import time. The
+  remaining `core_ops` ingested-curation surface is trimmed to the 6-op
+  browse remainder; `org create` (a write) stays out of scope (#2305).
+
 ### Added — structural OpenAPI 3.x metaschema gate on spec ingest (#2292)
 
 - Spec ingest now validates a decoded OpenAPI 3.0/3.1 document against the

--- a/backend/src/meho_backplane/connectors/vcf_automation/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/__init__.py
@@ -57,6 +57,35 @@ from meho_backplane.connectors.vcf_automation.session import (
     VcfAutomationTargetLike,
     load_credentials_from_vault,
 )
+from meho_backplane.connectors.vcf_automation.typed_ops import (
+    VCFA_TYPED_OPS,
+    VCFA_TYPED_WHEN_TO_USE_BY_GROUP,
+    VcfaTypedOp,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_vcfa_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``VcfAutomationConnector.register_typed_operations``.
+
+    The canonical typed-op registration pattern is a module-level
+    ``async def register_xxx_typed_operations`` queued onto
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+    via :func:`register_typed_op_registrar`. The VCFA op walk is a
+    classmethod on the connector (so the test suite can drive it without
+    lifespan plumbing); this wrapper is the seam the standard registrar
+    mechanism calls. The ``embedding_service`` kwarg is accepted-and-
+    discarded — the runner passes it to every registrar, and
+    :meth:`VcfAutomationConnector.register_typed_operations` resolves the
+    process-wide singleton via ``register_typed_operation``'s fallback.
+    """
+    del embedding_service  # runner-compatibility kwarg; singleton resolved downstream
+    await VcfAutomationConnector.register_typed_operations()
+
 
 register_connector_v2(
     product="vcfa",
@@ -78,6 +107,13 @@ register_connector_v2(
     cls=VcfAutomationConnector,
 )
 
+# Queue the typed-op upsert onto the lifespan-driven registrar list. The
+# runner (``run_typed_op_registrars``) iterates after
+# ``_eager_import_connectors`` so the five typed read descriptors land
+# before the first dispatch — no ingested catalog state required (VCFA
+# ships no vendor spec; typed conversion is the only working read path).
+register_typed_op_registrar(register_vcfa_typed_operations)
+
 __all__ = [
     "VCFA_CONNECTOR_ID",
     "VCFA_CORE_GROUPS",
@@ -85,6 +121,8 @@ __all__ = [
     "VCFA_IMPL_ID",
     "VCFA_PATH_RULES",
     "VCFA_PRODUCT",
+    "VCFA_TYPED_OPS",
+    "VCFA_TYPED_WHEN_TO_USE_BY_GROUP",
     "VCFA_VERSION",
     "SessionCredentials",
     "VcfAutomationConfigurationError",
@@ -93,7 +131,9 @@ __all__ = [
     "VcfAutomationTargetLike",
     "VcfaCoreGroup",
     "VcfaCoreOp",
+    "VcfaTypedOp",
     "apply_vcfa_core_curation",
     "classify_vcfa_op",
     "load_credentials_from_vault",
+    "register_vcfa_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/vcf_automation/_core_data.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/_core_data.py
@@ -1,7 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Curated VCFA core-ops data tables -- the 8 groups + 11 ops + classifier rules.
+"""Curated VCFA core-ops data tables -- the 5 groups + 6 ops + classifier rules.
+
+Since T5 (#2305) the audited read set (org/region list, provider health
+via ``/cloudapi/1.0.0/site``, ``/iaas/api/projects`` list, and the
+tenant ``/iaas/api/about`` probe) is served by ``source_kind="typed"``
+ops in :mod:`.typed_ops`, not by ingested-curation here. What remains in
+these tables is the still-curated ingested browse surface: the two
+get-by-id provider ops, the provider users list, and the tenant
+deployment/blueprint browse ops.
 
 Split out from :mod:`.core_ops` to keep the public module within the
 file-size budget. The contents here are pure data + the classifier
@@ -116,14 +124,17 @@ class VcfaCoreOp:
 #: -- but the tenant rules are listed first defensively so a future
 #: provider-side ``/iaas`` (unlikely, but possible) wouldn't shadow
 #: them.
+#:
+#: The audited read set (site/about, orgs list, regions list, projects
+#: list) was converted to ``source_kind="typed"`` ops in
+#: :mod:`.typed_ops` (T5 #2305); those paths carry no ingested-curation
+#: rule any more (the ``orgs`` / ``regions`` rules stay only for the
+#: still-curated get-by-id ops that share the collection prefix).
 VCFA_PATH_RULES: Final[tuple[tuple[str, str], ...]] = (
     # Tenant plane -- /iaas/api/* family.
-    ("/iaas/api/about", "tenant-about"),
-    ("/iaas/api/projects", "tenant-projects"),
     ("/iaas/api/deployments", "tenant-deployments"),
     ("/iaas/api/blueprints", "tenant-blueprints"),
     # Provider plane -- /cloudapi/1.0.0/* family.
-    ("/cloudapi/1.0.0/site", "provider-site"),
     ("/cloudapi/1.0.0/orgs", "provider-orgs"),
     ("/cloudapi/1.0.0/regions", "provider-regions"),
     ("/cloudapi/1.0.0/users", "provider-users"),
@@ -173,26 +184,13 @@ def _instructions(
     }
 
 
-#: Operator-reviewed ``when_to_use`` hints for the 8 VCFA groups
-#: (4 provider + 4 tenant). Every hint names its plane explicitly
-#: so the agent's group-selection step routes correctly across the
-#: dual-plane surface.
+#: Operator-reviewed ``when_to_use`` hints for the 5 curated VCFA groups
+#: (3 provider + 2 tenant) left as ingested-curation after the audited
+#: read set was converted to typed ops (:mod:`.typed_ops`, T5 #2305).
+#: Every hint names its plane explicitly so the agent's group-selection
+#: step routes correctly across the dual-plane surface.
 VCFA_CORE_GROUPS: Final[tuple[VcfaCoreGroup, ...]] = (
-    # ----- Provider plane (4 groups, 6 ops) -----
-    VcfaCoreGroup(
-        group_key="provider-site",
-        plane="provider",
-        name="VCFA Provider (site)",
-        when_to_use=(
-            "Use this group on the VCFA **provider plane** to read appliance-level "
-            "site identity: site name, configured organization count, and VCFA "
-            "appliance version. The probe surface the agent calls before any "
-            "heavier provider read or when confirming which VCFA instance the "
-            "target points at. Provider-plane ops authenticate with the "
-            "``admin@System`` (or equivalent) Basic-auth session and never "
-            "succeed against the tenant token."
-        ),
-    ),
+    # ----- Provider plane (3 groups, 3 ops) -----
     VcfaCoreGroup(
         group_key="provider-orgs",
         plane="provider",
@@ -232,33 +230,7 @@ VCFA_CORE_GROUPS: Final[tuple[VcfaCoreGroup, ...]] = (
             "v0.5 read core."
         ),
     ),
-    # ----- Tenant plane (4 groups, 5 ops) -----
-    VcfaCoreGroup(
-        group_key="tenant-about",
-        plane="tenant",
-        name="VCFA Tenant (about)",
-        when_to_use=(
-            "Use this group on the VCFA **tenant plane** to read the IaaS API "
-            "self-describe surface -- supported API versions and the latest "
-            "tenant API version. The probe surface the agent calls before any "
-            "tenant catalog read or when confirming tenant-plane reachability. "
-            "Tenant-plane ops authenticate with the tenant org login (``POST "
-            "/iaas/api/login``) and never succeed against the provider JWT."
-        ),
-    ),
-    VcfaCoreGroup(
-        group_key="tenant-projects",
-        plane="tenant",
-        name="VCFA Tenant Projects",
-        when_to_use=(
-            "Use this group on the VCFA **tenant plane** to list projects "
-            "within the tenant organization. Projects are the deployment-scoping "
-            "construct: every deployment belongs to exactly one project, and "
-            "blueprint access controls reference project membership. Use to "
-            "answer 'what projects exist in this org' or to pick the "
-            "project_id filter for a follow-up deployment list."
-        ),
-    ),
+    # ----- Tenant plane (2 groups, 3 ops) -----
     VcfaCoreGroup(
         group_key="tenant-deployments",
         plane="tenant",
@@ -290,63 +262,16 @@ VCFA_CORE_GROUPS: Final[tuple[VcfaCoreGroup, ...]] = (
 )
 
 
-#: The 11 curated read-only VCFA core ops (6 provider + 5 tenant).
-#: Paths cross-checked against the VCF Automation 9.0 API surface:
-#: the cloudapi family at
+#: The 6 curated read-only VCFA core ops (3 provider + 3 tenant) left as
+#: ingested-curation after the audited read set (site/about, orgs list,
+#: regions list, projects list) was converted to ``source_kind="typed"``
+#: ops in :mod:`.typed_ops` (T5 #2305). Paths cross-checked against the
+#: VCF Automation 9.0 API surface: the cloudapi family at
 #: https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/administration-sdks-cli-and-tools/about-the-vcf-automation-api.html
 #: and the tenant-plane IaaS family at
 #: https://developer.broadcom.com/xapis/vm-apps-org-provisioning-service/latest/.
 VCFA_CORE_OPS: Final[tuple[VcfaCoreOp, ...]] = (
-    # ----- Provider plane (6 ops) -----
-    VcfaCoreOp(
-        op_id="GET:/cloudapi/1.0.0/site",
-        group_key="provider-site",
-        plane="provider",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to read VCFA appliance site identity on the provider "
-                "plane: site name, configured organization count, and VCFA "
-                "appliance version. Useful as a pre-flight probe before "
-                "heavier provider reads or to confirm which VCFA instance the "
-                "target points at."
-            ),
-            output_shape=(
-                "Object with id, name, description, restName, and product "
-                "version fields plus a links collection. The product version "
-                "string identifies the VCFA appliance build."
-            ),
-            next_step=(
-                "Confirm the product version is in the supported range, then "
-                "proceed to vcfa.provider.org.list for the org inventory or "
-                "vcfa.provider.vdc.list for the region inventory."
-            ),
-        ),
-    ),
-    VcfaCoreOp(
-        op_id="GET:/cloudapi/1.0.0/orgs",
-        group_key="provider-orgs",
-        plane="provider",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call on the provider plane to list organizations on this "
-                "VCFA appliance. Returns the cross-tenant view (every tenant "
-                "appears here) -- the system administrator's inventory entry "
-                "point. Supports pagination via 'page' and 'pageSize' query "
-                "parameters."
-            ),
-            output_shape=(
-                "Object with a 'values' array of organization entries; each "
-                "entry carries id, name, displayName, description, isEnabled, "
-                "and orgVdcCount. The 'resultTotal' field reports the global "
-                "count for pagination."
-            ),
-            next_step=(
-                "Pick an org id for vcfa.provider.org.get to read its full "
-                "detail, or switch planes to tenant-side ops for per-org "
-                "project / deployment / blueprint reads."
-            ),
-        ),
-    ),
+    # ----- Provider plane (3 ops) -----
     VcfaCoreOp(
         op_id="GET:/cloudapi/1.0.0/orgs/{id}",
         group_key="provider-orgs",
@@ -369,31 +294,6 @@ VCFA_CORE_OPS: Final[tuple[VcfaCoreOp, ...]] = (
                 "If counts indicate the org has active workloads, switch "
                 "planes to vcfa.tenant.deployment.list (authenticated against "
                 "the same org's tenant token) for the catalog view."
-            ),
-        ),
-    ),
-    VcfaCoreOp(
-        op_id="GET:/cloudapi/1.0.0/regions",
-        group_key="provider-regions",
-        plane="provider",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call on the provider plane to list VCFA regions -- the VCFA 9 "
-                "evolution of the vCloud-Director provider VDC concept. Each "
-                "region maps to one NSX domain plus a collection of "
-                "supervisors backed by one or more VCF workload domains. Use "
-                "to answer 'what compute capacity does this VCFA appliance "
-                "offer'."
-            ),
-            output_shape=(
-                "Object with a 'values' array of region entries; each entry "
-                "carries id, name, description, nsxManager, supervisors, and "
-                "isEnabled. The 'resultTotal' field reports the global count "
-                "for pagination."
-            ),
-            next_step=(
-                "Pick a region id for vcfa.provider.vdc.get for the full "
-                "detail (capacity counters, configured storage policies)."
             ),
         ),
     ),
@@ -449,54 +349,7 @@ VCFA_CORE_OPS: Final[tuple[VcfaCoreOp, ...]] = (
             ),
         ),
     ),
-    # ----- Tenant plane (5 ops) -----
-    VcfaCoreOp(
-        op_id="GET:/iaas/api/about",
-        group_key="tenant-about",
-        plane="tenant",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call on the tenant plane to read the IaaS API self-describe "
-                "surface: supportedApis list and latestApiVersion. Useful as "
-                "a probe before any tenant catalog read or to confirm "
-                "tenant-plane reachability and version negotiation."
-            ),
-            output_shape=(
-                "Object with supportedApis[] (each carrying apiVersion + a "
-                "documentation URL) and latestApiVersion (string)."
-            ),
-            next_step=(
-                "Confirm latestApiVersion is in the connector's supported "
-                "range, then proceed to vcfa.tenant.project.list or "
-                "vcfa.tenant.deployment.list for the catalog view."
-            ),
-        ),
-    ),
-    VcfaCoreOp(
-        op_id="GET:/iaas/api/projects",
-        group_key="tenant-projects",
-        plane="tenant",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call on the tenant plane to list projects within the tenant "
-                "organization. Projects are the deployment-scoping construct "
-                "-- every deployment belongs to exactly one project. Supports "
-                "OData-like filtering via $filter, $orderby, $top, $skip."
-            ),
-            output_shape=(
-                "Object with a 'content' array of project entries; each "
-                "entry carries id, name, description, organizationId, "
-                "administrators[], members[], and operationTimeout. Page "
-                "metadata in totalElements + totalPages."
-            ),
-            next_step=(
-                "Pick a project id as the $filter argument for "
-                "vcfa.tenant.deployment.list (filter syntax: "
-                "$filter=projectId eq '<id>') to scope the deployment view "
-                "to one project."
-            ),
-        ),
-    ),
+    # ----- Tenant plane (3 ops) -----
     VcfaCoreOp(
         op_id="GET:/iaas/api/deployments",
         group_key="tenant-deployments",

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -125,6 +125,13 @@ from meho_backplane.connectors.vcf_automation.session import (
     VcfAutomationTargetLike,
     load_credentials_from_vault,
 )
+from meho_backplane.connectors.vcf_automation.typed_ops import (
+    PROVIDER_ORGS_PATH,
+    PROVIDER_REGIONS_PATH,
+    PROVIDER_SITE_PATH,
+    TENANT_ABOUT_PATH,
+    TENANT_PROJECTS_PATH,
+)
 
 __all__ = ["VcfAutomationConfigurationError", "VcfAutomationConnector"]
 
@@ -650,6 +657,150 @@ class VcfAutomationConnector(HttpConnector):
         )
 
     # ------------------------------------------------------------------
+    # Typed read ops on the dual-plane session (T5 #2305)
+    #
+    # Each handler is a thin idempotent GET against a single plane's
+    # surface. The request path drives plane selection inside
+    # :meth:`_request_json` (``plane_for_path`` → tenant for ``/iaas/api/*``,
+    # provider otherwise), so a provider handler and a tenant handler
+    # differ only by the constant path they pass; the per-plane Bearer
+    # session + 401 retry-once dance is shared. The dispatcher binds these
+    # bound methods to the per-process connector instance and threads
+    # ``operator`` by parameter name (see
+    # :func:`~meho_backplane.operations._branches.dispatch_typed`).
+    # ------------------------------------------------------------------
+
+    async def provider_org_list(
+        self,
+        operator: Operator,
+        target: VcfAutomationTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vcfa.provider.org.list`` — ``GET /cloudapi/1.0.0/orgs`` (provider plane)."""
+        return await self._request_json(
+            target,
+            "GET",
+            PROVIDER_ORGS_PATH,
+            operator=operator,
+            params=_provider_pagination_query(params),
+        )
+
+    async def provider_region_list(
+        self,
+        operator: Operator,
+        target: VcfAutomationTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vcfa.provider.region.list`` — ``GET /cloudapi/1.0.0/regions`` (provider plane)."""
+        return await self._request_json(
+            target,
+            "GET",
+            PROVIDER_REGIONS_PATH,
+            operator=operator,
+            params=_provider_pagination_query(params),
+        )
+
+    async def provider_health(
+        self,
+        operator: Operator,
+        target: VcfAutomationTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vcfa.provider.health`` — ``GET /cloudapi/1.0.0/site`` (provider plane)."""
+        del params  # schema declares the param object empty
+        return await self._request_json(target, "GET", PROVIDER_SITE_PATH, operator=operator)
+
+    async def tenant_project_list(
+        self,
+        operator: Operator,
+        target: VcfAutomationTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vcfa.tenant.project.list`` — ``GET /iaas/api/projects`` (tenant plane)."""
+        return await self._request_json(
+            target,
+            "GET",
+            TENANT_PROJECTS_PATH,
+            operator=operator,
+            params=_tenant_odata_query(params),
+        )
+
+    async def tenant_about(
+        self,
+        operator: Operator,
+        target: VcfAutomationTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vcfa.tenant.about`` — ``GET /iaas/api/about`` (tenant plane)."""
+        del params  # schema declares the param object empty
+        return await self._request_json(target, "GET", TENANT_ABOUT_PATH, operator=operator)
+
+    @classmethod
+    async def register_typed_operations(cls) -> None:
+        """Upsert every op in :data:`VCFA_TYPED_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan via the registrar queued in
+        :mod:`meho_backplane.connectors.vcf_automation.__init__`. Walks
+        :data:`~meho_backplane.connectors.vcf_automation.typed_ops.VCFA_TYPED_OPS`,
+        resolves each op's ``handler_attr`` to the bound method, looks the
+        group's curated ``when_to_use`` up in
+        :data:`~meho_backplane.connectors.vcf_automation.typed_ops.VCFA_TYPED_WHEN_TO_USE_BY_GROUP`,
+        and routes each row through
+        :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+        under the ``(product, version, impl_id) = ("vcfa", "9.0",
+        "vcfa-rest")`` triple. Idempotent across pod restarts (the helper
+        skips the embedding recompute on unchanged text) — mirrors the
+        argocd / bind9 / Kubernetes shape.
+        """
+        # Lazy import: the operations package pulls in the embedding
+        # pipeline (ONNX runtime + model) which pure fingerprint/probe unit
+        # tests should not pay. Lifespan callers have it warmed by now.
+        from meho_backplane.connectors.vcf_automation.typed_ops import (
+            VCFA_TYPED_OPS,
+            VCFA_TYPED_WHEN_TO_USE_BY_GROUP,
+        )
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        for op in VCFA_TYPED_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"VcfAutomationConnector typed op {op.op_id!r} declares "
+                    f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+                )
+            when_to_use = VCFA_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+            if when_to_use is None:
+                raise ValueError(
+                    f"VcfAutomationConnector typed op {op.op_id!r} declares "
+                    f"group_key={op.group_key!r} but no curated when_to_use exists "
+                    f"for that key. Add an entry to VCFA_TYPED_WHEN_TO_USE_BY_GROUP."
+                )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "vcfa_typed_operations_registered",
+            count=len(VCFA_TYPED_OPS),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+        )
+
+    # ------------------------------------------------------------------
     # Shutdown
     # ------------------------------------------------------------------
 
@@ -686,3 +837,27 @@ async def _try_probe(
     except (httpx.HTTPError, OSError) as exc:
         return exc
     return resp
+
+
+def _provider_pagination_query(params: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Extract the provider-plane ``page`` / ``pageSize`` query params.
+
+    Returns ``None`` when neither is present so the request carries no
+    query string and VCFA applies its appliance-default pagination.
+    """
+    query = {key: params[key] for key in ("page", "pageSize") if params.get(key) is not None}
+    return query or None
+
+
+def _tenant_odata_query(params: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Extract the tenant-plane OData ``$filter`` / ``$orderby`` / ``$top`` / ``$skip`` params.
+
+    Returns ``None`` when none are present so the request carries no query
+    string and VCFA lists the full (paged-default) result set.
+    """
+    query = {
+        key: params[key]
+        for key in ("$filter", "$orderby", "$top", "$skip")
+        if params.get(key) is not None
+    }
+    return query or None

--- a/backend/src/meho_backplane/connectors/vcf_automation/core_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/core_ops.py
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""VCF Automation 9.x read-only v0.5 core -- curated operator-enabled subset.
+"""VCF Automation 9.x read-only core -- curated operator-enabled subset.
 
-This module names the **11 read-only VCF Automation operations** the
-G3.6 dual-plane v0.5 ship enables out of the much larger
+This module names the **6 read-only VCF Automation operations** left as
+ingested-curation after T5 (#2305) converted the audited read set
+(org/region list, provider health via ``/cloudapi/1.0.0/site``,
+``/iaas/api/projects`` list, and the tenant ``/iaas/api/about`` probe)
+to ``source_kind="typed"`` ops in :mod:`.typed_ops`. The curated
+remainder is the ingested browse surface out of the larger
 ``vcf-automation-9.0/cloudapi.yaml`` + ``vcf-automation-9.0/iaas.yaml``
-corpus that the G0.7 spec-ingestion pipeline lands under
+corpus the G0.7 spec-ingestion pipeline would land under
 ``connector_id="vcfa-rest-9.0"``. The curation is two-layered:
 
 * :data:`VCFA_CORE_GROUPS` -- the operator-reviewed ``when_to_use``
@@ -15,8 +19,8 @@ corpus that the G0.7 spec-ingestion pipeline lands under
   selection step routes correctly across the dual-plane surface;
   generic hints would let a tenant question collapse onto a
   provider-only group and vice versa.
-* :data:`VCFA_CORE_OPS` -- the 11 ``EndpointDescriptor.op_id`` strings
-  (6 provider + 5 tenant) that flip to ``is_enabled=True`` at
+* :data:`VCFA_CORE_OPS` -- the 6 ``EndpointDescriptor.op_id`` strings
+  (3 provider + 3 tenant) that flip to ``is_enabled=True`` at
   operator-review time, paired with the per-op ``llm_instructions``
   blob the agent inlines into the reasoning context when it sees
   the op in
@@ -38,24 +42,20 @@ plane (``/iaas/api/*``) are two OpenAPI specs ingested under one
 each op to the correct auth plane (see
 :func:`~meho_backplane.connectors.vcf_automation._routing.plane_for_path`).
 The vSphere two-spec merge (``vcenter.yaml`` + ``vi-json.yaml``,
-ingested via #408) is the precedent.
+ingested via #408) is the precedent. The audited read set that operators
+actually run is served typed (:mod:`.typed_ops`) rather than through
+this ingested-curation path, since VCFA ships no vendor spec to ingest.
 
-The 11 ops:
+The 6 ops:
 
-Provider plane (6 ops, paths under ``/cloudapi/1.0.0/*``):
+Provider plane (3 ops, paths under ``/cloudapi/1.0.0/*``):
 
-* ``GET:/cloudapi/1.0.0/site`` -- ``vcfa.provider.about``
-* ``GET:/cloudapi/1.0.0/orgs`` -- ``vcfa.provider.org.list``
 * ``GET:/cloudapi/1.0.0/orgs/{id}`` -- ``vcfa.provider.org.get``
-* ``GET:/cloudapi/1.0.0/regions`` -- ``vcfa.provider.vdc.list``
-  (VCFA 9 evolution of the vCD provider VDC concept)
 * ``GET:/cloudapi/1.0.0/regions/{id}`` -- ``vcfa.provider.vdc.get``
 * ``GET:/cloudapi/1.0.0/users`` -- ``vcfa.provider.user.list``
 
-Tenant plane (5 ops, paths under ``/iaas/api/*``):
+Tenant plane (3 ops, paths under ``/iaas/api/*``):
 
-* ``GET:/iaas/api/about`` -- ``vcfa.tenant.about``
-* ``GET:/iaas/api/projects`` -- ``vcfa.tenant.project.list``
 * ``GET:/iaas/api/deployments`` -- ``vcfa.tenant.deployment.list``
   (largest tenant-side payload; trips the dispatcher's JSONFlux
   seam on large tenants)
@@ -66,7 +66,7 @@ Curation application
 --------------------
 
 :func:`apply_vcfa_core_curation` is the operator-review-time substrate
-call that makes exactly the 11 curated ops dispatchable. Mirrors
+call that makes exactly the 6 curated ops dispatchable. Mirrors
 :func:`apply_nsx_core_curation` /
 :func:`apply_harbor_core_curation` verbatim: per-group ``edit_op``
 override pass to mark non-core ops disabled, then ``edit_group`` +
@@ -285,12 +285,12 @@ async def apply_vcfa_core_curation(
     *,
     tenant_id: UUID | None,
 ) -> None:
-    """Apply the curated 11-op read core against an ingested VCFA connector.
+    """Apply the curated 6-op read core against an ingested VCFA connector.
 
     Drives the substrate so that, after this call returns, exactly
-    the 11 ops in :data:`VCFA_CORE_OPS` are dispatchable
+    the 6 ops in :data:`VCFA_CORE_OPS` are dispatchable
     (``is_enabled=True``) and every other ingested op stays
-    ``is_enabled=False``. The 8 curated groups land
+    ``is_enabled=False``. The 5 curated groups land
     ``review_status='enabled'`` so the agent's
     :func:`~meho_backplane.operations.meta_tools.search_operations`
     surfaces the core ops; non-curated groups are left untouched

--- a/backend/src/meho_backplane/connectors/vcf_automation/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/typed_ops.py
@@ -1,0 +1,503 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed VCFA read ops on the dual-plane session (T5 #2305).
+
+VCF Automation ships **no vendor OpenAPI spec at all** — the provider
+(management) plane publishes no machine-readable artifact and the tenant
+plane ships only Swagger 2.0 fragments the ingest parser rejects by
+decision (#2090). The G3.6 curated ``core_ops`` set (``core_ops.py`` /
+``_core_data.py``) therefore describes ``is_enabled`` curation over
+ingested rows that, absent an ingest, never actually exist: the curated
+op ids are dispatch-inert on a real deploy. Typed conversion is the only
+path to a *working* VCFA read surface.
+
+This module converts the **audited read set** (evoila/meho#2294 row 22:
+"org/region list + provider health"; the VCFA follow-up: "org/region
+list, /iaas/api/projects + about") to ``source_kind="typed"`` operations
+that dispatch through the connector's own dual-plane session — no
+``endpoint_descriptor`` catalog state required. Five ops:
+
+Provider plane (``/cloudapi/1.0.0/*`` — Basic-auth →
+``X-VMWARE-VCLOUD-ACCESS-TOKEN`` JWT session):
+
+* ``vcfa.provider.org.list`` — ``GET /cloudapi/1.0.0/orgs``
+* ``vcfa.provider.region.list`` — ``GET /cloudapi/1.0.0/regions``
+* ``vcfa.provider.health`` — ``GET /cloudapi/1.0.0/site`` (appliance
+  site identity + product version; the provider-plane health/probe
+  surface ``fingerprint`` and the operator use to confirm which VCFA
+  instance a target points at and that it answers)
+
+Tenant plane (``/iaas/api/*`` — JSON-body login → ``{"token": …}``
+session):
+
+* ``vcfa.tenant.project.list`` — ``GET /iaas/api/projects``
+* ``vcfa.tenant.about`` — ``GET /iaas/api/about``
+
+Every op declares the **plane it rides** (``provider`` / ``tenant``).
+The declaration is not merely documentation: the plane a request
+authenticates on is chosen at transport time by
+:func:`~meho_backplane.connectors.vcf_automation._routing.plane_for_path`
+applied to the op's path (``/iaas/api/*`` → tenant, everything else →
+provider). :func:`_validate_typed_op_planes` asserts at import time that
+each op's declared ``plane`` matches ``plane_for_path(op.path)`` — a
+drift (e.g. a provider op pointed at ``/iaas/…``) fails the import
+rather than surfacing as a misrouted HTTP 401 in production, since both
+planes carry a ``Bearer <token>`` header but reject the other plane's
+token.
+
+The dataclass + tuple shape mirrors
+:mod:`meho_backplane.connectors.argocd.ops` so the registration walk in
+:meth:`~meho_backplane.connectors.vcf_automation.connector.VcfAutomationConnector.register_typed_operations`
+reads identically to that sibling. Handler methods live on the connector
+(each a thin :meth:`_request_json` call) so the descriptor's
+``handler_ref`` round-trips through the dispatcher's
+:func:`~meho_backplane.operations._handler_resolve.import_handler` walk
+against a ``module.ClassName.method`` dotted path.
+
+Endpoint + response-field facts are pinned to the VCF Automation 9.0 API
+references cross-checked in :mod:`._core_data`: the cloudapi provider
+family at
+https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/administration-sdks-cli-and-tools/about-the-vcf-automation-api.html
+and the tenant IaaS family at
+https://developer.broadcom.com/xapis/vm-apps-org-provisioning-service/latest/.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final, Literal
+
+from meho_backplane.connectors.vcf_automation._routing import Plane, plane_for_path
+
+__all__ = [
+    "PROVIDER_ORGS_PATH",
+    "PROVIDER_REGIONS_PATH",
+    "PROVIDER_SITE_PATH",
+    "TENANT_ABOUT_PATH",
+    "TENANT_PROJECTS_PATH",
+    "VCFA_TYPED_OPS",
+    "VCFA_TYPED_WHEN_TO_USE_BY_GROUP",
+    "VcfaTypedOp",
+]
+
+
+# Request paths, shared verbatim between the op metadata below and the
+# connector handler bodies so the two never drift. plane_for_path()
+# reads these to pick the auth plane at transport time.
+PROVIDER_ORGS_PATH: Final[str] = "/cloudapi/1.0.0/orgs"
+PROVIDER_REGIONS_PATH: Final[str] = "/cloudapi/1.0.0/regions"
+PROVIDER_SITE_PATH: Final[str] = "/cloudapi/1.0.0/site"
+TENANT_PROJECTS_PATH: Final[str] = "/iaas/api/projects"
+TENANT_ABOUT_PATH: Final[str] = "/iaas/api/about"
+
+
+@dataclass(frozen=True)
+class VcfaTypedOp:
+    """Metadata for one typed VCFA read op registered at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the registrar splats the dataclass into the helper without
+    per-op boilerplate. ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.vcf_automation.connector.VcfAutomationConnector`
+    exposing the async handler; the registrar resolves the bound method
+    against the class so the dispatcher's ``handler_ref`` import walk can
+    recover the callable from the persisted ``module.ClassName.method``
+    path.
+
+    ``plane`` records the auth plane the op rides (``"provider"`` /
+    ``"tenant"``); ``path`` is the request path. The two are cross-checked
+    at import time by :func:`_validate_typed_op_planes` against
+    :func:`~meho_backplane.connectors.vcf_automation._routing.plane_for_path`
+    so a declared-plane / path drift fails the import.
+    """
+
+    op_id: str
+    handler_attr: str
+    plane: Plane
+    path: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurb per group. ``register_typed_operation``
+#: requires a non-empty string whenever ``group_key`` is set (#731); the
+#: registrar looks each op's ``group_key`` up here. Two groups, one per
+#: plane — every blurb names its plane so the agent's group-selection
+#: step never collapses a tenant question onto the provider group (or
+#: vice versa). Group keys are deliberately distinct from the curated
+#: ``_core_data`` group keys (``provider-orgs`` etc.) so the typed
+#: OperationGroup rows never collide with a curated group's row on the
+#: ``(product, version, impl_id, group_key)`` natural key.
+VCFA_TYPED_WHEN_TO_USE_BY_GROUP: Final[dict[str, str]] = {
+    "vcfa-provider-reads": (
+        "Use on the VCFA **provider (management) plane** to read the "
+        "cross-tenant appliance view a system administrator sees: list "
+        "organizations on the appliance (vcfa.provider.org.list), list "
+        "regions — the VCFA 9 evolution of the vCloud-Director provider "
+        "VDC, each backing compute/network under an NSX domain "
+        "(vcfa.provider.region.list), or read appliance site identity + "
+        "product version as a health/probe before heavier reads "
+        "(vcfa.provider.health). Provider-plane ops authenticate with the "
+        "admin@System (or equivalent) Basic-auth session and never "
+        "succeed against a tenant token. For per-tenant project / "
+        "deployment reads switch to the tenant-plane group."
+    ),
+    "vcfa-tenant-reads": (
+        "Use on the VCFA **tenant plane** to read within one tenant "
+        "organization: list projects, the deployment-scoping construct "
+        "every deployment belongs to (vcfa.tenant.project.list), or read "
+        "the IaaS API self-describe surface — supported API versions + "
+        "latest version — as a tenant-plane reachability/version probe "
+        "(vcfa.tenant.about). Tenant-plane ops authenticate with the "
+        "tenant org login (POST /iaas/api/login) and never succeed "
+        "against the provider JWT. For the cross-tenant org/region view "
+        "switch to the provider-plane group."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared parameter-schema fragments
+# ---------------------------------------------------------------------------
+
+#: The cloudapi provider-plane pagination query params (FIQL-style
+#: ``page`` / ``pageSize``) shared by org.list + region.list.
+_PROVIDER_PAGINATION_PROPERTIES: dict[str, Any] = {
+    "page": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "1-based page number for the provider-plane result set. Omit for page 1.",
+    },
+    "pageSize": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 128,
+        "description": "Page size (max 128). Omit for the appliance default.",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Provider plane
+# ---------------------------------------------------------------------------
+
+_PROVIDER_ORG_LIST = VcfaTypedOp(
+    op_id="vcfa.provider.org.list",
+    handler_attr="provider_org_list",
+    plane="provider",
+    path=PROVIDER_ORGS_PATH,
+    summary="List VCFA organizations on the appliance (provider plane).",
+    description=(
+        "Lists organizations on the VCFA appliance via "
+        "GET /cloudapi/1.0.0/orgs on the provider (management) plane — the "
+        "cross-tenant inventory a system administrator sees (every tenant "
+        "appears here). Supports FIQL-style 'page' / 'pageSize' pagination. "
+        "Returns a 'values' array; each entry carries id, name, displayName, "
+        "description, isEnabled, and orgVdcCount, plus 'resultTotal' for "
+        "pagination. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": dict(_PROVIDER_PAGINATION_PROPERTIES),
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "values": {"type": ["array", "null"]},
+            "resultTotal": {"type": ["integer", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key="vcfa-provider-reads",
+    tags=("read-only", "vcfa", "provider"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_call": (
+            "Call on the provider plane to enumerate the organizations "
+            "(tenants) on a VCFA appliance — the system-admin inventory "
+            "entry point. Paginate with 'page' / 'pageSize' on large "
+            "appliances."
+        ),
+        "output_shape": (
+            "{values: [Org, ...], resultTotal: int}. Each Org carries id, "
+            "name, displayName, isEnabled, orgVdcCount."
+        ),
+        "next_step": (
+            "Switch to the tenant plane (vcfa.tenant.project.list) for "
+            "per-org reads, or vcfa.provider.region.list for the compute "
+            "inventory backing those orgs."
+        ),
+    },
+)
+
+_PROVIDER_REGION_LIST = VcfaTypedOp(
+    op_id="vcfa.provider.region.list",
+    handler_attr="provider_region_list",
+    plane="provider",
+    path=PROVIDER_REGIONS_PATH,
+    summary="List VCFA regions on the appliance (provider plane).",
+    description=(
+        "Lists VCFA regions via GET /cloudapi/1.0.0/regions on the provider "
+        "plane — the VCFA 9 evolution of the vCloud-Director provider VDC. "
+        "Each region groups compute/memory/networking under one NSX domain, "
+        "typically backed by one or more VCF workload domains. Supports "
+        "'page' / 'pageSize' pagination. Returns a 'values' array; each "
+        "entry carries id, name, description, nsxManager, supervisors, and "
+        "isEnabled, plus 'resultTotal'. Use to answer 'what compute capacity "
+        "does this appliance offer' or 'which region backs tenant X'. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": dict(_PROVIDER_PAGINATION_PROPERTIES),
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "values": {"type": ["array", "null"]},
+            "resultTotal": {"type": ["integer", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key="vcfa-provider-reads",
+    tags=("read-only", "vcfa", "provider"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_call": (
+            "Call on the provider plane to list the appliance's regions and "
+            "the compute/network capacity each offers."
+        ),
+        "output_shape": (
+            "{values: [Region, ...], resultTotal: int}. Each Region carries "
+            "id, name, nsxManager, supervisors, isEnabled."
+        ),
+        "next_step": (
+            "Cross-reference a region id against tenant-plane deployment "
+            "reads to map workloads to regions."
+        ),
+    },
+)
+
+_PROVIDER_HEALTH = VcfaTypedOp(
+    op_id="vcfa.provider.health",
+    handler_attr="provider_health",
+    plane="provider",
+    path=PROVIDER_SITE_PATH,
+    summary="Read VCFA provider-plane appliance health/identity (site).",
+    description=(
+        "Reads VCFA appliance site identity via GET /cloudapi/1.0.0/site on "
+        "the provider plane — the provider-plane health/probe surface. "
+        "Returns id, name, description, restName, and the product version "
+        "string identifying the appliance build. A 2xx here confirms the "
+        "provider plane is reachable and which VCFA instance the target "
+        "points at; it is the provider-plane analogue of the tenant-plane "
+        "vcfa.tenant.about probe. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "id": {"type": ["string", "null"]},
+            "name": {"type": ["string", "null"]},
+            "productVersion": {"type": ["string", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key="vcfa-provider-reads",
+    tags=("read-only", "vcfa", "provider", "health"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_call": (
+            "Call as a pre-flight provider-plane probe: confirm the "
+            "appliance answers and read its product version before heavier "
+            "provider reads, or as a post-deploy health check."
+        ),
+        "output_shape": (
+            "{id, name, description, restName, productVersion}. The "
+            "productVersion string identifies the appliance build."
+        ),
+        "next_step": (
+            "Confirm productVersion is in the supported range, then proceed "
+            "to vcfa.provider.org.list or vcfa.provider.region.list."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Tenant plane
+# ---------------------------------------------------------------------------
+
+_TENANT_PROJECT_LIST = VcfaTypedOp(
+    op_id="vcfa.tenant.project.list",
+    handler_attr="tenant_project_list",
+    plane="tenant",
+    path=TENANT_PROJECTS_PATH,
+    summary="List projects within the tenant organization (tenant plane).",
+    description=(
+        "Lists projects within the tenant organization via "
+        "GET /iaas/api/projects on the tenant plane. Projects are the "
+        "deployment-scoping construct — every deployment belongs to exactly "
+        "one project. Supports OData-style $filter / $orderby / $top / $skip "
+        "query params. Returns a 'content' array; each entry carries id, "
+        "name, description, organizationId, administrators[], members[], and "
+        "operationTimeout, plus totalElements / totalPages page metadata. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "$filter": {
+                "type": "string",
+                "minLength": 1,
+                "description": ("Optional OData filter expression (e.g. \"name eq 'prod'\")."),
+            },
+            "$orderby": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional OData order-by expression.",
+            },
+            "$top": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional page size (OData $top).",
+            },
+            "$skip": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Optional offset (OData $skip).",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "content": {"type": ["array", "null"]},
+            "totalElements": {"type": ["integer", "null"]},
+            "totalPages": {"type": ["integer", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key="vcfa-tenant-reads",
+    tags=("read-only", "vcfa", "tenant"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_call": (
+            "Call on the tenant plane to list projects in the tenant org — "
+            "the scoping construct for deployments and blueprint access. "
+            "Narrow with $filter when the operator named a project."
+        ),
+        "output_shape": (
+            "{content: [Project, ...], totalElements, totalPages}. Each "
+            "Project carries id, name, organizationId, administrators[]."
+        ),
+        "next_step": ("Use a project id as the $filter scope for a follow-up deployment read."),
+    },
+)
+
+_TENANT_ABOUT = VcfaTypedOp(
+    op_id="vcfa.tenant.about",
+    handler_attr="tenant_about",
+    plane="tenant",
+    path=TENANT_ABOUT_PATH,
+    summary="Read the tenant IaaS API self-describe surface (tenant plane).",
+    description=(
+        "Reads the tenant IaaS API self-describe surface via "
+        "GET /iaas/api/about on the tenant plane — supportedApis[] (each "
+        "with an apiVersion + documentation URL) and latestApiVersion. A "
+        "2xx here confirms tenant-plane reachability and version "
+        "negotiation; it is the tenant-plane analogue of the provider-plane "
+        "vcfa.provider.health probe. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "latestApiVersion": {"type": ["string", "null"]},
+            "supportedApis": {"type": ["array", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key="vcfa-tenant-reads",
+    tags=("read-only", "vcfa", "tenant", "health"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_call": (
+            "Call as a tenant-plane probe: confirm the IaaS API answers and "
+            "read the latest supported API version before tenant catalog "
+            "reads, or as a post-deploy health check."
+        ),
+        "output_shape": ("{supportedApis: [{apiVersion, ...}], latestApiVersion}."),
+        "next_step": (
+            "Confirm latestApiVersion is in the supported range, then "
+            "proceed to vcfa.tenant.project.list."
+        ),
+    },
+)
+
+
+#: The five typed VCFA read ops the connector registers at lifespan
+#: startup — the audited read set (#2294). Ordered provider → tenant,
+#: probe last within each plane, to match the operator's typical drill
+#: path (inventory first, health as needed).
+VCFA_TYPED_OPS: Final[tuple[VcfaTypedOp, ...]] = (
+    _PROVIDER_ORG_LIST,
+    _PROVIDER_REGION_LIST,
+    _PROVIDER_HEALTH,
+    _TENANT_PROJECT_LIST,
+    _TENANT_ABOUT,
+)
+
+
+def _validate_typed_op_planes() -> None:
+    """Assert every op's declared ``plane`` matches ``plane_for_path(op.path)``.
+
+    Load-bearing: the auth plane a request rides is picked at transport
+    time by :func:`~meho_backplane.connectors.vcf_automation._routing.plane_for_path`
+    on the op's path, not by the ``plane`` field. The field is the
+    op author's declaration of intent; this check keeps it honest so a
+    provider op accidentally pointed at ``/iaas/…`` (or vice versa) fails
+    the import rather than surfacing as a misrouted HTTP 401 at dispatch.
+    Also asserts each op references a group with a curated
+    ``when_to_use`` blurb.
+    """
+    for op in VCFA_TYPED_OPS:
+        derived = plane_for_path(op.path)
+        if derived != op.plane:
+            raise AssertionError(
+                f"VCFA typed op {op.op_id!r} declares plane={op.plane!r} but "
+                f"plane_for_path({op.path!r}) returns {derived!r}"
+            )
+        if op.group_key not in VCFA_TYPED_WHEN_TO_USE_BY_GROUP:
+            raise AssertionError(
+                f"VCFA typed op {op.op_id!r} references group {op.group_key!r} "
+                f"with no curated when_to_use in VCFA_TYPED_WHEN_TO_USE_BY_GROUP"
+            )
+
+
+_validate_typed_op_planes()

--- a/backend/tests/test_connectors_vcf_automation_core_ops.py
+++ b/backend/tests/test_connectors_vcf_automation_core_ops.py
@@ -1,20 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Behavioural tests for the VCFA dual-plane read-only v0.5 core-ops curation.
+"""Behavioural tests for the VCFA dual-plane read-only core-ops curation.
 
-Covers :mod:`meho_backplane.connectors.vcf_automation.core_ops`:
+Covers :mod:`meho_backplane.connectors.vcf_automation.core_ops` (the
+ingested-curation browse remainder; the audited read set moved to typed
+ops in :mod:`~meho_backplane.connectors.vcf_automation.typed_ops`, T5
+#2305):
 
 * :func:`classify_vcfa_op` — path-prefix classifier rules across both
   the provider plane (``/cloudapi/1.0.0/*``) and the tenant plane
   (``/iaas/api/*``).
 * :func:`apply_vcfa_core_curation` — the operator-review-time
-  substrate call that flips ``review_status='enabled'`` on the 8
-  curated groups, lands ``llm_instructions`` on the 11 curated ops
-  (6 provider + 5 tenant), and explicitly disables non-core ops in
+  substrate call that flips ``review_status='enabled'`` on the 5
+  curated groups, lands ``llm_instructions`` on the 6 curated ops
+  (3 provider + 3 tenant), and explicitly disables non-core ops in
   curated groups via the audit-log-driven operator-override
   exclusion so the :meth:`enable_group` cascade skips them. The
-  load-bearing assertion is "11 ops dispatchable, every other op in
+  load-bearing assertion is "6 ops dispatchable, every other op in
   curated groups stays ``is_enabled=False``".
 * The dual-plane invariant: every enabled op's path resolves through
   :func:`plane_for_path` to the same plane its group declares. A
@@ -258,19 +261,23 @@ async def _group_statuses(*, tenant_id: uuid.UUID) -> dict[str, str]:
 @pytest.mark.parametrize(
     "op_id,expected",
     [
-        # Provider plane families.
-        ("GET:/cloudapi/1.0.0/site", "provider-site"),
-        ("GET:/cloudapi/1.0.0/orgs", "provider-orgs"),
+        # Provider plane families (still ingested-curation).
         ("GET:/cloudapi/1.0.0/orgs/abc-123", "provider-orgs"),
-        ("GET:/cloudapi/1.0.0/regions", "provider-regions"),
         ("GET:/cloudapi/1.0.0/regions/def-456", "provider-regions"),
         ("GET:/cloudapi/1.0.0/users", "provider-users"),
-        # Tenant plane families.
-        ("GET:/iaas/api/about", "tenant-about"),
-        ("GET:/iaas/api/projects", "tenant-projects"),
+        # Tenant plane families (still ingested-curation).
         ("GET:/iaas/api/deployments", "tenant-deployments"),
         ("GET:/iaas/api/deployments/abc-789", "tenant-deployments"),
         ("GET:/iaas/api/blueprints", "tenant-blueprints"),
+        # Audited read set converted to typed ops (T5 #2305): their paths
+        # carry no ingested-curation rule any more, so classify → "none".
+        ("GET:/cloudapi/1.0.0/site", "none"),
+        ("GET:/iaas/api/about", "none"),
+        ("GET:/iaas/api/projects", "none"),
+        # The orgs/regions *collection* prefixes still classify (the rule
+        # stays for the get-by-id ops that share the prefix).
+        ("GET:/cloudapi/1.0.0/orgs", "provider-orgs"),
+        ("GET:/cloudapi/1.0.0/regions", "provider-regions"),
         # Outside both curated families.
         ("GET:/cloudapi/1.0.0/cells", "none"),
         ("GET:/iaas/api/machines", "none"),
@@ -295,19 +302,21 @@ def test_classify_vcfa_op_maps_paths_to_expected_group_keys(
 # ---------------------------------------------------------------------------
 
 
-def test_vcfa_core_ops_has_eleven_entries_six_provider_five_tenant() -> None:
-    """The v0.5 read core is 11 ops total: 6 provider + 5 tenant (per #369 DoD).
+def test_vcfa_core_ops_has_six_entries_three_provider_three_tenant() -> None:
+    """The ingested-curation remainder is 6 ops total: 3 provider + 3 tenant.
 
-    The exact count is contractually fixed in #836's acceptance criteria
-    and the parent Initiative #369's definition of done. A drift here
-    (e.g. someone adds a 12th op) would silently widen the surface
-    beyond the operator-reviewed scope; this assertion catches it.
+    Since T5 (#2305) the audited read set (org/region list, provider
+    health, projects list, tenant about) is served by typed ops
+    (:mod:`~meho_backplane.connectors.vcf_automation.typed_ops`); what
+    stays curated-ingested here is the browse surface. A drift here would
+    either silently widen the ingested surface or re-shadow a converted
+    typed op; this assertion catches it.
     """
     provider_count = sum(1 for op in VCFA_CORE_OPS if op.plane == "provider")
     tenant_count = sum(1 for op in VCFA_CORE_OPS if op.plane == "tenant")
-    assert len(VCFA_CORE_OPS) == 11, f"expected 11 core ops, got {len(VCFA_CORE_OPS)}"
-    assert provider_count == 6, f"expected 6 provider ops, got {provider_count}"
-    assert tenant_count == 5, f"expected 5 tenant ops, got {tenant_count}"
+    assert len(VCFA_CORE_OPS) == 6, f"expected 6 core ops, got {len(VCFA_CORE_OPS)}"
+    assert provider_count == 3, f"expected 3 provider ops, got {provider_count}"
+    assert tenant_count == 3, f"expected 3 tenant ops, got {tenant_count}"
 
 
 def test_every_curated_op_plane_matches_path_classification() -> None:
@@ -365,7 +374,7 @@ def test_path_rules_cover_every_curated_group_key() -> None:
 
 @pytest.mark.asyncio
 async def test_apply_curation_enables_groups_and_lands_llm_instructions() -> None:
-    """All 8 curated groups end ``enabled``; all 11 core ops carry the curated blob."""
+    """All 5 curated groups end ``enabled``; all 6 core ops carry the curated blob."""
     tenant_id = _TEST_TENANT
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)
     operator = _make_operator(tenant_id=tenant_id)
@@ -391,9 +400,9 @@ async def test_apply_curation_keeps_non_core_ops_disabled_via_override_path() ->
     :func:`meho_backplane.operations.ingest._internals.operator_disabled_op_ids`)
     is the substrate that makes per-op exclusivity work inside a
     group-level enable. This test seeds 2 extra non-core ops per
-    curated group (16 extras total across 8 groups), runs the
-    helper, and asserts only the 11 curated ops flip to
-    ``is_enabled=True`` while the 16 non-core ops stay ``False``.
+    curated group (10 extras total across 5 groups), runs the
+    helper, and asserts only the 6 curated ops flip to
+    ``is_enabled=True`` while the 10 non-core ops stay ``False``.
     """
     tenant_id = _TEST_TENANT
     await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=2)
@@ -417,8 +426,8 @@ async def test_apply_curation_keeps_non_core_ops_disabled_via_override_path() ->
                 f"the operator-override path was the safeguard"
             )
             disabled_count += 1
-    assert enabled_count == len(VCFA_CORE_OPS) == 11
-    assert disabled_count == len(VCFA_CORE_GROUPS) * 2 == 16
+    assert enabled_count == len(VCFA_CORE_OPS) == 6
+    assert disabled_count == len(VCFA_CORE_GROUPS) * 2 == 10
 
 
 @pytest.mark.asyncio
@@ -430,7 +439,7 @@ async def test_every_enabled_op_carries_spec_source_tag_naming_its_plane() -> No
     ``spec:iaas`` on tenant-plane rows (sourced from
     ``vcf-automation-9.0/iaas.yaml``). Operators distinguish the
     two planes via these tags in ``meho connector review`` output;
-    this test pins that the curated 11-op core preserves the tag
+    this test pins that the curated 6-op core preserves the tag
     after curation runs (curation must not strip the
     spec_source marker).
     """
@@ -516,7 +525,7 @@ async def test_apply_curation_is_safe_to_rerun() -> None:
 
     The audit layer isn't idempotent (each ``edit_group`` /
     ``edit_op`` writes a fresh row even on no-op values), but the
-    end-state assertions hold: 11 ops enabled with the curated
+    end-state assertions hold: 6 ops enabled with the curated
     blob; non-core ops still disabled; all curated groups still
     enabled.
     """

--- a/backend/tests/test_connectors_vcf_automation_e2e.py
+++ b/backend/tests/test_connectors_vcf_automation_e2e.py
@@ -10,9 +10,12 @@ SQLite-backed test module (no Docker dependency; runs in the
 
 Acceptance contract:
 
-(a) **Both planes dispatch** -- all 11 curated VCFA core ops
-    (6 provider + 5 tenant) dispatch through ``call_operation``
+(a) **Both planes dispatch** -- all 6 curated VCFA core ops
+    (3 provider + 3 tenant) dispatch through ``call_operation``
     against a respx-mocked VCFA appliance and return ``status='ok'``.
+    (The audited read set — org/region list, provider health, tenant
+    projects/about — moved to typed ops in T5 #2305; that surface is
+    covered by ``test_connectors_vcf_automation_typed_reads.py``.)
     Each plane carries its bespoke auth flow (provider Basic ->
     ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` JWT; tenant JSON body ->
     ``{"token": ...}``); the connector picks the right token by path
@@ -121,6 +124,14 @@ _OPERATOR = Operator(
 # The op_id the JSONFlux force-handle test dispatches. ``deployments``
 # is the largest tenant payload by design (per #840 acceptance d).
 _FORCE_HANDLE_OP_ID = "GET:/iaas/api/deployments"
+
+# Per-plane representative ops for the auth-flow / audit / bearer tests.
+# The audited read set (site/about/orgs-list/regions-list/projects) moved
+# to typed ops (T5 #2305), so the ingested-curation E2E picks a remaining
+# curated op per plane: provider ``users`` and tenant ``blueprints`` (both
+# param-less list ops, one per auth plane).
+_PROVIDER_REPR_OP_ID = "GET:/cloudapi/1.0.0/users"
+_TENANT_REPR_OP_ID = "GET:/iaas/api/blueprints"
 
 # Path-template params for the two get-by-id ops (substitution at
 # dispatch time). Maps op_id -> the {id} value the route registers
@@ -600,7 +611,7 @@ async def vcfa_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_VcfaE2EB
 # ---------------------------------------------------------------------------
 
 _OP_IDS: tuple[str, ...] = tuple(op.op_id for op in VCFA_CORE_OPS)
-assert len(_OP_IDS) == 11, f"Expected 11 curated VCFA ops, got {len(_OP_IDS)}: {_OP_IDS}"
+assert len(_OP_IDS) == 6, f"Expected 6 curated VCFA ops, got {len(_OP_IDS)}: {_OP_IDS}"
 
 
 @pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
@@ -655,7 +666,7 @@ async def test_vcfa_e2e_provider_login_fires_once_per_target(
         _OPERATOR,
         {
             "connector_id": VCFA_CONNECTOR_ID,
-            "op_id": "GET:/cloudapi/1.0.0/site",
+            "op_id": _PROVIDER_REPR_OP_ID,
             "target": {"name": target_name},
             "params": {},
         },
@@ -685,7 +696,7 @@ async def test_vcfa_e2e_tenant_login_fires_once_per_target(
         _OPERATOR,
         {
             "connector_id": VCFA_CONNECTOR_ID,
-            "op_id": "GET:/iaas/api/about",
+            "op_id": _TENANT_REPR_OP_ID,
             "target": {"name": target_name},
             "params": {},
         },
@@ -704,7 +715,7 @@ async def test_vcfa_e2e_dispatch_writes_audit_row(
 
     Exercises acceptance criterion (c).
     """
-    op_id = "GET:/cloudapi/1.0.0/site"
+    op_id = _PROVIDER_REPR_OP_ID
     sessionmaker = get_sessionmaker()
 
     async def _count_dispatch_rows() -> int:
@@ -835,7 +846,7 @@ async def test_vcfa_e2e_per_call_fqdn_override_threads_to_connector(
                 _OPERATOR,
                 {
                     "connector_id": VCFA_CONNECTOR_ID,
-                    "op_id": "GET:/cloudapi/1.0.0/site",
+                    "op_id": _PROVIDER_REPR_OP_ID,
                     "target": {"name": VCFA_E2E_TARGET_NAME, "fqdn": VCFA_E2E_FQDN},
                     "params": {},
                 },
@@ -881,7 +892,7 @@ async def test_vcfa_e2e_ip_host_without_fqdn_surfaces_descriptive_error(
             _OPERATOR,
             {
                 "connector_id": VCFA_CONNECTOR_ID,
-                "op_id": "GET:/cloudapi/1.0.0/site",
+                "op_id": _PROVIDER_REPR_OP_ID,
                 "target": {"name": VCFA_E2E_TARGET_NAME},
                 "params": {},
             },
@@ -926,10 +937,11 @@ async def test_vcfa_e2e_provider_request_carries_bearer_jwt(
     instance = _resolve_connector()
 
     captured: dict[str, str] = {}
+    repr_path = "/cloudapi/1.0.0/users"
 
-    def _site_responder(request: httpx.Request) -> httpx.Response:
+    def _users_responder(request: httpx.Request) -> httpx.Response:
         captured[request.url.path] = request.headers.get("Authorization", "")
-        return httpx.Response(200, json=_PROVIDER_SITE)
+        return httpx.Response(200, json=_PROVIDER_USERS)
 
     try:
         async with respx.mock(
@@ -941,21 +953,21 @@ async def test_vcfa_e2e_provider_request_carries_bearer_jwt(
                 200,
                 headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": _PROVIDER_JWT},
             )
-            mock.get("/cloudapi/1.0.0/site").mock(side_effect=_site_responder)
+            mock.get(repr_path).mock(side_effect=_users_responder)
 
             result = await call_operation(
                 _OPERATOR,
                 {
                     "connector_id": VCFA_CONNECTOR_ID,
-                    "op_id": "GET:/cloudapi/1.0.0/site",
+                    "op_id": _PROVIDER_REPR_OP_ID,
                     "target": {"name": VCFA_E2E_TARGET_NAME},
                     "params": {},
                 },
             )
             assert result["status"] == "ok"
-            assert captured.get("/cloudapi/1.0.0/site") == f"Bearer {_PROVIDER_JWT}", (
+            assert captured.get(repr_path) == f"Bearer {_PROVIDER_JWT}", (
                 "Provider-plane GET must carry the provider JWT as Bearer; "
-                f"got Authorization={captured.get('/cloudapi/1.0.0/site')!r}"
+                f"got Authorization={captured.get(repr_path)!r}"
             )
     finally:
         await instance.aclose()

--- a/backend/tests/test_connectors_vcf_automation_typed_reads.py
+++ b/backend/tests/test_connectors_vcf_automation_typed_reads.py
@@ -1,0 +1,506 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed VCFA read ops on the dual-plane session (T5 #2305).
+
+Covers
+:mod:`meho_backplane.connectors.vcf_automation.typed_ops` and the
+connector handlers + registrar that back it. VCFA ships no vendor spec,
+so these ops are ``source_kind="typed"`` — they dispatch through the
+connector's own dual-plane session with **zero catalog / ingested
+state**. Acceptance contract (#2305):
+
+* **Typed dispatch on a fresh boot with zero catalog state** — after
+  ``register_typed_operations()`` and with **no** ingested
+  ``endpoint_descriptor`` rows seeded, all five audited ops (org list,
+  region list, provider health, tenant project list, tenant about)
+  dispatch through ``call_operation`` against a respx-mocked VCFA
+  appliance and return ``status="ok"``, with ``source_kind="typed"`` on
+  every registered row.
+
+* **Each op declares which plane it rides, and plane selection is
+  tested** — every op's declared ``plane`` matches
+  ``plane_for_path(op.path)`` (static invariant), and a live provider-op
+  dispatch establishes the **provider** session (Basic →
+  ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` JWT, ``Accept:
+  application/json;version=9.0.0``) while a live tenant-op dispatch
+  establishes the **tenant** session (JSON-body login → ``{"token": …}``,
+  ``Accept: application/json``). Cross-plane token isolation is asserted:
+  a provider dispatch never populates the tenant cache and vice versa.
+
+The respx routes + inlined payloads mirror the recorded-fixture shape of
+:mod:`tests.test_connectors_vcf_automation_e2e`; the dual-plane refresh
+tool intentionally excludes VCFA (G3.6-T13 #841), so the payloads live
+inline next to the assertions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import select
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.cache_key import target_cache_key
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.schemas import FingerprintResult
+from meho_backplane.connectors.vcf_automation import (
+    VCFA_CONNECTOR_ID,
+    VCFA_IMPL_ID,
+    VCFA_PRODUCT,
+    VCFA_TYPED_OPS,
+    VCFA_VERSION,
+    VcfAutomationConnector,
+)
+from meho_backplane.connectors.vcf_automation._routing import (
+    PROVIDER_CLOUDAPI_ACCEPT,
+    TENANT_ACCEPT,
+    plane_for_path,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import (
+    get_or_create_connector_instance,
+    reset_handler_cache,
+)
+from meho_backplane.operations.meta_tools import call_operation
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_OPERATOR_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000000fb")
+_FQDN = "vcfa-typed.test.invalid"
+_BASE_URL = f"https://{_FQDN}"
+_TARGET_NAME = "vcfa-typed-target"
+
+_PROVIDER_JWT = "vcfa-typed-provider-jwt"
+_TENANT_TOKEN = "vcfa-typed-tenant-token"
+
+_OPERATOR = Operator(
+    sub="vcfa-typed-test",
+    name="VCFA Typed Test Operator",
+    email=None,
+    raw_jwt="<vcfa-typed-raw-jwt>",
+    tenant_id=_OPERATOR_TENANT,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+# The connector class registers under the target product slug ("vcfa"),
+# which is also what parse_connector_id("vcfa-rest-9.0") derives — so the
+# typed descriptor triple and the registry key coincide for VCFA.
+_REGISTRY_PRODUCT = VcfAutomationConnector.product
+
+_FINGERPRINT: dict[str, Any] = FingerprintResult(
+    vendor="vmware",
+    product="vcfa",
+    version="9.0",
+    reachable=True,
+    probed_at=datetime(2026, 7, 10, 10, 0, 0, tzinfo=UTC),
+    probe_method="GET /api/versions + GET /iaas/api/about",
+    extras={"planes": ["provider", "tenant"]},
+).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Inlined respx payloads (recorded-fixture shape)
+# ---------------------------------------------------------------------------
+
+_PROVIDER_ORGS: dict[str, Any] = {
+    "values": [{"id": "org-1", "name": "acme", "displayName": "Acme", "isEnabled": True}],
+    "resultTotal": 1,
+}
+_PROVIDER_REGIONS: dict[str, Any] = {
+    "values": [{"id": "region-1", "name": "rg-a", "nsxManager": "nsx-1", "isEnabled": True}],
+    "resultTotal": 1,
+}
+_PROVIDER_SITE: dict[str, Any] = {
+    "id": "site-1",
+    "name": "VCFA-TYPED",
+    "restName": "vcfa-typed-rest",
+    "productVersion": "9.0.0.0-12345",
+}
+_TENANT_PROJECTS: dict[str, Any] = {
+    "content": [{"id": "project-1", "name": "proj-a", "organizationId": "org-1"}],
+    "totalElements": 1,
+    "totalPages": 1,
+}
+_TENANT_ABOUT: dict[str, Any] = {
+    "latestApiVersion": "9.0",
+    "supportedApis": [{"apiVersion": "9.0"}],
+}
+
+#: op_id -> the JSON body its respx route returns.
+_PAYLOAD_BY_OP: dict[str, dict[str, Any]] = {
+    "vcfa.provider.org.list": _PROVIDER_ORGS,
+    "vcfa.provider.region.list": _PROVIDER_REGIONS,
+    "vcfa.provider.health": _PROVIDER_SITE,
+    "vcfa.tenant.project.list": _TENANT_PROJECTS,
+    "vcfa.tenant.about": _TENANT_ABOUT,
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    from meho_backplane.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher + handler caches around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+
+
+@pytest.fixture(autouse=True)
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deterministic embedding stub so typed-op registration doesn't pull ONNX."""
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Stub :func:`publish_event` so the broadcast bus doesn't fire."""
+    events: list[Any] = []
+
+    async def _capture(event: Any) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _stub_credentials_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Stub loader — bypasses the live Vault read for the dispatch tests."""
+    return {"username": "svc-meho", "password": "vcfa-typed-password"}
+
+
+async def _seed_target(*, host: str, fqdn: str | None) -> Target:
+    """Insert the typed-reads Target row and return it (expunged)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            tenant_id=_OPERATOR_TENANT,
+            name=_TARGET_NAME,
+            aliases=[],
+            product=VcfAutomationConnector.product,
+            host=host,
+            port=443,
+            fqdn=fqdn,
+            secret_ref="vcfa/typed",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint=_FINGERPRINT,
+            notes="seeded by test_connectors_vcf_automation_typed_reads._seed_target",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _resolve_connector() -> VcfAutomationConnector:
+    """Resolve + cache the connector instance with a stubbed credentials loader."""
+    registry = all_connectors_v2()
+    connector_cls = registry.get((_REGISTRY_PRODUCT, VCFA_VERSION, VCFA_IMPL_ID))
+    if connector_cls is None:
+        import importlib
+
+        import meho_backplane.connectors.vcf_automation as _vcfa_pkg
+
+        importlib.reload(_vcfa_pkg)
+        registry = all_connectors_v2()
+        connector_cls = registry.get((_REGISTRY_PRODUCT, VCFA_VERSION, VCFA_IMPL_ID))
+    assert connector_cls is VcfAutomationConnector
+    instance = get_or_create_connector_instance(connector_cls)
+    instance._credentials_loader = _stub_credentials_loader  # type: ignore[attr-defined]
+    return instance
+
+
+def _register_routes(mock: respx.MockRouter, *, capture: dict[str, str] | None = None) -> None:
+    """Register the dual-plane login + five typed-op GET routes on *mock*.
+
+    When *capture* is passed, every GET records its ``Accept`` header under
+    the request path so the plane-selection tests can assert the media type.
+    """
+    mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+        200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": _PROVIDER_JWT}
+    )
+    mock.post("/iaas/api/login").respond(200, json={"token": _TENANT_TOKEN})
+
+    for op in VCFA_TYPED_OPS:
+        payload = _PAYLOAD_BY_OP[op.op_id]
+
+        def _responder(
+            request: httpx.Request, _payload: dict[str, Any] = payload
+        ) -> httpx.Response:
+            if capture is not None:
+                capture[request.url.path] = request.headers.get("Accept", "")
+            return httpx.Response(200, json=_payload)
+
+        mock.get(op.path).mock(side_effect=_responder)
+
+
+@dataclass(frozen=True)
+class _Bundle:
+    connector_instance: VcfAutomationConnector
+    db_target: Any
+
+
+@pytest.fixture
+async def typed_bundle(captured_events: list[Any]) -> AsyncIterator[_Bundle]:
+    """Register the five typed ops (zero ingested state) + respx-mock the appliance."""
+    await VcfAutomationConnector.register_typed_operations()
+    seeded = await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    instance = _resolve_connector()
+    async with respx.mock(
+        base_url=_BASE_URL, assert_all_called=False, assert_all_mocked=False
+    ) as m:
+        _register_routes(m)
+        try:
+            yield _Bundle(connector_instance=instance, db_target=seeded)
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+
+# ---------------------------------------------------------------------------
+# Registration shape
+# ---------------------------------------------------------------------------
+
+
+async def test_typed_ops_register_as_source_kind_typed_with_zero_ingested_rows() -> None:
+    """After registration every audited op is a ``typed`` row; no ingested rows exist."""
+    await VcfAutomationConnector.register_typed_operations()
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(EndpointDescriptor).where(
+                        EndpointDescriptor.product == VCFA_PRODUCT,
+                        EndpointDescriptor.version == VCFA_VERSION,
+                        EndpointDescriptor.impl_id == VCFA_IMPL_ID,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    by_op = {row.op_id: row for row in rows}
+    expected = {op.op_id for op in VCFA_TYPED_OPS}
+    assert expected.issubset(by_op), f"missing typed rows: {expected - set(by_op)}"
+    for op in VCFA_TYPED_OPS:
+        row = by_op[op.op_id]
+        assert row.source_kind == "typed", f"{op.op_id} source_kind={row.source_kind!r}"
+        assert row.handler_ref and op.handler_attr in row.handler_ref, row.handler_ref
+        assert row.safety_level == "safe"
+        assert row.requires_approval is False
+    # Zero catalog state: nothing was ingested for this connector.
+    assert not [r for r in rows if r.source_kind == "ingested"], (
+        "typed conversion must not depend on any ingested endpoint_descriptor row"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plane declaration (static)
+# ---------------------------------------------------------------------------
+
+
+def test_every_typed_op_declares_the_plane_its_path_rides() -> None:
+    """Each op's declared ``plane`` matches ``plane_for_path(op.path)``.
+
+    The import-time ``_validate_typed_op_planes()`` already enforces this;
+    pinning it as an explicit test documents the contract that a declared
+    plane / path drift is a hard failure (it would otherwise surface as a
+    misrouted HTTP 401 — both planes carry a Bearer header but reject the
+    other plane's token).
+    """
+    assert len(VCFA_TYPED_OPS) == 5
+    for op in VCFA_TYPED_OPS:
+        assert plane_for_path(op.path) == op.plane, (
+            f"op {op.op_id!r} declares plane={op.plane!r} but "
+            f"plane_for_path({op.path!r})={plane_for_path(op.path)!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Live typed dispatch — fresh boot, zero catalog state
+# ---------------------------------------------------------------------------
+
+_TYPED_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in VCFA_TYPED_OPS)
+
+
+@pytest.mark.parametrize("op_id", _TYPED_OP_IDS, ids=lambda op: op)
+async def test_typed_ops_dispatch_ok(op_id: str, typed_bundle: _Bundle) -> None:
+    """All five typed ops dispatch through ``call_operation`` and return ``status='ok'``."""
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VCFA_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", (
+        f"typed op {op_id!r} did not return status='ok': "
+        f"error={result.get('error')!r} full={result!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plane selection — provider vs tenant session, cross-plane isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_provider_typed_op_rides_provider_plane(captured_events: list[Any]) -> None:
+    """Provider typed op establishes the provider session + Accept; tenant cache stays empty."""
+    await VcfAutomationConnector.register_typed_operations()
+    seeded = await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    instance = _resolve_connector()
+    cache_key = target_cache_key(seeded)
+    accept_by_path: dict[str, str] = {}
+
+    try:
+        async with respx.mock(
+            base_url=_BASE_URL, assert_all_called=False, assert_all_mocked=False
+        ) as m:
+            _register_routes(m, capture=accept_by_path)
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VCFA_CONNECTOR_ID,
+                    "op_id": "vcfa.provider.health",
+                    "target": {"name": _TARGET_NAME},
+                    "params": {},
+                },
+            )
+            # Snapshot the caches before aclose() (in finally) clears them.
+            provider_cached = instance._provider_tokens.get(cache_key)
+            tenant_cached = instance._tenant_tokens.get(cache_key)
+    finally:
+        await instance.aclose()
+        reset_dispatcher_caches()
+
+    assert result["status"] == "ok", result
+    # Provider session established; tenant plane never touched.
+    assert provider_cached == _PROVIDER_JWT
+    assert tenant_cached is None, (
+        f"provider-only dispatch must not establish the tenant session; got {tenant_cached!r}"
+    )
+    # The request rode the provider plane's Accept media type.
+    assert accept_by_path.get("/cloudapi/1.0.0/site") == PROVIDER_CLOUDAPI_ACCEPT, accept_by_path
+
+
+async def test_tenant_typed_op_rides_tenant_plane(captured_events: list[Any]) -> None:
+    """Tenant typed op establishes the tenant session + Accept; provider cache stays empty."""
+    await VcfAutomationConnector.register_typed_operations()
+    seeded = await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    instance = _resolve_connector()
+    cache_key = target_cache_key(seeded)
+    accept_by_path: dict[str, str] = {}
+
+    try:
+        async with respx.mock(
+            base_url=_BASE_URL, assert_all_called=False, assert_all_mocked=False
+        ) as m:
+            _register_routes(m, capture=accept_by_path)
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VCFA_CONNECTOR_ID,
+                    "op_id": "vcfa.tenant.about",
+                    "target": {"name": _TARGET_NAME},
+                    "params": {},
+                },
+            )
+            # Snapshot the caches before aclose() (in finally) clears them.
+            tenant_cached = instance._tenant_tokens.get(cache_key)
+            provider_cached = instance._provider_tokens.get(cache_key)
+    finally:
+        await instance.aclose()
+        reset_dispatcher_caches()
+
+    assert result["status"] == "ok", result
+    # Tenant session established; provider plane never touched.
+    assert tenant_cached == _TENANT_TOKEN
+    assert provider_cached is None, (
+        f"tenant-only dispatch must not establish the provider session; got {provider_cached!r}"
+    )
+    # The request rode the tenant plane's plain-JSON Accept media type.
+    assert accept_by_path.get("/iaas/api/about") == TENANT_ACCEPT, accept_by_path
+
+
+async def test_provider_op_query_params_forward_pagination(captured_events: list[Any]) -> None:
+    """``vcfa.provider.org.list`` forwards ``page`` / ``pageSize`` as query params."""
+    await VcfAutomationConnector.register_typed_operations()
+    await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    instance = _resolve_connector()
+    captured: dict[str, str] = {}
+
+    def _orgs_responder(request: httpx.Request) -> httpx.Response:
+        captured["query"] = str(request.url.query.decode())
+        return httpx.Response(200, json=_PROVIDER_ORGS)
+
+    try:
+        async with respx.mock(
+            base_url=_BASE_URL, assert_all_called=False, assert_all_mocked=False
+        ) as m:
+            m.post("/cloudapi/1.0.0/sessions/provider").respond(
+                200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": _PROVIDER_JWT}
+            )
+            m.get("/cloudapi/1.0.0/orgs").mock(side_effect=_orgs_responder)
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VCFA_CONNECTOR_ID,
+                    "op_id": "vcfa.provider.org.list",
+                    "target": {"name": _TARGET_NAME},
+                    "params": {"page": 2, "pageSize": 50},
+                },
+            )
+    finally:
+        await instance.aclose()
+        reset_dispatcher_caches()
+
+    assert result["status"] == "ok", result
+    assert "page=2" in captured["query"] and "pageSize=50" in captured["query"], captured

--- a/docs/codebase/connectors-vcf-automation.md
+++ b/docs/codebase/connectors-vcf-automation.md
@@ -4,17 +4,49 @@
 
 The `vcf-automation` connector is the hand-rolled `HttpConnector` subclass that
 dispatches VCF Automation REST operations under the
-`(product="vcf-automation", version="9.0", impl_id="vcfa-rest")` registry
-triple. G3.6-T10 (#832) shipped the skeleton — dual-plane auth (provider +
+`(product="vcfa", version="9.0", impl_id="vcfa-rest")` registry triple
+(the `product` slug was unified to `"vcfa"` in #1814 — it matches what
+`parse_connector_id("vcfa-rest-9.0")` derives for the descriptor rows).
+G3.6-T10 (#832) shipped the skeleton — dual-plane auth (provider +
 tenant), vhost / FQDN routing, fingerprint, probe, and the G0.6 dispatch shim.
 G3.6-T11 (#836) added the dual-plane spec ingestion + operator-review
-curation: `core_ops.py` carries `VCFA_CORE_GROUPS` (8 groups: 4 provider + 4
-tenant) and `VCFA_CORE_OPS` (11 ops: 6 provider + 5 tenant) plus the
-`apply_vcfa_core_curation` helper that drives `ReviewService.edit_group` +
-`enable_group` + `edit_op(llm_instructions=…)` to make exactly the 11 ops
-dispatchable. G3.6-T12 (#840) will ship the CLI verb tree + recorded-fixture
-E2E. The operator runbook lives at
-`docs/cross-repo/g36-vcfa-canary.md`.
+curation. G3.6-T12 (#840) shipped the recorded-fixture E2E. The operator
+runbook lives at `docs/cross-repo/g36-vcfa-canary.md`.
+
+**Typed reads (T5 #2305).** VCFA ships **no vendor OpenAPI spec** (the
+provider plane publishes none; the tenant plane ships only Swagger 2.0
+fragments the ingest parser rejects by decision #2090), so the curated
+`core_ops` ingested-curation path is dispatch-inert on a real deploy —
+there is nothing to ingest. The **audited read set** (evoila/meho#2294:
+org/region list, provider health, `/iaas/api/projects` + tenant `about`)
+is therefore served by `source_kind="typed"` ops (`typed_ops.py`) that
+dispatch through the connector's own dual-plane session with **zero
+catalog state**. Five ops:
+
+| op_id | plane | path |
+|---|---|---|
+| `vcfa.provider.org.list` | provider | `GET /cloudapi/1.0.0/orgs` |
+| `vcfa.provider.region.list` | provider | `GET /cloudapi/1.0.0/regions` |
+| `vcfa.provider.health` | provider | `GET /cloudapi/1.0.0/site` |
+| `vcfa.tenant.project.list` | tenant | `GET /iaas/api/projects` |
+| `vcfa.tenant.about` | tenant | `GET /iaas/api/about` |
+
+Each op **declares the plane it rides**; `typed_ops._validate_typed_op_planes`
+asserts at import time that the declared `plane` matches
+`plane_for_path(op.path)`, so a drift fails the import rather than
+surfacing as a misrouted HTTP 401. The `org create` write
+(`POST /cloudapi/1.0.0/orgs`) is deliberately out of scope — a first
+write on a read-only connector belongs in a G3.x-mold approval-gated
+write-surface initiative. The remaining `core_ops` /`_core_data`
+ingested-curation surface is now the 5-group / 6-op browse remainder
+(the two get-by-id ops, provider users list, tenant deployment/blueprint
+browse) — declined from typed conversion because they are not in the
+operator-run audited set.
+
+`register_typed_operations` (a classmethod on the connector, queued onto
+the lifespan registrar list via `register_vcfa_typed_operations` in
+`__init__.py`) upserts the five descriptors on startup — the same
+argocd / bind9 / Kubernetes typed-registrar shape.
 
 Source: `backend/src/meho_backplane/connectors/vcf_automation/`.
 
@@ -30,7 +62,7 @@ domains.
 ## Key types
 
 - **`VcfAutomationConnector`** (`connector.py`) — `HttpConnector` subclass.
-  Class attributes: `product="vcf-automation"`, `version="9.0"`,
+  Class attributes: `product="vcfa"`, `version="9.0"`,
   `impl_id="vcfa-rest"`, `supported_version_range=">=9.0,<10.0"`,
   `priority=1`. The priority outranks a future `GenericRestConnector`
   auto-shim defensively if both somehow register for the same triple.
@@ -67,23 +99,27 @@ domains.
   asserted at module import time to match
   `_routing.plane_for_path(path)` — a path-vs-plane drift fails import
   rather than surfacing as a misrouted 401 in production.
+- **`VCFA_TYPED_OPS` / `VcfaTypedOp` / `VCFA_TYPED_WHEN_TO_USE_BY_GROUP`**
+  (`typed_ops.py`) — the five typed read ops (T5 #2305) and their two
+  per-plane groups (`vcfa-provider-reads`, `vcfa-tenant-reads`). Each
+  `VcfaTypedOp` carries a `plane` + `path`; the module's
+  `_validate_typed_op_planes()` cross-checks them at import.
 - **`VCFA_CORE_GROUPS` / `VCFA_CORE_OPS`** (`core_ops.py`) — the
-  read-only v0.5 core: 8 curated groups (4 provider + 4 tenant) and 11
-  curated ops (6 provider + 5 tenant). Every group's `when_to_use`
+  ingested-curation browse remainder: 5 curated groups (3 provider + 2
+  tenant) and 6 curated ops (3 provider + 3 tenant) left after the
+  audited read set moved to `typed_ops.py`. Every group's `when_to_use`
   names its plane explicitly so the agent's `list_operation_groups`
   step routes correctly across the dual-plane surface.
 - **`VCFA_PRODUCT` / `VCFA_VERSION` / `VCFA_IMPL_ID` /
-  `VCFA_CONNECTOR_ID`** (`core_ops.py`) — DB-side keys. Note
-  `VCFA_PRODUCT = "vcfa"` (what `parse_connector_id("vcfa-rest-9.0")`
-  extracts) is **not** the same as `VcfAutomationConnector.product =
-  "vcf-automation"` (the v2 registry key). All `endpoint_descriptor`
-  and `operation_group` rows carry `product="vcfa"`; the same split
-  the SDDC Manager precedent established (`"sddc"` vs
-  `"sddc-manager"`).
+  `VCFA_CONNECTOR_ID`** (`core_ops.py`) — DB-side keys. Since #1814 the
+  registry key `VcfAutomationConnector.product` was unified to `"vcfa"`,
+  matching `VCFA_PRODUCT` (what `parse_connector_id("vcfa-rest-9.0")`
+  extracts). All `endpoint_descriptor` and `operation_group` rows carry
+  `product="vcfa"`.
 - **`apply_vcfa_core_curation`** (`core_ops.py`) — async helper
   driving `ReviewService.edit_group` + `enable_group` +
   `edit_op(is_enabled=False)` (for non-core ops in curated groups)
-  + `edit_op(llm_instructions=…)` (for the 11 core ops) so exactly
+  + `edit_op(llm_instructions=…)` (for the 6 core ops) so exactly
   the curated set is dispatchable after the call returns. Mirrors
   `apply_nsx_core_curation` / `apply_harbor_core_curation`
   verbatim; the audit-log-driven operator-override exclusion is the
@@ -103,12 +139,16 @@ domains.
    `connectors/<product>/` subpackage in name-sorted order.
 2. Importing `meho_backplane.connectors.vcf_automation` triggers the
    module-level
-   `register_connector_v2(product="vcf-automation", version="9.0", impl_id="vcfa-rest", cls=VcfAutomationConnector)`
-   call.
-3. The registry's v2 table now resolves `("vcf-automation", "9.0",
+   `register_connector_v2(product="vcfa", version="9.0", impl_id="vcfa-rest", cls=VcfAutomationConnector)`
+   call and queues `register_vcfa_typed_operations` onto the lifespan
+   typed-op registrar list.
+3. The registry's v2 table now resolves `("vcfa", "9.0",
    "vcfa-rest")` to `VcfAutomationConnector`. The G0.7 auto-shim's
    idempotency check (in `ensure_connector_class_registered`) no-ops on
    subsequent ingests against the same triple.
+4. `run_typed_op_registrars()` (lifespan) invokes the registrar, which
+   upserts the five `typed_ops.VCFA_TYPED_OPS` descriptors — no ingest
+   needed, so the audited read surface works on a fresh boot.
 
 ### Vhost routing (load-bearing)
 
@@ -250,10 +290,12 @@ lifespan shutdown is more risk than benefit) and delegates to
 ### Operator-review curation (G3.6-T11 #836)
 
 `apply_vcfa_core_curation(review_service, *, tenant_id)` is the
-post-ingest helper that drives the substrate so exactly the 11 curated
-ops in `VCFA_CORE_OPS` end `is_enabled=True` and the 8 curated groups
-in `VCFA_CORE_GROUPS` end `review_status='enabled'`. The control flow
-mirrors `apply_nsx_core_curation`:
+post-ingest helper that drives the substrate so exactly the 6 curated
+ops in `VCFA_CORE_OPS` end `is_enabled=True` and the 5 curated groups
+in `VCFA_CORE_GROUPS` end `review_status='enabled'`. (This path applies
+only to the ingested-curation browse remainder; the audited read set is
+served typed and needs no curation.) The control flow mirrors
+`apply_nsx_core_curation`:
 
 1. `ReviewService.get_review_payload("vcfa-rest-9.0", tenant_id)` loads
    the post-ingest state.
@@ -263,9 +305,9 @@ mirrors `apply_nsx_core_curation`:
 3. `ReviewService.edit_group` lands the curated `name` +
    plane-named `when_to_use`; `ReviewService.enable_group` flips
    `review_status='enabled'` and cascades `is_enabled=True` only to
-   the 11 core ops.
+   the 6 core ops.
 4. `ReviewService.edit_op(..., llm_instructions=…)` lands the per-op
-   guidance blob on each of the 11 curated ops.
+   guidance blob on each of the 6 curated ops.
 
 The helper is safe to re-run (end-state idempotent) but emits redundant
 audit rows on re-runs — the intended posture is one-shot per ingest.


### PR DESCRIPTION
## Summary

- VCF Automation ships **no vendor OpenAPI spec**, so the curated `core_ops` ingested-curation path is dispatch-inert on a real deploy. This converts the operator-**audited** read set (#2294) to first-class `source_kind="typed"` ops that dispatch through the connector's existing dual-plane session with **zero catalog state** — the only working read surface for VCFA.
- Five typed ops, each declaring the auth plane it rides:
  - `vcfa.provider.org.list` → `GET /cloudapi/1.0.0/orgs` (provider)
  - `vcfa.provider.region.list` → `GET /cloudapi/1.0.0/regions` (provider)
  - `vcfa.provider.health` → `GET /cloudapi/1.0.0/site` (provider)
  - `vcfa.tenant.project.list` → `GET /iaas/api/projects` (tenant)
  - `vcfa.tenant.about` → `GET /iaas/api/about` (tenant)
- Plane declaration is load-bearing: `typed_ops._validate_typed_op_planes()` cross-checks each op's declared `plane` against `plane_for_path(op.path)` at import, so a drift fails the import rather than surfacing as a misrouted 401. Handlers are thin bound methods over the existing `_request_json` (the path drives plane selection); `register_typed_operations` is queued onto the lifespan registrar in `__init__.py` (argocd/bind9 shape).
- The converted ops are removed from `core_ops`/`_core_data` curation (11 ops/8 groups → 6 ops/5 groups browse remainder) and their path-classifier rules dropped. `org create` (`POST /cloudapi/1.0.0/orgs`, a write) stays out of scope.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/vcf_automation/` — clean
- [x] `code-quality.py --diff` — 0 blockers (1 warn: typed_ops.py 504 lines, <600)
- [x] **AC1 — typed dispatch on fresh boot, zero catalog state**: new `test_connectors_vcf_automation_typed_reads.py` registers the five typed ops (no ingested rows), asserts `source_kind="typed"` + no `ingested` rows, and dispatches all five via `call_operation` → `status="ok"`.
- [x] **AC1 — plane selection tested**: a provider-op dispatch establishes only the provider session (JWT cached, tenant cache empty) + provider `Accept: application/json;version=9.0.0`; a tenant-op dispatch establishes only the tenant session + tenant `Accept: application/json`. Plus a static test that every op's declared plane matches `plane_for_path(op.path)`.
- [x] **AC2 — curation trimmed**: `core_ops`/`_core_data` no longer flip ingested rows for the converted ops; `test_connectors_vcf_automation_core_ops.py` updated (6 ops/5 groups, classify → `none` for the converted paths). `#2262` two-world invariant respected (typed ops are self-contained, no ingested dispatch).
- [x] **AC2 — doubles updated**: `test_connectors_vcf_automation_e2e.py` updated to the 6-op ingested-curation remainder (provider `users` / tenant `blueprints` as per-plane representatives).
- [x] **AC3 — no OpenAPI snapshot delta**: re-ran `snapshot-openapi.py` → `cli/api/openapi.json` unchanged.
- [x] Broad sweep: `pytest -k "operations or ... or search_operations or register_ingested"` → 1245 passed, 0 failed.

## Out of scope
- `org create` (`POST /cloudapi/1.0.0/orgs`) — first write on a read-only connector → its own G3.x-mold approval-gated write-surface initiative.
- The remaining curated browse ops (org.get, region.get, users list, deployment/blueprint browse) — declined from typed conversion (not in the operator-run audited set); a decline-with-reasons note is posted on #2305.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2305
