### PR TITLE
fix(scheduler): renew Vault token on use + startup/periodic lookup-self (#2328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,31 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — scheduler Vault token renews on use + startup/periodic lookup-self (defuses the ~32-day periodic-token fuse) (#2328)
+
+- The scheduler now fires a best-effort `auth/token/renew-self` after
+  every successful Vault agent-secret read/write, so the documented
+  **periodic** service token (`-period=768h`) is renewed at scheduler-tick
+  frequency and never ages out while the process runs. Previously the
+  backplane never renewed it — a token minted per the onboarding guide
+  silently died ~32 days after standup and every Vault-first credential
+  read started returning 403. Renewal failures are logged and swallowed
+  (the read/write already succeeded), never a new failure mode.
+- The scheduler token is now self-looked-up (`auth/token/lookup-self`) at
+  startup and on a slow cadence (hourly), logging a dead or unreachable
+  token as a loud `scheduler_vault_token_dead` /
+  `scheduler_vault_token_unreachable` ERROR the moment it's observed —
+  cutting time-to-notice from weeks to minutes. The healthy path logs
+  `scheduler_vault_token_verified` with the token's `ttl`/`expire_time`
+  so operators can watch expiry advance across renewals.
+- The token is now resolved from its live source on every use. A new
+  optional `VAULT_SCHEDULER_TOKEN_FILE` names a file (a Vault-Agent
+  sidecar sink) the token is re-read from per read/write, so a re-mint is
+  picked up **without a pod restart** — removing the manual re-mint +
+  Secret-patch + pod-restart remediation the fuse otherwise forced. The
+  static `VAULT_SCHEDULER_TOKEN` remains the default; an unreadable/empty
+  file falls through to it.
+
 ### Added — approval-TTL lifecycle wired end-to-end (parked approvals now expire) (#2322)
 
 - Every parked approval is now stamped `expires_at = created_at +

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -120,6 +120,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -180,6 +181,14 @@ _SCHEDULER_ADVISORY_LOCK_KEY: int = 0x4D45_484F_5343_4844  # "MEHOSCHD"
 #: one-off workloads (the consumer doc anticipates "dozens" of
 #: triggers per deployment).
 _CLAIM_BATCH_LIMIT: int = 50
+
+#: Slow cadence (seconds) for the scheduler Vault-token ``lookup-self``
+#: health check (#2328). Deliberately a fixed constant, not a tunable:
+#: hourly is frequent enough to cut time-to-notice on a dead token from
+#: weeks to minutes without adding Vault load, and the substrate stays
+#: config-minimal. The renew-on-use path (which actually keeps the token
+#: alive) runs at tick frequency; this is only the visibility backstop.
+_TOKEN_CHECK_INTERVAL_SECONDS: float = 3600.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -718,6 +727,27 @@ async def run_one_tick(invoker: AgentInvoker | None = None) -> int:
     return fires
 
 
+async def _check_scheduler_vault_token(*, reason: str) -> None:
+    """Run the scheduler Vault-token ``lookup-self`` health check (#2328).
+
+    Thin, never-raising wrapper around
+    :func:`~meho_backplane.scheduler.vault_credentials.verify_scheduler_token`
+    so a token check (which reaches Vault) can never stall or crash the
+    tick loop. ``verify_scheduler_token`` already logs a dead/unreachable
+    token loudly; this only guards against an unexpected error escaping
+    it. An unconfigured token is a silent no-op there (the documented
+    env-var-fallback opt-out).
+    """
+    from meho_backplane.scheduler.vault_credentials import verify_scheduler_token
+
+    try:
+        await verify_scheduler_token(reason=reason)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        _log.warning("scheduler_vault_token_check_errored", reason=reason, exc_info=True)
+
+
 async def _scheduler_loop() -> None:
     """The forever loop: sleep one cadence, tick, repeat.
 
@@ -726,9 +756,16 @@ async def _scheduler_loop() -> None:
     of the lifespan eager-init complete before the loop touches the DB.
     Per-tick ``try`` / ``except`` so a transient failure (DB blip,
     advisory-lock query error) is logged and the loop continues.
+
+    A Vault-token ``lookup-self`` runs once at startup and then on a
+    slow cadence (:data:`_TOKEN_CHECK_INTERVAL_SECONDS`) so a dead
+    scheduler token surfaces as a loud log within minutes rather than
+    weeks (#2328).
     """
     interval = get_settings().scheduler_tick_interval_seconds
     _log.info("scheduler_started", interval_seconds=interval)
+    await _check_scheduler_vault_token(reason="startup")
+    last_token_check = time.monotonic()
     while True:
         # Sleep first so the very first tick does not race the rest of
         # the lifespan startup; CancelledError here unwinds cleanly.
@@ -739,6 +776,9 @@ async def _scheduler_loop() -> None:
             raise
         except Exception:
             _log.warning("scheduler_tick_failed", exc_info=True)
+        if time.monotonic() - last_token_check >= _TOKEN_CHECK_INTERVAL_SECONDS:
+            last_token_check = time.monotonic()
+            await _check_scheduler_vault_token(reason="periodic")
 
 
 def start_scheduler() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/scheduler/vault_credentials.py
+++ b/backend/src/meho_backplane/scheduler/vault_credentials.py
@@ -46,11 +46,42 @@ env-var rename").
 The secret payload shape is ``{"client_secret": "<value>"}``; the read
 returns the ``client_secret`` field. No secret value ever enters a log
 event or an error message — only the path and the field *name* do.
+
+Token lifetime — renew-on-use + self-lookup (#2328)
+===================================================
+
+The documented scheduler token is a Vault **periodic** token
+(``-period=768h`` in the onboarding guidance). A periodic token expires
+``period`` after its *last renewal*, so a long-running scheduler that
+never renews carries a built-in ~32-day fuse: once it blows, every
+Vault-first read returns 403 and the scheduler silently skips. Two
+mechanisms defuse it here:
+
+* :func:`_maybe_renew_scheduler_token` fires a best-effort
+  ``auth/token/renew-self`` after every successful read/write. The
+  token is renewed at scheduler-tick frequency, so a periodic token
+  with any sane ``period`` never expires while the process runs. The
+  renewal is best-effort: the read/write already succeeded, so a failed
+  renewal is logged and swallowed rather than turned into a new failure
+  mode.
+* :func:`verify_scheduler_token` runs ``auth/token/lookup-self`` at
+  scheduler startup and on a slow cadence from the tick loop. It does
+  not fix the fuse — it shortens time-to-notice from weeks to minutes
+  by logging a dead/unreachable token as a loud ``ERROR`` the moment
+  it's observed. Sibling #2327 consumes the same signal for its
+  ``/ready features.scheduler`` skip-state surface.
+
+The token is resolved from its live source on **every** use
+(:func:`_current_scheduler_token`) rather than frozen at process start,
+so a Vault-Agent sidecar (or an operator) that re-mints the token into
+``VAULT_SCHEDULER_TOKEN_FILE`` is picked up without a pod restart.
 """
 
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
+from pathlib import Path
 
 import hvac
 import hvac.exceptions
@@ -62,11 +93,13 @@ from meho_backplane.settings import Settings, get_settings
 
 __all__ = [
     "SECRET_FIELD",
+    "SchedulerTokenStatus",
     "SchedulerVaultBrokerError",
     "SchedulerVaultNotConfiguredError",
     "read_agent_secret",
     "split_kv_v2_api_path",
     "vault_path_for_client_id",
+    "verify_scheduler_token",
     "write_agent_secret",
 ]
 
@@ -167,24 +200,78 @@ def vault_path_for_client_id(client_id: str, *, settings: Settings | None = None
     return settings.scheduler_agent_vault_path_pattern.format(client_id=sanitised)
 
 
+def _current_scheduler_token(settings: Settings) -> str:
+    """Resolve the scheduler's Vault token from its live source (#2328).
+
+    Read fresh on every call so a Vault-Agent sidecar (or an operator)
+    that re-mints the token into the configured sink is picked up
+    **without a pod restart** — the lived remediation that previously
+    forced a restart is what this defuses. Resolution order:
+
+    1. :attr:`Settings.vault_scheduler_token_file` — a file a sidecar
+       rewrites on renewal/re-mint. Re-read on every call: the *path* is
+       static config (safe to cache in settings), the *contents* are
+       not. An unreadable or empty file falls through to the env var
+       rather than failing hard.
+    2. :attr:`Settings.vault_scheduler_token` — the static env-var token.
+
+    Returns the stripped token, or ``""`` when neither source yields one.
+    """
+    file_path = settings.vault_scheduler_token_file.strip()
+    if file_path:
+        try:
+            token = Path(file_path).read_text(encoding="utf-8").strip()
+        except OSError:
+            token = ""
+        if token:
+            return token
+    return settings.vault_scheduler_token.strip()
+
+
 def _scheduler_client(settings: Settings) -> hvac.Client:
     """Build a token-authenticated hvac client for the scheduler identity.
 
-    Raises :class:`SchedulerVaultNotConfiguredError` when
-    :attr:`Settings.vault_scheduler_token` is unset — the caller decides
-    whether that is a hard failure (register) or a fall-back trigger
-    (scheduler read).
+    Raises :class:`SchedulerVaultNotConfiguredError` when no scheduler
+    token is resolvable from either source
+    (:func:`_current_scheduler_token`) — the caller decides whether that
+    is a hard failure (register) or a fall-back trigger (scheduler read).
     """
-    token = settings.vault_scheduler_token.strip()
+    token = _current_scheduler_token(settings)
     if not token:
         raise SchedulerVaultNotConfiguredError(
-            "VAULT_SCHEDULER_TOKEN is not set; the scheduler has no Vault "
-            "read/write identity for agent client_credentials secrets"
+            "VAULT_SCHEDULER_TOKEN (or VAULT_SCHEDULER_TOKEN_FILE) is not "
+            "set; the scheduler has no Vault read/write identity for agent "
+            "client_credentials secrets"
         )
     # Reuse the auth.vault client builder so vault_addr / namespace /
-    # timeout mapping stays single-sourced; bind the static token instead
-    # of a JWT-login-issued one.
+    # timeout mapping stays single-sourced; bind the resolved token
+    # instead of a JWT-login-issued one.
     return _build_client(settings, token=token)
+
+
+def _renew_scheduler_token_blocking(client: hvac.Client) -> None:
+    """Synchronously fire ``auth/token/renew-self`` for *client*'s token."""
+    client.auth.token.renew_self()
+
+
+async def _maybe_renew_scheduler_token(client: hvac.Client) -> None:
+    """Best-effort renew of the scheduler's periodic Vault token (#2328).
+
+    Called after a successful read/write. Renewing at scheduler-tick
+    frequency keeps a periodic token (``-period=768h``) alive
+    indefinitely while the process runs, defusing the ~32-day fuse.
+
+    Best-effort by contract: the read/write already succeeded, so a
+    failed renewal (non-renewable token, transient Vault error, revoked
+    lease) is logged and swallowed rather than promoted to a new failure
+    mode. No token or secret value ever enters the log event.
+    """
+    try:
+        await asyncio.to_thread(_renew_scheduler_token_blocking, client)
+    except (requests.exceptions.RequestException, hvac.exceptions.VaultError) as exc:
+        _log.warning("scheduler_vault_token_renew_failed", reason=type(exc).__name__)
+        return
+    _log.debug("scheduler_vault_token_renewed")
 
 
 async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
@@ -227,6 +314,9 @@ async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
         raise SchedulerVaultBrokerError(
             f"vault rejected agent-secret write at {api_path!r}: {type(exc).__name__}"
         ) from exc
+    # The token just authenticated a write — renew it so the periodic
+    # token never ages out (#2328). Best-effort; never raises.
+    await _maybe_renew_scheduler_token(client)
     _log.info(
         "scheduler_agent_secret_written",
         identity_ref=identity_ref,
@@ -277,10 +367,116 @@ async def read_agent_secret(identity_ref: str) -> str | None:
         raise SchedulerVaultBrokerError(
             f"vault rejected agent-secret read at {api_path!r}: {type(exc).__name__}"
         ) from exc
+    # The token just authenticated a read — renew it so the periodic
+    # token never ages out (#2328). Best-effort; never raises.
+    await _maybe_renew_scheduler_token(client)
     secret = _unwrap_secret(payload)
     if not secret:
         return None
     return secret
+
+
+@dataclass(frozen=True)
+class SchedulerTokenStatus:
+    """Outcome of a scheduler Vault-token ``lookup-self`` (#2328).
+
+    Returned by :func:`verify_scheduler_token`. ``configured`` is
+    ``False`` when no scheduler token is wired (the documented
+    env-var-fallback opt-out) — a non-failure. ``ok`` is ``True`` when
+    Vault answered the ``lookup-self`` and the token is live; ``False``
+    when the token is dead (403 / expired) or Vault was unreachable.
+    ``ttl_seconds`` and ``expire_time`` echo Vault's own view so an
+    operator (or #2327's ``/ready`` surface) can watch ``expire_time``
+    advance across renewals. Never carries a token value.
+    """
+
+    configured: bool
+    ok: bool
+    detail: str
+    ttl_seconds: int | None = None
+    expire_time: str | None = None
+
+
+def _lookup_self_blocking(client: hvac.Client) -> object:
+    """Synchronously call ``auth/token/lookup-self`` for *client*'s token."""
+    return client.auth.token.lookup_self()
+
+
+def _unwrap_token_lifetime(payload: object) -> tuple[int | None, str | None]:
+    """Pull ``(ttl_seconds, expire_time)`` from a lookup-self response.
+
+    hvac's ``lookup_self`` returns ``{"data": {"ttl": <int>,
+    "expire_time": <iso8601|None>, ...}}``. Returns ``(None, None)`` for
+    any malformed shape rather than raising — the caller has already
+    logged the token's liveness; the lifetime fields are informational.
+    """
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        return None, None
+    ttl = data.get("ttl")
+    expire_time = data.get("expire_time")
+    ttl_int = int(ttl) if isinstance(ttl, (int, float)) and not isinstance(ttl, bool) else None
+    expire_str = str(expire_time) if expire_time else None
+    return ttl_int, expire_str
+
+
+async def verify_scheduler_token(*, reason: str = "check") -> SchedulerTokenStatus:
+    """Self-lookup the scheduler Vault token; log loudly when it's dead.
+
+    Called at scheduler startup and on a slow cadence from the tick loop
+    (:mod:`meho_backplane.scheduler.loop`). It does **not** fix the fuse
+    (that is :func:`_maybe_renew_scheduler_token`) — it shortens
+    time-to-notice from weeks to minutes by surfacing a dead or
+    unreachable token as a loud ``ERROR`` the moment it's observed,
+    rather than as silent credential-unresolved skips downstream.
+
+    Never raises. An unconfigured token returns ``configured=False``
+    (the documented env-var-fallback opt-out) and any Vault failure is
+    captured into ``ok=False`` with a ``detail`` class. Sibling #2327
+    consumes the returned status for its ``/ready features.scheduler``
+    skip-state surface.
+    """
+    settings = get_settings()
+    token = _current_scheduler_token(settings)
+    if not token:
+        return SchedulerTokenStatus(configured=False, ok=True, detail="not_configured")
+    client = _build_client(settings, token=token)
+    try:
+        payload = await asyncio.to_thread(_lookup_self_blocking, client)
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+        _log.error(
+            "scheduler_vault_token_unreachable",
+            reason=type(exc).__name__,
+            check=reason,
+        )
+        return SchedulerTokenStatus(
+            configured=True, ok=False, detail=f"unreachable:{type(exc).__name__}"
+        )
+    except hvac.exceptions.VaultError as exc:
+        # Forbidden (403) is the dead/expired-token signature — the exact
+        # failure this filing exists to make visible. Log it loudly.
+        _log.error(
+            "scheduler_vault_token_dead",
+            reason=type(exc).__name__,
+            check=reason,
+        )
+        return SchedulerTokenStatus(
+            configured=True, ok=False, detail=f"denied:{type(exc).__name__}"
+        )
+    ttl, expire_time = _unwrap_token_lifetime(payload)
+    _log.info(
+        "scheduler_vault_token_verified",
+        check=reason,
+        ttl_seconds=ttl,
+        expire_time=expire_time,
+    )
+    return SchedulerTokenStatus(
+        configured=True,
+        ok=True,
+        detail="ok",
+        ttl_seconds=ttl,
+        expire_time=expire_time,
+    )
 
 
 def _unwrap_secret(payload: object) -> str:

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -190,6 +190,16 @@ class Settings(BaseModel):
         surfaced in API responses. Operators wanting AppRole instead of a
         static token can wrap a Vault Agent sidecar that writes the token
         to this env var — additive, no code change.
+    vault_scheduler_token_file:
+        Optional filesystem path the scheduler reads its Vault token from,
+        **fresh on every read/write** (#2328). When set and non-empty it
+        takes precedence over :attr:`vault_scheduler_token`; an
+        unreadable/empty file falls through to the env-var token. This is
+        the sink a Vault Agent sidecar writes renewed/re-minted tokens to:
+        because the contents are re-read per use (only the path is cached),
+        a re-mint is picked up **without a pod restart** — the manual
+        remediation the ~32-day periodic-token fuse otherwise forced.
+        Default ``""`` (use the env-var token). Never logged.
     database_url:
         SQLAlchemy URL for the PostgreSQL database, e.g.
         ``postgresql+asyncpg://meho:<password>@<host>:5432/meho``.
@@ -905,6 +915,14 @@ class Settings(BaseModel):
     vault_namespace: str | None = None
     vault_timeout_seconds: float = Field(default=10.0, gt=0)
     vault_scheduler_token: str = Field(default="", repr=False)
+    # #2328 — optional path to a file the scheduler's Vault token is read
+    # **fresh from on every use**, so a Vault-Agent sidecar (or an
+    # operator) that re-mints the token into this sink is picked up
+    # without a pod restart. Takes precedence over ``vault_scheduler_token``
+    # when set and non-empty; an unreadable/empty file falls through to the
+    # env-var token. Only the path is config (safe to cache); the contents
+    # are re-read per read/write. Never logged.
+    vault_scheduler_token_file: str = Field(default="", repr=False)
     # #2229 (Initiative #2227) — names the credential backend a schemeless
     # target ``secret_ref`` resolves through. ``vault`` (the default) keeps
     # every existing install on today's Vault KV-v2 read with no config
@@ -1525,6 +1543,7 @@ def get_settings() -> Settings:
             os.environ.get("VAULT_TIMEOUT_SECONDS", "10.0"),
         ),
         vault_scheduler_token=os.environ.get("VAULT_SCHEDULER_TOKEN", "").strip(),
+        vault_scheduler_token_file=os.environ.get("VAULT_SCHEDULER_TOKEN_FILE", "").strip(),
         # Empty / whitespace-only ``CREDENTIAL_BACKEND`` falls back to the
         # ``vault`` default so a blank chart value never yields an unknown
         # ("") backend kind (``min_length=1`` on the field would reject it).

--- a/backend/tests/test_scheduler_vault_credentials.py
+++ b/backend/tests/test_scheduler_vault_credentials.py
@@ -39,6 +39,27 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch):
     get_settings.cache_clear()
 
 
+class _FakeTokenApi:
+    """In-memory stand-in for ``client.auth.token`` (renew/lookup-self)."""
+
+    def __init__(self) -> None:
+        self.renew_calls = 0
+        self.renew_raises: BaseException | None = None
+        self.lookup_result: Any = None
+        self.lookup_raises: BaseException | None = None
+
+    def renew_self(self, increment: int | None = None) -> Any:
+        self.renew_calls += 1
+        if self.renew_raises is not None:
+            raise self.renew_raises
+        return {"auth": {"lease_duration": 2764800}}
+
+    def lookup_self(self, mount_point: str = "token") -> Any:
+        if self.lookup_raises is not None:
+            raise self.lookup_raises
+        return self.lookup_result
+
+
 class _FakeKvV2:
     """In-memory stand-in for ``client.secrets.kv.v2``."""
 
@@ -47,6 +68,9 @@ class _FakeKvV2:
         self.read_result: Any = None
         self.read_raises: BaseException | None = None
         self.last_read: dict[str, Any] | None = None
+        #: Co-located so a test holding the kv fake can assert
+        #: renew-on-use without threading a second fixture through.
+        self.token_api = _FakeTokenApi()
 
     def create_or_update_secret(
         self, *, path: str, secret: dict[str, Any], mount_point: str
@@ -68,9 +92,15 @@ class _FakeSecrets:
         self.kv = type("KV", (), {"v2": kv})()
 
 
+class _FakeAuth:
+    def __init__(self, token: _FakeTokenApi) -> None:
+        self.token = token
+
+
 class _FakeClient:
     def __init__(self, kv: _FakeKvV2) -> None:
         self.secrets = _FakeSecrets(kv)
+        self.auth = _FakeAuth(kv.token_api)
 
 
 @pytest.fixture
@@ -81,6 +111,22 @@ def fake_kv(monkeypatch: pytest.MonkeyPatch) -> _FakeKvV2:
     def _fake_build_client(_settings: Any, *, token: str | None = None) -> _FakeClient:
         # Assert the scheduler token is threaded through.
         assert token == "scheduler-tok"
+        return _FakeClient(kv)
+
+    monkeypatch.setattr(vc, "_build_client", _fake_build_client)
+    return kv
+
+
+@pytest.fixture
+def fake_kv_any_token(monkeypatch: pytest.MonkeyPatch) -> _FakeKvV2:
+    """Like :func:`fake_kv` but does not pin the threaded-through token.
+
+    Used by the token-source and ``lookup-self`` tests, where the token
+    comes from a file / differs from the env-var default.
+    """
+    kv = _FakeKvV2()
+
+    def _fake_build_client(_settings: Any, *, token: str | None = None) -> _FakeClient:
         return _FakeClient(kv)
 
     monkeypatch.setattr(vc, "_build_client", _fake_build_client)
@@ -202,3 +248,118 @@ async def test_read_vault_error_maps_to_broker_error(fake_kv: _FakeKvV2) -> None
     fake_kv.read_raises = hvac.exceptions.Forbidden("denied")
     with pytest.raises(vc.SchedulerVaultBrokerError):
         await vc.read_agent_secret("agent:reporter")
+
+
+# --- renew-on-use (#2328) --------------------------------------------
+
+
+async def test_read_renews_token_on_success(fake_kv: _FakeKvV2) -> None:
+    fake_kv.read_result = {"data": {"data": {vc.SECRET_FIELD: "s"}, "metadata": {}}}
+    assert await vc.read_agent_secret("agent:reporter") == "s"
+    assert fake_kv.token_api.renew_calls == 1
+
+
+async def test_write_renews_token_on_success(fake_kv: _FakeKvV2) -> None:
+    await vc.write_agent_secret("agent:reporter", "s")
+    assert fake_kv.token_api.renew_calls == 1
+
+
+async def test_renew_failure_does_not_break_read(fake_kv: _FakeKvV2) -> None:
+    """A failed best-effort renew is swallowed — the read still returns."""
+    fake_kv.read_result = {"data": {"data": {vc.SECRET_FIELD: "s"}, "metadata": {}}}
+    fake_kv.token_api.renew_raises = hvac.exceptions.Forbidden("not renewable")
+    assert await vc.read_agent_secret("agent:reporter") == "s"
+    assert fake_kv.token_api.renew_calls == 1
+
+
+async def test_missing_path_read_does_not_renew(fake_kv: _FakeKvV2) -> None:
+    """InvalidPath (secret absent) returns before the renew step."""
+    fake_kv.read_raises = hvac.exceptions.InvalidPath("404")
+    assert await vc.read_agent_secret("agent:reporter") is None
+    assert fake_kv.token_api.renew_calls == 0
+
+
+# --- token source re-read (#2328) ------------------------------------
+
+
+def test_current_scheduler_token_prefers_file(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    token_file = tmp_path / "tok"
+    token_file.write_text("file-token\n", encoding="utf-8")
+    monkeypatch.setenv("VAULT_SCHEDULER_TOKEN_FILE", str(token_file))
+    get_settings.cache_clear()
+    assert vc._current_scheduler_token(get_settings()) == "file-token"
+
+
+def test_current_scheduler_token_falls_back_when_file_absent(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("VAULT_SCHEDULER_TOKEN_FILE", str(tmp_path / "nope"))
+    get_settings.cache_clear()
+    # env token from the autouse fixture is "scheduler-tok".
+    assert vc._current_scheduler_token(get_settings()) == "scheduler-tok"
+
+
+def test_current_scheduler_token_empty_file_falls_back(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    token_file = tmp_path / "tok"
+    token_file.write_text("   \n", encoding="utf-8")
+    monkeypatch.setenv("VAULT_SCHEDULER_TOKEN_FILE", str(token_file))
+    get_settings.cache_clear()
+    assert vc._current_scheduler_token(get_settings()) == "scheduler-tok"
+
+
+def test_current_scheduler_token_reread_per_call(
+    tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The file is re-read on every call — a re-mint is picked up live."""
+    token_file = tmp_path / "tok"
+    token_file.write_text("first", encoding="utf-8")
+    monkeypatch.setenv("VAULT_SCHEDULER_TOKEN_FILE", str(token_file))
+    get_settings.cache_clear()
+    settings = get_settings()
+    assert vc._current_scheduler_token(settings) == "first"
+    token_file.write_text("rotated", encoding="utf-8")
+    # Same (cached) settings object — but the token is resolved fresh.
+    assert vc._current_scheduler_token(settings) == "rotated"
+
+
+# --- lookup-self health check (#2328) --------------------------------
+
+
+async def test_verify_not_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VAULT_SCHEDULER_TOKEN", raising=False)
+    get_settings.cache_clear()
+    status = await vc.verify_scheduler_token()
+    assert status.configured is False
+    assert status.ok is True
+    assert status.detail == "not_configured"
+
+
+async def test_verify_ok_reports_lifetime(fake_kv_any_token: _FakeKvV2) -> None:
+    fake_kv_any_token.token_api.lookup_result = {
+        "data": {"ttl": 2764800, "expire_time": "2026-08-11T00:00:00Z"}
+    }
+    status = await vc.verify_scheduler_token(reason="startup")
+    assert status.configured is True
+    assert status.ok is True
+    assert status.ttl_seconds == 2764800
+    assert status.expire_time == "2026-08-11T00:00:00Z"
+
+
+async def test_verify_dead_token(fake_kv_any_token: _FakeKvV2) -> None:
+    fake_kv_any_token.token_api.lookup_raises = hvac.exceptions.Forbidden("403")
+    status = await vc.verify_scheduler_token()
+    assert status.configured is True
+    assert status.ok is False
+    assert status.detail.startswith("denied:")
+
+
+async def test_verify_unreachable(fake_kv_any_token: _FakeKvV2) -> None:
+    fake_kv_any_token.token_api.lookup_raises = requests.exceptions.ConnectionError("down")
+    status = await vc.verify_scheduler_token()
+    assert status.configured is True
+    assert status.ok is False
+    assert status.detail.startswith("unreachable:")

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -183,6 +183,20 @@ primitive with no AppRole `secret_id` bootstrap). Operators preferring
 AppRole run a Vault Agent sidecar that renews a token into the env var:
 additive, no code change.
 
+The documented mint is a **periodic** token (`-period=768h`), which
+expires `period` after its last renewal. To keep it alive the broker
+fires a best-effort `auth/token/renew-self` after every successful
+read/write (`_maybe_renew_scheduler_token`), renewing the token at
+tick frequency so it never ages out while the pod runs; failures are
+logged and swallowed. `verify_scheduler_token` runs
+`auth/token/lookup-self` at scheduler startup and hourly (driven from
+`loop.py`) and logs a dead/unreachable token loudly, cutting
+time-to-notice from weeks to minutes. The token is resolved from its
+live source per use (`_current_scheduler_token`): setting
+`VAULT_SCHEDULER_TOKEN_FILE` points at a sidecar's token sink that is
+re-read on every read/write, so a re-mint is picked up without a pod
+restart (#2328).
+
 ### Precondition gate vs invoke-time failure
 
 The two fire paths follow the same lifecycle shape:

--- a/docs/cross-repo/vault-provisioning.md
+++ b/docs/cross-repo/vault-provisioning.md
@@ -220,6 +220,44 @@ disables the Vault path entirely — the scheduler then falls back to the
 `SCHEDULER_AGENT_SECRET_ENV_PATTERN` env-var convention (an *unset*
 token is not an error; an *under-scoped* one is).
 
+#### Token renewal — the periodic-token fuse (#2328)
+
+The `-period=768h` above mints a **periodic** token. A Vault periodic
+token expires `period` after its **last renewal** — so a token that is
+never renewed carries a built-in ~32-day fuse: when it blows, every
+Vault-first credential read returns 403 and the scheduler silently skips
+every fire.
+
+Since #2328 the backplane renews the token itself: it fires a
+best-effort `auth/token/renew-self` after every successful agent-secret
+read/write, so at scheduler-tick frequency a periodic token with any
+sane `period` never expires while the pod runs. It also runs
+`auth/token/lookup-self` at startup and hourly and logs a dead or
+unreachable token loudly (`scheduler_vault_token_dead` /
+`scheduler_vault_token_unreachable`); the healthy path logs
+`scheduler_vault_token_verified` with the token's `ttl` / `expire_time`.
+Watch `expire_time` advance across renewals to confirm the loop is
+alive:
+
+```bash
+vault token lookup -accessor "$ACCESSOR"   # expire_time should advance
+```
+
+For this to work the policy must allow the token to renew itself. The
+default `token/renew-self` capability is granted to every token, so no
+policy change is required; a policy that explicitly `deny`s
+`auth/token/renew-self` breaks renewal (the WARN
+`scheduler_vault_token_renew_failed` surfaces it).
+
+**Re-mint without a pod restart.** A token fed via the
+`VAULT_SCHEDULER_TOKEN` env var is frozen for the pod's lifetime — a
+re-mint requires patching the Secret and restarting the pod. To let a
+Vault Agent sidecar (or an operator) re-mint the token live, point
+`VAULT_SCHEDULER_TOKEN_FILE` at the sidecar's token sink file instead:
+the scheduler re-reads that file on **every** use, so a rewritten token
+is picked up without a restart. When both are set the file wins; an
+unreadable/empty file falls through to `VAULT_SCHEDULER_TOKEN`.
+
 ## Verification
 
 Run from any host with the operator's Vault token (`vault login`


### PR DESCRIPTION
## Summary

- The scheduler authenticates to Vault with a static **periodic** service token (`-period=768h`) but never renewed it. A periodic token expires `period` after its *last renewal*, so a token minted per the onboarding guide silently died ~32 days after standup and every Vault-first credential read began returning 403 (silent-skip loop).
- **Renew-on-use**: fire a best-effort `auth/token/renew-self` after every successful agent-secret read/write, renewing the token at scheduler-tick frequency so any sane `period` never ages out. Failures are logged and swallowed (the read/write already succeeded) — never a new failure mode.
- **Startup + hourly `lookup-self`**: `verify_scheduler_token` runs at scheduler start and on a slow cadence from the tick loop, logging a dead/unreachable token loudly (`scheduler_vault_token_dead` / `scheduler_vault_token_unreachable`) so time-to-notice drops from weeks to minutes; the healthy path logs `ttl`/`expire_time`. It returns a `SchedulerTokenStatus` that sibling #2327 can surface via `/ready features.scheduler`.
- **Live token re-read**: the token is resolved from its source per use. New optional `VAULT_SCHEDULER_TOKEN_FILE` names a Vault-Agent sidecar sink re-read on every read/write, so a re-mint is picked up **without a pod restart** (the manual remediation the fuse otherwise forced). Static `VAULT_SCHEDULER_TOKEN` stays the default; an unreadable/empty file falls through to it.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on all touched files
- [x] `mypy` — no issues (vault_credentials.py, loop.py)
- [x] `code-quality.py --diff` — 0 blockers
- [x] `pytest tests/test_scheduler_vault_credentials.py` — 32 passed (incl. new renew-on-use, token-file re-read, and `lookup-self` status tests)
- [x] `pytest -k "settings or scheduler_vault or scheduler_credentials"` — 151 passed, 5 skipped
- [x] `pytest tests/test_scheduler.py` + scheduler loop tests — 36 + 2 passed
- [x] Renew-on-use verified best-effort: a failing/non-renewable renew (e.g. dev root token) is swallowed, the read/write still returns

## Out of scope

- Surfacing the dead-token state on `/ready features.scheduler` / trigger skip-state — owned by sibling #2327; this PR emits the `SchedulerTokenStatus` signal it consumes.
- Auth-method changes (Kubernetes auth, AppRole). The fix targets the documented static periodic-token path.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2328


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler Vault token reliability by renewing tokens after successful secret operations.
  * Added startup and hourly health checks with clear logging for expired, invalid, or unreachable tokens.
  * Prevented periodic token expiry issues by dynamically using refreshed token values.

* **New Features**
  * Added optional file-based token sourcing through `VAULT_SCHEDULER_TOKEN_FILE`, with fallback behavior for missing or empty files.

* **Documentation**
  * Documented token renewal, health checks, expiration behavior, and token re-minting without restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->