### PR TITLE
feat(connectors): redaction-safe proposed_effect preview for vault.kv.* credential writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,31 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — redaction-safe `proposed_effect` preview for `vault.kv.*` credential writes (#2332)
+
+- A parked `vault.kv.put` / `patch` / `delete` approval request now
+  carries a bespoke, redaction-safe `proposed_effect` preview instead of
+  the op-identity-only default. The approver sees the KV **mount**,
+  **path**, KV **version**, the write **semantics** (`put` = wholesale
+  replace, `patch` = merge, `delete` = version soft-delete), and the set
+  of **key names** being written — never their **values**. This restores
+  the approver's ability to distinguish "rotate the throwaway probe key"
+  from "clobber the production database password" while keeping the
+  value-redaction promise the credential-class suppression established
+  (#1422 / #1856). Wired as a bespoke builder (`vault.kv.put` / `patch`
+  classify `credential_write`, so the generic params-echo default is
+  suppressed for them), mirroring the Keycloak user-create builder mold
+  (#1857).
+- Every parked-request envelope now carries two reviewer-facing
+  provenance fields: `preview_populated` (a `bool` a caller can read to
+  refuse to auto-approve a blind, op-identity-only request) and, when a
+  preview is intentionally sparse, `preview_reason` —
+  `credential_write_redacted` (a deliberately-redacted credential write
+  with no bespoke builder) vs `connector_did_not_populate` (a
+  non-credential op that simply never populated one) — so the approval
+  surface can style the blind case as elevated-risk. `proposed_effect`
+  is a free-form JSON field, so no API schema / OpenAPI change (#2332).
+
 ### Fixed — vCenter filtered listings key `filter.*` params off the mount flavor (modern `/api` no longer 400s) (#2298)
 
 - Filtered vCenter listings sent legacy `/rest`-style `filter.`-prefixed

--- a/backend/src/meho_backplane/connectors/vault/__init__.py
+++ b/backend/src/meho_backplane/connectors/vault/__init__.py
@@ -45,6 +45,11 @@ refactor.
 """
 
 from meho_backplane.connectors.registry import register_connector_v2
+
+# Importing kv_write_preview runs its register_preview_builder calls (the
+# import side-effect that wires the park-time proposed_effect previews for
+# vault.kv.put / patch / delete — #2332).
+from meho_backplane.connectors.vault import kv_write_preview  # noqa: F401
 from meho_backplane.connectors.vault.connector import VaultConnector
 from meho_backplane.connectors.vault.ops import (
     register_vault_typed_operations,

--- a/backend/src/meho_backplane/connectors/vault/kv_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vault/kv_write_preview.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Park-time ``proposed_effect`` preview builders for the Vault KV-v2 write ops.
+
+G0.31 follow-up (#2332). Wires redaction-safe preview builders for the
+three ``vault.kv.*`` write ops onto the per-op builder hook shipped by
+#1437 (:mod:`meho_backplane.operations._preview`):
+
+================  ===================================================
+op_id             preview stored in ``ApprovalRequest.proposed_effect``
+================  ===================================================
+``vault.kv.put``    ``{mount, path, kv_version, semantics: replace, key_names, cas?}``
+``vault.kv.patch``  ``{mount, path, kv_version, semantics: merge, key_names}``
+``vault.kv.delete`` ``{mount, path, kv_version, semantics: soft_delete, versions}``
+================  ===================================================
+
+Why bespoke builders are required here
+======================================
+
+``vault.kv.put`` and ``vault.kv.patch`` classify as ``credential_write``
+(:data:`~meho_backplane.broadcast.events._CREDENTIAL_WRITE_OPS`): the
+KV-v2 secret ``data`` rides in the *request params*. The generic
+params-echo default (#1856) is therefore suppressed for them
+(:func:`~meho_backplane.operations._preview.build_proposed_effect` step 3),
+so before this module the parked request carried only the op-identity
+default ``{op_id, connector_id, target_id}``. The approver could see
+*that* a ``vault.kv.put`` against a target was pending, but not WHICH KV
+path or WHAT keys would be written — the four-eyes decision was made
+blind (#2332).
+
+A *bespoke* builder is the deliberate exception to the credential-class
+suppression: like the permission-preflight hook (G0.20-T4 #1504) and the
+Keycloak user-create preview (#1857), it is trusted to own its own field
+discipline and runs even for a credential-class op. These builders emit
+only the KV **path**, the **mount**, the KV **version**, the write
+**semantics** (put = wholesale replace vs patch = merge vs delete =
+version soft-delete), and — critically — the set of **key names** being
+written, never their **values**. That restores the approver's ability to
+distinguish "rotate the throwaway probe key" from "clobber the production
+database password" while keeping the value-redaction promise intact.
+
+``vault.kv.delete`` classifies as plain ``write`` (its params carry only
+the path + version numbers, no secret), so it would already get the
+generic params-echo default. A bespoke builder gives it the same
+resource-centric shape as its siblings for a consistent approval surface.
+
+Redaction discipline
+====================
+
+The preview reads only ``ctx.params`` and echoes:
+
+* ``mount`` / ``path`` — non-secret addressing. The path is what the
+  approver needs to reason about the blast radius.
+* ``key_names`` — the *top-level* keys of the ``data`` object being
+  written (``put`` / ``patch``), sorted, **names only**. A KV key name
+  (``db_password``, ``api_token``) is descriptive metadata, not secret
+  material; its *value* never leaves the params dict. Nested values are
+  never walked, so no secret rides along even from a nested structure.
+* ``versions`` — the integer version numbers a ``delete`` soft-deletes.
+* ``cas`` — the optional Check-And-Set version guard on a ``put`` (an
+  integer, not secret).
+
+No ``data`` *value* is ever read or echoed.
+
+Fail-soft
+=========
+
+Every builder is pure (no connector I/O) — it reads only ``ctx.params``.
+Should a malformed param shape raise anyway,
+:func:`~meho_backplane.operations._preview.build_proposed_effect` swallows
+it into the explicit ``preview_unavailable`` marker (#1628) rather than
+blocking the park, matching the existing builder contract.
+
+References
+----------
+
+* Task: https://github.com/evoila/meho/issues/2332
+* Parent goal: https://github.com/evoila/meho/issues/221
+* Parent initiative: https://github.com/evoila/meho/issues/2364
+* Builder seam: G11.7 #1437; credential-class suppression + bespoke
+  exception: #1856 / #1857.
+* KV-v2 write ops: G3.3-T1 #545; write-capability preflight: G0.20-T4 #1504.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.connectors.vault.ops import _DEFAULT_KV_MOUNT
+from meho_backplane.operations._preview import (
+    PreviewContext,
+    register_preview_builder,
+)
+
+#: KV-v2 is the only secret engine version these ops address (hvac's
+#: ``secrets.kv.v2`` client). Surfaced so the reviewer reads the engine
+#: version explicitly rather than inferring it from the op id.
+_KV_VERSION = 2
+
+
+def _mount_and_path(ctx: PreviewContext) -> tuple[str, str]:
+    """Resolve the ``(mount, path)`` the parked write addresses.
+
+    Mirrors the handler's mount defaulting (:data:`_DEFAULT_KV_MOUNT`)
+    without the raising path-shape pre-flight
+    (:func:`~meho_backplane.connectors.vault.ops._extract_mount_and_path`):
+    a preview must never fault on a formatting quirk that the write itself
+    would reject downstream. Both values are non-secret addressing.
+    """
+    mount = str(ctx.params.get("mount", _DEFAULT_KV_MOUNT)).strip()
+    path = str(ctx.params.get("path", "")).strip()
+    return mount, path
+
+
+def _data_key_names(ctx: PreviewContext) -> list[str]:
+    """Return the sorted top-level key names of the ``data`` param.
+
+    Names only — the values (the secret material) are never read. A
+    non-dict / absent ``data`` yields an empty list so a malformed param
+    shape previews no keys rather than raising.
+    """
+    data = ctx.params.get("data")
+    if not isinstance(data, dict):
+        return []
+    return sorted(str(key) for key in data)
+
+
+async def _kv_put_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vault.kv.put`` — path + key names visible, values never.
+
+    ``put`` replaces the latest version wholesale (KV-v2 does not merge),
+    so the semantics label is ``replace``. The set of key names that will
+    survive the write is exactly ``data``'s top-level keys.
+    """
+    mount, path = _mount_and_path(ctx)
+    preview: dict[str, Any] = {
+        "resource": "kv_secret",
+        "mount": mount,
+        "path": path,
+        "kv_version": _KV_VERSION,
+        "semantics": "replace",
+        "key_names": _data_key_names(ctx),
+    }
+    cas = ctx.params.get("cas")
+    if isinstance(cas, int) and not isinstance(cas, bool):
+        # A version guard, not a secret — surface so the reviewer sees a
+        # create-only (cas=0) or optimistic-lock (cas=N) write.
+        preview["cas"] = cas
+    return preview
+
+
+async def _kv_patch_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vault.kv.patch`` — merged key names visible, values never.
+
+    ``patch`` merges the supplied fields onto the current version, so the
+    semantics label is ``merge``; the key names are the fields being
+    added or overwritten (keys absent from ``data`` are preserved).
+    """
+    mount, path = _mount_and_path(ctx)
+    return {
+        "resource": "kv_secret",
+        "mount": mount,
+        "path": path,
+        "kv_version": _KV_VERSION,
+        "semantics": "merge",
+        "key_names": _data_key_names(ctx),
+    }
+
+
+async def _kv_delete_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vault.kv.delete`` — path + soft-deleted versions.
+
+    A version soft-delete carries no secret in its params; the blast
+    radius is *which versions* of *which path* stop being readable.
+    """
+    mount, path = _mount_and_path(ctx)
+    raw_versions = ctx.params.get("versions")
+    versions = (
+        [int(v) for v in raw_versions if isinstance(v, int) and not isinstance(v, bool)]
+        if isinstance(raw_versions, list)
+        else []
+    )
+    return {
+        "resource": "kv_secret",
+        "mount": mount,
+        "path": path,
+        "kv_version": _KV_VERSION,
+        "semantics": "soft_delete",
+        "versions": versions,
+    }
+
+
+def _register_vault_kv_write_preview_builders() -> None:
+    """Wire the Vault KV-v2 write preview builders. Called at import time."""
+    register_preview_builder("vault.kv.put", _kv_put_preview)
+    register_preview_builder("vault.kv.patch", _kv_patch_preview)
+    register_preview_builder("vault.kv.delete", _kv_delete_preview)
+
+
+_register_vault_kv_write_preview_builders()

--- a/backend/src/meho_backplane/operations/_preview.py
+++ b/backend/src/meho_backplane/operations/_preview.py
@@ -87,9 +87,12 @@ if TYPE_CHECKING:
     from meho_backplane.db.models import EndpointDescriptor
 
 __all__ = [
+    "PREVIEW_REASON_CREDENTIAL_REDACTED",
+    "PREVIEW_REASON_NOT_POPULATED",
     "PreviewContext",
     "build_permission_preflight",
     "build_proposed_effect",
+    "describe_preview_provenance",
     "register_permission_preflight",
     "register_preview_builder",
 ]
@@ -102,6 +105,21 @@ _log = structlog.get_logger(__name__)
 _SENSITIVE_CLASSES: frozenset[str] = frozenset(
     {"credential_read", "credential_mint", "credential_write"}
 )
+
+#: Reviewer-facing reason code (#2332) for a ``proposed_effect`` that
+#: collapsed to the op-identity-only default *because the op is a
+#: credential class with no bespoke builder* — the value redaction is
+#: intentional, not a missing preview. Distinguishes "asked to approve a
+#: deliberately-redacted credential write" from "the connector never
+#: populated a preview" so the approval surface can style it as
+#: elevated-risk rather than merely incomplete.
+PREVIEW_REASON_CREDENTIAL_REDACTED = "credential_write_redacted"
+
+#: Reviewer-facing reason code (#2332) for a ``proposed_effect`` that
+#: collapsed to the op-identity-only default for a *non*-credential op —
+#: no builder registered and nothing to echo (empty params), or a builder
+#: that declined. The preview is absent, not deliberately redacted.
+PREVIEW_REASON_NOT_POPULATED = "connector_did_not_populate"
 
 #: Sentinel substituted for a scrubbed secret-bearing param value. A
 #: non-empty marker (rather than dropping the key) keeps the param shape
@@ -452,6 +470,50 @@ async def build_proposed_effect(ctx: PreviewContext) -> dict[str, Any] | None:
         "op_class": op_class,
         "preview": preview,
     }
+
+
+def describe_preview_provenance(
+    preview: dict[str, Any] | None, *, op_id: str
+) -> tuple[bool, str | None]:
+    """Classify a built ``proposed_effect`` envelope for the reviewer surface (#2332).
+
+    Returns ``(preview_populated, preview_reason)`` from the value
+    :func:`build_proposed_effect` produced (before the identifier-only
+    default is merged in), so the dispatcher can stamp both onto every
+    parked-request envelope:
+
+    * ``preview_populated`` — ``True`` when a real bespoke ``preview`` or
+      generic ``params_echo`` landed; ``False`` when the envelope
+      collapsed to the op-identity-only default (a caller can then refuse
+      to auto-approve the blind case). A builder that *raised* (the
+      ``preview_unavailable`` marker, #1628) counts as **not** populated —
+      the blast radius is unknown, not shown.
+    * ``preview_reason`` — set only when ``preview_populated`` is ``False``
+      and the op is not the fault case:
+
+      - :data:`PREVIEW_REASON_CREDENTIAL_REDACTED` when the op is a
+        credential class (its preview is intentionally suppressed absent a
+        bespoke builder).
+      - :data:`PREVIEW_REASON_NOT_POPULATED` otherwise (no builder /
+        nothing to echo).
+
+      ``None`` when the preview is populated, or when the builder faulted
+      (that state carries its own ``preview_unavailable`` / ``preview_error``
+      marker and is not a "reason" for an intentionally-sparse preview).
+    """
+    if preview is not None and preview.get("preview_unavailable") is True:
+        # The builder ran but faulted — a distinct signaled state that
+        # already carries its own marker + reason; not "populated", and
+        # not an intentionally-sparse-preview reason code.
+        return False, None
+    if preview is not None and ("preview" in preview or "params_echo" in preview):
+        return True, None
+    # Collapsed to the identifier-only default: name WHY so the approver
+    # sees a deliberately-redacted credential write distinctly from a
+    # connector that simply never populated a preview.
+    if classify_op(op_id) in _SENSITIVE_CLASSES:
+        return False, PREVIEW_REASON_CREDENTIAL_REDACTED
+    return False, PREVIEW_REASON_NOT_POPULATED
 
 
 async def build_permission_preflight(ctx: PreviewContext) -> dict[str, Any] | None:

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -277,6 +277,7 @@ from meho_backplane.operations._preview import (
     PreviewContext,
     build_permission_preflight,
     build_proposed_effect,
+    describe_preview_provenance,
 )
 from meho_backplane.operations._validate import (
     compute_params_hash,
@@ -1600,6 +1601,20 @@ async def _build_proposed_effect(
             base = _identifier_default_effect(op_id=op_id, connector_id=connector_id, target=target)
         if preflight is not None:
             base["permission_preflight"] = preflight
+        # Stamp the reviewer-facing preview provenance onto every parked
+        # op's envelope (#2332). ``preview_populated`` lets a caller
+        # programmatically refuse to auto-approve an op-identity-only
+        # (blind) request; ``preview_reason`` names WHY a sparse preview is
+        # sparse — a deliberately-redacted credential write vs a connector
+        # that never populated one — so the approval surface can style the
+        # blind case as elevated-risk. Read from the value
+        # :func:`build_proposed_effect` produced (``preview``), so the
+        # identifier-only default that ``base`` may hold is classified
+        # correctly rather than mislabelled populated.
+        preview_populated, preview_reason = describe_preview_provenance(preview, op_id=op_id)
+        base["preview_populated"] = preview_populated
+        if preview_reason is not None:
+            base["preview_reason"] = preview_reason
         # Promote the catalog severity onto every parked op's envelope
         # (#1855). ``safety_level`` is op-identity metadata read straight
         # off the descriptor -- not recomputed -- so a parked ``dangerous``

--- a/backend/tests/test_connectors_vault_kv_write_preview.py
+++ b/backend/tests/test_connectors_vault_kv_write_preview.py
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the Vault KV-v2 park-time ``proposed_effect`` preview builders.
+
+G0.31 follow-up (#2332). The builders in
+:mod:`meho_backplane.connectors.vault.kv_write_preview` give the approval
+reviewer a redaction-safe view of the KV write a parked ``vault.kv.*``
+would perform: the mount, the path, the KV version, the write semantics,
+and the *names* of the keys being written — never their **values**.
+
+Acceptance criteria (Issue #2332):
+
+* Parking ``vault.kv.put`` surfaces the KV ``path`` and the set of
+  ``key_names`` being written (names, not values), plus the mount, KV
+  version, and put-vs-replace semantics.
+* No secret **value** ever lands in the durable approval row.
+* The parked-request envelope carries ``preview_populated`` (so a caller
+  can refuse to auto-approve a blind, op-identity-only request) and, when
+  a preview is intentionally sparse, a ``preview_reason``.
+
+The builders are pure (they read only ``ctx.params`` — no connector I/O),
+so these tests need no network mock. Importing the connector package wires
+the builders via the ``register_preview_builder`` import side-effect, so
+the tests exercise the real registration path through
+:func:`build_proposed_effect`.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+# Importing the package runs kv_write_preview's register_preview_builder
+# calls (the import side-effect under test).
+import meho_backplane.connectors.vault  # noqa: F401
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.operations._preview import (
+    PREVIEW_REASON_CREDENTIAL_REDACTED,
+    PREVIEW_REASON_NOT_POPULATED,
+    PreviewContext,
+    build_proposed_effect,
+    describe_preview_provenance,
+)
+
+
+@dataclass
+class _FakeDescriptor:
+    """Minimal stand-in -- the hook only reads ``op_id``."""
+
+    op_id: str
+
+
+def _operator() -> Operator:
+    return Operator(
+        sub="op-vault-preview-test",
+        name="Vault Preview Test Operator",
+        email=None,
+        raw_jwt="op.vault.preview.jwt",
+        tenant_id=uuid.UUID("00000000-0000-0000-0000-0000000000cc"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _ctx(op_id: str, params: dict[str, Any]) -> PreviewContext:
+    return PreviewContext(
+        descriptor=_FakeDescriptor(op_id=op_id),  # type: ignore[arg-type]
+        connector_instance=None,
+        operator=_operator(),
+        target=None,
+        params=params,
+        connector_id="vault-1.x",
+    )
+
+
+def _no_secret_anywhere(effect: dict[str, Any], *secrets: str) -> None:
+    """Assert none of *secrets* appears anywhere in the serialised effect."""
+    blob = json.dumps(effect)
+    for secret in secrets:
+        assert secret not in blob, f"secret value {secret!r} leaked into the durable row"
+
+
+# ---------------------------------------------------------------------------
+# vault.kv.put -- path + key names visible, values never
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kv_put_preview_shows_path_and_key_names_not_values() -> None:
+    """The headline criterion: path + key names visible, secret values redacted-away."""
+    ctx = _ctx(
+        "vault.kv.put",
+        {
+            "mount": "secret",
+            "path": "tenants/acme/db",
+            "data": {
+                "db_password": "super-secret-prod-pw",
+                "db_user": "svc-acme",
+            },
+        },
+    )
+    effect = await build_proposed_effect(ctx)
+    assert effect is not None
+    # A bespoke builder runs even though vault.kv.put classifies as
+    # credential_write -- the credential-class gate suppresses only the
+    # generic echo, not a trusted bespoke builder (#2332).
+    assert effect["op_class"] == "credential_write"
+    preview = effect["preview"]
+    assert preview["resource"] == "kv_secret"
+    assert preview["mount"] == "secret"
+    assert preview["path"] == "tenants/acme/db", "the KV path must be visible to the reviewer"
+    assert preview["kv_version"] == 2
+    assert preview["semantics"] == "replace", "put replaces the version wholesale"
+    # Key NAMES are visible (sorted); the VALUES never are.
+    assert preview["key_names"] == ["db_password", "db_user"]
+    _no_secret_anywhere(effect, "super-secret-prod-pw", "svc-acme")
+
+
+@pytest.mark.asyncio
+async def test_kv_put_preview_defaults_mount_and_surfaces_cas() -> None:
+    """Mount defaults to ``secret``; a CAS version guard is surfaced (not secret)."""
+    ctx = _ctx(
+        "vault.kv.put",
+        {"path": "tenants/acme/api", "data": {"token": "t0p"}, "cas": 3},
+    )
+    effect = await build_proposed_effect(ctx)
+    assert effect is not None
+    preview = effect["preview"]
+    assert preview["mount"] == "secret"
+    assert preview["cas"] == 3
+    assert preview["key_names"] == ["token"]
+    _no_secret_anywhere(effect, "t0p")
+
+
+# ---------------------------------------------------------------------------
+# vault.kv.patch -- merge semantics, key names visible
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kv_patch_preview_shows_merge_semantics_and_key_names() -> None:
+    ctx = _ctx(
+        "vault.kv.patch",
+        {"path": "tenants/acme/db", "data": {"db_password": "rotated-pw"}},
+    )
+    effect = await build_proposed_effect(ctx)
+    assert effect is not None
+    assert effect["op_class"] == "credential_write"
+    preview = effect["preview"]
+    assert preview["semantics"] == "merge", "patch merges onto the current version"
+    assert preview["path"] == "tenants/acme/db"
+    assert preview["key_names"] == ["db_password"]
+    _no_secret_anywhere(effect, "rotated-pw")
+
+
+# ---------------------------------------------------------------------------
+# vault.kv.delete -- version soft-delete, no data param at all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kv_delete_preview_shows_versions_and_soft_delete_semantics() -> None:
+    ctx = _ctx(
+        "vault.kv.delete",
+        {"mount": "kv-prod", "path": "tenants/acme/db", "versions": [2, 3]},
+    )
+    effect = await build_proposed_effect(ctx)
+    assert effect is not None
+    preview = effect["preview"]
+    assert preview["resource"] == "kv_secret"
+    assert preview["mount"] == "kv-prod"
+    assert preview["path"] == "tenants/acme/db"
+    assert preview["semantics"] == "soft_delete"
+    assert preview["versions"] == [2, 3]
+
+
+@pytest.mark.asyncio
+async def test_kv_put_preview_tolerates_malformed_data_param() -> None:
+    """A non-dict ``data`` previews no keys rather than raising (fail-soft)."""
+    ctx = _ctx("vault.kv.put", {"path": "tenants/acme/db", "data": "not-a-dict"})
+    effect = await build_proposed_effect(ctx)
+    assert effect is not None
+    assert effect["preview"]["key_names"] == []
+
+
+# ---------------------------------------------------------------------------
+# describe_preview_provenance -- the reviewer-facing provenance fields (#2332)
+# ---------------------------------------------------------------------------
+
+
+def test_provenance_populated_bespoke_preview() -> None:
+    populated, reason = describe_preview_provenance(
+        {"op_class": "credential_write", "preview": {"path": "x"}}, op_id="vault.kv.put"
+    )
+    assert populated is True
+    assert reason is None
+
+
+def test_provenance_populated_generic_echo() -> None:
+    populated, reason = describe_preview_provenance(
+        {"op_class": "write", "params_echo": {"name": "x"}}, op_id="vsphere.vm.create"
+    )
+    assert populated is True
+    assert reason is None
+
+
+def test_provenance_credential_class_none_is_redacted_reason() -> None:
+    """A credential-class op that collapsed to identifier-only ⇒ redacted reason.
+
+    ``vault.auth.userpass.write`` is a credential_write op with no bespoke
+    builder, so its preview is intentionally suppressed. The provenance
+    must name that as a deliberate redaction, not a missing preview.
+    """
+    populated, reason = describe_preview_provenance(None, op_id="vault.auth.userpass.write")
+    assert populated is False
+    assert reason == PREVIEW_REASON_CREDENTIAL_REDACTED
+
+
+def test_provenance_plain_op_none_is_not_populated_reason() -> None:
+    populated, reason = describe_preview_provenance(None, op_id="vsphere.vm.create")
+    assert populated is False
+    assert reason == PREVIEW_REASON_NOT_POPULATED
+
+
+def test_provenance_builder_fault_is_unpopulated_without_reason() -> None:
+    """A builder that faulted carries its own marker; not a sparse-preview reason."""
+    populated, reason = describe_preview_provenance(
+        {"op_class": "other", "preview_unavailable": True, "preview_error": "boom"},
+        op_id="k8s.apply",
+    )
+    assert populated is False
+    assert reason is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher envelope stamping -- preview_populated / preview_reason land on
+# the parked-request proposed_effect (#2332)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeStampDescriptor:
+    """Descriptor stand-in for the dispatcher stamping path (op_id + severity)."""
+
+    op_id: str
+    safety_level: str
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_stamps_preview_populated_for_vault_put(monkeypatch) -> None:
+    """A parked ``vault.kv.put`` envelope carries the populated preview + flag."""
+    from meho_backplane.operations import dispatcher
+
+    async def _no_connector(descriptor: Any, target: Any) -> tuple[Any, Any, Any]:
+        return None, None, None
+
+    async def _no_preflight(ctx: PreviewContext) -> dict[str, Any] | None:
+        return None
+
+    monkeypatch.setattr(dispatcher, "_resolve_connector_instance", _no_connector)
+    monkeypatch.setattr(dispatcher, "build_permission_preflight", _no_preflight)
+
+    effect = await dispatcher._build_proposed_effect(
+        op_id="vault.kv.put",
+        connector_id="vault-1.x",
+        descriptor=_FakeStampDescriptor(op_id="vault.kv.put", safety_level="caution"),  # type: ignore[arg-type]
+        operator=_operator(),
+        target=None,
+        params={"path": "tenants/acme/db", "data": {"db_password": "x"}},
+    )
+    assert effect is not None
+    assert effect["preview_populated"] is True
+    assert "preview_reason" not in effect
+    assert effect["preview"]["path"] == "tenants/acme/db"
+    assert effect["safety_level"] == "caution"
+    _no_secret_anywhere(effect, "x")
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_stamps_redacted_reason_for_builderless_credential_op(
+    monkeypatch,
+) -> None:
+    """A credential op with no builder collapses to identifier-only + redacted reason."""
+    from meho_backplane.operations import dispatcher
+
+    async def _no_connector(descriptor: Any, target: Any) -> tuple[Any, Any, Any]:
+        return None, None, None
+
+    async def _no_preflight(ctx: PreviewContext) -> dict[str, Any] | None:
+        return None
+
+    monkeypatch.setattr(dispatcher, "_resolve_connector_instance", _no_connector)
+    monkeypatch.setattr(dispatcher, "build_permission_preflight", _no_preflight)
+
+    effect = await dispatcher._build_proposed_effect(
+        op_id="vault.auth.userpass.write",
+        connector_id="vault-1.x",
+        descriptor=_FakeStampDescriptor(
+            op_id="vault.auth.userpass.write", safety_level="dangerous"
+        ),  # type: ignore[arg-type]
+        operator=_operator(),
+        target=None,
+        params={"username": "svc", "password": "sekret"},
+    )
+    assert effect is not None
+    assert effect["preview_populated"] is False
+    assert effect["preview_reason"] == PREVIEW_REASON_CREDENTIAL_REDACTED
+    # The identifier-only default still names the op for the reviewer.
+    assert effect["op_id"] == "vault.auth.userpass.write"
+    _no_secret_anywhere(effect, "sekret")

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -461,6 +461,7 @@ async def test_power_bulk_park_carries_action_filter_and_resolved_set(
             ],
             "total_resolved": 2,
         },
+        "preview_populated": True,
         "safety_level": "dangerous",
     }
     # The filter reached the listing read in the handler's wire shape;
@@ -568,6 +569,7 @@ async def test_host_evacuate_park_resolves_vm_set_on_host(
             "resolved": [{"vm": "vm-a", "name": "app-a"}],
             "total_resolved": 1,
         },
+        "preview_populated": True,
         "safety_level": "dangerous",
     }
     # Only the listing read fired — no recursive migrate, no maintenance.
@@ -594,6 +596,7 @@ async def test_host_detach_from_vds_park_resolves_vm_set_on_host(
             "resolved": [{"vm": "vm-a", "name": "app-a"}],
             "total_resolved": 1,
         },
+        "preview_populated": True,
         "safety_level": "dangerous",
     }
     assert recorder.specs == ["/vcenter/vm"]
@@ -623,6 +626,7 @@ async def test_cluster_patch_park_resolves_host_set(
             ],
             "total_resolved": 2,
         },
+        "preview_populated": True,
         "safety_level": "dangerous",
     }
     # Only the host listing fired — no maintenance / patch sub-ops.
@@ -656,6 +660,7 @@ async def test_vm_create_park_carries_echo_preview_without_any_read(
             "networks": [],
             "power_on_after_create": False,
         },
+        "preview_populated": True,
         "safety_level": "dangerous",
     }
     assert recorder.calls == []

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -2372,12 +2372,18 @@ async def test_park_without_builder_uses_identifier_default(
         row = await fresh.get(ApprovalRequest, approval_request_id)
         assert row is not None
         # Identifier-only default -- no built-preview envelope -- with the
-        # catalog safety_level stamped on by the dispatcher seam (#1855).
+        # catalog safety_level stamped on by the dispatcher seam (#1855)
+        # and the reviewer-facing preview provenance (#2332):
+        # preview_populated=False + a "connector_did_not_populate" reason
+        # so a caller can refuse to auto-approve the blind, op-identity-only
+        # request.
         assert row.proposed_effect == {
             "op_id": "vault.kv.no_preview_op",
             "connector_id": "vault-1.x",
             "target_id": str(target.id),
             "safety_level": "safe",
+            "preview_populated": False,
+            "preview_reason": "connector_did_not_populate",
         }
         assert "preview" not in row.proposed_effect
 

--- a/backend/tests/test_operations_preview.py
+++ b/backend/tests/test_operations_preview.py
@@ -159,16 +159,18 @@ async def test_no_builder_credential_class_op_yields_none() -> None:
     """A credential-class op with no builder still parks with no preview.
 
     Since #1856 a no-builder op gets the generic params-echo default, but
-    the credential-class suppression runs *first*: ``vault.kv.put`` is
-    ``credential_write``, so it collapses to the identifier-only default
-    (caller fallback) rather than echoing its (secret-bearing) params.
+    the credential-class suppression runs *first*: ``vault.auth.userpass.write``
+    is ``credential_write`` with no bespoke builder, so it collapses to the
+    identifier-only default (caller fallback) rather than echoing its
+    (secret-bearing) params. (``vault.kv.put`` now ships a bespoke builder,
+    #2332, so the exemplar here is a still-builderless credential op.)
     """
     ctx = PreviewContext(
-        descriptor=_FakeDescriptor(op_id="vault.kv.put"),  # type: ignore[arg-type]
+        descriptor=_FakeDescriptor(op_id="vault.auth.userpass.write"),  # type: ignore[arg-type]
         connector_instance=None,
         operator=_operator(),
         target=_FakeTarget(),
-        params={"path": "secret/data/x", "data": {"k": "v"}},
+        params={"username": "svc", "password": "s3kret"},
     )
     assert await build_proposed_effect(ctx) is None
 
@@ -422,11 +424,14 @@ async def test_credential_class_op_bespoke_builder_runs() -> None:
 async def test_permission_preflight_runs_for_credential_class_op() -> None:
     """A permission preflight runs even when the op classifies credential-class.
 
-    This is the whole point of the separate hook: ``vault.kv.put`` IS
-    ``credential_write`` (so its *preview* is suppressed), yet its
-    capability-only *permission* check must still run — it carries no
-    secret material, and it is exactly the op whose write Vault may deny
-    post-approval.
+    This is the whole point of the separate hook: ``vault.auth.userpass.write``
+    IS ``credential_write`` with no bespoke preview builder (so its
+    *preview* is suppressed), yet its capability-only *permission* check
+    must still run — it carries no secret material, and a credential write
+    is exactly the op whose write Vault may deny post-approval. (The
+    exemplar is a builderless credential op because ``vault.kv.put`` now
+    ships a bespoke preview builder, #2332, so its preview is no longer
+    suppressed.)
     """
     ran = False
 
@@ -435,13 +440,13 @@ async def test_permission_preflight_runs_for_credential_class_op() -> None:
         ran = True
         return {"check": "vault.capabilities-self", "will_be_denied": True}
 
-    register_permission_preflight("vault.kv.put", _preflight)
+    register_permission_preflight("vault.auth.userpass.write", _preflight)
     ctx = PreviewContext(
-        descriptor=_FakeDescriptor(op_id="vault.kv.put"),  # type: ignore[arg-type]
+        descriptor=_FakeDescriptor(op_id="vault.auth.userpass.write"),  # type: ignore[arg-type]
         connector_instance=None,
         operator=_operator(),
         target=_FakeTarget(),
-        params={"path": "secret/data/x", "data": {"k": "v"}},
+        params={"username": "svc", "password": "s3kret"},
     )
 
     # The preview is suppressed (credential class), proving the preflight


### PR DESCRIPTION
## Summary

- A parked `vault.kv.put` / `patch` / `delete` approval request previously carried only the op-identity default `{op_id, connector_id, target_id}` — the approver saw *that* a vault write was pending but not *which* path or *what* keys, so the four-eyes decision was blind. `vault.kv.put`/`patch` classify as `credential_write`, so the generic params-echo default is suppressed (the params carry the secret), and vault never got a bespoke builder.
- Wires a bespoke, **redaction-safe** preview builder for the three KV-v2 write ops (mirroring the keycloak user-create mold): emits the **mount**, **path**, KV **version**, write **semantics** (`put`=replace / `patch`=merge / `delete`=soft_delete), and the set of key **names** being written — never their **values**. A bespoke builder is the trusted exception to the credential-class suppression, so it runs even for the `credential_write` ops.
- Stamps two reviewer-facing provenance fields onto **every** parked envelope at the dispatcher seam: `preview_populated` (a `bool` a caller reads to refuse auto-approving a blind, op-identity-only request) and, when a preview is intentionally sparse, `preview_reason` — `credential_write_redacted` (deliberately-redacted credential write, no bespoke builder) vs `connector_did_not_populate` (a non-credential op that never populated one).
- `proposed_effect` is a free-form JSON field, so **no API schema / OpenAPI change**. TTL/`expires_at` (the issue's secondary observation) is out of scope — folds into #2322 per the maintainer's grounding note.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (changed source) — clean
- [x] `code-quality.py --diff` — 0 blockers (8 pre-existing dispatcher warnings, untouched)
- [x] New `tests/test_connectors_vault_kv_write_preview.py` — 15 tests: put/patch/delete previews surface path + key names + semantics, never leak secret values (`json.dumps` scan); `describe_preview_provenance` across all envelope shapes; dispatcher envelope stamping (populated + redacted-reason)
- [x] `tests/test_operations_preview.py` — repointed the two "credential-class op with no builder → suppressed" exemplars from `vault.kv.put` (now has a builder) to the still-builderless `vault.auth.userpass.write`; all pass
- [x] `tests/test_operations_dispatcher.py::test_park_without_builder_uses_identifier_default` — updated to assert the new `preview_populated`/`preview_reason` envelope fields
- [x] Ran broadcast + vault + approval-queue + api/ui-approvals + secret-move suites (535+ tests) — green

## Out of scope

- Redaction of actual secret **values** (values stay redacted — by design).
- `expires_at` / approval-request TTL (folds into sibling #2322).
- UI styling of the elevated-risk `preview_reason` (envelope now carries the field; rendering is a separate surface).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2332
