### PR TITLE
feat(ui): add browser favicon so the console is recognizable in tabs

### DIFF
--- a/backend/src/meho_backplane/ui/static/src/brand/favicon.svg
+++ b/backend/src/meho_backplane/ui/static/src/brand/favicon.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="meho">
+  <!--
+    SPDX-License-Identifier: Apache-2.0
+    Copyright (c) 2026 evoila Group
+
+    MEHO tab mark — the "Graphite & Signal" wordmark distilled to a
+    monogram: the lowercase "m" from the sidebar wordmark plus the
+    indigo signal caret that "types" the brand (see base.html brand
+    block + .meho-caret in static/src/styles.css). Colours are the
+    exact brand tokens converted from oklch to sRGB:
+      graphite tile  base-200 -> base-100  #080a0d -> #101316
+      wordmark ink   base-content          #e6e8eb
+      signal caret   primary               #6c7ae5
+    Scales cleanly from 16px tabs up. SVG-only: every browser MEHO
+    targets renders SVG favicons.
+  -->
+  <defs>
+    <linearGradient id="meho-tile" x1="16" y1="0" x2="16" y2="32" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#101316"/>
+      <stop offset="1" stop-color="#080a0d"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="32" height="32" rx="7" fill="url(#meho-tile)"/>
+  <rect x="0.5" y="0.5" width="31" height="31" rx="6.5" fill="none" stroke="#e6e8eb" stroke-opacity="0.08"/>
+  <!-- lowercase "m": left stem + two grotesque arches -->
+  <path d="M8 22 V15.6 C8 13.7 9.3 12.6 10.9 12.6 C12.5 12.6 13.8 13.7 13.8 15.6 V22
+           M13.8 15.6 C13.8 13.7 15.1 12.6 16.7 12.6 C18.3 12.6 19.6 13.7 19.6 15.6 V22"
+        fill="none" stroke="#e6e8eb" stroke-width="2.9" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- signal caret: thin beam, skewed ~12deg, blinks in the live UI (static here) -->
+  <path d="M24.7 11.8 L26.6 11.8 L24.1 22.2 L22.2 22.2 Z" fill="#6c7ae5"/>
+</svg>

--- a/backend/src/meho_backplane/ui/templates/_head_assets.html
+++ b/backend/src/meho_backplane/ui/templates/_head_assets.html
@@ -22,6 +22,11 @@
    paint or light-theme operators get a dark flash. External file,
    not inline, to preserve the zero-inline-script CSP posture. #}
 <script src="/ui/static/src/app/theme.js"></script>
+{# Tab mark — the "Graphite & Signal" wordmark distilled to a monogram
+   (static/src/brand/favicon.svg). SVG-only: every browser the console
+   targets renders SVG favicons, and one vector scales across tab sizes.
+   A <link> element, so it keeps the zero-inline-script CSP posture. #}
+<link rel="icon" href="/ui/static/src/brand/favicon.svg" type="image/svg+xml" />
 {# Compiled Tailwind 4 + DaisyUI 5 bundle; built by the ``tailwindcss``
    CLI step in backend/Dockerfile from static/src/styles.css. #}
 <link rel="stylesheet" href="/ui/static/dist/tailwind.css" />


### PR DESCRIPTION
## Problem

The Operator Console sets a `<title>` but ships **no favicon**, so browser tabs show the default blank/globe icon and MEHO is hard to pick out among open tabs.

## Change

Adds a monogram tab mark that distills the **"Graphite & Signal"** sidebar wordmark — the lowercase `m` plus the indigo signal caret, on a graphite tile. Colours are the exact brand tokens (`base-100/200`, `base-content`, `primary`) converted from the `oklch()` values in `static/src/styles.css` to sRGB:

| token | oklch | sRGB |
|---|---|---|
| graphite tile | `base-200 → base-100` | `#080a0d → #101316` |
| wordmark ink | `base-content` | `#e6e8eb` |
| signal caret | `primary` | `#6c7ae5` |

- **`static/src/brand/favicon.svg`** — SVG-only. Every browser the console targets renders SVG favicons, and one vector scales across tab sizes.
- **`_head_assets.html`** — `<link rel="icon" type="image/svg+xml">`. The partial is included by **both** `base.html` and the standalone `broadcast/wall.html`, so one edit covers every console page. It's a `<link>` element, so the zero-inline-script CSP posture is preserved; the `/ui` CSP is `frame-ancestors`-only, so nothing blocks the fetch.

## Verification

- SVG parses as valid XML.
- `_head_assets.html` renders with the favicon link present (`type="image/svg+xml"`).
- `tests/test_ui_templates.py` — 35 passed (head-asset ordering assertions unaffected).

## Out of scope

A root `GET /favicon.ico` handler — the `<link>` tag drives the visible tab icon; a root handler would only suppress the browser's automatic `/favicon.ico` 404 in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an SVG favicon for browser tabs.
  * The favicon scales cleanly across display sizes and remains compatible with content security policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->