### PR TITLE
feat(connectors): rke2.token.rotate — approval-gated RKE2 server-token rotation over SSH (#2429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — rke2.token.rotate approval-gated server-token rotation (#2429)
+
+- Add `rke2.token.rotate`, the first approval-gated write op on the
+  `rke2-ssh` connector (`safety_level=dangerous`, `requires_approval=True`).
+  It rotates the RKE2 server join token cluster-wide via `rke2 token rotate`
+  over sudo-SSH. It takes **no parameters and no token value**: the new token
+  is minted server-side, the old token is read on-disk as root inside the
+  rotate script, and the new token is written to Vault — only a pointer plus
+  non-secret metadata (`rotated` / `node` / `exit_status`) is returned, so no
+  token value ever reaches the result, the audit `raw_payload`, or the
+  broadcast feed (the op is pinned to `credential_mint` and carries a
+  no-secret park-time preview). A read-only fingerprint gate refuses a
+  non-server node, an inactive `rke2-server`, or a below-floor / known-bad
+  (`v1.27.10+rke2r1`) RKE2 version before any mutation, because a botched
+  rotate wedges future node joins (rancher/rke2#5785, #6250). Multi-node
+  restart choreography stays an operator runbook — `backend/src/meho_backplane/
+  connectors/rke2/ops_write.py`, `docs/codebase/connectors-rke2.md` (#2429).
+
 ### Added — node/rke2-ssh connector scaffold + read-only posture tier (#2221)
 
 - Add the `rke2` node-OS connector (`rke2-ssh-1.x`), the read-only entry in

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -112,6 +112,13 @@ _CREDENTIAL_MINT_OPS: Final[frozenset[str]] = frozenset(
         # ``OperationResult`` returned to the caller still carries it.
         "vault.token.create",
         "vault.auth.approle.generate_secret_id",
+        # G-Node/RKE2-T2 #2429 — the RKE2 server-token rotate mints a new
+        # join token server-side. The handler never returns the token value
+        # (only a Vault pointer), so nothing sensitive is in the response —
+        # but ``.rotate`` would otherwise classify ``other`` and broadcast
+        # full params/detail. Pinning to ``credential_mint`` collapses the
+        # broadcast to aggregate-only as defence-in-depth for the op class.
+        "rke2.token.rotate",
     }
 )
 

--- a/backend/src/meho_backplane/connectors/rke2/__init__.py
+++ b/backend/src/meho_backplane/connectors/rke2/__init__.py
@@ -33,6 +33,9 @@ v2 triple advertises this class.
 """
 
 from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.rke2 import (
+    ops_write_preview,  # noqa: F401 -- preview-builder registration side-effect
+)
 from meho_backplane.connectors.rke2.connector import Rke2SshConnector
 from meho_backplane.connectors.rke2.ops import RKE2_OPS, Rke2Op
 from meho_backplane.operations.typed_register import register_typed_op_registrar

--- a/backend/src/meho_backplane/connectors/rke2/_sudo.py
+++ b/backend/src/meho_backplane/connectors/rke2/_sudo.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Safe-by-construction ``sudo`` primitive for the RKE2 SSH write ops.
+
+RKE2's node-OS maintenance verbs (``rke2 token rotate`` and the T3/T4
+service/etcd ops) run as root, but the connector authenticates over SSH as
+an unprivileged login user and elevates via ``sudo -S``. This module is the
+one place the sudo password reaches the wire, and it is shaped so the
+password can never leak into the remote ``argv`` (``ps`` /
+``/proc/<pid>/cmdline``), the remote shell-history file, or a local log
+event.
+
+The wire shape is the same one bind9 hardened after the #697 stdio-buffer
+regression (``bind9/connector.py``): the caller passes *script* and
+*sudo_password* as **separate** arguments and cannot express a mis-ordered
+payload. :func:`build_sudo_bash_remote_cmd` renders a remote command whose
+only caller-derived interpolation is the script's UTF-8 **byte count** (an
+integer); the script body and the password ride on stdin. ``head -c <N>``
+reads exactly the script bytes into a ``umask 077`` temp file via unbuffered
+``read(2)``, then ``sudo -S`` reads the password from what remains on stdin
+(EOF immediately after the password newline, so sudo's buffered stdio has
+nothing past the password line to prefetch-and-swallow), and ``bash "$f"``
+runs the script body from the temp file rather than stdin.
+
+Each RKE2 SSH connector family carries its own copy of this primitive
+(holodeck carries ``_pwsh.py``; bind9 carries its sudo helper inline) rather
+than sharing a single module, so a change to one connector's elevation shape
+cannot silently alter another's. The bytes are identical to the bind9
+reference by design -- the safety analysis is load-bearing and must not
+drift between the two families.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import asyncssh
+import structlog
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.adapters.ssh import SshConnector
+
+__all__ = ["build_sudo_bash_remote_cmd", "run_remote_bash_with_sudo"]
+
+_log = structlog.get_logger(__name__)
+
+
+def build_sudo_bash_remote_cmd(script_byte_len: int) -> str:
+    """Render the remote command for :func:`run_remote_bash_with_sudo`.
+
+    Constant boilerplate parameterised only by *script_byte_len* -- an
+    integer derived from the caller's script bytes. Neither the script nor
+    the sudo password is interpolated into ``argv``. Module-level so the
+    unit suite (which mocks ``conn.run``) can assert against the exact
+    rendered shape without duplicating it.
+    """
+    return (
+        f"set -e; umask 077; f=$(mktemp); "
+        f'trap "rm -f $f" EXIT; '
+        f'head -c {script_byte_len} > "$f"; '
+        f'sudo -S -p "" bash "$f"'
+    )
+
+
+async def run_remote_bash_with_sudo(
+    connector: SshConnector,
+    target: Any,
+    script: str,
+    *,
+    operator: Operator | None = None,
+    sudo_password: str,
+    timeout: float = 60.0,
+) -> asyncssh.SSHCompletedProcess:
+    """Run *script* on *target* under ``sudo`` without leaking the password.
+
+    Free-function form of the bind9 ``_remote_bash_with_sudo`` primitive,
+    taking the connector explicitly (the holodeck ``_run_text`` convention)
+    so the RKE2 write handlers can call it from ``ops_write`` without a
+    connector-method shim per op. The connection is drawn from the
+    connector's SSH pool via :meth:`SshConnector._connect`; the password is
+    streamed as the last stdin line after the exact script bytes.
+
+    Parameters
+    ----------
+    connector
+        The RKE2 SSH connector whose pooled connection runs the script.
+    target
+        The :class:`Target` the SSH connection is keyed to.
+    script
+        The bash script body to run under sudo. Must **not** embed the sudo
+        password -- that is streamed separately via *sudo_password*.
+    operator
+        Forwarded to :meth:`SshConnector._connect` for the operator-context
+        Vault credential read on a pool miss (#2155).
+    sudo_password
+        The password ``sudo -S`` reads from stdin. Streamed as the final
+        stdin line; never in ``argv``, never logged.
+    timeout
+        Wall-clock timeout in seconds.
+
+    Raises
+    ------
+    ValueError
+        *sudo_password* contains ``\\n`` / ``\\r`` / ``\\x00`` -- a control
+        character would terminate sudo's password read early and feed the
+        trailing bytes to ``bash`` as commands, the exact leak this shape
+        exists to make unrepresentable. Checked **before** ``_connect`` so
+        an invalid credential never opens a wire connection.
+    """
+    if any(ch in sudo_password for ch in ("\n", "\r", "\x00")):
+        raise ValueError(
+            "sudo_password must be a single line: newline / carriage-return / NUL "
+            "characters would smuggle additional bash commands onto stdin"
+        )
+    conn = await connector._connect(target, operator)
+    script_bytes = script.encode("utf-8")
+    cmd = build_sudo_bash_remote_cmd(len(script_bytes))
+    # Script bytes first, password last, EOF immediately after (the #697
+    # wire shape): ``head -c <N>`` consumes exactly the script's byte count
+    # via unbuffered read(2), so sudo's buffered stdin sees only the
+    # password line and cannot prefetch-and-swallow script bytes.
+    stdin_payload = f"{script}{sudo_password}\n"
+    result = await asyncio.wait_for(
+        conn.run(cmd, input=stdin_payload, check=False),
+        timeout=timeout,
+    )
+    # Logging discipline: only lengths + exit code. Neither the script nor
+    # the password (nor any token the script rotates) is bound into the event.
+    _log.info(
+        "rke2_ssh_sudo_command_executed",
+        target=getattr(target, "name", None),
+        cmd_len=len(cmd),
+        script_len=len(script_bytes),
+        exit_code=result.exit_status,
+    )
+    return result

--- a/backend/src/meho_backplane/connectors/rke2/connector.py
+++ b/backend/src/meho_backplane/connectors/rke2/connector.py
@@ -57,6 +57,7 @@ from meho_backplane.auth.vault import VaultClientError
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters.ssh import SshConnector
 from meho_backplane.connectors.rke2.ops import RKE2_OPS
+from meho_backplane.connectors.rke2.ops_write import RKE2_WHEN_TO_USE_WRITE_BY_GROUP
 from meho_backplane.connectors.schemas import (
     FingerprintResult,
     OperationResult,
@@ -320,6 +321,26 @@ class Rke2SshConnector(SshConnector):
 
         return await _rke2_posture_show(self, target, params, operator)
 
+    async def token_rotate(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``rke2.token.rotate`` (G-Node/RKE2-T2 #2429).
+
+        **Approval-gated write.** Delegates to
+        :func:`~meho_backplane.connectors.rke2.ops_write.rke2_token_rotate`;
+        runs only on the ``_approved=True`` resume path. Mints a new server
+        join token, rotates it over sudo-SSH, and stashes it in Vault --
+        returning only a pointer, never the token value.
+        """
+        from meho_backplane.connectors.rke2.ops_write import (
+            rke2_token_rotate as _rke2_token_rotate,
+        )
+
+        return await _rke2_token_rotate(self, target, params, operator)
+
     @classmethod
     async def register_operations(cls) -> None:
         """Upsert every op in :data:`RKE2_OPS` into ``endpoint_descriptor``.
@@ -483,4 +504,7 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "Pair with a rotation runbook to confirm the token is present "
         "before rotating. Transport: plain SSH (``stat``, read-only)."
     ),
+    # Approval-gated write groups. Keys carry a ``-write`` suffix so they
+    # never collide with the read-op group keys above.
+    **RKE2_WHEN_TO_USE_WRITE_BY_GROUP,
 }

--- a/backend/src/meho_backplane/connectors/rke2/ops.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops.py
@@ -14,10 +14,12 @@ G-Node/RKE2-T1 (#2221) scaffold -- ships the read-only tier only:
   RKE2 config-file modes and the on-disk join-token presence with the
   token **value never read** (redacted by construction). Two ops total.
 
-The approval-gated write ops (``rke2.token.rotate`` /
-``rke2.node.service.restart`` / ``rke2.node.config.update`` /
-``rke2.etcd-snapshot.save``) ship in sibling Tasks #2429/#2430/#2431
-under Initiative #2172 -- explicitly **out of scope** here.
+The first approval-gated write op ``rke2.token.rotate`` (G-Node/RKE2-T2
+#2429) lands in :mod:`meho_backplane.connectors.rke2.ops_write` and is
+composed onto :data:`RKE2_OPS` here via :data:`WRITE_OPS`. The remaining
+write ops (``rke2.node.service.restart`` / ``rke2.node.config.update`` /
+``rke2.etcd-snapshot.save``) ship in sibling Tasks #2430/#2431 under
+Initiative #2172.
 
 The dataclass + tuple shape mirrors
 :mod:`~meho_backplane.connectors.bind9.ops` and
@@ -129,20 +131,20 @@ def _rke2_ops() -> tuple[Rke2Op, ...]:
     """Return the merged registration tuple.
 
     Composition: ``rke2.about`` (identity canary) + ``READ_OPS`` (the
-    read-only posture tier: ``rke2.posture.show``). Two ops total -- the
-    full T1 (#2221) read surface. The approval-gated write ops append to
-    this tuple in the sibling write Tasks, exactly as
-    :func:`meho_backplane.connectors.holodeck.ops._holodeck_ops` layers
-    its ``WRITE_OPS`` on.
+    read-only posture tier: ``rke2.posture.show``) + ``WRITE_OPS`` (the
+    approval-gated write tier: ``rke2.token.rotate``, G-Node/RKE2-T2 #2429),
+    exactly as :func:`meho_backplane.connectors.holodeck.ops._holodeck_ops`
+    layers its ``WRITE_OPS`` on.
 
     Implemented as a function call rather than a module-level literal so
     the import order stays linear: ``ops.py`` defines :class:`Rke2Op` +
-    ``_RKE2_ABOUT_OP``, then imports the read ops from
-    :mod:`meho_backplane.connectors.rke2.ops_read`.
+    ``_RKE2_ABOUT_OP``, then imports the read + write ops from their
+    sibling modules.
     """
     from meho_backplane.connectors.rke2.ops_read import READ_OPS
+    from meho_backplane.connectors.rke2.ops_write import WRITE_OPS
 
-    return (_RKE2_ABOUT_OP, *READ_OPS)
+    return (_RKE2_ABOUT_OP, *READ_OPS, *WRITE_OPS)
 
 
 #: The ops :class:`Rke2SshConnector` registers at lifespan startup.

--- a/backend/src/meho_backplane/connectors/rke2/ops_write.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_write.py
@@ -1,0 +1,535 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Approval-gated RKE2 server-token rotation over SSH (G-Node/RKE2-T2 #2429).
+
+The first write op on the ``rke2-ssh`` connector: ``rke2.token.rotate``
+rotates the RKE2 server join token cluster-wide. A cluster-wide credential
+change, so ``safety_level="dangerous"`` + ``requires_approval=True`` (the
+holodeck / argocd / bind9 write mold): the dispatcher's policy gate parks a
+USER dispatch at ``needs-approval`` and floors an agent, and the handler
+body below runs only on the ``_approved=True`` resume path.
+
+The load-bearing constraint (THE audit rule)
+=============================================
+
+The dispatcher persists the **raw** handler result on the audit row
+(``dispatcher.py`` ``raw_payload=redaction.raw``); connector-boundary
+redaction never scrubs ``raw_payload``. So the only reliable control is that
+this handler **never returns the token** -- old or new, not the value, not
+in any field. Both tokens are handled so they never reach a result surface:
+
+* The **OLD** token is read on-disk server-side from
+  ``/var/lib/rancher/rke2/server/token`` *inside the sudo script* (a shell
+  ``$(cat ...)``), so its value never enters Python and never enters the
+  result.
+* The **NEW** token is minted server-side here (:func:`secrets.token_hex`),
+  written to **Vault** under the operator's identity, and only a
+  **pointer** to the Vault location plus non-secret metadata
+  (``rotated`` / ``node`` / ``exit_status``) is returned. The minted value
+  is interpolated into the sudo script (streamed on stdin, never argv /
+  history / log) but never into the returned dict, the logs, or an operator
+  param -- ``ApprovalRequest.params`` is stored verbatim for resume, so the
+  op takes **no** token param at all.
+
+The op is additionally pinned in
+:data:`~meho_backplane.broadcast.events._CREDENTIAL_MINT_OPS` (defence in
+depth: ``.rotate`` would otherwise classify ``other`` and broadcast full
+params) and registers a non-secret park-time preview builder
+(``ops_write_preview``).
+
+Fingerprint gate (reject-before-rotate)
+=======================================
+
+A botched rotate wedges every future node-join (rancher/rke2#5785), so the
+handler refuses to proceed unless, checked over read-only SSH **before** any
+mutation:
+
+* the node is an RKE2 **server** (``rke2-server.service`` is installed),
+* ``rke2-server`` is **active**, and
+* the running RKE2 version is at or above the per-minor CVE-fix floor and is
+  **not** the known-bad ``v1.27.10+rke2r1`` build (rancher/rke2#6250).
+
+References
+----------
+
+* Task: https://github.com/evoila/meho/issues/2429
+* Parent initiative: https://github.com/evoila/meho/issues/2172
+* Write-op mold: ``holodeck/ops_write.py`` (#2154), bind9 safe-sudo (#697).
+* Approval routing: ``policy_gate`` / G11.7-T1 #1401.
+* raw_payload sink: ``dispatcher.py`` / ``middleware.py``.
+* ``rke2 token rotate`` / join-token wedge: rancher/rke2#5785, #6250.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import secrets
+import shlex
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors._shared.vault_creds import strip_credential_value
+from meho_backplane.connectors.rke2._sudo import run_remote_bash_with_sudo
+from meho_backplane.connectors.rke2.ops import SSH_TRANSPORT_NOTE, Rke2Op
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.rke2.connector import Rke2SshConnector
+
+__all__ = [
+    "RKE2_TOKEN_PATH",
+    "RKE2_WHEN_TO_USE_WRITE_BY_GROUP",
+    "WRITE_OPS",
+    "Rke2WriteError",
+    "rke2_token_rotate",
+    "rke2_version_rotate_verdict",
+]
+
+
+#: The on-disk RKE2 server join token. Read server-side (as root, inside the
+#: sudo script) as the OLD token; its value never enters Python. Mirrors the
+#: constant the read-posture tier reports presence for.
+RKE2_TOKEN_PATH: str = "/var/lib/rancher/rke2/server/token"
+
+#: Absolute path to the ``rke2`` binary the installer drops. Absolute so the
+#: sudo script never depends on root's ``PATH``.
+_RKE2_BIN: str = "/var/lib/rancher/rke2/bin/rke2"
+
+#: The systemd unit an RKE2 **server** node runs. Its presence in
+#: ``systemctl list-unit-files`` is the role signal; ``is-active`` on it is
+#: the running signal.
+_RKE2_SERVER_UNIT: str = "rke2-server.service"
+
+#: Per-minor CVE-fix floor for a safe token rotate (rancher/rke2#6250). A
+#: rotate on a below-floor server can wedge node re-joins. Keyed by
+#: ``(major, minor)`` -> the minimum ``(patch, rke2r)`` that carries the fix.
+_RKE2_ROTATE_FLOORS: dict[tuple[int, int], tuple[int, int]] = {
+    (1, 25): (15, 2),
+    (1, 26): (10, 2),
+    (1, 27): (7, 2),
+    (1, 28): (3, 2),
+}
+
+#: The single known-bad build that regressed rotate even though it is at/above
+#: its minor floor's patch (rancher/rke2#6250). Denied explicitly.
+_RKE2_KNOWN_BAD_BUILD: tuple[tuple[int, int, int], int] = ((1, 27, 10), 1)
+
+#: A parsed RKE2 release: ``v1.28.3+rke2r2`` -> ``((1, 28, 3), 2)``.
+_RKE2_RELEASE_RE: re.Pattern[str] = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)\+rke2r(\d+)$")
+
+_VERSION_PREFLIGHT_CMD: str = (
+    "printf 'ACTIVE=%s\\n' \"$(systemctl is-active rke2-server 2>/dev/null || true)\"; "
+    "printf 'UNIT=%s\\n' "
+    '"$(systemctl list-unit-files rke2-server.service --no-legend 2>/dev/null '
+    "| awk '{print $1}' | head -n1)\"; "
+    "printf 'VERSION=%s\\n' \"$("
+    "rke2 --version 2>/dev/null | head -n1 || "
+    '/usr/local/bin/rke2 --version 2>/dev/null | head -n1 || true)"'
+)
+
+#: Non-word characters collapse to ``-`` when deriving the Vault path segment
+#: from the target name -- keeps the KV path to a safe ``[A-Za-z0-9._-]`` set.
+_NODE_SLUG_RE: re.Pattern[str] = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class Rke2WriteError(ValueError):
+    """Raised when a write op cannot proceed (fingerprint gate, missing creds).
+
+    Subclass of :class:`ValueError` so the dispatcher's
+    ``result_connector_error`` envelope picks it up uniformly. The message
+    names the failed gate without echoing any secret material.
+    """
+
+
+def parse_rke2_release(version: str | None) -> tuple[tuple[int, int, int], int] | None:
+    """Parse an RKE2 release string into ``((major, minor, patch), rke2r)``.
+
+    Examples
+    --------
+
+    >>> parse_rke2_release("v1.28.3+rke2r2")
+    ((1, 28, 3), 2)
+    >>> parse_rke2_release("1.27.10+rke2r1")
+    ((1, 27, 10), 1)
+    >>> parse_rke2_release("v1.29.0") is None
+    True
+    >>> parse_rke2_release(None) is None
+    True
+    """
+    if not version:
+        return None
+    match = _RKE2_RELEASE_RE.match(version.strip())
+    if match is None:
+        return None
+    major, minor, patch, rke2r = (int(g) for g in match.groups())
+    return ((major, minor, patch), rke2r)
+
+
+def rke2_version_rotate_verdict(version: str | None) -> tuple[bool, str]:
+    """Return ``(safe, reason)`` for rotating on RKE2 *version*.
+
+    A version is safe when it is at/above the per-minor CVE-fix floor
+    (:data:`_RKE2_ROTATE_FLOORS`) for a covered minor line, or on any newer
+    minor line (>= 1.29, all patched), and is not the known-bad
+    ``v1.27.10+rke2r1`` build. Below the covered range (<= 1.24, EOL /
+    unpatched) or unparseable metadata is refused.
+    """
+    parsed = parse_rke2_release(version)
+    if parsed is None:
+        return False, f"unparseable RKE2 release metadata: {version!r}"
+    (major, minor, patch), rke2r = parsed
+
+    if ((major, minor, patch), rke2r) == _RKE2_KNOWN_BAD_BUILD:
+        return False, (
+            "v1.27.10+rke2r1 regressed token rotate (rancher/rke2#6250); "
+            "upgrade to v1.27.10+rke2r2 or newer before rotating"
+        )
+
+    minor_key = (major, minor)
+    floor = _RKE2_ROTATE_FLOORS.get(minor_key)
+    if floor is not None:
+        if (patch, rke2r) >= floor:
+            return True, "at or above the CVE-fix floor for its minor line"
+        floor_patch, floor_r = floor
+        return False, (
+            f"below the rotate CVE-fix floor for v{major}.{minor}: needs "
+            f">= v{major}.{minor}.{floor_patch}+rke2r{floor_r} (rancher/rke2#6250)"
+        )
+
+    # Unlisted minor line: newer than the covered range is patched; older is
+    # EOL / predates the fix.
+    if (major, minor) > max(_RKE2_ROTATE_FLOORS):
+        return True, "newer than the covered CVE-fix range (all builds patched)"
+    return False, (
+        f"v{major}.{minor} predates the rotate CVE-fix range "
+        "(EOL / no fixed build); upgrade before rotating"
+    )
+
+
+def _node_label(target: Any) -> str:
+    """Human-facing node label for the result / preview -- name, else host."""
+    name = getattr(target, "name", None)
+    if isinstance(name, str) and name.strip():
+        return name
+    host = getattr(target, "host", None)
+    return host if isinstance(host, str) and host.strip() else "unknown"
+
+
+def _vault_token_path(operator: Operator, target: Any) -> str:
+    """Build the per-tenant KV-v2 path the minted token is stashed under.
+
+    ``tenants/<tenant_id>/rke2/<node>/server-token`` on the default
+    ``secret`` mount -- the canonical per-tenant layout (#1723) so the write
+    lands where the operator's ``meho-mcp`` Vault policy already grants
+    ``create``/``update``. The node segment is a ``[A-Za-z0-9._-]`` slug of
+    the target name.
+    """
+    slug = _NODE_SLUG_RE.sub("-", _node_label(target)).strip("-") or "node"
+    return f"tenants/{operator.tenant_id}/rke2/{slug}/server-token"
+
+
+async def _resolve_sudo_password(
+    connector: Rke2SshConnector, target: Any, operator: Operator | None
+) -> str:
+    """Resolve the sudo password from the target's Vault secret (#2155).
+
+    Keys on a dedicated ``sudo_password`` field first, falling back to the
+    SSH ``password`` (the consumer-wrapper convention). Raises
+    :class:`Rke2WriteError` when neither is set -- the safe-sudo primitive
+    requires a non-empty single-line credential and the rotate cannot
+    legitimately proceed without root.
+    """
+    secret = await connector._resolve_secret(target, operator)
+    password = secret.get("sudo_password") or secret.get("password")
+    if not password:
+        raise Rke2WriteError(
+            "the target's Vault secret carries no sudo_password / password; "
+            "rke2.token.rotate needs a sudo credential to run as root"
+        )
+    return strip_credential_value(password)
+
+
+def _parse_preflight(stdout: str) -> dict[str, str]:
+    """Parse the ``KEY=VALUE`` preflight stdout into a flat map."""
+    fields: dict[str, str] = {}
+    for line in stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+async def _fingerprint_gate(
+    connector: Rke2SshConnector, target: Any, operator: Operator
+) -> dict[str, Any] | None:
+    """Read-only pre-rotate gate. Return an error envelope on refusal, else ``None``.
+
+    Runs one read-only SSH round-trip and refuses a node that is not an RKE2
+    server, whose ``rke2-server`` is not active, or whose RKE2 version cannot
+    safely rotate -- **before** any mutation.
+    """
+    proc = await connector._run_command(target, _VERSION_PREFLIGHT_CMD, operator=operator)
+    pre_raw = proc.stdout if hasattr(proc, "stdout") else ""
+    fields = _parse_preflight(pre_raw if isinstance(pre_raw, str) else "")
+
+    if fields.get("UNIT") != _RKE2_SERVER_UNIT:
+        return {
+            "rotated": False,
+            "error": (
+                "fingerprint gate: node is not an RKE2 server "
+                "(rke2-server.service is not installed)"
+            ),
+            "gate": "role",
+        }
+    active = fields.get("ACTIVE", "")
+    if active != "active":
+        return {
+            "rotated": False,
+            "error": f"fingerprint gate: rke2-server is not active (state={active!r})",
+            "gate": "service",
+        }
+    # Lazy import avoids a connector <-> ops_write import cycle (connector
+    # imports this module's when_to_use table at its own import time).
+    from meho_backplane.connectors.rke2.connector import parse_rke2_version
+
+    version = parse_rke2_version(fields.get("VERSION", ""))
+    safe, reason = rke2_version_rotate_verdict(version)
+    if not safe:
+        return {
+            "rotated": False,
+            "error": f"fingerprint gate: RKE2 version {version!r} cannot rotate -- {reason}",
+            "gate": "version",
+            "version": version,
+        }
+    return None
+
+
+async def _stash_token_in_vault(
+    operator: Operator, target: Any, *, new_token: str, node: str, exit_status: int | None
+) -> dict[str, Any]:
+    """Write the minted token to Vault and return a pointer (never the value).
+
+    On a Vault failure the rotate already succeeded (the new token is the live
+    cluster token, persisted on the node's own disk), so the partial state is
+    surfaced honestly -- ``rotated: True`` with ``token_ref: None`` and a
+    ``vault_error`` class name, still without the token value.
+    """
+    from meho_backplane.auth.vault import vault_client_for_operator
+
+    mount = "secret"
+    path = _vault_token_path(operator, target)
+    try:
+        async with vault_client_for_operator(operator) as client:
+            write_payload = await asyncio.to_thread(
+                client.secrets.kv.v2.create_or_update_secret,
+                path=path,
+                secret={"token": new_token},
+                mount_point=mount,
+            )
+        kv_version = write_payload["data"]["version"]
+    except Exception as exc:
+        return {
+            "rotated": True,
+            "node": node,
+            "exit_status": exit_status,
+            "token_ref": None,
+            "vault_error": type(exc).__name__,
+        }
+
+    return {
+        "rotated": True,
+        "node": node,
+        "exit_status": exit_status,
+        "token_ref": {
+            "backend": "vault",
+            "mount": mount,
+            "path": path,
+            "key": "token",
+            "kv_version": kv_version,
+        },
+    }
+
+
+def _build_rotate_script(new_token: str) -> str:
+    """Build the sudo script: read OLD on-disk as root, run ``rke2 token rotate``.
+
+    The OLD token is a shell variable (``$(cat ...)``) -- it never enters
+    Python. The NEW token is the only interpolated value (``shlex.quote``'d),
+    streamed on stdin via the safe-sudo primitive, never in argv / history /
+    log.
+    """
+    return (
+        "set -euo pipefail\n"
+        "umask 077\n"
+        f"TOKENFILE={shlex.quote(RKE2_TOKEN_PATH)}\n"
+        'if [ ! -r "$TOKENFILE" ]; then echo "old-token-unreadable" >&2; exit 3; fi\n'
+        'OLD=$(cat "$TOKENFILE")\n'
+        f'{shlex.quote(_RKE2_BIN)} token rotate --token "$OLD" '
+        f"--new-token {shlex.quote(new_token)}\n"
+    )
+
+
+async def rke2_token_rotate(
+    connector: Rke2SshConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``rke2.token.rotate`` -- approval-gated server-token rotation.
+
+    Runs only on the ``_approved=True`` resume path. Flow: fail closed
+    without an operator (no Vault sink) -> resolve the sudo credential ->
+    read-only fingerprint gate (server role + active service + safe version)
+    -> mint a new token -> one sudo script that reads the OLD token on-disk
+    and runs ``rke2 token rotate`` -> stash the NEW token in Vault -> return
+    a pointer + non-secret metadata. The token value (old or new) never
+    appears in the returned dict.
+    """
+    del params  # schema declares no params; the target addresses the node
+
+    if operator is None:
+        return {
+            "rotated": False,
+            "error": (
+                "rke2.token.rotate requires an operator identity for the Vault "
+                "token sink; refusing to rotate without a place to stash the "
+                "new token"
+            ),
+            "gate": "operator",
+        }
+
+    try:
+        sudo_password = await _resolve_sudo_password(connector, target, operator)
+    except Rke2WriteError as exc:
+        return {"rotated": False, "error": str(exc), "gate": "credentials"}
+
+    gate_error = await _fingerprint_gate(connector, target, operator)
+    if gate_error is not None:
+        return gate_error
+
+    # Mint + rotate. The OLD token is read on-disk as root inside the script;
+    # the NEW token is minted here and only ever leaves as a Vault pointer.
+    new_token = secrets.token_hex(32)
+    node = _node_label(target)
+    result = await run_remote_bash_with_sudo(
+        connector,
+        target,
+        _build_rotate_script(new_token),
+        operator=operator,
+        sudo_password=sudo_password,
+    )
+    exit_status = getattr(result, "exit_status", None)
+    if exit_status != 0:
+        # Never surface stdout/stderr: ``rke2 token rotate`` diagnostics could
+        # echo a token value, and the raw result is persisted on the audit row.
+        return {
+            "rotated": False,
+            "error": "rke2 token rotate exited non-zero",
+            "exit_status": exit_status,
+            "node": node,
+            "gate": "rotate",
+        }
+
+    return await _stash_token_in_vault(
+        operator, target, new_token=new_token, node=node, exit_status=exit_status
+    )
+
+
+# ---------------------------------------------------------------------------
+# Curated when_to_use + op metadata
+# ---------------------------------------------------------------------------
+
+_WHEN_TO_USE_TOKEN_WRITE: str = (
+    "Use to rotate an RKE2 cluster's server join token: "
+    "``rke2.token.rotate`` runs ``rke2 token rotate`` on a server node so a "
+    "leaked or aging join token is replaced cluster-wide. It is "
+    "approval-gated -- a dispatch parks for a human to approve before "
+    "anything changes -- and takes NO token parameter: the new token is "
+    "minted server-side, stashed in Vault, and only a pointer is returned "
+    "(the token value never appears in the result, the audit row, or the "
+    "feed). A read-only fingerprint gate refuses a non-server node, an "
+    "inactive rke2-server, or a below-floor / known-bad RKE2 version before "
+    "touching anything (a botched rotate wedges future node joins). The "
+    "right op when the join token must be rotated on a single server node; "
+    "multi-node restart choreography is a separate operator runbook. " + SSH_TRANSPORT_NOTE
+)
+
+#: Curated ``when_to_use`` per write group. The ``-write`` suffix keeps it
+#: from colliding with the read-op group keys the registration walk merges.
+RKE2_WHEN_TO_USE_WRITE_BY_GROUP: dict[str, str] = {
+    "rke2-token-write": _WHEN_TO_USE_TOKEN_WRITE,
+}
+
+
+_TOKEN_ROTATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rotated": {"type": "boolean"},
+        "node": {"type": ["string", "null"]},
+        "exit_status": {"type": ["integer", "null"]},
+        "token_ref": {
+            "type": ["object", "null"],
+            "properties": {
+                "backend": {"type": "string"},
+                "mount": {"type": "string"},
+                "path": {"type": "string"},
+                "key": {"type": "string"},
+                "kv_version": {"type": ["integer", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        "error": {"type": "string"},
+        "gate": {"type": "string"},
+        "vault_error": {"type": "string"},
+        "version": {"type": ["string", "null"]},
+    },
+    "required": ["rotated"],
+    "additionalProperties": True,
+}
+
+
+WRITE_OPS: tuple[Rke2Op, ...] = (
+    Rke2Op(
+        op_id="rke2.token.rotate",
+        handler_attr="token_rotate",
+        summary="Rotate the RKE2 server join token cluster-wide (approval-gated).",
+        description=(
+            "Runs ``rke2 token rotate`` on an RKE2 server node over SSH to "
+            "replace the cluster's server join token. Takes NO parameters "
+            "and NO token value: the new token is minted server-side, the "
+            "OLD token is read on-disk as root inside the rotate script, and "
+            "the new token is written to Vault -- only a pointer to the Vault "
+            "location plus non-secret metadata (rotated / node / exit_status) "
+            "is returned, so no token value ever reaches the result, the "
+            "audit row, or the broadcast feed. A read-only fingerprint gate "
+            "refuses a non-server node, an inactive rke2-server, or a "
+            "below-floor / known-bad (v1.27.10+rke2r1) RKE2 version before "
+            "any mutation, because a botched rotate wedges every future node "
+            "join (rancher/rke2#5785). safety_level=dangerous, "
+            "requires_approval=True -- parks for human approval first."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        response_schema=_TOKEN_ROTATE_RESPONSE_SCHEMA,
+        group_key="rke2-token-write",
+        tags=("write", "token", "rotate", "credential", "rke2"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_TOKEN_WRITE,
+            "parameter_hints": {},
+            "output_shape": (
+                "{rotated, node, exit_status, token_ref: {backend, mount, "
+                "path, key, kv_version}}. token_ref points at the Vault KV-v2 "
+                "location the new token was stashed at -- the token VALUE is "
+                "never returned. On a gate refusal or failure: {rotated: "
+                "false, error, gate}. If the rotate succeeded but the Vault "
+                "stash failed: {rotated: true, token_ref: null, vault_error}."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/rke2/ops_write_preview.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_write_preview.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Park-time ``proposed_effect`` preview builder for ``rke2.token.rotate`` (#2429).
+
+Wires the approval-gated RKE2 token-rotate op onto the per-op preview hook
+(:mod:`meho_backplane.operations._preview`) so a human approving the parked
+rotate reads *what it will do* -- which node, which service, that a new token
+will be minted -- rather than only the identifier-only default.
+
+``rke2.token.rotate`` classifies as ``credential_mint`` (pinned in
+``broadcast/events.py``), so the generic params-echo default is suppressed
+for it. A **bespoke** builder is the deliberate exception (#1857): it is
+trusted to own its own field discipline. This builder returns only
+side-effect-free, non-secret metadata -- it neither mints a token nor runs
+the rotate, and it never surfaces a token value -- so it is redaction-safe.
+It is fail-soft: a raise is swallowed by :func:`build_proposed_effect` into a
+``preview_unavailable`` marker and never blocks the park.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from meho_backplane.operations._preview import register_preview_builder
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from meho_backplane.operations._preview import PreviewContext
+
+__all__ = ["rke2_token_rotate_preview"]
+
+
+async def rke2_token_rotate_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview builder for ``rke2.token.rotate``.
+
+    Returns a non-secret summary of the approved rotate: the node, the
+    affected service, the rotate semantics, and that a new token will be
+    minted server-side (never the value). Declines (``None``) when no target
+    resolved, so the caller falls back to the identifier-only default.
+    """
+    if ctx.target is None:
+        return None
+    # Lazy import: keeps this preview module's top-level imports free of the
+    # ops <-> ops_write chain so importing it (a registration side-effect in
+    # __init__) never trips the connector package's partial-import order.
+    from meho_backplane.connectors.rke2.ops_write import _node_label
+
+    return {
+        "node": _node_label(ctx.target),
+        "service": "rke2-server",
+        "semantics": "rotate",
+        "new_token_minted": True,
+    }
+
+
+register_preview_builder("rke2.token.rotate", rke2_token_rotate_preview)

--- a/backend/tests/integration/test_g3_4_bind9_e2e.py
+++ b/backend/tests/integration/test_g3_4_bind9_e2e.py
@@ -1277,8 +1277,8 @@ def test_remote_bash_with_sudo_is_only_sudo_construction_in_connectors_tree() ->
     Python list / tuple argv (e.g. ``["sudo", "-S", ...]``,
     ``("sudo",)``).
 
-    Two files are whitelisted by absolute path because they own the
-    safe-sudo primitive:
+    Three files are whitelisted by absolute path because they own a
+    sanctioned safe-sudo primitive:
 
     * :mod:`~meho_backplane.connectors.bind9.connector` — the
       ``_remote_bash_with_sudo`` helper, the single legitimate
@@ -1289,6 +1289,12 @@ def test_remote_bash_with_sudo_is_only_sudo_construction_in_connectors_tree() ->
       script body to ``_remote_bash_with_sudo``); whitelisting it keeps
       the contract explicit so a future refactor that hoists a sudo
       argv there is still a deliberate, reviewed step.
+    * :mod:`~meho_backplane.connectors.rke2._sudo` — the rke2
+      connector's own sanctioned safe-sudo primitive, identical in
+      wire shape to bind9's helper: it stdin-streams a bash script
+      body to ``sudo -S -p "" bash`` so the password never lands in
+      argv / logs. The single legitimate sudo-argv site in the rke2
+      tree.
 
     Every sibling connector (and every other bind9 module —
     ``ops.py`` / ``ops_record.py`` / ``ops_config.py`` /
@@ -1321,7 +1327,7 @@ def test_remote_bash_with_sudo_is_only_sudo_construction_in_connectors_tree() ->
     assert connectors_root.is_dir(), (
         f"connectors root not found at {connectors_root}; test layout drifted"
     )
-    # Narrow whitelist: only the two files that own the safe-sudo
+    # Narrow whitelist: only the files that own a sanctioned safe-sudo
     # primitive. Everything else under bind9/ (ops_*.py) is held to
     # the invariant; they reference sudo only via docstrings / error
     # messages / the ``"sudo_password"`` dict key, all of which the
@@ -1329,6 +1335,7 @@ def test_remote_bash_with_sudo_is_only_sudo_construction_in_connectors_tree() ->
     allowed_files = {
         connectors_root / "bind9" / "connector.py",
         connectors_root / "bind9" / "_atomic.py",
+        connectors_root / "rke2" / "_sudo.py",
     }
     # Match `sudo` only as the first token of a string literal — the
     # universal shape of sudo argv construction, whether it's

--- a/backend/tests/test_broadcast_classifier_coverage.py
+++ b/backend/tests/test_broadcast_classifier_coverage.py
@@ -211,6 +211,17 @@ def test_deliberately_unpinned_fixture_op_fails_the_sweep() -> None:
     assert violations == [("acme.credstore.create", "write", ["password"])]
 
 
+def test_rke2_token_rotate_is_pinned_credential_mint() -> None:
+    """rke2.token.rotate mints a token server-side -> credential_mint (#2429).
+
+    ``.rotate`` is not a write/read suffix, so without the explicit pin the
+    op would classify ``other`` and broadcast full detail. The pin collapses
+    its broadcast to aggregate-only (defence-in-depth: the handler already
+    never returns the token, but the class must match the semantics).
+    """
+    assert classify_op("rke2.token.rotate") == "credential_mint"
+
+
 def test_boolean_and_integer_attrs_do_not_trip_the_sweep() -> None:
     """AppRole-style config attributes stay unflagged (vetted full detail)."""
     fixture_op: tuple[str, dict[str, Any] | None] = (

--- a/backend/tests/test_connectors_bind9.py
+++ b/backend/tests/test_connectors_bind9.py
@@ -454,9 +454,13 @@ def test_sudo_is_only_referenced_via_the_safe_primitive() -> None:
     commands, ``["sudo", "-S", ...]`` list-form argv,
     ``("sudo",)`` tuple-form). The only files allowed to carry such
     a literal are :mod:`~meho_backplane.connectors.bind9.connector`
-    (the ``_remote_bash_with_sudo`` helper) and
+    (the ``_remote_bash_with_sudo`` helper),
     :mod:`~meho_backplane.connectors.bind9._atomic` (the atomic-apply
-    primitive that funnels its writes through the helper).
+    primitive that funnels its writes through the helper), and
+    :mod:`~meho_backplane.connectors.rke2._sudo` (the rke2 connector's
+    own sanctioned safe-sudo primitive — same wire shape as bind9's
+    ``_remote_bash_with_sudo``: it stdin-streams a bash script body to
+    ``sudo -S -p "" bash`` so the password never lands in argv/logs).
 
     A failure means a new sudo argv slipped in somewhere; the
     operator must fold it back through :meth:`_remote_bash_with_sudo`.
@@ -476,13 +480,14 @@ def test_sudo_is_only_referenced_via_the_safe_primitive() -> None:
     connectors_root = (
         Path(__file__).resolve().parent.parent / "src" / "meho_backplane" / "connectors"
     )
-    # Narrow whitelist: only the two files that own the safe-sudo
+    # Narrow whitelist: only the files that own a sanctioned safe-sudo
     # primitive. ops_*.py files reference sudo only via docstrings /
     # error messages / the ``"sudo_password"`` dict key — all of which
     # the detection regex below correctly ignores.
     allowed_files = {
         connectors_root / "bind9" / "connector.py",
         connectors_root / "bind9" / "_atomic.py",
+        connectors_root / "rke2" / "_sudo.py",
     }
     sudo_argv_re = re.compile(r"""(?<=["'])sudo(?=["'\s\\])""")
     offenders: list[str] = []

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -24,6 +24,7 @@ Coverage matrix (per Task #2221 acceptance criteria):
 
 from __future__ import annotations
 
+import uuid
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -338,11 +339,13 @@ async def test_posture_show_never_leaks_secret_material(
 # ---------------------------------------------------------------------------
 
 
-_EXPECTED_OP_IDS: frozenset[str] = frozenset({"rke2.about", "rke2.posture.show"})
+_READ_OP_IDS: frozenset[str] = frozenset({"rke2.about", "rke2.posture.show"})
+_EXPECTED_OP_IDS: frozenset[str] = _READ_OP_IDS | {"rke2.token.rotate"}
 
 
-def test_rke2_ops_has_two_entries() -> None:
-    assert len(RKE2_OPS) == 2
+def test_rke2_ops_has_three_entries() -> None:
+    # Two read ops (#2221) + the approval-gated rke2.token.rotate write (#2429).
+    assert len(RKE2_OPS) == 3
 
 
 def test_rke2_ops_about_is_first() -> None:
@@ -358,9 +361,11 @@ def test_rke2_ops_all_namespaced() -> None:
         assert op.op_id.startswith("rke2."), f"{op.op_id!r} lacks rke2. prefix"
 
 
-def test_rke2_ops_all_safe_read_only_no_approval() -> None:
-    """AC: every op is safe-tier, read-only, and requires no approval."""
-    for op in RKE2_OPS:
+def test_rke2_read_ops_all_safe_read_only_no_approval() -> None:
+    """AC: every READ op is safe-tier, read-only, and requires no approval."""
+    read_ops = [op for op in RKE2_OPS if op.op_id in _READ_OP_IDS]
+    assert {op.op_id for op in read_ops} == _READ_OP_IDS
+    for op in read_ops:
         assert op.safety_level == "safe", f"{op.op_id!r} is not safe-tier"
         assert op.requires_approval is False, f"{op.op_id!r} requires approval"
         assert "read-only" in op.tags, f"{op.op_id!r} missing read-only tag"
@@ -394,3 +399,274 @@ def test_rke2_connector_registry_triple() -> None:
 
     registry = all_connectors_v2()
     assert registry.get(("rke2", "1.x", "rke2-ssh")) is Rke2SshConnector
+
+
+# ===========================================================================
+# rke2.token.rotate write op (#2429)
+# ===========================================================================
+
+import contextlib  # noqa: E402 -- grouped with the write-op section it serves
+
+from meho_backplane.auth.operator import Operator, TenantRole  # noqa: E402
+from meho_backplane.connectors.rke2.ops_write import (  # noqa: E402
+    WRITE_OPS,
+    parse_rke2_release,
+    rke2_token_rotate,
+    rke2_version_rotate_verdict,
+)
+
+# A minted-token canary. The handler must NEVER surface the minted token in
+# its result envelope (the raw result is persisted on the audit row).
+_CANARY_NEW_TOKEN = "K10CANARYnewtokenvalueMUSTNOTLEAK0000deadbeef"  # gitleaks:allow NOSONAR
+
+_OP_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000024f9")
+_OPERATOR = Operator(
+    sub="rke2-token-rotate-test",
+    name="RKE2 Rotate Test",
+    email=None,
+    raw_jwt="<rke2-rotate-raw-jwt>",
+    tenant_id=_OP_TENANT,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+
+def _preflight_stdout(
+    *,
+    unit: str = "rke2-server.service",
+    active: str = "active",
+    version: str = "rke2 version v1.28.5+rke2r2 (abc)",
+) -> str:
+    return f"ACTIVE={active}\nUNIT={unit}\nVERSION={version}\n"
+
+
+@contextlib.contextmanager
+def _patch_vault_write(version: int = 7, raises: bool = False):
+    """Patch vault_client_for_operator to a fake async-CM KV-v2 writer.
+
+    Yields the create_or_update_secret mock so a test can inspect what the
+    handler wrote (the minted token lands in Vault, not in the result).
+    """
+    write_mock = MagicMock(return_value={"data": {"version": version}})
+    if raises:
+        write_mock.side_effect = RuntimeError("vault down")
+    client = MagicMock()
+    client.secrets.kv.v2.create_or_update_secret = write_mock
+
+    @contextlib.asynccontextmanager
+    async def _fake_client(operator: Any):
+        yield client
+
+    with patch("meho_backplane.auth.vault.vault_client_for_operator", _fake_client):
+        yield write_mock
+
+
+def _write_op() -> Any:
+    return next(op for op in WRITE_OPS if op.op_id == "rke2.token.rotate")
+
+
+# --- Registration shape ----------------------------------------------------
+
+
+def test_token_rotate_is_dangerous_and_requires_approval() -> None:
+    op = _write_op()
+    assert op.safety_level == "dangerous"
+    assert op.requires_approval is True
+    assert "write" in op.tags
+
+
+def test_token_rotate_schema_has_no_token_param() -> None:
+    """AC: the schema takes no token field and is closed (no free-form input)."""
+    schema = _write_op().parameter_schema
+    assert schema["additionalProperties"] is False
+    assert schema["properties"] == {}
+
+
+def test_token_rotate_when_to_use_mentions_ssh_and_approval() -> None:
+    instr = _write_op().llm_instructions or {}
+    when = instr.get("when_to_use", "")
+    assert "SSH" in when
+    assert "approval-gated" in when
+
+
+# --- Version fingerprint gate (pure) ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["v1.28.3+rke2r2", "v1.25.15+rke2r2", "v1.27.10+rke2r2", "v1.29.0+rke2r1", "1.30.2+rke2r1"],
+)
+def test_version_verdict_accepts_patched(version: str) -> None:
+    ok, _ = rke2_version_rotate_verdict(version)
+    assert ok is True
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["v1.28.2+rke2r2", "v1.27.10+rke2r1", "v1.24.17+rke2r1", "v1.28.3+rke2r1", "junk", "v1.28.3"],
+)
+def test_version_verdict_refuses_below_floor_and_known_bad(version: str) -> None:
+    ok, reason = rke2_version_rotate_verdict(version)
+    assert ok is False
+    assert reason
+
+
+def test_parse_rke2_release_shapes() -> None:
+    assert parse_rke2_release("v1.28.3+rke2r2") == ((1, 28, 3), 2)
+    assert parse_rke2_release("1.27.10+rke2r1") == ((1, 27, 10), 1)
+    assert parse_rke2_release("v1.28.3") is None
+    assert parse_rke2_release(None) is None
+
+
+# --- Handler: happy path, no token leak ------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_token_rotate_happy_path_returns_pointer_never_token() -> None:
+    connector = Rke2SshConnector()
+    sudo_proc = _proc(stdout="", exit_status=0)
+    with (
+        patch.object(connector, "_resolve_secret", new_callable=AsyncMock) as mock_secret,
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        patch(
+            "meho_backplane.connectors.rke2.ops_write.run_remote_bash_with_sudo",
+            new_callable=AsyncMock,
+        ) as mock_sudo,
+        patch("secrets.token_hex", return_value=_CANARY_NEW_TOKEN),
+        _patch_vault_write(version=9) as write_mock,
+    ):
+        mock_secret.return_value = {"password": _CANARY_PASSWORD}
+        mock_cmd.return_value = _proc(stdout=_preflight_stdout())
+        mock_sudo.return_value = sudo_proc
+        result = await rke2_token_rotate(connector, _TARGET, {}, _OPERATOR)
+
+    assert result["rotated"] is True
+    assert result["exit_status"] == 0
+    ref = result["token_ref"]
+    assert ref["backend"] == "vault"
+    assert ref["kv_version"] == 9
+    assert f"tenants/{_OP_TENANT}/rke2/" in ref["path"]
+    # THE audit rule: the minted token never appears in the returned result.
+    assert _CANARY_NEW_TOKEN not in repr(result)
+    # ...but it WAS written to Vault (the sink) and passed to the sudo script.
+    write_mock.assert_called_once()
+    assert write_mock.call_args.kwargs["secret"] == {"token": _CANARY_NEW_TOKEN}
+    script = mock_sudo.await_args.args[2]
+    assert "/var/lib/rancher/rke2/bin/rke2 token rotate" in script
+    assert 'OLD=$(cat "$TOKENFILE")' in script  # OLD read server-side, never in Python
+    assert _CANARY_NEW_TOKEN in script  # new token quoted into the script body only
+
+
+@pytest.mark.asyncio
+async def test_token_rotate_vault_write_failure_is_honest_no_token() -> None:
+    connector = Rke2SshConnector()
+    with (
+        patch.object(connector, "_resolve_secret", new_callable=AsyncMock) as mock_secret,
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        patch(
+            "meho_backplane.connectors.rke2.ops_write.run_remote_bash_with_sudo",
+            new_callable=AsyncMock,
+        ) as mock_sudo,
+        patch("secrets.token_hex", return_value=_CANARY_NEW_TOKEN),
+        _patch_vault_write(raises=True),
+    ):
+        mock_secret.return_value = {"password": _CANARY_PASSWORD}
+        mock_cmd.return_value = _proc(stdout=_preflight_stdout())
+        mock_sudo.return_value = _proc(exit_status=0)
+        result = await rke2_token_rotate(connector, _TARGET, {}, _OPERATOR)
+
+    assert result["rotated"] is True  # the cluster token DID rotate
+    assert result["token_ref"] is None
+    assert result["vault_error"] == "RuntimeError"
+    assert _CANARY_NEW_TOKEN not in repr(result)
+
+
+# --- Handler: fingerprint-gate refusals (reject before any rotate) ---------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("preflight", "expected_gate"),
+    [
+        (_preflight_stdout(unit=""), "role"),  # not a server node
+        (_preflight_stdout(active="inactive"), "service"),  # rke2-server down
+        (_preflight_stdout(version="rke2 version v1.28.2+rke2r2 (x)"), "version"),  # below floor
+    ],
+)
+async def test_token_rotate_gate_refuses_before_rotate(preflight: str, expected_gate: str) -> None:
+    connector = Rke2SshConnector()
+    with (
+        patch.object(connector, "_resolve_secret", new_callable=AsyncMock) as mock_secret,
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        patch(
+            "meho_backplane.connectors.rke2.ops_write.run_remote_bash_with_sudo",
+            new_callable=AsyncMock,
+        ) as mock_sudo,
+    ):
+        mock_secret.return_value = {"password": _CANARY_PASSWORD}
+        mock_cmd.return_value = _proc(stdout=preflight)
+        result = await rke2_token_rotate(connector, _TARGET, {}, _OPERATOR)
+        mock_sudo.assert_not_awaited()  # no mutation on a gate refusal
+    assert result["rotated"] is False
+    assert result["gate"] == expected_gate
+
+
+@pytest.mark.asyncio
+async def test_token_rotate_without_operator_fails_closed() -> None:
+    """No operator => no Vault sink => refuse before touching anything."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await rke2_token_rotate(connector, _TARGET, {}, None)
+        mock_cmd.assert_not_awaited()
+    assert result["rotated"] is False
+    assert result["gate"] == "operator"
+
+
+@pytest.mark.asyncio
+async def test_token_rotate_missing_sudo_credential_refuses() -> None:
+    connector = Rke2SshConnector()
+    with (
+        patch.object(connector, "_resolve_secret", new_callable=AsyncMock) as mock_secret,
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+    ):
+        mock_secret.return_value = {"username": "root"}  # no password / sudo_password
+        result = await rke2_token_rotate(connector, _TARGET, {}, _OPERATOR)
+        mock_cmd.assert_not_awaited()
+    assert result["rotated"] is False
+    assert result["gate"] == "credentials"
+
+
+@pytest.mark.asyncio
+async def test_token_rotate_nonzero_exit_no_vault_no_output() -> None:
+    connector = Rke2SshConnector()
+    with (
+        patch.object(connector, "_resolve_secret", new_callable=AsyncMock) as mock_secret,
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd,
+        patch(
+            "meho_backplane.connectors.rke2.ops_write.run_remote_bash_with_sudo",
+            new_callable=AsyncMock,
+        ) as mock_sudo,
+        patch("secrets.token_hex", return_value=_CANARY_NEW_TOKEN),
+        _patch_vault_write() as write_mock,
+    ):
+        mock_secret.return_value = {"password": _CANARY_PASSWORD}
+        mock_cmd.return_value = _proc(stdout=_preflight_stdout())
+        mock_sudo.return_value = _proc(stdout="boom", stderr="rke2: rotate failed", exit_status=1)
+        result = await rke2_token_rotate(connector, _TARGET, {}, _OPERATOR)
+
+    assert result["rotated"] is False
+    assert result["gate"] == "rotate"
+    assert result["exit_status"] == 1
+    write_mock.assert_not_called()  # no Vault write on a failed rotate
+    # Never surface raw stdout/stderr (could echo a token); only structured fields.
+    assert "stderr" not in result
+    assert "stdout" not in result
+    assert _CANARY_NEW_TOKEN not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_token_rotate_shim_delegates_to_handler() -> None:
+    """The connector bound-method shim runs the same guarded path."""
+    connector = Rke2SshConnector()
+    result = await connector.token_rotate(_TARGET, {}, None)  # operator=None short-circuits
+    assert result["rotated"] is False
+    assert result["gate"] == "operator"

--- a/backend/tests/test_connectors_rke2_e2e.py
+++ b/backend/tests/test_connectors_rke2_e2e.py
@@ -23,6 +23,8 @@ Acceptance criteria verified (Issue #2221)
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import json
 import types
 import uuid
 from collections.abc import AsyncIterator, Iterator
@@ -95,6 +97,22 @@ async def _fake_shell_process_factory(process: Any) -> None:
         response = _RKE2_VERSION_FIXTURE
     elif cmd.startswith("stat -c '%n|%a|%U|%G'"):
         response = _STAT_FIXTURE
+    elif cmd.startswith("printf 'ACTIVE="):
+        # rke2.token.rotate fingerprint preflight: server node, active,
+        # patched version (1.29 is above the CVE-fix range).
+        response = (
+            "ACTIVE=active\nUNIT=rke2-server.service\n"
+            "VERSION=rke2 version v1.29.3+rke2r2 (a1b2c3d)\n"
+        )
+    elif cmd.startswith("set -e; umask 077; f=$(mktemp)"):
+        # The safe-sudo wire command streams the script + password on stdin;
+        # drain it (the real mktemp pipeline would consume it) so the client
+        # write side doesn't break, then simulate a successful
+        # `rke2 token rotate` (exit 0, no stdout, never echoing a token).
+        with contextlib.suppress(Exception):
+            await process.stdin.read()
+        process.exit(0)
+        return
     else:
         process.stderr.write(f"fake-shell: unknown command: {cmd!r}\n")
         process.exit(127)
@@ -316,3 +334,116 @@ async def test_rke2_e2e_posture_show_dispatches_ok_and_redacts(
     # Redaction: no token VALUE anywhere in the dispatch result.
     assert _TOKEN_VALUE_CANARY not in repr(result)
     assert "value" not in token
+
+
+# ---------------------------------------------------------------------------
+# rke2.token.rotate -- park -> approve -> execute -> audit (#2429)
+# ---------------------------------------------------------------------------
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from sqlalchemy import select  # noqa: E402
+
+from meho_backplane.db.models import AuditLog  # noqa: E402
+from meho_backplane.operations import dispatch  # noqa: E402
+from meho_backplane.targets.resolver import resolve_target  # noqa: E402
+
+# The minted token the handler generates on the approved path. Patched to a
+# fixed canary so the audit-row assertion can prove it never lands there.
+_MINTED_TOKEN_CANARY = "K10E2Ecanaryminted00000000deadbeefMUSTNOTLEAK"  # gitleaks:allow NOSONAR
+
+
+def _fake_vault_write(version: int = 3):
+    """Patch vault_client_for_operator to a fake async-CM KV-v2 writer."""
+    client = MagicMock()
+    client.secrets.kv.v2.create_or_update_secret = MagicMock(
+        return_value={"data": {"version": version}}
+    )
+
+    @contextlib.asynccontextmanager
+    async def _fake_client(operator: Any):
+        yield client
+
+    return patch("meho_backplane.auth.vault.vault_client_for_operator", _fake_client)
+
+
+async def _dispatch_rotate(bundle: _Rke2E2EBundle, *, approved: bool) -> dict[str, Any]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        resolved = await resolve_target(session, _OPERATOR.tenant_id, _TARGET_NAME)
+    # The sudo credential resolves off the target's Vault secret; the seeded
+    # connector's _auth_config doesn't cover _resolve_secret, so stub it.
+    with patch.object(
+        bundle.connector,
+        "_resolve_secret",
+        new=_AsyncReturn({"username": "root", "password": "e2e-sudo-pw"}),
+    ):
+        result = await dispatch(
+            operator=_OPERATOR,
+            connector_id=_CONNECTOR_ID,
+            op_id="rke2.token.rotate",
+            target=resolved,
+            params={},
+            _approved=approved,
+        )
+    return result.model_dump(mode="json")
+
+
+class _AsyncReturn:
+    """Minimal awaitable-returning stand-in for an async method patch."""
+
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    async def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self._value
+
+
+@pytest.mark.asyncio
+async def test_rke2_token_rotate_parks_for_user(
+    rke2_e2e: _Rke2E2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """An un-approved USER dispatch parks (not run, not hard-denied)."""
+    del captured_events
+    result = await _dispatch_rotate(rke2_e2e, approved=False)
+    assert result["status"] == "awaiting_approval", result
+    assert result.get("extras", {}).get("approval_request_id")
+
+
+@pytest.mark.asyncio
+async def test_rke2_token_rotate_approved_audit_row_has_no_token(
+    rke2_e2e: _Rke2E2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """AC: approved resume rotates + stashes to Vault; the raw audit row has NO token."""
+    del captured_events
+    op_id = "rke2.token.rotate"
+    with (
+        _fake_vault_write(version=5),
+        patch("secrets.token_hex", return_value=_MINTED_TOKEN_CANARY),
+    ):
+        result = await _dispatch_rotate(rke2_e2e, approved=True)
+
+    assert result["status"] == "ok", result.get("error")
+    payload = result["result"]
+    assert payload["rotated"] is True
+    assert payload["token_ref"]["backend"] == "vault"
+    assert payload["token_ref"]["kv_version"] == 5
+    # Caller view carries no token value.
+    assert _MINTED_TOKEN_CANARY not in json.dumps(result)
+
+    # THE audit rule: the RAW audit-row payload (persisted pre-redaction) must
+    # carry no token value either -- assert against the row, not just the view.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = await session.execute(
+            select(AuditLog)
+            .where(AuditLog.method == "DISPATCH", AuditLog.path == op_id)
+            .order_by(AuditLog.occurred_at.desc())
+            .limit(1)
+        )
+        row = rows.scalar_one()
+    assert row.raw_payload is not None
+    assert _MINTED_TOKEN_CANARY not in json.dumps(row.raw_payload)
+    assert _MINTED_TOKEN_CANARY not in json.dumps(row.payload)

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -26,10 +26,20 @@ T1 (#2221) ships the **connector scaffold + the read-only posture tier only**:
   join-token presence, **with the token value never read** (redacted by
   construction).
 
-Two ops total, both `safety_level="safe"` / `requires_approval=false`. The
-approval-gated write ops (`rke2.token.rotate`, `rke2.node.service.restart`,
-`rke2.node.config.update`, `rke2.etcd-snapshot.save`) ship in sibling Tasks
-#2429/#2430/#2431 — explicitly out of scope for T1.
+T2 (#2429) adds the **first approval-gated write op**:
+
+- `rke2.token.rotate` — rotates the RKE2 server join token cluster-wide via
+  `rke2 token rotate` over sudo-SSH. `safety_level="dangerous"`,
+  `requires_approval=True`. Takes **no parameters and no token value**: the
+  new token is minted server-side, the OLD token is read on-disk as root
+  inside the rotate script, and the new token is written to Vault — only a
+  **pointer** to the Vault location plus non-secret metadata (`rotated` /
+  `node` / `exit_status`) is returned. A read-only fingerprint gate refuses a
+  non-server node, an inactive `rke2-server`, or a below-floor / known-bad
+  (`v1.27.10+rke2r1`) RKE2 version before any mutation.
+
+The remaining write ops (`rke2.node.service.restart`, `rke2.node.config.update`,
+`rke2.etcd-snapshot.save`) ship in sibling Tasks #2430/#2431.
 
 Source: `backend/src/meho_backplane/connectors/rke2/`.
 
@@ -55,7 +65,20 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
 - **Op metadata** (`ops.py`) — `Rke2Op` frozen dataclass (mirrors
   `Bind9Op` / `HolodeckOp`), `SSH_TRANSPORT_NOTE` (the plain-SSH reminder
   copied into every op's `when_to_use`), `_RKE2_ABOUT_OP`, and `RKE2_OPS`
-  (`about` + the `READ_OPS` posture tuple).
+  (`about` + the `READ_OPS` posture tuple + the `WRITE_OPS` write tuple).
+
+- **Write tier** (`ops_write.py`, #2429) — `rke2_token_rotate` (the async
+  handler, bound to the connector via the `token_rotate` shim),
+  `rke2_version_rotate_verdict` / `parse_rke2_release` (the pure version-gate
+  logic against the per-minor CVE-fix floor + the `v1.27.10+rke2r1` deny),
+  and `WRITE_OPS` (`rke2.token.rotate`). The minted new token is stashed in
+  Vault under `secret/tenants/<tenant_id>/rke2/<node>/server-token`; only a
+  pointer is returned. `_sudo.py` carries the family's own safe-`sudo -S`
+  primitive (`run_remote_bash_with_sudo`) — the #697-hardened wire shape
+  (script bytes first, password last on stdin, never in argv / history /
+  log). `ops_write_preview.py` registers a non-secret park-time
+  `proposed_effect` preview builder (`{node, service, semantics,
+  new_token_minted}`).
 
 - **Registration** (`__init__.py`) — two-phase, mirroring bind9/holodeck.
   Synchronous `register_connector_v2` at import time (versioned triple +
@@ -101,6 +124,17 @@ foundation for the load-bearing Initiative #2172 rule: a secret-returning
 handler must never return the secret (the audit `raw_payload` stores the raw
 result).
 
+`rke2.token.rotate` (T2) is the write-side application of the same rule. The
+dispatcher persists the **raw** handler result on the audit row and
+connector-boundary redaction never scrubs `raw_payload`, so the only reliable
+control is that the handler never returns the token — old or new. Both are
+handled off the result surface: the OLD token is read on-disk as root inside
+the sudo script (a shell `$(cat ...)`, never entering Python), and the NEW
+token is minted here, written to Vault, and returned only as a pointer. The
+op is additionally pinned in `broadcast/events._CREDENTIAL_MINT_OPS`
+(defence-in-depth: `.rotate` would otherwise classify `other` and broadcast
+full detail) and its park-time preview carries no token value.
+
 ## Dependencies
 
 - `connectors/adapters/ssh.py` — the SSH transport base (pool, auth,
@@ -112,8 +146,12 @@ result).
 
 ## Known issues / follow-ups
 
-- Write ops (token rotate / service restart / config update / etcd-snapshot)
-  are deferred to #2429/#2430/#2431 under Initiative #2172.
+- `rke2.token.rotate` lands in T2 (#2429); the remaining write ops (service
+  restart / config update / etcd-snapshot) are deferred to #2430/#2431 under
+  Initiative #2172.
+- The rotate is a **single-node atomic op**: multi-node token-propagation /
+  restart choreography is an operator-composed runbook of T2+T3 ops, not part
+  of this op (per the Initiative DoD).
 - Host-key checking is disabled (`known_hosts=None`) at the adapter level for
   v0.2, shared across the whole SSH family; pinning is deferred repo-wide.
 - The RKE2 version probe is best-effort: `version` is `null` when the `rke2`


### PR DESCRIPTION
## Summary

- First approval-gated write op on the `rke2-ssh` connector (Initiative #2172, T2): **`rke2.token.rotate`** rotates the RKE2 server join token cluster-wide via `rke2 token rotate` over sudo-SSH. `safety_level=dangerous` + `requires_approval=True` — a USER dispatch parks at `needs-approval`; the handler runs only on the `_approved=True` resume path.
- **THE audit rule (load-bearing):** the dispatcher persists the RAW handler result on the audit row and connector-boundary redaction never scrubs `raw_payload`, so the only reliable control is that the handler **never returns the token**. The OLD token is read on-disk as root inside the sudo script (never enters Python); the NEW token is minted server-side, written to **Vault** under the operator's identity, and returned only as a **pointer** + non-secret metadata (`rotated` / `node` / `exit_status`). Pinned to `credential_mint` (defence-in-depth) + a no-secret park-time preview builder.
- **Fingerprint gate (reject-before-rotate):** refuses a non-server node, an inactive `rke2-server`, or a below-floor / known-bad (`v1.27.10+rke2r1`) RKE2 version before any mutation — a botched rotate wedges future node joins (rancher/rke2#5785, #6250).
- `_sudo.py` carries the connector family's own #697-hardened safe `sudo -S` primitive (script bytes first, password last on stdin, never in argv / history / log).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/rke2/ broadcast/events.py` — clean
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `pytest tests/test_connectors_rke2.py` — 34 passed (registration shape; schema has no token param; version-gate accept/deny incl. `v1.27.10+rke2r1`; handler mint/no-leak; every gate refusal rejects before any rotate; missing-operator / missing-sudo-cred fail closed; nonzero-exit surfaces no stdout/stderr)
- [x] `pytest tests/test_connectors_rke2_e2e.py` — 4 passed, incl. **park → approve → execute → audit** asserting the minted token appears in **neither the caller view nor the RAW audit row** (`raw_payload`)
- [x] `pytest tests/test_broadcast_classifier_coverage.py` — `classify_op("rke2.token.rotate") == "credential_mint"` pinned + the sweep
- [x] `pytest tests/test_broadcast_events.py tests/test_operations_preview.py tests/test_broadcast_credential_mint_dispatch.py` — 108 passed (no regressions)
- [x] No OpenAPI snapshot delta — registering a typed op adds no route; the snapshot references only the `rke2` product, already present.

## Out of scope

- Multi-node token-propagation / restart choreography (an operator runbook of T2+T3 ops, per the Initiative DoD).
- `rke2.node.service.restart` / `rke2.node.config.update` (#2430), `rke2.etcd-snapshot.save` (#2431).

## Adjacent findings (recorded, not fixed)

- `connector.py` (511 lines) and `ops_write.py` (536 lines) sit above the 400-line file-size *warning* threshold (both well under the 600 block limit); pre-existing `execute` / `fingerprint` function-size + PLR0911 warnings on the scaffold are untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2429
