### PR TITLE
fix(chart): drop serviceAccountName from migrate pre-install hook Job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — migrate hook ServiceAccount fresh-install ordering deadlock (#2391)
+
+- The `meho-migrate` `pre-install,pre-upgrade` hook Job no longer sets
+  `serviceAccountName`. Helm schedules hooks before it creates the chart's
+  normal (non-hook) resources, so the Job referenced the `meho`
+  ServiceAccount that did not exist yet — a fresh `helm install` deadlocked
+  with `serviceaccount "meho" not found` on every admission attempt until
+  the release timed out. The migration runner needs no Kubernetes API
+  access, so the pod now falls back to the namespace `default` SA and
+  (with `automountServiceAccountToken: false` unchanged) carries no token.
+  A `helm template` unit assertion pins that the hook Job renders without
+  `serviceAccountName` while the backplane Deployment keeps its own (#2391).
+
 ### Changed — stage-aware `connector_auth_failed` causes + truthful remediation (#2400)
 
 - The `connector_auth_failed` envelope's `extras.cause` is now **stage-aware**

--- a/backend/tests/test_chart_migrate_job_no_sa.py
+++ b/backend/tests/test_chart_migrate_job_no_sa.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Chart-render assertions for the migrate hook's ServiceAccount (#2391).
+
+The ``meho-migrate`` Job is a Helm ``pre-install,pre-upgrade`` hook. Helm
+schedules hooks **before** it creates the chart's normal (non-hook)
+resources — the ``meho`` ServiceAccount among them. A hook Job that
+references that SA therefore deadlocks a fresh ``helm install``: the
+apiserver rejects the migration pod with ``serviceaccount "meho" not
+found`` on every admission attempt until the release times out.
+
+The fix drops ``serviceAccountName`` from the migrate Job entirely — the
+runner needs no Kubernetes API access, so the pod falls back to the
+namespace ``default`` SA and (with ``automountServiceAccountToken:
+false``) carries no token. These tests pin that the pre-install hook Job
+never references the chart-managed SA, while the backplane Deployment
+still does.
+
+The authoritative chart gate is ``.github/workflows/chart.yml`` (lint +
+``helm template`` + ``kubeconform``). This test mirrors the assertion at
+the unit layer so the regression is catchable from ``pytest`` on any
+machine with ``helm`` installed; it skips cleanly where ``helm`` is
+absent (the backend unit-test sandbox does not ship it — the workflow
+gate covers that environment).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+# backend/tests/<this> → parents[2] == repo root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHART_DIR = _REPO_ROOT / "deploy" / "charts" / "meho"
+
+# Minimal chassis-required overrides that satisfy values.schema.json.
+_BASE_OVERRIDES = [
+    "--set",
+    "image.tag=test",
+    "--set",
+    "ingress.host=meho.test",
+    "--set",
+    "ingress.tls.secretName=meho-tls",
+    "--set",
+    "postgres.credentialsSecret=meho-postgres",
+    "--set",
+    "vault.address=https://vault.test",
+    "--set",
+    "keycloak.issuer=https://keycloak.test/realms/meho",
+    "--set",
+    "config.keycloakIssuerUrl=https://keycloak.test/realms/meho",
+    "--set",
+    "config.keycloakAudience=meho-backplane",
+    "--set",
+    "config.vaultAddr=https://vault.test",
+    "--set",
+    "networkPolicy.postgresCIDR=10.0.1.0/24",
+    "--set",
+    "networkPolicy.vaultCIDR=10.0.2.0/24",
+    "--set",
+    "networkPolicy.keycloakCIDR=10.0.3.0/24",
+]
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("helm") is None,
+    reason="helm not installed in this sandbox; chart.yml workflow gate covers CI",
+)
+
+
+def _render_template(template: str, *extra: str) -> dict[str, Any]:
+    """Return the parsed single manifest for ``--show-only <template>``."""
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "test",
+            str(_CHART_DIR),
+            *_BASE_OVERRIDES,
+            *extra,
+            "--show-only",
+            template,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return cast("dict[str, Any]", yaml.safe_load(result.stdout))
+
+
+def test_migrate_job_is_a_pre_install_hook() -> None:
+    """Guard the premise: the Job really is a pre-install/pre-upgrade hook."""
+    job = _render_template("templates/migration-job.yaml")
+    annotations = job["metadata"]["annotations"]
+    assert annotations["helm.sh/hook"] == "pre-install,pre-upgrade"
+
+
+def test_migrate_job_has_no_service_account_name() -> None:
+    """The hook Job must NOT reference the chart-managed (non-hook) SA (#2391).
+
+    A ``serviceAccountName`` here would point at the ``meho`` SA that Helm
+    only creates *after* the hook phase, deadlocking a cold ``helm install``.
+    """
+    job = _render_template("templates/migration-job.yaml")
+    pod_spec = job["spec"]["template"]["spec"]
+    assert "serviceAccountName" not in pod_spec
+    # The token mount stays disabled — no API access, no token.
+    assert pod_spec["automountServiceAccountToken"] is False
+
+
+def test_migrate_job_has_no_sa_even_with_custom_sa_name() -> None:
+    """Setting ``serviceAccount.name`` must not sneak a name onto the Job.
+
+    An operator who customises the shared SA name still gets a Job with no
+    ``serviceAccountName`` — the fix is unconditional, not a rename dodge.
+    """
+    job = _render_template(
+        "templates/migration-job.yaml",
+        "--set",
+        "serviceAccount.name=custom-meho-sa",
+    )
+    assert "serviceAccountName" not in job["spec"]["template"]["spec"]
+
+
+def test_deployment_still_binds_the_service_account() -> None:
+    """Regression guard: only the Job changed — the Deployment keeps its SA."""
+    deployment = _render_template("templates/deployment.yaml")
+    pod_spec = deployment["spec"]["template"]["spec"]
+    assert pod_spec["serviceAccountName"] == "test-meho"

--- a/deploy/charts/meho/templates/migration-job.yaml
+++ b/deploy/charts/meho/templates/migration-job.yaml
@@ -71,7 +71,22 @@ spec:
       # (subject to `backoffLimit`), which is cheaper than re-scheduling
       # the whole Pod for transient asyncpg connection errors.
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "meho.serviceAccountName" . }}
+      # Deliberately NO `serviceAccountName`. This Job is a
+      # `pre-install,pre-upgrade` hook, so Helm schedules it BEFORE it
+      # creates the chart's normal (non-hook) resources — the `meho`
+      # ServiceAccount (templates/serviceaccount.yaml) among them.
+      # Referencing that SA here deadlocks a fresh `helm install`: the
+      # apiserver rejects the migration pod with
+      # `serviceaccount "meho" not found` on every admission attempt until
+      # the hook exhausts its retries and the release times out (#2391).
+      # The migration runner needs no Kubernetes API access, so the pod
+      # falls back to the namespace `default` ServiceAccount (created by
+      # the SA controller in every namespace, hence always present at hook
+      # time) and — with the token mount disabled just below — carries no
+      # ServiceAccount token at all. Do NOT re-add `serviceAccountName`
+      # here, and do NOT annotate the shared `meho` SA as a hook: it backs
+      # the running Deployment, and any hook-delete-policy would delete it
+      # out from under that Deployment.
       automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -224,10 +224,21 @@ Pod spec:
   garbage-collection backstop: even if `helm uninstall` is delayed, the
   Job + Pod logs are reaped after the configured window (10 minutes by
   default).
-- Same `serviceAccountName`, `imagePullSecrets`, and pod/container
-  `securityContext` as the backplane Deployment (`runAsNonRoot`,
-  `readOnlyRootFilesystem`, `drop: [ALL]`), with `/tmp` mounted as an
-  `emptyDir` to keep the read-only root invariant.
+- **No `serviceAccountName`** — unlike the backplane Deployment, the Job
+  deliberately omits it (#2391). As a `pre-install,pre-upgrade` hook the
+  Job is scheduled *before* Helm creates the chart's normal (non-hook)
+  resources, so referencing the chart-managed `meho` ServiceAccount here
+  deadlocks a fresh `helm install` (`serviceaccount "meho" not found` on
+  every admission attempt until the release times out). The runner needs
+  no Kubernetes API access, so the pod falls back to the namespace
+  `default` SA and — with `automountServiceAccountToken: false` — mounts
+  no token. Annotating the shared `meho` SA as a hook is *not* the fix:
+  it backs the running Deployment and a hook-delete-policy would delete
+  it out from under that Deployment.
+- Same `imagePullSecrets` and pod/container `securityContext` as the
+  backplane Deployment (`runAsNonRoot`, `readOnlyRootFilesystem`,
+  `drop: [ALL]`), with `/tmp` mounted as an `emptyDir` to keep the
+  read-only root invariant.
 - `envFrom` reuses the backplane's ConfigMap so any Alembic-relevant env
   vars (pool sizes, timeouts) stay in lock-step; `DATABASE_URL` is
   pulled from `Values.postgres.credentialsSecret` at the `url` key


### PR DESCRIPTION
## Summary

- On a **fresh install** the `meho-migrate` Job (a `pre-install,pre-upgrade` Helm hook) referenced the chart's `meho` ServiceAccount, which Helm only creates *after* the hook phase. The apiserver rejected the migration pod with `serviceaccount "meho" not found` on every admission attempt until the release timed out (#2391).
- Fix: drop `serviceAccountName` from the migrate Job entirely. The runner needs no Kubernetes API access, so the pod falls back to the namespace `default` SA (always present) and — with the existing `automountServiceAccountToken: false` — mounts no token.
- Chose this over annotating the shared `meho` SA as a hook: that SA backs the running Deployment, and any `hook-delete-policy` would delete it out from under the Deployment (the hazard called out in the issue's grounding note).
- Added a `helm template` unit assertion, updated `docs/codebase/devops.md`, and a CHANGELOG entry.

## Test plan

- [x] `helm lint` — clean (chassis-required override set).
- [x] `helm template --show-only templates/migration-job.yaml` — renders the pre-install/pre-upgrade hook with **no** `serviceAccountName` field and `automountServiceAccountToken: false`.
- [x] `helm template --show-only templates/deployment.yaml` — backplane Deployment still binds `serviceAccountName: test-meho` (only the Job changed).
- [x] `pytest backend/tests/test_chart_migrate_job_no_sa.py` — 4 passed (hook premise, no-SA on Job, no-SA even with custom `serviceAccount.name`, Deployment keeps SA).
- [x] `ruff check` / `ruff format --check` / `mypy` on the new test — clean.
- Fresh-namespace `helm install` completing with zero `FailedCreate`/`serviceaccount not found`: verified by construction via the render (no reference to a not-yet-created SA); the live cold-install runs in the `chart.yml` CI kind lane.

## Acceptance criteria

- [x] Fresh-install no longer references a not-yet-created SA — the hook Job carries no `serviceAccountName`.
- [x] `helm upgrade` path unchanged (same annotations, same fallback).
- [x] Unit assertion pins the hook Job renders without `serviceAccountName`.

## Out of scope

- RBAC additions (the chart ships none for this SA).
- Sibling tasks #2392 (extension-prereq) and #2393 (startup-probe).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2391


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Helm installation and upgrade timeouts caused by the migration hook waiting on a ServiceAccount created later in the release.
  * Migration jobs now run without a chart-specific ServiceAccount while continuing to disable service-account token mounting.
  * The backplane deployment continues using its configured ServiceAccount.

* **Documentation**
  * Clarified migration hook ServiceAccount behavior and related security settings.

* **Tests**
  * Added Helm rendering checks covering hook annotations, ServiceAccount configuration, and token mounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->