### PR TITLE
fix(connectors): route keycloak write-op password read through the credential seam (#2401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — keycloak user write-op password read routed through the credential-backend seam (#2401)
+
+- `keycloak.user.create` / `keycloak.user.reset_password` sourced the
+  operator-supplied `password_secret_ref` by opening an hvac Vault client
+  directly, bypassing the #2229 credential-backend seam. On a
+  `CREDENTIAL_BACKEND=gsm` (no-Vault) deploy this left both write ops with
+  no working credential path — a `gsm:` ref was treated as a literal Vault
+  path. The reader now resolves the ref through `load_vault_secret_data`
+  (the same seam the connector's admin-credential loader and kubeconfig
+  loader ride), so a `gsm:<project>/<secret>#password` ref reaches GCP
+  Secret Manager while schemeless Vault refs resolve byte-for-byte as
+  before (`password_secret_mount` / `password_secret_key` unchanged; the
+  `#field` fragment subsumes `password_secret_key` for schemed refs).
+  Approval-gating of both write ops is untouched.
+
 ### Changed — stage-aware `connector_auth_failed` causes + truthful remediation (#2400)
 
 - The `connector_auth_failed` envelope's `extras.cause` is now **stage-aware**

--- a/backend/src/meho_backplane/connectors/keycloak/ops_write.py
+++ b/backend/src/meho_backplane/connectors/keycloak/ops_write.py
@@ -56,13 +56,19 @@ Password handling (critical security)
 =====================================
 
 ``user.create`` and ``user.reset_password`` **never** carry the password
-inline in op params. The password is read from Vault under the operator's
-identity (``password_secret_ref`` — a KV-v2 path; optional
-``password_secret_mount`` / ``password_secret_key``) via the same
-``vault_client_for_operator`` primitive the Vault connector ops use. Two
-layers of defence keep the password out of audit + broadcast:
+inline in op params. The password is read from the operator's configured
+credential backend under the operator's identity: ``password_secret_ref``
+is resolved through the credential-backend seam
+(:func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`,
+#2229), so a schemeless ref reads the deployment default (Vault KV-v2 —
+honouring ``password_secret_mount`` / ``password_secret_key``) while a
+``<kind>:`` ref (e.g. ``gsm:<project>/<secret>#password``) reaches that
+backend. This is the same seam the connector's admin-credential loader
+rides (``session.py``); the write-op reader no longer opens hvac
+directly. Two layers of defence keep the password out of audit +
+broadcast:
 
-* The **op params** carry only a Vault *path*, never the secret — so the
+* The **op params** carry only a secret *ref*, never the secret — so the
   audit row's ``params_hash`` (params are never stored verbatim) hashes a
   path, and the broadcast ``params`` view carries a path.
 * Both ops are additionally pinned in
@@ -89,11 +95,13 @@ References
 
 from __future__ import annotations
 
-import asyncio
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-import meho_backplane.auth.vault as _auth_vault
-from meho_backplane.connectors._shared.vault_creds import strip_credential_value
+from meho_backplane.connectors._shared.vault_creds import (
+    load_vault_secret_data,
+    strip_credential_value,
+)
 from meho_backplane.connectors.keycloak.session import quote_segment, resolve_realm_config
 
 if TYPE_CHECKING:
@@ -146,21 +154,50 @@ class KeycloakRoleNotFoundError(Exception):
 
 
 # ---------------------------------------------------------------------------
-# Vault-sourced password reader (operator-context)
+# Credential-backend-sourced password reader (operator-context)
 # ---------------------------------------------------------------------------
 
 
-async def _read_password_from_vault(operator: Operator, params: dict[str, Any]) -> str:
-    """Read a user password from Vault under the operator's identity.
+@dataclass(slots=True)
+class _PasswordSecretTarget:
+    """Adapter presenting the op's ``password_secret_ref`` to the seam.
 
-    The password is **never** an inline param — only its Vault location is.
-    ``password_secret_ref`` is the KV-v2 path; ``password_secret_mount``
-    (default ``secret``) the mount; ``password_secret_key`` (default
-    ``password``) the field within the secret payload. Forwards the
-    operator's validated JWT to Vault's JWT/OIDC auth method via
-    :func:`~meho_backplane.auth.vault.vault_client_for_operator` (the same
-    operator-context read the connector's admin-credential loader uses) and
-    offloads the blocking hvac call with ``asyncio.to_thread``.
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`
+    reads its ``secret_ref`` off a
+    :class:`~meho_backplane.connectors._shared.vault_creds.BasicCredentialsTargetLike`
+    (``name`` / ``host`` / ``secret_ref``). A user-write password lives at
+    a **per-op** ``password_secret_ref``, not at the connector target's
+    admin ``secret_ref`` — so this thin adapter carries the connector
+    target's ``name`` / ``host`` for log + error attribution while pointing
+    the seam at the op's password ref. Not frozen: the structural Protocol
+    declares settable members, so an immutable dataclass would not satisfy
+    it.
+    """
+
+    name: str
+    host: str
+    secret_ref: str | None
+
+
+async def _read_password_from_vault(
+    operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+) -> str:
+    """Read a user password via the credential-backend seam (#2229).
+
+    The password is **never** an inline param — only its secret *ref* is.
+    ``password_secret_ref`` is resolved through
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`,
+    so a schemeless ref reads the deployment-default backend (Vault KV-v2,
+    honouring ``password_secret_mount`` / ``password_secret_key``) while an
+    explicit ``<kind>:`` ref (e.g. ``gsm:<project>/<secret>#password``)
+    reaches that backend. ``password_secret_mount`` is the Vault KV-v2
+    mount (a Vault-only knob gsm ignores, matching the seam contract);
+    ``password_secret_key`` (default ``password``) names the field in the
+    returned payload — for a schemed ref carrying a ``#field`` fragment the
+    backend has already narrowed the payload to that one field, so the
+    fragment subsumes ``password_secret_key``. The read runs under the
+    operator's identity (the seam forwards the operator JWT); the write-op
+    reader no longer opens hvac directly.
 
     Raises :exc:`KeycloakPasswordSecretError` when the requested key is
     absent or its value is not a non-empty string.
@@ -169,14 +206,11 @@ async def _read_password_from_vault(operator: Operator, params: dict[str, Any]) 
     mount = str(params.get("password_secret_mount") or _DEFAULT_PASSWORD_MOUNT).strip()
     key = str(params.get("password_secret_key") or _DEFAULT_PASSWORD_KEY).strip()
 
-    async with _auth_vault.vault_client_for_operator(operator) as client:
-        payload = await asyncio.to_thread(
-            client.secrets.kv.v2.read_secret_version,
-            path=secret_ref,
-            mount_point=mount,
-            raise_on_deleted_version=False,
-        )
-    secret_data = payload["data"]["data"]
+    secret_data = await load_vault_secret_data(
+        _PasswordSecretTarget(name=target.name, host=target.host, secret_ref=secret_ref),
+        operator,
+        mount=mount,
+    )
     value = secret_data.get(key) if isinstance(secret_data, dict) else None
     # Whitespace-strip as the connector's credential loaders do (a trailing
     # newline would otherwise ride into the user's Keycloak password); check
@@ -184,11 +218,12 @@ async def _read_password_from_vault(operator: Operator, params: dict[str, Any]) 
     stripped = strip_credential_value(value) if isinstance(value, str) else None
     if not stripped:
         raise KeycloakPasswordSecretError(
-            f"keycloak_password_secret: Vault secret at mount={mount!r} "
-            f"path={secret_ref!r} carries no usable string value under key "
-            f"{key!r}. Store the password under that key (or set "
-            f"password_secret_key) so the user write can source it without "
-            f"the password ever appearing in op params."
+            f"keycloak_password_secret: credential secret at "
+            f"password_secret_ref={secret_ref!r} (mount={mount!r}) carries no "
+            f"usable string value under key {key!r}. Store the password under "
+            f"that key (or set password_secret_key, or select it with a "
+            f"'#field' fragment on a schemed ref) so the user write can source "
+            f"it without the password ever appearing in op params."
         )
     return stripped
 
@@ -460,7 +495,7 @@ async def keycloak_user_create(
     representation.setdefault("enabled", True)
 
     if params.get("password_secret_ref"):
-        password = await _read_password_from_vault(operator, params)
+        password = await _read_password_from_vault(operator, target, params)
         representation["credentials"] = [
             {"type": "password", "value": password, "temporary": _temporary_flag(params)}
         ]
@@ -511,7 +546,7 @@ async def keycloak_user_reset_password(
                 f"keycloak.user.reset_password: no user with username={username!r} in realm "
                 f"{realms.managed_realm!r}"
             )
-    password = await _read_password_from_vault(operator, params)
+    password = await _read_password_from_vault(operator, target, params)
     credential = {"type": "password", "value": password, "temporary": _temporary_flag(params)}
     await self._write_admin(
         target,

--- a/backend/tests/test_connectors_keycloak_auth.py
+++ b/backend/tests/test_connectors_keycloak_auth.py
@@ -701,6 +701,7 @@ async def test_user_write_password_reader_strips_trailing_newline(
 
     value = await _read_password_from_vault(
         _make_operator(),
+        _TARGET,
         {"password_secret_ref": "rdc/keycloak/user-pw"},
     )
 
@@ -724,7 +725,124 @@ async def test_user_write_password_reader_rejects_whitespace_only_secret(
     with pytest.raises(KeycloakPasswordSecretError):
         await _read_password_from_vault(
             _make_operator(),
+            _TARGET,
             {"password_secret_ref": "rdc/keycloak/user-pw"},
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_kc_loader_settings_env")
+async def test_user_write_password_reader_honours_custom_key_and_mount(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A schemeless ref reads the Vault backend, honouring key + mount (AC #2).
+
+    Regression pin: ``password_secret_key`` selects a non-default field and
+    ``password_secret_mount`` is threaded through to the KV-v2 read exactly
+    as before the seam routing — a schemeless ref must behave byte-for-byte.
+    """
+    from meho_backplane.connectors.keycloak.ops_write import _read_password_from_vault
+    from tests._vault_fakes import install_fake_client
+
+    fake = install_fake_client(monkeypatch, secret={"db_pw": "s3cret\n"})
+
+    value = await _read_password_from_vault(
+        _make_operator(),
+        _TARGET,
+        {
+            "password_secret_ref": "rdc/keycloak/user-pw",
+            "password_secret_key": "db_pw",
+            "password_secret_mount": "kv2",
+        },
+    )
+
+    assert value == "s3cret"
+    # The Vault backend received the op's mount + path verbatim (mount is a
+    # Vault-only knob) — proving schemeless routing is unchanged.
+    assert fake.secrets.kv.v2.read_calls[-1] == {
+        "path": "rdc/keycloak/user-pw",
+        "mount_point": "kv2",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_kc_loader_settings_env")
+async def test_user_write_password_reader_dispatches_gsm_scheme(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``gsm:``-schemed ref dispatches to the gsm backend, fragment-selected (AC #1).
+
+    Proves the write-op password read rides the #2229 credential-backend
+    seam: an explicit ``gsm:`` scheme reaches a registered gsm backend
+    (here a fake), the ``#field`` fragment subsumes ``password_secret_key``,
+    and ``password_secret_mount`` (a Vault-only knob) is ignored by gsm.
+    """
+    from meho_backplane.connectors._shared.credential_backend import (
+        CREDENTIAL_BACKEND_REGISTRY,
+    )
+    from meho_backplane.connectors.keycloak.ops_write import _read_password_from_vault
+
+    seen: dict[str, Any] = {}
+
+    class _FakeGsmBackend:
+        async def load_secret_data(
+            self,
+            secret_ref: str,
+            operator: Operator,
+            *,
+            target_name: str,
+            mount: str,
+        ) -> dict[str, object]:
+            seen["secret_ref"] = secret_ref
+            seen["mount"] = mount
+            # Mirror gsm's fragment contract: '<path>#<field>' narrows the
+            # payload to that one field. The scheme was already split off by
+            # the seam, so secret_ref is the scheme-stripped remainder.
+            _path, _sep, field = secret_ref.rpartition("#")
+            return {field: "gsm-sourced-pw\n"}
+
+    saved = CREDENTIAL_BACKEND_REGISTRY.get("gsm")
+    CREDENTIAL_BACKEND_REGISTRY["gsm"] = _FakeGsmBackend()  # type: ignore[assignment]
+    try:
+        value = await _read_password_from_vault(
+            _make_operator(),
+            _TARGET,
+            {
+                "password_secret_ref": "gsm:meho-prod/keycloak-user#password",
+                # A Vault-only knob gsm ignores — set to prove it is inert.
+                "password_secret_mount": "kv2",
+            },
+        )
+    finally:
+        if saved is not None:
+            CREDENTIAL_BACKEND_REGISTRY["gsm"] = saved
+        else:  # pragma: no cover - gsm self-registers at import
+            CREDENTIAL_BACKEND_REGISTRY.pop("gsm", None)
+
+    assert value == "gsm-sourced-pw"
+    # Scheme split off, fragment preserved; mount threaded but gsm-inert.
+    assert seen["secret_ref"] == "meho-prod/keycloak-user#password"
+    assert seen["mount"] == "kv2"
+
+
+def test_ops_write_has_no_direct_vault_client_usage() -> None:
+    """No direct ``vault_client_for_operator`` / hvac read remains (AC #3).
+
+    Grep-pins the seam adoption: the write-op password reader must resolve
+    ``password_secret_ref`` through ``load_vault_secret_data``, never open
+    an hvac client itself. A regression that re-introduces a direct Vault
+    read (the pre-#2401 shape that broke gsm deploys) fails here.
+    """
+    from pathlib import Path
+
+    import meho_backplane.connectors.keycloak.ops_write as ops_write_module
+
+    source = Path(ops_write_module.__file__).read_text(encoding="utf-8")
+    for forbidden in ("vault_client_for_operator", "read_secret_version", "import hvac"):
+        assert forbidden not in source, (
+            f"keycloak/ops_write.py must not use {forbidden!r} directly — "
+            "route the password read through the credential-backend seam "
+            "(load_vault_secret_data)"
         )
 
 

--- a/backend/tests/test_connectors_keycloak_write_e2e.py
+++ b/backend/tests/test_connectors_keycloak_write_e2e.py
@@ -138,10 +138,10 @@ def _stub_loader(_target: KeycloakTargetLike, _operator: Operator) -> Any:
     return _load()
 
 
-async def _stub_read_password(_operator: Operator, params: dict[str, Any]) -> str:
-    """Stand in for the operator-context Vault read.
+async def _stub_read_password(_operator: Operator, _target: Any, params: dict[str, Any]) -> str:
+    """Stand in for the operator-context credential-backend read.
 
-    Asserts the password is sourced via a Vault *path*, never inline: the
+    Asserts the password is sourced via a secret *ref*, never inline: the
     op params must carry ``password_secret_ref`` and must NOT carry an
     inline ``password``.
     """

--- a/docs/codebase/connectors-keycloak.md
+++ b/docs/codebase/connectors-keycloak.md
@@ -42,7 +42,8 @@ fresh target with no asserted version still resolves.
   the nine approval-gated write ops, reusing the `KeycloakOp` dataclass.
   Every op is `requires_approval=True`; a create treats HTTP 409 as an
   idempotent success; `user.create`/`user.reset_password` source the
-  password from Vault via `_read_password_from_vault` (never inline).
+  password through the credential-backend seam via
+  `_read_password_from_vault` (never inline).
   `WHEN_TO_USE_WRITE_BY_GROUP` carries the write groups' blurbs (keyed with
   a `_write` suffix so they never collide with the read groups when
   `register_operations` merges both maps).
@@ -220,9 +221,13 @@ Three load-bearing properties:
 - **Idempotency.** A create that hits HTTP 409 (already-exists) is a
   success (`conflict: true`), and the existing object's UUID is resolved.
 - **Password handling.** `user.create` / `user.reset_password` source the
-  password from Vault (`_read_password_from_vault`, operator-context
-  `vault_client_for_operator`) via a `password_secret_ref` path param —
-  **never** an inline `password`. The password lands in the Keycloak
+  password through the credential-backend seam (`_read_password_from_vault`
+  → `load_vault_secret_data`, #2229/#2401) via a `password_secret_ref`
+  param — **never** an inline `password`. A schemeless ref reads the
+  deployment-default backend (Vault KV-v2, honouring `password_secret_mount`
+  / `password_secret_key`); a `<kind>:` ref (e.g.
+  `gsm:<project>/<secret>#password`) reaches that backend, the `#field`
+  fragment subsuming `password_secret_key`. The password lands in the Keycloak
   credential body but never in op params; audit stores a `params_hash`
   (never raw params); and both ops are pinned in
   `broadcast.events._CREDENTIAL_WRITE_OPS` → aggregate-only broadcast.


### PR DESCRIPTION
## Summary

- `keycloak.user.create` / `keycloak.user.reset_password` read the operator-supplied `password_secret_ref` by opening an hvac Vault client directly (`_read_password_from_vault` → `vault_client_for_operator`), bypassing the #2229 credential-backend seam. On a `CREDENTIAL_BACKEND=gsm` (no-Vault) deploy both write ops had no working credential path — a `gsm:` ref was treated as a literal Vault path.
- The reader now resolves `password_secret_ref` through `load_vault_secret_data` (the same seam the connector's admin-credential loader and the kubeconfig loader ride), via a thin `_PasswordSecretTarget` adapter that presents the per-op ref as the seam's `secret_ref` while keeping the connector target's name/host for attribution.
- Schemeless Vault refs resolve byte-for-byte as before (`password_secret_mount` / `password_secret_key` unchanged); a schemed `gsm:<project>/<secret>#password` ref reaches GCP Secret Manager, the `#field` fragment subsuming `password_secret_key`. `password_secret_mount` stays a Vault-only knob (gsm ignores it).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on changed files
- [x] `mypy src/meho_backplane/connectors/keycloak/` — clean
- [x] **AC #1** gsm dispatch: `test_user_write_password_reader_dispatches_gsm_scheme` — a `gsm:`-schemed ref dispatches to a registered fake gsm backend, `#field` subsumes `password_secret_key`, mount ignored.
- [x] **AC #2** schemeless regression: `test_user_write_password_reader_honours_custom_key_and_mount` (+ the two pre-existing strip/reject reader tests) — custom `password_secret_key`/`password_secret_mount` threaded to the KV-v2 read verbatim.
- [x] **AC #3** grep-pin: `test_ops_write_has_no_direct_vault_client_usage` — no `vault_client_for_operator` / `read_secret_version` / `import hvac` remains in `keycloak/ops_write.py`.
- [x] **AC #4** approval-gating untouched: full `test_connectors_keycloak_write_e2e.py` green (integration doubles re-grepped — none reference the reader); 120 passed across the keycloak + credential-seam surfaces.
- [x] **AC #5** no OpenAPI snapshot delta: `make snapshot-openapi` produced no diff.

## Out of scope

- The kubeconfig loader (#2397) and the `secret.move` broker's gsm endpoint (separate by-design registry) — per the issue.
- Pre-existing file-size warning on `ops_write.py` (635 lines, was already over the 600 budget before this change) — recorded as an adjacent finding, not addressed here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2401
