### PR TITLE
feat(scheduler): reject kind=event trigger creation with a structured 422 until #826 (#2325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — reject `kind=event` scheduler triggers at create until #826 lands (#2325)
+
+- Creating a `kind=event` scheduled trigger now returns a structured 422
+  `event_triggers_not_implemented` (MCP invalid-params with the same
+  code; UI modal banner naming #826) on **every** transport — REST, MCP,
+  and the operator console. Previously the create succeeded and the
+  trigger reported `status=active`, but it could never fire: the
+  event-subscription matcher in `events/drain.py` is still the documented
+  T5 no-op, so events that real producers already emit onto the outbox
+  (e.g. `operations/agent_run.py` publishes agent-run terminal-transition
+  events) were silently swallowed. Accept-and-never-fire is dishonest;
+  the honest shape until #826 wires the matcher is a refusal at create.
+  The guard is a single check in `SchedulerAdminService.create` — removed
+  in the same change that lands #826.
+- Any pre-existing `active` event trigger is parked to `paused` by a
+  one-shot startup reconcile (`reconcile_active_event_triggers`, run once
+  before the first scheduler tick), with the reason logged under
+  `scheduler_event_triggers_parked` so an operator sees it parked (via
+  `?kind=event&status=paused` or the UI list) rather than misleadingly
+  active. No schema change, no migration; `cron` / `one_off` creation is
+  unchanged.
+
 ### Added — approval-TTL lifecycle wired end-to-end (parked approvals now expire) (#2322)
 
 - Every parked approval is now stamped `expires_at = created_at +

--- a/backend/src/meho_backplane/api/v1/scheduler.py
+++ b/backend/src/meho_backplane/api/v1/scheduler.py
@@ -73,6 +73,7 @@ from meho_backplane.scheduler.schemas import (
 )
 from meho_backplane.scheduler.service import (
     AgentDefinitionMissingError,
+    EventTriggersNotImplementedError,
     SchedulerAdminService,
 )
 
@@ -193,6 +194,14 @@ async def create_trigger(
             created_by_sub=operator.sub,
             payload=body,
         )
+    except EventTriggersNotImplementedError as exc:
+        # 422 -- kind=event is refused at create until #826 wires the
+        # event-subscription matcher (the drain matcher is a no-op today,
+        # so an accepted event trigger would never fire).
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=exc.error_code,
+        ) from exc
     except AgentDefinitionMissingError as exc:
         # 422 -- the payload is well-formed but its
         # ``agent_definition_id`` does not resolve to a definition in

--- a/backend/src/meho_backplane/mcp/tools/scheduler.py
+++ b/backend/src/meho_backplane/mcp/tools/scheduler.py
@@ -71,6 +71,7 @@ from meho_backplane.scheduler.schemas import (
 )
 from meho_backplane.scheduler.service import (
     AgentDefinitionMissingError,
+    EventTriggersNotImplementedError,
     SchedulerAdminService,
 )
 
@@ -236,6 +237,10 @@ async def _create_handler(
             created_by_sub=operator.sub,
             payload=payload,
         )
+    except EventTriggersNotImplementedError as exc:
+        # kind=event is refused at create until #826 wires the event-
+        # subscription matcher; same error code the REST route surfaces.
+        raise McpInvalidParamsError(exc.error_code) from exc
     except AgentDefinitionMissingError as exc:
         raise McpInvalidParamsError("agent_definition_not_found") from exc
     structlog.contextvars.bind_contextvars(audit_trigger_id=str(entry.id))
@@ -251,7 +256,10 @@ register_mcp_tool(
             "('cron'|'one_off'|'event'), agent_definition_id (UUID of an "
             "agent definition in the operator's tenant), and exactly one "
             "of cron_expr (for kind=cron), fire_at (ISO 8601 string for "
-            "kind=one_off), or event_filter (object for kind=event). For "
+            "kind=one_off), or event_filter (object for kind=event). NOTE: "
+            "kind=event is refused at create with 'event_triggers_not_"
+            "implemented' until #826 wires the event-subscription matcher "
+            "(an accepted event trigger cannot fire today). For "
             "kind=cron/one_off, inputs (JSON object) is REQUIRED and must "
             "render a non-empty prompt (a 'prompt' string, or any non-empty "
             "object; inputs: {} is rejected); it is optional for kind=event. "

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -159,10 +159,16 @@ from meho_backplane.scheduler.repository import (
 from meho_backplane.settings import get_settings
 
 __all__ = [
+    "reconcile_active_event_triggers",
     "run_one_tick",
     "start_scheduler",
     "stop_scheduler",
 ]
+
+#: Logged reason (and the code an operator greps) for an event trigger
+#: parked by the #2325 startup reconcile -- event dispatch is refused at
+#: create until #826 wires the event-subscription matcher.
+_EVENT_PARK_REASON: str = "event_triggers_not_implemented:826"
 
 _log = structlog.get_logger(__name__)
 
@@ -718,8 +724,48 @@ async def run_one_tick(invoker: AgentInvoker | None = None) -> int:
     return fires
 
 
+async def reconcile_active_event_triggers() -> int:
+    """Park any pre-existing ``active`` event triggers (#2325). Return the count.
+
+    ``kind=event`` triggers are refused at create until #826 wires the
+    event-subscription matcher (:mod:`meho_backplane.events.drain` is
+    still a no-op, so an event trigger sits ``active`` but can never
+    fire). Rows created ``active`` before that refusal landed would sit
+    silently dead. This one-shot startup reconcile transitions every
+    ``active`` event trigger to ``paused`` so an operator sees it parked
+    (via ``GET /api/v1/scheduler/triggers?kind=event&status=paused`` or
+    the UI list) rather than misleadingly ``active``; the reason is
+    logged under ``scheduler_event_triggers_parked`` -- mirroring the
+    :func:`_park_trigger` "reason is logged for audit" precedent, since
+    the row carries no reason column.
+
+    Idempotent: a second run finds no ``active`` event rows and parks
+    nothing. Removed in the change that lands the #826 matcher (event
+    triggers become dispatchable and no longer need parking).
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            update(ScheduledTrigger)
+            .where(
+                ScheduledTrigger.kind == ScheduledTriggerKind.EVENT.value,
+                ScheduledTrigger.status == ScheduledTriggerStatus.ACTIVE.value,
+            )
+            .values(status=ScheduledTriggerStatus.PAUSED.value)
+        )
+        await session.commit()
+    parked: int = result.rowcount or 0  # type: ignore[attr-defined]
+    if parked:
+        _log.warning(
+            "scheduler_event_triggers_parked",
+            count=parked,
+            reason=_EVENT_PARK_REASON,
+        )
+    return parked
+
+
 async def _scheduler_loop() -> None:
-    """The forever loop: sleep one cadence, tick, repeat.
+    """The forever loop: reconcile once, then sleep one cadence, tick, repeat.
 
     Sleep-then-tick (rather than tick-then-sleep) so the first tick
     after process start is delayed by one cadence -- letting the rest
@@ -729,6 +775,14 @@ async def _scheduler_loop() -> None:
     """
     interval = get_settings().scheduler_tick_interval_seconds
     _log.info("scheduler_started", interval_seconds=interval)
+    # #2325 one-shot startup reconcile: park any pre-existing active event
+    # triggers -- event dispatch is refused at create pending #826, so an
+    # active event row is silently dead. Guarded so a reconcile failure
+    # never stops the tick loop from starting.
+    try:
+        await reconcile_active_event_triggers()
+    except Exception:
+        _log.warning("scheduler_event_reconcile_failed", exc_info=True)
     while True:
         # Sleep first so the very first tick does not race the rest of
         # the lifespan startup; CancelledError here unwinds cleanly.

--- a/backend/src/meho_backplane/scheduler/service.py
+++ b/backend/src/meho_backplane/scheduler/service.py
@@ -79,6 +79,7 @@ from meho_backplane.scheduler.schemas import (
 
 __all__ = [
     "AgentDefinitionMissingError",
+    "EventTriggersNotImplementedError",
     "SchedulerAdminService",
 ]
 
@@ -111,6 +112,43 @@ class AgentDefinitionMissingError(Exception):
         self.agent_definition_id = agent_definition_id
         super().__init__(
             f"agent definition {agent_definition_id} not found in this tenant",
+        )
+
+
+class EventTriggersNotImplementedError(Exception):
+    """Raised when a create body carries ``kind=event`` (#2325).
+
+    Event-subscription triggers are refused at create until #826 wires
+    the event-outbox subscription matcher. Today
+    :mod:`meho_backplane.events.drain` is the documented T5 no-op matcher
+    -- it stamps ``processed_at`` on drained rows without ever consulting
+    ``scheduled_trigger`` -- so a persisted event trigger sits ``active``
+    but can never fire. Real producers already emit onto the outbox
+    (:mod:`meho_backplane.operations.agent_run` publishes agent-run
+    terminal-transition events), so those events are silently swallowed.
+    Accepting a trigger that can never fire is dishonest to the operator;
+    the honest shape until #826 lands is a refusal at create.
+
+    The refusal is a single create-site guard, removed in the same change
+    that lands the #826 matcher (at which point the
+    :func:`~meho_backplane.scheduler.repository.create_event_trigger`
+    branch in :meth:`SchedulerAdminService.create` comes back into play).
+    The REST route maps it to 422 ``event_triggers_not_implemented``; the
+    MCP tool to an invalid-params error with the same code; the UI to a
+    modal banner naming #826.
+    """
+
+    #: Machine-readable error code the boundary surfaces on every
+    #: transport so a caller branches on the string, not on prose.
+    error_code = "event_triggers_not_implemented"
+
+    def __init__(self) -> None:
+        super().__init__(
+            "kind=event triggers are not yet dispatchable: the "
+            "event-subscription matcher is a no-op pending #826, so an "
+            "accepted event trigger would stay active but never fire. "
+            "Refused at create until #826 lands -- use kind=cron or "
+            "kind=one_off.",
         )
 
 
@@ -182,11 +220,23 @@ class SchedulerAdminService:
 
         Raises
         ------
+        EventTriggersNotImplementedError
+            When ``payload.kind`` is ``event``. Refused at create until
+            #826 wires the event-subscription matcher (the drain matcher
+            is a no-op today, so an accepted event trigger never fires).
+            The boundary maps this to 422 ``event_triggers_not_implemented``.
         AgentDefinitionMissingError
             When ``agent_definition_id`` does not name a definition in
             *tenant_id*. The boundary maps this to 422
             ``agent_definition_not_found``.
         """
+        # #2325: refuse kind=event before any DB work. events/drain.py is
+        # still the documented T5 no-op, so a persisted event trigger is
+        # active-but-never-fires. Single create-site guard -- removed when
+        # #826 lands, at which point the create_event_trigger branch below
+        # dispatches for real.
+        if payload.kind == ScheduledTriggerKind.EVENT:
+            raise EventTriggersNotImplementedError()
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session:
             await self._assert_agent_definition_exists(
@@ -225,6 +275,9 @@ class SchedulerAdminService:
                         work_ref=payload.work_ref,
                     )
                 else:  # payload.kind == ScheduledTriggerKind.EVENT
+                    # Unreachable while the #2325 guard above stands; kept
+                    # so #826 re-enables event dispatch by deleting the
+                    # guard, not by re-authoring this branch.
                     assert payload.event_filter is not None
                     row = await create_event_trigger(
                         session,

--- a/backend/src/meho_backplane/ui/routes/scheduler/create.py
+++ b/backend/src/meho_backplane/ui/routes/scheduler/create.py
@@ -61,6 +61,7 @@ from meho_backplane.scheduler.cron import (
 from meho_backplane.scheduler.schemas import ScheduledTriggerCreate
 from meho_backplane.scheduler.service import (
     AgentDefinitionMissingError,
+    EventTriggersNotImplementedError,
     SchedulerAdminService,
 )
 from meho_backplane.ui.auth.middleware import UISessionContext
@@ -405,6 +406,15 @@ async def create_trigger(
             tenant_id=operator.tenant_id,
             created_by_sub=operator.sub,
             payload=payload,
+        )
+    except EventTriggersNotImplementedError as exc:
+        # kind=event is refused at create until #826 wires the event-
+        # subscription matcher; re-render the modal with the reason
+        # (names #826) rather than tearing the operator out of the flow.
+        return await _rerender_modal_with_error(
+            request,
+            session_ctx,
+            error_message=str(exc),
         )
     except AgentDefinitionMissingError:
         return await _rerender_modal_with_error(

--- a/backend/tests/test_scheduler_admin.py
+++ b/backend/tests/test_scheduler_admin.py
@@ -62,6 +62,7 @@ from meho_backplane.mcp.registry import get_tool
 from meho_backplane.scheduler.schemas import ScheduledTriggerCreate
 from meho_backplane.scheduler.service import (
     AgentDefinitionMissingError,
+    EventTriggersNotImplementedError,
     SchedulerAdminService,
 )
 from meho_backplane.settings import get_settings
@@ -412,25 +413,38 @@ async def test_service_create_one_off_trigger() -> None:
 
 
 @pytest.mark.asyncio
-async def test_service_create_event_trigger() -> None:
+async def test_service_create_rejects_event_trigger() -> None:
+    """kind=event is refused at create until #826 wires the matcher (#2325).
+
+    events/drain.py is still the documented no-op, so an accepted event
+    trigger sits active-but-never-fires. The service refuses it before
+    any DB write; no row is persisted.
+    """
     def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="event-bot")
     service = SchedulerAdminService()
-    entry = await service.create(
-        tenant_id=_TENANT_A,
-        created_by_sub="op-admin",
-        payload=ScheduledTriggerCreate(
-            kind=ScheduledTriggerKind.EVENT,
-            agent_definition_id=def_id,
-            event_filter={"connector_id": "bind9", "op_class": "write"},
-        ),
-    )
-    assert entry.kind == ScheduledTriggerKind.EVENT
-    assert entry.event_filter == {"connector_id": "bind9", "op_class": "write"}
-    assert entry.cron_expr is None
-    assert entry.fire_at is None
-    # Event triggers don't carry a wall-clock next_fire_at -- the outbox
-    # dispatcher (T3) wakes them.
-    assert entry.next_fire_at is None
+    with pytest.raises(EventTriggersNotImplementedError):
+        await service.create(
+            tenant_id=_TENANT_A,
+            created_by_sub="op-admin",
+            payload=ScheduledTriggerCreate(
+                kind=ScheduledTriggerKind.EVENT,
+                agent_definition_id=def_id,
+                event_filter={"connector_id": "bind9", "op_class": "write"},
+            ),
+        )
+    # No trigger row was persisted by the refused create.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(ScheduledTrigger).where(ScheduledTrigger.tenant_id == _TENANT_A)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert rows == []
 
 
 @pytest.mark.asyncio
@@ -974,6 +988,30 @@ async def test_rest_unknown_agent_definition_returns_422(client: TestClient) -> 
 
 
 @pytest.mark.asyncio
+async def test_rest_event_trigger_returns_422(client: TestClient) -> None:
+    """POST kind=event -> 422 'event_triggers_not_implemented' naming #826 (#2325)."""
+    def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="event-422")
+    key = make_rsa_keypair("kid-event-422")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key)}"}
+        result = client.post(
+            "/api/v1/scheduler/triggers",
+            json={
+                "kind": "event",
+                "agent_definition_id": str(def_id),
+                "event_filter": {"connector_id": "bind9", "op_class": "write"},
+            },
+            headers=headers,
+        )
+        assert result.status_code == 422, result.text
+        assert result.json()["detail"] == "event_triggers_not_implemented"
+        # The refused create persisted no row.
+        listed = client.get("/api/v1/scheduler/triggers", headers=headers)
+        assert listed.json()["triggers"] == []
+
+
+@pytest.mark.asyncio
 async def test_rest_invalid_cron_expr_returns_422(client: TestClient) -> None:
     """A POST with an invalid cron expression is rejected at schema time."""
     def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="invalid-cron")
@@ -1082,6 +1120,34 @@ async def test_mcp_create_rejects_cron_without_inputs() -> None:
                 "kind": "cron",
                 "agent_definition_id": str(def_id),
                 "cron_expr": "*/5 * * * *",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_mcp_create_rejects_event_trigger() -> None:
+    """meho.scheduler.create refuses kind=event as invalid-params (#2325).
+
+    Same 'event_triggers_not_implemented' code the REST route surfaces;
+    kind=event stays refused until #826 wires the matcher.
+    """
+    from meho_backplane.mcp.server import McpInvalidParamsError
+    from meho_backplane.mcp.tools.scheduler import _create_handler  # type: ignore[attr-defined]
+
+    def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="mcp-event-bot")
+    operator = Operator(
+        sub="mcp-admin",
+        raw_jwt="dummy",
+        tenant_id=_TENANT_A,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+    with pytest.raises(McpInvalidParamsError, match="event_triggers_not_implemented"):
+        await _create_handler(
+            operator,
+            {
+                "kind": "event",
+                "agent_definition_id": str(def_id),
+                "event_filter": {"connector_id": "bind9", "op_class": "write"},
             },
         )
 
@@ -1234,3 +1300,69 @@ async def test_durability_trigger_survives_scheduler_restart(
     second_tick_fires = await run_one_tick()
     assert second_tick_fires == 0
     assert fire_calls.count(entry.id) == 1
+
+
+# ---------------------------------------------------------------------------
+# Startup reconcile of pre-existing active event triggers (#2325)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconcile_parks_active_event_triggers() -> None:
+    """Pre-existing active event triggers are parked to 'paused' (#2325).
+
+    An event trigger created active before the create-time refusal landed
+    would sit silently dead (the drain matcher is a no-op pending #826).
+    The one-shot startup reconcile transitions it to 'paused' so an
+    operator sees it parked; cron / one_off rows are untouched. The
+    reconcile is idempotent -- a second run parks nothing.
+    """
+    from meho_backplane.scheduler.loop import reconcile_active_event_triggers
+    from meho_backplane.scheduler.repository import create_event_trigger
+
+    def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="reconcile-bot")
+
+    # Seed an active event trigger directly via the repository (the
+    # service refuses kind=event, which is exactly the state this
+    # reconcile cleans up for rows that predate the refusal).
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        event_row = await create_event_trigger(
+            session,
+            tenant_id=_TENANT_A,
+            agent_definition_id=def_id,
+            event_filter={"connector_id": "bind9", "op_class": "write"},
+            inputs=None,
+            identity_sub="__scheduler__",
+            created_by_sub="op-admin",
+            in_flight_policy="fail_into_audit",
+        )
+        event_id = event_row.id
+        await session.commit()
+
+    # A live cron trigger the reconcile must leave alone.
+    service = SchedulerAdminService()
+    cron = await service.create(
+        tenant_id=_TENANT_A,
+        created_by_sub="op-admin",
+        payload=ScheduledTriggerCreate(
+            kind=ScheduledTriggerKind.CRON,
+            agent_definition_id=def_id,
+            cron_expr="*/5 * * * *",
+            inputs={"prompt": "scheduled run"},
+        ),
+    )
+
+    parked = await reconcile_active_event_triggers()
+    assert parked == 1
+
+    async with sessionmaker() as session:
+        event_after = await session.get(ScheduledTrigger, event_id)
+        assert event_after is not None
+        assert event_after.status == ScheduledTriggerStatus.PAUSED.value
+    cron_after = await service.get(_TENANT_A, cron.id)
+    assert cron_after is not None
+    assert cron_after.status == ScheduledTriggerStatus.ACTIVE
+
+    # Idempotent: a second reconcile finds no active event rows.
+    assert await reconcile_active_event_triggers() == 0

--- a/backend/tests/test_ui_scheduler.py
+++ b/backend/tests/test_ui_scheduler.py
@@ -729,6 +729,33 @@ def test_create_submit_input_less_cron_rerenders_modal_with_error() -> None:
     assert _trigger_count(_TENANT_A) == 0
 
 
+def test_create_submit_event_rerenders_modal_with_error() -> None:
+    """A kind=event create surfaces the 422 as a banner naming #826 (#2325)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A)
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/scheduler/create",
+            data={
+                "kind": "event",
+                "agent_definition_id": str(_AGENT_ID),
+                "event_filter": '{"connector_id": "bind9", "op_class": "write"}',
+                "timezone": "UTC",
+                "in_flight_policy": "fail_into_audit",
+            },
+            headers=_form_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    assert "alert-error" in response.text
+    assert "#826" in response.text
+    assert _trigger_count(_TENANT_A) == 0
+
+
 def test_create_submit_rejects_operator_with_403() -> None:
     """An operator POST to create is 403'd server-side (the hidden button is UX only)."""
     _seed_tenant(_TENANT_A, "tenant-a")

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -450,6 +450,44 @@ invalid cron expression surfaces as `invalid_arguments` at the
 boundary; an unknown `agent_definition_id` surfaces as
 `agent_definition_not_found` (422 / MCP invalid-params).
 
+### `kind=event` is refused at create until #826 (#2325)
+
+`kind=event` trigger creation is **refused** with a structured 422
+`event_triggers_not_implemented` (MCP invalid-params with the same
+code; UI modal banner naming #826) on every transport. The refusal
+lives in one place — `SchedulerAdminService.create` raises
+`EventTriggersNotImplementedError` before any DB write — so the wire
+schema still models the `event` kind but no `event` row is ever
+persisted.
+
+Why: the event-subscription matcher in
+`backend/src/meho_backplane/events/drain.py` is still the documented
+T5 no-op (it stamps `processed_at` on drained rows without consulting
+`scheduled_trigger`). Real producers already emit onto the outbox —
+`backend/src/meho_backplane/operations/agent_run.py` publishes
+agent-run terminal-transition events — so those events land in
+`event_outbox` and are silently swallowed. Accepting a trigger that
+reports `status=active` but can never fire is dishonest to the
+operator; refusing at create is the honest shape until #826 wires the
+matcher. The guard is a single create-site check (not a feature-flag
+system) and is removed in the same change that lands #826, at which
+point the `create_event_trigger` branch below the guard dispatches for
+real.
+
+**Pre-existing rows.** Event triggers created `active` before this
+refusal landed are parked to `paused` by a one-shot startup reconcile
+(`reconcile_active_event_triggers` in `scheduler/loop.py`, run once at
+the top of `_scheduler_loop` before the first tick). Because an event
+trigger carries no `next_fire_at`, the tick loop's `claim_due_triggers`
+scan never sees it, so an in-loop park path would never fire — the
+reconcile is the deliberate cleanup. The park reason is logged under
+`scheduler_event_triggers_parked` (`reason=event_triggers_not_implemented:826`),
+mirroring the `_park_trigger` "reason is logged for audit" precedent
+since the row has no reason column; the parked state is visible via
+`GET /api/v1/scheduler/triggers?kind=event&status=paused` and the UI
+list. The reconcile is idempotent and removed alongside the guard when
+#826 lands.
+
 ### Cross-tenant admin
 
 `tenant_admin` callers may target another tenant by passing


### PR DESCRIPTION
## Summary

- Creating a `kind=event` scheduled trigger returned `status=active` but could never fire — `events/drain.py`'s subscription matcher is still the documented T5 no-op (#826), so events real producers already emit onto the outbox (`operations/agent_run.py:484` publishes agent-run terminal-transition events) are silently swallowed. Accept-and-never-fire is dishonest; the honest shape until #826 lands is a refusal at create.
- Refusal is a **single create-site guard**: `SchedulerAdminService.create` raises `EventTriggersNotImplementedError` before any DB write, surfaced as a structured **422 `event_triggers_not_implemented`** on REST, MCP invalid-params with the same code, and a UI modal banner naming #826. The wire schema still models the `event` kind, so #826 re-enables dispatch by deleting the guard.
- Pre-existing `active` event triggers are parked to `paused` by a one-shot startup reconcile (`reconcile_active_event_triggers`, run once before the first scheduler tick), reason logged under `scheduler_event_triggers_parked`. Event rows carry no `next_fire_at` so the tick loop never claims them — the reconcile is the deliberate cleanup.
- No schema change, no migration; `cron` / `one_off` creation unchanged.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` (scheduler + api + mcp + ui) — clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] OpenAPI snapshot regenerated — **no drift** (no schema surface change)
- [x] Full backend unit suite — **9811 passed, 418 skipped, 0 failed**
- [x] `kind=event` create → 422 `event_triggers_not_implemented` at REST route, MCP tool, and UI (`test_rest_event_trigger_returns_422`, `test_mcp_create_rejects_event_trigger`, `test_create_submit_event_rerenders_modal_with_error`)
- [x] Startup reconcile parks pre-existing active event triggers, leaves cron/one_off alone, idempotent (`test_reconcile_parks_active_event_triggers`)
- [x] `cron` / `one_off` creation + #2244 input-less regressions stay green

## Out of scope

- Implementing the #826 matcher, expanding the producer set, `event_outbox` retention (per issue).

Closes #2325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Event-based scheduled triggers are now rejected consistently across the REST API, MCP, and operator console with a structured error.
  * Existing active event triggers are automatically paused during startup and recorded with an operator-visible reason.
  * Cron and one-off trigger creation remains unchanged.

* **Documentation**
  * Added guidance on event-trigger availability, rejection behavior, and startup reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->