### PR TITLE
feat(gateway): outbound long-poll command plane over durable gateway_command queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — outbound long-poll gateway command plane (#2498)
+
+- Add the central command plane of the remote-execution gateway
+  (Initiative #2415, T2): a durable `gateway_command` queue (migration
+  `0059`) plus two runner-facing routes. `GET /api/v1/gateway/{runner}/next`
+  is a blocking long-poll — it holds up to `wait` seconds (default 25,
+  clamped to a 30 s ceiling; `wait=0` = one immediate claim attempt) and
+  returns `200` with the claimed command envelope (`id`, `op_id`, `params`,
+  resolved `target_descriptor`) or `204` on timeout.
+  `POST /api/v1/gateway/{runner}/result` records the outcome (`200`, or
+  `404` for an unknown/foreign command, `409` for a non-`delivered` row).
+  Both gate on the scoped runner principal (#2502) — a runner may only poll
+  and report its **own** queue — and every query filters `tenant_id`. The
+  claim is exactly-once under concurrent pollers (`SELECT … FOR UPDATE SKIP
+  LOCKED` on PostgreSQL, a conditional `UPDATE` on the SQLite test path),
+  and the hold is a bounded DB claim-poll loop that never holds a
+  transaction across its sleep (multi-replica-safe, no in-process
+  `asyncio.Event`). There is deliberately **no** HTTP enqueue endpoint —
+  central code enqueues via `gateway.queue.enqueue_command` so all
+  authorization stays central — `backend/src/meho_backplane/gateway/queue.py`,
+  `backend/src/meho_backplane/api/v1/gateway.py` (#2498).
+
 ### Added — scoped runner principal (gateway v1)
 
 - Add the identity substrate of the remote-execution gateway (Initiative

--- a/backend/alembic/versions/0059_create_gateway_command.py
+++ b/backend/alembic/versions/0059_create_gateway_command.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``gateway_command`` queue table for Initiative #2415 (#2498).
+
+Revision ID: 0059
+Revises: 0058
+Create Date: 2026-07-15
+
+This migration is the transport substrate of Task #2498 (outbound
+long-poll command plane) under Initiative #2415 (Remote execution
+gateway). It creates the ``gateway_command`` table — the durable queue
+that holds centrally-enqueued operations per satellite runner. The two
+runner-facing routes (blocking ``GET /api/v1/gateway/{runner}/next`` and
+``POST /api/v1/gateway/{runner}/result``) claim from and report onto rows
+of this table; central code enqueues via
+:func:`meho_backplane.gateway.queue.enqueue_command`.
+
+Serialized order (from the initiative's set-consistency review): this is
+the **second** migration in the chain (#2502 -> #2498 -> #2499 -> #2500
+-> #2501). It extends the then-current single head ``0058`` (#2502's
+``runner_principal`` table). Per the house Alembic rule, if a sibling
+migration lands on main first, renumber-before-merge — the number is not
+load-bearing, only ``down_revision`` extending the current head is.
+
+Lifecycle
+---------
+
+A row walks a closed four-state lifecycle, mirroring the
+``approval_request`` durable-queue discipline (#817):
+
+* ``pending``   — enqueued centrally, awaiting a runner claim.
+* ``delivered`` — claimed by the runner's long-poll (``pending`` flips to
+  ``delivered`` under ``SELECT ... FOR UPDATE SKIP LOCKED`` on PG / a
+  conditional ``UPDATE`` on the SQLite test path); ``delivered_at`` stamped.
+* ``succeeded`` / ``failed`` — terminal, set by ``POST .../result``;
+  ``result`` / ``error`` and ``completed_at`` stamped.
+
+A row that is claimed but never reported stays ``delivered`` — lost, not
+redelivered (the v1 at-most-once failure mode; #2500 bounds claimability
+via its own ``expires_at``, out of scope here).
+
+Columns
+-------
+
+* ``id`` — UUID primary key. PG production gets ``gen_random_uuid()`` via
+  this migration; the ORM ``default=uuid.uuid4`` covers SQLite and the
+  enqueue path.
+
+* ``tenant_id`` — UUID NOT NULL, ``REFERENCES tenant(id)``. A real FK
+  because ``gateway_command`` is a brand-new clean-slate table. ``NO
+  ACTION`` on delete: removing a tenant that still has queued commands is
+  blocked at the DB layer (same discipline as ``approval_request`` 0023
+  and ``runner_principal`` 0058).
+
+* ``runner_id`` — Text NOT NULL. The runner principal **name** (the wire
+  identity: #2498's ``{runner}`` path segment, ``MEHO_RUNNER_ID`` on the
+  runner, ``RunnerResultBatch.runner_id`` on the wire). Named ``runner_id``
+  to match that wire field; the per-tenant unique ``runner_principal``
+  ``name`` is what the gateway guard binds the token's ``runner_id`` UUID
+  claim to, so filtering the queue by name is correctly scoped.
+
+* ``op_id`` — Text NOT NULL. The operation id the runner executes.
+
+* ``params`` — portable JSON NOT NULL DEFAULT ``{}`` (JSONB on PG). The
+  validated op params.
+
+* ``target_descriptor`` — portable JSON **nullable** (JSONB on PG). The
+  centrally-resolved target descriptor a connector handler duck-reads
+  (``connectors/resolver.py`` is DB-bound; the runner has no local target
+  table). Nullable — not NOT NULL as the task sketch first drafted —
+  because targetless synthetic ops (``net.*``) carry no descriptor, which
+  the wire model already encodes as
+  ``RunnerWorkItem.target_descriptor: ResolvedTargetDescriptor | None``
+  (#2497). A NOT NULL column would force ``{}`` for those, and ``{}`` is
+  not a valid ``ResolvedTargetDescriptor`` (its ``name`` / ``product`` are
+  required) — so NULL is the wire-compatible encoding of "targetless".
+
+* ``status`` — Closed enum, portable ``IN (...)`` CHECK, DEFAULT ``pending``.
+
+* ``result`` — portable JSON nullable (JSONB on PG). The runner's success
+  payload; NULL until reported.
+
+* ``error`` — Text nullable. The runner's failure summary; NULL until a
+  failure is reported.
+
+* ``enqueued_by_sub`` — Text NOT NULL. The ``sub`` of the principal whose
+  central dispatch enqueued the command (audit provenance; #2500's minting
+  path is the production caller).
+
+* ``enqueued_at`` — ``timestamptz`` NOT NULL. PG ``now()`` server default;
+  ORM ``default`` for SQLite. Drives the FIFO claim order.
+
+* ``delivered_at`` / ``completed_at`` — ``timestamptz`` nullable. Stamped
+  on the ``pending -> delivered`` claim and the ``delivered -> terminal``
+  report respectively.
+
+Index
+-----
+
+* ``gateway_command_claim_idx`` — composite b-tree on
+  ``(tenant_id, runner_id, status, enqueued_at)``. Serves the hot claim
+  query (oldest ``pending`` row for a runner in a tenant) and the
+  tenant/runner-scoped result lookup.
+
+Dialect portability
+-------------------
+
+Mirrors ``0023`` / ``0056``: ``gen_random_uuid()`` / ``now()`` server
+defaults on PG with the ORM covering SQLite; portable
+``JSON().with_variant(JSONB(), "postgresql")`` JSON columns; a portable
+``IN (...)`` CHECK.
+
+Reversibility contract
+----------------------
+
+``upgrade()`` creates the table then its index; ``downgrade()`` drops the
+index then the table in inverse order. Purely additive on the way up (no
+destructive DDL), so the migration-compat CI guard passes.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0059"
+down_revision: str | None = "0058"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Closed ``gateway_command.status`` vocabulary — kept in lock-step with
+#: :class:`meho_backplane.db.models.GatewayCommandStatus`. Duplicated here
+#: as a literal tuple (not imported) so the migration's recorded DDL is a
+#: frozen snapshot independent of any later edit to the model enum — the
+#: same self-contained discipline migration ``0023`` follows. The drift
+#: guard in :mod:`tests.migrations.test_migration_0059_create_gateway_command`
+#: asserts the model enum and this recorded vocabulary agree.
+_GATEWAY_COMMAND_STATUSES: tuple[str, ...] = (
+    "pending",
+    "delivered",
+    "succeeded",
+    "failed",
+)
+
+
+def _check_in(column: str, values: tuple[str, ...]) -> str:
+    """Render a portable ``column IN ('a', 'b', ...)`` CHECK body."""
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"{column} IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Create the ``gateway_command`` table and its claim index."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    # Portable JSONB -> JSON variant; PG gets binary JSONB, SQLite text JSON.
+    json_type = sa.JSON().with_variant(postgresql.JSONB(), "postgresql")
+
+    op.create_table(
+        "gateway_command",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        # Real FK -- clean-slate substrate, no ondelete (tenant deletion
+        # must clear queued commands first; NO ACTION blocks the cascade).
+        sa.Column(
+            "tenant_id",
+            sa.Uuid(),
+            sa.ForeignKey("tenant.id"),
+            nullable=False,
+        ),
+        # The runner principal NAME (wire identity), not the UUID row id.
+        sa.Column("runner_id", sa.Text(), nullable=False),
+        sa.Column("op_id", sa.Text(), nullable=False),
+        sa.Column(
+            "params",
+            json_type,
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        # Nullable: targetless synthetic ops (net.*) carry no descriptor;
+        # NULL is the wire-compatible encoding of "targetless" (see docstring).
+        sa.Column("target_descriptor", json_type, nullable=True),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("result", json_type, nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("enqueued_by_sub", sa.Text(), nullable=False),
+        sa.Column(
+            "enqueued_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        # Closed enum -- portable IN(...) CHECK. Drift guard in test_migration.
+        sa.CheckConstraint(
+            _check_in("status", _GATEWAY_COMMAND_STATUSES),
+            name="ck_gateway_command_status",
+        ),
+    )
+
+    op.create_index(
+        "gateway_command_claim_idx",
+        "gateway_command",
+        ["tenant_id", "runner_id", "status", "enqueued_at"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Drop the claim index then the ``gateway_command`` table."""
+    op.drop_index("gateway_command_claim_idx", table_name="gateway_command")
+    op.drop_table("gateway_command")

--- a/backend/src/meho_backplane/api/v1/gateway.py
+++ b/backend/src/meho_backplane/api/v1/gateway.py
@@ -49,7 +49,8 @@ stream promotion). Each attempt opens a short-lived session, tries one
 and — on an empty queue — sleeps briefly before re-attempting. No DB
 transaction or pooled connection is held across the sleep, so the handler
 imports ``get_sessionmaker`` directly rather than taking a request-scoped
-``Depends(get_session)``.
+session dependency (which would keep one transaction open for the whole
+hold).
 """
 
 from __future__ import annotations

--- a/backend/src/meho_backplane/api/v1/gateway.py
+++ b/backend/src/meho_backplane/api/v1/gateway.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/api/v1/gateway/*`` — outbound long-poll command plane (runner-facing).
+
+Initiative #2415 (Remote execution gateway), Task #2498. Two routes a
+satellite runner dials outbound to receive and report centrally-authorized
+operations, over the durable ``gateway_command`` queue
+(:mod:`meho_backplane.gateway.queue`):
+
+* ``GET /api/v1/gateway/{runner}/next?wait=N`` — the blocking long-poll.
+  Holds up to ``N`` seconds (default 25, clamped to the exported
+  :data:`~meho_backplane.gateway.queue.GATEWAY_LONGPOLL_MAX_WAIT_SECONDS`;
+  ``wait=0`` = one immediate claim attempt), returning ``200`` with the
+  claimed command envelope or ``204 No Content`` on timeout.
+* ``POST /api/v1/gateway/{runner}/result`` — the runner reports an
+  outcome. ``200`` on success, ``404`` for an unknown/foreign command,
+  ``409`` for a non-``delivered`` row (duplicate report / never claimed).
+
+There is **no** HTTP enqueue endpoint: an enqueue surface not fronted by
+the policy gate would bypass the initiative's "all authorization stays
+central" principle. Central code enqueues via
+:func:`meho_backplane.gateway.queue.enqueue_command`; #2500's minting path
+(post-policy-gate) is the production caller.
+
+Auth (binding decision #2498-5)
+-------------------------------
+
+Both routes gate on the runner principal shipped by #2502 — **not** an
+operator JWT. :func:`~meho_backplane.auth.runner_guard.require_runner`
+admits only ``principal_kind=runner`` tokens; then
+:func:`~meho_backplane.auth.runner_guard.assert_runner_scope` binds the
+token's ``runner_id`` claim to the ``runner_principal`` row named by the
+``{runner}`` path segment, so a runner may only claim / report its own
+queue. Every query additionally filters ``tenant_id == operator.tenant_id``.
+A bare ``read_only`` role gate would let any human read_only principal
+destructively claim commands, and an operator-tier gate would 403 every
+runner token (runner tokens carry ``tenant_role=read_only``, rank 0) — so
+the runner-scope guard is the only correct gate here.
+
+Hold discipline (binding decision #2498-2)
+------------------------------------------
+
+The hold is a bounded claim-poll loop over Postgres, **not** an in-process
+``asyncio.Event`` (wrong under >1 replica: an enqueue on replica A cannot
+wake a hold on replica B) and **not** Valkey ``XREAD BLOCK`` (the deferred
+stream promotion). Each attempt opens a short-lived session, tries one
+:func:`~meho_backplane.gateway.queue.claim_next_command`, commits a win,
+and — on an empty queue — sleeps briefly before re-attempting. No DB
+transaction or pooled connection is held across the sleep, so the handler
+imports ``get_sessionmaker`` directly rather than taking a request-scoped
+``Depends(get_session)``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Annotated, Any, Final, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import status as http_status
+from pydantic import BaseModel, ConfigDict, Field
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.runner_guard import assert_runner_scope, require_runner
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GatewayCommand, GatewayCommandStatus
+from meho_backplane.gateway.queue import (
+    GATEWAY_LONGPOLL_DEFAULT_WAIT_SECONDS,
+    GATEWAY_LONGPOLL_MAX_WAIT_SECONDS,
+    GatewayCommandNotDeliveredError,
+    GatewayCommandNotFoundError,
+    claim_next_command,
+    clamp_longpoll_wait,
+    record_result,
+)
+
+__all__ = ["router"]
+
+_log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/gateway", tags=["gateway"])
+
+#: Module-level ``Depends`` closure — resolves the runner dependency once
+#: (FastAPI-idiomatic singleton) and avoids ruff B008. Same pattern as
+#: :mod:`meho_backplane.api.v1.approvals`'s ``_require_operator``.
+_require_runner = Depends(require_runner())
+
+#: Seconds between claim attempts while a long-poll holds an empty queue.
+#: Sized so an idle hold costs ~1 claim query/second; the runner re-polls
+#: immediately on a ``204``, so end-to-end delivery latency is bounded by
+#: this interval, not by the runner's tick cadence. Tests monkeypatch it
+#: down for a fast, deterministic hold assertion.
+_CLAIM_POLL_INTERVAL_SECONDS: Final[float] = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class GatewayCommandEnvelope(BaseModel):
+    """The claimed-command envelope returned by ``GET .../next`` (200)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: uuid.UUID
+    op_id: str
+    params: dict[str, Any]
+    # ``None`` for a targetless synthetic op (net.*); a resolved descriptor
+    # the runner's handler duck-reads otherwise.
+    target_descriptor: dict[str, Any] | None
+
+
+class GatewayResultBody(BaseModel):
+    """POST body for ``.../result`` — the runner's outcome report."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    command_id: uuid.UUID = Field(description="The delivered command's id.")
+    outcome: Literal["succeeded", "failed"] = Field(
+        description="Terminal outcome to record for the command."
+    )
+    result: dict[str, Any] | None = Field(
+        default=None,
+        description="Structured success payload (for a 'succeeded' outcome).",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Failure summary (for a 'failed' outcome).",
+    )
+
+
+class GatewayResultAck(BaseModel):
+    """Response for a successful ``.../result`` report (200)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    command_id: uuid.UUID
+    status: str  # "succeeded" | "failed"
+    completed_at: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _envelope(command: GatewayCommand) -> GatewayCommandEnvelope:
+    """Project a claimed :class:`GatewayCommand` row onto its wire envelope."""
+    return GatewayCommandEnvelope(
+        id=command.id,
+        op_id=command.op_id,
+        params=command.params,
+        target_descriptor=command.target_descriptor,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{runner}/next",
+    response_model=GatewayCommandEnvelope,
+    responses={
+        200: {"description": "A command was claimed; the envelope is returned."},
+        204: {"description": "No command became claimable before the wait deadline."},
+    },
+)
+async def poll_next_command(
+    runner: str,
+    wait: Annotated[
+        int,
+        Query(
+            ge=0,
+            description=(
+                "Long-poll hold in seconds. 0 = a single immediate claim attempt "
+                "(no hold). Values above the ceiling "
+                f"({GATEWAY_LONGPOLL_MAX_WAIT_SECONDS}s) are clamped down, not "
+                "rejected — the runner asking for a longer hold gets a bounded one."
+            ),
+        ),
+    ] = GATEWAY_LONGPOLL_DEFAULT_WAIT_SECONDS,
+    operator: Operator = _require_runner,
+) -> GatewayCommandEnvelope | Response:
+    """Long-poll for the next command queued for ``{runner}``.
+
+    Authenticated as the runner principal for ``{runner}`` (#2502's guard):
+    a runner may only poll its own queue. Holds up to ``wait`` seconds
+    (clamped to the exported ceiling) claiming the oldest ``pending``
+    command; returns ``200`` with the envelope on a claim or ``204`` on
+    timeout. The claim flips the row ``pending -> delivered`` durably.
+
+    The hold opens a fresh short-lived session per attempt and never holds
+    a DB transaction across the inter-attempt sleep (binding decision
+    #2498-2). A client disconnect cancels the handler; the
+    ``CancelledError`` is logged and re-raised per the asyncio contract.
+    """
+    sessionmaker = get_sessionmaker()
+
+    # Scope gate first: bind the token's runner_id to the named row (#2502).
+    async with sessionmaker() as session:
+        await assert_runner_scope(operator, runner_name=runner, session=session)
+
+    effective_wait = clamp_longpoll_wait(wait)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + effective_wait
+
+    try:
+        while True:
+            async with sessionmaker() as session:
+                command = await claim_next_command(
+                    session, tenant_id=operator.tenant_id, runner_id=runner
+                )
+                if command is not None:
+                    envelope = _envelope(command)
+                    await session.commit()
+                    return envelope
+            # Empty queue: hold until the deadline, sleeping in bounded steps
+            # with no session/transaction open across the sleep.
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return Response(status_code=http_status.HTTP_204_NO_CONTENT)
+            await asyncio.sleep(min(_CLAIM_POLL_INTERVAL_SECONDS, remaining))
+    except asyncio.CancelledError:
+        # Client disconnect — log + re-raise per the asyncio cancellation
+        # contract (Sonar S7497); never swallow the cancellation.
+        _log.info(
+            "gateway_poll_disconnected",
+            runner=runner,
+            operator_sub=operator.sub,
+        )
+        raise
+
+
+@router.post("/{runner}/result", response_model=GatewayResultAck)
+async def report_command_result(
+    runner: str,
+    body: GatewayResultBody,
+    operator: Operator = _require_runner,
+) -> GatewayResultAck:
+    """Report the outcome of a delivered command for ``{runner}``.
+
+    Authenticated as the runner principal for ``{runner}`` (#2502's guard).
+    Flips the command ``delivered -> succeeded|failed``, stamping the
+    result/error and ``completed_at``. Returns ``200`` with an ack; ``404``
+    when the command id is unknown or was enqueued for another runner /
+    tenant (no existence oracle); ``409`` when the command is not
+    ``delivered`` (a duplicate report or a never-claimed row).
+    """
+    sessionmaker = get_sessionmaker()
+    try:
+        async with sessionmaker() as session:
+            # Scope gate first (#2502), then record on the same session.
+            await assert_runner_scope(operator, runner_name=runner, session=session)
+            command = await record_result(
+                session,
+                tenant_id=operator.tenant_id,
+                runner_id=runner,
+                command_id=body.command_id,
+                outcome=GatewayCommandStatus(body.outcome),
+                result=body.result,
+                error=body.error,
+            )
+            ack = GatewayResultAck(
+                command_id=command.id,
+                status=command.status,
+                completed_at=command.completed_at.isoformat()
+                if command.completed_at is not None
+                else "",
+            )
+            await session.commit()
+    except GatewayCommandNotFoundError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="gateway_command_not_found",
+        ) from exc
+    except GatewayCommandNotDeliveredError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail=f"gateway_command_not_delivered: {exc.status}",
+        ) from exc
+    return ack

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4617,6 +4617,199 @@ class ApprovalRequest(Base):
 
 
 # ---------------------------------------------------------------------------
+# Gateway command queue (Initiative #2415 / #2498)
+# ---------------------------------------------------------------------------
+
+
+class GatewayCommandStatus(StrEnum):
+    """Closed lifecycle status of a :class:`GatewayCommand`.
+
+    Initiative #2415 (Remote execution gateway), Task #2498. The gateway
+    command plane parks a centrally-enqueued, pre-authorized operation
+    durably; the row walks a simple four-state lifecycle enforced by the
+    service (:mod:`meho_backplane.gateway.queue`).
+
+    Members:
+
+    * :attr:`PENDING` -- enqueued centrally, awaiting a runner claim
+      (initial state on insert).
+    * :attr:`DELIVERED` -- claimed by the runner's long-poll
+      (``pending`` flips to ``delivered`` under ``SELECT ... FOR UPDATE
+      SKIP LOCKED`` on PG / a conditional ``UPDATE`` on the SQLite test
+      path); ``delivered_at`` is stamped. A row that is claimed but never
+      reported stays here (lost, not redelivered -- the v1 at-most-once
+      failure mode).
+    * :attr:`SUCCEEDED` -- the runner reported a successful outcome via
+      ``POST .../result``; ``result`` + ``completed_at`` stamped. Terminal.
+    * :attr:`FAILED` -- the runner reported a failure; ``error`` +
+      ``completed_at`` stamped. Terminal.
+
+    The enum and the ``CHECK (status IN (...))`` constraint on the DB
+    table move in lock-step (migration ``0059``); the drift guard
+    :func:`tests.migrations.test_migration_0059_create_gateway_command.test_status_check_matches_enum`
+    asserts equality at unit-test time.
+    """
+
+    PENDING = "pending"
+    DELIVERED = "delivered"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+#: Closed ``gateway_command.status`` vocabulary derived from the enum --
+#: kept in sync with migration ``0059``'s ``_GATEWAY_COMMAND_STATUSES``
+#: literal. The drift guard asserts equality so the two never diverge.
+_GATEWAY_COMMAND_STATUSES: tuple[str, ...] = tuple(s.value for s in GatewayCommandStatus)
+
+
+class GatewayCommand(Base):
+    """One centrally-enqueued operation queued for a satellite runner.
+
+    Initiative #2415 (Remote execution gateway), Task #2498. Central code
+    enqueues a pre-authorized operation (via
+    :func:`meho_backplane.gateway.queue.enqueue_command`); the runner
+    claims it over the outbound long-poll
+    (``GET /api/v1/gateway/{runner}/next``) and reports the outcome back
+    (``POST /api/v1/gateway/{runner}/result``). The row is the durable
+    transport state that lets a central instance relay an operation to a
+    runner it cannot dial directly, without holding the request across a
+    process restart. Moulded on the ``approval_request`` durable-queue row
+    (#817): closed status enum + DB CHECK + drift guard, real tenant FK,
+    caller-owns-commit service functions.
+
+    Transport-only (binding decision, #2498): this schema stays strictly
+    transport. Capability binding (args-hash, expiry, request-id dedup) is
+    sibling #2500's own migration; nothing speculative lands here.
+
+    Schema decisions
+    ----------------
+
+    * ``id`` -- UUID primary key. PG-side ``gen_random_uuid()``; ORM
+      ``default=uuid.uuid4`` for SQLite.
+
+    * ``tenant_id`` -- UUID NOT NULL, real FK to ``tenant.id``. Clean-slate
+      table; hard FK enforced (no ondelete). Same discipline as
+      ``approval_request`` (0023) and ``runner_principal`` (0058).
+
+    * ``runner_id`` -- Text NOT NULL. The runner principal **name** (the
+      wire identity: #2498's ``{runner}`` path segment, ``MEHO_RUNNER_ID``
+      on the runner, ``RunnerResultBatch.runner_id`` on the wire). Named
+      ``runner_id`` to match that wire field; the guard binds the token's
+      ``runner_id`` UUID claim to the named ``runner_principal`` row before
+      any queue access, so filtering by name is correctly scoped.
+
+    * ``op_id`` -- Text NOT NULL. The operation the runner executes.
+
+    * ``params`` -- portable JSON NOT NULL DEFAULT ``{}`` (JSONB on PG).
+      The validated op params.
+
+    * ``target_descriptor`` -- portable JSON **nullable** (JSONB on PG).
+      The centrally-resolved target descriptor a connector handler
+      duck-reads (the runner has no local target table). Nullable because
+      targetless synthetic ops (``net.*``) carry no descriptor, which the
+      wire model encodes as ``RunnerWorkItem.target_descriptor:
+      ResolvedTargetDescriptor | None`` (#2497) -- NULL is the
+      wire-compatible encoding of "targetless".
+
+    * ``status`` -- Closed enum, DB ``CHECK``, default ``'pending'``.
+
+    * ``result`` -- portable JSON nullable (JSONB on PG). The runner's
+      success payload; NULL until reported.
+
+    * ``error`` -- Text nullable. The runner's failure summary; NULL until
+      a failure is reported.
+
+    * ``enqueued_by_sub`` -- Text NOT NULL. The ``sub`` of the principal
+      whose central dispatch enqueued the command (audit provenance).
+
+    * ``enqueued_at`` -- ``timestamptz`` NOT NULL. Drives the FIFO claim
+      order.
+
+    * ``delivered_at`` / ``completed_at`` -- ``timestamptz`` nullable.
+      Stamped on the ``pending -> delivered`` claim and the
+      ``delivered -> terminal`` report respectively.
+
+    Index
+    -----
+
+    * ``gateway_command_claim_idx`` -- composite ``(tenant_id, runner_id,
+      status, enqueued_at)``. Serves the hot claim query (oldest
+      ``pending`` row for a runner in a tenant) and the tenant/runner-scoped
+      result lookup.
+    """
+
+    __tablename__ = "gateway_command"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    # Real FK -- clean-slate substrate (see class docstring).
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    # The runner principal NAME (wire identity), not the UUID row id.
+    runner_id: Mapped[str] = mapped_column(Text, nullable=False)
+    op_id: Mapped[str] = mapped_column(Text, nullable=False)
+    params: Mapped[dict[str, object]] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=False,
+        default=dict,
+    )
+    # Nullable -- NULL is the wire-compatible "targetless" encoding.
+    target_descriptor: Mapped[dict[str, object] | None] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=True,
+        default=None,
+    )
+    status: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default=GatewayCommandStatus.PENDING.value,
+    )
+    result: Mapped[dict[str, object] | None] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=True,
+        default=None,
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    enqueued_by_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    enqueued_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    delivered_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+
+    __table_args__ = (
+        Index(
+            "gateway_command_claim_idx",
+            "tenant_id",
+            "runner_id",
+            "status",
+            "enqueued_at",
+            postgresql_using="btree",
+        ),
+        sa.CheckConstraint(
+            _ck_in("status", _GATEWAY_COMMAND_STATUSES),
+            name="ck_gateway_command_status",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Event outbox (G11.3-T3 / #824)
 # ---------------------------------------------------------------------------
 

--- a/backend/src/meho_backplane/gateway/__init__.py
+++ b/backend/src/meho_backplane/gateway/__init__.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Central side of the remote-execution gateway command plane (#2415).
+
+Task #2498. Re-exports the durable ``gateway_command`` queue service so
+consumers (the runner-facing routes in :mod:`meho_backplane.api.v1.gateway`
+and #2500's capability-minting path) import from the package root.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.gateway.queue import (
+    GATEWAY_LONGPOLL_DEFAULT_WAIT_SECONDS,
+    GATEWAY_LONGPOLL_MAX_WAIT_SECONDS,
+    GatewayCommandNotDeliveredError,
+    GatewayCommandNotFoundError,
+    claim_next_command,
+    clamp_longpoll_wait,
+    enqueue_command,
+    record_result,
+)
+
+__all__ = [
+    "GATEWAY_LONGPOLL_DEFAULT_WAIT_SECONDS",
+    "GATEWAY_LONGPOLL_MAX_WAIT_SECONDS",
+    "GatewayCommandNotDeliveredError",
+    "GatewayCommandNotFoundError",
+    "claim_next_command",
+    "clamp_longpoll_wait",
+    "enqueue_command",
+    "record_result",
+]

--- a/backend/src/meho_backplane/gateway/queue.py
+++ b/backend/src/meho_backplane/gateway/queue.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Durable command-queue service for the outbound gateway command plane.
+
+Initiative #2415 (Remote execution gateway), Task #2498. The central side
+of the push-only command plane: a durable ``gateway_command`` queue
+(:class:`~meho_backplane.db.models.GatewayCommand`) plus the three service
+functions the runner-facing routes (:mod:`meho_backplane.api.v1.gateway`)
+call through.
+
+* :func:`enqueue_command` — central code parks a pre-authorized operation
+  for a runner. No HTTP enqueue endpoint exists: an enqueue surface not
+  fronted by the policy gate would bypass the initiative's "all
+  authorization stays central" principle. #2500's capability-minting path
+  (post-policy-gate) is the production caller; tests enqueue directly.
+* :func:`claim_next_command` — one FIFO claim attempt: the oldest
+  ``pending`` row for ``(tenant_id, runner_id)`` flips to ``delivered``.
+  Multi-replica-safe via ``SELECT ... FOR UPDATE SKIP LOCKED`` on
+  PostgreSQL (moulded on :func:`meho_backplane.scheduler.repository.claim_due_triggers`,
+  #804) with a conditional-``UPDATE`` fallback on the SQLite test path so
+  two in-process claimers still deliver a row at most once.
+* :func:`record_result` — the runner reports an outcome, flipping
+  ``delivered -> succeeded|failed``. Distinguishes an unknown / foreign
+  command (404) from a non-``delivered`` row (409) for the route's
+  status-code split.
+
+Transaction discipline
+----------------------
+
+Every mutating function takes an open
+:class:`~sqlalchemy.ext.asyncio.AsyncSession`, flushes its changes, and
+returns — the **caller** owns the commit (mould:
+:mod:`meho_backplane.operations.approval_queue`). The long-poll handler
+opens a fresh short-lived session per claim attempt (never holding a DB
+transaction across its ``asyncio.sleep``) and commits a won claim itself.
+
+Hold-window ceiling
+-------------------
+
+:data:`GATEWAY_LONGPOLL_MAX_WAIT_SECONDS` is the exported cap on the
+long-poll hold. It lives here (not buried in the route closure) as an
+importable seam: #2501's dead-man threshold is a multiple of it. The
+route clamps the caller's ``wait`` to it via :func:`clamp_longpoll_wait`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Final
+
+import structlog
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.models import GatewayCommand, GatewayCommandStatus
+
+__all__ = [
+    "GATEWAY_LONGPOLL_DEFAULT_WAIT_SECONDS",
+    "GATEWAY_LONGPOLL_MAX_WAIT_SECONDS",
+    "GatewayCommandNotDeliveredError",
+    "GatewayCommandNotFoundError",
+    "claim_next_command",
+    "clamp_longpoll_wait",
+    "enqueue_command",
+    "record_result",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Ceiling on a single long-poll hold, in seconds. Sizing mirrors the SSE
+#: feed's intermediary-idle-timeout rationale (nginx ``proxy_read_timeout``
+#: / ALB idle default 60 s -- hold well below it so an idle-timeout kill
+#: never races a claim): the runner re-polls immediately on a ``204``.
+#: Exported (not a route-local literal) because #2501's dead-man threshold
+#: is a multiple of this constant.
+GATEWAY_LONGPOLL_MAX_WAIT_SECONDS: Final[int] = 30
+
+#: Default ``wait`` when the runner does not specify one. Below the ceiling
+#: so the common poll self-bounds without relying on the clamp.
+GATEWAY_LONGPOLL_DEFAULT_WAIT_SECONDS: Final[int] = 25
+
+
+def clamp_longpoll_wait(requested: int) -> int:
+    """Clamp a caller-requested ``wait`` into ``[0, ceiling]``.
+
+    ``wait=0`` means a single immediate claim attempt (no hold); a value
+    above :data:`GATEWAY_LONGPOLL_MAX_WAIT_SECONDS` is clamped **down** to
+    the ceiling rather than rejected — a runner asking for a longer hold
+    gets a bounded hold, not a 422 (binding decision #2498-3). A negative
+    value (shouldn't reach here past the ``Query(ge=0)`` bound) floors at 0.
+    """
+    return min(max(requested, 0), GATEWAY_LONGPOLL_MAX_WAIT_SECONDS)
+
+
+class GatewayCommandNotFoundError(Exception):
+    """No :class:`GatewayCommand` matches ``(command_id, tenant_id, runner_id)``.
+
+    Raised by :func:`record_result` when the id does not resolve, belongs
+    to a different tenant, or was enqueued for a different runner — the
+    three cases are indistinguishable to the caller (no cross-tenant /
+    cross-runner existence oracle). The route layer maps this to 404.
+    """
+
+    def __init__(self, command_id: uuid.UUID) -> None:
+        self.command_id = command_id
+        super().__init__(f"no gateway_command row for id {command_id} in this runner's queue")
+
+
+class GatewayCommandNotDeliveredError(Exception):
+    """The command exists but is not in the ``delivered`` state.
+
+    Raised by :func:`record_result` when the row is still ``pending``
+    (never claimed) or already terminal (``succeeded`` / ``failed`` — a
+    duplicate report). The route layer maps this to 409 (conflict).
+    """
+
+    def __init__(self, command_id: uuid.UUID, status: str) -> None:
+        self.command_id = command_id
+        self.status = status
+        super().__init__(
+            f"gateway_command {command_id} is {status!r}, not 'delivered'; "
+            "only a delivered command accepts a result"
+        )
+
+
+async def enqueue_command(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    runner_id: str,
+    op_id: str,
+    params: dict[str, Any],
+    enqueued_by_sub: str,
+    target_descriptor: dict[str, Any] | None = None,
+) -> GatewayCommand:
+    """Insert a ``pending`` :class:`GatewayCommand` for a runner.
+
+    The single central enqueue path (no HTTP surface). Flushes, not
+    committed — the caller owns the commit so the enqueue can compose with
+    the minting transaction (#2500).
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        tenant_id: The owning tenant.
+        runner_id: The runner principal **name** (wire identity) the
+            command is queued for.
+        op_id: The operation the runner will execute.
+        params: The validated op params. Stored verbatim.
+        enqueued_by_sub: The ``sub`` of the principal whose central
+            dispatch enqueued the command (audit provenance).
+        target_descriptor: The centrally-resolved target descriptor a
+            handler duck-reads, or ``None`` for a targetless synthetic op
+            (``net.*``).
+
+    Returns:
+        The flushed :class:`GatewayCommand` row (with its generated ``id``).
+    """
+    command = GatewayCommand(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        runner_id=runner_id,
+        op_id=op_id,
+        params=params,
+        target_descriptor=target_descriptor,
+        status=GatewayCommandStatus.PENDING.value,
+        enqueued_by_sub=enqueued_by_sub,
+        enqueued_at=datetime.now(UTC),
+    )
+    session.add(command)
+    await session.flush()
+    _log.info(
+        "gateway_command_enqueued",
+        command_id=str(command.id),
+        tenant_id=str(tenant_id),
+        runner_id=runner_id,
+        op_id=op_id,
+    )
+    return command
+
+
+async def claim_next_command(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    runner_id: str,
+) -> GatewayCommand | None:
+    """Claim the oldest ``pending`` command for a runner; flip it ``delivered``.
+
+    One FIFO claim attempt. On PostgreSQL the candidate row is selected
+    ``FOR UPDATE SKIP LOCKED`` so a second claimer in another transaction
+    (another replica / pod) sees zero rows for a row this transaction has
+    locked — the row lock releases on the caller's commit / rollback. On
+    SQLite (the test path) the locking clause no-ops; the conditional
+    ``UPDATE ... WHERE status='pending'`` is what enforces claim-at-most-once
+    across two in-process claimers sharing the connection pool (mould:
+    :func:`meho_backplane.scheduler.repository.claim_due_triggers` /
+    :func:`~meho_backplane.scheduler.repository.advance_cron_trigger`, #804).
+
+    Returns the delivered row (``status='delivered'``, ``delivered_at``
+    stamped) on a win, or ``None`` when the queue is empty **or** a
+    concurrent claimer won the row between the SELECT and the UPDATE.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed. The
+            caller commits to persist the ``pending -> delivered`` flip.
+        tenant_id: The runner's tenant (every query is tenant-scoped).
+        runner_id: The runner principal name whose queue to claim from.
+    """
+    conn = await session.connection()
+    stmt = (
+        select(GatewayCommand)
+        .where(
+            GatewayCommand.tenant_id == tenant_id,
+            GatewayCommand.runner_id == runner_id,
+            GatewayCommand.status == GatewayCommandStatus.PENDING.value,
+        )
+        .order_by(GatewayCommand.enqueued_at.asc())
+        .limit(1)
+    )
+    if conn.dialect.name == "postgresql":
+        stmt = stmt.with_for_update(skip_locked=True)
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return None
+
+    now = datetime.now(UTC)
+    # Conditional flip: the predicate + write commit together, so a second
+    # in-process claimer that SELECTed the same pending row loses (0 rows).
+    result = await session.execute(
+        update(GatewayCommand)
+        .where(
+            GatewayCommand.id == row.id,
+            GatewayCommand.status == GatewayCommandStatus.PENDING.value,
+        )
+        .values(status=GatewayCommandStatus.DELIVERED.value, delivered_at=now)
+    )
+    await session.flush()
+    rowcount: int = result.rowcount  # type: ignore[attr-defined]
+    if rowcount == 0:
+        return None
+    # Reflect the flip on the local row so the caller sees it without a
+    # re-query (mould: advance_cron_trigger).
+    row.status = GatewayCommandStatus.DELIVERED.value
+    row.delivered_at = now
+    _log.info(
+        "gateway_command_delivered",
+        command_id=str(row.id),
+        tenant_id=str(tenant_id),
+        runner_id=runner_id,
+        op_id=row.op_id,
+    )
+    return row
+
+
+async def record_result(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    runner_id: str,
+    command_id: uuid.UUID,
+    outcome: GatewayCommandStatus,
+    result: dict[str, Any] | None = None,
+    error: str | None = None,
+) -> GatewayCommand:
+    """Record a runner's outcome on a ``delivered`` command.
+
+    Flips ``delivered -> succeeded|failed``, stamps ``result`` / ``error``
+    and ``completed_at``. The precondition ladder gives the route its
+    404/409 split:
+
+    1. The row must resolve within ``(tenant_id, runner_id)`` — else
+       :class:`GatewayCommandNotFoundError` (404). Unknown id, a command
+       enqueued for another runner, and a cross-tenant id are all the same
+       404 (no existence oracle).
+    2. The row must be ``delivered`` — else
+       :class:`GatewayCommandNotDeliveredError` (409). A duplicate report
+       (already terminal) and a never-claimed ``pending`` row both 409.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        tenant_id: The runner's tenant.
+        runner_id: The runner principal name the command was queued for.
+        command_id: The command row's id.
+        outcome: Terminal state to record — ``SUCCEEDED`` or ``FAILED``.
+        result: The success payload (for ``SUCCEEDED``); may be ``None``.
+        error: The failure summary (for ``FAILED``); may be ``None``.
+
+    Returns:
+        The updated, flushed :class:`GatewayCommand`.
+
+    Raises:
+        ValueError: *outcome* is not a terminal state.
+        GatewayCommandNotFoundError: No row in this runner's queue.
+        GatewayCommandNotDeliveredError: Row is not ``delivered``.
+    """
+    if outcome not in (GatewayCommandStatus.SUCCEEDED, GatewayCommandStatus.FAILED):
+        raise ValueError(f"outcome must be 'succeeded' or 'failed'; got {outcome!r}")
+
+    row = await session.get(GatewayCommand, command_id)
+    if row is None or row.tenant_id != tenant_id or row.runner_id != runner_id:
+        raise GatewayCommandNotFoundError(command_id)
+    if row.status != GatewayCommandStatus.DELIVERED.value:
+        raise GatewayCommandNotDeliveredError(command_id, row.status)
+
+    now = datetime.now(UTC)
+    # Conditional on status='delivered' so a concurrent identical report
+    # loses the race (0 rows) rather than double-writing the outcome.
+    upd = await session.execute(
+        update(GatewayCommand)
+        .where(
+            GatewayCommand.id == command_id,
+            GatewayCommand.status == GatewayCommandStatus.DELIVERED.value,
+        )
+        .values(status=outcome.value, result=result, error=error, completed_at=now)
+    )
+    await session.flush()
+    rowcount: int = upd.rowcount  # type: ignore[attr-defined]
+    if rowcount == 0:
+        # A concurrent report flipped it terminal between our load + UPDATE.
+        await session.refresh(row)
+        raise GatewayCommandNotDeliveredError(command_id, row.status)
+
+    row.status = outcome.value
+    row.result = result
+    row.error = error
+    row.completed_at = now
+    _log.info(
+        "gateway_command_reported",
+        command_id=str(command_id),
+        tenant_id=str(tenant_id),
+        runner_id=runner_id,
+        outcome=outcome.value,
+    )
+    return row

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -82,6 +82,7 @@ from meho_backplane.api.v1.connectors_ingest import (
 from meho_backplane.api.v1.conventions import router as api_v1_conventions_router
 from meho_backplane.api.v1.doc_collections import router as api_v1_doc_collections_router
 from meho_backplane.api.v1.feed import router as api_v1_feed_router
+from meho_backplane.api.v1.gateway import router as api_v1_gateway_router
 from meho_backplane.api.v1.health import router as api_v1_health_router
 from meho_backplane.api.v1.kb import router as api_v1_kb_router
 from meho_backplane.api.v1.memory import router as api_v1_memory_router
@@ -890,6 +891,15 @@ app.include_router(api_v1_agent_principals_router)
 # the JWT; cross-tenant probes return 404. The minted runner token is caged
 # to the gateway path prefixes (see middleware.RUNNER_ALLOWED_PATH_PREFIXES).
 app.include_router(api_v1_runner_principals_router)
+# Initiative #2415 (#2498) -- outbound long-poll command plane (runner-facing).
+# GET /gateway/{runner}/next (blocking long-poll: 200 with a claimed command
+# envelope or 204 on timeout) + POST /gateway/{runner}/result (200 / 404 / 409).
+# Both gate on the runner principal (#2502's require_runner + assert_runner_scope),
+# NOT an operator JWT -- a runner may only poll/report its own queue; every query
+# filters tenant_id. No HTTP enqueue endpoint (central enqueues via
+# gateway.queue.enqueue_command so authorization stays central). Mounted under the
+# /api/v1/gateway/ cage prefix (see middleware.RUNNER_ALLOWED_PATH_PREFIXES).
+app.include_router(api_v1_gateway_router)
 # G11.3-T5 (#826) -- scheduler-admin surface. GET /scheduler/triggers
 # (list, paginated, operator-level), POST /scheduler/triggers (create,
 # tenant_admin), DELETE /scheduler/triggers/{id} (cancel, tenant_admin).

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -204,6 +204,13 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # errors at setup with ``cannot truncate a table referenced in a
     # foreign key constraint`` (the recurring fixture gotcha #1064 / #1065).
     "event_outbox",
+    # ``gateway_command.tenant_id`` is a real ``REFERENCES tenant(id)`` FK
+    # from migration ``0059`` (Initiative #2415 T2, #2498). Same rule: PG
+    # rejects truncating ``tenant`` unless every referencing table is listed
+    # in the same statement, so ``gateway_command`` must appear here or every
+    # PG-backed acceptance test errors at setup with ``cannot truncate a
+    # table referenced in a foreign key constraint``.
+    "gateway_command",
     # ``graph_edge_history`` carries a real FK ``graph_edge(id) ON DELETE
     # SET NULL`` per migration ``0012`` (#856 T1); the same applies to
     # ``graph_node_history``. PG rejects a TRUNCATE on the parent table

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -425,11 +425,14 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   FK to ``tenant(id)``; omitting it causes PG to reject the
         #   TRUNCATE with ``cannot truncate a table referenced in a foreign
         #   key constraint`` (the recurring fixture gotcha #1064 / #1065 hit).
+        # * ``gateway_command`` — migration 0059 (Initiative #2415 T2, #2498)
+        #   carries a real ``REFERENCES tenant(id)`` FK; same rule, must be
+        #   listed here or PG rejects the per-test TRUNCATE.
         await conn.execute(
             text(
                 "TRUNCATE TABLE approval_request, agent_permission, "
                 "agent_principal, runner_principal, "
-                "scheduled_trigger, event_outbox, "
+                "scheduled_trigger, event_outbox, gateway_command, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "
@@ -494,7 +497,7 @@ async def pg_engine_empty_tenant(
             text(
                 "TRUNCATE TABLE approval_request, agent_permission, "
                 "agent_principal, runner_principal, "
-                "scheduled_trigger, event_outbox, "
+                "scheduled_trigger, event_outbox, gateway_command, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "

--- a/backend/tests/migrations/test_migration_0059_create_gateway_command.py
+++ b/backend/tests/migrations/test_migration_0059_create_gateway_command.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0059_create_gateway_command``.
+
+Initiative #2415 (Remote execution gateway), Task #2498. Creates the
+``gateway_command`` queue table — the durable transport state the outbound
+long-poll command plane claims from and reports onto.
+
+Asserts the table + its columns land, the claim index exists, the
+``status`` CHECK constraint rejects an out-of-vocabulary value, the
+migration round-trips (downgrade drops it, re-upgrade recreates it), and
+the migration's recorded status vocabulary agrees with the model enum
+(:class:`~meho_backplane.db.models.GatewayCommandStatus`) — the drift
+guard.
+
+**Idempotency pinning (0049/0050/0053/0055 footgun).** Every forward /
+round-trip step targets this migration's **own** revision (``0059``) and
+its ``down_revision`` (``0058``), never ``head`` — so a future head
+migration cannot make ``upgrade("head")`` re-run this ``create_table`` on
+a schema that already has it. SQLite is the test driver and the migration
+uses only generic DDL, so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.db.models import GatewayCommandStatus
+from meho_backplane.settings import get_settings
+
+_REVISION = "0059"
+_DOWN_REVISION = "0058"
+_TABLE = "gateway_command"
+_EXPECTED_COLUMNS = {
+    "id",
+    "tenant_id",
+    "runner_id",
+    "op_id",
+    "params",
+    "target_descriptor",
+    "status",
+    "result",
+    "error",
+    "enqueued_by_sub",
+    "enqueued_at",
+    "delivered_at",
+    "completed_at",
+}
+_EXPECTED_INDEXES = {"gateway_command_claim_idx"}
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0059.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _table_names(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type = 'table'")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def _columns(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({_TABLE})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _index_names(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type = 'index'")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def test_upgrade_creates_table_columns_and_index(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0059`` creates ``gateway_command`` with its columns + claim index."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    assert _TABLE in _table_names(sync_url)
+    assert _columns(sync_url) >= _EXPECTED_COLUMNS
+    assert _index_names(sync_url) >= _EXPECTED_INDEXES
+
+
+def test_status_check_constraint_rejects_unknown_value(alembic_cfg: tuple[Config, str]) -> None:
+    """The ``status`` CHECK constraint bounds the enum to the four known values."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        # FK enforcement stays off (SQLite default) so the bogus tenant_id
+        # does not mask the status CHECK we are exercising.
+        with sync_eng.begin() as conn, pytest.raises(IntegrityError):
+            conn.execute(
+                text(
+                    "INSERT INTO gateway_command "
+                    "(id, tenant_id, runner_id, op_id, params, status, "
+                    "enqueued_by_sub, enqueued_at) "
+                    "VALUES ('cmd-1', 'ten-1', 'runner-a', 'net.ping', '{}', "
+                    "'bogus', 'sub-1', '2026-07-15')"
+                )
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0058"`` drops the table; ``upgrade "0059"`` recreates it.
+
+    Pinned to this migration's own revision on both legs (never ``head``)
+    so a future head migration cannot break the round-trip.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _TABLE in _table_names(sync_url)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert _TABLE not in _table_names(sync_url), "downgrade must drop gateway_command"
+    assert not (_EXPECTED_INDEXES & _index_names(sync_url)), (
+        "downgrade must drop the claim index too"
+    )
+
+    command.upgrade(cfg, _REVISION)
+    assert _TABLE in _table_names(sync_url)
+
+
+def _load_migration_0059() -> object:
+    """Load migration ``0059`` as a module via its file path.
+
+    Alembic version files are digit-prefixed and not importable as normal
+    dotted modules; loading by file path with :mod:`importlib.util` is the
+    robust way to reach the migration's recorded literal tuple.
+    """
+    import importlib.util
+
+    path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "alembic"
+        / "versions"
+        / "0059_create_gateway_command.py"
+    )
+    spec = importlib.util.spec_from_file_location("_migration_0059", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def test_status_check_matches_enum() -> None:
+    """The migration's status vocabulary matches :class:`GatewayCommandStatus`.
+
+    Drift guard: if a new member is added to the enum without a migration
+    update (or vice versa), this test catches the mismatch — the same
+    lock-step discipline as ``test_migration_0023_approval_request``.
+    """
+    migration = _load_migration_0059()
+
+    model_values = {s.value for s in GatewayCommandStatus}
+    migration_values = set(migration._GATEWAY_COMMAND_STATUSES)  # type: ignore[attr-defined]
+    assert model_values == migration_values

--- a/backend/tests/test_api_v1_gateway.py
+++ b/backend/tests/test_api_v1_gateway.py
@@ -1,0 +1,498 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Coverage for the outbound long-poll gateway command plane (#2415, #2498).
+
+Two layers:
+
+* **Route edge** — the runner-facing ``GET /api/v1/gateway/{runner}/next``
+  and ``POST /api/v1/gateway/{runner}/result`` over a minimal app carrying
+  the real ``RequestContextMiddleware`` (so #2502's route cage + runner
+  guard run for real). Tokens are minted with the shared
+  ``_oidc_jwt_helpers`` runner knobs; JWKS discovery is stubbed via
+  :mod:`respx`. App requests ride an explicit :class:`ASGITransport`
+  (which respx does not intercept), so the app's internal JWKS fetch is
+  the only thing respx mocks.
+* **Service** — :mod:`meho_backplane.gateway.queue`'s enqueue / claim /
+  record functions directly, for the concurrency (exactly-one-claimer),
+  tenant-isolation, and clamp assertions that are cleaner without HTTP.
+
+The ``gateway_command`` table is created by migration ``0059``, which the
+per-test schema template replays, so the autouse ``_default_database_url``
+DB has it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from collections.abc import AsyncIterator, Iterator
+
+import httpx
+import pytest
+import respx
+from fastapi import FastAPI
+from httpx import ASGITransport
+from sqlalchemy import select
+
+import meho_backplane.api.v1.gateway as gateway_route
+from meho_backplane.api.v1.gateway import router as gateway_router
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GatewayCommand, GatewayCommandStatus, RunnerPrincipal, Tenant
+from meho_backplane.gateway.queue import (
+    GATEWAY_LONGPOLL_MAX_WAIT_SECONDS,
+    GatewayCommandNotDeliveredError,
+    GatewayCommandNotFoundError,
+    claim_next_command,
+    clamp_longpoll_wait,
+    enqueue_command,
+    record_result,
+)
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import (
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_TENANT_B = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+_RUNNER_A_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_RUNNER_B_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+_RUNNER_A_NAME = "runner-a"
+_RUNNER_B_NAME = "runner-b"
+
+_TARGET_DESCRIPTOR = {"name": "vc01", "product": "vmware-vcenter", "version": "8.0"}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+def _build_app() -> FastAPI:
+    """A minimal app mounting the gateway router under the real middleware."""
+    app = FastAPI()
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(gateway_router)
+    return app
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=_build_app()),
+        base_url="https://testserver",
+    ) as ac:
+        yield ac
+
+
+async def _seed() -> None:
+    """Seed two tenants + runner-a / runner-b (both in tenant A)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        for tid, slug in ((_TENANT_A, "tenant-a"), (_TENANT_B, "tenant-b")):
+            if (
+                await session.execute(select(Tenant).where(Tenant.id == tid))
+            ).scalar_one_or_none() is None:
+                session.add(Tenant(id=tid, slug=slug, name=slug))
+        for rid, rname in ((_RUNNER_A_ID, _RUNNER_A_NAME), (_RUNNER_B_ID, _RUNNER_B_NAME)):
+            if (
+                await session.execute(select(RunnerPrincipal).where(RunnerPrincipal.id == rid))
+            ).scalar_one_or_none() is None:
+                session.add(
+                    RunnerPrincipal(
+                        id=rid,
+                        tenant_id=_TENANT_A,
+                        name=rname,
+                        keycloak_client_id=f"runner:{rname}",
+                        keycloak_internal_id=f"kc-{rname}",
+                        owner_sub="op-admin",
+                        revoked=False,
+                        created_by_sub="op-admin",
+                    )
+                )
+        await session.commit()
+
+
+def _runner_token(key: object, *, runner_id: uuid.UUID, tenant_id: uuid.UUID = _TENANT_A) -> str:
+    return mint_token(
+        key,
+        sub="runner-sub",
+        tenant_id=str(tenant_id),
+        tenant_role="read_only",
+        principal_kind="runner",
+        runner_id=str(runner_id),
+    )
+
+
+def _user_token(key: object) -> str:
+    return mint_token(key, sub="user-sub", tenant_id=str(_TENANT_A), tenant_role="operator")
+
+
+async def _enqueue(
+    *,
+    tenant_id: uuid.UUID,
+    runner_id: str,
+    op_id: str = "net.ping",
+    params: dict[str, object] | None = None,
+    target_descriptor: dict[str, object] | None = None,
+) -> uuid.UUID:
+    """Enqueue one command (committed) and return its id."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        command = await enqueue_command(
+            session,
+            tenant_id=tenant_id,
+            runner_id=runner_id,
+            op_id=op_id,
+            params=params if params is not None else {"host": "10.0.0.1"},
+            enqueued_by_sub="enqueuer-sub",
+            target_descriptor=target_descriptor,
+        )
+        await session.commit()
+        return command.id
+
+
+async def _get_row(command_id: uuid.UUID) -> GatewayCommand | None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        return await session.get(GatewayCommand, command_id)
+
+
+# ---------------------------------------------------------------------------
+# GET /next — claim + hold behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_next_empty_queue_immediate_204(client: httpx.AsyncClient) -> None:
+    """An empty queue with ``wait=0`` returns ``204`` after one claim attempt."""
+    await _seed()
+    key = make_rsa_keypair("kid-A")
+    jwks = public_jwks(key)
+    token = _runner_token(key, runner_id=_RUNNER_A_ID)
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, jwks)
+        resp = await client.get(
+            f"/api/v1/gateway/{_RUNNER_A_NAME}/next?wait=0",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 204
+    assert resp.content == b""
+
+
+@pytest.mark.asyncio
+async def test_next_returns_envelope_and_marks_delivered(client: httpx.AsyncClient) -> None:
+    """Enqueue then ``next?wait=0`` returns the envelope; the row is delivered."""
+    await _seed()
+    command_id = await _enqueue(
+        tenant_id=_TENANT_A,
+        runner_id=_RUNNER_A_NAME,
+        op_id="net.ping",
+        params={"host": "10.0.0.1"},
+        target_descriptor=_TARGET_DESCRIPTOR,
+    )
+    key = make_rsa_keypair("kid-A")
+    jwks = public_jwks(key)
+    token = _runner_token(key, runner_id=_RUNNER_A_ID)
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, jwks)
+        resp = await client.get(
+            f"/api/v1/gateway/{_RUNNER_A_NAME}/next?wait=0",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == str(command_id)
+    assert body["op_id"] == "net.ping"
+    assert body["params"] == {"host": "10.0.0.1"}
+    assert body["target_descriptor"] == _TARGET_DESCRIPTOR
+
+    row = await _get_row(command_id)
+    assert row is not None
+    assert row.status == GatewayCommandStatus.DELIVERED.value
+    assert row.delivered_at is not None
+
+
+@pytest.mark.asyncio
+async def test_next_long_poll_wakes_on_enqueue_before_deadline(
+    client: httpx.AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A held ``wait=5`` poll returns ``200`` when a command is enqueued mid-hold."""
+    await _seed()
+    # Tight poll interval so the hold reacts fast + the test stays quick.
+    monkeypatch.setattr(gateway_route, "_CLAIM_POLL_INTERVAL_SECONDS", 0.05)
+    key = make_rsa_keypair("kid-A")
+    jwks = public_jwks(key)
+    token = _runner_token(key, runner_id=_RUNNER_A_ID)
+
+    async def _enqueue_after_delay() -> uuid.UUID:
+        await asyncio.sleep(0.3)
+        return await _enqueue(tenant_id=_TENANT_A, runner_id=_RUNNER_A_NAME)
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, jwks)
+        started = time.monotonic()
+        poll_task = asyncio.create_task(
+            client.get(
+                f"/api/v1/gateway/{_RUNNER_A_NAME}/next?wait=5",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        )
+        command_id = await _enqueue_after_delay()
+        resp = await poll_task
+        elapsed = time.monotonic() - started
+
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(command_id)
+    assert elapsed < 5.0, (
+        f"poll should return on enqueue, not at the deadline (took {elapsed:.2f}s)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /result — report lifecycle + status-code split
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_result_records_outcome_then_conflicts_on_replay(
+    client: httpx.AsyncClient,
+) -> None:
+    """A delivered command accepts one result (200) then 409s on a replay."""
+    await _seed()
+    command_id = await _enqueue(tenant_id=_TENANT_A, runner_id=_RUNNER_A_NAME)
+    # Claim it (pending -> delivered) so a result is accepted.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await claim_next_command(session, tenant_id=_TENANT_A, runner_id=_RUNNER_A_NAME)
+        await session.commit()
+
+    key = make_rsa_keypair("kid-A")
+    jwks = public_jwks(key)
+    token = _runner_token(key, runner_id=_RUNNER_A_ID)
+    payload = {
+        "command_id": str(command_id),
+        "outcome": "succeeded",
+        "result": {"reachable": True},
+    }
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, jwks)
+        first = await client.post(
+            f"/api/v1/gateway/{_RUNNER_A_NAME}/result",
+            headers={"Authorization": f"Bearer {token}"},
+            json=payload,
+        )
+        second = await client.post(
+            f"/api/v1/gateway/{_RUNNER_A_NAME}/result",
+            headers={"Authorization": f"Bearer {token}"},
+            json=payload,
+        )
+
+    assert first.status_code == 200
+    assert first.json()["status"] == "succeeded"
+    assert second.status_code == 409
+
+    row = await _get_row(command_id)
+    assert row is not None
+    assert row.status == GatewayCommandStatus.SUCCEEDED.value
+    assert row.result == {"reachable": True}
+    assert row.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_result_foreign_command_returns_404(client: httpx.AsyncClient) -> None:
+    """A result naming a command enqueued for another runner is 404 (no oracle)."""
+    await _seed()
+    # Enqueue + deliver a command for runner-b, then POST it as runner-a.
+    command_id = await _enqueue(tenant_id=_TENANT_A, runner_id=_RUNNER_B_NAME)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await claim_next_command(session, tenant_id=_TENANT_A, runner_id=_RUNNER_B_NAME)
+        await session.commit()
+
+    key = make_rsa_keypair("kid-A")
+    jwks = public_jwks(key)
+    token = _runner_token(key, runner_id=_RUNNER_A_ID)
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, jwks)
+        resp = await client.post(
+            f"/api/v1/gateway/{_RUNNER_A_NAME}/result",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"command_id": str(command_id), "outcome": "succeeded"},
+        )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "gateway_command_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Auth matrix — the runner-scope guard (#2502) on both routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_next_non_runner_token_forbidden(client: httpx.AsyncClient) -> None:
+    """A human operator JWT is 403 on the poll route (require_runner)."""
+    await _seed()
+    key = make_rsa_keypair("kid-A")
+    jwks = public_jwks(key)
+    token = _user_token(key)
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, jwks)
+        resp = await client.get(
+            f"/api/v1/gateway/{_RUNNER_A_NAME}/next?wait=0",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "runner_scope_violation"
+
+
+@pytest.mark.asyncio
+async def test_result_non_runner_token_forbidden(client: httpx.AsyncClient) -> None:
+    """A human operator JWT is 403 on the result route too (require_runner)."""
+    await _seed()
+    key = make_rsa_keypair("kid-A")
+    jwks = public_jwks(key)
+    token = _user_token(key)
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, jwks)
+        resp = await client.post(
+            f"/api/v1/gateway/{_RUNNER_A_NAME}/result",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"command_id": str(uuid.uuid4()), "outcome": "succeeded"},
+        )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "runner_scope_violation"
+
+
+@pytest.mark.asyncio
+async def test_next_runner_scope_mismatch_forbidden(client: httpx.AsyncClient) -> None:
+    """A runner token for runner-a on runner-b's route is 403 runner_scope_violation."""
+    await _seed()
+    key = make_rsa_keypair("kid-A")
+    jwks = public_jwks(key)
+    token = _runner_token(key, runner_id=_RUNNER_A_ID)
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, jwks)
+        resp = await client.get(
+            f"/api/v1/gateway/{_RUNNER_B_NAME}/next?wait=0",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "runner_scope_violation"
+
+
+# ---------------------------------------------------------------------------
+# Service layer — clamp, concurrency, tenant isolation
+# ---------------------------------------------------------------------------
+
+
+def test_clamp_longpoll_wait_bounds() -> None:
+    """``clamp_longpoll_wait`` floors at 0 and caps at the exported ceiling."""
+    ceiling = GATEWAY_LONGPOLL_MAX_WAIT_SECONDS
+    assert clamp_longpoll_wait(0) == 0
+    assert clamp_longpoll_wait(10) == 10
+    assert clamp_longpoll_wait(ceiling) == ceiling
+    assert clamp_longpoll_wait(3600) == ceiling
+    assert clamp_longpoll_wait(ceiling + 1) == ceiling
+    assert clamp_longpoll_wait(-5) == 0
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_claimers_exactly_one_wins() -> None:
+    """One pending command + two concurrent claimers -> exactly one gets it."""
+    await _seed()
+    await _enqueue(tenant_id=_TENANT_A, runner_id=_RUNNER_A_NAME)
+
+    sessionmaker = get_sessionmaker()
+
+    async def _claim_once() -> bool:
+        async with sessionmaker() as session:
+            row = await claim_next_command(session, tenant_id=_TENANT_A, runner_id=_RUNNER_A_NAME)
+            await session.commit()
+            return row is not None
+
+    results = await asyncio.gather(_claim_once(), _claim_once())
+    assert sum(results) == 1, f"expected exactly one claimer to win, got {results}"
+
+
+@pytest.mark.asyncio
+async def test_claim_is_tenant_scoped() -> None:
+    """A pending command for tenant B is invisible to a tenant-A claim (204-equiv)."""
+    await _seed()
+    await _enqueue(tenant_id=_TENANT_B, runner_id=_RUNNER_A_NAME)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await claim_next_command(session, tenant_id=_TENANT_A, runner_id=_RUNNER_A_NAME)
+    assert row is None, "a tenant-A claim must never see tenant B's command"
+
+
+@pytest.mark.asyncio
+async def test_record_result_cross_tenant_is_not_found() -> None:
+    """Reporting a command under the wrong tenant is not-found (404-equiv)."""
+    await _seed()
+    command_id = await _enqueue(tenant_id=_TENANT_B, runner_id=_RUNNER_A_NAME)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await claim_next_command(session, tenant_id=_TENANT_B, runner_id=_RUNNER_A_NAME)
+        await session.commit()
+
+    async with sessionmaker() as session:
+        with pytest.raises(GatewayCommandNotFoundError):
+            await record_result(
+                session,
+                tenant_id=_TENANT_A,
+                runner_id=_RUNNER_A_NAME,
+                command_id=command_id,
+                outcome=GatewayCommandStatus.SUCCEEDED,
+            )
+
+
+@pytest.mark.asyncio
+async def test_record_result_on_pending_conflicts() -> None:
+    """A never-claimed (pending) command rejects a result with a conflict (409-equiv)."""
+    await _seed()
+    command_id = await _enqueue(tenant_id=_TENANT_A, runner_id=_RUNNER_A_NAME)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        with pytest.raises(GatewayCommandNotDeliveredError):
+            await record_result(
+                session,
+                tenant_id=_TENANT_A,
+                runner_id=_RUNNER_A_NAME,
+                command_id=command_id,
+                outcome=GatewayCommandStatus.FAILED,
+                error="boom",
+            )

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -7221,6 +7221,138 @@
         }
       }
     },
+    "/api/v1/gateway/{runner}/next": {
+      "get": {
+        "tags": [
+          "gateway"
+        ],
+        "summary": "Poll Next Command",
+        "description": "Long-poll for the next command queued for ``{runner}``.\n\nAuthenticated as the runner principal for ``{runner}`` (#2502's guard):\na runner may only poll its own queue. Holds up to ``wait`` seconds\n(clamped to the exported ceiling) claiming the oldest ``pending``\ncommand; returns ``200`` with the envelope on a claim or ``204`` on\ntimeout. The claim flips the row ``pending -> delivered`` durably.\n\nThe hold opens a fresh short-lived session per attempt and never holds\na DB transaction across the inter-attempt sleep (binding decision\n#2498-2). A client disconnect cancels the handler; the\n``CancelledError`` is logged and re-raised per the asyncio contract.",
+        "operationId": "poll_next_command_api_v1_gateway__runner__next_get",
+        "parameters": [
+          {
+            "name": "runner",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Runner"
+            }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Long-poll hold in seconds. 0 = a single immediate claim attempt (no hold). Values above the ceiling (30s) are clamped down, not rejected \u2014 the runner asking for a longer hold gets a bounded one.",
+              "default": 25,
+              "title": "Wait"
+            },
+            "description": "Long-poll hold in seconds. 0 = a single immediate claim attempt (no hold). Values above the ceiling (30s) are clamped down, not rejected \u2014 the runner asking for a longer hold gets a bounded one."
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A command was claimed; the envelope is returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayCommandEnvelope"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No command became claimable before the wait deadline."
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/gateway/{runner}/result": {
+      "post": {
+        "tags": [
+          "gateway"
+        ],
+        "summary": "Report Command Result",
+        "description": "Report the outcome of a delivered command for ``{runner}``.\n\nAuthenticated as the runner principal for ``{runner}`` (#2502's guard).\nFlips the command ``delivered -> succeeded|failed``, stamping the\nresult/error and ``completed_at``. Returns ``200`` with an ack; ``404``\nwhen the command id is unknown or was enqueued for another runner /\ntenant (no existence oracle); ``409`` when the command is not\n``delivered`` (a duplicate report or a never-claimed row).",
+        "operationId": "report_command_result_api_v1_gateway__runner__result_post",
+        "parameters": [
+          {
+            "name": "runner",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Runner"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GatewayResultBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayResultAck"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/scheduler/triggers": {
       "get": {
         "tags": [
@@ -22892,6 +23024,104 @@
         ],
         "title": "ForkInfo",
         "description": "Surfaced by ``meho.runbook.edit_template`` when editing a published template forks.\n\nEditing a *published* template cannot mutate it in place (published\ntemplates are immutable); the edit forks a new draft instead. This\nshape tells the senior what they are forking from -- the source\nversion and how many runs are still pinned to it -- so they can decide\nwhether the fork is the right move."
+      },
+      "GatewayCommandEnvelope": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "params": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Params"
+          },
+          "target_descriptor": {
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true,
+            "title": "Target Descriptor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "op_id",
+          "params",
+          "target_descriptor"
+        ],
+        "title": "GatewayCommandEnvelope",
+        "description": "The claimed-command envelope returned by ``GET .../next`` (200)."
+      },
+      "GatewayResultAck": {
+        "properties": {
+          "command_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Command Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "completed_at": {
+            "type": "string",
+            "title": "Completed At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "command_id",
+          "status",
+          "completed_at"
+        ],
+        "title": "GatewayResultAck",
+        "description": "Response for a successful ``.../result`` report (200)."
+      },
+      "GatewayResultBody": {
+        "properties": {
+          "command_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Command Id",
+            "description": "The delivered command's id."
+          },
+          "outcome": {
+            "type": "string",
+            "enum": [
+              "succeeded",
+              "failed"
+            ],
+            "title": "Outcome",
+            "description": "Terminal outcome to record for the command."
+          },
+          "result": {
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true,
+            "title": "Result",
+            "description": "Structured success payload (for a 'succeeded' outcome)."
+          },
+          "error": {
+            "type": "string",
+            "nullable": true,
+            "title": "Error",
+            "description": "Failure summary (for a 'failed' outcome)."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "command_id",
+          "outcome"
+        ],
+        "title": "GatewayResultBody",
+        "description": "POST body for ``.../result`` \u2014 the runner's outcome report."
       },
       "GraphEdgeKind": {
         "type": "string",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -170,6 +170,12 @@ const (
 	EvalResultOverallVerdictYellow EvalResultOverallVerdict = "yellow"
 )
 
+// Defines values for GatewayResultBodyOutcome.
+const (
+	GatewayResultBodyOutcomeFailed    GatewayResultBodyOutcome = "failed"
+	GatewayResultBodyOutcomeSucceeded GatewayResultBodyOutcome = "succeeded"
+)
+
 // Defines values for GraphEdgeKind.
 const (
 	AuthenticatesVia GraphEdgeKind = "authenticates-via"
@@ -512,9 +518,9 @@ const (
 
 // Defines values for RunbooksRunsUiRunbooksRunsGetParamsStatus.
 const (
-	RunbooksRunsUiRunbooksRunsGetParamsStatusAbandoned  RunbooksRunsUiRunbooksRunsGetParamsStatus = "abandoned"
-	RunbooksRunsUiRunbooksRunsGetParamsStatusCompleted  RunbooksRunsUiRunbooksRunsGetParamsStatus = "completed"
-	RunbooksRunsUiRunbooksRunsGetParamsStatusInProgress RunbooksRunsUiRunbooksRunsGetParamsStatus = "in_progress"
+	Abandoned  RunbooksRunsUiRunbooksRunsGetParamsStatus = "abandoned"
+	Completed  RunbooksRunsUiRunbooksRunsGetParamsStatus = "completed"
+	InProgress RunbooksRunsUiRunbooksRunsGetParamsStatus = "in_progress"
 )
 
 // AbortRunRequest Request body for “meho.runbook.abort“ -- terminate the run mid-flight.
@@ -3688,6 +3694,39 @@ type ForkInfo struct {
 	Slug             string `json:"slug"`
 	Version          int    `json:"version"`
 }
+
+// GatewayCommandEnvelope The claimed-command envelope returned by “GET .../next“ (200).
+type GatewayCommandEnvelope struct {
+	Id               openapi_types.UUID      `json:"id"`
+	OpId             string                  `json:"op_id"`
+	Params           map[string]interface{}  `json:"params"`
+	TargetDescriptor *map[string]interface{} `json:"target_descriptor"`
+}
+
+// GatewayResultAck Response for a successful “.../result“ report (200).
+type GatewayResultAck struct {
+	CommandId   openapi_types.UUID `json:"command_id"`
+	CompletedAt string             `json:"completed_at"`
+	Status      string             `json:"status"`
+}
+
+// GatewayResultBody POST body for “.../result“ — the runner's outcome report.
+type GatewayResultBody struct {
+	// CommandId The delivered command's id.
+	CommandId openapi_types.UUID `json:"command_id"`
+
+	// Error Failure summary (for a 'failed' outcome).
+	Error *string `json:"error"`
+
+	// Outcome Terminal outcome to record for the command.
+	Outcome GatewayResultBodyOutcome `json:"outcome"`
+
+	// Result Structured success payload (for a 'succeeded' outcome).
+	Result *map[string]interface{} `json:"result"`
+}
+
+// GatewayResultBodyOutcome Terminal outcome to record for the command.
+type GatewayResultBodyOutcome string
 
 // GraphEdgeKind Closed enum of :attr:`GraphEdge.kind` values -- v0.2 vocabulary.
 //
@@ -7054,6 +7093,18 @@ type FeedEndpointApiV1FeedGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// PollNextCommandApiV1GatewayRunnerNextGetParams defines parameters for PollNextCommandApiV1GatewayRunnerNextGet.
+type PollNextCommandApiV1GatewayRunnerNextGetParams struct {
+	// Wait Long-poll hold in seconds. 0 = a single immediate claim attempt (no hold). Values above the ceiling (30s) are clamped down, not rejected — the runner asking for a longer hold gets a bounded one.
+	Wait          *int    `form:"wait,omitempty" json:"wait,omitempty"`
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// ReportCommandResultApiV1GatewayRunnerResultPostParams defines parameters for ReportCommandResultApiV1GatewayRunnerResultPost.
+type ReportCommandResultApiV1GatewayRunnerResultPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // AuthenticatedHealthApiV1HealthGetParams defines parameters for AuthenticatedHealthApiV1HealthGet.
 type AuthenticatedHealthApiV1HealthGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
@@ -7862,6 +7913,9 @@ type UpdateConventionApiV1ConventionsSlugPatchJSONRequestBody = ConventionUpdate
 
 // CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody defines body for CreateDocCollectionEndpointApiV1DocCollectionsPost for application/json ContentType.
 type CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody = DocCollectionCreate
+
+// ReportCommandResultApiV1GatewayRunnerResultPostJSONRequestBody defines body for ReportCommandResultApiV1GatewayRunnerResultPost for application/json ContentType.
+type ReportCommandResultApiV1GatewayRunnerResultPostJSONRequestBody = GatewayResultBody
 
 // CreateKbApiV1KbPostJSONRequestBody defines body for CreateKbApiV1KbPost for application/json ContentType.
 type CreateKbApiV1KbPostJSONRequestBody = KbEntryCreate
@@ -9367,6 +9421,14 @@ type ClientInterface interface {
 
 	// FeedEndpointApiV1FeedGet request
 	FeedEndpointApiV1FeedGet(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PollNextCommandApiV1GatewayRunnerNextGet request
+	PollNextCommandApiV1GatewayRunnerNextGet(ctx context.Context, runner string, params *PollNextCommandApiV1GatewayRunnerNextGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ReportCommandResultApiV1GatewayRunnerResultPostWithBody request with any body
+	ReportCommandResultApiV1GatewayRunnerResultPostWithBody(ctx context.Context, runner string, params *ReportCommandResultApiV1GatewayRunnerResultPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	ReportCommandResultApiV1GatewayRunnerResultPost(ctx context.Context, runner string, params *ReportCommandResultApiV1GatewayRunnerResultPostParams, body ReportCommandResultApiV1GatewayRunnerResultPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// AuthenticatedHealthApiV1HealthGet request
 	AuthenticatedHealthApiV1HealthGet(ctx context.Context, params *AuthenticatedHealthApiV1HealthGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -11377,6 +11439,42 @@ func (c *Client) ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePos
 
 func (c *Client) FeedEndpointApiV1FeedGet(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewFeedEndpointApiV1FeedGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PollNextCommandApiV1GatewayRunnerNextGet(ctx context.Context, runner string, params *PollNextCommandApiV1GatewayRunnerNextGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPollNextCommandApiV1GatewayRunnerNextGetRequest(c.Server, runner, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ReportCommandResultApiV1GatewayRunnerResultPostWithBody(ctx context.Context, runner string, params *ReportCommandResultApiV1GatewayRunnerResultPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewReportCommandResultApiV1GatewayRunnerResultPostRequestWithBody(c.Server, runner, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ReportCommandResultApiV1GatewayRunnerResultPost(ctx context.Context, runner string, params *ReportCommandResultApiV1GatewayRunnerResultPostParams, body ReportCommandResultApiV1GatewayRunnerResultPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewReportCommandResultApiV1GatewayRunnerResultPostRequest(c.Server, runner, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -19861,6 +19959,139 @@ func NewFeedEndpointApiV1FeedGetRequest(server string, params *FeedEndpointApiV1
 	if err != nil {
 		return nil, err
 	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewPollNextCommandApiV1GatewayRunnerNextGetRequest generates requests for PollNextCommandApiV1GatewayRunnerNextGet
+func NewPollNextCommandApiV1GatewayRunnerNextGetRequest(server string, runner string, params *PollNextCommandApiV1GatewayRunnerNextGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "runner", runtime.ParamLocationPath, runner)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/gateway/%s/next", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Wait != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "wait", runtime.ParamLocationQuery, *params.Wait); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewReportCommandResultApiV1GatewayRunnerResultPostRequest calls the generic ReportCommandResultApiV1GatewayRunnerResultPost builder with application/json body
+func NewReportCommandResultApiV1GatewayRunnerResultPostRequest(server string, runner string, params *ReportCommandResultApiV1GatewayRunnerResultPostParams, body ReportCommandResultApiV1GatewayRunnerResultPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewReportCommandResultApiV1GatewayRunnerResultPostRequestWithBody(server, runner, params, "application/json", bodyReader)
+}
+
+// NewReportCommandResultApiV1GatewayRunnerResultPostRequestWithBody generates requests for ReportCommandResultApiV1GatewayRunnerResultPost with any type of body
+func NewReportCommandResultApiV1GatewayRunnerResultPostRequestWithBody(server string, runner string, params *ReportCommandResultApiV1GatewayRunnerResultPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "runner", runtime.ParamLocationPath, runner)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/gateway/%s/result", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -34560,6 +34791,14 @@ type ClientWithResponsesInterface interface {
 	// FeedEndpointApiV1FeedGetWithResponse request
 	FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error)
 
+	// PollNextCommandApiV1GatewayRunnerNextGetWithResponse request
+	PollNextCommandApiV1GatewayRunnerNextGetWithResponse(ctx context.Context, runner string, params *PollNextCommandApiV1GatewayRunnerNextGetParams, reqEditors ...RequestEditorFn) (*PollNextCommandApiV1GatewayRunnerNextGetResponse, error)
+
+	// ReportCommandResultApiV1GatewayRunnerResultPostWithBodyWithResponse request with any body
+	ReportCommandResultApiV1GatewayRunnerResultPostWithBodyWithResponse(ctx context.Context, runner string, params *ReportCommandResultApiV1GatewayRunnerResultPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ReportCommandResultApiV1GatewayRunnerResultPostResponse, error)
+
+	ReportCommandResultApiV1GatewayRunnerResultPostWithResponse(ctx context.Context, runner string, params *ReportCommandResultApiV1GatewayRunnerResultPostParams, body ReportCommandResultApiV1GatewayRunnerResultPostJSONRequestBody, reqEditors ...RequestEditorFn) (*ReportCommandResultApiV1GatewayRunnerResultPostResponse, error)
+
 	// AuthenticatedHealthApiV1HealthGetWithResponse request
 	AuthenticatedHealthApiV1HealthGetWithResponse(ctx context.Context, params *AuthenticatedHealthApiV1HealthGetParams, reqEditors ...RequestEditorFn) (*AuthenticatedHealthApiV1HealthGetResponse, error)
 
@@ -36994,6 +37233,52 @@ func (r FeedEndpointApiV1FeedGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r FeedEndpointApiV1FeedGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PollNextCommandApiV1GatewayRunnerNextGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *GatewayCommandEnvelope
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r PollNextCommandApiV1GatewayRunnerNextGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PollNextCommandApiV1GatewayRunnerNextGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ReportCommandResultApiV1GatewayRunnerResultPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *GatewayResultAck
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ReportCommandResultApiV1GatewayRunnerResultPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ReportCommandResultApiV1GatewayRunnerResultPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -43512,6 +43797,32 @@ func (c *ClientWithResponses) FeedEndpointApiV1FeedGetWithResponse(ctx context.C
 	return ParseFeedEndpointApiV1FeedGetResponse(rsp)
 }
 
+// PollNextCommandApiV1GatewayRunnerNextGetWithResponse request returning *PollNextCommandApiV1GatewayRunnerNextGetResponse
+func (c *ClientWithResponses) PollNextCommandApiV1GatewayRunnerNextGetWithResponse(ctx context.Context, runner string, params *PollNextCommandApiV1GatewayRunnerNextGetParams, reqEditors ...RequestEditorFn) (*PollNextCommandApiV1GatewayRunnerNextGetResponse, error) {
+	rsp, err := c.PollNextCommandApiV1GatewayRunnerNextGet(ctx, runner, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePollNextCommandApiV1GatewayRunnerNextGetResponse(rsp)
+}
+
+// ReportCommandResultApiV1GatewayRunnerResultPostWithBodyWithResponse request with arbitrary body returning *ReportCommandResultApiV1GatewayRunnerResultPostResponse
+func (c *ClientWithResponses) ReportCommandResultApiV1GatewayRunnerResultPostWithBodyWithResponse(ctx context.Context, runner string, params *ReportCommandResultApiV1GatewayRunnerResultPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ReportCommandResultApiV1GatewayRunnerResultPostResponse, error) {
+	rsp, err := c.ReportCommandResultApiV1GatewayRunnerResultPostWithBody(ctx, runner, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseReportCommandResultApiV1GatewayRunnerResultPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) ReportCommandResultApiV1GatewayRunnerResultPostWithResponse(ctx context.Context, runner string, params *ReportCommandResultApiV1GatewayRunnerResultPostParams, body ReportCommandResultApiV1GatewayRunnerResultPostJSONRequestBody, reqEditors ...RequestEditorFn) (*ReportCommandResultApiV1GatewayRunnerResultPostResponse, error) {
+	rsp, err := c.ReportCommandResultApiV1GatewayRunnerResultPost(ctx, runner, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseReportCommandResultApiV1GatewayRunnerResultPostResponse(rsp)
+}
+
 // AuthenticatedHealthApiV1HealthGetWithResponse request returning *AuthenticatedHealthApiV1HealthGetResponse
 func (c *ClientWithResponses) AuthenticatedHealthApiV1HealthGetWithResponse(ctx context.Context, params *AuthenticatedHealthApiV1HealthGetParams, reqEditors ...RequestEditorFn) (*AuthenticatedHealthApiV1HealthGetResponse, error) {
 	rsp, err := c.AuthenticatedHealthApiV1HealthGet(ctx, params, reqEditors...)
@@ -48892,6 +49203,72 @@ func ParseFeedEndpointApiV1FeedGetResponse(rsp *http.Response) (*FeedEndpointApi
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePollNextCommandApiV1GatewayRunnerNextGetResponse parses an HTTP response from a PollNextCommandApiV1GatewayRunnerNextGetWithResponse call
+func ParsePollNextCommandApiV1GatewayRunnerNextGetResponse(rsp *http.Response) (*PollNextCommandApiV1GatewayRunnerNextGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PollNextCommandApiV1GatewayRunnerNextGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GatewayCommandEnvelope
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseReportCommandResultApiV1GatewayRunnerResultPostResponse parses an HTTP response from a ReportCommandResultApiV1GatewayRunnerResultPostWithResponse call
+func ParseReportCommandResultApiV1GatewayRunnerResultPostResponse(rsp *http.Response) (*ReportCommandResultApiV1GatewayRunnerResultPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ReportCommandResultApiV1GatewayRunnerResultPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GatewayResultAck
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

- Adds the **central command plane** of the remote-execution gateway (Initiative #2415, T2): a durable `gateway_command` queue (migration `0059`) + two runner-facing routes.
- `GET /api/v1/gateway/{runner}/next?wait=N` — blocking long-poll: holds up to `wait` s (default 25, clamped to the exported 30 s ceiling; `wait=0` = one immediate claim attempt), returns `200` with the claimed command envelope (`id`, `op_id`, `params`, resolved `target_descriptor`) or `204` on timeout.
- `POST /api/v1/gateway/{runner}/result` — records the outcome (`200`, or `404` unknown/foreign, `409` non-`delivered`).
- Both gate on the **scoped runner principal** shipped by #2502 (`require_runner` + `assert_runner_scope`), mounted under the `/api/v1/gateway/` cage prefix — a runner may only poll/report its **own** queue; every query filters `tenant_id`. No HTTP enqueue endpoint (central enqueues via `gateway.queue.enqueue_command` so all authorization stays central).

## Design (per Initiative #2415 / #2498 binding decisions)

- **Hold = bounded DB claim-poll loop**, not an in-process `asyncio.Event` (wrong under >1 replica) and not Valkey `XREAD BLOCK` (deferred). Each attempt opens a short-lived session, tries one claim, commits a win; no transaction is held across the inter-attempt `asyncio.sleep`. Client-disconnect `CancelledError` is re-raised per the asyncio contract.
- **Exactly-one-claimer**: `SELECT … FOR UPDATE SKIP LOCKED` on PostgreSQL, a conditional `UPDATE … WHERE status='pending'` on the SQLite test path (mould: `scheduler/repository.py`, #804).
- **Transport-only schema**: no speculative capability columns — capability binding (args-hash/expiry/dedup) is sibling #2500's own migration.
- **`target_descriptor` is nullable** (a grounded deviation from the task sketch's NOT NULL): targetless synthetic ops (`net.*`) carry no descriptor, which the #2497 wire model already encodes as `RunnerWorkItem.target_descriptor: ResolvedTargetDescriptor | None`. `{}` is not a valid `ResolvedTargetDescriptor`, so NULL is the wire-compatible "targetless" encoding.

## Migration discipline

- New revision `0059` (`down_revision = '0058'`), extending the current single head. `alembic upgrade head` applies cleanly; `alembic heads` prints a single head. Migration test pins upgrades to its **own** revision (never `head`) per the stamp-replay idempotency rule.
- `gateway_command` carries a real `REFERENCES tenant(id)` FK, so it is added to **all three** per-test TRUNCATE lists (both integration conftest strings + the acceptance `_TRUNCATE_TABLES` tuple, with FK-rationale comments) and `tests/test_truncate_list_drift.py` passes.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on all touched files
- [x] `mypy` (source) — no issues
- [x] `code-quality.py --diff` — 0 blockers
- [x] `alembic upgrade head` + `alembic heads` — single head `0059`
- [x] `pytest tests/test_api_v1_gateway.py tests/migrations/test_migration_0059_create_gateway_command.py` — green (17)
- [x] `pytest tests/test_truncate_list_drift.py` — green (3)
- [x] `pytest tests/test_auth_runner_guard.py` — green (regression on the consumed guard)
- [x] `pytest tests/migrations/test_alembic_probe.py tests/migrations/test_migration_rollback.py` — green (new head is clean)
- [x] `cd cli && make snapshot-openapi && make generate` — re-run; `go build ./internal/api/...` compiles
- Acceptance criteria verified: empty-queue `wait=0` → 204 (`test_next_empty_queue_immediate_204`); enqueue→200 envelope + row `delivered`; two concurrent claimers → exactly one wins; long-poll wakes on mid-hold enqueue before deadline; clamp unit test (`3600 → 30`); result 200→409-on-replay + 404-foreign; auth matrix (non-runner 403, scope-mismatch 403, match passes); tenant isolation (claim 204-equiv, record 404-equiv).

## Out of scope

- Capability minting / expiry / dedup (#2500), assignment+result ingest API (#2499), heartbeat + dead-man switch (#2501), Valkey-stream promotion, command redelivery — per Initiative #2415.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2498
