### PR TITLE
chore(backend): unfreeze python:3.12-slim base digest, drop base pip, gate Trivy SARIF (#2491)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,11 @@
 
 # Dependabot configuration.
 #
-# Initial v0.1 scope: GitHub Actions only. Pip / npm / docker
-# ecosystems land when their manifests do (pyproject.toml,
-# package.json, Dockerfile). Adding them now would silently no-op
-# but invites confusion when manifests appear later — the schedule
-# would already be running.
+# Active ecosystems: GitHub Actions (workflows), uv (backend Python
+# deps), and docker (backend/Dockerfile base image). Pip / npm land
+# when their manifests do (a root pyproject.toml, a package.json).
+# Adding an ecosystem before its manifest exists silently no-ops but
+# invites confusion later — the schedule would already be running.
 
 version: 2
 updates:
@@ -56,6 +56,27 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
+  # The backplane image's base is `FROM python:3.12-slim@sha256:…` in
+  # backend/Dockerfile. Dependabot's docker ecosystem bumps that literal,
+  # tag-qualified digest when upstream rebuilds the tag, so newly disclosed
+  # base-OS CVEs arrive as an automatic PR instead of silently accumulating
+  # on a frozen digest. `directory` points at the Dockerfile's directory.
+  # Only literal `FROM image:tag@sha256:` references are tracked — an
+  # ARG-held digest is not resolved (dependabot-core#2057 / #4597), which
+  # is why the Dockerfile inlines the pin on both FROM lines.
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+
   # When other language manifests land, add per-ecosystem blocks below.
   # Reference (MEHO.X conventions):
   #
@@ -74,14 +95,5 @@ updates:
   #     interval: "weekly"
   #     day: "monday"
   #   labels: ["dependencies", "frontend"]
-  #   commit-message:
-  #     prefix: "chore(deps)"
-  #
-  # - package-ecosystem: "docker"
-  #   directory: "/<docker-context>"
-  #   schedule:
-  #     interval: "weekly"
-  #     day: "monday"
-  #   labels: ["dependencies", "docker"]
   #   commit-message:
   #     prefix: "chore(deps)"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -54,10 +54,11 @@
 #     attestation is content-addressed (bound to the digest, not a tag) so
 #     verification works for every tag alias.
 #   - aquasecurity/trivy-action scans the same digest for CVEs and emits SARIF.
-#     v0.1 is report-only (`exit-code: 0`) — the workflow never fails on
-#     findings. SARIF results land both on the GitHub Security tab (Code
-#     scanning alerts) and as a 30-day workflow artefact. v0.2 will flip on a
-#     severity-based gate once the baseline noise level is known.
+#     It runs post-push on main/tags with `exit-code: '1'`, so a CRITICAL/HIGH
+#     fixed CVE fails the run as a red-main alarm against silent CVE
+#     accumulation on a stale base image (it is not a PR merge gate — the step
+#     is skipped on pull_request). SARIF results land both on the GitHub
+#     Security tab (Code scanning alerts) and as a 30-day workflow artefact.
 #
 # Cross-repo deploy trigger (Task #51):
 #   - After image push on main, the workflow POSTs a `repository_dispatch`
@@ -301,12 +302,19 @@ jobs:
         # including the uv-installed Python wheels in /app/.venv). Emits
         # SARIF for upload to the GitHub Security tab.
         #
-        # v0.1 is *report-only*:
-        #   - `severity: CRITICAL,HIGH` filters the SARIF to the levels that
-        #     actually matter (LOW/MEDIUM are noise at this stage).
-        #   - `exit-code: '0'` keeps the workflow green regardless of
-        #     findings. v0.2 will flip this to fail on a defined policy once
-        #     the baseline noise is known (deliberate split per Goal #11).
+        #   - `severity: CRITICAL,HIGH` restricts the scan to the levels that
+        #     actually matter. `limit-severities-for-sarif: true` makes the
+        #     SARIF honour that filter — without it the trivy-action emits
+        #     ALL severities into SARIF regardless of `severity` (its
+        #     documented default), which is why the Security tab previously
+        #     showed LOW/MEDIUM alerts the `severity` input was meant to drop.
+        #   - `exit-code: '1'` makes the step FAIL when a CRITICAL/HIGH fixed
+        #     CVE is present. This scan runs POST-PUSH on main/tags against the
+        #     already-pushed digest — it is a red-main alarm against silent
+        #     CVE accumulation on a stale base image, NOT a PR merge gate (the
+        #     `if:` below skips it on pull_request). A red run means "the base
+        #     image drifted; bump the digest (Dependabot docker PR) and
+        #     re-push", not "this merge is blocked".
         #   - `ignore-unfixed: true` drops CVEs with no upstream fix
         #     available, which would otherwise dominate the SARIF without
         #     any operator action to take.
@@ -317,8 +325,9 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH
+          limit-severities-for-sarif: true
           ignore-unfixed: true
-          exit-code: '0'
+          exit-code: '1'
 
       - name: Upload trivy SARIF to GitHub Security tab
         # SARIF upload surfaces findings under repo -> Security -> Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Security — base-image digest unfreeze + Trivy SARIF (#2491)
+
+- Unfreeze the backplane image's base pin and stop CVEs accruing on a stale
+  snapshot (G0.34-T1). `backend/Dockerfile` now pins `python:3.12-slim` by a
+  **literal, tag-qualified digest** (`FROM python:3.12-slim@sha256:c3d81d25…`)
+  inline on both the builder and runtime `FROM` lines instead of via an
+  `ARG PYTHON_BASE_DIGEST`, because Dependabot's docker ecosystem only bumps
+  literal `FROM` references (it does not resolve an ARG-held digest —
+  dependabot-core#2057 / #4597). `.github/dependabot.yml` gains an active
+  `docker` block for `/backend` (weekly, `chore(deps)` prefix), so upstream
+  base rebuilds now arrive as automatic PRs. The runtime stage also
+  `pip uninstall -y pip`s the base image's own unused pip (5 alerts incl.
+  CVE-2026-8643 — nothing runs it; deps live in the uv-built `/app/.venv`).
+  Finally, `.github/workflows/image.yml`'s Trivy step adds
+  `limit-severities-for-sarif: true` (so the `severity: CRITICAL,HIGH`
+  filter actually applies to SARIF, dropping the LOW/MEDIUM noise the input
+  never suppressed) and flips `exit-code: '0' → '1'` to make a post-push
+  main/tag scan a **red-main alarm** against silent CVE accumulation (not a
+  PR merge gate). Stale "bookworm"/"v0.2 will flip this" comments corrected —
+  `backend/Dockerfile`, `.github/workflows/image.yml`, `.github/dependabot.yml`
+  (#2491).
+
 ### CI — coverage fail-visible contract (#2513)
 
 - Make a missing backend coverage import **loud instead of silent** (G0.35-T3).

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,23 +3,28 @@
 
 # syntax=docker/dockerfile:1.7
 
-# ---------- Base image (digest-pinned manifest list) ------------------------
+# ---------- Base image (digest-pinned, tag-qualified manifest list) ---------
 # Pin the base image by its OCI manifest-list digest, not by the floating
-# `:3.12-slim` tag. The manifest-list digest indirects into the per-arch
-# image (amd64, arm64, …) automatically when buildx builds for multiple
-# `--platform` targets — same line, correct arch, byte-identical input.
+# `:3.12-slim` tag alone. The manifest-list digest indirects into the
+# per-arch image (amd64, arm64, …) automatically when buildx builds for
+# multiple `--platform` targets — same line, correct arch, byte-identical
+# input.
 #
-# Refresh policy: every digest bump lands in a dedicated PR titled
-# "chore(backend): bump python:3.12-slim base digest to <new>" so the
-# supply-chain audit trail records when and why the input moved. Run
-# `docker manifest inspect python:3.12-slim` (or the Docker Hub `tags`
-# API for the current digest) to verify before bumping.
+# The pin is written *inline on both FROM lines* as
+# `python:3.12-slim@sha256:<digest>` (tag + digest) rather than via an
+# `ARG`, because Dependabot's docker ecosystem only bumps literal,
+# tag-qualified `FROM` references — it does not resolve an ARG-held
+# digest (dependabot-core#2057 / #4597). With the literal form the
+# docker block in `.github/dependabot.yml` opens an automatic
+# `chore(deps)` PR whenever upstream rebuilds the tag, so the digest no
+# longer silently ages. Both FROM lines carry the SAME digest and move
+# together in that PR. The uv installer image pin below is refreshed via
+# the separate dedicated-PR convention documented there.
 #
-# Pinned digest : sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe
-# Recorded on   : 2026-05-10
-# Source        : docker.io/library/python:3.12-slim (Debian bookworm,
+# Pinned digest : sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28
+# Recorded on   : 2026-07-15
+# Source        : docker.io/library/python:3.12-slim (Debian trixie,
 #                 Python 3.12.x, multi-arch manifest list)
-ARG PYTHON_BASE_DIGEST=sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe
 
 # ---------- Builder ----------------------------------------------------------
 # Resolves and installs locked dependencies into /app/.venv. The two-step
@@ -38,7 +43,7 @@ ARG PYTHON_BASE_DIGEST=sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa
 # `docs/codebase/backend.md`). `BUILDPLATFORM` and `TARGETPLATFORM` are
 # auto-populated by BuildKit and surfaced in the build log so CI runs
 # show which arch each layer compiled on.
-FROM python@${PYTHON_BASE_DIGEST} AS builder
+FROM python:3.12-slim@sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28 AS builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -46,8 +51,9 @@ RUN echo "Builder running on BUILDPLATFORM=${BUILDPLATFORM} for TARGETPLATFORM=$
 
 # uv installer image — pinned to a specific version AND manifest-list digest
 # so the build is byte-identical across rebuilds and the supply-chain audit
-# names the exact uv binary. Refresh in the same dedicated PR that bumps
-# PYTHON_BASE_DIGEST when the surrounding toolchain moves.
+# names the exact uv binary. Refresh in a dedicated PR when the surrounding
+# toolchain moves (this pin is NOT tracked by the Dependabot docker block,
+# which watches the `python:3.12-slim` base FROM lines).
 #
 # Pinned uv     : 0.11.12
 # Manifest-list : sha256:3a59a3cdd5f7c217faa36e32dbc7fddbb0412889c2a0a5229f6d790e5a019dd7
@@ -144,10 +150,18 @@ RUN set -eux; \
     test -s "${UI_SP}/static/dist/tailwind.css"
 
 # ---------- Runtime ----------------------------------------------------------
-FROM python@${PYTHON_BASE_DIGEST} AS runtime
+FROM python:3.12-slim@sha256:c3d81d25b3154142b0b42eb1e61300024426268edeb5b5a26dd7ddf64d9daf28 AS runtime
 
 # Non-root user (uid 1001 — fixed for k8s SecurityContext alignment).
 RUN useradd --system --uid 1001 --gid 0 --no-create-home --shell /usr/sbin/nologin meho
+
+# Remove the base image's own pip (site-packages pip 25.0.1) while still
+# root. Nothing in this stage runs pip — dependencies are installed into
+# /app/.venv by the builder via uv, and the runtime is a uvicorn CMD — so
+# the base pip is dead weight whose CVEs (e.g. CVE-2026-8643) accrue on
+# every Trivy scan with no code path to reach. Uninstalling is strictly
+# better than upgrading: it needs no recurring re-bump.
+RUN python -m pip uninstall -y pip
 
 # Build-identity stamps surfaced via GET /version. CI passes these via
 # `docker build --build-arg GIT_SHA=$(git rev-parse HEAD) \


### PR DESCRIPTION
## Summary

- Unfreeze the backplane base image: `backend/Dockerfile` now pins `python:3.12-slim` by a **literal, tag-qualified digest** inline on both the builder and runtime `FROM` lines (`FROM python:3.12-slim@sha256:c3d81d25…`, same digest on both), replacing the `ARG PYTHON_BASE_DIGEST` indirection that Dependabot's docker parser could not bump (dependabot-core#2057 / #4597). Digest resolved live at implementation time (2026-07-15) via the Docker registry manifest-list API.
- Activate a `docker` Dependabot block for `/backend` (weekly, `chore(deps)` prefix, `dependencies` + `docker` labels) so future base rebuilds arrive as automatic PRs instead of silently ageing.
- Uninstall the base image's own unused pip (`RUN python -m pip uninstall -y pip`, runtime stage, while still root) — nothing runs it (deps live in the uv-built `/app/.venv`), so removal beats a recurring re-bump. Clears the 5 pip alerts incl. CVE-2026-8643.
- Make the `image.yml` Trivy step honour its `severity: CRITICAL,HIGH` filter for SARIF (`limit-severities-for-sarif: true`, whose absence let LOW/MEDIUM through) and flip `exit-code: '0' → '1'` so a **post-push main/tag scan is a red-main alarm** against silent CVE accumulation — not a PR merge gate (the step is skipped on `pull_request`).
- Correct stale `bookworm` → `trixie` and remove the `v0.2 will flip this` comments.

## Test plan

- [x] AC#1: `grep -c 'FROM python:3.12-slim@sha256:' backend/Dockerfile` = **2**; `grep -c 'PYTHON_BASE_DIGEST' backend/Dockerfile` = **0**; `bookworm` = **0**; same digest on both FROM lines.
- [x] AC#3: `image.yml` Trivy step has `limit-severities-for-sarif: true` and `exit-code: '1'`; stale `v0.2 will flip` comment removed. Both workflow YAML files parse clean (`yaml.safe_load`).
- [x] AC#5: `.github/dependabot.yml` has an active `package-ecosystem: "docker"` block with `directory: "/backend"`, weekly, `chore(deps)` prefix, `dependencies` + `docker` labels; file parses clean.
- [ ] **AC#2 (post-merge-observable)**: image has no pip / still boots. Requires an image build; no docker daemon in this environment. Verified by the image smoke lane + Trivy scan post-merge on `main`.
- [ ] **AC#4 (post-merge-observable)**: open Trivy CVE alerts drop 67 → 0 after the next main-push rebuild + scan. Cannot be observed pre-merge (scan runs on the pushed digest).

## Out of scope

- `apt-get dist-upgrade` layer (conflicts with the byte-identical-rebuild supply-chain goal; digest pin + Dependabot is the posture-consistent mechanism).
- uv installer image digest (separate dedicated-PR convention); secret alert #39 and workflow token perms (G0.34-T2/T3); rolling the RDC lab to the rebuilt image (ops).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2491
