### PR TITLE
feat(connectors): node/rke2-ssh connector scaffold + read-only posture tier (#2221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — node/rke2-ssh connector scaffold + read-only posture tier (#2221)
+
+- Add the `rke2` node-OS connector (`rke2-ssh-1.x`), the read-only entry in
+  the governed SSH cluster-node OS-lifecycle family (Initiative #2172, the
+  holodeck-ssh mold). Ships two safe/no-approval ops over the shared SSH
+  adapter: `rke2.about` (identity — `rke2 --version` + `/etc/os-release`) and
+  `rke2.posture.show`, which `stat`s the RKE2 config-file modes under
+  `/etc/rancher/rke2/` plus the on-disk server join-token presence **with the
+  token value never read** (redacted by construction — no secret can reach
+  the result envelope, the audit `raw_payload`, or the logs). Auth resolves
+  via the fixed SSH adapter (`load_vault_secret_data`, the #2155 either/or
+  key-or-password shape), not the bind9 anti-shape. The approval-gated write
+  ops land in sibling Tasks #2429/#2430/#2431 — `backend/src/meho_backplane/
+  connectors/rke2/`, `docs/codebase/connectors-rke2.md` (#2221).
+
 ### Added — net.ping/trace/path_mtu ICMP cohort (unprivileged, degrade-not-crash) (#2411)
 
 - Add the `net.*` ICMP cohort completing local-tool parity: `net.ping`

--- a/backend/src/meho_backplane/connectors/rke2/__init__.py
+++ b/backend/src/meho_backplane/connectors/rke2/__init__.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.rke2 -- Rke2SshConnector package.
+
+Importing the package registers :class:`Rke2SshConnector` against the v2
+connector registry under the natural key
+``(product="rke2", version="1.x", impl_id="rke2-ssh")``, and queues the
+connector's typed-op upserts onto the lifespan-driven registrar list so
+``endpoint_descriptor`` rows land before the first dispatch.
+
+Two-phase registration (same shape as
+:mod:`meho_backplane.connectors.bind9.__init__` and
+:mod:`meho_backplane.connectors.holodeck.__init__`):
+
+* **Synchronous (import time)** -- the v2 registry entry lands via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2`
+  inside this module, so a probe firing during startup sees a
+  fully-populated registry.
+
+* **Asynchronous (lifespan startup)** --
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`register_rke2_typed_operations`, which delegates to
+  :meth:`Rke2SshConnector.register_operations`. Async because the helper
+  writes to the DB and the embedding-text encode step is async.
+  Idempotent on re-call with unchanged op text.
+
+The connector intentionally does **not** call the v1
+``register_connector`` -- the v1 entry path is for chassis-route
+backwards compatibility, and RKE2 has never shipped behind it. Skipping
+the v1 write keeps the resolver tie-break ladder unambiguous: only the
+v2 triple advertises this class.
+"""
+
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.rke2.connector import Rke2SshConnector
+from meho_backplane.connectors.rke2.ops import RKE2_OPS, Rke2Op
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_rke2_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``Rke2SshConnector.register_operations``.
+
+    The canonical typed-op registration pattern is a module-level
+    ``async def register_xxx_typed_operations`` queued onto
+    :func:`run_typed_op_registrars` via
+    :func:`register_typed_op_registrar`. RKE2 implements the underlying op
+    walk as a classmethod on :class:`Rke2SshConnector` so the test suite
+    can exercise it without lifespan plumbing; this wrapper is the seam
+    that lets the standard registrar mechanism drive it.
+
+    The ``embedding_service`` keyword-only parameter mirrors the bind9 /
+    holodeck sibling contract (#463) -- :func:`run_typed_op_registrars`
+    passes the process-wide :class:`EmbeddingService` (or a chassis-test
+    stub) to every registrar via ``registrar(embedding_service=...)``, so
+    each registrar **must** accept the kwarg or the lifespan crashes with
+    :class:`TypeError`. The wrapper accepts and discards it because
+    :meth:`Rke2SshConnector.register_operations` resolves the embedding
+    service via ``register_typed_operation``'s process-wide singleton
+    fallback -- the kwarg-accept-and-discard shape matches the siblings.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await Rke2SshConnector.register_operations()
+
+
+__all__ = [
+    "RKE2_OPS",
+    "Rke2Op",
+    "Rke2SshConnector",
+    "register_rke2_typed_operations",
+]
+
+
+# v2 entry -- the canonical resolver key. RKE2 has no v1 chassis history,
+# so the v1 ``register_connector`` write is intentionally omitted.
+register_connector_v2(
+    product="rke2",
+    version="1.x",
+    impl_id="rke2-ssh",
+    cls=Rke2SshConnector,
+)
+
+# Wildcard fallback -- a target with ``version=None`` (fresh,
+# unfingerprinted, no operator-asserted version yet) resolves to this
+# connector through the resolver's ``versioned_over_wildcard`` step
+# rather than 501-ing with ``no_connector``. The versioned entry above
+# always wins when both are present (resolver tie-break step 1).
+register_connector_v2(
+    product="rke2",
+    version="",
+    impl_id="",
+    cls=Rke2SshConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list.
+register_typed_op_registrar(register_rke2_typed_operations)

--- a/backend/src/meho_backplane/connectors/rke2/connector.py
+++ b/backend/src/meho_backplane/connectors/rke2/connector.py
@@ -1,0 +1,486 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Rke2SshConnector -- typed plain-SSH connector for RKE2 cluster nodes.
+
+G-Node/RKE2-T1 (#2221) scaffold -- the read-only entry in the SSH
+node-OS-lifecycle family (Initiative #2172), built on the same
+approval-gated write-op mold as holodeck-ssh (G3.18 #2145). RKE2 nodes
+expose no MEHO REST surface; the connector's only transport is plain SSH
+to the node OS over the shared
+:class:`~meho_backplane.connectors.adapters.ssh.SshConnector` adapter.
+
+This module ships:
+
+* :class:`Rke2SshConnector`, subclass of :class:`SshConnector`, carrying
+  the registry-v2 triple ``("rke2", "1.x", "rke2-ssh")``.
+* :meth:`Rke2SshConnector.fingerprint` -- SSH + ``rke2 --version`` +
+  ``cat /etc/os-release``. Returns the canonical :class:`FingerprintResult`
+  with ``vendor="rancher"`` / ``product="rke2"``; ``version`` is the
+  parsed RKE2 release string; ``extras`` carries ``node_os``. Unreachable
+  / SSH-failed targets surface as ``reachable=False`` + ``extras["error"]``.
+* :meth:`Rke2SshConnector.probe` -- TCP + SSH handshake + RKE2-presence
+  check with distinct ``ProbeResult.reason`` values.
+* :meth:`Rke2SshConnector.about` -- operator-facing wrapper around
+  :meth:`fingerprint`, registered as the ``rke2.about`` typed op.
+* :meth:`Rke2SshConnector.posture_show` -- the read-only posture tier
+  (``rke2.posture.show``): config-file modes + redacted token presence.
+* :meth:`Rke2SshConnector.execute` -- the G0.6 dispatcher shim (same
+  shape as :meth:`Bind9Connector.execute` / :meth:`HolodeckConnector.execute`).
+
+Auth uses the base :class:`SshConnector` ``_auth_config`` unchanged --
+key-preferred, password-fallback -- resolving ``target.secret_ref`` (a
+Vault KV-v2 path string) via ``load_vault_secret_data`` under the
+operator's identity (the #2155 either/or key-or-password shape). The
+connector does **not** override ``_auth_config`` and does **not** touch
+the bind9 anti-shape.
+
+The approval-gated write ops (``rke2.token.rotate`` /
+``rke2.node.service.restart`` / ``rke2.node.config.update`` /
+``rke2.etcd-snapshot.save``) ship in sibling Tasks #2429/#2430/#2431 by
+appending to :data:`~meho_backplane.connectors.rke2.ops.RKE2_OPS`; the
+dispatcher shim does not change.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncssh
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.adapters.ssh import SshConnector
+from meho_backplane.connectors.rke2.ops import RKE2_OPS
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["Rke2SshConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Forward declaration -- replaced with `from meho_backplane.targets import Target`
+# in G0.3's Target model rollout. Mirrors the placeholder in the SSH
+# adapter and the bind9 / holodeck siblings.
+type Target = Any
+
+
+# ``rke2 --version`` prints ``rke2 version v1.28.5+rke2r1 (<hash>)`` on
+# the first line. The token after ``rke2 version`` is the release string.
+_RKE2_VERSION_RE: re.Pattern[str] = re.compile(r"rke2 version\s+(\S+)")
+
+# ``/etc/os-release`` carries ``PRETTY_NAME="Ubuntu 22.04.3 LTS"`` on
+# every systemd distro RKE2 supports. Quotes are optional per the spec.
+_OS_PRETTY_NAME_RE: re.Pattern[str] = re.compile(
+    r'^PRETTY_NAME=(?:"([^"\n]*)"|([^\n]*))', re.MULTILINE
+)
+
+# ``rke2`` is not always on the login shell PATH; the installer symlinks
+# it into ``/usr/local/bin``. Try both, and never fail the command (the
+# ``|| true`` keeps the version probe non-fatal -- an agent node without
+# the binary on PATH is still a reachable node).
+_RKE2_VERSION_CMD: str = (
+    "rke2 --version 2>/dev/null || /usr/local/bin/rke2 --version 2>/dev/null || true"
+)
+
+# Marker used by :meth:`probe` to confirm the node is an RKE2 node: the
+# config directory RKE2 always creates, or the binary on PATH.
+_RKE2_MARKER_CMD: str = (
+    "test -e /etc/rancher/rke2 && echo present || "
+    "(command -v rke2 >/dev/null 2>&1 && echo present) || echo absent"
+)
+
+
+def parse_rke2_version(banner: str) -> str | None:
+    """Return the RKE2 release string from ``rke2 --version`` output.
+
+    Examples
+    --------
+
+    >>> parse_rke2_version("rke2 version v1.28.5+rke2r1 (abc123)\\ngo version go1.21")
+    'v1.28.5+rke2r1'
+    >>> parse_rke2_version("") is None
+    True
+    """
+    match = _RKE2_VERSION_RE.search(banner)
+    return match.group(1) if match else None
+
+
+def parse_os_pretty_name(content: str) -> str | None:
+    """Return the ``PRETTY_NAME`` from ``/etc/os-release``, or ``None``.
+
+    Examples
+    --------
+
+    >>> parse_os_pretty_name('NAME="Ubuntu"\\nPRETTY_NAME="Ubuntu 22.04 LTS"\\n')
+    'Ubuntu 22.04 LTS'
+    >>> parse_os_pretty_name("") is None
+    True
+    """
+    match = _OS_PRETTY_NAME_RE.search(content)
+    if match is None:
+        return None
+    value = match.group(1) if match.group(1) is not None else match.group(2)
+    value = (value or "").strip()
+    return value or None
+
+
+class Rke2SshConnector(SshConnector):
+    """RKE2 node connector built on the :class:`SshConnector` adapter.
+
+    Registry v2 triple: ``("rke2", "1.x", "rke2-ssh")``. The ``1.x``
+    version spans the RKE2 1.x release line; a future ``("rke2", "2.x",
+    ...)`` entry can ship alongside without disturbing 1.x targets.
+
+    **Auth: key-preferred + password-fallback.** Inherits the base
+    :class:`SshConnector` ``_auth_config`` unchanged: a Vault secret with
+    ``ssh_private_key`` prefers key auth, otherwise password auth runs.
+    Credentials resolve via ``load_vault_secret_data`` (the #2155
+    either/or shape), never the bind9 anti-shape.
+
+    **Transport: plain SSH.** Every op runs a fixed, typed command over
+    the pooled SSH connection. The read-only posture tier never reads
+    secret material -- it ``stat``s modes + presence only.
+    """
+
+    product = "rke2"
+    version = "1.x"
+    impl_id = "rke2-ssh"
+
+    async def fingerprint(
+        self,
+        target: Target,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Read ``rke2 --version`` + ``/etc/os-release`` -- canonical fingerprint.
+
+        Runs two ``_run_command`` calls in sequence (the SSH adapter's
+        pool ensures both share one connection): the RKE2 version probe
+        (non-fatal -- ``version`` is ``None`` when the binary is not on
+        PATH) and ``cat /etc/os-release`` for the node OS pretty-name.
+
+        Unreachable / SSH-failed / credential-unresolvable → ``reachable
+        =False`` + ``extras["error"]`` rather than propagating, so the
+        shared :meth:`SshConnector._assert_reachable` guard surfaces the
+        failure consistently from :meth:`about` (#986). The catch tuple
+        covers the transport (``OSError`` / ``asyncssh.Error``) plus the
+        credential-resolution failures ``_auth_config`` raises (the
+        two-phase Vault contract + ``ValueError``).
+
+        ``operator`` is threaded to the SSH adapter's ``_auth_config``,
+        which resolves ``target.secret_ref`` under the operator's identity
+        on a pool miss (#2155). ``None`` (background callers) fails closed
+        at Vault and maps to ``reachable=False``.
+        """
+        probed_at = datetime.now(UTC)
+        try:
+            os_proc = await self._run_command(target, "cat /etc/os-release", operator=operator)
+            ver_proc = await self._run_command(target, _RKE2_VERSION_CMD, operator=operator)
+        except (
+            OSError,
+            asyncssh.Error,
+            ValueError,
+            VaultClientError,
+            VaultCredentialsReadError,
+        ) as exc:
+            _log.warning(
+                "rke2_fingerprint_unreachable",
+                target=getattr(target, "name", None),
+                error=str(exc),
+            )
+            return FingerprintResult(
+                vendor="rancher",
+                product="rke2",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="ssh: rke2 --version",
+                extras={"error": str(exc)},
+            )
+
+        os_raw = (os_proc.stdout or "") if hasattr(os_proc, "stdout") else ""
+        os_content = os_raw if isinstance(os_raw, str) else ""
+        node_os = parse_os_pretty_name(os_content)
+
+        ver_raw = (ver_proc.stdout or "") if hasattr(ver_proc, "stdout") else ""
+        ver_content = ver_raw if isinstance(ver_raw, str) else ""
+        rke2_version = parse_rke2_version(ver_content)
+
+        return FingerprintResult(
+            vendor="rancher",
+            product="rke2",
+            version=rke2_version,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method="ssh: rke2 --version",
+            extras={"node_os": node_os},
+        )
+
+    async def probe(self, target: Target) -> ProbeResult:
+        """Reachability + auth + RKE2-presence check.
+
+        Failure modes (each surfaces a distinct ``reason``):
+
+        * ``tcp_unreachable`` -- the SSH TCP socket cannot connect (host
+          down, firewall, wrong port). Catches :exc:`OSError`.
+        * ``ssh_auth_failed`` -- credentials were rejected
+          (:exc:`asyncssh.PermissionDenied`) or the handshake failed for
+          a non-auth reason (:exc:`asyncssh.DisconnectError`), or the
+          Vault credential read failed. ``probe()`` carries no operator,
+          so the read runs under the synthesised system operator and
+          fails closed -- the remediation is the same as a rejected
+          password: check the target's Vault secret.
+        * ``rke2_undetected`` -- SSH succeeded but neither
+          ``/etc/rancher/rke2`` nor an ``rke2`` binary on PATH is present;
+          the target is reachable but is not an RKE2 node.
+
+        The probe does not mutate state -- ``test`` / ``stat`` are
+        read-only.
+        """
+        start = time.monotonic()
+        probed_at = datetime.now(UTC)
+
+        def _result(ok: bool, reason: str | None) -> ProbeResult:
+            latency_ms = (time.monotonic() - start) * 1000.0
+            return ProbeResult(ok=ok, reason=reason, latency_ms=latency_ms, probed_at=probed_at)
+
+        # Order matters: PermissionDenied (subclass of DisconnectError)
+        # must be caught before DisconnectError; OSError is the TCP-level
+        # failure. Credential-resolution failures fold into ssh_auth_failed.
+        try:
+            await self._connect(target)
+        except asyncssh.PermissionDenied:
+            return _result(False, "ssh_auth_failed")
+        except asyncssh.DisconnectError:
+            return _result(False, "ssh_auth_failed")
+        except OSError:
+            return _result(False, "tcp_unreachable")
+        except (ValueError, VaultClientError, VaultCredentialsReadError):
+            return _result(False, "ssh_auth_failed")
+
+        try:
+            marker_proc = await self._run_command(target, _RKE2_MARKER_CMD)
+        except (OSError, asyncssh.Error):
+            return _result(False, "ssh_auth_failed")
+        marker_raw = (marker_proc.stdout or "") if hasattr(marker_proc, "stdout") else ""
+        marker = marker_raw.strip() if isinstance(marker_raw, str) else ""
+        if marker != "present":
+            return _result(False, "rke2_undetected")
+
+        return _result(True, None)
+
+    async def about(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Return the RKE2 node's vendor/product/version/node-OS snapshot.
+
+        Op-id: ``rke2.about``. Reuses :meth:`fingerprint` so the
+        operator-facing op and the canonical fingerprint share one
+        network round-trip. :meth:`SshConnector._assert_reachable` maps an
+        unreachable target to a :exc:`ConnectorUnreachableError` the
+        dispatcher reports as a non-ok result (#986) rather than a hollow
+        ``status="ok"`` envelope of None fields.
+        """
+        del params  # declared empty in schema; intentionally ignored
+        result = await self.fingerprint(target, operator)
+        self._assert_reachable(result)
+        return {
+            "vendor": result.vendor,
+            "product": result.product,
+            "version": result.version,
+            "node_os": result.extras.get("node_os"),
+        }
+
+    async def posture_show(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``rke2.posture.show`` (G-Node/RKE2-T1 #2221).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.rke2.ops_read.rke2_posture_show`,
+        which ``stat``s the RKE2 config-file modes + the redacted
+        join-token presence over the shared SSH adapter.
+        """
+        from meho_backplane.connectors.rke2.ops_read import (
+            rke2_posture_show as _rke2_posture_show,
+        )
+
+        return await _rke2_posture_show(self, target, params, operator)
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`RKE2_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan after the registry has
+        eager-imported every connector module. Mirrors the
+        :meth:`Bind9Connector.register_operations` /
+        :meth:`HolodeckConnector.register_operations` shape -- idempotent
+        across pod restarts.
+        """
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        bindings: list[tuple[Any, Any]] = []
+        for op in RKE2_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"Rke2SshConnector op {op.op_id!r} declares "
+                    f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+                )
+            bindings.append((op, handler))
+
+        for op, handler in bindings:
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = _WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"Rke2SshConnector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated when_to_use "
+                        f"exists for that key. Add an entry to "
+                        f"_WHEN_TO_USE_BY_GROUP in "
+                        f"meho_backplane.connectors.rke2.connector."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "rke2_operations_registered",
+            count=len(bindings),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+        )
+
+    async def execute(
+        self,
+        target: Target,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Dispatcher shim -- delegate to the G0.6 lookup + invoke path.
+
+        Mirrors :meth:`Bind9Connector.execute` and
+        :meth:`HolodeckConnector.execute`. Operator-less (no policy gate,
+        no audit row, no broadcast) because direct callers do not carry an
+        :class:`~meho_backplane.auth.operator.Operator`; the operator-aware
+        surface is ``POST /api/v1/operations/call`` via the G0.6 meta-tools.
+        """
+        from sqlalchemy import select
+
+        from meho_backplane.db.engine import get_sessionmaker
+        from meho_backplane.db.models import EndpointDescriptor
+        from meho_backplane.operations._errors import (
+            result_connector_error,
+            result_invalid_params,
+            result_unknown_op,
+        )
+        from meho_backplane.operations._handler_resolve import (
+            import_handler,
+            is_unbound_method,
+        )
+        from meho_backplane.operations._lookup import count_known_ops
+        from meho_backplane.operations._validate import validate_params
+
+        start = time.monotonic()
+
+        def _elapsed() -> float:
+            return (time.monotonic() - start) * 1000.0
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.tenant_id.is_(None),
+                    EndpointDescriptor.product == self.product,
+                    EndpointDescriptor.version == self.version,
+                    EndpointDescriptor.impl_id == self.impl_id,
+                    EndpointDescriptor.op_id == op_id,
+                    EndpointDescriptor.is_enabled.is_(True),
+                )
+            )
+            descriptor = result.scalar_one_or_none()
+
+        if descriptor is None:
+            known_op_count = await count_known_ops(
+                tenant_id=None,  # operator-less chassis path: global rows only
+                product=self.product,
+                version=self.version,
+                impl_id=self.impl_id,
+            )
+            return result_unknown_op(op_id, known_op_count, _elapsed())
+
+        validation_errors = validate_params(descriptor.parameter_schema, params)
+        if validation_errors:
+            return result_invalid_params(op_id, validation_errors, _elapsed())
+
+        handler = import_handler(descriptor.handler_ref or "")
+        if is_unbound_method(handler, type(self)):
+            handler = handler.__get__(self, type(self))
+
+        try:
+            raw = await handler(target=target, params=params)
+        except Exception as exc:
+            return result_connector_error(op_id, exc, _elapsed())
+
+        return OperationResult(
+            status="ok",
+            op_id=op_id,
+            result=raw if isinstance(raw, (dict, list)) else {"value": raw},
+            duration_ms=_elapsed(),
+        )
+
+
+#: Curated ``when_to_use`` strings per group key, indexed by
+#: :meth:`Rke2SshConnector.register_operations`. Each entry covers a
+#: ``group_key`` declared in :data:`RKE2_OPS`; the registration walk fails
+#: closed with a :class:`ValueError` if a ``group_key`` lacks a curated
+#: entry (the bind9 / holodeck precedent). Defined after the class so the
+#: strings can reference the transport note without a forward import.
+_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "identity": (
+        "Use for RKE2 node identity questions before any posture or "
+        "(future) maintenance op: 'which RKE2 version is this node "
+        "running, on which node OS, and is it reachable via SSH?'. The "
+        "single ``rke2.about`` op returns vendor / product / RKE2 version "
+        "/ node OS. Transport: plain SSH (no REST surface)."
+    ),
+    "posture": (
+        "Use to audit an RKE2 node's config-surface security posture: "
+        "``rke2.posture.show`` reports the permission modes of "
+        "``/etc/rancher/rke2/config.yaml`` and the admin kubeconfig "
+        "``rke2.yaml``, plus whether the on-disk server join token "
+        "exists (presence + mode only -- the token VALUE is never read). "
+        "Pair with a rotation runbook to confirm the token is present "
+        "before rotating. Transport: plain SSH (``stat``, read-only)."
+    ),
+}

--- a/backend/src/meho_backplane/connectors/rke2/ops.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed operations exposed by :class:`Rke2SshConnector`.
+
+G-Node/RKE2-T1 (#2221) scaffold -- ships the read-only tier only:
+
+* ``rke2.about`` -- the identity canary. Operator-facing wrapper around
+  :meth:`Rke2SshConnector.fingerprint` (``rke2 --version`` +
+  ``/etc/os-release``). Proves the ``register_typed_operation()`` ->
+  dispatcher -> plain-SSH -> parse pipeline end-to-end, exactly as the
+  bind9 / holodeck siblings' ``about`` canaries did.
+* ``rke2.posture.show`` -- the read-only posture tier. ``stat``s the
+  RKE2 config-file modes and the on-disk join-token presence with the
+  token **value never read** (redacted by construction). Two ops total.
+
+The approval-gated write ops (``rke2.token.rotate`` /
+``rke2.node.service.restart`` / ``rke2.node.config.update`` /
+``rke2.etcd-snapshot.save``) ship in sibling Tasks #2429/#2430/#2431
+under Initiative #2172 -- explicitly **out of scope** here.
+
+The dataclass + tuple shape mirrors
+:mod:`~meho_backplane.connectors.bind9.ops` and
+:mod:`~meho_backplane.connectors.holodeck.ops` so the registration walk
+reads identically across SSH-transport connectors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+__all__ = ["RKE2_OPS", "SSH_TRANSPORT_NOTE", "Rke2Op", "_rke2_ops"]
+
+
+#: Canonical plain-SSH transport reminder copied verbatim into every op's
+#: ``llm_instructions.when_to_use``. RKE2 nodes expose no MEHO REST
+#: surface; every op is plain SSH to the node OS. The read tier never
+#: reads secret material -- it ``stat``s modes + presence only.
+SSH_TRANSPORT_NOTE: str = (
+    "RKE2 cluster nodes expose no MEHO REST API; the transport is plain "
+    "SSH to the node OS over the shared SSH adapter. The read-only "
+    "posture tier only ``stat``s file modes and token-file presence -- "
+    "it never reads secret material (the join token value is redacted by "
+    "construction)."
+)
+
+
+@dataclass(frozen=True)
+class Rke2Op:
+    """Metadata for one RKE2 op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the connector's ``register_operations()`` classmethod can
+    splat the dataclass into the helper without per-op boilerplate.
+    ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.rke2.connector.Rke2SshConnector`
+    that exposes the async handler.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: The identity canary. ``rke2.about`` wraps :meth:`fingerprint`.
+_RKE2_ABOUT_OP = Rke2Op(
+    op_id="rke2.about",
+    handler_attr="about",
+    summary="Return the RKE2 node's vendor, product, RKE2 version, and node OS.",
+    description=(
+        "Connects to a cluster node over SSH and runs ``rke2 --version`` "
+        "plus ``cat /etc/os-release`` to identify the node. Returns a "
+        "flat dict with the vendor (``rancher``), product (``rke2``), the "
+        "parsed RKE2 release string (e.g. ``v1.28.5+rke2r1``, or ``null`` "
+        "when the ``rke2`` binary is not on PATH), and the node OS "
+        "pretty-name. No params; safe to call on any reachable node. "
+        "Call this first to confirm the node is reachable via SSH before "
+        "issuing the posture / (future) maintenance ops."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "vendor": {"type": "string"},
+            "product": {"type": "string"},
+            "version": {"type": ["string", "null"]},
+            "node_os": {"type": ["string", "null"]},
+        },
+        "required": ["vendor", "product"],
+        "additionalProperties": True,
+    },
+    group_key="identity",
+    tags=("read-only", "identity", "rke2"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator wants to identify the RKE2 node "
+            "behind a target -- which RKE2 version it runs and on which "
+            "node OS -- or to confirm the node is reachable via SSH "
+            "before issuing the posture op. " + SSH_TRANSPORT_NOTE
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "Flat dict; ``version`` carries the parsed RKE2 release "
+            "string (e.g. ``v1.28.5+rke2r1``) when the ``rke2`` binary "
+            "was on PATH, ``null`` otherwise. ``node_os`` carries the "
+            "``/etc/os-release`` PRETTY_NAME (e.g. ``Ubuntu 22.04 LTS``)."
+        ),
+    },
+)
+
+
+def _rke2_ops() -> tuple[Rke2Op, ...]:
+    """Return the merged registration tuple.
+
+    Composition: ``rke2.about`` (identity canary) + ``READ_OPS`` (the
+    read-only posture tier: ``rke2.posture.show``). Two ops total -- the
+    full T1 (#2221) read surface. The approval-gated write ops append to
+    this tuple in the sibling write Tasks, exactly as
+    :func:`meho_backplane.connectors.holodeck.ops._holodeck_ops` layers
+    its ``WRITE_OPS`` on.
+
+    Implemented as a function call rather than a module-level literal so
+    the import order stays linear: ``ops.py`` defines :class:`Rke2Op` +
+    ``_RKE2_ABOUT_OP``, then imports the read ops from
+    :mod:`meho_backplane.connectors.rke2.ops_read`.
+    """
+    from meho_backplane.connectors.rke2.ops_read import READ_OPS
+
+    return (_RKE2_ABOUT_OP, *READ_OPS)
+
+
+#: The ops :class:`Rke2SshConnector` registers at lifespan startup.
+RKE2_OPS: tuple[Rke2Op, ...] = _rke2_ops()

--- a/backend/src/meho_backplane/connectors/rke2/ops_read.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_read.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Read-only posture tier for :class:`Rke2SshConnector` (G-Node/RKE2-T1 #2221).
+
+``rke2.posture.show`` reports the security posture of an RKE2 node's
+config surface without ever reading secret material:
+
+* **Config-file modes** -- the octal permission bits + owner/group of the
+  RKE2 config files under ``/etc/rancher/rke2/`` (``config.yaml`` and the
+  admin kubeconfig ``rke2.yaml``). A world-readable ``rke2.yaml`` or a
+  drifted ``config.yaml`` mode is the posture signal the operator wants.
+* **Token-key presence (redacted)** -- whether the on-disk server join
+  token at ``/var/lib/rancher/rke2/server/token`` exists and its mode,
+  **without reading the token value**. The handler only ``stat``s the
+  path; the file content is never fetched, so no secret can leak into
+  the result envelope, the audit ``raw_payload``, or the logs. Every
+  token entry carries ``redacted: true`` to make the guarantee explicit
+  to agents reading the schema.
+
+All measured paths are fixed constants in this module -- there is **no**
+operator-supplied path parameter, so there is no path-traversal or
+shell-injection surface. The single ``stat`` round-trip reports each
+existing path; paths absent from stdout are reported ``present: false``
+(``stat`` writes a diagnostic to stderr and skips them, which is exactly
+the "file not present" posture signal on an agent node with no server
+token).
+"""
+
+from __future__ import annotations
+
+import shlex
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.rke2.ops import SSH_TRANSPORT_NOTE, Rke2Op
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.rke2.connector import Rke2SshConnector, Target
+
+__all__ = [
+    "POSTURE_CONFIG_PATHS",
+    "READ_OPS",
+    "RKE2_TOKEN_PATH",
+    "parse_posture",
+    "parse_stat_output",
+    "rke2_posture_show",
+]
+
+
+#: RKE2 config files whose modes the posture tier reports. Path-bounded
+#: to ``/etc/rancher/rke2/*`` per the ratified Initiative #2172 design.
+#: ``config.yaml`` is the server/agent config; ``rke2.yaml`` is the
+#: cluster-admin kubeconfig RKE2 writes on server nodes.
+POSTURE_CONFIG_PATHS: tuple[str, ...] = (
+    "/etc/rancher/rke2/config.yaml",
+    "/etc/rancher/rke2/rke2.yaml",
+)
+
+#: The on-disk server join token. Its **presence + mode** are reported;
+#: its **value is never read** (redacted by construction). This is the
+#: same path the future ``rke2.token.rotate`` write op reads the OLD
+#: token from (Initiative #2172).
+RKE2_TOKEN_PATH: str = "/var/lib/rancher/rke2/server/token"
+
+
+def _normalise_mode(raw: str) -> str:
+    """Left-pad a ``stat %a`` octal mode to 4 digits (``600`` -> ``0600``).
+
+    ``stat -c '%a'`` drops the leading zero for the common ``0600`` /
+    ``0644`` modes; the operator reads posture more clearly with the
+    canonical 4-digit octal form. Non-numeric input (never expected from
+    ``%a``) is returned unchanged.
+    """
+    stripped = raw.strip()
+    if stripped.isdigit() and len(stripped) < 4:
+        return stripped.zfill(4)
+    return stripped
+
+
+def parse_stat_output(stdout: str) -> dict[str, dict[str, str]]:
+    """Parse ``stat -c '%n|%a|%U|%G'`` stdout into a path -> attrs map.
+
+    Each valid line is ``<path>|<octal-mode>|<owner>|<group>``. Lines
+    that do not split into exactly four ``|``-separated fields are
+    skipped (defensive against a stray banner line). Modes are
+    normalised to the 4-digit octal form.
+    """
+    result: dict[str, dict[str, str]] = {}
+    for line in stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split("|")
+        if len(parts) != 4:
+            continue
+        path, mode, owner, group = parts
+        result[path] = {
+            "mode": _normalise_mode(mode),
+            "owner": owner,
+            "group": group,
+        }
+    return result
+
+
+def _stat_entry(path: str, stat_map: dict[str, dict[str, str]]) -> dict[str, Any]:
+    """Build the per-path posture entry from the parsed ``stat`` map."""
+    info = stat_map.get(path)
+    if info is None:
+        return {"path": path, "present": False, "mode": None, "owner": None, "group": None}
+    return {
+        "path": path,
+        "present": True,
+        "mode": info["mode"],
+        "owner": info["owner"],
+        "group": info["group"],
+    }
+
+
+def parse_posture(
+    stat_map: dict[str, dict[str, str]],
+    config_paths: tuple[str, ...],
+    token_path: str,
+) -> dict[str, Any]:
+    """Compose the posture envelope from the parsed ``stat`` map.
+
+    Returns ``{"config_files": [...], "token": {...}}``. Every config
+    entry and the token entry carry ``present`` plus (when present)
+    ``mode`` / ``owner`` / ``group``. The token entry additionally
+    carries ``redacted: true`` -- the token **value** is never read, only
+    its presence + mode, so no secret material appears in the envelope.
+    """
+    config_files = [_stat_entry(path, stat_map) for path in config_paths]
+    token = _stat_entry(token_path, stat_map)
+    token["redacted"] = True
+    return {"config_files": config_files, "token": token}
+
+
+async def rke2_posture_show(
+    connector: Rke2SshConnector,
+    target: Target,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``rke2.posture.show``.
+
+    ``stat``s the fixed RKE2 config paths + the on-disk join-token path in
+    a single SSH round-trip and returns the redacted posture envelope. No
+    param is consumed -- the measured paths are code constants, never
+    operator input. Transport / auth failures propagate to the dispatcher,
+    which maps them to a ``connector_error`` result (the #986 discipline);
+    a merely-absent file surfaces as ``present: false``, not an error.
+    """
+    del params  # declared empty in schema; the measured paths are fixed
+    paths = (*POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
+    quoted = " ".join(shlex.quote(path) for path in paths)
+    cmd = f"stat -c '%n|%a|%U|%G' -- {quoted}"
+    proc = await connector._run_command(target, cmd, operator=operator)
+    stdout_raw = proc.stdout if hasattr(proc, "stdout") else ""
+    stdout = stdout_raw if isinstance(stdout_raw, str) else ""
+    stat_map = parse_stat_output(stdout)
+    return parse_posture(stat_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
+
+
+_RKE2_POSTURE_OP = Rke2Op(
+    op_id="rke2.posture.show",
+    handler_attr="posture_show",
+    summary="Report RKE2 config-file modes + join-token presence (values redacted).",
+    description=(
+        "Runs a single ``stat`` over the RKE2 config files under "
+        "``/etc/rancher/rke2/`` (``config.yaml`` and the admin kubeconfig "
+        "``rke2.yaml``) plus the on-disk server join token at "
+        "``/var/lib/rancher/rke2/server/token``. Returns each path's "
+        "octal mode + owner/group and a ``present`` flag. The join-token "
+        "entry reports presence + mode ONLY -- the token value is never "
+        "read, so no secret material appears in the result. Use it to "
+        "audit config-file permission drift (e.g. a world-readable "
+        "kubeconfig) and to confirm the server token exists before a "
+        "rotation. No params; safe and read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "config_files": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "present": {"type": "boolean"},
+                        "mode": {"type": ["string", "null"]},
+                        "owner": {"type": ["string", "null"]},
+                        "group": {"type": ["string", "null"]},
+                    },
+                    "required": ["path", "present"],
+                    "additionalProperties": False,
+                },
+            },
+            "token": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "present": {"type": "boolean"},
+                    "mode": {"type": ["string", "null"]},
+                    "owner": {"type": ["string", "null"]},
+                    "group": {"type": ["string", "null"]},
+                    "redacted": {"type": "boolean"},
+                },
+                "required": ["path", "present", "redacted"],
+                "additionalProperties": False,
+            },
+        },
+        "required": ["config_files", "token"],
+        "additionalProperties": False,
+    },
+    group_key="posture",
+    tags=("read-only", "posture", "rke2", "security"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to audit an RKE2 node's config-surface posture: the "
+            "permission modes of ``/etc/rancher/rke2/config.yaml`` and "
+            "the admin kubeconfig ``rke2.yaml``, and whether the on-disk "
+            "server join token exists (with its mode). The token VALUE is "
+            "never read -- only presence + mode. " + SSH_TRANSPORT_NOTE
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "``{config_files: [{path, present, mode, owner, group}], "
+            "token: {path, present, mode, owner, group, redacted: true}}``."
+            " ``mode`` is the 4-digit octal form (e.g. ``0600``). A path "
+            "that does not exist reports ``present: false`` with null "
+            "mode/owner/group. ``token.redacted`` is always true -- the "
+            "value is never fetched."
+        ),
+    },
+)
+
+
+#: The read-only posture tier ops. ``rke2.about`` (the identity canary)
+#: is composed alongside these in
+#: :func:`meho_backplane.connectors.rke2.ops._rke2_ops`.
+READ_OPS: tuple[Rke2Op, ...] = (_RKE2_POSTURE_OP,)

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the RKE2 node connector scaffold + posture tier (#2221).
+
+Coverage matrix (per Task #2221 acceptance criteria):
+
+* :func:`parse_rke2_version` / :func:`parse_os_pretty_name` -- identity
+  parsing from ``rke2 --version`` + ``/etc/os-release``.
+* :func:`parse_stat_output` / :func:`parse_posture` -- the posture
+  envelope: config-file modes + owner/group, missing paths reported
+  ``present: false``, and the redacted token entry.
+* Bound-method shims on :class:`Rke2SshConnector` -- ``about`` (identity)
+  and ``posture_show`` (posture) run the correct plain-SSH commands and
+  return the expected envelope shape.
+* Redaction invariant -- ``posture_show`` issues a single ``stat`` (never
+  a ``cat`` of the token path); the token entry carries ``redacted: true``
+  and no secret material bleeds into the result envelope or logs.
+* ``RKE2_OPS`` registration shape -- 2 ops, both ``safety_level='safe'``
+  / ``requires_approval=false`` / read-only, ``additionalProperties=False``
+  on the parameter schema, non-empty SSH-transport ``when_to_use``, and
+  ``rke2.`` namespace op_ids with handler methods on the class.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import meho_backplane.connectors.rke2  # noqa: F401 -- import for registry side-effects
+from meho_backplane.connectors.rke2 import RKE2_OPS, Rke2SshConnector
+from meho_backplane.connectors.rke2.connector import (
+    parse_os_pretty_name,
+    parse_rke2_version,
+)
+from meho_backplane.connectors.rke2.ops_read import (
+    POSTURE_CONFIG_PATHS,
+    RKE2_TOKEN_PATH,
+    parse_posture,
+    parse_stat_output,
+)
+from meho_backplane.settings import get_settings
+from tests._ssh_vault_stub import stub_ssh_vault_secrets
+
+# ---------------------------------------------------------------------------
+# Environment fixture (settings cache requires the env vars to resolve)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+_CANARY_PASSWORD = "rke2-canary-pw-xyz-771"  # gitleaks:allow NOSONAR -- synthetic canary
+# Synthetic key-shaped canary that does not trip the detect-private-key
+# hook (the regex keys on the literal ``BEGIN ... PRIVATE KEY`` opener).
+_CANARY_SSH_KEY = "RKE2-CANARY-KEY-MARKER-QWER5678ZX"  # gitleaks:allow -- synthetic canary
+# A token *value* canary. The posture tier must NEVER read the token
+# content, so this string must never surface anywhere.
+_CANARY_TOKEN_VALUE = "K10rke2canarytokenvalueDONOTLEAK::server:abc123"  # gitleaks:allow NOSONAR
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str  # a Vault KV-v2 path STRING (#2155)
+
+
+_TARGET_SECRET_PATH = "meho/testing/rke2/node-test"
+
+_TARGET = _StubTarget(
+    name="rke2-node-test",
+    host="rke2-node.test.invalid",
+    port=22,
+    secret_ref=_TARGET_SECRET_PATH,
+)
+
+
+@pytest.fixture(autouse=True)
+def _vault_secrets() -> Iterator[None]:
+    with stub_ssh_vault_secrets(
+        {
+            _TARGET_SECRET_PATH: {
+                "username": "root",
+                "password": _CANARY_PASSWORD,
+                "ssh_private_key": _CANARY_SSH_KEY,
+            }
+        }
+    ):
+        yield
+
+
+def _proc(*, stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    """Construct an ``SSHCompletedProcess``-shaped stub."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# parse_rke2_version / parse_os_pretty_name
+# ---------------------------------------------------------------------------
+
+
+def test_parse_rke2_version_extracts_release_string() -> None:
+    banner = "rke2 version v1.28.5+rke2r1 (abc1234)\ngo version go1.21.6\n"
+    assert parse_rke2_version(banner) == "v1.28.5+rke2r1"
+
+
+def test_parse_rke2_version_absent_returns_none() -> None:
+    assert parse_rke2_version("") is None
+    assert parse_rke2_version("command not found\n") is None
+
+
+def test_parse_os_pretty_name_quoted() -> None:
+    content = 'NAME="Ubuntu"\nPRETTY_NAME="Ubuntu 22.04.3 LTS"\nID=ubuntu\n'
+    assert parse_os_pretty_name(content) == "Ubuntu 22.04.3 LTS"
+
+
+def test_parse_os_pretty_name_unquoted_and_absent() -> None:
+    assert parse_os_pretty_name("PRETTY_NAME=Fedora Linux 39\n") == "Fedora Linux 39"
+    assert parse_os_pretty_name("NAME=Ubuntu\n") is None
+    assert parse_os_pretty_name("") is None
+
+
+# ---------------------------------------------------------------------------
+# parse_stat_output
+# ---------------------------------------------------------------------------
+
+
+def test_parse_stat_output_parses_and_normalises_mode() -> None:
+    stdout = (
+        "/etc/rancher/rke2/config.yaml|600|root|root\n/etc/rancher/rke2/rke2.yaml|644|root|rke2\n"
+    )
+    parsed = parse_stat_output(stdout)
+    assert parsed["/etc/rancher/rke2/config.yaml"] == {
+        "mode": "0600",
+        "owner": "root",
+        "group": "root",
+    }
+    # 3-digit mode left-padded to the canonical 4-digit octal form.
+    assert parsed["/etc/rancher/rke2/rke2.yaml"]["mode"] == "0644"
+
+
+def test_parse_stat_output_skips_malformed_lines() -> None:
+    stdout = "garbage banner line\n/etc/rancher/rke2/config.yaml|600|root|root\n\n"
+    parsed = parse_stat_output(stdout)
+    assert set(parsed) == {"/etc/rancher/rke2/config.yaml"}
+
+
+# ---------------------------------------------------------------------------
+# parse_posture
+# ---------------------------------------------------------------------------
+
+
+def test_parse_posture_present_and_redacted_token() -> None:
+    stat_map = {
+        "/etc/rancher/rke2/config.yaml": {"mode": "0600", "owner": "root", "group": "root"},
+        "/etc/rancher/rke2/rke2.yaml": {"mode": "0600", "owner": "root", "group": "root"},
+        RKE2_TOKEN_PATH: {"mode": "0600", "owner": "root", "group": "root"},
+    }
+    posture = parse_posture(stat_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
+    cfg = {c["path"]: c for c in posture["config_files"]}
+    assert cfg["/etc/rancher/rke2/config.yaml"]["present"] is True
+    assert cfg["/etc/rancher/rke2/config.yaml"]["mode"] == "0600"
+    # Token entry is present, carries its mode, and is explicitly redacted.
+    token = posture["token"]
+    assert token["path"] == RKE2_TOKEN_PATH
+    assert token["present"] is True
+    assert token["mode"] == "0600"
+    assert token["redacted"] is True
+    # No token VALUE field exists anywhere in the envelope.
+    assert "value" not in token
+    assert "token" not in {k for c in posture["config_files"] for k in c}
+
+
+def test_parse_posture_missing_paths_report_absent() -> None:
+    # Agent node: no server token, config.yaml only.
+    stat_map = {
+        "/etc/rancher/rke2/config.yaml": {"mode": "0600", "owner": "root", "group": "root"},
+    }
+    posture = parse_posture(stat_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
+    cfg = {c["path"]: c for c in posture["config_files"]}
+    assert cfg["/etc/rancher/rke2/rke2.yaml"]["present"] is False
+    assert cfg["/etc/rancher/rke2/rke2.yaml"]["mode"] is None
+    token = posture["token"]
+    assert token["present"] is False
+    assert token["mode"] is None
+    assert token["redacted"] is True
+
+
+# ---------------------------------------------------------------------------
+# about shim (identity)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_about_returns_identity_snapshot() -> None:
+    connector = Rke2SshConnector()
+    # fingerprint order: os-release, then rke2 --version.
+    sequence = [
+        _proc(stdout='PRETTY_NAME="Ubuntu 22.04.3 LTS"\n'),
+        _proc(stdout="rke2 version v1.29.3+rke2r1 (deadbee)\n"),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        result = await connector.about(_TARGET, {})
+    assert result["vendor"] == "rancher"
+    assert result["product"] == "rke2"
+    assert result["version"] == "v1.29.3+rke2r1"
+    assert result["node_os"] == "Ubuntu 22.04.3 LTS"
+    issued = [call.args[1] for call in mock_cmd.await_args_list]
+    assert issued[0] == "cat /etc/os-release"
+    assert "rke2 --version" in issued[1]
+
+
+@pytest.mark.asyncio
+async def test_about_version_none_when_binary_absent() -> None:
+    connector = Rke2SshConnector()
+    sequence = [
+        _proc(stdout='PRETTY_NAME="RHEL 9.3"\n'),
+        _proc(stdout=""),  # `|| true` swallows a missing rke2 binary
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        result = await connector.about(_TARGET, {})
+    assert result["version"] is None
+    assert result["node_os"] == "RHEL 9.3"
+
+
+@pytest.mark.asyncio
+async def test_about_unreachable_raises_connector_error() -> None:
+    """An unreachable node maps to ConnectorUnreachableError, not a hollow ok."""
+    from meho_backplane.connectors.adapters.ssh import ConnectorUnreachableError
+
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = OSError("connection refused")
+        with pytest.raises(ConnectorUnreachableError):
+            await connector.about(_TARGET, {})
+
+
+# ---------------------------------------------------------------------------
+# posture_show shim (posture tier) + redaction invariant
+# ---------------------------------------------------------------------------
+
+
+_STAT_STDOUT_FULL = (
+    "/etc/rancher/rke2/config.yaml|600|root|root\n"
+    "/etc/rancher/rke2/rke2.yaml|600|root|root\n"
+    "/var/lib/rancher/rke2/server/token|600|root|root\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_posture_show_returns_redacted_envelope() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_STAT_STDOUT_FULL)
+        result = await connector.posture_show(_TARGET, {})
+    # Single SSH round-trip; the command is a `stat`, never a `cat`.
+    mock_cmd.assert_awaited_once()
+    cmd = mock_cmd.await_args.args[1]
+    assert cmd.startswith("stat -c '%n|%a|%U|%G' --")
+    assert "cat" not in cmd
+    # Every measured path appears as a stat argument.
+    for path in (*POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH):
+        assert path in cmd
+    # Envelope shape + redaction.
+    assert result["token"]["present"] is True
+    assert result["token"]["mode"] == "0600"
+    assert result["token"]["redacted"] is True
+    cfg = {c["path"]: c for c in result["config_files"]}
+    assert cfg["/etc/rancher/rke2/config.yaml"]["mode"] == "0600"
+
+
+@pytest.mark.asyncio
+async def test_posture_show_reports_missing_token_as_absent() -> None:
+    connector = Rke2SshConnector()
+    # Agent node: config.yaml only in stat stdout (missing paths omitted).
+    stdout = "/etc/rancher/rke2/config.yaml|640|root|root\n"
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=stdout)
+        result = await connector.posture_show(_TARGET, {})
+    assert result["token"]["present"] is False
+    assert result["token"]["redacted"] is True
+    cfg = {c["path"]: c for c in result["config_files"]}
+    assert cfg["/etc/rancher/rke2/rke2.yaml"]["present"] is False
+
+
+@pytest.mark.asyncio
+async def test_posture_show_propagates_ssh_failure() -> None:
+    """A transport failure escapes so the dispatcher reports connector_error."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = OSError("connection refused")
+        with pytest.raises(OSError, match="connection refused"):
+            await connector.posture_show(_TARGET, {})
+
+
+@pytest.mark.asyncio
+async def test_posture_show_never_leaks_secret_material(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The posture envelope + logs carry no credential or token-value material."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_STAT_STDOUT_FULL)
+        with caplog.at_level("DEBUG"):
+            result = await connector.posture_show(_TARGET, {})
+    rendered = repr(result)
+    for canary in (_CANARY_PASSWORD, _CANARY_SSH_KEY, _CANARY_TOKEN_VALUE):
+        assert canary not in rendered
+        assert canary not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# RKE2_OPS registration shape
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED_OP_IDS: frozenset[str] = frozenset({"rke2.about", "rke2.posture.show"})
+
+
+def test_rke2_ops_has_two_entries() -> None:
+    assert len(RKE2_OPS) == 2
+
+
+def test_rke2_ops_about_is_first() -> None:
+    assert RKE2_OPS[0].op_id == "rke2.about"
+
+
+def test_rke2_ops_covers_expected_op_ids() -> None:
+    assert {op.op_id for op in RKE2_OPS} == _EXPECTED_OP_IDS
+
+
+def test_rke2_ops_all_namespaced() -> None:
+    for op in RKE2_OPS:
+        assert op.op_id.startswith("rke2."), f"{op.op_id!r} lacks rke2. prefix"
+
+
+def test_rke2_ops_all_safe_read_only_no_approval() -> None:
+    """AC: every op is safe-tier, read-only, and requires no approval."""
+    for op in RKE2_OPS:
+        assert op.safety_level == "safe", f"{op.op_id!r} is not safe-tier"
+        assert op.requires_approval is False, f"{op.op_id!r} requires approval"
+        assert "read-only" in op.tags, f"{op.op_id!r} missing read-only tag"
+
+
+def test_rke2_ops_parameter_schemas_closed() -> None:
+    for op in RKE2_OPS:
+        assert op.parameter_schema.get("additionalProperties") is False
+        # The read tier takes no operator parameters -- fixed paths only.
+        assert op.parameter_schema.get("properties") == {}
+
+
+def test_rke2_ops_have_ssh_transport_when_to_use() -> None:
+    for op in RKE2_OPS:
+        assert op.llm_instructions, f"{op.op_id!r} missing llm_instructions"
+        when_to_use = op.llm_instructions.get("when_to_use", "")
+        assert when_to_use.strip(), f"{op.op_id!r} empty when_to_use"
+        assert "SSH" in when_to_use, f"{op.op_id!r} when_to_use lacks SSH transport note"
+
+
+def test_rke2_ops_handler_attrs_exist_on_connector() -> None:
+    for op in RKE2_OPS:
+        assert callable(getattr(Rke2SshConnector, op.handler_attr, None)), (
+            f"{op.op_id!r}: Rke2SshConnector has no handler {op.handler_attr!r}"
+        )
+
+
+def test_rke2_connector_registry_triple() -> None:
+    """The v2 registry advertises this class under (rke2, 1.x, rke2-ssh)."""
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    assert registry.get(("rke2", "1.x", "rke2-ssh")) is Rke2SshConnector

--- a/backend/tests/test_connectors_rke2_e2e.py
+++ b/backend/tests/test_connectors_rke2_e2e.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""RKE2 connector recorded-fixture / asyncssh fake-shell E2E test (#2221).
+
+Drives ``rke2.about`` and ``rke2.posture.show`` through the full
+``call_operation`` dispatch stack against an in-process asyncssh
+fake-shell server that replays plain-SSH command stubs -- no Docker
+dependency, no live RKE2 node. The shape mirrors the G3.8 Holodeck
+recorded-fixture E2E precedent (``test_connectors_holodeck_e2e.py``).
+
+Acceptance criteria verified (Issue #2221)
+==========================================
+
+* A ``rke2.about`` / ``rke2.posture.show`` dispatch via ``call_operation``
+  against a registered target returns ``status="ok"`` -- the connector +
+  read-posture tier are dispatchable (AC1).
+* The posture result reports config-file modes + the join-token presence
+  with the token **value never present** (redacted); the ``stat`` command
+  is the only transport touched -- no ``cat`` of the token path (AC1/AC3).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import asyncssh
+import pytest
+
+import meho_backplane.connectors.rke2  # noqa: F401 -- import for registry side-effects
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.rke2 import Rke2SshConnector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.operations.reducer import PassThroughReducer
+
+# ---------------------------------------------------------------------------
+# Module-level key material (generated once per session)
+# ---------------------------------------------------------------------------
+
+_SERVER_KEY = asyncssh.generate_private_key("ssh-ed25519")
+_CLIENT_KEY = asyncssh.generate_private_key("ssh-ed25519")
+_CLIENT_PUB = _CLIENT_KEY.convert_to_public()
+
+# ---------------------------------------------------------------------------
+# Fixture responses -- minimal pre-recorded RKE2 node output
+# ---------------------------------------------------------------------------
+
+_OS_RELEASE_FIXTURE = 'NAME="Ubuntu"\nPRETTY_NAME="Ubuntu 22.04.3 LTS"\nID=ubuntu\n'
+_RKE2_VERSION_FIXTURE = "rke2 version v1.29.3+rke2r1 (a1b2c3d)\ngo version go1.21.8\n"
+# stat -c '%n|%a|%U|%G' output: config.yaml + rke2.yaml + on-disk token.
+# The token line carries its MODE only -- the value is never read.
+_STAT_FIXTURE = (
+    "/etc/rancher/rke2/config.yaml|600|root|root\n"
+    "/etc/rancher/rke2/rke2.yaml|600|root|root\n"
+    "/var/lib/rancher/rke2/server/token|600|root|root\n"
+)
+
+# A canary token value the fixture never emits (posture never reads the
+# token content). Asserted absent from every dispatch result.
+_TOKEN_VALUE_CANARY = "K10rke2e2ecanarytokenDONOTLEAK::server:zzz999"  # NOSONAR
+
+
+# ---------------------------------------------------------------------------
+# In-process fake-shell SSH server
+# ---------------------------------------------------------------------------
+
+
+class _FakeShellSSHServer(asyncssh.SSHServer):
+    """In-process asyncssh server that accepts key auth for the test client key."""
+
+    def public_key_auth_supported(self) -> bool:
+        return True
+
+    def validate_public_key(self, username: str, key: Any) -> bool:  # type: ignore[override]
+        return bool(key == _CLIENT_PUB)
+
+
+async def _fake_shell_process_factory(process: Any) -> None:
+    """Dispatch by command string (prefix-matched) to pre-recorded bytes."""
+    cmd: str = process.command or ""
+    if cmd == "cat /etc/os-release":
+        response: str | None = _OS_RELEASE_FIXTURE
+    elif cmd.startswith("rke2 --version"):
+        response = _RKE2_VERSION_FIXTURE
+    elif cmd.startswith("stat -c '%n|%a|%U|%G'"):
+        response = _STAT_FIXTURE
+    else:
+        process.stderr.write(f"fake-shell: unknown command: {cmd!r}\n")
+        process.exit(127)
+        return
+    process.stdout.write(response)
+    process.exit(0)
+
+
+@pytest.fixture(scope="module")
+def event_loop_policy() -> asyncio.DefaultEventLoopPolicy:
+    """Use the default event loop policy for this module's async tests."""
+    return asyncio.DefaultEventLoopPolicy()
+
+
+@pytest.fixture
+async def fake_shell_server() -> AsyncIterator[types.SimpleNamespace]:
+    """Yield a running in-process fake-shell asyncssh server."""
+    srv = await asyncssh.create_server(
+        _FakeShellSSHServer,
+        "127.0.0.1",
+        0,
+        server_host_keys=[_SERVER_KEY],
+        process_factory=_fake_shell_process_factory,
+    )
+    port: int = srv.sockets[0].getsockname()[1]
+    yield types.SimpleNamespace(host="127.0.0.1", port=port)
+    srv.close()
+    await srv.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# Environment + DB + broadcast fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    from meho_backplane.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Stub out :func:`publish_event` so the broadcast bus doesn't fire."""
+    events: list[Any] = []
+
+    async def _capture(event: Any) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Operator + target constants
+# ---------------------------------------------------------------------------
+
+_OPERATOR_TENANT_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-0000000042ee")
+
+_OPERATOR = Operator(
+    sub="rke2-e2e-test",
+    name="RKE2 E2E Test Operator",
+    email=None,
+    raw_jwt="<rke2-e2e-raw-jwt>",
+    tenant_id=_OPERATOR_TENANT_ID,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+_TARGET_NAME = "rke2-node-e2e"
+_CONNECTOR_ID = "rke2-ssh-1.x"
+
+
+# ---------------------------------------------------------------------------
+# Target + connector seeding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_rke2_target(host: str, port: int) -> TargetORM:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = TargetORM(
+            tenant_id=_OPERATOR_TENANT_ID,
+            name=_TARGET_NAME,
+            aliases=[],
+            product="rke2",
+            host=host,
+            port=port,
+            fqdn=None,
+            secret_ref="kv/dev/rke2/e2e",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint={"version": "1.x"},
+            notes="seeded by test_connectors_rke2_e2e",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+@dataclass
+class _Rke2E2EBundle:
+    target: TargetORM
+    connector: Rke2SshConnector
+
+
+def _wire_seeded_connector() -> Rke2SshConnector:
+    """Return a :class:`Rke2SshConnector` with the test client key injected."""
+    registry = all_connectors_v2()
+    connector_cls = registry.get(("rke2", "1.x", "rke2-ssh"))
+    assert connector_cls is Rke2SshConnector, (
+        f"Rke2SshConnector not registered for (rke2, 1.x, rke2-ssh); got {connector_cls!r}"
+    )
+
+    class _SeededRke2Connector(Rke2SshConnector):  # type: ignore[misc]
+        async def _auth_config(self, target: Any, operator: Any = None) -> dict[str, Any]:
+            return {
+                "username": "root",
+                "client_keys": [_CLIENT_KEY],
+                "known_hosts": None,
+            }
+
+    instance = _SeededRke2Connector()
+    from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+
+    _CONNECTOR_INSTANCE_CACHE[Rke2SshConnector] = instance  # type: ignore[assignment]
+    return instance
+
+
+@pytest.fixture
+async def rke2_e2e(
+    fake_shell_server: types.SimpleNamespace,
+    captured_events: list[Any],
+) -> AsyncIterator[_Rke2E2EBundle]:
+    del captured_events  # autouse via parameter; reading drains the stub
+    set_default_reducer(PassThroughReducer())
+    await Rke2SshConnector.register_operations()
+
+    target = await _seed_rke2_target(
+        host=fake_shell_server.host,
+        port=fake_shell_server.port,
+    )
+    connector = _wire_seeded_connector()
+    yield _Rke2E2EBundle(target=target, connector=connector)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Tests -- full dispatch path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rke2_e2e_about_dispatches_ok(
+    rke2_e2e: _Rke2E2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """rke2.about returns vendor/product/version/node_os via the fake-shell."""
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": _CONNECTOR_ID,
+            "op_id": "rke2.about",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"rke2.about failed: {result.get('error')}"
+    payload = result["result"]
+    assert payload["vendor"] == "rancher"
+    assert payload["product"] == "rke2"
+    assert payload["version"] == "v1.29.3+rke2r1"
+    assert payload["node_os"] == "Ubuntu 22.04.3 LTS"
+
+
+@pytest.mark.asyncio
+async def test_rke2_e2e_posture_show_dispatches_ok_and_redacts(
+    rke2_e2e: _Rke2E2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """rke2.posture.show returns config modes + a redacted token entry."""
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": _CONNECTOR_ID,
+            "op_id": "rke2.posture.show",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"rke2.posture.show failed: {result.get('error')}"
+    envelope = result["result"]
+    cfg = {c["path"]: c for c in envelope["config_files"]}
+    assert cfg["/etc/rancher/rke2/config.yaml"]["mode"] == "0600"
+    assert cfg["/etc/rancher/rke2/config.yaml"]["present"] is True
+    assert cfg["/etc/rancher/rke2/rke2.yaml"]["mode"] == "0600"
+    token = envelope["token"]
+    assert token["path"] == "/var/lib/rancher/rke2/server/token"
+    assert token["present"] is True
+    assert token["mode"] == "0600"
+    assert token["redacted"] is True
+    # Redaction: no token VALUE anywhere in the dispatch result.
+    assert _TOKEN_VALUE_CANARY not in repr(result)
+    assert "value" not in token

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -25693,6 +25693,7 @@
               "prometheus",
               "proxmox",
               "rabbitmq",
+              "rke2",
               "sddc",
               "vault",
               "vcfa",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -364,6 +364,7 @@ const (
 	Prometheus TargetCreateProduct = "prometheus"
 	Proxmox    TargetCreateProduct = "proxmox"
 	Rabbitmq   TargetCreateProduct = "rabbitmq"
+	Rke2       TargetCreateProduct = "rke2"
 	Sddc       TargetCreateProduct = "sddc"
 	Vault      TargetCreateProduct = "vault"
 	Vcfa       TargetCreateProduct = "vcfa"

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -1,0 +1,130 @@
+# Connector: rke2 (rke2-1.x / `rke2-ssh`)
+
+## Overview
+
+The `rke2` connector is the typed `Connector` subclass that dispatches
+operator-facing RKE2 **node-OS-lifecycle** operations over plain SSH. It is
+registered under the `(product="rke2", version="1.x", impl_id="rke2-ssh")`
+registry triple and is a child of the shared `SshConnector` adapter
+(`connectors/adapters/ssh.py`), the same transport base as `Bind9Connector`
+(G3.4) and `HolodeckConnector` (G3.8/G3.18).
+
+RKE2 cluster nodes expose **no MEHO REST API**; the only operator surface is
+SSH to the node OS. The `kubernetes` connector is Kubernetes-API-only (~25
+ops) and cannot reach a node at the OS level. Initiative #2172 adds a
+governed, typed, path-bounded SSH node-OS-lifecycle op surface so cluster-node
+maintenance (RKE2 join-token rotation, service restarts, config edits) runs
+through one identity + audit plane instead of an untracked local SSH wrapper
+(the field case: `claude-rdc-hetzner-dc#615`).
+
+T1 (#2221) ships the **connector scaffold + the read-only posture tier only**:
+
+- `rke2.about` — the identity canary. `rke2 --version` + `/etc/os-release`
+  wrapped in the standard fingerprint/`_assert_reachable` shape.
+- `rke2.posture.show` — the read-only posture tier. `stat`s the RKE2
+  config-file modes under `/etc/rancher/rke2/` and the on-disk server
+  join-token presence, **with the token value never read** (redacted by
+  construction).
+
+Two ops total, both `safety_level="safe"` / `requires_approval=false`. The
+approval-gated write ops (`rke2.token.rotate`, `rke2.node.service.restart`,
+`rke2.node.config.update`, `rke2.etcd-snapshot.save`) ship in sibling Tasks
+#2429/#2430/#2431 — explicitly out of scope for T1.
+
+Source: `backend/src/meho_backplane/connectors/rke2/`.
+
+## Key types
+
+- **`Rke2SshConnector`** (`connector.py`) — `SshConnector` subclass. Class
+  attributes: `product="rke2"`, `version="1.x"`, `impl_id="rke2-ssh"`.
+  Inherits the per-target asyncssh connection pool, `_auth_config`,
+  `_run_command`, `_assert_reachable`, and `aclose()` from the adapter.
+  Ships `fingerprint`, `probe`, `execute`, `about`, `posture_show`,
+  `register_operations`. Two module-level pure parsers live here:
+  `parse_rke2_version` (release string from `rke2 --version`) and
+  `parse_os_pretty_name` (`PRETTY_NAME` from `/etc/os-release`).
+
+- **Posture handler + parsers** (`ops_read.py`) — `rke2_posture_show`
+  (the async handler), `parse_stat_output` (`stat -c '%n|%a|%U|%G'` stdout
+  → path→attrs map, mode normalised to the 4-digit octal form), and
+  `parse_posture` (composes the `{config_files, token}` envelope; the token
+  entry always carries `redacted: true`). `POSTURE_CONFIG_PATHS` and
+  `RKE2_TOKEN_PATH` are fixed code constants — there is **no** operator path
+  parameter, so no path-traversal / shell-injection surface.
+
+- **Op metadata** (`ops.py`) — `Rke2Op` frozen dataclass (mirrors
+  `Bind9Op` / `HolodeckOp`), `SSH_TRANSPORT_NOTE` (the plain-SSH reminder
+  copied into every op's `when_to_use`), `_RKE2_ABOUT_OP`, and `RKE2_OPS`
+  (`about` + the `READ_OPS` posture tuple).
+
+- **Registration** (`__init__.py`) — two-phase, mirroring bind9/holodeck.
+  Synchronous `register_connector_v2` at import time (versioned triple +
+  the `("rke2", "", "")` wildcard fallback); async
+  `register_rke2_typed_operations` queued onto the lifespan registrar list.
+  No v1 `register_connector` — RKE2 has no chassis history.
+
+## Control flow
+
+1. **Boot** — `_eager_import_connectors()` imports the `rke2` subpackage;
+   `__init__.py` registers the v2 triple + wildcard synchronously and queues
+   the typed-op registrar.
+2. **Lifespan startup** — `run_typed_op_registrars()` calls
+   `register_rke2_typed_operations` → `Rke2SshConnector.register_operations`,
+   which upserts each `RKE2_OPS` entry into `endpoint_descriptor` (idempotent
+   across restarts) with the curated per-group `when_to_use`.
+3. **Dispatch** — `POST /api/v1/operations/call` → `call_operation` resolves
+   `connector_id="rke2-ssh-1.x"` + the target, runs the policy gate, and
+   invokes the bound handler. `about` reuses `fingerprint` and asserts
+   reachability (#986); `posture_show` runs one `stat` round-trip and returns
+   the redacted envelope. Transport/auth failures propagate to the
+   dispatcher's `connector_error` branch; a merely-absent file surfaces as
+   `present: false`.
+
+## Auth
+
+Uses the base `SshConnector._auth_config` **unchanged** — key-preferred,
+password-fallback. Credentials resolve via
+`_shared/vault_creds.load_vault_secret_data(target, operator)` from the Vault
+KV-v2 path string in `target.secret_ref` (the #2155 either/or shape:
+`load_vault_secret_data`, **not** `load_basic_credentials`, so a key-only or
+password-only secret resolves without demanding every field). The connector
+does not touch the pre-#2155 "bind9 anti-shape" (an embedded credential dict).
+
+## Redaction guarantee
+
+The posture tier reads **no secret material**. The join-token entry reports
+presence + mode only — the handler `stat`s the path and never `cat`s its
+content, so the token value cannot appear in the result envelope, the audit
+`raw_payload`, or the logs. Every token entry carries `redacted: true` to
+make the guarantee explicit to agents reading the schema. This is the T1
+foundation for the load-bearing Initiative #2172 rule: a secret-returning
+handler must never return the secret (the audit `raw_payload` stores the raw
+result).
+
+## Dependencies
+
+- `connectors/adapters/ssh.py` — the SSH transport base (pool, auth,
+  `_run_command`, `_assert_reachable`).
+- `_shared/vault_creds.py` — the operator-context Vault KV-v2 read (#2155).
+- `operations/typed_register.py` — the op-registration seam.
+- `connectors/registry.py` — the v2 registry + eager-import walk.
+- stdlib `re`, `shlex` (path quoting, defensive even though paths are fixed).
+
+## Known issues / follow-ups
+
+- Write ops (token rotate / service restart / config update / etcd-snapshot)
+  are deferred to #2429/#2430/#2431 under Initiative #2172.
+- Host-key checking is disabled (`known_hosts=None`) at the adapter level for
+  v0.2, shared across the whole SSH family; pinning is deferred repo-wide.
+- The RKE2 version probe is best-effort: `version` is `null` when the `rke2`
+  binary is not on the login shell PATH (agent nodes); reachability is not
+  affected.
+
+## References
+
+- Parent Initiative #2172 (SSH cluster-node OS-lifecycle write ops); Task
+  #2221 (this scaffold). Adapter fix prerequisite #2155.
+- Mold: holodeck-ssh (G3.18 #2145 / `docs/codebase/connectors-holodeck.md`),
+  bind9-ssh (`docs/codebase/connectors-bind9.md`).
+- Cross-repo coordination: `docs/cross-repo/rke2-infra-coordination.md`.
+- Field case: `claude-rdc-hetzner-dc#615` (RKE2 join-token rotation).


### PR DESCRIPTION
## Summary

- Adds the `rke2` node-OS connector (`rke2-ssh-1.x`) — the **read-only entry** in the governed SSH cluster-node OS-lifecycle family (Initiative #2172), built on the holodeck-ssh mold. RKE2 nodes expose no MEHO REST surface, so node-OS maintenance previously ran on an untracked local SSH wrapper outside MEHO's identity + audit plane.
- Two safe / no-approval ops over the shared `SshConnector` adapter: `rke2.about` (identity — `rke2 --version` + `/etc/os-release`) and `rke2.posture.show` (config-file modes under `/etc/rancher/rke2/` + on-disk server join-token presence).
- **Redaction by construction:** `posture.show` only `stat`s paths — the token *value* is never read, so no secret can reach the result envelope, the audit `raw_payload`, or the logs. Every token entry carries `redacted: true`.
- Auth resolves via the fixed SSH adapter (`load_vault_secret_data`, the #2155 either/or key-or-password shape), **not** `load_basic_credentials` / the bind9 anti-shape — the connector does not override `_auth_config`. Measured paths are fixed code constants (no operator path parameter → no traversal / injection surface).

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/rke2/` — no issues (4 files)
- [x] `pytest tests/test_connectors_rke2.py tests/test_connectors_rke2_e2e.py` — 26 passed
- [x] **AC1** (connector + posture tier dispatchable via `call_operation`): fake-shell E2E `test_rke2_e2e_about_dispatches_ok` + `test_rke2_e2e_posture_show_dispatches_ok_and_redacts` — both dispatch `status=ok` against a seeded target
- [x] **AC2** (auth via the fixed SSH adapter, not the anti-shape): connector inherits `SshConnector._auth_config` unchanged (resolves via `load_vault_secret_data`); verified structurally + `test_connectors_registry`/`resolver` green
- [x] **AC3** (ops safe / `requires_approval=false`; test asserts registration + a redacted posture result against a fixture): `test_rke2_ops_all_safe_read_only_no_approval`, `test_posture_show_returns_redacted_envelope`, `test_parse_posture_*`
- [x] `code-quality.py --diff` — 0 blockers (4 warnings mirroring the sibling connector dispatcher-shim boilerplate)
- [x] Full-set eager import — `rke2` registers alongside all 50 v2 entries with no collision

## Out of scope

- The approval-gated write ops (`rke2.token.rotate` / `rke2.node.service.restart` / `rke2.node.config.update` / `rke2.etcd-snapshot.save`) — sibling Tasks #2429/#2430/#2431 under Initiative #2172.

## Adjacent findings (recorded, deferred)

- `connector.py` is 487 lines and its `execute` dispatcher shim (77 lines, 7 returns) mirrors the verbatim bind9/holodeck boilerplate — code-quality warnings only, no blocker. A shared dispatcher-shim base class would remove the duplication across the SSH family but is out of scope for this scaffold.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only RKE2 node inspection over SSH.
  * Added RKE2 identity details, including version and operating system information.
  * Added posture reporting for configuration and join-token file presence and permissions, with token values always redacted.
  * Added connector registration and operation dispatch support.

* **Documentation**
  * Documented supported operations, security behavior, authentication, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->