### PR TITLE
feat(gateway): ingest + versioned assignment API for the satellite runner (#2499)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Gateway — versioned assignment + results ingest API
+
+- Add the central-side ingest + versioned assignment API for the push-only
+  satellite runner (Initiative #2415, #2499), mounted under `/api/v1/checks/`
+  (inside the runner route cage). `PUT /api/v1/checks/assignment/{runner}`
+  (operator) authors a runner's checks with create-time validation — each
+  item's target must resolve and its op must resolve to an enabled
+  `safety_level=='safe'` descriptor, else a structured 422
+  (`assignment_op_not_safe` / `assignment_op_unknown` /
+  `assignment_target_unknown`) and nothing is stored. `GET
+  /api/v1/checks/assignment?runner=…[&known_version=…]` (runner, own-only)
+  returns a digest-versioned `RunnerAssignment` whose items carry resolved
+  target descriptors (host/port/TLS + the `secret_ref` **reference**, never a
+  credential value), `handler_ref` + `safety_level`, and the runner principal
+  context — all materialised from live rows, so target-row drift (e.g. a
+  rotated `tls_ca_pin`) shifts the sha256 content digest and the runner
+  self-heals; a matching `known_version` yields `304 Not Modified`. `POST
+  /api/v1/checks/results` (runner, own-only) ingests a result batch
+  idempotently — `(tenant, runner, result_uid)` dedups on-disk-spool re-posts
+  and `received_at` is stamped by the central clock. The `runner/wire.py`
+  models are widened in place, not forked (one schema on both ends). Migration
+  `0059` creates `runner_assignments` + `runner_check_results` (#2499).
+
 ### Added — scoped runner principal (gateway v1)
 
 - Add the identity substrate of the remote-execution gateway (Initiative

--- a/backend/alembic/versions/0059_create_runner_assignment_tables.py
+++ b/backend/alembic/versions/0059_create_runner_assignment_tables.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``runner_assignments`` + ``runner_check_results`` tables (#2499).
+
+Revision ID: 0059
+Revises: 0058
+Create Date: 2026-07-15
+
+Initiative #2415 (Remote execution gateway), Task #2499 — the central-side
+ingest + versioned assignment API for the push-only satellite runner. Two
+gateway-owned tables:
+
+* ``runner_assignments`` — one operator-authored document per
+  ``(tenant_id, runner_name)``. ``PUT /api/v1/checks/assignment/{runner}``
+  replaces the row wholesale; the runner-facing ``GET`` materialises the
+  authored ``items`` (JSONB) into wire ``RunnerWorkItem`` objects at
+  request time, resolving the live target descriptor + the op's
+  ``handler_ref`` / ``safety_level`` so target-row drift is picked up on
+  the next poll rather than frozen at authoring time.
+
+* ``runner_check_results`` — one row per accepted result in a runner's
+  ``POST /api/v1/checks/results`` batch. ``received_at`` is stamped by the
+  central clock at ingest (never accepted from the client), because the
+  dead-man's switch (#2501) flips workloads stale on the central clock.
+  ``(tenant_id, runner_name, result_uid)`` is unique, making re-posts from
+  the runner's on-disk retry spool (#2497) idempotent.
+
+This migration is the **third** in the initiative's serialized chain
+(#2502 -> #2498 -> #2499 -> #2500 -> #2501); it extends the then-current
+single head ``0058`` (``runner_principal``). Per the house Alembic rule,
+if a sibling migration lands on main first, renumber-before-merge — never
+fork the linear chain.
+
+Schema notes
+------------
+
+* ``tenant_id`` is a real ``REFERENCES tenant(id)`` FK on both tables —
+  brand-new clean-slate tables, mould parity with ``runner_principal``
+  (``0058``). Both tables must therefore appear in the integration +
+  acceptance per-test TRUNCATE lists (``test_truncate_list_drift`` guards
+  this).
+* ``runner_name`` is a **soft** FK to ``runner_principal.name`` (no DB FK),
+  the same soft-reference discipline the gateway set uses so #2499/#2501
+  reference a runner by name without coupling to the principal lifecycle.
+* ``runner_check_results.status`` is bounded by a portable CHECK to the
+  tri-state ``ok`` / ``refused`` / ``error`` — the ``RunnerResult.status``
+  vocabulary the runner posts (a bare ``ok``/``error`` CHECK would reject
+  the ``refused`` rows the runner legitimately reports).
+* ``items`` / ``result_payload`` are portable ``JSON`` -> ``JSONB``
+  variants (mould ``0020``).
+
+Dialect portability
+-------------------
+
+Mirrors ``0058`` / ``0020``: ``gen_random_uuid()`` / ``now()`` server
+defaults on PG with the ORM ``default`` covering SQLite; ``JSON`` ->
+``JSONB`` variant for the document columns.
+
+Reversibility contract
+----------------------
+
+``upgrade()`` creates each table then its indexes; ``downgrade()`` drops
+the indexes then the tables in inverse order. Explicit index drops keep
+the inverse symmetric across both dialects (SQLite does not always cascade
+indexes on ``drop_table``). Purely additive on the way up.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0059"
+down_revision: str | None = "0058"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _json_variant() -> sa.types.TypeEngine[object]:
+    """Portable ``JSON`` -> ``JSONB`` column type (mould ``0020``)."""
+    return sa.JSON(none_as_null=True).with_variant(
+        postgresql.JSONB(none_as_null=True), "postgresql"
+    )
+
+
+def upgrade() -> None:
+    """Create the two gateway tables and their indexes."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.create_table(
+        "runner_assignments",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        # Real FK -- clean-slate table, mould parity with runner_principal.
+        sa.Column(
+            "tenant_id",
+            sa.Uuid(),
+            sa.ForeignKey("tenant.id"),
+            nullable=False,
+        ),
+        # Soft-FK to runner_principal.name (no DB FK).
+        sa.Column("runner_name", sa.Text(), nullable=False),
+        sa.Column("items", _json_variant(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+    )
+    op.create_index(
+        "runner_assignments_tenant_runner_idx",
+        "runner_assignments",
+        ["tenant_id", "runner_name"],
+        unique=True,
+        postgresql_using="btree",
+    )
+
+    op.create_table(
+        "runner_check_results",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        sa.Column(
+            "tenant_id",
+            sa.Uuid(),
+            sa.ForeignKey("tenant.id"),
+            nullable=False,
+        ),
+        sa.Column("runner_name", sa.Text(), nullable=False),
+        sa.Column("result_uid", sa.Text(), nullable=False),
+        sa.Column("check_ref", sa.Text(), nullable=False),
+        sa.Column("op_id", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("result_payload", _json_variant(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        # Central-stamped at ingest -- NOT accepted from the client.
+        sa.Column(
+            "received_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.CheckConstraint(
+            "status IN ('ok', 'refused', 'error')",
+            name="ck_runner_check_results_status",
+        ),
+    )
+    # Ingest idempotency: a re-posted spool batch collides here.
+    op.create_index(
+        "runner_check_results_uid_idx",
+        "runner_check_results",
+        ["tenant_id", "runner_name", "result_uid"],
+        unique=True,
+        postgresql_using="btree",
+    )
+    # #2501 staleness reads: latest result per (runner, check).
+    op.create_index(
+        "runner_check_results_staleness_idx",
+        "runner_check_results",
+        ["tenant_id", "runner_name", "check_ref", "received_at"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Drop the indexes then the two tables (reverse order)."""
+    op.drop_index(
+        "runner_check_results_staleness_idx",
+        table_name="runner_check_results",
+    )
+    op.drop_index(
+        "runner_check_results_uid_idx",
+        table_name="runner_check_results",
+    )
+    op.drop_table("runner_check_results")
+    op.drop_index(
+        "runner_assignments_tenant_runner_idx",
+        table_name="runner_assignments",
+    )
+    op.drop_table("runner_assignments")

--- a/backend/src/meho_backplane/api/v1/checks.py
+++ b/backend/src/meho_backplane/api/v1/checks.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``/api/v1/checks/*`` — the gateway assignment + result-ingest REST surface.
+
+Initiative #2415 (#2499). Three routes mounted under ``/api/v1/checks/`` —
+inside the runner route cage
+(:data:`~meho_backplane.middleware.RUNNER_ALLOWED_PATH_PREFIXES`), so a
+``principal_kind=runner`` token may reach them (and only them + the
+long-poll gateway plane):
+
+* ``PUT /api/v1/checks/assignment/{runner}`` — **operator**-authenticated
+  (:func:`~meho_backplane.auth.rbac.require_role` at ``OPERATOR``, the same
+  tier as scheduled-trigger authoring). Full-document replace of a runner's
+  assignment. Each item is validated at create time (target resolves, op
+  resolves to an enabled ``safety_level == 'safe'`` descriptor); a failing
+  item is a structured 422 and nothing is stored.
+
+* ``GET /api/v1/checks/assignment?runner=…[&known_version=…]`` —
+  **runner**-authenticated (:func:`~meho_backplane.auth.runner_guard.require_runner`
+  + :func:`~meho_backplane.auth.runner_guard.assert_runner_scope`, so a
+  runner fetches only its own assignment). Returns a
+  :class:`~meho_backplane.runner.wire.RunnerAssignment` with per-item
+  resolved target descriptors + ``handler_ref`` / ``safety_level`` /
+  principal context, materialised from live rows. ``known_version`` echoing
+  the current digest yields ``304 Not Modified`` with an empty body.
+
+* ``POST /api/v1/checks/results`` — **runner**-authenticated
+  (own-results-only). Idempotent batch ingest keyed on
+  ``(tenant, runner, result_uid)``; ``received_at`` is central-stamped.
+
+All authorization stays central (Initiative #2415 principle): the runner
+never self-authorizes. The wire shapes are the ones
+:mod:`meho_backplane.runner.wire` defines — one schema on both ends by
+construction.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Final
+
+import structlog
+from fastapi import APIRouter, Depends, Path, Query
+from fastapi import status as http_status
+from fastapi.responses import Response
+
+from meho_backplane.api.v1._errors import http_for, register_error
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.auth.runner_guard import assert_runner_scope, require_runner
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.gateway import assignment_service
+from meho_backplane.gateway.errors import (
+    AssignmentOpNotSafeError,
+    AssignmentOpUnknownError,
+    AssignmentTargetUnknownError,
+    AssignmentValidationError,
+)
+from meho_backplane.gateway.repository import ingest_results
+from meho_backplane.gateway.schemas import (
+    AssignmentDocument,
+    AssignmentDocumentResponse,
+    ResultIngestResponse,
+)
+from meho_backplane.runner import wire
+
+__all__ = ["router"]
+
+_log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/checks", tags=["checks"])
+
+#: Module-level Depends closures — required to satisfy ruff B008 (calls in
+#: default argument positions are disallowed). Same shape as
+#: :mod:`meho_backplane.api.v1.scheduler`.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+_require_runner = Depends(require_runner())
+
+#: Canonical op ids bound into ``audit_op_id`` per route (greppable; a typo
+#: surfaces as a mis-classified broadcast rather than a silent 500).
+_CHECKS_OP_IDS: Final[dict[str, str]] = {
+    "put_assignment": "checks.assignment.put",
+    "get_assignment": "checks.assignment.get",
+    "post_results": "checks.results.post",
+}
+
+
+# The gateway authoring errors surface as HTTPValidationError-conformant
+# 422s (``detail[0].type`` carries the machine-readable code) so the
+# generated CLI client deserialises them — the api/v1/_errors mould.
+register_error(
+    AssignmentTargetUnknownError,
+    status=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+    type_tag="assignment_target_unknown",
+    loc=("body", "items"),
+)
+register_error(
+    AssignmentOpUnknownError,
+    status=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+    type_tag="assignment_op_unknown",
+    loc=("body", "items"),
+)
+register_error(
+    AssignmentOpNotSafeError,
+    status=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+    type_tag="assignment_op_not_safe",
+    loc=("body", "items"),
+)
+
+
+@router.put("/assignment/{runner}", response_model=AssignmentDocumentResponse)
+async def put_assignment(
+    runner: Annotated[str, Path(min_length=1)],
+    body: AssignmentDocument,
+    operator: Annotated[Operator, _require_operator],
+) -> AssignmentDocumentResponse:
+    """Replace runner *runner*'s assignment document (operator-authenticated).
+
+    Validates every authored item before storing; a failing item is a
+    structured 422 (``assignment_target_unknown`` / ``assignment_op_unknown``
+    / ``assignment_op_not_safe``) and nothing is written.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_CHECKS_OP_IDS["put_assignment"],
+        audit_op_class="write",
+    )
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        try:
+            await assignment_service.store_assignment(
+                session,
+                tenant_id=operator.tenant_id,
+                runner_name=runner,
+                document=body,
+            )
+        except AssignmentValidationError as exc:
+            raise http_for(exc) from exc
+        await session.commit()
+    return AssignmentDocumentResponse(runner=runner, items=list(body.items))
+
+
+@router.get("/assignment", response_model=wire.RunnerAssignment)
+async def get_assignment(
+    operator: Annotated[Operator, _require_runner],
+    runner: Annotated[str, Query(min_length=1)],
+    known_version: Annotated[str | None, Query()] = None,
+) -> wire.RunnerAssignment | Response:
+    """Return runner *runner*'s versioned assignment (runner-authenticated).
+
+    A runner may fetch only its own assignment
+    (:func:`assert_runner_scope`). ``known_version`` matching the current
+    content digest yields ``304 Not Modified`` (empty body); the runner
+    keeps its cache.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_CHECKS_OP_IDS["get_assignment"],
+        audit_op_class="read",
+    )
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await assert_runner_scope(operator, runner_name=runner, session=session)
+        assignment = await assignment_service.materialize_assignment(
+            session,
+            tenant_id=operator.tenant_id,
+            runner_name=runner,
+            principal=_principal_from_operator(operator),
+        )
+    if known_version is not None and known_version == assignment.assignment_version:
+        return Response(status_code=http_status.HTTP_304_NOT_MODIFIED)
+    return assignment
+
+
+@router.post("/results", response_model=ResultIngestResponse)
+async def post_results(
+    batch: wire.RunnerResultBatch,
+    operator: Annotated[Operator, _require_runner],
+) -> ResultIngestResponse:
+    """Ingest a runner's result batch idempotently (runner-authenticated).
+
+    The runner submits only its own results (``batch.runner_id`` is the
+    runner name; :func:`assert_runner_scope` binds it to the token's
+    ``runner_id``). ``received_at`` is central-stamped; re-posts from the
+    runner's retry spool are deduped by ``result_uid``.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_CHECKS_OP_IDS["post_results"],
+        audit_op_class="write",
+    )
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await assert_runner_scope(operator, runner_name=batch.runner_id, session=session)
+        accepted, duplicates = await ingest_results(
+            session,
+            tenant_id=operator.tenant_id,
+            runner_name=batch.runner_id,
+            results=list(batch.results),
+        )
+        await session.commit()
+    return ResultIngestResponse(accepted=accepted, duplicates=duplicates)
+
+
+def _principal_from_operator(operator: Operator) -> wire.RunnerPrincipal:
+    """Project the authenticated runner operator into the wire principal context.
+
+    Rides on each work item so the runner reconstructs a read-only
+    ``Operator`` locally without minting a token (the op was authorized
+    centrally).
+    """
+    return wire.RunnerPrincipal(
+        sub=operator.sub,
+        tenant_id=operator.tenant_id,
+        tenant_role=operator.tenant_role,
+        principal_kind=operator.principal_kind,
+    )

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -3644,6 +3644,170 @@ class RunnerPrincipal(Base):
 
 
 # ---------------------------------------------------------------------------
+# Initiative #2415 (#2499) — gateway assignment + result-ingest storage
+# ---------------------------------------------------------------------------
+
+
+#: Closed set of runner-reported result statuses, mirrored in the
+#: ``runner_check_results.status`` CHECK constraint. Tri-state to match
+#: the ``runner/wire.py`` ``RunnerResult.status`` vocabulary (#2497): a
+#: handler that ran (``ok``), a runner that declined an unsafe item
+#: (``refused``), or a handler that raised (``error``). A bare
+#: ``ok``/``error`` CHECK would reject the ``refused`` rows #2497's runner
+#: legitimately posts.
+_RUNNER_RESULT_STATUSES: tuple[str, ...] = ("ok", "refused", "error")
+
+
+class RunnerAssignmentRow(Base):
+    """One satellite runner's current check assignment (Initiative #2415, #2499).
+
+    A single operator-authored document per ``(tenant_id, runner_name)``:
+    the ``PUT /api/v1/checks/assignment/{runner}`` route replaces the row
+    wholesale. ``items`` stores the *authored* checks
+    (``check_ref`` / ``target_name`` / ``op`` / ``params`` /
+    ``cadence_seconds``) as JSONB; the runner-facing ``GET`` materialises
+    each authored item into a wire ``RunnerWorkItem`` at request time
+    (resolving the live target descriptor + the op's ``handler_ref`` /
+    ``safety_level``), so target-row drift is picked up on the next poll
+    rather than frozen at authoring time.
+
+    ``runner_name`` is a soft-FK to :attr:`RunnerPrincipal.name` (no DB
+    FK — the same soft-reference discipline the gateway set uses so
+    #2499/#2501 reference a runner by name without coupling to the
+    principal table's lifecycle). ``tenant_id`` **is** a real
+    ``REFERENCES tenant(id)`` FK: a brand-new clean-slate table, mould
+    parity with :class:`RunnerPrincipal` (#2502).
+    """
+
+    __tablename__ = "runner_assignments"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    # Real FK -- clean-slate table, mould parity with runner_principal.
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    # Soft-FK to runner_principal.name (no DB FK): the gateway set keys
+    # runners by name and references them across #2499/#2501 by name.
+    runner_name: Mapped[str] = mapped_column(Text, nullable=False)
+    items: Mapped[list[dict[str, object]]] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=False,
+        default=list,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        # One assignment document per runner within a tenant; the upsert
+        # path keys on this pair.
+        Index(
+            "runner_assignments_tenant_runner_idx",
+            "tenant_id",
+            "runner_name",
+            unique=True,
+            postgresql_using="btree",
+        ),
+    )
+
+
+class RunnerCheckResult(Base):
+    """One ingested runner check-execution report (Initiative #2415, #2499).
+
+    Persisted by ``POST /api/v1/checks/results`` — one row per accepted
+    result in the runner's batch. ``received_at`` is stamped by the
+    central clock at ingest (never accepted from the client), because the
+    dead-man's switch (#2501) flips workloads stale on the central clock.
+
+    Idempotency: ``(tenant_id, runner_name, result_uid)`` is unique, so a
+    re-POST from the runner's on-disk retry spool (#2497) inserts nothing
+    and is reported as a duplicate rather than double-counted.
+    ``check_ref`` is an opaque per-item string (a soft reference — a
+    Sensor UUID from #2416 may ride in it later, with no FK), and the
+    ``(tenant_id, runner_name, check_ref, received_at)`` index serves
+    #2501's per-check staleness reads.
+
+    ``tenant_id`` is a real ``REFERENCES tenant(id)`` FK (clean-slate
+    table, mould parity with :class:`RunnerPrincipal`).
+    """
+
+    __tablename__ = "runner_check_results"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    runner_name: Mapped[str] = mapped_column(Text, nullable=False)
+    # Runner-generated uuid4 hex: the dedup key that makes spool re-posts
+    # idempotent.
+    result_uid: Mapped[str] = mapped_column(Text, nullable=False)
+    check_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    op_id: Mapped[str] = mapped_column(Text, nullable=False)
+    # Runner-level tri-state (ok / refused / error); see
+    # ``_RUNNER_RESULT_STATUSES``.
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    # The handler's structured payload (a failed probe is still a result,
+    # not a runner error). Nullable: refused/error rows carry none.
+    result_payload: Mapped[dict[str, object] | None] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=True,
+        default=None,
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Central-stamped at ingest -- NOT accepted from the client.
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        # Ingest idempotency: a re-posted spool batch collides here and is
+        # counted as a duplicate.
+        Index(
+            "runner_check_results_uid_idx",
+            "tenant_id",
+            "runner_name",
+            "result_uid",
+            unique=True,
+            postgresql_using="btree",
+        ),
+        # #2501 staleness reads: latest result per (runner, check).
+        Index(
+            "runner_check_results_staleness_idx",
+            "tenant_id",
+            "runner_name",
+            "check_ref",
+            "received_at",
+            postgresql_using="btree",
+        ),
+        sa.CheckConstraint(
+            "status IN ('ok', 'refused', 'error')",
+            name="ck_runner_check_results_status",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
 # G11.2-T3 — per-(principal, op, target) permission model
 # ---------------------------------------------------------------------------
 

--- a/backend/src/meho_backplane/gateway/__init__.py
+++ b/backend/src/meho_backplane/gateway/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Central-side machinery for the remote-execution gateway (Initiative #2415).
+
+This package holds **only** the central half of the push-only satellite
+runner: the ingest + versioned assignment API (#2499) and, later, the
+sibling long-poll / heartbeat surfaces (#2498/#2500/#2501). The runner
+half — the tick loop, poll/report client, and on-disk spool — lives under
+:mod:`meho_backplane.runner`; the two ends share one wire schema
+(:mod:`meho_backplane.runner.wire`) by construction.
+
+#2499 modules:
+
+* :mod:`~meho_backplane.gateway.schemas` — the operator-facing authoring
+  envelope (``PUT`` body / response) and the result-ingest accounting
+  response.
+* :mod:`~meho_backplane.gateway.errors` — typed PUT-time validation
+  failures, each with a machine-readable ``error_code``.
+* :mod:`~meho_backplane.gateway.repository` — DB access (assignment
+  upsert/get, portable result-batch dedup).
+* :mod:`~meho_backplane.gateway.assignment_service` — PUT-time validation
+  and GET-time materialisation (live target descriptors + op
+  handler_ref/safety_level) + the content digest.
+"""

--- a/backend/src/meho_backplane/gateway/assignment_service.py
+++ b/backend/src/meho_backplane/gateway/assignment_service.py
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Assignment validation + materialisation for the gateway checks API (#2499).
+
+Two concerns, sharing the same per-item resolution but differing in how
+they treat a failure:
+
+* **PUT-time validation** (:func:`store_assignment`) — every authored item
+  must resolve to a live target and an *enabled*, ``safety_level == 'safe'``
+  endpoint descriptor. The first failure raises a typed
+  :mod:`meho_backplane.gateway.errors` exception (the route maps it to a
+  structured 422) and **nothing is stored** — an assignment PUT is a
+  full-document replace, so a partial store is never acceptable.
+
+* **GET-time materialisation** (:func:`materialize_assignment`) — each
+  stored authored item is materialised into a wire
+  :class:`~meho_backplane.runner.wire.RunnerWorkItem` against the **live**
+  target row and op descriptor, so target-row drift (a rotated
+  ``tls_ca_pin``, a changed ``host``) is picked up on the next poll. An
+  item whose target was soft-deleted, whose connector no longer resolves,
+  or whose op is no longer a runnable safe descriptor is **dropped** with a
+  structured warning (the digest changes, so the runner self-heals) rather
+  than failing the whole fetch.
+
+The ``assignment_version`` is a sha256 over the canonical JSON of the fully
+materialised work items — not a stored counter — so "unchanged" means the
+materialisation is byte-identical, catching live target-row drift a counter
+would miss.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+from uuid import UUID
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.resolver import resolve_connector_or_label
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.gateway import repository
+from meho_backplane.gateway.errors import (
+    AssignmentOpNotSafeError,
+    AssignmentOpUnknownError,
+    AssignmentTargetUnknownError,
+)
+from meho_backplane.gateway.schemas import AssignmentDocument, AuthoredCheckItem
+from meho_backplane.operations._lookup import lookup_descriptor
+from meho_backplane.runner import wire
+from meho_backplane.targets.resolver import (
+    AmbiguousTargetError,
+    TargetNotFoundError,
+    resolve_target,
+)
+
+__all__ = [
+    "compute_assignment_version",
+    "descriptor_from_target",
+    "materialize_assignment",
+    "store_assignment",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: v1 authorizes read-only workloads only.
+_SAFE_LEVEL = "safe"
+
+
+def descriptor_from_target(target: TargetORM) -> wire.ResolvedTargetDescriptor:
+    """Project a live ``Target`` row into the wire descriptor the runner reads.
+
+    Carries the resolver inputs + connection-routing fields a connector
+    handler duck-reads; ``secret_ref`` is the reference only, never a
+    credential value.
+    """
+    return wire.ResolvedTargetDescriptor(
+        id=target.id,
+        tenant_id=target.tenant_id,
+        name=target.name,
+        aliases=tuple(target.aliases or ()),
+        product=target.product,
+        version=target.version,
+        fingerprint=dict(target.fingerprint) if target.fingerprint is not None else None,
+        preferred_impl_id=target.preferred_impl_id,
+        host=target.host,
+        port=target.port,
+        fqdn=target.fqdn,
+        secret_ref=target.secret_ref,
+        auth_model=target.auth_model,
+        verify_tls=target.verify_tls,
+        tls_ca_pin=target.tls_ca_pin,
+        tls_server_name=target.tls_server_name,
+        extras=dict(target.extras or {}),
+    )
+
+
+def compute_assignment_version(items: list[wire.RunnerWorkItem]) -> str:
+    """Return the sha256 hex digest over the canonical JSON of *items*.
+
+    ``sort_keys`` canonicalises dict key order; the item order is the
+    stable authored order. 64-char lowercase hex — an opaque cache key on
+    the runner, digest semantics owned here.
+    """
+    payload = [item.model_dump(mode="json") for item in items]
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _resolved_connector(target: TargetORM) -> type[Connector] | None:
+    """Return the target's resolved connector class, or ``None`` on a miss."""
+    cls, label, _message = resolve_connector_or_label(target)
+    if label is not None:
+        return None
+    # resolver contract: label is None ⇔ cls is set.
+    assert cls is not None
+    return cls
+
+
+async def store_assignment(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    runner_name: str,
+    document: AssignmentDocument,
+) -> None:
+    """Validate every authored item, then replace the runner's document.
+
+    Raises a typed :mod:`meho_backplane.gateway.errors` exception on the
+    first invalid item — before any write — so a rejected PUT stores
+    nothing. Does not commit; the caller owns the transaction.
+    """
+    for item in document.items:
+        await _validate_authored_item(session, tenant_id=tenant_id, item=item)
+    items_json: list[dict[str, Any]] = [item.model_dump(mode="json") for item in document.items]
+    await repository.upsert_assignment_row(
+        session, tenant_id=tenant_id, runner_name=runner_name, items=items_json
+    )
+
+
+async def _validate_authored_item(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    item: AuthoredCheckItem,
+) -> None:
+    """Raise the appropriate typed error when an authored item is unauthorable."""
+    try:
+        target = await resolve_target(session, tenant_id, item.target_name)
+    except (TargetNotFoundError, AmbiguousTargetError) as exc:
+        raise AssignmentTargetUnknownError(
+            check_ref=item.check_ref, target_name=item.target_name
+        ) from exc
+
+    cls = _resolved_connector(target)
+    if cls is None:
+        raise AssignmentOpUnknownError(
+            check_ref=item.check_ref,
+            op=item.op,
+            reason=f"target {item.target_name!r} resolves no connector",
+        )
+
+    descriptor = await lookup_descriptor(
+        tenant_id=tenant_id,
+        product=cls.product,
+        version=cls.version,
+        impl_id=cls.impl_id,
+        op_id=item.op,
+    )
+    if descriptor is None:
+        raise AssignmentOpUnknownError(
+            check_ref=item.check_ref,
+            op=item.op,
+            reason=f"no enabled descriptor for connector "
+            f"({cls.product}, {cls.version}, {cls.impl_id})",
+        )
+    if descriptor.safety_level != _SAFE_LEVEL:
+        raise AssignmentOpNotSafeError(
+            check_ref=item.check_ref, op=item.op, safety_level=descriptor.safety_level
+        )
+
+
+async def materialize_assignment(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    runner_name: str,
+    principal: wire.RunnerPrincipal,
+) -> wire.RunnerAssignment:
+    """Materialise the runner's stored document into the versioned wire shape.
+
+    Resolves each authored item against the live target + op descriptor;
+    drops (with a warning) any item that no longer resolves to a runnable
+    safe op so the runner self-heals on the next poll. The returned
+    ``assignment_version`` is the content digest over the surviving items.
+    """
+    row = await repository.get_assignment_row(session, tenant_id=tenant_id, runner_name=runner_name)
+    raw_items: list[dict[str, Any]] = list(row.items) if row is not None else []
+
+    work_items: list[wire.RunnerWorkItem] = []
+    for raw in raw_items:
+        authored = AuthoredCheckItem.model_validate(raw)
+        work_item = await _materialize_item(
+            session, tenant_id=tenant_id, authored=authored, principal=principal
+        )
+        if work_item is not None:
+            work_items.append(work_item)
+
+    return wire.RunnerAssignment(
+        assignment_version=compute_assignment_version(work_items),
+        items=work_items,
+    )
+
+
+async def _materialize_item(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    authored: AuthoredCheckItem,
+    principal: wire.RunnerPrincipal,
+) -> wire.RunnerWorkItem | None:
+    """Materialise one authored item, or ``None`` (logged) if it no longer resolves."""
+    try:
+        target = await resolve_target(session, tenant_id, authored.target_name)
+    except (TargetNotFoundError, AmbiguousTargetError):
+        _log.warning(
+            "assignment_item_dropped",
+            reason="target_unresolved",
+            check_ref=authored.check_ref,
+            target_name=authored.target_name,
+        )
+        return None
+
+    cls = _resolved_connector(target)
+    if cls is None:
+        _log.warning(
+            "assignment_item_dropped",
+            reason="connector_unresolved",
+            check_ref=authored.check_ref,
+            target_name=authored.target_name,
+        )
+        return None
+
+    descriptor = await lookup_descriptor(
+        tenant_id=tenant_id,
+        product=cls.product,
+        version=cls.version,
+        impl_id=cls.impl_id,
+        op_id=authored.op,
+    )
+    if not _is_runnable_safe(descriptor):
+        _log.warning(
+            "assignment_item_dropped",
+            reason="op_unresolved_or_unsafe",
+            check_ref=authored.check_ref,
+            op=authored.op,
+        )
+        return None
+    assert descriptor is not None and descriptor.handler_ref is not None
+
+    return wire.RunnerWorkItem(
+        check_ref=authored.check_ref,
+        op_id=authored.op,
+        product=cls.product,
+        version=cls.version,
+        impl_id=cls.impl_id,
+        handler_ref=descriptor.handler_ref,
+        params=dict(authored.params),
+        safety_level=descriptor.safety_level,
+        principal=principal,
+        target_descriptor=descriptor_from_target(target),
+    )
+
+
+def _is_runnable_safe(descriptor: EndpointDescriptor | None) -> bool:
+    """True when *descriptor* is an enabled, safe op the runner can execute.
+
+    Requires a non-empty ``handler_ref``: the runner executes an op by
+    importing that dotted handler, so a descriptor without one (an
+    ingested/generic op) is not remotely runnable and is dropped.
+    """
+    return (
+        descriptor is not None
+        and descriptor.safety_level == _SAFE_LEVEL
+        and bool(descriptor.handler_ref)
+    )

--- a/backend/src/meho_backplane/gateway/errors.py
+++ b/backend/src/meho_backplane/gateway/errors.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed PUT-time assignment-authoring validation failures (#2499).
+
+The ``PUT /api/v1/checks/assignment/{runner}`` route validates every
+authored item before it stores the document: the target must resolve, and
+its op must resolve to an *enabled*, ``safety_level == 'safe'`` endpoint
+descriptor the runner can actually execute. A failing item raises one of
+these — each carrying a class-level ``error_code`` the route surfaces as a
+structured 422 via :mod:`meho_backplane.api.v1._errors`, the same
+machine-readable-code discipline as
+:class:`~meho_backplane.scheduler.service.EventTriggersNotImplementedError`.
+
+Fail at the *first* offending item and write nothing: an assignment PUT is
+a full-document replace, so a partial store would leave the runner with a
+half-authored document.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "AssignmentOpNotSafeError",
+    "AssignmentOpUnknownError",
+    "AssignmentTargetUnknownError",
+    "AssignmentValidationError",
+]
+
+
+class AssignmentValidationError(Exception):
+    """Base for a rejected authored assignment item.
+
+    Subclasses pin a machine-readable :attr:`error_code`; the route maps
+    each to a structured 422 whose ``type`` discriminator is that code.
+    """
+
+    #: Machine-readable code a typed client branches on. Overridden per
+    #: subclass; the base value is never surfaced (the base is abstract).
+    error_code = "assignment_invalid"
+
+
+class AssignmentTargetUnknownError(AssignmentValidationError):
+    """An authored item names a target that does not resolve in the tenant."""
+
+    error_code = "assignment_target_unknown"
+
+    def __init__(self, *, check_ref: str, target_name: str) -> None:
+        super().__init__(
+            f"assignment item {check_ref!r} names target {target_name!r}, "
+            "which does not resolve to a live target in this tenant"
+        )
+
+
+class AssignmentOpUnknownError(AssignmentValidationError):
+    """An authored item's op does not resolve to an enabled endpoint descriptor.
+
+    Covers both a target whose connector cannot be resolved (no /
+    ambiguous connector) and an op id with no enabled descriptor for the
+    resolved ``(product, version, impl_id)`` — the runner would have
+    nothing to execute either way.
+    """
+
+    error_code = "assignment_op_unknown"
+
+    def __init__(self, *, check_ref: str, op: str, reason: str) -> None:
+        super().__init__(
+            f"assignment item {check_ref!r} op {op!r} does not resolve to an "
+            f"enabled endpoint descriptor: {reason}"
+        )
+
+
+class AssignmentOpNotSafeError(AssignmentValidationError):
+    """An authored item's op resolves but is not ``safety_level == 'safe'``.
+
+    v1 of the gateway authorizes read-only workloads only; a
+    ``caution``/``dangerous`` op over the runner is a v2 follow-on.
+    """
+
+    error_code = "assignment_op_not_safe"
+
+    def __init__(self, *, check_ref: str, op: str, safety_level: str) -> None:
+        super().__init__(
+            f"assignment item {check_ref!r} op {op!r} has safety_level "
+            f"{safety_level!r}; the gateway authorizes only safety_level='safe' "
+            "workloads in v1"
+        )

--- a/backend/src/meho_backplane/gateway/repository.py
+++ b/backend/src/meho_backplane/gateway/repository.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""DB access for the gateway assignment + result-ingest tables (#2499).
+
+Thin persistence layer over ``runner_assignments`` and
+``runner_check_results``. Holds no business logic — target resolution,
+op-descriptor materialisation, and the content digest live in
+:mod:`meho_backplane.gateway.assignment_service`. Every function takes an
+open :class:`AsyncSession` the caller owns (the caller commits).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.models import RunnerAssignmentRow, RunnerCheckResult
+from meho_backplane.runner.wire import RunnerResult
+
+__all__ = [
+    "get_assignment_row",
+    "ingest_results",
+    "upsert_assignment_row",
+]
+
+
+async def get_assignment_row(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    runner_name: str,
+) -> RunnerAssignmentRow | None:
+    """Return the single assignment row for ``(tenant_id, runner_name)`` or ``None``."""
+    result = await session.execute(
+        select(RunnerAssignmentRow).where(
+            RunnerAssignmentRow.tenant_id == tenant_id,
+            RunnerAssignmentRow.runner_name == runner_name,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def upsert_assignment_row(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    runner_name: str,
+    items: list[dict[str, Any]],
+) -> RunnerAssignmentRow:
+    """Replace the runner's assignment document wholesale (create or update).
+
+    One row per ``(tenant_id, runner_name)`` (unique index). An existing
+    row's ``items`` are overwritten and ``updated_at`` refreshed; otherwise
+    a fresh row is inserted. Does not commit — the caller owns the
+    transaction.
+    """
+    row = await get_assignment_row(session, tenant_id=tenant_id, runner_name=runner_name)
+    if row is None:
+        row = RunnerAssignmentRow(
+            tenant_id=tenant_id,
+            runner_name=runner_name,
+            items=items,
+        )
+        session.add(row)
+    else:
+        row.items = items
+        row.updated_at = datetime.now(UTC)
+    return row
+
+
+async def ingest_results(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    runner_name: str,
+    results: list[RunnerResult],
+) -> tuple[int, int]:
+    """Persist a runner's result batch idempotently; return ``(accepted, duplicates)``.
+
+    Idempotency key is ``(tenant_id, runner_name, result_uid)``. Portable
+    across PostgreSQL and SQLite: dedupe the batch by ``result_uid``, read
+    back which of those uids already exist, then insert only the new ones.
+    A re-posted spool batch therefore inserts nothing and is reported
+    entirely as duplicates. ``received_at`` is left to the ORM default
+    (central clock) — never taken from the client. Does not commit.
+
+    ``accepted + duplicates == len(results)``: a within-batch repeat of a
+    ``result_uid`` counts once as accepted and the rest as duplicates.
+    """
+    total = len(results)
+    if total == 0:
+        return 0, 0
+
+    # Dedupe within the batch, preserving first-seen order.
+    seen: set[str] = set()
+    unique: list[RunnerResult] = []
+    for item in results:
+        if item.result_uid in seen:
+            continue
+        seen.add(item.result_uid)
+        unique.append(item)
+
+    existing_result = await session.execute(
+        select(RunnerCheckResult.result_uid).where(
+            RunnerCheckResult.tenant_id == tenant_id,
+            RunnerCheckResult.runner_name == runner_name,
+            RunnerCheckResult.result_uid.in_(seen),
+        )
+    )
+    already: set[str] = set(existing_result.scalars().all())
+
+    accepted = 0
+    for item in unique:
+        if item.result_uid in already:
+            continue
+        session.add(
+            RunnerCheckResult(
+                tenant_id=tenant_id,
+                runner_name=runner_name,
+                result_uid=item.result_uid,
+                check_ref=item.check_ref,
+                op_id=item.op_id,
+                status=item.status,
+                result_payload=item.result,
+                error=item.error,
+            )
+        )
+        accepted += 1
+
+    return accepted, total - accepted

--- a/backend/src/meho_backplane/gateway/schemas.py
+++ b/backend/src/meho_backplane/gateway/schemas.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Central-side request/response envelopes for the gateway checks API (#2499).
+
+The *runner-facing* wire shapes (``RunnerAssignment`` / ``RunnerWorkItem`` /
+``ResolvedTargetDescriptor`` / ``RunnerResultBatch``) live in
+:mod:`meho_backplane.runner.wire` and are shared by both ends of the wire.
+This module holds only the shapes the *operator* authoring surface needs —
+the ``PUT`` document and the result-ingest accounting response — following
+``docs/codebase/api-shape-conventions.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "AssignmentDocument",
+    "AssignmentDocumentResponse",
+    "AuthoredCheckItem",
+    "ResultIngestResponse",
+]
+
+
+class AuthoredCheckItem(BaseModel):
+    """One operator-authored check in a runner's assignment document.
+
+    The runner-facing ``GET`` materialises each of these into a wire
+    :class:`~meho_backplane.runner.wire.RunnerWorkItem` at request time:
+    ``target_name`` is resolved to a live target descriptor, ``op`` to the
+    resolved connector's enabled descriptor (yielding ``handler_ref`` +
+    ``safety_level`` + the ``(product, version, impl_id)`` key). ``op`` is
+    the connector-side op id (e.g. ``"vsphere.host.list"``); the connector
+    triple is derived from the resolved target, not authored here.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    check_ref: str = Field(min_length=1)
+    target_name: str = Field(min_length=1)
+    op: str = Field(min_length=1)
+    params: dict[str, Any] = Field(default_factory=dict)
+    # Runner-side poll cadence in seconds; ``ge=1`` (not ``gt=0``) so the
+    # constraint renders as ``minimum`` — identical in OpenAPI 3.0/3.1 —
+    # rather than a 3.1-only numeric ``exclusiveMinimum`` the CLI codegen
+    # (OpenAPI 3.0) cannot parse.
+    cadence_seconds: int = Field(ge=1)
+
+
+class AssignmentDocument(BaseModel):
+    """Full-document ``PUT`` body: replaces a runner's assignment wholesale."""
+
+    model_config = ConfigDict(frozen=True)
+
+    items: list[AuthoredCheckItem] = Field(default_factory=list)
+
+
+class AssignmentDocumentResponse(BaseModel):
+    """Echo returned by ``PUT``: the stored authored document + runner name."""
+
+    model_config = ConfigDict(frozen=True)
+
+    runner: str
+    items: list[AuthoredCheckItem]
+
+
+class ResultIngestResponse(BaseModel):
+    """``POST /checks/results`` response — idempotency accounting.
+
+    ``accepted`` counts rows newly persisted; ``duplicates`` counts rows
+    whose ``result_uid`` was already ingested for this runner (a re-posted
+    spool batch). ``accepted + duplicates`` equals the batch length.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    accepted: int
+    duplicates: int

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -73,6 +73,7 @@ from meho_backplane.api.v1.auth_config import router as api_v1_auth_config_route
 from meho_backplane.api.v1.broadcast_overrides import (
     router as api_v1_broadcast_overrides_router,
 )
+from meho_backplane.api.v1.checks import router as api_v1_checks_router
 from meho_backplane.api.v1.connectors_ingest import (
     router as api_v1_connectors_ingest_router,
 )
@@ -890,6 +891,13 @@ app.include_router(api_v1_agent_principals_router)
 # the JWT; cross-tenant probes return 404. The minted runner token is caged
 # to the gateway path prefixes (see middleware.RUNNER_ALLOWED_PATH_PREFIXES).
 app.include_router(api_v1_runner_principals_router)
+# Initiative #2415 (#2499) -- gateway assignment + result-ingest API, mounted
+# under /api/v1/checks/ (inside the runner route cage). PUT /checks/assignment/
+# {runner} authors a runner's checks (operator); GET /checks/assignment (runner,
+# own-only) returns the digest-versioned assignment with resolved target
+# descriptors + handler_ref/safety_level; POST /checks/results (runner, own-only)
+# idempotently ingests results with a central-stamped received_at.
+app.include_router(api_v1_checks_router)
 # G11.3-T5 (#826) -- scheduler-admin surface. GET /scheduler/triggers
 # (list, paginated, operator-level), POST /scheduler/triggers (create,
 # tenant_admin), DELETE /scheduler/triggers/{id} (cancel, tenant_admin).

--- a/backend/src/meho_backplane/runner/wire.py
+++ b/backend/src/meho_backplane/runner/wire.py
@@ -58,24 +58,52 @@ class ResolvedTargetDescriptor(BaseModel):
     The runner has no local target table, so the central resolver
     (:mod:`meho_backplane.connectors.resolver`, DB-bound) materialises
     the fields a handler duck-reads off a ``Target`` row and ships them
-    on the assignment. The v1 seed carries exactly the resolver-read
-    attributes (product / fingerprint / version / preferred_impl_id) plus
-    the human-facing ``name`` and the ``extras`` escape hatch.
+    on the assignment. It carries the resolver-read attributes
+    (``product`` / ``fingerprint`` / ``version`` / ``preferred_impl_id``)
+    the tie-break ladder consumes **and** the connection-routing set
+    (``host`` / ``port`` / ``fqdn`` / ``secret_ref`` / ``auth_model`` /
+    TLS flags) the HTTP adapter reads, so on the runner the descriptor
+    feeds :func:`~meho_backplane.connectors.resolver.resolve_connector`
+    and the connector adapters directly — no DB session, no second
+    resolution mechanism.
 
-    #2499 widens this class with the connection-routing set
-    (host, port, secret_ref, TLS flags) moulded on the central
-    ``TargetSummary``. The runner tolerates the wider shape because a
-    handler only reads the attributes it needs.
+    The full field set is moulded on the central
+    :class:`~meho_backplane.targets.schemas.TargetSummary` (#2499): the
+    same identification + connection-routing projection of the
+    ``Target`` row, minus the server-managed timestamps and the
+    operator-authored ``notes`` (neither drives connector routing).
+
+    Credential discipline: ``secret_ref`` is the **reference** the runner
+    resolves outbound under its own read-only scope; no credential value
+    is ever embedded (the runner spools assignments on disk, so a value
+    would durably persist — a locked no-durable-artifact violation).
     """
 
     model_config = ConfigDict(frozen=True)
 
+    # Identity (stable cross-system keys the runner echoes in reports /
+    # audit; ``id`` + ``tenant_id`` mirror the ``Target`` row PK + scope).
+    id: UUID
+    tenant_id: UUID
     name: str
+    aliases: tuple[str, ...] = ()
+    # Resolver inputs: the tie-break ladder reads ``product`` +
+    # ``fingerprint.version`` / ``version`` + ``preferred_impl_id``.
     product: str
     version: str | None = None
     fingerprint: dict[str, Any] | None = None
-    extras: dict[str, Any] = Field(default_factory=dict)
     preferred_impl_id: str | None = None
+    # Connection routing: the HTTP adapter builds ``https://{host}[:{port}]``
+    # and reads the TLS trust knobs off these fields.
+    host: str
+    port: int | None = None
+    fqdn: str | None = None
+    secret_ref: str | None = None
+    auth_model: str = "shared_service_account"
+    verify_tls: bool = True
+    tls_ca_pin: str | None = None
+    tls_server_name: str | None = None
+    extras: dict[str, Any] = Field(default_factory=dict)
 
 
 class RunnerPrincipal(BaseModel):

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -226,6 +226,13 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # table referenced in a foreign key constraint``.
     "identity_budget",
     "operation_group",
+    # ``runner_assignments.tenant_id`` and ``runner_check_results.tenant_id``
+    # are real ``REFERENCES tenant(id)`` FKs from migration ``0059``
+    # (Initiative #2415 T3, #2499). Same rule as ``runner_principal`` below:
+    # PG rejects truncating ``tenant`` unless every referencing table is listed
+    # in the same statement, so both must appear here.
+    "runner_assignments",
+    "runner_check_results",
     # ``runner_principal.tenant_id`` is a real ``REFERENCES tenant(id)`` FK
     # from migration ``0058`` (Initiative #2415 T6, #2502). Same rule: PG
     # rejects truncating ``tenant`` unless every referencing table is listed

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -429,6 +429,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
             text(
                 "TRUNCATE TABLE approval_request, agent_permission, "
                 "agent_principal, runner_principal, "
+                "runner_assignments, runner_check_results, "
                 "scheduled_trigger, event_outbox, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
@@ -494,6 +495,7 @@ async def pg_engine_empty_tenant(
             text(
                 "TRUNCATE TABLE approval_request, agent_permission, "
                 "agent_principal, runner_principal, "
+                "runner_assignments, runner_check_results, "
                 "scheduled_trigger, event_outbox, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "

--- a/backend/tests/migrations/test_migration_0059_create_runner_assignment_tables.py
+++ b/backend/tests/migrations/test_migration_0059_create_runner_assignment_tables.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0059_create_runner_assignment_tables``.
+
+Initiative #2415, Task #2499. Creates the two gateway-owned tables —
+``runner_assignments`` (one authored document per runner) and
+``runner_check_results`` (ingested execution reports). The **third**
+migration in the initiative's serialized chain; extends the then-current
+single head ``0058`` (``runner_principal``).
+
+**Idempotency pinning (0049/0050/0053/0055/0057/0058 footgun).** Every
+forward / round-trip / stamp-replay step targets this migration's **own**
+revision (``0059``) and its ``down_revision`` (``0058``), never ``head`` —
+so a future head migration cannot make ``upgrade("head")`` re-run these
+``create_table`` calls on a schema that already has them. SQLite drives the
+test and the migration uses only generic DDL, so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0059"
+_DOWN_REVISION = "0058"
+
+_ASSIGNMENTS_TABLE = "runner_assignments"
+_RESULTS_TABLE = "runner_check_results"
+
+_ASSIGNMENTS_COLUMNS = {
+    "id",
+    "tenant_id",
+    "runner_name",
+    "items",
+    "created_at",
+    "updated_at",
+}
+_RESULTS_COLUMNS = {
+    "id",
+    "tenant_id",
+    "runner_name",
+    "result_uid",
+    "check_ref",
+    "op_id",
+    "status",
+    "result_payload",
+    "error",
+    "received_at",
+}
+_UNIQUE_INDEXES = {
+    "runner_assignments_tenant_runner_idx",
+    "runner_check_results_uid_idx",
+}
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0059.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _columns(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _index_names(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA index_list({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _unique_index_names(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA index_list({table})")).all()
+    finally:
+        sync_eng.dispose()
+    # PRAGMA index_list columns: (seq, name, unique, origin, partial).
+    return {str(row[1]) for row in rows if int(row[2]) == 1}
+
+
+def _table_names(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type = 'table'")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def _table_sql(sync_url: str, table: str) -> str:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = :n"),
+                {"n": table},
+            ).first()
+    finally:
+        sync_eng.dispose()
+    assert row is not None, f"table {table!r} not present"
+    return str(row[0])
+
+
+def test_upgrade_creates_both_tables(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0059`` creates both gateway tables with the full column sets."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    assert _columns(sync_url, _ASSIGNMENTS_TABLE) == _ASSIGNMENTS_COLUMNS
+    assert _columns(sync_url, _RESULTS_TABLE) == _RESULTS_COLUMNS
+
+
+def test_upgrade_creates_indexes(alembic_cfg: tuple[Config, str]) -> None:
+    """The unique + staleness indexes are created."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    assert _unique_index_names(sync_url, _ASSIGNMENTS_TABLE) >= {
+        "runner_assignments_tenant_runner_idx"
+    }
+    assert _unique_index_names(sync_url, _RESULTS_TABLE) >= {"runner_check_results_uid_idx"}
+    # The staleness index is non-unique; assert it exists at all.
+    assert "runner_check_results_staleness_idx" in _index_names(sync_url, _RESULTS_TABLE)
+
+
+def test_results_status_check_constraint(alembic_cfg: tuple[Config, str]) -> None:
+    """The ``status`` CHECK bounds to the tri-state ``ok``/``refused``/``error``."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    sql = _table_sql(sync_url, _RESULTS_TABLE)
+    # The tri-state (matching the wire ``RunnerResult.status`` vocabulary) is
+    # bounded, not a bare ``ok``/``error`` — ``refused`` must be permitted.
+    assert "refused" in sql
+    for value in ("ok", "refused", "error"):
+        assert value in sql
+
+
+def test_stamp_down_revision_then_upgrade_is_idempotent(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Stamp ``0058`` then upgrade to ``0059`` — pinned to own revisions, never ``head``.
+
+    Builds the schema through the parent revision, stamps the version table
+    to ``0058``, then replays **only** this migration to its own revision.
+    A future head migration cannot make this step re-run the ``create_table``
+    on an already-migrated schema, since no leg targets ``"head"``.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+    command.stamp(cfg, _DOWN_REVISION)
+    command.upgrade(cfg, _REVISION)
+
+    assert _ASSIGNMENTS_TABLE in _table_names(sync_url)
+    assert _RESULTS_TABLE in _table_names(sync_url)
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0058"`` drops both tables; ``upgrade "0059"`` recreates them.
+
+    Pinned to this migration's own revision on both legs (never ``head``).
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _ASSIGNMENTS_TABLE in _table_names(sync_url)
+    assert _RESULTS_TABLE in _table_names(sync_url)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    names = _table_names(sync_url)
+    assert _ASSIGNMENTS_TABLE not in names
+    assert _RESULTS_TABLE not in names
+
+    command.upgrade(cfg, _REVISION)
+    assert _columns(sync_url, _ASSIGNMENTS_TABLE) == _ASSIGNMENTS_COLUMNS
+    assert _columns(sync_url, _RESULTS_TABLE) == _RESULTS_COLUMNS

--- a/backend/tests/test_gateway_assignment_api.py
+++ b/backend/tests/test_gateway_assignment_api.py
@@ -1,0 +1,578 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the gateway checks API (Initiative #2415, #2499).
+
+Exercises :mod:`meho_backplane.api.v1.checks` end to end against a minimal
+app that mounts the real router behind the real JWT chain (respx-mocked
+JWKS) so the runner route cage + ``require_runner`` + ``assert_runner_scope``
+all run for real:
+
+* ``PUT /api/v1/checks/assignment/{runner}`` — operator authoring +
+  structured-422 validation (non-safe / unknown op, unknown target).
+* ``GET /api/v1/checks/assignment`` — digest-versioned materialisation with
+  resolved target descriptors, 304-on-unchanged, drift-changes-digest.
+* ``POST /api/v1/checks/results`` — idempotent batch ingest, central-stamped
+  ``received_at``.
+* Runner scoping: a runner reaches only its own assignment/results;
+  operator-only PUT; unauthenticated 401.
+
+The wire shapes are :mod:`meho_backplane.runner.wire`'s — one schema on both
+ends by construction.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import respx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select, update
+
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    EndpointDescriptor,
+    RunnerAssignmentRow,
+    RunnerCheckResult,
+    RunnerPrincipal,
+    Tenant,
+)
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.gateway.assignment_service import descriptor_from_target
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.runner import wire
+
+# Autouse fixtures (settings env, JWKS cache reset, connector-registry reset).
+from ._oidc_jwt_helpers import (
+    DEFAULT_TENANT_ID,
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from ._targets_helpers import (
+    _empty_connector_registry,  # noqa: F401  (autouse)
+    _isolated_jwks_cache,  # noqa: F401  (autouse)
+    _operator_token,
+    _settings_env,  # noqa: F401  (autouse)
+)
+
+_TENANT = uuid.UUID(DEFAULT_TENANT_ID)
+_RUNNER_A_ID = uuid.UUID("aaaaaaaa-0000-0000-0000-00000000000a")
+_RUNNER_B_ID = uuid.UUID("bbbbbbbb-0000-0000-0000-00000000000b")
+
+_PRODUCT = "checkprod"
+_VERSION = "1.x"
+_IMPL = "checkprod-api"
+_OP_SAFE = "check.status"
+_OP_CAUTION = "check.reboot"
+_OP_UNKNOWN = "check.ghost"
+_HANDLER_REF = "meho_backplane.connectors.checkprod.handlers.status"
+
+_TARGET_NAME = "check-target"
+_SECRET_REF = f"secret/tenants/{DEFAULT_TENANT_ID}/checkprod"
+_TLS_CA_PIN_A = "-----BEGIN CERTIFICATE-----\npin-A\n-----END CERTIFICATE-----"
+_TLS_CA_PIN_B = "-----BEGIN CERTIFICATE-----\npin-B-rotated\n-----END CERTIFICATE-----"
+_TLS_SERVER_NAME = "check.corp.internal"
+
+
+class _CheckConnector(Connector):
+    """A tiny versioned connector so the target resolves to a real class.
+
+    Class attrs match the registration triple (the canonical pattern real
+    connectors follow); ``supported_version_range`` unset ⇒ any version.
+    """
+
+    product = _PRODUCT
+    version = _VERSION
+    impl_id = _IMPL
+
+    async def probe(self, target: Any) -> Any:  # pragma: no cover - never dispatched
+        raise NotImplementedError
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> Any:
+        raise NotImplementedError
+
+    async def execute(  # pragma: no cover - never dispatched
+        self, target: Any, op_id: str, params: dict[str, Any]
+    ) -> Any:
+        raise NotImplementedError
+
+
+def _register_connector() -> None:
+    register_connector_v2(product=_PRODUCT, version=_VERSION, impl_id=_IMPL, cls=_CheckConnector)
+
+
+def _build_app() -> FastAPI:
+    from meho_backplane.api.v1.checks import router as checks_router
+
+    app = FastAPI()
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(checks_router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+def _runner_token(key: Any, *, runner_id: uuid.UUID, sub: str = "runner-sub") -> str:
+    return mint_token(
+        key,
+        sub=sub,
+        tenant_id=DEFAULT_TENANT_ID,
+        tenant_role="read_only",
+        principal_kind="runner",
+        runner_id=str(runner_id),
+    )
+
+
+async def _seed_identities() -> None:
+    """Seed the tenant + two runner principals (runner-a -> A, runner-b -> B)."""
+    async with get_sessionmaker()() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=_TENANT, slug="tenant-checks", name="Checks Tenant"))
+        for rid, rname in ((_RUNNER_A_ID, "runner-a"), (_RUNNER_B_ID, "runner-b")):
+            if (
+                await session.execute(select(RunnerPrincipal).where(RunnerPrincipal.id == rid))
+            ).scalar_one_or_none() is None:
+                session.add(
+                    RunnerPrincipal(
+                        id=rid,
+                        tenant_id=_TENANT,
+                        name=rname,
+                        keycloak_client_id=f"runner:{rname}",
+                        keycloak_internal_id=f"kc-{rname}",
+                        owner_sub="op-admin",
+                        created_by_sub="op-admin",
+                    )
+                )
+        await session.commit()
+
+
+def _new_target(**overrides: Any) -> TargetORM:
+    """Build a fully-specified (unpersisted) target row for the check connector."""
+    fields: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "tenant_id": _TENANT,
+        "name": _TARGET_NAME,
+        "aliases": [],
+        "product": _PRODUCT,
+        "version": _VERSION,
+        "host": "10.9.9.9",
+        "port": 443,
+        "fqdn": "check.corp",
+        "secret_ref": _SECRET_REF,
+        "auth_model": "shared_service_account",
+        "vpn_required": False,
+        "verify_tls": True,
+        "tls_ca_pin": _TLS_CA_PIN_A,
+        "tls_server_name": _TLS_SERVER_NAME,
+        "extras": {},
+        "notes": None,
+        "fingerprint": None,
+        "preferred_impl_id": None,
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+    }
+    fields.update(overrides)
+    return TargetORM(**fields)
+
+
+async def _seed_target(**overrides: Any) -> None:
+    async with get_sessionmaker()() as session:
+        session.add(_new_target(**overrides))
+        await session.commit()
+
+
+async def _seed_descriptor(
+    *, op_id: str, safety_level: str = "safe", handler_ref: str | None = _HANDLER_REF
+) -> None:
+    async with get_sessionmaker()() as session:
+        session.add(
+            EndpointDescriptor(
+                tenant_id=_TENANT,
+                product=_PRODUCT,
+                version=_VERSION,
+                impl_id=_IMPL,
+                op_id=op_id,
+                source_kind="typed",
+                handler_ref=handler_ref,
+                safety_level=safety_level,
+                is_enabled=True,
+            )
+        )
+        await session.commit()
+
+
+async def _assignment_row_count() -> int:
+    async with get_sessionmaker()() as session:
+        rows = (await session.execute(select(RunnerAssignmentRow))).scalars().all()
+        return len(rows)
+
+
+def _put_body(*items: dict[str, Any]) -> dict[str, Any]:
+    return {"items": list(items)}
+
+
+def _safe_item() -> dict[str, Any]:
+    return {
+        "check_ref": "chk-1",
+        "target_name": _TARGET_NAME,
+        "op": _OP_SAFE,
+        "params": {"detail": "full"},
+        "cadence_seconds": 60,
+    }
+
+
+# ---------------------------------------------------------------------------
+# PUT — authoring validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_put_rejects_non_safe_op(client: TestClient) -> None:
+    """Non-safe op → 422 assignment_op_not_safe; unknown op → assignment_op_unknown;
+    unknown target → structured error; nothing is stored on rejection."""
+    await _seed_identities()
+    await _seed_target()
+    await _seed_descriptor(op_id=_OP_SAFE, safety_level="safe")
+    await _seed_descriptor(op_id=_OP_CAUTION, safety_level="caution")
+    _register_connector()
+
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_operator_token(key)}"}
+
+        # Non-safe op.
+        non_safe = {**_safe_item(), "op": _OP_CAUTION}
+        resp_unsafe = client.put(
+            "/api/v1/checks/assignment/runner-a", json=_put_body(non_safe), headers=headers
+        )
+        # Unknown op (no descriptor).
+        unknown_op = {**_safe_item(), "op": _OP_UNKNOWN}
+        resp_unknown = client.put(
+            "/api/v1/checks/assignment/runner-a", json=_put_body(unknown_op), headers=headers
+        )
+        # Unknown target.
+        unknown_target = {**_safe_item(), "target_name": "no-such-target"}
+        resp_target = client.put(
+            "/api/v1/checks/assignment/runner-a", json=_put_body(unknown_target), headers=headers
+        )
+
+    assert resp_unsafe.status_code == 422
+    assert resp_unsafe.json()["detail"][0]["type"] == "assignment_op_not_safe"
+    assert resp_unknown.status_code == 422
+    assert resp_unknown.json()["detail"][0]["type"] == "assignment_op_unknown"
+    assert resp_target.status_code in (404, 422)
+    assert resp_target.json()["detail"][0]["type"] == "assignment_target_unknown"
+
+    # No row written on any rejection.
+    assert await _assignment_row_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_put_stores_safe_assignment(client: TestClient) -> None:
+    """A valid PUT stores exactly one document row and echoes it back."""
+    await _seed_identities()
+    await _seed_target()
+    await _seed_descriptor(op_id=_OP_SAFE)
+    _register_connector()
+
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        resp = client.put(
+            "/api/v1/checks/assignment/runner-a",
+            json=_put_body(_safe_item()),
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["runner"] == "runner-a"
+    assert resp.json()["items"][0]["check_ref"] == "chk-1"
+    assert await _assignment_row_count() == 1
+
+
+# ---------------------------------------------------------------------------
+# GET — digest-versioned materialisation
+# ---------------------------------------------------------------------------
+
+
+async def _author_via_put(client: TestClient, key: Any) -> None:
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        resp = client.put(
+            "/api/v1/checks/assignment/runner-a",
+            json=_put_body(_safe_item()),
+            headers={"Authorization": f"Bearer {_operator_token(key)}"},
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_assignment_versioned(client: TestClient) -> None:
+    """GET returns a hex digest + materialised item; 304 on match; digest shifts on drift."""
+    await _seed_identities()
+    await _seed_target()
+    await _seed_descriptor(op_id=_OP_SAFE)
+    _register_connector()
+
+    key = make_rsa_keypair("kid-A")
+    await _author_via_put(client, key)
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        rheaders = {"Authorization": f"Bearer {_runner_token(key, runner_id=_RUNNER_A_ID)}"}
+        first = client.get("/api/v1/checks/assignment?runner=runner-a", headers=rheaders)
+        digest = first.json()["assignment_version"]
+        second = client.get(
+            f"/api/v1/checks/assignment?runner=runner-a&known_version={digest}", headers=rheaders
+        )
+
+    assert first.status_code == 200
+    # 64-char lowercase hex digest.
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
+
+    item = first.json()["items"][0]
+    assert item["check_ref"] == "chk-1"
+    assert item["handler_ref"] == _HANDLER_REF
+    assert item["safety_level"] == "safe"
+    assert item["op_id"] == _OP_SAFE
+    assert item["product"] == _PRODUCT
+    # Principal context of the requesting runner.
+    assert item["principal"]["principal_kind"] == "runner"
+    assert item["principal"]["tenant_role"] == "read_only"
+    # Resolved target descriptor carries the full connection-routing set.
+    # (wire field name is ``target_descriptor``; the issue's "target".)
+    td = item["target_descriptor"]
+    for field in (
+        "host",
+        "port",
+        "product",
+        "fingerprint",
+        "preferred_impl_id",
+        "secret_ref",
+        "verify_tls",
+        "tls_ca_pin",
+        "tls_server_name",
+    ):
+        assert field in td, field
+    assert td["host"] == "10.9.9.9"
+    assert td["port"] == 443
+    assert td["secret_ref"] == _SECRET_REF
+    assert td["tls_ca_pin"] == _TLS_CA_PIN_A
+
+    # Unchanged → 304 with empty body.
+    assert second.status_code == 304
+    assert second.content == b""
+
+    # Drift: rotate the target's tls_ca_pin; same known_version now 200 + new digest.
+    async with get_sessionmaker()() as session:
+        await session.execute(
+            update(TargetORM)
+            .where(TargetORM.tenant_id == _TENANT, TargetORM.name == _TARGET_NAME)
+            .values(tls_ca_pin=_TLS_CA_PIN_B)
+        )
+        await session.commit()
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        rheaders = {"Authorization": f"Bearer {_runner_token(key, runner_id=_RUNNER_A_ID)}"}
+        after = client.get(
+            f"/api/v1/checks/assignment?runner=runner-a&known_version={digest}", headers=rheaders
+        )
+
+    assert after.status_code == 200
+    assert after.json()["assignment_version"] != digest
+    assert after.json()["items"][0]["target_descriptor"]["tls_ca_pin"] == _TLS_CA_PIN_B
+
+
+@pytest.mark.asyncio
+async def test_wire_models_shared(client: TestClient) -> None:
+    """The GET body parses as ``runner/wire.py``'s RunnerAssignment; one descriptor class."""
+    await _seed_identities()
+    await _seed_target()
+    await _seed_descriptor(op_id=_OP_SAFE)
+    _register_connector()
+
+    key = make_rsa_keypair("kid-A")
+    await _author_via_put(client, key)
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        resp = client.get(
+            "/api/v1/checks/assignment?runner=runner-a",
+            headers={"Authorization": f"Bearer {_runner_token(key, runner_id=_RUNNER_A_ID)}"},
+        )
+
+    assert resp.status_code == 200
+    # One schema on both sides — the response validates as the wire model.
+    parsed = wire.RunnerAssignment.model_validate(resp.json())
+    assert parsed.items[0].check_ref == "chk-1"
+    assert parsed.items[0].target_descriptor is not None
+
+    # ``ResolvedTargetDescriptor`` is defined in exactly one file (no fork).
+    src_root = Path(__file__).resolve().parent.parent / "src" / "meho_backplane"
+    hits = [
+        p
+        for p in src_root.rglob("*.py")
+        if "class ResolvedTargetDescriptor" in p.read_text(encoding="utf-8")
+    ]
+    assert len(hits) == 1
+    assert hits[0].name == "wire.py"
+
+
+@pytest.mark.asyncio
+async def test_descriptor_carries_no_secret_values(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The GET payload ships ``secret_ref`` verbatim and never a credential value."""
+    calls: list[Any] = []
+
+    def _spy(*args: Any, **kwargs: Any) -> Any:
+        calls.append((args, kwargs))
+        raise AssertionError("credential backend must not be dialed during assignment GET")
+
+    monkeypatch.setattr(
+        "meho_backplane.connectors._shared.vault_creds.load_basic_credentials", _spy
+    )
+
+    await _seed_identities()
+    await _seed_target()
+    await _seed_descriptor(op_id=_OP_SAFE)
+    _register_connector()
+
+    key = make_rsa_keypair("kid-A")
+    await _author_via_put(client, key)
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        resp = client.get(
+            "/api/v1/checks/assignment?runner=runner-a",
+            headers={"Authorization": f"Bearer {_runner_token(key, runner_id=_RUNNER_A_ID)}"},
+        )
+
+    assert resp.status_code == 200
+    assert not calls  # no Vault/GSM call during GET
+    td = resp.json()["items"][0]["target_descriptor"]
+    assert td["secret_ref"] == _SECRET_REF
+    for forbidden in ("password", "token", "secret_data"):
+        assert forbidden not in td
+    # And no credential value leaks anywhere in the serialised payload.
+    assert "secret_data" not in json.dumps(resp.json())
+
+
+def test_descriptor_duck_types_resolver() -> None:
+    """``resolve_connector`` picks the same class off the descriptor and the row."""
+    _register_connector()
+    target = _new_target()
+    descriptor = descriptor_from_target(target)
+
+    # No DB session is opened by ``resolve_connector`` — it reads attrs +
+    # the in-process registry only.
+    assert resolve_connector(descriptor) is resolve_connector(target)
+    assert resolve_connector(descriptor) is _CheckConnector
+
+
+# ---------------------------------------------------------------------------
+# POST — idempotent result ingest
+# ---------------------------------------------------------------------------
+
+
+def _result_batch(runner_id: str, *uids: str) -> dict[str, Any]:
+    return {
+        "runner_id": runner_id,
+        "results": [
+            {
+                "result_uid": uid,
+                "check_ref": "chk-1",
+                "op_id": _OP_SAFE,
+                "status": "ok",
+                "result": {"reachable": True},
+                "error": None,
+            }
+            for uid in uids
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_results_batch_idempotent(client: TestClient) -> None:
+    """POST N results → accepted N; re-POST identical → duplicates N; received_at server-set."""
+    await _seed_identities()
+    key = make_rsa_keypair("kid-A")
+    # A naive floor (aiosqlite reads ``DateTime(timezone=True)`` back as
+    # naive); a server-stamped ``received_at`` is well after this.
+    sentinel = datetime(2000, 1, 1)
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        rheaders = {"Authorization": f"Bearer {_runner_token(key, runner_id=_RUNNER_A_ID)}"}
+        batch = _result_batch("runner-a", "uid-1", "uid-2", "uid-3")
+        first = client.post("/api/v1/checks/results", json=batch, headers=rheaders)
+        second = client.post("/api/v1/checks/results", json=batch, headers=rheaders)
+
+    assert first.status_code == 200
+    assert first.json() == {"accepted": 3, "duplicates": 0}
+    assert second.status_code == 200
+    assert second.json() == {"accepted": 0, "duplicates": 3}
+
+    async with get_sessionmaker()() as session:
+        rows = (await session.execute(select(RunnerCheckResult))).scalars().all()
+    assert len(rows) == 3
+    # received_at is central-stamped, not the client sentinel (the wire model
+    # has no received_at field, so a client cannot inject it).
+    for row in rows:
+        stored = row.received_at
+        stored_naive = stored.replace(tzinfo=None) if stored.tzinfo is not None else stored
+        assert stored_naive > sentinel
+
+
+# ---------------------------------------------------------------------------
+# Runner scoping + auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runner_scoping(client: TestClient) -> None:
+    """A runner reaches only its own assignment/results; PUT is operator-only; 401 unauth."""
+    await _seed_identities()
+    key = make_rsa_keypair("kid-A")
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        a_headers = {"Authorization": f"Bearer {_runner_token(key, runner_id=_RUNNER_A_ID)}"}
+
+        # Runner A fetching runner B's assignment → 403.
+        cross_get = client.get("/api/v1/checks/assignment?runner=runner-b", headers=a_headers)
+        # Runner A posting results for runner B → 403.
+        cross_post = client.post(
+            "/api/v1/checks/results", json=_result_batch("runner-b", "x-1"), headers=a_headers
+        )
+        # Runner token on operator-only PUT → 403.
+        runner_put = client.put(
+            "/api/v1/checks/assignment/runner-a", json=_put_body(), headers=a_headers
+        )
+        # Unauthenticated GET / POST → 401.
+        unauth_get = client.get("/api/v1/checks/assignment?runner=runner-a")
+        unauth_post = client.post("/api/v1/checks/results", json=_result_batch("runner-a", "y-1"))
+
+    assert cross_get.status_code == 403
+    assert cross_post.status_code == 403
+    assert runner_put.status_code == 403
+    assert unauth_get.status_code == 401
+    assert unauth_post.status_code == 401

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -7221,6 +7221,188 @@
         }
       }
     },
+    "/api/v1/checks/assignment/{runner}": {
+      "put": {
+        "tags": [
+          "checks"
+        ],
+        "summary": "Put Assignment",
+        "description": "Replace runner *runner*'s assignment document (operator-authenticated).\n\nValidates every authored item before storing; a failing item is a\nstructured 422 (``assignment_target_unknown`` / ``assignment_op_unknown``\n/ ``assignment_op_not_safe``) and nothing is written.",
+        "operationId": "put_assignment_api_v1_checks_assignment__runner__put",
+        "parameters": [
+          {
+            "name": "runner",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "title": "Runner"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignmentDocument"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignmentDocumentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/checks/assignment": {
+      "get": {
+        "tags": [
+          "checks"
+        ],
+        "summary": "Get Assignment",
+        "description": "Return runner *runner*'s versioned assignment (runner-authenticated).\n\nA runner may fetch only its own assignment\n(:func:`assert_runner_scope`). ``known_version`` matching the current\ncontent digest yields ``304 Not Modified`` (empty body); the runner\nkeeps its cache.",
+        "operationId": "get_assignment_api_v1_checks_assignment_get",
+        "parameters": [
+          {
+            "name": "runner",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "title": "Runner"
+            }
+          },
+          {
+            "name": "known_version",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Known Version"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunnerAssignment"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/checks/results": {
+      "post": {
+        "tags": [
+          "checks"
+        ],
+        "summary": "Post Results",
+        "description": "Ingest a runner's result batch idempotently (runner-authenticated).\n\nThe runner submits only its own results (``batch.runner_id`` is the\nrunner name; :func:`assert_runner_scope` binds it to the token's\n``runner_id``). ``received_at`` is central-stamped; re-posts from the\nrunner's retry spool are deduped by ``result_uid``.",
+        "operationId": "post_results_api_v1_checks_results_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunnerResultBatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultIngestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/scheduler/triggers": {
       "get": {
         "tags": [
@@ -18918,6 +19100,42 @@
         "title": "AskDocsResponse",
         "description": "Successful response shape for ``/api/v1/ask_docs``.\n\n``answer`` is the grounded, cited answer -- composed strictly from the\nretrieved chunks (no claim without a citation) or, on an empty\nretrieval, the deterministic\n:data:`~meho_backplane.docs_search.NO_GROUNDED_ANSWER` string. Frozen so\nan accidental post-construction mutation surfaces as a pydantic error\nrather than a silently-altered response.\n\n``citations`` is the subset of retrieved chunks the answer relied on,\neach serialised with its resolved navigable ``link`` (#1919) -- the\n**same** citation shape the MCP ``ask_docs`` tool returns, so a client\nconsuming either face resolves citations identically. The list entries\nare the raw :class:`~meho_backplane.docs_search.DocsChunk` fields plus a\n``link`` member; modelled as ``list[dict]`` (not a typed model) because\nthe ``link`` shape is produced by the shared\n:func:`~meho_backplane.docs_search.citation_link_payload` helper, kept as\nthe single source of truth for the citation-link contract."
       },
+      "AssignmentDocument": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AuthoredCheckItem"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "title": "AssignmentDocument",
+        "description": "Full-document ``PUT`` body: replaces a runner's assignment wholesale."
+      },
+      "AssignmentDocumentResponse": {
+        "properties": {
+          "runner": {
+            "type": "string",
+            "title": "Runner"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AuthoredCheckItem"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "runner",
+          "items"
+        ],
+        "title": "AssignmentDocumentResponse",
+        "description": "Echo returned by ``PUT``: the stored authored document + runner name."
+      },
       "AuditEntry": {
         "properties": {
           "id": {
@@ -19230,6 +19448,44 @@
         ],
         "title": "AuthModel",
         "description": "Per-target identity model per v0.1-spec L447-454."
+      },
+      "AuthoredCheckItem": {
+        "properties": {
+          "check_ref": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Check Ref"
+          },
+          "target_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Target Name"
+          },
+          "op": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Op"
+          },
+          "params": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Params"
+          },
+          "cadence_seconds": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Cadence Seconds"
+          }
+        },
+        "type": "object",
+        "required": [
+          "check_ref",
+          "target_name",
+          "op",
+          "cadence_seconds"
+        ],
+        "title": "AuthoredCheckItem",
+        "description": "One operator-authored check in a runner's assignment document.\n\nThe runner-facing ``GET`` materialises each of these into a wire\n:class:`~meho_backplane.runner.wire.RunnerWorkItem` at request time:\n``target_name`` is resolved to a live target descriptor, ``op`` to the\nresolved connector's enabled descriptor (yielding ``handler_ref`` +\n``safety_level`` + the ``(product, version, impl_id)`` key). ``op`` is\nthe connector-side op id (e.g. ``\"vsphere.host.list\"``); the connector\ntriple is derived from the resolved target, not authored here."
       },
       "BackendReadiness": {
         "properties": {
@@ -24090,6 +24346,17 @@
         "title": "PreviewOperationBody",
         "description": "Request body for the ``POST /api/v1/operations/preview`` route.\n\nSame field shape as :class:`CallOperationBody` (#1683) -- a preview\nresolves the *same* op + target + params a real ``call_operation``\nwould, then returns the literal would-be HTTP request instead of\nsending it. Keeping the body identical means an operator who hit a\nwrite 4xx can re-issue the exact arguments against ``/preview`` to see\nwhat was put on the wire (the audit row persists only a hashed\n``params_hash``, so the request shape is otherwise unrecoverable).\n\n``target`` accepts the same three shapes as ``call_operation`` (bare\nstring, dict ``{\"name\": ...}``, or ``None``); see\n:class:`CallOperationBody` for the convention. A wrong-JSON-typed\n``target`` rides the ``target_invalid_type`` envelope instead of a 422\n(#2110; see :data:`_TargetArg`), identical to ``/call``.\n``extra=\"forbid\"`` keeps a typo in ``connector_id`` failing loud rather\nthan silently previewing nothing."
       },
+      "PrincipalKind": {
+        "type": "string",
+        "enum": [
+          "user",
+          "service",
+          "agent",
+          "runner"
+        ],
+        "title": "PrincipalKind",
+        "description": "Discriminator that distinguishes what authenticated this request.\n\nG11.2-T1 (#815) adds this field to :class:`Operator` so dispatch,\naudit, and the approval gate can tell a human operator apart from\na service account or an agent without re-examining the JWT payload.\n\nValues are the literal strings the Keycloak ``principal_kind``\nprotocol mapper emits on the agent client (or that the v0.3 token\nexchange layer will emit). Existing tokens that carry no\n``principal_kind`` claim default to :attr:`USER` \u2014 the graceful-\nfallback contract means all pre-G11.2 human-operator flows are\nunaffected.\n\nMembers:\n\n* :attr:`USER` \u2014 a human operator authenticated via the interactive\n  device-code flow. Default when no claim is present.\n* :attr:`SERVICE` \u2014 a non-interactive service account client that\n  uses client-credentials flow but is not a MEHO-managed agent.\n* :attr:`AGENT` \u2014 a Keycloak client registered by\n  ``meho agent-principal register``; the token carries\n  ``principal_kind=agent``. G11.2-T2 (RFC 8693 delegation) and\n  G11.2-T3 (per-principal permission model) branch on this value\n  to apply agent-specific authz.\n* :attr:`RUNNER` \u2014 a satellite runner's service principal registered\n  by ``meho runner-principal register`` (Initiative #2415, #2502);\n  the token carries ``principal_kind=runner`` plus a ``runner_id``\n  claim. A runner is a dumb, push-only executor with a **read-only**\n  credential scope: its token is fail-closed 403'd on every\n  authenticated route outside the gateway allowlist prefixes\n  (:data:`~meho_backplane.middleware.RUNNER_ALLOWED_PATH_PREFIXES`)\n  and on the MCP surface. The unforgeable discriminator is what the\n  negative cage keys on, so a runner client missing any other mapper\n  still cannot roam the read API."
+      },
       "PromoteBody": {
         "properties": {
           "to": {
@@ -24544,6 +24811,125 @@
         ],
         "title": "ReplayNode",
         "description": "One node of a per-session audit-replay tree (G8.2-T3).\n\nSubclasses :class:`AuditEntry` so it carries every audit field verbatim \u2014\nforward-compatible with the v0.2.next compliance-export contract, which\ntreats a replay node as an audit row plus its position in the session\ngraph. Two structural fields are added:\n\n* ``depth`` \u2014 distance from the session root. ``0`` for roots; assigned\n  during tree assembly in :func:`~meho_backplane.audit_query.replay.replay_session`.\n* ``children`` \u2014 the node's direct children, ordered by ``(occurred_at,\n  id)``. Self-referential \u2014 the forward reference is resolved by the\n  module-level :func:`ReplayNode.model_rebuild` call below.\n\nFrozen like its parent: a node handed to a caller cannot mutate after the\ntree is built."
+      },
+      "ResolvedTargetDescriptor": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Aliases",
+            "default": []
+          },
+          "product": {
+            "type": "string",
+            "title": "Product"
+          },
+          "version": {
+            "type": "string",
+            "nullable": true,
+            "title": "Version"
+          },
+          "fingerprint": {
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true,
+            "title": "Fingerprint"
+          },
+          "preferred_impl_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Preferred Impl Id"
+          },
+          "host": {
+            "type": "string",
+            "title": "Host"
+          },
+          "port": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Port"
+          },
+          "fqdn": {
+            "type": "string",
+            "nullable": true,
+            "title": "Fqdn"
+          },
+          "secret_ref": {
+            "type": "string",
+            "nullable": true,
+            "title": "Secret Ref"
+          },
+          "auth_model": {
+            "type": "string",
+            "title": "Auth Model",
+            "default": "shared_service_account"
+          },
+          "verify_tls": {
+            "type": "boolean",
+            "title": "Verify Tls",
+            "default": true
+          },
+          "tls_ca_pin": {
+            "type": "string",
+            "nullable": true,
+            "title": "Tls Ca Pin"
+          },
+          "tls_server_name": {
+            "type": "string",
+            "nullable": true,
+            "title": "Tls Server Name"
+          },
+          "extras": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Extras"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "tenant_id",
+          "name",
+          "product",
+          "host"
+        ],
+        "title": "ResolvedTargetDescriptor",
+        "description": "Centrally-resolved target attributes a connector handler reads.\n\nThe runner has no local target table, so the central resolver\n(:mod:`meho_backplane.connectors.resolver`, DB-bound) materialises\nthe fields a handler duck-reads off a ``Target`` row and ships them\non the assignment. It carries the resolver-read attributes\n(``product`` / ``fingerprint`` / ``version`` / ``preferred_impl_id``)\nthe tie-break ladder consumes **and** the connection-routing set\n(``host`` / ``port`` / ``fqdn`` / ``secret_ref`` / ``auth_model`` /\nTLS flags) the HTTP adapter reads, so on the runner the descriptor\nfeeds :func:`~meho_backplane.connectors.resolver.resolve_connector`\nand the connector adapters directly \u2014 no DB session, no second\nresolution mechanism.\n\nThe full field set is moulded on the central\n:class:`~meho_backplane.targets.schemas.TargetSummary` (#2499): the\nsame identification + connection-routing projection of the\n``Target`` row, minus the server-managed timestamps and the\noperator-authored ``notes`` (neither drives connector routing).\n\nCredential discipline: ``secret_ref`` is the **reference** the runner\nresolves outbound under its own read-only scope; no credential value\nis ever embedded (the runner spools assignments on disk, so a value\nwould durably persist \u2014 a locked no-durable-artifact violation)."
+      },
+      "ResultIngestResponse": {
+        "properties": {
+          "accepted": {
+            "type": "integer",
+            "title": "Accepted"
+          },
+          "duplicates": {
+            "type": "integer",
+            "title": "Duplicates"
+          }
+        },
+        "type": "object",
+        "required": [
+          "accepted",
+          "duplicates"
+        ],
+        "title": "ResultIngestResponse",
+        "description": "``POST /checks/results`` response \u2014 idempotency accounting.\n\n``accepted`` counts rows newly persisted; ``duplicates`` counts rows\nwhose ``result_uid`` was already ingested for this runner (a re-posted\nspool batch). ``accepted + duplicates`` equals the batch length."
       },
       "RetireChecklistReport": {
         "properties": {
@@ -25022,6 +25408,55 @@
         "title": "RunbookTemplateListResponse",
         "description": "Unified list envelope for ``GET /api/v1/runbooks/templates``.\n\nThe `{items, next_cursor}` shape codified in\n``docs/codebase/api-shape-conventions.md`` \u00a72. Per-entry shape is the\nsubstrate's :class:`~meho_backplane.runbooks.schemas.TemplateSummary`.\nThe listing is not cursor-paginated (``limit`` truncates), so\n``next_cursor`` is always ``None`` but present so the endpoint can\ngrow pagination later without a further breaking change."
       },
+      "RunnerAssignment": {
+        "properties": {
+          "assignment_version": {
+            "type": "string",
+            "title": "Assignment Version"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RunnerWorkItem"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": [
+          "assignment_version"
+        ],
+        "title": "RunnerAssignment",
+        "description": "The runner's current work assignment, fetched each tick.\n\n``assignment_version`` is an opaque digest the runner echoes back as\n``known_version`` so central can answer an unchanged assignment with a\n``304`` (see :meth:`RunnerClient.fetch_assignment`)."
+      },
+      "RunnerPrincipal": {
+        "properties": {
+          "sub": {
+            "type": "string",
+            "title": "Sub"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "tenant_role": {
+            "$ref": "#/components/schemas/TenantRole"
+          },
+          "principal_kind": {
+            "$ref": "#/components/schemas/PrincipalKind",
+            "default": "service"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sub",
+          "tenant_id",
+          "tenant_role"
+        ],
+        "title": "RunnerPrincipal",
+        "description": "Principal context an executed op runs under, carried on each item.\n\nEnough to reconstruct an :class:`~meho_backplane.auth.operator.Operator`\non the runner without a JWT: the runner never sees a bearer token for\nthe acting principal (the op was already authorized centrally), so the\nreconstructed operator's ``raw_jwt`` is empty."
+      },
       "RunnerPrincipalCreate": {
         "properties": {
           "name": {
@@ -25122,6 +25557,124 @@
         ],
         "title": "RunnerPrincipalRead",
         "description": "Row representation returned by every accessor."
+      },
+      "RunnerResult": {
+        "properties": {
+          "result_uid": {
+            "type": "string",
+            "title": "Result Uid"
+          },
+          "check_ref": {
+            "type": "string",
+            "title": "Check Ref"
+          },
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "result": {
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true,
+            "title": "Result"
+          },
+          "error": {
+            "type": "string",
+            "nullable": true,
+            "title": "Error"
+          }
+        },
+        "type": "object",
+        "required": [
+          "result_uid",
+          "check_ref",
+          "op_id",
+          "status"
+        ],
+        "title": "RunnerResult",
+        "description": "The outcome of executing one :class:`RunnerWorkItem`.\n\n``result_uid`` is generated on the runner (a uuid4 hex) so central\ningest can deduplicate spool re-posts idempotently \u2014 a batch written\nto the retry spool carries the same uids when it is re-posted.\n\n``status`` is a runner-level tri-state, distinct from any status\ninside ``result``:\n\n* ``ok`` \u2014 the handler ran and returned its structured payload\n  (which may itself report a failed probe; a failed check is a\n  result, not a runner error).\n* ``refused`` \u2014 the runner declined to execute (unsafe safety_level,\n  or a handler_ref outside the connector tree).\n* ``error`` \u2014 the handler raised; the exception is summarised in\n  ``error`` and never re-raised into the tick loop."
+      },
+      "RunnerResultBatch": {
+        "properties": {
+          "runner_id": {
+            "type": "string",
+            "title": "Runner Id"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/RunnerResult"
+            },
+            "type": "array",
+            "title": "Results"
+          }
+        },
+        "type": "object",
+        "required": [
+          "runner_id"
+        ],
+        "title": "RunnerResultBatch",
+        "description": "A batch of results the runner reports (or spools) in one POST."
+      },
+      "RunnerWorkItem": {
+        "properties": {
+          "check_ref": {
+            "type": "string",
+            "title": "Check Ref"
+          },
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "product": {
+            "type": "string",
+            "title": "Product"
+          },
+          "version": {
+            "type": "string",
+            "title": "Version",
+            "default": ""
+          },
+          "impl_id": {
+            "type": "string",
+            "title": "Impl Id",
+            "default": ""
+          },
+          "handler_ref": {
+            "type": "string",
+            "title": "Handler Ref"
+          },
+          "params": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Params"
+          },
+          "safety_level": {
+            "type": "string",
+            "title": "Safety Level"
+          },
+          "principal": {
+            "$ref": "#/components/schemas/RunnerPrincipal"
+          },
+          "target_descriptor": {
+            "$ref": "#/components/schemas/ResolvedTargetDescriptor",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "check_ref",
+          "op_id",
+          "product",
+          "handler_ref",
+          "safety_level",
+          "principal"
+        ],
+        "title": "RunnerWorkItem",
+        "description": "One centrally-authorized operation for the runner to execute.\n\nCarries the fields the runner needs to resolve and invoke a handler\nentirely locally: the dotted ``handler_ref`` (resolved via\n:func:`~meho_backplane.operations._handler_resolve.import_handler`),\nthe ``(product, version, impl_id)`` registry key used to rebind a\nbound-method handler against its connector instance, the validated\n``params``, the ``safety_level`` the runner re-checks (defence in\ndepth), the principal context, and the resolved target descriptor\n(``None`` for targetless synthetic ops such as ``net.*``)."
       },
       "ScheduledTriggerCreate": {
         "properties": {
@@ -26430,6 +26983,16 @@
         ],
         "title": "TemplateSummary",
         "description": "Operator-readable summary row surfaced by ``meho.runbook.list_templates``.\n\nThe list-view projection -- enough to identify a template and its\nlifecycle state without loading the full step list (which\n:class:`ShowTemplateResponse` carries)."
+      },
+      "TenantRole": {
+        "type": "string",
+        "enum": [
+          "tenant_admin",
+          "operator",
+          "read_only"
+        ],
+        "title": "TenantRole",
+        "description": "Per-tenant role granted to the operator by the JWT issuer.\n\nThe set is intentionally small in v0.2: a closed three-value enum\nlets the RBAC primitive (Task #234, ``require_role``) make\nexhaustive comparisons without leaking arbitrary string handling\ninto route code. A richer policy engine \u2014 topology-aware\npermissions, ABAC, approval workflows \u2014 is a separate v0.2.next\nGoal; widening this enum is the only ratcheting mechanism in the\ninterim.\n\nValues are the literal strings the Keycloak protocol-mapper recipe\n(Task #235) emits, so a JWT carrying ``\"tenant_admin\"`` materialises\ncleanly as :attr:`TENANT_ADMIN`. ``StrEnum`` (PEP 663, stdlib in\n3.11+) gives the members ``str`` semantics for free, so\n``f\"role={role}\"`` renders as ``\"role=tenant_admin\"`` rather than\n``\"role=TenantRole.TENANT_ADMIN\"``."
       },
       "Thresholds": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -233,6 +233,14 @@ const (
 	NeedsApproval PermissionVerdict = "needs-approval"
 )
 
+// Defines values for PrincipalKind.
+const (
+	PrincipalKindAgent   PrincipalKind = "agent"
+	PrincipalKindRunner  PrincipalKind = "runner"
+	PrincipalKindService PrincipalKind = "service"
+	PrincipalKindUser    PrincipalKind = "user"
+)
+
 // Defines values for RetireChecklistReportOverallVerdict.
 const (
 	RetireChecklistReportOverallVerdictNOTYET         RetireChecklistReportOverallVerdict = "NOT YET"
@@ -380,6 +388,13 @@ const (
 	TemplateSummaryStatusPublished  TemplateSummaryStatus = "published"
 )
 
+// Defines values for TenantRole.
+const (
+	Operator    TenantRole = "operator"
+	ReadOnly    TenantRole = "read_only"
+	TenantAdmin TenantRole = "tenant_admin"
+)
+
 // Defines values for TopologyDiffEntryChangeKind.
 const (
 	Created TopologyDiffEntryChangeKind = "created"
@@ -455,8 +470,8 @@ const (
 
 // Defines values for GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParamsPrefer.
 const (
-	Builtin GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParamsPrefer = "builtin"
-	Tenant  GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParamsPrefer = "tenant"
+	GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParamsPreferBuiltin GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParamsPrefer = "builtin"
+	GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParamsPreferTenant  GetReviewEndpointApiV1ConnectorsConnectorIdReviewGetParamsPrefer = "tenant"
 )
 
 // Defines values for UsageEndpointApiV1RetrieveUsageGetParamsSurface.
@@ -1078,6 +1093,17 @@ type AskDocsResponse struct {
 	Citations []map[string]interface{} `json:"citations"`
 }
 
+// AssignmentDocument Full-document “PUT“ body: replaces a runner's assignment wholesale.
+type AssignmentDocument struct {
+	Items *[]AuthoredCheckItem `json:"items,omitempty"`
+}
+
+// AssignmentDocumentResponse Echo returned by “PUT“: the stored authored document + runner name.
+type AssignmentDocumentResponse struct {
+	Items  []AuthoredCheckItem `json:"items"`
+	Runner string              `json:"runner"`
+}
+
 // AuditEntry One row of the audit query result.
 //
 // Field-to-column mapping (see module docstring for the substrate
@@ -1219,6 +1245,23 @@ type AuthConfigResponse struct {
 
 // AuthModel Per-target identity model per v0.1-spec L447-454.
 type AuthModel string
+
+// AuthoredCheckItem One operator-authored check in a runner's assignment document.
+//
+// The runner-facing “GET“ materialises each of these into a wire
+// :class:`~meho_backplane.runner.wire.RunnerWorkItem` at request time:
+// “target_name“ is resolved to a live target descriptor, “op“ to the
+// resolved connector's enabled descriptor (yielding “handler_ref“ +
+// “safety_level“ + the “(product, version, impl_id)“ key). “op“ is
+// the connector-side op id (e.g. “"vsphere.host.list"“); the connector
+// triple is derived from the resolved target, not authored here.
+type AuthoredCheckItem struct {
+	CadenceSeconds int                     `json:"cadence_seconds"`
+	CheckRef       string                  `json:"check_ref"`
+	Op             string                  `json:"op"`
+	Params         *map[string]interface{} `json:"params,omitempty"`
+	TargetName     string                  `json:"target_name"`
+}
 
 // BackendReadiness Typed result of a :meth:`SearchBackend.probe` call (T6 #1555).
 //
@@ -4563,6 +4606,42 @@ type PreviewOperationBody_Target struct {
 	union json.RawMessage
 }
 
+// PrincipalKind Discriminator that distinguishes what authenticated this request.
+//
+// G11.2-T1 (#815) adds this field to :class:`Operator` so dispatch,
+// audit, and the approval gate can tell a human operator apart from
+// a service account or an agent without re-examining the JWT payload.
+//
+// Values are the literal strings the Keycloak “principal_kind“
+// protocol mapper emits on the agent client (or that the v0.3 token
+// exchange layer will emit). Existing tokens that carry no
+// “principal_kind“ claim default to :attr:`USER` — the graceful-
+// fallback contract means all pre-G11.2 human-operator flows are
+// unaffected.
+//
+// Members:
+//
+//   - :attr:`USER` — a human operator authenticated via the interactive
+//     device-code flow. Default when no claim is present.
+//   - :attr:`SERVICE` — a non-interactive service account client that
+//     uses client-credentials flow but is not a MEHO-managed agent.
+//   - :attr:`AGENT` — a Keycloak client registered by
+//     “meho agent-principal register“; the token carries
+//     “principal_kind=agent“. G11.2-T2 (RFC 8693 delegation) and
+//     G11.2-T3 (per-principal permission model) branch on this value
+//     to apply agent-specific authz.
+//   - :attr:`RUNNER` — a satellite runner's service principal registered
+//     by “meho runner-principal register“ (Initiative #2415, #2502);
+//     the token carries “principal_kind=runner“ plus a “runner_id“
+//     claim. A runner is a dumb, push-only executor with a **read-only**
+//     credential scope: its token is fail-closed 403'd on every
+//     authenticated route outside the gateway allowlist prefixes
+//     (:data:`~meho_backplane.middleware.RUNNER_ALLOWED_PATH_PREFIXES`)
+//     and on the MCP surface. The unforgeable discriminator is what the
+//     negative cage keys on, so a runner client missing any other mapper
+//     still cannot roam the read API.
+type PrincipalKind string
+
 // PromoteBody POST body for “/api/v1/memory/{scope}/{slug}/promote“.
 //
 // G5.2-T4 (#626) of Initiative #374. Two required-ish fields plus a
@@ -4779,6 +4858,60 @@ type ReplayNode struct {
 	TenantId         *openapi_types.UUID    `json:"tenant_id"`
 	Ts               time.Time              `json:"ts"`
 	WorkRef          *string                `json:"work_ref"`
+}
+
+// ResolvedTargetDescriptor Centrally-resolved target attributes a connector handler reads.
+//
+// The runner has no local target table, so the central resolver
+// (:mod:`meho_backplane.connectors.resolver`, DB-bound) materialises
+// the fields a handler duck-reads off a “Target“ row and ships them
+// on the assignment. It carries the resolver-read attributes
+// (“product“ / “fingerprint“ / “version“ / “preferred_impl_id“)
+// the tie-break ladder consumes **and** the connection-routing set
+// (“host“ / “port“ / “fqdn“ / “secret_ref“ / “auth_model“ /
+// TLS flags) the HTTP adapter reads, so on the runner the descriptor
+// feeds :func:`~meho_backplane.connectors.resolver.resolve_connector`
+// and the connector adapters directly — no DB session, no second
+// resolution mechanism.
+//
+// The full field set is moulded on the central
+// :class:`~meho_backplane.targets.schemas.TargetSummary` (#2499): the
+// same identification + connection-routing projection of the
+// “Target“ row, minus the server-managed timestamps and the
+// operator-authored “notes“ (neither drives connector routing).
+//
+// Credential discipline: “secret_ref“ is the **reference** the runner
+// resolves outbound under its own read-only scope; no credential value
+// is ever embedded (the runner spools assignments on disk, so a value
+// would durably persist — a locked no-durable-artifact violation).
+type ResolvedTargetDescriptor struct {
+	Aliases         *[]string               `json:"aliases,omitempty"`
+	AuthModel       *string                 `json:"auth_model,omitempty"`
+	Extras          *map[string]interface{} `json:"extras,omitempty"`
+	Fingerprint     *map[string]interface{} `json:"fingerprint"`
+	Fqdn            *string                 `json:"fqdn"`
+	Host            string                  `json:"host"`
+	Id              openapi_types.UUID      `json:"id"`
+	Name            string                  `json:"name"`
+	Port            *int                    `json:"port"`
+	PreferredImplId *string                 `json:"preferred_impl_id"`
+	Product         string                  `json:"product"`
+	SecretRef       *string                 `json:"secret_ref"`
+	TenantId        openapi_types.UUID      `json:"tenant_id"`
+	TlsCaPin        *string                 `json:"tls_ca_pin"`
+	TlsServerName   *string                 `json:"tls_server_name"`
+	VerifyTls       *bool                   `json:"verify_tls,omitempty"`
+	Version         *string                 `json:"version"`
+}
+
+// ResultIngestResponse “POST /checks/results“ response — idempotency accounting.
+//
+// “accepted“ counts rows newly persisted; “duplicates“ counts rows
+// whose “result_uid“ was already ingested for this runner (a re-posted
+// spool batch). “accepted + duplicates“ equals the batch length.
+type ResultIngestResponse struct {
+	Accepted   int `json:"accepted"`
+	Duplicates int `json:"duplicates"`
 }
 
 // RetireChecklistReport Top-level shape returned by :func:`compute_retire_checklist`.
@@ -5050,6 +5183,80 @@ type RunbookTemplateListResponse struct {
 	NextCursor *string           `json:"next_cursor"`
 }
 
+// RunnerAssignment The runner's current work assignment, fetched each tick.
+//
+// “assignment_version“ is an opaque digest the runner echoes back as
+// “known_version“ so central can answer an unchanged assignment with a
+// “304“ (see :meth:`RunnerClient.fetch_assignment`).
+type RunnerAssignment struct {
+	AssignmentVersion string            `json:"assignment_version"`
+	Items             *[]RunnerWorkItem `json:"items,omitempty"`
+}
+
+// RunnerPrincipal Principal context an executed op runs under, carried on each item.
+//
+// Enough to reconstruct an :class:`~meho_backplane.auth.operator.Operator`
+// on the runner without a JWT: the runner never sees a bearer token for
+// the acting principal (the op was already authorized centrally), so the
+// reconstructed operator's “raw_jwt“ is empty.
+type RunnerPrincipal struct {
+	// PrincipalKind Discriminator that distinguishes what authenticated this request.
+	//
+	// G11.2-T1 (#815) adds this field to :class:`Operator` so dispatch,
+	// audit, and the approval gate can tell a human operator apart from
+	// a service account or an agent without re-examining the JWT payload.
+	//
+	// Values are the literal strings the Keycloak ``principal_kind``
+	// protocol mapper emits on the agent client (or that the v0.3 token
+	// exchange layer will emit). Existing tokens that carry no
+	// ``principal_kind`` claim default to :attr:`USER` — the graceful-
+	// fallback contract means all pre-G11.2 human-operator flows are
+	// unaffected.
+	//
+	// Members:
+	//
+	// * :attr:`USER` — a human operator authenticated via the interactive
+	//   device-code flow. Default when no claim is present.
+	// * :attr:`SERVICE` — a non-interactive service account client that
+	//   uses client-credentials flow but is not a MEHO-managed agent.
+	// * :attr:`AGENT` — a Keycloak client registered by
+	//   ``meho agent-principal register``; the token carries
+	//   ``principal_kind=agent``. G11.2-T2 (RFC 8693 delegation) and
+	//   G11.2-T3 (per-principal permission model) branch on this value
+	//   to apply agent-specific authz.
+	// * :attr:`RUNNER` — a satellite runner's service principal registered
+	//   by ``meho runner-principal register`` (Initiative #2415, #2502);
+	//   the token carries ``principal_kind=runner`` plus a ``runner_id``
+	//   claim. A runner is a dumb, push-only executor with a **read-only**
+	//   credential scope: its token is fail-closed 403'd on every
+	//   authenticated route outside the gateway allowlist prefixes
+	//   (:data:`~meho_backplane.middleware.RUNNER_ALLOWED_PATH_PREFIXES`)
+	//   and on the MCP surface. The unforgeable discriminator is what the
+	//   negative cage keys on, so a runner client missing any other mapper
+	//   still cannot roam the read API.
+	PrincipalKind *PrincipalKind     `json:"principal_kind,omitempty"`
+	Sub           string             `json:"sub"`
+	TenantId      openapi_types.UUID `json:"tenant_id"`
+
+	// TenantRole Per-tenant role granted to the operator by the JWT issuer.
+	//
+	// The set is intentionally small in v0.2: a closed three-value enum
+	// lets the RBAC primitive (Task #234, ``require_role``) make
+	// exhaustive comparisons without leaking arbitrary string handling
+	// into route code. A richer policy engine — topology-aware
+	// permissions, ABAC, approval workflows — is a separate v0.2.next
+	// Goal; widening this enum is the only ratcheting mechanism in the
+	// interim.
+	//
+	// Values are the literal strings the Keycloak protocol-mapper recipe
+	// (Task #235) emits, so a JWT carrying ``"tenant_admin"`` materialises
+	// cleanly as :attr:`TENANT_ADMIN`. ``StrEnum`` (PEP 663, stdlib in
+	// 3.11+) gives the members ``str`` semantics for free, so
+	// ``f"role={role}"`` renders as ``"role=tenant_admin"`` rather than
+	// ``"role=TenantRole.TENANT_ADMIN"``.
+	TenantRole TenantRole `json:"tenant_role"`
+}
+
 // RunnerPrincipalCreate Input shape for :meth:`RunnerPrincipalService.register`.
 type RunnerPrincipalCreate struct {
 	Name     string  `json:"name"`
@@ -5073,6 +5280,92 @@ type RunnerPrincipalRead struct {
 	Revoked            bool               `json:"revoked"`
 	TenantId           openapi_types.UUID `json:"tenant_id"`
 	UpdatedAt          time.Time          `json:"updated_at"`
+}
+
+// RunnerResult The outcome of executing one :class:`RunnerWorkItem`.
+//
+// “result_uid“ is generated on the runner (a uuid4 hex) so central
+// ingest can deduplicate spool re-posts idempotently — a batch written
+// to the retry spool carries the same uids when it is re-posted.
+//
+// “status“ is a runner-level tri-state, distinct from any status
+// inside “result“:
+//
+//   - “ok“ — the handler ran and returned its structured payload
+//     (which may itself report a failed probe; a failed check is a
+//     result, not a runner error).
+//   - “refused“ — the runner declined to execute (unsafe safety_level,
+//     or a handler_ref outside the connector tree).
+//   - “error“ — the handler raised; the exception is summarised in
+//     “error“ and never re-raised into the tick loop.
+type RunnerResult struct {
+	CheckRef  string                  `json:"check_ref"`
+	Error     *string                 `json:"error"`
+	OpId      string                  `json:"op_id"`
+	Result    *map[string]interface{} `json:"result"`
+	ResultUid string                  `json:"result_uid"`
+	Status    string                  `json:"status"`
+}
+
+// RunnerResultBatch A batch of results the runner reports (or spools) in one POST.
+type RunnerResultBatch struct {
+	Results  *[]RunnerResult `json:"results,omitempty"`
+	RunnerId string          `json:"runner_id"`
+}
+
+// RunnerWorkItem One centrally-authorized operation for the runner to execute.
+//
+// Carries the fields the runner needs to resolve and invoke a handler
+// entirely locally: the dotted “handler_ref“ (resolved via
+// :func:`~meho_backplane.operations._handler_resolve.import_handler`),
+// the “(product, version, impl_id)“ registry key used to rebind a
+// bound-method handler against its connector instance, the validated
+// “params“, the “safety_level“ the runner re-checks (defence in
+// depth), the principal context, and the resolved target descriptor
+// (“None“ for targetless synthetic ops such as “net.*“).
+type RunnerWorkItem struct {
+	CheckRef   string                  `json:"check_ref"`
+	HandlerRef string                  `json:"handler_ref"`
+	ImplId     *string                 `json:"impl_id,omitempty"`
+	OpId       string                  `json:"op_id"`
+	Params     *map[string]interface{} `json:"params,omitempty"`
+
+	// Principal Principal context an executed op runs under, carried on each item.
+	//
+	// Enough to reconstruct an :class:`~meho_backplane.auth.operator.Operator`
+	// on the runner without a JWT: the runner never sees a bearer token for
+	// the acting principal (the op was already authorized centrally), so the
+	// reconstructed operator's ``raw_jwt`` is empty.
+	Principal   RunnerPrincipal `json:"principal"`
+	Product     string          `json:"product"`
+	SafetyLevel string          `json:"safety_level"`
+
+	// TargetDescriptor Centrally-resolved target attributes a connector handler reads.
+	//
+	// The runner has no local target table, so the central resolver
+	// (:mod:`meho_backplane.connectors.resolver`, DB-bound) materialises
+	// the fields a handler duck-reads off a ``Target`` row and ships them
+	// on the assignment. It carries the resolver-read attributes
+	// (``product`` / ``fingerprint`` / ``version`` / ``preferred_impl_id``)
+	// the tie-break ladder consumes **and** the connection-routing set
+	// (``host`` / ``port`` / ``fqdn`` / ``secret_ref`` / ``auth_model`` /
+	// TLS flags) the HTTP adapter reads, so on the runner the descriptor
+	// feeds :func:`~meho_backplane.connectors.resolver.resolve_connector`
+	// and the connector adapters directly — no DB session, no second
+	// resolution mechanism.
+	//
+	// The full field set is moulded on the central
+	// :class:`~meho_backplane.targets.schemas.TargetSummary` (#2499): the
+	// same identification + connection-routing projection of the
+	// ``Target`` row, minus the server-managed timestamps and the
+	// operator-authored ``notes`` (neither drives connector routing).
+	//
+	// Credential discipline: ``secret_ref`` is the **reference** the runner
+	// resolves outbound under its own read-only scope; no credential value
+	// is ever embedded (the runner spools assignments on disk, so a value
+	// would durably persist — a locked no-durable-artifact violation).
+	TargetDescriptor *ResolvedTargetDescriptor `json:"target_descriptor,omitempty"`
+	Version          *string                   `json:"version,omitempty"`
 }
 
 // ScheduledTriggerCreate Request body for “POST /api/v1/scheduler/triggers“.
@@ -5982,6 +6275,24 @@ type TemplateSummary struct {
 
 // TemplateSummaryStatus defines model for TemplateSummary.Status.
 type TemplateSummaryStatus string
+
+// TenantRole Per-tenant role granted to the operator by the JWT issuer.
+//
+// The set is intentionally small in v0.2: a closed three-value enum
+// lets the RBAC primitive (Task #234, “require_role“) make
+// exhaustive comparisons without leaking arbitrary string handling
+// into route code. A richer policy engine — topology-aware
+// permissions, ABAC, approval workflows — is a separate v0.2.next
+// Goal; widening this enum is the only ratcheting mechanism in the
+// interim.
+//
+// Values are the literal strings the Keycloak protocol-mapper recipe
+// (Task #235) emits, so a JWT carrying “"tenant_admin"“ materialises
+// cleanly as :attr:`TENANT_ADMIN`. “StrEnum“ (PEP 663, stdlib in
+// 3.11+) gives the members “str“ semantics for free, so
+// “f"role={role}"“ renders as “"role=tenant_admin"“ rather than
+// “"role=TenantRole.TENANT_ADMIN"“.
+type TenantRole string
 
 // Thresholds Per-metric green-band thresholds for a verdict computation.
 //
@@ -6906,6 +7217,23 @@ type CreateOverrideApiV1BroadcastOverridesPostParams struct {
 
 // DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteParams defines parameters for DeleteOverrideApiV1BroadcastOverridesOverrideIdDelete.
 type DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// GetAssignmentApiV1ChecksAssignmentGetParams defines parameters for GetAssignmentApiV1ChecksAssignmentGet.
+type GetAssignmentApiV1ChecksAssignmentGetParams struct {
+	Runner        string  `form:"runner" json:"runner"`
+	KnownVersion  *string `form:"known_version,omitempty" json:"known_version,omitempty"`
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// PutAssignmentApiV1ChecksAssignmentRunnerPutParams defines parameters for PutAssignmentApiV1ChecksAssignmentRunnerPut.
+type PutAssignmentApiV1ChecksAssignmentRunnerPutParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// PostResultsApiV1ChecksResultsPostParams defines parameters for PostResultsApiV1ChecksResultsPost.
+type PostResultsApiV1ChecksResultsPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
@@ -7844,6 +8172,12 @@ type QueryApiV1AuditQueryPostJSONRequestBody = AuditQueryRequest
 
 // CreateOverrideApiV1BroadcastOverridesPostJSONRequestBody defines body for CreateOverrideApiV1BroadcastOverridesPost for application/json ContentType.
 type CreateOverrideApiV1BroadcastOverridesPostJSONRequestBody = BroadcastOverrideCreate
+
+// PutAssignmentApiV1ChecksAssignmentRunnerPutJSONRequestBody defines body for PutAssignmentApiV1ChecksAssignmentRunnerPut for application/json ContentType.
+type PutAssignmentApiV1ChecksAssignmentRunnerPutJSONRequestBody = AssignmentDocument
+
+// PostResultsApiV1ChecksResultsPostJSONRequestBody defines body for PostResultsApiV1ChecksResultsPost for application/json ContentType.
+type PostResultsApiV1ChecksResultsPostJSONRequestBody = RunnerResultBatch
 
 // IngestEndpointApiV1ConnectorsIngestPostJSONRequestBody defines body for IngestEndpointApiV1ConnectorsIngestPost for application/json ContentType.
 type IngestEndpointApiV1ConnectorsIngestPostJSONRequestBody = IngestRequest
@@ -9286,6 +9620,19 @@ type ClientInterface interface {
 
 	// DeleteOverrideApiV1BroadcastOverridesOverrideIdDelete request
 	DeleteOverrideApiV1BroadcastOverridesOverrideIdDelete(ctx context.Context, overrideId openapi_types.UUID, params *DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetAssignmentApiV1ChecksAssignmentGet request
+	GetAssignmentApiV1ChecksAssignmentGet(ctx context.Context, params *GetAssignmentApiV1ChecksAssignmentGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PutAssignmentApiV1ChecksAssignmentRunnerPutWithBody request with any body
+	PutAssignmentApiV1ChecksAssignmentRunnerPutWithBody(ctx context.Context, runner string, params *PutAssignmentApiV1ChecksAssignmentRunnerPutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PutAssignmentApiV1ChecksAssignmentRunnerPut(ctx context.Context, runner string, params *PutAssignmentApiV1ChecksAssignmentRunnerPutParams, body PutAssignmentApiV1ChecksAssignmentRunnerPutJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostResultsApiV1ChecksResultsPostWithBody request with any body
+	PostResultsApiV1ChecksResultsPostWithBody(ctx context.Context, params *PostResultsApiV1ChecksResultsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostResultsApiV1ChecksResultsPost(ctx context.Context, params *PostResultsApiV1ChecksResultsPostParams, body PostResultsApiV1ChecksResultsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListEndpointApiV1ConnectorsGet request
 	ListEndpointApiV1ConnectorsGet(ctx context.Context, params *ListEndpointApiV1ConnectorsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -11029,6 +11376,66 @@ func (c *Client) CreateOverrideApiV1BroadcastOverridesPost(ctx context.Context, 
 
 func (c *Client) DeleteOverrideApiV1BroadcastOverridesOverrideIdDelete(ctx context.Context, overrideId openapi_types.UUID, params *DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteRequest(c.Server, overrideId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetAssignmentApiV1ChecksAssignmentGet(ctx context.Context, params *GetAssignmentApiV1ChecksAssignmentGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAssignmentApiV1ChecksAssignmentGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PutAssignmentApiV1ChecksAssignmentRunnerPutWithBody(ctx context.Context, runner string, params *PutAssignmentApiV1ChecksAssignmentRunnerPutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutAssignmentApiV1ChecksAssignmentRunnerPutRequestWithBody(c.Server, runner, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PutAssignmentApiV1ChecksAssignmentRunnerPut(ctx context.Context, runner string, params *PutAssignmentApiV1ChecksAssignmentRunnerPutParams, body PutAssignmentApiV1ChecksAssignmentRunnerPutJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutAssignmentApiV1ChecksAssignmentRunnerPutRequest(c.Server, runner, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostResultsApiV1ChecksResultsPostWithBody(ctx context.Context, params *PostResultsApiV1ChecksResultsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostResultsApiV1ChecksResultsPostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostResultsApiV1ChecksResultsPost(ctx context.Context, params *PostResultsApiV1ChecksResultsPostParams, body PostResultsApiV1ChecksResultsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostResultsApiV1ChecksResultsPostRequest(c.Server, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -18486,6 +18893,199 @@ func NewDeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteRequest(server stri
 	if err != nil {
 		return nil, err
 	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewGetAssignmentApiV1ChecksAssignmentGetRequest generates requests for GetAssignmentApiV1ChecksAssignmentGet
+func NewGetAssignmentApiV1ChecksAssignmentGetRequest(server string, params *GetAssignmentApiV1ChecksAssignmentGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/checks/assignment")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "runner", runtime.ParamLocationQuery, params.Runner); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if params.KnownVersion != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "known_version", runtime.ParamLocationQuery, *params.KnownVersion); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewPutAssignmentApiV1ChecksAssignmentRunnerPutRequest calls the generic PutAssignmentApiV1ChecksAssignmentRunnerPut builder with application/json body
+func NewPutAssignmentApiV1ChecksAssignmentRunnerPutRequest(server string, runner string, params *PutAssignmentApiV1ChecksAssignmentRunnerPutParams, body PutAssignmentApiV1ChecksAssignmentRunnerPutJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPutAssignmentApiV1ChecksAssignmentRunnerPutRequestWithBody(server, runner, params, "application/json", bodyReader)
+}
+
+// NewPutAssignmentApiV1ChecksAssignmentRunnerPutRequestWithBody generates requests for PutAssignmentApiV1ChecksAssignmentRunnerPut with any type of body
+func NewPutAssignmentApiV1ChecksAssignmentRunnerPutRequestWithBody(server string, runner string, params *PutAssignmentApiV1ChecksAssignmentRunnerPutParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "runner", runtime.ParamLocationPath, runner)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/checks/assignment/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewPostResultsApiV1ChecksResultsPostRequest calls the generic PostResultsApiV1ChecksResultsPost builder with application/json body
+func NewPostResultsApiV1ChecksResultsPostRequest(server string, params *PostResultsApiV1ChecksResultsPostParams, body PostResultsApiV1ChecksResultsPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostResultsApiV1ChecksResultsPostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewPostResultsApiV1ChecksResultsPostRequestWithBody generates requests for PostResultsApiV1ChecksResultsPost with any type of body
+func NewPostResultsApiV1ChecksResultsPostRequestWithBody(server string, params *PostResultsApiV1ChecksResultsPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/checks/results")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -34479,6 +35079,19 @@ type ClientWithResponsesInterface interface {
 	// DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteWithResponse request
 	DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteWithResponse(ctx context.Context, overrideId openapi_types.UUID, params *DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteResponse, error)
 
+	// GetAssignmentApiV1ChecksAssignmentGetWithResponse request
+	GetAssignmentApiV1ChecksAssignmentGetWithResponse(ctx context.Context, params *GetAssignmentApiV1ChecksAssignmentGetParams, reqEditors ...RequestEditorFn) (*GetAssignmentApiV1ChecksAssignmentGetResponse, error)
+
+	// PutAssignmentApiV1ChecksAssignmentRunnerPutWithBodyWithResponse request with any body
+	PutAssignmentApiV1ChecksAssignmentRunnerPutWithBodyWithResponse(ctx context.Context, runner string, params *PutAssignmentApiV1ChecksAssignmentRunnerPutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutAssignmentApiV1ChecksAssignmentRunnerPutResponse, error)
+
+	PutAssignmentApiV1ChecksAssignmentRunnerPutWithResponse(ctx context.Context, runner string, params *PutAssignmentApiV1ChecksAssignmentRunnerPutParams, body PutAssignmentApiV1ChecksAssignmentRunnerPutJSONRequestBody, reqEditors ...RequestEditorFn) (*PutAssignmentApiV1ChecksAssignmentRunnerPutResponse, error)
+
+	// PostResultsApiV1ChecksResultsPostWithBodyWithResponse request with any body
+	PostResultsApiV1ChecksResultsPostWithBodyWithResponse(ctx context.Context, params *PostResultsApiV1ChecksResultsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostResultsApiV1ChecksResultsPostResponse, error)
+
+	PostResultsApiV1ChecksResultsPostWithResponse(ctx context.Context, params *PostResultsApiV1ChecksResultsPostParams, body PostResultsApiV1ChecksResultsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*PostResultsApiV1ChecksResultsPostResponse, error)
+
 	// ListEndpointApiV1ConnectorsGetWithResponse request
 	ListEndpointApiV1ConnectorsGetWithResponse(ctx context.Context, params *ListEndpointApiV1ConnectorsGetParams, reqEditors ...RequestEditorFn) (*ListEndpointApiV1ConnectorsGetResponse, error)
 
@@ -36469,6 +37082,75 @@ func (r DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteResponse) Status() 
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetAssignmentApiV1ChecksAssignmentGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *RunnerAssignment
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAssignmentApiV1ChecksAssignmentGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAssignmentApiV1ChecksAssignmentGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PutAssignmentApiV1ChecksAssignmentRunnerPutResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AssignmentDocumentResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r PutAssignmentApiV1ChecksAssignmentRunnerPutResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PutAssignmentApiV1ChecksAssignmentRunnerPutResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostResultsApiV1ChecksResultsPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ResultIngestResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r PostResultsApiV1ChecksResultsPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostResultsApiV1ChecksResultsPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -43257,6 +43939,49 @@ func (c *ClientWithResponses) DeleteOverrideApiV1BroadcastOverridesOverrideIdDel
 	return ParseDeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteResponse(rsp)
 }
 
+// GetAssignmentApiV1ChecksAssignmentGetWithResponse request returning *GetAssignmentApiV1ChecksAssignmentGetResponse
+func (c *ClientWithResponses) GetAssignmentApiV1ChecksAssignmentGetWithResponse(ctx context.Context, params *GetAssignmentApiV1ChecksAssignmentGetParams, reqEditors ...RequestEditorFn) (*GetAssignmentApiV1ChecksAssignmentGetResponse, error) {
+	rsp, err := c.GetAssignmentApiV1ChecksAssignmentGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAssignmentApiV1ChecksAssignmentGetResponse(rsp)
+}
+
+// PutAssignmentApiV1ChecksAssignmentRunnerPutWithBodyWithResponse request with arbitrary body returning *PutAssignmentApiV1ChecksAssignmentRunnerPutResponse
+func (c *ClientWithResponses) PutAssignmentApiV1ChecksAssignmentRunnerPutWithBodyWithResponse(ctx context.Context, runner string, params *PutAssignmentApiV1ChecksAssignmentRunnerPutParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutAssignmentApiV1ChecksAssignmentRunnerPutResponse, error) {
+	rsp, err := c.PutAssignmentApiV1ChecksAssignmentRunnerPutWithBody(ctx, runner, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePutAssignmentApiV1ChecksAssignmentRunnerPutResponse(rsp)
+}
+
+func (c *ClientWithResponses) PutAssignmentApiV1ChecksAssignmentRunnerPutWithResponse(ctx context.Context, runner string, params *PutAssignmentApiV1ChecksAssignmentRunnerPutParams, body PutAssignmentApiV1ChecksAssignmentRunnerPutJSONRequestBody, reqEditors ...RequestEditorFn) (*PutAssignmentApiV1ChecksAssignmentRunnerPutResponse, error) {
+	rsp, err := c.PutAssignmentApiV1ChecksAssignmentRunnerPut(ctx, runner, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePutAssignmentApiV1ChecksAssignmentRunnerPutResponse(rsp)
+}
+
+// PostResultsApiV1ChecksResultsPostWithBodyWithResponse request with arbitrary body returning *PostResultsApiV1ChecksResultsPostResponse
+func (c *ClientWithResponses) PostResultsApiV1ChecksResultsPostWithBodyWithResponse(ctx context.Context, params *PostResultsApiV1ChecksResultsPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostResultsApiV1ChecksResultsPostResponse, error) {
+	rsp, err := c.PostResultsApiV1ChecksResultsPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostResultsApiV1ChecksResultsPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostResultsApiV1ChecksResultsPostWithResponse(ctx context.Context, params *PostResultsApiV1ChecksResultsPostParams, body PostResultsApiV1ChecksResultsPostJSONRequestBody, reqEditors ...RequestEditorFn) (*PostResultsApiV1ChecksResultsPostResponse, error) {
+	rsp, err := c.PostResultsApiV1ChecksResultsPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostResultsApiV1ChecksResultsPostResponse(rsp)
+}
+
 // ListEndpointApiV1ConnectorsGetWithResponse request returning *ListEndpointApiV1ConnectorsGetResponse
 func (c *ClientWithResponses) ListEndpointApiV1ConnectorsGetWithResponse(ctx context.Context, params *ListEndpointApiV1ConnectorsGetParams, reqEditors ...RequestEditorFn) (*ListEndpointApiV1ConnectorsGetResponse, error) {
 	rsp, err := c.ListEndpointApiV1ConnectorsGet(ctx, params, reqEditors...)
@@ -48178,6 +48903,105 @@ func ParseDeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteResponse(rsp *htt
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetAssignmentApiV1ChecksAssignmentGetResponse parses an HTTP response from a GetAssignmentApiV1ChecksAssignmentGetWithResponse call
+func ParseGetAssignmentApiV1ChecksAssignmentGetResponse(rsp *http.Response) (*GetAssignmentApiV1ChecksAssignmentGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAssignmentApiV1ChecksAssignmentGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest RunnerAssignment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePutAssignmentApiV1ChecksAssignmentRunnerPutResponse parses an HTTP response from a PutAssignmentApiV1ChecksAssignmentRunnerPutWithResponse call
+func ParsePutAssignmentApiV1ChecksAssignmentRunnerPutResponse(rsp *http.Response) (*PutAssignmentApiV1ChecksAssignmentRunnerPutResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PutAssignmentApiV1ChecksAssignmentRunnerPutResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AssignmentDocumentResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostResultsApiV1ChecksResultsPostResponse parses an HTTP response from a PostResultsApiV1ChecksResultsPostWithResponse call
+func ParsePostResultsApiV1ChecksResultsPostResponse(rsp *http.Response) (*PostResultsApiV1ChecksResultsPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostResultsApiV1ChecksResultsPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ResultIngestResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {


### PR DESCRIPTION
## Summary

Central-side ingest + versioned assignment API for the push-only satellite runner (Initiative #2415, read-only v1), mounted under `/api/v1/checks/` inside the runner route cage (#2502). Three routes:

- **`PUT /api/v1/checks/assignment/{runner}`** (operator, `require_role(OPERATOR)`) — full-document replace of a runner's authored checks. Each item is validated at create time: its `target_name` must resolve (`targets/resolver.py`) and its `op` must resolve to an enabled `safety_level=='safe'` `EndpointDescriptor` (via the target's connector + `operations/_lookup.py`). A failing item is a structured 422 (`assignment_op_not_safe` / `assignment_op_unknown` / `assignment_target_unknown`) and **nothing is stored**.
- **`GET /api/v1/checks/assignment?runner=…[&known_version=…]`** (runner principal, own-only via `assert_runner_scope`) — returns a digest-versioned `RunnerAssignment`. Each item is materialised from **live** rows and carries the resolved target descriptor (host/port/TLS + the `secret_ref` **reference** — never a credential value), `handler_ref` + `safety_level`, the resolved `(product, version, impl_id)`, and the runner principal context. `assignment_version` is a sha256 over the canonical JSON of the materialised items, so target-row drift (e.g. a rotated `tls_ca_pin`) shifts the digest and the runner self-heals; a matching `known_version` yields `304 Not Modified` (empty body). An item whose target soft-deleted / no longer resolves is dropped with a structured warning.
- **`POST /api/v1/checks/results`** (runner principal, own-only) — idempotent batch ingest keyed on `(tenant_id, runner_name, result_uid)`; `received_at` is stamped by the central clock (never accepted from the client). Response `{accepted, duplicates}`.

### Key design notes / corrections

- **Wire contract is the merged `runner/wire.py` (#2497), not the issue-body sketch.** The batch shape is `{runner_id, results:[{result_uid, check_ref, op_id, status, result, error}]}` (field `runner_id`, `op_id`, `result`, no `executed_at`), and `RunnerResult.status` is the tri-state `ok`/`refused`/`error` — so the `runner_check_results.status` CHECK bounds to that tri-state (not `ok`/`error`). `RunnerWorkItem` already carried every GET field including `target_descriptor`; only `ResolvedTargetDescriptor` was **widened in place** with the connection-routing set (one schema on both ends, no fork).
- **Connector triple** is read off the resolved connector **class** attrs (`cls.product/version/impl_id`) — the canonical identity real connectors set to match their registration (e.g. Loki) and what #2497's runner re-resolves against.
- **New `gateway/` package** holds central-only code: `schemas.py` (operator authoring envelope), `errors.py` (typed 422s with `error_code`), `repository.py` (assignment upsert/get, portable result dedup), `assignment_service.py` (PUT validation + GET materialisation + digest).
- **Migration `0059`** creates `runner_assignments` + `runner_check_results`. Both carry a **real `REFERENCES tenant(id)` FK** (mould parity with `runner_principal`/#2502), so both are added to **all three** per-test TRUNCATE lists (integration ×2 + acceptance) — `test_truncate_list_drift` passes. A sibling Wave-2 task (#2498) is also creating a migration off `0058`; a `0059` collision is expected and left for renumber-at-drain.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean on all changed source + tests
- [x] `mypy` — clean (17 files)
- [x] `code-quality.py --diff` — 0 blockers (only pre-existing warnings on `db/models.py`/`main.py`)
- [x] `uv run alembic upgrade head` — single head `0059`; `downgrade 0058` + re-`upgrade` round-trips
- [x] `tests/test_gateway_assignment_api.py` — 8 passed (put-rejects-non-safe-op, get-versioned + 304 + drift, wire-models-shared, no-secret-values, duck-types-resolver, results-batch-idempotent, runner-scoping)
- [x] `tests/migrations/test_migration_0059_*` — 5 passed twice in a row (stamp-replay pinned to its **own** revision; no sibling migration test pins touched)
- [x] `tests/test_truncate_list_drift.py` — 3 passed (both new tenant-FK tables covered)
- [x] runner regression (`test_runner_client/loop/executor/spool`) + `test_auth_runner_guard` + `migration_compat`/`rollback` — 62 passed, 3 skipped
- [x] `cd cli && make snapshot-openapi && make generate` — idempotent; `grep "/api/v1/checks/assignment" cli/api/openapi.json` succeeds; regenerated artefacts committed

## Out of scope

- Long-poll command plane `GET /gateway/{runner}/next` — #2498 (parallel Wave-2 sibling).
- Capability-command minting / at-most-once execution dedup — #2500.
- Heartbeat + stale/unknown flipping — #2501 (consumes the `received_at` index + `runner_assignments` rows shipped here).
- Runner-side polling/credential resolution — #2497.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2499
