### PR TITLE
ci(workflows): least-privilege tokens + quality-gate off self-hosted (#2492)

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -34,14 +34,37 @@ concurrency:
   group: quality-gate-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
+# Workflow-level floor: read-only. The sonarcloud job below declares its
+# own explicit token scope (job-level `permissions:`), so this floor caps
+# any future job that forgets to.
 permissions:
   contents: read
-  pull-requests: write  # required for PR decoration (Sonar comment with the gate result)
 
 jobs:
   sonarcloud:
     name: SonarCloud Analysis
-    runs-on: meho-runners-ci
+    # GitHub-hosted, ephemeral runner — deliberately NOT the self-hosted
+    # meho-runners-ci pool. This job checks out an untrusted
+    # workflow_run head_sha (see the checkout invariant below), so it must
+    # never land on persistent internal infrastructure (CodeQL
+    # actions/untrusted-checkout, alert #109). SonarCloud + apt mirrors are
+    # reachable from GitHub-hosted runners (the vendor-default topology);
+    # Harbor / internal network are not needed here.
+    runs-on: ubuntu-latest
+    # Job-scoped least-privilege token. contents:read = checkout the
+    # analyzed commit; actions:read = cross-run actions/download-artifact
+    # pulling coverage from the triggering CI run (per download-artifact
+    # docs). pull-requests:write is retained CONSERVATIVELY: SonarCloud
+    # decorates PRs via its GitHub App + SONAR_TOKEN, not the workflow
+    # GITHUB_TOKEN, and this job is push-only (see `if:` below) so no
+    # GITHUB_TOKEN PR-decoration path actually runs here — but the drop is
+    # UNVERIFIED (no live PR-decoration test is possible pre-merge). Kept
+    # until decoration is empirically confirmed unaffected, then dropped as
+    # a follow-up (#2492).
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
     timeout-minutes: 20
     continue-on-error: true
     # Only analyze main pushes. CI runs on both `push` and `pull_request`,
@@ -54,6 +77,14 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
       && github.event.workflow_run.event == 'push'
     steps:
+      # SECURITY INVARIANT — load-bearing: no step in this workflow may
+      # execute code from the checkout (no make/pytest/npm/scripts/
+      # build-wrapper); artifacts downloaded from the triggering run are
+      # untrusted input. This checkout is a workflow_run head_sha, which on
+      # a fork PR is attacker-controlled source. The Sonar scanner only
+      # reads source; every `run:` step invokes fixed sed/grep/apt-get/
+      # command -v. Adding any step that runs a file from the checkout turns
+      # this into arbitrary code execution with SONAR_TOKEN in scope.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0  # full history for accurate blame + new-code detection

--- a/.github/workflows/runner-smoke.yml
+++ b/.github/workflows/runner-smoke.yml
@@ -24,6 +24,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# The smoke job uses zero GITHUB_TOKEN capability: no checkout, no `gh`,
+# no API call that authenticates as the workflow (the Harbor probe is
+# anonymous against a public project). An empty map is the honest
+# minimum — it drops the repo-default write-all token this job would
+# otherwise carry on the self-hosted meho-runners-ci pool (CodeQL
+# actions/missing-workflow-permissions, alert #36).
+permissions: {}
+
 env:
   # Pinned image used for the smoke pull. Bump deliberately as part of an
   # alpine upgrade ticket; the smoke is verifying the cache pipeline, not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Security — workflow token hardening (#2492)
+
+- Least-privilege the two workflows CodeQL flagged as token/isolation gaps
+  (G0.34-T2). `runner-smoke.yml` gains a top-level `permissions: {}` — the
+  smoke job uses zero `GITHUB_TOKEN` capability (no checkout, no `gh`,
+  anonymous Harbor probe), so it no longer carries the repo-default write-all
+  token on the self-hosted `meho-runners-ci` pool (CodeQL alert #36). In
+  `quality-gate.yml` the `sonarcloud` job moves **off** the self-hosted pool
+  to the ephemeral GitHub-hosted `ubuntu-latest`, so the untrusted
+  `workflow_run` `head_sha` checkout never lands on persistent internal
+  infrastructure (CodeQL alert #109); its token is scoped at job level to
+  `contents: read` + `actions: read` (the latter required by the cross-run
+  `actions/download-artifact`), the workflow-level floor drops to
+  `contents: read`, and a load-bearing invariant comment above the checkout
+  documents that no step may execute code from the checkout. `pull-requests:
+  write` is retained conservatively pending empirical verification that
+  SonarCloud PR decoration (GitHub App + `SONAR_TOKEN`, not `GITHUB_TOKEN`) is
+  unaffected — `.github/workflows/runner-smoke.yml`,
+  `.github/workflows/quality-gate.yml` (#2492).
+
 ### CI — coverage fail-visible contract (#2513)
 
 - Make a missing backend coverage import **loud instead of silent** (G0.35-T3).


### PR DESCRIPTION
## Summary

- Close the two open CodeQL workflow-token/isolation alerts (G0.34-T2), both sitting on the self-hosted `meho-runners-ci` pool.
- `runner-smoke.yml`: add top-level `permissions: {}` — the smoke job uses zero `GITHUB_TOKEN` capability (no checkout, no `gh`, anonymous Harbor probe), so it stops carrying the repo-default write-all token (alert #36, `actions/missing-workflow-permissions`).
- `quality-gate.yml`: move the `sonarcloud` job to `ubuntu-latest` so the untrusted `workflow_run` `head_sha` checkout never lands on persistent internal infra (alert #109, `actions/untrusted-checkout`); scope its token at job level to `contents: read` + `actions: read`; drop the workflow-level floor to `contents: read`; add a load-bearing no-execution invariant comment above the checkout. `head_sha`-pinned checkout unchanged.

## `pull-requests: write` decision

Retained **conservatively** on the `sonarcloud` job, documented in-line. Rationale: SonarCloud decorates PRs via its GitHub App + `SONAR_TOKEN` (not the workflow `GITHUB_TOKEN`), and the job is push-only (`if: … event == 'push'`, #2511) so no `GITHUB_TOKEN` PR-decoration path actually runs here — a drop is likely safe. But no live PR-decoration test is possible pre-merge, so per the least-risk path the scope is kept until empirically confirmed unaffected, then dropped as a follow-up.

## Test plan

- [x] Both workflows parse as valid YAML (`yaml.safe_load`).
- [x] Invariant verified: `grep` finds no `run:` step in `quality-gate.yml` that invokes a file from the checkout (no `make`/`pytest`/`npm`/`./`/`bash scripts`) — AC #5 review evidence.
- [x] `.claude/hooks/code-quality.py --diff` — pass (exit 0).
- [x] Edits sit in regions distinct from merged siblings #2511 (push-only `if:` filter) and #2517 (fail-visible artifact step); neither is reverted or disturbed.
- [ ] AC #1 (alert #36 closed) / AC #5 (alert #109 closed-or-dismissed) — observable on the **next default-branch CodeQL analysis** (post-merge).
- [ ] AC #3 (real PR shows CI → quality-gate green on GitHub-hosted runner → coverage downloaded → SonarCloud analysis) — the `sonarcloud` job is push-only, so it runs on this branch's quality-gate only **after merge to main**; observable then.

## Out of scope

- Flipping the repo-default token permission + PR-approval setting (G0.34-T3, #2493 — settings, not workflow files).
- Adding CI's fork guard to quality-gate, pinning the smoke alpine by digest, any `ci.yml` change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2492
