### PR TITLE
feat(approvals): stamp expires_at at park + wire a periodic TTL sweep (#2322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — approval-TTL lifecycle wired end-to-end (parked approvals now expire) (#2322)
+
+- Every parked approval is now stamped `expires_at = created_at +
+  APPROVAL_DEFAULT_TTL` (new `APPROVAL_DEFAULT_TTL_SECONDS`, default 14
+  days) at park time across **all** transports — REST, MCP, and run-bound
+  dispatches (they all park through the dispatcher's
+  `_handle_needs_approval`, plus the composite park path). An explicit
+  caller deadline is honoured but capped at that ceiling, so no surface
+  can park an unbounded-lived approval. Previously every parked row
+  carried `expires_at: null` and the `expired` status / column /
+  `expire_stale_requests` helper existed but had zero production callers —
+  the TTL lifecycle was shipped but inert.
+- A dedicated periodic sweeper (`operations.approval_expiry`, gated on
+  `APPROVAL_EXPIRY_ENABLED`, `APPROVAL_EXPIRY_TICK_INTERVAL_SECONDS`
+  default 300s) drives `expire_stale_requests` per tenant under a
+  `system:approval-expiry` operator, so past-deadline pending approvals
+  transition to `expired` within one tick, each with a decision audit row
+  and a fail-open `approval.expired` broadcast. Expired rows leave the
+  default `?status=pending` view and cannot be approved or resumed.
+- Legacy pre-#2322 rows with `expires_at IS NULL` age out too: the sweep
+  coalesces a null deadline against `created_at + APPROVAL_DEFAULT_TTL`
+  (no schema change, no migration) and backfills the deadline on expiry.
+
 ### Fixed — vCenter filtered listings key `filter.*` params off the mount flavor (modern `/api` no longer 400s) (#2298)
 
 - Filtered vCenter listings sent legacy `/rest`-style `filter.`-prefixed

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -127,6 +127,10 @@ from meho_backplane.memory import (
 from meho_backplane.metrics import render_metrics
 from meho_backplane.middleware import BroadcastDetailMiddleware, RequestContextMiddleware
 from meho_backplane.operations import run_typed_op_registrars, set_default_reducer
+from meho_backplane.operations.approval_expiry import (
+    start_approval_expiry_sweeper,
+    stop_approval_expiry_sweeper,
+)
 from meho_backplane.operations.ingest import (
     build_anthropic_ingest_llm_client,
     load_catalog,
@@ -426,6 +430,7 @@ class _BackgroundTasks:
     memory_expiry: asyncio.Task[None] | None
     topology_history: asyncio.Task[None] | None
     grant_expiry: asyncio.Task[None] | None
+    approval_expiry: asyncio.Task[None] | None
     scheduler: asyncio.Task[None] | None
     agent_run_reaper: asyncio.Task[None] | None
     event_drain: asyncio.Task[None] | None
@@ -462,6 +467,13 @@ def _start_background_tasks() -> _BackgroundTasks:
     grant_expiry: asyncio.Task[None] | None = None
     if settings.grant_expiry_enabled:
         grant_expiry = start_grant_expiry_sweeper()
+    # #2322 (G0.31 #2364) — approval-TTL sweeper. Gated on
+    # APPROVAL_EXPIRY_ENABLED so operators running an external sweep don't
+    # double-expire. Drives ``expire_stale_requests`` per tenant so parked
+    # approvals actually age out (the lifecycle was inert before #2322).
+    approval_expiry: asyncio.Task[None] | None = None
+    if settings.approval_expiry_enabled:
+        approval_expiry = start_approval_expiry_sweeper()
     # G11.3-T2 #823 — cron + one-off agent-trigger scheduler. Gated on
     # SCHEDULER_ENABLED so operators using an external orchestrator
     # (or running the test path without a scheduler) can opt out.
@@ -486,6 +498,7 @@ def _start_background_tasks() -> _BackgroundTasks:
         memory_expiry=memory_expiry,
         topology_history=topology_history,
         grant_expiry=grant_expiry,
+        approval_expiry=approval_expiry,
         scheduler=scheduler,
         agent_run_reaper=agent_run_reaper,
         event_drain=event_drain,
@@ -506,6 +519,8 @@ async def _stop_background_tasks(tasks: _BackgroundTasks) -> None:
         await stop_agent_run_reaper(tasks.agent_run_reaper)
     if tasks.scheduler is not None:
         await stop_scheduler(tasks.scheduler)
+    if tasks.approval_expiry is not None:
+        await stop_approval_expiry_sweeper(tasks.approval_expiry)
     if tasks.grant_expiry is not None:
         await stop_grant_expiry_sweeper(tasks.grant_expiry)
     if tasks.topology_history is not None:

--- a/backend/src/meho_backplane/operations/approval_expiry.py
+++ b/backend/src/meho_backplane/operations/approval_expiry.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Scheduled background sweeper for stale ``requires_approval`` parks.
+
+Task #2322 (G0.31 #2364). Wires the long-shipped-but-inert
+:func:`~meho_backplane.operations.approval_queue.expire_stale_requests`
+into a periodic driver so parked approvals actually age out: without a
+caller the TTL lifecycle was half-built (the ``expired`` status + the
+``expires_at`` column existed, nothing stamped or swept them), leaving
+pending approvals to accumulate forever on a live deploy.
+
+Design
+------
+
+Mirrors the sibling governance-surface expiry sweepers
+(:mod:`meho_backplane.agents.grant_expiry`, the G11.2-T6 grant sweeper,
+and :mod:`meho_backplane.memory.expiry`): an ``asyncio.Task`` the FastAPI
+lifespan owns, a fixed tick cadence
+(``APPROVAL_EXPIRY_TICK_INTERVAL_SECONDS``, default 300s), sleep-then-
+sweep ordering, and a per-tick ``try/except`` so one bad tick never kills
+the loop.
+
+Why a dedicated sweeper (not the agent-trigger scheduler tick):
+``expire_stale_requests`` is **tenant-scoped** — it takes an
+:class:`~meho_backplane.auth.operator.Operator` and filters on
+``operator.tenant_id`` — so the sweep has to enumerate tenants and act as
+a per-tenant system operator, exactly the shape
+:mod:`meho_backplane.topology.scheduler` already uses. Following the
+established per-surface-sweeper convention (each with its own
+``*_enabled`` opt-out + ``*_tick_interval_seconds`` cadence) keeps the
+approval sweep independent of the cron/one-off scheduler's advisory lock
+and of ``SCHEDULER_ENABLED``.
+
+Per-tenant isolation
+--------------------
+
+Each tenant is swept in its own session/transaction. A failure sweeping
+one tenant is logged and swallowed so the remaining tenants still get
+swept — the same "loop survival over per-tick completeness" trade-off the
+topology scheduler makes.
+
+Audit + broadcast
+-----------------
+
+``expire_stale_requests`` writes one ``approval.decision`` audit row per
+expired request inside the sweep transaction (the durable truth). After
+that transaction commits, one fail-open ``approval.expired`` broadcast
+event is published per expired row via
+:func:`~meho_backplane.operations.approval_queue.publish_approval_event`
+so operator watchers see the transition live; a broadcast outage never
+blocks the durable decision.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Tenant
+from meho_backplane.operations.approval_queue import (
+    expire_stale_requests,
+    publish_approval_event,
+)
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "start_approval_expiry_sweeper",
+    "stop_approval_expiry_sweeper",
+    "sweep_expired_approvals",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The acting identity for sweeper-driven expiries. A stable synthetic
+#: sub makes swept expiries filterable in audit queries and distinct from
+#: operator-driven decisions — the same pattern the topology scheduler
+#: (``system:topology-scheduler``) and connector system contexts use.
+_SYSTEM_OPERATOR_SUB = "system:approval-expiry"
+
+
+def _system_operator(tenant_id: uuid.UUID) -> Operator:
+    """Build the synthetic per-tenant operator the sweep expires rows as.
+
+    ``raw_jwt`` is the empty string — the sweep forwards no token
+    downstream. ``OPERATOR`` role satisfies the ``>= operator`` floor
+    :func:`~meho_backplane.operations.approval_queue.expire_stale_requests`
+    enforces on the acting identity.
+    """
+    return Operator(
+        sub=_SYSTEM_OPERATOR_SUB,
+        name=None,
+        email=None,
+        raw_jwt="",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _sweep_one_tenant(
+    tenant_id: uuid.UUID,
+    *,
+    cutoff: datetime,
+    default_ttl: timedelta,
+) -> int:
+    """Expire the past-deadline pending rows for one tenant; return the count.
+
+    Opens a dedicated session so a failure sweeping this tenant rolls back
+    only its own work and is isolated from the rest of the sweep. The
+    ``approval.expired`` broadcasts are published **after** the sweep
+    transaction commits (fail-open) so a phantom event cannot outlive a
+    rolled-back expiry.
+    """
+    operator = _system_operator(tenant_id)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        try:
+            expired = await expire_stale_requests(
+                session,
+                operator=operator,
+                now=cutoff,
+                default_ttl=default_ttl,
+            )
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            _log.exception(
+                "approval_expiry_tenant_failed",
+                tenant_id=str(tenant_id),
+            )
+            return 0
+
+    for request in expired:
+        await publish_approval_event(
+            tenant_id=tenant_id,
+            request=request,
+            decision="expired",
+            principal_sub=operator.sub,
+            audit_id=request._audit_id,  # type: ignore[attr-defined]
+        )
+    return len(expired)
+
+
+async def sweep_expired_approvals(*, now: datetime | None = None) -> int:
+    """Run one full expiry sweep across every tenant; return rows expired.
+
+    Public so tests can drive a deterministic single sweep without the
+    cadence sleep. Enumerates tenants once, then expires each tenant's
+    past-deadline pending rows under a per-tenant system operator, passing
+    the configured ``APPROVAL_DEFAULT_TTL`` so legacy null-``expires_at``
+    rows age out via the sweep-time coalesce.
+    """
+    default_ttl = timedelta(seconds=get_settings().approval_default_ttl_seconds)
+    cutoff = now or datetime.now(UTC)
+    tick_started = time.perf_counter()
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_ids = list((await session.execute(select(Tenant.id))).scalars().all())
+
+    expired_total = 0
+    for tenant_id in tenant_ids:
+        expired_total += await _sweep_one_tenant(
+            tenant_id,
+            cutoff=cutoff,
+            default_ttl=default_ttl,
+        )
+
+    if expired_total:
+        _log.info(
+            "approval_expiry_tick_done",
+            expired_total=expired_total,
+            tenants=len(tenant_ids),
+            duration_ms=(time.perf_counter() - tick_started) * 1000.0,
+        )
+    else:
+        _log.debug("approval_expiry_tick_clean")
+    return expired_total
+
+
+async def _sweeper_loop() -> None:
+    """Forever loop: sleep one cadence, sweep, repeat.
+
+    Sleep-then-sweep (not sweep-then-sleep) so the first tick is delayed
+    by one cadence, giving the rest of lifespan startup time to complete.
+    ``CancelledError`` propagates so lifespan shutdown can stop the task
+    cleanly; any other per-tick failure is logged and the loop continues.
+    """
+    interval = get_settings().approval_expiry_tick_interval_seconds
+    _log.info("approval_expiry_sweeper_started", interval_seconds=interval)
+    while True:
+        await asyncio.sleep(get_settings().approval_expiry_tick_interval_seconds)
+        try:
+            await sweep_expired_approvals()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning("approval_expiry_tick_failed", exc_info=True)
+
+
+def start_approval_expiry_sweeper() -> asyncio.Task[None]:
+    """Start the background sweeper loop and return its task handle.
+
+    Registered in :func:`meho_backplane.main.lifespan` behind the
+    ``APPROVAL_EXPIRY_ENABLED`` setting. The returned task is cancelled on
+    lifespan shutdown; the caller awaits the cancellation so the loop
+    unwinds cleanly. Returning the task (rather than fire-and-forgetting)
+    keeps a strong reference alive — an un-referenced ``asyncio.Task`` can
+    be garbage-collected mid-flight.
+    """
+    return asyncio.create_task(_sweeper_loop(), name="approval-expiry-sweeper")
+
+
+async def stop_approval_expiry_sweeper(task: asyncio.Task[None]) -> None:
+    """Cancel the sweeper task and await its unwind.
+
+    Swallows the expected :class:`asyncio.CancelledError`; any other
+    exception propagates so a broken shutdown is visible. Mirrors
+    :func:`~meho_backplane.agents.grant_expiry.stop_grant_expiry_sweeper`.
+    """
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/backend/src/meho_backplane/operations/approval_queue.py
+++ b/backend/src/meho_backplane/operations/approval_queue.py
@@ -72,12 +72,12 @@ where a malicious approver swaps the params between the "request" and the
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any, cast
 
 import structlog
-from sqlalchemy import CursorResult, select, update
+from sqlalchemy import CursorResult, and_, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.delegation import resolve_actor_sub
@@ -222,6 +222,41 @@ def _now() -> datetime:
     return datetime.now(UTC)
 
 
+def _resolve_default_ttl() -> timedelta:
+    """The configured default approval TTL as a :class:`~datetime.timedelta`.
+
+    Read lazily off :func:`~meho_backplane.settings.get_settings` (mirrors
+    the local settings import in :func:`_check_self_approval`) so the queue
+    module stays decoupled from settings at import time.
+    """
+    from meho_backplane.settings import get_settings
+
+    return timedelta(seconds=get_settings().approval_default_ttl_seconds)
+
+
+def _bounded_expires_at(
+    created_at: datetime,
+    requested: datetime | None,
+    default_ttl: timedelta,
+) -> datetime:
+    """Resolve the deadline a parked approval is stamped with (#2322).
+
+    The TTL lifecycle is inert unless every parked row carries a concrete
+    ``expires_at`` for the sweep to act on, so a ``None`` request defaults
+    to ``created_at + default_ttl``. An explicit caller deadline is
+    honoured but **capped** at that same ceiling — the single configured
+    TTL doubles as the upper bound, so no surface can park an
+    unbounded-lived approval, while a shorter (e.g. preflight-probe) or
+    already-past deadline the caller asked for is respected as-is. There
+    is deliberately no lower bound / per-op policy (substrate minimalism,
+    #1177).
+    """
+    ceiling = created_at + default_ttl
+    if requested is None:
+        return ceiling
+    return min(requested, ceiling)
+
+
 async def _write_audit_row(
     session: AsyncSession,
     *,
@@ -363,7 +398,10 @@ async def create_pending_request(
             for non-agent-run dispatches.
         proposed_effect: Human-readable summary for the reviewer.
             Defaults to ``{"op_id": op_id, "connector_id": connector_id}``.
-        expires_at: Optional deadline. ``None`` means no expiry.
+        expires_at: Optional caller deadline (#2322). ``None`` defaults to
+            ``created_at + APPROVAL_DEFAULT_TTL``; an explicit value is
+            honoured but capped at that ceiling. The row is never parked
+            with a null deadline — the TTL sweep depends on it.
 
     Returns:
         The flushed :class:`ApprovalRequest` row.
@@ -405,7 +443,13 @@ async def create_pending_request(
     # context (agent run var, or the MCP transport's session binding)
     # is still live; the approve / resume surfaces run on a different
     # operator's task and re-hydrate it from the row.
+    # Stamp the approval-TTL deadline (#2322): default to
+    # ``created_at + APPROVAL_DEFAULT_TTL`` and cap any caller override at
+    # that ceiling, so every parked row — REST, MCP, and run-bound — leaves
+    # the queue with a concrete ``expires_at`` for the sweeper to act on.
     request_audit_id = uuid.uuid4()
+    created_at = _now()
+    bounded_expires_at = _bounded_expires_at(created_at, expires_at, _resolve_default_ttl())
     request = ApprovalRequest(
         id=uuid.uuid4(),
         tenant_id=operator.tenant_id,
@@ -419,8 +463,8 @@ async def create_pending_request(
         params=params,
         proposed_effect=proposed_effect,
         status=ApprovalRequestStatus.PENDING.value,
-        created_at=_now(),
-        expires_at=expires_at,
+        created_at=created_at,
+        expires_at=bounded_expires_at,
         work_ref=work_ref_var.get(),
         agent_session_id=resolve_agent_session_id(),
         request_audit_id=request_audit_id,
@@ -904,11 +948,41 @@ async def _rehydrate_resume_target(
     return None, denied
 
 
+def _deadline_passed_clause(cutoff: datetime, default_ttl: timedelta | None) -> Any:
+    """Build the "expiry deadline has passed" WHERE clause for the sweep (#2322).
+
+    A concrete ``expires_at`` compares directly. When *default_ttl* is
+    supplied, legacy null-expiry rows (parked before #2322) are coalesced
+    against ``created_at + default_ttl`` — expressed as
+    ``created_at <= cutoff - default_ttl`` rather than SQL
+    column+interval arithmetic so the predicate binds two plain Python
+    datetimes and stays dialect-portable (PG ``timestamptz`` + the SQLite
+    test path both compare cleanly), the same bound-parameter discipline
+    the grant-expiry sweeper uses. With no *default_ttl* only rows with a
+    concrete deadline are considered (the historical contract).
+    """
+    concrete = and_(
+        ApprovalRequest.expires_at.is_not(None),
+        ApprovalRequest.expires_at <= cutoff,
+    )
+    if default_ttl is None:
+        return concrete
+    legacy_cutoff = cutoff - default_ttl
+    return or_(
+        concrete,
+        and_(
+            ApprovalRequest.expires_at.is_(None),
+            ApprovalRequest.created_at <= legacy_cutoff,
+        ),
+    )
+
+
 async def expire_stale_requests(
     session: AsyncSession,
     *,
     operator: Operator,
     now: datetime | None = None,
+    default_ttl: timedelta | None = None,
 ) -> list[ApprovalRequest]:
     """Transition all ``pending`` rows past their ``expires_at`` to ``expired``.
 
@@ -916,8 +990,16 @@ async def expire_stale_requests(
     session (caller commits). Intended to be called from a background
     task / CLI sweep on a periodic interval.
 
-    Only rows with ``expires_at IS NOT NULL AND expires_at <= now`` and
-    ``status = 'pending'`` are affected.
+    Rows with ``expires_at IS NOT NULL AND expires_at <= now`` and
+    ``status = 'pending'`` are always affected. When *default_ttl* is
+    supplied (the periodic sweeper passes ``APPROVAL_DEFAULT_TTL``),
+    legacy rows parked before #2322 with ``expires_at IS NULL`` are also
+    aged out via a sweep-time coalesce: a null-expiry row is treated as
+    if its deadline were ``created_at + default_ttl`` and, when that
+    coalesced deadline has passed, the row is expired and its
+    ``expires_at`` is backfilled to that value so the decision row and
+    the persisted deadline agree. No schema change is needed — the
+    coalesce lives entirely in this predicate.
 
     Args:
         session: Open :class:`AsyncSession``; flushed, not committed.
@@ -926,6 +1008,10 @@ async def expire_stale_requests(
             ``operator`` role.
         now: Override for "current time" (used in tests). Defaults to
             :func:`datetime.now(UTC)`.
+        default_ttl: When set, null-``expires_at`` legacy rows are
+            coalesced against ``created_at + default_ttl`` (#2322). When
+            ``None`` (the historical contract), only rows with a concrete
+            ``expires_at`` are considered.
 
     Returns:
         List of the expired :class:`ApprovalRequest` rows (may be empty).
@@ -944,14 +1030,17 @@ async def expire_stale_requests(
     stmt = (
         select(ApprovalRequest)
         .where(ApprovalRequest.status == ApprovalRequestStatus.PENDING.value)
-        .where(ApprovalRequest.expires_at.is_not(None))
-        .where(ApprovalRequest.expires_at <= cutoff)
+        .where(_deadline_passed_clause(cutoff, default_ttl))
         .where(ApprovalRequest.tenant_id == operator.tenant_id)
     )
     result = await session.execute(stmt)
     rows = list(result.scalars().all())
 
     for request in rows:
+        # Backfill a legacy null deadline to the coalesced value so the
+        # decision audit row and the persisted row agree on when it expired.
+        if request.expires_at is None and default_ttl is not None:
+            request.expires_at = request.created_at + default_ttl
         request.status = ApprovalRequestStatus.EXPIRED.value
         request.decided_at = cutoff
         await session.flush()

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1014,6 +1014,21 @@ class Settings(BaseModel):
     # docs/codebase/approvals.md "Single-operator tenants: use an
     # agent-requester, not break-glass".
     approval_allow_self_approval: bool = False
+    # #2322 (G0.31 #2364) -- approval-TTL lifecycle. Every parked approval
+    # is stamped ``expires_at = created_at + APPROVAL_DEFAULT_TTL_SECONDS``
+    # (default 14 days); an explicit caller override is honoured but capped
+    # at that same ceiling so no surface can park an unbounded-lived
+    # approval. The default TTL is the single knob -- there is deliberately
+    # no per-op TTL policy (substrate minimalism, #1177). The periodic
+    # sweeper (``operations.approval_expiry``) drives
+    # ``expire_stale_requests`` per tenant on its own cadence; gated on
+    # APPROVAL_EXPIRY_ENABLED so an operator running an external sweep does
+    # not double-expire, and the 300s (5 min) default cadence matches the
+    # sibling GRANT_EXPIRY sweeper so a just-past-deadline row leaves the
+    # pending view within one tick.
+    approval_default_ttl_seconds: int = Field(default=14 * 24 * 3600, ge=60)
+    approval_expiry_enabled: bool = True
+    approval_expiry_tick_interval_seconds: int = Field(default=300, ge=60, le=86400)
     # G11.3-T4 #825 -- agent_run reaper knobs. Same opt-out shape as
     # GRANT_EXPIRY_ENABLED / MEMORY_EXPIRY_ENABLED so an operator
     # running an external lease-reclaim mechanism (DBOS Transact, a
@@ -1593,6 +1608,16 @@ def get_settings() -> Settings:
         # unless this break-glass switch is explicitly enabled.
         approval_allow_self_approval=parse_bool_env(
             os.environ.get("APPROVAL_ALLOW_SELF_APPROVAL", "false"),
+        ),
+        # #2322 — approval-TTL default + sweeper knobs.
+        approval_default_ttl_seconds=int(
+            os.environ.get("APPROVAL_DEFAULT_TTL_SECONDS", str(14 * 24 * 3600)),
+        ),
+        approval_expiry_enabled=parse_bool_env(
+            os.environ.get("APPROVAL_EXPIRY_ENABLED", "true"),
+        ),
+        approval_expiry_tick_interval_seconds=int(
+            os.environ.get("APPROVAL_EXPIRY_TICK_INTERVAL_SECONDS", "300"),
         ),
         agent_run_reaper_enabled=parse_bool_env(
             os.environ.get("AGENT_RUN_REAPER_ENABLED", "true"),

--- a/backend/tests/test_approval_expiry.py
+++ b/backend/tests/test_approval_expiry.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the #2322 approval-TTL periodic sweeper.
+
+Coverage matrix (Task #2322 acceptance criteria):
+
+* **Sweep expires past-deadline rows across tenants** — a sweep with a
+  stale pending row in each of two tenants flips both to ``expired`` and
+  writes a decision audit row per row, under a per-tenant system operator.
+* **Fresh rows are left pending** — a not-yet-expired row survives a sweep.
+* **Legacy null-expiry rows age out** — the sweeper passes the configured
+  ``APPROVAL_DEFAULT_TTL`` so a pre-#2322 null-``expires_at`` row past
+  ``created_at + TTL`` is coalesced and expired.
+* **Per-tenant failure isolation** — one tenant's sweep raising does not
+  stop the others.
+* **start/stop lifecycle** — the lifespan helpers create and cleanly
+  cancel the background task.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, ApprovalRequestStatus, AuditLog, Tenant
+from meho_backplane.operations import approval_expiry
+from meho_backplane.operations._validate import compute_params_hash
+from meho_backplane.operations.approval_expiry import (
+    start_approval_expiry_sweeper,
+    stop_approval_expiry_sweeper,
+    sweep_expired_approvals,
+)
+from meho_backplane.operations.approval_queue import create_pending_request
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _operator(tenant_id: uuid.UUID) -> Operator:
+    return Operator(
+        sub="agent-requester",
+        name=None,
+        email=None,
+        raw_jwt="<test>",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.AGENT,
+    )
+
+
+async def _seed_tenant(slug: str) -> uuid.UUID:
+    tenant_id = uuid.uuid4()
+    async with get_sessionmaker()() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        await session.commit()
+    return tenant_id
+
+
+async def _park(
+    tenant_id: uuid.UUID,
+    op_id: str,
+    *,
+    expires_at: datetime | None,
+) -> uuid.UUID:
+    async with get_sessionmaker()() as session:
+        request = await create_pending_request(
+            session,
+            operator=_operator(tenant_id),
+            connector_id="vault-1.x",
+            op_id=op_id,
+            target=None,
+            params={},
+            params_hash=compute_params_hash({}),
+            expires_at=expires_at,
+        )
+        await session.commit()
+        return request.id
+
+
+async def _status(request_id: uuid.UUID) -> str:
+    async with get_sessionmaker()() as session:
+        row = await session.get(ApprovalRequest, request_id)
+        assert row is not None
+        return row.status
+
+
+@pytest.mark.asyncio
+async def test_sweep_expires_past_deadline_across_tenants() -> None:
+    tenant_a = await _seed_tenant("ttl-a")
+    tenant_b = await _seed_tenant("ttl-b")
+    past = datetime.now(UTC) - timedelta(hours=1)
+
+    stale_a = await _park(tenant_a, "vault.kv.stale-a", expires_at=past)
+    stale_b = await _park(tenant_b, "vault.kv.stale-b", expires_at=past)
+
+    expired = await sweep_expired_approvals()
+
+    assert expired == 2
+    assert await _status(stale_a) == ApprovalRequestStatus.EXPIRED.value
+    assert await _status(stale_b) == ApprovalRequestStatus.EXPIRED.value
+
+    # One decision audit row per expired request.
+    async with get_sessionmaker()() as session:
+        decisions = (
+            (
+                await session.execute(
+                    AuditLog.__table__.select().where(AuditLog.path == "approval.decision")
+                )
+            )
+            .mappings()
+            .all()
+        )
+    assert len(decisions) == 2
+    assert all(d["status_code"] == 410 for d in decisions)
+
+
+@pytest.mark.asyncio
+async def test_sweep_leaves_fresh_pending() -> None:
+    tenant = await _seed_tenant("ttl-fresh")
+    fresh = await _park(tenant, "vault.kv.fresh", expires_at=datetime.now(UTC) + timedelta(hours=1))
+
+    expired = await sweep_expired_approvals()
+
+    assert expired == 0
+    assert await _status(fresh) == ApprovalRequestStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_sweep_ages_out_legacy_null_expiry() -> None:
+    tenant = await _seed_tenant("ttl-legacy")
+    row_id = await _park(tenant, "vault.kv.legacy", expires_at=None)
+
+    # Rewrite to the pre-#2322 shape: null deadline, created > default TTL ago.
+    async with get_sessionmaker()() as session:
+        row = await session.get(ApprovalRequest, row_id)
+        assert row is not None
+        row.expires_at = None
+        row.created_at = datetime.now(UTC) - timedelta(days=365)
+        await session.commit()
+
+    expired = await sweep_expired_approvals()
+
+    assert expired == 1
+    async with get_sessionmaker()() as session:
+        final = await session.get(ApprovalRequest, row_id)
+        assert final is not None
+        assert final.status == ApprovalRequestStatus.EXPIRED.value
+        # The coalesced deadline was backfilled onto the row.
+        assert final.expires_at is not None
+
+
+@pytest.mark.asyncio
+async def test_sweep_isolates_per_tenant_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One tenant's sweep raising is swallowed; the others still get swept."""
+    good = await _seed_tenant("ttl-good")
+    bad = await _seed_tenant("ttl-bad")
+    past = datetime.now(UTC) - timedelta(hours=1)
+    good_row = await _park(good, "vault.kv.good", expires_at=past)
+    await _park(bad, "vault.kv.bad", expires_at=past)
+
+    real_expire = approval_expiry.expire_stale_requests
+
+    async def _flaky(session: object, *, operator: Operator, **kwargs: object) -> object:
+        if operator.tenant_id == bad:
+            raise RuntimeError("boom")
+        return await real_expire(session, operator=operator, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(approval_expiry, "expire_stale_requests", _flaky)
+
+    # Does not raise despite the bad tenant blowing up.
+    expired = await sweep_expired_approvals()
+
+    assert expired == 1
+    assert await _status(good_row) == ApprovalRequestStatus.EXPIRED.value
+
+
+@pytest.mark.asyncio
+async def test_start_stop_lifecycle() -> None:
+    task = start_approval_expiry_sweeper()
+    assert isinstance(task, asyncio.Task)
+    assert not task.done()
+    await stop_approval_expiry_sweeper(task)
+    assert task.done()

--- a/backend/tests/test_approval_queue.py
+++ b/backend/tests/test_approval_queue.py
@@ -1274,6 +1274,224 @@ async def test_expire_stale_requests_publishes_approval_expired_broadcast(
 
 
 # ---------------------------------------------------------------------------
+# Approval-TTL: park-time expires_at stamping + bounding (#2322)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_pending_request_stamps_default_expires_at(
+    session: AsyncSession,
+) -> None:
+    """A parked row with no caller deadline defaults to created_at + APPROVAL_DEFAULT_TTL."""
+    operator = _make_operator()
+    request = await create_pending_request(
+        session,
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.ttl-default",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+    )
+    await session.commit()
+
+    assert request.expires_at is not None
+    ttl = timedelta(seconds=get_settings().approval_default_ttl_seconds)
+    # Deadline is created_at + the configured default TTL (allow a small
+    # clock-skew window between the two _now() reads).
+    assert abs((request.expires_at - request.created_at) - ttl) < timedelta(seconds=2)
+
+
+@pytest.mark.asyncio
+async def test_create_pending_request_caps_over_long_override(
+    session: AsyncSession,
+) -> None:
+    """A caller deadline longer than the ceiling is capped at created_at + default TTL."""
+    operator = _make_operator()
+    ttl = timedelta(seconds=get_settings().approval_default_ttl_seconds)
+    over_long = datetime.now(UTC) + ttl + timedelta(days=30)
+
+    request = await create_pending_request(
+        session,
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.ttl-cap",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+        expires_at=over_long,
+    )
+    await session.commit()
+
+    assert request.expires_at is not None
+    assert request.expires_at < over_long
+    # Capped to the ceiling (created_at + default TTL), not the caller value.
+    assert abs((request.expires_at - request.created_at) - ttl) < timedelta(seconds=2)
+
+
+@pytest.mark.asyncio
+async def test_create_pending_request_honours_shorter_override(
+    session: AsyncSession,
+) -> None:
+    """A caller deadline shorter than the ceiling is respected as-is."""
+    operator = _make_operator()
+    shorter = datetime.now(UTC) + timedelta(hours=1)
+
+    request = await create_pending_request(
+        session,
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.ttl-short",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+        expires_at=shorter,
+    )
+    await session.commit()
+
+    assert request.expires_at == shorter
+
+
+@pytest.mark.asyncio
+async def test_expire_stale_requests_coalesces_legacy_null_expiry(
+    session: AsyncSession,
+) -> None:
+    """With default_ttl, a legacy null-expires_at row past created_at+TTL ages out.
+
+    Rows parked before #2322 carry ``expires_at IS NULL``. The sweeper
+    passes ``default_ttl`` so they are coalesced against
+    ``created_at + default_ttl`` and expired once that deadline passes;
+    the null deadline is backfilled to the coalesced value.
+    """
+    operator = _make_operator()
+    ttl = timedelta(days=14)
+
+    # A legacy row: null expiry, created 15 days ago (past created_at + 14d).
+    old = await create_pending_request(
+        session,
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.legacy-old",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+    )
+    # A legacy row: null expiry, created 1 day ago (still within the TTL).
+    recent = await create_pending_request(
+        session,
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.legacy-recent",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+    )
+    await session.commit()
+
+    # Rewrite both to the pre-#2322 shape (null expiry) with backdated created_at.
+    async with get_sessionmaker()() as setup:
+        old_row = await setup.get(ApprovalRequest, old.id)
+        recent_row = await setup.get(ApprovalRequest, recent.id)
+        assert old_row is not None and recent_row is not None
+        old_row.expires_at = None
+        old_row.created_at = datetime.now(UTC) - timedelta(days=15)
+        recent_row.expires_at = None
+        recent_row.created_at = datetime.now(UTC) - timedelta(days=1)
+        await setup.commit()
+
+    async with get_sessionmaker()() as s2:
+        expired = await expire_stale_requests(s2, operator=operator, default_ttl=ttl)
+        await s2.commit()
+
+    assert [r.id for r in expired] == [old.id]
+
+    async with get_sessionmaker()() as fresh:
+        old_final = await fresh.get(ApprovalRequest, old.id)
+        recent_final = await fresh.get(ApprovalRequest, recent.id)
+        assert old_final is not None and recent_final is not None
+        assert old_final.status == ApprovalRequestStatus.EXPIRED.value
+        # Backfilled deadline == created_at + default TTL.
+        assert old_final.expires_at is not None
+        assert abs((old_final.expires_at - old_final.created_at) - ttl) < timedelta(seconds=2)
+        # The still-within-TTL legacy row is untouched.
+        assert recent_final.status == ApprovalRequestStatus.PENDING.value
+        assert recent_final.expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_expire_stale_requests_without_default_ttl_ignores_null_rows(
+    session: AsyncSession,
+) -> None:
+    """The historical contract: with no default_ttl, null-expiry rows are never swept."""
+    operator = _make_operator()
+    row = await create_pending_request(
+        session,
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.legacy-ignored",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as setup:
+        r = await setup.get(ApprovalRequest, row.id)
+        assert r is not None
+        r.expires_at = None
+        r.created_at = datetime.now(UTC) - timedelta(days=999)
+        await setup.commit()
+
+    async with get_sessionmaker()() as s2:
+        expired = await expire_stale_requests(s2, operator=operator)
+        await s2.commit()
+
+    assert expired == []
+    async with get_sessionmaker()() as fresh:
+        final = await fresh.get(ApprovalRequest, row.id)
+        assert final is not None
+        assert final.status == ApprovalRequestStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_expired_run_bound_request_cannot_be_approved(
+    session: AsyncSession,
+) -> None:
+    """An expired run-bound request is terminal — it cannot be approved or resumed (#2293).
+
+    Pins that once the TTL sweep flips a pending run-bound request to
+    ``expired``, no approval surface can revive it: ``approve_request``
+    hits the already-decided guard, so the op is never claimed or
+    re-dispatched.
+    """
+    requester = _make_operator(sub="agent-requester")
+    reviewer = _make_operator(sub="human-reviewer", principal_kind=PrincipalKind.USER)
+    past = datetime.now(UTC) - timedelta(hours=1)
+
+    request = await create_pending_request(
+        session,
+        operator=requester,
+        connector_id="vault-1.x",
+        op_id="vault.kv.expired-resume",
+        target=None,
+        params={},
+        params_hash=compute_params_hash({}),
+        run_id=uuid.uuid4(),
+        expires_at=past,
+    )
+    await session.commit()
+
+    async with get_sessionmaker()() as s2:
+        expired = await expire_stale_requests(s2, operator=requester)
+        await s2.commit()
+    assert [r.id for r in expired] == [request.id]
+
+    async with get_sessionmaker()() as approve_session:
+        with pytest.raises(ApprovalRequestAlreadyDecidedError):
+            await approve_request(approve_session, request.id, operator=reviewer)
+
+
+# ---------------------------------------------------------------------------
 # pause → approve → resume → execute (integration-style)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -335,6 +335,14 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                     memory_expiry_enabled=False,
                     topology_history_prune_enabled=False,
                     grant_expiry_enabled=False,
+                    # #2322 (G0.31 #2364) added an approval-TTL sweeper to
+                    # the lifespan body, gated on APPROVAL_EXPIRY_ENABLED
+                    # (default on). Pin it off here — a bare MagicMock
+                    # returns a truthy attribute, so without this the gate
+                    # reads True and the real start_approval_expiry_sweeper
+                    # runs its loop, which hits get_settings() ->
+                    # KeyError: 'KEYCLOAK_ISSUER_URL' (this test pins no env).
+                    approval_expiry_enabled=False,
                     scheduler_enabled=False,
                     agent_run_reaper_enabled=False,
                     event_drain_enabled=False,
@@ -350,9 +358,9 @@ def test_lifespan_calls_eager_import_connectors() -> None:
             patch("meho_backplane.main.start_grant_expiry_sweeper"),
             patch("meho_backplane.main.stop_grant_expiry_sweeper", new=AsyncMock()),
             # G11.3-T2 (#823) scheduler + G11.3-T4 (#825) agent_run-reaper
-            # + G11.3-T3 (#824) event-drain patches combined via
-            # ``patch.multiple`` to stay under CPython's "too many
-            # statically nested blocks" limit (20) the parenthesised
+            # + G11.3-T3 (#824) event-drain + #2322 approval-expiry patches
+            # combined via ``patch.multiple`` to stay under CPython's "too
+            # many statically nested blocks" limit (20) the parenthesised
             # ``with`` form imposes.
             # G3.11-T10 #1253 added validate_catalog_registry_coverage
             # to the lifespan after load_catalog. With _eager_import_connectors
@@ -368,6 +376,12 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                 stop_agent_run_reaper=AsyncMock(),
                 start_event_drain=MagicMock(),
                 stop_event_drain=AsyncMock(),
+                # #2322 — defensive: the gate above is pinned off so these
+                # never run, but patch them so a future default flip can't
+                # smuggle the real sweeper (and its get_settings() env read)
+                # back into this env-free test.
+                start_approval_expiry_sweeper=MagicMock(),
+                stop_approval_expiry_sweeper=AsyncMock(),
                 load_catalog=MagicMock(),
                 validate_catalog_registry_coverage=MagicMock(),
                 stamp_catalog_profiled_connectors=AsyncMock(),
@@ -426,6 +440,11 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                     memory_expiry_enabled=False,
                     topology_history_prune_enabled=False,
                     grant_expiry_enabled=False,
+                    # #2322 — pin the approval-TTL sweeper off; see the
+                    # sibling lifespan test for why a bare MagicMock
+                    # attribute (truthy) would otherwise start the real
+                    # sweeper and KeyError on KEYCLOAK_ISSUER_URL.
+                    approval_expiry_enabled=False,
                     scheduler_enabled=False,
                     agent_run_reaper_enabled=False,
                     event_drain_enabled=False,
@@ -441,9 +460,9 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
             patch("meho_backplane.main.start_grant_expiry_sweeper"),
             patch("meho_backplane.main.stop_grant_expiry_sweeper", new=AsyncMock()),
             # G11.3-T2 (#823) scheduler + G11.3-T4 (#825) agent_run-reaper
-            # + G11.3-T3 (#824) event-drain patches combined via
-            # ``patch.multiple`` to stay under CPython's "too many
-            # statically nested blocks" limit (20) the parenthesised
+            # + G11.3-T3 (#824) event-drain + #2322 approval-expiry patches
+            # combined via ``patch.multiple`` to stay under CPython's "too
+            # many statically nested blocks" limit (20) the parenthesised
             # ``with`` form imposes.
             # Same G3.11-T10 #1253 shape as the sibling lifespan test —
             # registry is empty under the mocks, so skip the catalog
@@ -457,6 +476,11 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                 stop_agent_run_reaper=AsyncMock(),
                 start_event_drain=MagicMock(),
                 stop_event_drain=AsyncMock(),
+                # #2322 — pinned off via the gate above; patched defensively
+                # (see the sibling lifespan test) so the real env-reading
+                # sweeper can never start in this env-free test.
+                start_approval_expiry_sweeper=MagicMock(),
+                stop_approval_expiry_sweeper=AsyncMock(),
                 load_catalog=MagicMock(),
                 validate_catalog_registry_coverage=MagicMock(),
                 stamp_catalog_profiled_connectors=AsyncMock(),

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -32,6 +32,63 @@ truth:
 The durable state is one `approval_request` row (table created by
 `backend/alembic/versions/0023_create_approval_request.py`, T4 #817).
 
+## Approval-TTL lifecycle (#2322)
+
+Parked approvals expire on a TTL so a pending queue cannot grow without
+bound. The lifecycle has two halves, both wired end-to-end by #2322 (the
+`expired` status, the `expires_at` column, and `expire_stale_requests`
+all pre-existed but had **zero production callers** and no park path ever
+stamped a deadline — the machinery was shipped but inert):
+
+1. **Stamp at park.** `create_pending_request` now stamps every parked
+   row with `expires_at = created_at + APPROVAL_DEFAULT_TTL` (setting
+   `approval_default_ttl_seconds`, default 14 days) so no row is ever
+   parked with a null deadline. This covers **every** transport
+   uniformly — REST, MCP, and run-bound dispatches all park through the
+   dispatcher's `_handle_needs_approval` → `create_pending_request`, and
+   the composite park path calls the same function. An explicit caller
+   `expires_at` is honoured but **capped** at that same ceiling
+   (`_bounded_expires_at`): the single configured TTL doubles as the
+   upper bound, so a surface can ask for a *shorter* deadline (e.g. a
+   preflight probe) but not an unbounded-lived one. There is deliberately
+   no per-op TTL policy — one global default is the whole knob (substrate
+   minimalism, #1177).
+
+2. **Sweep periodically.** `operations/approval_expiry.py` runs a
+   dedicated background sweeper (mirroring the sibling
+   `agents/grant_expiry.py` and `memory/expiry.py` sweepers): a
+   lifespan-owned `asyncio` task on a fixed cadence
+   (`approval_expiry_tick_interval_seconds`, default 300s), gated on
+   `APPROVAL_EXPIRY_ENABLED` so an operator running an external sweep does
+   not double-expire. Each tick enumerates tenants and calls
+   `expire_stale_requests` under a per-tenant **system operator**
+   (`system:approval-expiry`, `OPERATOR` role) — the same per-tenant
+   system-operator shape `topology/scheduler.py` uses, required because
+   `expire_stale_requests` is tenant-scoped on `operator.tenant_id`. It
+   is a *separate* loop from the cron/one-off agent scheduler
+   (`scheduler/loop.py`), independent of `SCHEDULER_ENABLED`, because the
+   established convention for a governance-surface expiry sweeper is its
+   own opt-out + cadence.
+
+**Legacy null-expiry rows.** Rows parked before #2322 carry
+`expires_at IS NULL`. `expire_stale_requests` takes an optional
+`default_ttl`; when the sweeper passes it, a null-expiry row is coalesced
+against `created_at + default_ttl` (expressed as
+`created_at <= now - default_ttl` so the predicate binds two plain
+datetimes and stays dialect-portable, the same discipline the
+grant-expiry sweeper uses) and, when that coalesced deadline has passed,
+the row is expired and its `expires_at` is backfilled to the coalesced
+value so the decision audit row and the persisted row agree. No schema
+change or migration is needed — the coalesce lives entirely in the query
+predicate.
+
+Expired rows leave the default `?status=pending` view (the status filter
+already excludes non-pending rows) and are visible under `?status=expired`
+on every read surface (REST, MCP, UI queue). An `expired` row is
+terminal, so it cannot be approved (the pending guard raises
+`ApprovalRequestAlreadyDecidedError`) — an expired run-bound request can
+never be claimed or re-dispatched (#2293).
+
 ## Subject + actor attribution on the request row (#1481)
 
 The `approval_request` row carries the RFC 8693 two-claim attribution
@@ -596,7 +653,7 @@ a phantom event cannot outlive a failed transaction:
 | Create | `approval.pending` | `create_pending_request` (dispatcher parks a `needs-approval` verdict). | `operations/dispatcher.py::_handle_needs_approval` |
 | Approve | `approval.approved` | `approve_request` succeeds. | `api/v1/approvals.py` (REST), `mcp/tools/approvals.py` (MCP) |
 | Reject | `approval.rejected` | `reject_request` succeeds. | `api/v1/approvals.py` (REST), `mcp/tools/approvals.py` (MCP) |
-| Expire | `approval.expired` | `expire_stale_requests` (sweeper / CLI sweep) per expired row. | sweeper caller (commits then publishes per returned row's `_audit_id`) |
+| Expire | `approval.expired` | `expire_stale_requests` (periodic sweeper) per expired row. | `operations/approval_expiry.py::_sweep_one_tenant` (commits then publishes per returned row's `_audit_id`) |
 
 Payload: `approval_request_id`, `decision`, `connector_id`,
 `approval_op_id`. The event's `audit_id` field is the decision row's
@@ -679,7 +736,8 @@ fail-open semantics on broadcast outage.
 
 ## References
 
-- `backend/src/meho_backplane/operations/approval_queue.py` — queue lifecycle (T4) + read helpers + broadcast (T5).
+- `backend/src/meho_backplane/operations/approval_queue.py` — queue lifecycle (T4) + read helpers + broadcast (T5) + park-time `expires_at` stamping and `expire_stale_requests` coalesce (#2322).
+- `backend/src/meho_backplane/operations/approval_expiry.py` — periodic per-tenant approval-TTL sweeper (#2322).
 - `backend/src/meho_backplane/api/v1/approvals.py` — REST routes.
 - `backend/src/meho_backplane/mcp/tools/approvals.py` — MCP tools.
 - `cli/internal/cmd/approvals/` — CLI verbs.


### PR DESCRIPTION
## Summary

- The approval-TTL lifecycle shipped **half-built and inert**: the `expired` status, the `expires_at` column, and `expire_stale_requests` all existed, but **no park path ever stamped a deadline** and the helper had **zero production callers** — so pending approvals accumulated forever. This PR wires both halves end-to-end.
- **Stamp at park:** `create_pending_request` now stamps every parked row with `expires_at = created_at + APPROVAL_DEFAULT_TTL` (new `APPROVAL_DEFAULT_TTL_SECONDS`, default 14 days) across **all** transports — REST, MCP, and run-bound dispatches (all park through the dispatcher's `_handle_needs_approval`; the composite park path calls the same helper). An explicit caller deadline is honoured but **capped** at that ceiling, so no surface can park an unbounded-lived approval. One global TTL is the whole knob — no per-op policy (substrate minimalism, #1177).
- **Sweep periodically:** a dedicated `operations.approval_expiry` sweeper (gated on `APPROVAL_EXPIRY_ENABLED`, `APPROVAL_EXPIRY_TICK_INTERVAL_SECONDS` default 300s) drives `expire_stale_requests` per tenant under a `system:approval-expiry` operator, registered in the FastAPI lifespan. Past-deadline pending rows transition to `expired` within one tick, each with a decision audit row and a fail-open `approval.expired` broadcast.
- **Legacy null-expiry rows** age out via a sweep-time coalesce against `created_at + APPROVAL_DEFAULT_TTL` (dialect-portable bound-param form; **no schema change, no migration**), with the deadline backfilled on expiry.

## Design note (driver choice)

The issue suggested wiring the sweep into the agent-trigger scheduler tick (`scheduler/loop.py`). I used a **dedicated sweeper** instead, mirroring the codebase's established governance-surface expiry-sweeper convention (`agents/grant_expiry.py`, `memory/expiry.py`) with the topology scheduler's per-tenant system-operator shape (`expire_stale_requests` is tenant-scoped, so the sweep must enumerate tenants and act per-tenant). This keeps the approval sweep independent of `SCHEDULER_ENABLED` and off the sibling #2327 loop edit (avoids a shared-file collision). The task's contract (stamp `expires_at` + periodic sweep + expired rows leave the pending view + audit rows) is fully satisfied either way.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on all changed files
- [x] `mypy` — clean (approval_queue, approval_expiry, main, settings)
- [x] `pytest tests/test_approval_queue.py tests/test_approval_expiry.py` — 57 passed
- [x] `pytest` approval surfaces (secret-move, api_v1, mcp, ui, agent-resume, settings) — 144 passed
- [x] `pytest tests/test_operations_dispatcher.py tests/test_operations_composite.py` — 55 passed
- [x] app imports + lifespan wiring smoke — OK
- [x] `code-quality.py --diff` — 0 blockers (pre-existing file-size warnings only)
- [x] AC — parked approvals return non-null `expires_at` (REST/MCP/run-bound), override respected + capped; sweep expires past-deadline rows within one interval with a decision audit row; expired run-bound request cannot be approved/resumed (#2293 pinned); legacy null-expiry rows age out (coalesce, tested); `?status=pending` hides expired, `?status=expired` shows them (existing status filter)

## Out of scope

- Approval routing/notification; per-op TTL policy; preview-content work (#2332); auto-decline for preflight probes.
- No OpenAPI/CLI regen: `expires_at` was already `str | None` on the read schema (it just returned null before) — no response-schema change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2322


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parked approvals now receive an automatic expiration deadline.
  * Expired approvals are processed periodically and marked as terminal, with audit records and notifications.
  * Legacy approvals without deadlines are expired using the default time-to-live.
  * Approval expiration behavior can be configured, including default duration, enablement, and sweep interval.

* **Documentation**
  * Added guidance on the approval expiration lifecycle and viewing expired approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->