### PR TITLE
fix(ui): render /ui/agents/create backend errors visibly (#2346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — `/ui/agents/create` now shows backend validation errors (#2346)
+
+- The Create-agent modal previously swallowed backend 4xx validation
+  responses: the handler re-rendered the modal with per-field errors but
+  returned it as `409` / `422`, and HTMX's default response handling
+  does not swap a non-2xx fragment — so a bad `identity_ref`, a
+  duplicate name, or an out-of-range `turn_budget` made the Create
+  button appear to "do nothing" while the failure was only visible in
+  DevTools. The recoverable-error re-render now returns `200` (the same
+  inline-error mold the runbooks start-run and conventions author modals
+  already ship) and carries a top-of-form error banner in addition to
+  the existing per-field messages, so the operator sees exactly which
+  field to fix and keeps their typed input. Sibling `/ui` create/edit
+  forms with the same missing handler (memory, kb) are tracked
+  separately for a follow-up sweep.
+
 ### Breaking changes — GET-list endpoints converged on the `{items, next_cursor}` envelope (#2338)
 
 - **BREAKING.** The seven reference `GET`-list endpoints now return the

--- a/backend/src/meho_backplane/ui/routes/agents/forms.py
+++ b/backend/src/meho_backplane/ui/routes/agents/forms.py
@@ -15,13 +15,21 @@ write surface on top:
   :class:`~meho_backplane.agents.schemas.AgentDefinitionCreate` from the
   form fields and persists via
   :meth:`~meho_backplane.agents.service.AgentDefinitionService.create`.
-  Success -> 204 + ``HX-Redirect: /ui/agents``. A Pydantic
-  :class:`~pydantic.ValidationError`, a duplicate-name
-  :class:`~meho_backplane.agents.service.AgentDefinitionExistsError`
-  (409), or an
-  :class:`~meho_backplane.agents.service.AgentIdentityRefInvalidError`
-  (422) all re-render the modal with per-field messages and the
-  matching HTTP status.
+  Success -> 204 + ``HX-Redirect: /ui/agents``. Any recoverable input
+  error -- a Pydantic :class:`~pydantic.ValidationError`, a duplicate-name
+  :class:`~meho_backplane.agents.service.AgentDefinitionExistsError`, or
+  an :class:`~meho_backplane.agents.service.AgentIdentityRefInvalidError`
+  -- re-renders the modal as a **200** fragment carrying a top-of-form
+  error banner plus the per-field messages, and HTMX swaps it back into
+  the modal container in place. The 200 is load-bearing: HTMX's default
+  response handling silently drops a non-2xx fragment (``swap: false``),
+  so the earlier 409 / 422 re-renders were computed by the server but
+  never shown to the operator -- the button appeared to "do nothing"
+  (#2346). This mirrors the shipped error mold of the runbooks start-run
+  modal (:func:`~meho_backplane.ui.routes.runbooks.runs._render_start_error`)
+  and the conventions author modal
+  (:func:`~meho_backplane.ui.routes.conventions.write._render_create_error`),
+  both of which re-render inline errors as 200.
 * **``GET /ui/agents/{name}/edit``** -- HTMX-loaded edit modal, fields
   pre-populated server-side. ``name`` is read-only (not updatable per
   :class:`~meho_backplane.agents.schemas.AgentDefinitionUpdate`).
@@ -259,11 +267,13 @@ async def submit_create(
 ) -> HTMLResponse:
     """Build an :class:`AgentDefinitionCreate` and persist it via the service.
 
-    A Pydantic :class:`ValidationError` re-renders the modal with
-    per-field messages + 422; a duplicate ``(tenant, name)`` re-renders
-    with a 409 ``name`` field error; an unknown / revoked
-    ``identity_ref`` re-renders with a 422 ``identity_ref`` field error.
-    A clean create returns 204 + ``HX-Redirect: /ui/agents``.
+    Any recoverable input error re-renders the modal as a **200**
+    fragment (so HTMX swaps it back in place) carrying a top-of-form
+    error banner + per-field messages: a Pydantic :class:`ValidationError`
+    surfaces the offending fields, a duplicate ``(tenant, name)`` a
+    ``name`` error, and an unknown / revoked ``identity_ref`` an
+    ``identity_ref`` error. A clean create returns 204 +
+    ``HX-Redirect: /ui/agents``.
     """
     raw_values = {
         "name": name,
@@ -305,7 +315,6 @@ async def submit_create(
             mode="create",
             field_errors={"name": "an agent with this name already exists"},
             values=raw_values,
-            status_code=status.HTTP_409_CONFLICT,
         )
     except AgentIdentityRefInvalidError:
         return _render_form_with_errors(
@@ -319,7 +328,6 @@ async def submit_create(
                 )
             },
             values=raw_values,
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         )
 
     _log.info(
@@ -394,7 +402,6 @@ async def submit_edit(
                 )
             },
             values=raw_values,
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         )
     if entry is None:
         from fastapi import HTTPException
@@ -483,16 +490,24 @@ def _render_form_with_errors(
     values: dict[str, object],
     exc: ValidationError | ValueError | None = None,
     field_errors: dict[str, str] | None = None,
-    status_code: int = status.HTTP_422_UNPROCESSABLE_CONTENT,
 ) -> HTMLResponse:
-    """Re-render the modal fragment carrying per-field errors + a status.
+    """Re-render the modal fragment carrying a top-of-form error banner + per-field errors.
 
     The HTMX form targets the modal container with
     ``hx-swap="innerHTML"`` so the error body replaces the dialog in
     place; the operator keeps their typed values (echoed via ``values``)
-    and sees the field-level messages. ``exc`` covers the Pydantic /
-    coercion path; ``field_errors`` covers the service-raised
-    duplicate-name (409) and identity_ref (422) cases.
+    and sees a summary banner plus the field-level messages. ``exc``
+    covers the Pydantic / coercion path; ``field_errors`` covers the
+    service-raised duplicate-name and identity_ref cases.
+
+    The fragment is returned as **200**, not the semantically-matching
+    409 / 422: HTMX's default response handling does not swap a non-2xx
+    response (``swap: false``), so a 4xx re-render is computed but never
+    shown -- the invisible-error defect #2346 fixes. Returning 200 is the
+    same inline-error mold the runbooks start-run and conventions author
+    modals already ship. These ``/ui`` routes are HTMX-only (the REST
+    agents API carries the machine-readable status contract), so the
+    fragment status is a rendering concern, not an external contract.
     """
     if field_errors is not None:
         errors = field_errors
@@ -510,7 +525,7 @@ def _render_form_with_errors(
         request,
         template,
         context,
-        status_code=status_code,
+        status_code=status.HTTP_200_OK,
     )
     _set_csrf_cookie(response, csrf_token)
     return response

--- a/backend/src/meho_backplane/ui/templates/agents/_agent_form_fields.html
+++ b/backend/src/meho_backplane/ui/templates/agents/_agent_form_fields.html
@@ -41,6 +41,28 @@
   {%- if errors and field in errors -%}{{ base }}{%- endif -%}
 {%- endmacro -%}
 
+{#- Top-of-form error summary banner. Rendered whenever the handler
+    re-renders the modal with ``errors`` populated (a Pydantic
+    ValidationError, a duplicate name, or an unknown / revoked
+    identity_ref). The re-render is a 200 fragment so HTMX swaps it back
+    into the modal container in place -- the runbooks / conventions
+    inline-error mold; without the 200 the banner would be computed but
+    silently dropped (#2346). Each field also shows its own inline
+    message via ``error_for`` below; this banner is the at-a-glance
+    summary. ``aria-live="assertive"`` announces it to assistive tech. -#}
+{%- if errors -%}
+  <div class="alert alert-error items-start" role="alert" aria-live="assertive" data-form-error-summary>
+    <div>
+      <span class="font-medium">Could not save the agent — please correct the highlighted fields.</span>
+      <ul class="mt-1 list-disc list-inside text-sm">
+        {%- for field, message in errors.items() -%}
+          <li><span class="font-mono">{{ field }}</span>: {{ message }}</li>
+        {%- endfor -%}
+      </ul>
+    </div>
+  </div>
+{%- endif -%}
+
 <label class="form-control">
   <span class="label-text">Name</span>
   <input

--- a/backend/tests/test_ui_agents.py
+++ b/backend/tests/test_ui_agents.py
@@ -12,9 +12,12 @@ acceptance criteria on issue #1825 are:
 * Operators see read-only views; create / edit / enable-disable /
   delete affordances are hidden for non-admins (soft) AND 403
   server-side (hard).
-* Create / edit go through a CSRF-double-submit BFF; 409 (duplicate
-  name) / 422 (unknown identity_ref) render inline, not as a generic
-  error.
+* Create / edit go through a CSRF-double-submit BFF; a duplicate name
+  or an unknown identity_ref re-renders the modal inline -- a
+  top-of-form error banner + per-field messages -- not as a generic
+  error. The re-render is a 200 fragment so HTMX swaps it back in place;
+  a non-2xx fragment would be silently dropped and the error never shown
+  (#2346).
 
 Suite shape mirrors :mod:`backend.tests.test_ui_memory_list`: a minimal
 FastAPI app wired with the chassis middlewares + the BFF auth router +
@@ -541,6 +544,8 @@ def test_create_modal_renders_for_admin() -> None:
     assert 'id="agents-create-modal"' in body
     assert 'name="identity_ref"' in body
     assert 'name="system_prompt"' in body
+    # A fresh (error-free) render carries no error summary banner.
+    assert "data-form-error-summary" not in body
 
 
 def test_create_persists_and_redirects() -> None:
@@ -578,8 +583,8 @@ def test_create_persists_and_redirects() -> None:
     assert "new-agent" in follow.text
 
 
-def test_create_duplicate_name_renders_409_inline() -> None:
-    """A duplicate (tenant, name) re-renders the modal with a 409 name error."""
+def test_create_duplicate_name_renders_inline() -> None:
+    """A duplicate (tenant, name) re-renders the modal inline with a name error."""
     _seed_tenant(_TENANT_A, "tenant-a")
     _seed_principal(tenant_id=_TENANT_A, keycloak_client_id="agent-dup")
     _seed_agent(tenant_id=_TENANT_A, name="dup", identity_ref="agent-dup")
@@ -601,16 +606,20 @@ def test_create_duplicate_name_renders_409_inline() -> None:
         )
     finally:
         mock.stop()
-    assert response.status_code == 409, response.text
+    # 200 (not 409) so HTMX swaps the re-rendered modal back in place;
+    # a non-2xx fragment would be silently dropped and the error never
+    # shown (#2346).
+    assert response.status_code == 200, response.text
     body = response.text
-    # The modal re-renders inline with a field-level error, not a
-    # generic error page.
+    # The modal re-renders inline with a top-of-form summary banner and a
+    # field-level error, not a generic error page.
+    assert "data-form-error-summary" in body
     assert 'data-error-for="name"' in body
     assert "already exists" in body
 
 
-def test_create_unknown_identity_ref_renders_422_inline() -> None:
-    """An identity_ref with no matching principal re-renders the modal with a 422."""
+def test_create_unknown_identity_ref_renders_inline() -> None:
+    """An identity_ref with no matching principal re-renders the modal inline."""
     _seed_tenant(_TENANT_A, "tenant-a")
     keypair, jwks = _make_keypair_and_jwks()
     token = _admin_session(keypair)
@@ -630,12 +639,13 @@ def test_create_unknown_identity_ref_renders_422_inline() -> None:
         )
     finally:
         mock.stop()
-    assert response.status_code == 422, response.text
+    assert response.status_code == 200, response.text
     body = response.text
+    assert "data-form-error-summary" in body
     assert 'data-error-for="identity_ref"' in body
 
 
-def test_create_invalid_turn_budget_renders_422_inline() -> None:
+def test_create_invalid_turn_budget_renders_inline() -> None:
     """An out-of-range turn_budget re-renders the modal with a field error."""
     _seed_tenant(_TENANT_A, "tenant-a")
     keypair, jwks = _make_keypair_and_jwks()
@@ -656,7 +666,8 @@ def test_create_invalid_turn_budget_renders_422_inline() -> None:
         )
     finally:
         mock.stop()
-    assert response.status_code == 422, response.text
+    assert response.status_code == 200, response.text
+    assert "data-form-error-summary" in response.text
     assert 'data-error-for="turn_budget"' in response.text
 
 


### PR DESCRIPTION
## Summary

- The `/ui/agents/create` Create-agent modal swallowed backend validation
  failures: the handler re-rendered the modal with per-field errors but
  returned it as `409` / `422`, and HTMX's default response handling does
  **not** swap a non-2xx fragment. A bad `identity_ref`, a duplicate name,
  or an out-of-range `turn_budget` therefore made the Create button appear
  to "do nothing" while the only signal lived in DevTools (the invisible-
  write-failure defect this task fixes).
- The recoverable-error re-render now returns **`200`** — the same
  inline-error mold the runbooks start-run modal (`_render_start_error`)
  and the conventions author modal (`_render_create_error`) already ship —
  so HTMX swaps the modal back into place.
- Added a top-of-form `alert-error` **summary banner** (`data-form-error-summary`)
  alongside the existing per-field messages, so the operator sees at a
  glance which fields to fix and keeps their typed input.

## Why 200, not a client-side 4xx swap

These `/ui` routes are HTMX-only; the REST agents API carries the
machine-readable status contract. Returning `200` for a recoverable form
error is a rendering concern, not an external contract break, and it
matches the two error molds already shipped in this codebase. It needs no
new (CSP-sensitive) client JS and stays clear of the sibling CSRF task's
client-side handler.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (changed src) — clean
- [x] `pytest tests/test_ui_agents.py` — 23 passed
  - `test_create_duplicate_name_renders_inline` — now asserts `200` + `data-form-error-summary` + `data-error-for="name"`
  - `test_create_unknown_identity_ref_renders_inline` — `200` + banner + `data-error-for="identity_ref"`
  - `test_create_invalid_turn_budget_renders_inline` — `200` + banner + `data-error-for="turn_budget"`
  - `test_create_modal_renders_for_admin` — asserts the banner is **absent** on a fresh render
- [x] `make snapshot-openapi` + `make generate` — no diff (in-handler status change does not touch the OpenAPI contract)

## Out of scope (deferred, per this wave's scoping)

- **Sibling-form sweep (memory, kb).** The maintainer's adoption comment
  promoted a sweep of the other `/ui/*` create/edit forms into the AC.
  `memory/create.py` and `kb/routes.py` (line ~682) share the same
  4xx-not-swapped bug; `conventions/write.py` already returns `200`
  (no bug). This PR is scoped to `/ui/agents/create` per the Wave 6
  worker directive (minimize overlap with the concurrent `#2345` CSRF and
  `#2339` scheduler tasks touching `/ui`); the memory/kb fixes are a
  trivial follow-up applying this same 200-mold.
- **Generic banner for the middleware-level `csrf_token_invalid` 403 / a
  raw 500.** Those responses are produced by `CSRFMiddleware` before the
  handler runs and are not handler-reachable; per the adoption comment
  that generic banner is "the carrier for #2345's visibility fix" and is
  left to `#2345`.

Closes #2346
