### PR TITLE
fix(connectors): evict cached credentials on establish-auth failure (#2396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — connector credential cache evicted on establish-auth failure (#2396)
+
+- Establish-time auth failures (a login POST rejected with 401/403) now evict
+  the connector's cached credentials so an operator's out-of-band restage
+  converges on the next dispatch **without a backplane restart**. Previously a
+  connector cached the credential bytes it read from Vault *before* attempting
+  the login (e.g. `SddcManagerConnector` writes `_creds_cache` ahead of
+  `POST /v1/tokens`), and `invalidate_session` deliberately left them intact —
+  so a rejected credential replayed forever until a process restart.
+- The dispatcher calls a duck-typed `invalidate_credentials(target)` hook from
+  both `ConnectorAuthError` arms (first-establish and post-`invalidate_session`
+  recovery). The hook is wired family-wide across the caching connectors
+  (`sddc_manager`, `harbor`, `argocd`, `proxmox`, `gcloud`, `hetzner_robot`,
+  `rabbitmq`) and delegates to the shared `CredentialsCache.invalidate` on the
+  `vcf_logs` / `vcf_fleet` / `vcf_operations` consumers. `nsx` and `vmware_rest`
+  are intentionally excluded — they re-read credentials on every establish and
+  cache no raw credential.
+
 ## [0.21.0] - 2026-07-11
 
 ### Breaking changes — GET-list endpoints converged on the `{items, next_cursor}` envelope (#2338)

--- a/backend/src/meho_backplane/connectors/argocd/connector.py
+++ b/backend/src/meho_backplane/connectors/argocd/connector.py
@@ -721,6 +721,18 @@ class ArgoCdConnector(HttpConnector):
             impl_id=cls.impl_id,
         )
 
+    async def invalidate_credentials(self, target: ArgoCdTargetLike) -> None:
+        """Duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Drops the cached token/credentials for *target* so the next credential
+        read re-reads Vault. Called by the dispatcher on an establish-auth
+        failure so an operator's out-of-band restage converges on the next
+        dispatch without a backplane restart. Holds :attr:`_creds_lock` so the
+        pop is serialised against an in-flight load.
+        """
+        async with self._creds_lock:
+            self._creds_cache.pop(target_cache_key(target), None)
+
     async def aclose(self) -> None:
         """Clear the cached token, then tear down the httpx pool.
 

--- a/backend/src/meho_backplane/connectors/gcloud/connector.py
+++ b/backend/src/meho_backplane/connectors/gcloud/connector.py
@@ -1153,6 +1153,23 @@ class GcloudConnector(HttpConnector):
             ],
         }
 
+    async def invalidate_credentials(self, target: GcloudTargetLike) -> None:
+        """Duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Drops both the cached impersonated-credentials object and the derived
+        bearer token for *target* so the next :meth:`auth_headers` re-runs
+        ADC + impersonation from a cold cache. Called by the dispatcher on an
+        establish-auth failure so a corrected ADC / impersonation-grant
+        converges on the next dispatch without a backplane restart. Acquires
+        the per-target token lock so the pop is serialised against an in-flight
+        fetch/refresh.
+        """
+        cache_key = target_cache_key(target)
+        lock = self._token_locks.setdefault(cache_key, asyncio.Lock())
+        async with lock:
+            self._creds_cache.pop(cache_key, None)
+            self._token_cache.pop(cache_key, None)
+
     async def aclose(self) -> None:
         """Clear cached tokens and credentials, then tear down the httpx pool.
 

--- a/backend/src/meho_backplane/connectors/harbor/connector.py
+++ b/backend/src/meho_backplane/connectors/harbor/connector.py
@@ -553,6 +553,18 @@ class HarborConnector(HttpConnector):
         resp.raise_for_status()
         return {"id": robot_id, "deleted": True}
 
+    async def invalidate_credentials(self, target: HarborTargetLike) -> None:
+        """Duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Drops the cached credentials for *target* so the next credential read
+        re-reads Vault. Called by the dispatcher on an establish-auth failure
+        so an operator's out-of-band restage converges on the next dispatch
+        without a backplane restart. Holds :attr:`_creds_lock` so the pop is
+        serialised against an in-flight load.
+        """
+        async with self._creds_lock:
+            self._creds_cache.pop(target_cache_key(target), None)
+
     async def aclose(self) -> None:
         """Clear cached credentials, then tear down the httpx pool.
 

--- a/backend/src/meho_backplane/connectors/hetzner_robot/connector.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/connector.py
@@ -430,6 +430,18 @@ class HetznerRobotConnector(HttpConnector):
             params=params,
         )
 
+    async def invalidate_credentials(self, target: HetznerRobotTargetLike) -> None:
+        """Duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Drops the cached credentials for *target* so the next credential read
+        re-reads Vault. Called by the dispatcher on an establish-auth failure
+        so an operator's out-of-band restage converges on the next dispatch
+        without a backplane restart. Holds :attr:`_creds_lock` so the pop is
+        serialised against an in-flight load.
+        """
+        async with self._creds_lock:
+            self._creds_cache.pop(target_cache_key(target), None)
+
     async def aclose(self) -> None:
         """Clear cached credentials, then tear down the httpx pool."""
         async with self._creds_lock:

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -290,6 +290,11 @@ class NsxConnector(HttpConnector):
             )
             return xsrf
 
+    # #2396: NSX deliberately exposes NO ``invalidate_credentials`` hook. It
+    # caches only the session token (evicted by ``invalidate_session`` below);
+    # the service-account credentials are re-read from Vault via
+    # ``_session_loader`` on every establish, so a restage already converges on
+    # the next cold-session dispatch with no credential cache to evict.
     async def invalidate_session(self, target: NsxTargetLike) -> None:
         """Public duck-typed session-eviction hook for the dispatch path.
 

--- a/backend/src/meho_backplane/connectors/proxmox/connector.py
+++ b/backend/src/meho_backplane/connectors/proxmox/connector.py
@@ -562,6 +562,18 @@ class ProxmoxConnector(HttpConnector):
             params=params,
         )
 
+    async def invalidate_credentials(self, target: ProxmoxTargetLike) -> None:
+        """Duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Drops the cached credentials for *target* so the next credential read
+        re-reads Vault. Called by the dispatcher on an establish-auth failure
+        so an operator's out-of-band restage converges on the next dispatch
+        without a backplane restart. Holds :attr:`_creds_lock` so the pop is
+        serialised against an in-flight load.
+        """
+        async with self._creds_lock:
+            self._creds_cache.pop(target_cache_key(target), None)
+
     async def aclose(self) -> None:
         """Clear cached credentials + tickets, then tear down the httpx pool."""
         async with self._creds_lock:

--- a/backend/src/meho_backplane/connectors/rabbitmq/connector.py
+++ b/backend/src/meho_backplane/connectors/rabbitmq/connector.py
@@ -584,6 +584,18 @@ class RabbitMqConnector(HttpConnector):
             params=params,
         )
 
+    async def invalidate_credentials(self, target: RabbitMqTargetLike) -> None:
+        """Duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Drops the cached credentials for *target* so the next credential read
+        re-reads Vault. Called by the dispatcher on an establish-auth failure
+        so an operator's out-of-band restage converges on the next dispatch
+        without a backplane restart. Holds :attr:`_creds_lock` so the pop is
+        serialised against an in-flight load.
+        """
+        async with self._creds_lock:
+            self._creds_cache.pop(target_cache_key(target), None)
+
     async def aclose(self) -> None:
         """Clear cached credentials, then tear down the httpx pool.
 

--- a/backend/src/meho_backplane/connectors/sddc_manager/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/connector.py
@@ -331,6 +331,21 @@ class SddcManagerConnector(HttpConnector):
         async with self._session_lock:
             self._session_tokens.pop(target_cache_key(target), None)
 
+    async def invalidate_credentials(self, target: SddcTargetLike) -> None:
+        """Public duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Drops the cached credentials for *target* so the next
+        :meth:`_load_credentials` re-reads Vault. The credential cache is
+        written *before* the login POST (even when that login 401s), and
+        :meth:`invalidate_session` deliberately leaves it intact; on an
+        establish-auth failure the dispatcher calls this hook so an operator's
+        out-of-band restage takes effect on the next dispatch without a
+        backplane restart. Holds :attr:`_creds_lock` so the pop is serialised
+        against an in-flight :meth:`_load_credentials`.
+        """
+        async with self._creds_lock:
+            self._creds_cache.pop(target_cache_key(target), None)
+
     async def _get_json_with_session_retry(
         self,
         target: SddcTargetLike,

--- a/backend/src/meho_backplane/connectors/vcf_fleet/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/connector.py
@@ -508,6 +508,16 @@ class VcfFleetConnector(HttpConnector):
             impl_id=cls.impl_id,
         )
 
+    async def invalidate_credentials(self, target: VcfFleetTargetLike) -> None:
+        """Public duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Delegates to the shared :class:`CredentialsCache.invalidate` so the
+        next credential read re-reads Vault. The dispatcher calls this hook on
+        an establish-auth failure so an operator's out-of-band restage
+        converges on the next dispatch without a backplane restart.
+        """
+        await self._creds.invalidate(target)
+
     async def aclose(self) -> None:
         """Clear cached credentials, then tear down the httpx pool.
 

--- a/backend/src/meho_backplane/connectors/vcf_logs/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/connector.py
@@ -432,6 +432,18 @@ class VcfLogsConnector(HttpConnector):
         """
         await self._invalidate_session(target)
 
+    async def invalidate_credentials(self, target: VcfLogsTargetLike) -> None:
+        """Public duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Delegates to the shared :class:`CredentialsCache.invalidate` so the
+        next credential read re-reads Vault. :meth:`invalidate_session`
+        deliberately leaves the credential cache intact (a 440/401 means the
+        *token* expired); the dispatcher calls this hook on an establish-auth
+        failure so an operator's out-of-band restage converges on the next
+        dispatch without a backplane restart.
+        """
+        await self._credentials.invalidate(target)
+
     async def _invalidate_session(self, target: VcfLogsTargetLike) -> None:
         """Drop the cached session token for *target*.
 

--- a/backend/src/meho_backplane/connectors/vcf_operations/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/connector.py
@@ -520,6 +520,16 @@ class VcfOperationsConnector(HttpConnector):
             params=query or None,
         )
 
+    async def invalidate_credentials(self, target: VcfOperationsTargetLike) -> None:
+        """Public duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Delegates to the shared :class:`CredentialsCache.invalidate` so the
+        next credential read re-reads Vault. The dispatcher calls this hook on
+        an establish-auth failure so an operator's out-of-band restage
+        converges on the next dispatch without a backplane restart.
+        """
+        await self._creds.invalidate(target)
+
     async def aclose(self) -> None:
         """Clear cached credentials, then tear down the httpx pool.
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -497,6 +497,11 @@ class VmwareRestConnector(HttpConnector):
         )
         return token
 
+    # #2396: vmware_rest deliberately exposes NO ``invalidate_credentials``
+    # hook. It caches only the session token (evicted below); the
+    # service-account credentials are re-read from Vault via ``_session_loader``
+    # on every ``_establish_and_cache_session``, so a restage already converges
+    # on the next cold-session dispatch with no credential cache to evict.
     async def invalidate_session(self, target: VsphereTargetLike) -> None:
         """Evict the cached session token + login path for *target*.
 

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -1075,6 +1075,12 @@ async def _run_branch_with_error_handling(
         # ``ConnectorAuthError`` subclasses ``SessionLoginError`` (a
         # ``RuntimeError``), so this arm MUST sit ahead of the generic
         # ``except Exception`` to win.
+        #
+        # #2396: evict any credentials the connector cached before the rejected
+        # login so the operator's restage takes effect on the next dispatch
+        # without a backplane restart (duck-typed; no-op for connectors with no
+        # credential cache).
+        await _evict_connector_credentials(connector_instance, target)
         duration_ms = await _audit_error(
             audit_id=audit_id,
             operator=operator,
@@ -1128,6 +1134,37 @@ async def _audit_error(
         duration_ms=duration_ms,
     )
     return duration_ms
+
+
+async def _evict_connector_credentials(connector_instance: Connector | None, target: Any) -> None:
+    """Evict *connector_instance*'s cached credentials for *target*, if it advertises the hook.
+
+    #2396: the establish-time companion to the #2067 ``invalidate_session``
+    seam. A family of connectors caches the credential bytes it reads from
+    Vault *before* attempting the login (e.g. ``SddcManagerConnector`` writes
+    ``_creds_cache`` ahead of ``POST /v1/tokens``); when that login is rejected
+    the cached bytes are the rejected ones, and ``invalidate_session`` leaves
+    them intact by design (a mid-session 401 means the *token* expired, not the
+    credential). A plain restage into Vault never reaches that in-process
+    cache, so every re-dispatch replayed the rejected bytes until a backplane
+    restart. Popping the cache on the establish-auth failure means the next
+    dispatch re-reads the store and the restage converges with no restart.
+
+    Duck-typed (``getattr``) like ``invalidate_session`` so connectors that
+    re-read credentials on each establish and cache no raw credential (nsx,
+    vmware_rest) or hold no credential cache at all (ProfiledRestConnector)
+    expose no hook and are simply skipped -- absence is harmless.
+
+    Eviction is deliberately *not* followed by a one-shot re-dispatch here (as
+    ``invalidate_session`` is in :func:`_retry_after_session_invalidation`): at
+    establish-auth-failure time the restage has not happened yet, so an
+    immediate retry would only replay the same rejected bytes. Convergence
+    needs the operator's out-of-band restage between dispatches; a single
+    failed attempt to prime the eviction is sufficient and loop-free.
+    """
+    evict = getattr(connector_instance, "invalidate_credentials", None)
+    if callable(evict):
+        await evict(target)
 
 
 def _classify_http_status_error(
@@ -1329,6 +1366,12 @@ async def _retry_after_session_invalidation(
         # uses rather than flattening to ``connector_error`` in the generic
         # arm below -- so a stale credential surfaced via mid-session recovery
         # reads identically to one surfaced at first establish.
+        #
+        # #2396: the cold-cache re-establish re-read Vault yet was still
+        # rejected -- the cached credential is stale. Evict it (in addition to
+        # the session token ``invalidate_session`` already dropped) so the next
+        # dispatch after a restage re-reads the store without a restart.
+        await _evict_connector_credentials(connector_instance, target)
         duration_ms = await _audit_error(
             audit_id=audit_id,
             operator=operator,

--- a/backend/tests/test_connectors_sddc_manager_auth.py
+++ b/backend/tests/test_connectors_sddc_manager_auth.py
@@ -30,7 +30,7 @@ from meho_backplane.connectors._shared.system_operator import (
     synthesise_system_operator,
 )
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
-from meho_backplane.connectors._shared.vcf_auth import SessionLoginError
+from meho_backplane.connectors._shared.vcf_auth import ConnectorAuthError, SessionLoginError
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.registry import (
     clear_registry,
@@ -550,6 +550,63 @@ async def test_invalidate_session_evicts_token_and_re_mints_on_next_call() -> No
 
         await connector.auth_headers(_TARGET_A, operator=_make_operator())
         assert token_route.call_count == 2
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# invalidate_credentials — the #2396 establish-auth-failure eviction seam
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_credentials_reloads_after_establish_401_restage() -> None:
+    """#2396 red-today: a restaged credential is re-read after establish-auth eviction.
+
+    The credential cache is written *before* the login POST (``connector.py``
+    caches ``_creds_cache`` then calls ``POST /v1/tokens``), so a login that
+    401s leaves the rejected bytes cached and ``invalidate_session`` leaves
+    them intact by design. Without an eviction path every re-dispatch replays
+    the rejected credential until a restart. This test proves the fix: the
+    first login 401s -> ``ConnectorAuthError`` (loader call 1); the dispatcher
+    calls ``invalidate_credentials``; the operator restages the correct
+    password; the next ``auth_headers`` re-runs the loader (call-count 2) and
+    the login succeeds -- no backplane restart. Red before #2396: the method
+    did not exist.
+    """
+    calls = {"n": 0}
+    creds = {"username": "svc-old", "password": "wrong"}
+
+    async def _swappable_loader(_target: SddcTargetLike, _operator: Operator) -> dict[str, str]:
+        calls["n"] += 1
+        return dict(creds)
+
+    def _login(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if body["password"] == "correct":
+            return httpx.Response(200, json={"accessToken": f"tok-{body['username']}"})
+        return httpx.Response(401, json={"message": "bad credentials"})
+
+    connector = SddcManagerConnector(credentials_loader=_swappable_loader)
+    async with respx.mock(base_url="https://sddc-a.test.invalid") as mock:
+        mock.post(_TOKEN_PATH).mock(side_effect=_login)
+
+        # First dispatch: the wrong staged password is cached, then rejected.
+        with pytest.raises(ConnectorAuthError):
+            await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        assert calls["n"] == 1
+        assert target_cache_key(_TARGET_A) in connector._creds_cache
+
+        # The dispatcher's establish-auth arm evicts the cached credential.
+        await connector.invalidate_credentials(_TARGET_A)
+        assert target_cache_key(_TARGET_A) not in connector._creds_cache
+
+        # The operator restages the corrected credential out of band.
+        creds.update(username="svc-new", password="correct")
+
+        # The next dispatch re-reads the store (call-count 2) and succeeds.
+        headers = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        assert calls["n"] == 2
+        assert headers == {"Authorization": "Bearer tok-svc-new"}
     await connector.aclose()
 
 

--- a/backend/tests/test_connectors_vcf_operations_auth.py
+++ b/backend/tests/test_connectors_vcf_operations_auth.py
@@ -238,6 +238,43 @@ async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
     await connector.aclose()
 
 
+@pytest.mark.asyncio
+async def test_invalidate_credentials_reloads_after_restage() -> None:
+    """#2396: invalidate_credentials drops the cache so a restage is re-read.
+
+    A CredentialsCache consumer caches the credential on first use, and the
+    shared cache's ``invalidate`` was previously reachable from no production
+    caller. The new ``invalidate_credentials`` hook (called by the dispatcher's
+    establish-auth arm) delegates to it, so after an operator restages the
+    credential the next ``auth_headers`` re-runs the loader (call-count 2) and
+    carries the new bytes -- with no backplane restart. Red before #2396: the
+    method did not exist.
+    """
+    call_count = 0
+    creds = {"username": "svc-old", "password": "old-pass"}
+
+    async def _swappable_loader(_target: VcfTargetLike, _operator: Operator) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return dict(creds)
+
+    connector = VcfOperationsConnector(credentials_loader=_swappable_loader)
+    h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    assert _decode_basic_auth(h1["Authorization"]) == ("svc-old", "old-pass")
+    assert call_count == 1
+
+    # The dispatcher evicts on the establish-auth failure.
+    await connector.invalidate_credentials(_TARGET_A)
+
+    # The operator restages the corrected credential out of band.
+    creds.update(username="svc-new", password="new-pass")
+
+    h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    assert call_count == 2
+    assert _decode_basic_auth(h2["Authorization"]) == ("svc-new", "new-pass")
+    await connector.aclose()
+
+
 # ---------------------------------------------------------------------------
 # Per-target isolation
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_connector_auth_failed.py
+++ b/backend/tests/test_operations_connector_auth_failed.py
@@ -1585,3 +1585,248 @@ async def test_dispatch_recovery_preserves_per_tenant_cache_isolation(
     assert connector.attempts[("", str(target_b.id))] == 2
     assert ("", str(target_a.id)) in connector.invalidations
     assert ("", str(target_b.id)) in connector.invalidations
+
+
+# ---------------------------------------------------------------------------
+# #2396: establish-auth-failure credential eviction
+#
+# The dispatcher must call a duck-typed ``invalidate_credentials(target)`` hook
+# from BOTH ``ConnectorAuthError`` arms -- the first-establish arm on the main
+# ladder and the post-invalidation arm inside
+# ``_retry_after_session_invalidation`` -- so a connector that cached the
+# credential bytes it read from Vault *before* a rejected login re-reads the
+# store on the next dispatch after an operator restage, with no backplane
+# restart. The hook is duck-typed (getattr) so its absence stays harmless.
+# ---------------------------------------------------------------------------
+
+
+class _EstablishAuthEvictConnector(_EstablishAuthConnector):
+    """Establish-auth-fails AND advertises the #2396 credential-eviction hook.
+
+    Models a real caching connector (the sddc_manager shape): its login POST
+    401s with credential bytes it cached before the attempt, and it exposes the
+    duck-typed ``invalidate_credentials`` hook the dispatcher must call from the
+    first-establish ``ConnectorAuthError`` arm. Records evictions keyed on
+    ``(tenant_id, target.id)`` so the test can assert exactly-one eviction.
+    """
+
+    impl_id = "vcfops-rest-establish-evict"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.evictions: list[tuple[str, str]] = []
+
+    async def invalidate_credentials(self, target: Any) -> None:
+        self.evictions.append(
+            (str(getattr(target, "tenant_id", "")), str(getattr(target, "id", "")))
+        )
+
+
+class _RetryThenEstablishAuthConnector(_Http401Connector):
+    """401 on first dispatch, then a ``ConnectorAuthError`` on the #2067 re-dispatch.
+
+    Models the mid-session-recovery path converging on #2396: a stale session
+    token 401s, ``invalidate_session`` evicts it, and the cold-cache
+    re-establish re-reads Vault yet the (also-stale) credential is itself
+    rejected -- the login POST raises ``ConnectorAuthError``, landing in the
+    dispatcher's post-invalidation ``ConnectorAuthError`` arm inside
+    ``_retry_after_session_invalidation``. That arm must evict credentials so
+    the next dispatch after a restage re-reads. Advertises both hooks and
+    records their calls per cache key.
+    """
+
+    impl_id = "vcfops-rest-retry-establish"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.attempts: dict[tuple[str, str], int] = {}
+        self.session_invalidations: list[tuple[str, str]] = []
+        self.cred_evictions: list[tuple[str, str]] = []
+
+    def _key(self, target: Any) -> tuple[str, str]:
+        return (str(getattr(target, "tenant_id", "")), str(getattr(target, "id", "")))
+
+    def _next(self, target: Any) -> dict[str, Any]:
+        key = self._key(target)
+        self.attempts[key] = self.attempts.get(key, 0) + 1
+        if self.attempts[key] == 1:
+            # First dispatch: a stale session token yields an upstream 401.
+            raise _make_http_status_error(
+                headers=self.response_headers,
+                json_body=self.response_body,
+                status_code=401,
+            )
+        # Re-dispatch after invalidate_session: the cold re-establish re-reads
+        # the still-stale credential and the login POST is itself rejected.
+        http_exc = _make_http_status_error(
+            headers=self.response_headers,
+            json_body={"message": "Cannot complete login: incorrect user name or password"},
+            status_code=401,
+        )
+        message = f"sddc session establish failed for target {getattr(target, 'name', None)!r}"
+        raise (
+            session_establish_auth_error(http_exc, message=message, target=target)
+            or RuntimeError(message)
+        ) from http_exc
+
+    async def _request_json(  # type: ignore[override]
+        self,
+        target: Any,
+        method: str,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        return self._next(target)
+
+    async def _post_json(  # type: ignore[override]
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        return self._next(target)
+
+    async def invalidate_session(self, target: Any) -> None:
+        self.session_invalidations.append(self._key(target))
+
+    async def invalidate_credentials(self, target: Any) -> None:
+        self.cred_evictions.append(self._key(target))
+
+
+@pytest.mark.asyncio
+async def test_dispatch_establish_auth_failure_evicts_cached_credentials(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """#2396: the first-establish ``ConnectorAuthError`` arm calls ``invalidate_credentials``.
+
+    A connector that caches credentials before a rejected login advertises the
+    duck-typed hook; the dispatcher evicts on the establish-auth failure so the
+    operator's next-dispatch restage re-reads the store with no restart. The
+    result is still the structured ``connector_auth_failed`` envelope.
+    """
+    register_connector_v2(
+        product="vcfops",
+        version="9",
+        impl_id="vcfops-rest-establish-evict",
+        cls=_EstablishAuthEvictConnector,
+    )
+    await _seed(
+        session=session,
+        impl_id="vcfops-rest-establish-evict",
+        embedding=stub_embedding_service.encode_one.return_value,
+    )
+
+    target = _FakeTarget(name="sddc-prod", host="sddc.lab.internal")
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id="vcfops-rest-establish-evict-9",
+        op_id="GET:/api/v2/events",
+        target=target,
+        params={},
+    )
+
+    assert result.status == "error"
+    assert result.extras["error_code"] == "connector_auth_failed"
+    assert result.extras["cause"] == "session_establish_401"
+
+    connector = get_or_create_connector_instance(_EstablishAuthEvictConnector)
+    assert isinstance(connector, _EstablishAuthEvictConnector)
+    # Exactly one eviction for this cache key -- the establish arm fired the hook.
+    assert connector.evictions == [("", str(target.id))]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_establish_auth_failure_without_hook_is_harmless(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A connector advertising no ``invalidate_credentials`` hook still resolves cleanly.
+
+    The eviction call is ``getattr``-guarded, so a stateless connector (no
+    credential cache, no hook) surfaces the same ``connector_auth_failed``
+    envelope with no error -- absence is harmless (the nsx / vmware_rest case).
+    """
+    assert not hasattr(_EstablishAuthConnector, "invalidate_credentials")
+    register_connector_v2(
+        product="vcfops",
+        version="9",
+        impl_id="vcfops-rest-establish",
+        cls=_EstablishAuthConnector,
+    )
+    await _seed(
+        session=session,
+        impl_id="vcfops-rest-establish",
+        embedding=stub_embedding_service.encode_one.return_value,
+    )
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id="vcfops-rest-establish-9",
+        op_id="GET:/api/v2/events",
+        target=_FakeTarget(name="vc-prod", host="vc-prod.lab.internal"),
+        params={},
+    )
+
+    assert result.status == "error"
+    assert result.extras["error_code"] == "connector_auth_failed"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_post_invalidation_establish_auth_failure_evicts_credentials(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """#2396: the post-invalidation ``ConnectorAuthError`` arm also evicts credentials.
+
+    The #2067 mid-session recovery evicts the session token and re-dispatches;
+    when that cold-cache re-establish is itself rejected with a
+    ``ConnectorAuthError``, the credential is stale. The dispatcher must evict
+    it (in addition to the token ``invalidate_session`` already dropped) so the
+    next dispatch after a restage re-reads. The result stays
+    ``connector_auth_failed``.
+    """
+    register_connector_v2(
+        product="vcfops",
+        version="9",
+        impl_id="vcfops-rest-retry-establish",
+        cls=_RetryThenEstablishAuthConnector,
+    )
+    await _seed(
+        session=session,
+        impl_id="vcfops-rest-retry-establish",
+        embedding=stub_embedding_service.encode_one.return_value,
+    )
+
+    target = _FakeTarget(name="vc-prod", host="vc-prod.lab.internal")
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id="vcfops-rest-retry-establish-9",
+        op_id="GET:/api/v2/events",
+        target=target,
+        params={},
+    )
+
+    assert result.status == "error"
+    assert result.extras["error_code"] == "connector_auth_failed"
+
+    connector = get_or_create_connector_instance(_RetryThenEstablishAuthConnector)
+    assert isinstance(connector, _RetryThenEstablishAuthConnector)
+    key = ("", str(target.id))
+    # Initial 401 + one re-dispatch that establish-auth-fails.
+    assert connector.attempts[key] == 2
+    # The #2067 token eviction fired, and the #2396 credential eviction fired.
+    assert connector.session_invalidations == [key]
+    assert connector.cred_evictions == [key]

--- a/docs/architecture/connector-auth.md
+++ b/docs/architecture/connector-auth.md
@@ -218,6 +218,35 @@ The guards split on *how* they identify a system/operator-less caller:
 the `auth_model == "shared_service_account"` boundary — and does not itself
 reject the system caller; the loader and the cache guards do.)
 
+### Cache eviction — establish-auth failures (#2396)
+
+The credential caches above are populated on the **first** load and are
+otherwise long-lived: the credential dict is written *before* the login
+attempt (e.g. `sddc-manager` writes `_creds_cache` then calls
+`POST /v1/tokens`), and the session-token invalidation seam
+(`invalidate_session`, the #2067 dispatch-path recovery) deliberately leaves
+the credential cache intact — a mid-session 401 means the *token* expired, not
+that the credential is wrong. That left one gap: a credential rejected at
+**establish** time (a rotated/stale password the login POST 401/403s) stayed
+cached, so an operator's out-of-band restage never took effect until a
+backplane restart.
+
+Since #2396 the dispatcher evicts the cached credential on an establish-auth
+failure. Each caching connector exposes a duck-typed
+`invalidate_credentials(target)` hook (the establish-time companion to
+`invalidate_session`) that pops its `_creds_cache` entry under the credential
+lock, or delegates to `CredentialsCache.invalidate` for the shared-VCF-helper
+consumers. The dispatcher calls it — `getattr`-guarded — from **both**
+`ConnectorAuthError` arms (first-establish and post-`invalidate_session`
+recovery), so the **next** dispatch after a restage re-reads Vault and
+converges with no restart. Eviction is not paired with an immediate retry: at
+failure time the restage has not happened yet, so a retry would only replay the
+rejected bytes; convergence needs the operator's restage between dispatches.
+
+`nsx` and `vmware-rest` expose no hook by design — they cache only the session
+token and re-read the service-account credential from Vault on every establish,
+so a restage already converges on the next cold-session dispatch.
+
 ### Why not key the cache on the operator too
 
 Under `shared_service_account` the underlying credential is shared. A


### PR DESCRIPTION
## Summary

- Establish-time auth failures (a login POST rejected 401/403) now **evict the
  connector's cached credentials**, so an operator's out-of-band restage
  converges on the next dispatch with **no backplane restart**. Root cause: the
  credential dict is cached *before* the login attempt (e.g.
  `sddc_manager/connector.py` writes `_creds_cache` ahead of `POST /v1/tokens`,
  even when that login 401s), and `invalidate_session` deliberately leaves
  credentials intact — a mid-session 401 means the *token* expired, not the
  credential. Nothing evicted the credential cache except process shutdown, so
  every re-dispatch replayed the rejected bytes until a restart.
- New duck-typed `invalidate_credentials(target)` hook (the establish-time
  companion to the #2067 `invalidate_session` seam), called `getattr`-guarded
  from **both** `ConnectorAuthError` arms in `operations/dispatcher.py`
  (first-establish + post-`invalidate_session` recovery).
- Wired family-wide: seven `_creds_cache` pops (`sddc_manager`, `harbor`,
  `argocd`, `proxmox`, `gcloud`, `hetzner_robot`, `rabbitmq`) + three
  `CredentialsCache.invalidate` delegations (`vcf_logs`, `vcf_fleet`,
  `vcf_operations`). `nsx` + `vmware_rest` are explicitly excluded (comment on
  each): they cache only the session token and re-read the credential from
  Vault on every establish, so a restage already converges with no cache to
  evict.
- **One-shot post-eviction re-dispatch: rejected** (documented in the helper
  docstring). At establish-auth-failure time the restage has not happened yet,
  so an immediate retry would only replay the rejected bytes; convergence needs
  the operator's restage *between* dispatches. Eviction alone is loop-free and
  sufficient.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (16 files)
- [x] `mypy src/meho_backplane/` — Success, no issues (607 files)
- [x] `code-quality.py --diff` — 0 blockers
- [x] **Red-today regression (AC #1)** — `test_invalidate_credentials_reloads_after_establish_401_restage`
      (sddc_manager): loader creds A → login 401 → `ConnectorAuthError` (loader
      call 1) → `invalidate_credentials` → restage creds B → next `auth_headers`
      re-reads store (loader call 2) and succeeds. Plus
      `test_invalidate_credentials_reloads_after_restage` on the
      `CredentialsCache` consumer `vcf_operations`.
- [x] **Both dispatcher arms (AC #2)** — `test_dispatch_establish_auth_failure_evicts_cached_credentials`
      (first-establish arm) + `test_dispatch_post_invalidation_establish_auth_failure_evicts_credentials`
      (post-`invalidate_session` recovery arm), #2067-style with a fake
      connector recording hook calls; absence stays harmless
      (`test_dispatch_establish_auth_failure_without_hook_is_harmless`).
- [x] **AC #3** — all ten enumerated connectors carry the hook; `nsx` +
      `vmware_rest` excluded with a comment stating why.
- [x] **AC #4** — one-shot re-dispatch decision made (rejected, with reason).
- [x] **AC #6** — no route/schema/docstring change → no OpenAPI snapshot delta
      (verified: `git diff` touches no route/schema files; snapshot unchanged).
- [x] Broad sweep of connector + dispatch suites — green.

## Out of scope / follow-up

- The `connector_auth_failed` remediation/taxonomy text (incl. the phantom
  `meho target credential set` command) — sibling task #2400 under #2399,
  serialized after this PR on the same `_errors.py`/`dispatcher.py` surface.
  `_errors.py` deliberately untouched here to minimize the #2400 rebase.
- **AC #5 (MFC live Phase-0 pin + Phase-1 acceptance)** is a live-deployment
  operator protocol (restart a pod / stage a wrong password / restage / dispatch
  without restart) that cannot run in a code-only sandbox. It is handed to the
  operator to record on the issue post-merge; the eviction path it exercises is
  proven here by the red-today unit regressions above.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2396


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cached connector credentials are now cleared after authentication failures, allowing updated credentials to be used on subsequent dispatches without restarting the backplane.
  * Recovery now works consistently after session invalidation and credential restaging.
  * Connectors without credential caching continue to handle authentication failures safely.

* **Documentation**
  * Documented credential-cache eviction behavior and connector-specific exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->