### PR TITLE
fix(chart): add backplane startupProbe to survive slow first boots (#2393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — Helm chart `startupProbe` stops liveness crash-looping slow first boots (#2393)
+
+- The backplane Deployment now renders a `startupProbe` on `/healthz` from a
+  new `probes.startup.*` values subtree. The kubelet disables the liveness and
+  readiness probes until the startup probe first passes, so a slow-but-healthy
+  first boot — full typed-op catalog registration plus the fastembed
+  embedding-model preload before the app binds `:8000`, ~2-3 min and longer on
+  a cold install that downloads model weights into an empty cache PVC — no
+  longer trips the short-delay liveness probe into a CrashLoopBackOff.
+- The default budget is `failureThreshold: 30` × `periodSeconds: 10` = 300s
+  (5 min), operator-tunable. `values.schema.json` accepts the new
+  `probes.startup` subtree; liveness/readiness defaults are unchanged. Opt out
+  on a fast cluster by clearing `probes.startup` (e.g. `--set probes.startup=null`).
+
 ### Changed — stage-aware `connector_auth_failed` causes + truthful remediation (#2400)
 
 - The `connector_auth_failed` envelope's `extras.cause` is now **stage-aware**

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -124,6 +124,23 @@ spec:
           # would mask startup deadlocks and let an unready Pod accept
           # traffic. Every probe field is operator-tunable via
           # `.Values.probes.<kind>.<field>`.
+          #
+          # `startupProbe` gates liveness/readiness until first boot succeeds
+          # (Issue #2393). First boot runs the full typed-op catalog
+          # registration plus the fastembed model preload before the app binds
+          # :8000 — ~2-3 min, longer on a cold install that downloads model
+          # weights into an empty cache PVC. Without this probe the kubelet
+          # starts liveness-checking mid-registration and CrashLoopBackOffs a
+          # slow-but-healthy pod. The default budget is
+          # `failureThreshold × periodSeconds` = 30 × 10s = 300s (5 min); the
+          # kubelet disables liveness/readiness until it passes, then the
+          # short-delay liveness probe takes over for fast hang detection. The
+          # `with` guard lets an operator opt out on a fast cluster by clearing
+          # `.Values.probes.startup`.
+          {{- with .Values.probes.startup }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.probes.liveness | nindent 12 }}
           readinessProbe:

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -169,7 +169,8 @@
       "required": ["liveness", "readiness"],
       "properties": {
         "liveness": { "$ref": "#/definitions/httpProbe" },
-        "readiness": { "$ref": "#/definitions/httpProbe" }
+        "readiness": { "$ref": "#/definitions/httpProbe" },
+        "startup": { "$ref": "#/definitions/httpProbe" }
       }
     },
     "resources": {

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -129,6 +129,16 @@ ingress:
 # period, 2s timeout × 3 failures = 15s detection window) so a flaky
 # dependency removes the pod from rotation promptly without triggering a
 # restart. Every field is operator-tunable.
+#
+# `startup` (Issue #2393) gates liveness/readiness until first boot
+# succeeds. First boot registers the full typed-op catalog and preloads the
+# fastembed embedding model before the app binds :8000 (~2-3 min, longer on
+# a cold install that downloads model weights into an empty cache PVC), so
+# the short-delay liveness probe would otherwise CrashLoopBackOff a
+# slow-but-healthy pod. The default budget is `failureThreshold` ×
+# `periodSeconds` = 30 × 10s = 300s (5 min); once it passes the kubelet
+# hands off to the liveness probe for fast hang detection. Clear
+# `probes.startup` to opt out on a fast cluster.
 probes:
   liveness:
     httpGet:
@@ -146,6 +156,15 @@ probes:
     periodSeconds: 5
     timeoutSeconds: 2
     failureThreshold: 3
+  startup:
+    httpGet:
+      path: /healthz
+      port: http
+    # 30 × 10s = 300s (5 min) first-boot budget; covers op-catalog
+    # registration + fastembed model preload/download on a cold install.
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 30
 
 # -- Container resources. Conservative production baselines for the v0.1
 # chassis backplane — sized for steady-state authn/authz traffic plus the

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -116,14 +116,29 @@ deployment path. Consumers mirroring through a private registry override
 
 ### Probes
 
-The Deployment always renders `livenessProbe` and `readinessProbe` against
-the backplane chassis endpoints from G2.1-T2
+The Deployment renders `startupProbe`, `livenessProbe`, and
+`readinessProbe` against the backplane chassis endpoints from G2.1-T2
 (`backend/src/meho_backplane/health.py`):
 
 | Probe | Endpoint | Failure semantics | Default timings (operator-tunable) |
 | --- | --- | --- | --- |
+| `startupProbe` | `/healthz` | Pod **restarts** once the budget is exhausted; disables liveness/readiness until it first passes | `periodSeconds: 10`, `timeoutSeconds: 1`, `failureThreshold: 30` (30 × 10s = 300s / 5-min first-boot budget) |
 | `livenessProbe` | `/healthz` (always 200 if the process is up) | Pod **restarts** on failure | `initialDelaySeconds: 30`, `periodSeconds: 10`, `timeoutSeconds: 1`, `failureThreshold: 3` |
 | `readinessProbe` | `/ready` (200 only when every registered probe in the readiness registry passes; 503 with an empty registry at the chassis stage) | Pod **removed from Service endpoints**, no restart | `initialDelaySeconds: 5`, `periodSeconds: 5`, `timeoutSeconds: 2`, `failureThreshold: 3` |
+
+The `startupProbe` (Issue #2393) exists because first boot registers the
+full typed-op catalog and preloads the fastembed embedding model inside the
+FastAPI lifespan **before** the app binds `:8000` — ~2-3 minutes, and longer
+on a cold install where the fastembed cache PVC is empty and the model
+weights are downloaded. The kubelet disables the liveness and readiness
+probes until the startup probe first succeeds, so a slow-but-healthy first
+boot no longer trips the short-delay liveness probe into a
+CrashLoopBackOff. The budget is `failureThreshold × periodSeconds` (300s by
+default); once it passes, the liveness probe's fast 30s detection window
+takes over for genuine hang detection. Inflating
+`probes.liveness.initialDelaySeconds` (the old-only lever) is strictly
+worse — it also blinds liveness to a real hang for the whole life of the
+Pod.
 
 The 30-second liveness `initialDelaySeconds` gives the FastAPI app time to
 import, build the JWKS cache, and bind structlog context before the first
@@ -133,12 +148,16 @@ total detection) makes the Pod fall out of rotation promptly when a
 downstream dependency goes flaky, without triggering an unnecessary
 restart of the backplane process itself.
 
-Probes are **always on** — there is no `enabled: false` escape valve.
-Disabling probes would mask startup deadlocks and let an unready Pod
-accept traffic; that tradeoff is never the right call for a governance
-backplane. Every field under `probes.liveness.*` and `probes.readiness.*`
-in `values.yaml` is operator-tunable for environments that need different
-timings.
+Liveness and readiness are **always on** — there is no `enabled: false`
+escape valve. Disabling them would mask startup deadlocks and let an
+unready Pod accept traffic; that tradeoff is never the right call for a
+governance backplane. Every field under `probes.liveness.*`,
+`probes.readiness.*`, and `probes.startup.*` in `values.yaml` is
+operator-tunable for environments that need different timings. The
+`startupProbe` alone is rendered under a `{{- with .Values.probes.startup }}`
+guard so an operator on a fast cluster can opt out by clearing
+`probes.startup` (e.g. `--set probes.startup=null`); it ships defaulted-on
+because slow first boots are the common case.
 
 The `/ready` endpoint **returns 503 by design** until G2.2 (Vault /
 Keycloak probes) and G2.3 (Alembic migration probe) register concrete
@@ -370,6 +389,7 @@ them).
 | `service.type` / `service.port` | `ClusterIP` / `8000` | Service shape. |
 | `ingress.className` | `""` | Cluster default IngressClass when empty. |
 | `probes.liveness.*` / `probes.readiness.*` | `/healthz` / `/ready` httpGet + tuned timings | Operator-tunable; never disabled. |
+| `probes.startup.*` | `/healthz` httpGet + 5-min first-boot budget (#2393) | Operator-tunable; defaulted-on, opt-out by clearing `probes.startup`. Gates liveness/readiness through catalog registration + fastembed preload. |
 | `resources.requests` / `resources.limits` | `100m`/`256Mi` / `1000m`/`1Gi` | Conservative chassis baselines. |
 | `networkPolicy.ingressControllerNamespace` | `ingress-nginx` | RKE2 default; override per cluster. |
 | `audit.postgresOnly` | `true` | Postgres-only audit sink baseline. |


### PR DESCRIPTION
## Summary

- The backplane's FastAPI lifespan registers the full typed-op catalog and preloads the fastembed embedding model **before** it binds `:8000` — ~2-3 min, longer on a cold install that downloads model weights into an empty cache PVC. The chart shipped only a short-delay `livenessProbe` and **no** `startupProbe`, so the kubelet started liveness-checking mid-registration and CrashLoopBackOff'd a slow-but-healthy pod before its first successful boot.
- Add a `startupProbe` on `/healthz` rendered from a new `probes.startup.*` values subtree, guarded by `{{- with .Values.probes.startup }}` so a fast cluster can opt out by clearing `probes.startup`. Default budget: `failureThreshold: 30` × `periodSeconds: 10` = 300s (5 min). The kubelet disables liveness/readiness until it first passes, then the short-delay liveness probe takes over for fast hang detection.
- `values.schema.json` accepts and validates the new subtree via the existing `httpProbe` definition. Liveness/readiness defaults are **unchanged**. `docs/codebase/devops.md` Probes section updated.

## Test plan

- [x] `helm lint` (with the CI override set) — clean
- [x] `helm template` renders `startupProbe` on the backplane Deployment: `/healthz`, `failureThreshold: 30`, `periodSeconds: 10`, `timeoutSeconds: 1` (= 300s / 5-min budget)
- [x] `kubeconform -strict -kubernetes-version 1.28.0` — 11/11 resources valid
- [x] **AC1** — `deployment.yaml` renders `startupProbe` on `/healthz` from `probes.startup.*` with a ≥5-min default budget
- [x] **AC2** — schema accepts `probes.startup`; meaningfully validated (`--set probes.startup.bogusField=1` → `additional properties 'bogusField' not allowed`; valid `failureThreshold` override passes)
- [x] **AC3** — liveness (`initialDelaySeconds: 30`, `failureThreshold: 3`) and readiness (`/ready`, `initialDelaySeconds: 5`) defaults unchanged; template tests + kubeconform pass
- [x] Opt-out verified — `--set probes.startup=null` renders no `startupProbe`
- [x] G0.8-T4 regression guards (`MCP_RESOURCE_URI` / `BACKPLANE_URL` derivation) still pass

## Out of scope

- Moving registration / model-preload out of the lifespan (backend change — separate ticket if wanted), per the issue's Out-of-scope.
- Sibling chart tickets #2391 / #2392 / #2394 touch the same chart; this PR is scoped to the `probes.startup` subtree to minimize serial-merge conflicts.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2393
