### PR TITLE
fix(ui): speed up topology graph wheel zoom + declutter layout & align filter banner (#167)

### DIFF
--- a/backend/src/meho_backplane/ui/static/src/app/topology-graph.js
+++ b/backend/src/meho_backplane/ui/static/src/app/topology-graph.js
@@ -39,6 +39,16 @@
 (function () {
   "use strict";
 
+  // Per-tick wheel zoom step (#167). Cytoscape scales the per-tick zoom
+  // exponent LINEARLY by this value (default 1.0), so bigger = more zoom
+  // per scroll notch — there's no diminishing-returns ceiling until a
+  // single tick would span the whole minZoom..maxZoom range (~80 here).
+  // The original 0.2 was sluggish; 25.0 gives a large, brisk step per
+  // scroll. This is the single knob to tune: raise for faster, lower for
+  // gentler. (Any non-1.0 value emits Cytoscape's "custom wheel
+  // sensitivity" console warning by design — expected, not a regression.)
+  const WHEEL_SENSITIVITY = 25.0;
+
   function readJsonIsland(id) {
     const el = document.getElementById(id);
     if (!el) {
@@ -135,8 +145,11 @@
     if (name === "cose-bilkent") {
       return {
         name: "cose-bilkent",
-        nodeRepulsion: 4500,
-        idealEdgeLength: 80,
+        // Wider spacing so the graph reads as distinct nodes rather than a
+        // tangled clump: more inter-node repulsion + longer ideal edges push
+        // neighbours apart and reduce edge crossings.
+        nodeRepulsion: 8000,
+        idealEdgeLength: 120,
         edgeElasticity: 0.45,
         nestingFactor: 0.1,
         gravity: 0.25,
@@ -294,7 +307,7 @@
       container: container,
       elements: elements,
       style: buildStyle().concat(buildOverlayStyle()),
-      wheelSensitivity: 0.2,
+      wheelSensitivity: WHEEL_SENSITIVITY,
       minZoom: 0.1,
       maxZoom: 4,
     });

--- a/backend/src/meho_backplane/ui/templates/topology/graph.html
+++ b/backend/src/meho_backplane/ui/templates/topology/graph.html
@@ -157,24 +157,24 @@
     role="search"
     aria-label="Filter topology nodes"
   >
-    <div class="card-body grid gap-3 md:grid-cols-4">
+    <div class="card-body grid gap-3 md:grid-cols-4 md:items-end">
       <input type="hidden" name="view" value="graph" />
-      <label class="form-control md:col-span-2">
-        <span class="label-text">Search by name</span>
+      <label class="flex flex-col gap-1 md:col-span-2">
+        <span class="text-sm font-medium">Search by name</span>
         <input
           type="search"
           name="q"
           value="{{ name_filter }}"
           placeholder="Substring match (case-insensitive)"
-          class="input input-bordered input-sm"
+          class="input input-sm w-full"
           aria-label="Filter nodes by name"
         />
       </label>
-      <label class="form-control">
-        <span class="label-text">Kind</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Kind</span>
         <select
           name="kind"
-          class="select select-bordered select-sm"
+          class="select select-sm w-full"
           aria-label="Filter nodes by kind"
         >
           <option value="">All kinds</option>
@@ -188,10 +188,11 @@
           {% endfor %}
         </select>
       </label>
-      <div class="form-control">
-        <span class="label-text">&nbsp;</span>
-        <button type="submit" class="btn btn-sm btn-primary">Apply</button>
-      </div>
+      {#- ``self-end`` bottom-aligns the button with the search / kind
+          controls (whose columns are taller by one label row);
+          ``justify-self-end`` right-aligns it and ``w-1/2`` gives it the
+          requested half-column width. -#}
+      <button type="submit" class="btn btn-sm btn-primary w-1/2 self-end justify-self-end">Apply</button>
     </div>
   </form>
 

--- a/backend/tests/test_ui_topology_queries.py
+++ b/backend/tests/test_ui_topology_queries.py
@@ -959,3 +959,36 @@ def test_topology_graph_js_defines_node_highlight_style() -> None:
     # And it carries a non-empty visual treatment (bold red border
     # matches the path-edge stroke colour for visual consistency).
     assert '"border-color": "#dc2626"' in source
+
+
+def test_topology_graph_js_wheel_sensitivity_raised_via_named_constant() -> None:
+    """Wheel-zoom sensitivity is raised from the sluggish 0.2 (#167).
+
+    Anchors:
+
+    * The controller no longer hardcodes ``wheelSensitivity: 0.2`` —
+      0.2 applied ~1/5 the zoom delta per wheel tick, so zoom read as
+      unresponsive.
+    * The value is a single named constant (``WHEEL_SENSITIVITY``) so it
+      stays tunable, and the Cytoscape init references the constant
+      rather than a literal.
+
+    The exact constant value is intentionally NOT pinned here — it is an
+    operator-tunable feel knob (raised well above the sluggish 0.2). The
+    test guards the mechanism (sluggish literal gone, value carried by a
+    named constant the init references), not a specific float.
+    """
+    import pathlib
+
+    js_path = (
+        pathlib.Path(__file__).parent.parent
+        / "src/meho_backplane/ui/static/src/app/topology-graph.js"
+    )
+    source = js_path.read_text(encoding="utf-8")
+
+    # The sluggish literal is gone.
+    assert "wheelSensitivity: 0.2" not in source
+    # A single tunable named constant carries the rate.
+    assert "const WHEEL_SENSITIVITY = " in source
+    # The Cytoscape constructor references the constant, not a literal.
+    assert "wheelSensitivity: WHEEL_SENSITIVITY," in source


### PR DESCRIPTION
## Summary

Primary fix for **task evoila-bosnia/meho-internal#167** (sluggish graph wheel zoom), plus two adjacent graph-view polish items from the same surface (Initiative #162), folded in while in the file.

**Wheel zoom (#167).** The Cytoscape init used `wheelSensitivity: 0.2` — ~1/5 the zoom delta per tick, so zoom felt sluggish. `wheelSensitivity` linearly scales the per-tick zoom exponent, so the value is raised well above the default and pulled into a single tunable named constant `WHEEL_SENSITIVITY = 25.0` (one knob — raise for faster).

**Declutter the layout.** Widened the cose-bilkent spacing (`nodeRepulsion` 4500→8000, `idealEdgeLength` 80→120) so the graph reads as distinct nodes rather than a tangled clump.

**Align the filter banner with the table view** (same root cause as #2454). daisyUI v5 dropped `form-control` / `label-text` (they compile to zero rules), so the graph's search/kind controls had no layout. Replaced with `flex flex-col gap-1` labels, `text-sm font-medium` label text, `w-full` controls, `md:items-end` for a shared baseline; the Apply button is compact + right-aligned (`w-1/2 self-end justify-self-end`).

Presentation/feel only — no change to the graph data island, layout switcher wiring, pan/zoom preservation, or filter query params.

## Changes
- `backend/src/meho_backplane/ui/static/src/app/topology-graph.js` — tunable `WHEEL_SENSITIVITY` constant; cose-bilkent spacing
- `backend/src/meho_backplane/ui/templates/topology/graph.html` — filter-banner alignment + Apply button
- `backend/tests/test_ui_topology_queries.py` — source-anchored test guarding the wheel-zoom mechanism (not the exact tunable float)

## Testing
- `pytest tests/test_ui_topology_queries.py tests/test_ui_topology_graph.py` → **50 passed**
- Verified against the local dev console: wheel zoom is responsive, graph nodes spread out, filter banner + Apply button aligned.

## Scope note
Only the **wheel-zoom** change is literally task #167 — that task lists layout and the filter banner as out of scope. The declutter + banner-alignment items are sibling graph-view polish under Initiative #162, bundled here by request. Happy to split if reviewers prefer.

Closes evoila-bosnia/meho-internal#167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved topology graph readability by increasing spacing between nodes.
  * Adjusted mouse-wheel zoom sensitivity for smoother navigation.
  * Refined topology filter controls and button alignment for a cleaner, more responsive layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->