### PR TITLE
docs(changelog): roll [Unreleased] into v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-13
+
 ### Added — rke2.etcd-snapshot.save safe managed-etcd snapshot op (#2431)
 
 - Add `rke2.etcd-snapshot.save` on the `rke2-ssh` connector — an on-demand


### PR DESCRIPTION
## Roll `[Unreleased]` → `## [0.22.0] - 2026-07-13`

Release-cutting PR for **v0.22.0** (`/release` Phase 2). CHANGELOG only —
no code, no version-file edits (version lives in the tag). Merge this,
then the tag `v0.22.0` gets pushed on the merge commit.

### What ships in v0.22.0

**Two new connector families**

- **`net.*` network-diagnostics** (Initiative #2405) — 8 targetless probe
  ops: `tcp_check`, `tls_inspect` (full presented cert chain), `http_probe`
  (no body, per-hop redirect re-gating), `dns_lookup` (full dig parity via
  dnspython), `ntp_check` (stdlib SNTP), and the ICMP cohort
  `ping`/`trace`/`path_mtu` (unprivileged, no `CAP_NET_RAW`). Governed by
  the dedicated, fail-closed `MEHO_NETDIAG_PROBE_ALLOWLIST` (empty ⇒ inert).
  All safe / no-approval; probes classify as reads.
- **`rke2-ssh` cluster-node OS-lifecycle** (Initiative #2172) — scaffold +
  read posture (`rke2.about`, `rke2.posture.show`), then the approval-gated
  write surface: `token.rotate` (server-side mint, no token in result/audit),
  `node.service.restart` (unit allow-list) + `node.config.update`
  (path-bounded backplane-owned key merge), and the safe `etcd-snapshot.save`.

**MFC live-appliance fixes** (Initiative #2399)

- vROps rebuilt on an acquired-token `OpsToken` session (#2395); connector
  credential cache evicted on establish-auth failure so a restage converges
  without a restart (#2396); stage-aware `connector_auth_failed` causes +
  truthful remediation (#2400).

**Credential-backend seam last-mile** (Initiative #2227)

- kubeconfig loader (#2397) and keycloak user write-op password read (#2401)
  both routed through `load_vault_secret_data` so `gsm:` refs work on a
  no-Vault deploy.

**Helm chart cold-install fixes** (Initiative #2390)

- migrate-hook SA ordering deadlock (#2391), pgvector superuser docs (#2392),
  `startupProbe` for slow first boots (#2393), render-time MCP-URI guard
  (#2394).

**Fix**

- Profiled-connector login-POST 401 stamped establish-stage, not
  `after_relogin` (#2414).

### ⚠️ Consumer-facing note (not a breaking change, but call it out)

#2400 renames the `connector_auth_failed` cause string for **no-session**
dispatch failures: `session_dispatch_<status>` → `dispatch_<status>`. A
consumer matching on `session_dispatch_` now matches only the genuine
post-re-login case (`session_dispatch_<status>_after_relogin`).

### Provenance

- Completeness audit: all 20 commits since v0.21.0 map to a bullet.
- Every parent initiative (#2172, #2405, #2390, #2399, #2227) is CLOSED.
- CI green on `main` (the lone `image` failure is the benign expired-token
  RDC notify step; build+push succeeded).

CHANGELOG only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new changelog section for version 0.22.0, dated July 13, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->