### PR TITLE
perf(topology): find_path per-branch target pruning + dense-mesh perf fixture + refresh-vs-annotate concurrency test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,35 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Performance — `find_path` per-branch target pruning + dense-mesh envelope + topology concurrency coverage (#2535)
+
+- Bound `find_path`'s recursive walk per branch: `_PATH_SQL` gains a
+  non-recursive `target` CTE and the recursive term now refuses to extend a
+  branch whose frontier row already is the destination (`NOT EXISTS` against
+  `target`). Results are byte-identical (same shortest hop count, same `None`
+  on unreachable — existing suite green unmodified); on a dense mesh the walk
+  no longer enumerates simple paths *through* the target (measured 1 544 →
+  795 materialised rows on the 20-node pruning fixture; regression-pinned).
+  Global cross-branch early termination is not expressible (PostgreSQL allows
+  exactly one recursive self-reference, outside subqueries; `ORDER BY hops
+  LIMIT 1` must consume the full walk) — the unreachable-target worst case
+  (dense cyclic mesh, `max_hops=32` API ceiling) is instead CI-pinned by a
+  new benchmark: exact walk-row-count pin (~31k rows, load-invariant),
+  hops-32/hops-8 timing ratio gate, generous absolute backstop; envelope
+  documented in `docs/architecture/topology.md` §Performance expectations.
+  The new `MeshSpec` / `seed_mesh_graph` generator (converging paths, cycles,
+  mixed edge kinds, optional soft-deleted rows) closes the fixture gap — the
+  prior 10k fixture was out-degree-1 hub-and-chains only. Also adds the
+  topology suite's first real-concurrency tests: `asyncio.gather`
+  refresh-vs-annotate race (no lost update, no dangling §6 markers, both
+  synchronous audit rows present) and the scheduler's per-target advisory
+  lock exercised against real PostgreSQL (skip while held, proceed after
+  release) instead of a mocked pre-held lock —
+  `backend/src/meho_backplane/topology/query.py`,
+  `backend/tests/fixtures/topology_10k_nodes.py`,
+  `backend/tests/integration/test_topology_path_pruning.py`,
+  `backend/tests/integration/test_topology_concurrency.py` (#2535).
+
 ### Security — agent-principal Keycloak-orphan rollback + bounded name (#2523)
 
 - Close the two credential-lifecycle gaps in the agent-principal register

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -516,9 +516,39 @@ async def find_dependencies(
 # CYCLE bookkeeping set (independent of ``node_ids``). The hop bound plus
 # the CYCLE guard terminate the search on cyclic graphs; ``ORDER BY hops
 # LIMIT 1`` yields a shortest path.
+#
+# Per-branch target pruning (#2535). The non-recursive ``target`` CTE
+# resolves the destination id once; the recursive term refuses to extend
+# a branch whose frontier row already *is* the target (``NOT EXISTS``
+# against ``target``). A branch that reaches the target stops growing —
+# extending past a hit can never shorten a path to that same hit, and
+# the CYCLE guard already forbids re-entering the target on the same
+# branch, so pruning removes only rows the final select could never
+# pick. On a dense mesh (branch factor b) the unpruned walk enumerates
+# ~b^hops simple paths regardless of where the target sits; the pruned
+# walk bounds every branch at its first hit. Results are byte-identical:
+# same shortest path, same ``None`` on unreachable. Only *per-branch*
+# pruning is expressible — PostgreSQL restricts the recursive
+# self-reference (one reference, not in a subquery), so a global
+# "some branch already found the target at h hops" cross-branch stop
+# cannot be written, and ``ORDER BY hops LIMIT 1`` cannot terminate
+# evaluation early because the sort must consume the full walk (PG 16
+# §7.8 — lazy CTE evaluation does not apply once the parent sorts).
+# Referencing the *non-recursive* ``target`` CTE inside the recursive
+# term's subquery is legal; the restriction covers only ``walk`` itself.
+# The unreachable-target worst case still enumerates the whole
+# ≤max_hops ball — that envelope is pinned by the dense-mesh benchmark
+# in ``tests/integration/test_topology_path_pruning.py``.
 _PATH_SQL = text(
     """
     WITH RECURSIVE
+    target AS (
+        SELECT id
+        FROM graph_node
+        WHERE name = :to_name
+          AND tenant_id = :tenant_id
+          AND (CAST(:to_kind AS text) IS NULL OR kind = :to_kind)
+    ),
     bi_edge AS (
         SELECT from_node_id AS src, to_node_id AS dst, kind
         FROM graph_edge
@@ -549,6 +579,7 @@ _PATH_SQL = text(
         FROM bi_edge be
         JOIN walk w ON be.src = w.node_id
         WHERE w.hops < :max_hops
+          AND NOT EXISTS (SELECT 1 FROM target t WHERE t.id = w.node_id)
     ) CYCLE node_id SET is_cycle USING visited
     SELECT w.hops, w.node_ids, w.edge_kinds
     FROM walk w

--- a/backend/tests/fixtures/topology_10k_nodes.py
+++ b/backend/tests/fixtures/topology_10k_nodes.py
@@ -37,17 +37,32 @@ keep that join sub-linear per level.
 Seeding cost is excluded from every performance assertion: the caller
 seeds once (outside the timed region), warms the connection/plan with a
 shallow query, then times the depth-16 traversal in isolation.
+
+Dense meshes (#2535)
+====================
+
+The forest shape above has out-degree exactly 1 — no converging paths,
+no cycles — which structurally cannot produce the load profile that
+makes ``find_path``'s bidirectional walk expensive (simple-path
+enumeration, ~branch_factor^hops on a mesh). :class:`MeshSpec` /
+:func:`seed_mesh_graph` generate that adversarial shape: layered
+meshes with configurable branch factor (converging paths), optional
+back-edges (cycles), mixed edge kinds, and optional soft-deleted rows.
+Used by ``tests/integration/test_topology_path_pruning.py`` to pin the
+per-branch pruning win and the worst-case envelope documented in
+``docs/architecture/topology.md`` §Performance expectations.
 """
 
 from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from meho_backplane.db.models import GraphEdge, GraphNode
 
-__all__ = ["TEN_K", "GraphSpec", "seed_perf_graph"]
+__all__ = ["TEN_K", "GraphSpec", "MeshSpec", "seed_mesh_graph", "seed_perf_graph"]
 
 
 @dataclass(frozen=True)
@@ -170,3 +185,173 @@ async def seed_perf_graph(
             prev = node_id
 
     return hub_id
+
+
+@dataclass(frozen=True)
+class MeshSpec:
+    """A parametric description of a dense layered mesh (#2535).
+
+    The hub-and-chains :class:`GraphSpec` forest has out-degree exactly
+    1, no converging paths, and no cycles — the exact opposite of the
+    load profile that makes ``find_path``'s bidirectional walk
+    expensive (the walk enumerates *simple paths*, which grow
+    ~branch_factor^hops on a mesh). This spec generates that adversarial
+    shape: ``layers`` rows of ``width`` nodes each, every node fanning
+    out to ``branch_factor`` nodes of the next layer (cross-column, so
+    paths both diverge and converge), plus optional back-edges (cycles)
+    and optional soft-deleted rows.
+
+    Attributes:
+        layers: Number of node layers (the mesh's depth). Must be >= 2.
+        width: Nodes per layer. Must be >= ``branch_factor`` so the
+            per-node fanout targets ``branch_factor`` *distinct*
+            next-layer columns.
+        branch_factor: Forward edges per node: node ``(L, i)`` connects
+            to ``(L+1, (i + j) % width)`` for ``j`` in
+            ``0..branch_factor-1``. Each next-layer node therefore also
+            *receives* ``branch_factor`` edges — converging paths, the
+            case the forest fixture never exercises.
+        cycle_stride: When > 0, every ``cycle_stride``-th column of
+            every layer ``L >= 2`` gains a back-edge ``(L, i) ->
+            (L-2, i)``, making the graph cyclic (exercises the CYCLE
+            clause under load). ``0`` keeps the mesh acyclic.
+        edge_kinds: Round-robin ``graph_edge.kind`` cycle applied over
+            all generated edges, so a ``kind_filter`` walk over the
+            fixture stays meaningful. Values must be valid
+            ``GraphEdgeKind`` members.
+        soft_delete_every: When > 0, every Nth forward edge is seeded
+            soft-deleted (``last_seen=NULL``). Traversal verbs do not
+            filter ``last_seen`` (last-refresh-wins, see
+            ``docs/architecture/topology.md`` §Soft-delete semantics),
+            so these rows still add walk load — which is exactly why
+            the perf fixture must include them. Live edges carry a
+            real ``last_seen`` timestamp. ``0`` seeds everything live.
+        name_prefix: Node-name prefix; node ``(L, i)`` is named
+            ``{name_prefix}-{L}-{i}`` (kind ``vm``).
+    """
+
+    layers: int
+    width: int
+    branch_factor: int = 2
+    cycle_stride: int = 0
+    edge_kinds: tuple[str, ...] = ("runs-on", "belongs-to")
+    soft_delete_every: int = 0
+    name_prefix: str = "mesh"
+
+    def __post_init__(self) -> None:
+        if self.layers < 2:
+            raise ValueError("MeshSpec.layers must be >= 2")
+        if self.branch_factor < 1 or self.branch_factor > self.width:
+            raise ValueError("MeshSpec.branch_factor must be in 1..width")
+        if not self.edge_kinds:
+            raise ValueError("MeshSpec.edge_kinds must be non-empty")
+
+    @property
+    def total_nodes(self) -> int:
+        """``layers * width`` — the mesh has no extra hub node."""
+        return self.layers * self.width
+
+    @property
+    def total_forward_edges(self) -> int:
+        """``(layers - 1) * width * branch_factor`` forward edges."""
+        return (self.layers - 1) * self.width * self.branch_factor
+
+    @property
+    def total_cycle_edges(self) -> int:
+        """Back-edges added by ``cycle_stride`` (0 when acyclic)."""
+        if self.cycle_stride <= 0:
+            return 0
+        per_layer = -(-self.width // self.cycle_stride)  # ceil division
+        return (self.layers - 2) * per_layer
+
+    @property
+    def total_edges(self) -> int:
+        """Forward plus cycle edges."""
+        return self.total_forward_edges + self.total_cycle_edges
+
+    def node_name(self, layer: int, col: int) -> str:
+        """Canonical name of the node at ``(layer, col)``."""
+        return f"{self.name_prefix}-{layer}-{col}"
+
+
+async def seed_mesh_graph(
+    session: Any,
+    *,
+    tenant_id: uuid.UUID,
+    spec: MeshSpec,
+) -> dict[str, uuid.UUID]:
+    """Seed *spec*'s mesh under *tenant_id*; return ``name -> node id``.
+
+    Same transaction contract as :func:`seed_perf_graph`: the caller
+    owns the surrounding ``session.begin()`` block and excludes this
+    call from any timed region. All nodes are flushed before any edge
+    is added so the unit-of-work never emits an edge ahead of its
+    endpoint row.
+
+    Args:
+        session: An open ``AsyncSession`` inside a ``session.begin()``.
+        tenant_id: The tenant every seeded row is written under.
+        spec: The mesh shape (see :class:`MeshSpec`).
+
+    Returns:
+        Mapping of every node's name to its ``graph_node.id`` so a test
+        can anchor a walk at any mesh position without re-deriving the
+        naming scheme.
+    """
+    now = datetime.now(UTC)
+    ids: dict[str, uuid.UUID] = {}
+    for layer in range(spec.layers):
+        for col in range(spec.width):
+            node_id = uuid.uuid4()
+            ids[spec.node_name(layer, col)] = node_id
+            session.add(
+                GraphNode(
+                    id=node_id,
+                    tenant_id=tenant_id,
+                    kind="vm",
+                    name=spec.node_name(layer, col),
+                    properties={},
+                    discovered_by="test",
+                )
+            )
+    await session.flush()
+
+    def _add_edge(edge_index: int, from_id: uuid.UUID, to_id: uuid.UUID) -> None:
+        soft_deleted = spec.soft_delete_every > 0 and (
+            (edge_index + 1) % spec.soft_delete_every == 0
+        )
+        session.add(
+            GraphEdge(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                from_node_id=from_id,
+                to_node_id=to_id,
+                kind=spec.edge_kinds[edge_index % len(spec.edge_kinds)],
+                source="auto",
+                discovered_by="test",
+                last_seen=None if soft_deleted else now,
+            )
+        )
+
+    edge_index = 0
+    for layer in range(spec.layers - 1):
+        for col in range(spec.width):
+            for j in range(spec.branch_factor):
+                _add_edge(
+                    edge_index,
+                    ids[spec.node_name(layer, col)],
+                    ids[spec.node_name(layer + 1, (col + j) % spec.width)],
+                )
+                edge_index += 1
+
+    if spec.cycle_stride > 0:
+        for layer in range(2, spec.layers):
+            for col in range(0, spec.width, spec.cycle_stride):
+                _add_edge(
+                    edge_index,
+                    ids[spec.node_name(layer, col)],
+                    ids[spec.node_name(layer - 2, col)],
+                )
+                edge_index += 1
+
+    return ids

--- a/backend/tests/integration/test_topology_concurrency.py
+++ b/backend/tests/integration/test_topology_concurrency.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Concurrency coverage for the topology write paths (#2535).
+
+The topology suite had zero real-concurrency tests: every write-path
+test runs its calls sequentially, and the scheduler's per-target
+advisory lock was exercised only against a *mocked* pre-held lock
+(unit suite). This module closes both gaps against the real
+``pgvector/pgvector:pg16`` container:
+
+* **refresh vs annotate race** — ``asyncio.gather`` of
+  :func:`~meho_backplane.topology.refresh.refresh_target_topology` and
+  :func:`~meho_backplane.topology.annotate.annotate_edge` on two
+  independent connections. Asserts the invariants that must hold under
+  *either* interleaving: the curated edge is never lost or clobbered
+  (no lost update), every §6 marker in the tenant references an
+  existing edge row (no dangling markers), and both operations'
+  synchronous audit rows are present.
+* **real advisory-lock path** — a held ``pg_advisory_lock`` on the
+  scheduler's ``(tenant, target)`` key makes
+  :func:`~meho_backplane.topology.scheduler._refresh_one_target` skip
+  the target (no audit row — the refresh never ran), and the same call
+  proceeds after release. This is the real-PG replacement for the
+  mocked pre-held-lock unit test.
+
+Determinism note: the race test's curated edge hangs off an *external*
+from-node (``target_id IS NULL``, not in the connector snapshot).
+``_load_reconcile_candidate_nodes`` loads only snapshot-key or
+target-owned nodes and ``_load_existing_edges_by_key`` loads edges by
+``from_node_id`` over that set, so the concurrent refresh structurally
+cannot see — much less soft-delete or rewrite — the curated row no
+matter how the two transactions interleave. The assertions therefore
+hold on every schedule instead of flaking on a lucky one; the
+same-triple auto-vs-curated write-write race is deliberately not
+staged here because its outcome is order-defined (last-refresh-wins by
+design, see ``docs/architecture/topology.md`` §Soft-delete semantics).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from sqlalchemy import func, select, text
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector
+from meho_backplane.connectors.schemas import (
+    CandidateHint,
+    EdgeHint,
+    FingerprintResult,
+    NodeHint,
+    OperationResult,
+    ProbeResult,
+    TopologyHints,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, GraphEdge, GraphNode
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+from meho_backplane.topology.annotate import NodeRef, annotate_edge
+from meho_backplane.topology.refresh import refresh_target_topology
+from meho_backplane.topology.scheduler import (
+    _advisory_lock_key,
+    _refresh_one_target,
+    _SchedulerState,
+)
+from tests.integration.conftest import DOCKER_AVAILABLE, SKIP_REASON
+
+# Match the tenant rows the ``pg_engine`` conftest fixture seeds.
+TENANT_A_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+_skip_no_docker = pytest.mark.skipif(not DOCKER_AVAILABLE, reason=SKIP_REASON)
+
+_PRODUCT = "race-test-product"
+
+#: Audit ``path`` values the two write paths stamp (mirrors
+#: ``refresh._REFRESH_OP_ID`` / ``annotate._ANNOTATE_OP_ID``).
+_REFRESH_OP_ID = "topology.refresh"
+_ANNOTATE_OP_ID = "topology.annotate"
+
+
+class _RaceTopoConnector(Connector):
+    """Deterministic 3-node / 2-edge snapshot keyed off the target name."""
+
+    product = _PRODUCT
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:
+        raise NotImplementedError
+
+    async def discover_topology(self, target: Any) -> TopologyHints:
+        tname = target.name
+        return TopologyHints(
+            nodes=(
+                NodeHint(kind="target", name=tname),
+                NodeHint(kind="vm", name=f"vm-{tname}"),
+                NodeHint(kind="host", name=f"host-{tname}"),
+            ),
+            edges=(
+                EdgeHint(
+                    from_kind="target",
+                    from_name=tname,
+                    to_kind="vm",
+                    to_name=f"vm-{tname}",
+                    kind="belongs-to",
+                ),
+                EdgeHint(
+                    from_kind="vm",
+                    from_name=f"vm-{tname}",
+                    to_kind="host",
+                    to_name=f"host-{tname}",
+                    kind="runs-on",
+                ),
+            ),
+            discovered_at=datetime.now(UTC),
+        )
+
+    async def list_candidates(self, seed_target: Any | None = None) -> list[CandidateHint]:
+        return []
+
+
+def _operator(tenant_id: uuid.UUID) -> Operator:
+    """Build a minimal :class:`Operator` pinned to *tenant_id*."""
+    return Operator(
+        sub="op-topology-race",
+        name=None,
+        email=None,
+        raw_jwt="not-a-real-jwt",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture
+async def race_target(pg_engine: None) -> AsyncIterator[TargetORM]:
+    """Register the connector, insert one target row, yield it loaded.
+
+    The target name carries a per-test random suffix: ``targets`` is
+    not in the conftest's per-test TRUNCATE list (it has no graph
+    coupling), so a fixed name would collide with the row a previous
+    test in the same container session inserted.
+    """
+    clear_registry()
+    _CONNECTOR_INSTANCE_CACHE.clear()
+    register_connector(_PRODUCT, _RaceTopoConnector)
+
+    target_id = uuid.uuid4()
+    now = datetime.now(UTC)
+    sm = get_sessionmaker()
+    async with sm() as session, session.begin():
+        session.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=TENANT_A_ID,
+                name=f"race-target-{uuid.uuid4().hex[:8]}",
+                product=_PRODUCT,
+                host="10.0.0.1",
+                aliases=[],
+                port=None,
+                fqdn=None,
+                secret_ref=None,
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                notes=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    async with sm() as session:
+        target = (
+            await session.execute(select(TargetORM).where(TargetORM.id == target_id))
+        ).scalar_one()
+
+    yield target
+
+    clear_registry()
+    _CONNECTOR_INSTANCE_CACHE.clear()
+
+
+async def _audit_count(op_id: str) -> int:
+    """Rows in ``audit_log`` whose ``path`` is *op_id* (tenant A)."""
+    sm = get_sessionmaker()
+    async with sm() as session:
+        result = await session.execute(
+            select(func.count())
+            .select_from(AuditLog)
+            .where(AuditLog.tenant_id == TENANT_A_ID, AuditLog.path == op_id)
+        )
+        return int(result.scalar_one())
+
+
+async def _assert_no_dangling_markers() -> None:
+    """Every §6 marker in the tenant references an existing edge row."""
+    sm = get_sessionmaker()
+    async with sm() as session:
+        edges = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == TENANT_A_ID)))
+            .scalars()
+            .all()
+        )
+        edge_ids = {str(e.id) for e in edges}
+        for edge in edges:
+            props = edge.properties or {}
+            superseded_by = props.get("superseded_by")
+            if superseded_by is not None:
+                assert superseded_by in edge_ids, (
+                    f"dangling superseded_by marker {superseded_by} on edge {edge.id}"
+                )
+            for other in props.get("conflicts_with", []) or []:
+                assert other in edge_ids, f"dangling conflicts_with entry {other} on edge {edge.id}"
+
+
+@_skip_no_docker
+async def test_refresh_vs_annotate_concurrent_writes_hold_invariants(
+    race_target: TargetORM,
+) -> None:
+    """``asyncio.gather(refresh, annotate)`` — invariants hold either way.
+
+    One initial refresh populates the target's 3-node / 2-edge graph.
+    Then three rounds of a genuinely concurrent refresh + annotate (two
+    independent asyncpg connections; the annotate's note changes per
+    round so the idempotent-upsert merge path races the reconcile too).
+    After every round:
+
+    * **No lost update** — the curated ``ext-svc --depends-on-->
+      host-<target>`` row exists, is still ``source='curated'``,
+      carries the round's note, and is live (``last_seen`` set). The
+      concurrent reconcile pass must never soft-delete or rewrite it.
+    * **No dangling markers** — every ``superseded_by`` /
+      ``conflicts_with`` value in the tenant resolves to an existing
+      ``graph_edge`` row.
+    * **Both audit rows present** — the synchronous-audit contract
+      (spec §6: no success without a committed audit row) holds under
+      concurrency: one ``topology.refresh`` and one
+      ``topology.annotate`` row per round.
+    * The snapshot itself reconciled cleanly (nothing spuriously
+      removed).
+    """
+    op = _operator(TENANT_A_ID)
+
+    first = await refresh_target_topology(race_target, op)
+    assert (first.added_nodes, first.added_edges) == (3, 2)
+
+    # The curated edge's from-node: external to the target (no
+    # target_id, never in the snapshot) — see the module docstring's
+    # determinism note.
+    sm = get_sessionmaker()
+    async with sm() as session, session.begin():
+        session.add(
+            GraphNode(
+                id=uuid.uuid4(),
+                tenant_id=TENANT_A_ID,
+                kind="service",
+                name="ext-svc",
+                properties={},
+                discovered_by="test",
+            )
+        )
+
+    host_name = f"host-{race_target.name}"
+
+    async def _annotate(note: str) -> GraphEdge:
+        async with sm() as session:
+            return await annotate_edge(
+                session,
+                op,
+                NodeRef(name="ext-svc", kind="service"),
+                "depends-on",
+                NodeRef(name=host_name, kind="host"),
+                note=note,
+            )
+
+    rounds = 3
+    for round_no in range(rounds):
+        note = f"curated race note {round_no}"
+        refresh_result, annotated = await asyncio.gather(
+            refresh_target_topology(race_target, op),
+            _annotate(note),
+        )
+
+        # Refresh reconciled the unchanged snapshot: nothing removed.
+        assert refresh_result.removed_nodes == 0
+        assert refresh_result.removed_edges == 0
+        assert annotated.source == "curated"
+
+        # No lost update: reload the curated row from a fresh session.
+        async with sm() as session:
+            curated = (
+                await session.execute(
+                    select(GraphEdge).where(
+                        GraphEdge.tenant_id == TENANT_A_ID,
+                        GraphEdge.id == annotated.id,
+                    )
+                )
+            ).scalar_one()
+            assert curated.source == "curated"
+            assert curated.properties.get("note") == note
+            assert curated.kind == "depends-on"
+            assert curated.last_seen is not None
+
+        await _assert_no_dangling_markers()
+
+        # Both synchronous audit rows landed for this round.
+        assert await _audit_count(_REFRESH_OP_ID) == 1 + (round_no + 1)  # initial + rounds
+        assert await _audit_count(_ANNOTATE_OP_ID) == round_no + 1
+
+    # The snapshot graph survived all rounds live (last-refresh-wins:
+    # a concurrent annotate must never knock out probe-derived rows).
+    async with sm() as session:
+        live_nodes = (
+            await session.execute(
+                select(func.count())
+                .select_from(GraphNode)
+                .where(GraphNode.tenant_id == TENANT_A_ID, GraphNode.last_seen.is_not(None))
+            )
+        ).scalar_one()
+    # 3 snapshot nodes; ext-svc was seeded with last_seen NULL (model
+    # default) so only the probe-owned rows count here.
+    assert int(live_nodes) == 3
+
+
+@_skip_no_docker
+async def test_scheduler_advisory_lock_skips_and_releases_on_real_pg(
+    race_target: TargetORM,
+) -> None:
+    """The per-target advisory lock is exercised against real PG.
+
+    While another connection holds ``pg_advisory_lock`` on the
+    scheduler's ``(tenant, target)`` key, ``_refresh_one_target`` must
+    skip the target without refreshing (no ``topology.refresh`` audit
+    row — the reconcile never ran; the previously unit-tested path used
+    a mocked pre-held lock and never touched ``pg_try_advisory_lock``
+    itself). After the holder releases, the same call refreshes
+    normally — proving the skip was the lock, not an error swallowed by
+    the scheduler's failure isolation.
+    """
+    key = _advisory_lock_key(TENANT_A_ID, race_target.id)
+    state = _SchedulerState()
+    sm = get_sessionmaker()
+
+    async with sm() as holder:
+        await holder.execute(text("SELECT pg_advisory_lock(:k)"), {"k": key})
+        try:
+            await _refresh_one_target(race_target, state)
+            assert await _audit_count(_REFRESH_OP_ID) == 0, (
+                "refresh ran despite a held advisory lock — the "
+                "stampede guard is broken on real PostgreSQL"
+            )
+        finally:
+            # Session-level lock: release explicitly before the pooled
+            # connection returns, or it would leak into the next test.
+            await holder.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": key})
+
+    await _refresh_one_target(race_target, state)
+    assert await _audit_count(_REFRESH_OP_ID) == 1

--- a/backend/tests/integration/test_topology_path_pruning.py
+++ b/backend/tests/integration/test_topology_path_pruning.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Dense-mesh ``find_path`` coverage: per-branch pruning + worst case.
+
+Task #2535 (Initiative #2533). Every prior perf artifact models a
+sparse hub-and-chains forest (out-degree exactly 1, no converging
+paths, no cycles — :class:`tests.fixtures.topology_10k_nodes.GraphSpec`),
+so the load profile that actually makes ``_PATH_SQL`` expensive — a
+dense mesh where the bidirectional walk enumerates ~branch_factor^hops
+simple paths — was never exercised in CI. This module pins it:
+
+* **Pruning equivalence** — the per-branch target prune added to
+  ``_PATH_SQL`` (a non-recursive ``target`` CTE + ``NOT EXISTS`` in the
+  recursive term) returns the same shortest-path hop count / ``None``
+  as the unpruned walk on the mesh, for near, far, cyclic and
+  unreachable endpoint pairs.
+* **Pruning row count** — the pruned walk materialises strictly fewer
+  rows than the unpruned equivalent when the target is reachable, with
+  the exact counts regression-pinned (they are deterministic functions
+  of the fixture shape, not of runner speed).
+* **Worst-case envelope** — an *unreachable* target (pruning can never
+  fire) on a dense cyclic mesh with ``max_hops`` at the API ceiling
+  (32, ``api/v1/topology.py::_MAX_HOPS_MAX``). Gated the same
+  load-invariant way as the depth-16 traversal test (#1434): a
+  row-count pin plus a hops-32 / hops-8 wall-clock *ratio* (runner load
+  inflates numerator and denominator together and divides out), with a
+  generous absolute ceiling as a catastrophic-regression backstop
+  only. The measured envelope is documented in
+  ``docs/architecture/topology.md`` §Performance expectations.
+
+Docker-gated like the rest of ``tests/integration`` (real
+``pgvector/pgvector:pg16`` — the recursive CYCLE clause is PG-only).
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GraphNode
+from meho_backplane.topology.query import _PATH_SQL, find_path
+from tests.fixtures.topology_10k_nodes import MeshSpec, seed_mesh_graph
+from tests.integration.conftest import DOCKER_AVAILABLE, SKIP_REASON
+
+# Match the tenant rows the ``pg_engine`` conftest fixture seeds.
+TENANT_A_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+_skip_no_docker = pytest.mark.skipif(not DOCKER_AVAILABLE, reason=SKIP_REASON)
+
+# The exact prune predicate shipped in ``_PATH_SQL``'s recursive term.
+# The harness derives the *unpruned* control statement by deleting this
+# line from the shipped SQL, so the substring doubles as a drift guard:
+# if the predicate is reworded or removed in ``query.py``, the
+# ``in``-assertion below fails before any query runs.
+_PRUNE_PREDICATE = "AND NOT EXISTS (SELECT 1 FROM target t WHERE t.id = w.node_id)"
+
+# Anchor of the final select in ``_PATH_SQL`` — everything before it is
+# the CTE list (including the CYCLE clause), which the row-count harness
+# reuses verbatim under a ``count(*)`` projection.
+_FINAL_SELECT_ANCHOR = "SELECT w.hops, w.node_ids, w.edge_kinds"
+
+# ---------------------------------------------------------------------------
+# Fixture shapes. Deliberately small node counts: the walk enumerates
+# *simple paths*, whose number grows combinatorially with density, so a
+# handful of well-connected nodes already produces walks of thousands of
+# rows — the load profile under test — while staying CI-cheap.
+# ---------------------------------------------------------------------------
+
+#: Mesh for the pruning equivalence / row-count tests. 20 nodes,
+#: 32 forward + 6 back edges, converging paths, cycles, mixed kinds and
+#: a sprinkle of soft-deleted rows (still walked — traversal does not
+#: filter ``last_seen``).
+_PRUNE_MESH = MeshSpec(
+    layers=5,
+    width=4,
+    branch_factor=2,
+    cycle_stride=2,
+    soft_delete_every=7,
+    name_prefix="prune",
+)
+
+#: Mesh for the worst-case benchmark. 16 nodes / 28 edges with
+#: converging forward fans and back-edges (undirected degree ~4-6): the
+#: full simple-path enumeration at the 32-hop ceiling materialises
+#: ~31k walk rows (measured; pinned below) — dense-mesh load the forest
+#: fixture structurally cannot produce, yet CI-cheap (~120 ms/query on
+#: a dev laptop).
+_WORST_MESH = MeshSpec(
+    layers=4,
+    width=4,
+    branch_factor=2,
+    cycle_stride=2,
+    soft_delete_every=5,
+    name_prefix="worst",
+)
+
+#: API-boundary hop ceiling (mirrors ``api/v1/topology.py::_MAX_HOPS_MAX``)
+#: — the worst value any operator-role caller can select.
+_MAX_HOPS_CEILING = 32
+
+# Regression pins for the walk-volume assertions. Row counts of a
+# recursive CTE are a deterministic function of graph shape + hop bound
+# (no runner-speed dependence); measured once on the seeded fixtures and
+# re-derived deliberately whenever a mesh spec or the walk semantics
+# change.
+_EXPECTED_PRUNED_ROWS = 795
+_EXPECTED_UNPRUNED_ROWS = 1544
+_EXPECTED_WORST_CASE_ROWS = 31_041
+
+# Perf-gate calibration for the worst-case benchmark. Measured healthy
+# hops-32 / hops-8 ratio on :data:`_WORST_MESH` is ~7.7 (row-count
+# driven: 31 041 vs 3 866 walk rows); the 20.0 ceiling sits ~2.6x above
+# healthy while any superlinear regression (broken CYCLE bookkeeping,
+# dropped hop bound) lands orders of magnitude higher. The absolute
+# ceiling is a catastrophic-regression backstop only (~40x the measured
+# ~121 ms median), mirroring the #1434 discipline.
+_PERF_SAMPLES = 5
+_WORST_RATIO_CEILING = 20.0
+_WORST_ABS_CEILING_MS = 5000.0
+
+
+def _operator(tenant_id: uuid.UUID) -> Operator:
+    """Build a minimal :class:`Operator` pinned to *tenant_id*."""
+    return Operator(
+        sub="op-topology-prune",
+        name=None,
+        email=None,
+        raw_jwt="not-a-real-jwt",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _path_sql(*, pruned: bool) -> str:
+    """The shipped ``_PATH_SQL`` text, optionally with the prune removed.
+
+    The ``in``-assertion is the drift guard: it fails loudly if the
+    prune predicate is reworded or dropped from ``query.py``, so this
+    harness can never silently compare the pruned statement against
+    itself.
+    """
+    sql = _PATH_SQL.text
+    assert _PRUNE_PREDICATE in sql, (
+        "per-branch prune predicate not found in _PATH_SQL — the "
+        "#2535 pruning was removed or reworded; update this harness "
+        "in lock-step"
+    )
+    return sql if pruned else sql.replace(_PRUNE_PREDICATE, "")
+
+
+def _walk_count_sql(*, pruned: bool) -> str:
+    """Rewrite the final select into ``count(*) FROM walk``.
+
+    Keeps the whole CTE list (target, bi_edge, walk + CYCLE clause)
+    byte-identical to the shipped statement so the counted volume is
+    exactly what a real ``find_path`` materialises.
+    """
+    sql = _path_sql(pruned=pruned)
+    head, sep, _tail = sql.partition(_FINAL_SELECT_ANCHOR)
+    assert sep, "final-select anchor not found in _PATH_SQL — update this harness"
+    return head + "SELECT count(*) AS walk_rows FROM walk"
+
+
+def _params(
+    from_name: str,
+    to_name: str,
+    *,
+    max_hops: int,
+) -> dict[str, object]:
+    """Bind-parameter dict matching ``_PATH_SQL``'s named binds."""
+    return {
+        "tenant_id": str(TENANT_A_ID),
+        "from_name": from_name,
+        "to_name": to_name,
+        "from_kind": None,
+        "to_kind": None,
+        "max_hops": max_hops,
+    }
+
+
+async def _walk_rows(from_name: str, to_name: str, *, max_hops: int, pruned: bool) -> int:
+    """Total rows the (pruned or unpruned) walk materialises."""
+    sm = get_sessionmaker()
+    async with sm() as session:
+        result = await session.execute(
+            text(_walk_count_sql(pruned=pruned)),
+            _params(from_name, to_name, max_hops=max_hops),
+        )
+        return int(result.scalar_one())
+
+
+async def _unpruned_hops(from_name: str, to_name: str, *, max_hops: int) -> int | None:
+    """Shortest-path hop count from the unpruned control statement."""
+    sm = get_sessionmaker()
+    async with sm() as session:
+        result = await session.execute(
+            text(_path_sql(pruned=False)),
+            _params(from_name, to_name, max_hops=max_hops),
+        )
+        row = result.first()
+        return None if row is None else int(row._mapping["hops"])
+
+
+@pytest.fixture
+async def prune_mesh(pg_engine: None) -> dict[str, uuid.UUID]:
+    """Seed :data:`_PRUNE_MESH` plus one edge-less island node."""
+    sm = get_sessionmaker()
+    async with sm() as session, session.begin():
+        ids = await seed_mesh_graph(session, tenant_id=TENANT_A_ID, spec=_PRUNE_MESH)
+        island = GraphNode(
+            id=uuid.uuid4(),
+            tenant_id=TENANT_A_ID,
+            kind="vm",
+            name="prune-island",
+            properties={},
+            discovered_by="test",
+        )
+        session.add(island)
+        ids["prune-island"] = island.id
+    return ids
+
+
+def test_mesh_spec_derived_counts() -> None:
+    """Cheap no-Docker smoke: the spec's derived sizes match the formula.
+
+    Mirrors ``test_module_imports_cleanly`` in the query suite — this
+    fails first on every sandbox if the generator's shape drifts, not
+    only on Docker-equipped runners.
+    """
+    assert _PRUNE_MESH.total_nodes == 5 * 4
+    assert _PRUNE_MESH.total_forward_edges == 4 * 4 * 2
+    assert _PRUNE_MESH.total_cycle_edges == 3 * 2  # layers 2..4, cols 0 and 2
+    assert _PRUNE_MESH.total_edges == 32 + 6
+    assert _WORST_MESH.total_nodes == 4 * 4
+    assert _WORST_MESH.total_edges == 3 * 4 * 2 + 2 * 2  # forward + back-edges
+    with pytest.raises(ValueError):
+        MeshSpec(layers=1, width=4)
+    with pytest.raises(ValueError):
+        MeshSpec(layers=3, width=2, branch_factor=3)
+    with pytest.raises(ValueError):
+        MeshSpec(layers=3, width=2, edge_kinds=())
+
+
+@_skip_no_docker
+async def test_pruned_path_results_match_unpruned_on_mesh(
+    prune_mesh: dict[str, uuid.UUID],
+) -> None:
+    """Pruning is behavior-invariant: same hops / same ``None``.
+
+    Compares the public ``find_path`` (pruned statement) against the
+    unpruned control statement on the same seeded mesh for an adjacent
+    pair, a cross-mesh pair (where back-edges shorten the route), and
+    an unreachable island. Only the hop count is compared — with ties
+    at the minimum hop count ``ORDER BY hops LIMIT 1`` may pick any
+    winning path in either variant, so the node sequence is not part
+    of the contract.
+    """
+    op = _operator(TENANT_A_ID)
+    cases = [
+        ("prune-0-0", "prune-1-0"),  # adjacent (1 forward hop)
+        ("prune-0-0", "prune-4-3"),  # far corner, through converging paths
+        ("prune-2-0", "prune-0-0"),  # reachable via a back-edge (cycle leg)
+        ("prune-0-1", "prune-island"),  # unreachable — pruning can't fire
+    ]
+    for from_name, to_name in cases:
+        pruned = await find_path(op, from_name, to_name, max_hops=6)
+        control = await _unpruned_hops(from_name, to_name, max_hops=6)
+        if control is None:
+            assert pruned is None, f"{from_name}->{to_name}: pruned found a path, control none"
+        else:
+            assert pruned is not None, f"{from_name}->{to_name}: control found a path, pruned none"
+            assert pruned.total_hops == control, f"{from_name}->{to_name}: hop count diverged"
+            assert pruned.nodes[0].name == from_name
+            assert pruned.nodes[-1].name == to_name
+
+
+@_skip_no_docker
+async def test_pruned_walk_materialises_fewer_rows(
+    prune_mesh: dict[str, uuid.UUID],
+) -> None:
+    """The pruned walk emits strictly fewer rows on a reachable target.
+
+    Row counts of a recursive CTE are a deterministic function of the
+    graph shape and the hop bound — no runner-speed dependence — so the
+    assertion is a strict inequality plus an exact regression pin. A
+    change to :data:`_PRUNE_MESH` or to the walk semantics moves the
+    pinned numbers and must be re-derived deliberately, which is the
+    point (issue #2535 acceptance: "EXPLAIN-level or row-count
+    assertion, regression-pinned").
+
+    The target (``prune-1-0``) is adjacent to the anchor and sits on
+    converging paths, so a large share of simple paths pass through it
+    — every one of them is cut at the hit under pruning, while the
+    unpruned walk keeps extending them to the hop bound.
+    """
+    pruned_rows = await _walk_rows("prune-0-0", "prune-1-0", max_hops=6, pruned=True)
+    unpruned_rows = await _walk_rows("prune-0-0", "prune-1-0", max_hops=6, pruned=False)
+
+    assert pruned_rows < unpruned_rows, (
+        f"pruning did not reduce walk volume: pruned={pruned_rows} unpruned={unpruned_rows}"
+    )
+    # Regression pins (deterministic — see docstring). Measured on the
+    # seeded fixture; re-derive on purpose if the mesh shape changes.
+    assert unpruned_rows == _EXPECTED_UNPRUNED_ROWS, (
+        f"unpruned walk volume moved: {unpruned_rows} != {_EXPECTED_UNPRUNED_ROWS} — "
+        f"fixture shape or walk semantics changed"
+    )
+    assert pruned_rows == _EXPECTED_PRUNED_ROWS, (
+        f"pruned walk volume moved: {pruned_rows} != {_EXPECTED_PRUNED_ROWS} — "
+        f"fixture shape, walk semantics, or prune placement changed"
+    )
+
+
+async def _median_path_ms(
+    op: Operator,
+    from_name: str,
+    to_name: str,
+    *,
+    max_hops: int,
+    samples: int = _PERF_SAMPLES,
+) -> float:
+    """Median wall-clock (ms) of ``samples`` ``find_path`` calls."""
+    elapsed: list[float] = []
+    for _ in range(samples):
+        started = time.monotonic()
+        await find_path(op, from_name, to_name, max_hops=max_hops)
+        elapsed.append((time.monotonic() - started) * 1000.0)
+    elapsed.sort()
+    return elapsed[len(elapsed) // 2]
+
+
+@pytest.fixture
+async def worst_mesh(pg_engine: None) -> dict[str, uuid.UUID]:
+    """Seed :data:`_WORST_MESH` plus the unreachable island target."""
+    sm = get_sessionmaker()
+    async with sm() as session, session.begin():
+        ids = await seed_mesh_graph(session, tenant_id=TENANT_A_ID, spec=_WORST_MESH)
+        island = GraphNode(
+            id=uuid.uuid4(),
+            tenant_id=TENANT_A_ID,
+            kind="vm",
+            name="worst-island",
+            properties={},
+            discovered_by="test",
+        )
+        session.add(island)
+        ids["worst-island"] = island.id
+    return ids
+
+
+@_skip_no_docker
+async def test_worst_case_find_path_envelope_on_dense_mesh(
+    worst_mesh: dict[str, uuid.UUID],
+) -> None:
+    """Worst case: unreachable target, dense cyclic mesh, ``max_hops=32``.
+
+    Pruning cannot fire (the target is never hit), so the walk
+    enumerates every simple path from the anchor — the cost profile the
+    hub-and-chains fixture structurally cannot produce and the one an
+    operator triggers with a typo'd ``to=`` plus ``max_hops=32`` (the
+    API ceiling).
+
+    Three gates, strongest first (same discipline as the depth-16
+    ratio gate, #1434 — load-invariant properties primary, wall-clock
+    backstop secondary):
+
+    1. **Row-count pin** — the materialised walk volume is a
+       deterministic function of the mesh, independent of runner speed.
+    2. **Hops-32 / hops-8 wall-clock ratio** — both sides are timed in
+       the same run so host contention divides out. On this 12-node
+       mesh every simple path is shorter than 12 hops, so hops-32 and
+       hops-8 differ only by how much of the combinatorial explosion
+       the bound cuts off; a superlinear regression (e.g. broken CYCLE
+       bookkeeping) blows the ratio while runner noise does not.
+    3. **Absolute ceiling** — generous catastrophic-regression backstop
+       only, not the load-bearing gate.
+    """
+    op = _operator(TENANT_A_ID)
+
+    # Correctness half: the island is genuinely unreachable.
+    result = await find_path(op, "worst-0-0", "worst-island", max_hops=_MAX_HOPS_CEILING)
+    assert result is None
+
+    # Gate 1 — deterministic volume pin (see docstring).
+    worst_rows = await _walk_rows(
+        "worst-0-0", "worst-island", max_hops=_MAX_HOPS_CEILING, pruned=True
+    )
+    assert worst_rows == _EXPECTED_WORST_CASE_ROWS, (
+        f"worst-case walk volume moved: {worst_rows} != {_EXPECTED_WORST_CASE_ROWS} — "
+        f"mesh shape or walk semantics changed; re-derive the envelope and update "
+        f"docs/architecture/topology.md §Performance expectations"
+    )
+
+    # Warm the connection/plan so the timed medians measure steady state.
+    await find_path(op, "worst-0-0", "worst-island", max_hops=1)
+
+    baseline_ms = await _median_path_ms(op, "worst-0-0", "worst-island", max_hops=8)
+    worst_ms = await _median_path_ms(op, "worst-0-0", "worst-island", max_hops=_MAX_HOPS_CEILING)
+
+    # Gate 2 — load-invariant scaling ratio.
+    ratio = worst_ms / baseline_ms
+    assert ratio < _WORST_RATIO_CEILING, (
+        f"worst-case find_path hops-32/hops-8 ratio {ratio:.1f} exceeds "
+        f"{_WORST_RATIO_CEILING} (hops-8 {baseline_ms:.1f} ms, hops-32 "
+        f"{worst_ms:.1f} ms) — the walk is scaling worse than the "
+        f"documented envelope; check the CYCLE guard and the hop bound."
+    )
+    # Gate 3 — generous absolute backstop (documented envelope lives in
+    # docs/architecture/topology.md; this only catches an
+    # order-of-magnitude catastrophe that also slowed the baseline).
+    assert worst_ms < _WORST_ABS_CEILING_MS, (
+        f"worst-case find_path took {worst_ms:.1f} ms (median), over the "
+        f"{_WORST_ABS_CEILING_MS:.0f} ms catastrophic-regression backstop"
+    )

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -311,6 +311,7 @@ Against a seeded ~10k-node / ~10k-edge tenant graph
 |---|---|
 | `find_dependents` depth 16 | < 100 ms |
 | `find_path` BFS | < 150 ms |
+| `find_path` worst case (dense mesh, unreachable target, `max_hops=32`) | < 500 ms (~31k walk rows on the 16-node `MeshSpec` benchmark mesh) |
 | `refresh_target_topology` (insert/update bottleneck) | < 500 ms |
 
 The `graph_edge_tenant_from_idx` / `graph_edge_tenant_to_idx` indexes
@@ -322,6 +323,39 @@ these against a real `pgvector/pgvector:pg16` container in the split-CI
 so ordinary runner variance doesn't flake the gate while an
 order-of-magnitude regression still fails it. The >10k-node case is a
 v0.3 concern, addressed only when a real tenant hits it.
+
+### `find_path` on dense meshes (#2535)
+
+The forest fixture's out-degree-1 shape hides `find_path`'s real cost
+profile: the bidirectional walk enumerates **simple paths**, which
+grow ~branch_factor^hops on a dense mesh (converging paths, cycles),
+not linearly with node count. Two mitigations bound it:
+
+- **Per-branch target pruning** in `_PATH_SQL` — the destination id
+  resolves in a non-recursive `target` CTE and the recursive term
+  refuses to extend a branch whose frontier row already is the target.
+  Behavior is identical (same shortest hop count, same `None`); on the
+  20-node pruning mesh the walk drops from 1 544 to 795 materialised
+  rows (regression-pinned in
+  `backend/tests/integration/test_topology_path_pruning.py`). Global
+  cross-branch early termination is **not** expressible — PostgreSQL
+  allows exactly one recursive self-reference, outside subqueries, and
+  `ORDER BY hops LIMIT 1` must consume the full walk before sorting.
+- **The `max_hops` bound** (route ceiling 32) — the only guard when
+  the target is unreachable, because pruning never fires. That worst
+  case (dense cyclic 16-node mesh, unreachable target, `max_hops=32`)
+  is CI-pinned: ~31k walk rows (exact row count asserted — it is a
+  deterministic function of the graph, immune to runner load), a
+  hops-32/hops-8 wall-clock ratio gate (~7.7 healthy, ceiling 20), and
+  a generous 5 s absolute backstop. Measured median on a dev laptop:
+  ~120 ms.
+
+The dense shapes come from the `MeshSpec` / `seed_mesh_graph`
+generator (same fixture module): layered meshes with configurable
+`branch_factor` (converging paths), `cycle_stride` (back-edges),
+mixed edge kinds, and optional soft-deleted rows — which the traversal
+verbs still walk (soft-delete is retention, not visibility; see
+§Soft-delete semantics).
 
 ## Tenant boundary
 

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -428,6 +428,27 @@ LIMIT 1` yields a shortest path. A second query materialises the
 winning path's node rows; `_build_path_nodes` re-orders them into path
 sequence and attaches `depth` / `via_edge_kind`.
 
+**Per-branch target pruning (#2535).** The walk enumerates simple
+paths, so on a dense mesh its row count grows ~branch_factor^hops. A
+non-recursive `target` CTE resolves the destination id once, and the
+recursive term carries `NOT EXISTS (SELECT 1 FROM target t WHERE t.id
+= w.node_id)` — a branch that reaches the target stops growing.
+Extending past a hit can never shorten a path to that same hit (and
+the CYCLE guard already forbids re-entering the target on the same
+branch), so pruning removes only rows the final select could never
+pick: results are identical, cost is bounded per branch. Referencing
+the non-recursive `target` CTE from the recursive term's subquery is
+legal — PostgreSQL's recursive-term restrictions cover only the
+recursive self-reference (`walk`), which must appear exactly once and
+not inside a subquery. That same restriction is why **global**
+cross-branch early termination cannot be written, and `ORDER BY hops
+LIMIT 1` cannot stop evaluation early because the sort consumes the
+full walk. The unreachable-target worst case therefore still
+enumerates the whole ≤`max_hops` ball; its envelope is pinned by
+`tests/integration/test_topology_path_pruning.py` on a dense
+`MeshSpec` mesh (row-count pin + load-invariant timing ratio, see
+`docs/architecture/topology.md` §Performance expectations).
+
 ### Cycle safety
 
 The `CYCLE` clause makes PostgreSQL track the visited-node set per
@@ -1393,8 +1414,12 @@ shape.
 - **PostgreSQL-only read path.** The `WITH RECURSIVE ... CYCLE` clause
   is not implemented by SQLite, so the query verbs cannot run on the
   unit suite's per-test SQLite DB. Tests live in
-  `backend/tests/integration/test_topology_query.py` against a real
-  `pgvector/pgvector:pg16` testcontainer (Docker-gated skip on
+  `backend/tests/integration/test_topology_query.py` (plus the
+  dense-mesh pruning/worst-case suite in
+  `backend/tests/integration/test_topology_path_pruning.py` and the
+  refresh-vs-annotate concurrency suite in
+  `backend/tests/integration/test_topology_concurrency.py`) against a
+  real `pgvector/pgvector:pg16` testcontainer (Docker-gated skip on
   no-Docker sandboxes; runs in CI). The pure Pydantic result-model
   contracts (deep `properties` immutability, `TopologyPath` invariants)
   have no DB dependency and are unit-tested in
@@ -1423,6 +1448,10 @@ shape.
 - Per-connector `discover_topology` overrides — each G3.x Initiative.
 - The advisory lock is a multi-replica stampede guard only; a single
   process serialises naturally and the SQLite test path no-ops it.
+  The real-PG lock path (skip while held, proceed after release) is
+  pinned by
+  `test_scheduler_advisory_lock_skips_and_releases_on_real_pg` in
+  `backend/tests/integration/test_topology_concurrency.py`.
 
 ## References
 


### PR DESCRIPTION
## Summary

- **`find_path` per-branch target pruning.** `_PATH_SQL`'s recursive term was target-blind: it enumerated the entire ≤`max_hops` undirected reachability ball (simple-path enumeration, ~branch_factor^hops on a dense mesh) before the final select filtered for the target. A non-recursive `target` CTE now resolves the destination id once and the recursive term refuses to extend a branch whose frontier row already is the target (`NOT EXISTS`) — extending past a hit can never shorten a path to that hit, so results are byte-identical while per-branch cost is bounded. Global cross-branch termination is deliberately **not** attempted: PostgreSQL allows exactly one recursive self-reference, outside subqueries, and `ORDER BY hops LIMIT 1` must consume the full walk (PG 16 §7.8).
- **Dense-mesh perf fixture.** New `MeshSpec` / `seed_mesh_graph` in `tests/fixtures/topology_10k_nodes.py` — layered meshes with converging paths (`branch_factor`), cycles (`cycle_stride`), mixed edge kinds, and optional soft-deleted rows; every parameter documented. The prior `GraphSpec` forest is out-degree-1 with no mesh/cycles, so the load profile that actually makes `find_path` expensive was never exercised in CI.
- **CI-pinned worst-case envelope.** New `tests/integration/test_topology_path_pruning.py`: pruning equivalence across near/far/cyclic/unreachable pairs, a regression-pinned row-count proof that the pruned walk materialises fewer rows (1 544 → 795 on the pruning mesh; deterministic counts, immune to runner load), and the worst case (unreachable target, dense cyclic mesh, `max_hops=32` API ceiling) gated by an exact walk-row pin (31 041 rows), a load-invariant hops-32/hops-8 timing ratio (measured ~7.7, ceiling 20), and a generous 5 s absolute backstop — mirroring the #1434 ratio-gate discipline. Envelope documented in `docs/architecture/topology.md` §Performance expectations.
- **First real-concurrency topology tests.** New `tests/integration/test_topology_concurrency.py`: `asyncio.gather(refresh_target_topology(...), annotate_edge(...))` on independent connections across three rounds — asserts no lost update (the curated edge survives with its note intact under every interleaving; the fixture's from-node is structurally outside the refresh's reconcile scope, so the assertions cannot flake on a lucky schedule), no dangling §6 markers, and both synchronous audit rows per round. Plus the scheduler's per-target advisory lock exercised against **real** PostgreSQL (skip while `pg_advisory_lock` held, refresh after release) — previously covered only by a mocked pre-held lock.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (1284 files)
- [x] `mypy src/` — 1 pre-existing, platform-specific error in untouched `connectors/net/icmp.py` (`socket.MSG_ERRQUEUE` is Linux-only; identical on `origin/main`, clean on Linux CI); topology package + fixture clean
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (8 pre-existing warnings in untouched `query.py` functions)
- [x] **Path results byte-identical on the existing suite**: `tests/integration/test_topology_query.py` + `test_topology_g91_acceptance.py` + `test_topology_annotate.py` + `test_topology_list_edges.py` + `test_topology_resolvers.py` + `test_topology_api.py` — 53 passed **unmodified** (shortest path, `None`-unreachable, superseded-both-legs included)
- [x] **Row-count assertion, regression-pinned**: `test_pruned_walk_materialises_fewer_rows` — pruned 795 < unpruned 1 544, exact pins asserted
- [x] **Worst-case benchmark CI-green with documented envelope**: `test_worst_case_find_path_envelope_on_dense_mesh` — 31 041-row pin + ratio gate + absolute ceiling; `docs/architecture/topology.md` perf table updated
- [x] **Concurrency test green against the real container**: `test_refresh_vs_annotate_concurrent_writes_hold_invariants` + `test_scheduler_advisory_lock_skips_and_releases_on_real_pg` — passed 3/3 repeat runs (Docker-gated skip mirrors the existing integration suite)
- [x] Unit sweep (`pytest -n 3 --ignore=tests/integration --ignore=tests/migrations`) — green apart from one pre-existing, environment-specific failure (`test_ca_pinned_context_trusts_chaining_cert`, fails identically on pristine `origin/main`; macOS TLS chain issue, green on Linux CI)

## Out of scope

- Lowering `_MAX_HOPS_MAX` (contract change; the pinned envelope shows the bounded walk holds at 32).
- Application-side BFS rewrite; closure-verb output shape (#2538 / T4).
- The initiative's two migrations (#2534 T1, #2536 T2) — this task carries none.
- Adjacent findings (pre-existing, untouched): `query.py` function-size warnings (`query_history` at 101 lines et al.); macOS-only `mypy` error in `connectors/net/icmp.py`; macOS-only TLS unit-test failure in `test_connectors_http_adapter.py`; curated *edges absent from a snapshot* are soft-deleted by the reconcile pass by design (last-refresh-wins) — related to #2536's curated-durability work, not staged in the race test because its outcome is order-defined.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2535
