### PR TITLE
test(targets): fix #2338-missed targets-import list-envelope test (unbreaks main)

### DIFF
--- a/backend/tests/test_api_v1_targets_import.py
+++ b/backend/tests/test_api_v1_targets_import.py
@@ -414,7 +414,7 @@ def test_list_targets_after_import_returns_all_names(client: TestClient) -> None
             headers={"Authorization": f"Bearer {_admin_token(key)}"},
         )
         assert r2.status_code == 200
-        listed_names = {t["name"] for t in r2.json()}
+        listed_names = {t["name"] for t in r2.json()["items"]}
         for entry in first_three:
             assert entry["name"] in listed_names
 


### PR DESCRIPTION
## Summary

Hotfix: `#2338` (GET-list `{items, next_cursor}` envelope convergence) missed one test consumer — `test_api_v1_targets_import.py::test_list_targets_after_import_returns_all_names` still iterated the bare-array `GET /api/v1/targets` response, which now iterates the envelope dict's keys → `TypeError: string indices must be integers`.

`#2338`'s unit lane stopped early on the known `#574` embedding/xdist flake, so this real failure was masked at merge time and landed red on `main`. This one-line fix (`r2.json()` → `r2.json()["items"]`) restores green.

**Scope verified:** ran every other list-endpoint consumer (targets, connectors, conventions, audit/my-recent, broadcast/overrides, runbooks templates+runs, plus the list-envelope contract test) against `main` — all pass; this was the sole miss.

Test-only; no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)