### PR TITLE
feat(connectors): SDDC typed reads on the #2290 token session (#2306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Connectors — SDDC typed reads (12-read lab-audit set incl. credential_read-gated /v1/credentials) (#2306)
+
+- The audited 12-read SDDC Manager lab-audit set — `domains`, `domains/{id}/status`,
+  `clusters`, `hosts`, `vcenters`, `nsxt-clusters`, `credentials`, `tasks`,
+  `system`, `vcf-services`, `sddc-managers`, `license-keys` — is now first-class
+  **typed** ops (`source_kind="typed"`, `sddc.*` op-ids) that dispatch on a fresh
+  boot with zero catalog ingest, on the post-#2290 `session_login_token` token
+  session, with one-shot 401 recovery via the #2067 `invalidate_session` seam.
+- `sddc.credential.list` (`GET /v1/credentials`) is gated as a credential-read:
+  `requires_approval=True` routes it through the policy-gate approval queue (not
+  dispatchable without operator approval), its op-id classifies as
+  `credential_read` so audit/broadcast rows collapse to aggregate-only, and the
+  handler scrubs every secret-keyed value at the connector boundary — no
+  credential material rides the result.
+- `core_ops.py` ingested-row curation is repointed for the converted ops: the 5
+  overlapping reads leave the curated set (now 4 non-audited browse-breadth reads:
+  release, domain detail, network-pools, bundles); the ingested VCF catalog stays
+  browsable as profiled-dispatch breadth under its own `METHOD:path` op_ids — two
+  surfaces, no resolver shadowing (#2262 invariant holds).
+
 ### Added — persisted spec provenance at ingest (sha256 + origin + operator/timestamp, surfaced in review) (#2291)
 
 - Every accepted spec ingest now writes a durable, non-spoofable

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -85,6 +85,12 @@ _CREDENTIAL_READ_OPS: Final[frozenset[str]] = frozenset(
     {
         "vault.kv.read",
         "vault.kv.list",
+        # SDDC Manager is the system of record for nested-infra credentials;
+        # its typed ``GET /v1/credentials`` read returns live account secrets
+        # (#2306). Classified credential_read so audit + broadcast payloads
+        # collapse to aggregate-only, on top of the op's requires_approval
+        # gate and the connector-boundary secret scrub.
+        "sddc.credential.list",
     }
 )
 

--- a/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
@@ -25,9 +25,14 @@ check there will no-op on the
 because this module has already registered the hand-rolled class. Until then,
 this module is the only registration path.
 
-Operations for this connector arrive in #617 via G0.7 spec ingestion of
-the SDDC Manager VCF API against the ``endpoint_descriptor`` table.
-The curated 9-op read-only v0.2 core ships in :mod:`.core_ops`.
+Operations span two surfaces. The audited 12-read lab-audit set (#2306)
+ships as first-class **typed** ops in :mod:`.typed_ops` / :mod:`.typed_reads`
+(``source_kind="typed"``), dispatchable on a fresh boot with zero catalog
+ingest. The four non-audited curated reads (release, domain detail,
+network-pools, bundles) stay as ingested-row curation in :mod:`.core_ops`;
+the wider VCF API catalog arrives via G0.7 spec ingestion against the
+``endpoint_descriptor`` table and stays browsable as profiled-dispatch
+breadth (#2271).
 """
 
 from meho_backplane.connectors.registry import register_connector_v2
@@ -52,6 +57,12 @@ from meho_backplane.connectors.sddc_manager.session import (
     SessionCredentials,
     load_credentials_from_vault,
 )
+from meho_backplane.connectors.sddc_manager.typed_ops import (
+    SDDC_TYPED_OPS,
+    SddcTypedOp,
+    register_sddc_typed_operations,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
 
 register_connector_v2(
     product="sddc",
@@ -73,6 +84,12 @@ register_connector_v2(
     cls=SddcManagerConnector,
 )
 
+# Queue the audited-read typed-op upsert (#2306) onto the lifespan-driven
+# registrar list. The runner (``run_typed_op_registrars``) iterates after
+# ``_eager_import_connectors`` so the ``source_kind='typed'`` descriptor
+# rows land before the first dispatch -- no catalog ingest required.
+register_typed_op_registrar(register_sddc_typed_operations)
+
 __all__ = [
     "SDDC_CONNECTOR_ID",
     "SDDC_CORE_GROUPS",
@@ -81,14 +98,17 @@ __all__ = [
     "SDDC_IMPL_ID",
     "SDDC_PATH_RULES",
     "SDDC_PRODUCT",
+    "SDDC_TYPED_OPS",
     "SDDC_VERSION",
     "SddcCoreGroup",
     "SddcCoreOp",
     "SddcCredentialsLoader",
     "SddcManagerConnector",
     "SddcTargetLike",
+    "SddcTypedOp",
     "SessionCredentials",
     "apply_sddc_core_curation",
     "classify_sddc_op",
     "load_credentials_from_vault",
+    "register_sddc_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/sddc_manager/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/connector.py
@@ -67,6 +67,24 @@ field when present (VCF 9.x may surface it explicitly), otherwise ``None``.
 fingerprint GET authenticates via the token session (SDDC Manager has no
 unauthenticated version endpoint), so it goes through
 :meth:`_get_json_with_session_retry`.
+
+Operations
+----------
+
+The audited 12-read lab-audit set (#2306) ships as **typed** ops
+(``source_kind="typed"``) via the bound-method shims below, registered
+through :mod:`meho_backplane.connectors.sddc_manager.typed_ops`; they
+dispatch on a fresh boot with zero catalog ingest. ``sddc.credential.list``
+(``GET /v1/credentials``) is credential-read gated
+(``requires_approval=True`` + ``credential_read`` classification +
+boundary redaction). The four non-audited curated reads (release,
+domain detail, network-pools, bundles) stay as ingested-row curation in
+:mod:`meho_backplane.connectors.sddc_manager.core_ops`; the wider ingested
+375-op VCF catalog stays browsable as profiled-dispatch breadth (#2271)
+under its own ``METHOD:path`` op_ids — two surfaces, no resolver shadowing
+(#1750/#1798 class), because typed ops never resolve through
+``endpoint_descriptor`` rows (#2262). The G0.6 :meth:`execute` shim remains
+for ABC compatibility.
 """
 
 from __future__ import annotations
@@ -513,6 +531,111 @@ class SddcManagerConnector(HttpConnector):
             target=target,
             params=params,
         )
+
+    # Typed read ops (#2306): thin bound-method shims delegating to
+    # ``sddc_manager.typed_reads`` bodies (kept in a sibling module for the
+    # file-length budget). All read-only; a raw 401 (SDDC Manager's
+    # expired-token signal) propagates to the dispatcher's #2067 arm, which
+    # calls the public :meth:`invalidate_session` hook and re-dispatches
+    # once. ``credential_list`` is the credential-read-gated op
+    # (requires_approval=True + credential_read classification + boundary
+    # redaction); the rest are safe reads.
+
+    async def domain_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.domain.list`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_domain_list_impl
+
+        return await sddc_domain_list_impl(self, operator, target, params)
+
+    async def domain_status(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.domain.status`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_domain_status_impl
+
+        return await sddc_domain_status_impl(self, operator, target, params)
+
+    async def cluster_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.cluster.list`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_cluster_list_impl
+
+        return await sddc_cluster_list_impl(self, operator, target, params)
+
+    async def host_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.host.list`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_host_list_impl
+
+        return await sddc_host_list_impl(self, operator, target, params)
+
+    async def vcenter_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.vcenter.list`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_vcenter_list_impl
+
+        return await sddc_vcenter_list_impl(self, operator, target, params)
+
+    async def nsxt_cluster_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.nsxt_cluster.list`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_nsxt_cluster_list_impl
+
+        return await sddc_nsxt_cluster_list_impl(self, operator, target, params)
+
+    async def credential_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.credential.list`` shim (#2306) — credential-read gated + redacted."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_credential_list_impl
+
+        return await sddc_credential_list_impl(self, operator, target, params)
+
+    async def task_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.task.list`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_task_list_impl
+
+        return await sddc_task_list_impl(self, operator, target, params)
+
+    async def system_info(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.system.info`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_system_info_impl
+
+        return await sddc_system_info_impl(self, operator, target, params)
+
+    async def vcf_service_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.vcf_service.list`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_vcf_service_list_impl
+
+        return await sddc_vcf_service_list_impl(self, operator, target, params)
+
+    async def manager_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.manager.list`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_manager_list_impl
+
+        return await sddc_manager_list_impl(self, operator, target, params)
+
+    async def license_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.license.list`` shim (#2306)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_license_list_impl
+
+        return await sddc_license_list_impl(self, operator, target, params)
 
     async def aclose(self) -> None:
         """Clear cached session tokens + credentials, then tear down the httpx pool.

--- a/backend/src/meho_backplane/connectors/sddc_manager/core_ops.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/core_ops.py
@@ -1,12 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""SDDC Manager 9.0 read-only v0.2 core — curated operator-enabled subset.
+"""SDDC Manager read-only core — curated operator-enabled subset (browse breadth).
 
-This module names the **9 read-only SDDC Manager operations** the G3.5
-SDDC Manager v0.2 ship enables out of the much larger VCF API corpus the
-G0.7 spec-ingestion pipeline lands under
-``connector_id="sddc-rest-9.0"``. The curation is two-layered:
+This module names the **4 read-only SDDC Manager operations** left as
+ingested-row curation after the audited 12-read lab-audit set (domains
+list + status, clusters, hosts, vcenters, nsxt-clusters, credentials,
+tasks, system, vcf-services, sddc-managers, license-keys) was promoted to
+first-class **typed** ops in
+:mod:`meho_backplane.connectors.sddc_manager.typed_ops` (#2306). The
+curated set here keeps the wider ingested breadth browsable (the SDDC
+Manager software release, per-domain detail, network pools, and LCM
+bundles) out of the much larger VCF API corpus the G0.7 spec-ingestion
+pipeline lands under ``connector_id="sddc-rest-9.0"``. The curation is
+two-layered:
 
 * :data:`SDDC_CORE_GROUPS` — the operator-reviewed ``when_to_use``
   hint per LLM-grouping pass output group. Each entry's ``group_key``
@@ -15,7 +22,7 @@ G0.7 spec-ingestion pipeline lands under
   is what the agent reads verbatim through
   :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
   to pick a group to search within.
-* :data:`SDDC_CORE_OPS` — the 9 ``EndpointDescriptor.op_id`` strings
+* :data:`SDDC_CORE_OPS` — the 4 ``EndpointDescriptor.op_id`` strings
   that flip to ``is_enabled=True`` at operator-review time, paired
   with the per-op ``llm_instructions`` blob the agent inlines into
   the reasoning context when it sees the op in
@@ -48,7 +55,7 @@ triple carry ``product="sddc"``; operators pass ``--product sddc`` when driving
 the product via ``parse_connector_id`` so the same constant is consistent
 across the ingestion, review, and dispatch legs.
 
-The 9 ops (paths cross-checked against VCF / SDDC Manager API 9.0 at
+The 4 ops (paths cross-checked against VCF / SDDC Manager API 9.0 at
 https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/):
 
 1. ``GET:/v1/releases/system`` — ``sddc.about`` — SDDC Manager software
@@ -56,44 +63,42 @@ https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/):
    operator reads to confirm the VCF build under management; exposing it
    as an agent-callable op lets the agent run a sanity probe before heavier
    inventory reads.
-2. ``GET:/v1/sddc-managers`` — ``sddc.manager.list`` — list of SDDC Manager
-   appliances (FQDN, IP, version, management domain). The primary read for
-   "which SDDC Manager appliance manages this VCF stack."
-3. ``GET:/v1/domains`` — ``sddc.domain.list`` — management + workload
-   domains under this SDDC Manager.
-4. ``GET:/v1/domains/{id}`` — ``sddc.domain.info`` — full domain detail
+2. ``GET:/v1/domains/{id}`` — ``sddc.domain.info`` — full domain detail
    including associated vCenter(s), NSX-T cluster, clusters, and hosts.
-5. ``GET:/v1/clusters`` — ``sddc.cluster.list`` — cluster inventory across
-   all or one domain (``?domainId=`` filter).
-6. ``GET:/v1/hosts`` — ``sddc.host.list`` — ESXi host inventory across all
-   or one domain or cluster (``?domainId=`` / ``?clusterId=`` filter).
-7. ``GET:/v1/network-pools`` — ``sddc.network_pool.list`` — network pools
+3. ``GET:/v1/network-pools`` — ``sddc.network_pool.list`` — network pools
    defining the IP ranges and VLANs provisioned to new hosts at commission
    time.
-8. ``GET:/v1/bundles`` — ``sddc.bundle.list`` — LCM bundle inventory (VCF
+4. ``GET:/v1/bundles`` — ``sddc.bundle.list`` — LCM bundle inventory (VCF
    update packages, async patches). Read-only; lifecycle writes stay
    ``staged`` per Initiative #368.
-9. ``GET:/v1/tasks`` — ``sddc.workflow.list`` — in-flight and recently
-   completed VCF workflow tasks. The SDDC Manager API surface uses the term
-   ``tasks``; the issue body calls this surface ``sddc.workflow.list`` for
-   operator clarity.
+
+The audited operational reads — domains list + status, clusters, hosts,
+vcenters, nsxt-clusters, credentials, tasks, system, vcf-services,
+sddc-managers, and license-keys — are **not** curated here: #2306 promoted
+them to first-class typed ops (``source_kind="typed"``,
+:mod:`meho_backplane.connectors.sddc_manager.typed_ops`) that dispatch on a
+fresh boot with zero catalog state. Their ingested rows still exist and
+stay browsable; this module simply no longer flips them to
+``is_enabled=True``. :data:`SDDC_PATH_RULES` retains the full ``/v1/``
+taxonomy so the ingested breadth keeps its group organisation.
 
 Path families and group_keys
 -----------------------------
 
-Every SDDC Manager REST path begins with ``/v1/``. The 9 curated ops
-span 8 distinct top-level resource families:
-``releases``, ``sddc-managers``, ``domains``, ``clusters``, ``hosts``,
-``network-pools``, ``bundles``, ``tasks``. :data:`SDDC_PATH_RULES`
-mirrors that taxonomy so an operator reviewing the connector sees the
-read-core ops fall into the expected 8 groups. The ``sddc-domains``
-group carries two ops (list + detail).
+Every SDDC Manager REST path begins with ``/v1/``. :data:`SDDC_PATH_RULES`
+retains the full taxonomy (``releases``, ``sddc-managers``, ``domains``,
+``clusters``, ``hosts``, ``network-pools``, ``bundles``, ``tasks``) so the
+ingested breadth keeps its group organisation even though only 4 of those
+families carry a curated read now. The 4 curated ops span 4 groups
+(``sddc-releases``, ``sddc-domains``, ``sddc-network-pools``,
+``sddc-bundles``); the ``sddc-domains`` group carries the domain-detail
+read (its list companion moved to the typed surface).
 
 Curation application
 --------------------
 
 :func:`apply_sddc_core_curation` is the operator-review-time substrate
-call that makes exactly the 9 curated ops dispatchable and leaves every
+call that makes exactly the 4 curated ops dispatchable and leaves every
 other ingested op disabled. The substrate has no "enable only ops X, Y, Z
 under group G" verb — :meth:`ReviewService.enable_group` cascades
 ``is_enabled=True`` to every child op. The helper threads this needle via
@@ -228,11 +233,11 @@ def classify_sddc_op(op_id: str) -> str:
     return "none"
 
 
-#: Operator-reviewed ``when_to_use`` hints for the 8 SDDC Manager groups
-#: the read-only v0.2 core spans. Two ops share the ``sddc-domains`` group
-#: (list + detail); every other group carries exactly one op. Every hint is
-#: one complete sentence the agent reads verbatim — vague hints poison
-#: ``search_operations`` ranking, per the ai_engineering pack.
+#: Operator-reviewed ``when_to_use`` hints for the 4 SDDC Manager groups
+#: the browse-breadth curated core spans (the audited operational groups
+#: moved to typed ops in #2306). Each group carries exactly one op. Every
+#: hint is one complete sentence the agent reads verbatim — vague hints
+#: poison ``search_operations`` ranking, per the ai_engineering pack.
 SDDC_CORE_GROUPS: Final[tuple[SddcCoreGroup, ...]] = (
     SddcCoreGroup(
         group_key="sddc-releases",
@@ -245,42 +250,13 @@ SDDC_CORE_GROUPS: Final[tuple[SddcCoreGroup, ...]] = (
         ),
     ),
     SddcCoreGroup(
-        group_key="sddc-managers",
-        name="SDDC Manager (appliance)",
-        when_to_use=(
-            "Use this group to list SDDC Manager appliances — their FQDN, IP "
-            "address, version, and the management domain they belong to. The "
-            "primary read for 'which SDDC Manager appliance manages this VCF "
-            "stack' questions."
-        ),
-    ),
-    SddcCoreGroup(
         group_key="sddc-domains",
         name="VCF Domains",
         when_to_use=(
-            "Use this group to list or inspect VCF domains (management and "
-            "workload). The entry point for any domain-scoped cluster, host, or "
-            "network-pool query, and for mapping which vCenter or NSX-T cluster "
-            "belongs to a given domain."
-        ),
-    ),
-    SddcCoreGroup(
-        group_key="sddc-clusters",
-        name="VCF Clusters",
-        when_to_use=(
-            "Use this group to list vSphere clusters across all or one VCF "
-            "domain. The primary inventory read for 'how many clusters exist', "
-            "'what datastore type does a cluster use', or 'which hosts are in "
-            "cluster X' questions."
-        ),
-    ),
-    SddcCoreGroup(
-        group_key="sddc-hosts",
-        name="VCF Hosts",
-        when_to_use=(
-            "Use this group to enumerate ESXi hosts across all VCF domains, or "
-            "filter to a specific domain or cluster. The primary read for host "
-            "count, FQDN, ESXi version, and assignment status questions."
+            "Use this group to inspect a single VCF domain in detail — its "
+            "associated vCenter(s), NSX-T cluster, clusters, and hosts. The "
+            "domain listing itself is the typed sddc.domain.list op; this "
+            "group's curated read is the per-domain detail."
         ),
     ),
     SddcCoreGroup(
@@ -300,16 +276,6 @@ SDDC_CORE_GROUPS: Final[tuple[SddcCoreGroup, ...]] = (
             "VCF update packages, component updates, and async patches. Read-only; "
             "use when answering 'which updates are available' or 'is the VCF stack "
             "compliant with the latest release'."
-        ),
-    ),
-    SddcCoreGroup(
-        group_key="sddc-tasks",
-        name="VCF Workflows (Tasks)",
-        when_to_use=(
-            "Use this group to list in-flight or recently completed VCF workflow "
-            "tasks. Use when answering 'what operations are running against this "
-            "VCF stack' or monitoring a domain-expand, host-commission, or "
-            "update-apply workflow."
         ),
     ),
 )
@@ -334,9 +300,12 @@ def _instructions(
     }
 
 
-#: The 9 curated read-only SDDC Manager core ops. Each entry carries the
+#: The 4 curated read-only SDDC Manager core ops. Each entry carries the
 #: op_id (``GET:/path`` form), the curated group assignment, and the
-#: operator-reviewed ``llm_instructions`` blob.
+#: operator-reviewed ``llm_instructions`` blob. The audited operational
+#: reads moved to typed ops in #2306
+#: (:mod:`meho_backplane.connectors.sddc_manager.typed_ops`); these four
+#: keep the wider ingested breadth browsable.
 #:
 #: Paths sourced against VCF / SDDC Manager API 9.0 at
 #: https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/.
@@ -357,54 +326,9 @@ SDDC_CORE_OPS: Final[tuple[SddcCoreOp, ...]] = (
                 "(each entry carries componentType and componentVersion)."
             ),
             next_step=(
-                "If the release looks current, proceed to domain or cluster "
-                "reads; if behind, surface the version to the operator for an "
-                "LCM update check via sddc.bundle.list."
-            ),
-        ),
-    ),
-    SddcCoreOp(
-        op_id="GET:/v1/sddc-managers",
-        group_key="sddc-managers",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to list SDDC Manager appliances — their FQDN, IP address, "
-                "version, and the management domain they belong to. The primary "
-                "read for 'which SDDC Manager manages this VCF stack' questions, "
-                "or when you need the appliance FQDN before making further "
-                "targeted calls."
-            ),
-            output_shape=(
-                "Paginated envelope with elements[] and pageMetadata; each "
-                "element carries id, fqdn, ipAddress, version, and a domain "
-                "object with id and name."
-            ),
-            next_step=(
-                "Cross-reference the management domain name against sddc.domain.list "
-                "for domain-scoped queries, or use the FQDN when targeting a "
-                "specific appliance."
-            ),
-        ),
-    ),
-    SddcCoreOp(
-        op_id="GET:/v1/domains",
-        group_key="sddc-domains",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to list all VCF domains managed by this SDDC Manager — "
-                "the management domain and any workload domains. The entry point "
-                "for domain-scoped cluster, host, or network-pool queries and for "
-                "mapping which vCenter or NSX-T cluster belongs to a given domain."
-            ),
-            output_shape=(
-                "Paginated envelope with elements[] and pageMetadata; each domain "
-                "carries id, name, type (MANAGEMENT or WORKLOAD), and references "
-                "to associated vcenters and nsxtCluster."
-            ),
-            next_step=(
-                "Pick a domain id for sddc.domain.info to get the full detail "
-                "including vCenter FQDN and NSX-T cluster, or pass domainId as a "
-                "filter to sddc.cluster.list / sddc.host.list."
+                "If the release looks current, proceed to the typed domain / "
+                "cluster reads; if behind, surface the version to the operator "
+                "for an LCM update check via sddc.bundle.list."
             ),
         ),
     ),
@@ -427,53 +351,6 @@ SDDC_CORE_OPS: Final[tuple[SddcCoreOp, ...]] = (
                 "Cross-reference vcenters[].fqdn against the vSphere connector "
                 "for VM reads, or use cluster ids for targeted sddc.cluster.list "
                 "or sddc.host.list queries."
-            ),
-        ),
-    ),
-    SddcCoreOp(
-        op_id="GET:/v1/clusters",
-        group_key="sddc-clusters",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to list vSphere clusters across all VCF domains, or filter "
-                "to a specific domain by passing domainId as a query parameter. "
-                "The primary inventory read for cluster count, datastore type, "
-                "and host membership questions."
-            ),
-            output_shape=(
-                "Paginated envelope with elements[] and pageMetadata; each cluster "
-                "carries id, name, primaryDatastoreType, domainId, and a hosts[] "
-                "array of host references."
-            ),
-            next_step=(
-                "Cross-reference domainId against the domain listing for "
-                "context, or use cluster ids to filter sddc.host.list to the "
-                "specific cluster's hosts."
-            ),
-        ),
-    ),
-    SddcCoreOp(
-        op_id="GET:/v1/hosts",
-        group_key="sddc-hosts",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to enumerate ESXi hosts across all VCF domains, or filter "
-                "by domainId or clusterId query parameters. The primary inventory "
-                "read for host count, FQDN, ESXi version, IP addresses, and "
-                "assignment status. Large VCF deployments may return dozens or "
-                "hundreds of hosts — use the JSONFlux handle path for big sets."
-            ),
-            output_shape=(
-                "Paginated envelope with elements[] and pageMetadata; each host "
-                "carries id, fqdn, esxiVersion, ipAddresses[], domain.id, "
-                "cluster.id, networkPool.id, and status "
-                "(ASSIGNED or UNASSIGNED_USEABLE)."
-            ),
-            next_step=(
-                "Cross-reference cluster.id against sddc.cluster.list, or use "
-                "fqdn when targeting a specific host for vSphere reads. For "
-                "hosts in UNASSIGNED_USEABLE status, surface them to the operator "
-                "as available for domain expansion."
             ),
         ),
     ),
@@ -525,32 +402,6 @@ SDDC_CORE_OPS: Final[tuple[SddcCoreOp, ...]] = (
             ),
         ),
     ),
-    SddcCoreOp(
-        op_id="GET:/v1/tasks",
-        group_key="sddc-tasks",
-        llm_instructions=_instructions(
-            when_to_call=(
-                "Call to list in-flight or recently completed VCF workflow tasks "
-                "(SDDC Manager calls these 'tasks'; the operator-facing name is "
-                "sddc.workflow.list). Use when answering 'what operations are "
-                "running against this VCF stack', monitoring a domain-expand or "
-                "host-commission operation, or triaging a workflow that failed. "
-                "Supports status filtering via the status query parameter "
-                "(Successful, Failed, In_Progress, Pending, Cancelled)."
-            ),
-            output_shape=(
-                "Task objects with id, name, status, type, creationTimestamp, "
-                "completionTimestamp, subtasks[] (nested task tree), and "
-                "errors[] (message + remediation hints for failed tasks)."
-            ),
-            next_step=(
-                "For a failed task, surface errors[].message and "
-                "errors[].remediationMessage to the operator. For an "
-                "in-progress task, poll via this op or wait for the status "
-                "to transition before proceeding with the next workflow step."
-            ),
-        ),
-    ),
 )
 
 
@@ -559,46 +410,32 @@ async def apply_sddc_core_curation(
     *,
     tenant_id: UUID | None,
 ) -> None:
-    """Apply the curated 9-op read core against an ingested SDDC Manager connector.
+    """Apply the curated 4-op read core against an ingested SDDC Manager connector.
 
     Drives the substrate so that, after this call returns, exactly
-    the 9 ops in :data:`SDDC_CORE_OPS` are dispatchable
+    the 4 ops in :data:`SDDC_CORE_OPS` are dispatchable
     (``is_enabled=True``) and every other ingested op stays
-    ``is_enabled=False``. The 8 curated groups land
+    ``is_enabled=False``. The 4 curated groups land
     ``review_status='enabled'`` so the agent's
     :func:`~meho_backplane.operations.meta_tools.search_operations`
     surfaces the core ops; non-curated groups are left untouched
     (``review_status='staged'`` from the G0.7 ingest default).
 
-    The substrate doesn't expose "enable only ops X, Y, Z under
-    group G": :meth:`ReviewService.enable_group`'s cascade flips
-    ``is_enabled=True`` on every child op in the group. The helper
-    works around this via the audit-log-driven operator-override
-    exclusion:
+    The substrate doesn't expose "enable only ops X, Y, Z under group G":
+    :meth:`ReviewService.enable_group`'s cascade flips ``is_enabled=True``
+    on every child op. The helper works around this via the
+    audit-log-driven operator-override exclusion: (1) ``get_review_payload``
+    loads each curated group's ops; (2) every non-core op in a curated group
+    gets an ``edit_op(is_enabled=False)`` override row the ``enable_group``
+    cascade then skips; (3) ``edit_group`` lands the reviewed name +
+    when_to_use; (4) ``enable_group`` flips ``review_status='enabled'`` and
+    cascades ``is_enabled=True`` to the curated ops; (5) ``edit_op`` lands
+    each curated ``llm_instructions`` blob. Same pattern as
+    :func:`~meho_backplane.connectors.nsx.core_ops.apply_nsx_core_curation`.
 
-    1. :meth:`ReviewService.get_review_payload` loads the current
-       state of every curated group and its child ops.
-    2. For each child op in a curated group that **isn't** in the
-       :data:`SDDC_CORE_OPS` allow-list,
-       :meth:`ReviewService.edit_op` with ``is_enabled=False``
-       writes the operator-override audit row. The follow-on
-       :meth:`enable_group` cascade detects these rows and skips
-       them.
-    3. :meth:`ReviewService.edit_group` lands the operator-reviewed
-       ``name`` + ``when_to_use`` on each curated group.
-    4. :meth:`ReviewService.enable_group` flips
-       ``review_status='enabled'`` and cascades ``is_enabled=True``
-       to the curated child ops (operator-overridden non-core ops
-       are skipped).
-    5. :meth:`ReviewService.edit_op` lands the curated
-       ``llm_instructions`` blob per entry in :data:`SDDC_CORE_OPS`.
-
-    Re-running is safe but not idempotent at the audit layer.
-    :meth:`enable_group` short-circuits on groups already in
-    ``review_status='enabled'`` (no audit row), but
-    :meth:`edit_group` and :meth:`edit_op` always emit one audit
-    row per call — even when the incoming value equals the
-    persisted one.
+    Re-running is safe but not idempotent at the audit layer:
+    ``enable_group`` short-circuits on already-enabled groups, but
+    ``edit_group`` / ``edit_op`` always emit one audit row per call.
 
     Raises :class:`~meho_backplane.operations.ingest.ConnectorNotFoundError`
     if no groups exist for ``sddc-rest-9.0`` under *tenant_id* (the

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
@@ -1,0 +1,750 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+# code-quality-allow: declarative typed-op metadata table. This module is a
+# data file — 12 audited-read SddcTypedOp records, each a data-only value with
+# grounded operator-facing prose (summary / description / llm_instructions) the
+# BM25 + embedding search surfaces read verbatim. Cyclomatic complexity is
+# trivial; the length is the 12-op catalog, not logic. Splitting the tuple
+# across files fragments the single source of truth the registrar iterates.
+
+"""Typed-op metadata + registrar for :class:`SddcManagerConnector` (#2306).
+
+The audited SDDC Manager read set (the #2294 12-read lab-audit surface) is
+registered as typed ops (``source_kind="typed"``) so it dispatches on a
+fresh boot with **zero catalog ingest** -- the #2247 failure class the
+ingested-row curation in
+:mod:`meho_backplane.connectors.sddc_manager.core_ops` was subject to
+(per-deploy catalog state). The op bodies live in
+:mod:`meho_backplane.connectors.sddc_manager.typed_reads`; thin
+bound-method shims on
+:class:`~meho_backplane.connectors.sddc_manager.connector.SddcManagerConnector`
+expose them under the ``handler_attr`` names below so the dispatcher's
+:func:`~meho_backplane.operations._handler_resolve.import_handler` walk
+recovers each callable from its persisted ``module.ClassName.method`` path.
+
+The dataclass + tuple + module-level registrar shape mirrors
+:mod:`meho_backplane.connectors.nsx.typed_ops`.
+
+Two surfaces, no resolver shadowing (#1750/#1798 class)
+------------------------------------------------------
+
+The typed curated set here is the **documented operational surface**; the
+ingested 375-op VCF catalog stays as profiled-dispatch breadth (#2271)
+under its own ``METHOD:path`` op_ids. The two never collide: a typed op
+carries a dotted op-id (``sddc.domain.list``) and a code ``handler_ref``,
+so it resolves through :func:`~meho_backplane.operations._branches.dispatch_typed`
+and never through an ``endpoint_descriptor`` ingested row (#2262). The
+converted reads are removed from the ``core_ops.py`` ingested curation;
+the four non-audited curated reads (releases/system, domain detail,
+network-pools, bundles) stay ingested-curated there.
+
+Credential-read gating (``sddc.credential.list``)
+-------------------------------------------------
+
+``GET /v1/credentials`` is SDDC Manager's system-of-record read for
+nested-infra credentials. Its typed op is gated as a credential-read
+mapped to the **existing** safety_level/policy mechanism:
+
+* ``requires_approval=True`` -- the dispatcher's
+  :func:`~meho_backplane.operations._validate.policy_gate` routes a
+  ``requires_approval`` op to the approval queue (G11.7-T1 #1401), so it
+  is **not dispatchable without the elevated policy path** (operator
+  approval).
+* op-id ``sddc.credential.list`` on
+  :data:`~meho_backplane.broadcast.events._CREDENTIAL_READ_OPS` (decision
+  #3's op-id classifier) -- ``classify_op`` returns ``credential_read`` so
+  audit + broadcast rows collapse to aggregate-only (redacted).
+* the handler additionally scrubs secret-keyed values at the connector
+  boundary (:func:`~meho_backplane.connectors.sddc_manager.typed_reads._redact_secrets`).
+
+The write surface (none wanted for SDDC), the session/auth itself
+(#2290), and the profiled ingested dispatch (#2271) are out of this
+task's scope.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import structlog
+
+if TYPE_CHECKING:
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "SDDC_TYPED_OPS",
+    "SDDC_TYPED_WHEN_TO_USE_BY_GROUP",
+    "SddcTypedOp",
+    "register_sddc_typed_operations",
+]
+
+_log = structlog.get_logger(__name__)
+
+# Typed-op group keys. Each groups the audited reads by the operator
+# question they answer; the ``when_to_use`` blurbs below are what the
+# agent reads verbatim through ``list_operation_groups`` to pick a group.
+_GROUP_INVENTORY = "sddc-inventory"
+_GROUP_PLATFORM = "sddc-platform"
+_GROUP_TASKS = "sddc-tasks-typed"
+_GROUP_CREDENTIALS = "sddc-credentials"
+
+
+@dataclass(frozen=True)
+class SddcTypedOp:
+    """Metadata for one SDDC Manager typed op registered at lifespan startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so :func:`register_sddc_typed_operations` can splat the
+    dataclass into the helper without per-op boilerplate. ``handler_attr``
+    is the attribute name on
+    :class:`~meho_backplane.connectors.sddc_manager.connector.SddcManagerConnector`
+    exposing the async handler; the registrar resolves the bound method
+    against the class at registration time. Mirrors
+    :class:`~meho_backplane.connectors.nsx.typed_ops.NsxTypedOp`.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: Curated ``when_to_use`` blurb per typed-op group.
+#: ``register_typed_operation`` requires a non-empty string whenever
+#: ``group_key`` is set (typed_register ``_validate_when_to_use_pairing``).
+SDDC_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    _GROUP_INVENTORY: (
+        "Use to read the VCF infrastructure inventory SDDC Manager governs: "
+        "domains and their lifecycle status (sddc.domain.list / "
+        "sddc.domain.status), vSphere clusters (sddc.cluster.list), ESXi "
+        "hosts (sddc.host.list), vCenters (sddc.vcenter.list), and NSX-T "
+        "clusters (sddc.nsxt_cluster.list). The right group for 'what does "
+        "this VCF stack contain' and for mapping a workload domain to its "
+        "vCenter and NSX-T cluster. Read-only."
+    ),
+    _GROUP_PLATFORM: (
+        "Use to read the SDDC Manager platform itself: the appliance "
+        "inventory (sddc.manager.list), system-level settings "
+        "(sddc.system.info), the running VCF micro-services and their "
+        "health (sddc.vcf_service.list), and the license keys "
+        "(sddc.license.list). The right group when confirming which SDDC "
+        "Manager manages the stack, whether its control plane is healthy, "
+        "or whether the deployment is licensed. Read-only."
+    ),
+    _GROUP_TASKS: (
+        "Use to read VCF workflow tasks (sddc.task.list) -- in-flight or "
+        "recently completed domain-expand, host-commission, or update-apply "
+        "operations, optionally filtered by status. The right group when "
+        "the question is 'what is running against this VCF stack right now' "
+        "or when triaging a workflow that failed. Read-only."
+    ),
+    _GROUP_CREDENTIALS: (
+        "Use to read the nested-infra credential inventory SDDC Manager is "
+        "the system of record for (sddc.credential.list) -- the ESXi / "
+        "vCenter / NSX-T / backup service accounts it stores and rotates. "
+        "Credential-read gated: dispatch requires operator approval and the "
+        "secret values are redacted; the read shows which accounts exist, "
+        "never their passwords. The group an operator reaches for during a "
+        "nested-infra credential audit or outage."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Shared parameter-schema fragments
+# ---------------------------------------------------------------------------
+
+#: The empty parameter object shared by the no-argument reads.
+_NO_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+def _instructions(
+    *,
+    when_to_use: str,
+    output_shape: str,
+    parameter_hints: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build the per-op ``llm_instructions`` blob with the canonical keys."""
+    blob: dict[str, Any] = {"when_to_use": when_to_use, "output_shape": output_shape}
+    if parameter_hints is not None:
+        blob["parameter_hints"] = parameter_hints
+    return blob
+
+
+# ---------------------------------------------------------------------------
+# sddc.domain.list
+# ---------------------------------------------------------------------------
+
+_DOMAIN_LIST = SddcTypedOp(
+    op_id="sddc.domain.list",
+    handler_attr="domain_list",
+    summary="VCF domains (management + workload) SDDC Manager governs.",
+    description=(
+        "Lists every VCF domain the SDDC Manager governs via "
+        "GET /v1/domains -- the management domain plus any workload "
+        "domains. The entry point for domain-scoped cluster / host / "
+        "vCenter reads and for mapping a workload domain to its vCenter and "
+        "NSX-T cluster. Works with zero catalog ingest. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "domain", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to list all VCF domains -- the management domain and any "
+            "workload domains -- as the entry point for domain-scoped reads."
+        ),
+        output_shape=(
+            "{elements: [{id, name, type (MANAGEMENT/WORKLOAD), vcenters, "
+            "nsxtCluster}, ...], pageMetadata}."
+        ),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.domain.status
+# ---------------------------------------------------------------------------
+
+_DOMAIN_STATUS = SddcTypedOp(
+    op_id="sddc.domain.status",
+    handler_attr="domain_status",
+    summary="Lifecycle status of one VCF domain.",
+    description=(
+        "Reads the lifecycle status of one VCF domain via "
+        "GET /v1/domains/{id}/status -- its ACTIVE / ACTIVATING / ERROR "
+        "state and the last status transition. Requires a domain id from "
+        "sddc.domain.list. The read an operator runs when a domain-create "
+        "or expand workflow is in flight or a domain is reported unhealthy. "
+        "Works with zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The VCF domain id (from sddc.domain.list).",
+            },
+        },
+        "required": ["id"],
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "domain", "status"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call with a domain id to check whether a domain is ACTIVE or "
+            "still activating / errored -- e.g. while a domain-expand "
+            "workflow runs."
+        ),
+        output_shape="{status, ...}. Surface the state and any error detail.",
+        parameter_hints={"id": "The VCF domain id from sddc.domain.list."},
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.cluster.list
+# ---------------------------------------------------------------------------
+
+_CLUSTER_LIST = SddcTypedOp(
+    op_id="sddc.cluster.list",
+    handler_attr="cluster_list",
+    summary="vSphere clusters across all or one VCF domain.",
+    description=(
+        "Lists vSphere clusters across all VCF domains via GET /v1/clusters, "
+        "or narrowed to one domain via the optional domainId filter. The "
+        "primary inventory read for cluster count, datastore type, and host "
+        "membership. Works with zero catalog ingest. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "domainId": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional VCF domain id filter. Omit for all domains.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "cluster", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=("Call to list vSphere clusters; pass domainId to scope to one domain."),
+        output_shape=(
+            "{elements: [{id, name, primaryDatastoreType, domainId, hosts}, ...], pageMetadata}."
+        ),
+        parameter_hints={"domainId": "VCF domain id; omit for all domains."},
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.host.list
+# ---------------------------------------------------------------------------
+
+_HOST_LIST = SddcTypedOp(
+    op_id="sddc.host.list",
+    handler_attr="host_list",
+    summary="ESXi hosts across all VCF domains, optionally filtered.",
+    description=(
+        "Enumerates ESXi hosts across all VCF domains via GET /v1/hosts, or "
+        "narrowed by the optional domainId / clusterId / status filters. "
+        "The primary read for host count, FQDN, ESXi version, and "
+        "assignment status. Large VCF deployments return dozens or hundreds "
+        "of hosts. Works with zero catalog ingest. safety_level=safe, "
+        "read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "domainId": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional VCF domain id filter. Omit for all domains.",
+            },
+            "clusterId": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional cluster id filter. Omit for all clusters.",
+            },
+            "status": {
+                "type": "string",
+                "minLength": 1,
+                "description": (
+                    "Optional host status filter (e.g. ASSIGNED, "
+                    "UNASSIGNED_USEABLE). Omit for all statuses."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "host", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to enumerate ESXi hosts; narrow with domainId / clusterId "
+            "/ status when the operator named one."
+        ),
+        output_shape=(
+            "{elements: [{id, fqdn, esxiVersion, ipAddresses, domain, "
+            "cluster, status}, ...], pageMetadata}."
+        ),
+        parameter_hints={
+            "domainId": "VCF domain id; omit for all.",
+            "clusterId": "cluster id; omit for all.",
+            "status": "ASSIGNED / UNASSIGNED_USEABLE; omit for all.",
+        },
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.vcenter.list
+# ---------------------------------------------------------------------------
+
+_VCENTER_LIST = SddcTypedOp(
+    op_id="sddc.vcenter.list",
+    handler_attr="vcenter_list",
+    summary="vCenter Server instances SDDC Manager manages.",
+    description=(
+        "Lists the vCenter Server instances SDDC Manager manages via "
+        "GET /v1/vcenters, or narrowed to one domain via the optional "
+        "domainId filter. Cross the returned fqdn against the vSphere "
+        "connector for VM-level reads. Works with zero catalog ingest. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "domainId": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional VCF domain id filter. Omit for all domains.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "vcenter", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to list managed vCenters; cross the fqdn against the "
+            "vSphere connector for VM reads."
+        ),
+        output_shape="{elements: [{id, fqdn, domain}, ...], pageMetadata}.",
+        parameter_hints={"domainId": "VCF domain id; omit for all."},
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.nsxt_cluster.list
+# ---------------------------------------------------------------------------
+
+_NSXT_CLUSTER_LIST = SddcTypedOp(
+    op_id="sddc.nsxt_cluster.list",
+    handler_attr="nsxt_cluster_list",
+    summary="NSX-T manager clusters SDDC Manager manages.",
+    description=(
+        "Lists the NSX-T manager clusters SDDC Manager manages via "
+        "GET /v1/nsxt-clusters and the domains each one backs. The read for "
+        "mapping which NSX-T cluster fronts a given workload domain. Works "
+        "with zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "nsxt", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to list NSX-T clusters and the domains they back -- e.g. "
+            "when mapping a workload domain to its NSX-T cluster."
+        ),
+        output_shape="{elements: [{id, vipFqdn, domainIds}, ...], pageMetadata}.",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.credential.list  (credential-read gated + redacted)
+# ---------------------------------------------------------------------------
+
+_CREDENTIAL_LIST = SddcTypedOp(
+    op_id="sddc.credential.list",
+    handler_attr="credential_list",
+    summary="Nested-infra credential inventory (credential-read gated, redacted).",
+    description=(
+        "Lists the nested-infra credentials SDDC Manager is the system of "
+        "record for via GET /v1/credentials -- the ESXi / vCenter / NSX-T / "
+        "backup service accounts it stores and rotates. Credential-read "
+        "gated: dispatch routes through the approval queue "
+        "(requires_approval=True -- not dispatchable without operator "
+        "approval), the op-id is classified credential_read so audit + "
+        "broadcast rows collapse to aggregate-only, and the handler scrubs "
+        "every secret-keyed value at the boundary. The read shows which "
+        "accounts exist (username, resource, accountType) with the password "
+        "/ private-key material replaced by ***REDACTED***. Works with zero "
+        "catalog ingest. safety_level=caution, requires_approval=True."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_CREDENTIALS,
+    tags=("read-only", "sddc", "vcf", "credential-read"),
+    safety_level="caution",
+    requires_approval=True,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call during a nested-infra credential audit or outage to see "
+            "which ESXi / vCenter / NSX-T / backup accounts SDDC Manager "
+            "holds. Dispatch requires operator approval; secret values are "
+            "always redacted."
+        ),
+        output_shape=(
+            "{elements: [{id, resource, accountType, credentialType, "
+            "username, password: ***REDACTED***}, ...]}. Never contains a "
+            "live secret."
+        ),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.task.list
+# ---------------------------------------------------------------------------
+
+_TASK_LIST = SddcTypedOp(
+    op_id="sddc.task.list",
+    handler_attr="task_list",
+    summary="In-flight or recent VCF workflow tasks, optionally filtered.",
+    description=(
+        "Lists in-flight or recently completed VCF workflow tasks via "
+        "GET /v1/tasks, optionally narrowed by the status filter "
+        "(Successful / Failed / In_Progress / Pending / Cancelled). The "
+        "read for monitoring a domain-expand, host-commission, or "
+        "update-apply workflow, or triaging one that failed. Works with "
+        "zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "status": {
+                "type": "string",
+                "enum": ["Successful", "Failed", "In_Progress", "Pending", "Cancelled"],
+                "description": "Optional task status filter. Omit for all statuses.",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_TASKS,
+    tags=("read-only", "sddc", "vcf", "task", "workflow"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to see what VCF workflows are running or recently ran; "
+            "narrow with status='Failed' when triaging."
+        ),
+        output_shape=(
+            "{elements: [{id, name, status, type, subtasks, errors}, ...], "
+            "pageMetadata}. For a failed task surface errors[].message."
+        ),
+        parameter_hints={
+            "status": "Successful / Failed / In_Progress / Pending / Cancelled; omit for all.",
+        },
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.system.info
+# ---------------------------------------------------------------------------
+
+_SYSTEM_INFO = SddcTypedOp(
+    op_id="sddc.system.info",
+    handler_attr="system_info",
+    summary="SDDC Manager system-level settings summary.",
+    description=(
+        "Reads the SDDC Manager system-level settings summary via "
+        "GET /v1/system -- the appliance-wide configuration (proxy, CEIP, "
+        "DNS/NTP posture) SDDC Manager exposes at its /v1/system root. The "
+        "read for confirming the SDDC Manager's own platform configuration "
+        "before an inventory or lifecycle operation. Works with zero "
+        "catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_PLATFORM,
+    tags=("read-only", "sddc", "vcf", "system", "platform"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to read the SDDC Manager appliance-wide system settings "
+            "before a heavier operation."
+        ),
+        output_shape="{...} system settings object.",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.vcf_service.list
+# ---------------------------------------------------------------------------
+
+_VCF_SERVICE_LIST = SddcTypedOp(
+    op_id="sddc.vcf_service.list",
+    handler_attr="vcf_service_list",
+    summary="Running VCF micro-services on the SDDC Manager appliance + health.",
+    description=(
+        "Lists the VCF platform micro-services running on the SDDC Manager "
+        "appliance and their status via GET /v1/vcf-services. The read for "
+        "confirming the SDDC Manager control plane is healthy -- which "
+        "service is degraded when an operation is failing for no obvious "
+        "inventory reason. Works with zero catalog ingest. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_PLATFORM,
+    tags=("read-only", "sddc", "vcf", "service", "health"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to confirm the SDDC Manager control plane is healthy, or "
+            "to find which VCF micro-service is degraded."
+        ),
+        output_shape="{elements: [{id, name, status, version}, ...]}.",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.manager.list
+# ---------------------------------------------------------------------------
+
+_MANAGER_LIST = SddcTypedOp(
+    op_id="sddc.manager.list",
+    handler_attr="manager_list",
+    summary="SDDC Manager appliance inventory.",
+    description=(
+        "Lists the SDDC Manager appliances via GET /v1/sddc-managers -- "
+        "their FQDN, IP, version, and the management domain each belongs "
+        "to. The primary read for 'which SDDC Manager manages this VCF "
+        "stack', and the same surface fingerprint reads, exposed as an "
+        "operator-callable typed op. Works with zero catalog ingest. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_PLATFORM,
+    tags=("read-only", "sddc", "vcf", "manager", "platform"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to identify the SDDC Manager appliance(s) -- FQDN, IP, "
+            "version, management domain -- as a probe or before targeted "
+            "reads."
+        ),
+        output_shape=("{elements: [{id, fqdn, ipAddress, version, domain}, ...], pageMetadata}."),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.license.list
+# ---------------------------------------------------------------------------
+
+_LICENSE_LIST = SddcTypedOp(
+    op_id="sddc.license.list",
+    handler_attr="license_list",
+    summary="License keys registered with SDDC Manager.",
+    description=(
+        "Lists the license keys registered with SDDC Manager via "
+        "GET /v1/license-keys -- their product type, key, description, and "
+        "usage. The read for a licensing-compliance question ('is this VCF "
+        "stack licensed', 'which keys are near their limit'). Works with "
+        "zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_PLATFORM,
+    tags=("read-only", "sddc", "vcf", "license", "platform"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=("Call to answer a licensing-compliance question about the VCF stack."),
+        output_shape=(
+            "{elements: [{key, productType, description, licenseKeyUsage}, ...], pageMetadata}."
+        ),
+    ),
+)
+
+
+#: The typed ops :class:`SddcManagerConnector` registers at lifespan
+#: startup -- the audited 12-read set (#2306). Ordered inventory ->
+#: credentials -> tasks -> platform to match the operator's typical path.
+SDDC_TYPED_OPS: tuple[SddcTypedOp, ...] = (
+    _DOMAIN_LIST,
+    _DOMAIN_STATUS,
+    _CLUSTER_LIST,
+    _HOST_LIST,
+    _VCENTER_LIST,
+    _NSXT_CLUSTER_LIST,
+    _CREDENTIAL_LIST,
+    _TASK_LIST,
+    _SYSTEM_INFO,
+    _VCF_SERVICE_LIST,
+    _MANAGER_LIST,
+    _LICENSE_LIST,
+)
+
+
+async def register_sddc_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every op in :data:`SDDC_TYPED_OPS` into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list via
+    :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`
+    in this package's ``__init__``; the runner
+    (:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`)
+    invokes it after
+    :func:`~meho_backplane.connectors.registry._eager_import_connectors`
+    has walked every connector subpackage, so the descriptor rows land
+    before the first dispatch. Idempotent across pod restarts (the helper
+    skips the embedding recompute on unchanged summary / description /
+    tags). Mirrors :func:`~meho_backplane.connectors.nsx.typed_ops.register_nsx_typed_operations`.
+
+    The ``embedding_service`` keyword-only parameter is the runner
+    contract: :func:`run_typed_op_registrars` passes the process-wide
+    :class:`EmbeddingService` (or a chassis-test stub) to every registrar,
+    so each registrar must accept the kwarg. It is forwarded to
+    :func:`register_typed_operation` (which falls back to the process-wide
+    singleton when ``None``).
+    """
+    # Lazy imports: the operations package pulls in the embedding pipeline
+    # (ONNX runtime + model), which pure connector/handler unit tests
+    # should not pay. Lifespan callers have it warmed by the time this runs.
+    from meho_backplane.connectors.sddc_manager.connector import SddcManagerConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    for op in SDDC_TYPED_OPS:
+        handler = getattr(SddcManagerConnector, op.handler_attr, None)
+        if handler is None:
+            raise AttributeError(
+                f"SddcManagerConnector typed op {op.op_id!r} declares "
+                f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+            )
+        when_to_use = (
+            None if op.group_key is None else SDDC_TYPED_WHEN_TO_USE_BY_GROUP.get(op.group_key)
+        )
+        if op.group_key is not None and when_to_use is None:
+            raise ValueError(
+                f"SddcManagerConnector typed op {op.op_id!r} declares "
+                f"group_key={op.group_key!r} but no curated when_to_use exists for "
+                f"that key. Add an entry to SDDC_TYPED_WHEN_TO_USE_BY_GROUP."
+            )
+        await register_typed_operation(
+            product=SddcManagerConnector.product,
+            version=SddcManagerConnector.version,
+            impl_id=SddcManagerConnector.impl_id,
+            op_id=op.op_id,
+            handler=handler,
+            summary=op.summary,
+            description=op.description,
+            parameter_schema=op.parameter_schema,
+            response_schema=op.response_schema,
+            group_key=op.group_key,
+            when_to_use=when_to_use,
+            tags=list(op.tags),
+            safety_level=op.safety_level,
+            requires_approval=op.requires_approval,
+            llm_instructions=op.llm_instructions,
+            embedding_service=embedding_service,
+        )
+    _log.info(
+        "sddc_typed_operations_registered",
+        count=len(SDDC_TYPED_OPS),
+        product=SddcManagerConnector.product,
+        version=SddcManagerConnector.version,
+        impl_id=SddcManagerConnector.impl_id,
+    )

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_reads.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed (bound-method) read implementations for :class:`SddcManagerConnector`.
+
+The audited SDDC Manager read set (#2306) is converted from the
+ingested-row curation in
+:mod:`meho_backplane.connectors.sddc_manager.core_ops` to typed ops
+(``source_kind="typed"``) so it dispatches on a fresh boot with **zero
+catalog state** -- the #2247 failure class the ingested curation was
+subject to (per-deploy catalog state). Each function here is the body a
+thin bound-method shim on
+:class:`~meho_backplane.connectors.sddc_manager.connector.SddcManagerConnector`
+delegates to; the metadata + registrar live in
+:mod:`meho_backplane.connectors.sddc_manager.typed_ops`.
+
+Every read is issued directly on the connector's own authenticated token
+session via :meth:`HttpConnector._get_json` -- no ``dispatch_child``, no
+ingested descriptor. A raw ``401`` from a downstream call (SDDC Manager's
+expired-token signal) propagates as :class:`httpx.HTTPStatusError` up to
+the dispatcher's G0.29-T2 (#2067) recovery arm, which evicts the cached
+session token via the connector's public
+:meth:`SddcManagerConnector.invalidate_session` hook (established by
+#2290) and re-dispatches once. The handlers therefore do **not** wrap
+calls in the connector's internal ``_get_json_with_session_retry``
+helper (that helper serves the fingerprint/probe path, which the
+dispatcher does not drive).
+
+The audited 12-read set (paths from the #2294 lab audit, cross-checked
+against the VCF / SDDC Manager 9.0 API at
+https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/):
+
+* ``sddc.domain.list`` -- ``GET /v1/domains`` (management + workload
+  domain inventory).
+* ``sddc.domain.status`` -- ``GET /v1/domains/{id}/status`` (per-domain
+  status: the READY / ACTIVATING / ERROR lifecycle state).
+* ``sddc.cluster.list`` -- ``GET /v1/clusters`` (vSphere cluster
+  inventory; optional ``domainId`` filter).
+* ``sddc.host.list`` -- ``GET /v1/hosts`` (ESXi host inventory; optional
+  ``domainId`` / ``clusterId`` / ``status`` filters).
+* ``sddc.vcenter.list`` -- ``GET /v1/vcenters`` (managed vCenter
+  inventory; optional ``domainId`` filter).
+* ``sddc.nsxt_cluster.list`` -- ``GET /v1/nsxt-clusters`` (NSX-T manager
+  cluster inventory).
+* ``sddc.credential.list`` -- ``GET /v1/credentials`` (nested-infra
+  credential inventory). **Credential-read gated** (#2306): dispatch
+  routes through the approval queue (``requires_approval=True``) and the
+  op-id is classified ``credential_read`` so audit/broadcast rows collapse
+  to aggregate-only; the handler additionally scrubs every secret-keyed
+  value (``password`` / ``privateKey`` / ...) so no credential material
+  ever rides the ``OperationResult``.
+* ``sddc.task.list`` -- ``GET /v1/tasks`` (in-flight / recent VCF
+  workflow tasks; optional ``status`` filter).
+* ``sddc.system.info`` -- ``GET /v1/system`` (SDDC Manager system-level
+  settings summary).
+* ``sddc.vcf_service.list`` -- ``GET /v1/vcf-services`` (the running VCF
+  micro-service inventory + health).
+* ``sddc.manager.list`` -- ``GET /v1/sddc-managers`` (SDDC Manager
+  appliance inventory).
+* ``sddc.license.list`` -- ``GET /v1/license-keys`` (the license-key
+  inventory).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.sddc_manager.session import SddcTargetLike
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.sddc_manager.connector import SddcManagerConnector
+
+__all__ = [
+    "REDACTED",
+    "sddc_cluster_list_impl",
+    "sddc_credential_list_impl",
+    "sddc_domain_list_impl",
+    "sddc_domain_status_impl",
+    "sddc_host_list_impl",
+    "sddc_license_list_impl",
+    "sddc_manager_list_impl",
+    "sddc_nsxt_cluster_list_impl",
+    "sddc_system_info_impl",
+    "sddc_task_list_impl",
+    "sddc_vcenter_list_impl",
+    "sddc_vcf_service_list_impl",
+]
+
+_log = structlog.get_logger(__name__)
+
+# Spec-relative SDDC Manager endpoints. Every SDDC Manager REST path
+# begins with ``/v1/``; the connector's pooled per-target client carries
+# the ``Authorization: Bearer <accessToken>`` header the token session
+# primed (#2290).
+_DOMAINS_PATH = "/v1/domains"
+_DOMAIN_STATUS_PATH = "/v1/domains/{id}/status"
+_CLUSTERS_PATH = "/v1/clusters"
+_HOSTS_PATH = "/v1/hosts"
+_VCENTERS_PATH = "/v1/vcenters"
+_NSXT_CLUSTERS_PATH = "/v1/nsxt-clusters"
+_CREDENTIALS_PATH = "/v1/credentials"
+_TASKS_PATH = "/v1/tasks"
+_SYSTEM_PATH = "/v1/system"
+_VCF_SERVICES_PATH = "/v1/vcf-services"
+_SDDC_MANAGERS_PATH = "/v1/sddc-managers"
+_LICENSE_KEYS_PATH = "/v1/license-keys"
+
+#: Sentinel written in place of a scrubbed secret value. A non-empty
+#: marker (rather than dropping the key) keeps the shape stable so the
+#: agent can see a credential *existed* without learning its value. Same
+#: convention :mod:`meho_backplane.connectors.nsx.typed_reads` uses.
+REDACTED = "***REDACTED***"
+
+#: Key names (matched case-insensitively) whose value -- scalar or
+#: subtree -- is secret material scrubbed wherever it appears in a
+#: ``sddc.credential.list`` response. SDDC Manager is the system of record
+#: for nested-infra credentials, so ``GET /v1/credentials`` returns the
+#: live ``password`` (and, for certificate/SSH accounts, private-key
+#: material) alongside the credential's identity. The handler masks every
+#: known secret spelling so the returned inventory shows *which* accounts
+#: exist (username, resource, accountType) without leaking their secrets.
+_SECRET_FIELDS: frozenset[str] = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "passphrase",
+        "secret",
+        "client_secret",
+        "token",
+        "private_key",
+        "privatekey",
+        "sshprivatekey",
+        "certificate",
+    }
+)
+
+
+def _redact_secrets(value: Any) -> Any:
+    """Return *value* with secret-keyed material scrubbed, recursively.
+
+    Walks dicts and lists. A key matching :data:`_SECRET_FIELDS`
+    (case-insensitively) has its whole value replaced with
+    :data:`REDACTED`; every other value is walked so a credential nested
+    inside ``elements[].password`` -- or a private key under a nested
+    certificate object -- is still caught. Scalars pass through unchanged.
+    The input is not mutated; a new structure is returned.
+    """
+    if isinstance(value, dict):
+        return {
+            key: (
+                REDACTED
+                if isinstance(key, str) and key.lower() in _SECRET_FIELDS
+                else _redact_secrets(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_secrets(item) for item in value]
+    return value
+
+
+def _optional_query(params: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any] | None:
+    """Build a query dict from the truthy *keys* present in *params*, or ``None``.
+
+    Mirrors the NSX ``nsx.alarm.list`` filter-forwarding shape: only keys
+    the caller supplied a truthy value for are forwarded, and an empty
+    result collapses to ``None`` so :meth:`HttpConnector._get_json` omits
+    the query string entirely.
+    """
+    query: dict[str, Any] = {}
+    for key in keys:
+        val = params.get(key)
+        if val:
+            query[key] = val
+    return query or None
+
+
+async def sddc_domain_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.domain.list`` -- ``GET /v1/domains``.
+
+    Lists every VCF domain the SDDC Manager governs -- the management
+    domain plus any workload domains -- as a paginated ``{elements: [...]}``
+    envelope. The entry point for domain-scoped cluster / host / vCenter
+    reads and for mapping a workload domain to its vCenter and NSX-T
+    cluster.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _DOMAINS_PATH, operator=operator)
+
+
+async def sddc_domain_status_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.domain.status`` -- ``GET /v1/domains/{id}/status``.
+
+    Reads the lifecycle status of one VCF domain (its ACTIVE / ACTIVATING
+    / ERROR state and the last status transition). Requires a domain
+    ``id`` from ``sddc.domain.list``; the read an operator runs when a
+    domain-create or expand workflow is in flight or a domain is reported
+    unhealthy.
+    """
+    domain_id = params["id"]
+    path = _DOMAIN_STATUS_PATH.format(id=domain_id)
+    return await connector._get_json(target, path, operator=operator)
+
+
+async def sddc_cluster_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.cluster.list`` -- ``GET /v1/clusters``.
+
+    Lists vSphere clusters across all VCF domains, or narrowed to one
+    domain via the optional ``domainId`` filter. The primary inventory
+    read for cluster count, datastore type, and host membership.
+    ``{elements: [...]}`` with ``id`` / ``name`` / ``primaryDatastoreType``
+    / ``domainId`` per cluster.
+    """
+    query = _optional_query(params, ("domainId",))
+    return await connector._get_json(target, _CLUSTERS_PATH, operator=operator, params=query)
+
+
+async def sddc_host_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.host.list`` -- ``GET /v1/hosts``.
+
+    Enumerates ESXi hosts across all VCF domains, or narrowed by the
+    optional ``domainId`` / ``clusterId`` / ``status`` filters. The
+    primary read for host count, FQDN, ESXi version, and assignment
+    status. Large VCF deployments return dozens or hundreds of hosts.
+    """
+    query = _optional_query(params, ("domainId", "clusterId", "status"))
+    return await connector._get_json(target, _HOSTS_PATH, operator=operator, params=query)
+
+
+async def sddc_vcenter_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.vcenter.list`` -- ``GET /v1/vcenters``.
+
+    Lists the vCenter Server instances the SDDC Manager manages, or
+    narrowed to one domain via the optional ``domainId`` filter. Cross
+    the returned ``fqdn`` against the vSphere connector for VM-level
+    reads. ``{elements: [...]}`` with ``id`` / ``fqdn`` / ``domain`` per
+    vCenter.
+    """
+    query = _optional_query(params, ("domainId",))
+    return await connector._get_json(target, _VCENTERS_PATH, operator=operator, params=query)
+
+
+async def sddc_nsxt_cluster_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.nsxt_cluster.list`` -- ``GET /v1/nsxt-clusters``.
+
+    Lists the NSX-T manager clusters SDDC Manager manages and the domains
+    each one backs. ``{elements: [...]}`` with ``id`` / ``vipFqdn`` /
+    ``domainIds`` per NSX-T cluster -- the read for mapping which NSX-T
+    cluster fronts a given workload domain.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _NSXT_CLUSTERS_PATH, operator=operator)
+
+
+async def sddc_credential_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.credential.list`` -- ``GET /v1/credentials`` (credential-read, redacted).
+
+    Lists the nested-infra credentials SDDC Manager is the system of
+    record for -- the ESXi / vCenter / NSX-T / backup service accounts it
+    rotates and stores. SDDC Manager returns the live ``password`` (and,
+    for certificate/SSH accounts, private-key material) on this endpoint,
+    so this handler scrubs every secret-keyed value at the boundary via
+    :func:`_redact_secrets`: the returned inventory shows *which* accounts
+    exist (``username`` / ``resource`` / ``accountType`` / ``credentialType``)
+    with each secret replaced by :data:`REDACTED`.
+
+    The op is additionally credential-read *gated*: its typed registration
+    carries ``requires_approval=True`` (so the dispatcher's policy gate
+    routes it to the approval queue -- not dispatchable without operator
+    approval) and its op-id ``sddc.credential.list`` is on the
+    ``_CREDENTIAL_READ_OPS`` allowlist so ``classify_op`` collapses its
+    audit + broadcast payload to aggregate-only. The boundary scrub here
+    is the third, belt-and-suspenders layer: even the approved
+    ``OperationResult`` the operator receives carries no secret value.
+    """
+    del params  # schema declares the param object empty
+    _log.info("sddc_credential_list_read", target=target.name)
+    raw = await connector._get_json(target, _CREDENTIALS_PATH, operator=operator)
+    return cast("dict[str, Any]", _redact_secrets(raw))
+
+
+async def sddc_task_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.task.list`` -- ``GET /v1/tasks``.
+
+    Lists in-flight or recently completed VCF workflow tasks, optionally
+    narrowed by the ``status`` filter (Successful / Failed / In_Progress /
+    Pending / Cancelled). The read for monitoring a domain-expand,
+    host-commission, or update-apply workflow, or triaging one that
+    failed. ``{elements: [...]}`` with ``id`` / ``name`` / ``status`` /
+    ``type`` / ``subtasks`` / ``errors`` per task.
+    """
+    query = _optional_query(params, ("status",))
+    return await connector._get_json(target, _TASKS_PATH, operator=operator, params=query)
+
+
+async def sddc_system_info_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.system.info`` -- ``GET /v1/system``.
+
+    Reads the SDDC Manager system-level settings summary -- the
+    appliance-wide configuration (proxy, CEIP, DNS/NTP posture) SDDC
+    Manager exposes at its ``/v1/system`` root. The read for confirming
+    the SDDC Manager's own platform configuration before an inventory or
+    lifecycle operation.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _SYSTEM_PATH, operator=operator)
+
+
+async def sddc_vcf_service_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.vcf_service.list`` -- ``GET /v1/vcf-services``.
+
+    Lists the VCF platform micro-services running on the SDDC Manager
+    appliance and their status. The read for confirming the SDDC Manager
+    control plane is healthy -- which service is degraded when an
+    operation is failing for no obvious inventory reason.
+    ``{elements: [...]}`` with ``id`` / ``name`` / ``status`` /
+    ``version`` per service.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _VCF_SERVICES_PATH, operator=operator)
+
+
+async def sddc_manager_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.manager.list`` -- ``GET /v1/sddc-managers``.
+
+    Lists the SDDC Manager appliances -- their FQDN, IP, version, and the
+    management domain each belongs to. The primary read for 'which SDDC
+    Manager manages this VCF stack', and the same surface
+    :meth:`SddcManagerConnector.fingerprint` reads, exposed as an
+    operator-callable typed op. ``{elements: [...]}`` with ``id`` /
+    ``fqdn`` / ``ipAddress`` / ``version`` / ``domain`` per appliance.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _SDDC_MANAGERS_PATH, operator=operator)
+
+
+async def sddc_license_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.license.list`` -- ``GET /v1/license-keys``.
+
+    Lists the license keys registered with SDDC Manager -- their product
+    type, key, description, and usage. The read for a licensing-compliance
+    question ('is this VCF stack licensed', 'which keys are near their
+    limit'). ``{elements: [...]}`` with ``key`` / ``productType`` /
+    ``description`` / ``licenseKeyUsage`` per key.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _LICENSE_KEYS_PATH, operator=operator)

--- a/backend/tests/acceptance/_sddc_canary_fixtures.py
+++ b/backend/tests/acceptance/_sddc_canary_fixtures.py
@@ -7,10 +7,10 @@ Two SDDC Manager acceptance modules (dispatch smoke + JSONFlux force-handle)
 share the same plumbing: a registered
 :class:`~meho_backplane.connectors.sddc_manager.SddcManagerConnector` instance
 with a stub credentials loader (so no Vault read is required), a probed
-:class:`~meho_backplane.db.models.Target` row, the 9 curated
+:class:`~meho_backplane.db.models.Target` row, the 4 curated
 :class:`~meho_backplane.db.models.EndpointDescriptor` rows from
 :data:`~meho_backplane.connectors.sddc_manager.core_ops.SDDC_CORE_OPS`, and a
-:mod:`respx`-mocked SDDC Manager REST surface answering each of the 9 curated
+:mod:`respx`-mocked SDDC Manager REST surface answering each of the 4 curated
 read ops.
 
 SDDC Manager is token-only: the connector establishes a session at
@@ -26,7 +26,8 @@ Why a minimal direct-insert path (not full G0.7 canary ingest)
 The full VCF API spec ingest needs the SDDC Manager 9.0 OpenAPI spec file
 reachable on the CI runner. Until the spec-shelf is wired to the
 meho-runners pool, the dispatch leg is exercised against a minimal
-direct-insert path that seeds the 9 curated endpoint_descriptor rows by
+direct-insert path that seeds the 4 curated endpoint_descriptor rows (plus
+the hosts breadth row the JSONFlux test dispatches) by
 hand. Same pattern :mod:`tests.acceptance._nsx_canary_fixtures` established
 for NSX (which also has no public CI simulator).
 
@@ -289,7 +290,7 @@ class IngestedSddcCanary:
 
 
 async def _insert_sddc_descriptors() -> None:
-    """Seed the 9 curated SDDC Manager core ops + their groups as enabled rows.
+    """Seed the 4 curated SDDC Manager core ops + their groups as enabled rows.
 
     One :class:`OperationGroup` per entry in :data:`SDDC_CORE_GROUPS`
     (``review_status='enabled'``), one :class:`EndpointDescriptor` per entry
@@ -343,6 +344,39 @@ async def _insert_sddc_descriptors() -> None:
                 tags=["spec:sddc-manager-9.0/api.yaml"],
             )
             session.add(descriptor)
+
+        # The JSONFlux force-handle test dispatches the ingested
+        # ``GET:/v1/hosts`` breadth op. Since #2306 promoted hosts to a
+        # first-class typed op (``sddc.host.list``), the ingested row is no
+        # longer part of the curated SDDC_CORE_OPS set -- but it still exists
+        # as browse breadth. Seed it explicitly (ungrouped) so the JSONFlux
+        # test exercises the ingested-breadth surface, proving the two
+        # surfaces coexist without shadowing.
+        if SDDC_FORCE_HANDLE_LIST_OP_ID not in {op.op_id for op in SDDC_CORE_OPS}:
+            force_method, force_path = SDDC_FORCE_HANDLE_LIST_OP_ID.split(":", 1)
+            session.add(
+                EndpointDescriptor(
+                    tenant_id=None,
+                    product=SDDC_PRODUCT,
+                    version=SDDC_VERSION,
+                    impl_id=SDDC_IMPL_ID,
+                    op_id=SDDC_FORCE_HANDLE_LIST_OP_ID,
+                    source_kind="ingested",
+                    method=force_method,
+                    path=force_path,
+                    handler_ref=None,
+                    group_id=None,
+                    summary=f"SDDC Manager ingested breadth op {SDDC_FORCE_HANDLE_LIST_OP_ID}.",
+                    description=f"SDDC Manager ingested breadth op {SDDC_FORCE_HANDLE_LIST_OP_ID}.",
+                    parameter_schema=_param_schema_for(force_path),
+                    response_schema={"type": "object"},
+                    llm_instructions=None,
+                    safety_level="safe",
+                    requires_approval=False,
+                    is_enabled=True,
+                    tags=["spec:sddc-manager-9.0/api.yaml"],
+                )
+            )
         await session.commit()
 
 
@@ -382,7 +416,7 @@ SDDC_CANARY_ACCESS_TOKEN: str = "sddc-canary-access-token"
 
 
 def _register_sddc_routes(mock: respx.MockRouter) -> None:
-    """Register the session-mint route + the 9 SDDC Manager read-op routes on *mock*.
+    """Register the session-mint route + the SDDC Manager read-op routes on *mock*.
 
     SDDC Manager is token-only: the connector first POSTs ``/v1/tokens`` to
     mint an ``accessToken`` (the ``session_login_token`` scheme, #2290), then
@@ -430,7 +464,7 @@ async def ingested_sddc_canary(
     Setup mirrors :func:`tests.acceptance._nsx_canary_fixtures.ingested_nsx_canary`:
 
     1. Insert built-in :class:`OperationGroup` + :class:`EndpointDescriptor`
-       rows for the 9 curated SDDC Manager core ops.
+       rows for the 4 curated SDDC Manager core ops (plus the hosts breadth row).
     2. Seed a :class:`Target` with ``product="sddc"`` and the
        :data:`SDDC_CANARY_FINGERPRINT` so the resolver binds
        :class:`SddcManagerConnector`.

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -177,10 +177,13 @@ class TestClassifyOp:
         [
             ("vault.kv.read", "credential_read"),
             ("vault.kv.list", "credential_read"),
+            # SDDC Manager's typed GET /v1/credentials read (#2306) — the
+            # nested-infra credential inventory (system of record).
+            ("sddc.credential.list", "credential_read"),
         ],
     )
     def test_credential_read_allowlist(self, op_id: str, expected: str) -> None:
-        """Exact-match allowlist — decision #3 names these two."""
+        """Exact-match allowlist — decision #3 names these; #2306 adds the SDDC read."""
         assert classify_op(op_id) == expected
 
     @pytest.mark.parametrize(

--- a/backend/tests/test_connectors_sddc_manager_core_ops.py
+++ b/backend/tests/test_connectors_sddc_manager_core_ops.py
@@ -7,12 +7,12 @@ Covers :mod:`meho_backplane.connectors.sddc_manager.core_ops`:
 
 * :func:`classify_sddc_op` — path-prefix classifier rules.
 * :func:`apply_sddc_core_curation` — the operator-review-time
-  substrate call that flips ``review_status='enabled'`` on the 8
-  curated groups, lands ``llm_instructions`` on the 9 curated ops,
+  substrate call that flips ``review_status='enabled'`` on the 4
+  curated groups, lands ``llm_instructions`` on the 4 curated ops,
   and explicitly disables non-core ops in curated groups via the
   audit-log-driven operator-override exclusion so the
   :meth:`enable_group` cascade skips them. The load-bearing
-  assertion is "9 ops dispatchable, every other op in curated
+  assertion is "4 ops dispatchable, every other op in curated
   groups stays ``is_enabled=False``".
 
 Test harness mirrors :mod:`tests.test_connectors_nsx_core_ops`:
@@ -236,7 +236,7 @@ def test_classify_sddc_op_maps_paths_to_expected_group_keys(
 
 @pytest.mark.asyncio
 async def test_apply_curation_enables_groups_and_lands_llm_instructions() -> None:
-    """All 8 curated groups end ``enabled``; all 9 core ops carry the curated blob."""
+    """All 4 curated groups end ``enabled``; all 4 core ops carry the curated blob."""
     tenant_id = _TEST_TENANT
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)
     operator = _make_operator(tenant_id=tenant_id)
@@ -259,8 +259,8 @@ async def test_apply_curation_keeps_non_core_ops_disabled_via_override_path() ->
     """Non-core ops in curated groups stay ``is_enabled=False`` after enable_group cascade.
 
     Seeds 2 extra non-core ops per curated group, runs the helper, and
-    asserts only the 9 curated ops flip to ``is_enabled=True`` while the
-    16 non-core ops (8 groups times 2 extras) stay ``False``.
+    asserts only the 4 curated ops flip to ``is_enabled=True`` while the
+    8 non-core ops (4 groups times 2 extras) stay ``False``.
     """
     tenant_id = _TEST_TENANT
     await _seed_curated_groups_and_ops(tenant_id=tenant_id, extra_ops_per_group=2)

--- a/backend/tests/test_connectors_sddc_manager_e2e.py
+++ b/backend/tests/test_connectors_sddc_manager_e2e.py
@@ -5,7 +5,7 @@
 
 Covers all four acceptance criteria from Issue #618:
 
-(a) All 9 curated SDDC Manager read ops dispatch through the full
+(a) All 4 curated SDDC Manager ingested read ops dispatch through the full
     ``call_operation`` stack against a respx-mocked SDDC Manager
     appliance and return ``status='ok'``.
 (b) Token-session auth path: the connector mints a session token at
@@ -193,7 +193,7 @@ async def sddc_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_SddcE2EB
     3. Resolve + cache the connector instance; patch its
        ``_credentials_loader`` to bypass Vault.
     4. Activate a respx router for :data:`SDDC_CANARY_BASE_URL` and
-       register the 9 read-op routes.
+       register the SDDC Manager read-op routes.
     """
     await _insert_sddc_descriptors()
     seeded_target = await _seed_target()
@@ -221,7 +221,7 @@ async def sddc_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_SddcE2EB
 # ---------------------------------------------------------------------------
 
 _OP_IDS: tuple[str, ...] = tuple(op.op_id for op in SDDC_CORE_OPS)
-assert len(_OP_IDS) == 9, f"Expected 9 curated SDDC Manager ops, got {len(_OP_IDS)}: {_OP_IDS}"
+assert len(_OP_IDS) == 4, f"Expected 4 curated SDDC Manager ops, got {len(_OP_IDS)}: {_OP_IDS}"
 
 
 @pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
@@ -229,7 +229,10 @@ async def test_sddc_e2e_all_ops_dispatch_ok(
     op_id: str,
     sddc_e2e_canary: _SddcE2EBundle,
 ) -> None:
-    """All 9 SDDC Manager core ops dispatch through the full dispatcher and return status='ok'.
+    """All 4 curated SDDC Manager ingested ops dispatch through the full dispatcher (status='ok').
+
+    The audited 12-read operational set is now typed ops (#2306); these 4
+    are the browse-breadth curation left in ``core_ops.py``.
 
     The connector mints a session token at ``POST /v1/tokens`` from the stub
     credentials loader on first dispatch (then caches both the credentials and
@@ -294,7 +297,7 @@ async def test_sddc_e2e_credentials_cached_after_first_dispatch(
         _OPERATOR,
         {
             "connector_id": SDDC_CONNECTOR_ID,
-            "op_id": "GET:/v1/sddc-managers",
+            "op_id": "GET:/v1/network-pools",
             "target": {"name": target_name},
             "params": {},
         },
@@ -320,7 +323,7 @@ async def test_sddc_e2e_dispatch_writes_audit_row(
     * ``row.payload["op_id"]`` equals the dispatched ``op_id``.
     * ``row.payload["params_hash"]`` is present (non-None string).
     """
-    op_id = "GET:/v1/domains"
+    op_id = "GET:/v1/network-pools"
     sessionmaker = get_sessionmaker()
 
     async def _count_dispatch_rows() -> int:

--- a/backend/tests/test_connectors_sddc_manager_typed_reads.py
+++ b/backend/tests/test_connectors_sddc_manager_typed_reads.py
@@ -1,0 +1,525 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the SDDC Manager audited-read typed ops (#2306).
+
+Coverage matrix (per Task #2306 acceptance criteria):
+
+* **Zero-catalog typed dispatch (AC #1).** Each audited read dispatches
+  through :func:`~meho_backplane.operations.dispatch` against a
+  respx-mocked SDDC Manager -- with **only** the typed registrar run (no
+  ingested descriptor rows) -- and returns ``status="ok"`` on the
+  post-#2290 token session (``POST /v1/tokens`` -> Bearer). The persisted
+  descriptors carry ``source_kind="typed"``.
+* **Credential-read gating (AC #2).** ``sddc.credential.list`` is not
+  dispatchable without the elevated policy path: with ``requires_approval``
+  set, dispatch parks at ``status="awaiting_approval"`` and the
+  ``/v1/credentials`` endpoint is never hit. Its op-id classifies as
+  ``credential_read`` (audit/broadcast redaction), and the handler scrubs
+  every secret-keyed value so no credential material rides the result.
+* **Session recovery via the #2067 seam (AC #3).** A 401 on the first
+  downstream GET is recovered by the dispatcher's auth-class arm calling
+  the connector's public ``invalidate_session`` hook (#2290) and
+  re-dispatching once; the op returns ``status="ok"``.
+* **Registration-shape invariants.** The 11 non-gated reads carry
+  ``safety_level="safe"``, ``requires_approval=False``, a ``read-only``
+  tag, and non-empty llm_instructions; no write op is registered.
+
+Mirrors :mod:`tests.test_connectors_nsx_typed_reads` for the dispatch
+lifecycle + embedding stub and
+:mod:`tests.test_connectors_sddc_manager_session_dispatch` for the SDDC
+token-session mock + credentials-loader stub.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast.events import classify_op
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.sddc_manager import (
+    SDDC_CONNECTOR_ID,
+    SDDC_IMPL_ID,
+    SDDC_PRODUCT,
+    SDDC_TYPED_OPS,
+    SDDC_VERSION,
+    SddcManagerConnector,
+    register_sddc_typed_operations,
+)
+from meho_backplane.connectors.sddc_manager.typed_reads import REDACTED
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import (
+    get_or_create_connector_instance,
+    reset_handler_cache,
+)
+from meho_backplane.operations.meta_tools import search_operations
+from meho_backplane.settings import get_settings
+
+_SDDC_HOST = "sddc-typed.test.invalid"
+_SDDC_BASE_URL = f"https://{_SDDC_HOST}"
+_TOKEN_PATH = "/v1/tokens"
+_ACCESS_TOKEN = "typed-access-token"
+
+_CREDENTIAL_OP_ID = "sddc.credential.list"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher/handler caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+    register_connector_v2(
+        product=SDDC_PRODUCT,
+        version=SDDC_VERSION,
+        impl_id=SDDC_IMPL_ID,
+        cls=SddcManagerConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    reset_handler_cache()
+    clear_registry()
+
+
+@pytest.fixture
+def _stub_embedding(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    """Deterministic embedding stub so registration/search don't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.operations._search.get_embedding_service",
+        lambda: service,
+    )
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _SddcReadTarget:
+    """Target satisfying both ``SddcTargetLike`` and the resolver shape."""
+
+    def __init__(self) -> None:
+        self.product = SDDC_PRODUCT
+        self.fingerprint = type("_FP", (), {"version": SDDC_VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = uuid.UUID("00000000-0000-0000-0000-0000000000c0")
+        self.name = "sddc-typed"
+        self.host = _SDDC_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-reads/sddc-typed"
+        self.auth_model = "shared_service_account"
+        self.sso_realm = "vsphere.local"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-reads-sddc",
+        name="SDDC Reads Operator",
+        email=None,
+        raw_jwt="op.reads.sddc.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000c4"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _sddc_credentials_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Static credentials loader -- bypasses the live operator-context Vault read."""
+    return {"username": "sddc-typed-svc", "password": "sddc-typed-pw"}
+
+
+async def _register_and_resolve(_stub_embedding: AsyncMock) -> SddcManagerConnector:
+    """Run the typed registrar (only) and return the credentials-stubbed instance."""
+    await register_sddc_typed_operations()
+    instance = get_or_create_connector_instance(SddcManagerConnector)
+    instance._credentials_loader = _sddc_credentials_loader  # type: ignore[attr-defined]
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# AC #1 -- zero-catalog typed dispatch (the 10 no-param reads)
+# ---------------------------------------------------------------------------
+
+_ENVELOPE: dict[str, Any] = {
+    "elements": [{"id": "row-1"}],
+    "pageMetadata": {"totalElements": 1},
+}
+_SYSTEM_PAYLOAD: dict[str, Any] = {"proxyConfiguration": {"isEnabled": False}}
+
+
+@pytest.mark.parametrize(
+    ("op_id", "path"),
+    [
+        ("sddc.domain.list", "/v1/domains"),
+        ("sddc.cluster.list", "/v1/clusters"),
+        ("sddc.host.list", "/v1/hosts"),
+        ("sddc.vcenter.list", "/v1/vcenters"),
+        ("sddc.nsxt_cluster.list", "/v1/nsxt-clusters"),
+        ("sddc.task.list", "/v1/tasks"),
+        ("sddc.system.info", "/v1/system"),
+        ("sddc.vcf_service.list", "/v1/vcf-services"),
+        ("sddc.manager.list", "/v1/sddc-managers"),
+        ("sddc.license.list", "/v1/license-keys"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_each_typed_op_dispatches_zero_catalog(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    op_id: str,
+    path: str,
+) -> None:
+    """AC #1: each audited read dispatches typed with zero ingested catalog state."""
+    await _register_and_resolve(_stub_embedding)
+    payload = _SYSTEM_PAYLOAD if op_id == "sddc.system.info" else _ENVELOPE
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        token_route = mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        route = mock.get(path).respond(200, json=payload)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_CONNECTOR_ID,
+            op_id=op_id,
+            target=_SddcReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == payload
+    assert route.called and route.call_count == 1
+    # SDDC Manager is token-only: the session mint ran and the Bearer token
+    # rides the read -- never HTTP Basic.
+    assert token_route.called
+    assert route.calls[0].request.headers.get("authorization") == f"Bearer {_ACCESS_TOKEN}"
+
+
+@pytest.mark.asyncio
+async def test_domain_status_builds_path_from_id(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """AC #1: sddc.domain.status interpolates the domain id into the path."""
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        route = mock.get("/v1/domains/domain-mgmt/status").respond(200, json={"status": "ACTIVE"})
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_CONNECTOR_ID,
+            op_id="sddc.domain.status",
+            target=_SddcReadTarget(),
+            params={"id": "domain-mgmt"},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == {"status": "ACTIVE"}
+    assert route.called and route.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_filters_forwarded_as_query_params(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """AC #1: cluster/host/task filters forward as query params; omitted keys drop."""
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        host_route = mock.get("/v1/hosts").respond(200, json=_ENVELOPE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_CONNECTOR_ID,
+            op_id="sddc.host.list",
+            target=_SddcReadTarget(),
+            params={"domainId": "domain-mgmt", "status": "ASSIGNED"},
+        )
+
+    assert result.status == "ok", result.error
+    sent = host_route.calls[0].request.url
+    assert sent.params.get("domainId") == "domain-mgmt"
+    assert sent.params.get("status") == "ASSIGNED"
+    # clusterId was not supplied -> not forwarded.
+    assert "clusterId" not in sent.params
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_source_kind_typed(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """AC #1: the persisted descriptor rows carry ``source_kind='typed'``."""
+    await register_sddc_typed_operations()
+
+    rows = (
+        (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == SDDC_PRODUCT,
+                    EndpointDescriptor.impl_id == SDDC_IMPL_ID,
+                    EndpointDescriptor.op_id.in_([op.op_id for op in SDDC_TYPED_OPS]),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert {r.op_id for r in rows} == {op.op_id for op in SDDC_TYPED_OPS}
+    assert all(r.source_kind == "typed" for r in rows)
+    assert all(r.handler_ref is not None for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# AC #2 -- credential-read gating (sddc.credential.list)
+# ---------------------------------------------------------------------------
+
+_CREDENTIALS_PAYLOAD: dict[str, Any] = {
+    "elements": [
+        {
+            "id": "cred-esxi-01",
+            "resource": {"resourceName": "esx-01.test.invalid", "resourceType": "ESXI"},
+            "accountType": "USER",
+            "credentialType": "SSH",
+            "username": "root",
+            "password": "super-secret-esxi-pw",
+        },
+        {
+            "id": "cred-vc-01",
+            "resource": {"resourceName": "vcenter-mgmt.test.invalid", "resourceType": "VCENTER"},
+            "accountType": "SYSTEM",
+            "credentialType": "SSO",
+            "username": "administrator@vsphere.local",
+            "password": "super-secret-vc-pw",
+        },
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_credential_list_is_gated_awaiting_approval(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """AC #2: dispatch parks at awaiting_approval; the credentials endpoint is never hit."""
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        creds_route = mock.get("/v1/credentials").respond(200, json=_CREDENTIALS_PAYLOAD)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_CONNECTOR_ID,
+            op_id=_CREDENTIAL_OP_ID,
+            target=_SddcReadTarget(),
+            params={},
+        )
+
+    # The elevated policy path (approval queue) fires: the op is NOT
+    # dispatchable without an operator approval, so the read never runs.
+    assert result.status == "awaiting_approval", result
+    assert not creds_route.called
+    # No credential value could have leaked -- the endpoint wasn't called.
+    assert "super-secret-esxi-pw" not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_credential_list_handler_redacts_secrets(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """AC #2: the handler scrubs every secret value even on the approved read path.
+
+    The approval gate blocks a full dispatch, so the handler's boundary
+    redaction is exercised directly (the code that runs once an operator
+    approves and the run resumes).
+    """
+    instance = await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        mock.get("/v1/credentials").respond(200, json=_CREDENTIALS_PAYLOAD)
+        result = await instance.credential_list(_make_operator(), _SddcReadTarget(), {})
+
+    elements = result["elements"]
+    assert [e["password"] for e in elements] == [REDACTED, REDACTED]
+    # Non-secret identity fields survive so the inventory is still useful.
+    assert elements[0]["username"] == "root"
+    assert elements[0]["resource"]["resourceType"] == "ESXI"
+    # No secret value appears anywhere in the returned structure.
+    blob = repr(result)
+    assert "super-secret-esxi-pw" not in blob
+    assert "super-secret-vc-pw" not in blob
+
+
+def test_credential_op_registration_shape() -> None:
+    """AC #2: the credential op is gated via the existing safety_level/policy mechanism."""
+    op = next(o for o in SDDC_TYPED_OPS if o.op_id == _CREDENTIAL_OP_ID)
+    assert op.requires_approval is True
+    assert op.safety_level == "caution"
+    assert "credential-read" in op.tags
+
+
+def test_credential_op_classifies_as_credential_read() -> None:
+    """AC #2: classify_op returns credential_read so audit/broadcast rows redact."""
+    assert classify_op(_CREDENTIAL_OP_ID) == "credential_read"
+
+
+# ---------------------------------------------------------------------------
+# AC #3 -- session recovery via the #2067 dispatch-path seam
+# ---------------------------------------------------------------------------
+
+
+def test_connector_advertises_public_invalidate_session() -> None:
+    """AC #3: the #2067 duck-typed hook is present (established by #2290)."""
+    hook = getattr(SddcManagerConnector, "invalidate_session", None)
+    assert callable(hook)
+
+
+@pytest.mark.asyncio
+async def test_typed_dispatch_recovers_from_session_expiry(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """AC #3: a 401 on the first read is recovered via invalidate_session + re-dispatch."""
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        token_route = mock.post(_TOKEN_PATH)
+        token_route.side_effect = [
+            httpx.Response(200, json={"accessToken": _ACCESS_TOKEN}),
+            httpx.Response(200, json={"accessToken": f"{_ACCESS_TOKEN}-2"}),
+        ]
+        domains_route = mock.get("/v1/domains")
+        domains_route.side_effect = [
+            httpx.Response(401),
+            httpx.Response(200, json=_ENVELOPE),
+        ]
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_CONNECTOR_ID,
+            op_id="sddc.domain.list",
+            target=_SddcReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == _ENVELOPE
+    # One 401 + one recovered 200 = two domain calls; two token mints.
+    assert domains_route.call_count == 2
+    assert token_route.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# search_operations visibility + registration-shape invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_registered_ops_are_visible_to_search_operations(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """The registered typed ops are retrievable via search_operations."""
+    await register_sddc_typed_operations()
+
+    result = await search_operations(
+        _make_operator(),
+        {
+            "connector_id": SDDC_CONNECTOR_ID,
+            "query": "sddc vcf domains hosts credentials tasks licenses",
+            "limit": 25,
+        },
+    )
+    found = {hit["op_id"] for hit in result["hits"]}
+    expected = {op.op_id for op in SDDC_TYPED_OPS}
+    assert expected <= found, f"missing from search: {expected - found}"
+
+
+_EXPECTED_OP_IDS = {
+    "sddc.domain.list",
+    "sddc.domain.status",
+    "sddc.cluster.list",
+    "sddc.host.list",
+    "sddc.vcenter.list",
+    "sddc.nsxt_cluster.list",
+    "sddc.credential.list",
+    "sddc.task.list",
+    "sddc.system.info",
+    "sddc.vcf_service.list",
+    "sddc.manager.list",
+    "sddc.license.list",
+}
+
+
+def test_typed_ops_table_is_exactly_the_audited_read_set() -> None:
+    assert {op.op_id for op in SDDC_TYPED_OPS} == _EXPECTED_OP_IDS
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS - {_CREDENTIAL_OP_ID}))
+def test_each_non_credential_op_is_safe_no_approval_and_read_only(op_id: str) -> None:
+    op = next(o for o in SDDC_TYPED_OPS if o.op_id == op_id)
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert "read-only" in op.tags
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_has_llm_instructions_with_when_to_use_and_output_shape(op_id: str) -> None:
+    op = next(o for o in SDDC_TYPED_OPS if o.op_id == op_id)
+    assert op.llm_instructions is not None
+    assert op.llm_instructions.get("when_to_use", "").strip() != ""
+    assert "output_shape" in op.llm_instructions
+
+
+@pytest.mark.parametrize("op_id", sorted(_EXPECTED_OP_IDS))
+def test_each_op_parameter_schema_disallows_additional_properties(op_id: str) -> None:
+    op = next(o for o in SDDC_TYPED_OPS if o.op_id == op_id)
+    assert op.parameter_schema.get("additionalProperties") is False
+
+
+def test_no_write_or_mutating_op_is_registered() -> None:
+    """Read-only Task: no create/write op ships (SDDC writes are out of scope)."""
+    for op in SDDC_TYPED_OPS:
+        assert not any(
+            token in op.op_id for token in (".create", ".delete", ".update", ".set", ".put")
+        )
+        assert "write" not in op.tags

--- a/docs/codebase/connectors-sddc-manager.md
+++ b/docs/codebase/connectors-sddc-manager.md
@@ -5,10 +5,19 @@
 The `sddc-manager` connector is the hand-rolled `HttpConnector` subclass that
 dispatches SDDC Manager REST operations under the
 `(product="sddc-manager", version="9.0", impl_id="sddc-rest")` registry triple.
-G3.5-T4 (#616) shipped the skeleton — HTTP Basic auth, fingerprint, probe, and
-the G0.6 dispatch shim. G3.5-T5 (#617) added spec ingestion + operator-review
-curation + 9 read-only core ops. G3.5-T6 (#618) shipped the CLI verb tree
-(`meho sddc-manager …`) + recorded-fixture E2E integration test.
+G3.5-T4 (#616) shipped the skeleton — fingerprint, probe, and the G0.6 dispatch
+shim. G3.5-T5 (#617) added spec ingestion + operator-review curation. #2290
+rebuilt the auth on the profile-derived `session_login_token` token session
+(`POST /v1/tokens` → Bearer; the appliance rejects HTTP Basic). G3.5-T6 (#618)
+shipped the CLI verb tree (`meho sddc-manager …`) + recorded-fixture E2E test.
+
+#2306 converted the audited 12-read lab-audit set to first-class **typed** ops
+(`source_kind="typed"`, `typed_ops.py` / `typed_reads.py`) that dispatch on a
+fresh boot with zero catalog ingest. This is now the documented operational
+surface; the wider ingested VCF catalog stays as profiled-dispatch breadth
+(#2271) under its own `METHOD:path` op_ids (two surfaces, no resolver
+shadowing — typed ops never resolve through `endpoint_descriptor` rows, #2262).
+The four non-audited curated reads stay as ingested-row curation in `core_ops.py`.
 
 Source: `backend/src/meho_backplane/connectors/sddc_manager/`.
 
@@ -143,10 +152,50 @@ client.
 - **structlog** — a single `sddc_manager_credentials_loaded` info event per
   successful first-use credential load; no other emit points in this skeleton.
 
+## `typed_ops.py` / `typed_reads.py` — typed read surface (#2306)
+
+The audited 12-read lab-audit set ships as typed ops. `typed_reads.py` holds
+the async handler bodies (each issues one `connector._get_json(...)` on the
+token session); `connector.py` exposes them as thin bound-method shims
+(`domain_list`, `credential_list`, …) so the dispatcher's `import_handler`
+walk recovers each callable from its persisted `module.ClassName.method`
+`handler_ref`. `typed_ops.py` carries the `SddcTypedOp` metadata tuple
+(`SDDC_TYPED_OPS`) and the `register_sddc_typed_operations` registrar, queued
+onto the lifespan runner in `__init__.py`. A raw `401` propagates to the
+dispatcher's #2067 recovery arm, which calls the connector's public
+`invalidate_session` hook (from #2290) and re-dispatches once.
+
+| op_id | group | path |
+|---|---|---|
+| `sddc.domain.list` | `sddc-inventory` | `GET /v1/domains` |
+| `sddc.domain.status` | `sddc-inventory` | `GET /v1/domains/{id}/status` |
+| `sddc.cluster.list` | `sddc-inventory` | `GET /v1/clusters` |
+| `sddc.host.list` | `sddc-inventory` | `GET /v1/hosts` |
+| `sddc.vcenter.list` | `sddc-inventory` | `GET /v1/vcenters` |
+| `sddc.nsxt_cluster.list` | `sddc-inventory` | `GET /v1/nsxt-clusters` |
+| `sddc.credential.list` | `sddc-credentials` | `GET /v1/credentials` |
+| `sddc.task.list` | `sddc-tasks-typed` | `GET /v1/tasks` |
+| `sddc.system.info` | `sddc-platform` | `GET /v1/system` |
+| `sddc.vcf_service.list` | `sddc-platform` | `GET /v1/vcf-services` |
+| `sddc.manager.list` | `sddc-platform` | `GET /v1/sddc-managers` |
+| `sddc.license.list` | `sddc-platform` | `GET /v1/license-keys` |
+
+**Credential-read gating (`sddc.credential.list`).** SDDC Manager is the system
+of record for nested-infra credentials; its `GET /v1/credentials` read returns
+live account secrets. The typed op is gated via the existing mechanism:
+`requires_approval=True` (so `policy_gate` routes it to the approval queue —
+not dispatchable without operator approval), the op-id is on
+`broadcast.events._CREDENTIAL_READ_OPS` (so `classify_op` returns
+`credential_read` and audit/broadcast rows collapse to aggregate-only), and the
+handler scrubs every secret-keyed value at the connector boundary
+(`_redact_secrets`). Three layers; no secret ever rides the result. `safety_level`
+is `caution`; the other 11 reads are `safe` / no-approval.
+
 ## `core_ops.py` — curation module
 
-`core_ops.py` is the operator-review metadata store for the curated 9-op read
-core. It mirrors the pattern `connectors/nsx/core_ops.py` established for NSX.
+`core_ops.py` is the operator-review metadata store for the 4 non-audited curated
+reads left after #2306 promoted the audited set to typed ops. It mirrors the
+pattern `connectors/nsx/core_ops.py` established for NSX.
 
 ### `classify_sddc_op(op_id) -> str`
 
@@ -159,8 +208,8 @@ classification.
 
 The operator-review-time substrate call. After this call:
 
-- All 8 curated groups land `review_status='enabled'`.
-- Exactly the 9 ops in `SDDC_CORE_OPS` are `is_enabled=True`.
+- All 4 curated groups land `review_status='enabled'`.
+- Exactly the 4 ops in `SDDC_CORE_OPS` are `is_enabled=True`.
 - Every other op in a curated group carries an operator-override audit row
   (`is_enabled=False`) that the `enable_group` cascade respects.
 - Each curated op carries the reviewed `llm_instructions` blob.
@@ -173,19 +222,21 @@ Re-running is safe: `enable_group` short-circuits on already-enabled groups
 (no audit row), but `edit_group` and `edit_op` always emit one audit row per
 call even on no-op values. Intended posture is a one-shot curation after ingest.
 
-### The 9 curated ops
+### The 4 curated ops
 
 | op_id | group | cli alias |
 |---|---|---|
 | `GET:/v1/releases/system` | `sddc-releases` | `sddc.about` |
-| `GET:/v1/sddc-managers` | `sddc-managers` | `sddc.manager.list` |
-| `GET:/v1/domains` | `sddc-domains` | `sddc.domain.list` |
 | `GET:/v1/domains/{id}` | `sddc-domains` | `sddc.domain.info` |
-| `GET:/v1/clusters` | `sddc-clusters` | `sddc.cluster.list` |
-| `GET:/v1/hosts` | `sddc-hosts` | `sddc.host.list` |
 | `GET:/v1/network-pools` | `sddc-network-pools` | `sddc.network_pool.list` |
 | `GET:/v1/bundles` | `sddc-bundles` | `sddc.bundle.list` |
-| `GET:/v1/tasks` | `sddc-tasks` | `sddc.workflow.list` |
+
+The audited operational reads (domains list + status, clusters, hosts, vcenters,
+nsxt-clusters, credentials, tasks, system, vcf-services, sddc-managers,
+license-keys) moved to typed ops in #2306 (see the typed read surface above);
+their ingested rows still exist and stay browsable but `core_ops.py` no longer
+flips them to `is_enabled=True`. `SDDC_PATH_RULES` retains the full `/v1/`
+taxonomy so the ingested breadth keeps its group organisation.
 
 Lifecycle-write ops (`workflow start`, `domain create`, `cluster expand`,
 `host commission`) remain `staged` (never enabled) per Initiative #368 v0.2


### PR DESCRIPTION
## Summary

- Converts the audited **12-read SDDC Manager lab-audit set** (`domains`, `domains/{id}/status`, `clusters`, `hosts`, `vcenters`, `nsxt-clusters`, `credentials`, `tasks`, `system`, `vcf-services`, `sddc-managers`, `license-keys`) to first-class **typed ops** (`source_kind="typed"`, `sddc.*` op-ids) that dispatch on a fresh boot with **zero catalog ingest**, riding the post-#2290 `session_login_token` token session (`POST /v1/tokens` → Bearer) with one-shot 401 recovery via the #2067 `invalidate_session` seam.
- New `typed_ops.py` (metadata + lifespan registrar) + `typed_reads.py` (handler bodies) mirror the NSX #2302 pattern; the connector exposes thin bound-method shims. Built against the **post-#2290 token session** the current `connectors/sddc_manager/` code leaves canonical (not the old Basic-only session).
- `core_ops.py` ingested-row curation is **repointed for the converted ops**: the 5 overlapping reads leave the curated set (now 4 non-audited browse-breadth reads: release, domain detail, network-pools, bundles), while the ingested VCF catalog stays browsable as profiled-dispatch breadth (#2271) under its own `METHOD:path` op-ids — **two surfaces, no resolver shadowing** (#2262 invariant holds: typed ops carry dotted op-ids + `handler_ref` and never resolve through `endpoint_descriptor` rows).

## Credential-read gating for `/v1/credentials`

Mapped to the **existing** safety_level/policy mechanism (no new mechanism invented):

- **`requires_approval=True`** → the dispatcher's `policy_gate` routes it to the approval queue (G11.7-T1 #1401) — **not dispatchable without the elevated policy path** (operator approval). Verified: dispatch parks at `status="awaiting_approval"` and `GET /v1/credentials` is never hit.
- op-id `sddc.credential.list` added to **`broadcast.events._CREDENTIAL_READ_OPS`** → `classify_op` returns `credential_read`, so audit + broadcast rows collapse to **aggregate-only** (redacted) — the same mechanism `vault.kv.read` uses.
- the handler **scrubs every secret-keyed value** at the connector boundary (`_redact_secrets`) so no credential material rides the `OperationResult` even on the approved path.
- `safety_level="caution"` (elevated-sensitivity read); the other 11 reads are `safe` / no-approval.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (8 source files)
- [x] `code-quality.py --diff` — 0 blockers (one justified `code-quality-allow` on the declarative 12-op metadata table)
- [x] New `test_connectors_sddc_manager_typed_reads.py` — 57 passed: zero-catalog typed dispatch of all reads (Bearer, not Basic); credential gating (awaiting_approval, endpoint never hit); handler redaction; `credential_read` classification; #2067 session-expiry recovery; `source_kind="typed"` rows; registration-shape invariants.
- [x] `test_broadcast_events.py` — `classify_op("sddc.credential.list") == "credential_read"` pinned.
- [x] SDDC core-ops / e2e / credread / auth / session-dispatch / acceptance smoke — updated for the 4-op curated set; green (211 passed in the SDDC+broadcast sweep).
- [x] Broader dispatch/lifespan/meta-tools/boot-stamp/catalog/NSX sweep — 661 passed, 0 failed.
- [x] **No OpenAPI snapshot delta** (AC #4): no FastAPI route/schema touched; `make snapshot-openapi` produced no diff.
- [x] Integration doubles under `tests/integration/` — none reference the SDDC connector.

## Out of scope

- The session/auth itself (#2290), SDDC writes (none wanted), profiled ingested dispatch (#2271), T7 apparatus retirement.
- Pre-existing staleness in `docs/codebase/connectors-sddc-manager.md` referring to "HTTP Basic auth" in some sections is a #2290 doc miss (adjacent finding); the auth Overview + the surfaces this task changed are corrected here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2306


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 12 typed, read-only SDDC Manager operations available immediately without catalog ingestion.
  * Added inventory, platform, task, license, and service read capabilities with guided usage details.
  * Added automatic one-time recovery when an authenticated session expires.

* **Security**
  * Credential inventory reads now require approval.
  * Sensitive credential values are redacted from results and event broadcasts.

* **Updates**
  * Refined the curated SDDC Manager operation set to four core reads.
  * Updated connector documentation and acceptance coverage for the expanded read surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->