### PR TITLE
fix(ui): send htmx callers to login on an expired-session redirect (#161)

### DIFF
--- a/backend/src/meho_backplane/ui/auth/middleware.py
+++ b/backend/src/meho_backplane/ui/auth/middleware.py
@@ -273,10 +273,14 @@ def _redirect_to_login(
     encoded = quote(original_path_with_query, safe="")
     location = f"{LOGIN_PATH}?return_to={encoded}"
     if is_htmx:
+        # No ``content-length`` here: RFC 9110 §8.6 forbids it on a 204,
+        # and this middleware writes the raw ASGI response (no framework
+        # header sanitisation), so an invalid header would reach h11 /
+        # strict proxies and can raise ``LocalProtocolError``. The 302
+        # branch below keeps ``content-length: 0`` -- that status permits it.
         return status.HTTP_204_NO_CONTENT, [
             (b"hx-redirect", location.encode("ascii")),
             (b"cache-control", b"no-store"),
-            (b"content-length", b"0"),
         ]
     return status.HTTP_302_FOUND, [
         (b"location", location.encode("ascii")),

--- a/backend/src/meho_backplane/ui/auth/middleware.py
+++ b/backend/src/meho_backplane/ui/auth/middleware.py
@@ -223,7 +223,28 @@ def _extract_session_cookie(scope: Scope) -> str | None:
     return None
 
 
-def _redirect_to_login(original_path_with_query: str) -> tuple[int, list[tuple[bytes, bytes]]]:
+def _request_is_htmx(scope: Scope) -> bool:
+    """True when the request carries htmx's ``HX-Request: true`` header.
+
+    Read straight off the raw ASGI headers (ASGI lower-cases header names
+    per spec, so we match ``b"hx-request"``) to keep the redirect path
+    allocation-light -- no :class:`Request` construction needed.
+    """
+    headers = scope.get("headers")
+    if not isinstance(headers, list):
+        return False
+    for name, value in headers:
+        if not isinstance(name, (bytes, bytearray)) or name != b"hx-request":
+            continue
+        if not isinstance(value, (bytes, bytearray)):
+            continue
+        return value.strip().lower() == b"true"
+    return False
+
+
+def _redirect_to_login(
+    original_path_with_query: str, *, is_htmx: bool = False
+) -> tuple[int, list[tuple[bytes, bytes]]]:
     """Build the ASGI ``http.response.start`` shape for the login redirect.
 
     Returns the status code + the encoded headers list. Constructing
@@ -236,9 +257,27 @@ def _redirect_to_login(original_path_with_query: str) -> tuple[int, list[tuple[b
     characters round-trips cleanly. The login route's
     :func:`_safe_return_to` validates the decoded value before it
     lands in any subsequent redirect.
+
+    Two response shapes, one ``return_to`` (byte-identical between them):
+
+    * **Non-htmx** (``is_htmx=False``) -- a plain ``302`` + ``Location``.
+      A full-document navigation follows it and lands on the login page.
+    * **htmx** (``is_htmx=True``) -- a ``204`` + ``HX-Redirect`` (#161).
+      An htmx XHR follows a ``302`` transparently, so the browser silently
+      fetches the login HTML and htmx swaps it into the target slot (or
+      no-ops) -- the operator sees a dead control instead of the login
+      bounce. ``HX-Redirect`` makes htmx perform a full-page navigation to
+      the same login URL instead, reusing the repo's 204+``HX-Redirect``
+      precedent (e.g. ``ui/routes/connectors/forms.py``).
     """
     encoded = quote(original_path_with_query, safe="")
     location = f"{LOGIN_PATH}?return_to={encoded}"
+    if is_htmx:
+        return status.HTTP_204_NO_CONTENT, [
+            (b"hx-redirect", location.encode("ascii")),
+            (b"cache-control", b"no-store"),
+            (b"content-length", b"0"),
+        ]
     return status.HTTP_302_FOUND, [
         (b"location", location.encode("ascii")),
         (b"cache-control", b"no-store"),
@@ -405,11 +444,13 @@ class UISessionMiddleware:
                 else ""
             )
             full_path = f"{path}?{query_string}" if query_string else path
-            status_code, headers = _redirect_to_login(full_path)
+            is_htmx = _request_is_htmx(scope)
+            status_code, headers = _redirect_to_login(full_path, is_htmx=is_htmx)
             log.info(
                 "ui_session_missing_or_invalid",
                 path=path,
                 had_cookie=cookie_value is not None,
+                is_htmx=is_htmx,
             )
             await send(
                 {

--- a/backend/tests/test_ui_chassis_smoke.py
+++ b/backend/tests/test_ui_chassis_smoke.py
@@ -65,6 +65,7 @@ from meho_backplane.ui.auth.flow import (
     clear_discovery_cache,
     reset_verifier_store_for_testing,
 )
+from meho_backplane.ui.auth.middleware import _redirect_to_login
 from meho_backplane.ui.auth.session_store import (
     EncryptionKeyMissingError,
     create_session,
@@ -358,6 +359,27 @@ def test_htmx_with_valid_session_is_not_hijacked_by_login_redirect() -> None:
         response = client.get("/ui/", headers={"HX-Request": "true"})
     assert response.status_code == 200
     assert "HX-Redirect" not in response.headers
+
+
+def test_redirect_to_login_204_omits_content_length_but_302_keeps_it() -> None:
+    """RFC 9110 §8.6: the htmx ``204`` must NOT carry a ``Content-Length``.
+
+    The middleware writes the raw ASGI response (no framework header
+    sanitisation), so a ``Content-Length`` on a ``204`` would reach h11 /
+    a strict proxy and can raise ``LocalProtocolError``. The non-htmx
+    ``302`` (which permits the header) keeps its ``content-length: 0``.
+    """
+    htmx_status, htmx_headers = _redirect_to_login("/ui/topology", is_htmx=True)
+    htmx_names = {name.lower() for name, _ in htmx_headers}
+    assert htmx_status == 204
+    assert b"content-length" not in htmx_names
+    assert b"hx-redirect" in htmx_names
+
+    plain_status, plain_headers = _redirect_to_login("/ui/topology", is_htmx=False)
+    plain_names = {name.lower() for name, _ in plain_headers}
+    assert plain_status == 302
+    assert b"location" in plain_names
+    assert b"content-length" in plain_names
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_chassis_smoke.py
+++ b/backend/tests/test_ui_chassis_smoke.py
@@ -307,6 +307,60 @@ def test_dashboard_unauthenticated_redirects_to_login() -> None:
 
 
 # ---------------------------------------------------------------------------
+# #161: htmx session-miss returns a client-actionable HX-Redirect, not a
+# bare 302 the XHR follows transparently (silent no-op)
+# ---------------------------------------------------------------------------
+
+
+def test_htmx_unauthenticated_returns_hx_redirect_not_silent_302() -> None:
+    """#161 AC1: an htmx request with no session yields a 204 + ``HX-Redirect``
+    to login (client-actionable), never a bare 302 an XHR silently follows."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get(
+            "/ui/topology?view=graph",
+            headers={"HX-Request": "true"},
+        )
+    # htmx branch: 204, no Location (so the XHR does not transparently
+    # follow a redirect and swap login HTML into the target slot).
+    assert response.status_code == 204
+    assert "location" not in {k.lower() for k in response.headers}
+    hx_redirect = response.headers["HX-Redirect"]
+    assert hx_redirect.startswith("/ui/auth/login?return_to=")
+    return_to = parse_qs(urlparse(hx_redirect).query)["return_to"][0]
+    assert return_to == "/ui/topology?view=graph"
+
+
+def test_htmx_and_non_htmx_login_return_to_are_byte_identical() -> None:
+    """#161 AC3: for the same original URL, the login target (and its
+    ``return_to``) is byte-identical whether the expired request was htmx
+    (204 + ``HX-Redirect``) or a full-document nav (302 + ``Location``)."""
+    path = "/ui/topology?view=graph&selected=abc"
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        plain = client.get(path)
+        htmx = client.get(path, headers={"HX-Request": "true"})
+    assert plain.status_code == 302
+    assert htmx.status_code == 204
+    # Same login URL string -> same encoded return_to by construction.
+    assert plain.headers["location"] == htmx.headers["HX-Redirect"]
+
+
+def test_htmx_with_valid_session_is_not_hijacked_by_login_redirect() -> None:
+    """#161 invariant (guards the #122 422/2xx contract): the HX-Request
+    branch fires ONLY on a session miss. An authenticated htmx request flows
+    through untouched -- the middleware never converts a live response
+    (a 2xx swap, a 422 form re-render) into a login bounce."""
+    session_id = _seed_session_sync()
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        response = client.get("/ui/", headers={"HX-Request": "true"})
+    assert response.status_code == 200
+    assert "HX-Redirect" not in response.headers
+
+
+# ---------------------------------------------------------------------------
 # AC 2: GET /ui/auth/login -> 302 to Keycloak
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes **task evoila-bosnia/meho-internal#161** (Initiative #119, web-UI auth-session resilience).

`UISessionMiddleware` returned a bare **`302`** to `/ui/auth/login` for every missing/expired/revoked session. Full-document navigations recover fine, but an **htmx XHR follows the `302` transparently** — htmx receives the login page's `200` HTML and swaps it into the target slot (or no-ops), so the operator sees a **dead control** instead of the login bounce. #122's client safety net (`session-expiry.js`) only fires on `401`/CSRF-`403`, never on this `302`, so the gap was invisible.

## What changed
`_redirect_to_login()` now varies its response by caller:
- **Non-htmx** → unchanged: `302` + `Location`.
- **htmx** (`HX-Request: true`, read off the raw ASGI headers via new `_request_is_htmx`) → `204` + `HX-Redirect: <login url>`, so htmx performs a full-page navigation to login. Reuses the repo's 204+`HX-Redirect` precedent (e.g. `ui/routes/connectors/forms.py`).

`return_to` is built from the same `quote(full_path)` in both branches, so it is **byte-identical** whether the expired request was htmx or a full-document nav.

## Why option (a) `HX-Redirect`, not the issue's "preferred" (b) `401`
The issue offered two shapes. I chose (a):
- (b)'s `return_to` is **client-derived** from `window.location` in the shipped `session-expiry.js`, so it can be neither byte-identical to the `302` nor asserted at the middleware — which **AC3** explicitly requires as a middleware test.
- (a) is a **server-only** change: it does not touch the #122 `session-expiry.js` handler, so the existing `401`/CSRF-`403` recovery is unregressed (protects AC4).
- AC1 explicitly sanctions the `HX-Redirect` shape.

The htmx branch fires **only** on a session miss; an authenticated htmx request (a `2xx` swap, a `422` form re-render) flows through untouched.

## Changes
- `backend/src/meho_backplane/ui/auth/middleware.py` — `_request_is_htmx()` + `is_htmx` branch in `_redirect_to_login()`; call-site wiring + `is_htmx` log field
- `backend/tests/test_ui_chassis_smoke.py` — 3 tests

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/.../middleware.py` — clean
- [x] `pytest tests/test_ui_chassis_smoke.py tests/test_ui_token_refresh.py tests/test_ui_auth_flow.py` — **64 passed**
- [x] **AC1** — htmx + no session → `204` + `HX-Redirect` (not a silent `302`)
- [x] **AC2** — non-htmx + no session → `302` + `Location` (existing `test_dashboard_unauthenticated_redirects_to_login`)
- [x] **AC3** — `return_to` byte-identical between htmx and non-htmx for the same URL
- [x] **AC4** — authenticated htmx not hijacked (`2xx`/`422` invariant); asserted by `test_htmx_with_valid_session_is_not_hijacked_by_login_redirect`
- [ ] **Manual** — after a session miss, an htmx action navigates to login instead of silently no-opping (Network tab shows `204` + `HX-Redirect`)

## Out of scope
- The `401 token_expired` client handling — shipped in #122.
- Server-side refresh seam (#121) and session-lifetime policy.

Closes evoila-bosnia/meho-internal#161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in redirects for htmx requests by returning the appropriate htmx redirect response.
  * Preserved the original page and query parameters when redirecting to sign-in.
  * Prevented authenticated htmx requests from being incorrectly redirected.
  * Added coverage for unauthenticated and authenticated htmx session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->