### PR TITLE
fix(ui): polish topology node drawer + annotate-edge form (#166)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/topology/_annotate_modal.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_annotate_modal.html
@@ -65,32 +65,32 @@
       hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
       class="space-y-3"
     >
-      <fieldset class="grid grid-cols-2 gap-2">
-        <label class="form-control">
-          <span class="label-text text-xs opacity-70">from (name)</span>
+      <fieldset class="grid grid-cols-2 gap-3">
+        <label class="flex flex-col gap-1">
+          <span class="text-xs font-medium opacity-70">From (name)</span>
           <input
             type="text" name="from_name" required
             value="{{ submitted.from_name | default('') }}"
-            class="input input-bordered input-sm font-mono"
+            class="input input-bordered input-sm font-mono w-full"
             aria-label="From node name"
           />
         </label>
-        <label class="form-control">
-          <span class="label-text text-xs opacity-70">from kind (optional)</span>
+        <label class="flex flex-col gap-1">
+          <span class="text-xs font-medium opacity-70">From kind (optional)</span>
           <input
             type="text" name="from_kind"
             value="{{ submitted.from_kind | default('') }}"
-            class="input input-bordered input-sm font-mono"
+            class="input input-bordered input-sm font-mono w-full"
             aria-label="From node kind"
           />
         </label>
       </fieldset>
 
-      <label class="form-control">
-        <span class="label-text text-xs opacity-70">edge kind</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-medium opacity-70">Edge kind</span>
         <select
           name="kind" required
-          class="select select-bordered select-sm font-mono"
+          class="select select-bordered select-sm font-mono w-full"
           aria-label="Edge kind"
         >
           <option value="" disabled {{ 'selected' if not submitted.get('kind') else '' }}>
@@ -102,42 +102,42 @@
         </select>
       </label>
 
-      <fieldset class="grid grid-cols-2 gap-2">
-        <label class="form-control">
-          <span class="label-text text-xs opacity-70">to (name)</span>
+      <fieldset class="grid grid-cols-2 gap-3">
+        <label class="flex flex-col gap-1">
+          <span class="text-xs font-medium opacity-70">To (name)</span>
           <input
             type="text" name="to_name" required
             value="{{ submitted.to_name | default('') }}"
-            class="input input-bordered input-sm font-mono"
+            class="input input-bordered input-sm font-mono w-full"
             aria-label="To node name"
           />
         </label>
-        <label class="form-control">
-          <span class="label-text text-xs opacity-70">to kind (optional)</span>
+        <label class="flex flex-col gap-1">
+          <span class="text-xs font-medium opacity-70">To kind (optional)</span>
           <input
             type="text" name="to_kind"
             value="{{ submitted.to_kind | default('') }}"
-            class="input input-bordered input-sm font-mono"
+            class="input input-bordered input-sm font-mono w-full"
             aria-label="To node kind"
           />
         </label>
       </fieldset>
 
-      <label class="form-control">
-        <span class="label-text text-xs opacity-70">note (optional)</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-medium opacity-70">Note (optional)</span>
         <textarea
           name="note" rows="2" maxlength="{{ max_note_length }}"
-          class="textarea textarea-bordered textarea-sm"
+          class="textarea textarea-bordered textarea-sm w-full"
           aria-label="Annotation note"
         >{{ submitted.note | default('') }}</textarea>
       </label>
 
-      <label class="form-control">
-        <span class="label-text text-xs opacity-70">evidence_url (optional)</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-xs font-medium opacity-70">Evidence URL (optional)</span>
         <input
           type="url" name="evidence_url" maxlength="{{ max_evidence_url_length }}"
           value="{{ submitted.evidence_url | default('') }}"
-          class="input input-bordered input-sm font-mono"
+          class="input input-bordered input-sm font-mono w-full"
           aria-label="Evidence URL"
         />
       </label>

--- a/backend/src/meho_backplane/ui/templates/topology/_drawer.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_drawer.html
@@ -134,7 +134,7 @@
           onclick="
             const el = document.getElementById('node-drawer');
             if (el) {
-              el.outerHTML = '<aside id=\'node-drawer\' class=\'card bg-base-100 border-base-300 border shadow-sm\' aria-live=\'polite\' aria-label=\'Node detail drawer\'><div class=\'card-body text-sm opacity-70\'>Select a row to inspect a node.</div></aside>';
+              el.outerHTML = '<aside id=\'node-drawer\' class=\'card bg-base-100 border-base-300 border shadow-sm\' aria-live=\'polite\' aria-label=\'Node detail drawer\'><div class=\'card-body text-sm opacity-70\'>Click <strong>View</strong> on any row for details.</div></aside>';
             }
             return false;
           "
@@ -150,36 +150,38 @@
       shares this id so the swap is stable, and a successful POST swaps the
       created-edge fragment back into the same slot.
     -#}
-    <div id="topology-edge-modal" data-test="edge-modal-slot"></div>
+    <div id="topology-edge-modal" data-test="edge-modal-slot" class="empty:hidden"></div>
 
     {#- Refresh-result mount slot (Task #1954). Empty until the "Refresh"
         button POSTs; the synchronous ``RefreshResult`` counts (or the 404
         near-miss hint) swap in here. -#}
     {% if node.kind == "target" %}
-      <div id="topology-refresh-result" data-test="refresh-result-slot"></div>
+      <div id="topology-refresh-result" data-test="refresh-result-slot" class="empty:hidden"></div>
     {% endif %}
 
     {# ---------- Properties ---------- #}
     <section aria-label="Node properties">
       <h3 class="text-sm font-semibold uppercase opacity-60">Properties</h3>
       <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
-        <dt class="opacity-60">id</dt>
-        <dd class="font-mono">{{ node.id }}</dd>
-        <dt class="opacity-60">kind</dt>
+        <dt class="opacity-60">Kind</dt>
         <dd>{{ node.kind }}</dd>
-        <dt class="opacity-60">name</dt>
+        <dt class="opacity-60">Name</dt>
         <dd class="font-mono">{{ node.name }}</dd>
-        <dt class="opacity-60">discovered_by</dt>
+        <dt class="opacity-60">Discovered by</dt>
         <dd>{{ node.discovered_by }}</dd>
-        {% if node.target_id %}
-          <dt class="opacity-60">target_id</dt>
-          <dd class="font-mono">{{ node.target_id }}</dd>
-        {% endif %}
-        <dt class="opacity-60">first_seen</dt>
-        <dd>{{ node.first_seen.isoformat() }}</dd>
-        <dt class="opacity-60">last_seen</dt>
+        {#- Console-standard timestamp format (matches the table surface):
+            the machine-readable ISO stays in the ``datetime`` attribute; the
+            display uses ``%Y-%m-%d %H:%M UTC``. Timestamps are stored
+            tz-aware UTC. -#}
+        <dt class="opacity-60">First seen</dt>
         <dd>
-          {% if node.last_seen %}{{ node.last_seen.isoformat() }}{% else %}<span class="opacity-50">—</span>{% endif %}
+          <time datetime="{{ node.first_seen.isoformat() }}">{{ node.first_seen.strftime("%Y-%m-%d %H:%M UTC") }}</time>
+        </dd>
+        <dt class="opacity-60">Last seen</dt>
+        <dd>
+          {% if node.last_seen %}
+            <time datetime="{{ node.last_seen.isoformat() }}">{{ node.last_seen.strftime("%Y-%m-%d %H:%M UTC") }}</time>
+          {% else %}<span class="opacity-50">—</span>{% endif %}
         </dd>
       </dl>
       {% if node.properties %}

--- a/backend/src/meho_backplane/ui/templates/topology/table.html
+++ b/backend/src/meho_backplane/ui/templates/topology/table.html
@@ -211,7 +211,7 @@
     aria-label="Node detail drawer"
   >
     <div class="card-body text-sm opacity-70">
-      Select a row's <em>view</em> button to inspect a node.
+      Click <strong>View</strong> on any row for details.
     </div>
   </aside>
   </div>

--- a/backend/tests/test_ui_topology_table.py
+++ b/backend/tests/test_ui_topology_table.py
@@ -759,9 +759,11 @@ def test_drawer_renders_node_properties_and_edges() -> None:
     # stretching the full grid-column height. Pin it on the fragment.
     assert 'id="node-drawer"' in body
     assert "self-start" in body
-    # Node identity surfaces.
+    # Node identity surfaces by name.
     assert "vm-on-host-1" in body
-    assert str(child_id) in body
+    # Task #166: the raw node UUID is no longer surfaced in the drawer
+    # (the ``ID`` Properties row was removed as operator-facing noise).
+    assert str(child_id) not in body
     # Outgoing edge surfaces (vm -> host-1).
     assert "host-1" in body
     assert "runs-on" in body
@@ -772,6 +774,17 @@ def test_drawer_renders_node_properties_and_edges() -> None:
     assert "Show dependents" in body
     assert "view=graph" in body
     assert "from=vm-on-host-1" in body
+    # Task #166 drawer polish: Properties labels are capitalized (not the
+    # raw ``first_seen`` / ``discovered_by`` field names).
+    assert "First seen" in body
+    assert "Last seen" in body
+    assert "Discovered by" in body
+    # first_seen / last_seen render the console-standard ``%H:%M UTC``
+    # display (raw ISO only survives in the ``<time datetime=...>`` attr).
+    assert "UTC</time>" in body
+    # The empty HTMX mount slots are ``empty:hidden`` so they don't inject
+    # phantom gaps into the ``space-y-3`` drawer rhythm while unfilled.
+    assert "empty:hidden" in body
 
 
 def test_drawer_renders_recent_ops_for_target_backed_node() -> None:
@@ -801,6 +814,9 @@ def test_drawer_renders_recent_ops_for_target_backed_node() -> None:
     assert "Recent operations" in body
     assert "POST" in body
     assert "/api/v1/targets/vmware-prod/probe" in body
+    # Task #166: the ``Target ID`` Properties row was removed, so the raw
+    # target UUID is no longer surfaced in the drawer.
+    assert str(target_id) not in body
 
 
 def test_drawer_shows_inner_node_has_no_audit_trail() -> None:


### PR DESCRIPTION
## Summary

Cleans up the topology detail surfaces reached from the table's **View** button (node detail drawer) and the **Annotate edge** modal. Shares a root cause with the filter/diff spacing work: **daisyUI v5 removed `.form-control` and `.label-text`**, so any form still using them renders unstyled.

### Node detail drawer (`_drawer.html`)
- **Even spacing** — the empty HTMX mount slots (`#topology-edge-modal`, `#topology-refresh-result`) were sitting in the `space-y-3` rhythm while unfilled, injecting phantom gaps between the header and Properties. Marked `empty:hidden` so they take no vertical space until swapped into.
- **Readable labels** — Properties labels are capitalized (`Kind`, `Name`, `Discovered by`, `First seen`, `Last seen`) instead of raw snake_case field names.
- **Formatted timestamps** — `first_seen` / `last_seen` render the console-standard `%Y-%m-%d %H:%M UTC`; the ISO value survives in the `<time datetime="...">` attribute.
- **Removed noise** — dropped the `ID` and `Target ID` rows (raw UUIDs); identity is carried by `Name`.
- **Clearer empty state** — consistent placeholder "Click **View** on any row for details." (was two inconsistent, awkwardly-worded variants).

### Annotate-edge modal (`_annotate_modal.html`)
- Replaced the dead `form-control` / `label-text` classes with working `flex flex-col gap-1` label columns; widened the paired-field grids to `gap-3`.
- Added `w-full` to every control — daisyUI's `.input` caps at `width: clamp(3rem, 20rem, 100%)`, so the standalone Edge kind / Note / Evidence URL fields stopped short of the right edge; they now align with the From/To grids.
- Capitalized all field labels (`From (name)`, `Edge kind`, `Evidence URL (optional)`, …).

## Changes
- `backend/src/meho_backplane/ui/templates/topology/_drawer.html`
- `backend/src/meho_backplane/ui/templates/topology/_annotate_modal.html`
- `backend/src/meho_backplane/ui/templates/topology/table.html` — empty-drawer placeholder
- `backend/tests/test_ui_topology_table.py` — regression assertions

## Testing
- `pytest tests/test_ui_topology_table.py tests/test_ui_topology_annotate.py` → **46 passed**
- Verified locally against the dev console: even drawer spacing, capitalized labels, formatted timestamps, no UUID rows, full-width annotate fields aligned to the right edge.

## Scope note
Task evoila-bosnia/meho-internal#166's literal title is the **filter / diff** form inputs, which are being handled on a separate branch. This PR fixes the **sibling drawer + annotate** surfaces that share the same daisyUI-v5 root cause. The remaining `form-control`/`label-text` usages in `graph.html`, `timeline.html`, and `_bulk_import_modal.html` are left for a dedicated daisyUI-v5 migration follow-up.

Relates to evoila-bosnia/meho-internal#166

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated topology node details to show clearer, streamlined properties and consistently formatted UTC timestamps.
  * Removed technical identifiers such as raw node and target UUIDs from the details drawer.
  * Improved empty-state guidance to direct users to click **View** on a row.
  * Refined annotation form layouts and field styling for better consistency.
  * Prevented empty modal and refresh areas from creating unnecessary spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->