### PR TITLE
fix(ui): render /ui/kb editor save errors visibly — 200-on-recoverable-error mold (#2384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — `/ui/kb` editor save renders backend errors visibly (200-on-recoverable-error mold, #2384)
+
+- The KB editor modal's save handler (`POST /ui/kb/new`) re-rendered
+  its inline error banner on a validation failure (invalid slug, empty
+  body) but returned **422**. The form swaps with `hx-swap="outerHTML"`,
+  and HTMX 2 does not swap a non-2xx response, so the error fragment was
+  computed server-side and silently dropped — the operator saw the Save
+  button appear to do nothing. The re-render now returns **200** (the
+  mold established for `/ui/agents/create` in #2346, and already shipped
+  on the runbooks start-run and conventions author modals), so the error
+  swaps back into the modal in place with the operator's input and the
+  CSRF-token refresh preserved. The memory create form was assessed and
+  intentionally **not** changed: it already surfaces recoverable errors
+  via its client-side `hx-on::response-error` handler (#1754) over a
+  `hx-swap="none"` post, which — unlike a server re-render — is the only
+  path that can display the chassis CSRF-middleware 403; returning 200
+  there would suppress `htmx:responseError` and regress it (see #2384
+  discussion).
+
 ### Docs — curated-until-populator-covers policy for auto-only edge kinds + grandfather rule (#2336)
 
 - Documented that the four auto-discoverable topology edge kinds

--- a/backend/src/meho_backplane/ui/routes/kb/routes.py
+++ b/backend/src/meho_backplane/ui/routes/kb/routes.py
@@ -625,7 +625,9 @@ def build_kb_router() -> APIRouter:
         On success, returns ``HX-Redirect`` to the new entry's detail
         page so HTMX swaps the page without a full navigation. On
         validation failure (invalid slug, empty body) re-renders the
-        editor modal with an inline error message.
+        editor modal with an inline error message as a **200** fragment
+        so HTMX swaps it back in place -- a non-2xx re-render is silently
+        dropped by HTMX 2 (#2384; the mold established in #2346).
 
         Tag parsing: the ``tags`` field is a comma-separated string
         (``"tag-a, tag-b"``); individual values are stripped of
@@ -678,8 +680,19 @@ def build_kb_router() -> APIRouter:
             "tags": tags,
             "csrf_token": csrf_token,
         }
+        # The fragment is returned as 200, not the semantically-matching 422:
+        # the form posts with hx-swap="outerHTML", and HTMX 2's default
+        # response handling does not swap a non-2xx response (swap: false),
+        # so a 422 re-render is computed server-side but never shown -- the
+        # operator sees the error banner dropped and the Save button appears
+        # to do nothing (#2384, sibling of #2346). Returning 200 is the same
+        # inline-error mold the agents create, runbooks start-run, and
+        # conventions author modals already ship. This /ui route is
+        # HTMX-only (the REST /api/v1/kb surface carries the machine-readable
+        # status contract), so the fragment status is a rendering concern,
+        # not an external contract.
         response = get_templates().TemplateResponse(
-            request, "kb/_editor_modal.html", context, status_code=422
+            request, "kb/_editor_modal.html", context, status_code=200
         )
         response.set_cookie(
             key=CSRF_COOKIE_NAME,

--- a/backend/src/meho_backplane/ui/templates/kb/_editor_modal.html
+++ b/backend/src/meho_backplane/ui/templates/kb/_editor_modal.html
@@ -54,8 +54,11 @@
     1. A full ``<dialog>`` block included from ``index.html`` (initial
        page render — ``error_message`` is None).
     2. A bare fragment re-rendered by ``POST /ui/kb/new`` on validation
-       failure (422 — ``error_message`` is set). In that case HTMX
-       swaps ``#kb-editor-modal`` with this response.
+       failure (``error_message`` is set). In that case HTMX swaps
+       ``#kb-editor-modal`` with this response. The re-render returns
+       200, not the semantically-matching 422: HTMX 2 does not swap a
+       non-2xx response, so a 4xx error fragment is computed but never
+       shown (#2384, the mold from #2346).
 -#}
 <dialog
   id="kb-editor-modal"

--- a/backend/tests/test_ui_kb_editor.py
+++ b/backend/tests/test_ui_kb_editor.py
@@ -271,6 +271,10 @@ def test_kb_index_renders_new_entry_button() -> None:
     assert "kb-editor-modal" in body
     # CodeMirror bundle script tag present.
     assert "codemirror-bundle.min.js" in body
+    # Negative assertion (#2384): a fresh render carries no error banner --
+    # the ``alert-error`` block only appears when the save handler
+    # re-renders the modal with an ``error_message`` set.
+    assert "alert-error" not in body
 
 
 # ---------------------------------------------------------------------------
@@ -403,8 +407,14 @@ def test_editor_save_operator_role_returns_403() -> None:
     assert response.status_code == 403, response.text
 
 
-def test_editor_save_invalid_slug_returns_422_with_error() -> None:
-    """``POST /ui/kb/new`` with an invalid slug re-renders the modal with an error."""
+def test_editor_save_invalid_slug_returns_200_with_error() -> None:
+    """``POST /ui/kb/new`` with an invalid slug re-renders the modal with an error.
+
+    The re-render returns 200, not 422: the form posts with
+    ``hx-swap="outerHTML"`` and HTMX 2 does not swap a non-2xx response,
+    so a 4xx error fragment would be computed but silently dropped
+    (#2384, the 200-on-recoverable-error mold from #2346).
+    """
     _seed_tenant(_TENANT_A, "tenant-a")
     session_id = _seed_session_sync(tenant_id=_TENANT_A)
     csrf = _csrf_token(session_id)
@@ -432,8 +442,10 @@ def test_editor_save_invalid_slug_returns_422_with_error() -> None:
                 headers={CSRF_HEADER_NAME: csrf},
             )
 
-    assert response.status_code == 422, response.text
+    assert response.status_code == 200, response.text
     assert "BAD SLUG" in response.text or "invalid slug" in response.text.lower()
+    # The error banner is rendered in the swapped fragment.
+    assert "alert-error" in response.text
     # Re-renders the editor modal (not full page).
     assert "kb-editor-modal" in response.text
     assert "<!doctype html>" not in response.text.lower()
@@ -552,12 +564,12 @@ def test_detail_page_kb_body_class_present() -> None:
 
 
 # ---------------------------------------------------------------------------
-# B1 — CSRF cookie refreshed on 422 re-render (fix verification)
+# B1 — CSRF cookie refreshed on error re-render (fix verification)
 # ---------------------------------------------------------------------------
 
 
-def test_editor_save_422_sets_fresh_csrf_cookie() -> None:
-    """422 re-render must set a fresh CSRF cookie so subsequent POSTs succeed.
+def test_editor_save_error_rerender_sets_fresh_csrf_cookie() -> None:
+    """Error re-render must set a fresh CSRF cookie so subsequent POSTs succeed.
 
     Without the fix, ``kb_editor_save`` minted a fresh token for the
     template context but never called ``response.set_cookie``.  The browser
@@ -566,10 +578,13 @@ def test_editor_save_422_sets_fresh_csrf_cookie() -> None:
     every follow-up HTMX POST to receive 403 from CSRFMiddleware.
 
     This test asserts:
-    1. The 422 response carries a ``Set-Cookie`` header for ``csrf_token``.
+    1. The error re-render carries a ``Set-Cookie`` header for ``csrf_token``.
     2. The cookie value is a non-empty string (a freshly minted token).
     3. A subsequent ``POST /ui/kb/editor-preview`` using the new token
        succeeds (200), proving the refreshed cookie round-trips correctly.
+
+    The re-render returns 200 (the #2384 mold) so HTMX swaps the fragment
+    back into the modal; the CSRF cookie refresh is preserved.
     """
     from meho_backplane.kb.schemas import InvalidKbSlugError
 
@@ -581,7 +596,7 @@ def test_editor_save_422_sets_fresh_csrf_cookie() -> None:
         client = _authenticated_client(session_id)
         client.cookies.set(CSRF_COOKIE_NAME, csrf)
 
-        # --- Step 1: trigger a 422 ---
+        # --- Step 1: trigger a validation-error re-render ---
         with (
             patch(
                 "meho_backplane.ui.routes.kb.routes.verify_access_token_with_refresh",
@@ -594,17 +609,17 @@ def test_editor_save_422_sets_fresh_csrf_cookie() -> None:
                 side_effect=InvalidKbSlugError("invalid slug: 'BAD'"),
             ),
         ):
-            r422 = client.post(
+            r_err = client.post(
                 "/ui/kb/new",
                 data={"slug": "BAD", "body": "body text", "tags": ""},
                 headers={CSRF_HEADER_NAME: csrf},
             )
 
-    assert r422.status_code == 422, r422.text
+    assert r_err.status_code == 200, r_err.text
 
     # The response must set a fresh CSRF cookie.
-    new_csrf = r422.cookies.get(CSRF_COOKIE_NAME)
-    assert new_csrf is not None, "422 response did not set a fresh CSRF cookie"
+    new_csrf = r_err.cookies.get(CSRF_COOKIE_NAME)
+    assert new_csrf is not None, "error re-render did not set a fresh CSRF cookie"
     assert len(new_csrf) > 0
 
     # --- Step 2: use the new token for a follow-up preview POST ---
@@ -621,12 +636,12 @@ def test_editor_save_422_sets_fresh_csrf_cookie() -> None:
 
 
 # ---------------------------------------------------------------------------
-# B2 — Re-rendered modal contains editor anchor and fresh CSRF token
+# B2 — Re-rendered modal (200) contains editor anchor and fresh CSRF token
 # ---------------------------------------------------------------------------
 
 
-def test_editor_save_422_rerenders_modal_with_editor_anchor_and_csrf() -> None:
-    """422 fragment must contain ``#kb-editor-cm`` and a non-empty CSRF token.
+def test_editor_save_error_rerenders_modal_with_editor_anchor_and_csrf() -> None:
+    """Error fragment must contain ``#kb-editor-cm`` and a non-empty CSRF token.
 
     This verifies the server side of the B2 fix: after a failed save the
     re-rendered ``_editor_modal.html`` fragment must include the CodeMirror
@@ -661,7 +676,7 @@ def test_editor_save_422_rerenders_modal_with_editor_anchor_and_csrf() -> None:
                 headers={CSRF_HEADER_NAME: csrf},
             )
 
-    assert response.status_code == 422, response.text
+    assert response.status_code == 200, response.text
     html = response.text
 
     # Modal root element present (HTMX outerHTML swap target).
@@ -672,7 +687,7 @@ def test_editor_save_422_rerenders_modal_with_editor_anchor_and_csrf() -> None:
     # The token is rendered by Jinja2 into the two hx-headers strings;
     # it must be non-empty so the re-mounted editor can POST successfully.
     new_csrf_cookie = response.cookies.get(CSRF_COOKIE_NAME)
-    assert new_csrf_cookie, "422 fragment must carry a fresh CSRF cookie"
+    assert new_csrf_cookie, "error fragment must carry a fresh CSRF cookie"
     assert new_csrf_cookie in html, (
         "Fresh CSRF token must appear inside the re-rendered modal fragment"
     )


### PR DESCRIPTION
## Summary

- Fixes the KB editor modal (`POST /ui/kb/new`): a validation-failure re-render (invalid slug, empty body) previously returned **422**. The form swaps with `hx-swap="outerHTML"` and HTMX 2 does not swap a non-2xx response, so the error banner was computed server-side but silently dropped — the Save button appeared to do nothing. The re-render now returns **200**, matching the `/ui/agents/create` mold from #2346 (and the runbooks/conventions modals). The CSRF-token cookie refresh is preserved.
- **Memory create was intentionally not changed** — see "Out of scope / pushback" below. It is not affected by the #2346 bug.

## Test plan

- [x] `ruff check` — clean (changed files)
- [x] `ruff format --check` — clean
- [x] `mypy src/.../kb/routes.py --ignore-missing-imports` — clean
- [x] `pytest tests/test_ui_kb_editor.py tests/test_ui_memory_create_promote.py` — 51 passed
- [x] Updated the three kb tests that asserted 422 → assert **200** + rendered `alert-error` fragment + preserved CSRF cookie.
- [x] Added a negative assertion: a fresh KB index render carries no `alert-error` banner.
- [x] `code-quality.py --diff` — 0 blockers (2 pre-existing function-size warnings).
- [x] No route signature touched → no OpenAPI snapshot drift (only an in-handler `status_code` literal changed).

## Out of scope / pushback — memory create is a misdiagnosis

The issue framed memory create as a sibling of the same bug, but its create form does **not** use the server-side re-render mold. It posts with `hx-swap="none"` and surfaces recoverable errors via a **client-side** `hx-on::response-error` handler (`window.memoryCreateShowError`, #1754) that reads the non-2xx JSON `detail` and reveals a banner. Consequences:

- Returning 200 on the memory error path would make `htmx:responseError` **not** fire; with `hx-swap="none"` nothing swaps and there is no `HX-Redirect`, so the operator would see the form unchanged with no error — reintroducing the exact "button does nothing" defect on the error path.
- It would break `test_create_submit_empty_body_returns_422` and `test_create_submit_target_scoped_without_target_name_returns_422`, plus contradict `test_create_modal_renders_visible_error_handler` (which asserts the client-side mechanism).
- The client-side handler is the **only** path that can display the chassis CSRF-middleware **403** (raised before the handler runs, so it can never be server-re-rendered) — this is why #1754 chose it.

A pushback comment with this rationale is posted on #2384; recommend AC #2 (memory) be dropped or re-scoped.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2384


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed KB editor save failures so validation messages now appear correctly in the editor modal.
  * Preserved CSRF token refresh behavior after recoverable save errors.
  * Ensured refreshed editor content remains usable for preview and subsequent actions.
  * Prevented error banners from appearing on newly loaded KB index pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->