### PR TITLE
fix(connectors): reword gcloud SA-key docstring to clear FP secret alert (#2493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Security — gcloud docstring reword to clear FP secret alert (#2493)
+
+- Reword the SA-JSON-key-refusal docstring in
+  `backend/src/meho_backplane/connectors/gcloud/session.py` so it no longer
+  embeds the literal JSON-shaped `"type": "service_account"` marker that made
+  Trivy's builtin `gcp-service-account` secret rule raise a permanently-open
+  CRITICAL false positive (code-scanning alert #39, open since 2026-05-23) on
+  the in-image copy of the file. The prose now describes *a `type` field of
+  `service_account`* and names the `_SA_KEY_FIELDS` / `_contains_sa_key_fields`
+  refusal gate — meaning unchanged, no key material ever present. The
+  `gcp-service-account` rule is deliberately **not** suppressed via trivyignore
+  (that would blind the scan to a real future leak) — G0.34-T3 (#2493).
+
 ### CI — coverage fail-visible contract (#2513)
 
 - Make a missing backend coverage import **loud instead of silent** (G0.35-T3).

--- a/backend/src/meho_backplane/connectors/gcloud/session.py
+++ b/backend/src/meho_backplane/connectors/gcloud/session.py
@@ -15,8 +15,9 @@ SA-JSON-key refusal
 Org policy ``constraints/iam.disableServiceAccountKeyCreation`` is active
 on the consumer's GCP organisation. The connector enforces this policy in
 code: if the Vault ``secret_ref`` payload contains fields that look like a
-service-account JSON key (``"type": "service_account"`` + ``"private_key"``,
-or any of the JSON-key field names), ``auth_headers()`` raises
+service-account JSON key (a ``type`` field of ``service_account`` plus a
+``private_key`` field, or any of the ``_SA_KEY_FIELDS`` JSON-key field
+names — see :func:`_contains_sa_key_fields`), ``auth_headers()`` raises
 :exc:`ValueError` with a clear message and no token is built.
 
 The only accepted credential material in ``secret_ref`` is:


### PR DESCRIPTION
## Summary

- Reword the SA-JSON-key-refusal docstring in `backend/src/meho_backplane/connectors/gcloud/session.py` so it no longer embeds the literal JSON-shaped `"type": "service_account"` marker.
- That literal made Trivy's builtin `gcp-service-account` secret rule raise a permanently-open **CRITICAL false positive** (code-scanning alert #39, open since 2026-05-23) on the in-image copy of the file. No key material was ever committed — the string documented the refusal gate.
- The prose now describes *a `type` field of `service_account`* and names the `_SA_KEY_FIELDS` / `_contains_sa_key_fields` refusal gate. Meaning unchanged.
- The `gcp-service-account` rule is deliberately **not** suppressed via trivyignore (that would blind the scan to a real future leak); rewording the source prevents fingerprint drift from re-opening a fresh alert.

## Scope of this PR — docstring reword ONLY

Issue #2493 has four desired-state actions. **This PR implements only desired-state action #2's code half (the docstring reword).** The other four API/settings/ops actions are **maintainer/ops follow-ups** that require repo-admin permissions + ops coordination and remain tracked on the issue — this is expected and correct, not an omission of this PR:

1. Flip repo default token to read (`PUT .../actions/permissions/workflow`) — **maintainer follow-up**.
2. Dismiss FP alert #39 (`PATCH .../code-scanning/alerts/39`) — **maintainer follow-up**, and must run only **after this PR merges** (dismiss-before-reword would re-open on the next scan).
3. RDC dispatch token rotate/delete (`RDC_DISPATCH_TOKEN` secret) — **ops follow-up**.
4. Enable Python CodeQL (`PATCH .../code-scanning/default-setup`) — **maintainer follow-up**.

## Test plan

- [x] `git grep -F '"type": "service_account"' -- backend/src` returns nothing (literal gone).
- [x] Fake-key test fixture in `backend/tests/test_connectors_gcloud_auth.py:174` left untouched (out of scope; not image-shipped).
- [x] Reworded docstring still clearly names the refusal semantics (`_SA_KEY_FIELDS` / `_contains_sa_key_fields`).
- [x] `uv run pytest -k gcloud` — 80 passed, 2 skipped.
- [x] `ruff check` / `ruff format --check` on the touched file — clean.
- [x] CHANGELOG `[Unreleased]` entry under a distinct `### Security — gcloud docstring reword to clear FP secret alert (#2493)` header.

## Out of scope

- The four maintainer/ops actions above (tracked on #2493).
- Fixing findings a future Python CodeQL analysis surfaces.
- G0.34-T1 (Dockerfile/image.yml/dependabot) and G0.34-T2 (workflow permission blocks).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2493


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for Google Cloud service-account key detection and rejection.
  * Updated the unreleased changelog to note the documentation change and improved security-scanner compatibility.
  * No changes to application behavior, APIs, or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->