### PR TITLE
fix(connectors): rebuild vrops auth on acquired-token OpsToken session (#2395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,17 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — vROps OpsToken session auth
+
+- Rebuild the `vcf-operations` (vROps) connector auth on an acquired-token
+  session: acquire via `POST /suite-api/api/auth/token/acquire` and present
+  `Authorization: OpsToken <token>` on both the typed and generic-ingested
+  dispatch paths, replacing the stateless HTTP Basic that live VCF
+  Operations 9.0.2 rejects. Adds an `invalidate_session` hook so the
+  dispatcher's session-expiry seam re-acquires on a mid-flight 401, moves
+  `authSource` federation into the acquire body, and deletes the
+  per-request `?auth-source=` query mechanism (#2395).
+
 ## [0.21.0] - 2026-07-11
 
 ### Breaking changes — GET-list endpoints converged on the `{items, next_cursor}` envelope (#2338)

--- a/backend/src/meho_backplane/connectors/vcf_operations/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/__init__.py
@@ -43,6 +43,7 @@ All four share the same registration shape; vROps + vRLI + Fleet share the
 
 from typing import Final
 
+from meho_backplane.connectors._shared.vcf_auth import SessionLoginError
 from meho_backplane.connectors.registry import register_connector_v2
 from meho_backplane.connectors.vcf_operations.connector import VcfOperationsConnector
 from meho_backplane.connectors.vcf_operations.session import (
@@ -101,6 +102,7 @@ __all__ = [
     "VROPS_PRODUCT",
     "VROPS_TYPED_OPS",
     "VROPS_VERSION",
+    "SessionLoginError",
     "VcfOperationsConnector",
     "VcfOperationsCredentialsLoader",
     "VcfOperationsTargetLike",

--- a/backend/src/meho_backplane/connectors/vcf_operations/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/connector.py
@@ -3,10 +3,6 @@
 
 """VcfOperationsConnector — hand-rolled HttpConnector subclass for vROps 9.0.
 
-Skeleton-only — auth + fingerprint + probe + the G0.6 dispatch shim.
-Operations arrive in G3.6-T2 (#833) via G0.7 spec ingestion against the vROps
-``/suite-api`` OpenAPI spec into the ``endpoint_descriptor`` table.
-
 Registered against the v2 registry at module-import time via
 :func:`~meho_backplane.connectors.registry.register_connector_v2` in
 :mod:`meho_backplane.connectors.vcf_operations.__init__`. The G0.7 auto-shim's
@@ -15,33 +11,52 @@ idempotency check (in
 no-ops on subsequent ingests against the same
 ``(product="vrops", version="9.0", impl_id="vrops-rest")`` triple.
 
-Auth
-----
+Auth — acquired-token session (``OpsToken``)
+--------------------------------------------
 
-vROps' ``/suite-api/api/*`` surface accepts HTTP Basic on every request — no
-session cookie or token is established. The connector caches the raw
-service-account credentials (loaded once per target from Vault via an
-injectable loader) and computes the ``Authorization: Basic`` header on each
-:meth:`auth_headers` call.
+VCF Operations 9.0.2 rejects stateless HTTP Basic on ``/suite-api/api/*``
+(the earlier skeleton's "Basic on every request" design assumption was false
+against a live appliance — #2395). The connector establishes a session token
+and presents it on every request:
 
-Optional ``auth-source`` routing
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* **Acquire**: ``POST /suite-api/api/auth/token/acquire`` with a JSON body
+  ``{"username", "password"}`` (plus ``"authSource"`` when the target
+  federates identity — see below). ``Content-Type`` /
+  ``Accept: application/json``. The 200 response carries
+  ``{"token", "validity", "expiresAt", "roles"}``; the connector extracts
+  ``token``.
+* **Present**: ``Authorization: OpsToken <token>`` on every authenticated
+  request. The 9.x-native scheme is preferred over the legacy
+  ``vRealizeOpsToken`` alias — the connector pins ``>=9.0,<10.0`` (every
+  supported appliance is VCF Operations 9.x where ``OpsToken`` is
+  product-native). Neither ``Basic`` nor ``Bearer`` is accepted by the
+  appliance.
+
+The token is cached per target under the tenant-unique
+``(tenant_id, target.id)`` key and reused until it is evicted by
+:meth:`invalidate_session` (the dispatcher's #2067 seam) — the appliance
+extends the token's six-hour validity on each call, so a re-acquire happens
+only after an idle expiry or a rotation.
+
+The login round-trip delegates to the shared
+:func:`~meho_backplane.connectors._shared.vcf_auth.vcf_session_login` helper —
+the same helper vRLI (#830) uses — so the token-session shape is declared
+once. A 401/403 at acquire wraps into a
+:class:`~meho_backplane.connectors._shared.vcf_auth.ConnectorAuthError` the
+dispatcher maps to ``connector_auth_failed`` (cause
+``session_establish_401`` / ``session_establish_403``).
+
+Optional ``authSource`` federation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 vROps can federate identity through multiple sources (the local realm,
 ``vIDM``, an Active Directory realm name, etc.). When ``target.auth_source``
-is set, the connector appends ``?auth-source=<value>`` as a query parameter
-on every authenticated request so vROps can route the Basic-auth challenge
-to the named identity domain. When ``target.auth_source`` is ``None`` (the
-default), the query parameter is omitted and vROps falls back to its local
-realm. The value is passed through verbatim.
-
-The auth-source query parameter rides alongside any caller-supplied params
-through an :meth:`_request_json` override that merges the auth-supplied
-mapping into the caller-supplied one. Authenticated requests therefore
-always carry ``?auth-source=...`` when configured, regardless of which
-operation handler issued them; unauthenticated transport (none in the
-skeleton, since :meth:`fingerprint` and :meth:`probe` both go through
-:meth:`_get_json` with Basic auth attached) is unaffected.
+is set, it rides the **acquire body** as ``"authSource"`` — its token-era
+home. When ``target.auth_source`` is ``None`` (or an empty string), the field
+is omitted and vROps authenticates against its default local realm. The value
+is passed through verbatim. (The pre-token skeleton rode this as a
+``?auth-source=`` query parameter on every request; that mechanism is gone —
+the appliance reads ``authSource`` only at ``token/acquire``.)
 
 Auth model gating
 -----------------
@@ -52,26 +67,21 @@ v0.2 locks the connector to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` (or
 clear :exc:`NotImplementedError` naming both the target and the requested
 mode. Lifted from
 :func:`~meho_backplane.connectors._shared.vcf_auth.is_acceptable_auth_model`
-so all G3.6 skeletons enforce the same gate identically.
+so all the VCF management-plane connectors enforce the same gate identically.
 
-No 401-retry-once wrapper
--------------------------
+Session-expiry recovery (the #2067 seam)
+----------------------------------------
 
-vROps Basic auth is stateless — there is no session token to refresh and no
-``acquire`` round-trip to re-run on a 401. A 401 from the appliance always
-means "bad credentials" (or a misconfigured auth-source); retrying with the
-same credentials would not help, and retrying with different credentials is
-outside the connector's contract. The shared
-:class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
-exposes :meth:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache.invalidate`
-for a future rotation-event admin endpoint to call between the rotation and
-the next dispatch; that path is the right place to drop the cache, not a
-transport-layer retry loop.
-
-Contrast vRLI (#830) and Fleet (#831): vRLI establishes a session and uses
-the shared :func:`~meho_backplane.connectors._shared.vcf_auth.vcf_session_login`
-helper, with the 401-retry-once loop in the consumer connector around its
-downstream calls. vROps doesn't need that — same reason Harbor doesn't.
+The connector advertises a duck-typed
+:meth:`invalidate_session` hook. On an auth-class status (401) from a
+dispatched op, the generic-ingested dispatch path evicts the cached token via
+this hook and re-dispatches the op exactly once (G0.29-T2 #2067) — so an
+idle-expired session re-acquires there rather than failing until restart. A
+second auth failure (the re-acquire also failed) falls through to
+``connector_auth_failed``. The typed connector carries no
+:class:`~meho_backplane.connectors.profile.ExecutionProfile`, so the
+dispatcher classifies its 401 against the typed-connector global
+:data:`~meho_backplane.operations._errors._AUTH_FAILED_STATUSES`.
 
 Fingerprint
 -----------
@@ -81,14 +91,10 @@ Fingerprint
 :attr:`FingerprintResult.version` and ``buildNumber`` into
 :attr:`FingerprintResult.build`. Extras carry ``humanlyReadableReleaseName``
 when the appliance returns it (some 9.0 builds do, some don't) for
-operator-visible audit display.
-
-The version endpoint is unauthenticated on vROps; the connector still sends
-Basic auth on the call because (a) the appliance ignores unsolicited auth
-headers on unauthenticated paths, (b) keeping a single
-``_request_json``-shaped transport path simplifies auditing, and (c) the
-Harbor / SDDC Manager / NSX precedents all do the same. The behaviour is
-identical with or without ``target.auth_source`` set.
+operator-visible audit display. The call rides the connector's ``OpsToken``
+session like every other read; a credential / session failure surfaces as a
+non-reachable :class:`FingerprintResult` whose ``extras["error"]`` carries the
+exception class + message.
 
 Probe
 -----
@@ -97,12 +103,13 @@ Delegates to :meth:`fingerprint` — same endpoint, same predicate
 (``reachable=True`` ⇒ ``ok=True``). vROps does not expose a dedicated
 ``/health`` endpoint distinct from the version surface; the SDDC Manager
 and NSX precedents established the "probe delegates to fingerprint" shape
-for this case. Harbor's purpose-built ``/api/v2.0/health`` is the
-exception, not the rule.
+for this case.
 """
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlencode
@@ -111,11 +118,14 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors._shared.vcf_auth import (
     CredentialsCache,
-    basic_auth_header,
+    SessionLoginError,
     is_acceptable_auth_model,
+    vcf_session_login,
 )
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.schemas import (
@@ -130,29 +140,81 @@ from meho_backplane.connectors.vcf_operations.session import (
     load_credentials_from_vault,
 )
 
-__all__ = ["VcfOperationsConnector"]
+# Re-export ``SessionLoginError`` so callers that catch the helper's
+# structured failure don't have to reach into the shared module.
+__all__ = ["SessionLoginError", "VcfOperationsConnector"]
 
 _log = structlog.get_logger(__name__)
 
+#: Session-establish endpoint. POST with JSON body ``{username, password}``
+#: (plus ``authSource`` when the target federates identity); a 200 carries
+#: ``{"token", "validity", "expiresAt", "roles"}``. Verified against the VCF
+#: Operations 9.0 API reference (``POST /suite-api/api/auth/token/acquire``).
+_SESSION_ACQUIRE_PATH = "/suite-api/api/auth/token/acquire"
+
+#: The 9.x-native authorization scheme for a suite-api token. Preferred over
+#: the legacy ``vRealizeOpsToken`` alias — the connector pins ``>=9.0,<10.0``
+#: where ``OpsToken`` is product-native (#2395). Not ``Bearer``, not ``Basic``.
+_OPS_TOKEN_SCHEME = "OpsToken"
+
 #: Spec-relative paths the typed read ops (#2303) hit on the connector's
-#: HTTP Basic (+ optional auth-source) session.
+#: ``OpsToken`` session.
 _VERSIONS_CURRENT_PATH = "/suite-api/api/versions/current"
 _ALERTS_PATH = "/suite-api/api/alerts"
 _RESOURCES_QUERY_PATH = "/suite-api/api/resources/query"
 
 
+def _vrops_acquire_payload_builder(
+    auth_source: str | None,
+) -> Callable[[str, str], dict[str, Any]]:
+    """Return a payload-builder closure binding *auth_source* into the acquire body.
+
+    The shared :func:`vcf_session_login` helper's
+    :data:`~meho_backplane.connectors._shared.vcf_auth.SessionPayloadBuilder`
+    is ``(username, password) -> dict``; vROps adds an optional ``authSource``
+    (its token-era home), so we close over the per-target value. A falsy
+    ``auth_source`` (``None`` or an empty string) omits the field — vROps
+    then authenticates against its default local realm.
+    """
+
+    def _build(username: str, password: str) -> dict[str, Any]:
+        body: dict[str, Any] = {"username": username, "password": password}
+        if auth_source:
+            body["authSource"] = auth_source
+        return body
+
+    return _build
+
+
+def _extract_ops_token(resp: httpx.Response) -> str | None:
+    """Pull ``token`` out of the ``token/acquire`` response body.
+
+    The 200 response is ``{"token": "<t>", "validity": <epoch-ms>,
+    "expiresAt": "<human>", "roles": [...]}``; the connector consumes only
+    ``token``. Returns ``None`` for the missing / null / empty / malformed
+    case and lets :func:`vcf_session_login` raise the consistent
+    target-named :exc:`SessionLoginError`.
+    """
+    try:
+        payload = resp.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("token")
+    if not isinstance(value, str) or not value:
+        return None
+    return value
+
+
 class VcfOperationsConnector(HttpConnector):
-    """vROps 9.0 REST connector with HTTP Basic auth (+ optional ``auth-source``).
+    """vROps 9.0 REST connector with acquired-token (``OpsToken``) auth.
 
-    Per-target credentials cached in :attr:`_creds` (loaded once via the
-    injectable :class:`VcfOperationsCredentialsLoader`). HTTP Basic auth is
-    sent on every request via ``Authorization: Basic <b64>`` — no session
-    token is established and no 401-driven re-login is needed (see the module
-    docstring's "No 401-retry-once wrapper" section).
-
-    The :attr:`priority` is set to ``1`` so a future ``GenericRestConnector``
-    auto-shim that somehow registers for the same triple loses the registry's
-    tie-break ladder.
+    Per-target session token cached in :attr:`_session_tokens`; per-target
+    credentials cached in :attr:`_creds` (the shared :class:`CredentialsCache`
+    instance). The :attr:`priority` is set to ``1`` so a future
+    ``GenericRestConnector`` auto-shim that somehow registers for the same
+    triple loses the registry's tie-break ladder.
     """
 
     # G0.6 v2 registry metadata. The (product, version, impl_id) triple
@@ -170,6 +232,8 @@ class VcfOperationsConnector(HttpConnector):
         credentials_loader: VcfOperationsCredentialsLoader | None = None,
     ) -> None:
         super().__init__()
+        self._session_tokens: dict[tuple[str, str], str] = {}
+        self._session_lock = asyncio.Lock()
         self._creds = CredentialsCache(
             credentials_loader if credentials_loader is not None else load_credentials_from_vault,
             product_label="vrops",
@@ -180,29 +244,23 @@ class VcfOperationsConnector(HttpConnector):
         target: VcfOperationsTargetLike,
         operator: Operator,
     ) -> dict[str, str]:
-        """Return ``{"Authorization": "Basic ..."}`` for the request.
+        """Return ``{"Authorization": "OpsToken <token>"}`` for the request.
 
-        Loads credentials from Vault on first call against *target*, caches
-        them (via the shared :class:`CredentialsCache`), and reuses the cached
-        values on subsequent calls. The full ``operator`` is threaded into
-        the loader so the live default
-        (:func:`~meho_backplane.connectors._shared.vcf_auth.load_credentials_from_vault`)
-        reads the per-target KV-v2 secret under the operator's Vault
-        Identity entity via
-        :func:`~meho_backplane.auth.vault.vault_client_for_operator` —
-        the locked Option A decision. An injected test loader receives
-        the same ``(target, operator)`` pair.
+        Lazily acquires the session token on first call against *target*
+        (``POST /suite-api/api/auth/token/acquire``); subsequent calls reuse
+        the cached token. The full ``operator`` is threaded into
+        :meth:`_session_token` so the live credentials loader (the default
+        :func:`~meho_backplane.connectors._shared.vcf_auth.load_credentials_from_vault`)
+        reads the per-target KV-v2 secret under the operator's Vault Identity
+        entity via
+        :func:`~meho_backplane.auth.vault.vault_client_for_operator` — the
+        locked Option A decision. An injected test loader receives the same
+        ``(target, operator)`` pair.
 
         Raises :exc:`NotImplementedError` if ``target.auth_model`` is anything
         other than ``shared_service_account`` or ``None``. Same predicate as
-        Harbor / NSX / SDDC Manager — all G3.6 skeletons share it via
+        the other VCF management-plane connectors via
         :func:`~meho_backplane.connectors._shared.vcf_auth.is_acceptable_auth_model`.
-
-        The ``auth-source`` query parameter is **not** part of this method's
-        return value — query parameters are merged in :meth:`_request_json`
-        via :meth:`_auth_query_params`. Keeping headers and query-params on
-        separate seams matches httpx's own API surface
-        (``client.request(..., headers=..., params=...)``).
         """
         auth_model = getattr(target, "auth_model", None)
         if not is_acceptable_auth_model(auth_model):
@@ -211,105 +269,97 @@ class VcfOperationsConnector(HttpConnector):
                 f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
                 f"{target.name!r} requested auth_model={auth_model!r}"
             )
-        creds = await self._creds.get(target, operator)
-        return {"Authorization": basic_auth_header(creds["username"], creds["password"])}
+        token = await self._session_token(target, operator)
+        return {"Authorization": f"{_OPS_TOKEN_SCHEME} {token}"}
 
-    def _auth_query_params(self, target: VcfOperationsTargetLike) -> dict[str, str]:
-        """Return the auth-source query-parameter mapping for *target*.
-
-        ``{"auth-source": target.auth_source}`` when ``target.auth_source`` is
-        a non-empty string, ``{}`` otherwise. Empty strings are treated as
-        unset — vROps rejects an empty ``?auth-source=`` and the silent-omit
-        behaviour is the friendlier default for an operator with a partially
-        populated target row.
-        """
-        auth_source = getattr(target, "auth_source", None)
-        if not auth_source:
-            return {}
-        return {"auth-source": auth_source}
-
-    async def _request_json(
+    async def _session_token(
         self,
         target: VcfOperationsTargetLike,
-        method: str,
-        path: str,
-        *,
         operator: Operator,
-        params: dict[str, Any] | None = None,
-        json: dict[str, Any] | None = None,
-        extra_headers: dict[str, str] | None = None,
-    ) -> dict[str, Any]:
-        """Merge the auth-source query param into *params* before the base call.
+    ) -> str:
+        """Return the cached session token for *target*, acquiring on first use.
 
-        The base :meth:`HttpConnector._request_json` carries the
-        :mod:`tenacity` retry decorator; overriding it here keeps the
-        decorator intact while threading the connector-specific query-param
-        contribution through every call site (including the indirect ones
-        via :meth:`_get_json`). Caller-supplied params win on key conflict —
-        an operation handler that explicitly sets ``auth-source`` overrides
-        the per-target default; nothing today exercises that path, but the
-        ordering documents the intended precedence. ``operator`` is forwarded
-        to the base method (and thence :meth:`auth_headers`) unchanged.
+        The lock serialises concurrent first-use callers for one target; the
+        cache fast-path means subsequent callers are bounded only by the lock
+        acquisition. The slow ``POST /suite-api/api/auth/token/acquire`` call
+        runs under the lock so two concurrent first-use callers against the
+        same target don't both pay the round-trip.
+
+        Credentials come from the shared :class:`CredentialsCache` (which
+        raises :exc:`RuntimeError` naming the target if the loader returns a
+        dict missing ``"username"``/``"password"``). The login round-trip
+        delegates to the shared :func:`vcf_session_login` helper, which wraps
+        a non-2xx into :exc:`SessionLoginError` (401/403 into the structured
+        :class:`~meho_backplane.connectors._shared.vcf_auth.ConnectorAuthError`)
+        and chains the underlying :exc:`httpx.HTTPStatusError`.
+
+        Raises :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+        when ``operator.raw_jwt`` is empty — a defense-in-depth fail-closed
+        check mirroring the loader path's pre-Vault guard and the sibling
+        check in :meth:`CredentialsCache.get`, raised before the cache lookup
+        so a token primed by an authenticated caller cannot leak to a
+        system-initiated caller via a cache hit.
         """
-        merged_params = dict(self._auth_query_params(target))
-        if params:
-            merged_params.update(params)
-        # An empty mapping is identical-to-None for httpx's params merge, but
-        # ``None`` keeps tests' ``request.url.params`` assertions clean when
-        # auth-source is unset and no caller params are supplied.
-        final_params = merged_params or None
-        return await super()._request_json(
-            target,
-            method,
-            path,
-            operator=operator,
-            params=final_params,
-            json=json,
-            extra_headers=extra_headers,
-        )
+        if not operator.raw_jwt:
+            raise VaultCredentialsReadError(
+                "operator-context credential read requires an authenticated operator; "
+                f"target={target.name!r} has no operator JWT (system-initiated calls "
+                "cannot read per-target vendor credentials)"
+            )
+        cache_key = target_cache_key(target)
+        async with self._session_lock:
+            cached = self._session_tokens.get(cache_key)
+            if cached is not None:
+                return cached
+            creds = await self._creds.get(target, operator)
+            auth_source = getattr(target, "auth_source", None) or None
+            client = await self._http_client(target)
+            token = await vcf_session_login(
+                client,
+                _SESSION_ACQUIRE_PATH,
+                username=creds["username"],
+                password=creds["password"],
+                target_name=target.name,
+                payload_builder=_vrops_acquire_payload_builder(auth_source),
+                token_extractor=_extract_ops_token,
+                request_headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+            )
+            self._session_tokens[cache_key] = token
+            _log.info(
+                "vrops_session_established",
+                target=target.name,
+                host=target.host,
+                auth_source=auth_source,
+            )
+            return token
 
-    async def _post_json(
-        self,
-        target: VcfOperationsTargetLike,
-        path: str,
-        *,
-        operator: Operator,
-        verb: str = "POST",
-        json: dict[str, Any] | None = None,
-        data: dict[str, Any] | None = None,
-        extra_headers: dict[str, str] | None = None,
-        params: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        """Thread the auth-source (and caller) query params onto a non-idempotent request.
+    async def invalidate_session(self, target: VcfOperationsTargetLike) -> None:
+        """Public duck-typed session-eviction hook for the dispatch path.
 
-        The base :meth:`HttpConnector._post_json` neither routes through
-        :meth:`_request_json` (so the auth-source merge there is bypassed)
-        nor accepts a ``params`` mapping. vROps still needs
-        ``?auth-source=<value>`` on **every** authenticated request when the
-        target federates identity, so this override merges the per-target
-        auth-source contribution (:meth:`_auth_query_params`) with any
-        caller-supplied ``params`` and encodes them onto the URL before
-        delegating to the base implementation. Caller params win on a key
-        clash — the same precedence the :meth:`_request_json` override
-        documents. ``doseq=True`` so a list value (a repeated query param)
-        serialises to repeated ``key=a&key=b`` pairs rather than a bracketed
-        string.
+        The seam the generic-ingested dispatch path calls on an auth-class
+        status (vROps' 401) before re-dispatching the op once (G0.29-T2
+        #2067). Delegates to :meth:`_invalidate_session` so the dispatch-path
+        recovery has a single eviction implementation. A connector with no
+        session state would expose no such hook and never be retried; vROps
+        now does, so an idle-expired token re-acquires there.
         """
-        merged: dict[str, Any] = dict(self._auth_query_params(target))
-        if params:
-            merged.update({key: value for key, value in params.items() if value is not None})
-        if merged:
-            separator = "&" if "?" in path else "?"
-            path = f"{path}{separator}{urlencode(merged, doseq=True)}"
-        return await super()._post_json(
-            target,
-            path,
-            operator=operator,
-            verb=verb,
-            json=json,
-            data=data,
-            extra_headers=extra_headers,
-        )
+        await self._invalidate_session(target)
+
+    async def _invalidate_session(self, target: VcfOperationsTargetLike) -> None:
+        """Drop the cached session token for *target*.
+
+        Called by the public :meth:`invalidate_session` dispatch-path hook
+        (#2067) so the subsequent :meth:`_session_token` re-issues
+        ``POST /suite-api/api/auth/token/acquire`` from a clean state. Holds
+        the lock so a concurrent re-acquire doesn't race the invalidation.
+        The credentials cache is left intact — a 401 means the *session token*
+        expired or was rejected, not that the credentials are wrong.
+        """
+        async with self._session_lock:
+            self._session_tokens.pop(target_cache_key(target), None)
 
     async def fingerprint(
         self,
@@ -322,23 +372,21 @@ class VcfOperationsConnector(HttpConnector):
         ``buildNumber`` becomes ``build``. ``extras`` carries
         ``humanlyReadableReleaseName`` when present (some 9.0 builds emit it).
 
-        On transport or status failure, returns a non-reachable
-        :class:`FingerprintResult` whose ``extras["error"]`` carries the
-        exception class + message — same pattern Harbor / SDDC Manager / NSX
-        established for transport-failure fingerprinting.
+        On transport, session-establish, or status failure, returns a
+        non-reachable :class:`FingerprintResult` whose ``extras["error"]``
+        carries the exception class + message — same pattern Harbor / SDDC
+        Manager / NSX established for transport-failure fingerprinting.
 
-        ``operator`` (optional, G0.16-T4 #1306) is forwarded to the
-        credentials loader so the per-target Vault read happens under
-        the operator's identity, matching the dispatch path. ``None``
-        falls back to a system operator whose placeholder JWT fails
-        closed at the live Vault round-trip.
+        ``operator`` (optional, G0.16-T4 #1306) is forwarded to the session
+        establish so the per-target Vault read happens under the operator's
+        identity, matching the dispatch path. ``None`` falls back to a system
+        operator whose placeholder JWT fails closed at the live Vault
+        round-trip.
         """
         probed_at = datetime.now(UTC)
         eff_operator = operator if operator is not None else synthesise_system_operator()
         try:
-            payload = await self._get_json(
-                target, "/suite-api/api/versions/current", operator=eff_operator
-            )
+            payload = await self._get_json(target, _VERSIONS_CURRENT_PATH, operator=eff_operator)
         except (httpx.HTTPError, OSError, RuntimeError) as exc:
             return FingerprintResult(
                 vendor="vmware",
@@ -396,8 +444,8 @@ class VcfOperationsConnector(HttpConnector):
         """Legacy shim — delegates to the G0.6 dispatcher.
 
         Mirrors :meth:`HarborConnector.execute`'s shape. Post-G0.6 callers
-        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI verbs
-        once #837 lands) construct a real :class:`Operator` and call
+        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI verbs)
+        construct a real :class:`Operator` and call
         :func:`meho_backplane.operations.dispatch` directly — they don't
         reach this method.
 
@@ -431,14 +479,13 @@ class VcfOperationsConnector(HttpConnector):
     # ------------------------------------------------------------------
     # Typed read ops (Initiative #2266 T3, #2303)
     #
-    # Each handler is a thin read directly on the connector's HTTP Basic
-    # (+ optional auth-source) session — no dispatch_child, no ingested
-    # descriptor — so the op works on a fresh boot with zero catalog
-    # ingest (the #2262 invariant). The dispatcher binds these bound
-    # methods to the per-process connector instance and threads
-    # ``operator`` / ``target`` / ``params`` by name (see
-    # :func:`~meho_backplane.operations._branches.dispatch_typed`). The op
-    # metadata + registrar live in
+    # Each handler is a thin read directly on the connector's ``OpsToken``
+    # session — no dispatch_child, no ingested descriptor — so the op works
+    # on a fresh boot with zero catalog ingest (the #2262 invariant). The
+    # dispatcher binds these bound methods to the per-process connector
+    # instance and threads ``operator`` / ``target`` / ``params`` by name
+    # (see :func:`~meho_backplane.operations._branches.dispatch_typed`). The
+    # op metadata + registrar live in
     # :mod:`meho_backplane.connectors.vcf_operations.typed_ops`.
     # ------------------------------------------------------------------
 
@@ -453,8 +500,7 @@ class VcfOperationsConnector(HttpConnector):
         Reachability + identity probe. Returns the appliance's
         ``releaseName`` / ``buildNumber`` (and ``humanlyReadableReleaseName``
         when present) — the same surface :meth:`fingerprint` reads, exposed
-        as an agent-callable typed op. The auth-source query param is merged
-        by the :meth:`_request_json` override.
+        as an agent-callable typed op on the connector's ``OpsToken`` session.
         """
         del params  # schema declares the param object empty
         return await self._get_json(target, _VERSIONS_CURRENT_PATH, operator=operator)
@@ -469,8 +515,8 @@ class VcfOperationsConnector(HttpConnector):
 
         Optional ``activeOnly`` / ``alertCriticality`` / ``alertStatus`` /
         ``resourceId`` filters and ``page`` / ``pageSize`` pagination ride as
-        query params (auth-source merged by the :meth:`_request_json`
-        override). ``resourceId`` is a list — httpx serialises it to repeated
+        query params on the connector's ``OpsToken`` session. ``resourceId``
+        is a list — httpx serialises it to repeated
         ``resourceId=a&resourceId=b`` pairs.
         """
         query: dict[str, Any] = {}
@@ -494,9 +540,10 @@ class VcfOperationsConnector(HttpConnector):
         A body-shaped POST: the ``ResourceQuerySpec`` fields
         (:data:`~meho_backplane.connectors.vcf_operations.typed_ops.VROPS_RESOURCE_QUERY_BODY_FIELDS`)
         form the JSON request body; ``page`` / ``pageSize`` ride as query
-        params. The auth-source query param is merged by the
-        :meth:`_post_json` override (the base ``_post_json`` bypasses the
-        ``_request_json`` auth-source seam).
+        params encoded onto the path (the base ``_post_json`` takes no
+        ``params`` mapping). The request rides the connector's ``OpsToken``
+        session via :meth:`auth_headers`. ``doseq=True`` so a repeated value
+        serialises to ``key=a&key=b`` rather than a bracketed string.
         """
         from meho_backplane.connectors.vcf_operations.typed_ops import (
             VROPS_RESOURCE_QUERY_BODY_FIELDS,
@@ -512,24 +559,25 @@ class VcfOperationsConnector(HttpConnector):
             value = params.get(key)
             if value is not None:
                 query[key] = value
-        return await self._post_json(
-            target,
-            _RESOURCES_QUERY_PATH,
-            operator=operator,
-            json=body,
-            params=query or None,
-        )
+        path = _RESOURCES_QUERY_PATH
+        if query:
+            path = f"{path}?{urlencode(query, doseq=True)}"
+        return await self._post_json(target, path, operator=operator, json=body)
 
     async def aclose(self) -> None:
-        """Clear cached credentials, then tear down the httpx pool.
+        """Clear cached session tokens + credentials, then tear down the httpx pool.
 
-        No server-side session to revoke — HTTP Basic is stateless. The
-        credential cache is cleared so a post-aclose reuse of the same
-        connector instance (e.g. a test that builds one connector across two
-        contexts) starts clean. Mirrors Harbor's ``aclose`` shape — the
-        shared :class:`CredentialsCache.clear` does the locked-mutation under
-        the hood so concurrent in-flight ``get(t)`` calls can't sneak a stale
+        No server-side revoke is issued — the vROps token idle-expires on the
+        appliance, and a per-target network call during lifespan shutdown is
+        more risk than benefit (same posture NSX / vRLI take). The token cache
+        is cleared so a post-aclose reuse of the same connector instance
+        starts clean; the credentials cache is cleared so secrets don't
+        outlive the connector instance. The shared
+        :class:`CredentialsCache.clear` does the locked-mutation under the
+        hood so concurrent in-flight ``get(t)`` calls can't sneak a stale
         entry past the clear.
         """
+        async with self._session_lock:
+            self._session_tokens.clear()
         await self._creds.clear()
         await super().aclose()

--- a/backend/src/meho_backplane/connectors/vcf_operations/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/session.py
@@ -5,25 +5,25 @@
 
 The hand-rolled
 :class:`~meho_backplane.connectors.vcf_operations.connector.VcfOperationsConnector`
-reads service-account credentials from the target's Vault path and sends them
-as HTTP Basic auth on every request — no session token is established; vROps'
-``/suite-api/api/*`` surface accepts Basic auth on each call.
+reads service-account credentials from the target's Vault path, acquires a
+session token via ``POST /suite-api/api/auth/token/acquire``, and presents it
+as ``Authorization: OpsToken <token>`` on every request — VCF Operations 9.0.2
+rejects stateless HTTP Basic (#2395).
 
 The credential fetch (Vault path → ``{"username": ..., "password": ...}`` dict)
 is delegated to the shared :class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
 and :data:`~meho_backplane.connectors._shared.vcf_auth.VcfCredentialsLoader`
-contract — all three G3.6 skeleton connectors (vROps #829, vRLI #830,
+contract — the VCF management-plane connectors (vROps #829, vRLI #830,
 Fleet #831) share the same load-once-per-target cache shape and the same
 ``RuntimeError``-naming-target contract for missing keys (#841).
 
 vROps adds one product-specific field on top of the shared target Protocol:
-``auth_source``. When set, the connector appends ``?auth-source=<value>`` as a
-query parameter on authenticated requests so vROps can route the Basic-auth
-challenge to a non-local identity domain (``Local``, ``vIDM``, an Active
-Directory realm name, etc.). When unset (``None``), the connector omits the
-query parameter and vROps routes against its default local realm. The exact
-acceptable values are operator-configured per vROps deployment; the connector
-passes the string through verbatim.
+``auth_source``. When set, it rides the **acquire body** as ``"authSource"``
+so vROps routes the login to a non-local identity domain (``Local``, ``vIDM``,
+an Active Directory realm name, etc.). When unset (``None`` or empty), the
+field is omitted and vROps authenticates against its default local realm. The
+exact acceptable values are operator-configured per vROps deployment; the
+connector passes the string through verbatim.
 """
 
 from __future__ import annotations
@@ -62,12 +62,12 @@ class VcfOperationsTargetLike(Protocol):
     the shared :class:`~meho_backplane.connectors._shared.vcf_auth.VcfTargetLike`
     base with one product-specific field:
 
-    * ``auth_source`` — optional vROps auth-source name. When set, the
-      connector appends ``?auth-source=<value>`` to authenticated request
-      URLs. When ``None``, no query parameter is added and vROps uses its
-      default local realm. The accepted values (``Local``, ``vIDM``, an AD
-      realm name, etc.) are operator-configured per vROps deployment; the
-      connector passes the string through verbatim.
+    * ``auth_source`` — optional vROps auth-source name. When set, it rides
+      the ``token/acquire`` body as ``"authSource"``. When ``None`` (or
+      empty), the field is omitted and vROps uses its default local realm.
+      The accepted values (``Local``, ``vIDM``, an AD realm name, etc.) are
+      operator-configured per vROps deployment; the connector passes the
+      string through verbatim.
 
     The base shared fields (``id``, ``tenant_id``, ``name``, ``host``,
     ``port``, ``secret_ref``, ``auth_model``) are gated and consumed

--- a/backend/src/meho_backplane/connectors/vcf_operations/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/typed_ops.py
@@ -7,7 +7,7 @@ Initiative #2266 (T3, #2303) converts the vROps *audited* read set —
 the ops the adopter actually runs (audit #2294) — from ``is_enabled``
 curation over ingested ``endpoint_descriptor`` rows to **typed** ops
 (``source_kind="typed"``) dispatched directly on the connector's
-existing hand-rolled HTTP Basic (+ optional ``auth-source``) session.
+acquired-token (``OpsToken``) session.
 A typed op works on a fresh boot with **zero catalog ingest**: the
 dispatcher resolves its ``handler_ref`` (a bound method on
 :class:`~meho_backplane.connectors.vcf_operations.connector.VcfOperationsConnector`)
@@ -166,7 +166,7 @@ VROPS_LIVENESS_OP = VropsTypedOp(
     summary="vROps appliance liveness and identity (release name + build number).",
     description=(
         "Reads GET /suite-api/api/versions/current directly on the "
-        "connector's HTTP Basic (+ optional auth-source) session — the same "
+        "connector's OpsToken session — the same "
         "surface the connector's reachability probe uses — so it works with "
         "zero catalog ingest. Returns the appliance's releaseName and "
         "buildNumber (and humanlyReadableReleaseName when the build emits "

--- a/backend/tests/acceptance/_vrops_canary_fixtures.py
+++ b/backend/tests/acceptance/_vrops_canary_fixtures.py
@@ -10,11 +10,14 @@ instance with a stub credentials loader (so no Vault read is required),
 a probed :class:`~meho_backplane.db.models.Target` row, the 6 ingested
 browse-breadth :class:`~meho_backplane.db.models.EndpointDescriptor` rows
 from :data:`_VROPS_SEED_OPS`, and a :mod:`respx`-mocked vROps REST surface
-answering each of the 6 read ops.
+answering the ``token/acquire`` session-establish plus each of the 6 read
+ops.
 
-vROps uses HTTP Basic on every request — no session establish call is
-needed. The stub credentials loader bypasses the Vault-backed loader;
-the respx router matches requests by path.
+vROps 9.0.2 authenticates on an acquired-token session (#2395): the first
+request per target POSTs to ``/suite-api/api/auth/token/acquire`` and the
+connector then presents ``Authorization: OpsToken <token>``. The stub
+credentials loader bypasses the Vault-backed loader; the respx router
+matches requests by path.
 
 Why a minimal direct-insert path (not full G0.7 canary ingest)
 ==============================================================
@@ -303,6 +306,17 @@ VROPS_CANARY_SUPERMETRICS: dict[str, object] = {
     "links": [{"href": "/suite-api/api/supermetrics", "rel": "SELF", "name": "current"}],
 }
 
+#: Synthetic ``token/acquire`` response — the OpsToken session establish
+#: (#2395). ``validity`` is an epoch-ms expiry, ``expiresAt`` a human string;
+#: the connector consumes only ``token``.
+VROPS_CANARY_ACQUIRE_TOKEN: str = "vrops-canary-ops-token"
+VROPS_CANARY_ACQUIRE_RESPONSE: dict[str, object] = {
+    "token": VROPS_CANARY_ACQUIRE_TOKEN,
+    "validity": 1470421325035,
+    "expiresAt": "Friday, August 5, 2016 6:22:05 PM UTC",
+    "roles": [],
+}
+
 #: Synthetic version response (the ``vrops.about`` op).
 VROPS_CANARY_VERSION: dict[str, object] = {
     "releaseName": "9.0.0.1.23456789",
@@ -445,14 +459,15 @@ async def _vrops_credentials_loader(
 
 
 def _register_vrops_routes(mock: respx.MockRouter) -> None:
-    """Register the 8 vROps read-op routes on *mock*.
+    """Register the session-establish + 8 vROps read-op routes on *mock*.
 
-    vROps uses HTTP Basic on every request — no session establish
-    call is needed. Each route returns a pre-seeded JSON body. The
-    one templated path (``/suite-api/api/resources/{id}``) is
-    registered for the specific id the smoke test dispatches
-    against.
+    vROps 9.0.2 authenticates on an acquired-token session (#2395): the
+    ``token/acquire`` POST returns the OpsToken the connector then presents
+    on each read. Each read route returns a pre-seeded JSON body. The one
+    templated path (``/suite-api/api/resources/{id}``) is registered for the
+    specific id the smoke test dispatches against.
     """
+    mock.post("/suite-api/api/auth/token/acquire").respond(200, json=VROPS_CANARY_ACQUIRE_RESPONSE)
     mock.get("/suite-api/api/versions/current").respond(200, json=VROPS_CANARY_VERSION)
     mock.get("/suite-api/api/resources").respond(200, json=VROPS_CANARY_RESOURCES)
     mock.get("/suite-api/api/resources/00000000-0000-4000-8000-000000000000").respond(

--- a/backend/tests/test_connectors_vcf_operations_auth.py
+++ b/backend/tests/test_connectors_vcf_operations_auth.py
@@ -1,26 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Unit tests for :class:`VcfOperationsConnector` (G3.6-T1 #829).
+"""Unit tests for :class:`VcfOperationsConnector` (G3.6-T1 #829, rebuilt #2395).
 
-Exercises HTTP Basic auth, the optional ``auth-source`` query parameter,
-per-target credential isolation, the auth_model boundary gate, and the
-fingerprint/probe shapes against mocked vROps ``/suite-api/api/*`` endpoints.
+Exercises the acquired-token (``OpsToken``) session auth VCF Operations
+9.0.2 requires — stateless HTTP Basic is rejected by the live appliance:
 
-Auth: no session token — HTTP Basic sent on every request. Credentials
-cached per target so Vault is only queried once per target per connector
-instance lifetime. The ``auth-source`` query parameter rides on every
-authenticated request when ``target.auth_source`` is set; absent when unset.
+* ``POST /suite-api/api/auth/token/acquire`` with a JSON body
+  ``{username, password}`` (plus ``authSource`` when the target federates
+  identity).
+* Response body ``{"token": "<t>", "validity": ..., "expiresAt": ...,
+  "roles": []}`` — ``token`` is extracted and cached per target.
+* Downstream auth header: ``Authorization: OpsToken <token>`` (never Basic,
+  never Bearer).
+* ``invalidate_session`` — the duck-typed dispatch-path eviction hook (#2067).
+* Per-target token isolation, the ``auth_model`` boundary gate, and the
+  fingerprint/probe shapes against a mocked vROps ``/suite-api/api/*``.
+
+The contract mirrors :mod:`tests.test_connectors_vcf_logs_auth` with vROps
+divergence: the acquire path/body/response shape, the ``authSource`` field on
+the acquire body (not a per-request query param), and the ``OpsToken`` scheme.
 """
 
 from __future__ import annotations
 
-import asyncio
-import base64
+import json
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from typing import Any
 from uuid import UUID, uuid4
 
+import httpx
 import pytest
 import respx
 
@@ -37,6 +47,24 @@ from meho_backplane.connectors.vcf_operations import (
     VcfOperationsConnector,
     VcfOperationsTargetLike,
 )
+
+# ---------------------------------------------------------------------------
+# OpsToken session-establish path + canned acquire response (#2395).
+# ---------------------------------------------------------------------------
+
+_ACQUIRE_PATH = "/suite-api/api/auth/token/acquire"
+_VERSIONS_PATH = "/suite-api/api/versions/current"
+_OPS_TOKEN = "vrops-ops-token-abc-123"
+
+
+def _acquire_response(token: str = _OPS_TOKEN) -> dict[str, Any]:
+    """A canonical ``token/acquire`` 200 body carrying *token*."""
+    return {
+        "token": token,
+        "validity": 1470421325035,
+        "expiresAt": "Friday, August 5, 2016 6:22:05 PM UTC",
+        "roles": [],
+    }
 
 
 def _make_operator(raw_jwt: str = "op.test.jwt") -> Operator:
@@ -128,14 +156,6 @@ def _make_connector() -> VcfOperationsConnector:
     return VcfOperationsConnector(credentials_loader=_stub_loader)
 
 
-def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
-    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
-    assert authorization_header.startswith("Basic ")
-    decoded = base64.b64decode(authorization_header[6:]).decode()
-    username, _, password = decoded.partition(":")
-    return username, password
-
-
 # ---------------------------------------------------------------------------
 # ABC + registration plumbing
 # ---------------------------------------------------------------------------
@@ -170,6 +190,8 @@ def test_default_credentials_loader_fails_closed_without_operator_jwt(
     silently falling back to a backplane identity. End-to-end coverage
     of the wired read lives in ``test_connectors_vcf_operations_credread.py``.
     """
+    import asyncio
+
     from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
     from meho_backplane.connectors.vcf_operations.session import (
         load_credentials_from_vault,
@@ -196,76 +218,179 @@ def test_default_credentials_loader_fails_closed_without_operator_jwt(
 
 
 # ---------------------------------------------------------------------------
-# HTTP Basic auth header
+# Session establishment — happy path (OpsToken)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_auth_headers_sends_basic_auth() -> None:
-    """auth_headers() produces Authorization: Basic with stub credentials."""
+async def test_auth_headers_acquires_token_and_returns_opstoken() -> None:
+    """First auth_headers call POSTs JSON creds to token/acquire and returns OpsToken.
+
+    Asserts the load-bearing auth contract: a JSON body (NOT form, NOT HTTP
+    Basic) with ``username`` + ``password`` (no ``authSource`` for a
+    local-realm target), the acquire POST carrying no stale Authorization
+    header, and the returned token presented as ``Authorization: OpsToken``.
+    """
     connector = _make_connector()
-    headers = await connector.auth_headers(_TARGET_A, operator=_make_operator())
 
-    assert "Authorization" in headers
-    assert headers["Authorization"].startswith("Basic ")
-    username, password = _decode_basic_auth(headers["Authorization"])
-    assert username == "admin"
-    assert password == "stub-password"
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        acquire_route = mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        headers = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert acquire_route.called and acquire_route.call_count == 1
+    assert headers == {"Authorization": f"OpsToken {_OPS_TOKEN}"}
+
+    request = acquire_route.calls[0].request
+    assert request.headers.get("content-type", "").startswith("application/json")
+    body = json.loads(request.read().decode())
+    assert body == {"username": "admin", "password": "stub-password"}
+    # The acquire POST itself must NOT carry a stale Authorization header.
+    assert "authorization" not in {k.lower() for k in request.headers}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_carries_authsource_in_acquire_body_when_set() -> None:
+    """target.auth_source lands as ``authSource`` in the token/acquire body."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-ad.test.invalid") as mock:
+        acquire_route = mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        headers = await connector.auth_headers(_TARGET_WITH_AUTH_SOURCE, operator=_make_operator())
+
+    assert headers == {"Authorization": f"OpsToken {_OPS_TOKEN}"}
+    body = json.loads(acquire_route.calls[0].request.read().decode())
+    assert body == {
+        "username": "admin",
+        "password": "stub-password",
+        "authSource": "corp-ad",
+    }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_session_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-POST token/acquire."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        acquire_route = mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert h1 == h2 == {"Authorization": f"OpsToken {_OPS_TOKEN}"}
+    # The load-bearing assertion — exactly one token/acquire for two calls.
+    assert acquire_route.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_session_tokens_separate() -> None:
+    """Two targets get two distinct cached tokens; no cross-target leakage."""
+    connector = _make_connector()
+
+    async with respx.mock() as mock:
+        route_a = mock.post("https://vrops-a.test.invalid" + _ACQUIRE_PATH).respond(
+            200, json=_acquire_response("token-a")
+        )
+        route_b = mock.post("https://vrops-b.test.invalid" + _ACQUIRE_PATH).respond(
+            200, json=_acquire_response("token-b")
+        )
+
+        h_a = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        h_b = await connector.auth_headers(_TARGET_B, operator=_make_operator())
+
+    assert route_a.called and route_b.called
+    assert h_a == {"Authorization": "OpsToken token-a"}
+    assert h_b == {"Authorization": "OpsToken token-b"}
+    assert connector._session_tokens == {
+        target_cache_key(_TARGET_A): "token-a",
+        target_cache_key(_TARGET_B): "token-b",
+    }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_public_invalidate_session_evicts_only_the_targets_slot() -> None:
+    """Public ``invalidate_session`` (the #2067 dispatch-path hook) evicts one slot.
+
+    Delegates to ``_invalidate_session``; seeds two targets and asserts only
+    A's token is dropped, so the dispatcher's re-acquire of a dispatched vROps
+    op preserves per-``(tenant_id, target.id)`` isolation.
+    """
+    connector = _make_connector()
+    key_a = target_cache_key(_TARGET_A)
+    key_b = target_cache_key(_TARGET_B)
+    connector._session_tokens[key_a] = "token-a"
+    connector._session_tokens[key_b] = "token-b"
+
+    await connector.invalidate_session(_TARGET_A)
+
+    assert connector._session_tokens == {key_b: "token-b"}
+    # No-op on an already-evicted target.
+    await connector.invalidate_session(_TARGET_A)
+    assert connector._session_tokens == {key_b: "token-b"}
     await connector.aclose()
 
 
 # ---------------------------------------------------------------------------
-# Credential caching
+# Session establishment — failure modes
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
-    """Second auth_headers call against the same target does NOT re-invoke the loader."""
-    call_count = 0
+async def test_acquire_401_surfaces_session_login_error_naming_target() -> None:
+    """401 from token/acquire raises SessionLoginError (ConnectorAuthError) naming the target."""
+    from meho_backplane.connectors.vcf_operations import SessionLoginError
 
-    async def _counting_loader(_target: VcfTargetLike, _operator: Operator) -> dict[str, str]:
-        nonlocal call_count
-        call_count += 1
-        return {"username": "admin", "password": "stub-password"}
+    connector = _make_connector()
 
-    connector = VcfOperationsConnector(credentials_loader=_counting_loader)
-    h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
-    h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(401, json={"message": "invalid_credentials"})
+        with pytest.raises(SessionLoginError, match=r"vrops-a") as exc_info:
+            await connector.auth_headers(_TARGET_A, operator=_make_operator())
 
-    assert h1 == h2
-    assert call_count == 1
+    assert "401" in str(exc_info.value)
     await connector.aclose()
-
-
-# ---------------------------------------------------------------------------
-# Per-target isolation
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_per_target_isolation_keeps_credentials_separate() -> None:
-    """Two targets get two distinct credential cache entries; no cross-target leakage."""
-    call_log: list[str] = []
+async def test_acquire_missing_token_in_body_raises() -> None:
+    """A 2xx response without a ``token`` field raises naming the target.
 
-    async def _tracking_loader(target: VcfTargetLike, _operator: Operator) -> dict[str, str]:
-        call_log.append(target.name)
-        return {"username": f"svc-{target.name}", "password": "pass"}
+    A misbehaving proxy can 200 with an empty body or the wrong field name;
+    the connector fails loudly rather than caching an empty token that would
+    silently 401 every subsequent call.
+    """
+    from meho_backplane.connectors.vcf_operations import SessionLoginError
 
-    connector = VcfOperationsConnector(credentials_loader=_tracking_loader)
-    h_a = await connector.auth_headers(_TARGET_A, operator=_make_operator())
-    h_b = await connector.auth_headers(_TARGET_B, operator=_make_operator())
+    connector = _make_connector()
 
-    username_a, _ = _decode_basic_auth(h_a["Authorization"])
-    username_b, _ = _decode_basic_auth(h_b["Authorization"])
-    assert username_a == "svc-vrops-a"
-    assert username_b == "svc-vrops-b"
-    assert call_log == ["vrops-a", "vrops-b"]
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json={"validity": 1470421325035})
+        with pytest.raises(SessionLoginError, match=r"vrops-a"):
+            await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_acquire_empty_token_raises() -> None:
+    """A 2xx response with an empty-string token raises naming the target."""
+    from meho_backplane.connectors.vcf_operations import SessionLoginError
+
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json={"token": "", "validity": 1})
+        with pytest.raises(SessionLoginError, match=r"vrops-a"):
+            await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
     await connector.aclose()
 
 
 # ---------------------------------------------------------------------------
-# Credential loading failure modes
+# Credential loading failure modes (raised before any acquire round-trip)
 # ---------------------------------------------------------------------------
 
 
@@ -296,7 +421,7 @@ async def test_loader_missing_username_key_raises_runtime_error_naming_target() 
 
 
 # ---------------------------------------------------------------------------
-# Auth model gating
+# Auth model gating (rejected before any acquire round-trip)
 # ---------------------------------------------------------------------------
 
 
@@ -331,14 +456,16 @@ async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> Non
     """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted."""
     target = _StubTarget(
         name="vrops-pre-g03",
-        host="vrops.test.invalid",
+        host="vrops-pre-g03.test.invalid",
         port=443,
         secret_ref="vrops/pre-g03",
         auth_model=None,
     )
     connector = _make_connector()
-    headers = await connector.auth_headers(target, operator=_make_operator())
-    assert headers["Authorization"].startswith("Basic ")
+    async with respx.mock(base_url="https://vrops-pre-g03.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response("pre-g03-token"))
+        headers = await connector.auth_headers(target, operator=_make_operator())
+    assert headers == {"Authorization": "OpsToken pre-g03-token"}
     await connector.aclose()
 
 
@@ -347,80 +474,16 @@ async def test_auth_headers_accepts_enum_member_for_auth_model() -> None:
     """An AuthModel enum member (not just its string value) is accepted."""
     target = _StubTarget(
         name="vrops-enum",
-        host="vrops.test.invalid",
+        host="vrops-enum.test.invalid",
         port=443,
         secret_ref="vrops/enum",
     )
     target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
     connector = _make_connector()
-    headers = await connector.auth_headers(target, operator=_make_operator())
-    assert headers["Authorization"].startswith("Basic ")
-    await connector.aclose()
-
-
-# ---------------------------------------------------------------------------
-# auth-source query parameter (vROps-specific)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_auth_source_appended_as_query_param_when_set() -> None:
-    """An authenticated request against a target with auth_source carries ?auth-source=..."""
-    connector = _make_connector()
-
-    async with respx.mock(base_url="https://vrops-ad.test.invalid") as mock:
-        route = mock.get("/suite-api/api/versions/current").respond(
-            200,
-            json={"releaseName": "9.0.0", "buildNumber": 12345678},
-        )
-        await connector.fingerprint(_TARGET_WITH_AUTH_SOURCE)
-
-    assert route.called
-    sent_url = route.calls[0].request.url
-    assert sent_url.params.get("auth-source") == "corp-ad"
-    await connector.aclose()
-
-
-@pytest.mark.asyncio
-async def test_auth_source_omitted_from_query_when_unset() -> None:
-    """Targets without auth_source send no auth-source query parameter."""
-    connector = _make_connector()
-
-    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
-        route = mock.get("/suite-api/api/versions/current").respond(
-            200,
-            json={"releaseName": "9.0.0", "buildNumber": 12345678},
-        )
-        await connector.fingerprint(_TARGET_A)
-
-    assert route.called
-    sent_url = route.calls[0].request.url
-    assert "auth-source" not in sent_url.params
-    await connector.aclose()
-
-
-@pytest.mark.asyncio
-async def test_auth_source_empty_string_is_treated_as_unset() -> None:
-    """``auth_source=""`` is silent-omitted — vROps rejects ?auth-source= empty values."""
-    target = _StubTarget(
-        name="vrops-empty-source",
-        host="vrops-empty-source.test.invalid",
-        port=443,
-        secret_ref="vrops/empty-source",
-        auth_source="",
-    )
-    connector = _make_connector()
-
-    async with respx.mock(base_url="https://vrops-empty-source.test.invalid") as mock:
-        route = mock.get("/suite-api/api/versions/current").respond(
-            200,
-            json={"releaseName": "9.0.0", "buildNumber": 12345678},
-        )
-        await connector.fingerprint(target)
-
-    assert route.called
-    sent_url = route.calls[0].request.url
-    assert "auth-source" not in sent_url.params
+    async with respx.mock(base_url="https://vrops-enum.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response("enum-token"))
+        headers = await connector.auth_headers(target, operator=_make_operator())
+    assert headers == {"Authorization": "OpsToken enum-token"}
     await connector.aclose()
 
 
@@ -435,7 +498,8 @@ async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
     connector = _make_connector()
 
     async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
-        mock.get("/suite-api/api/versions/current").respond(
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        mock.get(_VERSIONS_PATH).respond(
             200,
             json={
                 "releaseName": "9.0.0",
@@ -461,7 +525,8 @@ async def test_fingerprint_without_humanly_readable_name() -> None:
     connector = _make_connector()
 
     async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
-        mock.get("/suite-api/api/versions/current").respond(
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        mock.get(_VERSIONS_PATH).respond(
             200,
             json={"releaseName": "9.0.0", "buildNumber": 23456789},
         )
@@ -476,14 +541,12 @@ async def test_fingerprint_without_humanly_readable_name() -> None:
 
 @pytest.mark.asyncio
 async def test_fingerprint_unreachable_returns_reachable_false_with_structured_error() -> None:
-    """Transport/status failure returns reachable=False with extras['error']."""
+    """A 401 on the read (after a successful acquire) returns reachable=False with error."""
     connector = _make_connector()
 
     async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
-        mock.get("/suite-api/api/versions/current").respond(
-            401,
-            json={"error": "unauthorised"},
-        )
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        mock.get(_VERSIONS_PATH).respond(401, json={"error": "unauthorised"})
         fp = await connector.fingerprint(_TARGET_A)
 
     assert fp.vendor == "vmware"
@@ -492,6 +555,20 @@ async def test_fingerprint_unreachable_returns_reachable_false_with_structured_e
     assert fp.probe_method == "GET /suite-api/api/versions/current"
     error = fp.extras["error"]
     assert "HTTPStatusError" in error or "401" in error
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_acquire_failure() -> None:
+    """A 401 at token/acquire also yields reachable=False (session establish failed)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(401, json={"message": "invalid_credentials"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is False
+    assert "error" in fp.extras
     await connector.aclose()
 
 
@@ -506,7 +583,8 @@ async def test_probe_returns_ok_true_on_reachable_target() -> None:
     connector = _make_connector()
 
     async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
-        mock.get("/suite-api/api/versions/current").respond(
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        mock.get(_VERSIONS_PATH).respond(
             200,
             json={"releaseName": "9.0.0", "buildNumber": 23456789},
         )
@@ -523,9 +601,10 @@ async def test_probe_returns_ok_false_with_reason_on_transport_error() -> None:
     connector = _make_connector()
 
     async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
         # 401 is non-retryable (4xx) — surfaces immediately on the
         # fingerprint call which probe() delegates to.
-        mock.get("/suite-api/api/versions/current").respond(401)
+        mock.get(_VERSIONS_PATH).respond(401)
         result = await connector.probe(_TARGET_A)
 
     assert result.ok is False
@@ -540,23 +619,61 @@ async def test_probe_returns_ok_false_with_reason_on_transport_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_aclose_clears_credential_cache_and_pool() -> None:
-    """aclose() clears the in-memory credential cache and tears down the httpx pool."""
+async def test_aclose_clears_session_and_credential_caches_and_pool() -> None:
+    """aclose() clears the in-memory session + credential caches and tears down the pool."""
     connector = _make_connector()
-    await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert connector._session_tokens == {target_cache_key(_TARGET_A): _OPS_TOKEN}
     assert target_cache_key(_TARGET_A) in connector._creds.cached_targets
     await connector.aclose()
+    assert connector._session_tokens == {}
     assert connector._creds.cached_targets == frozenset()
     assert connector._clients == {}
 
 
 @pytest.mark.asyncio
-async def test_aclose_with_no_cached_credentials_is_a_noop() -> None:
-    """A fresh connector with no credentials established closes cleanly."""
+async def test_aclose_with_no_cached_session_is_a_noop() -> None:
+    """A fresh connector with no session established closes cleanly."""
     connector = _make_connector()
     await connector.aclose()
     assert connector._clients == {}
+    assert connector._session_tokens == {}
     assert connector._creds.cached_targets == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Downstream 401 re-acquire — belt-and-suspenders on the httpx side
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_then_auth_headers_reacquires_a_fresh_token() -> None:
+    """After ``invalidate_session``, the next auth_headers re-acquires a fresh token.
+
+    The unit-level shape of the #2067 dispatch-path recovery: evicting the
+    cached token forces a fresh ``token/acquire`` on the next call. The
+    end-to-end 401 → re-dispatch recovery is pinned in
+    ``test_connectors_vcf_operations_credread.py``.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vrops-a.test.invalid") as mock:
+        acquire_route = mock.post(_ACQUIRE_PATH)
+        acquire_route.side_effect = [
+            httpx.Response(200, json=_acquire_response("token-first")),
+            httpx.Response(200, json=_acquire_response("token-second")),
+        ]
+        h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+        await connector.invalidate_session(_TARGET_A)
+        h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert h1 == {"Authorization": "OpsToken token-first"}
+    assert h2 == {"Authorization": "OpsToken token-second"}
+    assert acquire_route.call_count == 2
+    await connector.aclose()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vcf_operations_credread.py
+++ b/backend/tests/test_connectors_vcf_operations_credread.py
@@ -11,7 +11,8 @@ non-injected) credential loader:
       -> dispatch_ingested -> auth_headers
       -> load_credentials_from_vault                # the live shared loader
       -> load_basic_credentials (G3.9-T2)           # operator-context Vault read
-      -> GET /suite-api/api/versions/current        # the actual read op (Basic auth)
+      -> POST /suite-api/api/auth/token/acquire     # OpsToken session establish
+      -> GET /suite-api/api/versions/current        # the read op (OpsToken auth)
       -> OperationResult(status="ok")
 
 The two "real" leaves are stubbed at their boundaries so the gate runs
@@ -28,14 +29,14 @@ in the **secret-free unit lane** (``pytest -n auto`` /
   ``credentials_loader``, so the default
   :func:`~meho_backplane.connectors._shared.vcf_auth.load_credentials_from_vault`
   runs.
-* **vROps** — respx replays ``GET /suite-api/api/versions/current``
+* **vROps** — respx replays ``POST /suite-api/api/auth/token/acquire``
+  (returns a canned OpsToken) and ``GET /suite-api/api/versions/current``
   (returns a canned version payload). No network.
 
-The vROps appliance uses HTTP Basic on every request (stateless — no
-session token; vROps has no ``/api/session`` analogue). So unlike the
-vmware-rest precedent there is no session establish call to mock; the
-single read op carries the Vault-read credentials in
-``Authorization: Basic <b64>``.
+vROps 9.0.2 authenticates on an acquired-token session (#2395): the first
+request per target POSTs the Vault-read credentials to
+``/suite-api/api/auth/token/acquire`` and the connector then presents the
+returned token as ``Authorization: OpsToken <token>`` on the read op.
 
 Why this lives in the unit lane (not ``tests/integration``)
 ===========================================================
@@ -51,6 +52,7 @@ already migrates per worker. Mirrors
 
 from __future__ import annotations
 
+import json
 import uuid
 from collections.abc import AsyncIterator, Iterator
 from datetime import UTC, datetime
@@ -58,6 +60,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 from uuid import UUID
 
+import httpx
 import pytest
 import respx
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -108,6 +111,16 @@ _VROPS_BASE_URL = f"https://{_VROPS_HOST}"
 _OP_RESPONSE: dict[str, Any] = {
     "releaseName": "9.0.0",
     "buildNumber": 23456789,
+}
+
+#: OpsToken session-establish path + canned acquire response (#2395).
+_ACQUIRE_PATH = "/suite-api/api/auth/token/acquire"
+_OPS_TOKEN = "vrops-credread-ops-token"
+_ACQUIRE_RESPONSE: dict[str, Any] = {
+    "token": _OPS_TOKEN,
+    "validity": 1470421325035,
+    "expiresAt": "Friday, August 5, 2016 6:22:05 PM UTC",
+    "roles": [],
 }
 
 
@@ -254,7 +267,7 @@ async def test_dispatch_executes_full_credread_chain_returns_ok(
     captured_events: list[BroadcastEvent],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The full dispatch->loader->vROps chain returns status="ok" with no injected loader."""
+    """The full dispatch->loader->acquire->vROps chain returns ok with no injected loader."""
     await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
 
     # Vault leaf: the in-process fake returns the canary creds via the
@@ -270,6 +283,7 @@ async def test_dispatch_executes_full_credread_chain_returns_ok(
     operator = _make_operator()
 
     async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        acquire_route = mock.post(_ACQUIRE_PATH).respond(200, json=_ACQUIRE_RESPONSE)
         op_route = mock.get(_OP_PATH).respond(200, json=_OP_RESPONSE)
 
         result = await dispatch(
@@ -288,10 +302,14 @@ async def test_dispatch_executes_full_credread_chain_returns_ok(
     # The default loader actually read Vault under the operator's identity.
     assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.credread.vrops.jwt"
     assert fake.secrets.kv.v2.read_calls[-1]["path"] == target.secret_ref
-    # The op route was hit, and the Basic-auth header carried the read creds.
+    # The session was acquired with the Vault-read credentials.
+    assert acquire_route.called and acquire_route.call_count == 1
+    acquire_body = json.loads(acquire_route.calls[0].request.content)
+    assert acquire_body == {"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    # The op route was hit, and the OpsToken header carried the acquired token.
     assert op_route.called and op_route.call_count == 1
     sent_auth = op_route.calls[0].request.headers.get("authorization")
-    assert sent_auth is not None and sent_auth.startswith("Basic ")
+    assert sent_auth == f"OpsToken {_OPS_TOKEN}"
     # One audit + one broadcast for the dispatched op.
     assert len(captured_events) == 1
 
@@ -316,6 +334,7 @@ async def test_credread_chain_never_leaks_credential_in_result_or_logs(
 
     with capture_logs() as captured:
         async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+            mock.post(_ACQUIRE_PATH).respond(200, json=_ACQUIRE_RESPONSE)
             mock.get(_OP_PATH).respond(200, json=_OP_RESPONSE)
 
             result = await dispatch(
@@ -343,6 +362,95 @@ async def test_credread_chain_never_leaks_credential_in_result_or_logs(
     events_blob = repr(captured_events)
     assert _CANARY_PASSWORD not in events_blob
     assert _CANARY_USERNAME not in events_blob
+
+
+@pytest.mark.asyncio
+async def test_dispatch_recovers_from_session_expiry_401_via_invalidate_and_retry(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 401 on a dispatched op re-acquires the token and retries once (the #2067 seam).
+
+    Mirrors the vRLI dispatch-path recovery: the connector advertises
+    ``invalidate_session`` so the generic-ingested dispatch path evicts the
+    stale token and re-dispatches the op exactly once. The acquire route
+    fires twice (initial + post-401 re-acquire); the read route fires twice
+    (401 then 200) and the second read carries the refreshed OpsToken.
+    """
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        acquire_route = mock.post(_ACQUIRE_PATH)
+        acquire_route.side_effect = [
+            httpx.Response(200, json={"token": "token-first", "validity": 1, "roles": []}),
+            httpx.Response(200, json={"token": "token-second", "validity": 1, "roles": []}),
+        ]
+        op_route = mock.get(_OP_PATH)
+        op_route.side_effect = [
+            httpx.Response(401),
+            httpx.Response(200, json=_OP_RESPONSE),
+        ]
+
+        result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert result.result == _OP_RESPONSE
+    # Re-acquire fired exactly once — two acquire POSTs, two reads.
+    assert acquire_route.call_count == 2
+    assert op_route.call_count == 2
+    assert op_route.calls[0].request.headers.get("authorization") == "OpsToken token-first"
+    assert op_route.calls[1].request.headers.get("authorization") == "OpsToken token-second"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_acquire_401_maps_to_connector_auth_failed(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 401 at token/acquire surfaces as connector_auth_failed (cause session_establish_401).
+
+    The session-establish auth-class failure is wrapped by the shared
+    ``vcf_session_login`` helper into a ``ConnectorAuthError`` the dispatcher
+    routes to the structured ``connector_auth_failed`` code — not the opaque
+    ``connector_error`` the pre-#2329 shape flattened it to.
+    """
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_ACQUIRE_PATH).respond(401, json={"message": "invalid_credentials"})
+
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=_CredReadTarget(),
+            params={},
+        )
+
+    assert result.status == "error"
+    assert result.extras.get("error_code") == "connector_auth_failed"
+    assert result.extras.get("cause") == "session_establish_401"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vcf_operations_e2e.py
+++ b/backend/tests/test_connectors_vcf_operations_e2e.py
@@ -8,11 +8,12 @@ Covers all four acceptance criteria from Issue #837:
 (a) All 8 curated vROps read ops dispatch through the full
     ``call_operation`` stack against a respx-mocked vROps appliance
     and return ``status='ok'``.
-(b) HTTP Basic auth path: vROps' ``/suite-api/api/*`` surface is
-    stateless — no session token, no 401-retry. The connector's stub
-    credentials loader is verified to be called (once, then cached)
-    on the first dispatch — mirrors the SDDC Manager Basic-auth
-    posture, not NSX's session-cookie-with-401-retry posture.
+(b) OpsToken session-auth path (#2395): vROps 9.0.2 authenticates on an
+    acquired-token session — the first dispatch POSTs to
+    ``/suite-api/api/auth/token/acquire`` and the connector then presents
+    ``Authorization: OpsToken <token>``. The connector's stub credentials
+    loader is verified to be called (once, then cached) on the first
+    dispatch.
 (c) Audit rows: each dispatch inserts an ``AuditLog`` row carrying
     ``method='DISPATCH'``, a non-null ``target_id``, and a
     ``payload["params_hash"]`` key.
@@ -268,13 +269,12 @@ async def test_vcf_operations_e2e_all_ops_dispatch_ok(
     op_id: str,
     vcf_operations_e2e_canary: _VropsE2EBundle,
 ) -> None:
-    """All 8 vROps core ops dispatch through the full dispatcher and return status='ok'.
+    """All 6 vROps ingested browse ops dispatch through the full dispatcher and return status='ok'.
 
-    Acceptance criterion (a). HTTP Basic auth is computed by the
-    connector's stub credentials loader on first dispatch (then
-    cached); no session-establish step is needed because Basic auth
-    is stateless on the vROps side. The parametrise reports one CI
-    case per op_id for granular failure attribution.
+    Acceptance criterion (a). The connector acquires an OpsToken on the
+    first dispatch (stub credentials loader → ``token/acquire``) and
+    presents it on each read. The parametrise reports one CI case per
+    op_id for granular failure attribution.
     """
     params = _RESOURCE_GET_OP_PARAMS.get(op_id, {})
     result = await call_operation(
@@ -297,17 +297,12 @@ async def test_vcf_operations_e2e_credentials_cached_after_first_dispatch(
 ) -> None:
     """First dispatch loads credentials; subsequent dispatches reuse the cache.
 
-    Acceptance criterion (b). vROps' Basic auth is stateless server-
-    side — there's no session token to refresh and no 401-retry. The
-    only thing the connector caches is the Vault-sourced
+    Acceptance criterion (b). The connector caches the Vault-sourced
     ``{"username": ..., "password": ...}`` mapping behind
-    :class:`CredentialsCache`. Pin the contract: cache empty on
-    first reach, populated after one dispatch, and not re-filled on
-    the second dispatch to the same target.
-
-    Mirrors :func:`test_sddc_e2e_credentials_cached_after_first_dispatch`
-    in the SDDC Manager E2E. NSX's analogue tests a 401-retry loop
-    that doesn't apply to vROps.
+    :class:`CredentialsCache` (and, separately, the acquired OpsToken).
+    Pin the credential-cache contract: cache empty on first reach,
+    populated after one dispatch, and not re-filled on the second
+    dispatch to the same target (the acquired token is likewise reused).
     """
     instance = vcf_operations_e2e_canary.connector_instance
     target_name = vcf_operations_e2e_canary.target_name

--- a/backend/tests/test_connectors_vcf_operations_typed_reads.py
+++ b/backend/tests/test_connectors_vcf_operations_typed_reads.py
@@ -4,8 +4,8 @@
 """Tests for the vROps typed read surface (Initiative #2266 T3, #2303).
 
 Covers the audited read set converted from ingested-row curation to
-**typed** ops (``source_kind="typed"``) on the connector's hand-rolled
-HTTP Basic (+ optional ``auth-source``) session:
+**typed** ops (``source_kind="typed"``) on the connector's acquired-token
+(``OpsToken``) session (#2395):
 
 * ``vrops.liveness`` — ``GET /suite-api/api/versions/current`` (appliance
   liveness + identity; the documented reachability surface — vROps'
@@ -26,10 +26,12 @@ Coverage matrix (per #2303 acceptance criteria):
   invariant: the dispatch path never touches an ingested descriptor row).
 * **The query op is a body POST** — ``vrops.resource.query`` sends the
   ``ResourceQuerySpec`` body and paginates via query params.
-* **auth-source rides every request** — both the GET (``_request_json``
-  override) and the body POST (``_post_json`` override) carry
-  ``?auth-source=<value>`` when the target federates identity, and omit it
-  otherwise.
+* **authSource rides the acquire body** — when the target federates
+  identity, ``target.auth_source`` lands as ``"authSource"`` in the
+  ``token/acquire`` body (not as a per-request query param), and is
+  omitted otherwise.
+* **OpsToken on every read** — each read carries
+  ``Authorization: OpsToken <token>``, never Basic or Bearer.
 * **Metadata shape** — all three are ``safety_level="safe"``,
   ``requires_approval=False``, tagged ``read-only``, with
   ``additionalProperties=False`` parameter schemas and non-empty
@@ -83,6 +85,16 @@ _VROPS_BASE_URL = f"https://{_VROPS_HOST}"
 _LIVENESS_PATH = "/suite-api/api/versions/current"
 _ALERTS_PATH = "/suite-api/api/alerts"
 _RESOURCES_QUERY_PATH = "/suite-api/api/resources/query"
+
+#: OpsToken session-establish path + canned acquire response (#2395).
+_ACQUIRE_PATH = "/suite-api/api/auth/token/acquire"
+_OPS_TOKEN = "vrops-typed-ops-token"
+_ACQUIRE_RESPONSE: dict[str, Any] = {
+    "token": _OPS_TOKEN,
+    "validity": 1470421325035,
+    "expiresAt": "Friday, August 5, 2016 6:22:05 PM UTC",
+    "roles": [],
+}
 
 _LIVENESS_RESPONSE: dict[str, Any] = {"releaseName": "9.0.0", "buildNumber": 23456789}
 _ALERTS_RESPONSE: dict[str, Any] = {
@@ -232,6 +244,7 @@ async def test_each_typed_read_dispatches_live_and_returns_payload(
     operator = _make_operator()
 
     async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_ACQUIRE_RESPONSE)
         route = mock.request(method, path).respond(200, json=payload)
         result = await dispatch(
             operator=operator,
@@ -244,8 +257,9 @@ async def test_each_typed_read_dispatches_live_and_returns_payload(
     assert result.status == "ok", result.error
     assert result.result == payload
     assert route.called and route.call_count == 1
+    # Scheme-regression pin: the read carries OpsToken, never Basic/Bearer.
     sent_auth = route.calls[0].request.headers.get("authorization")
-    assert sent_auth is not None and sent_auth.startswith("Basic ")
+    assert sent_auth == f"OpsToken {_OPS_TOKEN}"
 
 
 @pytest.mark.asyncio
@@ -303,6 +317,7 @@ async def test_resource_query_sends_body_and_paginates(
         "pageSize": 100,
     }
     async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_ACQUIRE_RESPONSE)
         route = mock.post(_RESOURCES_QUERY_PATH).respond(200, json=_RESOURCES_QUERY_RESPONSE)
         result = await dispatch(
             operator=_make_operator(),
@@ -327,10 +342,16 @@ async def test_resource_query_sends_body_and_paginates(
 
 
 @pytest.mark.asyncio
-async def test_auth_source_threads_on_get_and_post(
+async def test_auth_source_rides_acquire_body_not_the_reads(
     _stub_embedding: AsyncMock, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A federated target's auth-source rides both the GET and the body-POST reads."""
+    """A federated target's auth_source rides the token/acquire body, not the reads.
+
+    Its token-era home (#2395): ``authSource`` lands in the
+    ``/suite-api/api/auth/token/acquire`` body. The reads themselves carry
+    only the OpsToken header + their own query params — no ``auth-source``
+    query param (that mechanism is deleted).
+    """
     await _register_typed_ops(_stub_embedding)
     install_fake_client(
         monkeypatch, secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
@@ -338,6 +359,7 @@ async def test_auth_source_threads_on_get_and_post(
     target = _TypedReadTarget(auth_source="vIDM")
 
     async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        acquire_route = mock.post(_ACQUIRE_PATH).respond(200, json=_ACQUIRE_RESPONSE)
         alerts_route = mock.get(_ALERTS_PATH).respond(200, json=_ALERTS_RESPONSE)
         query_route = mock.post(_RESOURCES_QUERY_PATH).respond(200, json=_RESOURCES_QUERY_RESPONSE)
 
@@ -359,28 +381,40 @@ async def test_auth_source_threads_on_get_and_post(
     assert alerts_result.status == "ok", alerts_result.error
     assert query_result.status == "ok", query_result.error
 
-    # GET path — auth-source merged by the _request_json override, plus the filters.
+    # The acquire body carries authSource (the token cache means it fires once).
+    assert acquire_route.call_count == 1
+    acquire_body = json.loads(acquire_route.calls[0].request.content)
+    assert acquire_body == {
+        "username": _CANARY_USERNAME,
+        "password": _CANARY_PASSWORD,
+        "authSource": "vIDM",
+    }
+
+    # GET path — its own filters ride the query, but no auth-source param.
     alerts_params = alerts_route.calls[0].request.url.params
-    assert alerts_params["auth-source"] == "vIDM"
+    assert "auth-source" not in alerts_params
     assert alerts_params["alertCriticality"] == "CRITICAL"
     resource_ids = [value for key, value in alerts_params.multi_items() if key == "resourceId"]
     assert resource_ids == ["r-1", "r-2"]
+    assert alerts_route.calls[0].request.headers.get("authorization") == f"OpsToken {_OPS_TOKEN}"
 
-    # POST path — auth-source merged by the _post_json override.
-    assert query_route.calls[0].request.url.params["auth-source"] == "vIDM"
+    # POST path — no auth-source query param either.
+    assert "auth-source" not in query_route.calls[0].request.url.params
+    assert query_route.calls[0].request.headers.get("authorization") == f"OpsToken {_OPS_TOKEN}"
 
 
 @pytest.mark.asyncio
-async def test_auth_source_omitted_when_unset(
+async def test_auth_source_omitted_from_acquire_body_when_unset(
     _stub_embedding: AsyncMock, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """With no auth_source, the reads omit ?auth-source= (vROps' default local realm)."""
+    """With no auth_source, the acquire body omits authSource (vROps' default local realm)."""
     await _register_typed_ops(_stub_embedding)
     install_fake_client(
         monkeypatch, secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
     )
 
     async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        acquire_route = mock.post(_ACQUIRE_PATH).respond(200, json=_ACQUIRE_RESPONSE)
         route = mock.post(_RESOURCES_QUERY_PATH).respond(200, json=_RESOURCES_QUERY_RESPONSE)
         result = await dispatch(
             operator=_make_operator(),
@@ -391,6 +425,9 @@ async def test_auth_source_omitted_when_unset(
         )
 
     assert result.status == "ok", result.error
+    acquire_body = json.loads(acquire_route.calls[0].request.content)
+    assert "authSource" not in acquire_body
+    assert acquire_body == {"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
     assert "auth-source" not in route.calls[0].request.url.params
 
 

--- a/docs/codebase/connectors-vcf-operations.md
+++ b/docs/codebase/connectors-vcf-operations.md
@@ -5,29 +5,31 @@
 The `vcf-operations` connector is the hand-rolled `HttpConnector` subclass
 that dispatches VMware Aria Operations (formerly vRealize Operations Manager;
 "vROps") REST operations under the
-`(product="vcf-operations", version="9.0", impl_id="vrops-rest")` registry
-triple. G3.6-T1 (#829) shipped the skeleton — HTTP Basic auth with an
-optional `auth-source` query parameter, the `auth_model` boundary gate,
-fingerprint, probe, and the G0.6 dispatch shim. G3.6-T2 (#833) will add
-spec ingestion + operator-review curation against the vROps `/suite-api`
-OpenAPI spec; G3.6-T3 (#837) will ship the `meho vcf-operations <op>` CLI
-verb tree + recorded-fixture E2E.
+`(product="vrops", version="9.0", impl_id="vrops-rest")` registry triple.
+G3.6-T1 (#829) shipped the skeleton; #2395 rebuilt its auth on an
+acquired-token session (`OpsToken`) after live VCF Operations 9.0.2 rejected
+the original stateless HTTP Basic. The audited read set ships as typed ops
+(#2303); the remaining `/suite-api` breadth is ingested/curated.
 
 Source: `backend/src/meho_backplane/connectors/vcf_operations/`.
 
 The connector is **single-plane** (one API surface at `/suite-api/api/*`)
-and **stateless** (Basic auth on every request, no session token). This
-is the simplest of the four G3.6 management-plane connectors — vRLI #830
-adds session-token + 401-retry-once, Fleet #831 adds product-specific
+and **session-stateful**: it acquires a token via
+`POST /suite-api/api/auth/token/acquire` and presents it as
+`Authorization: OpsToken <token>` on every request, re-acquiring on an
+idle-expired session through the dispatcher's #2067 seam. This mirrors the
+vRLI (#830) token-session shape; Fleet #831 adds a product-specific
 fingerprint path, Automation #832 adds dual-plane auth + vhost routing.
 
 ## Key types
 
 - **`VcfOperationsConnector`** (`connector.py`) — `HttpConnector` subclass.
-  Class attributes: `product="vcf-operations"`, `version="9.0"`,
+  Class attributes: `product="vrops"`, `version="9.0"`,
   `impl_id="vrops-rest"`, `supported_version_range=">=9.0,<10.0"`,
   `priority=1`. The priority outranks a future `GenericRestConnector`
   auto-shim defensively if both somehow register for the same triple.
+  Holds a per-target session-token cache (`_session_tokens`, keyed on the
+  tenant-unique `(tenant_id, id)` tuple) plus the shared `CredentialsCache`.
 - **`VcfOperationsTargetLike`** (`session.py`) — runtime-checkable Protocol
   capturing the minimum target shape the connector reads: the shared
   `name` / `host` / `port` / `secret_ref` / `auth_model` quintet plus one
@@ -42,10 +44,13 @@ fingerprint path, Automation #832 adds dual-plane auth + vhost routing.
   integration tests, and pre-G0.3 production deploys override the default
   Vault loader.
 - **`load_credentials_from_vault`** (re-exported from
-  `connectors/_shared/vcf_auth.py`) — default loader, stubbed
-  `NotImplementedError` until the live operator-context per-target Vault
-  read lands. The same stub serves vROps / vRLI / Fleet (#841 lifted the
-  helper into `_shared` to centralise the swap-over point).
+  `connectors/_shared/vcf_auth.py`) — default loader; the live
+  operator-context per-target Vault KV-v2 read (G3.10-T2 #946). The same
+  loader serves vROps / vRLI / Fleet (#841 lifted the helper into `_shared`).
+- **`SessionLoginError`** (re-exported from `connectors/_shared/vcf_auth.py`)
+  — raised when `token/acquire` returns a non-2xx or a token-less 2xx; its
+  `ConnectorAuthError` subclass carries the 401/403 establish-auth cause the
+  dispatcher maps to `connector_auth_failed`.
 
 ## Control flow
 
@@ -56,72 +61,84 @@ fingerprint path, Automation #832 adds dual-plane auth + vhost routing.
    `connectors/<product>/` subpackage in name-sorted order.
 2. Importing `meho_backplane.connectors.vcf_operations` triggers the
    module-level
-   `register_connector_v2(product="vcf-operations", version="9.0", impl_id="vrops-rest", cls=VcfOperationsConnector)`
+   `register_connector_v2(product="vrops", version="9.0", impl_id="vrops-rest", cls=VcfOperationsConnector)`
    call.
-3. The registry's v2 table now resolves `("vcf-operations", "9.0",
-   "vrops-rest")` to `VcfOperationsConnector`. The G0.7 auto-shim's
-   idempotency check (in `ensure_connector_class_registered`) no-ops on
-   subsequent ingests against the same triple.
+3. The registry's v2 table now resolves `("vrops", "9.0", "vrops-rest")` to
+   `VcfOperationsConnector`. The G0.7 auto-shim's idempotency check (in
+   `ensure_connector_class_registered`) no-ops on subsequent ingests against
+   the same triple.
 
 The v1 `register_connector` entry point is deliberately **not** called —
-the v1 entry would land as `("vcf-operations", "", "")` and confuse
+the v1 entry would land as `("vrops", "", "")` and confuse
 `resolve_connector`'s tie-break ladder. Same pattern Harbor / SDDC Manager
-/ NSX / VCF Automation established.
+/ NSX / VCF Automation established. (A separate wildcard-fallback
+`("vrops", "", "")` v2 entry is registered so an unfingerprinted target
+still resolves — the versioned entry wins the tie-break when both exist.)
 
-### Authentication (HTTP Basic, stateless)
+### Authentication (acquired-token session, `OpsToken`)
 
-vROps' `/suite-api/api/*` surface accepts HTTP Basic on every request — no
-session cookie or token is established. The flow:
+Live VCF Operations 9.0.2 rejects stateless HTTP Basic on
+`/suite-api/api/*` (the earlier skeleton's design assumption was false —
+#2395). The connector establishes a session token and presents it on every
+request. The flow:
 
-1. First call against a target loads credentials via the injected
-   `VcfOperationsCredentialsLoader` and caches them under `target.name` in
-   the shared `CredentialsCache`. Missing-key (`"username"` /
-   `"password"`) returns from the loader surface as `RuntimeError` naming
-   both the target and the missing key.
-2. `auth_headers(target, operator)` checks `target.auth_model` via the
+1. `auth_headers(target, operator)` checks `target.auth_model` via the
    shared `is_acceptable_auth_model` predicate. Anything other than
    `shared_service_account` / the enum member / `None` (the pre-G0.3
    sentinel) raises `NotImplementedError` naming both the target and the
    requested mode.
-3. Returns `{"Authorization": "Basic <b64>"}` computed from the cached
-   credentials.
+2. `_session_token(target, operator)` returns the cached token on a hit.
+   On first use (under a per-connector lock, keyed on the tenant-unique
+   `(tenant_id, id)` tuple) it loads credentials via the injected
+   `VcfOperationsCredentialsLoader` (cached in the shared `CredentialsCache`;
+   missing `"username"`/`"password"` surfaces as `RuntimeError` naming the
+   target) and POSTs them to `POST /suite-api/api/auth/token/acquire`
+   through the shared `vcf_session_login` helper. The 200 body
+   `{"token", "validity", "expiresAt", "roles"}` yields `token`, which is
+   cached.
+3. Returns `{"Authorization": "OpsToken <token>"}`. The 9.x-native
+   `OpsToken` scheme is preferred over the legacy `vRealizeOpsToken` alias
+   (the connector pins `>=9.0,<10.0`); neither `Basic` nor `Bearer` is
+   accepted by the appliance.
 
-The full `operator` is threaded through `auth_headers(target, operator)`
-(G3.9-T1) so a future operator-context Vault read can run under the
-operator's identity. In `SHARED_SERVICE_ACCOUNT` mode the `operator` is
-accepted but unused — authentication uses the Vault-sourced service
-account, not the operator's OIDC token.
+The full `operator` is threaded through so the live default loader reads
+the per-target Vault secret under the operator's identity. An empty
+`operator.raw_jwt` fails closed (`VaultCredentialsReadError`) before the
+cache lookup, so a token primed by an authenticated caller can't leak to a
+system-initiated caller.
 
-### Optional `auth-source` query parameter
+Both dispatch paths — the typed reads and the generic-ingested path — attach
+auth through the same `auth_headers` seam (`adapters/http.py` at the
+`_request_json` and `_post_json` request sites), so both carry `OpsToken`.
+
+### Optional `authSource` federation
 
 vROps can federate identity through multiple sources (the local realm,
 `vIDM`, an Active Directory realm name, etc.). When `target.auth_source`
-is set, the connector appends `?auth-source=<value>` as a query parameter
-on every authenticated request through `_request_json`. When unset
-(`None` / `""`), the query parameter is omitted and vROps falls back to
-its local realm. The accepted values (the local realm label, an AD
-realm name, etc.) are operator-configured per vROps deployment; the
-connector passes the string through verbatim.
+is set, it rides the **`token/acquire` body** as `"authSource"` — its
+token-era home. When unset (`None` / `""`), the field is omitted and vROps
+authenticates against its default local realm. The accepted values are
+operator-configured per vROps deployment; the connector passes the string
+through verbatim. (The pre-token skeleton rode this as a `?auth-source=`
+query parameter on every request; that mechanism is deleted — the appliance
+reads `authSource` only at acquire time.)
 
-The `_request_json` override merges caller-supplied params with the
-auth-source contribution; **caller-supplied params win on key conflict**.
-The override sits on top of `HttpConnector._request_json`, preserving its
-tenacity retry decorator (3 retries on idempotent verbs, exponential
-backoff, only on connection errors + 5xx — not on 4xx, including 401).
+### Session-expiry recovery (the #2067 seam)
 
-### No 401-retry-once wrapper
+The connector advertises a duck-typed `invalidate_session(target)` hook. On
+an auth-class status (401) from a dispatched op, the generic-ingested
+dispatch path evicts the cached token via this hook and re-dispatches the op
+exactly once (G0.29-T2 #2067) — so an idle-expired session re-acquires there
+rather than failing until a process restart. A second auth failure (the
+re-acquire also failed) falls through to `connector_auth_failed`. A 401/403
+at `token/acquire` itself surfaces as `connector_auth_failed` with
+`cause=session_establish_401` / `_403` via the shared `ConnectorAuthError`.
 
-vROps Basic auth is stateless. A 401 always means "bad credentials" (or a
-misconfigured `auth-source`); retrying with the same credentials would
-not help. The shared `CredentialsCache.invalidate(target)` is the right
-seam for a future rotation-event admin endpoint to drop the cache between
-the rotation and the next dispatch — but at the transport layer, no
-retry loop is wired.
-
-This contrasts with vRLI (#830) and Fleet (#831), which establish session
-tokens via the shared `vcf_session_login` helper and add a 401-retry-once
-wrapper in the consumer connector around downstream calls. vROps doesn't
-need that — same reason Harbor doesn't.
+The typed connector carries no `ExecutionProfile`, so the dispatcher
+classifies its 401 against the typed-connector global auth-failed set
+(`{401, 440}`). The base `HttpConnector._request_json` tenacity decorator
+(3 retries, exponential backoff, connection errors + 5xx only — never 4xx)
+is inherited unchanged.
 
 ### Fingerprint
 
@@ -135,15 +152,13 @@ The connector lifts:
 - `humanlyReadableReleaseName` → `extras["humanly_readable_release_name"]`
   (some 9.0 builds emit it, some don't).
 
-The version endpoint is unauthenticated on vROps; the connector still sends
-Basic auth on the call because (a) the appliance ignores unsolicited auth
-headers on unauthenticated paths, (b) keeping a single `_request_json`
-transport path simplifies auditing, and (c) the Harbor / SDDC Manager /
-NSX precedents all do the same.
+The version call rides the connector's `OpsToken` session like every other
+read (through `_get_json`), so a credential / session-establish failure is
+part of the fingerprint's failure surface.
 
-On transport or status failure, the result carries `reachable=False` and
-`extras["error"]` set to `f"{type(exc).__name__}: {exc}"` — the same
-pattern Harbor / SDDC Manager / NSX use.
+On transport, session-establish, or status failure, the result carries
+`reachable=False` and `extras["error"]` set to `f"{type(exc).__name__}: {exc}"`
+— the same pattern Harbor / SDDC Manager / NSX use.
 
 ### Probe
 
@@ -167,15 +182,15 @@ dispatcher through this shim; post-G0.6 callers (the
 
 The connector exposes two operation surfaces: a **typed** read set
 (below) that works with zero catalog ingest, plus the **ingested**
-`/suite-api` breadth catalog curated in `core_ops.py`.
+`/suite-api` breadth catalog seeded from `tests.acceptance._vrops_canary_fixtures`.
 
 ### Typed read operations (#2303, Initiative #2266 T3)
 
 The adopter's *audited* vROps read set (audit #2294) ships as **typed**
 ops (`source_kind="typed"`) in `typed_ops.py`, dispatched directly on the
-connector's Basic (+ `auth-source`) session — no ingested descriptor row,
-so they work on a fresh boot with zero catalog ingest (the #2262
-no-shadow invariant). Handlers are bound methods on
+connector's `OpsToken` session — no ingested descriptor row, so they work
+on a fresh boot with zero catalog ingest (the #2262 no-shadow invariant).
+Handlers are bound methods on
 `VcfOperationsConnector`; a module-level `register_vcf_operations_typed_operations`
 registrar is queued via `register_typed_op_registrar` in the package
 `__init__` and run by the lifespan.
@@ -196,23 +211,23 @@ registrar is queued via `register_typed_op_registrar` in the package
   params.
 
 All three are `safety_level="safe"`, `requires_approval=False`,
-read-only. The `auth-source` query param rides both the GET path (the
-`_request_json` override) and the body POST (a `_post_json` override that
-threads auth-source + pagination onto the URL, since the base
-`_post_json` bypasses the `_request_json` seam and takes no params).
+read-only. Each rides the connector's `OpsToken` session; `authSource`
+federation lives in the acquire body, not on the reads. `vrops.resource.query`
+encodes its `page`/`pageSize` pagination onto the request path (the base
+`_post_json` takes no `params` mapping).
 
-The two converted GET reads are **removed** from the `core_ops.py`
-ingested curation so their ingested twin is never flipped alongside the
-typed op; the remaining 6 ingested-browse ops (resource list/get, alert
-definitions, symptoms, recommendations, super metrics) stay curated as
-browse breadth until Initiative #2266 T7 retires the apparatus.
+The remaining 6 ingested-browse ops (resource list/get, alert definitions,
+symptoms, recommendations, super metrics) stay browsable until Initiative
+#2266 T7 retires the apparatus.
 
 ### Shutdown
 
-`aclose()` clears the shared `CredentialsCache` under its lock (so a
-post-`aclose` reuse of the same connector instance starts clean) and
-delegates to `HttpConnector.aclose()` which closes every per-target httpx
-client.
+`aclose()` clears the in-memory session-token cache and the shared
+`CredentialsCache` under their locks (so a post-`aclose` reuse of the same
+connector instance starts clean) and delegates to `HttpConnector.aclose()`
+which closes every per-target httpx client. No server-side token revoke is
+issued — the vROps token idle-expires on the appliance (same posture
+NSX / vRLI take).
 
 ## Dependencies
 
@@ -220,13 +235,12 @@ client.
   `HttpConnector`; the per-target client carries the base URL
   (`https://{host}` or `https://{host}:{port}` when port ≠ 443),
   `Timeout(connect=5, read=30, write=30, pool=5)`, and
-  `follow_redirects=True`. The `_request_json` override threads
-  `auth-source` into the merged params; httpx merges params into the
-  request URL.
-- **tenacity 9.x** — base `HttpConnector._request_json` carries the
-  retry decorator (3 retries / exponential backoff / connection errors +
-  5xx only). The vROps override preserves the decorator by calling
-  `super()._request_json(...)` with the merged params.
+  `follow_redirects=True`. The `token/acquire` POST goes through the shared
+  `vcf_session_login` helper on this client (bypassing the tenacity
+  decorator by design — one attempt, surface the failure cleanly).
+- **tenacity 9.x** — base `HttpConnector._request_json` carries the retry
+  decorator (3 retries / exponential backoff / connection errors + 5xx
+  only); the connector inherits it unchanged (no `_request_json` override).
 - **pydantic 2.13.x** — `FingerprintResult` / `ProbeResult` /
   `OperationResult` are frozen models; the connector constructs them by
   keyword.
@@ -234,33 +248,28 @@ client.
   `CredentialsCache`; the connector itself doesn't add structlog calls
   beyond what the base + cache emit.
 - **respx 0.23.x (test-only)** — the unit-test module mocks every request
-  shape (auth header, auth-source query param both set + unset, missing
-  credentials, fingerprint reachable + unreachable, probe ok / not-ok)
-  without a network call. Recorded-fixture integration tests will land in
-  G3.6-T3 (#837) under `backend/tests/fixtures/vcf/`.
+  shape (`token/acquire` happy path + 401/missing-token/empty-token,
+  `authSource` in the acquire body set + unset, OpsToken scheme regression
+  on both the typed and ingested paths, the #2067 401 → re-acquire → retry
+  recovery, fingerprint/probe reachable + unreachable) without a network
+  call.
 
 ## Known issues
 
-- **Default loader stub** — `load_credentials_from_vault` raises
-  `NotImplementedError` until the operator-context per-target Vault read
-  lands (tracked under Goal #214). The supported workaround is to inject
-  a custom `credentials_loader` on `VcfOperationsConnector` at
-  construction time. Same stub serves vRLI + Fleet via the shared
-  `_shared/vcf_auth.py`.
-- **No 401-retry on credential rotation** — a credential rotation event
-  on the operator side requires explicit cache invalidation via
-  `CredentialsCache.invalidate(target)`. Until the admin endpoint for
-  rotation lands, the workaround is to restart the backplane process
-  (which clears the cache on `aclose`).
+- **Credential-cache eviction on rotation** — a rotated service-account
+  password is caught at `token/acquire` (401 → `connector_auth_failed`),
+  but the cached *credential* is not auto-evicted; the family-wide
+  credential-cache eviction hook is a sibling task (#2396). Until then a
+  process restart (which clears both caches on `aclose`) is the workaround.
 - **Ingested-curation retirement pending** — the 6 remaining
-  `core_ops.py` ingested-browse ops still depend on per-deploy catalog
-  state (an ingest of the vROps `/suite-api` spec + operator review); the
-  typed reads above do not. Retiring the whole ingested-curation
-  apparatus is Initiative #2266 T7.
+  ingested-browse ops still depend on per-deploy catalog state (an ingest of
+  the vROps `/suite-api` spec + operator review); the typed reads above do
+  not. Retiring the whole ingested-curation apparatus is Initiative #2266 T7.
 
 ## References
 
-- **Task**: <https://github.com/evoila/meho/issues/829>
+- **Task (skeleton)**: <https://github.com/evoila/meho/issues/829>
+- **Task (OpsToken auth rebuild)**: <https://github.com/evoila/meho/issues/2395>
 - **Parent initiative**: <https://github.com/evoila/meho/issues/369>
 - **Parent goal**: <https://github.com/evoila/meho/issues/214>
 - **Sibling skeletons (same Initiative wave)**:
@@ -274,7 +283,8 @@ client.
   [`connectors-vcf-automation.md`](connectors-vcf-automation.md),
   [`connectors-vcf-auth-shared.md`](connectors-vcf-auth-shared.md).
 - **vROps Suite API**:
-  <https://developer.broadcom.com/xapis/vrealize-operations-manager-api/latest/>
+  <https://developer.broadcom.com/xapis/vcf-operations-api/latest/>
+- **Acquire an authentication token (VCF Operations 9.0)**:
+  <https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/administration-sdks-cli-and-tools/understanding-the-vr-ops-api/getting-started-with-the-api/acquire-an-authentication-token.html>
 - **Release-readiness rubric**:
-  [`connector-release-readiness.md`](connector-release-readiness.md) — vROps
-  starts at **State 0.5** (class registered, no ops yet).
+  [`connector-release-readiness.md`](connector-release-readiness.md).


### PR DESCRIPTION
## Summary

- Live **VCF Operations 9.0.2 rejects the stateless HTTP Basic** the vROps connector sent on every request (both the typed reads and the generic-ingested path). The appliance requires a token from `POST /suite-api/api/auth/token/acquire` presented as `Authorization: OpsToken <token>` — the skeleton's "Basic accepted per-request" assumption was false against a live appliance.
- Rebuilds the connector on the **vRLI token-session mold** via the shared `vcf_session_login` helper: per-target token cache + lock, acquire round-trip extracting `token` from `{"token","validity","expiresAt","roles"}`, and `auth_headers` returning `OpsToken <token>` — attached at the single `adapters/http.py` seam both dispatch paths traverse.
- Adds an **`invalidate_session` hook** so the dispatcher's #2067 session-expiry seam evicts + re-acquires on a mid-flight 401 and retries once; an acquire 401/403 maps to `connector_auth_failed` (`cause=session_establish_401/_403`) via the shared `ConnectorAuthError`.
- Moves **`authSource` federation into the acquire body** and deletes the per-request `?auth-source=` query mechanism (its token-era home).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/.../vcf_operations/` — clean
- [x] `pytest` vcf_operations auth/typed_reads/credread/e2e + vcf_shared_auth + operations dispatcher/auth-failed — **165 passed**
- [x] **Scheme regression (AC1)**: respx asserts `Authorization == "OpsToken <t>"` (not Basic/Bearer) for a typed read (`vrops.liveness`) and an ingested `GET:/suite-api/api/versions/current` driven through `dispatch_ingested`.
- [x] **#2067 recovery (AC2)**: dispatch 401 → `invalidate_session` → re-acquire → retry-once succeeds; acquire-401 → `connector_auth_failed` (`session_establish_401`).
- [x] **authSource (AC3)**: carried in the acquire body when set, omitted when None; `_auth_query_params` + query-merge overrides deleted.
- [x] **Tests + docs (AC4/5)**: Basic pins rewritten, docstrings + `docs/codebase/connectors-vcf-operations.md` rewritten (incl. stale `product="vcf-operations"` claims fixed), `aclose()` clears the token cache.
- [x] Integration doubles re-grepped — no vrops doubles under `tests/integration/`.
- [x] No route/schema change → no OpenAPI snapshot delta (AC7).

## Out of scope

- Error-taxonomy split and family-wide credential-cache eviction (#2396) — sibling tasks under #2399.
- MFC live verification against the 9.0.2 appliance (AC6) — for the operator to record on the issue.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2395
