### PR TITLE
feat(connectors): rke2 node service.restart + config.update write ops (#2430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — rke2 node service.restart + config.update write ops (#2430)
+
+- Add the first two approval-gated node-write ops on the `rke2-ssh`
+  connector (Initiative #2172, T3), both `dangerous` / `requires_approval`
+  and parked for human approval before anything changes.
+  `rke2.node.service.restart` restarts EXACTLY one allow-listed unit
+  (`rke2-server` / `rke2-agent`) — a schema `enum` re-checked against a
+  module-level frozenset in the handler (fail-closed; no arbitrary unit or
+  `systemctl` action) — and health-gates on `systemctl is-active`.
+  `rke2.node.config.update` applies a **backplane-owned key merge** to a
+  bounded `/etc/rancher/rke2/*.yaml` file: the connector reads + parses the
+  current YAML in-process, applies the operator's key-level `patch`
+  (`merge`/`replace`), validates it re-parses, and writes it back atomically
+  (`0600 root:root`) — no host-side `sed`/`yq`. It does **not** restart
+  (config is inert until one), returning `restart_required: true` and changed
+  key **names** only. The op is pinned `credential_write` (its `patch` may
+  carry a `token:` value) and `.restart` joins the broadcast write-suffix set,
+  so both broadcast correctly. Approval-park previews render the systemd-unit
+  and config-file blast-radius shapes without the file body or values —
+  `backend/src/meho_backplane/connectors/rke2/ops_write.py`,
+  `docs/codebase/connectors-rke2.md` (#2430).
+
 ### Added — node/rke2-ssh connector scaffold + read-only posture tier (#2221)
 
 - Add the `rke2` node-OS connector (`rke2-ssh-1.x`), the read-only entry in

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -156,6 +156,13 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
         # aggregate-only rather than shipping it on the feed.
         "keycloak.user.create",
         "keycloak.user.reset_password",
+        # G-Node/RKE2-T3 #2430 — the RKE2 node-config write op. Its ``patch``
+        # param carries key -> value edits, and an RKE2 ``config.yaml`` body
+        # holds ``token:`` / ``agent-token:`` join credentials, so a plain
+        # ``write`` classification (the ``.update`` suffix) would broadcast a
+        # written token in full. Pinning it collapses the broadcast to
+        # aggregate-only. (The op result itself returns key NAMES only.)
+        "rke2.node.config.update",
     }
 )
 
@@ -200,6 +207,14 @@ _WRITE_SUFFIXES: Final[tuple[str, ...]] = (
     # falls through to ``other``. Classifying it ``write`` keeps the feed's
     # mutation signal accurate.
     ".assign",
+    # RKE2 node service-restart verb (G-Node/RKE2-T3 #2430).
+    # ``rke2.node.service.restart`` is a disruptive mutation; its params
+    # (a single allow-listed unit name) carry no secret, so the plain
+    # ``write`` class (full detail) is correct — but without this suffix it
+    # falls through to ``other`` and broadcasts the full param dict as an
+    # unclassified event. Classifying it ``write`` keeps the mutation signal
+    # accurate on the feed.
+    ".restart",
 )
 
 #: Op-id suffixes that imply non-mutating read. ``.ls`` and ``.about``
@@ -373,10 +388,11 @@ def classify_op(op_id: str) -> str:
        never matches.
     6. ``write`` — mutation suffixes (``.create`` / ``.update`` /
        ``.delete`` / ``.patch`` / ``.put`` / ``.write`` / ``.add`` /
-       ``.remove``). The ``_CREDENTIAL_WRITE_OPS`` allowlist (step 3)
-       runs first, so a ``.write``-shaped secret-bearing op like
-       ``vault.auth.userpass.write`` keeps its ``credential_write``
-       class.
+       ``.remove`` / ``.assign`` / ``.restart``). The
+       ``_CREDENTIAL_WRITE_OPS`` allowlist (step 3) runs first, so a
+       secret-bearing op like ``vault.auth.userpass.write`` or
+       ``rke2.node.config.update`` (``.update``-shaped, token-bearing
+       patch) keeps its ``credential_write`` class.
     7. ``read`` — non-mutating verb suffixes (``.list`` / ``.info`` /
        ``.get`` / ``.about`` / ``.ls`` / ``.health`` / ``.seal_status``
        / ``.versions``). ``.read`` is deliberately **not** a read

--- a/backend/src/meho_backplane/connectors/rke2/connector.py
+++ b/backend/src/meho_backplane/connectors/rke2/connector.py
@@ -57,6 +57,7 @@ from meho_backplane.auth.vault import VaultClientError
 from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters.ssh import SshConnector
 from meho_backplane.connectors.rke2.ops import RKE2_OPS
+from meho_backplane.connectors.rke2.ops_write import RKE2_WHEN_TO_USE_WRITE_BY_GROUP
 from meho_backplane.connectors.schemas import (
     FingerprintResult,
     OperationResult,
@@ -320,6 +321,47 @@ class Rke2SshConnector(SshConnector):
 
         return await _rke2_posture_show(self, target, params, operator)
 
+    async def service_restart(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``rke2.node.service.restart`` (G-Node/RKE2-T3 #2430).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.rke2.ops_write.rke2_service_restart`,
+        which restarts an allow-listed RKE2 unit and health-gates on
+        ``systemctl is-active``. Approval-gated -- runs only on the
+        ``_approved=True`` resume path.
+        """
+        from meho_backplane.connectors.rke2.ops_write import (
+            rke2_service_restart as _rke2_service_restart,
+        )
+
+        return await _rke2_service_restart(self, target, params, operator)
+
+    async def config_update(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``rke2.node.config.update`` (G-Node/RKE2-T3 #2430).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.rke2.ops_write.rke2_config_update`,
+        which applies a backplane-owned key merge to a bounded
+        ``/etc/rancher/rke2/*.yaml`` file and writes it back ``0600 root:root``
+        atomically. Approval-gated -- runs only on the ``_approved=True``
+        resume path.
+        """
+        from meho_backplane.connectors.rke2.ops_write import (
+            rke2_config_update as _rke2_config_update,
+        )
+
+        return await _rke2_config_update(self, target, params, operator)
+
     @classmethod
     async def register_operations(cls) -> None:
         """Upsert every op in :data:`RKE2_OPS` into ``endpoint_descriptor``.
@@ -465,8 +507,12 @@ class Rke2SshConnector(SshConnector):
 #: ``group_key`` declared in :data:`RKE2_OPS`; the registration walk fails
 #: closed with a :class:`ValueError` if a ``group_key`` lacks a curated
 #: entry (the bind9 / holodeck precedent). Defined after the class so the
-#: strings can reference the transport note without a forward import.
+#: strings can reference the transport note without a forward import. The
+#: write-op group (``rke2-node-write``) is merged in from
+#: :data:`~meho_backplane.connectors.rke2.ops_write.RKE2_WHEN_TO_USE_WRITE_BY_GROUP`
+#: (the holodeck precedent -- write blurbs live next to the write ops).
 _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    **RKE2_WHEN_TO_USE_WRITE_BY_GROUP,
     "identity": (
         "Use for RKE2 node identity questions before any posture or "
         "(future) maintenance op: 'which RKE2 version is this node "

--- a/backend/src/meho_backplane/connectors/rke2/ops.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops.py
@@ -14,10 +14,11 @@ G-Node/RKE2-T1 (#2221) scaffold -- ships the read-only tier only:
   RKE2 config-file modes and the on-disk join-token presence with the
   token **value never read** (redacted by construction). Two ops total.
 
-The approval-gated write ops (``rke2.token.rotate`` /
-``rke2.node.service.restart`` / ``rke2.node.config.update`` /
-``rke2.etcd-snapshot.save``) ship in sibling Tasks #2429/#2430/#2431
-under Initiative #2172 -- explicitly **out of scope** here.
+The approval-gated write ops arrive by appending to :data:`RKE2_OPS`:
+``rke2.node.service.restart`` / ``rke2.node.config.update`` land here from
+:mod:`~meho_backplane.connectors.rke2.ops_write` (T3 #2430); the remaining
+write ops (``rke2.token.rotate`` T2 #2429, ``rke2.etcd-snapshot.save`` T4
+#2431) append to the same tuple from their own sibling modules.
 
 The dataclass + tuple shape mirrors
 :mod:`~meho_backplane.connectors.bind9.ops` and
@@ -129,20 +130,23 @@ def _rke2_ops() -> tuple[Rke2Op, ...]:
     """Return the merged registration tuple.
 
     Composition: ``rke2.about`` (identity canary) + ``READ_OPS`` (the
-    read-only posture tier: ``rke2.posture.show``). Two ops total -- the
-    full T1 (#2221) read surface. The approval-gated write ops append to
-    this tuple in the sibling write Tasks, exactly as
-    :func:`meho_backplane.connectors.holodeck.ops._holodeck_ops` layers
-    its ``WRITE_OPS`` on.
+    read-only posture tier: ``rke2.posture.show``) + ``WRITE_OPS`` (the
+    approval-gated node-write tier: ``rke2.node.service.restart`` /
+    ``rke2.node.config.update``, T3 #2430). This layers ``WRITE_OPS`` onto
+    the read surface exactly as
+    :func:`meho_backplane.connectors.holodeck.ops._holodeck_ops` does; the
+    remaining write ops (T2 #2429 / T4 #2431) append their own tuples the
+    same way.
 
     Implemented as a function call rather than a module-level literal so
     the import order stays linear: ``ops.py`` defines :class:`Rke2Op` +
-    ``_RKE2_ABOUT_OP``, then imports the read ops from
-    :mod:`meho_backplane.connectors.rke2.ops_read`.
+    ``_RKE2_ABOUT_OP``, then imports the read + write ops from their
+    sibling modules.
     """
     from meho_backplane.connectors.rke2.ops_read import READ_OPS
+    from meho_backplane.connectors.rke2.ops_write import WRITE_OPS
 
-    return (_RKE2_ABOUT_OP, *READ_OPS)
+    return (_RKE2_ABOUT_OP, *READ_OPS, *WRITE_OPS)
 
 
 #: The ops :class:`Rke2SshConnector` registers at lifespan startup.

--- a/backend/src/meho_backplane/connectors/rke2/ops_write.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_write.py
@@ -1,0 +1,599 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Approval-gated node-write ops for :class:`Rke2SshConnector` (G-Node/RKE2-T3 #2430).
+
+The first two **write** ops of Initiative #2172, both ``dangerous`` /
+``requires_approval=True`` and in the shared ``rke2-node-write`` group:
+
+* ``rke2.node.service.restart`` -- ``systemctl restart <UNIT>`` for a UNIT in
+  the two-entry :data:`_RESTARTABLE_UNIT_SET` allow-list (a schema ``enum``
+  re-checked in the handler; the proxmox method-allowlist mold -- schema
+  advisory, frozenset authoritative), health-gated on ``systemctl is-active``.
+  No arbitrary unit / ``systemctl`` action.
+* ``rke2.node.config.update`` -- a **backplane-owned key merge** of a bounded
+  ``/etc/rancher/rke2/*.yaml`` file (:func:`ensure_config_path_under_root`,
+  the bind9 ``ensure_path_under_root`` mold). The handler reads + parses the
+  current YAML in-process, applies the operator's key-level patch, validates
+  it re-parses, and writes it back atomically (temp under
+  ``/etc/rancher/rke2``, ``chmod 0600`` + ``chown root:root``, ``mv``) -- no
+  host-side ``sed`` / ``yq`` clobber, no arbitrary-file-write primitive. It
+  does **not** restart (config is inert until one); it returns
+  ``restart_required: true`` and changed key **names** only.
+
+Approval routing: the policy gate routes a ``USER``/agent dispatch of a
+``requires_approval`` op to ``needs-approval`` (G11.7-T1 #1401), so the
+handlers below run only on the ``_approved=True`` resume path.
+
+Privilege model: the connector operates as ``root`` over SSH (the T1 posture
+tier ``stat``s ``0600 root:root`` token files), so writes run via
+``_run_command`` without a separate sudo-password stream.
+
+Secret discipline: an RKE2 ``config.yaml`` body carries ``token:`` /
+``agent-token:`` join credentials, so ``config.update`` is pinned in
+:data:`~meho_backplane.broadcast.events._CREDENTIAL_WRITE_OPS` and its result +
+approval preview surface key **names** only -- never a value, never the body.
+
+References: Task #2430; Initiative #2172; molds proxmox/bind9/holodeck
+``ops_write.py``; Rancher RKE2 STIG V-254564 (``config.yaml`` is ``0600``).
+"""
+
+from __future__ import annotations
+
+import base64
+import posixpath
+import shlex
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from meho_backplane.connectors.rke2.ops import SSH_TRANSPORT_NOTE, Rke2Op
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.rke2.connector import Rke2SshConnector, Target
+    from meho_backplane.operations._preview import PreviewContext
+
+__all__ = [
+    "RKE2_WHEN_TO_USE_WRITE_BY_GROUP",
+    "WRITE_OPS",
+    "ConfigPathRejectedError",
+    "Rke2WriteSafetyError",
+    "apply_config_patch",
+    "bound_config_path",
+    "changed_config_keys",
+    "ensure_config_path_under_root",
+    "rke2_config_update",
+    "rke2_service_restart",
+]
+
+
+# ---------------------------------------------------------------------------
+# Bounds
+# ---------------------------------------------------------------------------
+
+#: The only systemd units ``rke2.node.service.restart`` may restart. Both are
+#: the RKE2 node daemons; a server node runs ``rke2-server`` and an agent node
+#: ``rke2-agent``. Every other unit name is rejected -- this is a typed
+#: restart, not a generic ``systemctl`` op.
+_RESTARTABLE_UNITS: tuple[str, ...] = ("rke2-agent", "rke2-server")
+_RESTARTABLE_UNIT_SET: frozenset[str] = frozenset(_RESTARTABLE_UNITS)
+
+#: The directory tree ``rke2.node.config.update`` is confined to. The RKE2
+#: server/agent config (``config.yaml``) and its drop-ins (``config.yaml.d/
+#: *.yaml``) all live under this prefix; a path that normalises outside it is
+#: rejected before any SSH traffic.
+_RKE2_CONFIG_ROOT: str = "/etc/rancher/rke2"
+
+#: The config file edited when the operator supplies no ``path``.
+_DEFAULT_CONFIG_PATH: str = "/etc/rancher/rke2/config.yaml"
+
+#: Accepted ``semantics`` values. ``merge`` applies the operator's patch on
+#: top of the current top-level keys; ``replace`` swaps the whole config for
+#: the patch object.
+_CONFIG_SEMANTICS: tuple[str, ...] = ("merge", "replace")
+
+#: Success sentinel the atomic-write script emits on its last line. The
+#: leading marker comment lets the recorded fake-shell harness prefix-match
+#: the write command without decoding the base64 body.
+_CONFIG_WRITE_MARKER: str = "# meho-rke2-config-update"
+_CONFIG_WRITE_SENTINEL: str = "===RKE2_CONFIG_WRITTEN==="
+
+
+class Rke2WriteSafetyError(ValueError):
+    """A write op's input escaped its declared bound.
+
+    Subclass of :class:`ValueError` so the dispatcher's
+    ``result_connector_error`` envelope picks it up uniformly. The message
+    names the offending category (unit / semantics / patch) without echoing
+    the full operator-supplied value.
+    """
+
+
+class ConfigPathRejectedError(Rke2WriteSafetyError):
+    """The requested config path failed the ``/etc/rancher/rke2/*`` filter.
+
+    The message echoes the *sanitised* candidate path, never the raw input and
+    never the file body, so log scraping surfaces no secret material.
+    """
+
+
+def bound_unit(params: dict[str, Any]) -> str:
+    """Return the validated restart unit, or raise :exc:`Rke2WriteSafetyError`.
+
+    ``unit`` must be a member of :data:`_RESTARTABLE_UNIT_SET`; this handler-side
+    re-check is authoritative (the proxmox method-allowlist mold -- the schema
+    ``enum`` is advisory).
+    """
+    unit = params.get("unit")
+    if not isinstance(unit, str) or unit not in _RESTARTABLE_UNIT_SET:
+        raise Rke2WriteSafetyError(
+            f"unit must be one of {sorted(_RESTARTABLE_UNIT_SET)}; refusing to restart"
+        )
+    return unit
+
+
+def ensure_config_path_under_root(requested: str, allowed_root: str) -> str:
+    """Return an absolute ``*.yaml`` path under *allowed_root*, or raise.
+
+    Lexical confinement (the bind9 ``ensure_path_under_root`` mold): the
+    candidate is ``posixpath.normpath``-collapsed and must lie strictly inside
+    *allowed_root* (a trailing-slash sentinel stops ``/etc/rancher/rke2-evil``
+    matching) and carry a ``.yaml`` suffix; control bytes are refused. Raises
+    :class:`ConfigPathRejectedError` (a :class:`ValueError`) on any violation.
+    """
+    if not allowed_root.startswith("/"):
+        raise ConfigPathRejectedError(
+            f"allowed_root {allowed_root!r} must be an absolute POSIX path; refusing to filter"
+        )
+    if not isinstance(requested, str) or not requested.strip():
+        raise ConfigPathRejectedError("requested path is empty")
+    if any(ch in requested for ch in ("\x00", "\n", "\r")):
+        raise ConfigPathRejectedError("requested path contains a control character; refusing")
+
+    candidate = posixpath.normpath(posixpath.join(allowed_root, requested))
+    canonical_root = posixpath.normpath(allowed_root)
+    if not candidate.startswith(canonical_root + "/"):
+        raise ConfigPathRejectedError(
+            f"path {candidate!r} is outside the RKE2 config root {canonical_root!r}"
+        )
+    if not candidate.endswith(".yaml"):
+        raise ConfigPathRejectedError(
+            f"path {candidate!r} must be a .yaml file under {canonical_root}/"
+        )
+    return candidate
+
+
+def bound_config_path(raw_path: Any) -> str:
+    """Return the confined config path (``None`` -> default ``config.yaml``)."""
+    if raw_path is None:
+        return _DEFAULT_CONFIG_PATH
+    return ensure_config_path_under_root(raw_path, _RKE2_CONFIG_ROOT)
+
+
+def bound_semantics(raw: Any) -> str:
+    """Return the validated merge semantics (default ``"merge"``)."""
+    if raw is None:
+        return "merge"
+    if raw not in _CONFIG_SEMANTICS:
+        raise Rke2WriteSafetyError(f"semantics must be one of {list(_CONFIG_SEMANTICS)}")
+    return str(raw)
+
+
+def bound_patch(raw: Any) -> dict[str, Any]:
+    """Return the validated patch object (non-empty, string keys)."""
+    if not isinstance(raw, dict) or not raw:
+        raise Rke2WriteSafetyError("patch must be a non-empty object of key -> value")
+    for key in raw:
+        if not isinstance(key, str):
+            raise Rke2WriteSafetyError("patch keys must be strings")
+    return raw
+
+
+def apply_config_patch(
+    current: dict[str, Any], patch: dict[str, Any], semantics: str
+) -> dict[str, Any]:
+    """Apply *patch* to *current* per *semantics*, returning a new mapping.
+
+    ``merge`` is a shallow top-level key merge (each patch key overlays/adds;
+    other keys preserved -- the ratified "key-level edit"); ``replace`` makes
+    the config *patch* verbatim. Neither input is mutated.
+    """
+    if semantics == "replace":
+        return dict(patch)
+    return {**current, **patch}
+
+
+def changed_config_keys(before: dict[str, Any], after: dict[str, Any]) -> list[str]:
+    """Return the sorted top-level key names whose value changed (names only).
+
+    A key is "changed" when added, removed, or its value differs. Names only --
+    no value leaks into the result envelope, audit ``raw_payload``, or feed.
+    """
+    keys = set(before) | set(after)
+    return sorted(k for k in keys if before.get(k) != after.get(k))
+
+
+def _build_atomic_write_script(path: str, content: str) -> str:
+    """Render the root-owned atomic config-write bash script.
+
+    The content is base64-encoded (safe to splice into the command line) and
+    decoded into a temp file in the same directory as *path* (so the final
+    ``mv`` is an atomic same-filesystem rename), ``chmod 0600`` +
+    ``chown root:root`` before the rename. Every path is ``shlex.quote``-quoted.
+    """
+    b64 = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    quoted_path = shlex.quote(path)
+    quoted_dir = shlex.quote(posixpath.dirname(path))
+    quoted_b64 = shlex.quote(b64)
+    return (
+        f"{_CONFIG_WRITE_MARKER}\n"
+        "set -eu\n"
+        "umask 077\n"
+        f'tmp="$(mktemp {quoted_dir}/.meho-config.XXXXXX)"\n'
+        f'printf %s {quoted_b64} | base64 -d > "$tmp"\n'
+        'chmod 0600 "$tmp"\n'
+        'chown root:root "$tmp"\n'
+        f'mv -f "$tmp" {quoted_path}\n'
+        f"echo '{_CONFIG_WRITE_SENTINEL}'\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Handlers (bound-method shims on Rke2SshConnector, resume path only)
+# ---------------------------------------------------------------------------
+
+
+def _stdout(proc: Any) -> str:
+    raw = (proc.stdout or "") if hasattr(proc, "stdout") else ""
+    return raw if isinstance(raw, str) else ""
+
+
+def _stderr(proc: Any) -> str:
+    raw = (proc.stderr or "") if hasattr(proc, "stderr") else ""
+    text = raw if isinstance(raw, str) else ""
+    return text[:4096]
+
+
+async def rke2_service_restart(
+    connector: Rke2SshConnector,
+    target: Target,
+    params: dict[str, Any],
+    operator: Any = None,
+) -> dict[str, Any]:
+    """Handler for ``rke2.node.service.restart`` (resume path only).
+
+    Re-validates the unit against :data:`_RESTARTABLE_UNIT_SET` before any SSH
+    traffic (out-of-list -> error envelope, no command sent), restarts it, and
+    health-gates on ``systemctl is-active <UNIT> == "active"``.
+    """
+    try:
+        unit = bound_unit(params)
+    except Rke2WriteSafetyError as exc:
+        return {"restarted": False, "error": f"service.restart safety check: {exc}"}
+
+    quoted_unit = shlex.quote(unit)
+    node = getattr(target, "name", None)
+
+    restart_cmd = f"systemctl restart {quoted_unit}"
+    restart_proc = await connector._run_command(
+        target, restart_cmd, operator=operator, timeout=120.0
+    )
+    restarted = getattr(restart_proc, "exit_status", None) == 0
+    if not restarted:
+        return {
+            "restarted": False,
+            "unit": unit,
+            "action": "restart",
+            "node": node,
+            "error": _stderr(restart_proc) or "systemctl restart returned a non-zero status",
+        }
+
+    active_cmd = f"systemctl is-active {quoted_unit}"
+    active_proc = await connector._run_command(target, active_cmd, operator=operator)
+    is_active = _stdout(active_proc).strip() == "active"
+    return {
+        "restarted": True,
+        "unit": unit,
+        "action": "restart",
+        "node": node,
+        "is_active": is_active,
+    }
+
+
+async def rke2_config_update(
+    connector: Rke2SshConnector,
+    target: Target,
+    params: dict[str, Any],
+    operator: Any = None,
+) -> dict[str, Any]:
+    """Handler for ``rke2.node.config.update`` (resume path only).
+
+    Backplane-owned key merge of a bounded ``/etc/rancher/rke2/*.yaml`` file:
+    read + parse the current YAML, apply the key-level patch, validate it
+    re-parses, write it back atomically (``0600 root:root``). Does **not**
+    restart -- returns ``restart_required: true`` + changed key **names** only.
+    """
+    try:
+        path = bound_config_path(params.get("path"))
+        patch = bound_patch(params.get("patch"))
+        semantics = bound_semantics(params.get("semantics"))
+    except Rke2WriteSafetyError as exc:
+        return {"updated": False, "error": f"config.update safety check: {exc}"}
+
+    quoted_path = shlex.quote(path)
+    read_cmd = f"if [ -e {quoted_path} ]; then cat -- {quoted_path}; fi"
+    read_proc = await connector._run_command(target, read_cmd, operator=operator)
+    if getattr(read_proc, "exit_status", None) not in (0, None):
+        return {"updated": False, "path": path, "error": "failed to read the current config file"}
+
+    try:
+        current_raw = yaml.safe_load(_stdout(read_proc))
+    except yaml.YAMLError as exc:
+        return {"updated": False, "path": path, "error": f"current config is not valid YAML: {exc}"}
+    current: dict[str, Any] = current_raw if current_raw is not None else {}
+    if not isinstance(current, dict):
+        return {"updated": False, "path": path, "error": "current config is not a YAML mapping"}
+
+    merged = apply_config_patch(current, patch, semantics)
+    try:
+        new_text = yaml.safe_dump(merged, default_flow_style=False, sort_keys=False)
+        reparsed = yaml.safe_load(new_text)
+    except yaml.YAMLError as exc:
+        return {
+            "updated": False,
+            "path": path,
+            "error": f"merged config failed to serialise: {exc}",
+        }
+    if reparsed != merged:
+        return {
+            "updated": False,
+            "path": path,
+            "error": "merged config did not round-trip as YAML",
+        }
+
+    write_proc = await connector._run_command(
+        target, _build_atomic_write_script(path, new_text), operator=operator, timeout=60.0
+    )
+    if getattr(write_proc, "exit_status", None) != 0:
+        return {
+            "updated": False,
+            "path": path,
+            "error": _stderr(write_proc) or "atomic config write returned a non-zero status",
+        }
+
+    return {
+        "updated": True,
+        "path": path,
+        "restart_required": True,
+        "changed_keys": changed_config_keys(current, merged),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Approval-park preview builders (blast-radius shapes; never file body/values)
+# ---------------------------------------------------------------------------
+
+
+async def _rke2_service_restart_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview builder for ``rke2.node.service.restart`` -- the systemd-unit
+    blast-radius shape. Declines (``None``) an out-of-list unit so a preview
+    never advertises an out-of-bounds one."""
+    unit = ctx.params.get("unit")
+    if not isinstance(unit, str) or unit not in _RESTARTABLE_UNIT_SET:
+        return None
+    return {
+        "resource": "systemd_unit",
+        "unit": unit,
+        "action": "restart",
+        "node": getattr(ctx.target, "name", None),
+    }
+
+
+async def _rke2_config_update_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview builder for ``rke2.node.config.update`` -- the config-file
+    blast-radius shape (path, semantics, patch **key names**), never values or
+    the body. Runs even for the ``credential_write`` class: a bespoke builder
+    owns its field discipline (#1857) and this one only surfaces key names."""
+    patch = ctx.params.get("patch")
+    if not isinstance(patch, dict):
+        return None
+    path = ctx.params.get("path") or _DEFAULT_CONFIG_PATH
+    semantics = ctx.params.get("semantics") or "merge"
+    return {
+        "resource": "config_file",
+        "path": path,
+        "semantics": semantics,
+        "key_names": sorted(str(k) for k in patch),
+    }
+
+
+def register_rke2_write_previews() -> None:
+    """Register the two write-op approval-park preview builders (import-time).
+
+    Mirrors the vault ``kv_write_preview`` import side-effect so the builders
+    are wired before the first dispatch parks. Idempotent.
+    """
+    from meho_backplane.operations._preview import register_preview_builder
+
+    register_preview_builder("rke2.node.service.restart", _rke2_service_restart_preview)
+    register_preview_builder("rke2.node.config.update", _rke2_config_update_preview)
+
+
+# ---------------------------------------------------------------------------
+# Curated when_to_use blurb (shared rke2-node-write group)
+# ---------------------------------------------------------------------------
+
+_WHEN_TO_USE_NODE_WRITE = (
+    "Use for the two approval-gated RKE2 node-write ops, both dangerous and "
+    "parked for human approval before anything changes: "
+    "``rke2.node.service.restart`` restarts EXACTLY one of ``rke2-server`` / "
+    "``rke2-agent`` (no other unit, no arbitrary systemctl action) and "
+    "health-gates on ``systemctl is-active``; ``rke2.node.config.update`` "
+    "edits a ``/etc/rancher/rke2/*.yaml`` file via a backplane-owned key "
+    "merge (read + parse + patch + write back 0600 root:root atomically -- "
+    "no host-side sed/yq) and returns restart_required=true WITHOUT "
+    "restarting, so batch multiple config edits behind a single restart "
+    "approval. Config changes are inert until a restart. " + SSH_TRANSPORT_NOTE
+)
+
+#: Curated ``when_to_use`` blurb per write-op group. The ``rke2-node-write``
+#: key never collides with the read-op group keys (``identity`` / ``posture``)
+#: the connector's ``register_operations`` walk merges alongside it.
+RKE2_WHEN_TO_USE_WRITE_BY_GROUP: dict[str, str] = {
+    "rke2-node-write": _WHEN_TO_USE_NODE_WRITE,
+}
+
+
+# ---------------------------------------------------------------------------
+# Op metadata
+# ---------------------------------------------------------------------------
+
+_RKE2_SERVICE_RESTART_OP = Rke2Op(
+    op_id="rke2.node.service.restart",
+    handler_attr="service_restart",
+    summary="Restart an allow-listed RKE2 unit (rke2-server/rke2-agent) (approval-gated).",
+    description=(
+        "Runs ``systemctl restart <UNIT>`` over SSH, where UNIT must be "
+        "``rke2-server`` or ``rke2-agent`` -- any other unit is rejected at the "
+        "schema enum AND re-checked in the handler before any SSH traffic "
+        "(fail-closed); there is NO arbitrary-unit / arbitrary-action surface. "
+        "It then health-gates on ``systemctl is-active <UNIT>``. A restart is "
+        "disruptive -- it reloads the otherwise-inert on-disk config and briefly "
+        "interrupts the control-plane / kubelet. safety_level=dangerous, "
+        "requires_approval=True -- parks for human approval before restarting."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "unit": {
+                "type": "string",
+                "enum": list(_RESTARTABLE_UNITS),
+                "description": (
+                    "The RKE2 systemd unit to restart. Only 'rke2-server' "
+                    "(server nodes) or 'rke2-agent' (agent nodes) are allowed."
+                ),
+            },
+        },
+        "required": ["unit"],
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "restarted": {"type": "boolean"},
+            "unit": {"type": ["string", "null"]},
+            "action": {"type": "string"},
+            "node": {"type": ["string", "null"]},
+            "is_active": {"type": "boolean"},
+            "error": {"type": "string"},
+        },
+        "required": ["restarted"],
+        "additionalProperties": True,
+    },
+    group_key="rke2-node-write",
+    tags=("write", "rke2", "systemd", "restart"),
+    safety_level="dangerous",
+    requires_approval=True,
+    llm_instructions={
+        "when_to_use": _WHEN_TO_USE_NODE_WRITE,
+        "parameter_hints": {
+            "unit": "Required; exactly 'rke2-server' or 'rke2-agent'. Nothing else is accepted.",
+        },
+        "output_shape": (
+            "{restarted, unit, action: 'restart', node, is_active}. On a bound "
+            "violation or a failed restart: {restarted: false, ..., error}."
+        ),
+    },
+)
+
+
+_RKE2_CONFIG_UPDATE_OP = Rke2Op(
+    op_id="rke2.node.config.update",
+    handler_attr="config_update",
+    summary="Backplane-owned key merge of a bounded RKE2 config file (approval-gated).",
+    description=(
+        "Edits a ``/etc/rancher/rke2/*.yaml`` file (default ``config.yaml``; "
+        "drop-ins ``config.yaml.d/*.yaml``) via a backplane-owned merge: the "
+        "connector reads + parses the current YAML in-process, applies the "
+        "operator's key-level ``patch`` ('merge' overlays keys; 'replace' swaps "
+        "the whole config), validates it re-parses, and writes it back "
+        "atomically (temp under /etc/rancher/rke2, chmod 0600, chown root:root, "
+        "mv). NO host-side sed/yq, NO arbitrary-file-write; the path is confined "
+        "to /etc/rancher/rke2/*.yaml (traversal / escape rejected, no body "
+        "leaked). Config is inert until a restart, so this op does NOT restart "
+        "-- it returns restart_required=true (batch edits, then one restart) and "
+        "changed key NAMES only, never values. safety_level=dangerous, "
+        "requires_approval=True."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "pattern": r"^/etc/rancher/rke2/[^\x00\n\r]*\.yaml$",
+                "description": (
+                    "Absolute path to the RKE2 config file. Must be a .yaml "
+                    "file under /etc/rancher/rke2/ (default "
+                    "/etc/rancher/rke2/config.yaml). Omit for the default."
+                ),
+            },
+            "patch": {
+                "type": "object",
+                "minProperties": 1,
+                "additionalProperties": True,
+                "description": (
+                    "Key -> value edits to apply to the config. Under 'merge' "
+                    "each key overlays (or adds) that top-level key; under "
+                    "'replace' this object becomes the whole config."
+                ),
+            },
+            "semantics": {
+                "type": "string",
+                "enum": list(_CONFIG_SEMANTICS),
+                "description": (
+                    "'merge' (default) overlays the patch keys onto the current "
+                    "config; 'replace' swaps the whole config for the patch."
+                ),
+            },
+        },
+        "required": ["patch"],
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "updated": {"type": "boolean"},
+            "path": {"type": "string"},
+            "restart_required": {"type": "boolean"},
+            "changed_keys": {"type": "array", "items": {"type": "string"}},
+            "error": {"type": "string"},
+        },
+        "required": ["updated"],
+        "additionalProperties": True,
+    },
+    group_key="rke2-node-write",
+    tags=("write", "rke2", "config"),
+    safety_level="dangerous",
+    requires_approval=True,
+    llm_instructions={
+        "when_to_use": _WHEN_TO_USE_NODE_WRITE,
+        "parameter_hints": {
+            "path": "Optional; a .yaml file under /etc/rancher/rke2/. Omit for config.yaml.",
+            "patch": "Required non-empty key->value object; the key-level edit to apply.",
+            "semantics": "'merge' (default) or 'replace'.",
+        },
+        "output_shape": (
+            "{updated, path, restart_required: true, changed_keys: [names]} -- "
+            "key NAMES only, never values, never the file body. Does NOT "
+            "restart. On a bound violation: {updated: false, error}."
+        ),
+    },
+)
+
+
+#: The approval-gated write ops. Composed onto :data:`RKE2_OPS` after the read
+#: tier in :func:`meho_backplane.connectors.rke2.ops._rke2_ops`.
+WRITE_OPS: tuple[Rke2Op, ...] = (_RKE2_SERVICE_RESTART_OP, _RKE2_CONFIG_UPDATE_OP)
+
+
+register_rke2_write_previews()

--- a/backend/tests/test_broadcast_classifier_coverage.py
+++ b/backend/tests/test_broadcast_classifier_coverage.py
@@ -224,3 +224,27 @@ def test_boolean_and_integer_attrs_do_not_trip_the_sweep() -> None:
         },
     )
     assert _unpinned_secret_bearing_ops([fixture_op]) == []
+
+
+def test_rke2_node_write_ops_classify_as_expected() -> None:
+    """G-Node/RKE2-T3 #2430 -- the two node-write ops land in the right class.
+
+    ``rke2.node.service.restart`` carries no secret in its params (a single
+    allow-listed unit) and classifies plain ``write`` via the new ``.restart``
+    write-suffix. ``rke2.node.config.update`` carries a token-bearing
+    ``patch`` and is pinned to ``credential_write`` so its broadcast collapses
+    to aggregate-only rather than shipping a written join token in full.
+    """
+    assert classify_op("rke2.node.service.restart") == "write"
+    assert classify_op("rke2.node.config.update") == "credential_write"
+
+
+def test_rke2_node_write_ops_are_registered_and_pinned(
+    registered_ops: list[tuple[str, dict[str, Any] | None]],
+) -> None:
+    """Both node-write ops are in the registered set and none is unpinned-secret."""
+    ids = {op_id for op_id, _ in registered_ops}
+    assert "rke2.node.service.restart" in ids
+    assert "rke2.node.config.update" in ids
+    unpinned = {op_id for op_id, _, _ in _unpinned_secret_bearing_ops(registered_ops)}
+    assert "rke2.node.config.update" not in unpinned

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -338,11 +338,19 @@ async def test_posture_show_never_leaks_secret_material(
 # ---------------------------------------------------------------------------
 
 
-_EXPECTED_OP_IDS: frozenset[str] = frozenset({"rke2.about", "rke2.posture.show"})
+#: The read-only tier (T1 #2221). Every entry is safe-tier / no-approval and
+#: takes no operator parameters.
+_READ_OP_IDS: frozenset[str] = frozenset({"rke2.about", "rke2.posture.show"})
+
+#: The approval-gated node-write tier (T3 #2430). Every entry is
+#: dangerous-tier / requires-approval.
+_WRITE_OP_IDS: frozenset[str] = frozenset({"rke2.node.service.restart", "rke2.node.config.update"})
+
+_EXPECTED_OP_IDS: frozenset[str] = _READ_OP_IDS | _WRITE_OP_IDS
 
 
-def test_rke2_ops_has_two_entries() -> None:
-    assert len(RKE2_OPS) == 2
+def test_rke2_ops_count_matches_expected() -> None:
+    assert len(RKE2_OPS) == len(_EXPECTED_OP_IDS)
 
 
 def test_rke2_ops_about_is_first() -> None:
@@ -358,19 +366,41 @@ def test_rke2_ops_all_namespaced() -> None:
         assert op.op_id.startswith("rke2."), f"{op.op_id!r} lacks rke2. prefix"
 
 
-def test_rke2_ops_all_safe_read_only_no_approval() -> None:
-    """AC: every op is safe-tier, read-only, and requires no approval."""
+def test_rke2_read_ops_all_safe_read_only_no_approval() -> None:
+    """AC: every read-tier op is safe-tier, read-only, and requires no approval."""
     for op in RKE2_OPS:
+        if op.op_id not in _READ_OP_IDS:
+            continue
         assert op.safety_level == "safe", f"{op.op_id!r} is not safe-tier"
         assert op.requires_approval is False, f"{op.op_id!r} requires approval"
         assert "read-only" in op.tags, f"{op.op_id!r} missing read-only tag"
 
 
-def test_rke2_ops_parameter_schemas_closed() -> None:
+def test_rke2_write_ops_all_dangerous_approval_gated() -> None:
+    """AC: every node-write op is dangerous-tier, approval-gated, write-tagged."""
     for op in RKE2_OPS:
+        if op.op_id not in _WRITE_OP_IDS:
+            continue
+        assert op.safety_level == "dangerous", f"{op.op_id!r} is not dangerous-tier"
+        assert op.requires_approval is True, f"{op.op_id!r} must require approval"
+        assert "write" in op.tags, f"{op.op_id!r} missing write tag"
+
+
+def test_rke2_read_ops_parameter_schemas_closed() -> None:
+    for op in RKE2_OPS:
+        if op.op_id not in _READ_OP_IDS:
+            continue
         assert op.parameter_schema.get("additionalProperties") is False
         # The read tier takes no operator parameters -- fixed paths only.
         assert op.parameter_schema.get("properties") == {}
+
+
+def test_rke2_write_ops_parameter_schemas_closed() -> None:
+    for op in RKE2_OPS:
+        if op.op_id not in _WRITE_OP_IDS:
+            continue
+        # Write ops take bounded params but reject unknown keys.
+        assert op.parameter_schema.get("additionalProperties") is False
 
 
 def test_rke2_ops_have_ssh_transport_when_to_use() -> None:

--- a/backend/tests/test_connectors_rke2_write.py
+++ b/backend/tests/test_connectors_rke2_write.py
@@ -5,9 +5,13 @@
 
 Coverage matrix (per Task #2430 acceptance criteria):
 
-* ``WRITE_OPS`` registration shape -- two ops, both
-  ``safety_level='dangerous'`` + ``requires_approval=True``, both carry the
-  ``write`` tag and the SSH-only transport note.
+* ``WRITE_OPS`` registration shape -- three ops (``rke2.token.rotate`` from
+  T2 #2429 plus this task's two node ops ``service.restart`` +
+  ``config.update``), all ``safety_level='dangerous'`` + ``requires_approval=True``,
+  all carrying the ``write`` tag and an SSH transport note. token.rotate is the
+  credential-minting op (group ``rke2-token-write``, distinct from the node ops'
+  ``rke2-node-write``); its Vault-pointer / no-token-value contract is asserted
+  in ``test_connectors_rke2.py``.
 * Bounds (pure, no event loop):
   - ``service.restart`` -- rejects any unit outside {rke2-server, rke2-agent}
     at the schema enum AND the handler frozenset re-check.
@@ -121,13 +125,13 @@ def _op(op_id: str) -> Any:
 # ---------------------------------------------------------------------------
 
 EXPECTED_WRITE_OP_IDS: frozenset[str] = frozenset(
-    {"rke2.node.service.restart", "rke2.node.config.update"}
+    {"rke2.token.rotate", "rke2.node.service.restart", "rke2.node.config.update"}
 )
 
 
 def test_write_ops_registration_set() -> None:
     assert {op.op_id for op in WRITE_OPS} == EXPECTED_WRITE_OP_IDS
-    assert len(WRITE_OPS) == 2
+    assert len(WRITE_OPS) == 3
 
 
 def test_write_ops_are_dangerous_and_require_approval() -> None:
@@ -142,7 +146,23 @@ def test_write_ops_carry_transport_note_and_instructions() -> None:
         instr = op.llm_instructions or {}
         assert "SSH" in instr.get("when_to_use", ""), f"{op.op_id} missing SSH transport note"
         assert instr.get("output_shape"), f"{op.op_id} missing output_shape"
-        assert op.group_key == "rke2-node-write"
+        # token.rotate is a credential-write op in its own group; the two node
+        # ops share rke2-node-write. Both are valid RKE2 write groups.
+        assert op.group_key in {"rke2-node-write", "rke2-token-write"}
+
+
+def test_token_rotate_is_the_credential_minting_write_op() -> None:
+    """The union brought T2 #2429's ``rke2.token.rotate`` into ``WRITE_OPS``.
+
+    Its credential-mint / Vault-pointer contract is exercised in full by
+    ``test_connectors_rke2.py``; here we only guard that the distinguishing
+    credential identity is not silently dropped from the write set again.
+    """
+    token_op = _op("rke2.token.rotate")
+    assert "credential" in token_op.tags
+    assert token_op.group_key == "rke2-token-write"
+    assert token_op.safety_level == "dangerous"
+    assert token_op.requires_approval is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_rke2_write.py
+++ b/backend/tests/test_connectors_rke2_write.py
@@ -1,0 +1,654 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the RKE2 approval-gated node-write ops (G-Node/RKE2-T3 #2430).
+
+Coverage matrix (per Task #2430 acceptance criteria):
+
+* ``WRITE_OPS`` registration shape -- two ops, both
+  ``safety_level='dangerous'`` + ``requires_approval=True``, both carry the
+  ``write`` tag and the SSH-only transport note.
+* Bounds (pure, no event loop):
+  - ``service.restart`` -- rejects any unit outside {rke2-server, rke2-agent}
+    at the schema enum AND the handler frozenset re-check.
+  - ``config.update`` -- rejects any path outside /etc/rancher/rke2/*.yaml
+    (traversal / absolute escape / non-yaml), refuses an empty/bad patch,
+    and never leaks the file body in the rejection.
+  - backplane-owned merge / replace + changed-key-names.
+* Handler-layer (mocked ``_run_command``): the restart health-gates on
+  ``is-active``; ``config.update`` reads + merges + writes ``0600 root:root``
+  atomically, returns key NAMES only + ``restart_required: true`` and does
+  NOT restart; a bound violation fails closed with no SSH traffic.
+* Preview builders render the blast-radius shapes with no file body/values.
+* Dispatch park -> approve -> execute -> audit (recorded fake-shell SSH):
+  an un-approved USER dispatch parks; the ``_approved=True`` resume path runs
+  the handler and writes a ``DISPATCH`` audit row; no secret value on the row.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncssh
+import jsonschema
+import pytest
+import yaml
+from sqlalchemy import select
+
+import meho_backplane.connectors.rke2  # noqa: F401 -- import for registry side-effects
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.rke2 import Rke2SshConnector
+from meho_backplane.connectors.rke2.ops_write import (
+    WRITE_OPS,
+    ConfigPathRejectedError,
+    Rke2WriteSafetyError,
+    _rke2_config_update_preview,
+    _rke2_service_restart_preview,
+    apply_config_patch,
+    bound_config_path,
+    bound_unit,
+    changed_config_keys,
+    ensure_config_path_under_root,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.settings import get_settings
+from meho_backplane.targets.resolver import resolve_target
+
+# ---------------------------------------------------------------------------
+# Environment fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Stub target for the unit-level handler tests
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str  # a Vault KV-v2 path STRING (#2155); never resolved here.
+
+
+_TARGET = _StubTarget(
+    name="rke2-node-write-test",
+    host="rke2-node.test.invalid",
+    port=22,
+    secret_ref="meho/testing/rke2/node-write-test",
+)
+
+#: A token-value canary that must never surface in a result / preview / log.
+_TOKEN_CANARY = "K10rke2writecanaryDONOTLEAK::server:qqq123"  # gitleaks:allow NOSONAR
+
+
+def _proc(*, stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+def _op(op_id: str) -> Any:
+    return next(op for op in WRITE_OPS if op.op_id == op_id)
+
+
+# ---------------------------------------------------------------------------
+# Registration contract (acceptance criterion 1)
+# ---------------------------------------------------------------------------
+
+EXPECTED_WRITE_OP_IDS: frozenset[str] = frozenset(
+    {"rke2.node.service.restart", "rke2.node.config.update"}
+)
+
+
+def test_write_ops_registration_set() -> None:
+    assert {op.op_id for op in WRITE_OPS} == EXPECTED_WRITE_OP_IDS
+    assert len(WRITE_OPS) == 2
+
+
+def test_write_ops_are_dangerous_and_require_approval() -> None:
+    for op in WRITE_OPS:
+        assert op.safety_level == "dangerous", f"{op.op_id} must be dangerous"
+        assert op.requires_approval is True, f"{op.op_id} must require approval"
+        assert "write" in op.tags, f"{op.op_id} should carry the write tag"
+
+
+def test_write_ops_carry_transport_note_and_instructions() -> None:
+    for op in WRITE_OPS:
+        instr = op.llm_instructions or {}
+        assert "SSH" in instr.get("when_to_use", ""), f"{op.op_id} missing SSH transport note"
+        assert instr.get("output_shape"), f"{op.op_id} missing output_shape"
+        assert op.group_key == "rke2-node-write"
+
+
+# ---------------------------------------------------------------------------
+# Bounds -- service.restart unit allow-list (acceptance criterion 1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("unit", ["rke2-server", "rke2-agent"])
+def test_bound_unit_accepts_allowed(unit: str) -> None:
+    assert bound_unit({"unit": unit}) == unit
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"unit": "rke2-killall"},
+        {"unit": "nginx"},
+        {"unit": "rke2-server; rm -rf /"},
+        {"unit": "RKE2-SERVER"},
+        {"unit": ""},
+        {},
+        {"unit": None},
+    ],
+)
+def test_bound_unit_rejects_others(params: dict[str, Any]) -> None:
+    with pytest.raises(Rke2WriteSafetyError):
+        bound_unit(params)
+
+
+@pytest.mark.parametrize("unit", ["rke2-server", "rke2-agent"])
+def test_restart_schema_accepts_allowed_unit(unit: str) -> None:
+    jsonschema.validate({"unit": unit}, _op("rke2.node.service.restart").parameter_schema)
+
+
+@pytest.mark.parametrize(
+    "params",
+    [{"unit": "nginx"}, {"unit": "rke2-killall"}, {}, {"unit": "rke2-server", "extra": 1}],
+)
+def test_restart_schema_rejects_others(params: dict[str, Any]) -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(params, _op("rke2.node.service.restart").parameter_schema)
+
+
+# ---------------------------------------------------------------------------
+# Bounds -- config.update path confinement (acceptance criterion 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "requested,expected",
+    [
+        ("config.yaml", "/etc/rancher/rke2/config.yaml"),
+        ("config.yaml.d/10-extra.yaml", "/etc/rancher/rke2/config.yaml.d/10-extra.yaml"),
+        ("/etc/rancher/rke2/config.yaml", "/etc/rancher/rke2/config.yaml"),
+    ],
+)
+def test_ensure_config_path_accepts_inside_tree(requested: str, expected: str) -> None:
+    assert ensure_config_path_under_root(requested, "/etc/rancher/rke2") == expected
+
+
+@pytest.mark.parametrize(
+    "requested",
+    [
+        "/etc/shadow",  # absolute escape
+        "../../etc/passwd",  # relative traversal
+        "/etc/rancher/rke2/../../etc/passwd",  # traversal via the prefix
+        "/etc/rancher/rke2-evil/config.yaml",  # sibling prefix, not under root
+        "/etc/rancher/rke2",  # the root dir itself
+        "/etc/rancher/rke2/config.conf",  # wrong suffix
+        "config.txt",  # relative, wrong suffix
+        "",  # empty
+        "   ",  # whitespace-only
+        "config.yaml\nx",  # control char
+    ],
+)
+def test_ensure_config_path_rejects_escape(requested: str) -> None:
+    with pytest.raises(ConfigPathRejectedError):
+        ensure_config_path_under_root(requested, "/etc/rancher/rke2")
+
+
+def test_bound_config_path_defaults_to_config_yaml() -> None:
+    assert bound_config_path(None) == "/etc/rancher/rke2/config.yaml"
+
+
+def test_config_path_rejection_message_carries_no_body() -> None:
+    """A rejection names the sanitised candidate, never a file body."""
+    try:
+        ensure_config_path_under_root("/etc/shadow", "/etc/rancher/rke2")
+    except ConfigPathRejectedError as exc:
+        assert "root:" not in str(exc)  # no /etc/shadow content shape leaked
+
+
+# ---------------------------------------------------------------------------
+# Bounds -- backplane-owned merge / replace + changed keys
+# ---------------------------------------------------------------------------
+
+
+def test_apply_config_patch_merge_overlays_keys() -> None:
+    current = {"a": 1, "token": "OLD"}
+    merged = apply_config_patch(current, {"b": 2, "token": "NEW"}, "merge")
+    assert merged == {"a": 1, "token": "NEW", "b": 2}
+    assert current == {"a": 1, "token": "OLD"}  # input not mutated
+
+
+def test_apply_config_patch_replace_swaps_whole_config() -> None:
+    assert apply_config_patch({"a": 1}, {"x": 9}, "replace") == {"x": 9}
+
+
+def test_changed_config_keys_is_names_only() -> None:
+    before = {"a": 1, "token": "OLD"}
+    after = {"a": 1, "token": "NEW", "b": 2}
+    assert changed_config_keys(before, after) == ["b", "token"]
+    # Replace that drops a key surfaces it as changed.
+    assert changed_config_keys({"a": 1, "b": 2}, {"a": 1}) == ["b"]
+
+
+# ---------------------------------------------------------------------------
+# Preview builders (acceptance criterion 4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_restart_preview_shape() -> None:
+    ctx = types.SimpleNamespace(
+        params={"unit": "rke2-server"}, target=types.SimpleNamespace(name="node-1")
+    )
+    preview = await _rke2_service_restart_preview(ctx)  # type: ignore[arg-type]
+    assert preview == {
+        "resource": "systemd_unit",
+        "unit": "rke2-server",
+        "action": "restart",
+        "node": "node-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_service_restart_preview_declines_out_of_list_unit() -> None:
+    ctx = types.SimpleNamespace(params={"unit": "nginx"}, target=types.SimpleNamespace(name="n"))
+    assert await _rke2_service_restart_preview(ctx) is None  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_config_update_preview_key_names_only_no_values() -> None:
+    ctx = types.SimpleNamespace(
+        params={
+            "path": "/etc/rancher/rke2/config.yaml",
+            "patch": {"token": _TOKEN_CANARY, "server": "https://x"},
+            "semantics": "merge",
+        },
+        target=types.SimpleNamespace(name="node-1"),
+    )
+    preview = await _rke2_config_update_preview(ctx)  # type: ignore[arg-type]
+    assert preview == {
+        "resource": "config_file",
+        "path": "/etc/rancher/rke2/config.yaml",
+        "semantics": "merge",
+        "key_names": ["server", "token"],
+    }
+    assert _TOKEN_CANARY not in repr(preview)  # no value ever
+
+
+# ---------------------------------------------------------------------------
+# Handler-layer -- service.restart (mocked SSH)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_restart_happy_path_health_gates() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(exit_status=0), _proc(stdout="active\n")]
+        result = await connector.service_restart(_TARGET, {"unit": "rke2-server"})
+    assert result["restarted"] is True
+    assert result["unit"] == "rke2-server"
+    assert result["is_active"] is True
+    cmds = [call.args[1] for call in mock_cmd.await_args_list]
+    assert cmds == ["systemctl restart rke2-server", "systemctl is-active rke2-server"]
+
+
+@pytest.mark.asyncio
+async def test_service_restart_reports_inactive_after_restart() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [_proc(exit_status=0), _proc(stdout="activating\n")]
+        result = await connector.service_restart(_TARGET, {"unit": "rke2-agent"})
+    assert result["restarted"] is True
+    assert result["is_active"] is False
+
+
+@pytest.mark.asyncio
+async def test_service_restart_rejects_bad_unit_no_ssh() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.service_restart(_TARGET, {"unit": "nginx"})
+        mock_cmd.assert_not_awaited()
+    assert result["restarted"] is False
+    assert "safety check" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Handler-layer -- config.update (mocked SSH)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_config_update_merges_and_writes_atomically() -> None:
+    connector = Rke2SshConnector()
+    current = "server: https://old\ntoken: " + _TOKEN_CANARY + "\n"
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(stdout=current, exit_status=0),  # read
+            _proc(stdout="===RKE2_CONFIG_WRITTEN===\n", exit_status=0),  # write
+        ]
+        result = await connector.config_update(
+            _TARGET,
+            {
+                "patch": {"server": "https://new", "cluster-cidr": "10.0.0.0/16"},
+                "semantics": "merge",
+            },
+        )
+    assert result["updated"] is True
+    assert result["path"] == "/etc/rancher/rke2/config.yaml"
+    assert result["restart_required"] is True
+    # key NAMES only (server changed, cluster-cidr added); token unchanged.
+    assert result["changed_keys"] == ["cluster-cidr", "server"]
+    # The write script writes 0600 root:root atomically and the merge is
+    # backplane-owned (the decoded body carries the preserved token).
+    write_cmd = mock_cmd.await_args_list[1].args[1]
+    assert write_cmd.startswith("# meho-rke2-config-update")
+    assert "chmod 0600" in write_cmd and "chown root:root" in write_cmd and "mv -f" in write_cmd
+    # No token value leaks into the result envelope (only the base64 body,
+    # which is on the wire, carries it -- never the returned dict).
+    assert _TOKEN_CANARY not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_config_update_preserves_existing_token_in_merge() -> None:
+    """A merge that doesn't touch the token still writes it back (backplane merge)."""
+    connector = Rke2SshConnector()
+    current = "token: " + _TOKEN_CANARY + "\n"
+    captured: dict[str, str] = {}
+
+    async def _run(target: Any, cmd: str, **kwargs: Any) -> Any:
+        if cmd.startswith("if [ -e"):
+            return _proc(stdout=current, exit_status=0)
+        captured["write"] = cmd
+        return _proc(stdout="===RKE2_CONFIG_WRITTEN===\n", exit_status=0)
+
+    with patch.object(connector, "_run_command", side_effect=_run):
+        result = await connector.config_update(_TARGET, {"patch": {"debug": True}})
+    assert result["updated"] is True
+    assert result["changed_keys"] == ["debug"]
+    # Decode the base64 body the backplane composed and confirm the merge
+    # preserved the pre-existing token key/value.
+    import base64
+    import shlex
+
+    # The body is the single-quoted token after ``printf %s``.
+    line = next(ln for ln in captured["write"].splitlines() if ln.startswith("printf %s"))
+    b64 = shlex.split(line)[2]
+    body = base64.b64decode(b64).decode()
+    parsed = yaml.safe_load(body)
+    assert parsed == {"token": _TOKEN_CANARY, "debug": True}
+
+
+@pytest.mark.asyncio
+async def test_config_update_rejects_out_of_tree_path_no_ssh() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.config_update(_TARGET, {"path": "/etc/shadow", "patch": {"a": 1}})
+        mock_cmd.assert_not_awaited()
+    assert result["updated"] is False
+    assert "safety check" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_config_update_rejects_empty_patch_no_ssh() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.config_update(_TARGET, {"patch": {}})
+        mock_cmd.assert_not_awaited()
+    assert result["updated"] is False
+
+
+@pytest.mark.asyncio
+async def test_config_update_rejects_non_mapping_current_config() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="- a\n- b\n", exit_status=0)  # a YAML list
+        result = await connector.config_update(_TARGET, {"patch": {"a": 1}})
+    assert result["updated"] is False
+    assert "mapping" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_config_update_absent_file_creates_from_patch() -> None:
+    """An absent config (empty read, exit 0) merges onto an empty mapping."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(stdout="", exit_status=0),  # absent -> empty
+            _proc(stdout="===RKE2_CONFIG_WRITTEN===\n", exit_status=0),
+        ]
+        result = await connector.config_update(_TARGET, {"patch": {"server": "https://x"}})
+    assert result["updated"] is True
+    assert result["changed_keys"] == ["server"]
+
+
+# ===========================================================================
+# Dispatch park -> approve -> execute -> audit (recorded fake-shell SSH)
+# ===========================================================================
+
+_SERVER_KEY = asyncssh.generate_private_key("ssh-ed25519")
+_CLIENT_KEY = asyncssh.generate_private_key("ssh-ed25519")
+_CLIENT_PUB = _CLIENT_KEY.convert_to_public()
+
+_CONNECTOR_ID = "rke2-ssh-1.x"
+_TARGET_NAME = "rke2-node-write-e2e"
+_OPERATOR_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000024e2")
+_OPERATOR = Operator(
+    sub="rke2-write-e2e-test",
+    name="RKE2 Write E2E Operator",
+    email=None,
+    raw_jwt="<rke2-write-e2e-raw-jwt>",
+    tenant_id=_OPERATOR_TENANT_ID,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+_E2E_CURRENT_CONFIG = "server: https://old.example:9345\n"
+
+
+class _FakeShellSSHServer(asyncssh.SSHServer):
+    def public_key_auth_supported(self) -> bool:
+        return True
+
+    def validate_public_key(self, username: str, key: Any) -> bool:  # type: ignore[override]
+        return bool(key == _CLIENT_PUB)
+
+
+async def _fake_shell_process_factory(process: Any) -> None:
+    cmd: str = process.command or ""
+    if cmd.startswith("systemctl restart "):
+        process.exit(0)
+        return
+    if cmd.startswith("systemctl is-active "):
+        process.stdout.write("active\n")
+        process.exit(0)
+        return
+    if cmd.startswith("if [ -e "):  # config read
+        process.stdout.write(_E2E_CURRENT_CONFIG)
+        process.exit(0)
+        return
+    if cmd.startswith("# meho-rke2-config-update"):  # atomic write script
+        process.stdout.write("===RKE2_CONFIG_WRITTEN===\n")
+        process.exit(0)
+        return
+    process.stderr.write(f"fake-shell: unknown command: {cmd!r}\n")
+    process.exit(127)
+
+
+@pytest.fixture(scope="module")
+def event_loop_policy() -> asyncio.DefaultEventLoopPolicy:
+    return asyncio.DefaultEventLoopPolicy()
+
+
+@pytest.fixture
+async def fake_shell_server() -> AsyncIterator[types.SimpleNamespace]:
+    srv = await asyncssh.create_server(
+        _FakeShellSSHServer,
+        "127.0.0.1",
+        0,
+        server_host_keys=[_SERVER_KEY],
+        process_factory=_fake_shell_process_factory,
+    )
+    port: int = srv.sockets[0].getsockname()[1]
+    yield types.SimpleNamespace(host="127.0.0.1", port=port)
+    srv.close()
+    await srv.wait_closed()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+async def _seed_target(host: str, port: int) -> TargetORM:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = TargetORM(
+            tenant_id=_OPERATOR_TENANT_ID,
+            name=_TARGET_NAME,
+            aliases=[],
+            product="rke2",
+            host=host,
+            port=port,
+            fqdn=None,
+            secret_ref="kv/dev/rke2/write-e2e",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint={"version": "1.x"},
+            notes="seeded by test_connectors_rke2_write",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _wire_seeded_connector() -> Rke2SshConnector:
+    class _SeededRke2Connector(Rke2SshConnector):  # type: ignore[misc]
+        async def _auth_config(self, target: Any, operator: Any = None) -> dict[str, Any]:
+            return {"username": "root", "client_keys": [_CLIENT_KEY], "known_hosts": None}
+
+    instance = _SeededRke2Connector()
+    from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+
+    _CONNECTOR_INSTANCE_CACHE[Rke2SshConnector] = instance  # type: ignore[assignment]
+    return instance
+
+
+@pytest.fixture
+async def rke2_write_e2e(
+    fake_shell_server: types.SimpleNamespace,
+) -> AsyncIterator[Rke2SshConnector]:
+    set_default_reducer(PassThroughReducer())
+    await Rke2SshConnector.register_operations()
+    await _seed_target(fake_shell_server.host, fake_shell_server.port)
+    connector = _wire_seeded_connector()
+    yield connector
+    await connector.aclose()
+
+
+async def _dispatch(op_id: str, params: dict[str, Any], *, approved: bool) -> dict[str, Any]:
+    """Dispatch a write op. ``approved=False`` hits the policy gate (parks);
+    ``approved=True`` is the approvals-API resume path that runs the handler."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        resolved_target = await resolve_target(session, _OPERATOR.tenant_id, _TARGET_NAME)
+    result = await dispatch(
+        operator=_OPERATOR,
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        target=resolved_target,
+        params=params,
+        _approved=approved,
+    )
+    dumped: dict[str, Any] = result.model_dump(mode="json")
+    return dumped
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "op_id,params",
+    [
+        ("rke2.node.service.restart", {"unit": "rke2-server"}),
+        ("rke2.node.config.update", {"patch": {"debug": True}}),
+    ],
+)
+async def test_write_op_parks_for_user_not_hard_deny(
+    rke2_write_e2e: Rke2SshConnector, op_id: str, params: dict[str, Any]
+) -> None:
+    """An un-approved USER dispatch parks in the approve-queue (not denied, not run)."""
+    result = await _dispatch(op_id, params, approved=False)
+    assert result["status"] == "awaiting_approval", result
+    assert result.get("extras", {}).get("approval_request_id")
+
+
+@pytest.mark.asyncio
+async def test_service_restart_approved_executes_and_audits(
+    rke2_write_e2e: Rke2SshConnector,
+) -> None:
+    op_id = "rke2.node.service.restart"
+    sessionmaker = get_sessionmaker()
+
+    async def _count() -> int:
+        async with sessionmaker() as session:
+            rows = await session.execute(
+                select(AuditLog).where(AuditLog.method == "DISPATCH", AuditLog.path == op_id)
+            )
+            return len(list(rows.scalars().all()))
+
+    baseline = await _count()
+    result = await _dispatch(op_id, {"unit": "rke2-server"}, approved=True)
+    assert result["status"] == "ok", result.get("error")
+    assert result["result"]["restarted"] is True
+    assert result["result"]["is_active"] is True
+    assert await _count() == baseline + 1
+
+
+@pytest.mark.asyncio
+async def test_config_update_approved_executes_and_redacts(
+    rke2_write_e2e: Rke2SshConnector,
+) -> None:
+    result = await _dispatch(
+        "rke2.node.config.update",
+        {"patch": {"node-label": ["role=worker"]}, "semantics": "merge"},
+        approved=True,
+    )
+    assert result["status"] == "ok", result.get("error")
+    payload = result["result"]
+    assert payload["updated"] is True
+    assert payload["restart_required"] is True
+    assert payload["changed_keys"] == ["node-label"]
+    # No file body / value on the returned envelope.
+    assert "server" not in payload  # the pre-existing config body is never echoed

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -26,10 +26,31 @@ T1 (#2221) ships the **connector scaffold + the read-only posture tier only**:
   join-token presence, **with the token value never read** (redacted by
   construction).
 
-Two ops total, both `safety_level="safe"` / `requires_approval=false`. The
-approval-gated write ops (`rke2.token.rotate`, `rke2.node.service.restart`,
-`rke2.node.config.update`, `rke2.etcd-snapshot.save`) ship in sibling Tasks
-#2429/#2430/#2431 — explicitly out of scope for T1.
+Both `safety_level="safe"` / `requires_approval=false`.
+
+T3 (#2430) adds the first two **approval-gated node-write ops**
+(`safety_level="dangerous"` / `requires_approval=true`), both in the shared
+`rke2-node-write` group:
+
+- `rke2.node.service.restart` — restarts EXACTLY one allow-listed unit
+  (`rke2-server` / `rke2-agent`) via `systemctl restart <UNIT>` and
+  health-gates on `systemctl is-active`. The unit is a schema `enum`
+  re-checked against a module-level frozenset in the handler (fail-closed,
+  the proxmox method-allowlist mold); no other unit and no arbitrary
+  `systemctl` action.
+- `rke2.node.config.update` — a **backplane-owned key merge** of a bounded
+  `/etc/rancher/rke2/*.yaml` file. The handler reads + parses the current
+  YAML in-process, applies the operator's key-level `patch`
+  (`semantics: merge|replace`), validates it re-parses, and writes it back
+  atomically (temp under `/etc/rancher/rke2`, `chmod 0600` + `chown
+  root:root`, `mv`). No host-side `sed`/`yq`, no arbitrary-file-write
+  primitive. RKE2 config is inert until a restart, so this op does **not**
+  restart — it returns `restart_required: true` and changed key **names**
+  only (never a value; the config body carries `token:` join credentials).
+
+The remaining write ops (`rke2.token.rotate` T2 #2429,
+`rke2.etcd-snapshot.save` T4 #2431) append to `RKE2_OPS` from their own
+sibling modules the same way.
 
 Source: `backend/src/meho_backplane/connectors/rke2/`.
 
@@ -55,7 +76,19 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
 - **Op metadata** (`ops.py`) — `Rke2Op` frozen dataclass (mirrors
   `Bind9Op` / `HolodeckOp`), `SSH_TRANSPORT_NOTE` (the plain-SSH reminder
   copied into every op's `when_to_use`), `_RKE2_ABOUT_OP`, and `RKE2_OPS`
-  (`about` + the `READ_OPS` posture tuple).
+  (`about` + the `READ_OPS` posture tuple + the `WRITE_OPS` node-write tuple).
+
+- **Write ops** (`ops_write.py`, T3 #2430) — the bounds
+  (`bound_unit` frozenset re-check; `ensure_config_path_under_root` /
+  `bound_config_path` lexical `/etc/rancher/rke2/*.yaml` confinement +
+  `ConfigPathRejectedError`; `apply_config_patch` / `changed_config_keys`
+  backplane-owned merge), the `rke2_service_restart` / `rke2_config_update`
+  handlers, the two approval-park preview builders (registered at import via
+  `register_rke2_write_previews`), `WRITE_OPS`, and
+  `RKE2_WHEN_TO_USE_WRITE_BY_GROUP` (merged into the connector's
+  `_WHEN_TO_USE_BY_GROUP`). Privilege model: the connector operates as `root`
+  over SSH (the posture tier already `stat`s `0600 root:root` token files),
+  so writes run via `_run_command` without a separate sudo-password stream.
 
 - **Registration** (`__init__.py`) — two-phase, mirroring bind9/holodeck.
   Synchronous `register_connector_v2` at import time (versioned triple +
@@ -110,10 +143,26 @@ result).
 - `connectors/registry.py` — the v2 registry + eager-import walk.
 - stdlib `re`, `shlex` (path quoting, defensive even though paths are fixed).
 
+## Broadcast / approval wiring (T3 #2430)
+
+- `rke2.node.service.restart` classifies plain `write` via the `.restart`
+  write-suffix added to `broadcast/events.py::_WRITE_SUFFIXES`; its params
+  (a single unit) carry no secret.
+- `rke2.node.config.update` is pinned in
+  `broadcast/events.py::_CREDENTIAL_WRITE_OPS` (its `patch` may carry a
+  `token:` value), so the broadcast collapses to aggregate-only.
+- Approval-park previews: `_rke2_service_restart_preview` renders
+  `{resource: systemd_unit, unit, action, node}`; `_rke2_config_update_preview`
+  renders `{resource: config_file, path, semantics, key_names}` — key names
+  only, never the file body or values.
+
 ## Known issues / follow-ups
 
-- Write ops (token rotate / service restart / config update / etcd-snapshot)
-  are deferred to #2429/#2430/#2431 under Initiative #2172.
+- Remaining write ops (`token.rotate` #2429, `etcd-snapshot.save` #2431) are
+  deferred to their sibling Tasks under Initiative #2172.
+- The write ops assume `root` SSH access (consistent with the read posture
+  tier); a future non-root + sudo-password path would mirror bind9's
+  `_remote_bash_with_sudo` if a target ever connects as a non-root user.
 - Host-key checking is disabled (`known_hosts=None`) at the adapter level for
   v0.2, shared across the whole SSH family; pinning is deferred repo-wide.
 - The RKE2 version probe is best-effort: `version` is `null` when the `rke2`


### PR DESCRIPTION
## Summary

- Add the first two **approval-gated node-write ops** on the `rke2-ssh` connector (Initiative #2172, T3), both `safety_level="dangerous"` / `requires_approval=True` and parked for human approval before anything changes. Built on the T1 scaffold (#2432).
- `rke2.node.service.restart` — restarts EXACTLY one allow-listed unit (`rke2-server` / `rke2-agent`): a schema `enum` re-checked against a module-level frozenset in the handler (fail-closed, the proxmox method-allowlist mold — no arbitrary unit or `systemctl` action), health-gated on `systemctl is-active`.
- `rke2.node.config.update` — a **backplane-owned key merge** of a bounded `/etc/rancher/rke2/*.yaml` file: read + parse the current YAML in-process, apply the operator's key-level `patch` (`merge`/`replace`), validate it re-parses, write it back atomically (temp under `/etc/rancher/rke2`, `chmod 0600` + `chown root:root`, `mv`) — no host-side `sed`/`yq`, no arbitrary-file write. It does **not** restart (config is inert until one): returns `restart_required: true` and changed key **names** only, never a value or the body.
- **Classifier**: `config.update` pinned in `_CREDENTIAL_WRITE_OPS` (its `patch` may carry a `token:` value) and `.restart` joins `_WRITE_SUFFIXES` — both broadcast correctly. Approval-park previews render the systemd-unit / config-file blast-radius shapes with no file body or values.
- **Privilege model**: the connector operates as `root` over SSH (the T1 posture tier already `stat`s `0600 root:root` token files), so writes run via `_run_command` without a separate sudo-password stream.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean
- [x] `pytest tests/test_connectors_rke2.py tests/test_connectors_rke2_write.py tests/test_connectors_rke2_e2e.py tests/test_broadcast_classifier_coverage.py` — 86 passed
- [x] AC1 — `service.restart` rejects any unit outside `{rke2-server, rke2-agent}` at the schema enum AND the handler frozenset (fail-closed); on an allowed unit it restarts + health-gates on `is-active`
- [x] AC2 — `config.update` refuses a path outside `/etc/rancher/rke2/*` (structured `ConfigPathRejectedError`, no body leaked); an allowed patch is backplane-merged, written `0600 root:root` atomically, re-parses; result carries `changed_keys` names only + `restart_required: true` and does **not** restart
- [x] AC3 — `config.update` pinned in `_CREDENTIAL_WRITE_OPS` + `.restart` added to `_WRITE_SUFFIXES`; classifier-coverage test extended; a `config.update` broadcast never carries `token:` values
- [x] AC4 — both ops park for USER (`awaiting_approval`) and execute on `_approved=True` resume (recorded fake-shell SSH harness); preview builders render blast-radius shapes without file body/values
- [x] AC5 — no integration doubles reference rke2; **no OpenAPI snapshot delta** (no FastAPI route/schema touched — typed ops register into `endpoint_descriptor`)

## Out of scope

- `token.rotate` (T2 #2429), `etcd-snapshot.save` (T4 #2431) — sibling Tasks; they append to `RKE2_OPS`/`ops_write.py` the same way. Kept cleanly separable (distinct functions + registration entries) for the serial union-merge.
- Live config reload (RKE2 has none — restart is required and stays a separate approval).

Closes #2430


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added approval-gated RKE2 node operations to restart allow-listed services and update bounded YAML configuration files.
  * Service restarts now include health checks and configuration updates report restart requirements and changed keys without exposing values.
  * Added secure previews, auditing, and redaction for these operations.

* **Documentation**
  * Updated RKE2 connector documentation and changelog with operation behavior, safety requirements, and approval workflows.

* **Tests**
  * Added coverage for validation, approval flows, health gating, atomic updates, security, and sensitive-data redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->