### PR TITLE
docs(changelog): flag vRLI overlay swap as a v0.21.0 operator action (#2358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,18 @@ connector-related release-notes line.
   identity constants each package re-exports are preserved (relocated into the
   package `__init__.py`), so `from meho_backplane.connectors.<pkg> import
   <PROD>_CONNECTOR_ID` still resolves.
+- **Operator action — vRLI canonical-spec swap on the consumer deploy.** If a
+  deploy still serves the hand-edited **gist overlay** of the `vcf-logs-9.0`
+  OpenAPI spec, retire it in this upgrade: the two blockers that forced the
+  overlay are fixed as of v0.20.0 (`#2066` `{+path}` reserved-expansion render,
+  `#1796` `servers[]` base path), so the **canonical** spec now ingests clean.
+  Re-ingest the canonical spec, confirm it does not trip the `#2272`
+  YAML-timestamp ingest class, spot-check a read (`GET:/api/v2/version` → ok;
+  the typed `vrli.event.query` op is unaffected — typed reads have no ingest
+  dependency), then delete the gist. No MEHO code change is required — it is an
+  operator action on the deploy. Tracked with a runbook on `#2358` and
+  coordinated on `evoila-bosnia/claude-rdc-hetzner-dc#1790`.
+
 ### Changed — nsx/connector.py split under the file-size budget (#2356)
 
 - `nsx/connector.py` dropped from 600 to ~562 lines, back under the


### PR DESCRIPTION
## Summary

Records the remaining #2358 (T7) operator follow-up in the **v0.21.0** release
notes (the `[Unreleased]` section), attached to the curation-retirement entry it
belongs to.

The vRLI production **gist overlay** on the consumer deploy can be retired now
that its two blockers are fixed in v0.20.0 (#2066 `{+path}`, #1796 `servers[]`):
re-ingest the canonical `vcf-logs-9.0` spec, verify it doesn't trip #2272, delete
the gist. No MEHO code change — an operator action, surfaced so operators reading
v0.21.0 notes see it. Runbook lives on #2358; coordinated on
evoila-bosnia/claude-rdc-hetzner-dc#1790.

## Test plan

- [x] CHANGELOG-only change (12-line note under the existing `## [Unreleased]`
  Removed entry). No code, no schema, no tests affected.

Refs #2358