### PR TITLE
test(ingest): delegate SSRF getaddrinfo mocks to the real resolver — kill xdist cross-test flake (#2385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,27 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — leaky `_ingest_getaddrinfo` test shim now delegates to the real resolver, killing the xdist cross-test flake (#2385)
+
+- The ingest SSRF-guard mocks in `test_api_v1_connectors_ingest.py`
+  (`_ingest_getaddrinfo` and the `_resolver_allowing` twin) patched the
+  **global** `socket.getaddrinfo` attribute (`openapi.socket` is the
+  shared `socket` module), so the patch leaked process-wide onto any
+  worker also running the embedding/DNS path under `pytest-xdist`
+  (`test_real_descriptor_embedding_path`, `test_g51_memory_canary`).
+  The two-positional-arg signature crashed the leaked positional call
+  with `TypeError: takes 2 positional arguments but N were given`
+  (evoila/meho#574), and its early-stop masked a real failure at #2338's
+  merge (hotfix #2383).
+- Both stand-ins now accept the full `getaddrinfo` positional arity
+  (`*args`/`**kwargs`) and delegate non-test hosts to the **real**
+  resolver captured at import time (`_REAL_GETADDRINFO`) instead of the
+  re-looked-up, still-patched `socket.getaddrinfo` — which would recurse
+  infinitely. A leaked/active patch is now a transparent no-op, never a
+  `TypeError` or `RecursionError`. SSRF-guard behavior is unchanged: test
+  hostnames still resolve to the fixed public test IP and the destination
+  guard still fires.
+
 ### Docs — curated-until-populator-covers policy for auto-only edge kinds + grandfather rule (#2336)
 
 - Documented that the four auto-discoverable topology edge kinds

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -166,6 +166,17 @@ def _reset_ingest_job_registry() -> Iterator[None]:
 # per the ipaddress module so the SSRF destination guard passes.
 _INGEST_TEST_PUBLIC_IP = "93.184.216.34"
 
+# The genuine ``socket.getaddrinfo``, captured at import time before any
+# fixture patches the global attribute. The stand-ins below delegate to it
+# for non-test hosts. They must NOT re-reference ``socket.getaddrinfo`` for
+# that delegation: the autouse fixture patches the *global* module attribute
+# (``openapi.socket`` is the shared ``socket`` module), so ``socket.getaddrinfo``
+# is the mock itself while a patch is active — delegating through it recurses
+# infinitely. A leaked/active patch reaching an unrelated caller (e.g. the
+# embedding-model load resolving a HuggingFace CDN host) must resolve through
+# the real function to stay a transparent no-op (evoila/meho#574, #2385).
+_REAL_GETADDRINFO = socket.getaddrinfo
+
 # Hostname for all spec mock endpoints in this module.
 _SPEC_HOST = "specs.example.test"
 _SPEC_BASE = f"https://{_SPEC_HOST}"
@@ -186,17 +197,29 @@ _INGEST_TEST_HOSTS = frozenset(
 
 
 def _ingest_getaddrinfo(
-    host: str, port: object, **kwargs: object
+    host: str, port: object, *args: object, **kwargs: object
 ) -> list[tuple[int, int, int, str, tuple[str, int]]]:
     """Mock for ``socket.getaddrinfo`` in the SSRF guard.
 
     Returns a public IP for test hostnames so the destination guard
     accepts them; delegates to the real function for everything else so
     that the discovery/JWKS mock routes wired by respx still resolve.
+
+    The trailing ``*args``/``**kwargs`` mirror the full ``getaddrinfo``
+    arity (``family``, ``type``, ``proto``, ``flags``). ``mock.patch`` here
+    rebinds the *global* ``socket.getaddrinfo`` attribute, so a resolution
+    that runs outside this module -- e.g. the embedding-model load, which
+    calls ``getaddrinfo`` positionally as
+    ``getaddrinfo(host, port, family, type, proto, flags)`` -- can hit the
+    patch if it is still active on the worker. Accepting all positional args
+    and delegating to the captured real function (never the re-looked-up,
+    still-patched ``socket.getaddrinfo``, which would recurse) makes such a
+    leaked call a transparent no-op rather than a ``TypeError`` or a
+    ``RecursionError`` (evoila/meho#574, #2385).
     """
     if host in _INGEST_TEST_HOSTS:
         return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (_INGEST_TEST_PUBLIC_IP, 443))]
-    return socket.getaddrinfo(host, port, **kwargs)  # type: ignore[arg-type]
+    return _REAL_GETADDRINFO(host, port, *args, **kwargs)  # type: ignore[arg-type]
 
 
 @pytest.fixture(autouse=True)
@@ -4233,10 +4256,15 @@ def _resolver_allowing(hosts: set[str]) -> Callable[..., _AddrInfo]:
 
     allowed = set(hosts) | _INGEST_TEST_HOSTS
 
-    def _resolver(host: str, port: object, **kwargs: object) -> _AddrInfo:
+    # ``*args``/``**kwargs`` mirror the full ``getaddrinfo`` positional arity,
+    # and the delegation targets the captured real function (not the still-
+    # patched ``socket.getaddrinfo``), so a leaked/active patch on an unrelated
+    # caller is a transparent no-op, never a ``TypeError`` or ``RecursionError``
+    # (evoila/meho#574, #2385).
+    def _resolver(host: str, port: object, *args: object, **kwargs: object) -> _AddrInfo:
         if host in allowed:
             return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (_INGEST_TEST_PUBLIC_IP, 443))]
-        return socket.getaddrinfo(host, port, **kwargs)  # type: ignore[arg-type]
+        return _REAL_GETADDRINFO(host, port, *args, **kwargs)  # type: ignore[arg-type]
 
     return _resolver
 


### PR DESCRIPTION
## Summary

- Fixes the CI-infra flake tracked as evoila/meho#574: `test_real_descriptor_embedding_path` (and co-scheduled `test_g51_memory_canary`) failing under the `pytest-xdist` unit lane, passing on isolated rerun. Its early-stop masked a real failure at #2338's merge (hotfix #2383).
- Root cause: the ingest SSRF-guard mocks (`_ingest_getaddrinfo` and the `_resolver_allowing` twin) patch the **global** `socket.getaddrinfo` attribute (`openapi.socket` is the shared `socket` module), so the patch leaks process-wide onto any worker also running the embedding/DNS path.
- Two compounding defects: (1) the shims took only two positional params → a leaked positional call `getaddrinfo(host, port, family, type, proto, flags)` crashed with `TypeError`; (2) once arity is fixed, the non-test-host delegate re-referenced the still-patched `socket.getaddrinfo` (the mock itself) → `RecursionError`.
- Fix: both stand-ins now accept the full positional arity and delegate to the **real** resolver captured at import time (`_REAL_GETADDRINFO`), so a leaked/active patch is a transparent no-op — never a `TypeError` or `RecursionError`. Test-only; no product behavior change.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — neutral (same 7 pre-existing errors as `main`; the 2 `return-value` errors just move with the delegate lines)
- [x] `.claude/hooks/code-quality.py --diff` — exit 0
- [x] **Flake repro + fix proof:** `pytest -n auto tests/test_api_v1_connectors_ingest.py tests/test_operations_meta_tools.py::test_real_descriptor_embedding_path tests/acceptance/test_g51_memory_canary.py` — reliably RED before (3/3), **5/5 green** after (`107 passed, 13 skipped`)
- [x] **No SSRF-guard regression:** full `tests/test_api_v1_connectors_ingest.py` — `105 passed`; test hostnames still resolve to the fixed public test IP and the destination guard still fires

## Notes on the leak investigation

The autouse `_mock_ssrf_getaddrinfo` fixture's `with patch(...)` restores reliably in the main thread. The leak is the process-global patch reaching worker-thread resolutions (the embedding-model load via `_preload_embedding_model`, and `assert_public_destination_async` wrapping `getaddrinfo` in `asyncio.to_thread`). Fully eliminating the leak by narrowing the patch symbol would require a production source change to `openapi.py` (`from socket import getaddrinfo`) plus updating every sibling test's patch target — out of scope for a test-only fix. Delegating to the captured real resolver makes the leak genuinely harmless, satisfying all acceptance criteria.

## Out of scope

- Sibling test files carry the same two-positional-arg `getaddrinfo` shim pattern (`test_api_v1_connectors_delete.py`, `test_operations_spec_provenance.py`, `test_operations_ingest_openapi.py`, `test_operations_register_ingested.py`). They are latent but not the proven culprit here (the reported traceback names `_ingest_getaddrinfo` specifically). Recommend a follow-up sweep.
- Pre-existing `mypy` debt in this file (`Class cannot subclass Any`, `return-value`, unused-ignore) predates this change.

Closes #2385
