### PR TITLE
feat(connectors): structured post-approval vault-write-forbidden error + envelope write-capability warning (#2331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — structured post-approval vault-write-forbidden error + write-capability warning on the approval envelope (#2331)
+
+- A typed `vault.kv.put` / `patch` / `delete` that Vault denies at
+  dispatch now surfaces a dedicated `connector_vault_write_forbidden`
+  result (the write-side sibling of the read-oriented
+  `connector_vault_forbidden`, #2091) naming the exact `<mount>/data/<path>`
+  Vault denied, the acting operator identity, and the write-policy stanza
+  to add — instead of a bare permission-denied or a misleading read-path
+  diagnosis. The park-time `sys/capabilities-self` write preflight already
+  shipped; #2331 promotes its `will_be_denied` signal to a top-level
+  `write_capability_warning` on the parked `proposed_effect` envelope so
+  the approval surface can render a "this write may not land" banner
+  (a warning, not a gate), and documents the per-operator templated
+  write-identity contract in `docs/cross-repo/connector-vault-policy.md`
+  (#2331).
+
 ### Added — redaction-safe `proposed_effect` preview for `vault.kv.*` credential writes (#2332)
 
 - A parked `vault.kv.put` / `patch` / `delete` approval request now

--- a/backend/src/meho_backplane/operations/_errors.py
+++ b/backend/src/meho_backplane/operations/_errors.py
@@ -50,6 +50,7 @@ __all__ = [
     "result_connector_tls_verify_failed",
     "result_connector_unsupported",
     "result_connector_vault_forbidden",
+    "result_connector_vault_write_forbidden",
     "result_denied",
     "result_handler_unreachable",
     "result_invalid_params",
@@ -1094,6 +1095,93 @@ def result_connector_vault_forbidden(
             "error_code": "connector_vault_forbidden",
             "secret_ref": secret_ref,
             "expected_secret_ref": expected_secret_ref,
+            "exception_class": type(exc).__name__,
+            "exception_message": msg,
+        },
+    )
+
+
+#: Setup-doc anchor the write-identity-forbidden remediation points at.
+#: Kept as a module constant so the operator-facing text and the machine
+#: ``extras["doc_ref"]`` stay single-sourced.
+_VAULT_WRITE_POLICY_DOC = "docs/cross-repo/connector-vault-policy.md"
+
+
+def result_connector_vault_write_forbidden(
+    op_id: str,
+    exc: BaseException,
+    duration_ms: float,
+    *,
+    write_path: str | None,
+    identity_hint: str | None = None,
+) -> OperationResult:
+    """A KV-v2 write was denied by Vault RBAC (post-approval write-identity gap).
+
+    #2331 (Initiative #2364). The write-side sibling of
+    :func:`result_connector_vault_forbidden` (#2091). The four-eyes flow
+    can succeed end to end — park → approve → re-dispatch — and the write
+    still fails at Vault's ACL because the identity the connector dispatches
+    with lacks ``create`` / ``update`` on the target ``<mount>/data/<path>``.
+    Routing that denial through the read-oriented
+    :func:`result_connector_vault_forbidden` mis-describes it: that builder
+    talks about a target's ``secret_ref`` being outside the readable
+    per-tenant subtree, which does not apply to a typed ``vault.kv.*`` write
+    (the write authorizes against the operator's own templated write path,
+    not a target credential read). This builder names the **write** cause
+    instead — the exact data path Vault denied, the acting identity, the
+    write-policy stanza to add — so the operator sees the actionable
+    problem rather than a bare ``permission denied`` or a misleading
+    read-path diagnosis.
+
+    Unlike the read builder there is no ``secret_ref`` to fabricate: the
+    path is the op's own ``<mount>/data/<path>`` (rendered by the caller
+    via :func:`~meho_backplane.connectors.vault.ops.vault_kv_write_target_path`),
+    and the identity hint is the dispatching / reviewing operator's ``sub``.
+    The remediation points at the write-capability stanza (§6.1) and the
+    ``sys/capabilities-self`` probe (§6.2) of the policy doc, and repeats
+    the do-NOT-widen-the-shared-policy warning: the grant is per-operator
+    templated, not a role-wide widen.
+
+    ``extras`` carries the machine-usable fields
+    (``error_code`` / ``path`` / ``identity_hint`` / ``doc_ref`` /
+    ``exception_class`` / ``exception_message``) so an agent can branch on
+    the write-identity gap without re-parsing the text (#1141 convention).
+    The hvac ``Forbidden`` text names only the operator-supplied path — no
+    secret material — and tails the operator-facing string under the
+    :data:`_EXC_MESSAGE_CAP` discipline.
+    """
+    msg = str(exc)
+    if len(msg) > _EXC_MESSAGE_CAP:
+        msg = msg[:_EXC_MESSAGE_CAP] + "...<truncated>"
+    path_clause = f" on {write_path!r}" if write_path else ""
+    identity_clause = (
+        f" The write dispatched under identity {identity_hint!r}." if identity_hint else ""
+    )
+    summary = (
+        f"vault_write_identity_forbidden: Vault denied the KV-v2 write{path_clause} "
+        f"(permission denied). The approval handshake succeeded, but the identity "
+        f"the connector dispatched the write with lacks 'create'/'update' on that "
+        f"data path.{identity_clause} This is a deploy write-identity gap, not a bug "
+        f"in the approve→execute flow: add the per-operator write-capability stanza "
+        f"(§6.1) so the dispatching/reviewing operator's token can write the path, "
+        f"and verify it with the 'sys/capabilities-self' probe (§6.2). Do NOT widen "
+        f"the backplane's shared Vault policy — the write grant is per-operator "
+        f"templated. See {_VAULT_WRITE_POLICY_DOC} §6 for the write-identity contract."
+    )
+    if msg:
+        # hvac renders Forbidden as "permission denied, on POST <url>" — the
+        # URL is the operator-supplied data path, never secret material.
+        summary = f"{summary} Vault said: {msg}"
+    return OperationResult(
+        status="error",
+        op_id=op_id,
+        error=summary,
+        duration_ms=duration_ms,
+        extras={
+            "error_code": "vault_write_identity_forbidden",
+            "path": write_path,
+            "identity_hint": identity_hint,
+            "doc_ref": f"{_VAULT_WRITE_POLICY_DOC}#6-kv-v2-write-surface",
             "exception_class": type(exc).__name__,
             "exception_message": msg,
         },

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -253,6 +253,7 @@ from meho_backplane.operations._errors import (
     result_connector_tls_verify_failed,
     result_connector_unsupported,
     result_connector_vault_forbidden,
+    result_connector_vault_write_forbidden,
     result_denied,
     result_handler_unreachable,
     result_invalid_params,
@@ -1007,6 +1008,38 @@ async def _run_branch_with_error_handling(
             result_status="error",
             duration_ms=duration_ms,
         )
+        # #2331: a typed KV-v2 *write* (``vault.kv.put`` / ``patch`` /
+        # ``delete``) that Vault denies is the post-approval write-identity
+        # gap, not a credential-resolution read. The read-oriented
+        # ``connector_vault_forbidden`` below would mis-describe it (it talks
+        # about a target's ``secret_ref`` outside the readable subtree, which
+        # does not apply to a write against the operator's own templated
+        # write path). Emit the write-specific structured cause naming the
+        # data path + acting identity + the §6.1 write stanza instead. The
+        # park-time preflight (#1514) already warns on this at approval time;
+        # this is the post-approval terminal error when the warning went
+        # unheeded (or the reviewer's token lacked the grant the dispatcher's
+        # did).
+        from meho_backplane.connectors.vault.ops import (
+            VAULT_KV_WRITE_CAPABILITIES,
+            vault_kv_write_target_path,
+        )
+
+        if op_id in VAULT_KV_WRITE_CAPABILITIES:
+            try:
+                write_path = vault_kv_write_target_path(params)
+            except (KeyError, ValueError):
+                # ``path`` normalises to nothing (validate_params guarantees
+                # presence, but stay defensive inside the never-raises arm) —
+                # omit the path rather than fault.
+                write_path = None
+            return result_connector_vault_write_forbidden(
+                op_id,
+                vault_exc,
+                duration_ms,
+                write_path=write_path,
+                identity_hint=operator.sub,
+            )
         expected_secret_ref: str | None = None
         target_name = getattr(target, "name", None)
         if target_name:
@@ -1601,6 +1634,15 @@ async def _build_proposed_effect(
             base = _identifier_default_effect(op_id=op_id, connector_id=connector_id, target=target)
         if preflight is not None:
             base["permission_preflight"] = preflight
+            # #2331: promote a will-be-denied preflight to a named,
+            # top-level warning on the envelope so the approval surface can
+            # render a "this write may not land" banner without reaching
+            # into the ``permission_preflight`` sub-dict. Rides #2332's
+            # preview provenance surface (its natural carrier per the task):
+            # a warning, not a gate — refuse-to-park stays off by default,
+            # the approver may know the write policy is landing alongside.
+            if preflight.get("will_be_denied") is True:
+                base["write_capability_warning"] = "connector_identity_may_lack_write"
         # Stamp the reviewer-facing preview provenance onto every parked
         # op's envelope (#2332). ``preview_populated`` lets a caller
         # programmatically refuse to auto-approve an op-identity-only

--- a/backend/tests/test_operations_connector_vault_forbidden.py
+++ b/backend/tests/test_operations_connector_vault_forbidden.py
@@ -431,6 +431,96 @@ def test_builder_empty_message_has_no_dangling_tail() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Write-identity-forbidden builder shape (#2331)
+# ---------------------------------------------------------------------------
+
+
+def test_write_forbidden_names_path_identity_and_write_stanza() -> None:
+    """Write shape: path, acting identity, §6.1 stanza, do-not-widen warning."""
+    from meho_backplane.operations._errors import result_connector_vault_write_forbidden
+
+    out = result_connector_vault_write_forbidden(
+        "vault.kv.put",
+        _make_forbidden("targets/op-x/prod"),
+        duration_ms=1.0,
+        write_path="secret/data/targets/op-x/prod",
+        identity_hint="op-x",
+    )
+    assert out.status == "error"
+    assert out.op_id == "vault.kv.put"
+    assert out.error is not None
+    assert out.error.startswith("vault_write_identity_forbidden:")
+    # Names the denied data path + the acting identity.
+    assert "'secret/data/targets/op-x/prod'" in out.error
+    assert "'op-x'" in out.error
+    # Frames it as a write-identity gap, not a read/secret_ref diagnosis.
+    assert "lacks 'create'/'update'" in out.error
+    assert "secret_ref" not in out.error
+    # Remediation names the write stanza + probe + the policy-doc contract.
+    assert "§6.1" in out.error
+    assert "§6.2" in out.error
+    assert "Do NOT widen the backplane's shared Vault policy" in out.error
+    assert "docs/cross-repo/connector-vault-policy.md" in out.error
+    # hvac tail present.
+    assert "Vault said:" in out.error
+    assert "permission denied" in out.error
+    # Structured, machine-usable extras.
+    assert out.extras["error_code"] == "vault_write_identity_forbidden"
+    assert out.extras["path"] == "secret/data/targets/op-x/prod"
+    assert out.extras["identity_hint"] == "op-x"
+    assert out.extras["doc_ref"].startswith("docs/cross-repo/connector-vault-policy.md")
+    assert out.extras["exception_class"] == "Forbidden"
+    assert "permission denied" in out.extras["exception_message"]
+
+
+def test_write_forbidden_omits_clauses_when_path_and_identity_absent() -> None:
+    """No path / identity → no fabricated clause, extras carry None."""
+    from meho_backplane.operations._errors import result_connector_vault_write_forbidden
+
+    out = result_connector_vault_write_forbidden(
+        "vault.kv.delete",
+        hvac.exceptions.Forbidden("permission denied"),
+        duration_ms=1.0,
+        write_path=None,
+        identity_hint=None,
+    )
+    assert out.error is not None
+    assert out.error.startswith("vault_write_identity_forbidden:")
+    assert "dispatched under identity" not in out.error
+    assert out.extras["path"] is None
+    assert out.extras["identity_hint"] is None
+
+
+def test_write_forbidden_caps_oversized_message() -> None:
+    """A pathological hvac message is capped like the read sibling."""
+    from meho_backplane.operations._errors import result_connector_vault_write_forbidden
+
+    out = result_connector_vault_write_forbidden(
+        "vault.kv.put",
+        hvac.exceptions.Forbidden("x" * 400),
+        duration_ms=0.5,
+        write_path="secret/data/x",
+    )
+    message = out.extras["exception_message"]
+    assert isinstance(message, str)
+    assert message.endswith("...<truncated>")
+
+
+def test_write_forbidden_empty_message_has_no_dangling_tail() -> None:
+    """An empty exception leaves no dangling ``Vault said:`` tail."""
+    from meho_backplane.operations._errors import result_connector_vault_write_forbidden
+
+    out = result_connector_vault_write_forbidden(
+        "vault.kv.put",
+        Exception(),
+        duration_ms=0.5,
+        write_path="secret/data/x",
+    )
+    assert out.error is not None
+    assert "Vault said:" not in out.error
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher conversion (the #2091 acceptance-criterion tests)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -269,6 +269,22 @@ async def _module_handler_raises(
     raise RuntimeError("simulated handler explosion")
 
 
+async def _module_handler_raises_vault_forbidden(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Handler that raises hvac Forbidden -- the post-approval write denial (#2331)."""
+    import hvac.exceptions
+
+    raise hvac.exceptions.Forbidden(
+        "1 error occurred:\n\t* permission denied",
+        errors=["permission denied"],
+        method="POST",
+        url="https://vault.test/v1/secret/data/meho/test/x",
+    )
+
+
 async def _module_handler_target_optional(
     operator: Operator,
     target: Any,
@@ -1878,6 +1894,56 @@ async def test_dispatch_returns_connector_error_when_handler_raises(
     assert captured_events[0].result_status == "error"
 
 
+@pytest.mark.asyncio
+async def test_dispatch_kv_write_forbidden_uses_write_identity_error(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A denied ``vault.kv.put`` -> ``vault_write_identity_forbidden`` (#2331).
+
+    The post-approval write-identity gap: the op reached the connector and
+    Vault answered ``permission denied``. The dispatcher's Forbidden arm
+    routes a KV *write* op to the write-specific structured cause naming
+    the data path + acting identity + the §6.1 stanza — NOT the
+    read-oriented ``connector_vault_forbidden`` (which would talk about a
+    target ``secret_ref``).
+    """
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.put",
+        handler=_module_handler_raises_vault_forbidden,
+        summary="Write a KV v2 secret.",
+        description="Write a secret; the handler simulates a Vault RBAC denial.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    operator = _make_operator(sub="op-writer")
+    target = _FakeTarget(product="vault")
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.put",
+        target=target,
+        params={"path": "meho/test/x", "data": {"k": "v"}},
+    )
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("vault_write_identity_forbidden:")
+    assert result.extras["error_code"] == "vault_write_identity_forbidden"
+    # Data path rendered from mount default + params; identity is the caller.
+    assert result.extras["path"] == "secret/data/meho/test/x"
+    assert result.extras["identity_hint"] == "op-writer"
+    # NOT mislabelled as the read-path credential-resolution cause.
+    assert "connector_vault_forbidden" not in result.error
+    assert result.extras["error_code"] != "connector_vault_forbidden"
+
+
 # ---------------------------------------------------------------------------
 # Policy gate
 # ---------------------------------------------------------------------------
@@ -2463,6 +2529,82 @@ async def test_park_merges_permission_preflight_onto_identifier_default(
             assert "data" not in row.proposed_effect
     finally:
         _PERMISSION_PREFLIGHTS.pop("vault.kv.preflight_op", None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("will_be_denied", [True, False])
+async def test_park_stamps_write_capability_warning_when_denied(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+    will_be_denied: bool,
+) -> None:
+    """A will-be-denied preflight promotes a named top-level warning (#2331).
+
+    When the park-time capability probe reports ``will_be_denied: true``,
+    the envelope carries ``write_capability_warning =
+    "connector_identity_may_lack_write"`` so the approval surface can render
+    a banner without reaching into ``permission_preflight``. It is a
+    warning, not a gate — the park still proceeds and the op is
+    ``awaiting_approval`` either way. Absent when the write will be
+    authorized.
+    """
+    from meho_backplane.db.models import ApprovalRequest
+    from meho_backplane.operations._preview import (
+        _PERMISSION_PREFLIGHTS,
+        PreviewContext,
+        register_permission_preflight,
+    )
+
+    async def _preflight(ctx: PreviewContext) -> dict[str, Any]:
+        return {
+            "check": "vault.capabilities-self",
+            "path": f"secret/data/{ctx.params.get('path', '?')}",
+            "required": ["create", "update"],
+            "granted": ["read"] if will_be_denied else ["create", "read", "update"],
+            "will_be_denied": will_be_denied,
+            "principal_sub": ctx.operator.sub,
+        }
+
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    target = _FakeTarget(product="vault")
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.warn_op",
+        handler=_module_handler_returning_dict,
+        summary="Op with a registered permission preflight.",
+        description="Parks for approval; the preflight may flag a will-be-denied write.",
+        parameter_schema={"type": "object"},
+        safety_level="caution",
+        requires_approval=True,
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+    register_permission_preflight("vault.kv.warn_op", _preflight)
+    try:
+        result = await dispatch(
+            operator=_make_operator(principal_kind=PrincipalKind.AGENT),
+            connector_id="vault-1.x",
+            op_id="vault.kv.warn_op",
+            target=target,
+            params={"path": "meho/test/x"},
+        )
+        assert result.status == "awaiting_approval"
+        approval_request_id = UUID(result.extras["approval_request_id"])
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as fresh:
+            row = await fresh.get(ApprovalRequest, approval_request_id)
+            assert row is not None
+            if will_be_denied:
+                assert (
+                    row.proposed_effect["write_capability_warning"]
+                    == "connector_identity_may_lack_write"
+                )
+            else:
+                assert "write_capability_warning" not in row.proposed_effect
+    finally:
+        _PERMISSION_PREFLIGHTS.pop("vault.kv.warn_op", None)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/cross-repo/connector-vault-policy.md
+++ b/docs/cross-repo/connector-vault-policy.md
@@ -426,6 +426,53 @@ Expected outcomes:
 > or the write fails post-approval despite a clean preflight. Verify the
 > reviewer's token with the same command above when in doubt.
 
+### 6.3 The write-identity contract (which identity writes, and its two signals)
+
+The read path (§2–§5) and the write path use the **same** federated
+identity model: every KV op runs under the acting **operator's**
+OIDC-federated Vault token (the `meho-mcp` role), never a shared god-mode
+backplane token. There is no separate service-account identity for agent
+writes in this model — an *agent-initiated* `vault.kv.put` still parks and
+executes under a human operator's token (the dispatcher's at park time,
+the reviewer's on approved re-dispatch; see the §6.2 reviewer-token
+caveat). The contract a deploy must satisfy is therefore:
+
+| Path | Acting identity | Required Vault capabilities on the templated path |
+|------|-----------------|---------------------------------------------------|
+| Read (`vault.kv.read`, credential resolution) | Operator's OIDC-federated token | `read` on `secret/data/…/{{identity…}}/*` (§2) |
+| Write (`vault.kv.put` / `patch`) | Operator's OIDC-federated token (dispatcher at park; **reviewer** on approved re-dispatch) | `create` + `update` on `secret/data/…/{{identity…}}/*` (§6.1) |
+| Write (`vault.kv.delete` version soft-delete) | same | `update` on the data path (§6.1) |
+
+A deploy that follows only the §2 read grant provisions **read-only** and
+discovers the missing write grant *after* an operator approves a parked
+write. Two product signals make that gap visible without reading Vault's
+logs:
+
+- **Park-time warning (before Approve).** The dispatcher runs the §6.2
+  `sys/capabilities-self` probe under the dispatching operator's token and,
+  when the token lacks `create`/`update`, stamps
+  `proposed_effect.write_capability_warning =
+  "connector_identity_may_lack_write"` on the approval row alongside the
+  `permission_preflight` banner (`will_be_denied: true` with the lacking
+  capabilities). This is a **warning, not a gate** — the park still
+  proceeds and the operator may approve anyway (e.g. the write policy is
+  landing in the same change). It surfaces the gap while a human is still
+  in the loop.
+- **Post-approval structured error (after Approve).** If the write is
+  approved and Vault still denies it, the op result is **not** a bare
+  `permission denied` or the read-oriented `connector_vault_forbidden`; it
+  is the write-specific `error_code: "vault_write_identity_forbidden"` with
+  `path` (the denied `secret/data/<path>`), `identity_hint` (the acting
+  operator's `sub`), and `doc_ref` pointing back at this §6. It names the
+  §6.1 write stanza as the fix and repeats the do-NOT-widen-the-shared-policy
+  warning (the grant is per-operator templated, not role-wide).
+
+To verify the contract for a given operator + target before wiring an
+approval flow, run the §6.2 `sys/capabilities-self` probe under **that
+operator's** token (and, once a reviewer is designated, theirs too).
+Both must return `["create","read","update"]` on the target's
+`secret/data/…` path for an approved write to land.
+
 ## Scope note — `shared_service_account` only; `per_user`/`impersonation` deferred
 
 This runbook covers the **`shared_service_account`** auth model: one


### PR DESCRIPTION
## Summary

Completes the write-identity leg of the four-eyes vault-write flow for **#2331** (Initiative #2364, G0.31 wave 2). Even with approve→execute working, an approved `vault.kv.*` write does not land until the connector's write identity has Vault write capability on the target path — and the failure was previously indistinguishable from a read-path denial.

Three parts (each independently actionable per the task):

1. **Structured post-approval error** — a typed `vault.kv.put`/`patch`/`delete` denied by Vault at dispatch now surfaces a dedicated `connector_vault_write_forbidden` result (the write-side sibling of `connector_vault_forbidden`, #2091), naming the exact `<mount>/data/<path>` Vault denied, the acting operator identity, and the §6.1 write-policy stanza to add — instead of a bare permission-denied or a misleading read-path diagnosis.
2. **Envelope write-capability warning** — the park-time `sys/capabilities-self` write preflight already shipped; this promotes its `will_be_denied` signal to a top-level `write_capability_warning` on the parked `proposed_effect` envelope (riding #2332's provenance surface) so the approval surface can render a "this write may not land" banner. A warning, not a gate — refuse-to-park stays off by default.
3. **Write-identity contract doc** — `docs/cross-repo/connector-vault-policy.md` documents the per-operator templated write path and the do-NOT-widen-the-shared-policy warning.

## Verification

- ruff / ruff-format / mypy clean on changed src.
- `test_operations_connector_vault_forbidden.py` + `test_operations_dispatcher.py`: 58 passed (incl. new write-forbidden + envelope-warning tests).
- No new alembic migration; no FastAPI route/schema change (so no OpenAPI regen).

Closes #2331

🤖 Generated with [Claude Code](https://claude.com/claude-code)