### PR TITLE
feat(scheduler): project skip-state onto trigger row + park after N unresolvable skips (#2327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — scheduler skip-state on the trigger row + park after N unresolvable skips (#2327)
+
+- The scheduler tick loop now projects its precondition **skips** onto the
+  `scheduled_trigger` row (migration `0057`, three columns): `skip_count`
+  (consecutive skips since the last successful fire), `last_skip_reason`
+  (machine tag — `definition_missing` / `definition_disabled` /
+  `credentials_unresolved`; the corrupt-cron / unknown-kind park paths also
+  stamp `invalid_cron_expr` / `unknown_kind`), and `last_skipped_at`.
+  Previously a permanent misconfiguration (revoked scheduler Vault token,
+  deleted-but-referenced definition, never-persisted agent secret) made the
+  loop skip every 30 s tick with the only trace a pod-log WARN, while
+  `meho scheduler list` showed a healthy-looking `active` trigger — a real
+  deploy lost ~360 hourly fires over 15 days before anyone noticed.
+- After a fixed number of **consecutive** unresolvable skips the loop parks
+  the trigger (`status='paused'`) so the state machine itself communicates
+  "broken, stopped trying" instead of re-tripping forever; a successful
+  fire resets the streak and clears the skip fields. The new state is
+  surfaced on `GET /api/v1/scheduler/triggers`, `meho.scheduler.list` /
+  `.show` (MCP), `meho scheduler list` (a `SKIPS` column), and the operator
+  console (a warning badge on the list row + a skip block on the detail
+  page). The at-most-once fire contract and transient-retry behaviour are
+  unchanged — the columns are additive visibility.
+
 ### Added — approval-TTL lifecycle wired end-to-end (parked approvals now expire) (#2322)
 
 - Every parked approval is now stamped `expires_at = created_at +

--- a/backend/alembic/versions/0057_add_scheduled_trigger_skip_state.py
+++ b/backend/alembic/versions/0057_add_scheduled_trigger_skip_state.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``scheduled_trigger`` skip-state projection columns (#2327).
+
+Revision ID: 0057
+Revises: 0056
+Create Date: 2026-07-11
+
+Initiative #2364, Task #2327. The tick loop's precondition gate
+(:func:`~meho_backplane.scheduler.loop._prepare_invocation`) skips a due
+trigger *without advancing its state* whenever the agent definition is
+missing/disabled or the agent credentials cannot be resolved. Skip-and-
+retry is right for a transient miss, but a **permanent** miss (expired
+scheduler Vault token, never-persisted agent secret, deleted-but-still-
+referenced definition) produced an infinite silent loop whose only trace
+was a WARN pair in the pod log every tick -- nothing on the trigger row,
+so ``scheduler list`` showed a healthy-looking ``active`` trigger while it
+skipped every fire for weeks (a real deploy lost ~360 hourly fires over 15
+days before anyone noticed).
+
+This migration adds three columns that project the cumulative skip state
+onto the row so the read surfaces agree with the pod-log WARNs:
+
+* ``last_skip_reason`` -- ``text`` nullable. The stable machine tag of the
+  most recent skip cause (``definition_missing`` / ``definition_disabled``
+  / ``credentials_unresolved``; the park paths also stamp
+  ``invalid_cron_expr`` / ``unknown_kind``). NULL until the first skip;
+  the loop clears it back to NULL on the next successful fire.
+* ``last_skipped_at`` -- ``timestamptz`` nullable. UTC time of the most
+  recent skip; NULL until the first skip, cleared on the next fire.
+* ``skip_count`` -- ``integer`` NOT NULL, server default ``0``. Consecutive
+  skips since the last successful fire (reset to 0 on the next fire). The
+  loop parks the trigger (``status='paused'``) once this reaches
+  ``_PARK_AFTER_CONSECUTIVE_SKIPS`` so a permanently-unresolvable trigger
+  stops silently re-tripping every tick.
+
+Soft-column discipline mirrors ``0043`` / ``0053`` / ``0055``: the two
+nullable columns take no server default (Python-side ``None`` /
+loop-set); ``skip_count`` takes a ``0`` server default so pre-#2327 rows
+backfill to "never skipped" without a data-migration pass. All three are
+purely additive, so ``helm rollback`` to the pre-0057 image (which never
+mentions the columns) is safe -- the forward-compat regression test
+covers this shape.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the three columns in reverse add order. SQLite's
+ALTER TABLE drop-column has been supported since 3.35.0 (we're on 3.45+),
+so Alembic's batch-mode fallback is not required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0057"
+down_revision: str | None = "0056"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the three skip-state columns to ``scheduled_trigger``."""
+    op.add_column(
+        "scheduled_trigger",
+        sa.Column("last_skip_reason", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "scheduled_trigger",
+        sa.Column("last_skipped_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "scheduled_trigger",
+        sa.Column(
+            "skip_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop the skip-state columns added in :func:`upgrade` (reverse order)."""
+    op.drop_column("scheduled_trigger", "skip_count")
+    op.drop_column("scheduled_trigger", "last_skipped_at")
+    op.drop_column("scheduled_trigger", "last_skip_reason")

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4053,6 +4053,48 @@ class ScheduledTrigger(Base):
         nullable=True,
         default=None,
     )
+    # Skip-state projection (#2327). The tick loop's precondition gate
+    # (:func:`~meho_backplane.scheduler.loop._prepare_invocation`) skips a
+    # due trigger without advancing its state when the definition is
+    # missing/disabled or credentials are unresolved. Before #2327 that
+    # skip was invisible on the row -- an operator's ``scheduler list``
+    # showed a healthy-looking ``active`` trigger while it silently
+    # skipped every 30 s tick for weeks. These three columns project the
+    # cumulative skip state onto the row so the read surfaces
+    # (``scheduler.list`` / ``scheduler.show`` / the operator console)
+    # agree with the pod-log WARNs. Migration ``0057`` adds them.
+    #
+    # * ``last_skip_reason`` -- the stable machine tag of the most recent
+    #   skip cause (``definition_missing`` / ``definition_disabled`` /
+    #   ``credentials_unresolved``; a park path also stamps
+    #   ``invalid_cron_expr`` / ``unknown_kind``). NULL until the first
+    #   skip; cleared back to NULL on the next successful fire.
+    last_skip_reason: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
+    # * ``last_skipped_at`` -- UTC time of the most recent skip. NULL
+    #   until the first skip; cleared on the next successful fire.
+    last_skipped_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    # * ``skip_count`` -- consecutive skips since the last successful
+    #   fire (reset to 0 on the next fire). The loop parks the trigger
+    #   (``status='paused'``) once this reaches
+    #   :data:`~meho_backplane.scheduler.loop._PARK_AFTER_CONSECUTIVE_SKIPS`
+    #   so a permanently-unresolvable trigger stops silently re-tripping
+    #   every tick and the state machine itself communicates "broken,
+    #   stopped trying". NOT NULL, default 0; migration 0057 backfills
+    #   pre-#2327 rows with the server-side ``0`` default.
+    skip_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default="0",
+    )
     # JSON payload forwarded as the agent run's initial input by the
     # dispatcher (T2 #823). Nullable: a trigger that just kicks off an
     # agent definition with no extra parameters leaves this NULL.

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -181,6 +181,51 @@ _SCHEDULER_ADVISORY_LOCK_KEY: int = 0x4D45_484F_5343_4844  # "MEHOSCHD"
 #: triggers per deployment).
 _CLAIM_BATCH_LIMIT: int = 50
 
+#: Consecutive precondition-skips a trigger tolerates before the loop
+#: parks it (``status='paused'``) with its ``last_skip_reason`` (#2327).
+#: A precondition skip (definition missing/disabled, credentials
+#: unresolved) leaves the row's fire state untouched so a *transient*
+#: miss self-heals on the next tick once the operator fixes the cause --
+#: but a *permanent* miss (revoked Vault token, deleted definition,
+#: never-persisted secret) would otherwise skip silently every tick
+#: forever. Parking after this many *consecutive* skips lets the state
+#: machine itself say "broken, stopped trying" rather than leaving a
+#: healthy-looking ``active`` row that never fires. The counter resets
+#: to 0 on the next successful fire, so an occasional transient blip
+#: never accumulates toward the park threshold. A module constant (not a
+#: per-deployment tunable) matches :data:`_CLAIM_BATCH_LIMIT`'s posture:
+#: dumb, fixed loop-behaviour bound. At the default 30 s tick this parks
+#: an unresolvable trigger after ~5 min -- past any normal
+#: credential-rotation window, fast enough to stop the silent loop.
+_PARK_AFTER_CONSECUTIVE_SKIPS: int = 10
+
+
+#: Stable machine tags for the precondition-skip causes (#2327). Written
+#: to ``scheduled_trigger.last_skip_reason`` and surfaced verbatim on the
+#: read surfaces, so they are part of the operator-facing contract -- keep
+#: them terse, lowercase, snake_case, and stable across releases.
+_SKIP_DEFINITION_MISSING: str = "definition_missing"
+_SKIP_DEFINITION_DISABLED: str = "definition_disabled"
+_SKIP_CREDENTIALS_UNRESOLVED: str = "credentials_unresolved"
+
+
+@dataclass(frozen=True, slots=True)
+class _PreconditionSkip:
+    """A due trigger the precondition gate could not fire -- with its cause.
+
+    Returned by :func:`_prepare_invocation` in place of the old bare
+    ``None`` so the caller can project the cause onto the trigger row
+    (:func:`_record_skip`) rather than skipping silently. ``reason`` is
+    one of the ``_SKIP_*`` machine tags above; it is written to
+    ``scheduled_trigger.last_skip_reason`` and surfaced on the read
+    surfaces. The row's fire state (``status`` / ``next_fire_at``) is
+    still left untouched by the caller so a transient miss self-heals on
+    the next tick -- the skip-state columns are additive visibility, not
+    a change to the at-most-once contract.
+    """
+
+    reason: str
+
 
 @dataclass(frozen=True, slots=True)
 class _ResolvedDefinition:
@@ -274,23 +319,115 @@ async def _park_trigger(
     *,
     reason: str,
 ) -> None:
-    """Transition a corrupted trigger to ``status='paused'``.
+    """Transition a corrupted trigger to ``status='paused'`` with a reason.
 
-    Called for a row whose persisted ``cron_expr`` no longer parses;
-    parking stops the loop from re-tripping on the same bad row every
-    tick. The reason is logged so an operator following audit logs
-    can find the offending row.
+    Called for a row whose persisted ``cron_expr`` no longer parses (or
+    whose ``kind`` is unrecognised); parking stops the loop from
+    re-tripping on the same bad row every tick. The reason is logged
+    *and* -- since #2327 -- stamped onto ``last_skip_reason`` /
+    ``last_skipped_at`` so the parked state explains itself on the read
+    surfaces (``scheduler list`` / ``scheduler show`` / the operator
+    console) rather than forcing the operator to grep pod logs for the
+    offending row.
     """
     await session.execute(
         update(ScheduledTrigger)
         .where(ScheduledTrigger.id == trigger_id)
-        .values(status=ScheduledTriggerStatus.PAUSED.value)
+        .values(
+            status=ScheduledTriggerStatus.PAUSED.value,
+            last_skip_reason=reason,
+            last_skipped_at=datetime.now(UTC),
+        )
     )
     _log.warning(
         "scheduler_trigger_paused",
         trigger_id=str(trigger_id),
         reason=reason,
     )
+
+
+async def _record_skip(
+    session: AsyncSession,
+    row: ScheduledTrigger,
+    *,
+    reason: str,
+) -> None:
+    """Project a precondition-skip onto the trigger row; park at the cap (#2327).
+
+    Called by :func:`_fire_cron` / :func:`_fire_one_off` when
+    :func:`_prepare_invocation` returns a :class:`_PreconditionSkip`.
+    Increments the consecutive ``skip_count`` and stamps
+    ``last_skip_reason`` / ``last_skipped_at`` so the silent every-tick
+    skip becomes visible on every read surface. Once the count reaches
+    :data:`_PARK_AFTER_CONSECUTIVE_SKIPS` the row is parked
+    (``status='paused'``) so a permanently-unresolvable trigger stops
+    re-tripping the loop -- the state machine itself communicates
+    "broken, stopped trying".
+
+    The ``skip_count`` is computed from the value the claim loaded
+    (``row.skip_count``, current because the row is claim-locked for the
+    open transaction) rather than a SQL ``+ 1`` so the local ``row``
+    object stays in sync for the caller and the park decision reads a
+    concrete integer. The ``UPDATE`` is guarded on ``status='active'``
+    so it never resurrects a row a concurrent claimer already moved off
+    ``active``.
+    """
+    now = datetime.now(UTC)
+    new_count = (row.skip_count or 0) + 1
+    should_park = new_count >= _PARK_AFTER_CONSECUTIVE_SKIPS
+    values: dict[str, object] = {
+        "skip_count": new_count,
+        "last_skip_reason": reason,
+        "last_skipped_at": now,
+    }
+    if should_park:
+        values["status"] = ScheduledTriggerStatus.PAUSED.value
+    await session.execute(
+        update(ScheduledTrigger)
+        .where(
+            ScheduledTrigger.id == row.id,
+            ScheduledTrigger.status == ScheduledTriggerStatus.ACTIVE.value,
+        )
+        .values(**values)
+    )
+    # Keep the in-memory row aligned so a later reference this tick reads
+    # the persisted values without a re-query.
+    row.skip_count = new_count
+    row.last_skip_reason = reason
+    row.last_skipped_at = now
+    if should_park:
+        row.status = ScheduledTriggerStatus.PAUSED.value
+        # One WARN on the park transition -- the per-tick skip is already
+        # logged by ``_prepare_invocation``; this line marks the moment
+        # the loop gave up, which is the operator-actionable event.
+        _log.warning(
+            "scheduler_trigger_parked_after_skips",
+            trigger_id=str(row.id),
+            reason=reason,
+            skip_count=new_count,
+        )
+
+
+async def _clear_skip_state(session: AsyncSession, row: ScheduledTrigger) -> None:
+    """Reset a trigger's skip state after a successful prepare (#2327).
+
+    A successful :func:`_prepare_invocation` means the precondition cause
+    that was tripping the skip is gone, so the consecutive-skip streak
+    breaks: reset ``skip_count`` to 0 and clear ``last_skip_reason`` /
+    ``last_skipped_at``. Called only when ``row.skip_count`` is already
+    non-zero, so the healthy hot path (every fire of a well-behaved
+    trigger) issues no extra ``UPDATE``. The write is flushed into the
+    caller's open transaction and committed alongside the advance /
+    mark-fired step.
+    """
+    await session.execute(
+        update(ScheduledTrigger)
+        .where(ScheduledTrigger.id == row.id)
+        .values(skip_count=0, last_skip_reason=None, last_skipped_at=None)
+    )
+    row.skip_count = 0
+    row.last_skip_reason = None
+    row.last_skipped_at = None
 
 
 def _coerce_inputs(inputs: dict[str, object] | None) -> str:
@@ -362,8 +499,10 @@ class _PreparedInvocation:
     work_ref: str | None
 
 
-async def _prepare_invocation(row: ScheduledTrigger) -> _PreparedInvocation | None:
-    """Resolve definition + credentials for a due trigger; ``None`` to skip.
+async def _prepare_invocation(
+    row: ScheduledTrigger,
+) -> _PreparedInvocation | _PreconditionSkip:
+    """Resolve definition + credentials for a due trigger; skip signal to skip.
 
     Called *before* the advance/mark-fired commit so a precondition
     miss (definition deleted, agent disabled, agent secret not wired)
@@ -373,9 +512,12 @@ async def _prepare_invocation(row: ScheduledTrigger) -> _PreparedInvocation | No
 
     Returns:
         :class:`_PreparedInvocation` on success.
-        ``None`` when the caller should skip the fire without advancing.
+        :class:`_PreconditionSkip` (carrying the machine-tag ``reason``)
+        when the caller should skip the fire without advancing -- the
+        caller projects that reason onto the row (#2327) instead of
+        skipping silently.
 
-    Skip-with-``None`` cases (each logged at WARN/INFO before return):
+    Skip cases (each logged at WARN/INFO before return):
 
     * **definition missing** -- the FK lookup returned no row. The
       ``agent_definition`` row was removed after the trigger was
@@ -408,14 +550,14 @@ async def _prepare_invocation(row: ScheduledTrigger) -> _PreparedInvocation | No
             trigger_id=str(row.id),
             agent_definition_id=str(row.agent_definition_id),
         )
-        return None
+        return _PreconditionSkip(reason=_SKIP_DEFINITION_MISSING)
     if not definition.enabled:
         _log.info(
             "scheduler_definition_disabled",
             trigger_id=str(row.id),
             agent_name=definition.name,
         )
-        return None
+        return _PreconditionSkip(reason=_SKIP_DEFINITION_DISABLED)
     try:
         agent_client_id, agent_client_secret = await resolve_agent_credentials(
             definition.identity_ref,
@@ -428,7 +570,7 @@ async def _prepare_invocation(row: ScheduledTrigger) -> _PreparedInvocation | No
             identity_ref=definition.identity_ref,
             reason=str(exc),
         )
-        return None
+        return _PreconditionSkip(reason=_SKIP_CREDENTIALS_UNRESOLVED)
     return _PreparedInvocation(
         name=definition.name,
         identity_ref=definition.identity_ref,
@@ -475,8 +617,16 @@ async def _fire_cron(
     other replica owns this tick).
     """
     prepared = await _prepare_invocation(row)
-    if prepared is None:
+    if isinstance(prepared, _PreconditionSkip):
+        # Project the skip onto the row (and park at the cap) instead of
+        # skipping silently (#2327). The row's fire state is still
+        # untouched -- a transient miss self-heals on the next tick.
+        await _record_skip(session, row, reason=prepared.reason)
+        await session.commit()
         return False
+    # The precondition cause (if any) has cleared -- break the skip streak.
+    if (row.skip_count or 0) > 0:
+        await _clear_skip_state(session, row)
     try:
         advanced = await advance_cron_trigger(
             session,
@@ -528,8 +678,16 @@ async def _fire_one_off(
     is visible in audit.
     """
     prepared = await _prepare_invocation(row)
-    if prepared is None:
+    if isinstance(prepared, _PreconditionSkip):
+        # Project the skip onto the row (and park at the cap) instead of
+        # skipping silently (#2327). The one-off stays ``active`` -- not
+        # consumed -- so it still fires once the operator fixes the cause.
+        await _record_skip(session, row, reason=prepared.reason)
+        await session.commit()
         return False
+    # The precondition cause (if any) has cleared -- break the skip streak.
+    if (row.skip_count or 0) > 0:
+        await _clear_skip_state(session, row)
     marked = await mark_one_off_fired(session, row, fire_instant=fire_instant)
     if marked is None:
         return False

--- a/backend/src/meho_backplane/scheduler/schemas.py
+++ b/backend/src/meho_backplane/scheduler/schemas.py
@@ -308,6 +308,42 @@ class ScheduledTriggerRead(BaseModel):
             ),
         ),
     ]
+    last_skip_reason: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Machine tag of the most recent tick the scheduler skipped this "
+                "trigger without firing -- one of 'definition_missing', "
+                "'definition_disabled', 'credentials_unresolved' (a park also "
+                "stamps 'invalid_cron_expr' / 'unknown_kind'). null when the "
+                "trigger has never skipped since its last successful fire "
+                "(cleared to null on the next fire). A non-null value on an "
+                "'active' trigger means it looks healthy but is silently not "
+                "firing -- fix the named cause. (#2327)"
+            ),
+        ),
+    ]
+    last_skipped_at: Annotated[
+        datetime | None,
+        Field(
+            description=(
+                "UTC timestamp of the most recent skipped tick; null until the "
+                "first skip and cleared on the next successful fire. (#2327)"
+            ),
+        ),
+    ]
+    skip_count: Annotated[
+        int,
+        Field(
+            description=(
+                "Consecutive ticks skipped since the last successful fire (0 when "
+                "healthy; reset to 0 on the next fire). The scheduler parks the "
+                "trigger ('status'='paused') once this reaches its internal "
+                "consecutive-skip cap, so a permanently-unresolvable trigger "
+                "stops silently re-tripping every tick. (#2327)"
+            ),
+        ),
+    ]
     inputs: dict[str, object] | None
     identity_sub: str
     created_by_sub: str

--- a/backend/src/meho_backplane/ui/routes/scheduler/detail.py
+++ b/backend/src/meho_backplane/ui/routes/scheduler/detail.py
@@ -124,6 +124,12 @@ def _build_context(
             "in_flight_policy": trigger.in_flight_policy.value,
             "next_fire_at": coerce_utc_aware(trigger.next_fire_at),
             "last_fired_at": coerce_utc_aware(trigger.last_fired_at),
+            # Skip-state projection (#2327) -- surfaces the silent-skip
+            # loop on the row so a healthy-looking 'active' trigger that
+            # is actually skipping every tick is visible to the operator.
+            "last_skip_reason": trigger.last_skip_reason,
+            "last_skipped_at": coerce_utc_aware(trigger.last_skipped_at),
+            "skip_count": trigger.skip_count,
             "inputs_json": _pretty_json(trigger.inputs),
             "identity_sub": trigger.identity_sub,
             "created_by_sub": trigger.created_by_sub,

--- a/backend/src/meho_backplane/ui/routes/scheduler/views.py
+++ b/backend/src/meho_backplane/ui/routes/scheduler/views.py
@@ -146,6 +146,11 @@ def project_trigger_to_view(
         "timezone": trigger.timezone,
         "next_fire_at": coerce_utc_aware(trigger.next_fire_at),
         "last_fired_at": coerce_utc_aware(trigger.last_fired_at),
+        # Skip-state projection (#2327): a non-zero count drives a warning
+        # badge next to the status so a silently-skipping 'active' trigger
+        # no longer reads as healthy at a glance in the list.
+        "skip_count": trigger.skip_count,
+        "last_skip_reason": trigger.last_skip_reason,
         "agent_name": agent_name or f"{str(trigger.agent_definition_id)[:8]}…",
         "agent_definition_id": str(trigger.agent_definition_id),
         "work_ref": trigger.work_ref,

--- a/backend/src/meho_backplane/ui/templates/scheduler/_table_rows.html
+++ b/backend/src/meho_backplane/ui/templates/scheduler/_table_rows.html
@@ -51,6 +51,15 @@
         </td>
         <td>
           <span class="badge {{ row.status_badge }} badge-sm">{{ row.status }}</span>
+          {# Skip-state signal (#2327): a silently-skipping 'active' trigger
+             gets a warning badge here so the row no longer reads as healthy
+             at a glance. Tooltip carries the machine-tag cause. #}
+          {% if row.skip_count and row.skip_count > 0 %}
+            <span
+              class="badge badge-warning badge-sm"
+              title="Skipped {{ row.skip_count }} consecutive tick(s){% if row.last_skip_reason %}: {{ row.last_skip_reason }}{% endif %}"
+            >⚠ {{ row.skip_count }}</span>
+          {% endif %}
         </td>
         <td class="font-mono text-xs">
           {{ row.schedule_summary }}

--- a/backend/src/meho_backplane/ui/templates/scheduler/detail.html
+++ b/backend/src/meho_backplane/ui/templates/scheduler/detail.html
@@ -83,6 +83,27 @@
 
           <dt class="opacity-60">Last fired</dt>
           <dd class="font-mono">{% if trigger.last_fired_at %}{{ trigger.last_fired_at.isoformat() }}{% else %}<span class="opacity-40">— (never)</span>{% endif %}</dd>
+
+          {# Skip state (#2327): a non-zero skip_count means the scheduler
+             is skipping this trigger every tick without firing it. Shown
+             only when there is something to show so a healthy trigger's
+             card stays uncluttered; a parked trigger's reason explains the
+             pause. #}
+          {% if trigger.skip_count and trigger.skip_count > 0 %}
+            <dt class="opacity-60">Skips</dt>
+            <dd>
+              <span class="badge badge-warning badge-sm">{{ trigger.skip_count }} consecutive</span>
+            </dd>
+            <dt class="opacity-60">Skip reason</dt>
+            <dd class="font-mono text-xs">{{ trigger.last_skip_reason or "—" }}</dd>
+            <dt class="opacity-60">Last skipped</dt>
+            <dd class="font-mono text-xs">{% if trigger.last_skipped_at %}{{ trigger.last_skipped_at.isoformat() }}{% else %}<span class="opacity-40">—</span>{% endif %}</dd>
+          {% elif trigger.last_skip_reason %}
+            {# skip_count reset to 0 by a later fire, but the last cause is
+               retained on a parked row -- keep the reason visible. #}
+            <dt class="opacity-60">Last skip reason</dt>
+            <dd class="font-mono text-xs">{{ trigger.last_skip_reason }}</dd>
+          {% endif %}
         </dl>
       </div>
     </div>

--- a/backend/tests/migrations/test_migration_0057_add_scheduled_trigger_skip_state.py
+++ b/backend/tests/migrations/test_migration_0057_add_scheduled_trigger_skip_state.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0057_add_scheduled_trigger_skip_state``.
+
+Initiative #2364, Task #2327. Adds the skip-state projection columns to
+``scheduled_trigger`` so the tick loop's silent every-tick precondition
+skips become visible on the row:
+
+* ``last_skip_reason`` -- ``text`` nullable; machine tag of the most recent
+  skip cause.
+* ``last_skipped_at`` -- ``timestamptz`` nullable; UTC time of the most
+  recent skip.
+* ``skip_count`` -- ``integer`` NOT NULL, server default ``0``; consecutive
+  skips since the last successful fire.
+
+Soft-column discipline mirrors ``0043`` / ``0053`` / ``0055``: additive,
+reversible, the two nullable columns take no server default, ``skip_count``
+carries a ``0`` server default so pre-#2327 rows backfill to "never
+skipped".
+
+**Idempotency pinning (0049/0050/0053/0055 footgun).** Every forward /
+round-trip step targets this migration's **own** revision (``0057``) and
+its ``down_revision`` (``0056``), never ``head`` -- so a future head
+migration that adds another column cannot make ``upgrade("head")`` re-run
+this ``add_column`` on a row that already has it (the duplicate-column
+stamp-replay footgun). SQLite is the test driver and the migration uses
+only generic DDL, so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0057"
+_DOWN_REVISION = "0056"
+_SKIP_COLUMNS = ("last_skip_reason", "last_skipped_at", "skip_count")
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0057.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _scheduled_trigger_table_info(sync_url: str) -> list[tuple[str, bool]]:
+    """Return ``(column_name, is_nullable)`` pairs for ``scheduled_trigger``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(scheduled_trigger)")).all()
+    finally:
+        sync_eng.dispose()
+    return [(str(row[1]), int(row[3]) == 0) for row in rows]
+
+
+def _scheduled_trigger_columns(sync_url: str) -> set[str]:
+    return {name for name, _ in _scheduled_trigger_table_info(sync_url)}
+
+
+def _column_is_nullable(sync_url: str, column: str) -> bool:
+    for name, nullable in _scheduled_trigger_table_info(sync_url):
+        if name == column:
+            return nullable
+    raise AssertionError(f"column {column!r} not present on scheduled_trigger")
+
+
+def test_upgrade_adds_skip_state_columns(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0057`` lands all three skip-state columns with the right nullability."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    columns = _scheduled_trigger_columns(sync_url)
+    for column in _SKIP_COLUMNS:
+        assert column in columns, f"migration 0057 must add scheduled_trigger.{column}"
+
+    assert _column_is_nullable(sync_url, "last_skip_reason")
+    assert _column_is_nullable(sync_url, "last_skipped_at")
+    # skip_count is NOT NULL (server default 0) so every row always carries
+    # a concrete count -- the loop's park arithmetic reads an int, never None.
+    assert not _column_is_nullable(sync_url, "skip_count")
+
+
+def test_skip_count_backfills_zero_on_existing_row(alembic_cfg: tuple[Config, str]) -> None:
+    """A row inserted at ``0056`` backfills ``skip_count=0`` when 0057 lands.
+
+    Proves the server default covers pre-#2327 rows without a data-migration
+    pass -- the "never skipped" starting state.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    # Insert a minimal cron trigger directly at the pre-0057 schema. SQLite
+    # does not enforce foreign keys by default, so the row needs no parent
+    # tenant / agent_definition -- the discriminated-union CHECK
+    # (kind='cron' => cron_expr NOT NULL, fire_at/event_filter NULL) and the
+    # NOT-NULL columns are all this test cares about. UUIDs are stored as
+    # 32-char hex (SQLAlchemy's ``Uuid`` on SQLite drops the dashes).
+    trigger_id = "33333333333333333333333333333333"
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO scheduled_trigger "
+                    "(id, tenant_id, agent_definition_id, kind, cron_expr, timezone, "
+                    "status, in_flight_policy, next_fire_at, identity_sub, created_by_sub, "
+                    "created_at, updated_at) "
+                    "VALUES (:id, '11111111111111111111111111111111', "
+                    "'22222222222222222222222222222222', 'cron', '*/5 * * * *', 'UTC', "
+                    "'active', 'fail_into_audit', '2026-01-01T00:05:00+00:00', "
+                    "'__scheduler__', 'seed', "
+                    "'2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')"
+                ),
+                {"id": trigger_id},
+            )
+    finally:
+        sync_eng.dispose()
+
+    command.upgrade(cfg, _REVISION)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT skip_count, last_skip_reason, last_skipped_at "
+                    "FROM scheduled_trigger WHERE id = :id"
+                ),
+                {"id": trigger_id},
+            ).one()
+    finally:
+        sync_eng.dispose()
+    assert row[0] == 0, "pre-0057 row must backfill skip_count=0 via the server default"
+    assert row[1] is None
+    assert row[2] is None
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0056"`` drops the columns; ``upgrade "0057"`` restores them.
+
+    Pinned to this migration's own revision on both legs (never ``head``)
+    so a future head migration cannot break the round-trip.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert set(_SKIP_COLUMNS) <= _scheduled_trigger_columns(sync_url)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    remaining = _scheduled_trigger_columns(sync_url)
+    for column in _SKIP_COLUMNS:
+        assert column not in remaining, f"downgrade must drop {column}"
+
+    command.upgrade(cfg, _REVISION)
+    assert set(_SKIP_COLUMNS) <= _scheduled_trigger_columns(sync_url)

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -1593,3 +1593,167 @@ async def test_blocking_run_does_not_stall_later_triggers_in_same_tick(
     assert all(r.status == AgentRunStatus.SUCCEEDED.value for r in final_runs), [
         r.status for r in final_runs
     ]
+
+
+# ---------------------------------------------------------------------------
+# Skip-state projection + park-after-N (#2327)
+# ---------------------------------------------------------------------------
+#
+# The precondition gate (`_prepare_invocation`) skips a due trigger without
+# advancing its state when the definition is missing/disabled or credentials
+# are unresolved. Before #2327 that skip was invisible on the row -- these
+# tests pin the fix: the loop projects the cumulative skip state onto the
+# `scheduled_trigger` row (`last_skip_reason` / `last_skipped_at` /
+# `skip_count`) and parks the trigger after `_PARK_AFTER_CONSECUTIVE_SKIPS`
+# consecutive skips so a permanently-unresolvable trigger stops silently
+# re-tripping every tick.
+
+
+@pytest.mark.asyncio
+async def test_unresolved_credentials_skip_records_skip_state_on_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A credentials-unresolved skip projects reason + count onto the row (#2327)."""
+    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    agent_id = await _seed_tenant_and_agent()
+    base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    trigger = await _create_cron(agent_definition_id=agent_id, base=base)
+    stuck_instant = base - timedelta(minutes=1)
+    await _force_due(trigger.id, stuck_instant)
+
+    fires = await run_one_tick(invoker=_make_invoker())
+    assert fires == 0
+
+    held = await _get_trigger(trigger.id)
+    # Still active + not advanced (the pre-#2327 contract is preserved) ...
+    assert held.status == ScheduledTriggerStatus.ACTIVE.value
+    assert _aware(held.next_fire_at) == stuck_instant
+    # ... but the skip is now visible on the row.
+    assert held.skip_count == 1
+    assert held.last_skip_reason == "credentials_unresolved"
+    assert held.last_skipped_at is not None
+
+
+@pytest.mark.asyncio
+async def test_missing_definition_skip_records_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deleted-definition skip stamps ``definition_missing`` on the row (#2327)."""
+    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    agent_id = await _seed_tenant_and_agent()
+    trigger = await _create_cron(
+        agent_definition_id=agent_id,
+        base=datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC),
+    )
+    await _force_due(trigger.id, datetime(2026, 1, 1, tzinfo=UTC))
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        from sqlalchemy import delete
+
+        from meho_backplane.db.models import AgentDefinition
+
+        await session.execute(delete(AgentDefinition).where(AgentDefinition.id == agent_id))
+        await session.commit()
+
+    fires = await run_one_tick(invoker=_make_invoker())
+    assert fires == 0
+
+    held = await _get_trigger(trigger.id)
+    assert held.status == ScheduledTriggerStatus.ACTIVE.value
+    assert held.skip_count == 1
+    assert held.last_skip_reason == "definition_missing"
+
+
+@pytest.mark.asyncio
+async def test_consecutive_skips_park_the_trigger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After ``_PARK_AFTER_CONSECUTIVE_SKIPS`` skips the row is parked (#2327).
+
+    Drives the same due-but-unresolvable trigger through the cap; the
+    parked (``paused``) status is what stops the silent every-tick loop and
+    lets the read surfaces say "broken, stopped trying".
+    """
+    from meho_backplane.scheduler.loop import _PARK_AFTER_CONSECUTIVE_SKIPS
+
+    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    agent_id = await _seed_tenant_and_agent()
+    base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    trigger = await _create_cron(agent_definition_id=agent_id, base=base)
+    await _force_due(trigger.id, base - timedelta(minutes=1))
+
+    # One tick short of the cap: still active, still climbing.
+    for _ in range(_PARK_AFTER_CONSECUTIVE_SKIPS - 1):
+        assert await run_one_tick(invoker=_make_invoker()) == 0
+    almost = await _get_trigger(trigger.id)
+    assert almost.status == ScheduledTriggerStatus.ACTIVE.value
+    assert almost.skip_count == _PARK_AFTER_CONSECUTIVE_SKIPS - 1
+
+    # The tick that reaches the cap parks the row.
+    assert await run_one_tick(invoker=_make_invoker()) == 0
+    parked = await _get_trigger(trigger.id)
+    assert parked.status == ScheduledTriggerStatus.PAUSED.value
+    assert parked.skip_count == _PARK_AFTER_CONSECUTIVE_SKIPS
+    assert parked.last_skip_reason == "credentials_unresolved"
+
+    # A parked row is no longer claimed, so it stops re-tripping.
+    assert await run_one_tick(invoker=_make_invoker()) == 0
+    still = await _get_trigger(trigger.id)
+    assert still.skip_count == _PARK_AFTER_CONSECUTIVE_SKIPS
+
+
+@pytest.mark.asyncio
+async def test_successful_fire_clears_skip_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful fire resets the consecutive-skip streak to a clean row (#2327)."""
+    monkeypatch.delenv("MEHO_AGENT_SECRET_AGENT_REPORTER", raising=False)
+    agent_id = await _seed_tenant_and_agent()
+    base = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    trigger = await _create_cron(agent_definition_id=agent_id, base=base)
+    await _force_due(trigger.id, base - timedelta(minutes=1))
+
+    # Skip once -- skip state is now non-zero.
+    assert await run_one_tick(invoker=_make_invoker()) == 0
+    skipped = await _get_trigger(trigger.id)
+    assert skipped.skip_count == 1
+    assert skipped.last_skip_reason == "credentials_unresolved"
+
+    # Wire the secret; the next tick fires and clears the skip state.
+    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    assert await run_one_tick(invoker=_make_invoker()) == 1
+    fired = await _get_trigger(trigger.id)
+    assert fired.skip_count == 0
+    assert fired.last_skip_reason is None
+    assert fired.last_skipped_at is None
+    assert fired.last_fired_at is not None
+
+
+@pytest.mark.asyncio
+async def test_corrupt_cron_park_stamps_skip_reason() -> None:
+    """The corrupt-cron park path also records a reason on the row (#2327).
+
+    The parked state now explains itself on the read surfaces rather than
+    living only in the pod log.
+    """
+    agent_id = await _seed_tenant_and_agent()
+    trigger = await _create_cron(
+        agent_definition_id=agent_id,
+        base=datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC),
+    )
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(ScheduledTrigger, trigger.id)
+        assert row is not None
+        row.cron_expr = "not a cron expr"
+        row.next_fire_at = datetime(2026, 1, 1, tzinfo=UTC)
+        await session.commit()
+
+    assert await run_one_tick(invoker=_make_invoker()) == 0
+
+    parked = await _get_trigger(trigger.id)
+    assert parked.status == ScheduledTriggerStatus.PAUSED.value
+    assert parked.last_skip_reason is not None
+    assert parked.last_skip_reason.startswith("invalid_cron_expr")
+    assert parked.last_skipped_at is not None

--- a/backend/tests/test_ui_scheduler_views.py
+++ b/backend/tests/test_ui_scheduler_views.py
@@ -40,6 +40,9 @@ def _read(
     status: ScheduledTriggerStatus = ScheduledTriggerStatus.ACTIVE,
     next_fire_at: datetime | None = None,
     work_ref: str | None = None,
+    skip_count: int = 0,
+    last_skip_reason: str | None = None,
+    last_skipped_at: datetime | None = None,
 ) -> ScheduledTriggerRead:
     now = datetime(2026, 6, 18, 12, 0, tzinfo=UTC)
     return ScheduledTriggerRead(
@@ -55,6 +58,9 @@ def _read(
         in_flight_policy=ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT,
         next_fire_at=next_fire_at,
         last_fired_at=None,
+        last_skip_reason=last_skip_reason,
+        last_skipped_at=last_skipped_at,
+        skip_count=skip_count,
         inputs=None,
         identity_sub="__scheduler__",
         created_by_sub="op-admin",
@@ -129,6 +135,23 @@ def test_project_coerces_naive_next_fire() -> None:
     next_fire = view["next_fire_at"]
     assert isinstance(next_fire, datetime)
     assert next_fire.tzinfo is UTC
+
+
+def test_project_surfaces_skip_state() -> None:
+    """The projection carries skip_count + last_skip_reason for the list badge (#2327)."""
+    view = project_trigger_to_view(
+        _read(skip_count=4, last_skip_reason="credentials_unresolved"),
+        agent_names={_AGENT_ID: "nightly"},
+    )
+    assert view["skip_count"] == 4
+    assert view["last_skip_reason"] == "credentials_unresolved"
+
+
+def test_project_healthy_trigger_has_zero_skip_count() -> None:
+    """A never-skipped trigger projects skip_count 0 and no reason."""
+    view = project_trigger_to_view(_read(), agent_names={_AGENT_ID: "nightly"})
+    assert view["skip_count"] == 0
+    assert view["last_skip_reason"] is None
 
 
 def test_build_agent_name_map_filters_bad_shapes() -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -24880,6 +24880,24 @@
             "title": "Last Fired At",
             "description": "Timestamp of the most recent fire (UTC), stamped with the scheduler tick that claimed the row -- not the trigger's fire_at / next_fire_at. Because fires are tick-aligned, successive last_fired_at values sit on the tick grid and can trail the requested time by up to one tick interval (SCHEDULER_TICK_INTERVAL_SECONDS, default 30 s); null until the first fire."
           },
+          "last_skip_reason": {
+            "type": "string",
+            "nullable": true,
+            "title": "Last Skip Reason",
+            "description": "Machine tag of the most recent tick the scheduler skipped this trigger without firing -- one of 'definition_missing', 'definition_disabled', 'credentials_unresolved' (a park also stamps 'invalid_cron_expr' / 'unknown_kind'). null when the trigger has never skipped since its last successful fire (cleared to null on the next fire). A non-null value on an 'active' trigger means it looks healthy but is silently not firing -- fix the named cause. (#2327)"
+          },
+          "last_skipped_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Last Skipped At",
+            "description": "UTC timestamp of the most recent skipped tick; null until the first skip and cleared on the next successful fire. (#2327)"
+          },
+          "skip_count": {
+            "type": "integer",
+            "title": "Skip Count",
+            "description": "Consecutive ticks skipped since the last successful fire (0 when healthy; reset to 0 on the next fire). The scheduler parks the trigger ('status'='paused') once this reaches its internal consecutive-skip cap, so a permanently-unresolvable trigger stops silently re-tripping every tick. (#2327)"
+          },
           "inputs": {
             "additionalProperties": true,
             "type": "object",
@@ -24924,6 +24942,9 @@
           "in_flight_policy",
           "next_fire_at",
           "last_fired_at",
+          "last_skip_reason",
+          "last_skipped_at",
+          "skip_count",
           "inputs",
           "identity_sub",
           "created_by_sub",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -5102,8 +5102,17 @@ type ScheduledTriggerRead struct {
 	// LastFiredAt Timestamp of the most recent fire (UTC), stamped with the scheduler tick that claimed the row -- not the trigger's fire_at / next_fire_at. Because fires are tick-aligned, successive last_fired_at values sit on the tick grid and can trail the requested time by up to one tick interval (SCHEDULER_TICK_INTERVAL_SECONDS, default 30 s); null until the first fire.
 	LastFiredAt *time.Time `json:"last_fired_at"`
 
+	// LastSkipReason Machine tag of the most recent tick the scheduler skipped this trigger without firing -- one of 'definition_missing', 'definition_disabled', 'credentials_unresolved' (a park also stamps 'invalid_cron_expr' / 'unknown_kind'). null when the trigger has never skipped since its last successful fire (cleared to null on the next fire). A non-null value on an 'active' trigger means it looks healthy but is silently not firing -- fix the named cause. (#2327)
+	LastSkipReason *string `json:"last_skip_reason"`
+
+	// LastSkippedAt UTC timestamp of the most recent skipped tick; null until the first skip and cleared on the next successful fire. (#2327)
+	LastSkippedAt *time.Time `json:"last_skipped_at"`
+
 	// NextFireAt Next instant the trigger is eligible to fire (UTC) -- the column the tick loop scans; null for event triggers (dispatched on event arrival, not the clock). The scheduler scans on a fixed grid every SCHEDULER_TICK_INTERVAL_SECONDS (default 30 s, env-tunable 1-3600 s) and fires on the first tick at or after this time -- so it is a floor, not an exact dispatch instant, and actual dispatch can trail it by up to one tick interval. SLA-sensitive deployments lower the tick interval (floor 1 s) per deployment.
 	NextFireAt *time.Time `json:"next_fire_at"`
+
+	// SkipCount Consecutive ticks skipped since the last successful fire (0 when healthy; reset to 0 on the next fire). The scheduler parks the trigger ('status'='paused') once this reaches its internal consecutive-skip cap, so a permanently-unresolvable trigger stops silently re-tripping every tick. (#2327)
+	SkipCount int `json:"skip_count"`
 
 	// Status Closed lifecycle status of a :class:`ScheduledTrigger`.
 	//

--- a/cli/internal/cmd/scheduler/list.go
+++ b/cli/internal/cmd/scheduler/list.go
@@ -231,8 +231,11 @@ func getList(
 }
 
 // printListTable renders the triggers as a compact table:
-// ID, KIND, STATUS, SCHEDULE (cron_expr or fire_at), NEXT_FIRE_AT.
-// Consumes `api.ScheduledTriggerListResponse` directly so the
+// ID, KIND, STATUS, SKIPS, SCHEDULE (cron_expr or fire_at), NEXT_FIRE_AT,
+// WORK_REF. The SKIPS column (#2327) surfaces the consecutive-skip count so
+// an `active` trigger that is silently skipping every tick no longer reads
+// as healthy on `meho scheduler list`; "-" when the trigger is firing
+// cleanly. Consumes `api.ScheduledTriggerListResponse` directly so the
 // generated typed envelope is the single source of truth for the
 // on-screen shape.
 func printListTable(w io.Writer, r *api.ScheduledTriggerListResponse) {
@@ -240,8 +243,8 @@ func printListTable(w io.Writer, r *api.ScheduledTriggerListResponse) {
 		fmt.Fprintln(w, "no scheduled triggers in this tenant")
 		return
 	}
-	fmt.Fprintf(w, "%-36s %-8s %-10s %-30s %-24s %s\n",
-		"ID", "KIND", "STATUS", "SCHEDULE", "NEXT_FIRE_AT", "WORK_REF")
+	fmt.Fprintf(w, "%-36s %-8s %-10s %-6s %-30s %-24s %s\n",
+		"ID", "KIND", "STATUS", "SKIPS", "SCHEDULE", "NEXT_FIRE_AT", "WORK_REF")
 	for _, t := range r.Triggers {
 		schedule := ""
 		switch string(t.Kind) {
@@ -267,7 +270,11 @@ func printListTable(w io.Writer, r *api.ScheduledTriggerListResponse) {
 		if t.WorkRef != nil && *t.WorkRef != "" {
 			workRef = *t.WorkRef
 		}
-		fmt.Fprintf(w, "%-36s %-8s %-10s %-30s %-24s %s\n",
-			t.Id.String(), string(t.Kind), string(t.Status), schedule, next, workRef)
+		skips := "-"
+		if t.SkipCount > 0 {
+			skips = fmt.Sprintf("%d", t.SkipCount)
+		}
+		fmt.Fprintf(w, "%-36s %-8s %-10s %-6s %-30s %-24s %s\n",
+			t.Id.String(), string(t.Kind), string(t.Status), skips, schedule, next, workRef)
 	}
 }

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -160,8 +160,12 @@ pod env var only when Vault yields nothing (#1478). The lookup chain:
 3. When **neither** source yields a secret,
    `AgentCredentialsUnresolvedError` is raised; the loop logs
    `scheduler_credentials_unresolved` and skips the fire. The trigger
-   stays `active` so a subsequent tick retries once the secret is
-   available — no parking.
+   stays `active` (fire state untouched) so a subsequent tick retries
+   once the secret is available. Since #2327 the skip is recorded on the
+   row (`last_skip_reason='credentials_unresolved'`, `skip_count++`) and,
+   after `_PARK_AFTER_CONSECUTIVE_SKIPS` consecutive skips, the trigger is
+   parked (`status='paused'`) so a permanently-unresolvable secret stops
+   the silent every-tick loop — see "Skip-state projection + park-after-N".
 
 The write side: registering an agent principal
 ([`AgentPrincipalService.register`](../../backend/src/meho_backplane/auth/agent_principals.py))
@@ -189,11 +193,18 @@ The two fire paths follow the same lifecycle shape:
 
 1. **Prepare** (`_prepare_invocation`) — look up the agent definition
    (FK; real-FK lookup-by-primary-key) and resolve the agent's
-   `client_credentials` pair Vault-first (env-var fallback). Returns
-   `None` (skip without state writes) when any precondition fails:
-   - the agent definition was removed since trigger creation, or
-   - the definition is disabled, or
-   - the agent's secret is in neither Vault nor the fallback env var.
+   `client_credentials` pair Vault-first (env-var fallback). Returns a
+   `_PreconditionSkip` (carrying a machine-tag `reason`; skip without
+   advancing fire state) when any precondition fails:
+   - the agent definition was removed since trigger creation
+     (`definition_missing`), or
+   - the definition is disabled (`definition_disabled`), or
+   - the agent's secret is in neither Vault nor the fallback env var
+     (`credentials_unresolved`).
+
+   The caller projects that reason onto the trigger row rather than
+   skipping silently — see "Skip-state projection + park-after-N"
+   below (#2327).
 2. **Advance / mark-fired** — only when the prepare step succeeded.
    The conditional `UPDATE` (status / next_fire_at guard) commits
    the row's state transition.
@@ -213,6 +224,61 @@ at-most-once contract honest for invoke-time failures (where it was
 always the right behaviour) without dropping work for the
 precondition cases (where it was always recoverable by the
 operator).
+
+### Skip-state projection + park-after-N (#2327)
+
+A precondition skip leaves the trigger's fire state untouched so a
+*transient* miss self-heals on the next tick once the operator fixes the
+cause. But before #2327 the skip was invisible on the row: a **permanent**
+miss (revoked scheduler Vault token, deleted-but-still-referenced
+definition, never-persisted agent secret) produced an infinite silent
+loop whose only trace was a WARN pair in the pod log every tick.
+`scheduler list` showed a healthy-looking `active` trigger; a real deploy
+lost ~360 hourly fires over 15 days before anyone noticed.
+
+The fix projects the cumulative skip state onto the row and parks a
+permanently-broken trigger:
+
+- **Three columns on `scheduled_trigger`** (migration `0057`):
+  - `last_skip_reason` (`text`, nullable) — the machine tag of the most
+    recent skip cause (`definition_missing` / `definition_disabled` /
+    `credentials_unresolved`; a park path also stamps `invalid_cron_expr`
+    / `unknown_kind`).
+  - `last_skipped_at` (`timestamptz`, nullable) — UTC time of the most
+    recent skip.
+  - `skip_count` (`integer` NOT NULL, default 0) — **consecutive** skips
+    since the last successful fire.
+- **On each skip** the loop calls `_record_skip`: increment `skip_count`,
+  stamp `last_skip_reason` / `last_skipped_at`. The row's `next_fire_at`
+  (cron) / `status='active'` (one-off) is still untouched, so the
+  at-most-once contract and the transient-retry behaviour are unchanged —
+  the columns are additive visibility only.
+- **Park at the cap**: once `skip_count` reaches
+  `_PARK_AFTER_CONSECUTIVE_SKIPS` (a module constant, 10, matching the
+  `_CLAIM_BATCH_LIMIT` "dumb fixed loop-bound" posture — no per-deployment
+  tunable) the same `_record_skip` transitions the row to
+  `status='paused'`. The state machine itself now says "broken, stopped
+  trying" instead of re-tripping every tick forever. At the default 30 s
+  tick that's ~5 min of an unresolvable trigger — past any normal
+  credential-rotation window.
+- **Reset on recovery**: a successful `_prepare_invocation` breaks the
+  streak. When `skip_count > 0` the loop calls `_clear_skip_state` before
+  the advance / mark-fired step, resetting `skip_count` to 0 and clearing
+  the reason / timestamp. The healthy hot path (a well-behaved trigger's
+  every fire) issues no extra `UPDATE` — the reset only fires when there
+  was a streak to clear.
+- **Parks carry a reason too**: the corrupt-cron and unknown-kind park
+  paths (`_park_trigger`) also stamp `last_skip_reason` / `last_skipped_at`
+  now, so every paused-by-the-loop row explains itself on the read
+  surfaces.
+
+The state is surfaced everywhere the row is read: `ScheduledTriggerRead`
+carries the three fields, so `GET /api/v1/scheduler/triggers`,
+`meho.scheduler.list` / `.show` (MCP), `meho scheduler list` (a `SKIPS`
+column), and the operator console (a warning badge on the list row + a
+skip block on the detail page) all agree with the pod-log WARNs. This is
+the same read-surface projection pattern `last_fired_at` / `next_fire_at`
+already use.
 
 ### work_ref inheritance (#1663)
 
@@ -239,9 +305,11 @@ nothing when the trigger carries no ticket (the run lands `NULL`).
 
 ### Cron fire path (`_fire_cron`)
 
-1. `_prepare_invocation(row)` → `_PreparedInvocation` or `None`.
-   On `None` the trigger's `next_fire_at` stays unchanged so the
-   next tick re-claims and re-tries.
+1. `_prepare_invocation(row)` → `_PreparedInvocation` or
+   `_PreconditionSkip`. On a skip the loop records the skip state
+   (`_record_skip`) and the trigger's `next_fire_at` stays unchanged so
+   the next tick re-claims and re-tries; on success it clears any prior
+   skip state before advancing.
 2. `advance_cron_trigger(row, fire_instant=now)`:
    - Compute the next cron match via `croniter` from `now` in the
      trigger's timezone.
@@ -258,10 +326,11 @@ nothing when the trigger carries no ticket (the run lands `NULL`).
 
 ### One-off fire path (`_fire_one_off`)
 
-1. `_prepare_invocation(row)` → `_PreparedInvocation` or `None`.
-   On `None` the trigger stays `status='active'` (the row is
-   **not** consumed) so the next tick re-claims and re-tries once
-   the operator fixes the underlying issue.
+1. `_prepare_invocation(row)` → `_PreparedInvocation` or
+   `_PreconditionSkip`. On a skip the loop records the skip state
+   (`_record_skip`) and the trigger stays `status='active'` (the row is
+   **not** consumed) so the next tick re-claims and re-tries once the
+   operator fixes the underlying issue.
 2. `mark_one_off_fired(row, fire_instant=now)`:
    - Conditional `UPDATE` (`WHERE id=:id AND status='active' AND
      next_fire_at=:previous_next`) sets `status='fired'`,


### PR DESCRIPTION
## Summary

- The scheduler tick loop's precondition gate (`_prepare_invocation`) skips a due trigger without advancing its fire state when the agent definition is missing/disabled or credentials can't be resolved. That skip used to be **invisible on the row** — a permanent misconfiguration (revoked scheduler Vault token, deleted-but-referenced definition, never-persisted agent secret) skipped every 30 s tick with the only trace a pod-log WARN, while `meho scheduler list` showed a healthy-looking `active` trigger. This projects the skip state onto the row and parks the trigger after N consecutive unresolvable skips.
- **Migration 0057** adds three columns to `scheduled_trigger`: `skip_count` (consecutive skips since the last successful fire, NOT NULL default 0), `last_skip_reason` (machine tag), `last_skipped_at`. Additive/reversible; pre-#2327 rows backfill to "never skipped".
- **Loop**: `_prepare_invocation` now returns a typed `_PreconditionSkip(reason=…)` instead of a bare `None`; `_record_skip` increments the count + stamps the reason on every skip and parks the row (`status='paused'`) once it hits `_PARK_AFTER_CONSECUTIVE_SKIPS` (a fixed module constant, 10 — matching `_CLAIM_BATCH_LIMIT`'s "dumb fixed loop-bound" posture, no new tunable). A successful fire clears the skip state (`_clear_skip_state`). The corrupt-cron / unknown-kind park paths (`_park_trigger`) also stamp a reason now, so every paused-by-the-loop row explains itself.
- **Read surfaces**: `ScheduledTriggerRead` carries the three fields, so `GET /api/v1/scheduler/triggers`, `meho.scheduler.list` / `.show` (MCP), `meho scheduler list` (new `SKIPS` column), and the operator console (warning badge on the list row + skip block on the detail page) all agree with the pod-log WARNs. OpenAPI snapshot + typed Go client regenerated.
- The at-most-once fire contract and transient-retry behaviour are unchanged — the columns are additive visibility only.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (9 files)
- [x] `mypy` — clean (11 source files)
- [x] `code-quality.py --diff` — 0 blockers (pre-existing file-size + sub-100 function-size warnings only)
- [x] `alembic upgrade head` reaches `0057`; `downgrade 0056` + `upgrade head` round-trips on SQLite
- [x] `go build` / `go vet` / `go test ./internal/cmd/scheduler/` — pass; `gofmt` clean
- [x] New loop tests (`tests/test_scheduler.py`): unresolved-credentials skip records reason + count; missing-definition skip records `definition_missing`; N consecutive skips park the trigger; a successful fire clears skip state; corrupt-cron park stamps a reason
- [x] New migration tests (`tests/migrations/test_migration_0057_*`): upgrade adds the columns with correct nullability; `skip_count` backfills 0 on a pre-existing row; downgrade→upgrade round-trip (pinned to own revision `0057`, never `head`, per the stamp-replay footgun)
- [x] New UI-view tests: projection surfaces `skip_count` / `last_skip_reason`
- [x] Full backend unit suite — green

## Out of scope

- The third fix shape in the issue (an audit row on first-skip-per-cause, keyed `(trigger_id, cause_hash)`) — the issue calls it "a nice-to-have on top"; deferred.
- Fixing the underlying skip causes (token renewal, dangling references) — per-cause work, explicitly out of scope in the issue.
- Splitting `scheduler/loop.py` (now ~930 lines, pre-existing over the 600-line advisory; warning only, not agent-introduced) — a behavior-preserving refactor best done as its own task.

Closes #2327
