### PR TITLE
fix(broadcast): self-label the stream cursor on recent/watch rows and announce return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,20 @@ connector-related release-notes line.
   `backend/src/meho_backplane/connectors/adapters/http.py`,
   `docs/codebase/sonarcloud.md` (#2511).
 
+### Fixed — broadcast rows self-label their stream cursor (#2479)
+
+- `meho.broadcast.recent` / `meho.broadcast.watch` event rows and the
+  `meho.broadcast.announce` return now carry a self-labelled `cursor` field —
+  the Valkey stream entry id that round-trips as the tools' `cursor` input
+  arg. Previously the cursor was only exposed under misleading names: `id` on
+  rows (where every other MCP surface uses `id` for the row's domain UUID)
+  and `event_id` on the announce return (which is NOT a durable event UUID —
+  announcements carry none). Additive and backward-compatible: `id` and the
+  announce `event_id` remain as legacy aliases of the same value, now
+  documented as such in the tool descriptions —
+  `backend/src/meho_backplane/broadcast/history.py`,
+  `backend/src/meho_backplane/mcp/tools/broadcast.py` (#2479).
+
 ## [0.22.0] - 2026-07-13
 
 ### Added — rke2.etcd-snapshot.save safe managed-etcd snapshot op (#2431)

--- a/backend/src/meho_backplane/broadcast/history.py
+++ b/backend/src/meho_backplane/broadcast/history.py
@@ -444,9 +444,13 @@ async def _list_recent_events_core(
     require a Lua script and isn't worth the complexity for ``limit
     <= 1000``).
 
-    Returns ``{"events": [<event dict with id>, ...], "next_cursor":
-    <str or None>}``. ``next_cursor`` is the **stream entry id of the
-    last fetched entry** (NOT the last *matched* one) -- the caller
+    Returns ``{"events": [<event dict with id + cursor>, ...],
+    "next_cursor": <str or None>}``. Each event dict carries the
+    entry's Valkey stream id twice: as ``cursor`` (self-labelled to
+    match the tool-input arg it round-trips through, #2479) and as
+    ``id`` (the historical alias). ``next_cursor`` is the **stream
+    entry id of the last fetched entry** (NOT the last *matched* one)
+    -- the caller
     can pass it back as ``since`` to walk forward without overlap or
     gaps even when the filter dropped every entry in this page. The
     cursor is ``None`` when the stream returned fewer entries than
@@ -482,15 +486,19 @@ async def _list_recent_events_core(
             target=target,
         ):
             continue
-        # ``id`` is the Valkey stream entry id; the cursor a caller
-        # round-trips. The remaining fields come from the event model
+        # ``cursor`` is the Valkey stream entry id, self-labelled to
+        # match the ``cursor`` input arg it round-trips through
+        # (#2479); ``id`` is the historical alias of the same value —
+        # kept because every other MCP surface uses ``id`` for the
+        # row's domain UUID and broadcast rows predate that
+        # convention. The remaining fields come from the event model
         # (including ``event_id`` as the durable UUID for BroadcastEvent
         # or the announcement-id equivalent for AgentAnnouncementEvent).
-        # Both coexist so the caller can correlate a stream-cursor walk
+        # All coexist so the caller can correlate a stream-cursor walk
         # with the canonical audit row via ``event_id`` / ``audit_id``.
         # ``dump_event_wire`` wraps announcement free-text in the
         # untrusted-content envelope (stored-prompt-injection guard).
-        matched.append({"id": entry_id, **dump_event_wire(event)})
+        matched.append({"id": entry_id, "cursor": entry_id, **dump_event_wire(event)})
 
     # next_cursor pages forward from the LAST FETCHED entry, not the
     # last matched one -- a page where every entry was filtered out

--- a/backend/src/meho_backplane/mcp/tools/broadcast.py
+++ b/backend/src/meho_backplane/mcp/tools/broadcast.py
@@ -201,7 +201,12 @@ register_mcp_tool(
         description=(
             "Read the operator's tenant's recent broadcast events from "
             "meho:feed:{tenant_id} (Initiative #1090, Task #1091). "
-            "Returns {events, next_cursor}. Default window is the last "
+            "Returns {events, next_cursor}. Each event row carries "
+            "'cursor' -- its Valkey stream entry id, usable as this "
+            "tool's (or meho.broadcast.watch's) 'cursor' arg -- plus "
+            "'id' as a legacy alias of the same stream cursor (NOT "
+            "the event's UUID; that is 'event_id' on operation rows). "
+            "Default window is the last "
             "30 minutes when 'cursor' is omitted; pass an ISO-8601 "
             "timestamp ('2026-05-25T10:00:00Z') or a Valkey stream "
             "cursor ('1747800000000-0') to override. The 'filter' "
@@ -312,7 +317,7 @@ async def _publish_agent_announcement_impl(
     scope: str | None,
     phase: str,
 ) -> dict[str, Any]:
-    """Build + publish one :class:`AgentAnnouncementEvent`, return ``{event_id}``.
+    """Build + publish one :class:`AgentAnnouncementEvent`, return ``{event_id, cursor}``.
 
     Internal helper for ``meho.broadcast.announce``. Kept separate from
     :func:`_handler_announce` so the construction-and-publish seam is
@@ -344,7 +349,13 @@ async def _publish_agent_announcement_impl(
         ts=datetime.now(UTC),
     )
     entry_id = await publish_agent_announcement(event)
-    return {"event_id": entry_id}
+    # Both keys carry the Valkey stream entry id of the appended
+    # announcement. ``cursor`` is the self-labelled canonical name
+    # (round-trips through recent/watch's ``cursor`` arg, #2479);
+    # ``event_id`` is the historical alias — a misnomer kept for wire
+    # compatibility: it is the stream cursor, NOT a durable event
+    # UUID (announcements carry no UUID today; #2547 mints one).
+    return {"event_id": entry_id, "cursor": entry_id}
 
 
 async def _handler_announce(
@@ -435,9 +446,13 @@ register_mcp_tool(
             "audit-driven publisher which fail-opens). Tenant scoping "
             "is structural -- the input schema has no tenant_id "
             "argument; the event always writes to the operator's own "
-            "tenant stream. Returns {event_id} -- the Valkey stream "
-            "entry id, round-trip-able through meho.broadcast.recent's "
-            "'since' cursor for verification."
+            "tenant stream. Returns {event_id, cursor} -- both the "
+            "Valkey stream entry id of the appended announcement. "
+            "'cursor' is the canonical self-labelled name and "
+            "round-trips through meho.broadcast.recent/watch's "
+            "'cursor' arg for verification; 'event_id' is a legacy "
+            "alias of the same stream cursor, NOT a durable event "
+            "UUID (announcements carry no UUID)."
         ),
         inputSchema={
             "type": "object",
@@ -666,8 +681,10 @@ def _filter_xread_items(
 ) -> list[dict[str, Any]]:
     """Parse + filter the XREAD batch into the wire-shape events list.
 
-    Each surviving entry carries ``id`` (the Valkey stream cursor, the
-    round-trip handle) plus every :class:`BroadcastEvent` field
+    Each surviving entry carries the Valkey stream entry id twice --
+    as ``cursor`` (self-labelled to match the ``cursor`` input arg it
+    round-trips through, #2479) and as ``id`` (the historical alias)
+    -- plus every :class:`BroadcastEvent` field
     (including the durable ``event_id`` UUID and the ``audit_id`` for
     audit-log correlation). Entries that fail :func:`parse_entry` (bad
     field shape, malformed JSON) are logged + skipped inside the helper
@@ -692,7 +709,7 @@ def _filter_xread_items(
             target=target,
         ):
             continue
-        matched.append({"id": entry_id, **dump_event_wire(event)})
+        matched.append({"id": entry_id, "cursor": entry_id, **dump_event_wire(event)})
     return matched
 
 
@@ -817,7 +834,12 @@ register_mcp_tool(
             "'timeout_ms' as the block window (default 10000, cap "
             "30000 -- the chassis worker is tied up for up to that long, "
             "so the cap is a hard backpressure boundary, not a hint). "
-            "Returns {events, next_cursor}. When no events arrive within "
+            "Returns {events, next_cursor}. Each event row carries "
+            "'cursor' -- its Valkey stream entry id, usable as this "
+            "tool's (or meho.broadcast.recent's) 'cursor' arg -- plus "
+            "'id' as a legacy alias of the same stream cursor (NOT "
+            "the event's UUID; that is 'event_id' on operation rows). "
+            "When no events arrive within "
             "the window: returns {events: [], next_cursor: <unchanged>} -- "
             "re-poll with the same cursor. When events arrive: "
             "'next_cursor' advances to the last *fetched* entry id (NOT "

--- a/backend/tests/test_broadcast_history.py
+++ b/backend/tests/test_broadcast_history.py
@@ -131,6 +131,8 @@ async def test_fail_soft_returns_dict_shape_on_success() -> None:
     assert len(result["events"]) == 1
     assert result["events"][0]["op_id"] == "vsphere.vm.list"
     assert result["events"][0]["id"] == "1747800000000-0"
+    # ``cursor`` self-labels the same stream entry id (#2479).
+    assert result["events"][0]["cursor"] == "1747800000000-0"
 
 
 async def test_strict_returns_dict_shape_on_success() -> None:

--- a/backend/tests/test_mcp_tool_broadcast_announce.py
+++ b/backend/tests/test_mcp_tool_broadcast_announce.py
@@ -483,7 +483,14 @@ async def test_publish_agent_announcement_propagates_exception() -> None:
 def test_successful_publish_returns_event_id(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """On success the handler returns ``{event_id: <Valkey entry id>}``."""
+    """On success the handler returns the entry id as ``cursor`` + ``event_id``.
+
+    Both keys carry the Valkey stream entry id of the appended
+    announcement: ``cursor`` is the self-labelled canonical name
+    (round-trips through recent/watch's ``cursor`` arg, #2479);
+    ``event_id`` is the legacy alias kept for wire compatibility --
+    it is NOT a durable event UUID.
+    """
     client, _op = client_with_operator
     bc = get_broadcast_client()
     with patch.object(bc, "xadd", new=AsyncMock(return_value="1747800000000-7")):
@@ -492,7 +499,7 @@ def test_successful_publish_returns_event_id(
             _tools_call("meho.broadcast.announce", {"activity": "investigating"}),
         )
     result = _result_dict(resp)
-    assert result == {"event_id": "1747800000000-7"}
+    assert result == {"event_id": "1747800000000-7", "cursor": "1747800000000-7"}
 
 
 @pytest.mark.parametrize(
@@ -757,11 +764,15 @@ class TestBroadcastAnnounceIntegration:
             },
         )
         assert "event_id" in result
+        # Announce self-labels the entry id as ``cursor`` (#2479);
+        # ``event_id`` is the legacy alias of the same stream cursor.
+        assert result["cursor"] == result["event_id"]
 
         recent = await _handler_recent(op, {})
         assert len(recent["events"]) == 1
         event = recent["events"][0]
         assert event["event_kind"] == "agent_announcement"
+        assert event["cursor"] == result["cursor"]
         # dump_event_wire re-serves agent-authored free text inside the
         # untrusted-content envelope (_ANNOUNCEMENT_UNTRUSTED_FIELDS).
         assert event["activity"] == wrap_untrusted_text("investigating")

--- a/backend/tests/test_mcp_tool_broadcast_recent.py
+++ b/backend/tests/test_mcp_tool_broadcast_recent.py
@@ -672,11 +672,13 @@ def test_empty_stream_returns_empty_events_null_cursor(
 def test_event_dict_carries_stream_entry_id_and_event_fields(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """Each event surfaces both ``id`` (stream cursor) and BroadcastEvent fields.
+    """Each event surfaces ``cursor`` + ``id`` (stream cursor) and BroadcastEvent fields.
 
-    ``id`` is the Valkey stream entry id (the cursor a caller
-    round-trips); ``event_id`` / ``ts`` / ``audit_id`` / ``payload``
-    are the durable fields from :class:`BroadcastEvent`.
+    ``cursor`` is the Valkey stream entry id self-labelled to match
+    the tool-input arg it round-trips through (#2479); ``id`` is the
+    legacy alias of the same value; ``event_id`` / ``ts`` /
+    ``audit_id`` / ``payload`` are the durable fields from
+    :class:`BroadcastEvent`.
     """
     client, op = client_with_operator
     event = _make_event(op_id="vsphere.vm.list")
@@ -691,6 +693,7 @@ def test_event_dict_carries_stream_entry_id_and_event_fields(
     assert len(result["events"]) == 1
     e = result["events"][0]
     assert e["id"] == "1747800000000-0"
+    assert e["cursor"] == "1747800000000-0"
     assert e["event_id"] == str(event.event_id)
     assert e["tenant_id"] == str(op.tenant_id)
     assert e["op_id"] == "vsphere.vm.list"

--- a/backend/tests/test_mcp_tool_broadcast_watch.py
+++ b/backend/tests/test_mcp_tool_broadcast_watch.py
@@ -522,6 +522,14 @@ def test_new_events_returned_with_advanced_cursor(
     op_ids = [e["op_id"] for e in result["events"]]
     assert op_ids == ["vsphere.vm.list", "vsphere.vm.create", "vsphere.vm.delete"]
     assert result["next_cursor"] == "1747800000300-0"
+    # Each row self-labels its stream entry id as ``cursor`` (#2479);
+    # ``id`` stays as the legacy alias of the same value.
+    assert [e["cursor"] for e in result["events"]] == [
+        "1747800000100-0",
+        "1747800000200-0",
+        "1747800000300-0",
+    ]
+    assert all(e["cursor"] == e["id"] for e in result["events"])
 
 
 @pytest.mark.parametrize(

--- a/docs/codebase/broadcast.md
+++ b/docs/codebase/broadcast.md
@@ -45,6 +45,15 @@ Three layers, separated for traceability:
    The SSE backlog prelude is the v0.8.0 fix for #1305 — see *Known
    issues* below.
 
+   **Row identifier semantics (MCP recent/watch, #2479).** Every event
+   row the two MCP read tools return carries the entry's Valkey stream
+   id twice: `cursor` (self-labelled; round-trips as the tools'
+   `cursor` input arg) and `id` (legacy alias of the same value —
+   unlike every other MCP surface, a broadcast row's `id` is NOT the
+   row's domain UUID). The durable identifiers live on the event
+   fields: `event_id` / `audit_id` on operation rows; announcement
+   rows have no UUID (until #2547 mints one).
+
 ## Key types
 
 - `BroadcastEvent` (`broadcast/events.py`) — every audited operation
@@ -132,7 +141,10 @@ MCP tools/call meho.broadcast.announce
     → publish_agent_announcement(AgentAnnouncementEvent)  ← fail-loud
       → XADD meho:feed:{operator.tenant_id} {event: <json>} MAXLEN ~ 10000
       → returns Valkey entry id verbatim
-    → returns {event_id} to the agent
+    → returns {event_id, cursor} to the agent
+      (both the stream entry id — `cursor` is the canonical
+       self-labelled name, #2479; `event_id` is the legacy alias
+       and NOT a durable UUID: announcements carry no UUID)
 ```
 
 ### Read path (SSE)


### PR DESCRIPTION
## Summary
- Every `meho.broadcast.recent` / `meho.broadcast.watch` event row now carries a self-labelled `cursor` field — the Valkey stream entry id that round-trips as the tools' canonical `cursor` input arg (G0.18-T5 naming precedent). `id` remains as a documented legacy alias of the same value.
- The `meho.broadcast.announce` return gains the same `cursor` field; its existing `event_id` key (which was always the stream cursor, never a durable UUID — announcements carry none) is kept for wire compatibility and documented as a legacy alias. The real announcement UUID arrives with #2547.
- Tool descriptions, the row-builder comments, and `docs/codebase/broadcast.md` now state the identifier semantics explicitly: on broadcast rows `id` is the stream cursor, `event_id`/`audit_id` are the durable UUIDs (operation rows only).
- Additive and backward-compatible; no key removed or renamed, per the issue's triage note (deprecating `id` with a compat window was rejected as speculative optionality).

## Test plan
- [x] `ruff check` + `ruff format --check` — clean on all 6 touched Python files
- [x] `mypy` — clean on both touched source modules
- [x] `pytest` all `tests/test_*broadcast*.py` — 468 passed, 4 skipped (includes real-Valkey testcontainer round-trips)
- [x] Rows carry `cursor == id` — asserted in `test_broadcast_history.py`, `test_mcp_tool_broadcast_recent.py`, `test_mcp_tool_broadcast_watch.py`
- [x] Announce returns `{event_id, cursor}` with both equal to the entry id — asserted in `test_mcp_tool_broadcast_announce.py` (exact-shape + live round-trip: the announced row's `cursor` equals the announce return's `cursor`)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (5 pre-existing warnings on the already-over-limit module, untouched by this change)

## Out of scope
- Durable announcement UUIDs (`agent_announcement` table) — #2547 (Broadcast v2 T2).
- Structured intent claims on the same announce handler — #2544 sequences on this PR (`Depends-on: #2479`).
- `meho://tenant/{tenant_id}/feed` resource rows — they dump events without `id`/cursor; out of blast radius per the issue triage.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2479


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Broadcast history and watch results now include a clearly labeled `cursor` for each event.
  * Cursor values reliably round-trip with pagination inputs.
  * Existing `id` and `event_id` fields remain available as backward-compatible aliases.
  * Announcement responses now include both `event_id` and `cursor`.

* **Documentation**
  * Clarified the relationship between cursor fields, legacy aliases, and event identifiers in broadcast tool documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->