### PR TITLE
feat(gateway): mint single-use capability commands — safe-only post-gate, at-most-once replay refusal (#2500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,32 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — single-use gateway capability commands (#2500)
+
+- Add the authorization keystone of the remote-execution gateway (Initiative
+  #2415, T4): single-use **capability commands** bound to `(runner, op,
+  target, args-hash, expiry)`, minted centrally **after** the policy gate and
+  executed at most once. `mint_gateway_command` re-runs the dispatcher's
+  pre-execution ladder (`lookup_descriptor` → `validate_params` → **safe-only
+  wall** → `policy_gate`) and mints a `gateway_command` row **only** on an
+  explicit `AUTO_EXECUTE` for a `safety_level=='safe'` op — a non-`safe` op,
+  or a `DENY` / `NEEDS_APPROVAL` verdict, is a structured refusal that writes
+  no command row and never parks into the approval queue (change-ops over the
+  gateway are v2). The capability *is* the command row's opaque UUID (not a
+  JWT). Delivery re-hashes the stored params against `params_hash` and refuses
+  on mismatch (post-mint substitution defence); the claim predicate skips
+  expired (`expires_at > now`, bounded at mint against a module-constant
+  default TTL) and consumed rows. A one-way `consumed_at` latch
+  (`consume_command`) makes result acceptance at-most-once with central replay
+  refusal (`gateway_command_already_consumed` + a `gateway_command_replay_refused`
+  log), and the accepted result's audit row links back to the mint audit row
+  (`parent_audit_id = mint_audit_id`) so a remote execution forms one audit
+  subtree. Runner-side, `ExecutedCommandStore` + `execute_command_once` record
+  the command id before dispatch so a redelivery re-submits the spooled result
+  instead of re-executing. Migration `0061` adds the four binding columns to
+  `gateway_command` —
+  `backend/src/meho_backplane/operations/gateway_commands.py` (#2500).
+
 ### Gateway — versioned assignment + results ingest API
 
 - Add the central-side ingest + versioned assignment API for the push-only

--- a/backend/alembic/versions/0061_add_gateway_command_capability_binding.py
+++ b/backend/alembic/versions/0061_add_gateway_command_capability_binding.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add the ``gateway_command`` single-use capability binding columns (#2500).
+
+Revision ID: 0061
+Revises: 0060
+Create Date: 2026-07-15
+
+Initiative #2415 (Remote execution gateway), Task #2500 — the authorization
+keystone. #2498 shipped ``gateway_command`` as a strictly-transport queue
+row (migration ``0059``); this migration layers the capability binding on
+top so a delivered command is bound to ``(runner, op, target, args-hash,
+expiry)`` and executed at most once, with central replay refusal.
+
+Four columns on ``gateway_command``:
+
+* ``params_hash`` — Text NOT NULL. ``compute_params_hash(params)`` stamped
+  at mint. The delivery path (``claim_next_command``) re-hashes the stored
+  ``params`` against it and refuses delivery on mismatch — the post-mint
+  substitution defence ``approve_request`` runs on ``approval_request``.
+
+* ``expires_at`` — ``timestamptz`` NOT NULL. Bounded at mint against a
+  module-constant default TTL (caller may only shorten). The claim predicate
+  requires ``expires_at > now``, so an expired capability is never
+  delivered; a command lost after delivery (runner crash) is not
+  redelivered — it expires, and re-minting is the operator's explicit choice.
+
+* ``consumed_at`` — ``timestamptz`` nullable one-way latch. Won by a single
+  conditional ``UPDATE ... SET consumed_at = now WHERE consumed_at IS NULL
+  AND status = 'delivered'`` (``consume_command``, moulded on
+  ``claim_resume`` #2293): a result is accepted at most once and a replay is
+  centrally refused. Never cleared. A consumed row is excluded from claiming.
+
+* ``mint_audit_id`` — UUID nullable **soft** FK to ``audit_log.id`` (no DB
+  FK, same discipline as ``audit_log.parent_audit_id`` / ``target_id``).
+  The id of the synchronous ``gateway.command.mint`` audit row; the accepted
+  result's audit row stamps ``parent_audit_id = mint_audit_id`` so a remote
+  execution forms one audit subtree.
+
+Serialized order (initiative set-consistency review): this is the **fourth**
+migration in the chain (#2502 → #2498 → #2499 → #2500 → #2501). It extends
+the then-current single head ``0060`` (#2499's ``runner_assignments`` /
+``runner_check_results``). Per the house Alembic rule, if a sibling
+migration lands on main first, renumber-before-merge — only
+``down_revision`` extending the current head is load-bearing, never the
+number.
+
+NOT NULL ADD COLUMN on an empty clean-slate table
+-------------------------------------------------
+
+``gateway_command`` is a clean-slate table (``0059``, same in-flight
+initiative), so it is empty in every environment. ``params_hash`` and
+``expires_at`` are added NOT NULL with a **constant** ``server_default``
+(house pattern ``0044`` / ``0057``): SQLite's ``ALTER TABLE ADD COLUMN``
+forbids a ``NULL``, ``CURRENT_TIMESTAMP``, or parenthesised-expression
+default on a NOT NULL column, so the defaults are literal constants. Both
+are deliberately **fail-closed** sentinels — an empty ``params_hash`` never
+matches a real params hash (delivery refuses it) and the epoch ``expires_at``
+is already past (the claim predicate excludes it) — but no real row ever
+sees them: the mint / ``enqueue_command`` path stamps the true values.
+
+Reversibility contract
+----------------------
+
+``upgrade()`` adds the four columns; ``downgrade()`` drops them in inverse
+order. Purely additive on the way up (no destructive DDL), so the
+migration-compat CI guard passes. SQLite drop-column is supported since
+3.35.0 (we're on 3.45+), so Alembic batch mode is not required.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0061"
+down_revision: str | None = "0060"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+#: Fail-closed epoch sentinel for the NOT NULL ``expires_at`` ADD COLUMN on
+#: the empty table (a constant literal — SQLite forbids an expression
+#: default here). Every minted row overrides it with the bounded TTL.
+_EXPIRES_AT_SENTINEL = "'1970-01-01 00:00:00+00:00'"
+
+
+def upgrade() -> None:
+    """Add the four capability-binding columns to ``gateway_command``."""
+    op.add_column(
+        "gateway_command",
+        sa.Column(
+            "params_hash",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+    op.add_column(
+        "gateway_command",
+        sa.Column(
+            "expires_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text(_EXPIRES_AT_SENTINEL),
+        ),
+    )
+    op.add_column(
+        "gateway_command",
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "gateway_command",
+        sa.Column("mint_audit_id", sa.Uuid(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the four capability-binding columns in inverse order."""
+    op.drop_column("gateway_command", "mint_audit_id")
+    op.drop_column("gateway_command", "consumed_at")
+    op.drop_column("gateway_command", "expires_at")
+    op.drop_column("gateway_command", "params_hash")

--- a/backend/src/meho_backplane/api/v1/gateway.py
+++ b/backend/src/meho_backplane/api/v1/gateway.py
@@ -75,7 +75,10 @@ from meho_backplane.gateway.queue import (
     GatewayCommandNotFoundError,
     claim_next_command,
     clamp_longpoll_wait,
-    record_result,
+)
+from meho_backplane.operations.gateway_commands import (
+    GatewayCommandAlreadyConsumedError,
+    accept_command_result,
 )
 
 __all__ = ["router"]
@@ -247,20 +250,24 @@ async def report_command_result(
     """Report the outcome of a delivered command for ``{runner}``.
 
     Authenticated as the runner principal for ``{runner}`` (#2502's guard).
-    Flips the command ``delivered -> succeeded|failed``, stamping the
-    result/error and ``completed_at``. Returns ``200`` with an ack; ``404``
-    when the command id is unknown or was enqueued for another runner /
-    tenant (no existence oracle); ``409`` when the command is not
-    ``delivered`` (a duplicate report or a never-claimed row).
+    Wins the single-use consumption latch (#2500) **before** recording, then
+    flips the command ``delivered -> succeeded|failed``, stamping the
+    result/error and ``completed_at`` and writing the result audit row (linked
+    to the mint audit row). Returns ``200`` with an ack; ``404`` when the
+    command id is unknown or was enqueued for another runner / tenant (no
+    existence oracle); ``409`` when the command is not ``delivered`` (a
+    never-claimed row) or was **already consumed** (a replayed result —
+    centrally refused, at-most-once).
     """
     sessionmaker = get_sessionmaker()
     try:
         async with sessionmaker() as session:
-            # Scope gate first (#2502), then record on the same session.
+            # Scope gate first (#2502), then consume + record + audit on the
+            # same session (#2500's accept path).
             await assert_runner_scope(operator, runner_name=runner, session=session)
-            command = await record_result(
+            command = await accept_command_result(
                 session,
-                tenant_id=operator.tenant_id,
+                operator=operator,
                 runner_id=runner,
                 command_id=body.command_id,
                 outcome=GatewayCommandStatus(body.outcome),
@@ -279,6 +286,11 @@ async def report_command_result(
         raise HTTPException(
             status_code=http_status.HTTP_404_NOT_FOUND,
             detail="gateway_command_not_found",
+        ) from exc
+    except GatewayCommandAlreadyConsumedError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_409_CONFLICT,
+            detail="gateway_command_already_consumed",
         ) from exc
     except GatewayCommandNotDeliveredError as exc:
         raise HTTPException(

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4841,9 +4841,13 @@ class GatewayCommand(Base):
     (#817): closed status enum + DB CHECK + drift guard, real tenant FK,
     caller-owns-commit service functions.
 
-    Transport-only (binding decision, #2498): this schema stays strictly
-    transport. Capability binding (args-hash, expiry, request-id dedup) is
-    sibling #2500's own migration; nothing speculative lands here.
+    Capability binding (#2500) layers on top of the #2498 transport row:
+    ``params_hash`` / ``expires_at`` / ``consumed_at`` / ``mint_audit_id``
+    are added by migration ``0061`` so a delivered command is bound to
+    ``(runner, op, target, args-hash, expiry)`` and consumed at most once.
+    The row *is* the capability token — an opaque UUID PK, verified by DB
+    lookup and revoked/consumed by a conditional UPDATE, never a signed
+    stateless artifact (at-most-once inherently needs central state).
 
     Schema decisions
     ----------------
@@ -4892,6 +4896,35 @@ class GatewayCommand(Base):
     * ``delivered_at`` / ``completed_at`` -- ``timestamptz`` nullable.
       Stamped on the ``pending -> delivered`` claim and the
       ``delivered -> terminal`` report respectively.
+
+    Capability binding (#2500, migration ``0061``)
+    ----------------------------------------------
+
+    * ``params_hash`` -- Text NOT NULL. ``compute_params_hash(params)`` at
+      mint. The delivery path re-hashes the stored ``params`` against it
+      and refuses delivery on mismatch (post-mint substitution defence,
+      moulded on ``approve_request``). The migration sentinel default
+      ``''`` only satisfies the NOT NULL ADD COLUMN on the empty
+      clean-slate table; every real row is stamped by ``enqueue_command``.
+
+    * ``expires_at`` -- ``timestamptz`` NOT NULL. Bounded at mint against a
+      module-constant default TTL (caller may only shorten). The claim
+      predicate requires ``expires_at > now``, so an expired capability is
+      never delivered. The sentinel default (epoch) is fail-closed
+      (already expired) for the same ADD COLUMN reason as ``params_hash``.
+
+    * ``consumed_at`` -- ``timestamptz`` nullable one-way latch. Won by a
+      single conditional ``UPDATE ... SET consumed_at = now WHERE
+      consumed_at IS NULL AND status = 'delivered'`` (``consume_command``,
+      moulded on ``claim_resume``): the loser of a replayed result is
+      refused (``command_already_consumed``), so a result is accepted at
+      most once. A consumed row is also excluded from claiming.
+
+    * ``mint_audit_id`` -- UUID nullable **soft** FK to ``audit_log.id``
+      (no DB FK, same discipline as ``audit_log.parent_audit_id``). The id
+      of the synchronous ``gateway.command.mint`` audit row; the accepted
+      result's audit row stamps ``parent_audit_id = mint_audit_id`` so a
+      remote execution forms one audit subtree.
 
     Index
     -----
@@ -4953,6 +4986,34 @@ class GatewayCommand(Base):
     )
     completed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    # --- Capability binding (#2500, migration 0061) --------------------
+    # NOT NULL with a sentinel server_default: the ADD COLUMN lands on the
+    # empty clean-slate table across PG + SQLite (SQLite forbids a
+    # CURRENT_TIMESTAMP / expression default on ADD COLUMN, so the default
+    # is a constant), and both sentinels are fail-closed. ``enqueue_command``
+    # stamps the real values on every minted row.
+    params_hash: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        server_default=sa.text("''"),
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.text("'1970-01-01 00:00:00+00:00'"),
+    )
+    # One-way consumption latch (NULL until the result is accepted once).
+    consumed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    # Soft FK to audit_log.id -- the mint audit row's id (mint lineage).
+    mint_audit_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(),
         nullable=True,
         default=None,
     )

--- a/backend/src/meho_backplane/gateway/queue.py
+++ b/backend/src/meho_backplane/gateway/queue.py
@@ -70,7 +70,12 @@ __all__ = [
     "record_result",
 ]
 
-_log = structlog.get_logger(__name__)
+# NOTE: the structlog logger is resolved per-call at each log site below
+# rather than held as a module-level proxy -- production's
+# ``cache_logger_on_first_use=True`` orphans a cached BoundLogger's
+# processor chain from ``structlog.testing.capture_logs`` (the #738
+# ``-n 3 --dist loadscope`` flake). Same convention as
+# :mod:`meho_backplane.auth.jwt` / :mod:`meho_backplane.operations.gateway_commands`.
 
 #: Default capability-command TTL (#2500). A minted command stays
 #: claimable for this window; the mint caller may only *shorten* it
@@ -223,7 +228,7 @@ async def enqueue_command(
     )
     session.add(command)
     await session.flush()
-    _log.info(
+    structlog.get_logger(__name__).info(
         "gateway_command_enqueued",
         command_id=str(command.id),
         tenant_id=str(tenant_id),
@@ -298,7 +303,7 @@ async def claim_next_command(
     # — so it is fail-closed (the row stays pending, undelivered) and logged
     # at error level for an operator to investigate.
     if compute_params_hash(row.params) != row.params_hash:
-        _log.error(
+        structlog.get_logger(__name__).error(
             "gateway_command_params_hash_mismatch",
             command_id=str(row.id),
             tenant_id=str(tenant_id),
@@ -325,7 +330,7 @@ async def claim_next_command(
     # re-query (mould: advance_cron_trigger).
     row.status = GatewayCommandStatus.DELIVERED.value
     row.delivered_at = now
-    _log.info(
+    structlog.get_logger(__name__).info(
         "gateway_command_delivered",
         command_id=str(row.id),
         tenant_id=str(tenant_id),
@@ -407,7 +412,7 @@ async def record_result(
     row.result = result
     row.error = error
     row.completed_at = now
-    _log.info(
+    structlog.get_logger(__name__).info(
         "gateway_command_reported",
         command_id=str(command_id),
         tenant_id=str(tenant_id),

--- a/backend/src/meho_backplane/gateway/queue.py
+++ b/backend/src/meho_backplane/gateway/queue.py
@@ -47,7 +47,7 @@ route clamps the caller's ``wait`` to it via :func:`clamp_longpoll_wait`.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any, Final
 
 import structlog
@@ -55,12 +55,15 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.models import GatewayCommand, GatewayCommandStatus
+from meho_backplane.operations._validate import compute_params_hash
 
 __all__ = [
+    "GATEWAY_COMMAND_DEFAULT_TTL",
     "GATEWAY_LONGPOLL_DEFAULT_WAIT_SECONDS",
     "GATEWAY_LONGPOLL_MAX_WAIT_SECONDS",
     "GatewayCommandNotDeliveredError",
     "GatewayCommandNotFoundError",
+    "bound_capability_expiry",
     "claim_next_command",
     "clamp_longpoll_wait",
     "enqueue_command",
@@ -68,6 +71,35 @@ __all__ = [
 ]
 
 _log = structlog.get_logger(__name__)
+
+#: Default capability-command TTL (#2500). A minted command stays
+#: claimable for this window; the mint caller may only *shorten* it
+#: (:func:`bound_capability_expiry`), never extend it — the single default
+#: doubles as the ceiling, exactly like the approval queue's
+#: ``_bounded_expires_at`` (#2322). A module constant, not a settings knob:
+#: substrate minimalism (#1177), and the bound is a security property that
+#: should not be operator-tunable per environment. Sized well above the
+#: long-poll hold + a few runner ticks so a briefly-offline runner can
+#: still claim a fresh command, but short enough to bound the replay window.
+GATEWAY_COMMAND_DEFAULT_TTL: Final[timedelta] = timedelta(minutes=5)
+
+
+def bound_capability_expiry(requested: datetime | None, *, now: datetime | None = None) -> datetime:
+    """Resolve the ``expires_at`` a minted capability command is stamped with.
+
+    ``None`` defaults to ``now + GATEWAY_COMMAND_DEFAULT_TTL``. An explicit
+    caller deadline is honoured but **capped** at that same ceiling, so no
+    caller can mint an unbounded-lived capability while a shorter (probe /
+    already-past) deadline is respected as-is. No lower bound (substrate
+    minimalism). Moulded on
+    :func:`meho_backplane.operations.approval_queue._bounded_expires_at`.
+    """
+    current = now if now is not None else datetime.now(UTC)
+    ceiling = current + GATEWAY_COMMAND_DEFAULT_TTL
+    if requested is None:
+        return ceiling
+    return min(requested, ceiling)
+
 
 #: Ceiling on a single long-poll hold, in seconds. Sizing mirrors the SSE
 #: feed's intermediary-idle-timeout rationale (nginx ``proxy_read_timeout``
@@ -134,12 +166,24 @@ async def enqueue_command(
     params: dict[str, Any],
     enqueued_by_sub: str,
     target_descriptor: dict[str, Any] | None = None,
+    params_hash: str | None = None,
+    expires_at: datetime | None = None,
+    mint_audit_id: uuid.UUID | None = None,
 ) -> GatewayCommand:
     """Insert a ``pending`` :class:`GatewayCommand` for a runner.
 
     The single central enqueue path (no HTTP surface). Flushes, not
     committed — the caller owns the commit so the enqueue can compose with
     the minting transaction (#2500).
+
+    Every row carries its capability binding (#2500): ``params_hash``
+    (defaulting to ``compute_params_hash(params)`` so it always matches the
+    stored params), ``expires_at`` (bounded by
+    :func:`bound_capability_expiry`), and the optional ``mint_audit_id``
+    lineage. The mint path (:func:`meho_backplane.operations.gateway_commands.mint_gateway_command`)
+    passes an explicit ``params_hash`` (the one it also stamped on the mint
+    audit row) and ``mint_audit_id``; direct enqueues (tests) get the
+    computed hash and a default TTL.
 
     Args:
         session: Open :class:`AsyncSession`; flushed, not committed.
@@ -153,6 +197,12 @@ async def enqueue_command(
         target_descriptor: The centrally-resolved target descriptor a
             handler duck-reads, or ``None`` for a targetless synthetic op
             (``net.*``).
+        params_hash: The args-hash binding; computed from *params* when
+            omitted so it always matches the stored params.
+        expires_at: A caller deadline (bounded down to the default-TTL
+            ceiling); the default TTL when omitted.
+        mint_audit_id: The id of the synchronous ``gateway.command.mint``
+            audit row, stamped for result → mint audit lineage.
 
     Returns:
         The flushed :class:`GatewayCommand` row (with its generated ``id``).
@@ -167,6 +217,9 @@ async def enqueue_command(
         status=GatewayCommandStatus.PENDING.value,
         enqueued_by_sub=enqueued_by_sub,
         enqueued_at=datetime.now(UTC),
+        params_hash=params_hash if params_hash is not None else compute_params_hash(params),
+        expires_at=bound_capability_expiry(expires_at),
+        mint_audit_id=mint_audit_id,
     )
     session.add(command)
     await session.flush()
@@ -176,6 +229,7 @@ async def enqueue_command(
         tenant_id=str(tenant_id),
         runner_id=runner_id,
         op_id=op_id,
+        expires_at=command.expires_at.isoformat(),
     )
     return command
 
@@ -202,6 +256,14 @@ async def claim_next_command(
     stamped) on a win, or ``None`` when the queue is empty **or** a
     concurrent claimer won the row between the SELECT and the UPDATE.
 
+    Capability predicate (#2500): only an **unexpired** (``expires_at >
+    now``), **unconsumed** (``consumed_at IS NULL``) ``pending`` row is
+    claimable, so an expired or already-consumed capability is never
+    delivered. Before flipping the row the stored ``params`` are re-hashed
+    against ``params_hash``; a mismatch (post-mint substitution) refuses
+    delivery (returns ``None`` + an error log) — the same swap defence
+    ``approve_request`` runs, here guarding the params column.
+
     Args:
         session: Open :class:`AsyncSession`; flushed, not committed. The
             caller commits to persist the ``pending -> delivered`` flip.
@@ -209,12 +271,17 @@ async def claim_next_command(
         runner_id: The runner principal name whose queue to claim from.
     """
     conn = await session.connection()
+    now = datetime.now(UTC)
     stmt = (
         select(GatewayCommand)
         .where(
             GatewayCommand.tenant_id == tenant_id,
             GatewayCommand.runner_id == runner_id,
             GatewayCommand.status == GatewayCommandStatus.PENDING.value,
+            # Capability binding (#2500): never deliver an expired or an
+            # already-consumed command.
+            GatewayCommand.expires_at > now,
+            GatewayCommand.consumed_at.is_(None),
         )
         .order_by(GatewayCommand.enqueued_at.asc())
         .limit(1)
@@ -225,7 +292,21 @@ async def claim_next_command(
     if row is None:
         return None
 
-    now = datetime.now(UTC)
+    # Post-mint substitution defence (#2500): the stored params must still
+    # hash to the bound params_hash, else refuse delivery. A mismatch means
+    # the params column was mutated after mint — a tamper signal, not a race
+    # — so it is fail-closed (the row stays pending, undelivered) and logged
+    # at error level for an operator to investigate.
+    if compute_params_hash(row.params) != row.params_hash:
+        _log.error(
+            "gateway_command_params_hash_mismatch",
+            command_id=str(row.id),
+            tenant_id=str(tenant_id),
+            runner_id=runner_id,
+            op_id=row.op_id,
+        )
+        return None
+
     # Conditional flip: the predicate + write commit together, so a second
     # in-process claimer that SELECTed the same pending row loses (0 rows).
     result = await session.execute(

--- a/backend/src/meho_backplane/operations/gateway_commands.py
+++ b/backend/src/meho_backplane/operations/gateway_commands.py
@@ -1,0 +1,502 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Single-use capability commands for the remote execution gateway (#2500).
+
+Initiative #2415 (Remote execution gateway), Task #2500 — the authorization
+keystone of the push-only satellite runner. This module mints, consumes,
+and audits the durable ``gateway_command`` capability rows (#2498's queue
+table, extended with the binding columns in migration ``0061``).
+
+The three service functions:
+
+* :func:`mint_gateway_command` — the **central mint gate**. It re-runs the
+  dispatcher's pre-execution ladder (``lookup_descriptor`` →
+  ``validate_params`` → **safe-only wall** → ``policy_gate``) and only on an
+  explicit ``AUTO_EXECUTE`` verdict for a ``safety_level == 'safe'`` op does
+  it write a command row (+ its synchronous mint audit row). Any other
+  outcome is a structured refusal that writes **no** command row and does
+  **not** park into the approval queue — change-ops-over-gateway is v2
+  (#2415 out of scope). This is the v1 read-only guarantee: a non-``safe``
+  op can never reach a runner because it is never minted.
+
+* :func:`consume_command` — the one-way **consumption latch** (moulded on
+  :func:`meho_backplane.operations.approval_queue.claim_resume`). A single
+  conditional ``UPDATE ... SET consumed_at = now WHERE consumed_at IS NULL
+  AND status = 'delivered'`` wins the right to accept a result exactly once;
+  a replayed / already-consumed capability is centrally refused
+  (``command_already_consumed`` + a ``gateway_command_replay_refused`` log).
+
+* :func:`accept_command_result` — the result-ingest orchestration a
+  runner-facing handler calls: win the consumption latch, record the
+  terminal outcome (#2498's :func:`~meho_backplane.gateway.queue.record_result`),
+  then write the result audit row stamped ``parent_audit_id = mint_audit_id``
+  so a remote execution forms one audit subtree.
+
+Token shape (binding decision, #2500): the capability *is* the command
+row's opaque UUID primary key — not a JWT. At-most-once execution
+inherently requires central state (the ``consumed_at`` latch), so a signed
+stateless token would add a second trust artifact while enabling nothing:
+verification is a DB lookup, revocation is a row update, replay refusal is
+the conditional-UPDATE latch. Possession is not authorization — a command
+is only ever delivered over the runner's authenticated, ``runner_id``-scoped
+channel (#2498/#2502).
+
+Transaction discipline: :func:`mint_gateway_command` and
+:func:`accept_command_result` take an open session and flush; the **caller**
+owns the commit so the mint (or consume + record + audit) lands atomically
+(mould: :mod:`meho_backplane.operations.approval_queue`).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import StrEnum
+from typing import Any
+
+import structlog
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.models import (
+    AuditLog,
+    GatewayCommand,
+    GatewayCommandStatus,
+    PermissionVerdict,
+)
+from meho_backplane.gateway.queue import (
+    GatewayCommandNotDeliveredError,
+    GatewayCommandNotFoundError,
+    enqueue_command,
+    record_result,
+)
+from meho_backplane.operations._lookup import lookup_descriptor, parse_connector_id
+from meho_backplane.operations._validate import (
+    compute_params_hash,
+    policy_gate,
+    validate_params,
+)
+
+__all__ = [
+    "GatewayCommandAlreadyConsumedError",
+    "MintRefusalCode",
+    "MintResult",
+    "accept_command_result",
+    "consume_command",
+    "mint_gateway_command",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: ``audit_log`` bookkeeping for the gateway command lifecycle. ``GATEWAY``
+#: sits alongside ``DISPATCH`` / ``APPROVAL`` as the synthetic method for a
+#: capability event; the synthetic ``202`` (accepted / pending) mirrors the
+#: approval queue's ``_APPROVAL_STATUS_CODE`` convention for a durable park.
+_AUDIT_METHOD = "GATEWAY"
+_MINT_AUDIT_PATH = "gateway.command.mint"
+_MINT_AUDIT_STATUS = 202
+_RESULT_AUDIT_PATH = "gateway.command.result"
+_RESULT_AUDIT_STATUS = 200
+
+
+class GatewayCommandAlreadyConsumedError(Exception):
+    """A result was reported for a command whose ``consumed_at`` latch is set.
+
+    Raised by :func:`consume_command` when the one-way consumption latch is
+    already claimed — a replayed result. The route layer maps this to 409
+    (conflict), the same status as a duplicate report on a terminal row.
+    """
+
+    def __init__(self, command_id: uuid.UUID) -> None:
+        self.command_id = command_id
+        super().__init__(
+            f"gateway_command {command_id} is already consumed; its result was "
+            "accepted once and a replay is refused"
+        )
+
+
+class MintRefusalCode(StrEnum):
+    """Closed vocabulary of central mint refusals.
+
+    Every value is a fail-closed outcome: the command is **not** minted, so
+    it never reaches a runner. ``OP_NOT_SAFE`` is the v1 read-only wall;
+    ``POLICY_DENIED`` / ``NEEDS_APPROVAL`` are the policy-gate verdicts that
+    are not ``AUTO_EXECUTE`` (change-ops-over-gateway is v2, so a
+    ``needs-approval`` verdict is refused here rather than parked).
+    """
+
+    DESCRIPTOR_UNKNOWN = "descriptor_unknown"
+    INVALID_PARAMS = "invalid_params"
+    OP_NOT_SAFE = "op_not_safe"
+    POLICY_DENIED = "policy_denied"
+    NEEDS_APPROVAL = "needs_approval"
+
+
+@dataclass(frozen=True)
+class MintResult:
+    """The outcome of :func:`mint_gateway_command`.
+
+    On a successful mint, :attr:`command` and :attr:`mint_audit_id` are set
+    and :attr:`refusal_code` is ``None``. On a refusal, :attr:`command` is
+    ``None`` and :attr:`refusal_code` / :attr:`refusal_reason` explain why
+    — no command row and no approval row were written.
+    """
+
+    command: GatewayCommand | None = None
+    mint_audit_id: uuid.UUID | None = None
+    refusal_code: MintRefusalCode | None = None
+    refusal_reason: str | None = None
+
+    @property
+    def minted(self) -> bool:
+        """Whether a command row was minted (``True``) or refused (``False``)."""
+        return self.command is not None
+
+
+def _refused(code: MintRefusalCode, reason: str) -> MintResult:
+    """Build a fail-closed refusal result (no rows written)."""
+    return MintResult(refusal_code=code, refusal_reason=reason)
+
+
+async def _write_gateway_audit_row(
+    session: AsyncSession,
+    *,
+    audit_id: uuid.UUID,
+    operator: Operator,
+    path: str,
+    status_code: int,
+    duration_ms: float,
+    payload: dict[str, Any],
+    target_id: uuid.UUID | None = None,
+    parent_audit_id: uuid.UUID | None = None,
+) -> None:
+    """Insert one synchronous ``audit_log`` row for a gateway command event.
+
+    Same-transaction (caller commits), ``method='GATEWAY'``. ``parent_audit_id``
+    is set **directly** off the durable ``gateway_command.mint_audit_id`` for
+    a result row (the lineage the ``parent_audit_id_var`` mechanism provides,
+    read here off the row rather than a contextvar — same discipline as
+    :func:`meho_backplane.operations.approval_queue._write_audit_row` reading
+    ``request.request_audit_id``). Deliberately minimal (no redaction /
+    runbook extras): a capability mint / result is not a connector-boundary
+    response.
+    """
+    row = AuditLog(
+        id=audit_id,
+        occurred_at=datetime.now(UTC),
+        operator_sub=operator.sub,
+        tenant_id=operator.tenant_id,
+        target_id=target_id,
+        parent_audit_id=parent_audit_id,
+        method=_AUDIT_METHOD,
+        path=path,
+        status_code=status_code,
+        request_id=None,
+        duration_ms=Decimal(str(round(duration_ms, 2))),
+        payload=payload,
+    )
+    session.add(row)
+    await session.flush()
+
+
+async def mint_gateway_command(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    connector_id: str,
+    op_id: str,
+    target: Any,
+    params: dict[str, Any],
+    runner_id: str,
+    target_descriptor: dict[str, Any] | None = None,
+    expires_at: datetime | None = None,
+) -> MintResult:
+    """Mint a single-use capability command, or refuse fail-closed.
+
+    Re-runs the dispatcher's pre-execution ladder against the same
+    descriptor metadata (:func:`meho_backplane.operations.dispatcher.dispatch`
+    Steps 2-4), in order, and mints **only** on an explicit ``AUTO_EXECUTE``
+    for a ``safety_level == 'safe'`` op:
+
+    1. ``lookup_descriptor`` — unknown op → :attr:`MintRefusalCode.DESCRIPTOR_UNKNOWN`.
+    2. ``validate_params`` — invalid params → :attr:`MintRefusalCode.INVALID_PARAMS`.
+    3. **safe-only wall** — ``descriptor.safety_level != 'safe'`` →
+       :attr:`MintRefusalCode.OP_NOT_SAFE`. Checked **before** the policy
+       gate so a non-``safe`` op is refused without even consulting it (and
+       so a ``requires_approval`` non-``safe`` op is never parked).
+    4. ``policy_gate`` — any verdict other than ``AUTO_EXECUTE`` refuses
+       (``DENY`` → :attr:`MintRefusalCode.POLICY_DENIED`, ``NEEDS_APPROVAL``
+       → :attr:`MintRefusalCode.NEEDS_APPROVAL`); the defensive
+       ``is not AUTO_EXECUTE`` branch denies any unexpected verdict.
+
+    On success it stamps ``params_hash`` on the synchronous mint audit row,
+    then enqueues the command bound to ``(runner_id, op_id, target,
+    params_hash, expires_at)`` with ``mint_audit_id`` set. The session is
+    flushed, **not** committed — the caller owns the mint+audit commit.
+
+    A refusal writes **no** ``gateway_command`` row and **no**
+    ``approval_request`` row; the command never reaches a runner.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        operator: The authorising principal (the policy gate's subject).
+        connector_id: The ``product-version`` connector id (parsed for the
+            descriptor lookup).
+        op_id: The operation the runner will execute.
+        target: The resolved target row the policy gate scopes to (or
+            ``None`` for a targetless synthetic op).
+        params: The op params — validated, hashed, and stored verbatim.
+        runner_id: The runner principal **name** the capability is bound to.
+        target_descriptor: The centrally-resolved target descriptor shipped
+            in the command payload (the runner has no target table); ``None``
+            for a targetless op.
+        expires_at: An optional caller deadline, bounded down to the default
+            TTL ceiling; the default TTL when omitted.
+
+    Returns:
+        A :class:`MintResult` — minted (``command`` + ``mint_audit_id`` set)
+        or refused (``refusal_code`` set, no rows written).
+    """
+    started = time.monotonic()
+    params_hash = compute_params_hash(params)
+    product, version, impl_id = parse_connector_id(connector_id)
+
+    # --- Step 2: descriptor lookup ---------------------------------------
+    descriptor = await lookup_descriptor(
+        tenant_id=operator.tenant_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        op_id=op_id,
+    )
+    if descriptor is None:
+        _log.info(
+            "gateway_command_mint_refused",
+            reason=MintRefusalCode.DESCRIPTOR_UNKNOWN.value,
+            op_id=op_id,
+            connector_id=connector_id,
+            operator_sub=operator.sub,
+        )
+        return _refused(
+            MintRefusalCode.DESCRIPTOR_UNKNOWN,
+            f"no enabled descriptor for op {op_id!r} on connector {connector_id!r}",
+        )
+
+    # --- Step 3: parameter_schema validation -----------------------------
+    validation_errors = validate_params(descriptor.parameter_schema, params)
+    if validation_errors:
+        _log.info(
+            "gateway_command_mint_refused",
+            reason=MintRefusalCode.INVALID_PARAMS.value,
+            op_id=op_id,
+            operator_sub=operator.sub,
+        )
+        return _refused(
+            MintRefusalCode.INVALID_PARAMS,
+            f"params failed schema validation for op {op_id!r}",
+        )
+
+    # --- Safe-only wall (v1 read-only guarantee) -------------------------
+    # Bound to the real op-identity metadata read straight off the
+    # descriptor (dispatcher.py:1772), NOT a re-derived value. Checked
+    # before the policy gate so a non-'safe' op is refused centrally and is
+    # never parked — change-ops-over-gateway is a v2 follow-on (#2415).
+    if descriptor.safety_level != "safe":
+        _log.warning(
+            "gateway_command_mint_refused_non_safe",
+            reason=MintRefusalCode.OP_NOT_SAFE.value,
+            op_id=op_id,
+            safety_level=descriptor.safety_level,
+            operator_sub=operator.sub,
+            runner_id=runner_id,
+        )
+        return _refused(
+            MintRefusalCode.OP_NOT_SAFE,
+            f"op {op_id!r} has safety_level {descriptor.safety_level!r}; the gateway "
+            "mints only safety_level='safe' ops in v1",
+        )
+
+    # --- Step 4: policy gate (only AUTO_EXECUTE mints) -------------------
+    verdict, gate_reason = await policy_gate(
+        operator=operator, descriptor=descriptor, target=target
+    )
+    if verdict is not PermissionVerdict.AUTO_EXECUTE:
+        code = (
+            MintRefusalCode.NEEDS_APPROVAL
+            if verdict is PermissionVerdict.NEEDS_APPROVAL
+            else MintRefusalCode.POLICY_DENIED
+        )
+        _log.info(
+            "gateway_command_mint_refused",
+            reason=code.value,
+            verdict=verdict.value,
+            op_id=op_id,
+            operator_sub=operator.sub,
+        )
+        return _refused(
+            code,
+            gate_reason or f"policy gate returned {verdict.value!r}, not auto-execute",
+        )
+
+    # --- Mint: synchronous audit row + bound command row -----------------
+    mint_audit_id = uuid.uuid4()
+    command = await enqueue_command(
+        session,
+        tenant_id=operator.tenant_id,
+        runner_id=runner_id,
+        op_id=op_id,
+        params=params,
+        enqueued_by_sub=operator.sub,
+        target_descriptor=target_descriptor,
+        params_hash=params_hash,
+        expires_at=expires_at,
+        mint_audit_id=mint_audit_id,
+    )
+    await _write_gateway_audit_row(
+        session,
+        audit_id=mint_audit_id,
+        operator=operator,
+        path=_MINT_AUDIT_PATH,
+        status_code=_MINT_AUDIT_STATUS,
+        duration_ms=(time.monotonic() - started) * 1000,
+        target_id=getattr(target, "id", None) if target is not None else None,
+        payload={
+            "command_id": str(command.id),
+            "op_id": op_id,
+            "connector_id": connector_id,
+            "runner_id": runner_id,
+            "params_hash": params_hash,
+            "result_status": "minted",
+        },
+    )
+    _log.info(
+        "gateway_command_minted",
+        command_id=str(command.id),
+        mint_audit_id=str(mint_audit_id),
+        op_id=op_id,
+        runner_id=runner_id,
+        tenant_id=str(operator.tenant_id),
+        expires_at=command.expires_at.isoformat(),
+    )
+    return MintResult(command=command, mint_audit_id=mint_audit_id)
+
+
+async def consume_command(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    runner_id: str,
+    command_id: uuid.UUID,
+) -> GatewayCommand:
+    """Win the one-way consumption latch for a delivered command.
+
+    A single conditional ``UPDATE ... SET consumed_at = now WHERE id = :id
+    AND consumed_at IS NULL AND status = 'delivered'`` (mould:
+    :func:`meho_backplane.operations.approval_queue.claim_resume`). The
+    winner (one row touched) may accept the result; a loser is refused so a
+    result is accepted **at most once**. Flushed, not committed — the caller
+    commits to persist the latch (two independent callers each on their own
+    committed transaction race correctly).
+
+    Raises:
+        GatewayCommandNotFoundError: no row in this runner's queue (404).
+        GatewayCommandAlreadyConsumedError: the latch is already claimed —
+            a replay (409); emits a ``gateway_command_replay_refused`` log.
+        GatewayCommandNotDeliveredError: the row is not ``delivered`` (a
+            never-claimed ``pending`` row) (409).
+    """
+    row = await session.get(GatewayCommand, command_id)
+    if row is None or row.tenant_id != tenant_id or row.runner_id != runner_id:
+        raise GatewayCommandNotFoundError(command_id)
+
+    now = datetime.now(UTC)
+    result = await session.execute(
+        update(GatewayCommand)
+        .where(
+            GatewayCommand.id == command_id,
+            GatewayCommand.consumed_at.is_(None),
+            GatewayCommand.status == GatewayCommandStatus.DELIVERED.value,
+        )
+        .values(consumed_at=now)
+    )
+    await session.flush()
+    rowcount: int = result.rowcount  # type: ignore[attr-defined]
+    if rowcount == 0:
+        # Lost the latch: reload to classify replay (consumed) vs. a
+        # never-delivered row.
+        await session.refresh(row)
+        if row.consumed_at is not None:
+            _log.warning(
+                "gateway_command_replay_refused",
+                command_id=str(command_id),
+                tenant_id=str(tenant_id),
+                runner_id=runner_id,
+                op_id=row.op_id,
+            )
+            raise GatewayCommandAlreadyConsumedError(command_id)
+        raise GatewayCommandNotDeliveredError(command_id, row.status)
+
+    row.consumed_at = now
+    return row
+
+
+async def accept_command_result(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    runner_id: str,
+    command_id: uuid.UUID,
+    outcome: GatewayCommandStatus,
+    result: dict[str, Any] | None = None,
+    error: str | None = None,
+) -> GatewayCommand:
+    """Accept a runner's result once: consume the latch, record it, audit it.
+
+    Orchestrates the runner-facing result path (#2498's ``POST
+    .../result`` handler calls this): win the :func:`consume_command`
+    consumption latch **before** anything is recorded or audited (a replay
+    is refused here), flip the row to its terminal outcome
+    (:func:`meho_backplane.gateway.queue.record_result`), then write the
+    result audit row stamped ``parent_audit_id = mint_audit_id`` so the
+    remote execution links back to its mint under one audit subtree.
+
+    Flushed, not committed — the caller owns the commit so consume + record
+    + audit land atomically.
+    """
+    started = time.monotonic()
+    # Win the consumption latch first — a replayed result never reaches the
+    # record / audit writes (raises AlreadyConsumed).
+    await consume_command(
+        session, tenant_id=operator.tenant_id, runner_id=runner_id, command_id=command_id
+    )
+    row = await record_result(
+        session,
+        tenant_id=operator.tenant_id,
+        runner_id=runner_id,
+        command_id=command_id,
+        outcome=outcome,
+        result=result,
+        error=error,
+    )
+    await _write_gateway_audit_row(
+        session,
+        audit_id=uuid.uuid4(),
+        operator=operator,
+        path=_RESULT_AUDIT_PATH,
+        status_code=_RESULT_AUDIT_STATUS,
+        duration_ms=(time.monotonic() - started) * 1000,
+        parent_audit_id=row.mint_audit_id,
+        payload={
+            "command_id": str(command_id),
+            "op_id": row.op_id,
+            "runner_id": runner_id,
+            "outcome": outcome.value,
+            "result_status": outcome.value,
+        },
+    )
+    return row

--- a/backend/src/meho_backplane/operations/gateway_commands.py
+++ b/backend/src/meho_backplane/operations/gateway_commands.py
@@ -91,7 +91,16 @@ __all__ = [
     "mint_gateway_command",
 ]
 
-_log = structlog.get_logger(__name__)
+# NOTE: the structlog logger is resolved per-call at each log site below
+# rather than held as a module-level proxy. Production sets
+# ``cache_logger_on_first_use=True`` in
+# ``meho_backplane.logging.configure_logging``; a cached BoundLogger pins a
+# reference to the processor chain it was built with, and later
+# ``structlog.configure(...)`` calls *replace* (not mutate) that reference --
+# so test fixtures using ``structlog.testing.capture_logs`` cannot observe
+# events written through the orphaned cached proxy (the ``-n 3 --dist
+# loadscope`` flake originally seen in #738). Same precedent + rationale as
+# :mod:`meho_backplane.auth.jwt` and :mod:`meho_backplane.mcp.tools.memory`.
 
 #: ``audit_log`` bookkeeping for the gateway command lifecycle. ``GATEWAY``
 #: sits alongside ``DISPATCH`` / ``APPROVAL`` as the synthetic method for a
@@ -275,7 +284,7 @@ async def mint_gateway_command(
         op_id=op_id,
     )
     if descriptor is None:
-        _log.info(
+        structlog.get_logger(__name__).info(
             "gateway_command_mint_refused",
             reason=MintRefusalCode.DESCRIPTOR_UNKNOWN.value,
             op_id=op_id,
@@ -290,7 +299,7 @@ async def mint_gateway_command(
     # --- Step 3: parameter_schema validation -----------------------------
     validation_errors = validate_params(descriptor.parameter_schema, params)
     if validation_errors:
-        _log.info(
+        structlog.get_logger(__name__).info(
             "gateway_command_mint_refused",
             reason=MintRefusalCode.INVALID_PARAMS.value,
             op_id=op_id,
@@ -307,7 +316,7 @@ async def mint_gateway_command(
     # before the policy gate so a non-'safe' op is refused centrally and is
     # never parked — change-ops-over-gateway is a v2 follow-on (#2415).
     if descriptor.safety_level != "safe":
-        _log.warning(
+        structlog.get_logger(__name__).warning(
             "gateway_command_mint_refused_non_safe",
             reason=MintRefusalCode.OP_NOT_SAFE.value,
             op_id=op_id,
@@ -331,7 +340,7 @@ async def mint_gateway_command(
             if verdict is PermissionVerdict.NEEDS_APPROVAL
             else MintRefusalCode.POLICY_DENIED
         )
-        _log.info(
+        structlog.get_logger(__name__).info(
             "gateway_command_mint_refused",
             reason=code.value,
             verdict=verdict.value,
@@ -374,7 +383,7 @@ async def mint_gateway_command(
             "result_status": "minted",
         },
     )
-    _log.info(
+    structlog.get_logger(__name__).info(
         "gateway_command_minted",
         command_id=str(command.id),
         mint_audit_id=str(mint_audit_id),
@@ -431,7 +440,7 @@ async def consume_command(
         # never-delivered row.
         await session.refresh(row)
         if row.consumed_at is not None:
-            _log.warning(
+            structlog.get_logger(__name__).warning(
                 "gateway_command_replay_refused",
                 command_id=str(command_id),
                 tenant_id=str(tenant_id),

--- a/backend/src/meho_backplane/runner/executor.py
+++ b/backend/src/meho_backplane/runner/executor.py
@@ -39,9 +39,10 @@ from meho_backplane.operations._handler_resolve import (
     import_handler,
     is_unbound_method,
 )
+from meho_backplane.runner.spool import ExecutedCommandStore
 from meho_backplane.runner.wire import RunnerResult, RunnerWorkItem
 
-__all__ = ["execute_work_item"]
+__all__ = ["execute_command_once", "execute_work_item"]
 
 _log = structlog.get_logger(__name__)
 
@@ -97,6 +98,54 @@ async def _invoke(handler: Callable[..., Awaitable[Any]], item: RunnerWorkItem) 
             item, "error", payload=None, error=f"handler returned non-dict {type(payload).__name__}"
         )
     return _result(item, "ok", payload=payload, error=None)
+
+
+async def execute_command_once(
+    command_id: str,
+    item: RunnerWorkItem,
+    store: ExecutedCommandStore,
+) -> RunnerResult:
+    """Execute a gateway command at most once, keyed on its UUID request id.
+
+    The runner's half of the at-most-once guarantee (#2500): *command_id* is
+    recorded in *store* **before** the local dispatch (record-before-execute),
+    so a redelivery is never re-executed —
+
+    * a redelivery whose result was spooled is re-submitted (the centre's
+      ``consumed_at`` latch refuses a double-accept, so re-submission is safe);
+    * a redelivery recorded but with no stored result (a crash mid-dispatch)
+      returns a structured ``duplicate_delivery`` refusal — still no re-run.
+
+    A first delivery records the id, executes via :func:`execute_work_item`,
+    stores the result, and returns it.
+    """
+    if not store.record(command_id):
+        prior = store.load_result(command_id)
+        if prior is not None:
+            _log.info(
+                "runner_command_duplicate_resubmit",
+                command_id=command_id,
+                op_id=item.op_id,
+                check_ref=item.check_ref,
+            )
+            return prior
+        _log.warning(
+            "runner_command_duplicate_no_result",
+            command_id=command_id,
+            op_id=item.op_id,
+            check_ref=item.check_ref,
+        )
+        return _result(
+            item,
+            "refused",
+            payload=None,
+            error=f"duplicate_delivery: command {command_id} already recorded, "
+            "no spooled result to re-submit",
+        )
+
+    result = await execute_work_item(item)
+    store.store_result(command_id, result)
+    return result
 
 
 async def execute_work_item(item: RunnerWorkItem) -> RunnerResult:

--- a/backend/src/meho_backplane/runner/spool.py
+++ b/backend/src/meho_backplane/runner/spool.py
@@ -36,9 +36,9 @@ from pathlib import Path
 
 import structlog
 
-from meho_backplane.runner.wire import RunnerResultBatch
+from meho_backplane.runner.wire import RunnerResult, RunnerResultBatch
 
-__all__ = ["ResultSpool"]
+__all__ = ["ExecutedCommandStore", "ResultSpool"]
 
 _log = structlog.get_logger(__name__)
 
@@ -105,3 +105,81 @@ class ResultSpool:
                 path=str(oldest),
                 max_files=self._max_files,
             )
+
+
+class ExecutedCommandStore:
+    """Persisted record-before-execute set of gateway command ids (#2500).
+
+    The runner's half of the at-most-once guarantee: a gateway command's
+    UUID is the request id, and it is recorded on disk **before** the
+    handler is dispatched, so a crash between record and execute still
+    refuses re-execution on redelivery. The produced :class:`RunnerResult`
+    is persisted alongside the marker so a redelivery whose central
+    consumption latch has not yet closed can be **re-submitted** rather than
+    re-run (the centre's ``consumed_at`` latch makes re-submission safe).
+
+    One file per command id, ``<command_id>.json``, in a dedicated subdir of
+    the runner's spool directory:
+
+    * :meth:`record` atomically creates an empty marker (``O_CREAT|O_EXCL``),
+      returning ``True`` only for the caller that created it — the
+      record-before-execute step.
+    * :meth:`store_result` atomically overwrites the marker with the result
+      JSON (tmp + :func:`os.replace`), after the handler ran.
+    * :meth:`load_result` returns the stored result, or ``None`` when the id
+      is unknown **or** the marker is still empty (recorded but the execution
+      never produced a stored result — e.g. a crash mid-dispatch).
+    """
+
+    def __init__(self, executed_dir: str | os.PathLike[str]) -> None:
+        self._dir = Path(executed_dir)
+
+    def _path(self, command_id: str) -> Path:
+        return self._dir / f"{command_id}.json"
+
+    def record(self, command_id: str) -> bool:
+        """Atomically record *command_id* before execution.
+
+        Returns ``True`` when this call created the marker (proceed to
+        execute), ``False`` when it already existed (a duplicate delivery —
+        never re-execute).
+        """
+        self._dir.mkdir(parents=True, exist_ok=True)
+        try:
+            fd = os.open(self._path(command_id), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        except FileExistsError:
+            return False
+        os.close(fd)
+        return True
+
+    def has(self, command_id: str) -> bool:
+        """Whether *command_id* has been recorded (executed or in-flight)."""
+        return self._path(command_id).exists()
+
+    def store_result(self, command_id: str, result: RunnerResult) -> None:
+        """Persist *result* for a recorded *command_id* (atomic overwrite)."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+        final = self._path(command_id)
+        tmp = final.with_suffix(final.suffix + _TMP_SUFFIX)
+        tmp.write_text(result.model_dump_json(), encoding="utf-8")
+        os.replace(tmp, final)
+
+    def load_result(self, command_id: str) -> RunnerResult | None:
+        """Return the stored result for *command_id*, or ``None``.
+
+        ``None`` covers both an unknown id and a recorded-but-empty marker
+        (recorded before execute, no result stored yet). A corrupt file is
+        logged and treated as absent rather than raising into the tick loop.
+        """
+        path = self._path(command_id)
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        if not raw:
+            return None
+        try:
+            return RunnerResult.model_validate_json(raw)
+        except ValueError as exc:
+            _log.warning("runner_executed_store_unreadable", path=str(path), error=str(exc))
+            return None

--- a/backend/tests/migrations/test_migration_0061_add_gateway_command_capability_binding.py
+++ b/backend/tests/migrations/test_migration_0061_add_gateway_command_capability_binding.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0061`` (#2500).
+
+Initiative #2415 (Remote execution gateway), Task #2500. Adds the four
+single-use capability-binding columns to ``gateway_command``:
+``params_hash`` / ``expires_at`` (NOT NULL, sentinel-defaulted) and
+``consumed_at`` / ``mint_audit_id`` (nullable).
+
+Asserts the columns land after ``upgrade 0061`` and that the migration
+round-trips (downgrade to ``0060`` drops all four, re-upgrade re-adds them).
+
+**Idempotency pinning (0049/0050/0055 footgun).** Every forward / round-trip
+step targets this migration's **own** revision (``0061``) and its
+``down_revision`` (``0060``), never ``head`` — so a future head migration
+cannot make ``upgrade("head")`` re-run this ``add_column`` on a schema that
+already has it. SQLite is the test driver and the migration uses only
+generic DDL, so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0061"
+_DOWN_REVISION = "0060"
+_TABLE = "gateway_command"
+_CAPABILITY_COLUMNS = {"params_hash", "expires_at", "consumed_at", "mint_audit_id"}
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0061.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _columns(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({_TABLE})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def test_upgrade_adds_capability_columns(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0061`` adds the four capability-binding columns."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    assert _columns(sync_url) >= _CAPABILITY_COLUMNS
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0060"`` drops the four columns; ``upgrade "0061"`` re-adds them.
+
+    Pinned to this migration's own revision on both legs (never ``head``) so
+    a future head migration cannot break the round-trip.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert _columns(sync_url) >= _CAPABILITY_COLUMNS
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert not (_CAPABILITY_COLUMNS & _columns(sync_url)), (
+        "downgrade must drop every capability-binding column"
+    )
+
+    command.upgrade(cfg, _REVISION)
+    assert _columns(sync_url) >= _CAPABILITY_COLUMNS
+
+
+def test_expires_at_is_not_null_with_sentinel_default(alembic_cfg: tuple[Config, str]) -> None:
+    """The NOT NULL ``expires_at``/``params_hash`` ADD COLUMN lands on the empty table.
+
+    A raw insert that omits the two NOT NULL capability columns succeeds via
+    their constant server defaults (the migration-mechanics sentinels) —
+    proving the ADD COLUMN is valid on the empty clean-slate table across
+    dialects rather than requiring a backfill.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            # FK enforcement stays off (SQLite default) so the bogus tenant_id
+            # does not mask the columns under test.
+            conn.execute(
+                text(
+                    "INSERT INTO gateway_command "
+                    "(id, tenant_id, runner_id, op_id, params, status, "
+                    "enqueued_by_sub, enqueued_at) "
+                    "VALUES ('cmd-1', 'ten-1', 'runner-a', 'net.ping', '{}', "
+                    "'pending', 'sub-1', '2026-07-15')"
+                )
+            )
+            row = conn.execute(
+                text(
+                    "SELECT params_hash, expires_at, consumed_at, mint_audit_id "
+                    "FROM gateway_command WHERE id = 'cmd-1'"
+                )
+            ).one()
+    finally:
+        sync_eng.dispose()
+
+    params_hash, expires_at, consumed_at, mint_audit_id = row
+    assert params_hash == ""  # empty-string sentinel default
+    assert expires_at is not None  # epoch sentinel default (NOT NULL satisfied)
+    assert consumed_at is None  # nullable, no default
+    assert mint_audit_id is None  # nullable, no default

--- a/backend/tests/test_gateway_commands.py
+++ b/backend/tests/test_gateway_commands.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Single-use capability commands — mint gate, latches, audit lineage (#2500).
+
+Initiative #2415 (Remote execution gateway), Task #2500 — the authorization
+keystone. Covers the central mint gate (the safe-only wall + policy-gate
+refusals that write no rows), the delivery predicate + params-hash
+substitution defence, the one-way consumption latch with central replay
+refusal, expiry bounding, and the result → mint audit lineage.
+
+Service-level (no HTTP): ``lookup_descriptor`` / ``policy_gate`` are patched
+where a controlled verdict is needed, so the tests exercise the mint
+*orchestration* (the order of the ladder and its fail-closed refusals)
+against the real ``gateway_command`` / ``audit_log`` tables.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select, update
+from structlog.testing import capture_logs
+
+import meho_backplane.operations.gateway_commands as gc
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    ApprovalRequest,
+    AuditLog,
+    EndpointDescriptor,
+    GatewayCommand,
+    GatewayCommandStatus,
+    PermissionVerdict,
+    Tenant,
+)
+from meho_backplane.gateway.queue import (
+    GATEWAY_COMMAND_DEFAULT_TTL,
+    claim_next_command,
+    enqueue_command,
+)
+from meho_backplane.operations._validate import compute_params_hash
+from meho_backplane.operations.gateway_commands import (
+    GatewayCommandAlreadyConsumedError,
+    MintRefusalCode,
+    accept_command_result,
+    consume_command,
+    mint_gateway_command,
+)
+from meho_backplane.settings import get_settings
+
+_TENANT = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_RUNNER = "runner-a"
+_CONNECTOR_ID = "net-1.x"
+_OP_ID = "net.ping"
+_PARAMS: dict[str, object] = {"host": "10.0.0.1"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Each test file pins the required settings fields (the conftest owns
+    # only DATABASE_URL); get_sessionmaker + the mint audit path load Settings.
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+
+
+async def _seed_tenant() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if (
+            await session.execute(select(Tenant).where(Tenant.id == _TENANT))
+        ).scalar_one_or_none() is None:
+            session.add(Tenant(id=_TENANT, slug="tenant-a", name="tenant-a"))
+            await session.commit()
+
+
+def _operator() -> Operator:
+    # A non-agent (service) principal: the policy gate default-allows an
+    # ordinary op, so a safe op with requires_approval=False auto-executes.
+    return Operator(
+        sub="minter-sub",
+        raw_jwt="",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.READ_ONLY,
+        principal_kind=PrincipalKind.SERVICE,
+    )
+
+
+def _descriptor(
+    *, safety_level: str = "safe", requires_approval: bool = False
+) -> EndpointDescriptor:
+    return EndpointDescriptor(
+        product="net",
+        version="1.x",
+        impl_id="net",
+        op_id=_OP_ID,
+        source_kind="typed",
+        safety_level=safety_level,
+        requires_approval=requires_approval,
+        parameter_schema={},
+        is_enabled=True,
+    )
+
+
+def _patch_lookup(monkeypatch: pytest.MonkeyPatch, descriptor: EndpointDescriptor | None) -> None:
+    async def _fake_lookup(**_kwargs: object) -> EndpointDescriptor | None:
+        return descriptor
+
+    monkeypatch.setattr(gc, "lookup_descriptor", _fake_lookup)
+
+
+async def _count(model: type) -> int:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        return (await session.execute(select(func.count()).select_from(model))).scalar_one()
+
+
+async def _enqueue(*, params: dict[str, object] | None = None) -> uuid.UUID:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        command = await enqueue_command(
+            session,
+            tenant_id=_TENANT,
+            runner_id=_RUNNER,
+            op_id=_OP_ID,
+            params=params if params is not None else dict(_PARAMS),
+            enqueued_by_sub="enq-sub",
+        )
+        command_id = command.id
+        await session.commit()
+        return command_id
+
+
+async def _claim() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await claim_next_command(session, tenant_id=_TENANT, runner_id=_RUNNER)
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Mint gate — the safe-only wall + policy-gate refusals (no rows)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("level", ["caution", "dangerous"])
+async def test_mint_refuses_non_safe_op(monkeypatch: pytest.MonkeyPatch, level: str) -> None:
+    """A non-'safe' op is refused before the policy gate — no rows written."""
+    await _seed_tenant()
+    _patch_lookup(monkeypatch, _descriptor(safety_level=level))
+
+    async def _gate_must_not_run(**_kwargs: object) -> tuple[PermissionVerdict, str | None]:
+        raise AssertionError("policy_gate must not be consulted for a non-safe op")
+
+    monkeypatch.setattr(gc, "policy_gate", _gate_must_not_run)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await mint_gateway_command(
+            session,
+            operator=_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params=dict(_PARAMS),
+            runner_id=_RUNNER,
+        )
+        await session.commit()
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.OP_NOT_SAFE
+    assert await _count(GatewayCommand) == 0
+    assert await _count(ApprovalRequest) == 0
+
+
+async def test_mint_refuses_denied_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A DENY verdict refuses the mint — no command row, no approval park."""
+    await _seed_tenant()
+    _patch_lookup(monkeypatch, _descriptor(safety_level="safe"))
+
+    async def _deny(**_kwargs: object) -> tuple[PermissionVerdict, str | None]:
+        return PermissionVerdict.DENY, "denied by test"
+
+    monkeypatch.setattr(gc, "policy_gate", _deny)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await mint_gateway_command(
+            session,
+            operator=_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params=dict(_PARAMS),
+            runner_id=_RUNNER,
+        )
+        await session.commit()
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.POLICY_DENIED
+    assert await _count(GatewayCommand) == 0
+    assert await _count(ApprovalRequest) == 0
+
+
+async def test_mint_refuses_needs_approval_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A requires_approval op yields NEEDS_APPROVAL — refused, never parked."""
+    await _seed_tenant()
+    # Real policy_gate: a non-agent principal on a requires_approval op routes
+    # to NEEDS_APPROVAL. The gateway refuses it (change-ops-over-gateway is v2)
+    # rather than writing an approval_request row.
+    _patch_lookup(monkeypatch, _descriptor(safety_level="safe", requires_approval=True))
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await mint_gateway_command(
+            session,
+            operator=_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params=dict(_PARAMS),
+            runner_id=_RUNNER,
+        )
+        await session.commit()
+
+    assert not result.minted
+    assert result.refusal_code is MintRefusalCode.NEEDS_APPROVAL
+    assert await _count(GatewayCommand) == 0
+    assert await _count(ApprovalRequest) == 0
+
+
+# ---------------------------------------------------------------------------
+# Mint gate — the happy path: command row + synchronous audit row
+# ---------------------------------------------------------------------------
+
+
+async def test_mint_writes_synchronous_audit_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful mint writes the command row + its GATEWAY mint audit row."""
+    await _seed_tenant()
+    _patch_lookup(monkeypatch, _descriptor(safety_level="safe"))
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await mint_gateway_command(
+            session,
+            operator=_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params=dict(_PARAMS),
+            runner_id=_RUNNER,
+        )
+        command_id = result.command.id  # captured before commit expiry
+        mint_audit_id = result.mint_audit_id
+        await session.commit()
+
+    assert result.minted
+    assert mint_audit_id is not None
+    expected_hash = compute_params_hash(_PARAMS)
+
+    async with sessionmaker() as session:
+        command = await session.get(GatewayCommand, command_id)
+        assert command is not None
+        assert command.params_hash == expected_hash
+        assert command.mint_audit_id == mint_audit_id
+        assert command.expires_at is not None
+        assert command.status == GatewayCommandStatus.PENDING.value
+
+        audit = await session.get(AuditLog, mint_audit_id)
+        assert audit is not None
+        assert audit.method == "GATEWAY"
+        assert audit.path == "gateway.command.mint"
+        assert audit.status_code == 202
+        assert audit.payload["params_hash"] == expected_hash
+        assert audit.payload["command_id"] == str(command_id)
+
+    assert await _count(GatewayCommand) == 1
+
+
+async def test_mint_bounds_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """expires_at is NOT NULL at mint and a too-long caller TTL is bounded down."""
+    await _seed_tenant()
+    _patch_lookup(monkeypatch, _descriptor(safety_level="safe"))
+    far_future = datetime.now(UTC) + timedelta(days=1)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await mint_gateway_command(
+            session,
+            operator=_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params=dict(_PARAMS),
+            runner_id=_RUNNER,
+            expires_at=far_future,
+        )
+        expires_at = result.command.expires_at
+        await session.commit()
+
+    ceiling = datetime.now(UTC) + GATEWAY_COMMAND_DEFAULT_TTL
+    assert expires_at is not None
+    assert expires_at < far_future, "a caller TTL longer than the default is bounded down"
+    assert expires_at <= ceiling + timedelta(seconds=5)
+
+
+# ---------------------------------------------------------------------------
+# Consumption latch — central replay refusal (at-most-once)
+# ---------------------------------------------------------------------------
+
+
+async def test_consume_command_refuses_replay() -> None:
+    """Of two consume attempts, exactly one wins; the replay is refused + logged."""
+    await _seed_tenant()
+    command_id = await _enqueue()
+    await _claim()  # pending -> delivered
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        won = await consume_command(
+            session, tenant_id=_TENANT, runner_id=_RUNNER, command_id=command_id
+        )
+        assert won.consumed_at is not None
+        await session.commit()
+
+    with capture_logs() as logs:
+        async with sessionmaker() as session:
+            with pytest.raises(GatewayCommandAlreadyConsumedError):
+                await consume_command(
+                    session, tenant_id=_TENANT, runner_id=_RUNNER, command_id=command_id
+                )
+
+    assert any(entry["event"] == "gateway_command_replay_refused" for entry in logs)
+
+
+async def test_claim_delivery_predicate() -> None:
+    """Claim never hands out an expired, already-delivered, or consumed command."""
+    await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+
+    # (a) A fresh unexpired pending command is claimable.
+    fresh = await _enqueue()
+    async with sessionmaker() as session:
+        row = await claim_next_command(session, tenant_id=_TENANT, runner_id=_RUNNER)
+        await session.commit()
+        assert row is not None and row.id == fresh
+
+    # (b) Re-claiming finds nothing (the only command is now delivered).
+    async with sessionmaker() as session:
+        assert await claim_next_command(session, tenant_id=_TENANT, runner_id=_RUNNER) is None
+
+    # (c) An expired pending command is not claimable.
+    expired = await _enqueue()
+    async with sessionmaker() as session:
+        await session.execute(
+            update(GatewayCommand)
+            .where(GatewayCommand.id == expired)
+            .values(expires_at=datetime.now(UTC) - timedelta(minutes=1))
+        )
+        await session.commit()
+    async with sessionmaker() as session:
+        assert await claim_next_command(session, tenant_id=_TENANT, runner_id=_RUNNER) is None
+
+    # (d) A pending-but-consumed command is not claimable (consumed_at latch).
+    consumed = await _enqueue()
+    async with sessionmaker() as session:
+        await session.execute(
+            update(GatewayCommand)
+            .where(GatewayCommand.id == consumed)
+            .values(consumed_at=datetime.now(UTC))
+        )
+        await session.commit()
+    async with sessionmaker() as session:
+        assert await claim_next_command(session, tenant_id=_TENANT, runner_id=_RUNNER) is None
+
+    # (e) A second fresh command is still claimable — the predicate excludes
+    #     only the bad rows, not everything.
+    fresh2 = await _enqueue()
+    async with sessionmaker() as session:
+        row = await claim_next_command(session, tenant_id=_TENANT, runner_id=_RUNNER)
+        await session.commit()
+        assert row is not None and row.id == fresh2
+
+
+async def test_delivery_refuses_params_hash_mismatch() -> None:
+    """Delivery re-hashes stored params against params_hash and refuses on mismatch."""
+    await _seed_tenant()
+    command_id = await _enqueue(params={"host": "orig"})
+
+    # Tamper the params column post-mint without updating params_hash.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await session.execute(
+            update(GatewayCommand)
+            .where(GatewayCommand.id == command_id)
+            .values(params={"host": "tampered"})
+        )
+        await session.commit()
+
+    with capture_logs() as logs:
+        async with sessionmaker() as session:
+            row = await claim_next_command(session, tenant_id=_TENANT, runner_id=_RUNNER)
+
+    assert row is None, "a params_hash mismatch must refuse delivery"
+    assert any(entry["event"] == "gateway_command_params_hash_mismatch" for entry in logs)
+
+    # The tampered row stays pending (undelivered) — fail-closed.
+    async with sessionmaker() as session:
+        tampered = await session.get(GatewayCommand, command_id)
+        assert tampered is not None
+        assert tampered.status == GatewayCommandStatus.PENDING.value
+
+
+# ---------------------------------------------------------------------------
+# Audit lineage — accepted result links back to the mint row
+# ---------------------------------------------------------------------------
+
+
+async def test_result_audit_links_to_mint_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The accepted result's audit row carries parent_audit_id == mint_audit_id."""
+    await _seed_tenant()
+    _patch_lookup(monkeypatch, _descriptor(safety_level="safe"))
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await mint_gateway_command(
+            session,
+            operator=_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=None,
+            params=dict(_PARAMS),
+            runner_id=_RUNNER,
+        )
+        command_id = result.command.id
+        mint_audit_id = result.mint_audit_id
+        await session.commit()
+
+    await _claim()  # pending -> delivered
+
+    async with sessionmaker() as session:
+        await accept_command_result(
+            session,
+            operator=_operator(),
+            runner_id=_RUNNER,
+            command_id=command_id,
+            outcome=GatewayCommandStatus.SUCCEEDED,
+            result={"reachable": True},
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result_rows = (
+            (
+                await session.execute(
+                    select(AuditLog).where(AuditLog.path == "gateway.command.result")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(result_rows) == 1
+        assert result_rows[0].parent_audit_id == mint_audit_id
+
+        # The terminal command carries its consumption latch + outcome.
+        command = await session.get(GatewayCommand, command_id)
+        assert command is not None
+        assert command.status == GatewayCommandStatus.SUCCEEDED.value
+        assert command.consumed_at is not None
+        assert command.result == {"reachable": True}

--- a/backend/tests/test_runner_command_dedup.py
+++ b/backend/tests/test_runner_command_dedup.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runner-side request-id dedup for gateway capability commands (#2500).
+
+The runner's half of the at-most-once guarantee: a redelivered command id is
+never re-executed. :class:`ExecutedCommandStore` records the id before
+dispatch; :func:`execute_command_once` re-submits the spooled result on a
+redelivery (or returns a ``duplicate_delivery`` refusal when no result was
+stored — a crash mid-dispatch), never running the handler twice.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+import meho_backplane.runner.executor as executor_mod
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.runner.executor import execute_command_once
+from meho_backplane.runner.spool import ExecutedCommandStore
+from meho_backplane.runner.wire import RunnerPrincipal, RunnerResult, RunnerWorkItem
+
+
+def _item() -> RunnerWorkItem:
+    return RunnerWorkItem(
+        check_ref="chk-1",
+        op_id="net.tcp_check",
+        product="net",
+        version="1.x",
+        impl_id="net-probe",
+        handler_ref="meho_backplane.connectors.net.ops.net_tcp_check",
+        params={"host": "127.0.0.1", "port": 9},
+        safety_level="safe",
+        principal=RunnerPrincipal(
+            sub="runner-svc", tenant_id=uuid.uuid4(), tenant_role=TenantRole.READ_ONLY
+        ),
+    )
+
+
+async def test_runner_refuses_duplicate_command_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A redelivered command id runs the handler once and re-submits the result."""
+    store = ExecutedCommandStore(tmp_path / "executed")
+    item = _item()
+    calls = {"n": 0}
+
+    async def _fake_execute(work_item: RunnerWorkItem) -> RunnerResult:
+        calls["n"] += 1
+        return RunnerResult(
+            result_uid=uuid.uuid4().hex,
+            check_ref=work_item.check_ref,
+            op_id=work_item.op_id,
+            status="ok",
+            result={"connected": True},
+            error=None,
+        )
+
+    monkeypatch.setattr(executor_mod, "execute_work_item", _fake_execute)
+
+    command_id = uuid.uuid4().hex
+    first = await execute_command_once(command_id, item, store)
+    second = await execute_command_once(command_id, item, store)
+
+    assert calls["n"] == 1, "exactly one local execution for a redelivered command id"
+    assert first.status == "ok"
+    # The redelivery re-submits the spooled result verbatim (same result_uid),
+    # so central ingest dedups it idempotently.
+    assert second == first
+    assert store.has(command_id)
+
+
+async def test_recorded_without_result_returns_duplicate_delivery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A recorded-but-un-stored id (crash mid-dispatch) refuses without re-running."""
+    store = ExecutedCommandStore(tmp_path / "executed")
+    item = _item()
+    # Simulate the record-before-execute marker surviving a crash before the
+    # result was stored.
+    assert store.record(uuid.uuid4().hex) is True
+    command_id = uuid.uuid4().hex
+    store.record(command_id)  # recorded, no result stored
+
+    calls = {"n": 0}
+
+    async def _fake_execute(work_item: RunnerWorkItem) -> RunnerResult:
+        calls["n"] += 1
+        raise AssertionError("handler must not run for a recorded command id")
+
+    monkeypatch.setattr(executor_mod, "execute_work_item", _fake_execute)
+
+    result = await execute_command_once(command_id, item, store)
+
+    assert calls["n"] == 0
+    assert result.status == "refused"
+    assert "duplicate_delivery" in (result.error or "")
+
+
+def test_record_is_atomic_at_most_once(tmp_path: Path) -> None:
+    """``record`` returns True exactly once per id (O_EXCL create)."""
+    store = ExecutedCommandStore(tmp_path / "executed")
+    command_id = uuid.uuid4().hex
+    assert store.record(command_id) is True
+    assert store.record(command_id) is False
+    assert store.load_result(command_id) is None  # recorded, no result yet

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -7296,7 +7296,7 @@
           "gateway"
         ],
         "summary": "Report Command Result",
-        "description": "Report the outcome of a delivered command for ``{runner}``.\n\nAuthenticated as the runner principal for ``{runner}`` (#2502's guard).\nFlips the command ``delivered -> succeeded|failed``, stamping the\nresult/error and ``completed_at``. Returns ``200`` with an ack; ``404``\nwhen the command id is unknown or was enqueued for another runner /\ntenant (no existence oracle); ``409`` when the command is not\n``delivered`` (a duplicate report or a never-claimed row).",
+        "description": "Report the outcome of a delivered command for ``{runner}``.\n\nAuthenticated as the runner principal for ``{runner}`` (#2502's guard).\nWins the single-use consumption latch (#2500) **before** recording, then\nflips the command ``delivered -> succeeded|failed``, stamping the\nresult/error and ``completed_at`` and writing the result audit row (linked\nto the mint audit row). Returns ``200`` with an ack; ``404`` when the\ncommand id is unknown or was enqueued for another runner / tenant (no\nexistence oracle); ``409`` when the command is not ``delivered`` (a\nnever-claimed row) or was **already consumed** (a replayed result \u2014\ncentrally refused, at-most-once).",
         "operationId": "report_command_result_api_v1_gateway__runner__result_post",
         "parameters": [
           {


### PR DESCRIPTION
## Summary

- **Security keystone of the remote-execution gateway (Initiative #2415, T4).** Adds single-use **capability commands** bound to `(runner, op, target, args-hash, expiry)`, minted centrally **after** the policy gate and executed **at most once**.
- **Safe-only wall (v1 read-only guarantee).** `mint_gateway_command` re-runs the dispatcher's pre-execution ladder (`lookup_descriptor` → `validate_params` → **safe-only** → `policy_gate`) and mints a `gateway_command` row **only** on an explicit `AUTO_EXECUTE` for a `safety_level=='safe'` op. A non-`safe` op — or a `DENY` / `NEEDS_APPROVAL` verdict — is a structured refusal that writes **no** command row and **never** parks into the approval queue (change-ops over the gateway are v2). The safe check binds to the real `descriptor.safety_level` metadata and runs *before* the policy gate, so a non-`safe` op is refused without even consulting it.
- **At-most-once + central replay refusal.** The capability *is* the command row's opaque UUID (not a JWT). Delivery re-hashes stored params against `params_hash` and refuses on mismatch (post-mint substitution defence); the claim predicate skips expired (`expires_at > now`, bounded at mint against a module-constant TTL, caller may only shorten) and consumed rows. A one-way `consumed_at` latch (`consume_command`, moulded on `claim_resume`) makes result acceptance at-most-once (`command_already_consumed` + `gateway_command_replay_refused`), and the accepted result's audit row links back to the mint audit row (`parent_audit_id = mint_audit_id`).
- **Runner dedup.** `ExecutedCommandStore` + `execute_command_once` record the command id before dispatch so a redelivery re-submits the spooled result instead of re-executing.
- **Migration `0061`** adds the four binding columns to `gateway_command` (extends single head `0060`).

Reconciled against merged Waves 1+2: #2498 shipped `gateway_command` as a transport-only queue with `enqueue_command` / `claim_next_command` / `record_result`; this task extends those (no parallel twin) and adds the capability layer on top.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `uv run mypy src/` (strict) — clean, 642 files
- [x] `uv run alembic upgrade head` — clean; `alembic heads` → single head `0061`
- [x] `tests/test_gateway_commands.py` — 10 passed (safe-only refusal for `caution`+`dangerous`, DENY/NEEDS_APPROVAL refusals with zero command + zero approval rows, synchronous mint audit row, expiry bounding, consume replay refusal + log, claim predicate, params-hash mismatch refusal, result→mint audit lineage)
- [x] `tests/test_runner_command_dedup.py` — 3 passed (record-before-execute, one execution per id, spooled re-submission, duplicate_delivery)
- [x] `tests/migrations/test_migration_0061_*` — 3 passed (own-revision pinned, round-trip, sentinel-default ADD COLUMN)
- [x] `tests/test_truncate_list_drift.py` — 3 passed (`gateway_command` already in all three lists from #2498; no new tenant-FK table)
- [x] `tests/migrations/` (whole dir) — green (additive migration triggers no stamp-replay footgun)
- [x] gateway/runner cluster (`test_api_v1_gateway`, `test_gateway_assignment_api`, runner + auth guard + principals) — 80 passed
- [x] `cd cli && make snapshot-openapi && make generate` — only the `report_command_result` route description changed (docstring); snapshot committed, no client-code change

## Out of scope

- The long-poll endpoints + base `gateway_command` table (#2498); the runner process + spool construction (#2497); assignment API (#2499); heartbeat (#2501); runner principal hardening (#2502).
- JWTs / signed tokens, minting non-`safe` ops, approval-parked gateway commands — v2 per #2415.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2500


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added single-use capability commands for remote execution.
  * Commands now support expiry, safe-operation and policy checks, parameter integrity validation, and audit tracking.
  * Prevented duplicate delivery and execution, including replay protection and result re-submission.

* **Bug Fixes**
  * Duplicate command results now return a clear conflict response.
  * Invalid or tampered command parameters fail closed without delivery.

* **Documentation**
  * Updated the changelog and API documentation with command consumption and replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->