### PR TITLE
feat(gateway): runner dead-man switch + mandatory heartbeat (#2501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Gateway — runner dead-man switch + mandatory heartbeat
+
+- Add the runner dead-man switch + mandatory heartbeat for the push-only
+  satellite runner (Initiative #2415, #2501). Every authenticated
+  runner-plane request now stamps `runner_principal.last_seen_at` on the
+  central clock through the single shared choke-point (`assert_runner_scope`)
+  — keyed by the token's `runner_id` claim, never a client value, and with
+  no dedicated heartbeat endpoint (a healthy idle runner already polls once
+  per window, so the idle work cycle *is* the heartbeat; the #1501 lesson).
+  A central interval-tick sweeper (`gateway/deadman.py`, gated on
+  `GATEWAY_DEADMAN_ENABLED`, default on) flips a lapsed runner's
+  `runner_assignments.stale_at` once its `last_seen_at` falls behind
+  `GATEWAY_RUNNER_STALE_AFTER_MULTIPLIER × GATEWAY_LONGPOLL_MAX_WAIT_SECONDS`
+  (default 3 × 30 s = 90 s) judged on the central clock, writing one
+  `gateway.runner.stale` audit row per flip; a fixed advisory lock plus a
+  conditional `WHERE stale_at IS NULL` flip keep it exactly-once under
+  concurrent replicas. Recovery is data-driven — an accepted result
+  ingestion clears the marker; the sweeper only ever flips. `stale_at IS NOT
+  NULL` maps to the `UNKNOWN` rollup state (#2416 / #2506). Migration `0061`
+  adds `runner_principal.last_seen_at` (+ index) and
+  `runner_assignments.stale_at` (#2501).
+
 ### Gateway — versioned assignment + results ingest API
 
 - Add the central-side ingest + versioned assignment API for the push-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,13 +97,16 @@ connector-related release-notes line.
   runner-plane request now stamps `runner_principal.last_seen_at` on the
   central clock through the single shared choke-point (`assert_runner_scope`)
   — keyed by the token's `runner_id` claim, never a client value, and with
-  no dedicated heartbeat endpoint (a healthy idle runner already polls once
-  per window, so the idle work cycle *is* the heartbeat; the #1501 lesson).
+  no dedicated heartbeat endpoint (a healthy idle runner already fetches its
+  assignment once per ~60 s tick — `tick_interval_seconds`, #2499 — so the
+  idle work cycle *is* the heartbeat; the #1501 lesson).
   A central interval-tick sweeper (`gateway/deadman.py`, gated on
   `GATEWAY_DEADMAN_ENABLED`, default on) flips a lapsed runner's
   `runner_assignments.stale_at` once its `last_seen_at` falls behind
   `GATEWAY_RUNNER_STALE_AFTER_MULTIPLIER × GATEWAY_LONGPOLL_MAX_WAIT_SECONDS`
-  (default 3 × 30 s = 90 s) judged on the central clock, writing one
+  (default 3 × 30 s = 90 s, deliberately above the runner's ~60 s poll
+  cadence so a healthy idle runner never false-trips) judged on the central
+  clock, writing one
   `gateway.runner.stale` audit row per flip; a fixed advisory lock plus a
   conditional `WHERE stale_at IS NULL` flip keep it exactly-once under
   concurrent replicas. Recovery is data-driven — an accepted result

--- a/backend/alembic/versions/0061_add_gateway_deadman_columns.py
+++ b/backend/alembic/versions/0061_add_gateway_deadman_columns.py
@@ -77,14 +77,23 @@ def upgrade() -> None:
     is_postgres = bind.dialect.name == "postgresql"
 
     if is_postgres:
-        last_seen_default: sa.sql.elements.TextClause = sa.text("now()")
+        last_seen_default: str | sa.sql.elements.TextClause = sa.text("now()")
     else:
         # SQLite rejects CURRENT_TIMESTAMP / expressions as an ADD COLUMN
         # default (only constant literals are allowed). Pin a migration-time
         # literal so the NOT NULL add succeeds and any pre-existing row
         # initialises to ~now (treated as freshly-seen, not epoch-stale).
-        _now_literal = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")
-        last_seen_default = sa.text(f"'{_now_literal}'")
+        #
+        # Pass the literal as a plain ``str`` server_default -- SQLAlchemy
+        # renders it as a properly-quoted SQL literal, giving DDL identical
+        # to ``sa.text(f"'{value}'")`` -- rather than wrapping it in an
+        # interpolated ``sa.text(...)``. A non-literal ``text()`` argument
+        # trips Semgrep's ``avoid-sqlalchemy-text`` rule, and CI's
+        # registry-pack Semgrep does not honour an inline ``# nosemgrep``
+        # for it, so the repo convention (``events/outbox.py``,
+        # ``retrieval/retriever.py``, ``topology/query.py``) is to keep the
+        # value off ``text()`` entirely.
+        last_seen_default = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")
 
     op.add_column(
         "runner_principal",

--- a/backend/alembic/versions/0061_add_gateway_deadman_columns.py
+++ b/backend/alembic/versions/0061_add_gateway_deadman_columns.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add the gateway dead-man's-switch liveness columns (#2501).
+
+Revision ID: 0061
+Revises: 0060
+Create Date: 2026-07-15
+
+Initiative #2415 (Remote execution gateway), Task #2501 — the runner
+dead-man's switch + mandatory heartbeat. Two additive columns on the
+gateway tables the earlier tasks landed:
+
+* ``runner_principal.last_seen_at`` (``timestamptz``, ``NOT NULL``,
+  server-default ``now()``) — the runner-liveness stamp. Every
+  authenticated runner-plane request refreshes it on the central clock
+  (the single choke-point is
+  :func:`meho_backplane.auth.runner_guard.assert_runner_scope`), so a
+  runner's ability to reach central is observable without a dedicated
+  heartbeat endpoint. The server default initialises both the
+  pre-existing rows this migration back-fills and any future non-ORM
+  insert to "seen now" rather than epoch, so an already-registered
+  runner is treated as alive the instant the column lands, not
+  immediately stale.
+
+* ``runner_assignments.stale_at`` (``timestamptz``, ``NULL``) — the flip
+  marker. ``NULL`` = fresh; non-``NULL`` = the moment the central
+  dead-man sweeper declared this runner's workloads unknown because its
+  ``last_seen_at`` fell behind ``N x GATEWAY_LONGPOLL_MAX_WAIT_SECONDS``.
+  An accepted result ingestion clears it; the sweeper only ever flips it.
+  Shape mirrors ``web_session.revoked_at`` (NULL-marker timestamp).
+
+A b-tree index on ``runner_principal.last_seen_at`` backs the sweeper's
+``last_seen_at < cutoff`` predicate (index-rationale mould: the
+``web_session_expires_at_idx`` sweep index).
+
+This migration is the **fifth** in the initiative's serialized chain
+(#2502 -> #2498 -> #2499 -> #2500 -> #2501); it extends the then-current
+single head ``0060`` (``runner_assignments`` / ``runner_check_results``).
+Per the house Alembic rule, if a sibling migration lands on main first,
+renumber-before-merge — never fork the linear chain.
+
+Dialect portability
+-------------------
+
+PostgreSQL keeps a live ``now()`` server default on ``last_seen_at``.
+SQLite (the dev / test driver) forbids ``CURRENT_TIMESTAMP`` and every
+other expression as an ``ALTER TABLE ADD COLUMN`` default — only a
+constant literal is permitted — so the SQLite branch pins a
+migration-time literal. Freshly-registered runners get their real
+timestamp from the ORM ``default`` regardless of dialect; the literal
+only ever back-fills rows that predate this column.
+
+Reversibility contract
+----------------------
+
+``upgrade()`` adds the two columns + the index; ``downgrade()`` drops
+them in inverse order. Purely additive on the way up.
+"""
+
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0061"
+down_revision: str | None = "0060"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``last_seen_at`` + its index and ``stale_at``."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    if is_postgres:
+        last_seen_default: sa.sql.elements.TextClause = sa.text("now()")
+    else:
+        # SQLite rejects CURRENT_TIMESTAMP / expressions as an ADD COLUMN
+        # default (only constant literals are allowed). Pin a migration-time
+        # literal so the NOT NULL add succeeds and any pre-existing row
+        # initialises to ~now (treated as freshly-seen, not epoch-stale).
+        _now_literal = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f")
+        last_seen_default = sa.text(f"'{_now_literal}'")
+
+    op.add_column(
+        "runner_principal",
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=last_seen_default,
+        ),
+    )
+    op.create_index(
+        "runner_principal_last_seen_at_idx",
+        "runner_principal",
+        ["last_seen_at"],
+        postgresql_using="btree",
+    )
+    op.add_column(
+        "runner_assignments",
+        sa.Column("stale_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop ``stale_at``, then the index and ``last_seen_at`` (reverse order)."""
+    op.drop_column("runner_assignments", "stale_at")
+    op.drop_index(
+        "runner_principal_last_seen_at_idx",
+        table_name="runner_principal",
+    )
+    op.drop_column("runner_principal", "last_seen_at")

--- a/backend/src/meho_backplane/api/v1/checks.py
+++ b/backend/src/meho_backplane/api/v1/checks.py
@@ -50,6 +50,7 @@ from meho_backplane.auth.rbac import require_role
 from meho_backplane.auth.runner_guard import assert_runner_scope, require_runner
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.gateway import assignment_service
+from meho_backplane.gateway.deadman import clear_runner_stale
 from meho_backplane.gateway.errors import (
     AssignmentOpNotSafeError,
     AssignmentOpUnknownError,
@@ -195,6 +196,11 @@ async def post_results(
             runner_name=batch.runner_id,
             results=list(batch.results),
         )
+        # Recovery clear seam (#2501): an accepted result batch proves the
+        # runner is alive and reporting, so reset any dead-man flip marker
+        # the central sweeper set. The sweeper only ever flips; this is the
+        # only clear path. Idempotent when the runner was never flipped.
+        await clear_runner_stale(session, tenant_id=operator.tenant_id, runner_name=batch.runner_id)
         await session.commit()
     return ResultIngestResponse(accepted=accepted, duplicates=duplicates)
 

--- a/backend/src/meho_backplane/api/v1/gateway.py
+++ b/backend/src/meho_backplane/api/v1/gateway.py
@@ -68,6 +68,7 @@ from meho_backplane.auth.operator import Operator
 from meho_backplane.auth.runner_guard import assert_runner_scope, require_runner
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import GatewayCommand, GatewayCommandStatus
+from meho_backplane.gateway.deadman import clear_runner_stale
 from meho_backplane.gateway.queue import (
     GATEWAY_LONGPOLL_DEFAULT_WAIT_SECONDS,
     GATEWAY_LONGPOLL_MAX_WAIT_SECONDS,
@@ -267,6 +268,10 @@ async def report_command_result(
                 result=body.result,
                 error=body.error,
             )
+            # Recovery clear seam (#2501): an accepted command result proves
+            # the runner is alive and reporting, so reset any dead-man flip
+            # marker the central sweeper set (sweeper only flips; this clears).
+            await clear_runner_stale(session, tenant_id=operator.tenant_id, runner_name=runner)
             ack = GatewayResultAck(
                 command_id=command.id,
                 status=command.status,

--- a/backend/src/meho_backplane/auth/runner_guard.py
+++ b/backend/src/meho_backplane/auth/runner_guard.py
@@ -50,6 +50,7 @@ for a dead/revoked runner is #2501's dead-man switch.
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import UTC, datetime
 
 import structlog
 from fastapi import Depends, HTTPException, status
@@ -128,8 +129,25 @@ async def assert_runner_scope(
     Resolves the tenant-scoped ``runner_principal`` row for
     ``(operator.tenant_id, runner_name)`` — one indexed read on the unique
     ``(tenant_id, name)`` index — and requires ``row.id ==
-    operator.runner_id``. Returns the row so callers can reuse it (e.g.
-    #2501's ``last_seen_at`` stamp) without a second query.
+    operator.runner_id``. Returns the row so callers can reuse it without a
+    second query.
+
+    Heartbeat side effect (#2501)
+    -----------------------------
+    On a successful scope match this guard stamps ``row.last_seen_at =
+    now()`` on the **central clock** and commits it — the dead-man switch's
+    mandatory heartbeat. This is the single choke-point every runner-plane
+    request passes through (#2498's ``GET .../next`` + ``POST .../result``,
+    #2499's ``GET /checks/assignment`` + ``POST /checks/results`` all call
+    it, and nothing else does), so piggybacking the stamp here measures the
+    runner's real ability to reach central and cannot be missed by a future
+    runner route that forgets to stamp. The stamp is keyed by ``row.id``
+    (the token's unforgeable ``runner_id`` claim) and reads no request
+    field, so ``last_seen_at`` is never client-controlled — the exact
+    discipline ``web_session.last_seen_at`` follows. There is deliberately
+    **no** dedicated heartbeat endpoint: a healthy idle runner still issues
+    at least one authenticated request per poll window, so the idle work
+    cycle *is* the heartbeat (the #1501 zombie-heartbeat lesson).
 
     Fail-closed with **no existence oracle**: a name that resolves to no
     row *and* a name that resolves to a **different** runner both raise the
@@ -143,8 +161,13 @@ async def assert_runner_scope(
             :func:`require_runner`). ``operator.runner_id`` must be set;
             :func:`require_runner` guarantees this.
         runner_name: The runner name the route addresses (path/query param).
-        session: An open :class:`AsyncSession` the caller owns. This
-            function only reads; it neither commits nor closes.
+        session: An open :class:`AsyncSession` the caller owns. On a
+            successful match this guard stamps the heartbeat and
+            ``commit()``s it on this session (see "Heartbeat side effect");
+            it does not close the session. Callers must therefore invoke
+            ``assert_runner_scope`` **before** any other mutation on the
+            session — its natural position as the auth/scope gate — so the
+            commit flushes only the heartbeat.
 
     Returns:
         The matching :class:`~meho_backplane.db.models.RunnerPrincipal` row.
@@ -172,4 +195,13 @@ async def assert_runner_scope(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=_RUNNER_SCOPE_VIOLATION,
         )
+    # Heartbeat (#2501): stamp runner liveness on the central clock, keyed
+    # by the token's ``runner_id`` claim (``row.id``), reading no request
+    # field. Committed on the caller's own session (no nested session -- the
+    # SQLite dev/test pool is a single-connection StaticPool). This guard is
+    # always the first operation in each runner-plane handler, so the commit
+    # flushes only the heartbeat and it persists even for the callers (the
+    # long-poll GET and the assignment GET) that never otherwise commit.
+    row.last_seen_at = datetime.now(UTC)
+    await session.commit()
     return row

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -3625,6 +3625,21 @@ class RunnerPrincipal(Base):
         nullable=False,
         default=lambda: datetime.now(UTC),
     )
+    # #2501 dead-man switch. Refreshed on every authenticated runner-plane
+    # request (the single choke-point is
+    # :func:`~meho_backplane.auth.runner_guard.assert_runner_scope`) on the
+    # central clock, never a client-supplied value -- the exact discipline
+    # ``web_session.last_seen_at`` follows (``models.py`` above). The central
+    # dead-man sweeper flips a runner's workloads stale once this falls behind
+    # ``gateway_runner_stale_after_multiplier x GATEWAY_LONGPOLL_MAX_WAIT_SECONDS``.
+    # ``0061`` carries the ``NOT NULL`` server-default ``now()`` so pre-existing
+    # and freshly-registered rows are initialised; the ORM ``default`` supplies
+    # the tz-aware value on ORM inserts.
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
 
     __table_args__ = (
         Index(
@@ -3638,6 +3653,13 @@ class RunnerPrincipal(Base):
             "runner_principal_keycloak_client_id_idx",
             "keycloak_client_id",
             unique=True,
+            postgresql_using="btree",
+        ),
+        # Backs the dead-man sweeper's ``last_seen_at < cutoff`` scan (#2501);
+        # index-rationale mould: ``web_session_expires_at_idx``.
+        Index(
+            "runner_principal_last_seen_at_idx",
+            "last_seen_at",
             postgresql_using="btree",
         ),
     )
@@ -3709,6 +3731,20 @@ class RunnerAssignmentRow(Base):
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(UTC),
+    )
+    # #2501 dead-man flip marker. ``NULL`` = fresh; non-``NULL`` = the moment
+    # the central sweeper declared this runner's workloads unknown (its
+    # ``runner_principal.last_seen_at`` fell behind
+    # ``multiplier x GATEWAY_LONGPOLL_MAX_WAIT_SECONDS`` on the central clock).
+    # Per-runner granularity (one assignment row per ``(tenant_id,
+    # runner_name)``); an accepted result ingestion clears it, the sweeper
+    # only ever sets it. Timestamp-marker shape mirrors
+    # ``web_session.revoked_at`` (NULL = active). ``stale_at IS NOT NULL``
+    # maps to the ``UNKNOWN`` state in #2416's five-state rollup (#2506).
+    stale_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
     )
 
     __table_args__ = (

--- a/backend/src/meho_backplane/gateway/deadman.py
+++ b/backend/src/meho_backplane/gateway/deadman.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Central dead-man's-switch sweeper for satellite runners (#2415, #2501).
+
+A satellite runner that dies, wedges, or loses its network path must not
+leave its workloads silently reporting last-known-good forever. This
+module owns the *enforcement* half of the runner dead-man switch: an
+interval-tick loop the FastAPI lifespan owns that flips a lapsed runner's
+:class:`~meho_backplane.db.models.RunnerAssignmentRow` to a stale/unknown
+marker (``stale_at``) once the runner's central-clock ``last_seen_at``
+(stamped on every runner-plane request by
+:func:`~meho_backplane.auth.runner_guard.assert_runner_scope`) falls
+behind ``N x GATEWAY_LONGPOLL_MAX_WAIT_SECONDS``.
+
+The stamp half lives in the runner guard (piggybacked on the existing
+request cycle — no dedicated heartbeat endpoint, per the #1501 lesson: a
+dedicated heartbeat loop can stay alive while the work loops are wedged).
+
+Design moulds
+-------------
+
+* Interval-tick loop + start/stop pair: copied in shape from
+  :mod:`meho_backplane.memory.expiry` (``_sweeper_loop`` /
+  ``start_*`` / ``stop_*``) — sleep-then-tick, per-tick ``try`` /
+  ``except`` so one bad tick never stalls the loop, ``CancelledError``
+  propagates for a clean lifespan shutdown. Binding per #2415: the
+  in-process interval-tick sweeper, **not** the DB-session-bound
+  scheduler trigger loop.
+* Lapse-then-flip tick body + advisory lock: moulded on the agent-run
+  reaper (:mod:`meho_backplane.agent.reaper`) — a fixed non-blocking PG
+  advisory lock elects one replica per tick (no-op on SQLite), the flip
+  is per-row isolated, one internal audit row per flipped runner.
+* Internal audit row: :func:`~meho_backplane.memory.audit.write_internal_audit_row`
+  (opens its own session, commits) — mould parity with the memory sweeper.
+
+Central-clock discipline
+------------------------
+
+The flip cutoff and the reported lapse are computed **only** from
+:func:`datetime.now` in UTC and the central-stamped ``last_seen_at``.
+No runner-reported timestamp participates in the staleness decision — a
+runner cannot keep itself alive by lying about its clock.
+
+Idempotency + multi-replica safety
+-----------------------------------
+
+Each candidate is flipped by a conditional ``UPDATE ... WHERE stale_at IS
+NULL`` whose ``rowcount`` gates the audit write: the tick that wins the
+flip (``rowcount == 1``) writes the audit row; a racing tick sees
+``rowcount == 0`` and writes nothing. This makes an immediate second tick
+a natural no-op and keeps "exactly one audit row per flip" true even when
+the advisory lock is a no-op (the SQLite test path) or two replicas race.
+
+Recovery
+--------
+
+Recovery is data-driven, never sweeper-driven. The sweeper only ever
+*sets* ``stale_at``; :func:`clear_runner_stale` (called from the result-
+ingest paths) is the only clear path. Runner-level derived staleness
+clears the instant the runner's next request re-stamps ``last_seen_at``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import sqlalchemy as sa
+import structlog
+from sqlalchemy import select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import RunnerAssignmentRow, RunnerPrincipal
+from meho_backplane.gateway.queue import GATEWAY_LONGPOLL_MAX_WAIT_SECONDS
+from meho_backplane.memory.audit import (
+    INTERNAL_METHOD,
+    SYSTEM_OPERATOR_SUB,
+    write_internal_audit_row,
+)
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "GATEWAY_RUNNER_STALE_PATH",
+    "clear_runner_stale",
+    "start_gateway_deadman_sweeper",
+    "stop_gateway_deadman_sweeper",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Canonical internal-audit ``path`` for a dead-man flip. Defined here (the
+#: module that owns the ``stale_at`` lifecycle) next to the sweeper, mould
+#: parity with the reaper's local ``_AUDIT_PATH_*`` literals. Documented in
+#: ``docs/codebase/satellite-runner.md`` as the forward reference for the
+#: G8 audit-query consumers; ``stale_at IS NOT NULL`` maps to ``UNKNOWN`` in
+#: #2416's five-state rollup (#2506).
+GATEWAY_RUNNER_STALE_PATH: str = "gateway.runner.stale"
+
+#: The fixed advisory-lock key the sweeper holds during a tick. Same
+#: hashing shape the reaper / topology scheduler use; a single scalar (no
+#: per-row key) because this is a singleton sweep, not a per-row claimer.
+_DEADMAN_ADVISORY_LOCK_KEY: int = (
+    int.from_bytes(
+        hashlib.blake2b(b"gateway_deadman:v1", digest_size=8).digest(),
+        "big",
+    )
+    & 0x7FFF_FFFF_FFFF_FFFF
+)
+
+
+def _threshold_seconds() -> int:
+    """Central-clock staleness threshold: ``multiplier x cadence``.
+
+    ``cadence`` is #2498's exported
+    :data:`~meho_backplane.gateway.queue.GATEWAY_LONGPOLL_MAX_WAIT_SECONDS`
+    — the maximum quiet interval of a healthy idle runner (its long-poll
+    client re-issues the blocking GET immediately after every response or
+    timeout, so a healthy idle runner authenticates at least once per
+    window). Never re-hardcode the number here.
+    """
+    return get_settings().gateway_runner_stale_after_multiplier * GATEWAY_LONGPOLL_MAX_WAIT_SECONDS
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Coerce a possibly-naive ``timestamptz`` read to UTC-aware.
+
+    aiosqlite reads ``DateTime(timezone=True)`` columns back as naive
+    (the PG driver returns aware); coerce so the lapse subtraction is
+    well-defined on both dialects.
+    """
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+async def _try_advisory_lock(session: AsyncSession, key: int) -> bool:
+    """Acquire a session-level PG advisory lock; ``True`` on non-PG.
+
+    Returns ``True`` when the lock is held (or the dialect has no advisory
+    locks, i.e. the single-replica SQLite test path) and the caller should
+    proceed; ``False`` when another replica holds it and this tick should
+    be skipped. Mould: :func:`meho_backplane.agent.reaper._try_advisory_lock`.
+    """
+    conn = await session.connection()
+    if conn.dialect.name != "postgresql":
+        return True
+    locked = await session.scalar(text("SELECT pg_try_advisory_lock(:k)"), {"k": key})
+    return bool(locked)
+
+
+async def _release_advisory_lock(session: AsyncSession, key: int) -> None:
+    """Release the session-level PG advisory lock; no-op on non-PG."""
+    conn = await session.connection()
+    if conn.dialect.name != "postgresql":
+        return
+    await session.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": key})
+
+
+async def _run_one_tick() -> None:
+    """One sweep: flip lapsed runners' assignment rows, audit each flip.
+
+    Two-phase shape (reaper mould):
+
+    1. Acquire the single advisory lock (skip the tick on PG if another
+       replica won).
+    2. Select the assignment rows whose runner's ``last_seen_at`` is behind
+       the central-clock cutoff and which are not already flipped, then
+       flip each with a conditional ``UPDATE ... WHERE stale_at IS NULL``
+       and collect the ones this tick actually won (``rowcount == 1``).
+
+    Commits the flips once, then writes one internal audit row per won flip
+    (the memory-sweeper ordering: mutate + commit, then audit). An audit-
+    write failure is logged loud but never rolls back a flip.
+    """
+    tick_started = time.perf_counter()
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(seconds=_threshold_seconds())
+    sessionmaker = get_sessionmaker()
+    # (tenant_id, runner_name, lapse_seconds) for each flip this tick won.
+    flipped: list[tuple[uuid.UUID, str, float]] = []
+    async with sessionmaker() as session:
+        if not await _try_advisory_lock(session, _DEADMAN_ADVISORY_LOCK_KEY):
+            _log.debug("gateway_deadman_tick_skipped_lock_held")
+            return
+        try:
+            candidate_stmt = (
+                select(
+                    RunnerAssignmentRow.id,
+                    RunnerAssignmentRow.tenant_id,
+                    RunnerAssignmentRow.runner_name,
+                    RunnerPrincipal.last_seen_at,
+                )
+                .join(
+                    RunnerPrincipal,
+                    sa.and_(
+                        RunnerPrincipal.tenant_id == RunnerAssignmentRow.tenant_id,
+                        RunnerPrincipal.name == RunnerAssignmentRow.runner_name,
+                    ),
+                )
+                .where(
+                    RunnerPrincipal.last_seen_at < cutoff,
+                    RunnerAssignmentRow.stale_at.is_(None),
+                )
+                .order_by(RunnerPrincipal.last_seen_at.asc())
+            )
+            candidates = (await session.execute(candidate_stmt)).all()
+            for assignment_id, tenant_id, runner_name, last_seen_at in candidates:
+                # Conditional flip: the ``stale_at IS NULL`` predicate makes
+                # the audit gate exact even when the advisory lock is a
+                # no-op (SQLite) or two replicas race -- only the tick whose
+                # UPDATE matches a still-fresh row (rowcount == 1) audits.
+                result = await session.execute(
+                    update(RunnerAssignmentRow)
+                    .where(
+                        RunnerAssignmentRow.id == assignment_id,
+                        RunnerAssignmentRow.stale_at.is_(None),
+                    )
+                    .values(stale_at=now)
+                )
+                # ``rowcount`` is only typed on the concrete ``CursorResult``
+                # subclass an UPDATE produces at runtime, not on the
+                # ``Result`` the ``AsyncSession.execute`` stub advertises --
+                # the ignore mirrors the sibling ``gateway/queue.py``.
+                won_flip: int = result.rowcount  # type: ignore[attr-defined]
+                if won_flip == 1:
+                    lapse_seconds = (now - _as_utc(last_seen_at)).total_seconds()
+                    flipped.append((tenant_id, runner_name, lapse_seconds))
+            await session.commit()
+        finally:
+            await _release_advisory_lock(session, _DEADMAN_ADVISORY_LOCK_KEY)
+
+    if not flipped:
+        _log.debug("gateway_deadman_tick_clean")
+        return
+
+    duration_ms = (time.perf_counter() - tick_started) * 1000.0
+    for tenant_id, runner_name, lapse_seconds in flipped:
+        try:
+            await write_internal_audit_row(
+                operator_sub=SYSTEM_OPERATOR_SUB,
+                tenant_id=tenant_id,
+                method=INTERNAL_METHOD,
+                path=GATEWAY_RUNNER_STALE_PATH,
+                status_code=200,
+                duration_ms=duration_ms,
+                payload={"runner": runner_name, "lapse_seconds": lapse_seconds},
+            )
+        except Exception:
+            # An audit-write failure must not stall the tick (the flip is
+            # already committed; we cannot roll it back from here). Surface
+            # it loud so operators see it in logs.
+            _log.exception(
+                "gateway_deadman_audit_write_failed",
+                tenant_id=str(tenant_id),
+                runner=runner_name,
+            )
+    _log.info(
+        "gateway_deadman_tick_done",
+        flipped=len(flipped),
+        threshold_seconds=_threshold_seconds(),
+        duration_ms=duration_ms,
+    )
+
+
+async def clear_runner_stale(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    runner_name: str,
+) -> None:
+    """Clear a runner's dead-man flip marker on an accepted result ingestion.
+
+    Recovery is data-driven, never sweeper-driven (#2501): an accepted
+    result batch proves the runner is alive and reporting, so its
+    ``runner_assignments.stale_at`` is reset to ``NULL``. The sweeper only
+    ever *sets* ``stale_at``; this is the only clear path.
+
+    Operates on the caller's session and does **not** commit — the caller's
+    result-ingest transaction owns the commit. Idempotent: the
+    ``stale_at IS NOT NULL`` predicate makes it a no-op ``UPDATE`` when the
+    runner was never flipped, so the fresh-runner hot path pays nothing.
+    """
+    await session.execute(
+        update(RunnerAssignmentRow)
+        .where(
+            RunnerAssignmentRow.tenant_id == tenant_id,
+            RunnerAssignmentRow.runner_name == runner_name,
+            RunnerAssignmentRow.stale_at.is_not(None),
+        )
+        .values(stale_at=None)
+    )
+
+
+async def _sweeper_loop() -> None:
+    """The forever loop: sleep one cadence, sweep, repeat.
+
+    Sleep-then-sweep (memory-expiry / reaper mould) so the first tick after
+    process start does not race the rest of the startup work. Per-tick
+    ``try`` / ``except`` guards mean a transient DB blip is logged and the
+    loop continues; ``CancelledError`` propagates so lifespan shutdown can
+    stop the task cleanly.
+    """
+    interval = get_settings().gateway_deadman_tick_interval_seconds
+    _log.info(
+        "gateway_deadman_sweeper_started",
+        interval_seconds=interval,
+        threshold_seconds=_threshold_seconds(),
+    )
+    while True:
+        await asyncio.sleep(get_settings().gateway_deadman_tick_interval_seconds)
+        try:
+            await _run_one_tick()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning(
+                "gateway_deadman_tick_failed",
+                exc_info=True,
+            )
+
+
+def start_gateway_deadman_sweeper() -> asyncio.Task[None]:
+    """Start the background sweeper loop and return its task handle.
+
+    Registered in :func:`meho_backplane.main.lifespan` behind
+    ``GATEWAY_DEADMAN_ENABLED`` (default on — that is what "mandatory"
+    means: central enforcement is on by default and a runner cannot opt
+    out of heartbeating because the stamp is a request side effect). The
+    returned task is cancelled on lifespan shutdown; the caller awaits the
+    cancellation so the loop unwinds cleanly. Returning the task (rather
+    than fire-and-forgetting) keeps a strong reference alive — an
+    un-referenced :class:`asyncio.Task` can be garbage-collected mid-flight,
+    producing the "Task was destroyed but it is pending!" warnings the
+    chassis bars under pytest-asyncio shutdown.
+    """
+    return asyncio.create_task(_sweeper_loop(), name="gateway-deadman-sweeper")
+
+
+async def stop_gateway_deadman_sweeper(task: asyncio.Task[None]) -> None:
+    """Cancel the sweeper task and await its unwind.
+
+    Swallows the expected :class:`asyncio.CancelledError`; any other
+    exception surfaced during unwind propagates so a broken shutdown is
+    visible. Shape mirrors
+    :func:`meho_backplane.memory.expiry.stop_memory_expiry_sweeper` verbatim.
+    """
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/backend/src/meho_backplane/gateway/deadman.py
+++ b/backend/src/meho_backplane/gateway/deadman.py
@@ -115,14 +115,21 @@ _DEADMAN_ADVISORY_LOCK_KEY: int = (
 
 
 def _threshold_seconds() -> int:
-    """Central-clock staleness threshold: ``multiplier x cadence``.
+    """Central-clock staleness threshold: ``multiplier x unit``.
 
-    ``cadence`` is #2498's exported
+    The threshold is ``gateway_runner_stale_after_multiplier`` times
     :data:`~meho_backplane.gateway.queue.GATEWAY_LONGPOLL_MAX_WAIT_SECONDS`
-    — the maximum quiet interval of a healthy idle runner (its long-poll
-    client re-issues the blocking GET immediately after every response or
-    timeout, so a healthy idle runner authenticates at least once per
-    window). Never re-hardcode the number here.
+    (30 s) — 3 x 30 s = 90 s by default. What it must clear is the runner's
+    real idle cadence: the satellite runner is a sweep-then-sleep
+    interval-tick loop (:func:`meho_backplane.runner.loop.run_one_tick`)
+    that fetches its assignment every ``tick_interval_seconds`` (#2499's
+    ``GET /checks/assignment``, default 60 s) — an authenticated
+    runner-plane request that re-stamps ``last_seen_at`` — even when idle.
+    There is no long-poll client on the runner, so the 30 s unit is a
+    convenient multiplicand, not the runner's cadence. Invariant: keep
+    ``multiplier x GATEWAY_LONGPOLL_MAX_WAIT_SECONDS >= runner
+    tick_interval_seconds`` (90 s >= 60 s) or a healthy idle runner
+    false-trips. Never re-hardcode the number here.
     """
     return get_settings().gateway_runner_stale_after_multiplier * GATEWAY_LONGPOLL_MAX_WAIT_SECONDS
 

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -119,6 +119,10 @@ from meho_backplane.db.engine import dispose_engine, get_engine
 from meho_backplane.db.migrations import db_migration_probe
 from meho_backplane.docs_search.readiness_probe import docs_backends_readiness_probe
 from meho_backplane.events import start_event_drain, stop_event_drain
+from meho_backplane.gateway.deadman import (
+    start_gateway_deadman_sweeper,
+    stop_gateway_deadman_sweeper,
+)
 from meho_backplane.health import register_probe
 from meho_backplane.health import router as health_router
 from meho_backplane.logging import configure_logging
@@ -439,6 +443,7 @@ class _BackgroundTasks:
     scheduler: asyncio.Task[None] | None
     agent_run_reaper: asyncio.Task[None] | None
     event_drain: asyncio.Task[None] | None
+    gateway_deadman: asyncio.Task[None] | None
 
 
 def _start_background_tasks() -> _BackgroundTasks:
@@ -498,6 +503,14 @@ def _start_background_tasks() -> _BackgroundTasks:
     event_drain: asyncio.Task[None] | None = None
     if settings.event_drain_enabled:
         event_drain = start_event_drain()
+    # Initiative #2415 (#2501) — gateway runner dead-man switch. Gated on
+    # GATEWAY_DEADMAN_ENABLED; default-on is what "mandatory" means (a
+    # runner cannot opt out of heartbeating — the stamp is a request side
+    # effect — so central enforcement is on by default). Operators running
+    # an external liveness sweep can disable the in-tree one via the flag.
+    gateway_deadman: asyncio.Task[None] | None = None
+    if settings.gateway_deadman_enabled:
+        gateway_deadman = start_gateway_deadman_sweeper()
     return _BackgroundTasks(
         topology_scheduler=topology_scheduler,
         memory_expiry=memory_expiry,
@@ -507,6 +520,7 @@ def _start_background_tasks() -> _BackgroundTasks:
         scheduler=scheduler,
         agent_run_reaper=agent_run_reaper,
         event_drain=event_drain,
+        gateway_deadman=gateway_deadman,
     )
 
 
@@ -518,6 +532,8 @@ async def _stop_background_tasks(tasks: _BackgroundTasks) -> None:
     branches (``None`` task handles) are tolerated cleanly so a
     disable-and-shutdown sequence does not raise.
     """
+    if tasks.gateway_deadman is not None:
+        await stop_gateway_deadman_sweeper(tasks.gateway_deadman)
     if tasks.event_drain is not None:
         await stop_event_drain(tasks.event_drain)
     if tasks.agent_run_reaper is not None:

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1074,6 +1074,17 @@ class Settings(BaseModel):
     agent_run_reaper_tick_interval_seconds: int = Field(default=30, ge=5, le=3600)
     agent_run_reaper_max_per_tick: int = Field(default=50, ge=1, le=1000)
     agent_run_lease_ttl_seconds: int = Field(default=60, ge=10, le=3600)
+    # Initiative #2415 (#2501) -- gateway runner dead-man switch. Same
+    # opt-out shape as AGENT_RUN_REAPER_ENABLED, but default-on is what
+    # "mandatory" means: a runner cannot opt out of heartbeating (the stamp
+    # is a request side effect) and central enforcement is on by default.
+    # The stale threshold is ``gateway_runner_stale_after_multiplier x
+    # GATEWAY_LONGPOLL_MAX_WAIT_SECONDS`` (30s) -- the default 3x = 90s gives
+    # a healthy idle runner (which authenticates at least once per long-poll
+    # window) ~3 windows of slack before its workloads flip to unknown.
+    gateway_deadman_enabled: bool = True
+    gateway_deadman_tick_interval_seconds: int = Field(default=30, ge=5, le=3600)
+    gateway_runner_stale_after_multiplier: int = Field(default=3, ge=1, le=100)
     ui_keycloak_client_id: str = ""
     ui_keycloak_client_secret: str = ""
     ui_session_encryption_key: str = ""
@@ -1664,6 +1675,15 @@ def get_settings() -> Settings:
         ),
         agent_run_lease_ttl_seconds=int(
             os.environ.get("AGENT_RUN_LEASE_TTL_SECONDS", "60"),
+        ),
+        gateway_deadman_enabled=parse_bool_env(
+            os.environ.get("GATEWAY_DEADMAN_ENABLED", "true"),
+        ),
+        gateway_deadman_tick_interval_seconds=int(
+            os.environ.get("GATEWAY_DEADMAN_TICK_INTERVAL_SECONDS", "30"),
+        ),
+        gateway_runner_stale_after_multiplier=int(
+            os.environ.get("GATEWAY_RUNNER_STALE_AFTER_MULTIPLIER", "3"),
         ),
         ui_keycloak_client_id=os.environ.get("UI_KEYCLOAK_CLIENT_ID", "").strip(),
         ui_keycloak_client_secret=os.environ.get("UI_KEYCLOAK_CLIENT_SECRET", "").strip(),

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1079,9 +1079,13 @@ class Settings(BaseModel):
     # "mandatory" means: a runner cannot opt out of heartbeating (the stamp
     # is a request side effect) and central enforcement is on by default.
     # The stale threshold is ``gateway_runner_stale_after_multiplier x
-    # GATEWAY_LONGPOLL_MAX_WAIT_SECONDS`` (30s) -- the default 3x = 90s gives
-    # a healthy idle runner (which authenticates at least once per long-poll
-    # window) ~3 windows of slack before its workloads flip to unknown.
+    # GATEWAY_LONGPOLL_MAX_WAIT_SECONDS`` (30s) -- default 3x = 90s. It must
+    # clear the runner's real idle cadence: the runner fetches its assignment
+    # every ``tick_interval_seconds`` (#2499, default 60s), re-stamping
+    # last_seen_at each tick even when idle, so 90s > 60s leaves ~1.5 poll
+    # cadences of slack. Invariant: keep multiplier x
+    # GATEWAY_LONGPOLL_MAX_WAIT_SECONDS >= the runner tick_interval_seconds
+    # or a healthy idle runner false-trips.
     gateway_deadman_enabled: bool = True
     gateway_deadman_tick_interval_seconds: int = Field(default=30, ge=5, le=3600)
     gateway_runner_stale_after_multiplier: int = Field(default=3, ge=1, le=100)

--- a/backend/tests/migrations/test_migration_0061_add_gateway_deadman_columns.py
+++ b/backend/tests/migrations/test_migration_0061_add_gateway_deadman_columns.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0061_add_gateway_deadman_columns``.
+
+Initiative #2415, Task #2501. Adds the dead-man-switch liveness columns:
+``runner_principal.last_seen_at`` (``NOT NULL``, server-default ``now()``,
++ a b-tree index) and ``runner_assignments.stale_at`` (``NULL``). The
+**fifth** migration in the initiative's serialized chain; extends the
+then-current single head ``0060`` (``runner_assignments`` /
+``runner_check_results``).
+
+**Idempotency pinning (0049/0050/0053/0055/0057/0058/0060 footgun).** Every
+forward / round-trip / stamp-replay step targets this migration's **own**
+revision (``0061``) and its ``down_revision`` (``0060``), never ``head`` —
+so a future head migration cannot make ``upgrade("head")`` re-run these
+``add_column`` calls on a schema that already has them. SQLite drives the
+test; the migration branches the ``last_seen_at`` default per dialect
+(``now()`` on PG, a constant literal on SQLite, which forbids
+``CURRENT_TIMESTAMP`` as an ADD COLUMN default).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0061"
+_DOWN_REVISION = "0060"
+
+_PRINCIPAL_TABLE = "runner_principal"
+_ASSIGNMENTS_TABLE = "runner_assignments"
+_LAST_SEEN_COLUMN = "last_seen_at"
+_STALE_COLUMN = "stale_at"
+_LAST_SEEN_INDEX = "runner_principal_last_seen_at_idx"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0061.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _columns(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _column_row(sync_url: str, table: str, column: str) -> tuple[object, ...]:
+    """Return the ``PRAGMA table_info`` row for *column* (cid, name, type, notnull, dflt, pk)."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            return tuple(row)
+    raise AssertionError(f"column {column!r} not present on {table!r}")
+
+
+def _index_names(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA index_list({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def test_upgrade_adds_both_columns(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0061`` adds ``last_seen_at`` + ``stale_at`` to the gateway tables."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    assert _LAST_SEEN_COLUMN in _columns(sync_url, _PRINCIPAL_TABLE)
+    assert _STALE_COLUMN in _columns(sync_url, _ASSIGNMENTS_TABLE)
+
+
+def test_last_seen_at_not_null_with_default(alembic_cfg: tuple[Config, str]) -> None:
+    """``last_seen_at`` lands ``NOT NULL`` with a non-NULL default (initialises rows)."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    # PRAGMA table_info: (cid, name, type, notnull, dflt_value, pk).
+    _cid, _name, _type, notnull, dflt_value, _pk = _column_row(
+        sync_url, _PRINCIPAL_TABLE, _LAST_SEEN_COLUMN
+    )
+    assert notnull == 1, "last_seen_at must be NOT NULL"
+    assert dflt_value is not None, "last_seen_at needs a server default to initialise existing rows"
+
+
+def test_stale_at_is_nullable(alembic_cfg: tuple[Config, str]) -> None:
+    """``stale_at`` is nullable — ``NULL`` = fresh, the un-flipped default."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    _cid, _name, _type, notnull, _dflt, _pk = _column_row(
+        sync_url, _ASSIGNMENTS_TABLE, _STALE_COLUMN
+    )
+    assert notnull == 0, "stale_at must be nullable (NULL = fresh)"
+
+
+def test_upgrade_creates_last_seen_index(alembic_cfg: tuple[Config, str]) -> None:
+    """The sweeper's ``last_seen_at`` scan index is created."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    assert _LAST_SEEN_INDEX in _index_names(sync_url, _PRINCIPAL_TABLE)
+
+
+def test_stamp_down_revision_then_upgrade_is_idempotent(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Stamp ``0060`` then upgrade to ``0061`` — pinned to own revisions, never ``head``.
+
+    Builds the schema through the parent revision, stamps the version table
+    to ``0060``, then replays **only** this migration to its own revision. A
+    future head migration cannot make this step re-run the ``add_column`` on
+    an already-migrated schema, since no leg targets ``"head"``.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+    command.stamp(cfg, _DOWN_REVISION)
+    command.upgrade(cfg, _REVISION)
+
+    assert _LAST_SEEN_COLUMN in _columns(sync_url, _PRINCIPAL_TABLE)
+    assert _STALE_COLUMN in _columns(sync_url, _ASSIGNMENTS_TABLE)
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0060"`` drops the columns + index; ``upgrade "0061"`` re-adds them.
+
+    Pinned to this migration's own revision on both legs (never ``head``).
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _LAST_SEEN_COLUMN in _columns(sync_url, _PRINCIPAL_TABLE)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert _LAST_SEEN_COLUMN not in _columns(sync_url, _PRINCIPAL_TABLE)
+    assert _STALE_COLUMN not in _columns(sync_url, _ASSIGNMENTS_TABLE)
+    assert _LAST_SEEN_INDEX not in _index_names(sync_url, _PRINCIPAL_TABLE)
+
+    command.upgrade(cfg, _REVISION)
+    assert _LAST_SEEN_COLUMN in _columns(sync_url, _PRINCIPAL_TABLE)
+    assert _STALE_COLUMN in _columns(sync_url, _ASSIGNMENTS_TABLE)

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -346,6 +346,14 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                     scheduler_enabled=False,
                     agent_run_reaper_enabled=False,
                     event_drain_enabled=False,
+                    # Initiative #2415 (#2501) added the gateway dead-man
+                    # sweeper, gated on GATEWAY_DEADMAN_ENABLED (default on).
+                    # Pin it off (a bare MagicMock attribute is truthy, so
+                    # without this the gate reads True and the real
+                    # start_gateway_deadman_sweeper runs _sweeper_loop, which
+                    # hits the real get_settings() -> KeyError on
+                    # KEYCLOAK_ISSUER_URL, since this test pins no env).
+                    gateway_deadman_enabled=False,
                 ),
             ),
             patch("meho_backplane.main.start_memory_expiry_sweeper"),
@@ -382,6 +390,9 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                 # back into this env-free test.
                 start_approval_expiry_sweeper=MagicMock(),
                 stop_approval_expiry_sweeper=AsyncMock(),
+                # #2501 gateway dead-man sweeper — same defensive patch.
+                start_gateway_deadman_sweeper=MagicMock(),
+                stop_gateway_deadman_sweeper=AsyncMock(),
                 load_catalog=MagicMock(),
                 validate_catalog_registry_coverage=MagicMock(),
                 stamp_catalog_profiled_connectors=AsyncMock(),
@@ -448,6 +459,11 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                     scheduler_enabled=False,
                     agent_run_reaper_enabled=False,
                     event_drain_enabled=False,
+                    # #2501 gateway dead-man sweeper — pin off; a bare
+                    # MagicMock attribute is truthy, which would start the
+                    # real sweeper and KeyError on KEYCLOAK_ISSUER_URL (this
+                    # env-free test pins no env). Same shape as the sibling.
+                    gateway_deadman_enabled=False,
                 ),
             ),
             patch("meho_backplane.main.start_memory_expiry_sweeper"),
@@ -481,6 +497,9 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                 # sweeper can never start in this env-free test.
                 start_approval_expiry_sweeper=MagicMock(),
                 stop_approval_expiry_sweeper=AsyncMock(),
+                # #2501 gateway dead-man sweeper — same defensive patch.
+                start_gateway_deadman_sweeper=MagicMock(),
+                stop_gateway_deadman_sweeper=AsyncMock(),
                 load_catalog=MagicMock(),
                 validate_catalog_registry_coverage=MagicMock(),
                 stamp_catalog_profiled_connectors=AsyncMock(),

--- a/backend/tests/test_gateway_deadman.py
+++ b/backend/tests/test_gateway_deadman.py
@@ -1,0 +1,572 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the gateway runner dead-man switch (#2415, #2501).
+
+Three layers:
+
+* **Sweeper** — :func:`meho_backplane.gateway.deadman._run_one_tick` driven
+  directly against seeded rows (reaper / memory-expiry test mould): a
+  lapsed runner's ``runner_assignments`` row flips to ``stale_at`` with one
+  audit row, a fresh runner is untouched, a second tick is a no-op,
+  concurrency yields exactly one audit row, and an accepted result batch
+  clears the flip.
+* **Heartbeat** — the four runner-plane endpoints
+  (#2498 ``GET .../next`` + ``POST .../result``, #2499 ``GET
+  /checks/assignment`` + ``POST /checks/results``) over the real middleware
+  + runner guard: each strictly advances ``runner_principal.last_seen_at``
+  on the central clock, and the stamp is never client-controlled.
+* **Idle end-to-end** — the landed runner tick loop drives an authenticated
+  poll against a stub central even when idle; the idle work cycle *is* the
+  heartbeat (the #1501 lesson), with no dedicated ping endpoint.
+
+The ``last_seen_at`` / ``stale_at`` columns are created by migration
+``0061``, which the per-test schema template replays, so the autouse
+``_default_database_url`` DB has them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+from fastapi import FastAPI
+from httpx import ASGITransport
+from sqlalchemy import select
+
+from meho_backplane.api.v1.checks import router as checks_router
+from meho_backplane.api.v1.gateway import router as gateway_router
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AuditLog,
+    RunnerAssignmentRow,
+    RunnerPrincipal,
+    Tenant,
+)
+from meho_backplane.gateway.deadman import (
+    GATEWAY_RUNNER_STALE_PATH,
+    _run_one_tick,
+    _threshold_seconds,
+    start_gateway_deadman_sweeper,
+    stop_gateway_deadman_sweeper,
+)
+from meho_backplane.gateway.queue import (
+    claim_next_command,
+    enqueue_command,
+)
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.runner.client import RunnerClient
+from meho_backplane.runner.loop import RunnerState, run_one_tick
+from meho_backplane.runner.spool import ResultSpool
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import (
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+
+_TENANT = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+_RUNNER_ID = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+_RUNNER_NAME = "runner-dm"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env vars :class:`Settings` requires + reset caches per test."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_runner(
+    *,
+    tenant_id: uuid.UUID,
+    runner_id: uuid.UUID,
+    name: str,
+    last_seen_age_seconds: float,
+    tenant_slug: str,
+    with_assignment: bool = True,
+) -> None:
+    """Seed a tenant + runner principal (``last_seen_at`` back-dated) + assignment."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == tenant_id))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=tenant_id, slug=tenant_slug, name=tenant_slug))
+        session.add(
+            RunnerPrincipal(
+                id=runner_id,
+                tenant_id=tenant_id,
+                name=name,
+                keycloak_client_id=f"runner:{name}:{runner_id}",
+                keycloak_internal_id=f"kc-{runner_id}",
+                owner_sub="op-admin",
+                created_by_sub="op-admin",
+                last_seen_at=datetime.now(UTC) - timedelta(seconds=last_seen_age_seconds),
+            )
+        )
+        if with_assignment:
+            session.add(
+                RunnerAssignmentRow(
+                    id=uuid.uuid4(),
+                    tenant_id=tenant_id,
+                    runner_name=name,
+                    items=[],
+                    stale_at=None,
+                )
+            )
+        await session.commit()
+
+
+async def _stale_at(tenant_id: uuid.UUID, runner_name: str) -> datetime | None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stale: datetime | None = await session.scalar(
+            select(RunnerAssignmentRow.stale_at).where(
+                RunnerAssignmentRow.tenant_id == tenant_id,
+                RunnerAssignmentRow.runner_name == runner_name,
+            )
+        )
+    return stale
+
+
+async def _stale_audit_rows(runner_name: str | None = None) -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(AuditLog).where(AuditLog.path == GATEWAY_RUNNER_STALE_PATH)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    if runner_name is None:
+        return list(rows)
+    return [r for r in rows if r.payload.get("runner") == runner_name]
+
+
+def _lapsed_age() -> float:
+    """A ``last_seen_at`` age comfortably past the stale threshold."""
+    return float(_threshold_seconds() + 60)
+
+
+# ---------------------------------------------------------------------------
+# Sweeper — flip / no-flip / idempotency / recovery
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lapsed_runner_flips_stale_and_audits() -> None:
+    """A runner past ``multiplier x cadence`` flips ``stale_at`` + one audit row.
+
+    AC (a): one tick sets ``stale_at`` on the ``runner_assignments`` row AND
+    writes exactly one audit row with ``method='INTERNAL'``,
+    ``path='gateway.runner.stale'``, payload carrying the runner name +
+    lapse seconds.
+    """
+    tenant = uuid.uuid4()
+    await _seed_runner(
+        tenant_id=tenant,
+        runner_id=uuid.uuid4(),
+        name="lapsed-a",
+        last_seen_age_seconds=_lapsed_age(),
+        tenant_slug=f"t-{tenant.hex[:8]}",
+    )
+
+    await _run_one_tick()
+
+    stale_at = await _stale_at(tenant, "lapsed-a")
+    assert stale_at is not None, "the lapsed runner's assignment row must be flipped"
+
+    audits = await _stale_audit_rows("lapsed-a")
+    assert len(audits) == 1
+    audit = audits[0]
+    assert audit.method == "INTERNAL"
+    assert audit.path == "gateway.runner.stale"
+    assert audit.status_code == 200
+    assert audit.payload["runner"] == "lapsed-a"
+    # Lapse seconds is central-clock derived and at least the threshold.
+    assert audit.payload["lapse_seconds"] >= float(_threshold_seconds())
+
+
+@pytest.mark.asyncio
+async def test_fresh_runner_is_untouched() -> None:
+    """AC (b): a runner seen within the threshold is not flipped and not audited."""
+    tenant = uuid.uuid4()
+    await _seed_runner(
+        tenant_id=tenant,
+        runner_id=uuid.uuid4(),
+        name="fresh-a",
+        last_seen_age_seconds=0.0,
+        tenant_slug=f"t-{tenant.hex[:8]}",
+    )
+
+    await _run_one_tick()
+
+    assert await _stale_at(tenant, "fresh-a") is None
+    assert await _stale_audit_rows("fresh-a") == []
+
+
+@pytest.mark.asyncio
+async def test_second_tick_is_a_no_op() -> None:
+    """AC (c): an immediate second tick flips nothing and writes zero extra audit rows."""
+    tenant = uuid.uuid4()
+    await _seed_runner(
+        tenant_id=tenant,
+        runner_id=uuid.uuid4(),
+        name="lapsed-b",
+        last_seen_age_seconds=_lapsed_age(),
+        tenant_slug=f"t-{tenant.hex[:8]}",
+    )
+
+    await _run_one_tick()
+    first_stale = await _stale_at(tenant, "lapsed-b")
+    assert first_stale is not None
+
+    await _run_one_tick()
+    # The ``stale_at IS NULL`` filter makes the second tick a natural no-op:
+    # the marker is unchanged and no additional audit row is written.
+    assert await _stale_at(tenant, "lapsed-b") == first_stale
+    assert len(await _stale_audit_rows("lapsed-b")) == 1
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_ticks_write_exactly_one_audit_row() -> None:
+    """Multi-replica safety: two concurrent ticks flip once and audit once.
+
+    The advisory lock is a no-op on SQLite, so exactness rests on the
+    conditional ``UPDATE ... WHERE stale_at IS NULL`` + ``rowcount`` gate.
+    """
+    tenant = uuid.uuid4()
+    await _seed_runner(
+        tenant_id=tenant,
+        runner_id=uuid.uuid4(),
+        name="lapsed-c",
+        last_seen_age_seconds=_lapsed_age(),
+        tenant_slug=f"t-{tenant.hex[:8]}",
+    )
+
+    await asyncio.gather(_run_one_tick(), _run_one_tick())
+
+    assert await _stale_at(tenant, "lapsed-c") is not None
+    assert len(await _stale_audit_rows("lapsed-c")) == 1
+
+
+@pytest.mark.asyncio
+async def test_result_ingest_clears_stale_and_leaves_others_flipped() -> None:
+    """AC (d): an accepted result clears the reporter's flip; a sibling stays flipped.
+
+    Recovery is data-driven — :func:`clear_runner_stale` (called from the
+    result-ingest path) is the only clear; the sweeper never un-flips.
+    """
+    tenant = uuid.uuid4()
+    slug = f"t-{tenant.hex[:8]}"
+    await _seed_runner(
+        tenant_id=tenant,
+        runner_id=uuid.uuid4(),
+        name="recover",
+        last_seen_age_seconds=_lapsed_age(),
+        tenant_slug=slug,
+    )
+    await _seed_runner(
+        tenant_id=tenant,
+        runner_id=uuid.uuid4(),
+        name="still-stale",
+        last_seen_age_seconds=_lapsed_age(),
+        tenant_slug=slug,
+    )
+
+    await _run_one_tick()
+    assert await _stale_at(tenant, "recover") is not None
+    assert await _stale_at(tenant, "still-stale") is not None
+
+    # An accepted result ingestion from ``recover`` clears only its marker.
+    from meho_backplane.gateway.deadman import clear_runner_stale
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await clear_runner_stale(session, tenant_id=tenant, runner_name="recover")
+        await session.commit()
+
+    assert await _stale_at(tenant, "recover") is None
+    assert await _stale_at(tenant, "still-stale") is not None
+
+
+@pytest.mark.asyncio
+async def test_central_clock_only_no_runner_timestamp() -> None:
+    """Central-clock discipline: the flip ignores any runner-reported time.
+
+    A runner whose ``last_seen_at`` is future-dated far past the cutoff is
+    not flipped — proving the cutoff is judged on ``last_seen_at`` (the
+    central stamp) alone. There is no runner-reported timestamp the sweeper
+    could consult; this pins the intent behaviourally.
+    """
+    tenant = uuid.uuid4()
+    await _seed_runner(
+        tenant_id=tenant,
+        runner_id=uuid.uuid4(),
+        name="future-clock",
+        last_seen_age_seconds=-3600.0,  # last_seen_at an hour in the future
+        tenant_slug=f"t-{tenant.hex[:8]}",
+    )
+
+    await _run_one_tick()
+
+    assert await _stale_at(tenant, "future-clock") is None
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat — the four runner-plane endpoints stamp last_seen_at
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """Minimal app mounting both runner-plane routers under real middleware."""
+    app = FastAPI()
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(gateway_router)
+    app.include_router(checks_router)
+    return app
+
+
+@pytest.fixture
+async def client() -> AsyncIterator[httpx.AsyncClient]:
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=_build_app()),
+        base_url="https://testserver",
+    ) as ac:
+        yield ac
+
+
+def _runner_token(key: object) -> str:
+    return mint_token(
+        key,
+        sub="runner-sub",
+        tenant_id=str(_TENANT),
+        tenant_role="read_only",
+        principal_kind="runner",
+        runner_id=str(_RUNNER_ID),
+    )
+
+
+async def _read_last_seen() -> datetime:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        value: datetime | None = await session.scalar(
+            select(RunnerPrincipal.last_seen_at).where(RunnerPrincipal.id == _RUNNER_ID)
+        )
+    assert value is not None
+    return value
+
+
+@pytest.mark.asyncio
+async def test_all_four_runner_plane_endpoints_stamp_last_seen(
+    client: httpx.AsyncClient,
+) -> None:
+    """AC: each of the four runner-plane endpoints strictly advances ``last_seen_at``.
+
+    The single choke-point (``assert_runner_scope``) stamps on the central
+    clock as a side effect of every authenticated runner-plane request.
+    """
+    await _seed_runner(
+        tenant_id=_TENANT,
+        runner_id=_RUNNER_ID,
+        name=_RUNNER_NAME,
+        last_seen_age_seconds=3600.0,  # start an hour stale so advances are obvious
+        tenant_slug="tenant-hb",
+    )
+    # A delivered command so POST /gateway/.../result returns 200.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        command = await enqueue_command(
+            session,
+            tenant_id=_TENANT,
+            runner_id=_RUNNER_NAME,
+            op_id="net.ping",
+            params={"host": "10.0.0.1"},
+            enqueued_by_sub="enqueuer",
+            target_descriptor=None,
+        )
+        await claim_next_command(session, tenant_id=_TENANT, runner_id=_RUNNER_NAME)
+        await session.commit()
+        command_id = command.id
+
+    key = make_rsa_keypair("kid-hb")
+    jwks = public_jwks(key)
+    token = _runner_token(key)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    async def _assert_advances(call: object, label: str) -> None:
+        before = await _read_last_seen()
+        await asyncio.sleep(0.01)  # guarantee a distinct central-clock tick
+        resp = await call()  # type: ignore[operator]
+        assert resp.status_code not in (401, 403), f"{label}: guard rejected ({resp.status_code})"
+        after = await _read_last_seen()
+        assert after > before, f"{label}: last_seen_at did not advance ({before} -> {after})"
+
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, jwks)
+
+        await _assert_advances(
+            lambda: client.get(f"/api/v1/gateway/{_RUNNER_NAME}/next?wait=0", headers=headers),
+            "gateway.next",
+        )
+        await _assert_advances(
+            lambda: client.post(
+                f"/api/v1/gateway/{_RUNNER_NAME}/result",
+                headers=headers,
+                json={"command_id": str(command_id), "outcome": "succeeded", "result": {}},
+            ),
+            "gateway.result",
+        )
+        await _assert_advances(
+            lambda: client.get(f"/api/v1/checks/assignment?runner={_RUNNER_NAME}", headers=headers),
+            "checks.assignment",
+        )
+        await _assert_advances(
+            lambda: client.post(
+                "/api/v1/checks/results",
+                headers=headers,
+                json={"runner_id": _RUNNER_NAME, "results": []},
+            ),
+            "checks.results",
+        )
+
+
+@pytest.mark.asyncio
+async def test_last_seen_is_never_client_controlled(client: httpx.AsyncClient) -> None:
+    """AC: the stamp is keyed by the token claim and reads no request field.
+
+    A bogus ``last_seen_at`` query field is ignored; the stored value is the
+    fresh central stamp, not the 1999 value the client supplied.
+    """
+    await _seed_runner(
+        tenant_id=_TENANT,
+        runner_id=_RUNNER_ID,
+        name=_RUNNER_NAME,
+        last_seen_age_seconds=3600.0,
+        tenant_slug="tenant-hb",
+    )
+    key = make_rsa_keypair("kid-hb")
+    jwks = public_jwks(key)
+    headers = {"Authorization": f"Bearer {_runner_token(key)}"}
+
+    before = await _read_last_seen()
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, jwks)
+        resp = await client.get(
+            f"/api/v1/gateway/{_RUNNER_NAME}/next?wait=0&last_seen_at=1999-01-01T00:00:00%2B00:00",
+            headers=headers,
+        )
+    assert resp.status_code == 204
+
+    after = await _read_last_seen()
+    # The stamp advanced to ~now (not the 1999 value, and not unchanged).
+    assert after > before
+    assert after.year >= 2026
+
+
+# ---------------------------------------------------------------------------
+# Idle heartbeat end-to-end — the idle cycle is the heartbeat (#1501 lesson)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idle_runner_issues_authenticated_request_no_dedicated_ping(
+    tmp_path: Path,
+) -> None:
+    """AC: an idle runner still issues an authenticated poll — the heartbeat.
+
+    Drives the landed runner tick loop against a stub central with an empty
+    (idle) assignment and asserts the tick lands an authenticated
+    ``GET /api/v1/checks/assignment`` — the request the runner guard stamps
+    ``last_seen_at`` on — and that no dedicated heartbeat/ping endpoint is
+    dialed. The idle work cycle carries the heartbeat; a healthy idle runner
+    therefore refreshes ``last_seen_at`` at least once per poll window (the
+    ``GATEWAY_LONGPOLL_MAX_WAIT_SECONDS``-anchored threshold gives slack).
+    """
+    seen: list[tuple[str, str, str | None]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path, request.headers.get("authorization")))
+        if request.url.path.endswith("/assignment"):
+            # Idle: an empty assignment, no work to execute.
+            return httpx.Response(200, json={"assignment_version": "v0", "items": []})
+        return httpx.Response(200, json={"accepted": 0, "duplicates": 0})
+
+    client = RunnerClient(
+        central_url="https://central.test",
+        runner_id="runner-idle",
+        token="tok-idle-123",
+        transport=httpx.MockTransport(handler),
+    )
+    state = RunnerState()
+    async with client:
+        await run_one_tick(
+            client=client,
+            spool=ResultSpool(tmp_path, max_files=100),
+            state=state,
+            runner_id="runner-idle",
+        )
+
+    assignment_calls = [r for r in seen if r[1].endswith("/assignment")]
+    assert len(assignment_calls) == 1, "the idle tick must issue exactly one assignment poll"
+    method, _path, auth = assignment_calls[0]
+    assert method == "GET"
+    assert auth == "Bearer tok-idle-123", "the idle poll must carry the runner's bearer token"
+    # No dedicated heartbeat/ping endpoint exists or was dialed — the stamp
+    # piggybacks the real work request (the #1501 zombie-heartbeat lesson).
+    assert not any("heartbeat" in path or path.endswith("/ping") for _m, path, _a in seen)
+
+
+# ---------------------------------------------------------------------------
+# Lifespan gating — mandatory / default-on
+# ---------------------------------------------------------------------------
+
+
+def test_deadman_setting_default_on() -> None:
+    """AC: with ``GATEWAY_DEADMAN_ENABLED`` unset the sweeper is enabled by default."""
+    assert get_settings().gateway_deadman_enabled is True
+
+
+@pytest.mark.asyncio
+async def test_deadman_sweeper_start_stop_clean() -> None:
+    """AC: the lifespan starts a live sweeper task and cancels it cleanly.
+
+    Mirrors the ``main.py`` gating shape (a task handle exists when enabled)
+    and the clean cancel-and-await unwind (no "Task was destroyed but it is
+    pending!" warning under pytest-asyncio).
+    """
+    task = start_gateway_deadman_sweeper()
+    try:
+        assert isinstance(task, asyncio.Task)
+        assert not task.done()
+    finally:
+        await stop_gateway_deadman_sweeper(task)
+    assert task.cancelled() or task.done()

--- a/docs/codebase/satellite-runner.md
+++ b/docs/codebase/satellite-runner.md
@@ -139,9 +139,10 @@ else does). It is keyed by the token's unforgeable `runner_id` claim and
 reads no request field, so `last_seen_at` is never client-controlled
 (the same discipline `web_session.last_seen_at` follows). There is
 deliberately **no** `POST /gateway/{runner}/heartbeat`: a healthy idle
-runner still issues at least one authenticated request per poll window
-(its tick loop fetches the assignment every cadence even with no work),
-so the idle work cycle *is* the heartbeat. This is the #1501 lesson — a
+runner still issues at least one authenticated request per tick (its tick
+loop fetches the assignment every `tick_interval_seconds` — #2499's `GET
+/checks/assignment`, default 60 s — even with no work), so the idle work
+cycle *is* the heartbeat. This is the #1501 lesson — a
 dedicated heartbeat loop can stay alive while the work loops are wedged,
 which is exactly the zombie state to avoid; stamping the real work
 requests measures the liveness that matters.
@@ -160,11 +161,17 @@ advisory lock is a no-op or two replicas race, and make an immediate
 second tick a natural no-op.
 
 **Threshold.** `threshold_seconds = gateway_runner_stale_after_multiplier
-× GATEWAY_LONGPOLL_MAX_WAIT_SECONDS` — the multiplier (default 3) times
-#2498's exported long-poll window (30 s), i.e. the maximum quiet interval
-of a healthy idle runner. The number is never re-hardcoded here; it is
-imported from the gateway queue package. Default 90 s gives a healthy
-runner ~3 windows of slack.
+× GATEWAY_LONGPOLL_MAX_WAIT_SECONDS` — the multiplier (default 3) times the
+gateway queue's exported `GATEWAY_LONGPOLL_MAX_WAIT_SECONDS` (30 s), i.e. a
+default 90 s. The number is never re-hardcoded here; it is imported from the
+gateway queue package. What 90 s must clear is the runner's real idle
+cadence: the satellite runner is a sweep-then-sleep interval-tick loop
+(`runner/loop.py`) that fetches its assignment every `tick_interval_seconds`
+(#2499, default 60 s) — an authenticated request that re-stamps
+`last_seen_at` — even when idle. There is no long-poll client on the runner,
+so the 30 s unit is a convenient multiplicand, not the runner cadence.
+**Invariant:** keep `multiplier × GATEWAY_LONGPOLL_MAX_WAIT_SECONDS ≥ runner
+tick_interval_seconds` (90 s ≥ 60 s) or a healthy idle runner false-trips.
 
 **Recovery is data-driven, never sweeper-driven.** The sweeper only ever
 *sets* `stale_at`. An accepted result ingestion (`POST /checks/results`

--- a/docs/codebase/satellite-runner.md
+++ b/docs/codebase/satellite-runner.md
@@ -121,6 +121,71 @@ authorization boundary is central minting, #2500):
    becomes a structured `error` result — a failed check is a result,
    never a crashed tick.
 
+## Dead-man switch + mandatory heartbeat (#2501)
+
+A runner that dies, wedges, or loses its network path must not leave its
+workloads silently reporting last-known-good forever. Two halves make
+runner liveness observable and enforced, both on the **central clock** —
+a runner's own clock is never consulted.
+
+**Heartbeat (piggybacked, never a dedicated endpoint).** Every
+authenticated runner-plane request stamps `runner_principal.last_seen_at
+= now()` on the central clock. The stamp lives in the single choke-point
+all four runner-plane endpoints pass through —
+`auth/runner_guard.py::assert_runner_scope` (#2498's `GET
+/gateway/{runner}/next` + `POST /gateway/{runner}/result`, #2499's `GET
+/checks/assignment` + `POST /checks/results` all call it, and nothing
+else does). It is keyed by the token's unforgeable `runner_id` claim and
+reads no request field, so `last_seen_at` is never client-controlled
+(the same discipline `web_session.last_seen_at` follows). There is
+deliberately **no** `POST /gateway/{runner}/heartbeat`: a healthy idle
+runner still issues at least one authenticated request per poll window
+(its tick loop fetches the assignment every cadence even with no work),
+so the idle work cycle *is* the heartbeat. This is the #1501 lesson — a
+dedicated heartbeat loop can stay alive while the work loops are wedged,
+which is exactly the zombie state to avoid; stamping the real work
+requests measures the liveness that matters.
+
+**Central sweeper (`gateway/deadman.py`).** An in-process interval-tick
+loop the FastAPI lifespan owns (mould: `memory/expiry.py`, **not** the
+DB-bound scheduler trigger loop). Each tick takes a fixed non-blocking
+advisory lock (reaper mould; no-op on SQLite), selects the
+`runner_assignments` rows whose runner's `last_seen_at` is behind the
+cutoff and whose `stale_at IS NULL`, flips each with a conditional
+`UPDATE ... WHERE stale_at IS NULL`, and writes one internal audit row
+per flip (`method='INTERNAL'`, `path='gateway.runner.stale'`, payload
+`{runner, lapse_seconds}`). The `stale_at IS NULL` predicate + the
+`rowcount` gate keep "exactly one audit row per flip" true even when the
+advisory lock is a no-op or two replicas race, and make an immediate
+second tick a natural no-op.
+
+**Threshold.** `threshold_seconds = gateway_runner_stale_after_multiplier
+× GATEWAY_LONGPOLL_MAX_WAIT_SECONDS` — the multiplier (default 3) times
+#2498's exported long-poll window (30 s), i.e. the maximum quiet interval
+of a healthy idle runner. The number is never re-hardcoded here; it is
+imported from the gateway queue package. Default 90 s gives a healthy
+runner ~3 windows of slack.
+
+**Recovery is data-driven, never sweeper-driven.** The sweeper only ever
+*sets* `stale_at`. An accepted result ingestion (`POST /checks/results`
+or `POST /gateway/{runner}/result`) clears it via
+`gateway/deadman.py::clear_runner_stale` — the only clear path.
+Runner-level derived staleness clears the instant the runner's next
+request re-stamps `last_seen_at`.
+
+**Surfacing contract (#2416 / #2506).** `stale_at IS NOT NULL` maps to
+the `UNKNOWN` state for every check assigned to that runner in the
+five-state rollup #2506 defines (`UNKNOWN → degraded`). This task lands
+the marker + audit trail only; it builds no UI and no rollup — until
+#2416 lands, the flip is observable on the `runner_assignments` row and
+in the `gateway.runner.stale` audit path.
+
+**Settings.** `GATEWAY_DEADMAN_ENABLED` (default `true` — that is what
+"mandatory" means: a runner cannot opt out of heartbeating because the
+stamp is a request side effect, and central enforcement is on by
+default), `GATEWAY_DEADMAN_TICK_INTERVAL_SECONDS` (default 30),
+`GATEWAY_RUNNER_STALE_AFTER_MULTIPLIER` (default 3).
+
 ## Dependencies
 
 - `httpx` (already a direct backend dependency) for the poll/report


### PR DESCRIPTION
## Summary

- **Runner dead-man switch + mandatory heartbeat** for the push-only satellite runner (Initiative #2415, #2501). A runner that dies, wedges, or loses its network path no longer leaves its workloads silently reporting last-known-good forever.
- **Heartbeat = piggyback, no dedicated endpoint.** Every authenticated runner-plane request stamps `runner_principal.last_seen_at` on the **central clock** through the single shared choke-point `auth/runner_guard.py::assert_runner_scope` — the one seam all four runner-plane endpoints (#2498 `GET .../next` + `POST .../result`, #2499 `GET /checks/assignment` + `POST /checks/results`) pass through, and nothing else does. Keyed by the token's unforgeable `runner_id` claim, reads no request field (never client-controlled). A healthy idle runner already polls once per window, so the idle work cycle *is* the heartbeat (the #1501 zombie-heartbeat lesson — a dedicated ping can stay alive while the work loops are wedged).
- **Central sweeper** (`gateway/deadman.py`, in-process interval-tick loop moulded on `memory/expiry.py`, gated on `GATEWAY_DEADMAN_ENABLED`, default-on) flips a lapsed runner's `runner_assignments.stale_at` once its `last_seen_at` falls behind `GATEWAY_RUNNER_STALE_AFTER_MULTIPLIER × GATEWAY_LONGPOLL_MAX_WAIT_SECONDS` (default 3 × 30 s = 90 s) on the central clock, writing one `gateway.runner.stale` audit row per flip. A fixed advisory lock (reaper mould, no-op on SQLite) + a conditional `UPDATE ... WHERE stale_at IS NULL` gated on `rowcount` keep it **exactly-once** under concurrent replicas and make a second tick a natural no-op.
- **Recovery is data-driven, never sweeper-driven** — an accepted result ingestion clears `stale_at` (`clear_runner_stale`, the only clear path); the sweeper only flips. `stale_at IS NOT NULL` maps to the `UNKNOWN` rollup state for #2416/#2506 (documented; no UI built here).

## Migration

- `0061_add_gateway_deadman_columns` extends the single head `0060`: adds `runner_principal.last_seen_at` (timestamptz `NOT NULL`, server-default `now()` — PG keeps a live `now()`, SQLite pins a migration-time literal since it forbids `CURRENT_TIMESTAMP` as an ADD COLUMN default) + a b-tree index, and `runner_assignments.stale_at` (timestamptz `NULL`). Purely additive; reversible. Only columns added (no new tenant-FK table) → no TRUNCATE-list change. The stamp-replay idempotency test is pinned to its **own** revision (`0061`/`0060`), never `head`.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (all changed source + tests + migration)
- [x] `mypy` — clean (7 changed source files)
- [x] `pytest tests/test_gateway_deadman.py` — 11 passed: flip+audit, fresh untouched, second-tick no-op, two-concurrent-ticks → exactly one audit row, result-ingest clears (sibling stays flipped), central-clock-only, all-four-endpoints stamp, never-client-controlled, idle-runner authenticated poll (no dedicated ping), default-on start/stop clean
- [x] `pytest tests/migrations/test_migration_0061_...` — 6 passed (own-revision pinned); siblings `0058`/`0060` still green
- [x] `pytest tests/test_auth_runner_guard.py tests/test_api_v1_gateway.py tests/test_gateway_assignment_api.py tests/test_runner_loop.py tests/test_api_v1_runner_principals.py` — 47 passed (no regressions from the guard stamp/commit + clear seam)
- [x] `pytest tests/test_truncate_list_drift.py` — 3 passed (no drift)
- [x] `uv run alembic upgrade head` → single head `0061`; downgrade/upgrade round-trips
- [x] `cd cli && make snapshot-openapi` — **no diff** (route bodies only; no schema/signature change, no new REST route)
- [x] Full backend suite — `cd backend && uv run pytest`

## Out of scope (per the task)

- No dedicated `POST /gateway/{runner}/heartbeat` endpoint (decided against); no persisted runner-health enum; no eviction/failover/auto-reassignment; no UI/rollup/alerting (that is #2416/#2506, which consumes the `stale_at ⇒ UNKNOWN` marker + audit trail this lands).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2501
