### PR TITLE
fix(scheduler): convert one_off fire_at picker to UTC on submit (#2339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — scheduler one_off `fire_at` picker now converts local time to UTC on submit (#2339)
+
+- The `/ui/scheduler` Create-trigger modal's `fire_at` `datetime-local`
+  picker showed the operator their own wall-clock time but posted a
+  naive string the engine stored verbatim as UTC, so a CEST (UTC+2)
+  operator who picked "11:00" got a trigger that fired at 11:00Z — two
+  hours late. The modal now converts the picked local value to a
+  UTC ISO-8601 instant on submit (via the browser's DST-aware `Date`,
+  so CET/CEST both resolve correctly), and a live hint next to the
+  field shows the resolved UTC so the conversion is visible rather than
+  silent. Engine-side `fire_at` handling is unchanged.
+
 ### Breaking changes — GET-list endpoints converged on the `{items, next_cursor}` envelope (#2338)
 
 - **BREAKING.** The seven reference `GET`-list endpoints now return the

--- a/backend/src/meho_backplane/ui/templates/scheduler/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/scheduler/_create_modal.html
@@ -132,16 +132,30 @@
       </div>
 
       {# ---------- one_off fields ---------- #}
+      {# The datetime-local picker shows the operator their own wall-clock
+         time but posts a naive ``YYYY-MM-DDTHH:MM`` string the engine stored
+         verbatim as UTC -- a CEST operator's "11:00" landed as 11:00Z (2h
+         late). The inline script below converts the picked local value to a
+         UTC ISO-8601 instant on submit (``htmx:configRequest``) using the
+         browser's own DST-aware ``Date``; the live hint shows the resolved
+         UTC so the conversion is visible, not silent (#2339). #}
       <div x-show="kind === 'one_off'" x-cloak class="space-y-2 rounded-box border border-base-300 p-3">
         <label class="form-control">
-          <span class="label-text">Fire at</span>
+          <span class="label-text">Fire at (your local time)</span>
           <input
             type="datetime-local"
             name="fire_at"
             class="input input-bordered input-sm"
+            data-fire-at
             aria-label="Fire at"
+            aria-describedby="scheduler-fire-at-hint"
           />
-          <span class="label-text-alt opacity-60">Interpreted as UTC if no offset.</span>
+          <span
+            id="scheduler-fire-at-hint"
+            class="label-text-alt opacity-60"
+            data-fire-at-hint
+            aria-live="polite"
+          >Enter your local wall-clock time — it is converted to UTC on submit.</span>
         </label>
       </div>
 
@@ -238,3 +252,67 @@
     <button>close</button>
   </form>
 </dialog>
+
+{# Inline script: convert the one_off ``fire_at`` datetime-local value from
+   the operator's local zone to a UTC ISO-8601 instant on submit, and mirror
+   the resolved UTC into the field hint so the conversion is visible (#2339).
+   Pulled inline (not a <script src>) because the modal is HTMX-injected and a
+   separate JS fetch would race showModal() -- the memory-create modal follows
+   the same pattern. The browser's own ``Date`` is DST-aware, so CEST (UTC+2)
+   and CET (UTC+1) resolve correctly without a hardcoded offset. #}
+<script>
+  (function () {
+    var modal = document.getElementById('scheduler-create-modal');
+    if (!modal) return;
+    var form = modal.querySelector('#scheduler-create-form');
+    if (!form) return;
+    var input = form.querySelector('[data-fire-at]');
+    var hint = form.querySelector('[data-fire-at-hint]');
+    // A naive datetime-local value carries no zone: YYYY-MM-DDTHH:MM[:SS].
+    // An already-offset value (Z or +hh:mm) is left untouched.
+    var NAIVE_LOCAL = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/;
+    var zone = '';
+    try {
+      zone = Intl.DateTimeFormat().resolvedOptions().timeZone || '';
+    } catch (e) {
+      zone = '';
+    }
+
+    function localToUtcIso(value) {
+      if (!value || !NAIVE_LOCAL.test(value)) return null;
+      var d = new Date(value);
+      if (isNaN(d.getTime())) return null;
+      return d.toISOString();
+    }
+
+    function renderHint() {
+      if (!hint) return;
+      var value = input ? input.value : '';
+      var utc = localToUtcIso(value);
+      if (!utc) {
+        hint.textContent =
+          'Enter your local wall-clock time — it is converted to UTC on submit.';
+        return;
+      }
+      var utcMinute = utc.slice(0, 16) + 'Z';
+      hint.textContent =
+        'Fires at ' + utcMinute + ' (UTC)' +
+        (zone ? ' — your local zone: ' + zone : '') + '.';
+    }
+
+    if (input) {
+      input.addEventListener('input', renderHint);
+      input.addEventListener('change', renderHint);
+      renderHint();
+    }
+
+    // htmx serialises the form before this fires; rewriting parameters here
+    // changes the request body without mutating the picker the operator sees.
+    form.addEventListener('htmx:configRequest', function (evt) {
+      var params = evt && evt.detail ? evt.detail.parameters : null;
+      if (!params) return;
+      var utc = localToUtcIso(params.fire_at);
+      if (utc) params.fire_at = utc;
+    });
+  }());
+</script>

--- a/backend/tests/test_ui_scheduler.py
+++ b/backend/tests/test_ui_scheduler.py
@@ -233,6 +233,20 @@ def _load_trigger_status(tenant_id: uuid.UUID, trigger_id: uuid.UUID) -> str | N
     return asyncio.run(_do())
 
 
+def _load_trigger_fire_at(tenant_id: uuid.UUID) -> datetime | None:
+    from sqlalchemy import select
+
+    async def _do() -> datetime | None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            stmt = select(ScheduledTrigger.fire_at).where(
+                ScheduledTrigger.tenant_id == tenant_id,
+            )
+            return (await session.execute(stmt)).scalars().first()
+
+    return asyncio.run(_do())
+
+
 def _trigger_count(tenant_id: uuid.UUID) -> int:
     from sqlalchemy import func, select
 
@@ -571,6 +585,31 @@ def test_create_modal_renders_for_tenant_admin() -> None:
     assert 'hx-post="/ui/scheduler/validate-cron"' in body  # live cron validation
 
 
+def test_create_modal_carries_fire_at_utc_conversion() -> None:
+    """The one_off fire_at field ships the client-side local->UTC submit conversion (#2339).
+
+    The datetime-local picker posts a naive local wall-clock string the engine
+    stores verbatim as UTC; the modal must carry the ``htmx:configRequest``
+    handler that rewrites ``fire_at`` to a UTC ISO instant plus the live hint
+    that makes the conversion visible. Asserts the load-bearing markers rather
+    than exercising the JS (covered by the Playwright regression in CI).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A)
+    client, mock, _ = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.get("/ui/scheduler/create")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "data-fire-at" in body  # the picker + its live hint are wired
+    assert "htmx:configRequest" in body  # submit-time param rewrite hook
+    assert "toISOString" in body  # DST-aware browser-native UTC conversion
+
+
 def test_create_modal_rejects_operator_with_403() -> None:
     """An operator (non-admin) GET on the create modal is 403'd server-side."""
     _seed_tenant(_TENANT_A, "tenant-a")
@@ -672,6 +711,43 @@ def test_create_submit_persists_cron_trigger_and_redirects() -> None:
     assert response.status_code == 204, response.text
     assert response.headers["HX-Redirect"] == "/ui/scheduler"
     assert _trigger_count(_TENANT_A) == 1
+
+
+def test_create_submit_one_off_utc_fire_at_persists_instant() -> None:
+    """A one_off create with the JS-converted UTC ``fire_at`` stores that instant (#2339).
+
+    The submit handler's client-side conversion posts a UTC ISO-8601 string
+    (``...Z``) rather than the naive datetime-local value; the server honours
+    the offset as-is. A CEST operator picking 11:00 local -> 09:00Z must land
+    exactly 09:00Z, not 11:00Z (the 2h-off defect).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A)
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/scheduler/create",
+            data={
+                "kind": "one_off",
+                "agent_definition_id": str(_AGENT_ID),
+                "fire_at": "2026-07-01T09:00:00.000Z",
+                "inputs": '{"prompt": "scheduled run"}',
+                "in_flight_policy": "fail_into_audit",
+            },
+            headers=_form_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert _trigger_count(_TENANT_A) == 1
+    stored = _load_trigger_fire_at(_TENANT_A)
+    assert stored is not None
+    # Normalise to an aware UTC instant (the column may hydrate naive-UTC).
+    if stored.tzinfo is None:
+        stored = stored.replace(tzinfo=UTC)
+    assert stored == datetime(2026, 7, 1, 9, 0, tzinfo=UTC)
 
 
 def test_create_submit_invalid_cron_rerenders_modal_with_error() -> None:


### PR DESCRIPTION
## Summary
- The `/ui/scheduler` Create-trigger modal's `fire_at` `datetime-local` picker showed operators their **local** wall-clock time but posted a naive `YYYY-MM-DDTHH:MM` string the engine stored **verbatim as UTC** — a CEST (UTC+2) operator who picked "11:00" got a trigger that fired at `11:00Z`, two hours late. Every non-UTC operator was affected (#2339).
- Fix (Option A, client-side): an inline submit handler converts the picked local value to a UTC ISO-8601 instant on `htmx:configRequest`, using the browser's own **DST-aware** `Date` so CET/CEST both resolve without a hardcoded offset. A live hint next to the field mirrors the resolved UTC so the conversion is **visible**, not silent.
- Engine-side `fire_at` handling is untouched — the server already honours an offset-carrying (`…Z`) value as-is.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] `pytest tests/test_ui_scheduler.py` — 32 passed
- [x] New `test_create_modal_carries_fire_at_utc_conversion` — asserts the modal ships the `htmx:configRequest` handler + `toISOString` conversion + `data-fire-at` hint.
- [x] New `test_create_submit_one_off_utc_fire_at_persists_instant` — a `one_off` submit with the JS-converted `2026-07-01T09:00:00.000Z` persists exactly `09:00Z` (proves the offset is honoured, not re-interpreted).

## Out of scope
- Detail-view local-time rendering of the stored UTC `fire_at` (display-only; the scheduling defect is the submit conversion). Noted as an adjacent follow-up.
- Cron triggers (already carry an explicit `timezone` field) and engine-side `fire_at` handling.
- Sibling Wave-6 tasks: #2345 (CSRF), #2346 (agents), #2244 (no-inputs footgun).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2339
