### PR TITLE
feat(topology): open node/edge kind vocabularies — slug-validated open kinds, well-known set as convention

### DIFF
--- a/backend/alembic/versions/0063_open_graph_kind_vocabularies.py
+++ b/backend/alembic/versions/0063_open_graph_kind_vocabularies.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Open the graph node / edge kind vocabularies (#2534).
+
+Revision ID: 0063
+Revises: 0062
+Create Date: 2026-07-16
+
+Initiative #2533 (Topology v2), Task #2534 (T1, the keystone). The
+closed kind vocabularies -- ``ck_graph_node_kind``'s 14-member IN-list
+(migration ``0007``) and ``ck_graph_edge_kind``'s 10-member IN-list
+(migration ``0010``) -- are replaced with one portable **minimal shape
+CHECK** per table::
+
+    length(kind) >= 2 AND length(kind) <= 63 AND kind = lower(kind)
+
+Rationale (reverses #364's vocabulary lock and #593): the lock existed
+so a v0.2.next policy engine parsing ``kind`` would keep a portable
+grammar across tenants. That consumer never shipped and nothing tracks
+it, while the closed set makes routine cross-system traces
+(``dns-record``, ``database``, ``certificate``, ``resolves-to``,
+``same-as``) unrepresentable without a migration each. Post-0063 the
+kind space is open: full slug validation (pattern
+``^[a-z0-9]+(?:[._-][a-z0-9]+)*$``, 2--63 chars) runs Python-side at
+every write boundary (:mod:`meho_backplane.topology.nodes`,
+:mod:`meho_backplane.topology.annotate`, the REST body models, the MCP
+inputSchemas), and the old members survive as the *documented
+well-known set* (``WELL_KNOWN_NODE_KINDS`` / ``GraphEdgeKind`` in
+:mod:`meho_backplane.db.models`). The shape CHECK is deliberately
+weaker than the slug pattern because regex CHECKs are not portable
+across PostgreSQL 16 and the SQLite unit suite; it exists as the
+DB-layer backstop against out-of-band inserts landing
+obviously-malformed kinds.
+
+Backward compatibility is automatic on upgrade: all 14 node kinds and
+all 10 edge kinds are lowercase slugs of length 2--17, so every
+pre-migration row satisfies the widened constraint and no backfill or
+scrub is needed.
+
+SQLite batch-mode CHECK caveat
+------------------------------
+
+``graph_edge`` carries a second CHECK, ``ck_graph_edge_source``, that
+this migration must not disturb. Under the SQLite dialect
+:func:`op.batch_alter_table` rebuilds the table (copy rows -> new
+schema -> rename); per the Alembic batch documentation
+(https://alembic.sqlalchemy.org/en/latest/batch.html#working-with-constraints)
+**named** CHECK constraints participate in batch mode like any other
+constraint -- only *unnamed* constraints are silently omitted from the
+recreate. Both graph CHECKs are named (``ck_...``), so the plain
+drop-and-recreate mold from migration ``0010`` is sufficient and no
+``table_args`` re-declaration is needed. The survival of
+``ck_graph_edge_source`` across this rebuild is pinned by this
+migration's behavioural test
+(:mod:`tests.migrations.test_migration_0063_open_graph_kind_vocabularies`)
+and by :func:`tests.test_topology_schema.test_graph_edge_source_check_constraint_rejects_unknown`,
+which runs against a head-migrated DB.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` narrows both constraints back to their closed IN-lists.
+Mirroring migration ``0010``'s downgrade discipline, it first counts
+rows whose ``kind`` falls outside the post-downgrade vocabulary and
+raises :class:`RuntimeError` naming the offending kinds and row counts
+before any DDL runs -- a clear operator-facing refusal instead of an
+opaque mid-DDL ``IntegrityError``.
+
+The migration is self-contained: the closed tuples are inlined verbatim
+(never imported from :mod:`meho_backplane.db.models`) because Alembic
+must run against any historical revision's model graph.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0063"
+down_revision: str | None = "0062"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: The closed 14-kind node vocabulary migration ``0007`` shipped --
+#: what ``downgrade()`` narrows ``ck_graph_node_kind`` back to.
+_NODE_KINDS_CLOSED: tuple[str, ...] = (
+    "target",
+    "vm",
+    "host",
+    "network",
+    "datastore",
+    "namespace",
+    "pod",
+    "service",
+    "ingress",
+    "node",
+    "principal",
+    "vault-role",
+    "vault-mount",
+    "volume",
+)
+
+#: The closed 10-kind edge vocabulary migration ``0010`` shipped --
+#: what ``downgrade()`` narrows ``ck_graph_edge_kind`` back to.
+_EDGE_KINDS_CLOSED: tuple[str, ...] = (
+    "runs-on",
+    "mounts",
+    "routes-through",
+    "belongs-to",
+    "authenticates-via",
+    "depends-on",
+    "replicates-to",
+    "backed-up-by",
+    "routes-via",
+    "policy-binds",
+)
+
+#: Kind length bounds for the shape CHECK. Mirror
+#: ``KIND_SLUG_MIN_LENGTH`` / ``KIND_SLUG_MAX_LENGTH`` in
+#: :mod:`meho_backplane.db.models`; inlined per the self-containment
+#: rule.
+_KIND_MIN_LENGTH = 2
+_KIND_MAX_LENGTH = 63
+
+
+def _check_in(column: str, values: tuple[str, ...]) -> str:
+    """Render a ``column IN ('a', 'b', ...)`` clause for a CHECK constraint.
+
+    Mirrors the helper in ``0007`` / ``0010`` -- migrations are
+    self-contained, so the helper is inlined rather than imported.
+    """
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"{column} IN ({quoted})"
+
+
+def _check_kind_shape(column: str) -> str:
+    """Render the portable minimal shape CHECK for an open kind column.
+
+    ``length()`` and ``lower()`` are portable across PostgreSQL 16 and
+    SQLite; a regex CHECK (PG ``~``) is not. Mirrors
+    ``_ck_kind_shape`` in :mod:`meho_backplane.db.models`.
+    """
+    return (
+        f"length({column}) >= {_KIND_MIN_LENGTH} "
+        f"AND length({column}) <= {_KIND_MAX_LENGTH} "
+        f"AND {column} = lower({column})"
+    )
+
+
+def upgrade() -> None:
+    """Replace both closed IN-list kind CHECKs with the minimal shape CHECK.
+
+    Wrapped in :func:`op.batch_alter_table` for SQLite portability
+    (same mold as migration ``0010``): SQLite has no
+    ``ALTER TABLE ... DROP CONSTRAINT`` DDL, so Alembic batch mode
+    rebuilds each table under the SQLite dialect while PostgreSQL runs
+    the equivalent native ``ALTER TABLE`` statements. Every
+    pre-migration row's ``kind`` is a lowercase slug of length 2--17,
+    so no row violates the widened constraint.
+    """
+    with op.batch_alter_table("graph_node") as batch_op:
+        batch_op.drop_constraint("ck_graph_node_kind", type_="check")
+        batch_op.create_check_constraint(
+            "ck_graph_node_kind",
+            _check_kind_shape("kind"),
+        )
+
+    with op.batch_alter_table("graph_edge") as batch_op:
+        batch_op.drop_constraint("ck_graph_edge_kind", type_="check")
+        batch_op.create_check_constraint(
+            "ck_graph_edge_kind",
+            _check_kind_shape("kind"),
+        )
+
+
+def _refuse_if_rows_outside(table: str, closed_kinds: tuple[str, ...]) -> None:
+    """Raise :class:`RuntimeError` when *table* has rows outside *closed_kinds*.
+
+    The downgrade pre-check (migration ``0010``'s mold): narrowing a
+    CHECK while non-member rows exist would orphan them on next write
+    or crash opaquely mid-DDL. Counting first turns that into an
+    actionable "remove or re-classify these rows" message. Core
+    ``sa.table`` / ``sa.column`` keep the query parameterised without
+    reflecting the ORM model.
+    """
+    tbl = sa.table(table, sa.column("kind", sa.Text()))
+    count_col = sa.func.count().label("n")
+    blocking_stmt = (
+        sa.select(tbl.c.kind, count_col).where(tbl.c.kind.not_in(closed_kinds)).group_by(tbl.c.kind)
+    )
+
+    bind = op.get_bind()
+    blocking_rows = bind.execute(blocking_stmt).all()
+
+    if blocking_rows:
+        total = sum(row.n for row in blocking_rows)
+        details = ", ".join(f"{row.kind}={row.n}" for row in blocking_rows)
+        raise RuntimeError(
+            f"Cannot downgrade migration 0063: {table} contains "
+            f"{total} row(s) with kind(s) outside the closed vocabulary "
+            f"({details}) that would be orphaned by the narrowed CHECK "
+            "constraint. Remove or re-classify them before running "
+            "`alembic downgrade`."
+        )
+
+
+def downgrade() -> None:
+    """Narrow both kind CHECKs back to the closed IN-list vocabularies.
+
+    Refuses loudly (per-table pre-check) when rows with novel kinds
+    exist -- see :func:`_refuse_if_rows_outside`. Both pre-checks run
+    before any DDL so a refusal leaves the schema untouched.
+    """
+    _refuse_if_rows_outside("graph_node", _NODE_KINDS_CLOSED)
+    _refuse_if_rows_outside("graph_edge", _EDGE_KINDS_CLOSED)
+
+    with op.batch_alter_table("graph_node") as batch_op:
+        batch_op.drop_constraint("ck_graph_node_kind", type_="check")
+        batch_op.create_check_constraint(
+            "ck_graph_node_kind",
+            _check_in("kind", _NODE_KINDS_CLOSED),
+        )
+
+    with op.batch_alter_table("graph_edge") as batch_op:
+        batch_op.drop_constraint("ck_graph_edge_kind", type_="check")
+        batch_op.create_check_constraint(
+            "ck_graph_edge_kind",
+            _check_in("kind", _EDGE_KINDS_CLOSED),
+        )

--- a/backend/src/meho_backplane/api/v1/topology.py
+++ b/backend/src/meho_backplane/api/v1/topology.py
@@ -94,11 +94,11 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Any, Final
+from typing import Annotated, Any, Final
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.api.v1._envelope import ENVELOPE_QUERY, EnvelopeVersion
@@ -109,7 +109,14 @@ from meho_backplane.connectors import (
     NoMatchingConnector,
 )
 from meho_backplane.db.engine import get_raw_session
-from meho_backplane.db.models import GraphEdge, GraphEdgeKind, GraphNode
+from meho_backplane.db.models import (
+    KIND_SLUG_MAX_LENGTH,
+    KIND_SLUG_MIN_LENGTH,
+    KIND_SLUG_PATTERN,
+    GraphEdge,
+    GraphEdgeKind,
+    GraphNode,
+)
 from meho_backplane.targets.resolver import resolve_target
 from meho_backplane.topology.annotate import (
     AutoEdgeDeletionError,
@@ -707,15 +714,35 @@ class _EdgeEndpoint(BaseModel):
         return NodeRef(name=self.name, kind=self.kind)
 
 
+#: Wire type for an edge kind under the open vocabulary (T1 #2534):
+#: any lowercase slug matching
+#: :data:`~meho_backplane.db.models.KIND_SLUG_PATTERN` (2-63 chars).
+#: Pydantic enforces the same grammar the service-side
+#: :func:`~meho_backplane.db.models.is_valid_kind_slug` checks, so a
+#: malformed kind 422s at the HTTP boundary while a novel-but-valid
+#: kind (``resolves-to``, ``same-as``) passes straight through. The
+#: constraints surface as ``pattern`` / ``minLength`` / ``maxLength``
+#: in the generated OpenAPI schema (the old closed ``GraphEdgeKind``
+#: enum component becomes a plain constrained string on the wire).
+_EdgeKindSlug = Annotated[
+    str,
+    StringConstraints(
+        min_length=KIND_SLUG_MIN_LENGTH,
+        max_length=KIND_SLUG_MAX_LENGTH,
+        pattern=KIND_SLUG_PATTERN,
+    ),
+]
+
+
 class _AnnotateEdgeRequest(BaseModel):
     """Inbound body for ``POST /api/v1/topology/edges``.
 
-    ``kind`` is typed against :class:`GraphEdgeKind` so an unknown kind
+    ``kind`` is typed against :data:`_EdgeKindSlug` so a malformed kind
     fails Pydantic validation (HTTP 422) **before** the service runs —
     the service still raises :class:`InvalidEdgeKindError` for
     non-route callers, but at the HTTP boundary the operator gets the
-    standard FastAPI validation error shape (with the candidate list in
-    the error context) rather than a 500-shaped diagnostic.
+    standard FastAPI validation error shape (with the pattern in the
+    error context) rather than a 500-shaped diagnostic.
 
     The keyword ``from`` is reserved in Python so the attribute name is
     ``from_endpoint``; ``alias="from"`` keeps the wire shape the issue
@@ -732,7 +759,7 @@ class _AnnotateEdgeRequest(BaseModel):
     )
 
     from_endpoint: _EdgeEndpoint = Field(alias="from")
-    kind: GraphEdgeKind
+    kind: _EdgeKindSlug
     to_endpoint: _EdgeEndpoint = Field(alias="to")
     note: str | None = Field(default=None, max_length=2000)
     evidence_url: str | None = Field(default=None, max_length=2000)
@@ -784,24 +811,25 @@ async def annotate_edge_route(
             session,
             operator,
             body.from_endpoint.to_ref(),
-            body.kind.value,
+            body.kind,
             body.to_endpoint.to_ref(),
             note=body.note,
             evidence_url=body.evidence_url,
         )
     except InvalidEdgeKindError as exc:
-        # The Pydantic ``kind: GraphEdgeKind`` field rejects unknown
+        # The Pydantic ``kind: _EdgeKindSlug`` field rejects malformed
         # kinds at the boundary, so this branch only ever fires for a
-        # mid-flight enum widening where Pydantic accepts a value the
-        # service-layer ``_validate_kind`` does not yet recognise.
-        # Re-raise as 422 with the candidate list so the operator's
-        # diagnostic still matches the Pydantic-rejected case.
+        # drift between the wire pattern and the service-layer
+        # ``_validate_kind`` grammar. Re-raise as 422 with the pattern
+        # and the well-known suggestions so the operator's diagnostic
+        # still matches the Pydantic-rejected case.
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={
                 "error": "invalid_edge_kind",
                 "kind": exc.kind,
-                "kinds": sorted(k.value for k in GraphEdgeKind),
+                "pattern": KIND_SLUG_PATTERN,
+                "well_known_kinds": sorted(k.value for k in GraphEdgeKind),
             },
         ) from exc
     except AmbiguousNodeError as exc:
@@ -885,7 +913,7 @@ async def unannotate_edge_route(
 
 @router.get("/edges", response_model=list[TopologyEdge])
 async def list_edges_route(
-    kind: GraphEdgeKind | None = Query(default=None),
+    kind: _EdgeKindSlug | None = Query(default=None),
     source: str | None = Query(default=None, pattern="^(auto|curated)$"),
     from_name: str | None = Query(default=None, alias="from"),
     to_name: str | None = Query(default=None, alias="to"),
@@ -907,8 +935,9 @@ async def list_edges_route(
     Python keyword); the tenant boundary comes from ``operator.tenant_id``
     and is non-overrideable by query string or body.
 
-    ``kind`` is typed against :class:`GraphEdgeKind` so an unknown kind
-    is rejected at the HTTP boundary (422) before the helper runs;
+    ``kind`` is typed against :data:`_EdgeKindSlug` so a malformed kind
+    is rejected at the HTTP boundary (422) before the helper runs
+    (any well-formed slug is a legal filter — the vocabulary is open);
     ``source`` is constrained to the two ``graph_edge.source`` values
     by a regex pattern; ``conflicts=true`` forwards
     ``conflicts_only=True`` to surface the recoverability listing for
@@ -936,7 +965,7 @@ async def list_edges_route(
         edges = await list_edges(
             session,
             operator.tenant_id,
-            kind=kind.value if kind is not None else None,
+            kind=kind,
             source=source,
             from_ref=from_name,
             to_ref=to_name,
@@ -960,7 +989,7 @@ class _BulkImportEdge(BaseModel):
     Same wire shape as :class:`_AnnotateEdgeRequest` (``{from, kind, to,
     note?, evidence_url?}``) — ``from`` is bound via ``alias`` because
     it is a Python keyword. ``kind`` is typed against
-    :class:`GraphEdgeKind` so an unknown kind fails at the boundary
+    :data:`_EdgeKindSlug` so a malformed kind fails at the boundary
     (HTTP 422) before any service call runs, and the per-row error
     surfaces inside the standard FastAPI validation envelope with the
     row index in ``loc``. ``extra="forbid"`` rejects typo'd keys so a
@@ -971,7 +1000,7 @@ class _BulkImportEdge(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid", populate_by_name=True)
 
     from_endpoint: _EdgeEndpoint = Field(alias="from")
-    kind: GraphEdgeKind
+    kind: _EdgeKindSlug
     to_endpoint: _EdgeEndpoint = Field(alias="to")
     note: str | None = Field(default=None, max_length=2000)
     evidence_url: str | None = Field(default=None, max_length=2000)
@@ -1086,7 +1115,7 @@ async def bulk_import_edges_route(
     rows = [
         BulkImportRow(
             from_ref=edge.from_endpoint.to_ref(),
-            kind=edge.kind.value,
+            kind=edge.kind,
             to_ref=edge.to_endpoint.to_ref(),
             note=edge.note,
             evidence_url=edge.evidence_url,

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -233,10 +233,12 @@ References
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from datetime import UTC, datetime
 from decimal import Decimal
 from enum import StrEnum
+from typing import Final
 
 import sqlalchemy as sa
 from pgvector.sqlalchemy import Vector
@@ -261,6 +263,11 @@ from sqlalchemy.types import TypeDecorator, TypeEngine
 
 __all__ = [
     "EVENT_OUTBOX_NOTIFY_CHANNEL",
+    "KIND_SLUG_MAX_LENGTH",
+    "KIND_SLUG_MIN_LENGTH",
+    "KIND_SLUG_PATTERN",
+    "KIND_SLUG_RE",
+    "WELL_KNOWN_NODE_KINDS",
     "AgentRun",
     "AgentRunStatus",
     "AgentRunTrigger",
@@ -288,6 +295,7 @@ __all__ = [
     "TenantConvention",
     "TenantConventionHistory",
     "WebSession",
+    "is_valid_kind_slug",
 ]
 
 
@@ -1665,12 +1673,56 @@ class SpecProvenance(Base):
     )
 
 
-#: Closed enum of :attr:`GraphNode.kind` values. Mirrored verbatim in
-#: migration ``0007``'s ``_NODE_KINDS`` constant; the two MUST stay in
-#: lock-step or the DB-layer CHECK constraint will reject ORM-shaped
-#: inserts. Widening the vocabulary (G9.2's curated extensions) is a
-#: migration that updates both sides at once.
-_GRAPH_NODE_KINDS: tuple[str, ...] = (
+#: Slug grammar for :attr:`GraphNode.kind` / :attr:`GraphEdge.kind` --
+#: the open-vocabulary contract Initiative #2533 (T1 #2534) replaces the
+#: closed IN-list CHECKs with. Lowercase alphanumeric runs joined by
+#: single ``.`` / ``_`` / ``-`` separators; no leading / trailing /
+#: doubled separators. Full validation (pattern + length) lives in
+#: Python at every write boundary (:mod:`meho_backplane.topology.nodes`,
+#: :mod:`meho_backplane.topology.annotate`, the REST body models, the
+#: MCP inputSchemas); the DB layer keeps only the portable minimal
+#: shape CHECK below (length bounds + lowercase) because regex CHECKs
+#: are not portable across PostgreSQL and the SQLite unit suite.
+KIND_SLUG_PATTERN: Final[str] = r"^[a-z0-9]+(?:[._-][a-z0-9]+)*$"
+
+#: Length bounds for a kind slug. Mirrored in migration ``0063``'s
+#: shape CHECK and in every boundary schema (Pydantic
+#: ``StringConstraints``, MCP ``minLength`` / ``maxLength``).
+KIND_SLUG_MIN_LENGTH: Final[int] = 2
+KIND_SLUG_MAX_LENGTH: Final[int] = 63
+
+#: Compiled form of :data:`KIND_SLUG_PATTERN` for the Python-side
+#: validators. Module-level so the write paths don't recompile per call.
+KIND_SLUG_RE: Final[re.Pattern[str]] = re.compile(KIND_SLUG_PATTERN)
+
+
+def is_valid_kind_slug(kind: str) -> bool:
+    """Return ``True`` when *kind* satisfies the open-vocabulary slug grammar.
+
+    The single Python-side source of truth for kind validation --
+    :func:`meho_backplane.topology.nodes._validate_kind` and
+    :func:`meho_backplane.topology.annotate._validate_kind` both call
+    this, so the node and edge paths cannot drift. Checks the length
+    bounds first (the regex has no length anchor) and then the slug
+    pattern.
+    """
+    return (
+        KIND_SLUG_MIN_LENGTH <= len(kind) <= KIND_SLUG_MAX_LENGTH
+        and KIND_SLUG_RE.fullmatch(kind) is not None
+    )
+
+
+#: Well-known :attr:`GraphNode.kind` values -- the documented core set,
+#: **not** an enforced vocabulary. Initiative #2533 (T1 #2534) opened
+#: the kind space: any slug matching :data:`KIND_SLUG_PATTERN` is a
+#: valid node kind, and this tuple survives as the convention layer --
+#: docs tables, UI filter dropdowns, and error-message suggestions all
+#: source from it. Prefer a well-known kind when one fits; a novel kind
+#: (``dns-record``, ``database``, ``certificate``, ...) enters the
+#: graph through a normal write. Same open-set-plus-documented-core
+#: pattern as Backstage's well-known relations and ServiceNow's
+#: extensible CI classes.
+WELL_KNOWN_NODE_KINDS: tuple[str, ...] = (
     "target",
     "vm",
     "host",
@@ -1689,15 +1741,20 @@ _GRAPH_NODE_KINDS: tuple[str, ...] = (
 
 
 class GraphEdgeKind(StrEnum):
-    """Closed enum of :attr:`GraphEdge.kind` values -- v0.2 vocabulary.
+    """Well-known :attr:`GraphEdge.kind` values -- the documented core set.
 
-    Initiative #364 (G9.2) locks the edge-kind vocabulary at ten members:
-    the four auto-discoverable kinds G9.1 (#363) shipped, plus six
-    operator-curated cross-system kinds that auto-discovery cannot infer
-    (decision #6 in :file:`docs/planning/v0.2-decisions.md`). The vocabulary
-    is closed -- widening it is a coordinated DB + model change (new
-    migration, new enum member, new decision row) so the v0.2.next
-    policy-engine grammar parsing ``kind`` stays portable across tenants.
+    Initiative #364 (G9.2) originally locked the edge-kind vocabulary at
+    these ten members so the (never-shipped) v0.2.next policy-engine
+    grammar would stay portable across tenants. Initiative #2533 (T1
+    #2534) reversed the lock: the kind space is **open** -- any slug
+    matching :data:`KIND_SLUG_PATTERN` is a valid edge kind -- and this
+    enum survives as the *well-known* set, the convention layer that
+    feeds docs tables, UI suggestion lists (``datalist``), and
+    error-message hints. Membership is no longer enforced anywhere;
+    prefer a well-known kind when one fits, and use a novel slug
+    (``resolves-to``, ``same-as``, ...) when none does. The ``same-as``
+    curated-edge convention for cross-system identity stitching is
+    documented in :file:`docs/architecture/topology.md`.
 
     The four auto-discoverable kinds (refresh service writes these on
     every probe-derived edge):
@@ -1730,11 +1787,11 @@ class GraphEdgeKind(StrEnum):
       connector boundaries (e.g., ``kubernetes-namespace-prod`` ->
       ``vault-policy-prod-read``).
 
-    Mirrors the closed-enum pattern :class:`AuthModel`
-    (:mod:`meho_backplane.connectors.schemas`) sets: a Python
-    :class:`enum.StrEnum` paired with a portable DB ``CHECK`` constraint,
-    both moved in lock-step by one Alembic migration so the enum and the
-    constraint cannot drift.
+    Unlike the closed-enum pattern :class:`AuthModel` follows, this
+    enum is **not** paired with a membership CHECK constraint --
+    migration ``0063`` replaced ``ck_graph_edge_kind``'s IN-list with
+    the minimal slug-shape CHECK (length bounds + lowercase), and full
+    slug validation lives Python-side via :func:`is_valid_kind_slug`.
     """
 
     RUNS_ON = "runs-on"
@@ -1749,13 +1806,6 @@ class GraphEdgeKind(StrEnum):
     POLICY_BINDS = "policy-binds"
 
 
-#: Closed enum of :attr:`GraphEdge.kind` -- the v0.2 ten-kind vocabulary.
-#: Derived from :class:`GraphEdgeKind` so the enum and the CHECK constraint
-#: cannot drift; the drift guard
-#: :func:`tests.test_topology_schema.test_graph_edge_kinds_match_enum`
-#: enforces the equality at unit-test time.
-_GRAPH_EDGE_KINDS: tuple[str, ...] = tuple(k.value for k in GraphEdgeKind)
-
 #: Closed enum of :attr:`GraphEdge.source` -- ``auto`` for
 #: probe-derived edges (T3 refresh), ``curated`` reserved for the
 #: operator-asserted edges G9.2 lands. v0.2 writes ``auto`` exclusively.
@@ -1767,6 +1817,24 @@ def _ck_in(column: str, values: tuple[str, ...]) -> str:
     return f"{column} IN ({', '.join(f"'{v}'" for v in values)})"
 
 
+def _ck_kind_shape(column: str) -> str:
+    """Render the portable minimal shape CHECK for an open kind column.
+
+    Length bounds plus a lowercase guard -- ``length()`` and ``lower()``
+    are portable across PostgreSQL 16 and SQLite, while regex CHECKs
+    are not (PG's ``~`` operator has no SQLite equivalent). The full
+    slug grammar (:data:`KIND_SLUG_PATTERN`) is enforced Python-side
+    at every write boundary; this CHECK is the DB-layer backstop that
+    keeps out-of-band inserts from landing obviously-malformed kinds.
+    Mirrored verbatim in migration ``0063``.
+    """
+    return (
+        f"length({column}) >= {KIND_SLUG_MIN_LENGTH} "
+        f"AND length({column}) <= {KIND_SLUG_MAX_LENGTH} "
+        f"AND {column} = lower({column})"
+    )
+
+
 class GraphNode(Base):
     """A node in the per-tenant topology graph.
 
@@ -1774,8 +1842,10 @@ class GraphNode(Base):
     one object an agent may need to reason about: a registered target,
     a VM, a host, a network, a datastore, a namespace, a pod, a
     service, an ingress, a node, a principal, a vault mount, a vault
-    role, a volume. The closed enum (``kind``) is documented on the
-    migration; widening it is a coordinated DB + model change.
+    role, a volume -- or any other resource class a connector or
+    operator needs to represent: ``kind`` is an open slug-validated
+    vocabulary (T1 #2534), with :data:`WELL_KNOWN_NODE_KINDS` as the
+    documented core set.
 
     Schema decisions for :class:`GraphNode`:
 
@@ -1795,9 +1865,11 @@ class GraphNode(Base):
       ``ondelete`` clause -- tenant deletion is a major operation
       that must clear the tenant's graph first; the default
       ``NO ACTION`` blocks the cascade.
-    * ``kind`` -- Text NOT NULL with a DB-layer
-      ``CHECK kind IN (...)`` constraint enforced by migration
-      ``0007`` (see :data:`_GRAPH_NODE_KINDS` for the v0.2 vocabulary).
+    * ``kind`` -- Text NOT NULL with a DB-layer minimal shape CHECK
+      (length 2--63, lowercase; migration ``0063``). The vocabulary is
+      open: full slug validation (:data:`KIND_SLUG_PATTERN`) runs
+      Python-side at every write boundary, and
+      :data:`WELL_KNOWN_NODE_KINDS` documents the core set.
     * ``name`` -- Text NOT NULL. Human-readable handle within the
       tenant + kind axis. Uniqueness is enforced by the named
       ``graph_node_tenant_kind_name_idx`` (unique b-tree on
@@ -1887,7 +1959,7 @@ class GraphNode(Base):
             postgresql_using="btree",
         ),
         sa.CheckConstraint(
-            _ck_in("kind", _GRAPH_NODE_KINDS),
+            _ck_kind_shape("kind"),
             name="ck_graph_node_kind",
         ),
     )
@@ -1914,15 +1986,12 @@ class GraphEdge(Base):
       soft-deletes (``GraphNode.last_seen=NULL``) leave the edges
       alone, so the cascade is invisible during normal operation and
       exists only for tenant purges + test cleanup.
-    * ``kind`` -- Text NOT NULL with a DB-layer
-      ``CHECK kind IN (...)`` constraint. The closed v0.2 ten-kind
-      vocabulary is :class:`GraphEdgeKind` -- four auto-discoverable
-      kinds (refresh writes these) plus six curated-only kinds
-      (operator annotation only). :data:`_GRAPH_EDGE_KINDS` is derived
-      from the enum so the CHECK constraint and the Python type cannot
-      drift; widening requires a new Alembic migration that updates
-      both in lock-step (G9.2 #364 / migration ``0010`` was the first
-      widening, from G9.1's four to v0.2's ten).
+    * ``kind`` -- Text NOT NULL with a DB-layer minimal shape CHECK
+      (length 2--63, lowercase; migration ``0063``). The vocabulary is
+      open: full slug validation (:data:`KIND_SLUG_PATTERN`) runs
+      Python-side at every write boundary, and :class:`GraphEdgeKind`
+      documents the well-known core set (four auto-discoverable kinds
+      the refresh service writes plus six curated cross-system kinds).
     * ``source`` -- Text NOT NULL with a DB-layer
       ``CHECK source IN (...)`` constraint. ``auto`` for
       probe-derived (T3 refresh); ``curated`` for the
@@ -2022,7 +2091,7 @@ class GraphEdge(Base):
             postgresql_using="btree",
         ),
         sa.CheckConstraint(
-            _ck_in("kind", _GRAPH_EDGE_KINDS),
+            _ck_kind_shape("kind"),
             name="ck_graph_edge_kind",
         ),
         sa.CheckConstraint(
@@ -2240,8 +2309,9 @@ class GraphHistoryChangeKind(StrEnum):
 #: Derived from :class:`GraphHistoryChangeKind` so the enum and the
 #: DB-layer ``CHECK`` constraint cannot drift; the drift guard at
 #: :mod:`tests.test_topology_history_migration` enforces the equality
-#: at unit-test time. Mirrors the :data:`_GRAPH_EDGE_KINDS` pattern
-#: :class:`GraphEdge` uses.
+#: at unit-test time. (The graph ``kind`` columns dropped this
+#: derived-tuple pattern when T1 #2534 opened their vocabularies;
+#: ``change_kind`` remains a genuinely closed enum.)
 _GRAPH_HISTORY_CHANGE_KINDS: tuple[str, ...] = tuple(k.value for k in GraphHistoryChangeKind)
 
 

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -90,7 +90,13 @@ from sqlalchemy import select
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import GraphEdgeKind, Tenant
+from meho_backplane.db.models import (
+    KIND_SLUG_MAX_LENGTH,
+    KIND_SLUG_MIN_LENGTH,
+    KIND_SLUG_PATTERN,
+    GraphEdgeKind,
+    Tenant,
+)
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
@@ -160,11 +166,12 @@ _TIMELINE_LIMIT_MAX: Final[int] = 1000
 #: don't (same reasoning T3 used for the REST and CLI defaults).
 _HISTORY_LIMIT_MAX: Final[int] = 5000
 
-#: Canonical ``GraphEdgeKind`` values, materialised once at module load
-#: so the inputSchema enum + the kind_filter description stay in lock-step
-#: with :class:`~meho_backplane.db.models.GraphEdgeKind` without
-#: duplicating the ten-string list. A future widening of the enum
-#: surfaces in both the schema and the description automatically.
+#: Well-known ``GraphEdgeKind`` values, materialised once at module
+#: load so the inputSchema descriptions' suggestion lists stay in
+#: lock-step with :class:`~meho_backplane.db.models.GraphEdgeKind`
+#: without duplicating the ten-string list. The vocabulary is open
+#: (T1 #2534): the write schemas constrain `kind` by slug pattern,
+#: not by membership, and this list is advisory.
 _EDGE_KIND_VALUES: Final[list[str]] = sorted(k.value for k in GraphEdgeKind)
 
 
@@ -250,8 +257,9 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
                 "kinds, restricts the walk to edges of that kind "
                 "(e.g. `runs-on`, `mounts`, `routes-through`, "
                 "`belongs-to`). For `kind=edges`, restricts the flat "
-                "listing to edges of that kind. Closed v0.2 vocabulary: "
-                f"one of {_EDGE_KIND_VALUES}. Ignored for `path`."
+                "listing to edges of that kind. The vocabulary is "
+                f"open; well-known kinds: {_EDGE_KIND_VALUES}. "
+                "Ignored for `path`."
             ),
             "maxLength": 64,
         },
@@ -1412,16 +1420,26 @@ _ANNOTATE_INPUT_SCHEMA: Final[dict[str, Any]] = {
         },
         "kind": {
             "type": "string",
-            "enum": _EDGE_KIND_VALUES,
+            "pattern": KIND_SLUG_PATTERN,
+            "minLength": KIND_SLUG_MIN_LENGTH,
+            "maxLength": KIND_SLUG_MAX_LENGTH,
             "description": (
-                "Closed v0.2 edge-kind vocabulary. Operator-curated "
-                "kinds (`authenticates-via`, `depends-on`, "
+                "Edge kind: a lowercase slug (letters/digits joined "
+                "by `.`, `_` or `-`; 2-63 chars). The vocabulary is "
+                "open — any slug matching the pattern is accepted — "
+                "but prefer a well-known kind when one fits. "
+                "Operator-curated well-known kinds "
+                "(`authenticates-via`, `depends-on`, "
                 "`replicates-to`, `backed-up-by`, `routes-via`, "
                 "`policy-binds`) cover the cross-system relationships "
                 "auto-discovery cannot infer — those are the canonical "
                 "use cases. The four auto-discoverable kinds "
                 "(`runs-on`, `mounts`, `routes-through`, `belongs-to`) "
-                "are accepted too. A curated assertion of an auto-kind "
+                "are accepted too, as are novel kinds "
+                "(`resolves-to`, `same-as`, ...) when no well-known "
+                "kind describes the relationship — `same-as` is the "
+                "documented convention for cross-system identity "
+                "stitching. A curated assertion of an auto-kind "
                 "lands as a §6 conflict marker *only when a competing "
                 "**auto** edge already exists for that pair* — i.e. on "
                 "a pair a probe covers (today, only the Kubernetes "
@@ -1557,10 +1575,11 @@ async def _annotate_handler(
       ``-32602`` (operator-actionable input problem; same shape the
       closure kinds use).
     * :class:`InvalidEdgeKindError` is structurally unreachable —
-      ``kind`` is enum-pinned by the inputSchema — but the catch is
-      retained as a belt-and-suspenders guard against a future enum
-      drift between :class:`GraphEdgeKind` and the cached
-      :data:`_EDGE_KIND_VALUES`.
+      ``kind`` is pattern-pinned by the inputSchema and the service
+      validates the same slug grammar — but the catch is retained as
+      a belt-and-suspenders guard against a future drift between the
+      schema's ``pattern`` and the service-side
+      :data:`~meho_backplane.db.models.KIND_SLUG_PATTERN`.
     """
     sessionmaker = get_sessionmaker()
     from_name: str = arguments["from_name"]
@@ -1686,9 +1705,12 @@ _UNANNOTATE_INPUT_SCHEMA: Final[dict[str, Any]] = {
         },
         "kind": {
             "type": "string",
-            "enum": list(_EDGE_KIND_VALUES),
+            "pattern": KIND_SLUG_PATTERN,
+            "minLength": KIND_SLUG_MIN_LENGTH,
+            "maxLength": KIND_SLUG_MAX_LENGTH,
             "description": (
-                "Triple selector: the edge's `graph_edge.kind`. Must "
+                "Triple selector: the edge's `graph_edge.kind` (any "
+                "lowercase kind slug; the vocabulary is open). Must "
                 "appear together with `from_name` and `to_name`."
             ),
         },

--- a/backend/src/meho_backplane/mcp/tools/topology_create_node.py
+++ b/backend/src/meho_backplane/mcp/tools/topology_create_node.py
@@ -39,7 +39,12 @@ from typing import Any, Final
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import _GRAPH_NODE_KINDS
+from meho_backplane.db.models import (
+    KIND_SLUG_MAX_LENGTH,
+    KIND_SLUG_MIN_LENGTH,
+    KIND_SLUG_PATTERN,
+    WELL_KNOWN_NODE_KINDS,
+)
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.topology.nodes import (
@@ -52,12 +57,12 @@ __all__: list[str] = []
 
 _CREATE_NODE_TOOL_NAME: Final[str] = "meho.topology.create_node"
 
-#: Closed v0.2 graph-node vocabulary, materialised once at module
-#: load. Sourced from :data:`_GRAPH_NODE_KINDS` so a future widening of
-#: the kind set surfaces in the inputSchema enum automatically — same
-#: lock-step discipline ``mcp.tools.topology`` uses for
-#: :data:`_EDGE_KIND_VALUES`.
-_NODE_KIND_VALUES: Final[list[str]] = sorted(_GRAPH_NODE_KINDS)
+#: Well-known graph-node kinds, materialised once at module load.
+#: Sourced from :data:`WELL_KNOWN_NODE_KINDS` so the description's
+#: suggestion list tracks the documented core set automatically. The
+#: vocabulary is open (T1 #2534): the schema constrains `kind` by slug
+#: pattern, not by membership.
+_NODE_KIND_VALUES: Final[list[str]] = sorted(WELL_KNOWN_NODE_KINDS)
 
 
 _CREATE_NODE_INPUT_SCHEMA: Final[dict[str, Any]] = {
@@ -65,13 +70,18 @@ _CREATE_NODE_INPUT_SCHEMA: Final[dict[str, Any]] = {
     "properties": {
         "kind": {
             "type": "string",
-            "enum": _NODE_KIND_VALUES,
+            "pattern": KIND_SLUG_PATTERN,
+            "minLength": KIND_SLUG_MIN_LENGTH,
+            "maxLength": KIND_SLUG_MAX_LENGTH,
             "description": (
-                "Closed v0.2 graph-node-kind vocabulary. The four "
-                "auto-discoverable kinds (`target`, `vm`, `host`, "
-                "`pod`, ...) are accepted here too — manual seeds are "
-                "useful when an agent needs to assert a curated edge "
-                "against a target that has not yet been refreshed. "
+                "Node kind: a lowercase slug (letters/digits joined "
+                "by `.`, `_` or `-`; 2-63 chars). The vocabulary is "
+                "open — any slug matching the pattern is accepted — "
+                "but prefer a well-known kind when one fits: "
+                + ", ".join(f"`{k}`" for k in _NODE_KIND_VALUES)
+                + ". Novel kinds (`dns-record`, `keycloak-realm`, "
+                "`database`, ...) are the right call when no "
+                "well-known kind describes the resource class. "
                 "Inner-graph kinds like `vault-role`, `vault-mount`, "
                 "`principal` are the canonical use case: those rows "
                 "cannot be auto-discovered (no probe walks the Vault "
@@ -157,17 +167,18 @@ async def _create_node_handler(
     """Dispatch a ``meho.topology.create_node`` call to :func:`create_or_get_node`.
 
     The dispatcher has already jsonschema-validated *arguments* against
-    :data:`_CREATE_NODE_INPUT_SCHEMA`, so ``kind`` is guaranteed to be
-    in the closed vocabulary and ``name`` is guaranteed non-empty.
+    :data:`_CREATE_NODE_INPUT_SCHEMA`, so ``kind`` is guaranteed to
+    match the slug pattern and ``name`` is guaranteed non-empty.
     Tenant scope comes from *operator* inside the service — never from
     *arguments* (``additionalProperties: false`` already rejects a
     smuggled ``tenant_id`` at the schema layer).
 
     :class:`InvalidNodeKindError` is structurally unreachable from this
-    front — ``kind`` is enum-pinned by the inputSchema — but the catch
-    is retained as a belt-and-suspenders guard against a future enum
-    drift between :data:`_GRAPH_NODE_KINDS` and the cached
-    :data:`_NODE_KIND_VALUES`.
+    front — ``kind`` is pattern-pinned by the inputSchema and the
+    service validates the same grammar — but the catch is retained as
+    a belt-and-suspenders guard against a future drift between the
+    schema's ``pattern`` and the service-side
+    :data:`~meho_backplane.db.models.KIND_SLUG_PATTERN`.
     """
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:

--- a/backend/src/meho_backplane/topology/__init__.py
+++ b/backend/src/meho_backplane/topology/__init__.py
@@ -47,7 +47,8 @@ NULL``) as well as registered targets.
 
 **Annotate / unannotate — Task #595 (G9.2-T3):** the curated-edge
 write service. Resolves both endpoints, validates ``kind`` against
-:class:`~meho_backplane.db.models.GraphEdgeKind`, runs §6 conflict
+the open slug grammar
+(:data:`~meho_backplane.db.models.KIND_SLUG_PATTERN`), runs §6 conflict
 detection (sticky ``superseded_by`` for same-kind/different-endpoint
 auto edges; bidirectional ``conflicts_with`` for incompatible kinds
 over the same endpoint pair), and writes one audit row + one

--- a/backend/src/meho_backplane/topology/annotate.py
+++ b/backend/src/meho_backplane/topology/annotate.py
@@ -20,9 +20,11 @@ off — they own:
    impossible by construction (the resolver scopes on
    ``operator.tenant_id``).
 
-2. **Kind validation** against :class:`GraphEdgeKind` (#593). The closed
-   v0.2 ten-kind vocabulary is the load-bearing modeling decision; a
-   typo'd / made-up kind never reaches the DB-layer CHECK.
+2. **Kind validation** against the open slug grammar
+   (:data:`~meho_backplane.db.models.KIND_SLUG_PATTERN`, T1 #2534). Any
+   lowercase slug (2-63 chars) is a valid edge kind; the ten
+   :class:`GraphEdgeKind` members survive as the documented well-known
+   set. A malformed kind never reaches the DB-layer CHECK.
 
 3. **Idempotent upsert** keyed on
    ``graph_edge_tenant_endpoints_kind_idx`` (``(tenant_id,
@@ -83,11 +85,15 @@ from sqlalchemy import select
 
 from meho_backplane.broadcast import BroadcastEvent, publish_event
 from meho_backplane.db.models import (
+    KIND_SLUG_MAX_LENGTH,
+    KIND_SLUG_MIN_LENGTH,
+    KIND_SLUG_PATTERN,
     AuditLog,
     GraphEdge,
     GraphEdgeKind,
     GraphHistoryChangeKind,
     GraphNode,
+    is_valid_kind_slug,
 )
 from meho_backplane.topology.history import (
     edge_snapshot,
@@ -176,20 +182,23 @@ class NodeRef:
 
 
 class InvalidEdgeKindError(ValueError):
-    """The supplied ``kind`` is not in the v0.2 :class:`GraphEdgeKind` enum.
+    """The supplied ``kind`` is not a valid kind slug.
 
-    Raised by :func:`annotate_edge` before any DB write — the closed
-    enum is the policy-layer grammar's first guard rail. The API layer
-    maps it to a 422 with the supplied value and the candidate list in
-    ``detail``; CLI maps it to a usage error with the same candidate
-    list.
+    Raised by :func:`annotate_edge` before any DB write — the slug
+    grammar (T1 #2534's open vocabulary) is the first guard rail. The
+    API layer maps it to a 422 with the supplied value, the pattern,
+    and the well-known suggestions in ``detail``; CLI maps it to a
+    usage error with the same hints.
     """
 
     def __init__(self, kind: str) -> None:
         self.kind = kind
-        valid = sorted(k.value for k in GraphEdgeKind)
+        well_known = sorted(k.value for k in GraphEdgeKind)
         super().__init__(
-            f"edge kind {kind!r} is not in the v0.2 vocabulary; valid kinds: {valid!r}"
+            f"edge kind {kind!r} is not a valid kind slug (pattern "
+            f"{KIND_SLUG_PATTERN}, {KIND_SLUG_MIN_LENGTH}-"
+            f"{KIND_SLUG_MAX_LENGTH} chars); well-known kinds: "
+            f"{well_known!r}"
         )
 
 
@@ -242,17 +251,17 @@ class AnnotateConflictError(ValueError):
 
 
 def _validate_kind(kind: str) -> str:
-    """Validate ``kind`` against :class:`GraphEdgeKind`; return the value.
+    """Validate ``kind`` against the open slug grammar; return the value.
 
-    The enum membership check is the first guard rail — failing here
-    avoids a more obscure DB ``CHECK`` violation later. Returns the
-    canonical string form so subsequent code uses the StrEnum value,
-    not the raw input (defensive against future kind aliases).
+    The slug check is the first guard rail — failing here avoids a
+    more obscure DB ``CHECK`` violation later. Any slug matching
+    :data:`~meho_backplane.db.models.KIND_SLUG_PATTERN` (2-63 chars)
+    is accepted (T1 #2534's open vocabulary); :class:`GraphEdgeKind`
+    membership is a documentation convention, not a gate.
     """
-    try:
-        return GraphEdgeKind(kind).value
-    except ValueError as exc:
-        raise InvalidEdgeKindError(kind) from exc
+    if not is_valid_kind_slug(kind):
+        raise InvalidEdgeKindError(kind)
+    return kind
 
 
 async def _find_existing_edge(
@@ -632,8 +641,8 @@ async def annotate_edge(
     """Create or refresh a curated ``graph_edge`` row + apply §6 conflicts.
 
     Resolves the two endpoints in ``operator.tenant_id`` via
-    :func:`resolve_node` (#594), validates ``kind`` against
-    :class:`GraphEdgeKind` (#593), then:
+    :func:`resolve_node` (#594), validates ``kind`` against the open
+    slug grammar (T1 #2534), then:
 
     * If a row already exists for ``(tenant_id, from_node_id,
       to_node_id, kind)`` (the
@@ -670,8 +679,11 @@ async def annotate_edge(
             (T5 #597) — the service trusts its caller.
         from_ref: Operator-supplied :class:`NodeRef` for the
             ``from`` endpoint.
-        kind: One of the v0.2 :class:`GraphEdgeKind` values.
-            Wrong value raises :class:`InvalidEdgeKindError`.
+        kind: Any slug matching
+            :data:`~meho_backplane.db.models.KIND_SLUG_PATTERN`
+            (2-63 chars); prefer a :class:`GraphEdgeKind` member when
+            one fits. A malformed slug raises
+            :class:`InvalidEdgeKindError`.
         to_ref: Operator-supplied :class:`NodeRef` for the
             ``to`` endpoint.
         note: Optional free-text annotation. Stored on
@@ -684,8 +696,7 @@ async def annotate_edge(
         The created or refreshed :class:`GraphEdge` row (post-commit).
 
     Raises:
-        InvalidEdgeKindError: ``kind`` not in
-            :class:`GraphEdgeKind`.
+        InvalidEdgeKindError: ``kind`` is not a valid kind slug.
         NodeNotFoundError: Either endpoint does not exist in this
             tenant.
         AmbiguousNodeError: An endpoint's name is ambiguous across
@@ -1347,8 +1358,8 @@ async def unannotate_edge(
         AmbiguousNodeError: A triple-form endpoint's name is
             ambiguous and no ``kind`` was pinned on the ``NodeRef``.
         AutoEdgeDeletionError: The targeted row has ``source='auto'``.
-        InvalidEdgeKindError: A triple-form ``kind`` is not in
-            :class:`GraphEdgeKind`.
+        InvalidEdgeKindError: A triple-form ``kind`` is not a valid
+            kind slug.
         ValueError: The triple form resolves to no row.
     """
     _check_unannotate_selectors(edge_id=edge_id, from_ref=from_ref, kind=kind, to_ref=to_ref)

--- a/backend/src/meho_backplane/topology/bulk_import.py
+++ b/backend/src/meho_backplane/topology/bulk_import.py
@@ -226,7 +226,8 @@ async def bulk_import_edges(
     The function performs two passes:
 
     1. **Validation pass.** Resolves both endpoints of every row,
-       canonicalises the ``kind`` against :class:`GraphEdgeKind`, and
+       validates the ``kind`` against the open slug grammar
+       (:data:`~meho_backplane.db.models.KIND_SLUG_PATTERN`), and
        records what the apply pass would do (``create`` for a row that
        does not yet exist; ``update`` for a row that matches an
        existing ``(tenant, from, to, kind)``; ``conflict`` for a row
@@ -447,8 +448,9 @@ async def _classify_row(
         _RowValidationError: Any of the three validation surfaces
             failed for this row.
     """
-    # Validate kind first — fail-fast on a typo before doing any
-    # node-resolution IO.
+    # Validate kind first — fail-fast on a malformed slug before doing
+    # any node-resolution IO. `kinds` carries the well-known set as
+    # suggestions (the vocabulary is open; membership is not enforced).
     try:
         canonical_kind = _validate_kind(row.kind)
     except InvalidEdgeKindError as exc:

--- a/backend/src/meho_backplane/topology/nodes.py
+++ b/backend/src/meho_backplane/topology/nodes.py
@@ -62,10 +62,14 @@ from sqlalchemy import select
 
 from meho_backplane.broadcast import BroadcastEvent, publish_event
 from meho_backplane.db.models import (
-    _GRAPH_NODE_KINDS,
+    KIND_SLUG_MAX_LENGTH,
+    KIND_SLUG_MIN_LENGTH,
+    KIND_SLUG_PATTERN,
+    WELL_KNOWN_NODE_KINDS,
     AuditLog,
     GraphHistoryChangeKind,
     GraphNode,
+    is_valid_kind_slug,
 )
 from meho_backplane.topology.history import node_snapshot, record_node_change
 
@@ -115,21 +119,24 @@ _CREATE_NODE_HEARTBEAT_PROPERTY_KEYS: tuple[str, ...] = ("seeded_at",)
 
 
 class InvalidNodeKindError(ValueError):
-    """The supplied ``kind`` is not in the v0.2 ``_GRAPH_NODE_KINDS`` vocabulary.
+    """The supplied ``kind`` is not a valid kind slug.
 
     Raised by :func:`create_or_get_node` before any DB write — the
-    closed enum is the policy-layer grammar's first guard rail and
-    failing here avoids a more obscure DB ``CHECK ck_graph_node_kind``
-    violation later. The MCP layer maps it to a JSON-RPC ``-32602``
-    with the candidate list echoed in the message; the REST layer (when
-    one lands) would map it to a 422.
+    slug grammar (T1 #2534's open vocabulary) is the first guard rail
+    and failing here avoids a more obscure DB ``CHECK
+    ck_graph_node_kind`` violation later. The MCP layer maps it to a
+    JSON-RPC ``-32602`` with the pattern and the well-known suggestions
+    echoed in the message; the REST layer (when one lands) would map it
+    to a 422.
     """
 
     def __init__(self, kind: str) -> None:
         self.kind = kind
         super().__init__(
-            f"node kind {kind!r} is not in the v0.2 vocabulary; "
-            f"valid kinds: {list(_GRAPH_NODE_KINDS)!r}"
+            f"node kind {kind!r} is not a valid kind slug (pattern "
+            f"{KIND_SLUG_PATTERN}, {KIND_SLUG_MIN_LENGTH}-"
+            f"{KIND_SLUG_MAX_LENGTH} chars); well-known kinds: "
+            f"{sorted(WELL_KNOWN_NODE_KINDS)!r}"
         )
 
 
@@ -151,15 +158,17 @@ class CreateNodeResult:
 
 
 def _validate_kind(kind: str) -> str:
-    """Validate ``kind`` against :data:`_GRAPH_NODE_KINDS`; return the value.
+    """Validate ``kind`` against the open slug grammar; return the value.
 
-    Mirrors :func:`annotate._validate_kind`'s shape — the closed enum
+    Mirrors :func:`annotate._validate_kind`'s shape — the slug check
     is the first guard rail, failing here avoids a more obscure DB
-    ``CHECK`` violation later. Returns the canonical string (the
-    constant itself, not the raw input) so subsequent code uses the
-    vocabulary value, not whatever the caller typed.
+    ``CHECK`` violation later. Any slug matching
+    :data:`~meho_backplane.db.models.KIND_SLUG_PATTERN` (2-63 chars)
+    is accepted (T1 #2534's open vocabulary); membership in
+    :data:`~meho_backplane.db.models.WELL_KNOWN_NODE_KINDS` is a
+    documentation convention, not a gate.
     """
-    if kind not in _GRAPH_NODE_KINDS:
+    if not is_valid_kind_slug(kind):
         raise InvalidNodeKindError(kind)
     return kind
 
@@ -305,10 +314,10 @@ async def create_or_get_node(
     :func:`~meho_backplane.topology.annotate.annotate_edge` to assert
     the cross-system edge between them.
 
-    Validates ``kind`` against the closed
-    :data:`~meho_backplane.db.models._GRAPH_NODE_KINDS` vocabulary
-    *before* any DB write — raises :class:`InvalidNodeKindError` so a
-    typo never reaches the DB-layer CHECK.
+    Validates ``kind`` against the open slug grammar
+    (:data:`~meho_backplane.db.models.KIND_SLUG_PATTERN`) *before* any
+    DB write — raises :class:`InvalidNodeKindError` so a malformed
+    kind never reaches the DB-layer CHECK.
 
     Idempotency keyed on the unique
     ``graph_node_tenant_kind_name_idx`` (``(tenant_id, kind, name)``):
@@ -358,9 +367,12 @@ async def create_or_get_node(
             audit attribution. Role gating (``tenant_admin``) is the
             front layer's job (MCP / REST); the service trusts its
             caller.
-        kind: One of the v0.2
-            :data:`~meho_backplane.db.models._GRAPH_NODE_KINDS` values.
-            Wrong value raises :class:`InvalidNodeKindError`.
+        kind: Any slug matching
+            :data:`~meho_backplane.db.models.KIND_SLUG_PATTERN`
+            (2-63 chars); prefer a
+            :data:`~meho_backplane.db.models.WELL_KNOWN_NODE_KINDS`
+            member when one fits. A malformed slug raises
+            :class:`InvalidNodeKindError`.
         name: ``graph_node.name``. Must be non-empty (the MCP
             inputSchema enforces ``minLength=1`` before the call).
         note: Optional free-text annotation. Stored on
@@ -374,8 +386,7 @@ async def create_or_get_node(
         row + ``was_created`` flag.
 
     Raises:
-        InvalidNodeKindError: ``kind`` not in
-            :data:`_GRAPH_NODE_KINDS`.
+        InvalidNodeKindError: ``kind`` is not a valid kind slug.
     """
     canonical_kind = _validate_kind(kind)
     # Pre-allocate ``audit_id`` so the history row's ``audit_id``

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -848,10 +848,10 @@ async def list_edges(
             commits, no flushes.
         tenant_id: The tenant scope. Mandatory and non-optional — there
             is no "list every edge across tenants" mode by construction.
-        kind: Optional :class:`~meho_backplane.db.models.GraphEdgeKind`
-            filter (one of the ten v0.2 vocabulary values). The CHECK
-            constraint already restricts the column; this filter
-            narrows the listing.
+        kind: Optional exact-match ``graph_edge.kind`` filter (any
+            kind slug; the vocabulary is open per T1 #2534, with
+            :class:`~meho_backplane.db.models.GraphEdgeKind` as the
+            well-known set). This filter narrows the listing.
         source: Optional ``graph_edge.source`` filter (``'auto'`` for
             probe-derived edges, ``'curated'`` for operator-asserted
             ones — see :class:`~meho_backplane.db.models.GraphEdge`).
@@ -1085,10 +1085,10 @@ async def list_nodes(
             across tenants" mode by construction. The first SQL WHERE
             clause is always ``graph_node.tenant_id = :tenant_id``;
             no filter combination overrides it.
-        kind: Optional exact-match ``graph_node.kind`` filter (one of
-            :data:`meho_backplane.db.models._GRAPH_NODE_KINDS`). The
-            CHECK constraint already restricts the column; this
-            narrows the listing.
+        kind: Optional exact-match ``graph_node.kind`` filter (any
+            kind slug; the vocabulary is open per T1 #2534, with
+            :data:`meho_backplane.db.models.WELL_KNOWN_NODE_KINDS` as
+            the well-known set). This narrows the listing.
         name_contains: Optional case-insensitive substring filter on
             ``graph_node.name``. Uses SQLAlchemy ``ilike`` with the
             user-controllable input wrapped in ``%`` on both sides;

--- a/backend/src/meho_backplane/ui/routes/topology/batch.py
+++ b/backend/src/meho_backplane/ui/routes/topology/batch.py
@@ -150,9 +150,10 @@ _EDGE_CHANGED_EVENT = "meho:topology-edge-changed"
 #: ``targets.yaml`` import surface's ``_YAML_MAX_BYTES``.
 _BULK_MAX_BYTES = 256 * 1024
 
-#: The closed edge-kind vocabulary surfaced to the panel (single source of
-#: truth — a future widening of :class:`GraphEdgeKind` lands in the panel's
-#: hint list for free).
+#: The well-known edge kinds surfaced to the panel's hint list. The
+#: vocabulary is open (T1 #2534) — any valid kind slug is accepted per
+#: row — so this list is advisory (single source of truth: a future
+#: widening of :class:`GraphEdgeKind` lands in the hint list for free).
 _EDGE_KIND_OPTIONS = [k.value for k in GraphEdgeKind]
 
 

--- a/backend/src/meho_backplane/ui/routes/topology/batch_parse.py
+++ b/backend/src/meho_backplane/ui/routes/topology/batch_parse.py
@@ -19,7 +19,7 @@ list of ``{from, kind, to, note?, evidence_url?}`` rows, where ``from`` /
 resolves the paste-vs-upload precedence, decodes the bytes, and coerces every
 row into a :class:`~meho_backplane.topology.bulk_import.BulkImportRow`; the
 ``kind`` is forwarded verbatim so the service's per-row ``invalid_bulk``
-aggregation surfaces an out-of-vocabulary kind alongside every other bad row.
+aggregation surfaces a malformed kind slug alongside every other bad row.
 """
 
 from __future__ import annotations
@@ -110,9 +110,10 @@ def _row_from_mapping(row: Any, *, index: int) -> BulkImportRow:
 
     Validates the row is a mapping carrying ``from`` / ``kind`` / ``to`` and
     coerces the endpoints + optional ``note`` / ``evidence_url``. The
-    ``kind`` is forwarded verbatim — the service canonicalises it against
-    :class:`~meho_backplane.db.models.GraphEdgeKind` and aggregates an
-    out-of-vocabulary kind into the per-row ``invalid_bulk`` error, so the
+    ``kind`` is forwarded verbatim — the service validates it against the
+    open slug grammar
+    (:data:`~meho_backplane.db.models.KIND_SLUG_PATTERN`) and aggregates a
+    malformed kind into the per-row ``invalid_bulk`` error, so the
     panel surfaces it alongside every other bad row rather than aborting here
     on the first one.
 

--- a/backend/src/meho_backplane/ui/routes/topology/edges.py
+++ b/backend/src/meho_backplane/ui/routes/topology/edges.py
@@ -143,9 +143,11 @@ _EDGE_CHANGED_EVENT = "meho:topology-edge-changed"
 _MAX_NOTE_LENGTH = 2000
 _MAX_EVIDENCE_URL_LENGTH = 2000
 
-#: The closed v0.2 edge-kind vocabulary, surfaced to the modal's ``kind``
-#: dropdown. Sourced from the enum (single source of truth) so a future
-#: widening of :class:`GraphEdgeKind` lands in the modal for free.
+#: The well-known edge kinds, surfaced to the modal's ``kind`` field as
+#: ``datalist`` suggestions. The vocabulary is open (T1 #2534): the
+#: modal accepts any slug matching the kind grammar and the service
+#: validates it; this list is advisory. Sourced from the enum so a
+#: future widening of :class:`GraphEdgeKind` lands in the modal for free.
 _EDGE_KIND_OPTIONS = [k.value for k in GraphEdgeKind]
 
 

--- a/backend/src/meho_backplane/ui/routes/topology/graph.py
+++ b/backend/src/meho_backplane/ui/routes/topology/graph.py
@@ -66,7 +66,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from meho_backplane.db.models import _GRAPH_NODE_KINDS, GraphEdge, GraphNode
+from meho_backplane.db.models import WELL_KNOWN_NODE_KINDS, GraphEdge, GraphNode
 from meho_backplane.topology.query import TopologyNodeListEntry, list_nodes
 from meho_backplane.ui.auth.middleware import UISessionContext
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
@@ -352,11 +352,12 @@ def _build_template_context(
     -- every key is consumed by ``topology/graph.html``.
 
     ``node_kind_options`` mirrors the T1 (#880) ``table.py`` pattern of
-    sourcing the kind filter dropdown from the closed enum
-    (:data:`meho_backplane.db.models._GRAPH_NODE_KINDS`) rather than
-    hard-coding the vocabulary in the template. When the closed enum
-    widens (a new connector contributes a new ``kind``), both the
-    table and graph dropdowns pick up the new option for free.
+    sourcing the kind filter dropdown from the well-known set
+    (:data:`meho_backplane.db.models.WELL_KNOWN_NODE_KINDS`) rather than
+    hard-coding the vocabulary in the template. The kind space is open
+    (T1 #2534); nodes of a novel kind still render — the dropdown just
+    lists the documented core set (surfacing novel kinds in the filter
+    is future console work).
     """
     return {
         "page_title": "Topology",
@@ -369,9 +370,10 @@ def _build_template_context(
         "edge_count": edge_count,
         "graph_node_cap": GRAPH_NODE_CAP,
         "truncated": truncated,
-        # Sourced from the closed enum -- single source of truth shared
-        # with the T1 tabular surface (``table.py._node_kind_options``).
-        "node_kind_options": sorted(_GRAPH_NODE_KINDS),
+        # Sourced from the well-known set -- single source of truth
+        # shared with the T1 tabular surface
+        # (``table.py._node_kind_options``).
+        "node_kind_options": sorted(WELL_KNOWN_NODE_KINDS),
         # ``selected_id`` is the cross-link payload: when the operator
         # clicks a table row's "Show in graph" button (or arrived via
         # ``?view=graph&selected=<id>`` from any source), the init
@@ -504,7 +506,7 @@ def _build_overlay_template_context(
         "edge_count": edge_count,
         "graph_node_cap": GRAPH_NODE_CAP,
         "truncated": truncated,
-        "node_kind_options": sorted(_GRAPH_NODE_KINDS),
+        "node_kind_options": sorted(WELL_KNOWN_NODE_KINDS),
         # No table cross-link target in overlay mode -- empty string
         # so Jinja's ``StrictUndefined`` env does not raise on the
         # template read.

--- a/backend/src/meho_backplane/ui/routes/topology/table.py
+++ b/backend/src/meho_backplane/ui/routes/topology/table.py
@@ -88,7 +88,7 @@ from pydantic import StringConstraints
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_raw_session
-from meho_backplane.db.models import _GRAPH_NODE_KINDS
+from meho_backplane.db.models import WELL_KNOWN_NODE_KINDS
 from meho_backplane.topology.query import list_nodes
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
@@ -310,10 +310,11 @@ def _next_direction_factory(
 
 
 def _node_kind_options() -> list[str]:
-    """Return the closed-enum list of kinds for the filter dropdown.
+    """Return the well-known list of kinds for the filter dropdown.
 
-    Sourced from :data:`meho_backplane.db.models._GRAPH_NODE_KINDS`,
-    the same closed vocabulary the DB-layer CHECK constraint pins.
+    Sourced from :data:`meho_backplane.db.models.WELL_KNOWN_NODE_KINDS`,
+    the documented core set (the vocabulary itself is open per T1
+    #2534; surfacing novel kinds in the filter is future console work).
     Deriving the dropdown from the *current page's* rows was wrong
     for two reasons:
 
@@ -323,12 +324,12 @@ def _node_kind_options() -> list[str]:
       kind, blocking the operator from clearing back to a different
       kind without manually editing the URL.
 
-    Using the closed enum gives the operator the full kind vocabulary
-    regardless of paging or active filter, at zero substrate cost
+    Using the well-known set gives the operator the documented core
+    vocabulary regardless of paging or active filter, at zero substrate cost
     (no extra ``SELECT DISTINCT`` round trip). Sorted alphabetically
     for stable rendering across page loads.
     """
-    return sorted(_GRAPH_NODE_KINDS)
+    return sorted(WELL_KNOWN_NODE_KINDS)
 
 
 #: Module-level :class:`fastapi.Depends` closures -- required to satisfy

--- a/backend/src/meho_backplane/ui/templates/topology/_annotate_modal.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_annotate_modal.html
@@ -88,18 +88,23 @@
 
       <label class="flex flex-col gap-1">
         <span class="text-xs font-medium opacity-70">Edge kind</span>
-        <select
-          name="kind" required
-          class="select select-bordered select-sm font-mono w-full"
+        {# Free-text input + datalist (not a closed <select>): the kind
+           vocabulary is open (T1 #2534) — the well-known kinds are
+           offered as suggestions, and any lowercase slug (2–63 chars;
+           letters/digits joined by `.`, `_` or `-`) is accepted. #}
+        <input
+          type="text" name="kind" required
+          list="edge-kind-suggestions"
+          value="{{ submitted.get('kind') | default('') }}"
+          placeholder="depends-on, resolves-to, same-as, …"
+          class="input input-bordered input-sm font-mono w-full"
           aria-label="Edge kind"
-        >
-          <option value="" disabled {{ 'selected' if not submitted.get('kind') else '' }}>
-            Select a kind…
-          </option>
+        />
+        <datalist id="edge-kind-suggestions">
           {% for k in edge_kind_options %}
-            <option value="{{ k }}" {{ 'selected' if submitted.get('kind') == k else '' }}>{{ k }}</option>
+            <option value="{{ k }}"></option>
           {% endfor %}
-        </select>
+        </datalist>
       </label>
 
       <fieldset class="grid grid-cols-2 gap-3">

--- a/backend/src/meho_backplane/ui/templates/topology/_bulk_import_modal.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_bulk_import_modal.html
@@ -85,7 +85,7 @@
               <span>{{ err.message }}</span>
               {% if err.kinds %}
                 <span class="opacity-70">
-                  (valid: {{ err.kinds | join(', ') }})
+                  (well-known kinds: {{ err.kinds | join(', ') }})
                 </span>
               {% endif %}
             </li>

--- a/backend/src/meho_backplane/ui/templates/topology/graph.html
+++ b/backend/src/meho_backplane/ui/templates/topology/graph.html
@@ -178,8 +178,8 @@
           aria-label="Filter nodes by kind"
         >
           <option value="">All kinds</option>
-          {# ``node_kind_options`` is the closed enum
-             (``_GRAPH_NODE_KINDS``) the route handler ships -- single
+          {# ``node_kind_options`` is the well-known set
+             (``WELL_KNOWN_NODE_KINDS``) the route handler ships -- single
              source of truth shared with the T1 tabular surface. -#}
           {% for option in node_kind_options %}
             <option value="{{ option }}" {% if option == kind_filter %}selected{% endif %}>

--- a/backend/tests/integration/test_topology_annotate.py
+++ b/backend/tests/integration/test_topology_annotate.py
@@ -388,7 +388,7 @@ async def _seed_incompatible_kinds_fixture(
     """
     svc = await _seed_node(tenant_id=tenant_id, kind="service", name="svc")
     # ``volume`` is the closest in-vocabulary kind to "stateful storage
-    # node" for this scenario; the closed v0.2 ``_GRAPH_NODE_KINDS``
+    # node" for this scenario; the well-known ``WELL_KNOWN_NODE_KINDS``
     # (mirrored in migration 0007's ``_NODE_KINDS``) does not include
     # ``database``. Widening the vocabulary is a coordinated DB + model
     # migration scoped to G9.2's curated extensions, not a test-only
@@ -638,7 +638,7 @@ async def test_conflict_incompatible_kinds_persists_both_rows_with_bidirectional
                     "kind": "depends-on",
                     # ``volume`` matches the seed in
                     # :func:`_seed_incompatible_kinds_fixture`; ``database``
-                    # is not in the closed v0.2 ``_GRAPH_NODE_KINDS``.
+                    # is not in the well-known ``WELL_KNOWN_NODE_KINDS`` set.
                     "to": {"name": "db", "kind": "volume"},
                 },
                 headers=_authed(token),
@@ -986,6 +986,95 @@ async def test_audit_and_broadcast_one_per_write(
 
     # Broadcast was called exactly twice (one annotate + one unannotate).
     assert publish_mock.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# T1 #2534 — open kind vocabulary, end-to-end against PostgreSQL
+# ---------------------------------------------------------------------------
+
+
+@_skip_no_docker
+async def test_novel_kinds_flow_end_to_end_on_postgres(
+    annotate_app: FastAPI,
+) -> None:
+    """Novel node + edge kinds land end-to-end against the PG shape CHECK.
+
+    The T1 #2534 acceptance path on the production dialect:
+
+    1. :func:`create_or_get_node` (the service primitive behind
+       ``meho.topology.create_node``) seeds a ``dns-record`` node and
+       a ``keycloak-realm`` node — both outside the old closed
+       14-kind vocabulary, the latter being the pre-T1 doc-vs-enum
+       drift example that must now round-trip.
+    2. ``POST /api/v1/topology/edges`` asserts a ``resolves-to`` edge
+       (outside the old closed ten-kind vocabulary) between the novel
+       node and a well-known-kind node → 201, row persisted with the
+       novel kind intact.
+
+    Proves migration ``0063``'s minimal shape CHECK accepts
+    well-formed novel slugs on real PostgreSQL (the unit suite covers
+    the same contract on SQLite).
+    """
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.topology.nodes import create_or_get_node
+    from tests._oidc_jwt_helpers import mock_discovery_and_jwks, public_jwks
+
+    operator = Operator(
+        sub="op-a",
+        name=None,
+        email=None,
+        raw_jwt="not-a-real-jwt",
+        tenant_id=uuid.UUID(TENANT_A_ID),
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+    sm = get_sessionmaker()
+    with patch(
+        "meho_backplane.topology.nodes.publish_event",
+        new_callable=AsyncMock,
+    ):
+        async with sm() as session:
+            created = await create_or_get_node(
+                session,
+                operator,
+                kind="dns-record",
+                name="www.example.com",
+            )
+        async with sm() as session:
+            realm = await create_or_get_node(
+                session,
+                operator,
+                kind="keycloak-realm",
+                name="master",
+            )
+    assert created.was_created is True
+    assert created.node.kind == "dns-record"
+    assert realm.node.kind == "keycloak-realm"
+
+    await _seed_node(tenant_id=TENANT_A_ID, kind="service", name="frontend-svc")
+
+    key, token = _token(role=TenantRole.TENANT_ADMIN, tenant_id=TENANT_A_ID, sub="op-a")
+
+    with patch(_PUBLISH_PATCH, new_callable=AsyncMock), respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        async with _make_async_client(annotate_app) as client:
+            ann = await client.post(
+                "/api/v1/topology/edges",
+                json={
+                    "from": {"name": "www.example.com", "kind": "dns-record"},
+                    "kind": "resolves-to",
+                    "to": {"name": "frontend-svc", "kind": "service"},
+                },
+                headers=_authed(token),
+            )
+            assert ann.status_code == 201, ann.text
+            assert ann.json()["kind"] == "resolves-to"
+            edge_id = uuid.UUID(ann.json()["id"])
+
+    async with sm() as session:
+        row = (await session.execute(select(GraphEdge).where(GraphEdge.id == edge_id))).scalar_one()
+    assert row.kind == "resolves-to"
+    assert row.source == "curated"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/migrations/test_migration_0063_open_graph_kind_vocabularies.py
+++ b/backend/tests/migrations/test_migration_0063_open_graph_kind_vocabularies.py
@@ -1,0 +1,351 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0063_open_graph_kind_vocabularies``.
+
+Initiative #2533 (Topology v2), Task #2534 (T1). The migration replaces
+the closed IN-list CHECKs ``ck_graph_node_kind`` (14 kinds, migration
+``0007``) and ``ck_graph_edge_kind`` (10 kinds, migration ``0010``)
+with one portable minimal shape CHECK per table
+(``length(kind) BETWEEN 2 AND 63 AND kind = lower(kind)``).
+
+Coverage:
+
+* **Forward** — post-``0063`` a novel node kind (``dns-record``) and a
+  novel edge kind (``resolves-to``) insert cleanly; every closed-set
+  member still validates; a shape-violating kind (uppercase, too
+  short, too long) is rejected by :class:`IntegrityError`.
+* **Sibling-CHECK survival** — ``ck_graph_edge_source`` still rejects
+  an unknown ``source`` after the batch table rebuild (the SQLite
+  batch-mode CHECK caveat: named CHECKs participate in the rebuild,
+  and this test pins that behaviour empirically).
+* **Pre-upgrade** — at revision ``0062`` the novel kinds are still
+  rejected by the closed IN-lists.
+* **Round-trip** — ``upgrade 0063`` → ``downgrade 0062`` → ``upgrade
+  0063`` is clean on an empty graph.
+* **Downgrade refusal** — ``downgrade 0062`` raises
+  :class:`RuntimeError` naming kinds + row counts when novel-kind rows
+  exist (mirrors migration ``0010``'s pre-check discipline).
+
+**Idempotency pinning (0049/0050/0054/0055 footgun).** Every
+forward / round-trip step targets this migration's **own** revision
+(``0063``) and its ``down_revision`` (``0062``), never ``head`` — so a
+future head migration cannot silently change what these tests
+exercise. SQLite is the test driver; the migration uses only
+batch-mode generic DDL, so PG parity holds (PG runs the equivalent
+native ``ALTER TABLE`` statements).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0063"
+_DOWN_REVISION = "0062"
+
+#: The closed vocabularies the migration opens — inlined (not imported
+#: from the model layer) so the test pins the historical contract.
+_NODE_KINDS_CLOSED: tuple[str, ...] = (
+    "target",
+    "vm",
+    "host",
+    "network",
+    "datastore",
+    "namespace",
+    "pod",
+    "service",
+    "ingress",
+    "node",
+    "principal",
+    "vault-role",
+    "vault-mount",
+    "volume",
+)
+_EDGE_KINDS_CLOSED: tuple[str, ...] = (
+    "runs-on",
+    "mounts",
+    "routes-through",
+    "belongs-to",
+    "authenticates-via",
+    "depends-on",
+    "replicates-to",
+    "backed-up-by",
+    "routes-via",
+    "policy-binds",
+)
+
+#: Kinds that violate the post-0063 shape CHECK (uppercase, too short,
+#: too long) — must raise :class:`IntegrityError` on direct insert.
+_SHAPE_VIOLATIONS: tuple[str, ...] = ("DNS-Record", "x", "a" * 64)
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0063.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _seed_tenant_and_nodes(sync_url: str) -> tuple[str, str, str]:
+    """Insert a tenant + two closed-kind nodes; return ``(tenant, from, to)`` ids."""
+    eng = sa_create_engine(sync_url)
+    tenant_id = str(uuid.uuid4())
+    from_id = str(uuid.uuid4())
+    to_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    try:
+        with eng.begin() as conn:
+            conn.execute(text("PRAGMA foreign_keys = ON"))
+            conn.execute(
+                text(
+                    "INSERT INTO tenant (id, slug, name, created_at) "
+                    "VALUES (:id, :slug, :name, :created_at)"
+                ),
+                {
+                    "id": tenant_id,
+                    "slug": f"t-{tenant_id[:8]}",
+                    "name": "Vocabulary Tenant",
+                    "created_at": now,
+                },
+            )
+            for node_id, kind, name in (
+                (from_id, "service", "svc-under-test"),
+                (to_id, "vm", "vm-under-test"),
+            ):
+                conn.execute(
+                    text(
+                        "INSERT INTO graph_node "
+                        "(id, tenant_id, kind, name, properties, "
+                        "discovered_by, first_seen) "
+                        "VALUES (:id, :tenant_id, :kind, :name, '{}', "
+                        ":discovered_by, :first_seen)"
+                    ),
+                    {
+                        "id": node_id,
+                        "tenant_id": tenant_id,
+                        "kind": kind,
+                        "name": name,
+                        "discovered_by": "vocab-test",
+                        "first_seen": now,
+                    },
+                )
+    finally:
+        eng.dispose()
+    return tenant_id, from_id, to_id
+
+
+def _insert_node(sync_url: str, tenant_id: str, kind: str, name: str) -> None:
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO graph_node "
+                    "(id, tenant_id, kind, name, properties, "
+                    "discovered_by, first_seen) "
+                    "VALUES (:id, :tenant_id, :kind, :name, '{}', "
+                    ":discovered_by, :first_seen)"
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "tenant_id": tenant_id,
+                    "kind": kind,
+                    "name": name,
+                    "discovered_by": "vocab-test",
+                    "first_seen": datetime.now(UTC).isoformat(),
+                },
+            )
+    finally:
+        eng.dispose()
+
+
+def _insert_edge(
+    sync_url: str,
+    tenant_id: str,
+    from_id: str,
+    to_id: str,
+    kind: str,
+    *,
+    source: str = "curated",
+) -> None:
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO graph_edge "
+                    "(id, tenant_id, from_node_id, to_node_id, kind, "
+                    "source, properties, discovered_by, first_seen) "
+                    "VALUES (:id, :tenant_id, :from_id, :to_id, :kind, "
+                    ":source, '{}', :discovered_by, :first_seen)"
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "tenant_id": tenant_id,
+                    "from_id": from_id,
+                    "to_id": to_id,
+                    "kind": kind,
+                    "source": source,
+                    "discovered_by": "vocab-test",
+                    "first_seen": datetime.now(UTC).isoformat(),
+                },
+            )
+    finally:
+        eng.dispose()
+
+
+def test_upgrade_accepts_novel_and_closed_kinds(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Post-0063: novel slugs and every closed-set member insert cleanly."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    tenant_id, from_id, to_id = _seed_tenant_and_nodes(sync_url)
+
+    # Novel kinds — the point of the migration.
+    _insert_node(sync_url, tenant_id, "dns-record", "www.example.com")
+    _insert_node(sync_url, tenant_id, "keycloak-realm", "master")
+    _insert_edge(sync_url, tenant_id, from_id, to_id, "resolves-to")
+    _insert_edge(sync_url, tenant_id, from_id, to_id, "same-as")
+
+    # Every closed-set member still validates (backward compatibility).
+    for kind in _NODE_KINDS_CLOSED:
+        _insert_node(sync_url, tenant_id, kind, f"compat-{kind}")
+    for kind in _EDGE_KINDS_CLOSED:
+        _insert_edge(sync_url, tenant_id, from_id, to_id, kind)
+
+
+@pytest.mark.parametrize("bad_kind", _SHAPE_VIOLATIONS)
+def test_upgrade_shape_check_rejects_malformed_kind(
+    alembic_cfg: tuple[Config, str],
+    bad_kind: str,
+) -> None:
+    """Post-0063: uppercase / too-short / too-long kinds violate the CHECK."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    tenant_id, from_id, to_id = _seed_tenant_and_nodes(sync_url)
+
+    with pytest.raises(IntegrityError):
+        _insert_node(sync_url, tenant_id, bad_kind, "bad-node")
+    with pytest.raises(IntegrityError):
+        _insert_edge(sync_url, tenant_id, from_id, to_id, bad_kind)
+
+
+def test_upgrade_preserves_ck_graph_edge_source(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``ck_graph_edge_source`` survives the batch table rebuild.
+
+    The SQLite batch-mode caveat: :func:`op.batch_alter_table` rebuilds
+    the table under the SQLite dialect, and only **named** CHECK
+    constraints participate in the recreate (Alembic batch docs,
+    "Working with constraints"). Both graph CHECKs are named, so the
+    sibling ``source`` constraint must still reject an unknown value
+    post-0063 — this test is the empirical pin for that behaviour.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    tenant_id, from_id, to_id = _seed_tenant_and_nodes(sync_url)
+
+    with pytest.raises(IntegrityError):
+        _insert_edge(
+            sync_url,
+            tenant_id,
+            from_id,
+            to_id,
+            "runs-on",
+            source="inferred",
+        )
+
+
+def test_pre_upgrade_rejects_novel_kinds(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """At revision 0062 the closed IN-lists still reject novel kinds."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+    tenant_id, from_id, to_id = _seed_tenant_and_nodes(sync_url)
+
+    with pytest.raises(IntegrityError):
+        _insert_node(sync_url, tenant_id, "dns-record", "www.example.com")
+    with pytest.raises(IntegrityError):
+        _insert_edge(sync_url, tenant_id, from_id, to_id, "resolves-to")
+
+
+def test_downgrade_then_upgrade_round_trips(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``downgrade 0062`` → ``upgrade 0063`` is clean on a compliant graph.
+
+    Pinned to this migration's own revision on both legs (never
+    ``head``). The seeded rows all use closed-set kinds, so the
+    downgrade pre-check passes; post-round-trip the open constraint is
+    back in effect (novel kind inserts cleanly).
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    tenant_id, from_id, to_id = _seed_tenant_and_nodes(sync_url)
+    _insert_edge(sync_url, tenant_id, from_id, to_id, "depends-on")
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    with pytest.raises(IntegrityError):
+        _insert_node(sync_url, tenant_id, "dns-record", "www.example.com")
+
+    command.upgrade(cfg, _REVISION)
+    _insert_node(sync_url, tenant_id, "dns-record", "www.example.com")
+
+
+def test_downgrade_refuses_when_novel_kind_rows_exist(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``downgrade 0062`` raises :class:`RuntimeError` naming novel kinds.
+
+    Mirrors migration ``0010``'s downgrade pre-check discipline: the
+    refusal must name each offending kind with its row count so the
+    operator can write the targeted cleanup before retrying.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    tenant_id, from_id, to_id = _seed_tenant_and_nodes(sync_url)
+    _insert_node(sync_url, tenant_id, "dns-record", "www.example.com")
+    _insert_edge(sync_url, tenant_id, from_id, to_id, "resolves-to")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        command.downgrade(cfg, _DOWN_REVISION)
+
+    message = str(exc_info.value)
+    assert "Cannot downgrade migration 0063" in message
+    # graph_node is pre-checked first, so its kind is the one named.
+    assert "dns-record=1" in message

--- a/backend/tests/test_api_v1_topology.py
+++ b/backend/tests/test_api_v1_topology.py
@@ -925,10 +925,43 @@ async def test_annotate_edge_admin_round_trip(client: TestClient) -> None:
     }
 
 
-def test_annotate_edge_unknown_kind_returns_422(client: TestClient) -> None:
-    """Pydantic enum field rejects an unknown ``kind`` before the service runs."""
+def test_annotate_edge_malformed_kind_returns_422(client: TestClient) -> None:
+    """The Pydantic slug pattern rejects a malformed ``kind`` before the service runs.
+
+    T1 #2534: the vocabulary is open — rejection is by slug shape
+    (pattern + length), not membership. Uppercase / punctuated and
+    over-long kinds both 422 at the boundary.
+    """
     key, token = _admin_token_value()
     fake = AsyncMock()
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.annotate_edge", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        for bad_kind in ("Made Up Kind!", "a" * 64):
+            resp = client.post(
+                "/api/v1/topology/edges",
+                headers=_authed(token),
+                json={
+                    "from": {"name": "a"},
+                    "kind": bad_kind,
+                    "to": {"name": "b"},
+                },
+            )
+            assert resp.status_code == 422, bad_kind
+    fake.assert_not_awaited()
+
+
+def test_annotate_edge_novel_kind_passes_boundary(client: TestClient) -> None:
+    """A well-formed novel ``kind`` (`resolves-to`) reaches the service.
+
+    The open-vocabulary counterpart of the malformed-kind 422: the
+    boundary must not re-close the kind space, so a slug outside the
+    well-known set flows through to ``annotate_edge`` verbatim.
+    """
+    key, token = _admin_token_value()
+    fake = AsyncMock(side_effect=NodeNotFoundError("a", None))
     with (
         respx.mock as mock_router,
         patch("meho_backplane.api.v1.topology.annotate_edge", fake),
@@ -939,12 +972,14 @@ def test_annotate_edge_unknown_kind_returns_422(client: TestClient) -> None:
             headers=_authed(token),
             json={
                 "from": {"name": "a"},
-                "kind": "made-up-kind",
+                "kind": "resolves-to",
                 "to": {"name": "b"},
             },
         )
-    assert resp.status_code == 422
-    fake.assert_not_awaited()
+    # 404 proves the request cleared Pydantic validation and invoked
+    # the (mocked) service with the novel kind.
+    assert resp.status_code == 404
+    assert fake.call_args.args[3] == "resolves-to"
 
 
 def test_annotate_edge_unknown_field_returns_422(client: TestClient) -> None:
@@ -1144,12 +1179,16 @@ def test_list_edges_default_filters(client: TestClient) -> None:
 
 
 def test_list_edges_invalid_kind_returns_422(client: TestClient) -> None:
-    """Pydantic rejects an unknown ``kind`` query param."""
+    """Pydantic rejects a malformed ``kind`` query param (slug pattern).
+
+    T1 #2534: any well-formed slug is a legal filter (the vocabulary
+    is open), so only a shape-violating value 422s here.
+    """
     key, token = _token(TenantRole.OPERATOR)
     with respx.mock as mock_router:
         _mock_discovery_and_jwks(mock_router, _public_jwks(key))
         resp = client.get(
-            "/api/v1/topology/edges?kind=not-a-kind",
+            "/api/v1/topology/edges?kind=Not%20A%20Kind!",
             headers=_authed(token),
         )
     assert resp.status_code == 422

--- a/backend/tests/test_mcp_tools_topology_annotate.py
+++ b/backend/tests/test_mcp_tools_topology_annotate.py
@@ -528,21 +528,55 @@ async def test_annotate_is_idempotent_on_repeat(
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
-def test_annotate_rejects_unknown_kind_at_schema_layer(
+def test_annotate_rejects_malformed_kind_at_schema_layer(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """A made-up `kind` value fails the inputSchema enum (-32602)."""
+    """A malformed `kind` slug fails the inputSchema pattern (-32602).
+
+    T1 #2534: the schema constrains by slug shape, not membership —
+    an uppercase / punctuated kind is rejected before the handler
+    runs, while a well-formed novel kind passes (covered by
+    ``test_annotate_accepts_novel_kind``).
+    """
     client, _op = client_with_operator
     response = _annotate_call(
         client,
         30,
         {
             "from_name": "a",
-            "kind": "made-up-kind",
+            "kind": "Made Up Kind!",
             "to_name": "b",
         },
     )
     assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_annotate_accepts_novel_kind(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """A novel edge kind (`resolves-to`) annotates end-to-end (T1 #2534)."""
+    client, _op = client_with_operator
+    await _seed_node(kind="dns-record", name="www.example.com")
+    await _seed_node(kind="service", name="frontend")
+
+    with patch(_PUBLISH_PATCH, new=AsyncMock()):
+        response = _annotate_call(
+            client,
+            33,
+            {
+                "from_name": "www.example.com",
+                "kind": "resolves-to",
+                "to_name": "frontend",
+            },
+        )
+
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["kind"] == "resolves-to"
+    assert payload["source"] == "curated"
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)

--- a/backend/tests/test_mcp_tools_topology_create_node.py
+++ b/backend/tests/test_mcp_tools_topology_create_node.py
@@ -119,21 +119,33 @@ def test_create_node_tool_registers_with_tenant_admin_and_write() -> None:
     assert defn.op_class == "write"
 
 
-def test_create_node_input_schema_enums_against_graph_node_kinds() -> None:
-    """The inputSchema's ``kind`` enum mirrors ``_GRAPH_NODE_KINDS`` verbatim.
+def test_create_node_input_schema_kind_is_pattern_constrained() -> None:
+    """The inputSchema's ``kind`` carries the slug pattern, not an enum.
 
-    Drift guard: a future widening of the node-kind vocabulary should
-    surface in the tool's schema automatically (sourced from the
-    constant). The test pins the expected v0.2 vocabulary so a silent
-    widening lands a visible diff.
+    T1 #2534 drift guard: the open vocabulary means the schema
+    constrains by shape (``pattern`` + length bounds mirroring
+    :data:`KIND_SLUG_PATTERN`) and the well-known kinds appear only as
+    description suggestions. A reintroduced ``enum`` would silently
+    re-close the vocabulary at the MCP boundary.
     """
-    from meho_backplane.db.models import _GRAPH_NODE_KINDS
+    from meho_backplane.db.models import (
+        KIND_SLUG_MAX_LENGTH,
+        KIND_SLUG_MIN_LENGTH,
+        KIND_SLUG_PATTERN,
+        WELL_KNOWN_NODE_KINDS,
+    )
 
     entry = get_tool("meho.topology.create_node")
     assert entry is not None
     defn, _ = entry
-    schema_enum = defn.inputSchema["properties"]["kind"]["enum"]
-    assert sorted(schema_enum) == sorted(_GRAPH_NODE_KINDS)
+    kind_schema = defn.inputSchema["properties"]["kind"]
+    assert "enum" not in kind_schema
+    assert kind_schema["pattern"] == KIND_SLUG_PATTERN
+    assert kind_schema["minLength"] == KIND_SLUG_MIN_LENGTH
+    assert kind_schema["maxLength"] == KIND_SLUG_MAX_LENGTH
+    # The well-known kinds survive as description suggestions.
+    for kind in WELL_KNOWN_NODE_KINDS:
+        assert kind in kind_schema["description"]
 
 
 def test_annotate_description_states_bootstrap_precondition() -> None:
@@ -276,13 +288,34 @@ async def test_create_node_is_idempotent_on_repeat(
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
-def test_create_node_rejects_unknown_kind_at_schema_layer(
+def test_create_node_rejects_malformed_kind_at_schema_layer(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """A made-up `kind` fails the inputSchema enum (-32602) before the service runs."""
+    """A malformed `kind` slug fails the inputSchema pattern (-32602)."""
     client, _op = client_with_operator
-    response = _create_node_call(client, 30, {"kind": "quantum-blob", "name": "entangled"})
+    response = _create_node_call(client, 30, {"kind": "DNS Record!", "name": "entangled"})
     assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_create_node_accepts_novel_kind_keycloak_realm(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """`keycloak-realm` — the pre-T1 #2534 doc-vs-enum drift — now round-trips.
+
+    The annotate tool's description advertised `keycloak-realm` as a
+    seedable kind while the closed enum rejected it at the inputSchema
+    layer. With the open vocabulary the advertised example must work
+    end-to-end.
+    """
+    client, _op = client_with_operator
+    response = _create_node_call(client, 32, {"kind": "keycloak-realm", "name": "master"})
+    body = response.json()
+    assert "error" not in body, body
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["kind"] == "keycloak-realm"
+    assert payload["name"] == "master"
+    assert payload["was_created"] is True
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)

--- a/backend/tests/test_topology_annotate.py
+++ b/backend/tests/test_topology_annotate.py
@@ -18,8 +18,10 @@ Coverage matrix (Task #595 acceptance criteria):
   ``source='auto'`` row raises :class:`AutoEdgeDeletionError`.
 * **Selector validation** — both / neither / partial triple raises
   :class:`UnannotateSelectorError`.
-* **Kind validation** — non-enum ``kind`` raises
-  :class:`InvalidEdgeKindError` *before* any DB write.
+* **Kind validation** — a malformed kind slug raises
+  :class:`InvalidEdgeKindError` *before* any DB write; a well-formed
+  novel slug (``resolves-to``) annotates cleanly (T1 #2534's open
+  vocabulary).
 * **Tenant boundary** — a tenant-A annotate cannot reference a
   tenant-B node (``NodeNotFoundError``).
 * **Audit + broadcast** — every annotate / unannotate writes exactly
@@ -498,8 +500,14 @@ async def test_promoted_edge_survives_subsequent_refresh() -> None:
 
 
 @pytest.mark.asyncio
-async def test_annotate_rejects_unknown_kind() -> None:
-    """A kind outside :class:`GraphEdgeKind` raises before any DB write."""
+@pytest.mark.parametrize("bad_kind", ["DNS Record!", "a" * 64])
+async def test_annotate_rejects_malformed_kind(bad_kind: str) -> None:
+    """A malformed kind slug raises before any DB write.
+
+    T1 #2534: rejection is by slug shape (pattern + length), not
+    membership. The error message names the pattern and echoes the
+    well-known kinds as suggestions.
+    """
     tenant_id = await _seed_tenant()
     await _seed_node(tenant_id, kind="principal", name="foo")
     await _seed_node(tenant_id, kind="vault-role", name="bar")
@@ -507,14 +515,18 @@ async def test_annotate_rejects_unknown_kind() -> None:
     sessionmaker = get_sessionmaker()
     with patch(_PUBLISH, new=AsyncMock()):
         async with sessionmaker() as session:
-            with pytest.raises(InvalidEdgeKindError):
+            with pytest.raises(InvalidEdgeKindError) as excinfo:
                 await annotate_edge(
                     session,
                     _operator(tenant_id),
                     NodeRef("foo", "principal"),
-                    "made-up-kind",
+                    bad_kind,
                     NodeRef("bar", "vault-role"),
                 )
+
+    message = str(excinfo.value)
+    assert "[a-z0-9]" in message
+    assert "authenticates-via" in message
 
     # No edge was written.
     async with sessionmaker() as session:
@@ -524,6 +536,37 @@ async def test_annotate_rejects_unknown_kind() -> None:
             .all()
         )
     assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_annotate_accepts_novel_kind() -> None:
+    """A well-formed novel kind (``resolves-to``) annotates end-to-end.
+
+    The T1 #2534 acceptance case: an edge kind outside the old closed
+    ten-member vocabulary flows through validation, insert, and
+    round-trip without a migration.
+    """
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, kind="dns-record", name="www.example.com")
+    await _seed_node(tenant_id, kind="service", name="frontend")
+
+    sessionmaker = get_sessionmaker()
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            edge = await annotate_edge(
+                session,
+                _operator(tenant_id),
+                NodeRef("www.example.com", "dns-record"),
+                "resolves-to",
+                NodeRef("frontend", "service"),
+            )
+
+    assert edge.kind == "resolves-to"
+    assert edge.source == "curated"
+
+    async with sessionmaker() as session:
+        row = (await session.execute(select(GraphEdge).where(GraphEdge.id == edge.id))).scalar_one()
+    assert row.kind == "resolves-to"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_topology_bulk_import.py
+++ b/backend/tests/test_topology_bulk_import.py
@@ -324,7 +324,11 @@ async def test_bulk_import_dry_run_writes_nothing() -> None:
 
 @pytest.mark.asyncio
 async def test_bulk_import_rejects_whole_batch_on_invalid_kind() -> None:
-    """One bad ``kind`` aborts the entire batch — no partial apply."""
+    """One malformed ``kind`` slug aborts the entire batch — no partial apply.
+
+    T1 #2534: the vocabulary is open, so the invalid row is a
+    shape-violating slug, not a non-member.
+    """
     tenant_id = await _seed_tenant()
     await _seed_node(tenant_id, kind="vm", name="vm-1")
     await _seed_node(tenant_id, kind="host", name="host-1")
@@ -339,7 +343,7 @@ async def test_bulk_import_rejects_whole_batch_on_invalid_kind() -> None:
         ),
         BulkImportRow(
             from_ref=NodeRef("svc-1", "service"),
-            kind="not-a-real-kind",
+            kind="Not A Real Kind!",
             to_ref=NodeRef("db-1", "service"),
         ),
     ]
@@ -354,7 +358,7 @@ async def test_bulk_import_rejects_whole_batch_on_invalid_kind() -> None:
     err = exc_info.value.errors[0]
     assert err.index == 1
     assert err.error == "invalid_kind"
-    assert err.kind == "not-a-real-kind"
+    assert err.kind == "Not A Real Kind!"
 
     async with sessionmaker() as session:
         edges = (

--- a/backend/tests/test_topology_create_node.py
+++ b/backend/tests/test_topology_create_node.py
@@ -254,8 +254,14 @@ async def test_create_node_over_auto_promotes_discovered_by() -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_node_rejects_unknown_kind_before_db_write() -> None:
-    """A non-vocabulary kind raises ``InvalidNodeKindError`` pre-DB."""
+@pytest.mark.parametrize("bad_kind", ["DNS Record!", "a" * 64])
+async def test_create_node_rejects_malformed_kind_before_db_write(bad_kind: str) -> None:
+    """A malformed kind slug raises ``InvalidNodeKindError`` pre-DB.
+
+    T1 #2534: the vocabulary is open, so rejection is by slug shape
+    (pattern + length), not membership. The error message names the
+    pattern and echoes the well-known kinds as suggestions.
+    """
     tenant_id = await _seed_tenant()
     sessionmaker = get_sessionmaker()
 
@@ -265,13 +271,16 @@ async def test_create_node_rejects_unknown_kind_before_db_write() -> None:
                 await create_or_get_node(
                     session,
                     _operator(tenant_id),
-                    kind="quantum-blob",
+                    kind=bad_kind,
                     name="entangled",
                 )
 
-    assert "quantum-blob" in str(excinfo.value)
-    # Vocabulary list is echoed for the operator to recover from.
-    assert "vault-role" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert bad_kind in message
+    # The slug pattern is named for the operator to recover from...
+    assert "[a-z0-9]" in message
+    # ...and the well-known kinds are echoed as suggestions.
+    assert "vault-role" in message
 
     # No row landed, no broadcast emitted.
     async with sessionmaker() as session:
@@ -282,6 +291,37 @@ async def test_create_node_rejects_unknown_kind_before_db_write() -> None:
         )
     assert rows == []
     publish_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_node_accepts_novel_kind() -> None:
+    """A well-formed novel kind (``dns-record``) creates a node end-to-end.
+
+    The T1 #2534 acceptance case: a kind that was outside the old
+    closed 14-member vocabulary flows through validation, insert, and
+    round-trip without a migration.
+    """
+    tenant_id = await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            result = await create_or_get_node(
+                session,
+                _operator(tenant_id),
+                kind="dns-record",
+                name="www.example.com",
+            )
+
+    assert result.was_created is True
+    assert result.node.kind == "dns-record"
+
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(select(GraphNode).where(GraphNode.id == result.node.id))
+        ).scalar_one()
+    assert row.kind == "dns-record"
+    assert row.name == "www.example.com"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_topology_history_migration.py
+++ b/backend/tests/test_topology_history_migration.py
@@ -28,7 +28,7 @@ Coverage matrix (Task #856 acceptance criteria):
   ``removed``) and rejects anything else with :class:`IntegrityError`.
 * **Drift guard** -- :class:`GraphHistoryChangeKind` and the migration's
   inlined ``_CHANGE_KINDS`` tuple stay in sync; the same drift guard
-  pattern :class:`GraphEdgeKind` / :data:`_GRAPH_EDGE_KINDS` follows
+  pattern :class:`GraphHistoryChangeKind` follows
   for the live-edge vocabulary.
 * **ORM round-trip** -- inserting a :class:`GraphNodeHistory` /
   :class:`GraphEdgeHistory` round-trips every field through SQLite
@@ -532,7 +532,8 @@ def test_change_kind_enum_has_exactly_three_members() -> None:
 def test_change_kind_enum_matches_ck_constraint_tuple() -> None:
     """:data:`_GRAPH_HISTORY_CHANGE_KINDS` mirrors :class:`GraphHistoryChangeKind`.
 
-    Same drift-guard pattern :data:`_GRAPH_EDGE_KINDS` follows for the
+    Same drift-guard pattern the graph tables' kind CHECKs followed
+    pre-#2534 for the
     live-edge vocabulary: the Python type-level enum and the DB-layer
     ``CHECK change_kind IN (...)`` constraint must move in lock-step.
     Equality is the regression guard at unit-test time.

--- a/backend/tests/test_topology_schema.py
+++ b/backend/tests/test_topology_schema.py
@@ -13,10 +13,12 @@ Coverage matrix (Task #448 acceptance criteria):
   :class:`GraphNode` and ``(tenant_id, from_node_id, to_node_id, kind)``
   on :class:`GraphEdge` both reject duplicate rows with
   :class:`IntegrityError`. Cross-tenant collision is allowed.
-* **CHECK constraints** -- ``graph_node.kind``, ``graph_edge.kind``,
-  ``graph_edge.source`` each reject an out-of-vocabulary value with
-  :class:`IntegrityError`. The closed-enum vocabulary is the v0.2
-  contract; G9.2 widens it via a follow-up migration.
+* **CHECK constraints** -- ``graph_node.kind`` / ``graph_edge.kind``
+  reject a shape-violating value (uppercase, too short, too long) and
+  accept any well-formed slug (the vocabulary is open per T1 #2534;
+  migration ``0063`` replaced the closed IN-lists with the minimal
+  shape CHECK); ``graph_edge.source`` remains a closed enum and
+  rejects unknown values with :class:`IntegrityError`.
 * **Foreign keys** -- ``graph_node.target_id`` rejects an unknown
   target id, and ``graph_edge.from_node_id`` / ``to_node_id`` reject
   unknown node ids, with :class:`IntegrityError`. SQLite enforces FKs
@@ -63,7 +65,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
 from meho_backplane.db.models import (
-    _GRAPH_EDGE_KINDS,
     GraphEdge,
     GraphEdgeKind,
     GraphNode,
@@ -336,13 +337,41 @@ async def test_graph_node_same_name_allowed_across_tenants() -> None:
 
 
 @pytest.mark.asyncio
-async def test_graph_node_kind_check_constraint_rejects_unknown() -> None:
-    """A ``graph_node.kind`` outside the closed enum raises :class:`IntegrityError`.
+async def test_graph_node_kind_check_accepts_novel_slug() -> None:
+    """A well-formed novel ``graph_node.kind`` inserts cleanly (open vocabulary).
 
-    The DB-layer CHECK is what makes the closed-enum contract
-    unbreakable: a typo'd kind (``"vmm"`` instead of ``"vm"``) cannot
-    silently land. Widening the vocabulary is a coordinated
-    migration + :data:`_GRAPH_NODE_KINDS` update.
+    T1 #2534 / migration ``0063``: the closed 14-kind IN-list is gone;
+    any lowercase slug passes the DB-layer shape CHECK. Full slug
+    validation lives Python-side at the write boundaries.
+    """
+    sessionmaker = get_sessionmaker()
+    node_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        session.add(
+            GraphNode(
+                id=node_id,
+                tenant_id=tenant_id,
+                kind="dns-record",  # not in the old closed enum
+                name="www.example.com",
+                discovered_by="curated",
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        row = (await session.execute(select(GraphNode).where(GraphNode.id == node_id))).scalar_one()
+    assert row.kind == "dns-record"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_kind", ["Bad-Kind", "x", "a" * 64])
+async def test_graph_node_kind_check_constraint_rejects_malformed(bad_kind: str) -> None:
+    """A shape-violating ``graph_node.kind`` raises :class:`IntegrityError`.
+
+    Migration ``0063``'s minimal shape CHECK (length 2--63, lowercase)
+    is the DB-layer backstop for out-of-band inserts; uppercase,
+    single-char, and over-long kinds must not land.
     """
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -350,7 +379,7 @@ async def test_graph_node_kind_check_constraint_rejects_unknown() -> None:
         session.add(
             GraphNode(
                 tenant_id=tenant_id,
-                kind="not-a-real-kind",  # outside the closed enum
+                kind=bad_kind,
                 name="bad-kind",
                 discovered_by="vmware",
             )
@@ -552,13 +581,44 @@ async def test_graph_edge_different_kind_between_same_endpoints_allowed() -> Non
 
 
 @pytest.mark.asyncio
-async def test_graph_edge_kind_check_constraint_rejects_unknown() -> None:
-    """A ``graph_edge.kind`` outside the closed v0.2 enum raises :class:`IntegrityError`.
+async def test_graph_edge_kind_check_accepts_novel_slug() -> None:
+    """A well-formed novel ``graph_edge.kind`` inserts cleanly (open vocabulary).
 
-    Post-G9.2 (#364 / migration ``0010``), the closed v0.2 vocabulary is
-    the ten-kind set on :class:`GraphEdgeKind`. The CHECK constraint
-    rejects anything outside that set; widening requires a new
-    migration that updates the constraint and the enum in lock-step.
+    T1 #2534 / migration ``0063``: the closed ten-kind IN-list is gone;
+    any lowercase slug passes the DB-layer shape CHECK (`resolves-to`,
+    `same-as`, ...). Full slug validation lives Python-side at the
+    write boundaries.
+    """
+    sessionmaker = get_sessionmaker()
+    edge_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        from_id, to_id = await _seed_two_nodes(session, tenant_id)
+        session.add(
+            GraphEdge(
+                id=edge_id,
+                tenant_id=tenant_id,
+                from_node_id=from_id,
+                to_node_id=to_id,
+                kind="resolves-to",  # not in the old closed enum
+                source="curated",
+                discovered_by="curated",
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        row = (await session.execute(select(GraphEdge).where(GraphEdge.id == edge_id))).scalar_one()
+    assert row.kind == "resolves-to"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_kind", ["Bad-Kind", "x", "a" * 64])
+async def test_graph_edge_kind_check_constraint_rejects_malformed(bad_kind: str) -> None:
+    """A shape-violating ``graph_edge.kind`` raises :class:`IntegrityError`.
+
+    Migration ``0063``'s minimal shape CHECK (length 2--63, lowercase)
+    is the DB-layer backstop for out-of-band inserts.
     """
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -569,7 +629,7 @@ async def test_graph_edge_kind_check_constraint_rejects_unknown() -> None:
                 tenant_id=tenant_id,
                 from_node_id=from_id,
                 to_node_id=to_id,
-                kind="not-a-real-edge-kind",  # outside the v0.2 ten-kind vocabulary
+                kind=bad_kind,
                 source="auto",
                 discovered_by="curated",
             )
@@ -979,14 +1039,14 @@ _G9_2_CURATED_KINDS: tuple[str, ...] = (
 
 
 def test_graph_edge_kind_enum_has_exactly_ten_members() -> None:
-    """:class:`GraphEdgeKind` has the ten members the v0.2 vocabulary lock requires.
+    """:class:`GraphEdgeKind` carries the ten documented well-known members.
 
-    Decision #6 in :file:`docs/planning/v0.2-decisions.md` fixes the
-    closed-vocabulary set at ten kinds for v0.2 -- four
-    auto-discoverable (G9.1) plus six curated-only (G9.2). A
-    regression that drops or adds a member without a coordinated
-    migration would fragment the v0.2.next policy-engine grammar; the
-    explicit member count is the regression guard.
+    Post-T1 #2534 the enum is the *well-known set*, not an enforced
+    vocabulary -- it feeds docs tables, UI ``datalist`` suggestions,
+    and error-message hints. The explicit member pin guards against a
+    silent drop/rename that would desynchronise those surfaces from
+    :file:`docs/architecture/topology.md`'s well-known table; widening
+    the set is a deliberate docs + enum change (no migration needed).
     """
     assert len(GraphEdgeKind) == 10
     assert {k.value for k in GraphEdgeKind} == {
@@ -1001,20 +1061,6 @@ def test_graph_edge_kind_enum_has_exactly_ten_members() -> None:
         "routes-via",
         "policy-binds",
     }
-
-
-def test_graph_edge_kind_enum_matches_ck_constraint_tuple() -> None:
-    """:data:`_GRAPH_EDGE_KINDS` mirrors :class:`GraphEdgeKind`; equality is the drift guard.
-
-    The Python type-level enum and the DB-layer ``CHECK kind IN (...)``
-    constraint must move in lock-step -- a v0.2.next addition that
-    updated the enum without a corresponding migration (or vice
-    versa) would let agents emit an enum value the DB rejects, or let
-    the DB accept a value the agent's type checker forbids. The
-    equality assertion is what makes the closed-vocabulary contract
-    enforceable at unit-test time.
-    """
-    assert set(_GRAPH_EDGE_KINDS) == {k.value for k in GraphEdgeKind}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_ui_topology_annotate.py
+++ b/backend/tests/test_ui_topology_annotate.py
@@ -762,8 +762,45 @@ def test_topology_ui_annotate_modal_open_renders_for_admin_with_csrf() -> None:
     # The modal mints + sets a fresh meho_csrf cookie so the POST carries a
     # valid double-submit token.
     assert CSRF_COOKIE_NAME in response.cookies
-    # The closed edge-kind vocabulary is surfaced in the dropdown.
+    # The well-known edge kinds are surfaced as datalist suggestions.
     assert "authenticates-via" in body
+
+
+def test_topology_ui_annotate_modal_kind_is_free_text_with_datalist() -> None:
+    """The modal's kind field is a free-text input + datalist, not a closed select.
+
+    T1 #2534 acceptance criterion: the vocabulary is open, so the UI
+    must accept a novel kind (`resolves-to`, `same-as`, ...) while
+    offering the well-known kinds as ``datalist`` suggestions. A
+    ``<select name="kind">`` would silently re-close the vocabulary at
+    the console boundary.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/topology/edges/annotate")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Free-text input bound to the suggestions datalist...
+    assert 'name="kind"' in body
+    assert 'list="edge-kind-suggestions"' in body
+    assert '<datalist id="edge-kind-suggestions">' in body
+    # ...and no closed <select> for the kind field.
+    assert '<select\n          name="kind"' not in body
+    assert '<select name="kind"' not in body
+    # Every well-known kind renders as a suggestion option.
+    from meho_backplane.db.models import GraphEdgeKind
+
+    for kind in GraphEdgeKind:
+        assert f'<option value="{kind.value}"' in body
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_topology_bulk_refresh.py
+++ b/backend/tests/test_ui_topology_bulk_refresh.py
@@ -558,12 +558,13 @@ def test_topology_ui_bulk_invalid_rows_surface_every_error_together() -> None:
     _seed_node(tenant_id=_TENANT_A, kind="principal", name="sa-foo")
     _seed_node(tenant_id=_TENANT_A, kind="vault-role", name="role-bar")
 
-    # Row 0: unknown edge kind. Row 1: unresolvable endpoint. Two DISTINCT
+    # Row 0: malformed edge-kind slug (T1 #2534: rejection is by shape,
+    # not membership). Row 1: unresolvable endpoint. Two DISTINCT
     # row failures -> the panel must surface BOTH, not abort on the first.
     rows = (
         "edges:\n"
         "  - from: { name: sa-foo, kind: principal }\n"
-        "    kind: made-up-kind\n"
+        "    kind: 'Made Up Kind!'\n"
         "    to: { name: role-bar, kind: vault-role }\n"
         "  - from: { name: ghost-node, kind: principal }\n"
         "    kind: authenticates-via\n"
@@ -591,7 +592,7 @@ def test_topology_ui_bulk_invalid_rows_surface_every_error_together() -> None:
     indices = set(re.findall(r'data-test="bulk-row-error" data-row-index="(\d+)"', body))
     assert indices >= {"0", "1"}, indices
     # The invalid-kind row names the bad kind; the missing-node row is present.
-    assert "made-up-kind" in body
+    assert "Made Up Kind!" in body
     assert "ghost-node" in body
     # Nothing persisted.
     assert _count_edges(_TENANT_A) == 0

--- a/backend/tests/test_ui_topology_graph.py
+++ b/backend/tests/test_ui_topology_graph.py
@@ -518,18 +518,19 @@ def test_graph_filter_by_name_substring_narrows_results() -> None:
     assert names == {"vm-prod-01"}
 
 
-def test_graph_kind_dropdown_matches_closed_enum() -> None:
-    """The graph view's kind dropdown sources its options from ``_GRAPH_NODE_KINDS``.
+def test_graph_kind_dropdown_matches_well_known_set() -> None:
+    """The graph view's kind dropdown sources its options from ``WELL_KNOWN_NODE_KINDS``.
 
     Regression for the previously hardcoded vocabulary in
     ``graph.html``. T1's tabular surface already routes through
-    ``node_kind_options`` (sourced from the closed enum); the graph
-    surface now mirrors that, so a widening of the closed enum (a new
-    connector contributing a new kind) reaches both filter dropdowns
-    without a template edit. The test asserts every ``_GRAPH_NODE_KINDS``
-    member renders as an ``<option>`` in the graph view.
+    ``node_kind_options`` (sourced from the well-known set); the graph
+    surface now mirrors that, so a widening of the well-known set (a new
+    connector contributing a new documented kind) reaches both filter
+    dropdowns without a template edit. The test asserts every
+    ``WELL_KNOWN_NODE_KINDS`` member renders as an ``<option>`` in the
+    graph view.
     """
-    from meho_backplane.db.models import _GRAPH_NODE_KINDS
+    from meho_backplane.db.models import WELL_KNOWN_NODE_KINDS
 
     _seed_tenant_row(_TENANT_A, "tenant-a")
     session_id = _seed_session_sync(tenant_id=_TENANT_A)
@@ -538,9 +539,9 @@ def test_graph_kind_dropdown_matches_closed_enum() -> None:
         response = client.get("/ui/topology?view=graph")
     assert response.status_code == 200, response.text
     body = response.text
-    for kind in _GRAPH_NODE_KINDS:
+    for kind in WELL_KNOWN_NODE_KINDS:
         assert f'<option value="{kind}"' in body, (
-            f"closed-enum kind {kind!r} missing from graph view's filter dropdown"
+            f"well-known kind {kind!r} missing from graph view's filter dropdown"
         )
 
 

--- a/backend/tests/test_ui_topology_table.py
+++ b/backend/tests/test_ui_topology_table.py
@@ -1005,7 +1005,7 @@ def test_kind_dropdown_lists_all_kinds_regardless_of_active_filter() -> None:
     ``?kind=vm`` left the dropdown with only ``vm`` as an option,
     blocking the operator from switching kinds without manually
     editing the URL. The dropdown is now sourced from
-    ``_GRAPH_NODE_KINDS`` so the full vocabulary stays available.
+    ``WELL_KNOWN_NODE_KINDS`` so the documented core set stays available.
 
     The acceptance shape also covers the "paged out" sibling failure:
     51 ``vm`` rows + 1 ``target`` row at the default limit=50 would
@@ -1030,7 +1030,7 @@ def test_kind_dropdown_lists_all_kinds_regardless_of_active_filter() -> None:
     # ``<option>`` rows.
     assert '<option value="vm"' in body
     assert '<option value="target"' in body
-    # Sanity: a few more enum members from db.models._GRAPH_NODE_KINDS.
+    # Sanity: a few more members from db.models.WELL_KNOWN_NODE_KINDS.
     assert '<option value="host"' in body
     assert '<option value="datastore"' in body
 

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -1968,7 +1968,7 @@
           "topology"
         ],
         "summary": "List Edges Route",
-        "description": "Flat filterable listing of edges in the caller's tenant.\n\nWraps :func:`~meho_backplane.topology.query.list_edges` (G9.2-T4\n#596). The query params are forwarded straight through (``from`` /\n``to`` are bound via :class:`Query` ``alias`` because ``from`` is a\nPython keyword); the tenant boundary comes from ``operator.tenant_id``\nand is non-overrideable by query string or body.\n\n``kind`` is typed against :class:`GraphEdgeKind` so an unknown kind\nis rejected at the HTTP boundary (422) before the helper runs;\n``source`` is constrained to the two ``graph_edge.source`` values\nby a regex pattern; ``conflicts=true`` forwards\n``conflicts_only=True`` to surface the recoverability listing for\na wrong annotation (\u00a76 of Initiative #364).\n\nA bare ``from`` / ``to`` name that resolves to multiple kinds in\nthe tenant surfaces as **409 ambiguous_node** (same shape as the\ntraversal verbs) so the caller can re-issue with a kind-qualified\nendpoint. A name that does not resolve at all yields an empty\nlist, not a 404 \u2014 consistent with the helper's \"missing anchor \u2192\nempty result\" shape.\n\nThe route binds ``audit_op_id=\"topology.list_edges\"`` /\n``audit_op_class=\"read\"`` so the audit row + broadcast event carry\nthe canonical identity. ``.list_edges`` is not in the broadcast\nclassifier's read/write suffix tables, so the explicit override is\nload-bearing (same rationale as the traversal verbs' ``.dependents``\n/ ``.dependencies`` / ``.path`` bindings).",
+        "description": "Flat filterable listing of edges in the caller's tenant.\n\nWraps :func:`~meho_backplane.topology.query.list_edges` (G9.2-T4\n#596). The query params are forwarded straight through (``from`` /\n``to`` are bound via :class:`Query` ``alias`` because ``from`` is a\nPython keyword); the tenant boundary comes from ``operator.tenant_id``\nand is non-overrideable by query string or body.\n\n``kind`` is typed against :data:`_EdgeKindSlug` so a malformed kind\nis rejected at the HTTP boundary (422) before the helper runs\n(any well-formed slug is a legal filter \u2014 the vocabulary is open);\n``source`` is constrained to the two ``graph_edge.source`` values\nby a regex pattern; ``conflicts=true`` forwards\n``conflicts_only=True`` to surface the recoverability listing for\na wrong annotation (\u00a76 of Initiative #364).\n\nA bare ``from`` / ``to`` name that resolves to multiple kinds in\nthe tenant surfaces as **409 ambiguous_node** (same shape as the\ntraversal verbs) so the caller can re-issue with a kind-qualified\nendpoint. A name that does not resolve at all yields an empty\nlist, not a 404 \u2014 consistent with the helper's \"missing anchor \u2192\nempty result\" shape.\n\nThe route binds ``audit_op_id=\"topology.list_edges\"`` /\n``audit_op_class=\"read\"`` so the audit row + broadcast event carry\nthe canonical identity. ``.list_edges`` is not in the broadcast\nclassifier's read/write suffix tables, so the explicit override is\nload-bearing (same rationale as the traversal verbs' ``.dependents``\n/ ``.dependencies`` / ``.path`` bindings).",
         "operationId": "list_edges_route_api_v1_topology_edges_get",
         "parameters": [
           {
@@ -1976,7 +1976,10 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/GraphEdgeKind",
+              "type": "string",
+              "minLength": 2,
+              "maxLength": 63,
+              "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$",
               "nullable": true,
               "title": "Kind"
             }
@@ -23380,23 +23383,6 @@
         "title": "GatewayResultBody",
         "description": "POST body for ``.../result`` \u2014 the runner's outcome report."
       },
-      "GraphEdgeKind": {
-        "type": "string",
-        "enum": [
-          "runs-on",
-          "mounts",
-          "routes-through",
-          "belongs-to",
-          "authenticates-via",
-          "depends-on",
-          "replicates-to",
-          "backed-up-by",
-          "routes-via",
-          "policy-binds"
-        ],
-        "title": "GraphEdgeKind",
-        "description": "Closed enum of :attr:`GraphEdge.kind` values -- v0.2 vocabulary.\n\nInitiative #364 (G9.2) locks the edge-kind vocabulary at ten members:\nthe four auto-discoverable kinds G9.1 (#363) shipped, plus six\noperator-curated cross-system kinds that auto-discovery cannot infer\n(decision #6 in :file:`docs/planning/v0.2-decisions.md`). The vocabulary\nis closed -- widening it is a coordinated DB + model change (new\nmigration, new enum member, new decision row) so the v0.2.next\npolicy-engine grammar parsing ``kind`` stays portable across tenants.\n\nThe four auto-discoverable kinds (refresh service writes these on\nevery probe-derived edge):\n\n* :attr:`RUNS_ON` -- ``vm`` ``runs-on`` ``host``, ``pod`` ``runs-on``\n  ``node``: the physical / scheduling host of a workload.\n* :attr:`MOUNTS` -- ``vm`` ``mounts`` ``datastore``, ``pod`` ``mounts``\n  ``volume``: storage attachment.\n* :attr:`ROUTES_THROUGH` -- ``ingress`` ``routes-through`` ``service``,\n  ``service`` ``routes-through`` ``pod``: network routing path.\n* :attr:`BELONGS_TO` -- ``pod`` ``belongs-to`` ``namespace``, ``vm``\n  ``belongs-to`` ``host`` (logical group membership).\n\nThe six curated-only kinds (operator-asserted via\n``meho topology annotate``; cannot be derived from probes):\n\n* :attr:`AUTHENTICATES_VIA` -- principal -> identity-provider node\n  (e.g. ``k8s-sa-foo`` -> ``vault-role-bar``). The canonical\n  cross-system example.\n* :attr:`DEPENDS_ON` -- cross-system functional dependency (e.g.\n  ``service-X`` -> ``database-Y`` where neither side knows about the\n  other in its own probe output).\n* :attr:`REPLICATES_TO` -- operator-asserted replication relationship\n  between two storage / database nodes.\n* :attr:`BACKED_UP_BY` -- operator-asserted backup relationship.\n* :attr:`ROUTES_VIA` -- operator-asserted network path through an\n  intermediary (e.g., ``vm-A`` -> ``firewall-X`` -> ``vm-B`` when the\n  probes only see point-to-point reachability).\n* :attr:`POLICY_BINDS` -- RBAC / policy attachment that crosses\n  connector boundaries (e.g., ``kubernetes-namespace-prod`` ->\n  ``vault-policy-prod-read``).\n\nMirrors the closed-enum pattern :class:`AuthModel`\n(:mod:`meho_backplane.connectors.schemas`) sets: a Python\n:class:`enum.StrEnum` paired with a portable DB ``CHECK`` constraint,\nboth moved in lock-step by one Alembic migration so the enum and the\nconstraint cannot drift."
-      },
       "GroupingResultModel": {
         "properties": {
           "connector_id": {
@@ -27785,7 +27771,11 @@
             "$ref": "#/components/schemas/_EdgeEndpoint"
           },
           "kind": {
-            "$ref": "#/components/schemas/GraphEdgeKind"
+            "type": "string",
+            "maxLength": 63,
+            "minLength": 2,
+            "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$",
+            "title": "Kind"
           },
           "to": {
             "$ref": "#/components/schemas/_EdgeEndpoint"
@@ -27811,7 +27801,7 @@
           "to"
         ],
         "title": "_AnnotateEdgeRequest",
-        "description": "Inbound body for ``POST /api/v1/topology/edges``.\n\n``kind`` is typed against :class:`GraphEdgeKind` so an unknown kind\nfails Pydantic validation (HTTP 422) **before** the service runs \u2014\nthe service still raises :class:`InvalidEdgeKindError` for\nnon-route callers, but at the HTTP boundary the operator gets the\nstandard FastAPI validation error shape (with the candidate list in\nthe error context) rather than a 500-shaped diagnostic.\n\nThe keyword ``from`` is reserved in Python so the attribute name is\n``from_endpoint``; ``alias=\"from\"`` keeps the wire shape the issue\nbody specifies (``{from, kind, to, note?, evidence_url?}``).\n``populate_by_name`` lets the alias **and** the attribute name both\nwork \u2014 handy for hand-written test fixtures that use the Python\nattribute names."
+        "description": "Inbound body for ``POST /api/v1/topology/edges``.\n\n``kind`` is typed against :data:`_EdgeKindSlug` so a malformed kind\nfails Pydantic validation (HTTP 422) **before** the service runs \u2014\nthe service still raises :class:`InvalidEdgeKindError` for\nnon-route callers, but at the HTTP boundary the operator gets the\nstandard FastAPI validation error shape (with the pattern in the\nerror context) rather than a 500-shaped diagnostic.\n\nThe keyword ``from`` is reserved in Python so the attribute name is\n``from_endpoint``; ``alias=\"from\"`` keeps the wire shape the issue\nbody specifies (``{from, kind, to, note?, evidence_url?}``).\n``populate_by_name`` lets the alias **and** the attribute name both\nwork \u2014 handy for hand-written test fixtures that use the Python\nattribute names."
       },
       "_BulkImportEdge": {
         "properties": {
@@ -27819,7 +27809,11 @@
             "$ref": "#/components/schemas/_EdgeEndpoint"
           },
           "kind": {
-            "$ref": "#/components/schemas/GraphEdgeKind"
+            "type": "string",
+            "maxLength": 63,
+            "minLength": 2,
+            "pattern": "^[a-z0-9]+(?:[._-][a-z0-9]+)*$",
+            "title": "Kind"
           },
           "to": {
             "$ref": "#/components/schemas/_EdgeEndpoint"
@@ -27845,7 +27839,7 @@
           "to"
         ],
         "title": "_BulkImportEdge",
-        "description": "One edge in the ``POST /api/v1/topology/edges/bulk`` body.\n\nSame wire shape as :class:`_AnnotateEdgeRequest` (``{from, kind, to,\nnote?, evidence_url?}``) \u2014 ``from`` is bound via ``alias`` because\nit is a Python keyword. ``kind`` is typed against\n:class:`GraphEdgeKind` so an unknown kind fails at the boundary\n(HTTP 422) before any service call runs, and the per-row error\nsurfaces inside the standard FastAPI validation envelope with the\nrow index in ``loc``. ``extra=\"forbid\"`` rejects typo'd keys so a\nmisspelled ``evidnce_url`` is caught at the boundary rather than\nsilently dropped."
+        "description": "One edge in the ``POST /api/v1/topology/edges/bulk`` body.\n\nSame wire shape as :class:`_AnnotateEdgeRequest` (``{from, kind, to,\nnote?, evidence_url?}``) \u2014 ``from`` is bound via ``alias`` because\nit is a Python keyword. ``kind`` is typed against\n:data:`_EdgeKindSlug` so a malformed kind fails at the boundary\n(HTTP 422) before any service call runs, and the per-row error\nsurfaces inside the standard FastAPI validation envelope with the\nrow index in ``loc``. ``extra=\"forbid\"`` rejects typo'd keys so a\nmisspelled ``evidnce_url`` is caught at the boundary rather than\nsilently dropped."
       },
       "_BulkImportRequest": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -176,20 +176,6 @@ const (
 	GatewayResultBodyOutcomeSucceeded GatewayResultBodyOutcome = "succeeded"
 )
 
-// Defines values for GraphEdgeKind.
-const (
-	AuthenticatesVia GraphEdgeKind = "authenticates-via"
-	BackedUpBy       GraphEdgeKind = "backed-up-by"
-	BelongsTo        GraphEdgeKind = "belongs-to"
-	DependsOn        GraphEdgeKind = "depends-on"
-	Mounts           GraphEdgeKind = "mounts"
-	PolicyBinds      GraphEdgeKind = "policy-binds"
-	ReplicatesTo     GraphEdgeKind = "replicates-to"
-	RoutesThrough    GraphEdgeKind = "routes-through"
-	RoutesVia        GraphEdgeKind = "routes-via"
-	RunsOn           GraphEdgeKind = "runs-on"
-)
-
 // Defines values for IngestJobHandleStatus.
 const (
 	IngestJobHandleStatusDegraded  IngestJobHandleStatus = "degraded"
@@ -3771,54 +3757,6 @@ type GatewayResultBody struct {
 // GatewayResultBodyOutcome Terminal outcome to record for the command.
 type GatewayResultBodyOutcome string
 
-// GraphEdgeKind Closed enum of :attr:`GraphEdge.kind` values -- v0.2 vocabulary.
-//
-// Initiative #364 (G9.2) locks the edge-kind vocabulary at ten members:
-// the four auto-discoverable kinds G9.1 (#363) shipped, plus six
-// operator-curated cross-system kinds that auto-discovery cannot infer
-// (decision #6 in :file:`docs/planning/v0.2-decisions.md`). The vocabulary
-// is closed -- widening it is a coordinated DB + model change (new
-// migration, new enum member, new decision row) so the v0.2.next
-// policy-engine grammar parsing “kind“ stays portable across tenants.
-//
-// The four auto-discoverable kinds (refresh service writes these on
-// every probe-derived edge):
-//
-//   - :attr:`RUNS_ON` -- “vm“ “runs-on“ “host“, “pod“ “runs-on“
-//     “node“: the physical / scheduling host of a workload.
-//   - :attr:`MOUNTS` -- “vm“ “mounts“ “datastore“, “pod“ “mounts“
-//     “volume“: storage attachment.
-//   - :attr:`ROUTES_THROUGH` -- “ingress“ “routes-through“ “service“,
-//     “service“ “routes-through“ “pod“: network routing path.
-//   - :attr:`BELONGS_TO` -- “pod“ “belongs-to“ “namespace“, “vm“
-//     “belongs-to“ “host“ (logical group membership).
-//
-// The six curated-only kinds (operator-asserted via
-// “meho topology annotate“; cannot be derived from probes):
-//
-//   - :attr:`AUTHENTICATES_VIA` -- principal -> identity-provider node
-//     (e.g. “k8s-sa-foo“ -> “vault-role-bar“). The canonical
-//     cross-system example.
-//   - :attr:`DEPENDS_ON` -- cross-system functional dependency (e.g.
-//     “service-X“ -> “database-Y“ where neither side knows about the
-//     other in its own probe output).
-//   - :attr:`REPLICATES_TO` -- operator-asserted replication relationship
-//     between two storage / database nodes.
-//   - :attr:`BACKED_UP_BY` -- operator-asserted backup relationship.
-//   - :attr:`ROUTES_VIA` -- operator-asserted network path through an
-//     intermediary (e.g., “vm-A“ -> “firewall-X“ -> “vm-B“ when the
-//     probes only see point-to-point reachability).
-//   - :attr:`POLICY_BINDS` -- RBAC / policy attachment that crosses
-//     connector boundaries (e.g., “kubernetes-namespace-prod“ ->
-//     “vault-policy-prod-read“).
-//
-// Mirrors the closed-enum pattern :class:`AuthModel`
-// (:mod:`meho_backplane.connectors.schemas`) sets: a Python
-// :class:`enum.StrEnum` paired with a portable DB “CHECK“ constraint,
-// both moved in lock-step by one Alembic migration so the enum and the
-// constraint cannot drift.
-type GraphEdgeKind string
-
 // GroupingResultModel Pydantic projection of
 // :class:`~meho_backplane.operations.ingest.llm_groups.GroupingResult`.
 //
@@ -6749,12 +6687,12 @@ type VaultStatus struct {
 
 // UnderscoreAnnotateEdgeRequest Inbound body for “POST /api/v1/topology/edges“.
 //
-// “kind“ is typed against :class:`GraphEdgeKind` so an unknown kind
+// “kind“ is typed against :data:`_EdgeKindSlug` so a malformed kind
 // fails Pydantic validation (HTTP 422) **before** the service runs —
 // the service still raises :class:`InvalidEdgeKindError` for
 // non-route callers, but at the HTTP boundary the operator gets the
-// standard FastAPI validation error shape (with the candidate list in
-// the error context) rather than a 500-shaped diagnostic.
+// standard FastAPI validation error shape (with the pattern in the
+// error context) rather than a 500-shaped diagnostic.
 //
 // The keyword “from“ is reserved in Python so the attribute name is
 // “from_endpoint“; “alias="from"“ keeps the wire shape the issue
@@ -6774,55 +6712,8 @@ type UnderscoreAnnotateEdgeRequest struct {
 	// field; ``extra="forbid"`` rejects typo'd keys at the boundary
 	// (``{from: {nme: ...}}`` is a 422, not a silently-ignored body).
 	From UnderscoreEdgeEndpoint `json:"from"`
-
-	// Kind Closed enum of :attr:`GraphEdge.kind` values -- v0.2 vocabulary.
-	//
-	// Initiative #364 (G9.2) locks the edge-kind vocabulary at ten members:
-	// the four auto-discoverable kinds G9.1 (#363) shipped, plus six
-	// operator-curated cross-system kinds that auto-discovery cannot infer
-	// (decision #6 in :file:`docs/planning/v0.2-decisions.md`). The vocabulary
-	// is closed -- widening it is a coordinated DB + model change (new
-	// migration, new enum member, new decision row) so the v0.2.next
-	// policy-engine grammar parsing ``kind`` stays portable across tenants.
-	//
-	// The four auto-discoverable kinds (refresh service writes these on
-	// every probe-derived edge):
-	//
-	// * :attr:`RUNS_ON` -- ``vm`` ``runs-on`` ``host``, ``pod`` ``runs-on``
-	//   ``node``: the physical / scheduling host of a workload.
-	// * :attr:`MOUNTS` -- ``vm`` ``mounts`` ``datastore``, ``pod`` ``mounts``
-	//   ``volume``: storage attachment.
-	// * :attr:`ROUTES_THROUGH` -- ``ingress`` ``routes-through`` ``service``,
-	//   ``service`` ``routes-through`` ``pod``: network routing path.
-	// * :attr:`BELONGS_TO` -- ``pod`` ``belongs-to`` ``namespace``, ``vm``
-	//   ``belongs-to`` ``host`` (logical group membership).
-	//
-	// The six curated-only kinds (operator-asserted via
-	// ``meho topology annotate``; cannot be derived from probes):
-	//
-	// * :attr:`AUTHENTICATES_VIA` -- principal -> identity-provider node
-	//   (e.g. ``k8s-sa-foo`` -> ``vault-role-bar``). The canonical
-	//   cross-system example.
-	// * :attr:`DEPENDS_ON` -- cross-system functional dependency (e.g.
-	//   ``service-X`` -> ``database-Y`` where neither side knows about the
-	//   other in its own probe output).
-	// * :attr:`REPLICATES_TO` -- operator-asserted replication relationship
-	//   between two storage / database nodes.
-	// * :attr:`BACKED_UP_BY` -- operator-asserted backup relationship.
-	// * :attr:`ROUTES_VIA` -- operator-asserted network path through an
-	//   intermediary (e.g., ``vm-A`` -> ``firewall-X`` -> ``vm-B`` when the
-	//   probes only see point-to-point reachability).
-	// * :attr:`POLICY_BINDS` -- RBAC / policy attachment that crosses
-	//   connector boundaries (e.g., ``kubernetes-namespace-prod`` ->
-	//   ``vault-policy-prod-read``).
-	//
-	// Mirrors the closed-enum pattern :class:`AuthModel`
-	// (:mod:`meho_backplane.connectors.schemas`) sets: a Python
-	// :class:`enum.StrEnum` paired with a portable DB ``CHECK`` constraint,
-	// both moved in lock-step by one Alembic migration so the enum and the
-	// constraint cannot drift.
-	Kind GraphEdgeKind `json:"kind"`
-	Note *string       `json:"note"`
+	Kind string                 `json:"kind"`
+	Note *string                `json:"note"`
 
 	// To Inbound JSON shape for one annotation endpoint.
 	//
@@ -6840,7 +6731,7 @@ type UnderscoreAnnotateEdgeRequest struct {
 // Same wire shape as :class:`_AnnotateEdgeRequest` (“{from, kind, to,
 // note?, evidence_url?}“) — “from“ is bound via “alias“ because
 // it is a Python keyword. “kind“ is typed against
-// :class:`GraphEdgeKind` so an unknown kind fails at the boundary
+// :data:`_EdgeKindSlug` so a malformed kind fails at the boundary
 // (HTTP 422) before any service call runs, and the per-row error
 // surfaces inside the standard FastAPI validation envelope with the
 // row index in “loc“. “extra="forbid"“ rejects typo'd keys so a
@@ -6858,55 +6749,8 @@ type UnderscoreBulkImportEdge struct {
 	// field; ``extra="forbid"`` rejects typo'd keys at the boundary
 	// (``{from: {nme: ...}}`` is a 422, not a silently-ignored body).
 	From UnderscoreEdgeEndpoint `json:"from"`
-
-	// Kind Closed enum of :attr:`GraphEdge.kind` values -- v0.2 vocabulary.
-	//
-	// Initiative #364 (G9.2) locks the edge-kind vocabulary at ten members:
-	// the four auto-discoverable kinds G9.1 (#363) shipped, plus six
-	// operator-curated cross-system kinds that auto-discovery cannot infer
-	// (decision #6 in :file:`docs/planning/v0.2-decisions.md`). The vocabulary
-	// is closed -- widening it is a coordinated DB + model change (new
-	// migration, new enum member, new decision row) so the v0.2.next
-	// policy-engine grammar parsing ``kind`` stays portable across tenants.
-	//
-	// The four auto-discoverable kinds (refresh service writes these on
-	// every probe-derived edge):
-	//
-	// * :attr:`RUNS_ON` -- ``vm`` ``runs-on`` ``host``, ``pod`` ``runs-on``
-	//   ``node``: the physical / scheduling host of a workload.
-	// * :attr:`MOUNTS` -- ``vm`` ``mounts`` ``datastore``, ``pod`` ``mounts``
-	//   ``volume``: storage attachment.
-	// * :attr:`ROUTES_THROUGH` -- ``ingress`` ``routes-through`` ``service``,
-	//   ``service`` ``routes-through`` ``pod``: network routing path.
-	// * :attr:`BELONGS_TO` -- ``pod`` ``belongs-to`` ``namespace``, ``vm``
-	//   ``belongs-to`` ``host`` (logical group membership).
-	//
-	// The six curated-only kinds (operator-asserted via
-	// ``meho topology annotate``; cannot be derived from probes):
-	//
-	// * :attr:`AUTHENTICATES_VIA` -- principal -> identity-provider node
-	//   (e.g. ``k8s-sa-foo`` -> ``vault-role-bar``). The canonical
-	//   cross-system example.
-	// * :attr:`DEPENDS_ON` -- cross-system functional dependency (e.g.
-	//   ``service-X`` -> ``database-Y`` where neither side knows about the
-	//   other in its own probe output).
-	// * :attr:`REPLICATES_TO` -- operator-asserted replication relationship
-	//   between two storage / database nodes.
-	// * :attr:`BACKED_UP_BY` -- operator-asserted backup relationship.
-	// * :attr:`ROUTES_VIA` -- operator-asserted network path through an
-	//   intermediary (e.g., ``vm-A`` -> ``firewall-X`` -> ``vm-B`` when the
-	//   probes only see point-to-point reachability).
-	// * :attr:`POLICY_BINDS` -- RBAC / policy attachment that crosses
-	//   connector boundaries (e.g., ``kubernetes-namespace-prod`` ->
-	//   ``vault-policy-prod-read``).
-	//
-	// Mirrors the closed-enum pattern :class:`AuthModel`
-	// (:mod:`meho_backplane.connectors.schemas`) sets: a Python
-	// :class:`enum.StrEnum` paired with a portable DB ``CHECK`` constraint,
-	// both moved in lock-step by one Alembic migration so the enum and the
-	// constraint cannot drift.
-	Kind GraphEdgeKind `json:"kind"`
-	Note *string       `json:"note"`
+	Kind string                 `json:"kind"`
+	Note *string                `json:"note"`
 
 	// To Inbound JSON shape for one annotation endpoint.
 	//
@@ -7790,14 +7634,14 @@ type DiffRouteApiV1TopologyDiffGetParams struct {
 
 // ListEdgesRouteApiV1TopologyEdgesGetParams defines parameters for ListEdgesRouteApiV1TopologyEdgesGet.
 type ListEdgesRouteApiV1TopologyEdgesGetParams struct {
-	Kind          *GraphEdgeKind `form:"kind,omitempty" json:"kind,omitempty"`
-	Source        *string        `form:"source,omitempty" json:"source,omitempty"`
-	From          *string        `form:"from,omitempty" json:"from,omitempty"`
-	To            *string        `form:"to,omitempty" json:"to,omitempty"`
-	Conflicts     *bool          `form:"conflicts,omitempty" json:"conflicts,omitempty"`
-	Limit         *int           `form:"limit,omitempty" json:"limit,omitempty"`
-	Offset        *int           `form:"offset,omitempty" json:"offset,omitempty"`
-	Authorization *string        `json:"authorization,omitempty"`
+	Kind          *string `form:"kind,omitempty" json:"kind,omitempty"`
+	Source        *string `form:"source,omitempty" json:"source,omitempty"`
+	From          *string `form:"from,omitempty" json:"from,omitempty"`
+	To            *string `form:"to,omitempty" json:"to,omitempty"`
+	Conflicts     *bool   `form:"conflicts,omitempty" json:"conflicts,omitempty"`
+	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset        *int    `form:"offset,omitempty" json:"offset,omitempty"`
+	Authorization *string `json:"authorization,omitempty"`
 }
 
 // AnnotateEdgeRouteApiV1TopologyEdgesPostParams defines parameters for AnnotateEdgeRouteApiV1TopologyEdgesPost.

--- a/cli/internal/cmd/topology/annotate.go
+++ b/cli/internal/cmd/topology/annotate.go
@@ -17,13 +17,15 @@ import (
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// edgeKindVocabulary mirrors the closed 10-kind GraphEdgeKind enum
+// edgeKindVocabulary mirrors the well-known GraphEdgeKind set
 // (backend/src/meho_backplane/db/models.py). The order matches the
 // enum declaration order so the in-help table is stable across
 // releases — the four auto-discoverable kinds first, then the six
-// curated-only kinds. The vocabulary is closed; widening it is a
-// coordinated DB migration + enum + decision-row change per §12 of
-// Initiative #364. Keep this list in lock-step with the enum.
+// curated-only kinds. The vocabulary itself is OPEN (T1 #2534): any
+// lowercase slug (2-63 chars; letters/digits joined by `.`, `_` or
+// `-`) is a valid kind, and this table documents the well-known core
+// the operator should prefer when one fits. Keep this list in
+// lock-step with the backend enum.
 var edgeKindVocabulary = []edgeKindEntry{
 	// Four auto-discoverable kinds — refresh writes these on every probe.
 	{"runs-on", "vm runs-on host, pod runs-on node (physical/scheduling host)"},
@@ -44,13 +46,13 @@ type edgeKindEntry struct {
 	Desc string
 }
 
-// formatEdgeKindTable renders the 10-kind vocabulary as an aligned
+// formatEdgeKindTable renders the well-known kinds as an aligned
 // table block. Used both for the cobra `Long` help (§12 of Initiative
 // #364 requires the table to be discoverable from `--help`) and for
 // the unit tests that assert every name + description is present.
 func formatEdgeKindTable() string {
 	var b strings.Builder
-	b.WriteString("Edge kind vocabulary (closed 10-kind enum, §12 of Initiative #364):\n\n")
+	b.WriteString("Well-known edge kinds (the vocabulary is open — any lowercase slug is valid; prefer these when one fits):\n\n")
 	for _, e := range edgeKindVocabulary {
 		fmt.Fprintf(&b, "  %-18s %s\n", e.Name, e.Desc)
 	}
@@ -90,8 +92,10 @@ func newAnnotateCmd() *cobra.Command {
 			"and the recoverability lever for an incorrectly auto-" +
 			"discovered edge (the §6 supersede flow). Idempotent — a " +
 			"repeat call upserts the same row. Requires tenant_admin.\n\n" +
-			"<kind> must be one of the closed 10-kind vocabulary " +
-			"below. <from> and <to> are node names; pass --from-kind " +
+			"<kind> is any lowercase kind slug (2-63 chars; letters/" +
+			"digits joined by `.`, `_` or `-`) — prefer a well-known " +
+			"kind from the table below when one fits. <from> and <to> " +
+			"are node names; pass --from-kind " +
 			"/ --to-kind when a bare name is ambiguous across node " +
 			"kinds (the backend 409s otherwise).\n\n" +
 			formatEdgeKindTable(),
@@ -141,10 +145,10 @@ type annotateOptions struct {
 
 // buildAnnotateBody wraps the operator-typed annotate inputs into the
 // generated `UnderscoreAnnotateEdgeRequest` body. `Kind` is forwarded
-// as a plain string and validated server-side against the closed
-// 10-kind GraphEdgeKind vocabulary (a 422 with the per-row message is
-// the failure surface the operator sees if they typo the kind, same
-// shape as the pre-migration contract). Endpoint kinds are passed as
+// as a plain string and validated server-side against the open kind
+// slug grammar (a 422 with the pattern + well-known suggestions is
+// the failure surface the operator sees on a malformed kind; a novel
+// well-formed slug passes — T1 #2534). Endpoint kinds are passed as
 // nil pointers when the operator didn't supply --from-kind / --to-kind
 // so the wire shape sees an absent field rather than an empty string
 // (the backend's _EdgeEndpoint model treats absent and empty kind
@@ -152,7 +156,7 @@ type annotateOptions struct {
 func buildAnnotateBody(opts annotateOptions) api.UnderscoreAnnotateEdgeRequest {
 	body := api.UnderscoreAnnotateEdgeRequest{
 		From: api.UnderscoreEdgeEndpoint{Name: opts.From},
-		Kind: api.GraphEdgeKind(opts.Kind),
+		Kind: opts.Kind,
 		To:   api.UnderscoreEdgeEndpoint{Name: opts.To},
 	}
 	if opts.FromKind != "" {

--- a/cli/internal/cmd/topology/bulk_import.go
+++ b/cli/internal/cmd/topology/bulk_import.go
@@ -145,8 +145,9 @@ func newBulkImportCmd() *cobra.Command {
 			"`from` and `to` accept either a bare string (the common " +
 			"case) or a `{name, kind}` map when an endpoint is " +
 			"ambiguous and the operator wants to pin the kind. `kind` " +
-			"must be one of the closed 10-kind GraphEdgeKind vocabulary " +
-			"(`meho topology annotate --help` lists every kind).\n\n" +
+			"is any lowercase kind slug (the vocabulary is open); " +
+			"prefer a well-known kind when one fits " +
+			"(`meho topology annotate --help` lists them).\n\n" +
 			"--dry-run returns the per-row plan (create / update / " +
 			"conflict) and writes nothing; --json emits the raw response " +
 			"JSON for piping into a downstream consumer.\n\n" +
@@ -258,16 +259,15 @@ func parseBulkImportDoc(data []byte) (*bulkImportDoc, error) {
 
 // buildBulkImportBody projects the YAML-decoded `bulkImportDoc` onto
 // the generated `api.UnderscoreBulkImportRequest` body. The kind
-// rides as a typed `api.GraphEdgeKind` so the generated parser's
-// closed-vocabulary contract is the wire-level check (operators see
-// the substrate's per-row 422 message on a bad kind, same shape as
-// the pre-migration `httpError` ladder).
+// rides as a plain string; the backend's slug-pattern check is the
+// wire-level gate (operators see the substrate's per-row 422 message
+// on a malformed kind — the vocabulary itself is open per T1 #2534).
 func buildBulkImportBody(doc *bulkImportDoc, dryRun bool) api.UnderscoreBulkImportRequest {
 	edges := make([]api.UnderscoreBulkImportEdge, 0, len(doc.Edges))
 	for _, e := range doc.Edges {
 		edge := api.UnderscoreBulkImportEdge{
 			From: api.UnderscoreEdgeEndpoint{Name: e.From.Name},
-			Kind: api.GraphEdgeKind(e.Kind),
+			Kind: e.Kind,
 			To:   api.UnderscoreEdgeEndpoint{Name: e.To.Name},
 		}
 		if e.From.Kind != "" {

--- a/cli/internal/cmd/topology/list_edges.go
+++ b/cli/internal/cmd/topology/list_edges.go
@@ -158,16 +158,15 @@ func runListEdges(cmd *cobra.Command, opts listEdgesOptions) error {
 // `auto` or `curated`); the route's regex pattern enforces the same
 // closed pair.
 //
-// `Kind` rides as the typed `*GraphEdgeKind` enum because the
-// generator narrowed the wire pattern to the closed vocabulary; we
-// reuse the operator-typed string verbatim — invalid kinds round-
-// trip to a 422 with the per-row message rather than failing
-// client-side, matching the pre-migration contract where the CLI
-// didn't second-guess the substrate's vocabulary check.
+// `Kind` rides as a plain `*string` (the wire schema is an open
+// slug-patterned string since T1 #2534); we reuse the operator-typed
+// string verbatim — malformed kinds round-trip to a 422 with the
+// pattern message rather than failing client-side, so the CLI never
+// second-guesses the substrate's vocabulary check.
 func buildListEdgesParams(opts listEdgesOptions) *api.ListEdgesRouteApiV1TopologyEdgesGetParams {
 	params := &api.ListEdgesRouteApiV1TopologyEdgesGetParams{}
 	if opts.Kind != "" {
-		k := api.GraphEdgeKind(opts.Kind)
+		k := opts.Kind
 		params.Kind = &k
 	}
 	if opts.Source != "" {

--- a/cli/internal/cmd/topology/topology_test.go
+++ b/cli/internal/cmd/topology/topology_test.go
@@ -327,7 +327,7 @@ func TestFormatAmbiguousNode(t *testing.T) {
 
 // TestAnnotateHelpEmitsTenKindVocabulary — §12 acceptance criterion
 // for #599: `meho topology annotate --help` must surface every one of
-// the closed 10 GraphEdgeKind values with a one-line description so
+// the 10 well-known GraphEdgeKind values with a one-line description so
 // operators discover the vocabulary without leaving the CLI.
 func TestAnnotateHelpEmitsTenKindVocabulary(t *testing.T) {
 	cmd := newAnnotateCmd()
@@ -344,20 +344,24 @@ func TestAnnotateHelpEmitsTenKindVocabulary(t *testing.T) {
 		}
 	}
 	// Sanity: the help block names the table explicitly so the table
-	// header is searchable in shell scrollback.
-	if !strings.Contains(long, "Edge kind vocabulary") {
+	// header is searchable in shell scrollback, and states that the
+	// vocabulary is open (T1 #2534).
+	if !strings.Contains(long, "Well-known edge kinds") {
 		t.Errorf("annotate --help should label the table; got %q", long)
+	}
+	if !strings.Contains(long, "vocabulary is open") {
+		t.Errorf("annotate --help should state the vocabulary is open; got %q", long)
 	}
 }
 
 // TestEdgeKindVocabularyMatchesEnum — the in-help table must stay in
-// lock-step with the closed enum on the backend side. Both lists are
+// lock-step with the well-known enum on the backend side. Both lists are
 // declared in source; this test fails noisily when the count drifts
 // (the actual enum lives in backend/src/meho_backplane/db/models.py
 // and is asserted from the Python side; here we lock the CLI mirror).
 func TestEdgeKindVocabularyMatchesEnum(t *testing.T) {
 	if got := len(edgeKindVocabulary); got != 10 {
-		t.Fatalf("edgeKindVocabulary count = %d; want 10 (closed v0.2 enum)", got)
+		t.Fatalf("edgeKindVocabulary count = %d; want 10 (well-known set)", got)
 	}
 	seen := make(map[string]bool, 10)
 	for _, e := range edgeKindVocabulary {

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -75,16 +75,82 @@ CLI, REST (`/api/v1/topology*`, `/api/v1/targets/discover`), and the
 MCP meta-tools are **sibling fronts on one backplane** — each calls the
 `topology/` substrate directly; none is a thin wrapper of another.
 
-## The v0.2 edge-kind vocabulary
+## The kind vocabularies — open, slug-validated, with a documented well-known core
 
-G9.2 ([#364](https://github.com/evoila/meho/issues/364)) locks the
-edge-kind vocabulary at **ten** members: the four auto-discoverable
-kinds G9.1 ships, plus six operator-curated cross-system kinds that
-no probe can derive. The vocabulary is closed; widening it is a
-coordinated DB + model + decision-row change (migration `0010`
-widens the `graph_edge.kind` CHECK from the G9.1 subset; the
+Both `graph_node.kind` and `graph_edge.kind` are **open
+vocabularies** ([Initiative #2533](https://github.com/evoila/meho/issues/2533)
+T1 [#2534](https://github.com/evoila/meho/issues/2534), reversing the
+[#364](https://github.com/evoila/meho/issues/364) v0.2 lock). Any kind
+matching the **slug grammar** is valid:
+
+```
+^[a-z0-9]+(?:[._-][a-z0-9]+)*$        (2–63 characters)
+```
+
+lowercase alphanumeric runs joined by single `.` / `_` / `-`
+separators. A novel kind (`dns-record`, `database`, `certificate`,
+`chassis`, `resolves-to`, `same-as`, …) enters the graph through a
+normal write — no migration, no registry, no per-tenant governance
+table ("dumb substrate, smart agent"). Human `tenant_admin` writes
+stay zero-friction on every front; for AGENT principals the write
+itself is approval-gated (T3 [#2537](https://github.com/evoila/meho/issues/2537)),
+so a human sees a novel agent-invented kind at the moment it is
+proposed.
+
+Enforcement layers:
+
+- **Python (authoritative)** — the full slug pattern is validated at
+  every write boundary, single-sourced from
+  [`KIND_SLUG_PATTERN`](../../backend/src/meho_backplane/db/models.py)
+  (`is_valid_kind_slug`): the service primitives
+  (`topology/nodes.py`, `topology/annotate.py`), the REST body
+  models (Pydantic `StringConstraints`), and the MCP inputSchemas
+  (jsonschema `pattern`). Rejection cites the pattern and echoes the
+  well-known kinds as suggestions.
+- **DB (backstop)** — migration `0063` replaced the closed IN-list
+  CHECKs (`ck_graph_node_kind` 14 members, `ck_graph_edge_kind` 10
+  members) with a portable minimal shape CHECK
+  (`length(kind) BETWEEN 2 AND 63 AND kind = lower(kind)`); regex
+  CHECKs are not portable across PostgreSQL and the SQLite unit
+  suite, so the DB layer guards shape, not the full grammar.
+
+The old members survive as the **well-known set** — a documentation
+convention, not a gate.
+[`WELL_KNOWN_NODE_KINDS`](../../backend/src/meho_backplane/db/models.py)
+carries the 14 node kinds (`target`, `vm`, `host`, `network`,
+`datastore`, `namespace`, `pod`, `service`, `ingress`, `node`,
+`principal`, `vault-role`, `vault-mount`, `volume`);
 [`GraphEdgeKind`](../../backend/src/meho_backplane/db/models.py)
-`StrEnum` and the CHECK move in lock-step).
+carries the ten edge kinds tabulated below. **Prefer a well-known
+kind when one fits** — shared vocabulary keeps traversal answers and
+cross-operator conventions legible; reach for a novel slug when no
+well-known kind describes the resource class or relationship. The
+UI surfaces the well-known kinds as `datalist` suggestions with
+free-text input; MCP tool descriptions and error messages carry the
+same list.
+
+### The `same-as` convention — cross-system identity stitching
+
+When two connectors each discover *the same physical thing* under
+different names (the Kubernetes connector's `node` `worker-3` and a
+bare-metal inventory's `host` `hetzner-ax41-7`), assert a curated
+`same-as` edge between the two nodes:
+
+```
+meho topology annotate worker-3 same-as hetzner-ax41-7 \
+  --note "same machine; MAC 9c:6b:00:… verified 2026-07-10" \
+  --evidence-url https://…/INVENTORY.md#ax41-7
+```
+
+`same-as` is symmetric in meaning but stored as a directed edge like
+every other kind; pick a consistent direction per tenant (suggested:
+from the more specific / ephemeral representation to the more
+durable one) and record the evidence. Traversals then reach across
+the identity seam like any other edge. Machine-*suggested* matches
+(auto-matching by MAC/UUID) are a later initiative; T1 makes the
+assertion expressible and traversable today.
+
+### The well-known edge kinds
 
 **Four auto-discoverable kinds** — refresh writes these on every
 probe, **for the pair-types a populator covers** (see

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -93,8 +93,10 @@ separators. A novel kind (`dns-record`, `database`, `certificate`,
 normal write — no migration, no registry, no per-tenant governance
 table ("dumb substrate, smart agent"). Human `tenant_admin` writes
 stay zero-friction on every front; for AGENT principals the write
-itself is approval-gated (T3 [#2537](https://github.com/evoila/meho/issues/2537)),
-so a human sees a novel agent-invented kind at the moment it is
+itself becomes approval-gated when T3
+[#2537](https://github.com/evoila/meho/issues/2537) lands (until
+then agent writes are immediate, like human writes), at which point
+a human sees a novel agent-invented kind at the moment it is
 proposed.
 
 Enforcement layers:

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -29,7 +29,9 @@ models that G9.1-T1 (#448, migration `0007`) created.
 
 - `annotate_edge(session, operator, from_ref, kind, to_ref, *, note=None, evidence_url=None) -> GraphEdge`
   — create or refresh a curated edge. Resolves both endpoints via
-  `resolve_node`, validates `kind` against `GraphEdgeKind`,
+  `resolve_node`, validates `kind` against the open slug grammar
+  (`KIND_SLUG_PATTERN`, T1 #2534 — any lowercase slug, 2–63 chars;
+  `GraphEdgeKind` is the documented well-known set, not a gate),
   idempotent on `(tenant_id, from_node_id, to_node_id, kind)`. Runs
   §6 conflict detection (sticky `superseded_by` for
   same-kind/different-endpoint auto edges; bidirectional
@@ -52,8 +54,10 @@ models that G9.1-T1 (#448, migration `0007`) created.
 
 - `create_or_get_node(session, operator, *, kind, name, note=None, evidence_url=None) -> CreateNodeResult`
   — manually seed a `graph_node` row in the operator's tenant.
-  Validates `kind` against `_GRAPH_NODE_KINDS` (raise
-  `InvalidNodeKindError` *before* any DB write), then idempotent
+  Validates `kind` against the open slug grammar
+  (`KIND_SLUG_PATTERN`; raise `InvalidNodeKindError` *before* any DB
+  write — `WELL_KNOWN_NODE_KINDS` is the documented core set, not a
+  gate), then idempotent
   upsert on the `graph_node_tenant_kind_name_idx`
   (`(tenant_id, kind, name)`) unique key. Manual seeds set
   `discovered_by=operator.sub`; a re-seed over an auto-discovered row
@@ -98,7 +102,8 @@ funnel through these primitives.
   filter-composable edge listing. Joins both endpoint nodes so
   `from` / `to` carry `(id, kind, name)` without a second round
   trip. Filters compose: `kind=` restricts to one
-  `GraphEdgeKind`, `source=` selects `'auto'` vs `'curated'`,
+  kind slug (any well-formed slug; the vocabulary is open), `source=`
+  selects `'auto'` vs `'curated'`,
   `from_ref` / `to_ref` resolve via `resolve_node` (a ref that maps
   to no node yields an empty list, not an error; an ambiguous bare
   name raises `AmbiguousNodeError`), `conflicts_only=True` returns
@@ -189,7 +194,7 @@ as a warning callout next to the counts (#2210).
 | Field | Type | Meaning |
 |---|---|---|
 | `id` | `UUID` | `graph_node.id`. |
-| `kind` | `str` | `graph_node.kind` (closed enum from migration 0007). |
+| `kind` | `str` | `graph_node.kind` (open slug vocabulary since migration 0063 / T1 #2534; `WELL_KNOWN_NODE_KINDS` is the documented core set). |
 | `name` | `str` | `graph_node.name`, unique within `(tenant_id, kind)`. |
 | `properties` | `dict` | `graph_node.properties` JSONB; wrapped in `MappingProxyType` after validation so the frozen model is deeply immutable, serialised back to a plain `dict`. |
 | `depth` | `int` | Distance from the query root: root = 0, immediate = 1, transitive = 2, … |
@@ -223,7 +228,7 @@ separately via `resolve_node`.
 | `id` | `UUID` | `graph_edge.id`. |
 | `from_endpoint` | `TopologyEdgeEndpoint` | The edge's source node identity. The route layer (T5) applies the `from` / `to` alias on `model_dump(by_alias=True)` for the wire shape — the substrate model itself keeps plain attribute names so mypy/static checkers don't lose the kwarg signature. |
 | `to_endpoint` | `TopologyEdgeEndpoint` | The edge's destination node identity. |
-| `kind` | `str` | One of the ten `GraphEdgeKind` values (closed enum since G9.2-T1 #593). |
+| `kind` | `str` | Any kind slug (open vocabulary since migration 0063 / T1 #2534); the ten `GraphEdgeKind` values are the documented well-known set. |
 | `source` | `str` | `'auto'` (probe-derived) or `'curated'` (operator-asserted). |
 | `properties` | `dict` | `graph_edge.properties` JSONB; deep-frozen (same discipline as `TopologyNode.properties`). Carries the conflict markers `conflicts_with` (array, G9.2-T3 #595) and `superseded_by` (UUID, also #595). |
 | `last_seen` | `datetime \| None` | The refresh service's "I observed this edge at" timestamp. NULL after a soft-delete; soft-deleted edges are excluded from `list_edges` by default. Also the stable total-order key the helper paginates against. |
@@ -469,8 +474,10 @@ so the guard runs only where the column is JSONB.
 
 ### `annotate_edge`
 
-1. Validate `kind` against `GraphEdgeKind` (raise
-   `InvalidEdgeKindError` *before* any DB read).
+1. Validate `kind` against the open slug grammar
+   (`KIND_SLUG_PATTERN` via `is_valid_kind_slug`; raise
+   `InvalidEdgeKindError` *before* any DB read — the error message
+   names the pattern and echoes the well-known kinds as suggestions).
 2. `async with session.begin()` — one transaction wraps the whole
    resolve + write + conflict-scan + audit-row.
 3. `resolve_node` for both endpoints (`operator.tenant_id` is the
@@ -823,8 +830,11 @@ SSE / Slack feed.
 
 ### `create_or_get_node`
 
-1. Validate `kind` against `_GRAPH_NODE_KINDS` (raise
-   `InvalidNodeKindError` *before* any DB read).
+1. Validate `kind` against the open slug grammar
+   (`KIND_SLUG_PATTERN` via `is_valid_kind_slug`; raise
+   `InvalidNodeKindError` *before* any DB read — the error message
+   names the pattern and echoes `WELL_KNOWN_NODE_KINDS` as
+   suggestions).
 2. Pre-allocate `audit_id = uuid.uuid4()` (chassis "audit-id
    pre-allocation" pattern shared with `refresh` / `annotate` —
    the same uuid is threaded into the `audit_log` row and the
@@ -1075,12 +1085,14 @@ Load-bearing details:
   broadcast event would under-emit per §10. `GET /edges` binds
   `op_class="read"`.
 - **`POST /edges` body shape.** The request body is
-  `{"from": {"name": ..., "kind"?}, "kind": <GraphEdgeKind>,
+  `{"from": {"name": ..., "kind"?}, "kind": <kind-slug>,
     "to": {"name": ..., "kind"?}, "note"?, "evidence_url"?}` —
   `from` / `to` are nested `_EdgeEndpoint` objects (mirrors the
   service-layer `NodeRef` dataclass on the wire). `kind` is typed
-  against `GraphEdgeKind` so Pydantic rejects unknown kinds at the
-  boundary with 422 before the service runs. `extra="forbid"` rejects
+  against the `_EdgeKindSlug` `StringConstraints` alias
+  (`KIND_SLUG_PATTERN`, 2–63 chars) so Pydantic rejects malformed
+  kinds at the boundary with 422 before the service runs; any
+  well-formed slug — well-known or novel — passes through. `extra="forbid"` rejects
   typo'd keys at the boundary too.
 - **`GET /edges` query params** are forwarded straight through to
   `list_edges` (`kind?`, `source?` constrained to `auto|curated` by a
@@ -1175,9 +1187,10 @@ and broadcast event.
 **Wire shape.** The REST body is
 `{"edges": [{"from", "kind", "to", "note"?, "evidence_url"?}, ...], "dry_run"?: bool}`.
 `from` / `to` accept the same `_EdgeEndpoint` `{name, kind?}` shape
-the single-edge endpoint uses; `kind` is the closed `GraphEdgeKind`
-enum so an unknown kind is rejected at the Pydantic boundary (422)
-before any service runs. `extra="forbid"` rejects typo'd fields at
+the single-edge endpoint uses; `kind` is the `_EdgeKindSlug`
+`StringConstraints` alias so a malformed kind slug is rejected at the
+Pydantic boundary (422) before any service runs (the vocabulary is
+open — well-known and novel slugs both pass). `extra="forbid"` rejects typo'd fields at
 the boundary. The response is
 `{dry_run, created, updated, conflicts, rows: [...]}` where each row
 carries `{index, action, edge_id?, from_name, from_kind, to_name,

--- a/docs/cross-repo/topology-annotation.md
+++ b/docs/cross-repo/topology-annotation.md
@@ -218,7 +218,9 @@ The descriptions below match `meho topology annotate --help` verbatim
 — if you grep the CLI source
 ([`cli/internal/cmd/topology/annotate.go`](../../cli/internal/cmd/topology/annotate.go)
 `edgeKindVocabulary`), you'll see the same strings. They are the same
-strings the MCP `inputSchema` rejects unknown kinds against.
+strings the MCP write tools echo as *advisory suggestions* in their
+`kind` description — the `inputSchema` validates the slug pattern
+only, never membership in this table.
 
 | Kind                 | Source       | Description (verbatim from `--help`)                                                       |
 | -------------------- | ------------ | ------------------------------------------------------------------------------------------ |
@@ -237,9 +239,12 @@ Rule of thumb in one line: a row marked **auto** is written by a
 probe — *do not annotate*. A row marked **curated** is invisible to
 probes — annotate it when the relationship exists.
 
-If a kind isn't in the table, the backend will refuse the call at the
-HTTP boundary with **422** and the candidate kinds echoed in
-`detail.kinds` — no need to grep the source to find the spelling.
+A kind that isn't in the table is **not** refused — any valid slug
+(lowercase alphanumeric runs joined by single `.` / `_` / `-`, 2-63
+chars) passes straight through. Only a *malformed* slug is rejected
+at the HTTP boundary with **422**; the error detail carries the slug
+`pattern` plus the well-known kinds under `well_known_kinds` as
+suggestions — no need to grep the source to find a spelling.
 
 ## CLI walkthrough
 
@@ -490,12 +495,13 @@ the `topology` router (`/api/v1/topology` prefix). The full request
 shapes:
 
 - `POST /api/v1/topology/edges` — body
-  `{"from": {"name": str, "kind"?: str}, "kind": GraphEdgeKind, "to":
+  `{"from": {"name": str, "kind"?: str}, "kind": str, "to":
   {"name": str, "kind"?: str}, "note"?: str, "evidence_url"?: str}`.
   Returns `201 TopologyEdge` (the typed Pydantic envelope, same
-  shape `GET /edges` returns). The body's `kind` is typed against
-  the `GraphEdgeKind` enum so an unknown value is rejected with
-  **422** before the service runs. **Role:** `tenant_admin`.
+  shape `GET /edges` returns). The body's `kind` is a slug-patterned
+  string (`KIND_SLUG_PATTERN`, 2-63 chars) so a malformed slug is
+  rejected with **422** before the service runs, while a
+  novel-but-valid kind passes through. **Role:** `tenant_admin`.
 - `DELETE /api/v1/topology/edges/{edge_id}` — returns `204 No
   Content` on success; **409 `auto_edge_deletion`** on an auto row
   with the verbatim remediation message; **404** on a missing /

--- a/docs/cross-repo/topology-annotation.md
+++ b/docs/cross-repo/topology-annotation.md
@@ -39,7 +39,9 @@ boundaries (a Kubernetes ServiceAccount authenticating against a
 Vault role, a service depending on a database in a different
 product) and that no single probe can ever see.
 
-The shape is one closed ten-kind vocabulary, two write verbs
+The shape is one open, slug-validated kind vocabulary with a
+documented ten-kind well-known core (T1
+[#2534](https://github.com/evoila/meho/issues/2534)), two write verbs
 (`annotate` / `unannotate`), one listing verb (`list-edges`), and a
 deterministic §6 conflict-resolution policy so a wrong assertion is
 recoverable in one CLI call.
@@ -74,8 +76,8 @@ for callers wiring their own tooling.
 
 ## When to annotate, when not to
 
-The closed vocabulary splits cleanly into two halves and the rule of
-thumb follows from the split:
+The well-known vocabulary splits cleanly into two halves and the rule
+of thumb follows from the split:
 
 - **Six curated-only kinds** (`authenticates-via`, `depends-on`,
   `replicates-to`, `backed-up-by`, `routes-via`, `policy-binds`) — no
@@ -196,18 +198,21 @@ ships the non-k8s populator. Recording the commitment now means you can
 model `runs-on` correctly today without fear that a later populator
 will punish you for it.
 
-## The closed 10-kind vocabulary
+## The well-known 10-kind set
 
-The vocabulary is closed. Widening it is a coordinated DB + model +
-decision-row change (a new Alembic migration, a new
-[`GraphEdgeKind`](../../backend/src/meho_backplane/db/models.py) enum
-member, and a row in
-[`docs/planning/v0.2-decisions.md`](../planning/v0.2-decisions.md))
-so the v0.2.next policy-engine grammar parsing `kind` stays portable
-across tenants. The same table is rendered by
-`meho topology annotate --help` and pinned into the MCP tool's
-`inputSchema` enum, so an operator can never spell a kind the backend
-won't accept.
+The vocabulary is **open** since T1
+[#2534](https://github.com/evoila/meho/issues/2534): any lowercase
+slug (2-63 chars; letters/digits joined by `.`, `_` or `-`) is a
+valid edge kind, and the ten kinds below survive as the *documented
+well-known set* — prefer one when it fits, reach for a novel slug
+(`resolves-to`, `same-as`, ...) when none does (see
+[docs/architecture/topology.md](../architecture/topology.md) for the
+slug grammar and the `same-as` identity-stitching convention).
+Widening the *well-known* set is a docs + enum change (a new
+[`GraphEdgeKind`](../../backend/src/meho_backplane/db/models.py)
+member — no migration needed). The same table is rendered by
+`meho topology annotate --help` and echoed in the MCP tool's `kind`
+description as suggestions.
 
 The descriptions below match `meho topology annotate --help` verbatim
 — if you grep the CLI source
@@ -619,10 +624,12 @@ would let a probing operator distinguish "row never existed" from
 - **Self-edges.** Asserting `nodeX kind nodeX` returns **422
   `self_edge`** — every curated kind expresses a relationship
   between two distinct nodes.
-- **Unknown kind.** A typo'd kind is rejected at the
-  Pydantic / `inputSchema` boundary with HTTP 422 (REST) or
-  JSON-RPC `-32602` (MCP); the response echoes the closed candidate
-  list so the operator can correct without reading the source.
+- **Malformed kind.** A kind that violates the slug grammar
+  (uppercase, spaces, punctuation, length outside 2-63) is rejected
+  at the Pydantic / `inputSchema` boundary with HTTP 422 (REST) or
+  JSON-RPC `-32602` (MCP); the response names the pattern and echoes
+  the well-known kinds as suggestions. A well-formed novel kind is
+  accepted — the vocabulary is open.
 - **Role gating on writes.** `annotate` / `unannotate` require
   `tenant_admin`. An `operator`-role caller never sees the
   `meho.topology.*` tools in `tools/list` and a direct `tools/call`
@@ -639,8 +646,9 @@ would let a probing operator distinguish "row never existed" from
 ## References
 
 - **Parent Initiative:** G9.2
-  [#364](https://github.com/evoila/meho/issues/364) — closed
-  10-kind vocabulary + curated-edge surface.
+  [#364](https://github.com/evoila/meho/issues/364) — the original
+  closed 10-kind vocabulary + curated-edge surface (the vocabulary
+  lock was reversed by [#2534](https://github.com/evoila/meho/issues/2534)).
 - **Parent Goal:** G9
   [#220](https://github.com/evoila/meho/issues/220) — the topology
   graph + history half of the v0.2 chassis.


### PR DESCRIPTION
## Summary

- **Opens the node/edge kind vocabularies** (Initiative #2533 T1, the keystone): migration `0063` drops the closed IN-list CHECKs `ck_graph_node_kind` (14 kinds) / `ck_graph_edge_kind` (10 kinds) and replaces each with a portable minimal shape CHECK (`length(kind) BETWEEN 2 AND 63 AND kind = lower(kind)`), following migration `0010`'s batch drop-and-recreate mold with a `0010`-style downgrade pre-check that refuses to narrow while novel-kind rows exist.
- **Full slug validation moves to Python, single-sourced**: `KIND_SLUG_PATTERN` (`^[a-z0-9]+(?:[._-][a-z0-9]+)*$`, 2–63 chars) + `is_valid_kind_slug` in `db/models.py` drive `nodes._validate_kind`, `annotate._validate_kind` (bulk-import inherits), the REST `_EdgeKindSlug` `StringConstraints` alias, and the MCP inputSchemas (`pattern` replaces `enum`). Error messages now cite the pattern and echo the well-known kinds as suggestions.
- **Well-known set demoted to convention**: `_GRAPH_NODE_KINDS` → `WELL_KNOWN_NODE_KINDS`; `GraphEdgeKind` retained as the documented well-known edge set (docs tables, UI `datalist` suggestions, error hints — no longer enforced). The UI annotate modal's kind field becomes free-text + `datalist` (was a closed `<select>`). The `keycloak-realm` doc-vs-enum drift retires itself — the advertised example now round-trips (pinned by test).
- **Wire schema + CLI regenerated**: `GraphEdgeKind` OpenAPI enum component becomes a pattern-constrained string; `cli/api/openapi.json` re-snapshot + `oapi-codegen` regen; Go call sites updated (`api.GraphEdgeKind` type no longer generated) and CLI help reworded to "well-known kinds / open vocabulary".
- **Docs**: `docs/architecture/topology.md` vocabulary section rewritten (open slug grammar, enforcement layers, well-known core, the `same-as` cross-system identity-stitching convention); `docs/codebase/topology.md` validation passages updated; `docs/cross-repo/topology-annotation.md` closed-vocabulary claims corrected.

Per the initiative's binding principle ("dumb substrate, smart agent"): no kind registry, no per-tenant governance tables — approval-gating of *agent* writes is T3 (#2537), not this task.

## Test plan

- [x] `uv run ruff check` — clean on all touched paths (`alembic/versions/0023` RUF034 pre-existing, untouched)
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy` on all touched modules — clean (`connectors/net/icmp.py` MSG_ERRQUEUE error is pre-existing, Linux-only attr on darwin)
- [x] `pytest tests/migrations/test_migration_0063_open_graph_kind_vocabularies.py` — 8 passed (forward novel/closed/malformed matrix, `ck_graph_edge_source` batch-rebuild survival, pre-upgrade rejection at `0062`, round-trip, downgrade refusal naming kinds+counts; all legs pinned to `0063`/`0062`, never `head`)
- [x] `pytest tests/ -k topology` (unit) — green (525+ tests)
- [x] `pytest tests/integration/test_topology_annotate.py::test_novel_kinds_flow_end_to_end_on_postgres` — passed against the real pgvector/pg16 container: `create_or_get_node {kind: dns-record}` + `{kind: keycloak-realm}` + REST annotate `{kind: resolves-to}` land end-to-end
- [x] Acceptance: `dns-record` / `resolves-to` succeed; `"DNS Record!"` and 64-char kinds rejected with typed errors naming the pattern (unit, node + edge paths); all 14+10 existing kinds still validate; existing rows survive the migration
- [x] MCP inputSchemas carry `pattern` (no `enum`) — pinned by `test_create_node_input_schema_kind_is_pattern_constrained`; `keycloak-realm` round-trip pinned by `test_create_node_accepts_novel_kind_keycloak_realm`
- [x] `cd cli && make snapshot-openapi && make generate` — `GraphEdgeKind` enum gone from the wire schema; `go build ./...` + `go test ./...` green
- [x] UI annotate modal: free-text input + `datalist` — pinned by `test_topology_ui_annotate_modal_kind_is_free_text_with_datalist`

## Out of scope

- Approval-gating of agent topology writes — T3 #2537
- `graph_node.source` column + curated-node durability — T2 #2536 (the initiative's second migration)
- Traversal/output changes — T4 #2538 / T6 #2535
- Removing `GraphEdgeKind` entirely (it remains the well-known set)
- Surfacing novel kinds in the console's node-kind filter dropdowns (they still list the well-known set; novel-kind nodes render fine)

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2534


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Topology node and edge kinds now support valid novel lowercase slugs beyond the well-known vocabulary.
  * Added consistent validation for kind format, length, and casing across APIs, MCP tools, CLI commands, bulk imports, and the web interface.
  * Edge annotation now uses a free-text field with well-known kind suggestions.

* **Bug Fixes**
  * Malformed kinds are rejected consistently before data is written.
  * Database downgrades now safely refuse when novel kinds would violate older constraints.

* **Documentation**
  * Updated topology guidance to explain open vocabularies and well-known kind suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-07-16)

Addressed review findings from review iteration 1 (`.claude/auto/review-results/pr-2555-iter-1.json`):

- **B1** `d4a64d3a` — docs/cross-repo/topology-annotation.md: rewrote the three closed-vocabulary passages (MCP inputSchema validates slug pattern not membership; unlisted-but-valid slugs accepted, only malformed slugs 422 with `pattern` + `well_known_kinds`; POST body `kind` is a slug-patterned string, not the `GraphEdgeKind` enum).
- **M1** `4a1cd3c3` — docs/architecture/topology.md: AGENT write approval-gating reframed as future behavior landing with T3 #2537 (until then agent writes are immediate, like human writes).

<!-- auto-implement-issue: continue, iteration 1 -->
