### PR TITLE
feat(connectors): net.tls_inspect — full presented cert chain (pyOpenSSL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,26 @@ connector-related release-notes line.
   `{connected: false, reason}` with `status="ok"`, never a `connector_*`
   error). `net.*` ops classify as reads in the broadcast feed
   (#2406 / #2405).
+
+### Added — net.tls_inspect full presented certificate chain (openssl s_client parity)
+
+- Add `net.tls_inspect` on the `net.*` keystone — a targetless probe
+  that opens a TLS handshake with certificate verification **off** and
+  reports the **full chain the server presents** (leaf → intermediates →
+  root-if-sent, leaf-first): per-cert subject / SAN / issuer / validity
+  window / serial / self-signed flag, plus `chain_complete` (did the
+  server send a self-signed root), a leaf `hostname_match` computed
+  independently of the disabled verification, and the negotiated protocol
+  and cipher — `openssl s_client -showcerts` parity. A self-signed /
+  expired / hostname-mismatched cert is **inspected and reported**
+  (`handshake=true`, `status="ok"`), never rejected; a refused /
+  timed-out / DNS-failed / non-TLS endpoint returns `{handshake: false,
+  reason}` with `status="ok"`. Reuses the T1 probe allowlist, audit-
+  visible `host:port`, and return-failures contract. Adds `pyOpenSSL`
+  (full-chain read; stdlib `ssl` on the 3.12 floor exposes only the leaf)
+  and promotes `cryptography` to a declared runtime dependency — both
+  Apache-2.0 (#2407 / #2405).
+
 ### Fixed — harden ingest-job timeout warning tests against xdist logger-cache ordering (#2397)
 
 - `test_operations_ingest_jobs.py` rebinds `jobs._log` to a fresh structlog

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -93,6 +93,20 @@ dependencies = [
     # legs alike) instead of partially ingesting. Builds on the existing
     # ``jsonschema`` dependency; used metaschema-only (no semantic add-ons).
     "openapi-spec-validator>=0.9.0",
+    # Full presented TLS certificate-chain inspection for the synthetic
+    # ``net.tls_inspect`` diagnostic op (#2407). Stdlib ``ssl`` on Python
+    # 3.12 (the ``requires-python`` floor) exposes only the **leaf** via
+    # ``getpeercert`` — the full-chain ``SSLSocket.get_unverified_chain()``
+    # is 3.13+. pyOpenSSL's ``Connection.get_peer_cert_chain()`` returns
+    # the whole chain the server sent on an unverified handshake, and each
+    # cert's ``.to_cryptography()`` hands off to the ``cryptography`` x509
+    # parser already used elsewhere. Apache-2.0 (license-check clean).
+    "pyopenssl>=25.0.0",
+    # Direct runtime dependency now: ``net.tls_inspect`` parses each
+    # presented cert via ``cryptography.x509`` (subject/SAN/issuer/validity
+    # extraction). Previously a dev-only + transitive (pyjwt[crypto],
+    # pyopenssl) install; declared here because the app imports it directly.
+    "cryptography>=49.0.0",
 ]
 
 [dependency-groups]
@@ -101,7 +115,6 @@ dev = [
     "pytest-asyncio>=1.4.0",
     "ruff>=0.15.20",
     "mypy>=2.1.0",
-    "cryptography>=49.0.0",
     "respx>=0.21",
     "pytest-cov>=5.0",
     "pytest-xdist>=3.6",

--- a/backend/src/meho_backplane/connectors/net/__init__.py
+++ b/backend/src/meho_backplane/connectors/net/__init__.py
@@ -18,21 +18,30 @@ via :func:`~meho_backplane.operations.typed_register.register_typed_op_registrar
 so the ``endpoint_descriptor`` row lands before the first dispatch.
 
 This is the keystone (#2406) of the ``net.*`` family: ``net.tcp_check``
-plus the three foundations sibling ops (T2-T4) reuse — the dedicated
-probe allowlist (``MEHO_NETDIAG_PROBE_ALLOWLIST``, empty ⇒ inert), the
-audit-visible host:port, and the return-failures contract (a failed
-probe is ``status="ok"`` with ``connected=false``, never a
-``connector_*`` error). See :mod:`meho_backplane.connectors.net.ops` and
+plus the sibling ops (T2-T4) reuse — the dedicated probe allowlist
+(``MEHO_NETDIAG_PROBE_ALLOWLIST``, empty ⇒ inert), the audit-visible
+host:port, and the return-failures contract (a failed probe is
+``status="ok"`` with ``connected=false``, never a ``connector_*``
+error). ``net.tls_inspect`` (T2, #2407) is the first sibling: it reuses
+all three foundations to report the full presented TLS certificate chain
+on an unverified handshake. Each op ships its own module + registrar and
+queues it here, so siblings extend this package without contending for a
+single registrar function. See :mod:`meho_backplane.connectors.net.ops`,
+:mod:`meho_backplane.connectors.net.tls`, and
 :mod:`meho_backplane.connectors.net.allowlist`.
 """
 
 from meho_backplane.connectors.net.ops import register_net_typed_operations
+from meho_backplane.connectors.net.tls import register_net_tls_inspect_operation
 from meho_backplane.operations.typed_register import register_typed_op_registrar
 
-# Queue the net.tcp_check typed-op upsert onto the lifespan-driven
-# registrar list (run after the connector eager-import pass).
+# Queue each net.* typed-op upsert onto the lifespan-driven registrar
+# list (run after the connector eager-import pass). One registrar per op
+# keeps siblings from contending for a shared function.
 register_typed_op_registrar(register_net_typed_operations)
+register_typed_op_registrar(register_net_tls_inspect_operation)
 
 __all__ = [
+    "register_net_tls_inspect_operation",
     "register_net_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/net/tls.py
+++ b/backend/src/meho_backplane/connectors/net/tls.py
@@ -1,0 +1,586 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Network-diagnostics typed op ``net.tls_inspect`` + its registrar.
+
+The second ``net.*`` op (#2407) on the T1 keystone (#2406). It performs
+an ``openssl s_client -showcerts``-parity read: open a TLS handshake to
+``host:port`` with certificate verification **off** (self-signed
+appliances are the point) and report the **full presented certificate
+chain** the server sent, leaf-first, plus chain-level completeness, the
+leaf hostname match, negotiated protocol, and cipher.
+
+Why pyOpenSSL and not stdlib ``ssl``: on the ``requires-python`` floor
+(3.12) ``ssl.SSLSocket.getpeercert`` returns only the **leaf** cert; the
+full-chain ``ssl.SSLSocket.get_unverified_chain`` is 3.13+. pyOpenSSL's
+:meth:`OpenSSL.SSL.Connection.get_peer_cert_chain` returns the whole
+chain the peer presented on an unverified handshake, and its
+``as_cryptography=True`` mode (pyOpenSSL 24.3+) hands back
+:class:`cryptography.x509.Certificate` objects directly, so the parse
+reuses the ``cryptography`` x509 API already used elsewhere in the tree.
+
+This op inherits the three T1 foundations verbatim:
+
+* **Probe allowlist** — :func:`~meho_backplane.connectors.net.allowlist.assert_probe_allowed`
+  screens the dialed ``host`` *before* any socket opens
+  (``MEHO_NETDIAG_PROBE_ALLOWLIST`` empty ⇒ every probe refused).
+* **Audit-visible host:port** — the return dict carries the literal
+  ``host``/``port``/``server_name`` (a host:port is not a secret), so the
+  durable audit row's ``raw_payload`` answers "who inspected what".
+* **Return-failures contract** — a refused, timed-out, DNS-failed, or
+  non-TLS endpoint is the **product**, not an error: the handler returns
+  ``{"handshake": false, "reason": <code>, ...}`` with dispatch
+  ``status="ok"``. A self-signed / expired / hostname-mismatched cert is
+  **inspected and reported** (``handshake=true``), never rejected —
+  verification is off by design, so the cert is data, not a failure.
+
+``safety_level="safe"`` + ``requires_approval=False``: a read-only
+handshake that sends no application bytes, so the probe allowlist is the
+sole floor (same posture as ``net.tcp_check``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import ipaddress
+import select
+import socket
+import time
+from typing import TYPE_CHECKING, Any
+
+import structlog
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from OpenSSL import SSL
+
+from meho_backplane.connectors.net.allowlist import (
+    ProbeNotAllowedError,
+    assert_probe_allowed,
+)
+
+# Reuse the shared probe timeout bounds/clamp from the keystone module.
+# ``ops`` never imports ``tls`` (the __init__ queues each registrar
+# independently), so this package-internal import forms no cycle.
+from meho_backplane.connectors.net.ops import (
+    _DEFAULT_TIMEOUT_SECONDS,
+    _MAX_TIMEOUT_SECONDS,
+    _clamp_timeout,
+)
+from meho_backplane.operations.typed_register import register_typed_operation
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "NET_TLS_INSPECT_PARAMETER_SCHEMA",
+    "net_tls_inspect",
+    "register_net_tls_inspect_operation",
+]
+
+_log = structlog.get_logger(__name__)
+
+NET_TLS_INSPECT_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Hostname or IP literal to open the TLS handshake to. Must "
+                "be covered by MEHO_NETDIAG_PROBE_ALLOWLIST or the probe is "
+                "refused before any socket opens."
+            ),
+        },
+        "port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "TCP port the TLS service listens on (e.g. 443, 8443, 636).",
+        },
+        "server_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "SNI server name to send and to match the leaf certificate "
+                "against. Defaults to host. Set it when the endpoint is "
+                "dialed by IP but presents a name-based virtual host."
+            ),
+        },
+        "timeout_seconds": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "maximum": _MAX_TIMEOUT_SECONDS,
+            "description": (
+                "Combined connect + handshake timeout in seconds (default "
+                "5, max 30). A handshake that does not complete in time "
+                "returns handshake=false with reason='timeout'."
+            ),
+        },
+    },
+    "required": ["host", "port"],
+    "additionalProperties": False,
+}
+
+_CHAIN_ITEM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "subject": {"type": "string", "description": "RFC 4514 subject DN."},
+        "issuer": {"type": "string", "description": "RFC 4514 issuer DN."},
+        "san": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Subject Alternative Names (DNS names then IP literals).",
+        },
+        "not_before": {"type": "string", "description": "ISO 8601 UTC notBefore."},
+        "not_after": {"type": "string", "description": "ISO 8601 UTC notAfter."},
+        "serial": {"type": "string", "description": "Serial number as a decimal string."},
+        "self_signed": {
+            "type": "boolean",
+            "description": "True iff subject == issuer (a root or self-signed leaf).",
+        },
+    },
+    "required": ["subject", "issuer", "san", "not_before", "not_after", "serial", "self_signed"],
+    "additionalProperties": False,
+}
+
+_NET_TLS_INSPECT_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "handshake": {
+            "type": "boolean",
+            "description": "True iff the TLS handshake completed (verification is off).",
+        },
+        "reason": {
+            "type": ["string", "null"],
+            "description": (
+                "Null on a completed handshake; otherwise a failure code: "
+                "not_in_probe_allowlist, timeout, refused, dns_failure, "
+                "unreachable, tls_error."
+            ),
+        },
+        "host": {"type": "string", "description": "The dialed host (audit-visible)."},
+        "port": {"type": "integer", "description": "The dialed port (audit-visible)."},
+        "server_name": {
+            "type": "string",
+            "description": "The SNI / hostname-match name used (audit-visible).",
+        },
+        "protocol": {
+            "type": ["string", "null"],
+            "description": "Negotiated TLS protocol (e.g. 'TLSv1.3'); null on failure.",
+        },
+        "cipher": {
+            "type": ["string", "null"],
+            "description": "Negotiated cipher suite; null on failure.",
+        },
+        "chain": {
+            "type": "array",
+            "items": _CHAIN_ITEM_SCHEMA,
+            "description": "Presented certificate chain, leaf-first (empty on failure).",
+        },
+        "leaf": {
+            **{k: v for k, v in _CHAIN_ITEM_SCHEMA.items() if k != "type"},
+            "type": ["object", "null"],
+            "description": "Convenience alias for chain[0]; null on failure.",
+        },
+        "not_after": {
+            "type": ["string", "null"],
+            "description": "Leaf notAfter (ISO 8601 UTC) for the common 'is it expiring' read.",
+        },
+        "hostname_match": {
+            "type": "boolean",
+            "description": (
+                "True iff server_name matches the leaf SAN (or CN when no SAN), "
+                "computed independently of the disabled stack verification."
+            ),
+        },
+        "chain_complete": {
+            "type": "boolean",
+            "description": "True iff the last presented cert is self-signed (a root was sent).",
+        },
+    },
+    "required": [
+        "handshake",
+        "reason",
+        "host",
+        "port",
+        "server_name",
+        "protocol",
+        "cipher",
+        "chain",
+        "leaf",
+        "not_after",
+        "hostname_match",
+        "chain_complete",
+    ],
+    "additionalProperties": False,
+}
+
+_NET_TLS_INSPECT_WHEN_TO_USE = (
+    "Inspect the full TLS certificate chain an endpoint presents — the "
+    "openssl 's_client -showcerts' read: 'what cert does the load "
+    "balancer serve on 443?', 'is this appliance's cert expired or "
+    "self-signed?', 'did the server send the intermediate?'. Verification "
+    "is OFF, so a self-signed / expired / mismatched cert is inspected and "
+    "reported, never rejected — the cert is the answer. A refused, "
+    "timed-out, or non-TLS endpoint is a normal result, not an error. The "
+    "destination must be inside MEHO_NETDIAG_PROBE_ALLOWLIST."
+)
+
+_NET_TLS_INSPECT_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Use to read the certificate chain a TLS endpoint presents "
+        "(leaf, intermediates, root-if-sent) without trusting it: chain "
+        "completeness, per-cert validity window, self-signed flags, and "
+        "whether the leaf matches a hostname. Read-only: no application "
+        "bytes are sent."
+    ),
+    "parameter_hints": {
+        "host": "Required. Hostname or IP literal. Must be allowlisted for probing.",
+        "port": "Required. TLS port (e.g. 443, 8443, 636).",
+        "server_name": "Optional. SNI + hostname-match name; defaults to host.",
+        "timeout_seconds": "Optional. Connect+handshake timeout (default 5, max 30).",
+    },
+    "output_shape": (
+        "On a completed handshake: {'handshake': true, 'reason': null, "
+        "'chain': [{subject, issuer, san, not_before, not_after, serial, "
+        "self_signed}, ...] (leaf-first), 'leaf': <chain[0]>, "
+        "'hostname_match': <bool>, 'chain_complete': <bool>, 'protocol': "
+        "<str>, 'cipher': <str>, 'not_after': <leaf notAfter>, 'host', "
+        "'port', 'server_name'}. On a refused / timed-out / non-TLS "
+        "endpoint: the same keys with handshake=false, reason set, chain=[] "
+        "and leaf=null — still a successful (status=ok) op."
+    ),
+}
+
+
+def _encode_sni(server_name: str) -> bytes | None:
+    """Return the SNI bytes for *server_name*, or ``None`` to omit SNI.
+
+    SNI carries a DNS hostname, never an IP literal (RFC 6066 §3), so an
+    IP ``server_name`` yields ``None``. A hostname is encoded to its IDNA
+    A-label form, falling back to ASCII (underscore-bearing internal names
+    are not valid IDNA but are valid ASCII); an un-encodable value omits
+    SNI rather than failing the handshake.
+    """
+    candidate = server_name.strip().rstrip(".")
+    if not candidate:
+        return None
+    literal = (
+        candidate[1:-1] if candidate.startswith("[") and candidate.endswith("]") else candidate
+    )
+    try:
+        ipaddress.ip_address(literal)
+        return None
+    except ValueError:
+        pass
+    try:
+        return candidate.encode("idna")
+    except (UnicodeError, ValueError):
+        try:
+            return candidate.encode("ascii")
+        except UnicodeError:
+            return None
+
+
+def _san(cert: x509.Certificate) -> x509.SubjectAlternativeName | None:
+    """Return the leaf's SubjectAlternativeName extension value, or ``None``."""
+    try:
+        return cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    except x509.ExtensionNotFound:
+        return None
+
+
+def _san_dns_names(cert: x509.Certificate) -> list[str]:
+    """Return the leaf's SAN dNSName values, or ``[]`` when absent."""
+    san = _san(cert)
+    return list(san.get_values_for_type(x509.DNSName)) if san is not None else []
+
+
+def _san_ip_addresses(cert: x509.Certificate) -> list[str]:
+    """Return the leaf's SAN iPAddress values as strings, or ``[]``."""
+    san = _san(cert)
+    return [str(ip) for ip in san.get_values_for_type(x509.IPAddress)] if san is not None else []
+
+
+def _common_name(cert: x509.Certificate) -> str | None:
+    """Return the subject Common Name, or ``None`` when the cert has none."""
+    attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+    return str(attrs[0].value) if attrs else None
+
+
+def _dns_name_matches(patterns: list[str], hostname: str) -> bool:
+    """Match *hostname* against DNS *patterns*, honouring a leftmost wildcard.
+
+    A ``*.example.com`` pattern matches exactly one extra leftmost label
+    (``a.example.com`` but not ``example.com`` or ``a.b.example.com``) —
+    the RFC 6125 wildcard rule. Matching is case-insensitive with trailing
+    dots stripped.
+    """
+    host = hostname.rstrip(".").lower()
+    for raw in patterns:
+        pattern = raw.rstrip(".").lower()
+        if not pattern:
+            continue
+        if pattern == host:
+            return True
+        if pattern.startswith("*."):
+            suffix = pattern[1:]  # ".example.com"
+            if host.endswith(suffix):
+                leftmost = host[: -len(suffix)]
+                if leftmost and "." not in leftmost:
+                    return True
+    return False
+
+
+def _leaf_hostname_match(cert: x509.Certificate, server_name: str) -> bool:
+    """Return whether *server_name* matches the leaf cert.
+
+    Computed **independently** of the TLS stack because the inspection
+    context disables ``check_hostname`` (verification is off). An IP
+    ``server_name`` is matched against the SAN iPAddress entries; a
+    hostname against the SAN dNSName entries (wildcard-aware), falling
+    back to the subject CN only when the cert carries no SAN dNSName
+    (legacy appliances).
+    """
+    name = server_name.strip().rstrip(".")
+    literal = name[1:-1] if name.startswith("[") and name.endswith("]") else name
+    try:
+        target_ip = ipaddress.ip_address(literal)
+    except ValueError:
+        target_ip = None
+    if target_ip is not None:
+        return any(target_ip == ipaddress.ip_address(entry) for entry in _san_ip_addresses(cert))
+    dns_names = _san_dns_names(cert)
+    if dns_names:
+        return _dns_name_matches(dns_names, name)
+    common_name = _common_name(cert)
+    return common_name is not None and _dns_name_matches([common_name], name)
+
+
+def _cert_to_dict(cert: x509.Certificate) -> dict[str, Any]:
+    """Flatten one presented certificate into the audit-safe report shape.
+
+    ``serial`` is stringified (a serial is a large integer that a JS
+    consumer would silently truncate as a JSON number); timestamps use the
+    tz-aware ``*_utc`` accessors (naive ``not_valid_after`` is deprecated
+    in ``cryptography``).
+    """
+    return {
+        "subject": cert.subject.rfc4514_string(),
+        "issuer": cert.issuer.rfc4514_string(),
+        "san": _san_dns_names(cert) + _san_ip_addresses(cert),
+        "not_before": cert.not_valid_before_utc.isoformat(),
+        "not_after": cert.not_valid_after_utc.isoformat(),
+        "serial": str(cert.serial_number),
+        "self_signed": cert.subject == cert.issuer,
+    }
+
+
+def _failure(host: str, port: int, server_name: str, reason: str) -> dict[str, Any]:
+    """Build the uniform structured payload shared by every failed inspection."""
+    return {
+        "handshake": False,
+        "reason": reason,
+        "host": host,
+        "port": port,
+        "server_name": server_name,
+        "protocol": None,
+        "cipher": None,
+        "chain": [],
+        "leaf": None,
+        "not_after": None,
+        "hostname_match": False,
+        "chain_complete": False,
+    }
+
+
+def _run_until_ready(sock: socket.socket, deadline: float, action: Any) -> Any:
+    """Drive a pyOpenSSL non-blocking op to completion under a deadline.
+
+    A socket with a timeout is non-blocking under the hood, so pyOpenSSL
+    raises :class:`~OpenSSL.SSL.WantReadError` /
+    :class:`~OpenSSL.SSL.WantWriteError` instead of blocking. Re-run
+    *action* after ``select``-waiting for readiness, bounded by
+    ``deadline`` (raising :class:`TimeoutError` when it lapses) so a stalled
+    peer can never pin the worker thread past the caller's timeout.
+    """
+    while True:
+        try:
+            return action()
+        except SSL.WantReadError:
+            read_fds, write_fds = [sock], []
+        except SSL.WantWriteError:
+            read_fds, write_fds = [], [sock]
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("tls handshake timed out")
+        select.select(read_fds, write_fds, [], remaining)
+
+
+def _blocking_tls_inspect(
+    host: str, port: int, server_name: str, timeout: float
+) -> tuple[list[x509.Certificate], str, str]:
+    """Open an unverified TLS handshake and return (chain, protocol, cipher).
+
+    Runs off the event loop (the caller wraps it in
+    :func:`asyncio.to_thread`). The context disables verification
+    (``VERIFY_NONE``) so a self-signed / expired / mismatched cert
+    completes the handshake and is returned for inspection rather than
+    rejected. The full presented chain is pulled via
+    ``get_peer_cert_chain(as_cryptography=True)`` (pyOpenSSL 24.3+), which
+    returns :class:`cryptography.x509.Certificate` objects directly.
+    Connect and handshake share one ``deadline`` derived from *timeout*.
+    """
+    deadline = time.monotonic() + timeout
+    raw = socket.create_connection((host, port), timeout=timeout)
+    try:
+        context = SSL.Context(SSL.TLS_CLIENT_METHOD)
+        context.set_verify(SSL.VERIFY_NONE)
+        connection = SSL.Connection(context, raw)
+        connection.set_connect_state()
+        sni = _encode_sni(server_name)
+        if sni is not None:
+            connection.set_tlsext_host_name(sni)
+        _run_until_ready(raw, deadline, connection.do_handshake)
+        chain = connection.get_peer_cert_chain(as_cryptography=True) or []
+        protocol = connection.get_protocol_version_name()
+        cipher = connection.get_cipher_name() or ""
+        # A clean bidirectional close-notify is best-effort; the chain we
+        # already read is the product, so a shutdown hiccup is moot.
+        with contextlib.suppress(SSL.Error, OSError, TimeoutError):
+            _run_until_ready(raw, deadline, connection.shutdown)
+        return list(chain), protocol, cipher
+    finally:
+        raw.close()
+
+
+def _connect_failure_reason(exc: BaseException) -> str:
+    """Map a connect/handshake exception to a return-failures reason code.
+
+    Order is significant: :class:`socket.gaierror`, :class:`TimeoutError`
+    (which ``socket.timeout`` aliases and ``_run_until_ready``'s
+    deadline-lapse raises), and :class:`ConnectionRefusedError` are all
+    :class:`OSError` subclasses, so they are checked before the generic
+    ``OSError`` fallthrough. :class:`~OpenSSL.SSL.Error` (peer is not TLS,
+    protocol/alert, reset mid-handshake) is not an ``OSError``.
+    """
+    if isinstance(exc, socket.gaierror):
+        return "dns_failure"
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+    if isinstance(exc, ConnectionRefusedError):
+        return "refused"
+    if isinstance(exc, SSL.Error):
+        return "tls_error"
+    return "unreachable"
+
+
+async def net_tls_inspect(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Inspect the full presented TLS certificate chain of ``host:port``.
+
+    Op-id: ``net.tls_inspect``. Synthetic typed op (``target`` is always
+    ``None``); the dispatcher has validated the schema. Flow: screen
+    ``host`` against the probe allowlist → run an unverified pyOpenSSL
+    handshake off the event loop → flatten each presented cert via the
+    ``cryptography`` x509 API → compute ``hostname_match`` /
+    ``chain_complete`` locally (the stack did not verify). A refused,
+    timed-out, DNS-failed, or non-TLS endpoint returns ``handshake=false``
+    with ``status="ok"`` (the return-failures contract); a self-signed /
+    expired / mismatched cert is **inspected**, never failed. The return
+    dict carries the literal ``host``/``port``/``server_name`` for the
+    durable audit row.
+    """
+    host = str(params["host"])
+    port = int(params["port"])
+    raw_server_name = str(params.get("server_name") or "").strip()
+    server_name = raw_server_name or host
+    timeout = _clamp_timeout(params.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS))
+
+    try:
+        assert_probe_allowed(host)
+    except ProbeNotAllowedError:
+        _log.info("net.tls_inspect.refused", host=host, port=port, reason="not_in_probe_allowlist")
+        return _failure(host, port, server_name, "not_in_probe_allowlist")
+
+    try:
+        chain, protocol, cipher = await asyncio.to_thread(
+            _blocking_tls_inspect, host, port, server_name, timeout
+        )
+    except (OSError, SSL.Error) as exc:
+        # Every connect/handshake failure is the product, not an error:
+        # map it to a reason code and return status="ok". SSL.Error is not
+        # an OSError, so both bases are caught here.
+        return _failure(host, port, server_name, _connect_failure_reason(exc))
+
+    chain_dicts = [_cert_to_dict(cert) for cert in chain]
+    leaf = chain_dicts[0] if chain_dicts else None
+    hostname_match = bool(chain) and _leaf_hostname_match(chain[0], server_name)
+    chain_complete = bool(chain) and (chain[-1].subject == chain[-1].issuer)
+
+    return {
+        "handshake": True,
+        "reason": None,
+        "host": host,
+        "port": port,
+        "server_name": server_name,
+        "protocol": protocol,
+        "cipher": cipher,
+        "chain": chain_dicts,
+        "leaf": leaf,
+        "not_after": leaf["not_after"] if leaf else None,
+        "hostname_match": hostname_match,
+        "chain_complete": chain_complete,
+    }
+
+
+async def register_net_tls_inspect_operation(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the ``net.tls_inspect`` typed op into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list by the package
+    ``__init__`` (a sibling registrar to ``net.tcp_check``'s), run after
+    the connector eager-import pass. Registered under the same synthetic
+    natural key as the keystone
+    (``product="net", version="1.x", impl_id="net-probe"``), so both ops
+    share the ``net-probe-1.x`` wire ``connector_id``. Idempotent. ``safe``
+    + ``requires_approval=False`` — the probe allowlist is the only floor.
+    """
+    await register_typed_operation(
+        product="net",
+        version="1.x",
+        impl_id="net-probe",
+        op_id="net.tls_inspect",
+        handler=net_tls_inspect,
+        group_key="probe",
+        when_to_use=_NET_TLS_INSPECT_WHEN_TO_USE,
+        summary="Inspect the full presented TLS certificate chain of a host:port.",
+        description=(
+            "Opens a TLS handshake to a host:port with certificate "
+            "verification OFF and reports the full chain the server "
+            "presents (leaf → intermediates → root-if-sent), leaf-first: "
+            "per-cert subject / SAN / issuer / validity window / serial / "
+            "self-signed flag, plus chain completeness, the leaf hostname "
+            "match (computed independently of the disabled verification), "
+            "and the negotiated protocol and cipher — openssl 's_client "
+            "-showcerts' parity. A self-signed / expired / mismatched cert "
+            "is inspected and reported, never rejected. The destination "
+            "must be inside MEHO_NETDIAG_PROBE_ALLOWLIST or the probe is "
+            "refused before any socket opens. A refused, timed-out, or "
+            "non-TLS endpoint returns handshake=false with a reason code "
+            "and status=ok — a failed handshake is the product, never a "
+            "connector error."
+        ),
+        parameter_schema=NET_TLS_INSPECT_PARAMETER_SCHEMA,
+        response_schema=_NET_TLS_INSPECT_RESPONSE_SCHEMA,
+        tags=["net", "probe", "read", "diagnostics", "tls"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_NET_TLS_INSPECT_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )

--- a/backend/tests/test_connectors_net_tls_inspect.py
+++ b/backend/tests/test_connectors_net_tls_inspect.py
@@ -1,0 +1,620 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for ``net.tls_inspect`` — full presented chain (#2407, Initiative #2405).
+
+Covers T2 of the net.* family on the T1 keystone (#2406):
+
+* The **full presented chain** (leaf → intermediates → root-if-sent) is
+  returned leaf-first for a multi-cert endpoint, targetless, fresh boot.
+* ``hostname_match`` is computed independently of the (disabled) stack
+  verification — pinned true for a SAN match and false for a mismatch.
+* A self-signed / expired / mismatched cert is **inspected**
+  (``handshake=true``, ``status="ok"``), never rejected;
+  ``chain_complete`` reflects whether a self-signed root was presented.
+* ``host`` is probe-allowlist-gated (T1 foundation) and the audit row
+  records the literal host:port.
+* Failed handshakes (refused / timeout / DNS / non-TLS) return
+  ``handshake=false`` with ``status="ok"`` — the return-failures contract.
+
+The TLS server runs in a background thread serving a real cert chain
+built with ``cryptography``; the handler dials it over loopback (which
+the tests add to ``MEHO_NETDIAG_PROBE_ALLOWLIST``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime
+import socket
+import ssl
+import threading
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.net import tls as net_tls
+from meho_backplane.connectors.net.allowlist import PROBE_ALLOWLIST_ENV
+from meho_backplane.connectors.net.tls import (
+    net_tls_inspect,
+    register_net_tls_inspect_operation,
+)
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "net-probe-1.x"
+_OP_ID = "net.tls_inspect"
+_LEAF_CN = "appliance.local"
+
+
+# ---------------------------------------------------------------------------
+# Settings env + dispatcher isolation (mirrors the T1 test module)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.delenv(PROBE_ALLOWLIST_ENV, raising=False)
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+    yield
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_tls_inspect_op(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    await register_net_tls_inspect_operation(embedding_service=stub_embedding_service)
+    yield
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt="fake.jwt.value",
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_inspect(params: dict[str, Any]) -> OperationResult:
+    return await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=None,
+        params=params,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Certificate + TLS-server test doubles
+# ---------------------------------------------------------------------------
+
+_NOW = datetime.datetime.now(datetime.UTC)
+
+
+def _new_key() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _sign(
+    subject_cn: str,
+    subject_key: rsa.RSAPrivateKey,
+    issuer_name: x509.Name | None,
+    issuer_key: rsa.RSAPrivateKey,
+    *,
+    san_dns: list[str] | None = None,
+    is_ca: bool = False,
+    not_before: datetime.datetime | None = None,
+    not_after: datetime.datetime | None = None,
+) -> x509.Certificate:
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subject_cn)])
+    # ``issuer_name is None`` ⇒ a self-signed cert (issuer == subject), so
+    # ``subject == issuer`` holds and the handler flags it self_signed.
+    if issuer_name is None:
+        issuer_name = subject
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer_name)
+        .public_key(subject_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before or (_NOW - datetime.timedelta(days=1)))
+        .not_valid_after(not_after or (_NOW + datetime.timedelta(days=365)))
+    )
+    if is_ca:
+        builder = builder.add_extension(x509.BasicConstraints(ca=True, path_length=None), True)
+    if san_dns:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(name) for name in san_dns]), False
+        )
+    return builder.sign(issuer_key, hashes.SHA256())
+
+
+def _pem(cert: x509.Certificate) -> bytes:
+    return cert.public_bytes(serialization.Encoding.PEM)
+
+
+def _key_pem(key: rsa.RSAPrivateKey) -> bytes:
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
+    )
+
+
+class _TLSServer:
+    """A loopback TLS server that presents a fixed cert chain to each client.
+
+    Serves in a daemon thread: accept → TLS handshake → drain a few bytes
+    → close, looping until :meth:`stop`. ``chain_pem`` is the concatenated
+    leaf-first PEM bundle the server presents; the ordering is exactly what
+    ``get_peer_cert_chain`` reads back.
+    """
+
+    def __init__(self, tmp_path: Path, chain_pem: bytes, key_pem: bytes) -> None:
+        cert_file = tmp_path / "chain.pem"
+        key_file = tmp_path / "key.pem"
+        cert_file.write_bytes(chain_pem)
+        key_file.write_bytes(key_pem)
+        self._ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        self._ctx.load_cert_chain(str(cert_file), str(key_file))
+        self._sock = socket.socket()
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(5)
+        self._sock.settimeout(0.5)
+        self.port: int = self._sock.getsockname()[1]
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        while not self._stop.is_set():
+            try:
+                client, _ = self._sock.accept()
+            except (TimeoutError, OSError):
+                continue
+            try:
+                tls = self._ctx.wrap_socket(client, server_side=True)
+                tls.recv(64)
+                tls.close()
+            except (ssl.SSLError, OSError):
+                with contextlib.suppress(OSError):
+                    client.close()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=2)
+        self._sock.close()
+
+
+@pytest.fixture
+def multi_cert_server(tmp_path: Path) -> Iterator[_TLSServer]:
+    """A server presenting a full 3-cert chain: leaf → intermediate → root."""
+    root_key = _new_key()
+    root = _sign("Test Root CA", root_key, None, root_key, is_ca=True)
+    root_name = root.subject
+    int_key = _new_key()
+    intermediate = _sign("Test Intermediate CA", int_key, root_name, root_key, is_ca=True)
+    leaf_key = _new_key()
+    leaf = _sign(
+        _LEAF_CN, leaf_key, intermediate.subject, int_key, san_dns=[_LEAF_CN, "*.wild.local"]
+    )
+    bundle = _pem(leaf) + _pem(intermediate) + _pem(root)
+    server = _TLSServer(tmp_path, bundle, _key_pem(leaf_key))
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+def _self_signed_server(
+    tmp_path: Path,
+    *,
+    san_dns: list[str] | None = None,
+    not_before: datetime.datetime | None = None,
+    not_after: datetime.datetime | None = None,
+) -> _TLSServer:
+    key = _new_key()
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, _LEAF_CN)])
+    cert = _sign(
+        _LEAF_CN,
+        key,
+        name,
+        key,
+        not_before=not_before,
+        san_dns=san_dns if san_dns is not None else [_LEAF_CN],
+        not_after=not_after,
+    )
+    return _TLSServer(tmp_path, _pem(cert), _key_pem(key))
+
+
+# ---------------------------------------------------------------------------
+# Full chain, leaf-first, targetless, fresh boot
+# ---------------------------------------------------------------------------
+
+
+async def test_returns_full_chain_leaf_first(
+    monkeypatch: pytest.MonkeyPatch,
+    multi_cert_server: _TLSServer,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """A multi-cert endpoint yields leaf → intermediate → root, leaf-first."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    result = await _dispatch_inspect(
+        {"host": "127.0.0.1", "port": multi_cert_server.port, "server_name": _LEAF_CN}
+    )
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["handshake"] is True
+    assert body["reason"] is None
+    chain = body["chain"]
+    assert len(chain) == 3
+    # Leaf-first ordering.
+    assert chain[0]["subject"] == "CN=appliance.local"
+    assert chain[1]["subject"] == "CN=Test Intermediate CA"
+    assert chain[2]["subject"] == "CN=Test Root CA"
+    # leaf is the convenience alias for chain[0].
+    assert body["leaf"] == chain[0]
+    assert body["not_after"] == chain[0]["not_after"]
+    # The root the server sent is self-signed → chain terminates complete.
+    assert chain[2]["self_signed"] is True
+    assert chain[0]["self_signed"] is False
+    assert body["chain_complete"] is True
+    assert body["protocol"].startswith("TLS")
+    assert body["cipher"]
+
+
+# ---------------------------------------------------------------------------
+# hostname_match — both ways, independent of disabled verification
+# ---------------------------------------------------------------------------
+
+
+async def test_hostname_match_true_for_san_match(
+    monkeypatch: pytest.MonkeyPatch,
+    multi_cert_server: _TLSServer,
+    _registered_tls_inspect_op: None,
+) -> None:
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    result = await _dispatch_inspect(
+        {"host": "127.0.0.1", "port": multi_cert_server.port, "server_name": _LEAF_CN}
+    )
+    assert result.status == "ok", result.error
+    assert result.result["hostname_match"] is True
+
+
+async def test_hostname_match_false_for_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    multi_cert_server: _TLSServer,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """A non-matching server_name → hostname_match False, cert still inspected."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    result = await _dispatch_inspect(
+        {"host": "127.0.0.1", "port": multi_cert_server.port, "server_name": "wrong.example.com"}
+    )
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["handshake"] is True  # verification is off — still inspected
+    assert body["hostname_match"] is False
+    assert len(body["chain"]) == 3
+
+
+async def test_hostname_match_true_for_wildcard_san(
+    monkeypatch: pytest.MonkeyPatch,
+    multi_cert_server: _TLSServer,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """A ``*.wild.local`` SAN matches one leftmost label."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    result = await _dispatch_inspect(
+        {"host": "127.0.0.1", "port": multi_cert_server.port, "server_name": "node1.wild.local"}
+    )
+    assert result.status == "ok", result.error
+    assert result.result["hostname_match"] is True
+
+
+# ---------------------------------------------------------------------------
+# Self-signed / expired inspected, never rejected; chain_complete signal
+# ---------------------------------------------------------------------------
+
+
+async def test_self_signed_cert_is_inspected_not_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """A self-signed leaf handshakes, reports self_signed + chain_complete."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    server = _self_signed_server(tmp_path)
+    try:
+        result = await _dispatch_inspect(
+            {"host": "127.0.0.1", "port": server.port, "server_name": _LEAF_CN}
+        )
+    finally:
+        server.stop()
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["handshake"] is True
+    assert body["reason"] is None
+    assert len(body["chain"]) == 1
+    assert body["chain"][0]["self_signed"] is True
+    assert body["chain_complete"] is True
+    assert body["hostname_match"] is True
+
+
+async def test_expired_cert_is_inspected_not_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """An expired cert completes the handshake and reports a past not_after."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    past = _NOW - datetime.timedelta(days=10)
+    server = _self_signed_server(
+        tmp_path, not_before=_NOW - datetime.timedelta(days=400), not_after=past
+    )
+    try:
+        result = await _dispatch_inspect(
+            {"host": "127.0.0.1", "port": server.port, "server_name": _LEAF_CN}
+        )
+    finally:
+        server.stop()
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["handshake"] is True
+    leaf_not_after = datetime.datetime.fromisoformat(body["not_after"])
+    assert leaf_not_after < _NOW
+
+
+async def test_chain_complete_false_when_root_not_sent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """A leaf + intermediate (no root) presents an incomplete chain."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    root_key = _new_key()
+    root = _sign("Test Root CA", root_key, None, root_key, is_ca=True)
+    int_key = _new_key()
+    intermediate = _sign("Test Intermediate CA", int_key, root.subject, root_key, is_ca=True)
+    leaf_key = _new_key()
+    leaf = _sign(_LEAF_CN, leaf_key, intermediate.subject, int_key, san_dns=[_LEAF_CN])
+    bundle = _pem(leaf) + _pem(intermediate)  # root deliberately omitted
+    server = _TLSServer(tmp_path, bundle, _key_pem(leaf_key))
+    try:
+        result = await _dispatch_inspect(
+            {"host": "127.0.0.1", "port": server.port, "server_name": _LEAF_CN}
+        )
+    finally:
+        server.stop()
+    assert result.status == "ok", result.error
+    body = result.result
+    assert len(body["chain"]) == 2
+    assert body["chain"][-1]["self_signed"] is False
+    assert body["chain_complete"] is False
+
+
+# ---------------------------------------------------------------------------
+# Probe allowlist (T1 foundation) + audit row records host:port
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_allowlist_refuses_before_any_socket_opens(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """Empty allowlist ⇒ structured refusal, no socket opened."""
+
+    def _boom(*_a: object, **_kw: object) -> object:
+        raise AssertionError("create_connection must not run when the probe is refused")
+
+    monkeypatch.setattr(net_tls.socket, "create_connection", _boom)
+    result = await _dispatch_inspect({"host": "10.1.2.3", "port": 8443})
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["handshake"] is False
+    assert body["reason"] == "not_in_probe_allowlist"
+    assert body["host"] == "10.1.2.3"
+    assert body["port"] == 8443
+    assert body["chain"] == []
+    assert body["leaf"] is None
+
+
+async def test_audit_row_records_literal_host_and_port(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_tls_inspect_op: None,
+) -> None:
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    server = _self_signed_server(tmp_path)
+    try:
+        result = await _dispatch_inspect(
+            {"host": "127.0.0.1", "port": server.port, "server_name": _LEAF_CN}
+        )
+    finally:
+        server.stop()
+    assert result.status == "ok", result.error
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = list(
+            (await session.execute(select(AuditLog).where(AuditLog.path == _OP_ID))).scalars().all()
+        )
+    assert len(rows) == 1
+    raw = rows[0].raw_payload
+    assert raw is not None
+    assert raw["host"] == "127.0.0.1"
+    assert raw["port"] == server.port
+    assert raw["server_name"] == _LEAF_CN
+
+
+# ---------------------------------------------------------------------------
+# Return-failures contract — failed handshake is status=ok, never connector_*
+# ---------------------------------------------------------------------------
+
+
+async def test_refused_connect_is_ok_status_not_connector_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """A closed port returns handshake=false / reason=refused, status=ok."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    probe = socket.socket()
+    probe.bind(("127.0.0.1", 0))
+    port = probe.getsockname()[1]
+    probe.close()  # port is now (almost certainly) closed
+
+    result = await _dispatch_inspect({"host": "127.0.0.1", "port": port})
+    assert result.status == "ok", result.error
+    assert result.extras.get("exception_class") is None
+    assert result.result["handshake"] is False
+    assert result.result["reason"] == "refused"
+    assert result.result["chain"] == []
+
+
+async def test_non_tls_endpoint_maps_to_tls_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """A plaintext endpoint (no TLS) is a normal failure, not an error."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    plain = socket.socket()
+    plain.bind(("127.0.0.1", 0))
+    plain.listen(1)
+    port = plain.getsockname()[1]
+    stop = threading.Event()
+
+    def _serve() -> None:
+        while not stop.is_set():
+            plain.settimeout(0.5)
+            try:
+                client, _ = plain.accept()
+            except (TimeoutError, OSError):
+                continue
+            # Speak plaintext at the TLS client, then close.
+            with contextlib.suppress(OSError):
+                client.sendall(b"HTTP/1.0 400 Bad Request\r\n\r\n")
+                client.close()
+
+    thread = threading.Thread(target=_serve, daemon=True)
+    thread.start()
+    try:
+        result = await _dispatch_inspect({"host": "127.0.0.1", "port": port, "timeout_seconds": 5})
+    finally:
+        stop.set()
+        thread.join(timeout=2)
+        plain.close()
+    assert result.status == "ok", result.error
+    assert result.result["handshake"] is False
+    assert result.result["reason"] == "tls_error"
+
+
+@pytest.mark.parametrize(
+    "exc,expected_reason",
+    [
+        (socket.gaierror("name resolution failed"), "dns_failure"),
+        (TimeoutError(), "timeout"),
+        (ConnectionRefusedError(), "refused"),
+        (OSError("network is unreachable"), "unreachable"),
+    ],
+    ids=["gaierror", "timeout", "refused", "other-oserror"],
+)
+async def test_handler_maps_connect_exceptions_to_reason_codes(
+    monkeypatch: pytest.MonkeyPatch,
+    exc: BaseException,
+    expected_reason: str,
+) -> None:
+    """Every connect/handshake exception maps to a reason code, never re-raises."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "203.0.113.5")
+
+    def _raise(*_a: object, **_kw: object) -> object:
+        raise exc
+
+    monkeypatch.setattr(net_tls.socket, "create_connection", _raise)
+    result = await net_tls_inspect(_make_operator(), None, {"host": "203.0.113.5", "port": 8443})
+    assert result["handshake"] is False
+    assert result["reason"] == expected_reason
+    assert result["host"] == "203.0.113.5"
+    assert result["port"] == 8443
+    assert result["server_name"] == "203.0.113.5"
+
+
+# ---------------------------------------------------------------------------
+# Registration + classification
+# ---------------------------------------------------------------------------
+
+
+async def test_tls_inspect_registered_as_safe_ungated_typed_op(
+    _registered_tls_inspect_op: None,
+) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == "net",
+                    EndpointDescriptor.version == "1.x",
+                    EndpointDescriptor.impl_id == "net-probe",
+                    EndpointDescriptor.op_id == _OP_ID,
+                )
+            )
+        ).scalar_one()
+    assert row.source_kind == "typed"
+    assert row.safety_level == "safe"
+    assert row.requires_approval is False
+
+
+def test_tls_inspect_classifies_as_read() -> None:
+    from meho_backplane.broadcast.events import classify_op
+
+    assert classify_op("net.tls_inspect") == "read"
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper unit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_encode_sni_omits_ip_literals() -> None:
+    assert net_tls._encode_sni("10.0.0.5") is None
+    assert net_tls._encode_sni("[2001:db8::1]") is None
+    assert net_tls._encode_sni("appliance.local") == b"appliance.local"
+    assert net_tls._encode_sni("host_underscore.internal") == b"host_underscore.internal"
+
+
+def test_dns_name_wildcard_matching() -> None:
+    assert net_tls._dns_name_matches(["*.example.com"], "a.example.com") is True
+    assert net_tls._dns_name_matches(["*.example.com"], "example.com") is False
+    assert net_tls._dns_name_matches(["*.example.com"], "a.b.example.com") is False
+    assert net_tls._dns_name_matches(["Host.Example.com"], "host.example.com.") is True

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1801,6 +1801,7 @@ dependencies = [
     { name = "asyncssh" },
     { name = "authlib" },
     { name = "croniter" },
+    { name = "cryptography" },
     { name = "defusedxml" },
     { name = "duckdb" },
     { name = "fastapi" },
@@ -1826,6 +1827,7 @@ dependencies = [
     { name = "pygments" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pymongo" },
+    { name = "pyopenssl" },
     { name = "python-frontmatter" },
     { name = "python-multipart" },
     { name = "redis" },
@@ -1840,7 +1842,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "aiosqlite" },
-    { name = "cryptography" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1859,6 +1860,7 @@ requires-dist = [
     { name = "asyncssh", specifier = ">=2.24.0,<3.0" },
     { name = "authlib", specifier = ">=1.3" },
     { name = "croniter", specifier = ">=6.2.3" },
+    { name = "cryptography", specifier = ">=49.0.0" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.5.4" },
     { name = "fastapi", specifier = ">=0.139.0,<0.140" },
@@ -1884,6 +1886,7 @@ requires-dist = [
     { name = "pygments", specifier = ">=2.18" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.13.0,<3" },
     { name = "pymongo", specifier = ">=4.13,<5" },
+    { name = "pyopenssl", specifier = ">=25.0.0" },
     { name = "python-frontmatter", specifier = ">=1.3.0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
     { name = "redis", specifier = ">=8.0.1,<9" },
@@ -1898,7 +1901,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "aiosqlite", specifier = ">=0.19" },
-    { name = "cryptography", specifier = ">=49.0.0" },
     { name = "mypy", specifier = ">=2.1.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
@@ -3047,6 +3049,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/d8/b75f6f4ab6c8beb50b0270a4f1e2530b5774f5e116563440e1677ca1820f/pymongo-4.17.0-cp314-cp314t-win32.whl", hash = "sha256:b93b22eedc62598cf5ee9d8c8007a8e9121c50fd88137012d8985500e9dc3151", size = 1056356, upload-time = "2026-04-20T16:39:22.996Z" },
     { url = "https://files.pythonhosted.org/packages/e4/5e/648c8a238eef18a25ed8a169ea6542d4a860bbec3e95b3d9badac2935c71/pymongo-4.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:3689ea34f6b647c7d1e7bdc60fcfb214b2789ed1359a7fb96569c69f50e5f18f", size = 1090964, upload-time = "2026-04-20T16:39:24.989Z" },
     { url = "https://files.pythonhosted.org/packages/dc/cb/d9780b66939c4fc1f024bcc7be23a2abcfe06a9745ca8fa76dc73395482e/pymongo-4.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9543d8f84c2e5608565c08ac679774811e6730770d8a645439b073422a4276fb", size = 1058526, upload-time = "2026-04-20T16:39:27.924Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b7/da07bae88f5a9506b4def6f2f4903cf4c3b8831e560dba8fa18ca08f758f/pyopenssl-26.3.0.tar.gz", hash = "sha256:589de7fae1c9ea670d18422ed00fc04da787bbde8e1454aea872aa57b49ad341", size = 182024, upload-time = "2026-06-12T20:28:07.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl", hash = "sha256:46367f8f66b92271e6d218da9c87607e1ef5a0bc5c8dea5bb3db82f395c385a3", size = 56008, upload-time = "2026-06-12T20:28:05.999Z" },
 ]
 
 [[package]]

--- a/docs/codebase/connectors-net-diagnostics.md
+++ b/docs/codebase/connectors-net-diagnostics.md
@@ -15,7 +15,15 @@ module-level functions the dispatcher routes to with
 
 This page describes the keystone (#2406, Initiative #2405 T1):
 `net.tcp_check` plus the three foundations every sibling op (T2–T4:
-`tls_inspect` / `http_probe` / `dns_lookup`) reuses.
+`tls_inspect` / `http_probe` / `dns_lookup`) reuses, and the first
+sibling `net.tls_inspect` (#2407, T2 — see below).
+
+Every op ships its own module + registrar function and queues it in
+`__init__.py` (`net.tcp_check` → `ops.register_net_typed_operations`,
+`net.tls_inspect` → `tls.register_net_tls_inspect_operation`). Siblings
+therefore extend the package by adding a module and one registrar-queue
+line rather than contending for a single registrar function — which also
+keeps parallel task branches from colliding on one shared file.
 
 ## Core mechanism
 
@@ -98,6 +106,63 @@ and `ConnectionRefusedError` are all `OSError` subclasses — so the
 handler's `except` arms are ordered specific-before-general
 (timeout → DNS → refused → generic `OSError`).
 
+## `net.tls_inspect` — full presented certificate chain (T2, #2407)
+
+`net.tls_inspect(host, port, server_name?, timeout_seconds?)` opens a TLS
+handshake with **certificate verification off** and reports the **full
+chain the server presented** — `openssl s_client -showcerts` parity. It
+inspects; it never verifies (self-signed appliances are the point), so a
+self-signed / expired / hostname-mismatched cert is **reported**, never
+rejected.
+
+Why pyOpenSSL and not stdlib `ssl`: on the `requires-python` floor (3.12)
+`ssl.SSLSocket.getpeercert` returns only the **leaf**; the full-chain
+`ssl.SSLSocket.get_unverified_chain` is 3.13+. pyOpenSSL's
+`Connection.get_peer_cert_chain(as_cryptography=True)` (the
+`as_cryptography` kwarg landed in pyOpenSSL 24.3) returns the whole
+presented chain as `cryptography.x509.Certificate` objects directly, so
+the parse reuses the `cryptography` x509 API.
+
+Control flow (`connectors/net/tls.py`):
+
+1. `assert_probe_allowed(host)` — the T1 allowlist floor, before any
+   socket opens.
+2. `asyncio.to_thread(_blocking_tls_inspect, ...)` — the blocking
+   socket + handshake runs off the event loop. The context is
+   `SSL.Context(TLS_CLIENT_METHOD)` with `set_verify(VERIFY_NONE)`; SNI
+   is set from `server_name` (default `host`) **only for hostnames**
+   (RFC 6066 forbids an IP-literal SNI).
+3. Because a socket with a timeout is non-blocking under the hood,
+   pyOpenSSL raises `WantReadError` / `WantWriteError`; `_run_until_ready`
+   drives `do_handshake` (and the best-effort `shutdown`) to completion
+   by `select`-waiting under a single `deadline` derived from the
+   clamped timeout, so a stalled peer cannot pin the worker thread.
+4. Each presented cert is flattened to
+   `{subject, issuer, san, not_before, not_after, serial, self_signed}`
+   (leaf-first). `serial` is stringified (a serial is a large integer a
+   JSON number consumer would truncate); timestamps use the tz-aware
+   `not_valid_*_utc` accessors.
+
+Derived top-level fields:
+
+- `leaf` — convenience alias for `chain[0]`; `not_after` — the leaf's,
+  for the common "is it expiring" read.
+- `hostname_match` — computed **independently** of the (disabled) stack
+  verification: `server_name` vs the leaf SAN dNSNames (wildcard-aware,
+  RFC 6125 single-leftmost-label), SAN iPAddresses for an IP
+  `server_name`, falling back to the subject CN only when the cert
+  carries no SAN dNSName (legacy appliances).
+- `chain_complete` — whether the **last** presented cert is self-signed
+  (i.e. the server sent a root), not a trust decision.
+
+It shares the same synthetic natural key as `net.tcp_check`
+(`net-probe-1.x`), reuses the return-failures contract (a refused /
+timed-out / DNS-failed / non-TLS endpoint returns `handshake=false` with
+a reason code — `not_in_probe_allowlist` / `timeout` / `refused` /
+`dns_failure` / `unreachable` / `tls_error` — and `status="ok"`), and is
+`safety_level="safe"` + `requires_approval=False`. A completed handshake
+sends **no** application bytes.
+
 ## Broadcast classification
 
 `net.*` ops classify as `read` in the broadcast sensitivity taxonomy
@@ -113,11 +178,17 @@ connectors' ops.
 
 ## Key types / control flow
 
-- `connectors/net/__init__.py` — queues `register_net_typed_operations`
+- `connectors/net/__init__.py` — queues both op registrars
+  (`register_net_typed_operations`, `register_net_tls_inspect_operation`)
   onto the lifespan registrar list via `register_typed_op_registrar`
   (auto-imported by the `_eager_import_connectors` package walk).
 - `connectors/net/ops.py` — `net_tcp_check` handler, its parameter /
-  response schema, and the registrar.
+  response schema, the registrar, and the shared timeout bounds/clamp
+  (`_DEFAULT_TIMEOUT_SECONDS` / `_MAX_TIMEOUT_SECONDS` / `_clamp_timeout`)
+  reused by `tls.py` (package-internal import; `ops` never imports `tls`,
+  so no cycle).
+- `connectors/net/tls.py` — `net_tls_inspect` handler, its schemas, the
+  cert-flattening / hostname-match / chain helpers, and its registrar.
 - `connectors/net/allowlist.py` — `PROBE_ALLOWLIST_ENV`,
   `parse_probe_allowlist`, `assert_probe_allowed`,
   `ProbeNotAllowedError`.
@@ -129,11 +200,21 @@ audit (`raw_payload` = handler return) → broadcast (`read` class).
 
 ## Dependencies
 
-Standard library only (`asyncio`, `socket`, `ipaddress`, `time`) — no
-new runtime dependency.
+- `net.tcp_check`: standard library only (`asyncio`, `socket`,
+  `ipaddress`, `time`).
+- `net.tls_inspect`: `pyOpenSSL` (full presented chain via
+  `get_peer_cert_chain`) + `cryptography` (x509 parsing) — both Apache-2.0
+  (Python License Check clean). `pyOpenSSL` was promoted to a runtime
+  dependency and `cryptography` from a dev-only + transitive install to a
+  declared runtime dependency (the handler imports `cryptography.x509`
+  directly).
 
 ## Known issues / deferred
 
+- `net.tls_inspect` **inspects, never verifies** — trust-store
+  verification, OCSP/CRL/revocation, and client-cert / mTLS presentation
+  are explicitly out of scope (#2407). `chain_complete` is a
+  "did the server send a self-signed root" signal, not a trust decision.
 - No port-scoped allowlist (v1 scopes hosts only).
 - Hostname allowlisting is verbatim; an operator who allowlists a CIDR
   cannot probe a hostname that merely resolves into it (list the name).
@@ -144,7 +225,8 @@ new runtime dependency.
 
 ## References
 
-- Parent: Initiative #2405, Task #2406. Mold: secret broker
+- Parent: Initiative #2405, Tasks #2406 (T1 keystone) + #2407 (T2
+  `tls_inspect`). Mold: secret broker
   (`docs/codebase/connectors-secret-broker.md`). SSRF sibling:
   `docs/codebase/target-ssrf-guard.md`. Broadcast taxonomy:
   `docs/codebase/broadcast.md`.


### PR DESCRIPTION
## Summary

- Adds `net.tls_inspect` (T2, #2407) on the T1 `net.*` keystone (#2406): a **targetless** probe that opens a TLS handshake with certificate verification **off** and reports the **full chain the server presents** (leaf → intermediates → root-if-sent, leaf-first) — `openssl s_client -showcerts` parity. Per cert: subject / SAN / issuer / validity window / serial / self-signed flag; top-level: `chain_complete`, a leaf `hostname_match` computed independently of the disabled stack verification, and the negotiated `protocol` / `cipher` / leaf `not_after`.
- **Inspect, never verify:** a self-signed / expired / hostname-mismatched cert is inspected and reported (`handshake=true`, `status="ok"`), never rejected — self-signed appliances are the point. A refused / timed-out / DNS-failed / non-TLS endpoint returns `{handshake: false, reason}` with `status="ok"` (the T1 return-failures contract). The probe allowlist and audit-visible `host:port` are reused verbatim.
- **Why pyOpenSSL:** stdlib `ssl` on the `requires-python` 3.12 floor exposes only the leaf (`getpeercert`); the full-chain `get_unverified_chain` is 3.13+. `Connection.get_peer_cert_chain(as_cryptography=True)` (pyOpenSSL 24.3+) returns the whole presented chain as `cryptography.x509.Certificate` objects — the modern, non-deprecated equivalent of the issue's `.to_cryptography()` note. The blocking handshake runs in `asyncio.to_thread`; a `select`-driven want-retry loop bounds connect+handshake by one deadline.
- **Packaging:** `pyOpenSSL` added as a runtime dep; `cryptography` promoted from dev-only/transitive to a declared runtime dep (the handler imports `cryptography.x509` directly). Both Apache-2.0 — covered by the existing `Python License Check` allow-list (`Apache Software License`; `Apache-2.0 OR BSD-3-Clause`).
- **Module layout:** each `net.*` op ships its own module + registrar queued in `__init__.py`, so parallel siblings extend the package without contending for a single registrar function.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — clean (4 source files)
- [x] `pytest tests/test_connectors_net_tls_inspect.py` — 19 passed
- [x] `pytest tests/test_connectors_net_probe.py` (T1 regression) — 17 passed
- [x] broadcast classifier coverage — 11 passed (`net.tls_inspect` → `read` via the `net.` prefix arm)
- [x] `code-quality.py --diff` — 0 blockers (1 advisory: `tls.py` 587 lines, < 600 block)
- [x] import-time smoke — `import meho_backplane.connectors.net` OK

Acceptance criteria, each proven by a test:
- [x] **Full chain, leaf-first, targetless, fresh boot** — `test_returns_full_chain_leaf_first` (3-cert leaf→intermediate→root endpoint)
- [x] **`hostname_match` true for SAN match, false otherwise, computed independently** — `test_hostname_match_true_for_san_match` / `_false_for_mismatch` / `_true_for_wildcard_san`
- [x] **Self-signed / expired / mismatched inspected, not rejected; `chain_complete` reflects a self-signed root** — `test_self_signed_cert_is_inspected_not_rejected` / `test_expired_cert_is_inspected_not_rejected` / `test_chain_complete_false_when_root_not_sent`
- [x] **`host` probe-allowlist-gated; audit records host:port** — `test_empty_allowlist_refuses_before_any_socket_opens` / `test_audit_row_records_literal_host_and_port`
- [x] **`pyOpenSSL` added to pyproject + lock; import smoke + license scan green** — deps added, `uv.lock` updated, smoke passes, licenses in the allow-list

## Out of scope

- Trust-store **verification**, OCSP/CRL/revocation, client-cert / mTLS presentation (this op inspects, never verifies — per #2407).
- Sibling `net.*` ops (T3/T4: `http_probe` / `dns_lookup`) — separate tasks.

## Adjacent finding (deferred)

- `connectors/net/tls.py` is 587 lines (advisory warn > 400; block > 600). Cohesive (one op + schemas + helpers); a split is only warranted if it grows further.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2407
