### PR TITLE
feat(connectors): net.ntp_check — clock offset/skew + stratum from the backplane (stdlib SNTP, #2410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — net.ntp_check clock offset/skew + stratum diagnostics op (#2410)
+
+- Add `net.ntp_check` on the T1 `net.*` mold — a targetless NTP
+  diagnostic (`ntpdate -q` / `sntp` parity) that sends one mode-3 (client)
+  NTPv4 packet over an **unprivileged** UDP socket and reports the queried
+  server's clock offset and skew **against the backplane's own clock** per
+  RFC 5905, plus `stratum`, `ref_id`, `root_delay_ms` /
+  `root_dispersion_ms`, and the `leap` indicator — clock skew is a common
+  root cause of TLS-cert-validity and Kerberos/auth failures. Read-only
+  (never sets a clock) and **no new dependency**: the 48-byte SNTP
+  request/reply is built and parsed with the stdlib `struct`, sent off the
+  event loop via `asyncio` datagram endpoints. The `host` is gated through
+  the same `MEHO_NETDIAG_PROBE_ALLOWLIST` guard; a timeout, a refused /
+  unreachable peer, a malformed or off-path (origin-mismatch) reply, or a
+  kiss-o'-death (stratum-0, with the `kiss_code`) packet return
+  `{reachable: false, reason}` with `status="ok"` (never a `connector_*`
+  error). Parent Initiative #2405.
+
 ### Added — net.dns_lookup full dig-parity DNS diagnostics op (#2409)
 
 - Add `net.dns_lookup` on the T1 `net.*` mold — a targetless DNS

--- a/backend/src/meho_backplane/connectors/net/__init__.py
+++ b/backend/src/meho_backplane/connectors/net/__init__.py
@@ -32,6 +32,7 @@ single registrar function. See :mod:`meho_backplane.connectors.net.ops`,
 """
 
 from meho_backplane.connectors.net.http_probe import register_net_http_probe_operations
+from meho_backplane.connectors.net.ntp import register_net_ntp_check_operation
 from meho_backplane.connectors.net.ops import register_net_typed_operations
 from meho_backplane.connectors.net.tls import register_net_tls_inspect_operation
 from meho_backplane.operations.typed_register import register_typed_op_registrar
@@ -40,13 +41,15 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 # list (run after the connector eager-import pass). Each sibling op has
 # its own registrar so the family extends without editing a shared
 # function body (net.tcp_check #2406, net.tls_inspect #2407,
-# net.http_probe #2408, …).
+# net.http_probe #2408, net.dns_lookup #2409, net.ntp_check #2410, …).
 register_typed_op_registrar(register_net_typed_operations)
 register_typed_op_registrar(register_net_tls_inspect_operation)
 register_typed_op_registrar(register_net_http_probe_operations)
+register_typed_op_registrar(register_net_ntp_check_operation)
 
 __all__ = [
     "register_net_http_probe_operations",
+    "register_net_ntp_check_operation",
     "register_net_tls_inspect_operation",
     "register_net_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/net/ntp.py
+++ b/backend/src/meho_backplane/connectors/net/ntp.py
@@ -1,0 +1,579 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Network-diagnostics typed op ``net.ntp_check`` + its registrar.
+
+The fifth ``net.*`` op (#2410, Initiative #2405 T5) on the T1 keystone
+(#2406). It performs an ``ntpdate -q`` / ``sntp``-parity read: send one
+mode-3 (client) NTPv4 packet to ``host:port`` over an **unprivileged**
+client UDP socket, read the server's reply, and report reachability plus
+the **clock offset and skew of that server against the backplane's own
+clock** (RFC 5905 §8), the stratum, reference id, root delay/dispersion,
+and the leap indicator.
+
+Clock skew is a load-bearing cause of TLS-certificate-validity and
+Kerberos/auth failures, so "is this appliance's clock sane from here" is
+a real pre-flight / post-mortem read. This op answers it read-only: it
+never sets a clock.
+
+Why the standard library and no dependency: a mode-3 SNTP request is a
+fixed 48-byte packet (RFC 5905 §7.3) — a first byte of ``0x23`` (leap 0,
+version 4, mode 3 client) and a transmit timestamp — and the reply is
+the same 48-byte header. ``struct`` builds and parses it; ``asyncio``'s
+``loop.create_datagram_endpoint`` sends and receives it off the event
+loop. No raw socket and no added pod capability: a client UDP socket
+needs none.
+
+This op inherits the three T1 foundations verbatim:
+
+* **Probe allowlist** — :func:`~meho_backplane.connectors.net.allowlist.assert_probe_allowed`
+  screens the dialed ``host`` *before* any socket opens
+  (``MEHO_NETDIAG_PROBE_ALLOWLIST`` empty ⇒ every probe refused).
+* **Audit-visible host:port** — the return dict carries the literal
+  ``host``/``port`` (a host:port is not a secret), so the durable audit
+  row's ``raw_payload`` answers "who probed what".
+* **Return-failures contract** — a refused, timed-out, DNS-failed, or
+  kiss-o'-death (KoD) query is the **product**, not an error: the handler
+  returns ``{"reachable": false, "reason": <code>, ...}`` with dispatch
+  ``status="ok"``. It never raises a ``connector_*`` error for a query
+  that did not answer.
+
+``safety_level="safe"`` + ``requires_approval=False``: a read-only
+single-shot query that sends one packet and mutates nothing, so the probe
+allowlist is the sole floor (same posture as ``net.tcp_check``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import struct
+import time
+from typing import TYPE_CHECKING, Any, Final, NamedTuple
+
+import structlog
+
+from meho_backplane.connectors.net.allowlist import (
+    ProbeNotAllowedError,
+    assert_probe_allowed,
+)
+
+# Reuse the shared probe timeout bounds/clamp from the keystone module.
+# ``ops`` never imports ``ntp`` (the __init__ queues each registrar
+# independently), so this package-internal import forms no cycle.
+from meho_backplane.connectors.net.ops import (
+    _DEFAULT_TIMEOUT_SECONDS,
+    _MAX_TIMEOUT_SECONDS,
+    _clamp_timeout,
+)
+from meho_backplane.operations.typed_register import register_typed_operation
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "NET_NTP_CHECK_PARAMETER_SCHEMA",
+    "net_ntp_check",
+    "register_net_ntp_check_operation",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The well-known NTP service port; the caller rarely overrides it.
+_DEFAULT_NTP_PORT: Final[int] = 123
+
+#: Seconds between the NTP epoch (1900-01-01) and the Unix epoch
+#: (1970-01-01) — RFC 5905 §6. Added to a Unix time to get NTP seconds.
+_NTP_EPOCH_OFFSET: Final[int] = 2_208_988_800
+
+#: 2**32, the divisor that turns an NTP timestamp fraction into a
+#: sub-second float, and 2**16 for the 16.16 fixed-point "short" format
+#: used by root delay / root dispersion (RFC 5905 §6).
+_FRAC_32: Final[int] = 1 << 32
+_FRAC_16: Final[int] = 1 << 16
+
+#: First octet of a client request: leap indicator 0, version 4, mode 3
+#: (client) → ``0b00_100_011`` = ``0x23`` (RFC 5905 §7.3).
+_CLIENT_FIRST_OCTET: Final[int] = 0x23
+
+#: The 48-byte NTP packet header (RFC 5905 §7.3): leap/version/mode,
+#: stratum, poll (signed), precision (signed), then eleven 32-bit words —
+#: root delay, root dispersion, reference id, and the four 64-bit
+#: timestamps (reference / origin / receive / transmit) as sec+frac pairs.
+_NTP_PACKET: Final[struct.Struct] = struct.Struct("!B B b b 11I")
+
+NET_NTP_CHECK_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Hostname or IP literal of the NTP server to query. Must "
+                "be covered by MEHO_NETDIAG_PROBE_ALLOWLIST or the probe "
+                "is refused before any socket opens."
+            ),
+        },
+        "port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "UDP port the NTP service listens on (default 123).",
+        },
+        "timeout_seconds": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "maximum": _MAX_TIMEOUT_SECONDS,
+            "description": (
+                "Query timeout in seconds (default 5, max 30). A query "
+                "that does not answer in time returns reachable=false with "
+                "reason='timeout'."
+            ),
+        },
+    },
+    "required": ["host"],
+    "additionalProperties": False,
+}
+
+_NET_NTP_CHECK_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "reachable": {
+            "type": "boolean",
+            "description": "True iff the server returned a usable time reply.",
+        },
+        "reason": {
+            "type": ["string", "null"],
+            "description": (
+                "Null on success; otherwise a failure code: "
+                "not_in_probe_allowlist, timeout, refused, dns_failure, "
+                "unreachable, kod, invalid_response."
+            ),
+        },
+        "host": {"type": "string", "description": "The queried host (audit-visible)."},
+        "port": {"type": "integer", "description": "The queried UDP port (audit-visible)."},
+        "stratum": {
+            "type": ["integer", "null"],
+            "description": (
+                "Server stratum (1 = primary reference, 2-15 = secondary); null on any failure."
+            ),
+        },
+        "ref_id": {
+            "type": ["string", "null"],
+            "description": (
+                "Reference identifier: a 4-char refclock code at stratum 1 "
+                "(e.g. 'GPS'), the upstream server's IPv4 at stratum >=2; "
+                "null on failure."
+            ),
+        },
+        "leap": {
+            "type": ["integer", "null"],
+            "description": (
+                "Leap indicator (0 = in sync, 1 = +1s, 2 = -1s, 3 = "
+                "unsynchronized/alarm); null on failure."
+            ),
+        },
+        "offset_ms": {
+            "type": ["number", "null"],
+            "description": (
+                "Server clock offset vs the backplane clock in milliseconds "
+                "(RFC 5905): positive ⇒ the server is ahead. Null on failure."
+            ),
+        },
+        "round_trip_ms": {
+            "type": ["number", "null"],
+            "description": "Measured round-trip delay in milliseconds; null on failure.",
+        },
+        "root_delay_ms": {
+            "type": ["number", "null"],
+            "description": "Server's total round-trip delay to the reference clock (ms).",
+        },
+        "root_dispersion_ms": {
+            "type": ["number", "null"],
+            "description": "Server's maximum error relative to the reference clock (ms).",
+        },
+        "kiss_code": {
+            "type": ["string", "null"],
+            "description": (
+                "The 4-char kiss-o'-death code (e.g. 'RATE', 'DENY') when the "
+                "server returned a stratum-0 KoD packet; null otherwise."
+            ),
+        },
+    },
+    "required": [
+        "reachable",
+        "reason",
+        "host",
+        "port",
+        "stratum",
+        "ref_id",
+        "leap",
+        "offset_ms",
+        "round_trip_ms",
+        "root_delay_ms",
+        "root_dispersion_ms",
+        "kiss_code",
+    ],
+    "additionalProperties": False,
+}
+
+_NET_NTP_CHECK_WHEN_TO_USE = (
+    "Check an NTP server's clock offset and skew from the backplane's "
+    "vantage — the 'ntpdate -q' / 'sntp' read: 'is this appliance's clock "
+    "sane from here?', 'how far off is the time source?', 'what stratum is "
+    "it?'. Clock skew is a common root cause of TLS-cert-validity and "
+    "Kerberos/auth failures, so this is a real pre-flight / post-mortem "
+    "probe. Read-only: it queries the time, it never sets a clock. A "
+    "timeout, a refused query, or a kiss-o'-death reply is a normal "
+    "result, not an error. The destination must be inside "
+    "MEHO_NETDIAG_PROBE_ALLOWLIST."
+)
+
+_NET_NTP_CHECK_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Use to measure an NTP server's clock offset (skew) against the "
+        "backplane clock and read its stratum before assuming a "
+        "time-sync problem behind a TLS or Kerberos failure. Read-only: "
+        "one client packet is sent, nothing is set."
+    ),
+    "parameter_hints": {
+        "host": "Required. NTP server hostname or IP literal. Must be allowlisted for probing.",
+        "port": "Optional. UDP port (default 123).",
+        "timeout_seconds": "Optional. Query timeout (default 5, max 30).",
+    },
+    "output_shape": (
+        "On success: {'reachable': true, 'reason': null, 'stratum': <int>, "
+        "'ref_id': <str>, 'leap': <int>, 'offset_ms': <float>, "
+        "'round_trip_ms': <float>, 'root_delay_ms': <float>, "
+        "'root_dispersion_ms': <float>, 'kiss_code': null, 'host', 'port'}. "
+        "On a refused / timed-out / KoD query: the same keys with "
+        "reachable=false, reason set, and the clock fields null — still a "
+        "successful (status=ok) op."
+    ),
+}
+
+
+class _NtpReply(NamedTuple):
+    """The parsed, RFC-5905-derived fields of one NTP server reply."""
+
+    leap: int
+    stratum: int
+    ref_id: str
+    kiss_code: str | None
+    offset_ms: float
+    round_trip_ms: float
+    root_delay_ms: float
+    root_dispersion_ms: float
+
+
+def _encode_ntp_timestamp(unix_time: float) -> tuple[int, int]:
+    """Split a Unix time into an NTP (seconds, fraction) 32-bit pair.
+
+    The integer seconds are masked to 32 bits so a time past the 2036
+    NTP era-0 rollover still packs; the fraction is the sub-second part
+    scaled by 2**32 (RFC 5905 §6).
+    """
+    ntp = unix_time + _NTP_EPOCH_OFFSET
+    seconds = int(ntp)
+    fraction = int((ntp - seconds) * _FRAC_32)
+    return seconds & 0xFFFFFFFF, fraction & 0xFFFFFFFF
+
+
+def _decode_ntp_timestamp(seconds: int, fraction: int) -> float | None:
+    """Turn an NTP (seconds, fraction) pair back into a Unix time.
+
+    An all-zero timestamp means the field was never set (RFC 5905 uses it
+    for "unknown"); it decodes to ``None`` so callers treat the reply as
+    invalid rather than computing an offset against 1900.
+    """
+    if seconds == 0 and fraction == 0:
+        return None
+    return seconds + fraction / _FRAC_32 - _NTP_EPOCH_OFFSET
+
+
+def _ntp_short_to_ms(value: int) -> float:
+    """Convert an NTP 16.16 fixed-point "short" value to milliseconds."""
+    return (value / _FRAC_16) * 1000.0
+
+
+def _format_ref_id(ref_id_word: int, stratum: int) -> str:
+    """Render the reference-id word per the stratum (RFC 5905 §7.3).
+
+    At stratum 0 (KoD) or 1 the word is four ASCII characters naming the
+    kiss code or the reference clock (e.g. ``GPS``); at stratum >=2 it is
+    the IPv4 address of the upstream server, rendered dotted-decimal.
+    """
+    raw = struct.pack("!I", ref_id_word)
+    if stratum <= 1:
+        return raw.rstrip(b"\x00").decode("ascii", errors="replace")
+    return ".".join(str(octet) for octet in raw)
+
+
+def _build_request(transmit_unix: float) -> bytes:
+    """Build the 48-byte mode-3 client request with its transmit timestamp.
+
+    Only the first octet (client mode) and the transmit timestamp (the
+    origin timestamp the server echoes back) are set; every other field
+    is zero, which is what a client sends (RFC 5905 §7.3).
+    """
+    seconds, fraction = _encode_ntp_timestamp(transmit_unix)
+    words = [0] * 11
+    words[9] = seconds
+    words[10] = fraction
+    return _NTP_PACKET.pack(_CLIENT_FIRST_OCTET, 0, 0, 0, *words)
+
+
+def _parse_reply(data: bytes, t1: float, t4: float, sent: tuple[int, int]) -> _NtpReply | None:
+    """Parse a server reply and compute the offset/delay, or ``None``.
+
+    ``t1`` is our transmit time and ``t4`` our receive time (both on the
+    backplane clock); ``sent`` is the (seconds, fraction) we put in the
+    request. Returns ``None`` when the reply is too short, does not echo
+    our transmit timestamp in its origin field (an off-path / stale
+    packet), or carries an unset server timestamp — all "invalid_response"
+    cases. A stratum-0 KoD reply parses successfully with ``kiss_code``
+    set and the clock fields zeroed; the caller maps it to a KoD failure.
+
+    Offset and round-trip follow RFC 5905 §8 with T1/T4 on the backplane
+    clock and T2/T3 (receive/transmit) on the server clock::
+
+        offset     = ((T2 - T1) + (T3 - T4)) / 2
+        round_trip = (T4 - T1) - (T3 - T2)
+    """
+    if len(data) < _NTP_PACKET.size:
+        return None
+    first, stratum, _poll, _precision, *words = _NTP_PACKET.unpack(data[: _NTP_PACKET.size])
+    leap = (first >> 6) & 0x3
+    root_delay, root_dispersion, ref_id_word = words[0], words[1], words[2]
+
+    # Anti-spoof / anti-stale: the reply's origin timestamp must echo the
+    # transmit timestamp we sent. A mismatch means this is not the answer
+    # to our request.
+    if (words[5], words[6]) != sent:
+        return None
+
+    kiss_code: str | None = None
+    if stratum == 0:
+        # Kiss-o'-death: the ref-id holds a 4-char code and no usable time.
+        kiss_code = _format_ref_id(ref_id_word, stratum)
+        return _NtpReply(leap, stratum, "", kiss_code, 0.0, 0.0, 0.0, 0.0)
+
+    t2 = _decode_ntp_timestamp(words[7], words[8])  # server receive
+    t3 = _decode_ntp_timestamp(words[9], words[10])  # server transmit
+    if t2 is None or t3 is None:
+        return None
+
+    offset = ((t2 - t1) + (t3 - t4)) / 2
+    round_trip = (t4 - t1) - (t3 - t2)
+    return _NtpReply(
+        leap=leap,
+        stratum=stratum,
+        ref_id=_format_ref_id(ref_id_word, stratum),
+        kiss_code=None,
+        offset_ms=offset * 1000.0,
+        round_trip_ms=round_trip * 1000.0,
+        root_delay_ms=_ntp_short_to_ms(root_delay),
+        root_dispersion_ms=_ntp_short_to_ms(root_dispersion),
+    )
+
+
+class _NtpClientProtocol(asyncio.DatagramProtocol):
+    """One-shot datagram protocol: send the request, capture the reply.
+
+    ``connection_made`` stamps the transmit time as close to the send as
+    possible (the ``t1`` used for the offset math) and fires the packet;
+    ``datagram_received`` stamps ``t4`` and resolves the future. A socket
+    error (an ICMP port-unreachable surfaces here on a connected UDP
+    socket) rejects the future so the handler can map it to a reason.
+    """
+
+    def __init__(self, future: asyncio.Future[tuple[bytes, float]]) -> None:
+        self._future = future
+        self._transport: asyncio.DatagramTransport | None = None
+        self.t1: float = 0.0
+        self.sent: tuple[int, int] = (0, 0)
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        self._transport = transport  # type: ignore[assignment]
+        self.t1 = time.time()
+        self.sent = _encode_ntp_timestamp(self.t1)
+        transport.sendto(_build_request(self.t1))  # type: ignore[attr-defined]
+
+    def datagram_received(self, data: bytes, _addr: Any) -> None:
+        if not self._future.done():
+            self._future.set_result((data, time.time()))
+
+    def error_received(self, exc: Exception) -> None:
+        if not self._future.done():
+            self._future.set_exception(exc)
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        if exc is not None and not self._future.done():
+            self._future.set_exception(exc)
+
+
+async def _query_ntp(
+    host: str, port: int, timeout: float
+) -> tuple[bytes, float, float, tuple[int, int]]:
+    """Send one client packet to ``host:port`` and await the reply.
+
+    Returns ``(reply_bytes, t1, t4, sent)``. ``create_datagram_endpoint``
+    with ``remote_addr`` resolves DNS and connects the socket (so an
+    unreachable/refused peer surfaces as an ``OSError``); the whole
+    exchange is bounded by ``timeout``.
+    """
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[tuple[bytes, float]] = loop.create_future()
+    transport, protocol = await asyncio.wait_for(
+        loop.create_datagram_endpoint(
+            lambda: _NtpClientProtocol(future),
+            remote_addr=(host, port),
+        ),
+        timeout=timeout,
+    )
+    try:
+        data, t4 = await asyncio.wait_for(future, timeout=timeout)
+    finally:
+        transport.close()
+    return data, protocol.t1, t4, protocol.sent
+
+
+def _failure(host: str, port: int, reason: str, *, kiss_code: str | None = None) -> dict[str, Any]:
+    """Build the uniform structured payload shared by every failed query."""
+    return {
+        "reachable": False,
+        "reason": reason,
+        "host": host,
+        "port": port,
+        "stratum": None,
+        "ref_id": None,
+        "leap": None,
+        "offset_ms": None,
+        "round_trip_ms": None,
+        "root_delay_ms": None,
+        "root_dispersion_ms": None,
+        "kiss_code": kiss_code,
+    }
+
+
+def _connect_failure_reason(exc: BaseException) -> str:
+    """Map a socket exception to a return-failures reason code.
+
+    Order is significant: :class:`socket.gaierror`, :class:`TimeoutError`,
+    and :class:`ConnectionRefusedError` are all :class:`OSError`
+    subclasses checked before the generic ``OSError`` fallthrough. On a
+    connected UDP socket an ICMP port-unreachable arrives as
+    ``ConnectionRefusedError``.
+    """
+    if isinstance(exc, socket.gaierror):
+        return "dns_failure"
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+    if isinstance(exc, ConnectionRefusedError):
+        return "refused"
+    return "unreachable"
+
+
+async def net_ntp_check(operator: Operator, target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Query an NTP server and report its clock offset/skew from the backplane.
+
+    Op-id: ``net.ntp_check``. Synthetic typed op (no vendor connector,
+    ``target`` is always ``None``). The dispatcher has validated the param
+    schema, so ``host`` is present and well-typed.
+
+    Flow: screen ``host`` against the probe allowlist → send one mode-3
+    NTPv4 client packet over an unprivileged UDP socket under
+    :func:`asyncio.wait_for` → parse the reply and compute offset/delay
+    per RFC 5905 §8 against the backplane's own clock. A refused,
+    timed-out, DNS-failed, kiss-o'-death, or malformed reply returns a
+    structured ``reachable=false`` payload with ``status="ok"`` (the
+    return-failures contract); it is never raised as a ``connector_*``
+    error. The returned dict carries the literal ``host``/``port`` so the
+    durable audit row's ``raw_payload`` records what was probed.
+    """
+    host = str(params["host"])
+    port = int(params.get("port", _DEFAULT_NTP_PORT))
+    timeout = _clamp_timeout(params.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS))
+
+    try:
+        assert_probe_allowed(host)
+    except ProbeNotAllowedError:
+        _log.info("net.ntp_check.refused", host=host, port=port, reason="not_in_probe_allowlist")
+        return _failure(host, port, "not_in_probe_allowlist")
+
+    try:
+        data, t1, t4, sent = await _query_ntp(host, port, timeout)
+    except TimeoutError:
+        return _failure(host, port, "timeout")
+    except OSError as exc:
+        return _failure(host, port, _connect_failure_reason(exc))
+
+    reply = _parse_reply(data, t1, t4, sent)
+    if reply is None:
+        return _failure(host, port, "invalid_response")
+    if reply.kiss_code is not None:
+        _log.info("net.ntp_check.kod", host=host, port=port, kiss_code=reply.kiss_code)
+        return _failure(host, port, "kod", kiss_code=reply.kiss_code)
+
+    return {
+        "reachable": True,
+        "reason": None,
+        "host": host,
+        "port": port,
+        "stratum": reply.stratum,
+        "ref_id": reply.ref_id,
+        "leap": reply.leap,
+        "offset_ms": reply.offset_ms,
+        "round_trip_ms": reply.round_trip_ms,
+        "root_delay_ms": reply.root_delay_ms,
+        "root_dispersion_ms": reply.root_dispersion_ms,
+        "kiss_code": None,
+    }
+
+
+async def register_net_ntp_check_operation(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the ``net.ntp_check`` typed op into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list by the package
+    ``__init__`` (a sibling registrar to ``net.tcp_check``'s), run after
+    the connector eager-import pass. Registered under the same synthetic
+    natural key as the keystone
+    (``product="net", version="1.x", impl_id="net-probe"``), so it shares
+    the ``net-probe-1.x`` wire ``connector_id``. Idempotent. ``safe`` +
+    ``requires_approval=False`` — the probe allowlist is the only floor.
+    """
+    await register_typed_operation(
+        product="net",
+        version="1.x",
+        impl_id="net-probe",
+        op_id="net.ntp_check",
+        handler=net_ntp_check,
+        group_key="probe",
+        when_to_use=_NET_NTP_CHECK_WHEN_TO_USE,
+        summary="Measure an NTP server's clock offset/skew and stratum from the backplane.",
+        description=(
+            "Sends one mode-3 (client) NTPv4 packet to a host:port over an "
+            "unprivileged UDP socket and reports reachability plus the "
+            "server clock's offset and skew against the backplane's own "
+            "clock (RFC 5905), the stratum, reference id, root "
+            "delay/dispersion, and the leap indicator — 'ntpdate -q' / "
+            "'sntp' parity. Read-only: it reads the time, it never sets a "
+            "clock, and it needs no raw socket or added pod capability. The "
+            "destination must be inside MEHO_NETDIAG_PROBE_ALLOWLIST or the "
+            "probe is refused before any socket opens. A refused, timed-out, "
+            "DNS-failed, or kiss-o'-death query returns reachable=false with "
+            "a reason code and status=ok — a failed probe is the product, "
+            "never a connector error."
+        ),
+        parameter_schema=NET_NTP_CHECK_PARAMETER_SCHEMA,
+        response_schema=_NET_NTP_CHECK_RESPONSE_SCHEMA,
+        tags=["net", "probe", "read", "diagnostics", "ntp", "time"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_NET_NTP_CHECK_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )

--- a/backend/tests/test_connectors_net_ntp_check.py
+++ b/backend/tests/test_connectors_net_ntp_check.py
@@ -1,0 +1,474 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for ``net.ntp_check`` — #2410 (Initiative #2405 T5).
+
+``ntpdate -q`` parity on the T1 ``net.*`` mold:
+
+* offset + stratum + ref-id against a test NTP responder, dispatched
+  targetless on a fresh boot; the offset is computed vs the backplane's
+  clock (sign correct — proven with a fixture whose clock is skewed both
+  ways);
+* the **return-failures contract**: a timeout, a malformed reply, an
+  off-path (origin-mismatch) reply, or a kiss-o'-death packet return
+  ``{reachable: false, reason}`` with dispatch ``status="ok"`` — never a
+  ``connector_*`` error;
+* the queried ``host`` + ``port`` land in the durable audit row's
+  ``raw_payload``; the ``host`` is probe-allowlist-gated before any socket
+  opens.
+
+The NTP query runs against an **in-process UDP fixture server** (real
+``asyncio`` datagram wire path, no outbound network): the handler dials
+``127.0.0.1:<ephemeral port>`` and the fixture answers with a well-formed
+NTPv4 reply that echoes the request's transmit timestamp and offsets its
+own clock by a configurable skew.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import struct
+import time
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.net import ntp as net_ntp
+from meho_backplane.connectors.net.allowlist import PROBE_ALLOWLIST_ENV
+from meho_backplane.connectors.net.ntp import register_net_ntp_check_operation
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "net-probe-1.x"
+_OP_ID = "net.ntp_check"
+
+_NTP_PACKET = struct.Struct("!B B b b 11I")
+_EPOCH = 2_208_988_800
+
+
+def _encode(unix_time: float) -> tuple[int, int]:
+    ntp = unix_time + _EPOCH
+    seconds = int(ntp)
+    fraction = int((ntp - seconds) * (1 << 32))
+    return seconds & 0xFFFFFFFF, fraction & 0xFFFFFFFF
+
+
+# ---------------------------------------------------------------------------
+# Settings env + dispatcher isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the minimal Settings env + reset dispatcher caches per test."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.delenv(PROBE_ALLOWLIST_ENV, raising=False)
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+    yield
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def stub_embedding_service() -> Any:
+    from unittest.mock import AsyncMock
+
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_net_ops(stub_embedding_service: Any) -> AsyncIterator[None]:
+    """Upsert the ``net.ntp_check`` descriptor row for dispatch-driving tests."""
+    await register_net_ntp_check_operation(embedding_service=stub_embedding_service)
+    yield
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt="fake.jwt.value",
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_ntp(params: dict[str, Any]) -> OperationResult:
+    """Dispatch ``net.ntp_check`` through the real targetless path."""
+    return await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=None,
+        params=params,
+    )
+
+
+async def _fetch_audit_rows() -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# In-process UDP fixture NTP server
+# ---------------------------------------------------------------------------
+
+
+class _NtpFixture:
+    """Controls how the fixture NTP server answers a query.
+
+    Mutate the attributes to steer the reply: ``skew`` (seconds the
+    server clock leads the backplane by), ``stratum``, ``ref_id_word``,
+    ``leap``, ``root_delay`` / ``root_dispersion`` (NTP 16.16 short
+    format), and ``mode`` (``answer`` | ``no_response`` | ``short`` |
+    ``origin_mismatch``).
+    """
+
+    def __init__(self) -> None:
+        self.mode = "answer"
+        self.skew = 0.0
+        self.stratum = 2
+        # 203.0.113.1 — a TEST-NET-3 address rendered dotted at stratum >= 2.
+        self.ref_id_word = struct.unpack("!I", bytes([203, 0, 113, 1]))[0]
+        self.leap = 0
+        self.root_delay = 0x0001_0000  # 1.0 s -> 1000 ms
+        self.root_dispersion = 0x0000_8000  # 0.5 s -> 500 ms
+
+    def build_response(self, request: bytes) -> bytes | None:
+        if self.mode == "no_response":
+            return None
+        if self.mode == "short":
+            return b"\x00" * 10
+        _, _, _, _, *words = _NTP_PACKET.unpack(request[:48])
+        origin_sec, origin_frac = words[9], words[10]
+        if self.mode == "origin_mismatch":
+            origin_sec ^= 0xFFFF
+        server_now = time.time() + self.skew
+        recv = _encode(server_now)
+        transmit = _encode(server_now)
+        first = (self.leap << 6) | (4 << 3) | 4  # leap, version 4, mode 4 (server)
+        out = [0] * 11
+        out[0] = self.root_delay
+        out[1] = self.root_dispersion
+        out[2] = self.ref_id_word
+        out[3], out[4] = _encode(server_now)  # reference timestamp
+        out[5], out[6] = origin_sec, origin_frac  # origin echo
+        out[7], out[8] = recv
+        out[9], out[10] = transmit
+        return _NTP_PACKET.pack(first, self.stratum, 0, -6, *out)
+
+
+class _NtpFixtureProtocol(asyncio.DatagramProtocol):
+    def __init__(self, controller: _NtpFixture) -> None:
+        self._controller = controller
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        self._transport = transport
+
+    def datagram_received(self, data: bytes, addr: Any) -> None:
+        response = self._controller.build_response(data)
+        if response is not None:
+            self._transport.sendto(response, addr)  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+async def ntp_fixture(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[tuple[_NtpFixture, int]]:
+    """Bind a fixture NTP server on 127.0.0.1 and yield (controller, port)."""
+    controller = _NtpFixture()
+    loop = asyncio.get_running_loop()
+    transport, _ = await loop.create_datagram_endpoint(
+        lambda: _NtpFixtureProtocol(controller), local_addr=("127.0.0.1", 0)
+    )
+    port = transport.get_extra_info("socket").getsockname()[1]
+    try:
+        yield controller, port
+    finally:
+        transport.close()
+
+
+# ---------------------------------------------------------------------------
+# Offset / stratum against a skewed responder — sign correctness
+# ---------------------------------------------------------------------------
+
+
+async def test_offset_and_stratum_against_skewed_responder(
+    monkeypatch: pytest.MonkeyPatch,
+    ntp_fixture: tuple[_NtpFixture, int],
+    _registered_net_ops: None,
+) -> None:
+    """A +1h-skewed server yields offset ~= +3_600_000 ms — targetless, fresh boot."""
+    controller, port = ntp_fixture
+    controller.skew = 3600.0
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.0/8")
+
+    result = await _dispatch_ntp({"host": "127.0.0.1", "port": port})
+
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["reachable"] is True
+    assert body["reason"] is None
+    assert body["stratum"] == 2
+    assert body["ref_id"] == "203.0.113.1"
+    assert body["leap"] == 0
+    # Server leads by ~3600 s; the round-trip on loopback is sub-millisecond.
+    assert abs(body["offset_ms"] - 3_600_000) < 1_000
+    assert 0.0 <= body["round_trip_ms"] < 1_000
+    assert abs(body["root_delay_ms"] - 1000.0) < 1.0
+    assert abs(body["root_dispersion_ms"] - 500.0) < 1.0
+
+
+async def test_negative_offset_sign(
+    monkeypatch: pytest.MonkeyPatch,
+    ntp_fixture: tuple[_NtpFixture, int],
+    _registered_net_ops: None,
+) -> None:
+    """A server whose clock trails yields a negative offset (sign correct)."""
+    controller, port = ntp_fixture
+    controller.skew = -3600.0
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.0/8")
+
+    result = await _dispatch_ntp({"host": "127.0.0.1", "port": port})
+
+    assert result.status == "ok", result.error
+    assert result.result["reachable"] is True
+    assert abs(result.result["offset_ms"] - (-3_600_000)) < 1_000
+
+
+async def test_stratum_one_ref_id_is_ascii_refclock(
+    monkeypatch: pytest.MonkeyPatch,
+    ntp_fixture: tuple[_NtpFixture, int],
+    _registered_net_ops: None,
+) -> None:
+    """At stratum 1 the ref-id is the 4-char ASCII reference-clock code."""
+    controller, port = ntp_fixture
+    controller.stratum = 1
+    controller.ref_id_word = struct.unpack("!I", b"GPS\x00")[0]
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.0/8")
+
+    result = await _dispatch_ntp({"host": "127.0.0.1", "port": port})
+
+    assert result.status == "ok", result.error
+    assert result.result["stratum"] == 1
+    assert result.result["ref_id"] == "GPS"
+
+
+async def test_default_port_is_123(
+    monkeypatch: pytest.MonkeyPatch,
+    ntp_fixture: tuple[_NtpFixture, int],
+    _registered_net_ops: None,
+) -> None:
+    """Omitting ``port`` dials the NTP default — proven by pointing the default at the fixture."""
+    _controller, port = ntp_fixture
+    monkeypatch.setattr(net_ntp, "_DEFAULT_NTP_PORT", port)
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.0/8")
+
+    result = await _dispatch_ntp({"host": "127.0.0.1"})
+
+    assert result.status == "ok", result.error
+    assert result.result["reachable"] is True
+    assert result.result["port"] == port
+
+
+# ---------------------------------------------------------------------------
+# Return-failures contract — status=ok, never connector_*
+# ---------------------------------------------------------------------------
+
+
+async def test_timeout_returns_reachable_false(
+    monkeypatch: pytest.MonkeyPatch,
+    ntp_fixture: tuple[_NtpFixture, int],
+    _registered_net_ops: None,
+) -> None:
+    """A silent server returns reachable=false, reason='timeout', status=ok."""
+    controller, port = ntp_fixture
+    controller.mode = "no_response"
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.0/8")
+
+    result = await _dispatch_ntp({"host": "127.0.0.1", "port": port, "timeout_seconds": 0.3})
+
+    assert result.status == "ok", result.error
+    assert result.extras.get("exception_class") is None
+    assert result.result["reachable"] is False
+    assert result.result["reason"] == "timeout"
+    assert result.result["offset_ms"] is None
+    assert result.result["stratum"] is None
+
+
+async def test_kiss_of_death_returns_reason_kod(
+    monkeypatch: pytest.MonkeyPatch,
+    ntp_fixture: tuple[_NtpFixture, int],
+    _registered_net_ops: None,
+) -> None:
+    """A stratum-0 KoD reply returns reachable=false, reason='kod', with the kiss code."""
+    controller, port = ntp_fixture
+    controller.stratum = 0
+    controller.ref_id_word = struct.unpack("!I", b"RATE")[0]
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.0/8")
+
+    result = await _dispatch_ntp({"host": "127.0.0.1", "port": port})
+
+    assert result.status == "ok", result.error
+    assert result.result["reachable"] is False
+    assert result.result["reason"] == "kod"
+    assert result.result["kiss_code"] == "RATE"
+
+
+async def test_short_reply_is_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    ntp_fixture: tuple[_NtpFixture, int],
+    _registered_net_ops: None,
+) -> None:
+    """A truncated (< 48 byte) reply returns reason='invalid_response'."""
+    controller, port = ntp_fixture
+    controller.mode = "short"
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.0/8")
+
+    result = await _dispatch_ntp({"host": "127.0.0.1", "port": port, "timeout_seconds": 1})
+
+    assert result.status == "ok", result.error
+    assert result.result["reachable"] is False
+    assert result.result["reason"] == "invalid_response"
+
+
+async def test_origin_mismatch_is_invalid_response(
+    monkeypatch: pytest.MonkeyPatch,
+    ntp_fixture: tuple[_NtpFixture, int],
+    _registered_net_ops: None,
+) -> None:
+    """A reply that does not echo our transmit timestamp is rejected (anti-spoof)."""
+    controller, port = ntp_fixture
+    controller.mode = "origin_mismatch"
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.0/8")
+
+    result = await _dispatch_ntp({"host": "127.0.0.1", "port": port, "timeout_seconds": 1})
+
+    assert result.status == "ok", result.error
+    assert result.result["reachable"] is False
+    assert result.result["reason"] == "invalid_response"
+
+
+# ---------------------------------------------------------------------------
+# Allowlist gating — host screened before any socket
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_allowlist_refuses_before_any_socket(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_net_ops: None,
+) -> None:
+    """Empty allowlist ⇒ structured refusal, no UDP socket ever opened."""
+
+    async def _boom(*_a: object, **_kw: object) -> object:
+        raise AssertionError("no query may run when the probe is refused")
+
+    monkeypatch.setattr(net_ntp, "_query_ntp", _boom)
+
+    result = await _dispatch_ntp({"host": "10.0.0.1"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "reachable": False,
+        "reason": "not_in_probe_allowlist",
+        "host": "10.0.0.1",
+        "port": 123,
+        "stratum": None,
+        "ref_id": None,
+        "leap": None,
+        "offset_ms": None,
+        "round_trip_ms": None,
+        "root_delay_ms": None,
+        "root_dispersion_ms": None,
+        "kiss_code": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Audit row records host + port
+# ---------------------------------------------------------------------------
+
+
+async def test_audit_row_records_host_and_port(
+    monkeypatch: pytest.MonkeyPatch,
+    ntp_fixture: tuple[_NtpFixture, int],
+    _registered_net_ops: None,
+) -> None:
+    """The durable audit row's raw_payload carries the probed host/port."""
+    _controller, port = ntp_fixture
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.0/8")
+
+    result = await _dispatch_ntp({"host": "127.0.0.1", "port": port})
+    assert result.status == "ok", result.error
+
+    rows = await _fetch_audit_rows()
+    ntp_rows = [row for row in rows if row.path == _OP_ID]
+    assert len(ntp_rows) == 1
+    raw = ntp_rows[0].raw_payload
+    assert raw is not None
+    assert raw["host"] == "127.0.0.1"
+    assert raw["port"] == port
+
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests — packet build/parse, reason mapping
+# ---------------------------------------------------------------------------
+
+
+def test_build_request_is_a_48_byte_client_packet() -> None:
+    """The request is a 48-byte mode-3 client packet carrying the transmit ts."""
+    now = time.time()
+    request = net_ntp._build_request(now)
+    assert len(request) == 48
+    assert request[0] == 0x23  # leap 0, version 4, mode 3 (client)
+    _, _, _, _, *words = _NTP_PACKET.unpack(request)
+    assert (words[9], words[10]) == net_ntp._encode_ntp_timestamp(now)
+
+
+def test_ntp_timestamp_roundtrips() -> None:
+    """Encoding then decoding a Unix time returns it within sub-ms precision."""
+    now = 1_700_000_000.5
+    seconds, fraction = net_ntp._encode_ntp_timestamp(now)
+    assert net_ntp._decode_ntp_timestamp(seconds, fraction) == pytest.approx(now, abs=1e-3)
+
+
+def test_zero_timestamp_decodes_to_none() -> None:
+    """An all-zero NTP timestamp is 'unset', decoding to None."""
+    assert net_ntp._decode_ntp_timestamp(0, 0) is None
+
+
+def test_ntp_short_to_ms_is_fixed_point() -> None:
+    """The 16.16 short format converts to milliseconds."""
+    assert net_ntp._ntp_short_to_ms(0x0001_0000) == pytest.approx(1000.0)
+    assert net_ntp._ntp_short_to_ms(0x0000_8000) == pytest.approx(500.0)
+
+
+def test_format_ref_id_by_stratum() -> None:
+    """Ref-id renders as ASCII at stratum <=1 and as IPv4 at stratum >=2."""
+    gps = struct.unpack("!I", b"GPS\x00")[0]
+    ipv4 = struct.unpack("!I", bytes([203, 0, 113, 1]))[0]
+    assert net_ntp._format_ref_id(gps, 1) == "GPS"
+    assert net_ntp._format_ref_id(ipv4, 2) == "203.0.113.1"
+
+
+def test_connect_failure_reason_mapping() -> None:
+    """Each socket error maps to its return-failures reason code."""
+    assert net_ntp._connect_failure_reason(socket.gaierror()) == "dns_failure"
+    assert net_ntp._connect_failure_reason(TimeoutError()) == "timeout"
+    assert net_ntp._connect_failure_reason(ConnectionRefusedError()) == "refused"
+    assert net_ntp._connect_failure_reason(OSError()) == "unreachable"

--- a/docs/codebase/connectors-net-diagnostics.md
+++ b/docs/codebase/connectors-net-diagnostics.md
@@ -14,19 +14,21 @@ module-level functions the dispatcher routes to with
 **param**, not a registered `Target`.
 
 This page describes the keystone (#2406, Initiative #2405 T1):
-`net.tcp_check` plus the three foundations every sibling op (T2–T4:
-`tls_inspect` / `http_probe` / `dns_lookup`) reuses, and the sibling ops
-`net.tls_inspect` (#2407, T2), `net.http_probe` (#2408, T3), and
-`net.dns_lookup` (#2409, T4) built on that mold — all described below.
+`net.tcp_check` plus the three foundations every sibling op (T2–T5:
+`tls_inspect` / `http_probe` / `dns_lookup` / `ntp_check`) reuses, and the
+sibling ops `net.tls_inspect` (#2407, T2), `net.http_probe` (#2408, T3),
+`net.dns_lookup` (#2409, T4), and `net.ntp_check` (#2410, T5) built on
+that mold — all described below.
 
 Each op queues a registrar in `__init__.py` via
 `register_typed_op_registrar` (`net.tcp_check` and `net.dns_lookup` share
 `ops.register_net_typed_operations`; `net.tls_inspect` →
 `tls.register_net_tls_inspect_operation`; `net.http_probe` →
-`http_probe.register_net_http_probe_operations`). Siblings therefore
-extend the package by adding (at most) a module and one registrar-queue
-line rather than contending for a single registrar function — which also
-keeps parallel task branches from colliding on one shared file.
+`http_probe.register_net_http_probe_operations`; `net.ntp_check` →
+`ntp.register_net_ntp_check_operation`). Siblings therefore extend the
+package by adding (at most) a module and one registrar-queue line rather
+than contending for a single registrar function — which also keeps
+parallel task branches from colliding on one shared file.
 
 ## Core mechanism
 
@@ -194,6 +196,64 @@ before the handler runs. Reason codes extend the T1 set with
 Because it issues an HTTP request, `net.http_probe` adds **`httpx`** to
 the family's dependency surface (already a project dep — no new dep).
 
+## `net.ntp_check` — clock offset/skew + stratum (T5, #2410)
+
+`net.ntp_check(host, port=123, timeout_seconds?)` sends **one** mode-3
+(client) NTPv4 packet to `host:port` over an **unprivileged** client UDP
+socket and reports reachability plus the queried server's **clock offset
+and skew against the backplane's own clock** (RFC 5905 §8), the
+`stratum`, `ref_id`, `root_delay_ms` / `root_dispersion_ms`, and the
+`leap` indicator — `ntpdate -q` / `sntp` parity. Clock skew is a common
+root cause of TLS-cert-validity and Kerberos/auth failures, so "is this
+appliance's clock sane from here" is a real pre-flight / post-mortem
+read. It is **read-only**: it reads the time, it never sets a clock.
+
+Lives in `connectors/net/ntp.py` with its own registrar
+(`register_net_ntp_check_operation`), queued alongside `net.tcp_check`'s
+in the package `__init__`. It reuses the same three foundations and the
+shared timeout bounds/clamp from `ops.py`.
+
+**No dependency — stdlib only.** A mode-3 SNTP request is a fixed 48-byte
+packet (RFC 5905 §7.3): a first octet of `0x23` (leap 0, version 4, mode
+3) and a transmit timestamp; the reply is the same 48-byte header.
+`struct` (`"!B B b b 11I"`) builds and parses it; `asyncio`'s
+`loop.create_datagram_endpoint` sends and receives it off the event loop.
+No raw socket and no added pod capability — a client UDP socket needs
+none.
+
+Control flow:
+
+1. `assert_probe_allowed(host)` — the T1 allowlist floor, before any
+   socket opens.
+2. A one-shot `DatagramProtocol` (`_NtpClientProtocol`) stamps the
+   transmit time `t1` as close to the send as possible, fires the packet,
+   and stamps the receive time `t4` on the reply. The exchange is bounded
+   by `asyncio.wait_for(timeout)`.
+3. `_parse_reply` checks the reply echoes our transmit timestamp in its
+   origin field (an off-path / stale packet fails this → `invalid_response`),
+   then computes offset and round-trip per RFC 5905 §8 with `t1`/`t4` on
+   the backplane clock and the server's receive (`T2`) / transmit (`T3`)
+   timestamps on the server clock:
+
+   ```
+   offset     = ((T2 - t1) + (T3 - t4)) / 2
+   round_trip = (t4 - t1) - (T3 - T2)
+   ```
+
+Timestamps convert via the NTP epoch offset (`2_208_988_800` s between
+1900 and 1970) and a 2**32 fraction scale; `root_delay` / `root_dispersion`
+are NTP 16.16 fixed-point "short" values (`/2**16` seconds → ms). `ref_id`
+renders as a 4-char ASCII refclock code at stratum ≤1 and the upstream
+server's dotted IPv4 at stratum ≥2.
+
+**Return-failures:** a timeout, DNS failure, a refused/unreachable peer,
+a malformed or origin-mismatched reply, or a **kiss-o'-death** (stratum-0)
+packet return `{reachable: false, reason}` with `status="ok"` — reason
+codes extend the T1 set with `kod` and `invalid_response`. A KoD reply
+also surfaces the 4-char `kiss_code` (e.g. `RATE`, `DENY`). None are
+raised as `connector_*` errors; the `host`/`port` in the return dict are
+audit-visible via `raw_payload`.
+
 ## `net.tls_inspect` — full presented certificate chain (T2, #2407)
 
 `net.tls_inspect(host, port, server_name?, timeout_seconds?)` opens a TLS
@@ -284,6 +344,10 @@ connectors' ops.
   (`_walk_redirects`), the TLS summary (`_tls_summary`), the
   size/hash-only body reader (`_consume_body_size_and_hash`), and the
   registrar.
+- `connectors/net/ntp.py` — `net_ntp_check` handler, its schemas, the
+  48-byte packet build/parse (`_build_request` / `_parse_reply`), the
+  NTP-timestamp codec, the one-shot `_NtpClientProtocol`, and the
+  registrar.
 - `connectors/net/allowlist.py` — `PROBE_ALLOWLIST_ENV`,
   `parse_probe_allowlist`, `assert_probe_allowed`,
   `ProbeNotAllowedError`.
@@ -311,6 +375,9 @@ audit (`raw_payload` = handler return) → broadcast (`read` class).
   `backend/pyproject.toml` so the connector's requirement is explicit) —
   used via `dns.asyncresolver` / `dns.reversename` / `dns.rdatatype` /
   `dns.flags`.
+- `net.ntp_check`: standard library only (`asyncio`, `socket`, `struct`,
+  `time`) — the SNTP request/reply is a fixed 48-byte packet, so no
+  runtime dependency is added.
 
 ## Known issues / deferred
 
@@ -329,8 +396,9 @@ audit (`raw_payload` = handler return) → broadcast (`read` class).
 ## References
 
 - Parent: Initiative #2405, Tasks #2406 (T1 `tcp_check`) + #2407 (T2
-  `tls_inspect`) + #2408 (T3 `http_probe`) + #2409 (T4 `dns_lookup`).
-  Mold: secret broker
+  `tls_inspect`) + #2408 (T3 `http_probe`) + #2409 (T4 `dns_lookup`) +
+  #2410 (T5 `ntp_check`). RFC 5905 (NTPv4) for the `ntp_check` packet and
+  offset/delay math. Mold: secret broker
   (`docs/codebase/connectors-secret-broker.md`). SSRF sibling:
   `docs/codebase/target-ssrf-guard.md`. Broadcast taxonomy:
   `docs/codebase/broadcast.md`.


### PR DESCRIPTION
## Summary

- Add `net.ntp_check`, the fifth `net.*` diagnostic op (T5, Initiative #2405) on the T1 keystone mold: send one mode-3 (client) NTPv4 packet over an **unprivileged** UDP socket and report the queried server's **clock offset/skew vs the backplane's own clock** (RFC 5905 §8), plus `stratum`, `ref_id`, `root_delay_ms` / `root_dispersion_ms`, and the `leap` indicator — `ntpdate -q` / `sntp` parity. Read-only; it never sets a clock.
- **No new dependency** (satisfies the issue preference): the 48-byte SNTP request/reply is built and parsed with the stdlib `struct` and sent off the event loop via `asyncio` datagram endpoints — no raw socket, no added pod capability.
- Ships its own module (`connectors/net/ntp.py`) + registrar queued in the package `__init__`, matching the `tls_inspect` / `http_probe` siblings; reuses the three T1 foundations verbatim — the `MEHO_NETDIAG_PROBE_ALLOWLIST` gate (host screened before any socket), audit-visible `host:port` via `raw_payload`, and the return-failures contract.
- A timeout, a refused/unreachable peer, a malformed or off-path (origin-mismatch) reply, or a kiss-o'-death stratum-0 packet return `{reachable: false, reason}` with `status="ok"` — never a `connector_*` error. The reply's origin timestamp must echo our transmit timestamp (anti-spoof / anti-stale); KoD surfaces the 4-char `kiss_code`.

## Test plan

- [x] `ruff check` — clean (ntp.py, test, __init__.py)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (handler + test)
- [x] `pytest tests/test_connectors_net_ntp_check.py` — 16 passed
- [x] **AC1** offset + stratum against a skewed responder, targetless, fresh boot; sign correct — proven both ways (`+3600s → offset ~ +3_600_000 ms`, `-3600s → ~ -3_600_000 ms`) via an in-process UDP fixture NTP server
- [x] **AC2** timeout / no-response → `{reachable: false, reason: "timeout"}` with `status="ok"` (also `short` and `origin_mismatch` → `invalid_response`, stratum-0 → `kod`)
- [x] **AC3** `host` probe-allowlist-gated (empty allowlist refuses before any socket opens — `_query_ntp` monkeypatched to assert it never runs); audit row's `raw_payload` records `host`/`port`
- [x] **AC4** no raw socket / no added capability (`asyncio` client UDP only); **no runtime dependency** (stdlib `struct` + `socket` + `asyncio`)
- [x] Full `net.*` family (85) + broadcast/classifier coverage (499) suites green — `net.` prefix classification auto-covers `net.ntp_check`
- [x] `docs/codebase/connectors-net-diagnostics.md` updated; CHANGELOG `[Unreleased]` entry added

## Out of scope

- Acting on the skew (no clock-set — read-only), NTP symmetric-key / NTS authentication, and continuous monitoring — all per the issue.
- Adjacent finding: `connectors/net/ntp.py` is 580 lines (code-quality warn >400, block >600) — under the block threshold and consistent with the sibling `tls.py` / `http_probe.py` sizes; not split.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2410
