### PR TITLE
feat(ui): /ui/agents polish — card Toggle, no auto-open Stop dialog, sub-view back-nav (#2347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — `/ui/agents` polish: card toggle, no auto-open Stop dialog, sub-view back-nav (#2347)
+
+- The `/ui/agents` cards now carry a one-click enable/disable **Toggle**
+  (tenant_admin only), routed through the same `/ui/agents/{name}/toggle`
+  endpoint the detail view uses — an operator no longer has to open the
+  detail page and navigate back just to flip an agent's state.
+- Submitting **Run** on an agent no longer auto-opens the "Stop this run"
+  confirm dialog. The dialog ships inside the run-transcript fragment
+  swapped in on submit, and the app-shell modal controller's
+  `htmx:afterSwap` sweep was popping it the instant a run started, hiding
+  the live logs. Button-driven dialogs now opt out of the sweep via
+  `data-auto-open="false"`, so the Stop confirm opens only on the Stop
+  button.
+- The `/ui/agents/runs` list and per-run detail views gained a
+  breadcrumb back to `/ui/agents` (the run detail now links the agents
+  console directly, not only the runs list), matching the grants and
+  principals sub-views.
+
 ### Fixed — unified the `/ui` CSRF double-submit token pattern (#2345)
 
 - The operator console's `/ui/*` write surfaces no longer `403

--- a/backend/src/meho_backplane/ui/static/src/app/modal-dialogs.js
+++ b/backend/src/meho_backplane/ui/static/src/app/modal-dialogs.js
@@ -107,6 +107,16 @@
       if (dialog.open || typeof dialog.showModal !== "function") {
         continue;
       }
+      // Respect an explicit opt-out. A button-driven inline dialog (e.g.
+      // the agent run console's Stop-confirm) ships INSIDE a swapped-in
+      // fragment -- the run transcript, swapped over ``#agent-run-transcript``
+      // on Run submit -- but must open only on its own trigger, never on the
+      // swap. Without this guard the auto-open sweep pops the Stop dialog the
+      // instant a run starts, blocking the live transcript the operator
+      // wanted to watch (#2347). The dialog carries ``data-auto-open="false"``.
+      if (dialog.dataset.autoOpen === "false") {
+        continue;
+      }
       // Never open a dialog nested inside another already-open dialog --
       // the operator-facing modal is the top-level one; a stray nested
       // duplicate must not steal the top layer.

--- a/backend/src/meho_backplane/ui/templates/agents/_cards.html
+++ b/backend/src/meho_backplane/ui/templates/agents/_cards.html
@@ -73,6 +73,30 @@
               >
                 updated {{ agent.updated_at.isoformat() }}
               </div>
+
+              {# One-click enable / disable straight from the card, so a
+                 tenant_admin never has to open the detail view to flip an
+                 agent's state (#2347). It POSTs the flipped ``enabled`` to
+                 the same ``/ui/agents/{name}/toggle`` route the detail view
+                 uses; the 204 + ``HX-Redirect`` reloads the list with the
+                 new pill. Rendered for tenant_admins only (the top-level
+                 ``can_write``); the route re-checks the role server-side. #}
+              {% if can_write %}
+                <div class="card-actions justify-end pt-1">
+                  <button
+                    type="button"
+                    class="btn btn-xs btn-ghost"
+                    data-action="toggle"
+                    hx-post="/ui/agents/{{ agent.name | urlencode }}/toggle"
+                    hx-vals='{"enabled": "{{ "false" if agent.enabled else "true" }}"}'
+                    hx-target="body"
+                    hx-swap="none"
+                    aria-label="{{ "Disable" if agent.enabled else "Enable" }} {{ agent.name }}"
+                  >
+                    {% if agent.enabled %}Disable{% else %}Enable{% endif %}
+                  </button>
+                </div>
+              {% endif %}
             </div>
           </article>
         </li>

--- a/backend/src/meho_backplane/ui/templates/agents/_run_transcript.html
+++ b/backend/src/meho_backplane/ui/templates/agents/_run_transcript.html
@@ -138,8 +138,15 @@
        Native <dialog> (the console's destructive-action confirm pattern).
        The run id is interpolated client-side so the operator sees exactly
        which run halts. The agent stops after its current step (the cancel
-       is observed on the next turn boundary, not a synchronous tear-down). -#}
-    <dialog x-ref="stopConfirm" class="modal" data-role="stop-confirm">
+       is observed on the next turn boundary, not a synchronous tear-down).
+
+       ``data-auto-open="false"`` opts this dialog out of the app-shell
+       modal controller's ``htmx:afterSwap`` auto-open sweep
+       (``app/modal-dialogs.js``): this fragment is itself swapped in on Run
+       submit, and without the opt-out the sweep would pop the Stop dialog
+       the instant a run starts, hiding the live transcript. It opens only
+       on the Stop button's ``@click`` (#2347). -#}
+    <dialog x-ref="stopConfirm" class="modal" data-role="stop-confirm" data-auto-open="false">
       <div class="modal-box max-w-md">
         <h3 class="text-base font-semibold">Stop this run?</h3>
         <p class="py-3 text-sm opacity-80">

--- a/backend/src/meho_backplane/ui/templates/agents/runs/detail.html
+++ b/backend/src/meho_backplane/ui/templates/agents/runs/detail.html
@@ -20,7 +20,16 @@
 {% block content %}
 <section class="space-y-5">
   <header class="space-y-1">
-    <a href="/ui/agents/runs" class="link link-hover text-sm opacity-70">&larr; Agent runs</a>
+    {# Full breadcrumb back through the runs list to the agents console, so
+       the operator has a one-click return to ``/ui/agents`` (not only to
+       the runs list) matching the other agents sub-views (#2347). #}
+    <nav class="text-sm opacity-70" aria-label="Breadcrumb">
+      <a href="/ui/agents" class="link link-hover">Agents</a>
+      <span aria-hidden="true">/</span>
+      <a href="/ui/agents/runs" class="link link-hover">Runs</a>
+      <span aria-hidden="true">/</span>
+      <span class="font-mono">{{ run.run_id }}</span>
+    </nav>
     <h1 class="text-xl font-semibold flex items-center gap-3">
       <span>Run</span>
       <span class="font-mono text-sm opacity-70">{{ run.run_id }}</span>

--- a/backend/src/meho_backplane/ui/templates/agents/runs/list.html
+++ b/backend/src/meho_backplane/ui/templates/agents/runs/list.html
@@ -27,6 +27,17 @@
 
 {% block content %}
 <section class="space-y-4">
+  {# ---------- Back-to-agents breadcrumb ----------
+     The runs list is a sub-surface of the agents console; a breadcrumb
+     back to ``/ui/agents`` matches the grants / principals sub-views and
+     gives a one-click return without relying on the browser back button
+     (which an HTMX filter swap does not populate) (#2347). #}
+  <nav class="text-sm" aria-label="Breadcrumb">
+    <a href="/ui/agents" class="link link-hover">Agents</a>
+    <span aria-hidden="true">/</span>
+    <span>Runs</span>
+  </nav>
+
   {# ---------- Definitions / Runs tab strip ---------- #}
   <div role="tablist" class="tabs tabs-bordered">
     <a role="tab" class="tab" href="/ui/agents">Definitions</a>

--- a/backend/tests/test_ui_agent_run_console.py
+++ b/backend/tests/test_ui_agent_run_console.py
@@ -420,6 +420,37 @@ def test_run_post_returns_transcript_with_stream_token() -> None:
     assert "summarise the topology" not in body  # prompt rides in the token, not the URL.
 
 
+def test_run_transcript_stop_dialog_opts_out_of_autopen() -> None:
+    """The Stop-confirm dialog must not auto-open when the transcript swaps in.
+
+    The run transcript is swapped over ``#agent-run-transcript`` on Run submit;
+    the app-shell modal controller auto-opens freshly swapped-in
+    ``dialog.modal`` fragments on ``htmx:afterSwap``. The Stop dialog is
+    button-driven, so it carries ``data-auto-open="false"`` to opt out of that
+    sweep -- otherwise the confirm pops the instant a run starts and hides the
+    live transcript (#2347).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="a1")
+    reset_agent_invoker_for_testing(_FakeInvoker())
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_token(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/agents/a1/run",
+            data={"input": "go"},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-role="stop-confirm"' in body
+    assert 'data-auto-open="false"' in body
+
+
 def test_run_post_disabled_agent_renders_409_inline() -> None:
     """A disabled agent renders an inline 409 alert, not a torn stream."""
     _seed_tenant(_TENANT_A, "tenant-a")

--- a/backend/tests/test_ui_agent_runs.py
+++ b/backend/tests/test_ui_agent_runs.py
@@ -233,6 +233,18 @@ def test_list_renders_run_row_for_operator() -> None:
     assert "toolset" not in body
 
 
+def test_list_renders_back_to_agents_breadcrumb() -> None:
+    """The runs list carries a breadcrumb back to ``/ui/agents`` (#2347)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_run(tenant_id=_TENANT_A, status_value=AgentRunStatus.SUCCEEDED.value)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'aria-label="Breadcrumb"' in body
+    assert '<a href="/ui/agents" class="link link-hover">Agents</a>' in body
+
+
 def test_list_status_filter_narrows_rows() -> None:
     """``?status=failed`` shows only the failed run, not the running one."""
     _seed_tenant(_TENANT_A, "tenant-a")
@@ -355,6 +367,20 @@ def test_detail_renders_terminal_run_statically() -> None:
     # the approvals bell -- so we assert the panel's own poll target is
     # absent rather than the bare "hx-trigger" substring.)
     assert f'hx-get="/ui/agents/runs/{rid}"' not in body
+
+
+def test_detail_renders_back_to_agents_breadcrumb() -> None:
+    """The run-detail page breadcrumbs back to ``/ui/agents`` (not only the
+    runs list), matching the other agents sub-views (#2347)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_run(tenant_id=_TENANT_A, status_value=AgentRunStatus.SUCCEEDED.value)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get(f"/ui/agents/runs/{rid}")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'aria-label="Breadcrumb"' in body
+    assert '<a href="/ui/agents" class="link link-hover">Agents</a>' in body
+    assert '<a href="/ui/agents/runs" class="link link-hover">Runs</a>' in body
 
 
 def test_detail_non_terminal_run_self_polls() -> None:

--- a/backend/tests/test_ui_agents.py
+++ b/backend/tests/test_ui_agents.py
@@ -433,6 +433,51 @@ def test_list_shows_new_agent_button_for_admin() -> None:
     assert 'hx-get="/ui/agents/create"' in response.text
 
 
+def test_list_card_shows_toggle_for_admin_with_flipped_state() -> None:
+    """Each card carries a one-click enable/disable toggle for a tenant_admin.
+
+    The card toggle POSTs the *flipped* ``enabled`` value to the same
+    ``/ui/agents/{name}/toggle`` route the detail view uses, so an admin can
+    flip an agent's state without opening the detail page (#2347).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="on-agent", enabled=True)
+    _seed_agent(tenant_id=_TENANT_A, name="off-agent", enabled=False)
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _admin_session(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/agents")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    assert 'data-action="toggle"' in body
+    # An enabled agent's toggle disables it; a disabled agent's enables it.
+    assert 'hx-post="/ui/agents/on-agent/toggle"' in body
+    assert 'hx-post="/ui/agents/off-agent/toggle"' in body
+    assert '"enabled": "false"' in body  # on-agent -> disable
+    assert '"enabled": "true"' in body  # off-agent -> enable
+
+
+def test_list_card_hides_toggle_for_operator() -> None:
+    """A non-admin operator sees no card-level toggle (soft gate)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="on-agent", enabled=True)
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_session(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/agents")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    assert 'data-action="toggle"' not in response.text
+    assert "/ui/agents/on-agent/toggle" not in response.text
+
+
 # ---------------------------------------------------------------------------
 # Detail view
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three small UX-friction gaps on the `/ui/agents` operator-console surface, grouped into one PR per the issue (they share the "operator needs an extra click / navigation for a one-click action" pattern).

- **D1 — card-level Toggle.** Each agent card now carries a one-click enable/disable button (tenant_admin only), routed through the same `/ui/agents/{name}/toggle` route the detail view uses. No more detail-view round-trip just to flip an agent's state. The button POSTs the *flipped* `enabled` value; the route's 204 + `HX-Redirect` reloads the list with the new pill.
- **D2 — no auto-open Stop dialog.** The run-transcript fragment (swapped over `#agent-run-transcript` on Run submit) ships a button-driven Stop-confirm `<dialog>`. The app-shell modal controller's `htmx:afterSwap` sweep (`app/modal-dialogs.js`) auto-opened it the instant a run started, blocking the live transcript. Button-driven dialogs now opt out of the sweep via `data-auto-open="false"`; the Stop confirm opens only on the Stop button. Same swap/late-DOM-ref family as #2242 / #2340.
- **D3 — back-nav on sub-views.** `/ui/agents/runs` (list) and the per-run detail view gained a breadcrumb back to `/ui/agents`; the run detail now links the agents console directly, not only the runs list.

## Note on D3 scope

The issue lists four sub-views as lacking back-nav; on current `main` the `grants` and `principals` index views **already** carry an `Agents /` breadcrumb, so the real gap was `runs` (list) and `run-detail` only. Those two are fixed here; grants/principals were left untouched (already compliant).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on changed files
- [x] `pytest tests/test_ui_agents.py tests/test_ui_agent_run_console.py tests/test_ui_agent_runs.py tests/test_ui_agent_grants.py tests/test_ui_agent_principals.py tests/test_ui_templates.py` — 157 passed
- [x] **D1**: `test_list_card_shows_toggle_for_admin_with_flipped_state`, `test_list_card_hides_toggle_for_operator`
- [x] **D2**: `test_run_transcript_stop_dialog_opts_out_of_autopen`
- [x] **D3**: `test_list_renders_back_to_agents_breadcrumb`, `test_detail_renders_back_to_agents_breadcrumb`
- No FastAPI routes or schemas changed, so the OpenAPI snapshot is untouched; no new alembic migration.

## Out of scope

- The broader `/ui/*` deep-sub-view back-nav audit (runbooks/scheduler) — a separate follow-up under Goal #336 per the issue.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2347
