### PR TITLE
feat(connectors): accept inline spec content on the MCP connector.ingest tool (#2326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — inline spec content on the MCP `connector.ingest` tool (#2326)
+
+- Each `specs[*]` entry on the `meho.connector.ingest` MCP tool now
+  accepts an optional `content` field carrying the spec text inline
+  (~20 MiB cap, the REST bound). When set, the backplane uses the bytes
+  verbatim and skips the fetch — the same `SpecSource.content` on-ramp
+  the CLI upload already uses. Previously the tool required a `uri`-only
+  entry and rejected `file://` / `docs:` schemes at the https fetch
+  guard, forcing agent-driven flows to publish private lab specs to a
+  public gist purely to satisfy the fetcher. Inline content bypasses the
+  fetcher entirely (no SSRF surface, strictly safer than the gist
+  workaround it retires), so an appliance-served or hand-authored spec
+  with no public https URL (NSX, VCFA) can be ingested over a fully
+  MCP-drivable flow; `uri` stays the audit label, so the resulting
+  L1/L2 rows match a CLI upload of the same file (#2326).
+
 ### Added — structured post-approval vault-write-forbidden error + write-capability warning on the approval envelope (#2331)
 
 - A typed `vault.kv.put` / `patch` / `delete` that Vault denies at

--- a/backend/src/meho_backplane/mcp/tools/connector_ingest.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_ingest.py
@@ -164,12 +164,31 @@ def _build_ingest_request(arguments: dict[str, Any]) -> IngestRequest:
     guaranteed non-None after validation. The asserts pin the invariant
     for mypy after the schema's optional typing widened to support the
     REST ``catalog_entry`` shape (G0.14-T9 / #1150).
+
+    Each ``specs[*]`` entry carries a required ``uri`` (the audit label)
+    and an optional ``content`` string (#2326). When ``content`` is set,
+    it is passed straight to :attr:`SpecSource.content`, so the pipeline
+    uses the inline bytes verbatim and skips the fetch — the same on-ramp
+    the CLI upload uses (:func:`_catalog_entry_specs` /
+    ``meho connector ingest --spec file://…`` reads the file client-side
+    and posts the bytes here, #1535). This lets an MCP-driven flow ingest
+    an appliance-served or hand-authored spec that has no public https URL
+    (NSX, VCFA) without publishing it to a gist purely to satisfy the
+    fetcher; the ``uri`` stays the audit label the origin classification
+    reads (a non-``spec:`` label with inline content classifies as
+    ``inline``, matching the CLI upload). ``file://`` on a **content-less**
+    ``uri`` is still rejected by the fetch-path scheme guard — inline
+    content is the supported private-spec path, not a co-located
+    filesystem fetch (the task's out-of-scope deployment-topology
+    question).
     """
     request = IngestRequest(
         product=arguments["product"],
         version=arguments["version"],
         impl_id=arguments["impl_id"],
-        specs=[SpecSource(uri=spec["uri"]) for spec in arguments["specs"]],
+        specs=[
+            SpecSource(uri=spec["uri"], content=spec.get("content")) for spec in arguments["specs"]
+        ],
         base_url=arguments.get("base_url"),
         dry_run=bool(arguments.get("dry_run", False)),
         # #2289: an operator-selected named auth scheme (+ optional secret-field
@@ -525,6 +544,12 @@ _INGEST_DESCRIPTION: Final[str] = (
     "Use when adding a new vendor surface (product=vmware version=9.0 "
     "impl_id=vmware-rest specs=[...]); supports merging multiple specs "
     "under one connector (vSphere ingests vcenter.yaml + vi-json.yaml). "
+    "Each specs entry needs a uri (the audit label); add an optional "
+    "content field to upload the spec text inline (~20 MiB cap) — the "
+    "backplane then uses those bytes verbatim and skips the fetch, the "
+    "same path the CLI upload uses. Use content for an appliance-served "
+    "or hand-authored spec with no public https URL (NSX, VCFA); omit it "
+    "to have the backplane fetch uri under the https guard. "
     "For a real-world vendor spec set async=true to get a job handle "
     "back immediately (the parse+register+grouping pass blocks past the "
     "tool-call timeout otherwise); then poll meho.connector.ingest_status "
@@ -568,6 +593,24 @@ register_mcp_tool(
                         "type": "object",
                         "properties": {
                             "uri": {"type": "string", "minLength": 1, "maxLength": 2048},
+                            "content": {
+                                "type": ["string", "null"],
+                                "minLength": 1,
+                                "maxLength": 20 * 1024 * 1024,
+                                "description": (
+                                    "Inline spec text (YAML/JSON). When set, the "
+                                    "backplane uses these bytes verbatim and skips "
+                                    "the fetch — the same on-ramp the CLI upload "
+                                    "uses (meho connector ingest --spec file://… "
+                                    "reads the file client-side and posts it here). "
+                                    "Use for an appliance-served or hand-authored "
+                                    "spec with no public https URL (NSX, VCFA) "
+                                    "instead of publishing it to a gist to satisfy "
+                                    "the fetcher; uri stays the audit label. Omit "
+                                    "to have the backplane fetch uri under the "
+                                    "https guard. ~20 MiB cap (the REST bound)."
+                                ),
+                            },
                         },
                         "required": ["uri"],
                         "additionalProperties": False,

--- a/backend/tests/test_mcp_tools_connector_ingest.py
+++ b/backend/tests/test_mcp_tools_connector_ingest.py
@@ -16,6 +16,11 @@ Coverage matrix:
   - ``tenant_admin`` sees both.
 * Both tools' ``inputSchema`` is strict JSON-Schema 2020-12 with
   ``additionalProperties: false``; descriptions name when (not) to use.
+* **Inline spec content** (#2326): each ``specs[*]`` entry exposes an
+  optional ``content`` field that threads through to
+  :attr:`SpecSource.content` verbatim (the CLI-upload on-ramp for a
+  private / appliance-served spec with no public https URL); an omitted
+  ``content`` leaves the historical fetch shape unchanged.
 * **Inline path** (``dry_run=true`` / ``async`` unset) returns the
   canonical ``IngestResponse`` synchronously — the pre-#1531 behaviour
   (no regression). Specs + flags + tenant_id thread through to the
@@ -327,6 +332,31 @@ def test_ingest_schema_exposes_closed_auth_scheme_selector(
     assert "auth_secret" not in {k for k in props if "value" in k}
 
 
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_ingest_schema_exposes_inline_spec_content(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Each specs entry advertises an optional inline ``content`` field (#2326)."""
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    tools = {t["name"]: t for t in response.json()["result"]["tools"]}
+    spec_item = tools[_INGEST_TOOL]["inputSchema"]["properties"]["specs"]["items"]
+
+    # uri stays the required audit label; content is optional (string | null).
+    assert spec_item["required"] == ["uri"]
+    content = spec_item["properties"]["content"]
+    assert content["type"] == ["string", "null"]
+    # Size cap mirrors the REST SpecSource.content bound (~20 MiB chars).
+    assert content["maxLength"] == 20 * 1024 * 1024
+    # No stray field crept into the strict item schema.
+    assert spec_item["additionalProperties"] is False
+    assert set(spec_item["properties"]) == {"uri", "content"}
+
+
 async def test_inline_ingest_threads_auth_scheme_to_service(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -461,6 +491,73 @@ async def test_inline_default_returns_grouping(
     assert "job_id" not in payload
     [call] = fake.ingest_calls
     assert call["dry_run"] is False
+
+
+async def test_inline_content_threads_to_service_verbatim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inline ``content`` reaches the pipeline as ``SpecSource.content`` (#2326).
+
+    A private spec with no public https URL (an appliance-served /
+    hand-authored spec) is uploaded inline: the ``file://`` ``uri`` is
+    the audit label, ``content`` carries the bytes, and the pipeline
+    uses them verbatim — the fetch (and its https scheme guard) is
+    bypassed, so no gist workaround is needed. Mirrors what the CLI
+    upload path sends the backplane.
+    """
+    fake = _FakeIngestionPipelineService()
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", fake)
+    op = build_operator(TenantRole.TENANT_ADMIN)
+
+    spec_text = "openapi: 3.1.0\ninfo:\n  title: probe\n  version: '0.0'\npaths: {}\n"
+    payload = await ci_mod._ingest_handler(
+        op,
+        {
+            "product": "probe",
+            "version": "0.0",
+            "impl_id": "probe-rest",
+            "specs": [{"uri": "file:///tmp/probe-spec.yaml", "content": spec_text}],
+            "dry_run": True,
+            "tenant_id": str(OPERATOR_TENANT_ID),
+        },
+    )
+
+    assert "job_id" not in payload  # inline (dry-run) shape, not a handle
+    [call] = fake.ingest_calls
+    [source] = call["specs"]
+    # uri preserved as the audit label; content threaded through verbatim.
+    assert source.uri == "file:///tmp/probe-spec.yaml"
+    assert source.content == spec_text
+
+
+async def test_inline_omitted_content_stays_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A specs entry without ``content`` yields ``SpecSource.content is None`` (#2326).
+
+    The historical fetch shape is unchanged: an entry that carries only
+    a ``uri`` still leaves ``content`` unset, so the pipeline fetches the
+    URL under the https guard exactly as before.
+    """
+    fake = _FakeIngestionPipelineService()
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", fake)
+    op = build_operator(TenantRole.TENANT_ADMIN)
+
+    await ci_mod._ingest_handler(
+        op,
+        {
+            "product": "vmware",
+            "version": "9.0",
+            "impl_id": "vmware-rest",
+            "specs": [{"uri": "https://example.test/vcenter.yaml"}],
+            "dry_run": True,
+        },
+    )
+
+    [call] = fake.ingest_calls
+    [source] = call["specs"]
+    assert source.uri == "https://example.test/vcenter.yaml"
+    assert source.content is None
 
 
 async def test_inline_version_mismatch_maps_to_invalid_params(

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -389,6 +389,27 @@ synchronously (no regression for small-spec / CI callers). This
 parallels the `meho.agents.run` + `meho.agents.run_status` async
 precedent (#811).
 
+**Inline spec content on the MCP tool (#2326).** Each `specs[*]` entry
+on `meho.connector.ingest` carries a required `uri` (the audit label)
+and an optional `content` string. When `content` is set the handler
+passes it straight to `SpecSource(uri=…, content=…)`, so the pipeline
+uses the inline bytes verbatim and skips the fetch — the same
+`SpecSource.content` on-ramp the CLI upload uses (`meho connector ingest
+--spec file://… / docs:…` reads the file client-side and posts the bytes
+here, #1535). Before this, the MCP tool schema required a `uri`-only
+entry and a `file://` / `docs:` scheme was rejected by the fetch-path
+https guard, forcing agent-driven flows to publish private lab specs to
+a public gist purely to satisfy the fetcher. Inline content bypasses the
+fetcher entirely, so it adds no SSRF surface (strictly safer than the
+gist workaround it retires) and lets an appliance-served or
+hand-authored spec with no public https URL (NSX, VCFA) be ingested over
+a fully MCP-drivable flow. The `uri` stays the audit label the origin
+classification reads (a non-`spec:` label with inline content →
+`inline`), so the resulting L1/L2 rows match what the CLI upload of the
+same file produces. A `file://` on a **content-less** `uri` is still
+rejected — inline content is the private-spec path, not a co-located
+filesystem fetch (a separate deployment-topology question).
+
 The `ingest` handler additionally maps **every typed `SpecError`
 sibling** to JSON-RPC `-32602 Invalid Params` with the structured
 detail on `error.data` **on the inline path**: `VersionMismatchError`


### PR DESCRIPTION
## Summary

- The `meho.connector.ingest` MCP tool rejected any spec URI whose scheme
  was not `https`, so agent-driven flows could not ingest an
  appliance-served or hand-authored spec with no public URL (NSX, VCFA) —
  they had to publish private lab specs to a public gist purely to satisfy
  the fetcher.
- Each `specs[*]` entry now accepts an optional `content` field (~20 MiB
  cap, the REST bound). When set it is passed straight to
  `SpecSource(uri=…, content=…)`, so the backplane uses the inline bytes
  verbatim and skips the fetch — the exact `SpecSource.content` on-ramp
  the CLI upload already uses (#1535). `uri` stays the audit label, so the
  resulting L1/L2 rows match a CLI upload of the same file.
- Inline content bypasses the fetcher entirely, so it adds no SSRF surface
  (strictly safer than the gist workaround it retires). A `file://` on a
  content-less `uri` is still rejected by the https fetch guard — inline
  content is the private-spec path, not a co-located filesystem fetch.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/mcp/tools/connector_ingest.py` — clean
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (only
      pre-existing file-size / function-size warnings)
- [x] New unit tests in `tests/test_mcp_tools_connector_ingest.py`:
  - `test_ingest_schema_exposes_inline_spec_content` — the tool schema
    advertises the optional `content` field, size-capped, `uri` still
    the sole required item field, item schema stays strict.
  - `test_inline_content_threads_to_service_verbatim` — a `file://` uri +
    inline content reaches the pipeline as `SpecSource.content` verbatim,
    no fetch, no https-guard rejection (AC: dry-run with inline content
    accepted, returns the plan; rows match the CLI upload label/origin).
  - `test_inline_omitted_content_stays_none` — the historical fetch shape
    is unchanged when `content` is omitted.
- [x] Full backend unit suite — green (default xdist)
- [x] OpenAPI snapshot regenerated — no diff (MCP tool schema is not
      surfaced in the snapshot; `/mcp` is a single JSON-RPC endpoint)

## Out of scope

- The CLI upload path (already works).
- Multipart-file `spec_file` variant (nice-to-have; `spec_content` alone
  covers the sub-1 MB common case).
- `file://` fetch on the backplane's own filesystem (deployment-topology
  question; explicitly rejected in the issue's out-of-scope).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2326
