### PR TITLE
fix(approvals): bind parent_audit_id on agent-run resume dispatch (#2323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — agent-run resume stamps `parent_audit_id` so approved chains replay as one subtree (#2323)
+
+- Completing #2086: an approval chain resumed by the **in-process agent
+  runtime** (broadcast-driven `/decide` / MCP path) now emits its executed
+  DISPATCH row with `parent_audit_id` pointing at the `approval.request`
+  row, matching what the decision row already did. Previously the agent
+  waiter re-dispatched on the agent's own task, where `parent_audit_id_var`
+  still held the top-level value (`None`), so the executed row orphaned as a
+  **second root** in `meho.audit.query` / `meho.audit.replay` even though
+  `agent_session_id` anchored the chain.
+- Fix is scoped to `agent/approval_wait.py::_resume_approved_or_already_resumed`:
+  it loads the parked row's pre-generated `request_audit_id` (tenant-isolated
+  `get_request`) and binds `parent_audit_id_var` (token-scoped) around
+  `call_operation_with_approval`. The operator/REST resume path already bound
+  it via #2312's `_dispatch_resume_with_bound_context`; this closes the
+  remaining agent-run gap. No schema change (column shipped in migration
+  0053), no route/OpenAPI change.
+- Adds a regression test that drives the four-eyes agent decide-path resume
+  end to end and asserts the executed dispatch back-links to the request,
+  the chain has exactly one null-parent row, and `replay_session`
+  reconstructs one subtree (`approval.request` → {`approval.decision`,
+  `<op_id>`}).
+
 ### Fixed — vCenter filtered listings key `filter.*` params off the mount flavor (modern `/api` no longer 400s) (#2298)
 
 - Filtered vCenter listings sent legacy `/rest`-style `filter.`-prefixed

--- a/backend/src/meho_backplane/agent/approval_wait.py
+++ b/backend/src/meho_backplane/agent/approval_wait.py
@@ -511,6 +511,19 @@ async def _resume_approved_or_already_resumed(
     operator surface already executed it, so surface a clean
     already-executed envelope to the agent rather than double-dispatching.
 
+    Audit lineage (#2323, completing #2086): the executed dispatch row must
+    parent-link to the ``approval.request`` row so an approved chain replays
+    as one subtree (request → decision + executed dispatch), not two roots.
+    The operator resume path binds ``parent_audit_id`` off the parked row in
+    :func:`~meho_backplane.operations.approval_queue._dispatch_resume_with_bound_context`;
+    this in-process waiter re-dispatches on the *agent's own task*, where
+    ``parent_audit_id_var`` still carries the original top-level value
+    (``None`` for a plain agent tool call) — so without the bind below the
+    resumed dispatch would emit ``parent_audit_id = NULL`` and orphan as a
+    second audit root. ``agent_session_id_var`` is already bound on the
+    agent task (the requester's run), so the session anchor needs no
+    re-bind; only the parent link does.
+
     Local imports mirror each other (and the wider module convention):
     ``meta_tools`` imports from ``operations.dispatcher`` which imports back
     through ``meho_backplane.agent.invoke``, so a module-level import here
@@ -533,9 +546,27 @@ async def _resume_approved_or_already_resumed(
 
     # The re-dispatch threads ``_approved=True`` through the policy gate, so
     # the durable approval-decision row is the authorization.
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.operations._audit import parent_audit_id_var
+    from meho_backplane.operations.approval_queue import get_request
     from meho_backplane.operations.meta_tools import call_operation_with_approval
 
-    return await call_operation_with_approval(operator, call_arguments)
+    # Load the parked row's pre-generated ``approval.request`` audit id
+    # (tenant-isolated) so the resumed dispatch back-links to it. Pre-0053
+    # rows carry ``request_audit_id IS NULL`` → binds ``None`` (the var's
+    # default), which is the correct no-op for a chain that never had the
+    # anchor.
+    async with get_sessionmaker()() as session:
+        request = await get_request(
+            session,
+            tenant_id=operator.tenant_id,
+            request_id=approval_request_id,
+        )
+    parent_token = parent_audit_id_var.set(request.request_audit_id)
+    try:
+        return await call_operation_with_approval(operator, call_arguments)
+    finally:
+        parent_audit_id_var.reset(parent_token)
 
 
 async def resume_or_surface_awaiting_approval(

--- a/backend/tests/test_agent_approval_resume.py
+++ b/backend/tests/test_agent_approval_resume.py
@@ -521,6 +521,191 @@ async def test_resume_re_dispatches_on_approval_via_decide_path(
     clear_registry()
 
 
+async def test_resume_stamps_parent_audit_id_so_chain_replays_as_one_subtree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2323 (completing #2086): the agent-resumed dispatch back-links to the request.
+
+    The in-process agent waiter re-dispatches on the agent's own task, where
+    ``parent_audit_id_var`` still carries the original top-level value
+    (``None`` for a plain tool call). Before the fix the executed DISPATCH
+    row therefore emitted ``parent_audit_id = NULL`` and replayed as a
+    *second root*, breaking the one-subtree invariant #2086 established.
+
+    This drives the full agent decide-path resume with an ``agent_session_id``
+    bound (as a real agent run has), then asserts:
+
+    1. The executed DISPATCH row's ``parent_audit_id`` equals the parking
+       ``approval.request`` row's audit id (the same anchor the decision row
+       parents to).
+    2. The chain has exactly one null-parent row — the ``approval.request``
+       root — not two.
+    3. ``replay_session`` reconstructs one subtree: the request row as root
+       with the decision and the executed dispatch as its children.
+    """
+    import meho_backplane.operations._audit as audit_module
+    from meho_backplane.audit_query.replay import replay_session
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+    from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+    from meho_backplane.operations import (
+        dispatch,
+        register_typed_operation,
+        reset_dispatcher_caches,
+    )
+    from meho_backplane.operations._audit import agent_session_id_var, parent_audit_id_var
+    from meho_backplane.operations.approval_queue import approve_request
+
+    async def _capture(event: Any) -> None:
+        pass
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+
+    reset_dispatcher_caches()
+    clear_registry()
+
+    class _OkConnector(Connector):
+        product = "appres2test"
+        version = "1.x"
+        impl_id = "appres2test"
+        priority = 10
+
+        async def fingerprint(self, host: str, port: int | None) -> FingerprintResult:
+            return FingerprintResult(
+                probe=ProbeResult(reachable=True, probe_method="none"),
+                product="appres2test",
+                version="1.x",
+            )
+
+        async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(  # type: ignore[override]
+            self, target: Any, op_id: str, params: dict[str, Any]
+        ) -> Any:
+            raise NotImplementedError
+
+    register_connector_v2(product="appres2test", version="", impl_id="", cls=_OkConnector)
+
+    stub_emb = AsyncMock()
+    stub_emb.encode_one.return_value = [0.1] * 384
+    stub_emb.encode.return_value = [[0.1] * 384]
+    stub_emb.dimension = 384
+
+    await register_typed_operation(
+        product="appres2test",
+        version="1.x",
+        impl_id="appres2test",
+        op_id="appres2test.op",
+        handler=_approval_resume_test_handler,
+        summary="Test op requiring approval.",
+        description="Test.",
+        parameter_schema={"type": "object"},
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_emb,
+    )
+
+    operator = _make_operator(sub="agent-lineage-requester")
+    call_arguments: dict[str, Any] = {
+        "connector_id": "appres2test-1.x",
+        "op_id": "appres2test.op",
+        "params": {"x": 7},
+        "target": None,
+    }
+
+    # Step 1: park the op under a bound agent session — exactly what
+    # AgentInvoker sets around a run, so the parked row (and every resumed
+    # row) anchors in the session and replay can reconstruct the chain.
+    session_id = uuid.uuid4()
+    session_token = agent_session_id_var.set(session_id)
+    try:
+        first = await dispatch(
+            operator=operator,
+            connector_id="appres2test-1.x",
+            op_id="appres2test.op",
+            target=None,
+            params=call_arguments["params"],
+        )
+    finally:
+        agent_session_id_var.reset(session_token)
+    assert first.status == "awaiting_approval"
+    approval_request_id = uuid.UUID(first.extras["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        from meho_backplane.db.models import ApprovalRequest
+
+        parked = await s.get(ApprovalRequest, approval_request_id)
+        assert parked is not None
+        assert parked.agent_session_id == session_id
+        assert parked.request_audit_id is not None
+        request_audit_id = parked.request_audit_id
+
+    # Step 2: a distinct human operator approves via the /decide path.
+    reviewer = _make_operator(sub="human-reviewer", principal_kind=PrincipalKind.USER)
+    async with get_sessionmaker()() as s:
+        row = await approve_request(s, approval_request_id, operator=reviewer, params=None)
+        await s.commit()
+    assert row.status == "approved"
+
+    # Step 3: drive the agent resume with the session re-bound (as the
+    # agent's own task still carries it while it awaits the decision).
+    _stub_broadcast_client_with_decision(
+        monkeypatch=monkeypatch,
+        decision_entry=_build_decision_entry(
+            approval_request_id=approval_request_id,
+            decision="approved",
+        ),
+    )
+    awaiting_envelope = first.model_dump(mode="json")
+    session_token = agent_session_id_var.set(session_id)
+    try:
+        resumed = await resume_or_surface_awaiting_approval(
+            operator=operator,
+            call_arguments=call_arguments,
+            awaiting_envelope=awaiting_envelope,
+            timeout_seconds=2.0,
+        )
+    finally:
+        agent_session_id_var.reset(session_token)
+    assert resumed["status"] == "ok", f"expected ok, got {resumed!r}"
+    # The bind is token-scoped: the var is back to its default after resume.
+    assert parent_audit_id_var.get() is None
+
+    async with get_sessionmaker()() as fresh:
+        dispatch_row = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.method == "DISPATCH")))
+            .scalars()
+            .one()
+        )
+        # (1) the executed dispatch back-links to the parking request row.
+        assert dispatch_row.parent_audit_id == request_audit_id
+        assert dispatch_row.agent_session_id == session_id
+
+        # (2) exactly one null-parent row across the chain — the request root.
+        anchored = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.agent_session_id == session_id)))
+            .scalars()
+            .all()
+        )
+        assert len(anchored) >= 3
+        null_parents = [r for r in anchored if r.parent_audit_id is None]
+        assert len(null_parents) == 1
+        assert null_parents[0].path == "approval.request"
+
+        # (3) replay renders one subtree, not two roots.
+        forest = await replay_session(session_id, tenant_id=_TENANT_ID, session=fresh)
+
+    assert len(forest) == 1
+    chain_root = forest[0]
+    assert chain_root.path == "approval.request"
+    child_paths = sorted(child.path for child in chain_root.children)
+    assert child_paths == ["appres2test.op", "approval.decision"]
+
+    reset_dispatcher_caches()
+    clear_registry()
+
+
 async def test_resume_surfaces_rejection_to_model(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -639,14 +639,32 @@ re-hydrate later. Two columns on `approval_request` (migration `0053`):
 `approval_queue._write_audit_row` reads both off the row (never the
 approver's contextvars): the request row anchors on the session with no
 parent (chain root); decision rows anchor on the same session and
-parent-link to `request_audit_id`. `resume_dispatch_after_approval`
-re-binds `agent_session_id_var` + `parent_audit_id_var` (token-scoped,
-alongside `work_ref_var`) around the `dispatch(..., _approved=True)`, so
-the executed op's DISPATCH row anchors in the originating session and
-back-links to the parking row. Net result: >= 3 session-anchored rows
-per approved chain, tree shape `approval.request` → {`approval.decision`,
-`<op_id>`}. Pre-0053 rows keep NULLs and simply stay out of replay (the
-pre-fix behaviour).
+parent-link to `request_audit_id`.
+
+The executed-dispatch row must also carry `parent_audit_id` for the
+chain to replay as one subtree, and both resume paths bind it:
+
+- **Operator surfaces** (REST `/approve` + `/decide`, MCP, UI) —
+  `resume_dispatch_after_approval` →
+  `_dispatch_resume_with_bound_context` re-binds `agent_session_id_var`
+  \+ `parent_audit_id_var` (token-scoped, alongside `work_ref_var`)
+  around the `dispatch(..., _approved=True)`, because the approver runs
+  on a fresh task whose contextvars are unset.
+- **In-process agent-run resume** (#2323, completing #2086) — the
+  broadcast-driven agent waiter
+  (`agent/approval_wait.py::_resume_approved_or_already_resumed`)
+  re-dispatches on the agent's *own* task, where `agent_session_id_var`
+  is still bound but `parent_audit_id_var` holds the original top-level
+  value (`None` for a plain tool call). It loads the parked row's
+  `request_audit_id` (tenant-isolated `get_request`) and binds
+  `parent_audit_id_var` around `call_operation_with_approval`, so the
+  agent-run chain no longer orphans its executed dispatch as a second
+  root.
+
+Net result on either path: >= 3 session-anchored rows per approved
+chain, tree shape `approval.request` → {`approval.decision`, `<op_id>`}.
+Pre-0053 rows keep NULLs and simply stay out of replay (the pre-fix
+behaviour).
 
 ## MCP elicitation URL-mode (forward-looking)
 


### PR DESCRIPTION
## Summary

- Completes #2086: the **in-process agent-runtime** resume path now stamps `parent_audit_id` on the executed dispatch so an approved chain replays as one subtree, not two roots.
- Root cause (mechanism-confirmed in the issue's grounding comment): the agent waiter re-dispatches on the agent's own task, where `parent_audit_id_var` still holds the original top-level value (`None` for a plain tool call), so the executed DISPATCH row emitted `parent_audit_id = NULL` and orphaned as a second audit root. The operator/REST resume path already bound it via #2312's `_dispatch_resume_with_bound_context`; this closes the remaining agent-run gap.
- Fix is scoped to `agent/approval_wait.py::_resume_approved_or_already_resumed`: load the parked row's pre-generated `request_audit_id` (tenant-isolated `get_request`) and bind `parent_audit_id_var` (token-scoped) around `call_operation_with_approval`. `agent_session_id_var` is already bound on the agent task, so only the parent link needed re-binding.
- No schema change (the column shipped in migration 0053), no route/schema change, no OpenAPI snapshot change, no new migration.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/agent/approval_wait.py` — Success, no issues
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (warnings only, pre-existing / under the 100-line hard cap)
- [x] New regression test `test_resume_stamps_parent_audit_id_so_chain_replays_as_one_subtree` — drives the four-eyes agent decide-path resume end to end and asserts (1) the executed dispatch back-links to the request row, (2) the chain has exactly one null-parent row (`approval.request`), (3) `replay_session` reconstructs one subtree. Verified it **fails** without the source fix and passes with it.
- [x] `pytest tests/test_agent_approval_resume.py tests/test_approval_queue.py tests/test_audit_replay.py tests/test_api_v1_approvals.py tests/test_agent_audit_invocation.py` — 84 passed.

## Out of scope

- The REST/operator resume path — already binds `parent_audit_id` via #2312 (`_dispatch_resume_with_bound_context`), with existing coverage in `test_approval_queue.py`.
- Backfill of pre-fix historical chains via `agent_session_id` (the issue flags it as an optional follow-up; not done here).
- Same-files note: serialized with the approvals-cluster siblings #2322 / #2332.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2323


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed approval-chain resumes so audit records remain linked to the original approval request.
  * Prevented resumed operations from appearing as separate roots during session replay.

* **Documentation**
  * Clarified approval audit lineage and replay behavior for operator and agent-run resume paths.

* **Tests**
  * Added integration coverage verifying resumed approval chains reconstruct as a single replay subtree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->