### PR TITLE
feat(broadcast): structured intent claims on announce — trusted fields, enveloped prose

### DIFF
--- a/backend/src/meho_backplane/broadcast/__init__.py
+++ b/backend/src/meho_backplane/broadcast/__init__.py
@@ -11,7 +11,14 @@ foundation.
 
 from meho_backplane.broadcast.agent_events import (
     ACTIVITY_MAX_CHARS,
+    MAX_TARGETS,
+    PLANNED_OP_CLASS_VALUES,
+    TARGET_MAX_CHARS,
+    TTL_MAX_MINUTES,
+    TTL_MIN_MINUTES,
+    WORK_REF_MAX_CHARS,
     AgentAnnouncementEvent,
+    PlannedOpClass,
 )
 from meho_backplane.broadcast.client import (
     BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS,
@@ -58,10 +65,17 @@ __all__ = [
     "BROADCAST_MAXLEN",
     "BROADCAST_PUBLISH_ERRORS_TOTAL",
     "DEFAULT_WINDOW_MINUTES",
+    "MAX_TARGETS",
     "OP_CLASS_ENUM",
+    "PLANNED_OP_CLASS_VALUES",
+    "TARGET_MAX_CHARS",
+    "TTL_MAX_MINUTES",
+    "TTL_MIN_MINUTES",
+    "WORK_REF_MAX_CHARS",
     "AgentAnnouncementEvent",
     "BroadcastEvent",
     "InvalidSinceError",
+    "PlannedOpClass",
     "broadcast_readiness_probe",
     "classify_op",
     "compute_effective_broadcast_detail",

--- a/backend/src/meho_backplane/broadcast/agent_events.py
+++ b/backend/src/meho_backplane/broadcast/agent_events.py
@@ -59,6 +59,30 @@ as untrusted:
   envelope (:mod:`meho_backplane.untrusted_text`) on every LLM-facing
   re-serve.
 
+Structure is trusted; prose is quarantined (load-bearing)
+=========================================================
+
+The trust boundary above quarantines free *prose* because prose can
+carry instructions a reading agent might absorb. It does NOT extend to
+**server-validated structured metadata**. The typed coordination fields
+this model carries -- ``planned_op_class`` (a bounded enum),
+``ttl_minutes`` (a bounded int), ``run_id`` (a UUID), ``phase`` (an
+enum), ``ts`` / ``expires_at`` (timestamps) -- are validated by pydantic
+at construction: a value that is not a member of its type is rejected at
+the boundary, never stored, never served. Such a field cannot express an
+injection payload, so it is serialised **unwrapped** and other agents
+may read it as trustworthy coordination data. This is the same split the
+``target`` equality filter already relies on -- it runs on the unwrapped
+model before :func:`~meho_backplane.broadcast.history.dump_event_wire`
+wraps the prose (see that module).
+
+The string fields stay quarantined even when they look structured:
+``activity`` / ``scope`` / ``target`` / ``targets[]`` / ``work_ref`` are
+all agent-authored text, so every LLM-facing dump wraps them (the
+list-valued ``targets`` per-element). Equality filtering on ``target`` /
+``targets`` / ``work_ref`` runs on the raw model value *before* the wrap,
+so narrowing is unaffected by the envelope.
+
 Publish semantics
 =================
 
@@ -99,15 +123,22 @@ References
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Final, Literal
+from datetime import datetime, timedelta
+from typing import Annotated, Final, Literal, get_args
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 __all__ = [
     "ACTIVITY_MAX_CHARS",
+    "MAX_TARGETS",
+    "PLANNED_OP_CLASS_VALUES",
+    "TARGET_MAX_CHARS",
+    "TTL_MAX_MINUTES",
+    "TTL_MIN_MINUTES",
+    "WORK_REF_MAX_CHARS",
     "AgentAnnouncementEvent",
+    "PlannedOpClass",
 ]
 
 
@@ -122,6 +153,59 @@ __all__ = [
 #: a 10kB activity string ever lands on the stream and propagates to
 #: every subscriber.
 ACTIVITY_MAX_CHARS: Final[int] = 500
+
+#: Per-string cap on ``target`` / ``targets[]`` attribution values.
+#: Matches the announce inputSchema's 256-char ceiling on ``target``.
+TARGET_MAX_CHARS: Final[int] = 256
+
+#: Per-claim cap on the number of ``targets`` an announcement may name.
+#: A single announcement is a coordination signal, not a bulk fleet
+#: sweep -- an agent claiming ten targets at once is already stretching
+#: the "avoid crossfire" contract; beyond that the entry stops being
+#: legible on the feed. Over-long lists reject at the boundary with
+#: ``-32602``.
+MAX_TARGETS: Final[int] = 10
+
+#: Cap on the opaque ``work_ref`` change-ticket reference. Mirrors the
+#: convention on :attr:`meho_backplane.db.models.AgentRun.work_ref`
+#: (an opaque string such as ``"gh:evoila/meho#123"``).
+WORK_REF_MAX_CHARS: Final[int] = 256
+
+#: Lower / upper bounds on a claim's ``ttl_minutes``. 1 minute floor
+#: (a sub-minute claim is noise); 1440-minute (24h) ceiling matches the
+#: broadcast stream's ~24h retention heuristic
+#: (:data:`meho_backplane.broadcast.publisher.BROADCAST_MAXLEN`) -- a
+#: claim outliving the substrate that carries it is a false promise.
+#: Kubernetes Events default ``--event-ttl`` is 1h, a point inside this
+#: band.
+TTL_MIN_MINUTES: Final[int] = 1
+TTL_MAX_MINUTES: Final[int] = 1440
+
+#: The op-class an agent may *declare* it is about to run. Spans the
+#: full :func:`meho_backplane.broadcast.events.classify_op` output
+#: taxonomy -- deliberately wider than the recent/watch read-filter
+#: :data:`meho_backplane.broadcast.history.OP_CLASS_ENUM` (which omits
+#: ``credential_write`` / ``approval``): a *declaration* must be able to
+#: name the sensitive write classes precisely because those are the
+#: highest-crossfire operations to warn peers about, whereas the read
+#: filter narrows already-classified :class:`BroadcastEvent` rows. The
+#: value is trusted structured metadata (a bounded enum, not prose), so
+#: it is served UNWRAPPED.
+PlannedOpClass = Literal[
+    "read",
+    "write",
+    "credential_read",
+    "credential_write",
+    "credential_mint",
+    "audit_query",
+    "approval",
+    "other",
+]
+
+#: Tuple form of :data:`PlannedOpClass`, derived from the Literal so the
+#: JSON-Schema enum on the announce tool and the model type stay a
+#: single source of truth.
+PLANNED_OP_CLASS_VALUES: Final[tuple[str, ...]] = get_args(PlannedOpClass)
 
 
 class AgentAnnouncementEvent(BaseModel):
@@ -158,12 +242,43 @@ class AgentAnnouncementEvent(BaseModel):
     * ``activity`` -- the free-text body. UNTRUSTED, agent-authored.
       Capped at :data:`ACTIVITY_MAX_CHARS`; longer strings surface as
       JSON-RPC ``-32602``.
-    * ``target`` -- optional target_name attribution. Caller passes
-      a string when the announcement scopes to a specific managed
+    * ``target`` -- optional single target_name attribution. Caller
+      passes a string when the announcement scopes to a specific managed
       target (``"prod-vc-1"``, ``"kube-prod"``); ``None`` when the
       activity is target-less (e.g. cross-cluster investigation).
+      Retained for backward compatibility; ``targets`` supersedes it
+      for multi-target claims. UNTRUSTED prose.
+    * ``targets`` -- optional list of target_name attributions (each
+      1..:data:`TARGET_MAX_CHARS` chars, at most :data:`MAX_TARGETS`
+      entries). Supersedes -- does not replace -- the single ``target``:
+      a claim spanning several targets names them all here, and the
+      ``target`` filter on recent/watch matches an event when the query
+      value equals ``target`` OR appears in ``targets``. UNTRUSTED prose
+      (each element wrapped on display).
     * ``scope`` -- optional free-form scope hint (``"investigating
-      cluster X latency"``). Also UNTRUSTED.
+      cluster X latency"``). Also UNTRUSTED prose.
+    * ``planned_op_class`` -- optional declared intent: the
+      :data:`PlannedOpClass` the agent is about to run
+      (``"write"`` / ``"credential_read"`` / ...). TRUSTED structured
+      metadata (a validated enum), served unwrapped so peers can reason
+      about crossfire without absorbing prose.
+    * ``ttl_minutes`` -- optional claim lifetime in minutes
+      (:data:`TTL_MIN_MINUTES`..:data:`TTL_MAX_MINUTES`). Consumers
+      derive ``expires_at = ts + ttl``; the ``active_only`` read filter
+      drops claims whose ``expires_at`` has elapsed. TRUSTED int.
+    * ``work_ref`` -- optional opaque change-ticket reference
+      (``"gh:evoila/meho#123"``), same convention + cap
+      (:data:`WORK_REF_MAX_CHARS`) as
+      :attr:`meho_backplane.db.models.AgentRun.work_ref`. Joins an
+      announcement to the out-of-band record that authorised the work;
+      the recent/watch ``work_ref`` filter matches on it. UNTRUSTED
+      prose (wrapped on display), but exact-match filterable pre-wrap.
+    * ``run_id`` -- optional :class:`~uuid.UUID` of the agent run the
+      announcement belongs to, so a human or peer can group a run's
+      announcements. TRUSTED UUID, served unwrapped.
+    * ``expires_at`` -- derived (computed) ``ts + ttl_minutes``, or
+      ``None`` when ``ttl_minutes`` is unset. TRUSTED timestamp, served
+      unwrapped.
     * ``phase`` -- ``"start"`` / ``"update"`` / ``"completion"``.
       ``"update"`` is the default; ``"start"`` marks an intent
       announcement at the beginning of a task, ``"completion"`` marks
@@ -193,6 +308,30 @@ class AgentAnnouncementEvent(BaseModel):
     principal_sub: str
     activity: str = Field(min_length=1, max_length=ACTIVITY_MAX_CHARS)
     target: str | None = None
+    targets: list[Annotated[str, Field(min_length=1, max_length=TARGET_MAX_CHARS)]] = Field(
+        default_factory=list,
+        max_length=MAX_TARGETS,
+    )
     scope: str | None = None
+    planned_op_class: PlannedOpClass | None = None
+    ttl_minutes: int | None = Field(default=None, ge=TTL_MIN_MINUTES, le=TTL_MAX_MINUTES)
+    work_ref: str | None = Field(default=None, min_length=1, max_length=WORK_REF_MAX_CHARS)
+    run_id: UUID | None = None
     phase: Literal["start", "update", "completion"] = "update"
     ts: datetime
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def expires_at(self) -> datetime | None:
+        """Wall-clock instant the claim's TTL elapses, or ``None`` if unbounded.
+
+        Derived, never stored: ``ts + ttl_minutes``. ``None`` when
+        ``ttl_minutes`` is unset (the announcement is not a
+        time-bounded claim). Served UNWRAPPED on the wire -- a derived
+        timestamp cannot carry an injection -- and drives the
+        ``active_only`` read filter
+        (:func:`meho_backplane.broadcast.history.event_matches`).
+        """
+        if self.ttl_minutes is None:
+            return None
+        return self.ts + timedelta(minutes=self.ttl_minutes)

--- a/backend/src/meho_backplane/broadcast/history.py
+++ b/backend/src/meho_backplane/broadcast/history.py
@@ -245,17 +245,66 @@ def _iso8601_to_min_cursor(raw: str) -> str:
     return str(int(parsed.timestamp() * 1000))
 
 
+def _target_matches(event: BroadcastEvent | AgentAnnouncementEvent, target: str) -> bool:
+    """Exact-match the ``target`` filter against an event's attribution.
+
+    :class:`BroadcastEvent` carries a single ``target_name``.
+    :class:`AgentAnnouncementEvent` carries a single ``target`` AND a
+    ``targets`` list (which supersedes-not-replaces the single field);
+    a query matches when it equals ``target`` OR appears in ``targets``.
+    Events with no target attribution never qualify.
+    """
+    if isinstance(event, BroadcastEvent):
+        return event.target_name == target
+    return event.target == target or target in event.targets
+
+
+def _work_ref_matches(event: BroadcastEvent | AgentAnnouncementEvent, work_ref: str) -> bool:
+    """Exact-match the ``work_ref`` filter; only announcements carry one.
+
+    A :class:`BroadcastEvent` has no ``work_ref`` field, so it can never
+    satisfy a ``work_ref`` filter -- the caller asked for an
+    announcement-linked claim. Mirrors the ``op_class``-vs-announcement
+    asymmetry (an announcement never satisfies an ``op_class`` filter).
+    """
+    if isinstance(event, AgentAnnouncementEvent):
+        return event.work_ref == work_ref
+    return False
+
+
+def _is_expired_claim(
+    event: BroadcastEvent | AgentAnnouncementEvent,
+    now: datetime,
+) -> bool:
+    """Return ``True`` iff *event* is a TTL'd claim whose expiry has passed.
+
+    Only :class:`AgentAnnouncementEvent` with a bound ``ttl_minutes``
+    can expire. Everything else -- audit-driven :class:`BroadcastEvent`
+    rows and announcements without a TTL -- is never "expired" and so
+    always survives an ``active_only`` filter.
+    """
+    if not isinstance(event, AgentAnnouncementEvent):
+        return False
+    expires_at = event.expires_at
+    return expires_at is not None and expires_at <= now
+
+
 def event_matches(
     event: BroadcastEvent | AgentAnnouncementEvent,
     *,
     op_class: str | None,
     principal: str | None,
     target: str | None,
+    work_ref: str | None = None,
+    active_only: bool = False,
+    now: datetime | None = None,
 ) -> bool:
-    """Return ``True`` iff *event* matches every non-``None`` filter.
+    """Return ``True`` iff *event* matches every active filter.
 
     Exact-match semantics on each non-``None`` field; mirrors
-    :func:`meho_backplane.api.v1.feed._passes_filter`.
+    :func:`meho_backplane.api.v1.feed._passes_filter`. All matching runs
+    on the raw model *before* :func:`dump_event_wire` wraps agent prose,
+    so the untrusted envelope never affects narrowing.
 
     Two event classes share the broadcast stream: the audit-driven
     :class:`BroadcastEvent` (one event per audited operation, written
@@ -263,19 +312,21 @@ def event_matches(
     the agent-authored :class:`AgentAnnouncementEvent` (one event per
     ``meho.broadcast.announce`` call, written by
     :func:`~meho_backplane.broadcast.publisher.publish_agent_announcement`).
-    They share ``principal_sub`` but diverge on ``op_class`` and
-    target attribution:
+    They share ``principal_sub`` but diverge on the other filters:
 
     * **op_class filter:** Only audit-driven events carry an
       ``op_class``. Announcements have no operation classification, so
-      a caller asking ``filter.op_class=write`` is asking for a
-      specific *operation* class -- an announcement doesn't qualify
-      regardless of its content. (Mirrors the "untagged event doesn't
-      satisfy a target filter" rule below.)
-    * **target filter:** :class:`BroadcastEvent` carries ``target_name``;
-      :class:`AgentAnnouncementEvent` carries ``target``. Both behave
-      identically under a non-``None`` filter -- events with no target
-      attribution (either field ``None``) never qualify.
+      an announcement never qualifies regardless of its content.
+    * **target filter:** matches a :class:`BroadcastEvent`'s
+      ``target_name`` or an :class:`AgentAnnouncementEvent`'s ``target``
+      / any of its ``targets`` (see :func:`_target_matches`).
+    * **work_ref filter:** only announcements carry a ``work_ref``; a
+      :class:`BroadcastEvent` never qualifies (see
+      :func:`_work_ref_matches`).
+    * **active_only:** when ``True``, drops TTL'd announcement claims
+      whose ``expires_at`` (``ts + ttl_minutes``) is at or before
+      ``now`` (defaulting to the current UTC instant). Non-TTL events
+      always pass (see :func:`_is_expired_claim`).
     """
     if op_class is not None:
         # AgentAnnouncementEvent has no ``op_class``; the caller asked
@@ -286,11 +337,11 @@ def event_matches(
             return False
     if principal is not None and event.principal_sub != principal:
         return False
-    if target is not None:
-        event_target = event.target_name if isinstance(event, BroadcastEvent) else event.target
-        if event_target != target:
-            return False
-    return True
+    if target is not None and not _target_matches(event, target):
+        return False
+    if work_ref is not None and not _work_ref_matches(event, work_ref):
+        return False
+    return not (active_only and _is_expired_claim(event, now or datetime.now(UTC)))
 
 
 def parse_entry(
@@ -377,12 +428,27 @@ def parse_entry(
         return None
 
 
-#: Announcement fields that carry agent-authored free text. Kept in
-#: one place so every LLM-facing dump site wraps the same set; the
+#: Scalar announcement fields that carry agent-authored free text. Kept
+#: in one place so every LLM-facing dump site wraps the same set; the
 #: audit-driven :class:`BroadcastEvent` has no counterpart (its
 #: ``payload`` is server-derived and redacted upstream, its op fields
-#: are chassis-classified — none are agent prose).
-_ANNOUNCEMENT_UNTRUSTED_FIELDS: Final[tuple[str, ...]] = ("activity", "scope", "target")
+#: are chassis-classified — none are agent prose). The structured
+#: coordination fields (``planned_op_class`` / ``ttl_minutes`` /
+#: ``run_id`` / ``phase`` / ``ts`` / ``expires_at``) are deliberately
+#: absent: they are server-validated typed values that cannot carry an
+#: injection, so they are served UNWRAPPED (see
+#: :mod:`meho_backplane.broadcast.agent_events`).
+_ANNOUNCEMENT_UNTRUSTED_FIELDS: Final[tuple[str, ...]] = (
+    "activity",
+    "scope",
+    "target",
+    "work_ref",
+)
+
+#: List-valued announcement fields whose *elements* carry agent-authored
+#: free text. Wrapped per-element on display (the value is a
+#: ``list[str]``, not a scalar, so it needs its own dump branch).
+_ANNOUNCEMENT_UNTRUSTED_LIST_FIELDS: Final[tuple[str, ...]] = ("targets",)
 
 
 def dump_event_wire(
@@ -419,6 +485,12 @@ def dump_event_wire(
             value = data.get(field)
             if isinstance(value, str):
                 data[field] = wrap_untrusted_text(value)
+        for field in _ANNOUNCEMENT_UNTRUSTED_LIST_FIELDS:
+            value = data.get(field)
+            if isinstance(value, list):
+                data[field] = [
+                    wrap_untrusted_text(item) if isinstance(item, str) else item for item in value
+                ]
     return data
 
 
@@ -429,6 +501,8 @@ async def _list_recent_events_core(
     op_class: str | None,
     principal: str | None,
     target: str | None,
+    work_ref: str | None,
+    active_only: bool,
     limit: int,
 ) -> dict[str, Any]:
     """Read recent events for *operator*'s tenant; the shared core body.
@@ -474,6 +548,9 @@ async def _list_recent_events_core(
         ),
     )
 
+    # Pin one ``now`` for the whole page so a slow XRANGE parse can't
+    # let an ``active_only`` claim flip expiry-state mid-page.
+    now = datetime.now(UTC)
     matched: list[dict[str, Any]] = []
     for entry_id, fields in raw_entries:
         event = parse_entry(entry_id, fields, stream_key=key)
@@ -484,6 +561,9 @@ async def _list_recent_events_core(
             op_class=op_class,
             principal=principal,
             target=target,
+            work_ref=work_ref,
+            active_only=active_only,
+            now=now,
         ):
             continue
         # ``cursor`` is the Valkey stream entry id, self-labelled to
@@ -517,6 +597,8 @@ async def list_recent_events_strict(
     op_class: str | None = None,
     principal: str | None = None,
     target: str | None = None,
+    work_ref: str | None = None,
+    active_only: bool = False,
     limit: int = 100,
 ) -> dict[str, Any]:
     """Fail-loud variant: re-raises any :class:`RedisError` from Valkey.
@@ -531,6 +613,10 @@ async def list_recent_events_strict(
     :class:`InvalidSinceError`; wire-layer callers map that to
     ``-32602`` Invalid Params.
 
+    ``work_ref`` narrows to announcement claims linked to that opaque
+    change-ticket reference; ``active_only`` drops TTL'd claims whose
+    ``expires_at`` has already elapsed (see :func:`event_matches`).
+
     Mirrors the fail-loud contract on
     :func:`~meho_backplane.broadcast.publisher.publish_agent_announcement`
     (its write-side counterpart).
@@ -541,6 +627,8 @@ async def list_recent_events_strict(
         op_class=op_class,
         principal=principal,
         target=target,
+        work_ref=work_ref,
+        active_only=active_only,
         limit=limit,
     )
 
@@ -552,6 +640,8 @@ async def list_recent_events_fail_soft(
     op_class: str | None = None,
     principal: str | None = None,
     target: str | None = None,
+    work_ref: str | None = None,
+    active_only: bool = False,
     limit: int = 100,
 ) -> dict[str, Any]:
     """Fail-soft variant: a :class:`RedisError` returns the empty result.
@@ -581,6 +671,8 @@ async def list_recent_events_fail_soft(
             op_class=op_class,
             principal=principal,
             target=target,
+            work_ref=work_ref,
+            active_only=active_only,
             limit=limit,
         )
     except RedisError as exc:

--- a/backend/src/meho_backplane/mcp/tools/broadcast.py
+++ b/backend/src/meho_backplane/mcp/tools/broadcast.py
@@ -80,16 +80,24 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
-from typing import Any, Final, cast
+from typing import Any, Final, NamedTuple, cast
+from uuid import UUID
 
 import structlog
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast import (
     ACTIVITY_MAX_CHARS,
+    MAX_TARGETS,
     OP_CLASS_ENUM,
+    PLANNED_OP_CLASS_VALUES,
+    TARGET_MAX_CHARS,
+    TTL_MAX_MINUTES,
+    TTL_MIN_MINUTES,
+    WORK_REF_MAX_CHARS,
     AgentAnnouncementEvent,
     InvalidSinceError,
+    PlannedOpClass,
     get_broadcast_blocking_client,
     list_recent_events_strict,
     publish_agent_announcement,
@@ -113,14 +121,30 @@ _log = structlog.get_logger(__name__)
 # ===========================================================================
 
 
-def _extract_filter(arguments: dict[str, Any]) -> tuple[str | None, str | None, str | None]:
-    """Extract the three ``filter.*`` sub-keys, asserting string-or-absent.
+class _BroadcastFilter(NamedTuple):
+    """Typed view of the ``filter`` object shared by recent + watch."""
+
+    op_class: str | None
+    principal: str | None
+    target: str | None
+    work_ref: str | None
+    active_only: bool
+
+
+def _extract_filter(arguments: dict[str, Any]) -> _BroadcastFilter:
+    """Extract the ``filter.*`` sub-keys, asserting each field's type.
 
     The wire schema's ``filter`` object permits each sub-key to be
-    omitted entirely OR set to a string. Anything else (a number, a
-    list, an object) surfaces as JSON-RPC ``-32602`` -- the JSON
-    Schema validator at the dispatcher layer catches structural
-    violations; this helper picks the typed view for the handler.
+    omitted entirely OR set to its typed value (string for
+    ``op_class`` / ``principal`` / ``target`` / ``work_ref``, boolean
+    for ``active_only``). Anything else (a number, a list, an object)
+    surfaces as JSON-RPC ``-32602`` -- the JSON Schema validator at the
+    dispatcher layer catches structural violations; this helper picks
+    the typed view for the handler.
+
+    ``work_ref`` narrows to announcement claims linked to that opaque
+    change-ticket reference; ``active_only`` (default ``False``) drops
+    TTL'd claims whose ``expires_at`` has already elapsed.
     """
     filter_obj = arguments.get("filter") or {}
     if not isinstance(filter_obj, dict):
@@ -128,10 +152,19 @@ def _extract_filter(arguments: dict[str, Any]) -> tuple[str | None, str | None, 
     op_class = filter_obj.get("op_class")
     principal = filter_obj.get("principal")
     target = filter_obj.get("target")
-    for name, value in (("op_class", op_class), ("principal", principal), ("target", target)):
+    work_ref = filter_obj.get("work_ref")
+    for name, value in (
+        ("op_class", op_class),
+        ("principal", principal),
+        ("target", target),
+        ("work_ref", work_ref),
+    ):
         if value is not None and not isinstance(value, str):
             raise McpInvalidParamsError(f"filter.{name}: must be a string when provided")
-    return op_class, principal, target
+    active_only = filter_obj.get("active_only", False)
+    if not isinstance(active_only, bool):
+        raise McpInvalidParamsError("filter.active_only: must be a boolean when provided")
+    return _BroadcastFilter(op_class, principal, target, work_ref, active_only)
 
 
 async def _handler_recent(
@@ -176,7 +209,7 @@ async def _handler_recent(
     since = cursor_arg if cursor_arg is not None else since_arg
     if since is not None and not isinstance(since, str):
         raise McpInvalidParamsError("cursor: must be a string when provided")
-    op_class, principal, target = _extract_filter(arguments)
+    flt = _extract_filter(arguments)
     raw_limit = arguments.get("limit", 100)
     if not isinstance(raw_limit, int) or isinstance(raw_limit, bool):
         raise McpInvalidParamsError("limit: must be an integer in [1, 1000]")
@@ -186,9 +219,11 @@ async def _handler_recent(
         return await list_recent_events_strict(
             operator,
             since=since,
-            op_class=op_class,
-            principal=principal,
-            target=target,
+            op_class=flt.op_class,
+            principal=flt.principal,
+            target=flt.target,
+            work_ref=flt.work_ref,
+            active_only=flt.active_only,
             limit=raw_limit,
         )
     except InvalidSinceError as exc:
@@ -211,7 +246,9 @@ register_mcp_tool(
             "timestamp ('2026-05-25T10:00:00Z') or a Valkey stream "
             "cursor ('1747800000000-0') to override. The 'filter' "
             "object narrows by exact-match op_class / principal "
-            "(JWT 'sub') / target (target_name). 'limit' caps the "
+            "(JWT 'sub') / target (target_name or any of an "
+            "announcement's 'targets') / work_ref, plus 'active_only' "
+            "(drop expired TTL claims). 'limit' caps the "
             "page at 1..1000 (default 100); the response's "
             "'next_cursor' round-trips as the next call's 'cursor' "
             "for gap-free pagination. 'since' is accepted as a "
@@ -270,13 +307,38 @@ register_mcp_tool(
                             "type": "string",
                             "minLength": 1,
                             "maxLength": 256,
-                            "description": ("Exact-match filter on event target_name."),
+                            "description": (
+                                "Exact-match filter on target attribution. "
+                                "Matches a BroadcastEvent's target_name or "
+                                "an announcement's single 'target' OR any "
+                                "entry in its 'targets' list."
+                            ),
+                        },
+                        "work_ref": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": WORK_REF_MAX_CHARS,
+                            "description": (
+                                "Exact-match filter on an announcement's "
+                                "'work_ref' (e.g. 'gh:evoila/meho#123'). "
+                                "Audit-driven events never match it."
+                            ),
+                        },
+                        "active_only": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": (
+                                "When true, drop TTL'd announcement claims "
+                                "whose expires_at (ts + ttl_minutes) has "
+                                "elapsed. Non-TTL events always pass."
+                            ),
                         },
                     },
                     "additionalProperties": False,
                     "description": (
                         "Filter narrows the result; all sub-keys "
-                        "optional. Each non-null sub-key is exact-match."
+                        "optional. Each non-null sub-key is exact-match "
+                        "(except 'active_only', a boolean mode)."
                     ),
                 },
                 "limit": {
@@ -309,6 +371,88 @@ register_mcp_tool(
 # ===========================================================================
 
 
+class _AnnounceClaims(NamedTuple):
+    """Validated structured intent claims from an announce call."""
+
+    targets: list[str]
+    planned_op_class: PlannedOpClass | None
+    ttl_minutes: int | None
+    work_ref: str | None
+    run_id: UUID | None
+
+
+def _parse_targets(raw: Any) -> list[str]:
+    """Validate the optional ``targets`` list; -32602 on any violation.
+
+    Empty/absent → ``[]`` (the model's default). A non-list, an
+    over-long list, or a non-string / out-of-bounds element rejects.
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise McpInvalidParamsError("targets: must be an array of strings when provided")
+    if len(raw) > MAX_TARGETS:
+        raise McpInvalidParamsError(f"targets: at most {MAX_TARGETS} entries")
+    for item in raw:
+        if not isinstance(item, str) or not 1 <= len(item) <= TARGET_MAX_CHARS:
+            raise McpInvalidParamsError(
+                f"targets: each entry must be a string 1..{TARGET_MAX_CHARS} chars",
+            )
+    return cast("list[str]", raw)
+
+
+def _parse_run_id(raw: Any) -> UUID | None:
+    """Validate the optional ``run_id``; -32602 on a non-UUID string."""
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        raise McpInvalidParamsError("run_id: must be a UUID string when provided")
+    try:
+        return UUID(raw)
+    except ValueError as exc:
+        raise McpInvalidParamsError("run_id: must be a valid UUID string") from exc
+
+
+def _parse_announce_claims(arguments: dict[str, Any]) -> _AnnounceClaims:
+    """Validate the optional structured-claim fields; -32602 on any miss.
+
+    These are TRUSTED coordination fields (a bounded enum, a bounded
+    int, a UUID, a list of bounded strings): the handler re-validates
+    them belt-and-suspenders (the dispatcher's JSON-Schema runs first)
+    so a direct handler call gets the same typed contract. Validated
+    structured metadata cannot carry an injection, so these values are
+    echoed back unwrapped on the response and served unwrapped on reads.
+    """
+    planned = arguments.get("planned_op_class")
+    if planned is not None and planned not in PLANNED_OP_CLASS_VALUES:
+        raise McpInvalidParamsError(
+            f"planned_op_class: must be one of {list(PLANNED_OP_CLASS_VALUES)}",
+        )
+    ttl = arguments.get("ttl_minutes")
+    if ttl is not None:
+        if not isinstance(ttl, int) or isinstance(ttl, bool):
+            raise McpInvalidParamsError(
+                f"ttl_minutes: must be an integer in [{TTL_MIN_MINUTES}, {TTL_MAX_MINUTES}]",
+            )
+        if ttl < TTL_MIN_MINUTES or ttl > TTL_MAX_MINUTES:
+            raise McpInvalidParamsError(
+                f"ttl_minutes: must be in [{TTL_MIN_MINUTES}, {TTL_MAX_MINUTES}]",
+            )
+    work_ref = arguments.get("work_ref")
+    if work_ref is not None:
+        if not isinstance(work_ref, str):
+            raise McpInvalidParamsError("work_ref: must be a string when provided")
+        if not 1 <= len(work_ref) <= WORK_REF_MAX_CHARS:
+            raise McpInvalidParamsError(f"work_ref: must be 1..{WORK_REF_MAX_CHARS} chars")
+    return _AnnounceClaims(
+        targets=_parse_targets(arguments.get("targets")),
+        planned_op_class=cast("PlannedOpClass | None", planned),
+        ttl_minutes=ttl,
+        work_ref=work_ref,
+        run_id=_parse_run_id(arguments.get("run_id")),
+    )
+
+
 async def _publish_agent_announcement_impl(
     operator: Operator,
     *,
@@ -316,8 +460,9 @@ async def _publish_agent_announcement_impl(
     target: str | None,
     scope: str | None,
     phase: str,
+    claims: _AnnounceClaims | None = None,
 ) -> dict[str, Any]:
-    """Build + publish one :class:`AgentAnnouncementEvent`, return ``{event_id, cursor}``.
+    """Build + publish one :class:`AgentAnnouncementEvent`, return the ack.
 
     Internal helper for ``meho.broadcast.announce``. Kept separate from
     :func:`_handler_announce` so the construction-and-publish seam is
@@ -333,18 +478,30 @@ async def _publish_agent_announcement_impl(
     value would raise :class:`ValidationError` at the model
     constructor, which the handler maps to ``-32602`` upstream.
 
+    ``claims`` carries the optional structured intent fields (typed
+    targets / planned_op_class / TTL / work_ref / run_id). When
+    omitted, the announcement is a plain narrative event (the pre-v2
+    shape). The declared (non-empty) claim fields are echoed back on
+    the ack so the caller can confirm what landed.
+
     Tenant scoping is structural: the ``tenant_id`` on the constructed
     event is sourced exclusively from ``operator.tenant_id`` (the
     JWT-bound claim). The handler's input schema has no ``tenant_id``
     field; a cross-tenant announce is impossible by construction, not
     by check-then-reject.
     """
+    claims = claims or _AnnounceClaims([], None, None, None, None)
     event = AgentAnnouncementEvent(
         tenant_id=operator.tenant_id,
         principal_sub=operator.sub,
         activity=activity,
         target=target,
+        targets=claims.targets,
         scope=scope,
+        planned_op_class=claims.planned_op_class,
+        ttl_minutes=claims.ttl_minutes,
+        work_ref=claims.work_ref,
+        run_id=claims.run_id,
         phase=phase,  # type: ignore[arg-type]  # pydantic validates the Literal at construction
         ts=datetime.now(UTC),
     )
@@ -355,7 +512,21 @@ async def _publish_agent_announcement_impl(
     # ``event_id`` is the historical alias — a misnomer kept for wire
     # compatibility: it is the stream cursor, NOT a durable event
     # UUID (announcements carry no UUID today; #2547 mints one).
-    return {"event_id": entry_id, "cursor": entry_id}
+    ack: dict[str, Any] = {"event_id": entry_id, "cursor": entry_id}
+    # Echo only the declared (non-empty) structured claims -- a plain
+    # announce keeps the pre-v2 ``{event_id, cursor}`` ack shape. These
+    # are trusted structured values, so they are echoed unwrapped.
+    if claims.targets:
+        ack["targets"] = claims.targets
+    if claims.planned_op_class is not None:
+        ack["planned_op_class"] = claims.planned_op_class
+    if claims.ttl_minutes is not None:
+        ack["ttl_minutes"] = claims.ttl_minutes
+    if claims.work_ref is not None:
+        ack["work_ref"] = claims.work_ref
+    if claims.run_id is not None:
+        ack["run_id"] = str(claims.run_id)
+    return ack
 
 
 async def _handler_announce(
@@ -383,15 +554,19 @@ async def _handler_announce(
     Trust boundary
     --------------
 
-    ``activity`` and ``scope`` are agent-authored free text. The
-    handler does NOT sanitise or rewrite them -- consumers MUST treat
-    the strings as UNTRUSTED. This mirrors the
-    :mod:`~meho_backplane.conventions.preamble` precedent for
-    operator-authored convention bodies wrapped in
+    ``activity`` / ``scope`` / ``target`` / ``targets`` / ``work_ref``
+    are agent-authored free text. The handler does NOT sanitise or
+    rewrite them -- consumers MUST treat the strings as UNTRUSTED. This
+    mirrors the :mod:`~meho_backplane.conventions.preamble` precedent
+    for operator-authored convention bodies wrapped in
     ``<<TENANT_CONVENTIONS ... END_TENANT_CONVENTIONS>>`` delimiters.
+    The structured intent claims (``planned_op_class`` / ``ttl_minutes``
+    / ``run_id``, plus ``phase`` / ``ts``) are the inverse: bounded
+    enums, ints, UUIDs and timestamps, server-validated at the boundary,
+    so they are served UNWRAPPED as trustworthy coordination data.
     See :class:`AgentAnnouncementEvent`'s docstring for the per-surface
     contract (frontend escapes, Slack plain-text, downstream agents
-    must not interpret as policy).
+    must not interpret prose as policy).
     """
     activity = arguments.get("activity")
     if not isinstance(activity, str):
@@ -413,12 +588,14 @@ async def _handler_announce(
         raise McpInvalidParamsError(
             "phase: must be one of 'start', 'update', 'completion'",
         )
+    claims = _parse_announce_claims(arguments)
     return await _publish_agent_announcement_impl(
         operator,
         activity=activity,
         target=target,
         scope=scope,
         phase=phase_arg,
+        claims=claims,
     )
 
 
@@ -440,16 +617,30 @@ register_mcp_tool(
             "'activity' is mandatory (1..500 chars), 'target' and "
             "'scope' are optional free-form attribution, 'phase' is "
             "one of 'start' / 'update' / 'completion' (default "
-            "'update'). The publish is fail-loud -- a Valkey teardown "
-            "surfaces as JSON-RPC -32603 Internal Error so the agent "
-            "knows the announcement did not land (distinct from the "
-            "audit-driven publisher which fail-opens). Tenant scoping "
-            "is structural -- the input schema has no tenant_id "
-            "argument; the event always writes to the operator's own "
-            "tenant stream. Returns {event_id, cursor} -- both the "
-            "Valkey stream entry id of the appended announcement. "
-            "'cursor' is the canonical self-labelled name and "
-            "round-trips through meho.broadcast.recent/watch's "
+            "'update'). Optional STRUCTURED INTENT CLAIMS turn an "
+            "announcement into coordination data other agents can trust: "
+            "'targets' (up to 10 target names the work touches -- "
+            "supersedes 'target' for multi-target claims), "
+            "'planned_op_class' (the op class you are about to run, e.g. "
+            "'write' / 'credential_read'), 'ttl_minutes' (1..1440; the "
+            "claim's lifetime -- readers derive expires_at = ts + ttl "
+            "and can filter to active claims), 'work_ref' (an opaque "
+            "change-ticket reference such as 'gh:evoila/meho#123'), and "
+            "'run_id' (the UUID of the agent run). These typed fields are "
+            "server-validated and served UNWRAPPED (they cannot carry an "
+            "injection); the free-text 'activity' / 'scope' / 'target' / "
+            "'targets' / 'work_ref' stay quarantined behind the "
+            "untrusted-content envelope on read. The publish is fail-loud "
+            "-- a Valkey teardown surfaces as JSON-RPC -32603 Internal "
+            "Error so the agent knows the announcement did not land "
+            "(distinct from the audit-driven publisher which fail-opens). "
+            "Tenant scoping is structural -- the input schema has no "
+            "tenant_id argument; the event always writes to the "
+            "operator's own tenant stream. Returns {event_id, cursor} "
+            "plus any declared claim fields echoed back. Both event_id "
+            "and cursor are the Valkey stream entry id of the appended "
+            "announcement; 'cursor' is the canonical self-labelled name "
+            "and round-trips through meho.broadcast.recent/watch's "
             "'cursor' arg for verification; 'event_id' is a legacy "
             "alias of the same stream cursor, NOT a durable event "
             "UUID (announcements carry no UUID)."
@@ -471,12 +662,31 @@ register_mcp_tool(
                 "target": {
                     "type": "string",
                     "minLength": 1,
-                    "maxLength": 256,
+                    "maxLength": TARGET_MAX_CHARS,
                     "description": (
-                        "Optional target_name attribution -- the "
+                        "Optional single target_name attribution -- the "
                         "managed target the activity scopes to "
                         "(e.g. 'prod-vc-1', 'kube-prod'). Omit when "
-                        "the activity is target-less."
+                        "the activity is target-less. Use 'targets' for "
+                        "a multi-target claim. UNTRUSTED prose."
+                    ),
+                },
+                "targets": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": TARGET_MAX_CHARS,
+                    },
+                    "maxItems": MAX_TARGETS,
+                    "description": (
+                        "Optional list of target_names the claim touches "
+                        f"(each 1..{TARGET_MAX_CHARS} chars, at most "
+                        f"{MAX_TARGETS}). Supersedes 'target' for "
+                        "multi-target work; recent/watch's target filter "
+                        "matches an event when the query equals 'target' "
+                        "OR appears in 'targets'. UNTRUSTED prose "
+                        "(each element wrapped on read)."
                     ),
                 },
                 "scope": {
@@ -488,6 +698,50 @@ register_mcp_tool(
                         "'investigating cluster X latency'). UNTRUSTED "
                         "agent-authored content; same render rules as "
                         "'activity'."
+                    ),
+                },
+                "planned_op_class": {
+                    "type": "string",
+                    "enum": list(PLANNED_OP_CLASS_VALUES),
+                    "description": (
+                        "Optional declared intent: the op class the "
+                        "agent is about to run (the classify_op "
+                        "taxonomy). TRUSTED structured metadata, served "
+                        "unwrapped so peers can reason about crossfire."
+                    ),
+                },
+                "ttl_minutes": {
+                    "type": "integer",
+                    "minimum": TTL_MIN_MINUTES,
+                    "maximum": TTL_MAX_MINUTES,
+                    "description": (
+                        "Optional claim lifetime in minutes "
+                        f"({TTL_MIN_MINUTES}..{TTL_MAX_MINUTES}). Readers "
+                        "derive expires_at = ts + ttl and can drop "
+                        "elapsed claims via recent/watch 'active_only'. "
+                        "TRUSTED int, served unwrapped."
+                    ),
+                },
+                "work_ref": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": WORK_REF_MAX_CHARS,
+                    "description": (
+                        "Optional opaque change-ticket reference "
+                        "(e.g. 'gh:evoila/meho#123'), same convention as "
+                        "AgentRun.work_ref. Exact-match filterable on "
+                        "recent/watch. UNTRUSTED prose (wrapped on read) "
+                        "but filtered pre-wrap."
+                    ),
+                },
+                "run_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": (
+                        "Optional UUID of the agent run this "
+                        "announcement belongs to, so peers/humans can "
+                        "group a run's announcements. TRUSTED UUID, "
+                        "served unwrapped."
                     ),
                 },
                 "phase": {
@@ -678,6 +932,8 @@ def _filter_xread_items(
     op_class: str | None,
     principal: str | None,
     target: str | None,
+    work_ref: str | None = None,
+    active_only: bool = False,
 ) -> list[dict[str, Any]]:
     """Parse + filter the XREAD batch into the wire-shape events list.
 
@@ -693,10 +949,14 @@ def _filter_xread_items(
     Serialisation goes through
     :func:`~meho_backplane.broadcast.history.dump_event_wire` so
     agent-authored announcement free-text (``activity`` / ``scope`` /
-    ``target``) reaches the calling agent wrapped in the
-    untrusted-content envelope — same stored-prompt-injection guard as
-    the ``broadcast.recent`` path (evoila-bosnia/meho-internal#154).
+    ``target`` / ``targets`` / ``work_ref``) reaches the calling agent
+    wrapped in the untrusted-content envelope — same
+    stored-prompt-injection guard as the ``broadcast.recent`` path
+    (evoila-bosnia/meho-internal#154). The structured claim fields
+    (``planned_op_class`` / ``ttl_minutes`` / ``run_id`` / ``phase`` /
+    ``ts`` / ``expires_at``) are served unwrapped.
     """
+    now = datetime.now(UTC)
     matched: list[dict[str, Any]] = []
     for entry_id, fields in items:
         event = parse_entry(entry_id, fields, stream_key=stream_key)
@@ -707,6 +967,9 @@ def _filter_xread_items(
             op_class=op_class,
             principal=principal,
             target=target,
+            work_ref=work_ref,
+            active_only=active_only,
+            now=now,
         ):
             continue
         matched.append({"id": entry_id, "cursor": entry_id, **dump_event_wire(event)})
@@ -720,6 +983,8 @@ async def _watch_events_impl(
     op_class: str | None,
     principal: str | None,
     target: str | None,
+    work_ref: str | None,
+    active_only: bool,
     timeout_ms: int,
 ) -> dict[str, Any]:
     """Long-poll the operator's tenant stream for entries strictly past *since_cursor*.
@@ -771,6 +1036,8 @@ async def _watch_events_impl(
         op_class=op_class,
         principal=principal,
         target=target,
+        work_ref=work_ref,
+        active_only=active_only,
     )
     return {"events": matched, "next_cursor": next_cursor}
 
@@ -812,14 +1079,16 @@ async def _handler_watch(
         raise McpInvalidParamsError(
             "cursor: required, must be a non-empty Valkey stream cursor",
         )
-    op_class, principal, target = _extract_filter(arguments)
+    flt = _extract_filter(arguments)
     timeout_ms = _validate_timeout_ms(arguments.get("timeout_ms"))
     return await _watch_events_impl(
         operator,
         since_cursor=since_cursor,
-        op_class=op_class,
-        principal=principal,
-        target=target,
+        op_class=flt.op_class,
+        principal=flt.principal,
+        target=flt.target,
+        work_ref=flt.work_ref,
+        active_only=flt.active_only,
         timeout_ms=timeout_ms,
     )
 
@@ -851,7 +1120,9 @@ register_mcp_tool(
             "accepted as a deprecated alias for 'cursor' (v0.8.0 wire "
             "shape) and is mutually exclusive with it. The 'filter' "
             "object narrows by exact-match op_class / principal "
-            "(JWT 'sub') / target (target_name). Tenant scoping is "
+            "(JWT 'sub') / target (target_name or any of an "
+            "announcement's 'targets') / work_ref, plus 'active_only' "
+            "(drop expired TTL claims). Tenant scoping is "
             "structural -- every watch targets the operator's own tenant "
             "stream; there is no input that could request another "
             "tenant's stream. Payloads inherit the publisher-side "
@@ -910,13 +1181,38 @@ register_mcp_tool(
                             "type": "string",
                             "minLength": 1,
                             "maxLength": 256,
-                            "description": ("Exact-match filter on event target_name."),
+                            "description": (
+                                "Exact-match filter on target attribution. "
+                                "Matches a BroadcastEvent's target_name or "
+                                "an announcement's single 'target' OR any "
+                                "entry in its 'targets' list."
+                            ),
+                        },
+                        "work_ref": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": WORK_REF_MAX_CHARS,
+                            "description": (
+                                "Exact-match filter on an announcement's "
+                                "'work_ref' (e.g. 'gh:evoila/meho#123'). "
+                                "Audit-driven events never match it."
+                            ),
+                        },
+                        "active_only": {
+                            "type": "boolean",
+                            "default": False,
+                            "description": (
+                                "When true, drop TTL'd announcement claims "
+                                "whose expires_at (ts + ttl_minutes) has "
+                                "elapsed. Non-TTL events always pass."
+                            ),
                         },
                     },
                     "additionalProperties": False,
                     "description": (
                         "Filter narrows the result; all sub-keys "
-                        "optional. Each non-null sub-key is exact-match."
+                        "optional. Each non-null sub-key is exact-match "
+                        "(except 'active_only', a boolean mode)."
                     ),
                 },
                 "timeout_ms": {

--- a/backend/tests/test_broadcast_structured_claims.py
+++ b/backend/tests/test_broadcast_structured_claims.py
@@ -1,0 +1,533 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Structured intent claims on ``meho.broadcast.announce`` (T1, #2544).
+
+Covers the keystone contract of Broadcast v2 (Initiative #2543):
+
+* ``AgentAnnouncementEvent`` gains optional typed fields -- ``targets``,
+  ``planned_op_class``, ``ttl_minutes``, ``work_ref``, ``run_id`` -- and
+  a derived ``expires_at``.
+* Trust split: the validated structured fields (``planned_op_class`` /
+  ``ttl_minutes`` / ``run_id`` / ``phase`` / ``ts`` / ``expires_at``)
+  serialise UNWRAPPED; the free-text fields (``activity`` / ``scope`` /
+  ``target`` / ``targets[]`` / ``work_ref``) stay behind the
+  untrusted-content envelope. Filtering runs pre-wrap on the model.
+* ``meho.broadcast.recent`` gains ``work_ref`` + ``active_only`` filters
+  and the ``target`` filter now matches an announcement's ``targets``
+  list; invalid claims reject at the boundary with ``-32602``.
+* Back-compat: single-``target`` announcements and pre-v2 stream entries
+  (no claim fields) still parse and render.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import (
+    PLANNED_OP_CLASS_VALUES,
+    AgentAnnouncementEvent,
+    BroadcastEvent,
+    get_broadcast_client,
+    reset_broadcast_client_for_testing,
+)
+from meho_backplane.broadcast.history import dump_event_wire, event_matches
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.mcp.tools.broadcast import _handler_recent
+from meho_backplane.settings import get_settings
+from meho_backplane.untrusted_text import wrap_untrusted_text
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    build_operator,
+    client_with_operator,  # noqa: F401 -- pytest-discovered fixture
+    isolated_registry,  # noqa: F401 -- pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 -- pytest-discovered autouse fixture
+)
+
+_AUDIT_ID: UUID = UUID("44444444-4444-4444-4444-444444444444")
+_RUN_ID: UUID = UUID("99999999-9999-9999-9999-999999999999")
+
+
+@pytest.fixture(autouse=True)
+def _isolated_broadcast_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin a stub broadcast URL + reset the cached client around each test."""
+    monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
+    get_settings.cache_clear()
+    reset_broadcast_client_for_testing()
+    yield
+    reset_broadcast_client_for_testing()
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _announcement(
+    *,
+    activity: str = "rotating tokens",
+    target: str | None = None,
+    targets: list[str] | None = None,
+    scope: str | None = None,
+    planned_op_class: str | None = None,
+    ttl_minutes: int | None = None,
+    work_ref: str | None = None,
+    run_id: UUID | None = None,
+    ts: datetime | None = None,
+) -> AgentAnnouncementEvent:
+    """Build an :class:`AgentAnnouncementEvent` with sensible defaults."""
+    return AgentAnnouncementEvent(
+        tenant_id=OPERATOR_TENANT_ID,
+        principal_sub="op-test",
+        activity=activity,
+        target=target,
+        targets=targets or [],
+        scope=scope,
+        planned_op_class=planned_op_class,  # type: ignore[arg-type]
+        ttl_minutes=ttl_minutes,
+        work_ref=work_ref,
+        run_id=run_id,
+        ts=ts or datetime(2026, 5, 25, 10, 0, tzinfo=UTC),
+    )
+
+
+def _broadcast_event(*, target_name: str | None = None) -> BroadcastEvent:
+    return BroadcastEvent(
+        event_id=uuid4(),
+        ts=datetime(2026, 5, 25, 10, 0, tzinfo=UTC),
+        tenant_id=OPERATOR_TENANT_ID,
+        principal_sub="op-test",
+        target_name=target_name,
+        op_id="vsphere.vm.list",
+        op_class="read",
+        result_status="ok",
+        audit_id=_AUDIT_ID,
+        payload={"op_class": "read"},
+    )
+
+
+def _entry(
+    event: AgentAnnouncementEvent | BroadcastEvent,
+    entry_id: str,
+) -> tuple[str, dict[str, str]]:
+    return entry_id, {"event": event.model_dump_json()}
+
+
+def _result_dict(response: Any) -> dict[str, Any]:
+    body = response.json()
+    assert "error" not in body, body
+    return json.loads(body["result"]["content"][0]["text"])
+
+
+def _tools_call(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Model: new fields + derived expires_at + defense-in-depth validation
+# ---------------------------------------------------------------------------
+
+
+def test_model_accepts_structured_claims_and_derives_expires_at() -> None:
+    """The model carries the typed claims; ``expires_at`` = ``ts + ttl``."""
+    event = _announcement(
+        targets=["cluster-x", "cluster-y"],
+        planned_op_class="write",
+        ttl_minutes=30,
+        work_ref="gh:evoila/meho#123",
+        run_id=_RUN_ID,
+    )
+    assert event.targets == ["cluster-x", "cluster-y"]
+    assert event.planned_op_class == "write"
+    assert event.ttl_minutes == 30
+    assert event.work_ref == "gh:evoila/meho#123"
+    assert event.run_id == _RUN_ID
+    assert event.expires_at == event.ts + timedelta(minutes=30)
+
+
+def test_model_expires_at_none_without_ttl() -> None:
+    """No ``ttl_minutes`` → the announcement is not a time-bounded claim."""
+    assert _announcement().expires_at is None
+
+
+def test_model_defaults_preserve_pre_v2_shape() -> None:
+    """A bare announcement has empty ``targets`` and None claim fields."""
+    event = _announcement()
+    assert event.targets == []
+    assert event.planned_op_class is None
+    assert event.ttl_minutes is None
+    assert event.work_ref is None
+    assert event.run_id is None
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"targets": [f"t{i}" for i in range(11)]},  # 11 > MAX_TARGETS
+        {"targets": ["x" * 257]},  # element over TARGET_MAX_CHARS
+        {"ttl_minutes": 0},  # below TTL_MIN_MINUTES
+        {"ttl_minutes": 1441},  # above TTL_MAX_MINUTES
+        {"work_ref": "x" * 257},  # over WORK_REF_MAX_CHARS
+        {"planned_op_class": "not-a-class"},  # outside the enum
+    ],
+)
+def test_model_rejects_out_of_bounds_claims(kwargs: dict[str, Any]) -> None:
+    """pydantic enforces the same bounds the handler does (defense in depth)."""
+    with pytest.raises(ValidationError):
+        _announcement(**kwargs)
+
+
+def test_planned_op_class_enum_matches_classify_op_taxonomy() -> None:
+    """The declaration enum spans the full classify_op output taxonomy."""
+    assert set(PLANNED_OP_CLASS_VALUES) == {
+        "read",
+        "write",
+        "credential_read",
+        "credential_write",
+        "credential_mint",
+        "audit_query",
+        "approval",
+        "other",
+    }
+
+
+# ---------------------------------------------------------------------------
+# dump_event_wire: structured trusted (unwrapped) vs prose (enveloped)
+# ---------------------------------------------------------------------------
+
+
+def test_dump_wraps_prose_and_leaves_structure_unwrapped() -> None:
+    """Free text is enveloped; enums/int/UUID/timestamps are served raw."""
+    event = _announcement(
+        activity="rotating tokens",
+        target="cluster-x",
+        targets=["cluster-x", "cluster-y"],
+        scope="token rotation",
+        planned_op_class="credential_write",
+        ttl_minutes=30,
+        work_ref="gh:evoila/meho#123",
+        run_id=_RUN_ID,
+    )
+    data = dump_event_wire(event)
+
+    # Prose enveloped.
+    assert data["activity"] == wrap_untrusted_text("rotating tokens")
+    assert data["scope"] == wrap_untrusted_text("token rotation")
+    assert data["target"] == wrap_untrusted_text("cluster-x")
+    assert data["work_ref"] == wrap_untrusted_text("gh:evoila/meho#123")
+    assert data["targets"] == [
+        wrap_untrusted_text("cluster-x"),
+        wrap_untrusted_text("cluster-y"),
+    ]
+
+    # Structure unwrapped -- trustworthy coordination data.
+    assert data["planned_op_class"] == "credential_write"
+    assert data["ttl_minutes"] == 30
+    assert data["run_id"] == str(_RUN_ID)
+    assert data["phase"] == "update"
+    assert data["expires_at"].startswith("2026-05-25T10:30:00")
+
+
+def test_dump_leaves_empty_targets_and_none_claims_alone() -> None:
+    """A bare announcement dumps an empty list + null structured fields."""
+    data = dump_event_wire(_announcement())
+    assert data["targets"] == []
+    assert data["planned_op_class"] is None
+    assert data["ttl_minutes"] is None
+    assert data["run_id"] is None
+    assert data["expires_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# event_matches: target-vs-targets, work_ref, active_only
+# ---------------------------------------------------------------------------
+
+
+def test_target_filter_matches_targets_list_member() -> None:
+    """A ``target`` filter matches when the value is in ``targets``."""
+    event = _announcement(targets=["cluster-x", "cluster-y"])
+    assert event_matches(event, op_class=None, principal=None, target="cluster-y")
+    assert not event_matches(event, op_class=None, principal=None, target="cluster-z")
+
+
+def test_target_filter_still_matches_single_target() -> None:
+    """Back-compat: the single ``target`` field still satisfies the filter."""
+    event = _announcement(target="prod-vc-1")
+    assert event_matches(event, op_class=None, principal=None, target="prod-vc-1")
+
+
+def test_work_ref_filter_matches_announcement_only() -> None:
+    """``work_ref`` matches an announcement; a BroadcastEvent never does."""
+    ann = _announcement(work_ref="gh:evoila/meho#123")
+    assert event_matches(
+        ann, op_class=None, principal=None, target=None, work_ref="gh:evoila/meho#123"
+    )
+    assert not event_matches(ann, op_class=None, principal=None, target=None, work_ref="gh:other#9")
+    bev = _broadcast_event(target_name="cluster-x")
+    assert not event_matches(
+        bev, op_class=None, principal=None, target=None, work_ref="gh:evoila/meho#123"
+    )
+
+
+def test_active_only_drops_expired_claim_keeps_others() -> None:
+    """``active_only`` drops an elapsed TTL claim; non-TTL events survive."""
+    now = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
+    expired = _announcement(
+        ttl_minutes=30,
+        ts=now - timedelta(minutes=60),  # expires_at = now - 30m (elapsed)
+    )
+    active = _announcement(ttl_minutes=30, ts=now - timedelta(minutes=10))
+    no_ttl = _announcement()  # not a claim -- always active
+    bev = _broadcast_event()  # audit event -- always active
+
+    assert not event_matches(
+        expired, op_class=None, principal=None, target=None, active_only=True, now=now
+    )
+    assert event_matches(
+        active, op_class=None, principal=None, target=None, active_only=True, now=now
+    )
+    assert event_matches(
+        no_ttl, op_class=None, principal=None, target=None, active_only=True, now=now
+    )
+    assert event_matches(bev, op_class=None, principal=None, target=None, active_only=True, now=now)
+
+
+# ---------------------------------------------------------------------------
+# Announce inputSchema exposes the new claim fields
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_announce_schema_exposes_claim_fields(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The wire schema advertises the structured-claim properties + bounds."""
+    client, _op = client_with_operator
+    resp = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    announce = next(
+        t for t in resp.json()["result"]["tools"] if t["name"] == "meho.broadcast.announce"
+    )
+    props = announce["inputSchema"]["properties"]
+    assert props["targets"]["type"] == "array"
+    assert props["targets"]["maxItems"] == 10
+    assert props["targets"]["items"]["maxLength"] == 256
+    assert set(props["planned_op_class"]["enum"]) == set(PLANNED_OP_CLASS_VALUES)
+    assert props["ttl_minutes"]["minimum"] == 1
+    assert props["ttl_minutes"]["maximum"] == 1440
+    assert props["work_ref"]["maxLength"] == 256
+    assert props["run_id"]["format"] == "uuid"
+    # Structured claims are optional -- only 'activity' stays required.
+    assert announce["inputSchema"]["required"] == ["activity"]
+
+
+# ---------------------------------------------------------------------------
+# Announce validation: invalid claims reject with -32602
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator,bad_args",
+    [
+        (TenantRole.OPERATOR, {"targets": [f"t{i}" for i in range(11)]}),
+        (TenantRole.OPERATOR, {"ttl_minutes": 0}),
+        (TenantRole.OPERATOR, {"work_ref": "x" * 257}),
+        (TenantRole.OPERATOR, {"run_id": "not-a-uuid"}),
+        (TenantRole.OPERATOR, {"planned_op_class": "nope"}),
+        (TenantRole.OPERATOR, {"targets": "cluster-x"}),  # not a list
+    ],
+    indirect=["client_with_operator"],
+)
+def test_announce_invalid_claim_rejects_with_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    bad_args: dict[str, Any],
+) -> None:
+    """Each malformed claim surfaces as JSON-RPC -32602 at the boundary."""
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        _tools_call("meho.broadcast.announce", {"activity": "x", **bad_args}),
+    )
+    body = resp.json()
+    assert "error" in body, body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# Announce echo + published wire shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_announce_echoes_declared_claims_and_publishes_them(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The ack echoes declared claims; the XADD'd JSON carries them typed."""
+    client, op = client_with_operator
+    bc = get_broadcast_client()
+    with patch.object(bc, "xadd", new=AsyncMock(return_value="1747800000000-0")) as xa:
+        resp = post_mcp(
+            client,
+            _tools_call(
+                "meho.broadcast.announce",
+                {
+                    "activity": "rotating tokens on cluster X",
+                    "targets": ["cluster-x"],
+                    "planned_op_class": "write",
+                    "ttl_minutes": 30,
+                    "work_ref": "gh:evoila/meho#123",
+                    "run_id": str(_RUN_ID),
+                    "phase": "start",
+                },
+            ),
+        )
+    result = _result_dict(resp)
+    assert result["cursor"] == "1747800000000-0"
+    assert result["event_id"] == "1747800000000-0"
+    assert result["targets"] == ["cluster-x"]
+    assert result["planned_op_class"] == "write"
+    assert result["ttl_minutes"] == 30
+    assert result["work_ref"] == "gh:evoila/meho#123"
+    assert result["run_id"] == str(_RUN_ID)
+
+    announce_payloads = [
+        json.loads(call.args[1]["event"])
+        for call in xa.await_args_list
+        if "event" in call.args[1]
+        and json.loads(call.args[1]["event"]).get("event_kind") == "agent_announcement"
+    ]
+    assert len(announce_payloads) == 1
+    decoded = announce_payloads[0]
+    assert decoded["targets"] == ["cluster-x"]
+    assert decoded["planned_op_class"] == "write"
+    assert decoded["ttl_minutes"] == 30
+    assert decoded["work_ref"] == "gh:evoila/meho#123"
+    assert decoded["run_id"] == str(_RUN_ID)
+    assert decoded["tenant_id"] == str(op.tenant_id)
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_bare_announce_keeps_pre_v2_ack_shape(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """No claims → the ack stays the pre-v2 ``{event_id, cursor}`` shape."""
+    client, _op = client_with_operator
+    bc = get_broadcast_client()
+    with patch.object(bc, "xadd", new=AsyncMock(return_value="1747800000000-7")):
+        resp = post_mcp(
+            client,
+            _tools_call("meho.broadcast.announce", {"activity": "investigating"}),
+        )
+    assert _result_dict(resp) == {"event_id": "1747800000000-7", "cursor": "1747800000000-7"}
+
+
+# ---------------------------------------------------------------------------
+# recent round-trip: target / work_ref / active_only each surface the claim
+# ---------------------------------------------------------------------------
+
+
+async def test_recent_target_and_work_ref_filters_surface_the_claim() -> None:
+    """A claim on ``cluster-x`` is found by target and by work_ref filters."""
+    op = build_operator(TenantRole.OPERATOR)
+    claim = _announcement(
+        activity="rotating tokens",
+        targets=["cluster-x"],
+        planned_op_class="write",
+        ttl_minutes=30,
+        work_ref="gh:evoila/meho#123",
+        ts=datetime.now(UTC),
+    )
+    other = _announcement(activity="unrelated", targets=["cluster-z"])
+    entries = [_entry(claim, "1-0"), _entry(other, "2-0")]
+    bc = get_broadcast_client()
+
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=entries)):
+        by_target = await _handler_recent(op, {"filter": {"target": "cluster-x"}})
+        by_work_ref = await _handler_recent(op, {"filter": {"work_ref": "gh:evoila/meho#123"}})
+
+    assert [e["targets"] for e in by_target["events"]] == [[wrap_untrusted_text("cluster-x")]]
+    assert by_target["events"][0]["planned_op_class"] == "write"
+    assert len(by_work_ref["events"]) == 1
+    assert by_work_ref["events"][0]["work_ref"] == wrap_untrusted_text("gh:evoila/meho#123")
+
+
+async def test_recent_active_only_excludes_expired_claim() -> None:
+    """Before TTL elapses ``active_only`` surfaces the claim; after, it drops."""
+    op = build_operator(TenantRole.OPERATOR)
+    fresh = _announcement(targets=["cluster-x"], ttl_minutes=30, ts=datetime.now(UTC))
+    stale = _announcement(
+        targets=["cluster-x"],
+        ttl_minutes=30,
+        ts=datetime.now(UTC) - timedelta(minutes=90),
+    )
+    bc = get_broadcast_client()
+
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=[_entry(fresh, "1-0")])):
+        active = await _handler_recent(op, {"filter": {"active_only": True}})
+    assert len(active["events"]) == 1
+
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=[_entry(stale, "1-0")])):
+        expired = await _handler_recent(op, {"filter": {"active_only": True}})
+    assert expired["events"] == []
+
+
+# ---------------------------------------------------------------------------
+# Back-compat: pre-v2 stream entries (no claim fields) parse + render
+# ---------------------------------------------------------------------------
+
+
+async def test_pre_v2_entry_without_claim_fields_still_parses() -> None:
+    """An entry written before the claim fields existed round-trips cleanly.
+
+    The wire JSON omits ``targets`` / ``planned_op_class`` / ``ttl_minutes``
+    / ``work_ref`` / ``run_id`` entirely (the v0.8.0 announcement shape);
+    the model fills defaults and the reader serves it beside a v2 claim on
+    the same mixed stream.
+    """
+    op = build_operator(TenantRole.OPERATOR)
+    legacy_json = json.dumps(
+        {
+            "kind": "agent_announcement",
+            "event_kind": "agent_announcement",
+            "tenant_id": str(OPERATOR_TENANT_ID),
+            "principal_sub": "op-test",
+            "activity": "legacy announce",
+            "target": "prod-vc-1",
+            "scope": None,
+            "phase": "start",
+            "ts": "2026-05-25T09:00:00Z",
+        }
+    )
+    v2 = _announcement(activity="v2 announce", targets=["cluster-x"], ttl_minutes=30)
+    entries = [("1-0", {"event": legacy_json}), _entry(v2, "2-0")]
+    bc = get_broadcast_client()
+
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=entries)):
+        result = await _handler_recent(op, {})
+
+    activities = [e["activity"] for e in result["events"]]
+    assert activities == [
+        wrap_untrusted_text("legacy announce"),
+        wrap_untrusted_text("v2 announce"),
+    ]
+    # Legacy entry renders with the claim defaults (empty list, nulls).
+    legacy = result["events"][0]
+    assert legacy["targets"] == []
+    assert legacy["planned_op_class"] is None
+    assert legacy["expires_at"] is None

--- a/docs/codebase/broadcast.md
+++ b/docs/codebase/broadcast.md
@@ -54,6 +54,17 @@ Three layers, separated for traceability:
    fields: `event_id` / `audit_id` on operation rows; announcement
    rows have no UUID (until #2547 mints one).
 
+   **Read-side `filter` object (MCP recent/watch).** Both tools accept a
+   `filter` object narrowing by exact-match `op_class` / `principal` /
+   `target` / `work_ref`, plus the boolean `active_only`. `target`
+   matches a `BroadcastEvent`'s `target_name` or an announcement's single
+   `target` **or any entry in its `targets` list**. `work_ref` matches
+   an announcement's `work_ref` only (an audit-derived event never has
+   one). `active_only` (default `false`) drops TTL'd announcement claims
+   whose `expires_at` has elapsed; non-TTL events (announcements without
+   a TTL, and all audit-derived rows) always pass. All matching runs on
+   the raw model before the untrusted-text wrap (#2544).
+
 ## Key types
 
 - `BroadcastEvent` (`broadcast/events.py`) — every audited operation
@@ -63,9 +74,36 @@ Three layers, separated for traceability:
   `event_kind = "audit_derived"` discriminator.
 - `AgentAnnouncementEvent` (`broadcast/agent_events.py`) — agent-
   authored announcements published via `meho.broadcast.announce`.
-  Fields: `tenant_id`, `principal_sub`, `activity`, `target`,
-  `scope`, `phase`. `event_kind = "agent_announcement"` discriminator
-  so readers can dispatch on the kind.
+  Fields: `tenant_id`, `principal_sub`, `activity`, `target`, `scope`,
+  `phase`, plus the optional **structured intent claims** (Broadcast
+  v2, #2544): `targets` (list, ≤10 names, each ≤256 chars — supersedes
+  the single `target` for multi-target work), `planned_op_class` (the
+  declared op class, spanning the full `classify_op` taxonomy),
+  `ttl_minutes` (1..1440), `work_ref` (opaque change-ticket ref, ≤256,
+  same convention as `AgentRun.work_ref`), `run_id` (UUID). A derived
+  `expires_at` computed field (`ts + ttl_minutes`, or `None`) drives
+  the `active_only` read filter. `kind` / `event_kind =
+  "agent_announcement"` discriminator so readers can dispatch on the
+  kind. All claim fields are optional with back-compatible defaults
+  (`targets=[]`, the rest `None`), so pre-v2 stream entries parse
+  unchanged.
+
+  **Structure is trusted; prose is quarantined.** The typed fields
+  (`planned_op_class`, `ttl_minutes`, `run_id`, `phase`, `ts`,
+  `expires_at`) are server-validated bounded enums / ints / UUIDs /
+  timestamps — they cannot carry a prompt injection, so `dump_event_wire`
+  serves them **unwrapped** as trustworthy coordination data. The
+  free-text fields (`activity`, `scope`, `target`, `targets[]`,
+  `work_ref`) stay agent-authored prose and keep the untrusted-content
+  envelope (`_ANNOUNCEMENT_UNTRUSTED_FIELDS` +
+  `_ANNOUNCEMENT_UNTRUSTED_LIST_FIELDS`, wrapped per-element for the
+  list). All filtering (`event_matches`) runs on the raw model **before**
+  the wrap, so narrowing is unaffected by the envelope — the same split
+  the pre-existing `target` filter already relied on. Invalid claims
+  (11 targets, `ttl_minutes=0`, a 257-char `work_ref`, a non-UUID
+  `run_id`, an out-of-enum `planned_op_class`) reject at the MCP
+  boundary with JSON-RPC `-32602`, belt-and-suspenders with the
+  pydantic `Field` bounds on the model.
 - `op_class` sensitivity taxonomy (`classify_op` / `redact_payload` in
   `broadcast/events.py`) — derived from the op-id (no per-descriptor
   column), drives how `payload` is redacted before publish:


### PR DESCRIPTION
## Summary

- Adds optional **structured intent claims** to `meho.broadcast.announce` — `targets` (list, ≤10 names), `planned_op_class` (the full `classify_op` taxonomy), `ttl_minutes` (1..1440), `work_ref`, `run_id` — plus a derived `expires_at` (`ts + ttl_minutes`), turning announcements from quarantined prose into coordination data (keystone of Initiative #2543).
- **Structure is trusted; prose is quarantined.** Server-validated enum/int/UUID/timestamp fields (`planned_op_class`, `ttl_minutes`, `run_id`, `phase`, `ts`, `expires_at`) serialise **unwrapped**; free text (`activity`, `scope`, `target`, `targets[]`, `work_ref`) keeps the untrusted-content envelope. All filtering runs on the raw model before the wrap — the same split the pre-existing `target` filter relied on.
- `meho.broadcast.recent`/`watch` gain `work_ref` and `active_only` filters; the `target` filter now matches an announcement's `targets` list too. Invalid claims reject at the boundary with `-32602`, belt-and-suspenders with pydantic `Field` bounds.
- Fully back-compatible: every claim field is optional with a default (`targets=[]`, rest `None`), so single-`target` announcements and pre-v2 stream entries parse and render unchanged. Builds on #2479's self-labelled `cursor` — the ack stays `{event_id, cursor}` and echoes any declared claim fields.

## Test plan

- [x] `ruff check` — clean (broadcast package, MCP tool, new test)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (4 changed source modules)
- [x] `pytest -k broadcast` — 551 passed, 5 skipped (Docker-gated), 0 failed
- [x] `code-quality.py --diff` — 0 blockers (8 pre-existing size warnings)
- [x] Round-trip: announce `{targets:["cluster-x"], planned_op_class:"write", ttl_minutes:30, work_ref:"gh:evoila/meho#123"}` surfaced by `recent {target}`, `{work_ref}`, `{active_only}`; excluded by `active_only` after TTL elapses
- [x] Wire dump: structured fields unwrapped, prose (incl. `targets[]`) enveloped; `event_matches` matches on unwrapped values
- [x] Invalid claims (11 targets, ttl 0, 257-char work_ref, bad UUID / enum) → `-32602`
- [x] Mixed-stream back-compat (legacy no-claim entry + v2 claim) parse and render

## Out of scope (later tasks in #2543)

- Durable persistence (#2547 / T2), rate limiting (#2546 / T6), hosted-agent bridge (#2548 / T4), human/UI + SSE rendering (#2549 / T5), dispatch advisory (#2550 / T7).
- Adjacent findings (pre-existing, unchanged): `broadcast/history.py` and `mcp/tools/broadcast.py` exceed the 600-line file-size soft threshold; several handlers exceed the 60-line function-size warn threshold (all under the 100-line block threshold).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2544
