### PR TITLE
docs(topology): curated-until-populator-covers policy + grandfather rule (#2336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Docs — curated-until-populator-covers policy for auto-only edge kinds + grandfather rule (#2336)
+
+- Documented that the four auto-discoverable topology edge kinds
+  (`runs-on`, `mounts`, `routes-through`, `belongs-to`) MAY be curated
+  on any pair no populator covers — v0.2 auto-discovery is
+  Kubernetes-only (base `discover_topology` is a no-op; only the k8s
+  connector overrides it), so on a non-k8s pair no probe emits the edge
+  and the curated write inserts clean (`source: curated, conflicts:
+  []`). §6 conflict detection stays dormant because it only keys off
+  `source='auto'` rows / existing different-kind edges.
+- Recorded the **grandfather commitment**: any populator that begins
+  covering a previously-uncovered kind ships with a one-shot
+  reconciliation that keeps pre-existing curated edges visible and
+  free of retroactive §6 conflicts — the same operator-owned-rows
+  principle `refresh._refresh_curated_edge` already applies for the
+  identical pair. Policy-only; the `curated_until_populator_covers`
+  bucket and the reconciliation job are deferred to the non-k8s
+  populator initiative. Updated `docs/architecture/topology.md` and
+  `docs/cross-repo/topology-annotation.md`.
+
 ### Fixed — unified the `/ui` CSRF double-submit token pattern (#2345)
 
 - The operator console's `/ui/*` write surfaces no longer `403

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -87,7 +87,9 @@ widens the `graph_edge.kind` CHECK from the G9.1 subset; the
 `StrEnum` and the CHECK move in lock-step).
 
 **Four auto-discoverable kinds** — refresh writes these on every
-probe. Probe-derived edges have to be high-confidence — a wrong
+probe, **for the pair-types a populator covers** (see
+[Curated-until-populator-covers policy](#curated-until-populator-covers-policy)
+below). Probe-derived edges have to be high-confidence — a wrong
 edge in a `dependents` answer misleads the operator on the very op
 the verb is supposed to make safer.
 
@@ -117,6 +119,50 @@ different product) and cannot be derived from any single probe.
 The operator-facing recipe for *when* to annotate, the §6 conflict
 rules below, and the CLI walkthrough live in
 [`docs/cross-repo/topology-annotation.md`](../cross-repo/topology-annotation.md).
+
+### Curated-until-populator-covers policy
+
+The auto/curated split assumes **populator coverage**: an
+auto-discoverable kind is left to the probes only where a populator
+actually emits it. v0.2 auto-discovery is **Kubernetes-only** — the
+base connector's `discover_topology` is a no-op
+([`connectors/base.py`](../../backend/src/meho_backplane/connectors/base.py))
+and only the Kubernetes connector overrides it
+([`connectors/kubernetes/connector.py`](../../backend/src/meho_backplane/connectors/kubernetes/connector.py))
+— so for a non-k8s pair (a virtualization-management appliance
+`runs-on` its host cluster, a workload `runs-on` a hypervisor) no probe
+ever emits `runs-on` / `mounts` / `routes-through` / `belongs-to`.
+
+The policy that follows: **an auto-discoverable kind MAY be curated on
+any pair no populator covers.** Choosing the semantically-correct kind
+is legitimate there, not a workaround — an operator should not fall
+back to a weaker curated-only kind (`depends-on`) just to dodge the
+vocabulary. Such a write inserts clean (`source: curated, conflicts:
+[]`) because §6 detection keys off *existing* edges: the supersede pass
+(rule 1) only marks `source='auto'` rows and the incompatible-kind pass
+(rule 2) only fires against an existing different-kind edge on the same
+pair — a pair no populator covers has neither, so the §6 machinery is
+dormant.
+
+**Grandfather rule on populator ship.** So that today's correct
+modelling stays safe when coverage later arrives, MEHO commits that any
+populator newly covering a previously-uncovered kind ships with a
+one-shot reconciliation that grandfathers pre-existing curated edges of
+that kind — they stay visible, not retroactively §6-conflicted. The
+substrate already applies this for the *identical* pair:
+[`refresh._refresh_curated_edge`](../../backend/src/meho_backplane/topology/refresh.py)
+keeps an operator-curated row operator-owned when a probe re-discovers
+the same `(from, to, kind)` (it bumps `last_seen` only; the
+`source='curated'` marker and any §6 markers are untouched, and no
+competing auto row is inserted). The grandfather rule extends that same
+"operator-owned rows survive a populator arrival" principle to the
+related-pair interactions a future reconciliation must settle. The
+machine-readable `curated_until_populator_covers` bucket and the
+reconciliation job itself are deferred to the initiative that ships the
+non-k8s populator; recording the commitment now is what makes writing
+`runs-on` today safe. The operator runbook
+([`topology-annotation.md`](../cross-repo/topology-annotation.md#curating-an-auto-discoverable-kind-before-its-populator-exists))
+carries the full recipe.
 
 ## G9.2 curated-edge surface
 

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -138,18 +138,36 @@ any pair no populator covers.** Choosing the semantically-correct kind
 is legitimate there, not a workaround — an operator should not fall
 back to a weaker curated-only kind (`depends-on`) just to dodge the
 vocabulary. Such a write inserts clean (`source: curated, conflicts:
-[]`) because §6 detection keys off *existing* edges: the supersede pass
-(rule 1) only marks `source='auto'` rows and the incompatible-kind pass
-(rule 2) only fires against an existing different-kind edge on the same
-pair — a pair no populator covers has neither, so the §6 machinery is
-dormant.
+[]`) **only when no other edge already sits on that ordered pair**,
+because §6 detection keys off *existing* edges. The supersede pass
+(rule 1) only marks `source='auto'` rows
+([`annotate.py:314`](../../backend/src/meho_backplane/topology/annotate.py)),
+so it is genuinely dormant on an uncovered pair — there is no auto row to
+supersede. The incompatible-kind pass (rule 2), however, carries **no
+`source` filter**: it selects every different-kind edge on the same
+`(from, to)` pair regardless of origin
+([`annotate.py:366-371`](../../backend/src/meho_backplane/topology/annotate.py)).
+So the clean-insert guarantee holds only where the pair is otherwise
+empty. If a *pre-existing curated* different-kind edge already sits on it
+— an operator curated `depends-on(A→B)`, then later curates
+`runs-on(A→B)` — rule 2 still fires and the new curated row inserts with
+a **non-empty** `conflicts` array. That is by design: rule 2's own
+docstring describes exactly this `depends-on` ⇄ `routes-through`
+coexistence, where both rows survive and each carries the other's id.
+Clean insertion therefore requires *both* no existing `auto` row **and**
+no existing different-kind edge (of any source) on the pair.
 
 **Grandfather rule on populator ship.** So that today's correct
 modelling stays safe when coverage later arrives, MEHO commits that any
-populator newly covering a previously-uncovered kind ships with a
-one-shot reconciliation that grandfathers pre-existing curated edges of
-that kind — they stay visible, not retroactively §6-conflicted. The
-substrate already applies this for the *identical* pair:
+populator newly covering a `(kind, pair-type)` an operator already
+curated ships with a one-shot reconciliation that grandfathers those
+pre-existing curated edges — they stay visible, not retroactively
+§6-conflicted. Coverage is per `(kind, pair-type)`, not per kind
+globally: the k8s populator already covers `runs-on` for k8s pairs, so
+the trigger is a populator adding a previously-uncovered *pair-type* (a
+hypervisor host, an appliance→cluster) under a kind that may already be
+covered elsewhere. The substrate already applies this for the
+*identical* pair:
 [`refresh._refresh_curated_edge`](../../backend/src/meho_backplane/topology/refresh.py)
 keeps an operator-curated row operator-owned when a probe re-discovers
 the same `(from, to, kind)` (it bumps `last_seen` only; the

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -163,7 +163,8 @@ populator newly covering a `(kind, pair-type)` an operator already
 curated ships with a one-shot reconciliation that grandfathers those
 pre-existing curated edges — they stay visible, not retroactively
 §6-conflicted. Coverage is per `(kind, pair-type)`, not per kind
-globally: the k8s populator already covers `runs-on` for k8s pairs, so
+globally: the k8s populator already covers `belongs-to` for k8s pairs
+(namespace→target, node→target), so
 the trigger is a populator adding a previously-uncovered *pair-type* (a
 hypervisor host, an appliance→cluster) under a kind that may already be
 covered elsewhere. The substrate already applies this for the

--- a/docs/cross-repo/topology-annotation.md
+++ b/docs/cross-repo/topology-annotation.md
@@ -146,13 +146,25 @@ vocabulary.
 
 **Why it inserts clean today.** §6 conflict detection keys off
 *existing* edges. The supersede pass only marks `source='auto'` rows
-(`_mark_same_kind_different_endpoint_superseded` in
-[`topology/annotate.py`](../../backend/src/meho_backplane/topology/annotate.py)),
-and the incompatible-kind pass only fires when an edge of a *different*
-kind already sits on the same pair. On a pair no populator covers,
-neither condition holds, so the curated row inserts with `source:
-curated, conflicts: []` — the §6 machinery stays dormant until a
-competing edge exists.
+(`_mark_same_kind_different_endpoint_superseded`,
+[`annotate.py:314`](../../backend/src/meho_backplane/topology/annotate.py)),
+so it is dormant on an uncovered pair — there is no auto row to
+supersede. The incompatible-kind pass, however, carries **no `source`
+filter**: it selects every edge of a *different* kind on the same
+`(from, to)` pair, whatever its origin
+(`_mark_incompatible_kinds_conflict`,
+[`annotate.py:366-371`](../../backend/src/meho_backplane/topology/annotate.py)).
+So the curated row inserts with `source: curated, conflicts: []` **only
+when the pair is otherwise empty**. If a pre-existing curated
+different-kind edge already sits on it — an operator curated
+`depends-on(A→B)`, then curates `runs-on(A→B)` — the incompatible-kind
+pass still fires and the new row carries a **non-empty** `conflicts`
+array. That coexistence is by design (rule 2's docstring uses the
+`depends-on` ⇄ `routes-through` example: both rows survive, each
+referencing the other). Clean insertion therefore requires **both** no
+existing `auto` row and no existing different-kind edge of any source on
+the pair; on a genuinely empty pair the §6 machinery stays dormant until
+a competing edge exists.
 
 **The grandfather commitment.** The state above is safe but would be
 *fragile* without a forward guarantee: the day a non-k8s populator
@@ -161,9 +173,10 @@ curated, which could turn today's clean curated rows into §6
 conflict/supersede noise. The commitment is therefore:
 
 > Any populator that begins covering a previously-uncovered
-> auto-discoverable kind ships with a **one-shot reconciliation** that
-> grandfathers pre-existing curated edges of that kind — they stay
-> visible and are **not** retroactively marked as §6 conflicts.
+> `(kind, pair-type)` — coverage is per `(kind, pair-type)`, not per
+> kind globally — ships with a **one-shot reconciliation** that
+> grandfathers the pre-existing curated edges on that pair-type: they
+> stay visible and are **not** retroactively marked as §6 conflicts.
 
 The substrate already leans this way for the *identical* pair: when a
 refresh re-discovers an edge an operator has curated on the same

--- a/docs/cross-repo/topology-annotation.md
+++ b/docs/cross-repo/topology-annotation.md
@@ -83,14 +83,18 @@ thumb follows from the split:
   operator to assert them. These are the canonical use cases for
   `meho topology annotate`.
 - **Four auto-discoverable kinds** (`runs-on`, `mounts`,
-  `routes-through`, `belongs-to`) — probes write these on every
-  refresh. **Do not annotate them.** A duplicate annotation lands as
-  a §6 conflict marker (`conflicts_with` on both rows) and clutters
-  the inventory survey without semantic gain. The legitimate reason
-  to write one of these kinds yourself is the §6 *supersede* flow
-  below: the probe wrote a `runs-on` edge to the wrong endpoint and
-  you need the curated row to override it until the next probe
-  catches up.
+  `routes-through`, `belongs-to`) — a populator writes these on every
+  refresh **for the pair-types it covers**. Where a populator covers
+  the pair, **do not annotate the same relationship** — a duplicate
+  clutters the inventory survey without semantic gain, and asserting a
+  *different* endpoint fires the §6 *supersede* flow below (the
+  legitimate reason to write one of these kinds yourself: the probe
+  wrote a `runs-on` edge to the wrong host and you override it until
+  the next probe catches up). But auto-discovery is not yet universal —
+  v0.2 ships a populator for Kubernetes only — so for a pair-type **no
+  populator covers**, these kinds are legitimately curated-assertable.
+  See [Curating an auto-discoverable kind before its populator
+  exists](#curating-an-auto-discoverable-kind-before-its-populator-exists).
 
 The canonical example: a Kubernetes namespace `customer-a-prod`
 depends on a Postgres database `prod-db-1` (a `depends-on` curated
@@ -118,6 +122,66 @@ Kubernetes probe already writes that edge on every refresh. If your
 intent is "I want the graph to record the runtime placement", just
 run `meho topology refresh <k8s-target>`. If your intent is "the
 probe wrote the wrong host", that's the §6 supersede flow below.
+
+### Curating an auto-discoverable kind before its populator exists
+
+The "auto vs curated" split assumes **coverage**: an auto-discoverable
+kind is safe to leave to the probes only where a populator actually
+emits it for the pair-type in question. That assumption does not hold
+universally in v0.2 — auto-discovery is **Kubernetes-only**. The base
+connector's `discover_topology` is a no-op
+([`connectors/base.py`](../../backend/src/meho_backplane/connectors/base.py)),
+and the Kubernetes connector is the only one that overrides it
+([`connectors/kubernetes/connector.py`](../../backend/src/meho_backplane/connectors/kubernetes/connector.py)).
+So for a non-k8s pair — a virtualization-management appliance
+`runs-on` its host cluster, a workload `runs-on` a hypervisor — **no
+probe ever emits the edge**.
+
+**Policy: an auto-discoverable kind MAY be curated on any pair no
+populator covers.** Asserting `runs-on` (or `mounts` /
+`routes-through` / `belongs-to`) on such a pair is legitimate, not a
+workaround — pick the semantically-correct kind, don't fall back to a
+weaker curated-only kind (`depends-on`) chosen only to sidestep the
+vocabulary.
+
+**Why it inserts clean today.** §6 conflict detection keys off
+*existing* edges. The supersede pass only marks `source='auto'` rows
+(`_mark_same_kind_different_endpoint_superseded` in
+[`topology/annotate.py`](../../backend/src/meho_backplane/topology/annotate.py)),
+and the incompatible-kind pass only fires when an edge of a *different*
+kind already sits on the same pair. On a pair no populator covers,
+neither condition holds, so the curated row inserts with `source:
+curated, conflicts: []` — the §6 machinery stays dormant until a
+competing edge exists.
+
+**The grandfather commitment.** The state above is safe but would be
+*fragile* without a forward guarantee: the day a non-k8s populator
+ships, it starts emitting auto edges for pairs an operator already
+curated, which could turn today's clean curated rows into §6
+conflict/supersede noise. The commitment is therefore:
+
+> Any populator that begins covering a previously-uncovered
+> auto-discoverable kind ships with a **one-shot reconciliation** that
+> grandfathers pre-existing curated edges of that kind — they stay
+> visible and are **not** retroactively marked as §6 conflicts.
+
+The substrate already leans this way for the *identical* pair: when a
+refresh re-discovers an edge an operator has curated on the same
+`(from, to, kind)`, `_refresh_curated_edge`
+([`topology/refresh.py`](../../backend/src/meho_backplane/topology/refresh.py))
+keeps the row **operator-owned** — it bumps `last_seen` only, leaves
+the `source='curated'` marker and every §6 marker untouched, and never
+inserts a competing auto row. The grandfather commitment extends that
+same "operator-owned rows survive a populator arrival" principle to the
+related-pair interactions (a populator emitting the same kind to a
+*different* endpoint) that a future reconciliation must settle.
+
+This is a **documentation-level policy commitment**, not shipped
+machinery: the machine-readable `curated_until_populator_covers` bucket
+and the reconciliation job itself are deferred to the initiative that
+ships the non-k8s populator. Recording the commitment now means you can
+model `runs-on` correctly today without fear that a later populator
+will punish you for it.
 
 ## The closed 10-kind vocabulary
 


### PR DESCRIPTION
## Summary

- Documents the **curated-until-populator-covers** policy for the four
  auto-discoverable topology edge kinds (`runs-on`, `mounts`,
  `routes-through`, `belongs-to`): they MAY be curated on any pair no
  populator covers. v0.2 auto-discovery is Kubernetes-only (base
  `discover_topology` is a no-op — `connectors/base.py`; only the k8s
  connector overrides it), so on a non-k8s pair no probe emits the edge
  and the curated write inserts clean (`source: curated, conflicts: []`).
- Grounds the "safe today" claim in code: §6 conflict detection keys off
  *existing* edges — the supersede pass only marks `source='auto'` rows
  (`_mark_same_kind_different_endpoint_superseded`, `topology/annotate.py`)
  and the incompatible-kind pass only fires against an existing
  different-kind edge on the same pair. A pair no populator covers has
  neither.
- Records the **grandfather commitment**: any populator that begins
  covering a previously-uncovered kind ships with a one-shot
  reconciliation that keeps pre-existing curated edges visible and free
  of retroactive §6 conflicts — the same operator-owned-rows principle
  `refresh._refresh_curated_edge` (`topology/refresh.py`) already applies
  for the identical pair. Policy-only; the machine-readable
  `curated_until_populator_covers` bucket and the reconciliation job are
  deferred to the initiative that ships the non-k8s populator.

Adopts Options 1 + 4 from the issue (per the maintainer's grounding-delta
comment). Options 2 (the populator) and 3 (the bucket) are deferred.

## Files changed

- `docs/architecture/topology.md` — new "Curated-until-populator-covers
  policy" subsection + a coverage qualifier on the auto-discoverable-kinds
  intro.
- `docs/cross-repo/topology-annotation.md` — new "Curating an
  auto-discoverable kind before its populator exists" subsection +
  softened the flat "do not annotate" rule of thumb.
- `CHANGELOG.md` — `### Docs —` entry.

## Test plan

- [x] Docs-only — no code, no snapshot regen, no migration.
- [x] All source-file links in the new prose resolve (`base.py`,
  `kubernetes/connector.py`, `annotate.py`, `refresh.py`).
- [x] Cross-reference anchors resolve
  (`#curated-until-populator-covers-policy`,
  `#curating-an-auto-discoverable-kind-before-its-populator-exists`).
- [x] Policy claims verified against code: `discover_topology` overridden
  only by the k8s connector; §6 supersede filters `source='auto'`
  (annotate.py); `_refresh_curated_edge` keeps re-discovered curated rows
  operator-owned (refresh.py).
- [x] Pre-commit hooks (whitespace, EOF, conventional-commit, gitleaks)
  passed.

## Out of scope

- The non-k8s `discover_topology` populator itself (Option 2 — files via
  its own initiative when the blast-radius work is prioritized).
- The machine-readable `curated_until_populator_covers` bucket + write-time
  warning (Option 3 — deferred).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2336


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the policy for curating auto-discoverable topology edge types when no populator covers a pair type.
  * Clarified that probes generally manage covered edge types, avoiding unnecessary duplicate annotations.
  * Added guidance for grandfathering existing curated edges when future populator coverage is introduced.
  * Updated Kubernetes topology and annotation runbook documentation with the new rules and exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->