### PR TITLE
fix(ui): align topology filter banner controls 

### DIFF
--- a/backend/src/meho_backplane/ui/templates/topology/table.html
+++ b/backend/src/meho_backplane/ui/templates/topology/table.html
@@ -123,23 +123,23 @@
     aria-label="Filter topology nodes"
     onsubmit="return false;"
   >
-    <div class="card-body grid gap-3 md:grid-cols-4">
-      <label class="form-control md:col-span-2">
-        <span class="label-text">Search by name</span>
+    <div class="card-body grid gap-3 md:grid-cols-4 md:items-end">
+      <label class="flex flex-col gap-1 md:col-span-2">
+        <span class="text-sm font-medium">Search by name</span>
         <input
           type="search"
           name="q"
           value="{{ name_filter }}"
           placeholder="Substring match (case-insensitive)"
-          class="input input-bordered input-sm"
+          class="input input-sm w-full"
           aria-label="Filter nodes by name"
         />
       </label>
-      <label class="form-control">
-        <span class="label-text">Kind</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Kind</span>
         <select
           name="kind"
-          class="select select-bordered select-sm"
+          class="select select-sm w-full"
           aria-label="Filter nodes by kind"
         >
           <option value="">All kinds</option>


### PR DESCRIPTION
The topology filter bar stacked its fields with DaisyUI `form-control` and labelled them with `label-text`, but both classes were removed in DaisyUI 5 — they compile to zero CSS rules — so the fields had no layout and the "Search by name" input and "Kind" select did not line up.

Replace the dead classes with live utilities: `flex flex-col gap-1` to stack each label over its control, `text-sm font-medium` for the label text, and `w-full` so both controls fill their grid cell. Add `md:items-end` to the filter grid so all controls share one baseline.

Presentation only — no change to the filter/sort hx-* wiring or the submitted query params.

<!-- SPDX-License-Identifier: Apache-2.0 -->
<!-- Copyright (c) 2026 evoila Group -->

## Description

<!-- What and why -->

## Related issue

<!-- Closes #N -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] CI / build / chore

## Checklist

- [ ] Conventional Commits format on every commit
- [ ] Every commit has a `Signed-off-by:` line (DCO; `git commit -s`)
- [ ] Tests added/updated where applicable
- [ ] Documentation updated where applicable
- [ ] CI green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the topology filter bar layout for a cleaner, more consistent appearance.
  * Improved alignment and spacing across filter controls.
  * Standardized name and kind inputs with compact, full-width styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->