### PR TITLE
fix(types): annotate _collect_2xx_response_codes candidates as list[str]

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -1329,7 +1329,12 @@ def _collect_2xx_response_codes(responses: dict[str, Any]) -> list[str]:
     then any other key starting with ``"2"`` that wasn't already
     picked.
     """
-    candidates = [c for c in ("200", "201", "202", "203", "204") if c in responses]
+    # Annotate as list[str] so mypy widens the element type: the
+    # comprehension over a tuple of string literals otherwise infers
+    # list[Literal["200", ...]], which then rejects the "2XX" append,
+    # the str-keyed extend, and the list[str] return (list is
+    # invariant). mypy 2.3+ makes this inference; 2.1 did not.
+    candidates: list[str] = [c for c in ("200", "201", "202", "203", "204") if c in responses]
     if "2XX" in responses:
         candidates.append("2XX")
     candidates.extend(


### PR DESCRIPTION
## What

Add an explicit `list[str]` annotation to `candidates` in `_collect_2xx_response_codes` (`backend/src/meho_backplane/operations/ingest/openapi.py`).

## Why

mypy **2.3+** infers the list comprehension over the string-literal tuple `("200", "201", "202", "203", "204")` as `list[Literal["200", ...]]` instead of `list[str]`. Because `list` is invariant, that narrower type then rejects everything the function does next:

- `candidates.append("2XX")` — incompatible literal
- `candidates.extend(key for key in responses ...)` — `str` not assignable
- `return candidates` — `list[Literal[...]]` vs declared `list[str]`

= 3 errors under strict mypy. The explicit `list[str]` annotation widens the element type and clears all three. **Behavior is unchanged**, and the annotation is a no-op under the currently pinned mypy 2.1.0.

## Context

This unblocks the Dependabot mypy `2.1.0 → 2.3.0` bump (#2441), which otherwise fails the strict mypy CI gate on these exact three errors. After this lands, `@dependabot rebase` on #2441 will make its mypy gate pass.

## Validation

Ran locally in isolated worktrees, replicating CI (`uv sync --locked --all-groups` → `uv run mypy src/`):

- **mypy 2.1.0 (current main):** no openapi.py errors before or after this change (no regression)
- **mypy 2.3.0 (the bump):** 3 errors before → 0 after
- `ruff check` + `ruff format --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type annotations and static type-checking support.
  * No changes to runtime behavior or API response-code handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->