### PR TITLE
fix(ui): disinherit leaking hx-disabled-elt find-selectors across /ui modals (#2340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — disinherited leaking `hx-disabled-elt` find-selectors across `/ui` modals (#2340)
+
+- Five operator-console modals (`scheduler` create-trigger, `memory`
+  create + body-edit, `conventions` create + edit) bound
+  `hx-disabled-elt="find button[type=submit]"` on the `<form>` to disable
+  the submit button while a request is in flight. Because `hx-disabled-elt`
+  is an *inherited* htmx attribute, each form's descendant htmx requests —
+  the debounced cron-validate / token-preview `POST`s and the in-form
+  Cancel `hx-get` — inherited the value and resolved `find button[type=submit]`
+  against their own (submit-button-less) subtree, logging
+  `The selector "find button[type=submit]" on hx-disabled-elt returned no
+  matches!` on every such request while the intended disable-submit
+  affordance silently never fired. Each form now carries
+  `hx-disinherit="hx-disabled-elt"` (the pattern established for the runbook
+  editor in #2174), scoping the value to the form's own submit. A generic
+  `test_ui_templates.py` guard enforces the discipline across every `/ui`
+  template so a new modal cannot reintroduce the leak.
+
 ### Fixed — unified the `/ui` CSRF double-submit token pattern (#2345)
 
 - The operator console's `/ui/*` write surfaces no longer `403

--- a/backend/src/meho_backplane/ui/templates/conventions/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_create_modal.html
@@ -49,6 +49,7 @@
       hx-target="#conventions-write-result"
       hx-swap="innerHTML"
       hx-disabled-elt="find button[type=submit]"
+      hx-disinherit="hx-disabled-elt"
       class="space-y-3 py-2"
       aria-labelledby="conventions-create-modal-title"
     >

--- a/backend/src/meho_backplane/ui/templates/conventions/_edit_modal.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_edit_modal.html
@@ -30,6 +30,7 @@
       hx-target="#conventions-write-result"
       hx-swap="innerHTML"
       hx-disabled-elt="find button[type=submit]"
+      hx-disinherit="hx-disabled-elt"
       class="space-y-3 py-2"
       aria-labelledby="conventions-edit-modal-title"
     >

--- a/backend/src/meho_backplane/ui/templates/memory/_body_edit.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_body_edit.html
@@ -26,6 +26,7 @@
   hx-target="this"
   hx-swap="outerHTML"
   hx-disabled-elt="find button[type=submit]"
+  hx-disinherit="hx-disabled-elt"
   aria-label="Edit memory body"
 >
   <label class="form-control">

--- a/backend/src/meho_backplane/ui/templates/memory/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_create_modal.html
@@ -70,6 +70,7 @@
         hx-target="this"
         hx-swap="none"
         hx-disabled-elt="find button[type=submit]"
+        hx-disinherit="hx-disabled-elt"
         data-target-scoped-values="{{ target_scoped_values | join(',') }}"
         class="space-y-3 py-2"
         aria-labelledby="memory-create-modal-title"

--- a/backend/src/meho_backplane/ui/templates/scheduler/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/scheduler/_create_modal.html
@@ -58,6 +58,7 @@
       hx-target="#scheduler-modal-container"
       hx-swap="innerHTML"
       hx-disabled-elt="find button[type=submit]"
+      hx-disinherit="hx-disabled-elt"
       hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
       class="space-y-3 py-2"
       aria-labelledby="scheduler-create-modal-title"

--- a/backend/tests/test_ui_scheduler.py
+++ b/backend/tests/test_ui_scheduler.py
@@ -583,6 +583,10 @@ def test_create_modal_renders_for_tenant_admin() -> None:
     assert 'hx-post="/ui/scheduler/create"' in body
     assert str(_AGENT_ID) in body  # agent dropdown option
     assert 'hx-post="/ui/scheduler/validate-cron"' in body  # live cron validation
+    # #2340: the form's `find button[type=submit]` disabled-elt must be
+    # disinherited so the descendant validate-cron POST does not inherit it
+    # and log `... returned no matches!` on every debounced keystroke.
+    assert 'hx-disinherit="hx-disabled-elt"' in body
 
 
 def test_create_modal_carries_fire_at_utc_conversion() -> None:

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -594,3 +594,81 @@ def test_head_assets_loads_csrf_token_hook_after_htmx() -> None:
     htmx_pos = source.index("/ui/static/src/vendor/htmx.min.js")
     hook_pos = source.index("/ui/static/src/app/csrf-token.js")
     assert htmx_pos < hook_pos, "the CSRF hook must load after htmx.min.js"
+
+
+# ---------------------------------------------------------------------------
+# hx-disabled-elt find-selector inheritance discipline (#2340)
+#
+# ``hx-disabled-elt`` is an *inherited* htmx attribute. A form that binds
+# ``hx-disabled-elt="find button[type=submit]"`` (to disable its own submit
+# while a request is in flight) works for the form's own submit -- ``find``
+# resolves against the form's descendants and matches the submit button. But
+# every descendant that issues its OWN htmx request (a debounced preview POST,
+# a live cron-validate POST, an in-form Cancel ``hx-get``, ...) inherits that
+# value and resolves ``find button[type=submit]`` against ITS subtree -- which
+# has no submit button -- logging
+# ``The selector "find button[type=submit]" on hx-disabled-elt returned no
+# matches!`` once per descendant request, and the intended disable-submit
+# affordance never fires for those triggers.
+#
+# The fix (established by #2117-D1 / #2174 on ``runbooks/editor.html``) is to
+# add ``hx-disinherit="hx-disabled-elt"`` to the form: the value stays on the
+# form's own submit and stops leaking into the descendant triggers. This guard
+# enforces the discipline generically so a new modal cannot reintroduce the
+# leak -- the console-warning class the console has no browser harness to catch.
+# ---------------------------------------------------------------------------
+
+#: Re-find every opening ``<form ...>`` tag plus its body up to the first
+#: closing tag. Forms cannot nest in valid HTML, so a non-greedy ``</form>``
+#: correctly bounds each form (the DaisyUI ``form[method="dialog"]`` backdrop
+#: is a separate, attribute-free match that carries no ``hx-disabled-elt``).
+_FORM_BLOCK_RE = re.compile(r"<form\b([^>]*)>(.*?)</form>", re.IGNORECASE | re.DOTALL)
+
+#: A descendant htmx request trigger (any verb) inside a form body -- the
+#: element that would inherit the form's ``hx-disabled-elt`` and mis-resolve a
+#: ``find`` selector against its own (submit-button-less) subtree.
+_HX_REQUEST_ATTR_RE = re.compile(r"\bhx-(get|post|put|patch|delete)\s*=", re.IGNORECASE)
+
+#: An inheritance-sensitive ``find`` selector on ``hx-disabled-elt``. ``find``
+#: resolves relative to the issuing element, so it breaks under inheritance;
+#: ``this`` / document-wide id selectors do not, and are intentionally ignored.
+_DISABLED_ELT_FIND_RE = re.compile(r'hx-disabled-elt\s*=\s*"find\b', re.IGNORECASE)
+
+
+def _ui_template_sources() -> Iterator[tuple[str, str]]:
+    """Yield ``(relative_name, jinja-comment-stripped source)`` for every UI template."""
+    root = templates_dir()
+    for path in sorted(root.rglob("*.html")):
+        source = _JINJA_COMMENT_RE.sub("", path.read_text(encoding="utf-8"))
+        yield str(path.relative_to(root)), source
+
+
+def test_forms_with_find_disabled_elt_disinherit_it() -> None:
+    """Every form leaking a ``find`` ``hx-disabled-elt`` into a descendant disinherits it (#2340).
+
+    A form that carries ``hx-disabled-elt="find ..."`` AND contains a
+    descendant htmx request trigger must also carry
+    ``hx-disinherit="hx-disabled-elt"`` (or ``hx-disinherit="*"``); otherwise
+    the descendant inherits the ``find`` selector, resolves it against its own
+    subtree, and htmx logs ``... returned no matches!`` on every such request.
+    Scans the raw template sources so the guard is render-context independent
+    and catches the whole class, not just the modals fixed in #2340.
+    """
+    offenders: list[str] = []
+    for name, source in _ui_template_sources():
+        for open_tag, body in _FORM_BLOCK_RE.findall(source):
+            if not _DISABLED_ELT_FIND_RE.search(open_tag):
+                continue
+            if not _HX_REQUEST_ATTR_RE.search(body):
+                # No descendant request trigger -> the form's own submit is the
+                # only consumer of hx-disabled-elt; nothing to leak into.
+                continue
+            if "hx-disinherit" not in open_tag:
+                offenders.append(name)
+
+    assert not offenders, (
+        'these templates have a form with hx-disabled-elt="find ..." plus a '
+        'descendant htmx request, but no hx-disinherit="hx-disabled-elt" -- '
+        "the find selector leaks into the descendant request and htmx logs "
+        f"'... returned no matches!': {sorted(set(offenders))}"
+    )


### PR DESCRIPTION
## Summary

- Five `/ui` operator-console forms bind `hx-disabled-elt="find button[type=submit]"` to disable their submit button while a request is in flight. Because `hx-disabled-elt` is an **inherited** htmx attribute, each form's *descendant* htmx requests (debounced cron-validate / token-preview `POST`s and in-form Cancel `hx-get`) inherited the value and resolved `find button[type=submit]` against their own submit-button-less subtree — logging `The selector "find button[type=submit]" on hx-disabled-elt returned no matches!` on every such request while the disable-submit affordance silently never fired.
- Fix: add `hx-disinherit="hx-disabled-elt"` to each of the 5 leaking forms, scoping the value to the form's own submit (the exact pattern established for the runbook editor in #2174). Files: `scheduler/_create_modal.html`, `memory/_create_modal.html`, `memory/_body_edit.html`, `conventions/_create_modal.html`, `conventions/_edit_modal.html`.
- Added a **generic** `test_ui_templates.py` guard that scans every `/ui` template: any form with a `find` `hx-disabled-elt` plus a descendant htmx request must carry `hx-disinherit` — establishing the "htmx selectors must match the DOM" discipline generically (the console has no browser harness to catch this class).

## Grounding correction

The issue's grounding comment named `scheduler/_create_modal.html` (correct — leaks via the cron-validate `POST`) plus `memory/_promote_modal.html` and `runbooks/_run_step.html`. A per-form check showed the latter two carry **no descendant htmx request**, so their form-level `find` resolves cleanly against their own submit button and they warn nowhere — they are correctly **left untouched**. The actual leaking set is exactly 5 modals (matching the title's "5+"): the two `conventions` and two `memory` forms plus `scheduler`, each of which does have a descendant htmx trigger.

## Test plan

- [x] `ruff check` + `ruff format --check` on changed test files — clean
- [x] `pytest tests/test_ui_templates.py tests/test_ui_scheduler.py` — 71 passed (incl. new generic guard + scheduler focused assertion)
- [x] `pytest tests/test_ui_conventions_write.py tests/test_ui_memory_create_promote.py tests/test_ui_runbooks_editor.py` — 76 passed (no regression; the existing #2174 editor-disinherit test still green)
- [x] Confirmed the new guard fails if `hx-disinherit` is removed from any of the 5 forms and passes on the full current template tree

## Out of scope

- `find button[data-action=...]` disabled-elt selectors on keycloak/vault/operations single-button confirm forms — verified to have no descendant htmx requests, so no leak.
- Playwright console-warning assertions (no browser harness wired in this repo; the server-side generic guard is the pytest-level equivalent).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2340
