### PR TITLE
feat(connectors): rke2.etcd-snapshot.save — safe managed-etcd snapshot over SSH (#2431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — rke2.etcd-snapshot.save safe managed-etcd snapshot op (#2431)
+
+- Add `rke2.etcd-snapshot.save` on the `rke2-ssh` connector — an on-demand
+  managed-etcd snapshot over SSH (`rke2 etcd-snapshot save`, embedded-etcd
+  only). It is the lone **safe / non-gated** op in Initiative #2172:
+  `safety_level="safe"`, `requires_approval=false`, because it is read-only
+  with respect to running cluster state (copies etcd to disk) and returns
+  only a snapshot name + path — never etcd contents (so the audit
+  `raw_payload` carries no secret). An optional `name` is charset-bounded to
+  `^[A-Za-z0-9._-]+$` at the schema boundary **and** re-checked in the
+  handler (fail-closed), then `shlex.quote`'d into an absolute-path argv; a
+  fail-closed precondition guard refuses a non-server or
+  external-`datastore-endpoint` node. Runs under `sudo -n` (no secret in the
+  argv, so no password-hiding mold needed) — `backend/src/meho_backplane/
+  connectors/rke2/ops_snapshot.py`, `docs/codebase/connectors-rke2.md`
+  (#2431).
+
 ### Added — node/rke2-ssh connector scaffold + read-only posture tier (#2221)
 
 - Add the `rke2` node-OS connector (`rke2-ssh-1.x`), the read-only entry in

--- a/backend/src/meho_backplane/connectors/rke2/connector.py
+++ b/backend/src/meho_backplane/connectors/rke2/connector.py
@@ -25,6 +25,9 @@ This module ships:
   :meth:`fingerprint`, registered as the ``rke2.about`` typed op.
 * :meth:`Rke2SshConnector.posture_show` -- the read-only posture tier
   (``rke2.posture.show``): config-file modes + redacted token presence.
+* :meth:`Rke2SshConnector.etcd_snapshot_save` -- the safe, non-gated
+  ``rke2.etcd-snapshot.save`` op (T4 #2431): an on-demand managed-etcd
+  snapshot on a server node, returning a snapshot name + path.
 * :meth:`Rke2SshConnector.execute` -- the G0.6 dispatcher shim (same
   shape as :meth:`Bind9Connector.execute` / :meth:`HolodeckConnector.execute`).
 
@@ -36,10 +39,11 @@ connector does **not** override ``_auth_config`` and does **not** touch
 the bind9 anti-shape.
 
 The approval-gated write ops (``rke2.token.rotate`` /
-``rke2.node.service.restart`` / ``rke2.node.config.update`` /
-``rke2.etcd-snapshot.save``) ship in sibling Tasks #2429/#2430/#2431 by
-appending to :data:`~meho_backplane.connectors.rke2.ops.RKE2_OPS`; the
-dispatcher shim does not change.
+``rke2.node.service.restart`` / ``rke2.node.config.update``) ship in
+sibling Tasks #2429/#2430 by appending to
+:data:`~meho_backplane.connectors.rke2.ops.RKE2_OPS`; the dispatcher shim
+does not change. The safe, non-gated ``rke2.etcd-snapshot.save`` (T4
+#2431) lands here alongside the read tier.
 """
 
 from __future__ import annotations
@@ -320,6 +324,26 @@ class Rke2SshConnector(SshConnector):
 
         return await _rke2_posture_show(self, target, params, operator)
 
+    async def etcd_snapshot_save(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``rke2.etcd-snapshot.save`` (T4 #2431).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.rke2.ops_snapshot.rke2_etcd_snapshot_save`,
+        which guards the embedded-etcd server precondition and triggers an
+        on-demand managed-etcd snapshot over the shared SSH adapter. Safe
+        tier, non-gated -- the result carries a snapshot name + path only.
+        """
+        from meho_backplane.connectors.rke2.ops_snapshot import (
+            rke2_etcd_snapshot_save as _rke2_etcd_snapshot_save,
+        )
+
+        return await _rke2_etcd_snapshot_save(self, target, params, operator)
+
     @classmethod
     async def register_operations(cls) -> None:
         """Upsert every op in :data:`RKE2_OPS` into ``endpoint_descriptor``.
@@ -482,5 +506,16 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "exists (presence + mode only -- the token VALUE is never read). "
         "Pair with a rotation runbook to confirm the token is present "
         "before rotating. Transport: plain SSH (``stat``, read-only)."
+    ),
+    "rke2-etcd-snapshot": (
+        "Use to capture an on-demand managed-etcd snapshot on an RKE2 "
+        "server node before a risky change: ``rke2.etcd-snapshot.save`` "
+        "runs ``rke2 etcd-snapshot save`` under sudo and returns the "
+        "snapshot name + on-disk path (never etcd contents). Refuses "
+        "non-server or external-datastore nodes with a structured error. "
+        "Safe and non-mutating to running cluster state -- it copies etcd "
+        "to disk. Pair it ahead of the approval-gated node-write ops "
+        "(token rotate / config update / service restart) as the recovery "
+        "point. Transport: plain SSH."
     ),
 }

--- a/backend/src/meho_backplane/connectors/rke2/ops.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops.py
@@ -14,10 +14,11 @@ G-Node/RKE2-T1 (#2221) scaffold -- ships the read-only tier only:
   RKE2 config-file modes and the on-disk join-token presence with the
   token **value never read** (redacted by construction). Two ops total.
 
-The approval-gated write ops (``rke2.token.rotate`` /
-``rke2.node.service.restart`` / ``rke2.node.config.update`` /
-``rke2.etcd-snapshot.save``) ship in sibling Tasks #2429/#2430/#2431
-under Initiative #2172 -- explicitly **out of scope** here.
+The safe, non-gated ``rke2.etcd-snapshot.save`` op (T4 #2431) is composed
+in from :mod:`~meho_backplane.connectors.rke2.ops_snapshot`. The
+approval-gated write ops (``rke2.token.rotate`` /
+``rke2.node.service.restart`` / ``rke2.node.config.update``) ship in
+sibling Tasks #2429/#2430 under Initiative #2172 -- **out of scope** here.
 
 The dataclass + tuple shape mirrors
 :mod:`~meho_backplane.connectors.bind9.ops` and
@@ -129,20 +130,22 @@ def _rke2_ops() -> tuple[Rke2Op, ...]:
     """Return the merged registration tuple.
 
     Composition: ``rke2.about`` (identity canary) + ``READ_OPS`` (the
-    read-only posture tier: ``rke2.posture.show``). Two ops total -- the
-    full T1 (#2221) read surface. The approval-gated write ops append to
-    this tuple in the sibling write Tasks, exactly as
+    read-only posture tier: ``rke2.posture.show``) + ``SNAPSHOT_OPS`` (the
+    safe, non-gated ``rke2.etcd-snapshot.save`` -- T4 #2431). The
+    approval-gated write ops append to this tuple in the sibling write
+    Tasks (#2429/#2430), exactly as
     :func:`meho_backplane.connectors.holodeck.ops._holodeck_ops` layers
     its ``WRITE_OPS`` on.
 
     Implemented as a function call rather than a module-level literal so
     the import order stays linear: ``ops.py`` defines :class:`Rke2Op` +
-    ``_RKE2_ABOUT_OP``, then imports the read ops from
-    :mod:`meho_backplane.connectors.rke2.ops_read`.
+    ``_RKE2_ABOUT_OP``, then imports the per-tier ops from their sibling
+    modules.
     """
     from meho_backplane.connectors.rke2.ops_read import READ_OPS
+    from meho_backplane.connectors.rke2.ops_snapshot import SNAPSHOT_OPS
 
-    return (_RKE2_ABOUT_OP, *READ_OPS)
+    return (_RKE2_ABOUT_OP, *READ_OPS, *SNAPSHOT_OPS)
 
 
 #: The ops :class:`Rke2SshConnector` registers at lifespan startup.

--- a/backend/src/meho_backplane/connectors/rke2/ops_snapshot.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_snapshot.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Safe (non-gated) managed-etcd snapshot op for :class:`Rke2SshConnector`.
+
+G-Node/RKE2-T4 (#2431) -- ``rke2.etcd-snapshot.save`` triggers an
+on-demand RKE2 managed-etcd snapshot over SSH. It is the lone
+**non-gated** op in the Initiative #2172 surface: ``safety_level="safe"``,
+``requires_approval=False`` -- deliberately, because it is read-only with
+respect to *running* cluster state (it copies the embedded etcd store to
+a file on disk) and its result carries only a snapshot name + path, never
+secret material.
+
+Design notes
+------------
+
+* **Precondition guard (fail-closed).** A managed-etcd snapshot is only
+  meaningful on a *server* node running *embedded* etcd. The guard runs
+  first and refuses -- with a structured
+  :class:`Rke2SnapshotPreconditionError` -- when the node configures an
+  external ``datastore-endpoint`` (snapshots are unavailable there) or
+  when the embedded-etcd data directory is absent (an agent node, or a
+  server not yet initialised). No snapshot command runs on a refusal.
+
+* **Name bounding (fail-closed, defence-in-depth).** The single optional
+  ``name`` parameter is charset-bounded to ``^[A-Za-z0-9._-]+$`` at the
+  JSON-schema boundary AND re-checked in the handler before any command
+  is composed, mirroring the proxmox name-bounding mold. The value is
+  ``shlex.quote``'d into the argv regardless. No other flag is exposed;
+  the ``rke2`` binary is invoked by absolute path.
+
+* **Privilege.** The ``rke2`` binary and the config / etcd paths are
+  root-owned, so every remote command runs under ``sudo -n`` (non-
+  interactive). ``sudo -n`` needs no password on a root or NOPASSWD-sudo
+  operator account (the expected RKE2 node access model) and fails
+  *closed* -- exiting non-zero with ``sudo: a password is required`` --
+  rather than hanging when a password would be needed. The op carries no
+  secret in its argv, so the password-hiding
+  :meth:`Bind9Connector._remote_bash_with_sudo` mold (built for ops that
+  interpolate a credential) is not needed here; keeping the op self-
+  contained also lets this PR union cleanly with the concurrent
+  approval-gated write-op tasks (#2429/#2430) that add that primitive.
+
+* **No secret in the result.** ``rke2 etcd-snapshot save`` logs
+  ``Snapshot <name> saved.``; the handler parses that name and returns
+  ``{snapshot_name, path, exit_status}``. The snapshot *file* holds etcd
+  bootstrap data, but the result envelope (and thus the audit
+  ``raw_payload``) does not, so no redaction pin is required.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.rke2.ops import SSH_TRANSPORT_NOTE, Rke2Op
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.rke2.connector import Rke2SshConnector, Target
+
+__all__ = [
+    "SNAPSHOT_DEFAULT_DIR",
+    "SNAPSHOT_OPS",
+    "Rke2SnapshotError",
+    "Rke2SnapshotNameError",
+    "Rke2SnapshotPreconditionError",
+    "parse_saved_snapshot_name",
+    "rke2_etcd_snapshot_save",
+]
+
+
+#: Absolute path to the RKE2 binary the installer drops on server nodes.
+#: Always invoked by absolute path so the op never depends on the login
+#: shell PATH (the fingerprint probe already tolerates a PATH-less binary,
+#: but a maintenance op must be deterministic).
+_RKE2_BIN: str = "/var/lib/rancher/rke2/bin/rke2"
+
+#: RKE2's default managed-etcd snapshot directory
+#: (``${data-dir}/db/snapshots`` with ``data-dir=/var/lib/rancher/rke2``).
+#: Used to compose the returned ``path`` from the parsed snapshot name.
+SNAPSHOT_DEFAULT_DIR: str = "/var/lib/rancher/rke2/server/db/snapshots"
+
+#: The RKE2 config file the guard inspects for an external datastore.
+_RKE2_CONFIG_PATH: str = "/etc/rancher/rke2/config.yaml"
+
+#: The embedded-etcd data directory. Its presence is the server + embedded
+#: signal the guard requires before allowing a snapshot.
+_RKE2_ETCD_DIR: str = "/var/lib/rancher/rke2/server/db/etcd"
+
+#: The charset an operator-supplied snapshot ``name`` is bounded to, at
+#: both the schema boundary (``pattern``) and in the handler (re-check).
+_SNAPSHOT_NAME_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9._-]+$")
+
+#: ``rke2 etcd-snapshot save`` logs ``Snapshot <name> saved.`` (the name
+#: only, not a path) via logrus. The regex recovers ``<name>`` from
+#: stdout or stderr; the returned ``path`` is composed from it.
+_SNAPSHOT_SAVED_RE: re.Pattern[str] = re.compile(r"Snapshot\s+(\S+)\s+saved")
+
+#: Precondition guard: emit a single sentinel token describing the node's
+#: snapshot eligibility. ``external-datastore`` when a ``datastore-endpoint``
+#: is configured (snapshots meaningless), ``no-embedded-etcd`` when the
+#: embedded-etcd data dir is absent (agent node / uninitialised server),
+#: ``ok`` otherwise. Fixed constant -- no operator input is interpolated.
+_GUARD_SCRIPT: str = (
+    f'if grep -Eq "^[[:space:]]*datastore-endpoint" {shlex.quote(_RKE2_CONFIG_PATH)} '
+    f"2>/dev/null; then echo external-datastore; "
+    f"elif [ ! -d {shlex.quote(_RKE2_ETCD_DIR)} ]; then echo no-embedded-etcd; "
+    f"else echo ok; fi"
+)
+
+#: The guard command as run over SSH -- ``sudo -n`` because the inspected
+#: paths are root-owned (config.yaml is ``0600 root:root``).
+_GUARD_CMD: str = "sudo -n -- sh -c " + shlex.quote(_GUARD_SCRIPT)
+
+
+class Rke2SnapshotNameError(ValueError):
+    """A supplied snapshot ``name`` violates ``^[A-Za-z0-9._-]+$``."""
+
+
+class Rke2SnapshotPreconditionError(RuntimeError):
+    """The node is not an embedded-etcd server -- a snapshot is refused."""
+
+
+class Rke2SnapshotError(RuntimeError):
+    """``rke2 etcd-snapshot save`` exited non-zero."""
+
+
+def parse_saved_snapshot_name(output: str) -> str | None:
+    """Return the snapshot name from ``rke2 etcd-snapshot save`` output.
+
+    ``rke2`` logs ``Snapshot <name> saved.`` on success (name only, not a
+    path). Returns the parsed ``<name>`` or ``None`` when the line is
+    absent (e.g. an output format drift).
+
+    Examples
+    --------
+
+    >>> parse_saved_snapshot_name("INFO[0000] Snapshot on-demand-srv-0-171 saved.")
+    'on-demand-srv-0-171'
+    >>> parse_saved_snapshot_name("") is None
+    True
+    """
+    match = _SNAPSHOT_SAVED_RE.search(output)
+    return match.group(1) if match else None
+
+
+def _validate_name(name: Any) -> str | None:
+    """Fail-closed re-check of the optional ``name`` param.
+
+    Returns the validated name (or ``None`` when unset). Raises
+    :class:`Rke2SnapshotNameError` for a non-string or a value outside
+    ``^[A-Za-z0-9._-]+$`` -- the same bound the schema enforces, re-applied
+    in code because the schema is advisory once params reach the handler.
+    """
+    if name is None:
+        return None
+    if not isinstance(name, str) or not _SNAPSHOT_NAME_RE.match(name):
+        raise Rke2SnapshotNameError(
+            "snapshot name must match ^[A-Za-z0-9._-]+$ (letters, digits, "
+            "dot, underscore, hyphen); no path separators or whitespace"
+        )
+    return name
+
+
+async def rke2_etcd_snapshot_save(
+    connector: Rke2SshConnector,
+    target: Target,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``rke2.etcd-snapshot.save``.
+
+    Runs the precondition guard, then triggers an on-demand managed-etcd
+    snapshot via ``sudo -n /var/lib/rancher/rke2/bin/rke2 etcd-snapshot
+    save`` (plus ``--name <NAME>`` when supplied). Returns
+    ``{snapshot_name, path, exit_status}``; the snapshot name/path are the
+    only non-``exit_status`` fields and carry no secret material.
+
+    Raises :class:`Rke2SnapshotNameError` (bad name),
+    :class:`Rke2SnapshotPreconditionError` (non-server / external-datastore
+    node) or :class:`Rke2SnapshotError` (non-zero ``rke2`` exit); the
+    dispatcher maps each to a non-ok ``connector_error`` result. Transport
+    / auth failures propagate the same way (#986).
+    """
+    name = _validate_name(params.get("name"))
+
+    guard = await connector._run_command(target, _GUARD_CMD, operator=operator)
+    guard_raw = guard.stdout if hasattr(guard, "stdout") else ""
+    verdict = guard_raw.strip() if isinstance(guard_raw, str) else ""
+    if verdict == "external-datastore":
+        raise Rke2SnapshotPreconditionError(
+            "this RKE2 node configures an external datastore-endpoint; "
+            "managed-etcd snapshots apply to embedded etcd only"
+        )
+    if verdict != "ok":
+        raise Rke2SnapshotPreconditionError(
+            "this RKE2 node is not an embedded-etcd server "
+            "(no server/db/etcd data directory); cannot take a snapshot"
+        )
+
+    argv = [_RKE2_BIN, "etcd-snapshot", "save"]
+    if name is not None:
+        argv += ["--name", name]
+    save_cmd = "sudo -n -- " + " ".join(shlex.quote(arg) for arg in argv)
+    proc = await connector._run_command(target, save_cmd, operator=operator, timeout=120.0)
+    exit_status = getattr(proc, "exit_status", None)
+
+    stdout_raw = proc.stdout if hasattr(proc, "stdout") else ""
+    stderr_raw = proc.stderr if hasattr(proc, "stderr") else ""
+    stdout = stdout_raw if isinstance(stdout_raw, str) else ""
+    stderr = stderr_raw if isinstance(stderr_raw, str) else ""
+
+    if exit_status not in (0, None) and exit_status != 0:
+        raise Rke2SnapshotError(
+            f"rke2 etcd-snapshot save exited {exit_status}: {(stderr or stdout).strip()[:400]}"
+        )
+
+    snapshot_name = parse_saved_snapshot_name(stderr) or parse_saved_snapshot_name(stdout)
+    path = f"{SNAPSHOT_DEFAULT_DIR}/{snapshot_name}" if snapshot_name else None
+    return {
+        "snapshot_name": snapshot_name,
+        "path": path,
+        "exit_status": exit_status,
+    }
+
+
+_RKE2_ETCD_SNAPSHOT_SAVE_OP = Rke2Op(
+    op_id="rke2.etcd-snapshot.save",
+    handler_attr="etcd_snapshot_save",
+    summary="Trigger an on-demand RKE2 managed-etcd snapshot on a server node.",
+    description=(
+        "Runs ``rke2 etcd-snapshot save`` on an RKE2 server node over SSH "
+        "to capture an on-demand snapshot of the embedded etcd datastore "
+        "under ``/var/lib/rancher/rke2/server/db/snapshots``. An optional "
+        "``name`` (charset-bounded to ``^[A-Za-z0-9._-]+$``) sets the "
+        "snapshot base name; RKE2 appends the node + timestamp. A "
+        "fail-closed precondition guard refuses a node that is not an "
+        "embedded-etcd server (agent node, or one configuring an external "
+        "``datastore-endpoint`` -- snapshots do not apply there). The "
+        "result carries the snapshot name + path only; the snapshot FILE "
+        "holds etcd bootstrap data but the result does not. Safe tier, "
+        "non-gated: it copies etcd to disk without mutating running "
+        "cluster state."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "pattern": r"^[A-Za-z0-9._-]+$",
+                "description": (
+                    "Optional snapshot base name (letters, digits, dot, "
+                    "underscore, hyphen). RKE2 appends node + timestamp. "
+                    "Omit for the default ``on-demand`` prefix."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "snapshot_name": {"type": ["string", "null"]},
+            "path": {"type": ["string", "null"]},
+            "exit_status": {"type": ["integer", "null"]},
+        },
+        "required": ["snapshot_name", "path", "exit_status"],
+        "additionalProperties": False,
+    },
+    group_key="rke2-etcd-snapshot",
+    tags=("etcd", "snapshot", "maintenance", "rke2"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to capture an on-demand managed-etcd snapshot on an RKE2 "
+            "server node before a risky change (a config edit, a token "
+            "rotation, an upgrade). Returns the snapshot name + on-disk "
+            "path; it never returns etcd contents. Refuses non-server / "
+            "external-datastore nodes with a structured error. Safe and "
+            "non-mutating to running cluster state. " + SSH_TRANSPORT_NOTE
+        ),
+        "parameter_hints": {
+            "name": (
+                "Optional base name matching ^[A-Za-z0-9._-]+$; RKE2 "
+                "appends the node identity and a timestamp. Omit to use "
+                "the default ``on-demand`` prefix."
+            ),
+        },
+        "output_shape": (
+            "``{snapshot_name, path, exit_status}``. ``snapshot_name`` is "
+            "the full RKE2-assigned name (base + node + timestamp) parsed "
+            "from the save log; ``path`` is it joined under "
+            "``/var/lib/rancher/rke2/server/db/snapshots``; both are null "
+            "if the save log line could not be parsed (with exit_status 0)."
+        ),
+    },
+)
+
+
+#: The safe (non-gated) snapshot tier. Composed alongside the read ops +
+#: the approval-gated write ops in
+#: :func:`meho_backplane.connectors.rke2.ops._rke2_ops`.
+SNAPSHOT_OPS: tuple[Rke2Op, ...] = (_RKE2_ETCD_SNAPSHOT_SAVE_OP,)

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -16,10 +16,16 @@ Coverage matrix (per Task #2221 acceptance criteria):
 * Redaction invariant -- ``posture_show`` issues a single ``stat`` (never
   a ``cat`` of the token path); the token entry carries ``redacted: true``
   and no secret material bleeds into the result envelope or logs.
-* ``RKE2_OPS`` registration shape -- 2 ops, both ``safety_level='safe'``
-  / ``requires_approval=false`` / read-only, ``additionalProperties=False``
-  on the parameter schema, non-empty SSH-transport ``when_to_use``, and
-  ``rke2.`` namespace op_ids with handler methods on the class.
+* ``RKE2_OPS`` registration shape -- 3 ops, all ``safety_level='safe'``
+  / ``requires_approval=false``, ``additionalProperties=False`` on every
+  parameter schema, non-empty SSH-transport ``when_to_use``, and ``rke2.``
+  namespace op_ids with handler methods on the class. The two read-tier
+  ops (``rke2.about`` / ``rke2.posture.show``) take no params; the safe
+  non-gated ``rke2.etcd-snapshot.save`` (T4 #2431) takes an optional,
+  charset-bounded ``name``.
+* ``rke2.etcd-snapshot.save`` handler -- name charset re-check
+  (fail-closed), the embedded-etcd-server precondition guard, and a
+  bounded-name save parsed from the RKE2 ``Snapshot <name> saved.`` log.
 """
 
 from __future__ import annotations
@@ -42,6 +48,12 @@ from meho_backplane.connectors.rke2.ops_read import (
     RKE2_TOKEN_PATH,
     parse_posture,
     parse_stat_output,
+)
+from meho_backplane.connectors.rke2.ops_snapshot import (
+    SNAPSHOT_DEFAULT_DIR,
+    Rke2SnapshotNameError,
+    Rke2SnapshotPreconditionError,
+    parse_saved_snapshot_name,
 )
 from meho_backplane.settings import get_settings
 from tests._ssh_vault_stub import stub_ssh_vault_secrets
@@ -338,11 +350,12 @@ async def test_posture_show_never_leaks_secret_material(
 # ---------------------------------------------------------------------------
 
 
-_EXPECTED_OP_IDS: frozenset[str] = frozenset({"rke2.about", "rke2.posture.show"})
+_READ_OP_IDS: frozenset[str] = frozenset({"rke2.about", "rke2.posture.show"})
+_EXPECTED_OP_IDS: frozenset[str] = _READ_OP_IDS | {"rke2.etcd-snapshot.save"}
 
 
-def test_rke2_ops_has_two_entries() -> None:
-    assert len(RKE2_OPS) == 2
+def test_rke2_ops_has_three_entries() -> None:
+    assert len(RKE2_OPS) == 3
 
 
 def test_rke2_ops_about_is_first() -> None:
@@ -358,19 +371,35 @@ def test_rke2_ops_all_namespaced() -> None:
         assert op.op_id.startswith("rke2."), f"{op.op_id!r} lacks rke2. prefix"
 
 
-def test_rke2_ops_all_safe_read_only_no_approval() -> None:
-    """AC: every op is safe-tier, read-only, and requires no approval."""
+def test_rke2_ops_all_safe_no_approval() -> None:
+    """AC: every op is safe-tier and requires no approval (incl. the snapshot op)."""
     for op in RKE2_OPS:
         assert op.safety_level == "safe", f"{op.op_id!r} is not safe-tier"
         assert op.requires_approval is False, f"{op.op_id!r} requires approval"
-        assert "read-only" in op.tags, f"{op.op_id!r} missing read-only tag"
+
+
+def test_rke2_read_ops_tagged_read_only() -> None:
+    """The read-tier ops carry the read-only tag; the snapshot op does not."""
+    by_id = {op.op_id: op for op in RKE2_OPS}
+    for op_id in _READ_OP_IDS:
+        assert "read-only" in by_id[op_id].tags, f"{op_id!r} missing read-only tag"
+    # The snapshot op is active (copies etcd to disk), so it is NOT read-only.
+    assert "read-only" not in by_id["rke2.etcd-snapshot.save"].tags
 
 
 def test_rke2_ops_parameter_schemas_closed() -> None:
+    by_id = {op.op_id: op for op in RKE2_OPS}
     for op in RKE2_OPS:
         assert op.parameter_schema.get("additionalProperties") is False
-        # The read tier takes no operator parameters -- fixed paths only.
-        assert op.parameter_schema.get("properties") == {}
+    # The read tier takes no operator parameters -- fixed paths only.
+    for op_id in _READ_OP_IDS:
+        assert by_id[op_id].parameter_schema.get("properties") == {}
+    # The snapshot op exposes exactly one optional, charset-bounded param.
+    save_schema = by_id["rke2.etcd-snapshot.save"].parameter_schema
+    props = save_schema.get("properties", {})
+    assert set(props) == {"name"}
+    assert props["name"].get("pattern") == r"^[A-Za-z0-9._-]+$"
+    assert save_schema.get("required", []) == []  # name is optional
 
 
 def test_rke2_ops_have_ssh_transport_when_to_use() -> None:
@@ -394,3 +423,124 @@ def test_rke2_connector_registry_triple() -> None:
 
     registry = all_connectors_v2()
     assert registry.get(("rke2", "1.x", "rke2-ssh")) is Rke2SshConnector
+
+
+# ---------------------------------------------------------------------------
+# etcd-snapshot.save handler (T4 #2431)
+# ---------------------------------------------------------------------------
+
+
+_SAVE_LOG_OK = "INFO[0000] Snapshot on-demand-rke2-node-1754907117 saved.\n"
+
+
+def test_parse_saved_snapshot_name_variants() -> None:
+    assert parse_saved_snapshot_name(_SAVE_LOG_OK) == "on-demand-rke2-node-1754907117"
+    assert parse_saved_snapshot_name("Snapshot my-snap-42 saved.") == "my-snap-42"
+    assert parse_saved_snapshot_name("nothing here") is None
+    assert parse_saved_snapshot_name("") is None
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_save_success_default_name() -> None:
+    connector = Rke2SshConnector()
+    # side_effect order: precondition guard, then the save command.
+    sequence = [
+        _proc(stdout="ok\n"),
+        _proc(stderr=_SAVE_LOG_OK, exit_status=0),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        result = await connector.etcd_snapshot_save(_TARGET, {})
+    assert result["snapshot_name"] == "on-demand-rke2-node-1754907117"
+    assert result["path"] == f"{SNAPSHOT_DEFAULT_DIR}/on-demand-rke2-node-1754907117"
+    assert result["exit_status"] == 0
+    issued = [call.args[1] for call in mock_cmd.await_args_list]
+    # Guard runs first under sudo -n; then the save under sudo -n by
+    # absolute binary path, with no --name flag when none was supplied.
+    assert issued[0].startswith("sudo -n -- sh -c ")
+    assert "datastore-endpoint" in issued[0]
+    assert issued[1] == ("sudo -n -- /var/lib/rancher/rke2/bin/rke2 etcd-snapshot save")
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_save_bounded_name_quoted_in_argv() -> None:
+    connector = Rke2SshConnector()
+    sequence = [
+        _proc(stdout="ok\n"),
+        _proc(stderr="INFO[0000] Snapshot pre_up-grade.1-node-9 saved.\n"),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        result = await connector.etcd_snapshot_save(_TARGET, {"name": "pre_up-grade.1"})
+    save_cmd = mock_cmd.await_args_list[1].args[1]
+    assert save_cmd == (
+        "sudo -n -- /var/lib/rancher/rke2/bin/rke2 etcd-snapshot save --name pre_up-grade.1"
+    )
+    assert result["snapshot_name"] == "pre_up-grade.1-node-9"
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_save_rejects_bad_name_before_any_command() -> None:
+    """A name outside ^[A-Za-z0-9._-]+$ fails closed before any SSH command."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        for bad in ("../etc", "has space", "semi;colon", "$(inject)", ""):
+            with pytest.raises(Rke2SnapshotNameError):
+                await connector.etcd_snapshot_save(_TARGET, {"name": bad})
+        mock_cmd.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_save_refuses_external_datastore() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="external-datastore\n")
+        with pytest.raises(Rke2SnapshotPreconditionError, match="external datastore"):
+            await connector.etcd_snapshot_save(_TARGET, {})
+    # Guard ran; the save command never did (single await).
+    mock_cmd.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_save_refuses_non_server_node() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="no-embedded-etcd\n")
+        with pytest.raises(Rke2SnapshotPreconditionError, match="embedded-etcd server"):
+            await connector.etcd_snapshot_save(_TARGET, {})
+    mock_cmd.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_save_nonzero_exit_raises() -> None:
+    from meho_backplane.connectors.rke2.ops_snapshot import Rke2SnapshotError
+
+    connector = Rke2SshConnector()
+    sequence = [
+        _proc(stdout="ok\n"),
+        _proc(stderr="FATA[0000] etcd is not running\n", exit_status=1),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        with pytest.raises(Rke2SnapshotError, match="exited 1"):
+            await connector.etcd_snapshot_save(_TARGET, {})
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_save_never_leaks_credentials(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No SSH/sudo credential material appears in the result or logs."""
+    connector = Rke2SshConnector()
+    sequence = [
+        _proc(stdout="ok\n"),
+        _proc(stderr=_SAVE_LOG_OK, exit_status=0),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        with caplog.at_level("DEBUG"):
+            result = await connector.etcd_snapshot_save(_TARGET, {})
+    rendered = repr(result)
+    for canary in (_CANARY_PASSWORD, _CANARY_SSH_KEY, _CANARY_TOKEN_VALUE):
+        assert canary not in rendered
+        assert canary not in caplog.text

--- a/backend/tests/test_connectors_rke2_e2e.py
+++ b/backend/tests/test_connectors_rke2_e2e.py
@@ -3,11 +3,12 @@
 
 """RKE2 connector recorded-fixture / asyncssh fake-shell E2E test (#2221).
 
-Drives ``rke2.about`` and ``rke2.posture.show`` through the full
-``call_operation`` dispatch stack against an in-process asyncssh
-fake-shell server that replays plain-SSH command stubs -- no Docker
-dependency, no live RKE2 node. The shape mirrors the G3.8 Holodeck
-recorded-fixture E2E precedent (``test_connectors_holodeck_e2e.py``).
+Drives ``rke2.about``, ``rke2.posture.show`` and the safe, non-gated
+``rke2.etcd-snapshot.save`` (T4 #2431) through the full ``call_operation``
+dispatch stack against an in-process asyncssh fake-shell server that
+replays plain-SSH command stubs -- no Docker dependency, no live RKE2
+node. The shape mirrors the G3.8 Holodeck recorded-fixture E2E precedent
+(``test_connectors_holodeck_e2e.py``).
 
 Acceptance criteria verified (Issue #2221)
 ==========================================
@@ -65,6 +66,10 @@ _STAT_FIXTURE = (
     "/etc/rancher/rke2/rke2.yaml|600|root|root\n"
     "/var/lib/rancher/rke2/server/token|600|root|root\n"
 )
+# Precondition-guard sentinel for an embedded-etcd server node.
+_SNAPSHOT_GUARD_FIXTURE = "ok\n"
+# `rke2 etcd-snapshot save` logs the saved snapshot name to stderr.
+_SNAPSHOT_SAVE_FIXTURE = "INFO[0000] Snapshot pre-upgrade-rke2-node-e2e-1754907117 saved.\n"
 
 # A canary token value the fixture never emits (posture never reads the
 # token content). Asserted absent from every dispatch result.
@@ -95,6 +100,14 @@ async def _fake_shell_process_factory(process: Any) -> None:
         response = _RKE2_VERSION_FIXTURE
     elif cmd.startswith("stat -c '%n|%a|%U|%G'"):
         response = _STAT_FIXTURE
+    elif cmd.startswith("sudo -n -- sh -c"):
+        # Precondition guard -- report an embedded-etcd server node.
+        response = _SNAPSHOT_GUARD_FIXTURE
+    elif cmd.startswith("sudo -n -- /var/lib/rancher/rke2/bin/rke2 etcd-snapshot save"):
+        # rke2 logs the saved-snapshot line to stderr; stdout stays empty.
+        process.stderr.write(_SNAPSHOT_SAVE_FIXTURE)
+        process.exit(0)
+        return
     else:
         process.stderr.write(f"fake-shell: unknown command: {cmd!r}\n")
         process.exit(127)
@@ -316,3 +329,35 @@ async def test_rke2_e2e_posture_show_dispatches_ok_and_redacts(
     # Redaction: no token VALUE anywhere in the dispatch result.
     assert _TOKEN_VALUE_CANARY not in repr(result)
     assert "value" not in token
+
+
+@pytest.mark.asyncio
+async def test_rke2_e2e_etcd_snapshot_save_dispatches_ok_non_gated(
+    rke2_e2e: _Rke2E2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """rke2.etcd-snapshot.save (safe, non-gated) auto-executes -- no approval park.
+
+    A TENANT_ADMIN dispatch of the safe, non-approval snapshot op runs to
+    completion through the full ``call_operation`` stack: it does NOT park
+    at ``awaiting_approval`` (that gate is only for the sibling write ops),
+    and the result carries the parsed snapshot name + path with exit 0.
+    """
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": _CONNECTOR_ID,
+            "op_id": "rke2.etcd-snapshot.save",
+            "target": {"name": _TARGET_NAME},
+            "params": {"name": "pre-upgrade"},
+        },
+    )
+    # Non-gated: the dispatch executes rather than parking for approval.
+    assert result["status"] == "ok", f"rke2.etcd-snapshot.save did not auto-execute: {result}"
+    payload = result["result"]
+    assert payload["snapshot_name"] == "pre-upgrade-rke2-node-e2e-1754907117"
+    assert payload["path"] == (
+        "/var/lib/rancher/rke2/server/db/snapshots/pre-upgrade-rke2-node-e2e-1754907117"
+    )
+    assert payload["exit_status"] == 0

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -26,10 +26,21 @@ T1 (#2221) ships the **connector scaffold + the read-only posture tier only**:
   join-token presence, **with the token value never read** (redacted by
   construction).
 
-Two ops total, both `safety_level="safe"` / `requires_approval=false`. The
+T4 (#2431) adds the lone **safe, non-gated write-ish op**:
+
+- `rke2.etcd-snapshot.save` — triggers an on-demand managed-etcd snapshot on
+  a server node (`rke2 etcd-snapshot save`, embedded-etcd only). It is
+  `safety_level="safe"` / `requires_approval=false` because it is read-only
+  with respect to *running* cluster state (it copies etcd to a file on disk)
+  and returns only a snapshot name + path, never etcd contents. An optional
+  `name` param is charset-bounded to `^[A-Za-z0-9._-]+$` at the schema
+  boundary AND re-checked in the handler; a fail-closed precondition guard
+  refuses a non-server / external-`datastore-endpoint` node.
+
+Three ops total, all `safety_level="safe"` / `requires_approval=false`. The
 approval-gated write ops (`rke2.token.rotate`, `rke2.node.service.restart`,
-`rke2.node.config.update`, `rke2.etcd-snapshot.save`) ship in sibling Tasks
-#2429/#2430/#2431 — explicitly out of scope for T1.
+`rke2.node.config.update`) ship in sibling Tasks #2429/#2430 — out of scope
+here.
 
 Source: `backend/src/meho_backplane/connectors/rke2/`.
 
@@ -55,7 +66,16 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
 - **Op metadata** (`ops.py`) — `Rke2Op` frozen dataclass (mirrors
   `Bind9Op` / `HolodeckOp`), `SSH_TRANSPORT_NOTE` (the plain-SSH reminder
   copied into every op's `when_to_use`), `_RKE2_ABOUT_OP`, and `RKE2_OPS`
-  (`about` + the `READ_OPS` posture tuple).
+  (`about` + the `READ_OPS` posture tuple + the `SNAPSHOT_OPS` tuple).
+
+- **Snapshot handler + parser** (`ops_snapshot.py`) —
+  `rke2_etcd_snapshot_save` (the async handler: guard → `sudo -n` save →
+  parse), `parse_saved_snapshot_name` (recovers the name from the RKE2
+  `Snapshot <name> saved.` log), `_validate_name` (fail-closed charset
+  re-check), and the `Rke2SnapshotNameError` / `Rke2SnapshotPreconditionError`
+  / `Rke2SnapshotError` structured errors. The `rke2` binary is invoked by
+  absolute path; the single optional `name` is the only operator input and
+  is `shlex.quote`'d into the argv after the charset re-check.
 
 - **Registration** (`__init__.py`) — two-phase, mirroring bind9/holodeck.
   Synchronous `register_connector_v2` at import time (versioned triple +
@@ -110,10 +130,27 @@ result).
 - `connectors/registry.py` — the v2 registry + eager-import walk.
 - stdlib `re`, `shlex` (path quoting, defensive even though paths are fixed).
 
+## Privilege (etcd-snapshot.save)
+
+The snapshot op runs every remote command under `sudo -n` (non-interactive):
+the `rke2` binary and the config / etcd paths are root-owned. `sudo -n` needs
+no password on a root or NOPASSWD-sudo operator account (the expected RKE2
+node access model) and fails **closed** — exiting non-zero rather than
+hanging — when a password would be required. The op interpolates no secret
+into its argv (the only operator input, `name`, is charset-bounded and
+`shlex.quote`'d), so it does **not** need the password-hiding
+`_remote_bash_with_sudo` mold the approval-gated write ops (#2429/#2430)
+add; keeping it self-contained also lets it land independently of those
+concurrent tasks.
+
 ## Known issues / follow-ups
 
-- Write ops (token rotate / service restart / config update / etcd-snapshot)
-  are deferred to #2429/#2430/#2431 under Initiative #2172.
+- The approval-gated write ops (token rotate / service restart / config
+  update) are deferred to #2429/#2430 under Initiative #2172.
+- If a real deployment requires a sudo *password* (no root / NOPASSWD),
+  `rke2.etcd-snapshot.save` surfaces a `connector_error` (`sudo: a password
+  is required`) rather than executing; adopting the `_remote_bash_with_sudo`
+  primitive that #2429/#2430 add is the follow-up for that case.
 - Host-key checking is disabled (`known_hosts=None`) at the adapter level for
   v0.2, shared across the whole SSH family; pinning is deferred repo-wide.
 - The RKE2 version probe is best-effort: `version` is `null` when the `rke2`


### PR DESCRIPTION
## Summary

- Adds `rke2.etcd-snapshot.save` on the `rke2-ssh` connector (T4 of Initiative #2172) — an on-demand managed-etcd snapshot over SSH (`rke2 etcd-snapshot save`, embedded-etcd only).
- The lone **safe / non-gated** op in the surface: `safety_level="safe"`, `requires_approval=False`. It is read-only w.r.t. running cluster state (copies etcd to disk) and returns only `{snapshot_name, path, exit_status}` — never etcd contents, so the audit `raw_payload` carries no secret.
- The optional `name` is charset-bounded to `^[A-Za-z0-9._-]+$` at the schema boundary **and** re-checked in the handler (fail-closed), then `shlex.quote`'d into an absolute-path argv. A fail-closed precondition guard refuses a non-server or external-`datastore-endpoint` node before any snapshot command runs.
- Lives in its own `ops_snapshot.py` + a bound-method shim, composed into `RKE2_OPS` via `_rke2_ops` — cleanly separable from the concurrent approval-gated write-op tasks (#2429/#2430).

## Design note (sudo)

Runs under `sudo -n` (non-interactive). The op interpolates no secret into its argv, so the password-hiding `_remote_bash_with_sudo` mold (built for credential-bearing write ops, added by #2429/#2430) is not needed here; `sudo -n` fails **closed** (non-zero, not a hang) if a password would be required. Documented in `docs/codebase/connectors-rke2.md` with the follow-up path for password-sudo deployments.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/rke2/` — clean
- [x] `pytest tests/test_connectors_rke2.py tests/test_connectors_rke2_e2e.py` — 36 passed (registration shape 3 ops, name fail-closed reject, both guard refusals, bounded-name save, non-zero-exit raise, credential non-leak, e2e non-approval dispatch)
- [x] `pytest tests/test_broadcast_classifier_coverage.py` — 18 passed (`.save` classifies as `other`, non-leaking — no pin required per the issue)
- [x] code-quality `--diff` — 0 blockers (4 pre-existing warnings in `connector.py`, not introduced here)
- [x] No FastAPI route/schema touched → OpenAPI snapshot unaffected (typed-op registration is a DB row, not a route)

## Out of scope

- Snapshot restore / prune / list, S3 upload config, scheduled snapshots.
- The approval-gated write ops `rke2.token.rotate` (#2429) and `rke2.node.service.restart` / `rke2.node.config.update` (#2430).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2431


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a safe, non-approval-gated RKE2 operation to create embedded etcd snapshots over SSH.
  * Supports an optional, validated snapshot name and returns the snapshot name, path, and exit status.
  * Includes precondition checks to avoid running when snapshotting isn’t applicable (e.g., external datastore configuration or missing embedded etcd).
* **Documentation**
  * Updated RKE2 connector docs and changelog with the new operation’s behavior, safety, and usage.
* **Tests**
  * Expanded connector and end-to-end coverage for the new snapshot operation, including dispatch and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->