### PR TITLE
feat(checks): deterministic sensor check-runner — replica-safe no-LLM evaluation loop (#2505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,30 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — deterministic sensor check-runner (#2505)
+
+- Add `meho_backplane.checks.runner` — the lifespan-owned, no-LLM evaluation
+  loop that closes the check layer (#2505). Each tick claims every due
+  `Sensor` (#2503), dispatches its `safe` op through the operations
+  `dispatch()` seam under a synthetic per-tenant identity (`sub` from the
+  sensor's `identity_sub`, `principal_kind=user` → the policy gate
+  auto-executes the safe op), feeds the payload to #2504's pure
+  `evaluate_assertion`, and persists `{state, value, evidence, evaluated_at}`
+  via `record_sensor_result`. One loop drives both cadence kinds — sub-minute
+  `interval` on the tick grid, `>=1`-minute `cron` via the scheduler's
+  `next_fire_after` — riding #804's belt-and-braces durability
+  (`pg_try_advisory_lock` under a distinct key + `FOR UPDATE SKIP LOCKED`
+  claim + conditional advance-before-dispatch), so evaluation is at-most-once
+  per scheduled instant across replicas: a crashed or overlapping evaluation
+  surfaces as staleness, never a double-fire. Evaluations run as tracked
+  background tasks (never awaited under the lock — the #1502 wedge class),
+  bounded by a concurrency semaphore + per-evaluation timeout and a per-sensor
+  overlap guard; any non-`ok` dispatch or a timeout maps the sensor to
+  `unknown`. A row whose persisted cadence no longer parses is parked to
+  `paused` with a `status_reason`. Gated on `SENSOR_RUNNER_ENABLED`
+  (default on), cadence via `SENSOR_RUNNER_TICK_INTERVAL_SECONDS` (default
+  10 s). No migration, no new route.
+
 ### Added — Sensor assertion evaluator (#2504)
 
 - Add `meho_backplane.checks` with a pure, no-I/O bounded assertion

--- a/backend/src/meho_backplane/checks/repository.py
+++ b/backend/src/meho_backplane/checks/repository.py
@@ -24,8 +24,10 @@ flush-not-commit discipline
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.checks.assertions import CheckState
@@ -33,7 +35,10 @@ from meho_backplane.db.models import Sensor, SensorCadenceKind, SensorStatus
 from meho_backplane.scheduler.cron import next_fire_after
 
 __all__ = [
+    "advance_sensor_next_fire",
+    "claim_due_sensors",
     "create_sensor",
+    "park_sensor",
     "record_sensor_result",
 ]
 
@@ -169,3 +174,144 @@ async def record_sensor_result(
         row.state_since = evaluated_at
     await session.flush()
     return changed
+
+
+async def claim_due_sensors(
+    session: AsyncSession,
+    *,
+    now: datetime,
+    limit: int,
+) -> Sequence[Sensor]:
+    """Return up to *limit* active sensors whose ``next_fire_at`` <= *now*.
+
+    Copies :func:`meho_backplane.scheduler.repository.claim_due_triggers`'s
+    belt-and-braces replica-safety discipline onto the ``sensor`` table:
+
+    * On PostgreSQL: ``SELECT ... WHERE ... FOR UPDATE SKIP LOCKED`` so a
+      second claimer in another transaction (another replica, another
+      process) never receives a row this transaction has locked. The row
+      locks release on the caller's commit / rollback, so the runner holds
+      them across the conditional advance in
+      :func:`advance_sensor_next_fire` (the claim-advance sequence).
+    * On SQLite (the unit-test path): the locking clause no-ops (SQLite has
+      a single writer at a time). Single-fire across two in-process ticks is
+      enforced by the conditional ``UPDATE ... WHERE next_fire_at=:previous``
+      in :func:`advance_sensor_next_fire`.
+
+    ``next_fire_at <= now`` excludes NULL rows (a NULL comparison is NULL
+    under SQL), so only rows with a materialised next-fire are claimed. The
+    ``ORDER BY next_fire_at ASC`` fires the most-overdue sensors first (a
+    deployment resuming after a pause walks its backlog forward), riding
+    #2503's partial ``sensor_due_idx (status, next_fire_at) WHERE
+    status='active'``.
+    """
+    conn = await session.connection()
+    stmt = (
+        select(Sensor)
+        .where(
+            Sensor.status == SensorStatus.ACTIVE.value,
+            Sensor.next_fire_at <= now,
+        )
+        .order_by(Sensor.next_fire_at.asc())
+        .limit(limit)
+    )
+    if conn.dialect.name == "postgresql":
+        stmt = stmt.with_for_update(skip_locked=True)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def advance_sensor_next_fire(
+    session: AsyncSession,
+    row: Sensor,
+    *,
+    fire_instant: datetime,
+) -> Sensor | None:
+    """Advance *row*'s ``next_fire_at`` past *fire_instant*; return the row.
+
+    Handles both cadence kinds uniformly:
+
+    * ``interval`` -- ``next_fire_at = fire_instant + interval_seconds``.
+    * ``cron`` -- ``next_fire_at = next_fire_after(cron_expr, fire_instant,
+      timezone)`` (:func:`meho_backplane.scheduler.cron.next_fire_after`, the
+      same materialisation :func:`create_sensor` used at insert).
+
+    The advance is a conditional UPDATE (``WHERE status='active' AND
+    next_fire_at=:previous``) that mirrors
+    :func:`meho_backplane.scheduler.repository.advance_cron_trigger`: a
+    concurrent claimer that already advanced this row (the SKIP-LOCKED-less
+    dialect race, or the belt-and-braces guard on PG) matches zero rows, so
+    this call returns ``None`` and the runner skips the dispatch -- the other
+    claimer owns this tick. The advance commits (via the caller) *before* the
+    dispatch, so a slow or crashed evaluation cannot delay or double-fire the
+    next scheduled instant (the at-most-once contract #804 proved).
+
+    Returns the row on a successful advance, ``None`` when the conditional
+    UPDATE matched zero rows (another claimer won the race).
+
+    Raises:
+        ~meho_backplane.scheduler.cron.InvalidCronExpressionError: the
+            persisted ``cron_expr`` no longer parses (the runner catches this
+            and parks the row via :func:`park_sensor`).
+        ~meho_backplane.scheduler.cron.InvalidTimezoneError: the persisted
+            ``timezone`` is not a resolvable IANA name (same park path).
+    """
+    previous_next = row.next_fire_at
+    if row.cadence_kind == SensorCadenceKind.CRON.value:
+        # ``ck_sensor_cadence_fields`` guarantees a cron row carries a
+        # non-NULL cron_expr; assert it for the type-checker. A corrupt
+        # *value* (unparseable expression / timezone) raises out of
+        # next_fire_after, which the runner catches to park the row.
+        assert row.cron_expr is not None
+        new_next = next_fire_after(row.cron_expr, fire_instant, row.timezone)
+    else:
+        # ``ck_sensor_cadence_fields`` guarantees an interval row carries a
+        # non-NULL interval_seconds.
+        assert row.interval_seconds is not None
+        new_next = fire_instant + timedelta(seconds=row.interval_seconds)
+    stmt = (
+        update(Sensor)
+        .where(
+            Sensor.id == row.id,
+            Sensor.status == SensorStatus.ACTIVE.value,
+            Sensor.next_fire_at == previous_next,
+        )
+        .values(next_fire_at=new_next)
+    )
+    result = await session.execute(stmt)
+    await session.flush()
+    rowcount: int = result.rowcount  # type: ignore[attr-defined]
+    if rowcount == 0:
+        return None
+    # Refresh the in-memory object so the caller reads the advanced value
+    # without re-querying.
+    row.next_fire_at = new_next
+    return row
+
+
+async def park_sensor(
+    session: AsyncSession,
+    sensor_id: uuid.UUID,
+    *,
+    reason: str,
+) -> None:
+    """Transition a corrupt sensor to ``status='paused'`` with a reason.
+
+    Called by #2505's runner for a row whose persisted cadence no longer
+    computes a next fire (an unparseable ``cron_expr`` / ``timezone`` that
+    bypassed the create-time validator). Parking stops the runner from
+    re-tripping on the same bad row every tick; the *reason* is stamped onto
+    ``status_reason`` so the parked state explains itself on #2506's read
+    surfaces. Mirrors
+    :func:`meho_backplane.scheduler.loop._park_trigger`. Flush-not-commit --
+    the caller owns the transaction (and commits so a sibling-row rollback
+    later in the tick cannot revert the park)."""
+    await session.execute(
+        update(Sensor)
+        .where(Sensor.id == sensor_id)
+        .values(
+            status=SensorStatus.PAUSED.value,
+            status_reason=reason,
+        )
+    )
+    await session.flush()

--- a/backend/src/meho_backplane/checks/runner.py
+++ b/backend/src/meho_backplane/checks/runner.py
@@ -1,0 +1,532 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Deterministic, no-LLM sensor check-runner (#2505).
+
+The lifespan-owned background loop at the heart of Initiative #2416's check
+layer. On each cadence (default 10 s, ``SENSOR_RUNNER_TICK_INTERVAL_SECONDS``)
+it claims every due :class:`~meho_backplane.db.models.Sensor` row (#2503),
+dispatches each sensor's ``safe`` read-only op through the operations
+:func:`~meho_backplane.operations.dispatcher.dispatch` seam under a synthetic
+per-tenant identity, feeds the payload to #2504's pure
+:func:`~meho_backplane.checks.evaluate.evaluate_assertion`, and persists the
+outcome via #2503's :func:`~meho_backplane.checks.repository.record_sensor_result`.
+No agent, no model call, no LLM anywhere on this path.
+
+One loop, two cadences
+======================
+
+A single interval-tick loop drives both cadence kinds. Sub-minute *interval*
+sensors ride the tick grid directly; ``>=1``-minute *cron* sensors advance via
+:func:`~meho_backplane.scheduler.cron.next_fire_after`. Both share the durable
+claim/advance discipline the #804 scheduler proved out. **Sub-tick cadences
+quantize to the tick grid**: a sensor whose ``interval_seconds`` is below
+``SENSOR_RUNNER_TICK_INTERVAL_SECONDS`` fires at most once per tick, not once
+per its nominal interval (the precedent #2245 documented for the scheduler's
+30 s grid). Operators wanting finer granularity lower the tick interval.
+
+Replica-safety (copied from ``scheduler/loop.py``'s belt-and-braces)
+===================================================================
+
+Each tick acquires a process-wide ``pg_try_advisory_lock`` under
+:data:`_SENSOR_RUNNER_ADVISORY_LOCK_KEY` (a fixed 63-bit key distinct from the
+scheduler's ``_SCHEDULER_ADVISORY_LOCK_KEY`` and the topology per-target
+keyspace) so only one replica runs the tick body at a time. Due rows are
+claimed with ``FOR UPDATE SKIP LOCKED`` and each claimed row's ``next_fire_at``
+is advanced by a conditional ``UPDATE ... WHERE next_fire_at=:previous`` that
+commits *before* dispatch. The advisory lock alone leaves the SQLite test path
+uncovered; the conditional advance is what enforces single-fire there, and the
+combination is the at-most-once-per-scheduled-instant property #804 already
+proved. A crashed or overlapping evaluation surfaces as staleness
+(-> #2506's stale-``unknown`` derivation), never a double-fire.
+
+No lock-wedge (#1502 regression class)
+======================================
+
+Evaluations run as tracked background :class:`asyncio.Task`s, never awaited
+under the advisory lock. The tick advances the claimed rows, releases the lock,
+then spawns the evaluations and returns. A hung op dispatch (or a
+``requires_approval`` wait, which cannot happen here -- sensors reference only
+``safe`` ops) never strands the lock for the rest of the connection's life.
+
+Overlap + concurrency bounds
+============================
+
+Evaluations are tracked in a per-process ``dict[sensor_id, Task]``. If a
+sensor's previous evaluation is still running when it comes due again, the tick
+skips the new dispatch and logs ``sensor_evaluation_overlap_skipped`` -- the
+missed instant becomes staleness, consistent with the at-most-once contract.
+Concurrent evaluations are bounded by a fixed-constant
+:class:`asyncio.Semaphore` and each evaluation by an :func:`asyncio.timeout`
+that maps to ``unknown``. Residual cross-replica overlap (an evaluation
+outliving its cadence while the tick lock migrates replicas) is accepted, not
+guarded by a DB in-flight marker: the op is ``safe``/read-only and idempotent,
+the result write is last-writer-wins stamped with ``evaluated_at``, and a
+marker column would strand on crash and demand a reaper -- the same
+stampede-cost-below-noise-floor reasoning
+:mod:`meho_backplane.memory.expiry` documents.
+
+Dispatch identity
+=================
+
+Each dispatch runs as a synthetic per-tenant :class:`~meho_backplane.auth.operator.Operator`
+with ``sub=sensor.identity_sub`` (#2503's per-row column, default
+``"__sensor__"``), ``tenant_id=sensor.tenant_id``, ``raw_jwt=""``,
+``TenantRole.OPERATOR`` -- the topology-refresh ``_system_operator`` mould with
+the sub sourced from the row. ``principal_kind`` defaults to ``USER``, so
+:func:`~meho_backplane.operations._validate.policy_gate` auto-executes the
+``safe`` op (#2503's registration guard guarantees a sensor only ever
+references a ``safe`` op; the agent-credential path is never touched here and
+no agent run may exist on this path). A connector requiring an operator-context
+Vault credential read fails closed for a synthetic operator -- such a dispatch
+returns a structured error and the sensor reads ``unknown``; targets with
+stored credentials (the topology-refresh model) evaluate normally.
+
+Result vocabulary
+================
+
+The runner never synthesizes any state other than ``unknown``: a ``status ==
+"ok"`` dispatch routes its payload into #2504's evaluator and persists its
+emitted ``{state, value, evidence}``; any non-``ok`` dispatch status or an
+evaluation timeout persists ``unknown`` with evidence carrying the failure.
+Rollup, hysteresis, and ``skip`` derivation belong to #2506.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import cast
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.checks.assertions import AssertionOutcome, AssertionSpec
+from meho_backplane.checks.evaluate import evaluate_assertion
+from meho_backplane.checks.repository import (
+    advance_sensor_next_fire,
+    claim_due_sensors,
+    park_sensor,
+    record_sensor_result,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Sensor
+from meho_backplane.operations.dispatcher import dispatch
+from meho_backplane.scheduler.cron import (
+    InvalidCronExpressionError,
+    InvalidTimezoneError,
+)
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "run_one_sensor_tick",
+    "start_sensor_runner",
+    "stop_sensor_runner",
+]
+
+#: 63-bit signed-int key for ``pg_try_advisory_lock``. A fixed literal so every
+#: replica computes the same key and exactly one holds the lock at a time.
+#: Deliberately distinct from the scheduler's ``_SCHEDULER_ADVISORY_LOCK_KEY``
+#: (``0x4D45_484F_5343_4844`` -- "MEHOSCHD") and from the topology scheduler's
+#: per-target blake2b keyspace, so the sensor runner and the agent scheduler
+#: never contend on one lock. "MEHOSENS".
+_SENSOR_RUNNER_ADVISORY_LOCK_KEY: int = 0x4D45_484F_5345_4E53
+
+#: Maximum sensor rows claimed per tick. Bounds per-tick work even under a
+#: catch-up burst after an outage; the next tick picks up the rest. Matches the
+#: scheduler's ``_CLAIM_BATCH_LIMIT`` posture -- a dumb, fixed loop bound.
+_CLAIM_BATCH_LIMIT: int = 50
+
+#: Ceiling on concurrent in-flight evaluations. A fixed constant (not a
+#: per-deployment tunable), same posture as :data:`_CLAIM_BATCH_LIMIT`: a tick
+#: may claim up to the batch limit, and this bounds how many op dispatches hit
+#: their targets at once so a wide sensor fleet cannot open 50 simultaneous
+#: connector calls.
+_MAX_CONCURRENT_EVALUATIONS: int = 16
+
+#: Per-evaluation wall-clock ceiling (seconds). A backstop above the
+#: connector's own timeouts: a dispatch that hangs past this maps the sensor to
+#: ``unknown`` rather than pinning an evaluation slot forever. A fixed constant
+#: for the same substrate-minimalism reason as the bounds above.
+_EVAL_TIMEOUT_SECONDS: float = 30.0
+
+#: Per-process registry of in-flight evaluation tasks, keyed by sensor id. The
+#: overlap guard reads it (skip a sensor whose previous evaluation is not
+#: ``done()``); :func:`stop_sensor_runner` cancels every outstanding task.
+_IN_FLIGHT: dict[uuid.UUID, asyncio.Task[None]] = {}
+
+#: Lazily-created concurrency semaphore. Built on first use in the running loop
+#: rather than at import so it binds to the app's event loop (an
+#: import-time-constructed ``asyncio`` primitive strands across the per-test
+#: event loops pytest-asyncio creates). Reset via
+#: :func:`reset_sensor_runner_state`.
+_EVAL_SEMAPHORE: asyncio.Semaphore | None = None
+
+
+def _log() -> structlog.typing.FilteringBoundLogger:
+    """Resolve the structlog logger per call (not a module-level proxy).
+
+    A module-level ``_log = structlog.get_logger(__name__)`` proxy caches its
+    bound methods on first use under the production
+    ``cache_logger_on_first_use=True`` config; a later
+    :func:`structlog.testing.capture_logs` in the same worker then cannot reach
+    the orphaned closure, so the overlap-skip test's log assertion flakes under
+    pytest-xdist ``loadscope``. Resolving the logger on every call reads the
+    live config each time.
+
+    The :func:`~typing.cast` documents the runtime type the production
+    ``make_filtering_bound_logger`` config yields; ``structlog.get_logger`` is
+    typed ``Any`` in the stubs, so an un-cast return trips ``no-any-return``.
+    """
+    return cast("structlog.typing.FilteringBoundLogger", structlog.get_logger(__name__))
+
+
+def _eval_semaphore() -> asyncio.Semaphore:
+    """Get (or lazily build) the concurrency semaphore for the current loop."""
+    global _EVAL_SEMAPHORE
+    if _EVAL_SEMAPHORE is None:
+        _EVAL_SEMAPHORE = asyncio.Semaphore(_MAX_CONCURRENT_EVALUATIONS)
+    return _EVAL_SEMAPHORE
+
+
+def reset_sensor_runner_state() -> None:
+    """Drop all per-process runner state (test seam).
+
+    Clears the in-flight registry and the lazily-built semaphore so a fresh
+    test starts with no leftover tasks and a semaphore bound to its own event
+    loop. Mirrors :func:`meho_backplane.db.engine.reset_engine_for_testing`'s
+    role as an explicit reset for module-level state.
+    """
+    _IN_FLIGHT.clear()
+    global _EVAL_SEMAPHORE
+    _EVAL_SEMAPHORE = None
+
+
+@dataclass(frozen=True, slots=True)
+class _SensorSnapshot:
+    """The immutable view an evaluation needs, detached from the tick session.
+
+    Captured while the claimed row is still fresh in the tick's session, so the
+    backgrounded evaluation (which opens its own short session) never touches an
+    expired ORM object bound to a closed session.
+    """
+
+    id: uuid.UUID
+    tenant_id: uuid.UUID
+    name: str
+    connector_id: str
+    op_id: str
+    target: dict[str, object] | None
+    params: dict[str, object]
+    assertion: dict[str, object]
+    identity_sub: str
+
+    @classmethod
+    def from_row(cls, row: Sensor) -> _SensorSnapshot:
+        return cls(
+            id=row.id,
+            tenant_id=row.tenant_id,
+            name=row.name,
+            connector_id=row.connector_id,
+            op_id=row.op_id,
+            target=row.target,
+            params=row.params,
+            assertion=row.assertion,
+            identity_sub=row.identity_sub,
+        )
+
+
+async def _try_advisory_lock(session: AsyncSession, key: int) -> bool:
+    """Acquire the process-wide PG advisory lock; ``True`` on non-PG.
+
+    Returns ``True`` when the lock is held (or the dialect has no advisory
+    locks -- the SQLite single-replica test path) and the caller should
+    proceed; ``False`` when another replica holds it and this tick is skipped.
+    Mirrors :func:`meho_backplane.scheduler.loop._try_advisory_lock`.
+    """
+    conn = await session.connection()
+    if conn.dialect.name != "postgresql":
+        return True
+    locked = await session.scalar(text("SELECT pg_try_advisory_lock(:k)"), {"k": key})
+    return bool(locked)
+
+
+async def _advisory_unlock(session: AsyncSession, key: int) -> None:
+    """Release the advisory lock; no-op on non-PG dialects."""
+    conn = await session.connection()
+    if conn.dialect.name != "postgresql":
+        return
+    await session.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": key})
+
+
+def _sensor_operator(snap: _SensorSnapshot) -> Operator:
+    """Build the synthetic per-tenant operator a sensor dispatch runs as.
+
+    ``raw_jwt`` is empty -- the runner forwards no bearer token; a target with
+    stored credentials evaluates normally, one needing an operator-context
+    Vault read fails closed to a structured error (-> ``unknown``).
+    ``principal_kind`` defaults to ``USER``, so the policy gate auto-executes
+    the ``safe`` op #2503's registration guard restricts sensors to.
+    """
+    return Operator(
+        sub=snap.identity_sub,
+        name=None,
+        email=None,
+        raw_jwt="",
+        tenant_id=snap.tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _unknown_outcome(reason: str, **extra: object) -> AssertionOutcome:
+    """An ``unknown`` outcome carrying *reason* (+ any extra evidence)."""
+    evidence: dict[str, object] = {"reason": reason}
+    evidence.update(extra)
+    return AssertionOutcome(state="unknown", value=None, evidence=evidence)
+
+
+async def _run_evaluation(snap: _SensorSnapshot) -> AssertionOutcome:
+    """Dispatch the sensor's op and evaluate the assertion. Never raises.
+
+    ``status == "ok"`` routes the payload into #2504's evaluator; any non-``ok``
+    dispatch status, an evaluation timeout, or a spec/evaluator failure maps to
+    ``unknown`` with the cause in the evidence.
+    """
+    now = datetime.now(UTC)
+    operator = _sensor_operator(snap)
+    try:
+        async with asyncio.timeout(_EVAL_TIMEOUT_SECONDS):
+            result = await dispatch(
+                operator=operator,
+                connector_id=snap.connector_id,
+                op_id=snap.op_id,
+                target=snap.target,
+                params=snap.params,
+            )
+    except TimeoutError:
+        return _unknown_outcome(
+            "evaluation_timeout",
+            timeout_seconds=_EVAL_TIMEOUT_SECONDS,
+        )
+
+    if result.status != "ok":
+        return _unknown_outcome(
+            "dispatch_not_ok",
+            dispatch_status=result.status,
+            dispatch_error=result.error,
+        )
+
+    try:
+        spec = AssertionSpec.model_validate(snap.assertion)
+        return evaluate_assertion(spec, result.result, now=now)
+    except Exception as exc:
+        # Never-raises contract: a corrupt persisted spec or an unexpected
+        # evaluator failure is an ``unknown`` outcome, not a crashed task.
+        return _unknown_outcome("assertion_evaluation_error", error=str(exc))
+
+
+async def _persist_outcome(snap: _SensorSnapshot, outcome: AssertionOutcome) -> None:
+    """Write *outcome* onto the sensor's latest-state projection (own session)."""
+    evaluated_at = datetime.now(UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await record_sensor_result(
+            session,
+            sensor_id=snap.id,
+            state=outcome.state,
+            value=outcome.value,
+            evidence=outcome.evidence,
+            evaluated_at=evaluated_at,
+        )
+        await session.commit()
+
+
+async def _evaluate_and_record(snap: _SensorSnapshot) -> None:
+    """One backgrounded evaluation: dispatch -> evaluate -> persist.
+
+    Bounded by the concurrency semaphore (around the dispatch/evaluate step)
+    and the per-evaluation timeout inside :func:`_run_evaluation`. Every failure
+    mode is contained so a broken evaluation never crashes the task with an
+    unretrieved exception; ``CancelledError`` propagates so shutdown can cancel
+    cleanly.
+    """
+    try:
+        async with _eval_semaphore():
+            outcome = await _run_evaluation(snap)
+        await _persist_outcome(snap, outcome)
+        _log().info(
+            "sensor_evaluated",
+            sensor_id=str(snap.id),
+            sensor_name=snap.name,
+            state=outcome.state,
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        _log().warning(
+            "sensor_evaluation_errored",
+            sensor_id=str(snap.id),
+            exc_info=True,
+        )
+
+
+def _spawn_evaluation(snap: _SensorSnapshot) -> bool:
+    """Spawn a background evaluation for *snap* unless one is still in flight.
+
+    Returns ``True`` when a task was spawned, ``False`` on an overlap skip. The
+    overlap guard is the only per-sensor serialization: a sensor whose previous
+    evaluation is not ``done()`` skips this dispatch and logs
+    ``sensor_evaluation_overlap_skipped``. Runs outside the advisory lock.
+    """
+    existing = _IN_FLIGHT.get(snap.id)
+    if existing is not None and not existing.done():
+        _log().info(
+            "sensor_evaluation_overlap_skipped",
+            sensor_id=str(snap.id),
+            sensor_name=snap.name,
+        )
+        return False
+    task = asyncio.create_task(
+        _evaluate_and_record(snap),
+        name=f"sensor-eval-{snap.id}",
+    )
+    _IN_FLIGHT[snap.id] = task
+    task.add_done_callback(lambda t: _discard_task(snap.id, t))
+    return True
+
+
+def _discard_task(sensor_id: uuid.UUID, task: asyncio.Task[None]) -> None:
+    """Drop a finished evaluation from the in-flight registry (if still current)."""
+    if _IN_FLIGHT.get(sensor_id) is task:
+        del _IN_FLIGHT[sensor_id]
+
+
+async def run_one_sensor_tick() -> int:
+    """Execute one runner tick. Returns the number of evaluations dispatched.
+
+    Public so tests can drive a deterministic single tick without the cadence
+    sleep (mould: :func:`meho_backplane.scheduler.loop.run_one_tick`). Claims
+    due sensors under the advisory lock, advances each claimed row's
+    ``next_fire_at`` (committing before dispatch), parks a row whose persisted
+    cadence no longer parses, then -- after releasing the lock -- spawns a
+    backgrounded evaluation per claimed row (subject to the overlap guard). The
+    tick never awaits the evaluations, so it returns promptly and the lock is
+    held for the DB work only.
+    """
+    now = datetime.now(UTC)
+    to_dispatch: list[_SensorSnapshot] = []
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        locked = await _try_advisory_lock(session, _SENSOR_RUNNER_ADVISORY_LOCK_KEY)
+        if not locked:
+            return 0
+        try:
+            rows = await claim_due_sensors(session, now=now, limit=_CLAIM_BATCH_LIMIT)
+            for row in rows:
+                try:
+                    try:
+                        advanced = await advance_sensor_next_fire(session, row, fire_instant=now)
+                    except (InvalidCronExpressionError, InvalidTimezoneError) as exc:
+                        await park_sensor(
+                            session,
+                            row.id,
+                            reason=f"invalid_cadence:{type(exc).__name__}",
+                        )
+                        # Commit the park so a later sibling-row rollback cannot
+                        # revert it and leave the row re-tripping every tick.
+                        await session.commit()
+                        _log().warning(
+                            "sensor_paused",
+                            sensor_id=str(row.id),
+                            reason=str(exc),
+                        )
+                        continue
+                    if advanced is None:
+                        # Another claimer already advanced this row -- it owns
+                        # this tick.
+                        continue
+                    # Snapshot while the row is fresh, then commit the advance
+                    # before dispatch (release the row lock).
+                    snap = _SensorSnapshot.from_row(row)
+                    await session.commit()
+                    to_dispatch.append(snap)
+                except Exception:
+                    # Per-row isolation: one bad row never stalls the tick.
+                    _log().exception("sensor_tick_row_failed", sensor_id=str(row.id))
+                    await session.rollback()
+        finally:
+            await _advisory_unlock(session, _SENSOR_RUNNER_ADVISORY_LOCK_KEY)
+            await session.commit()
+
+    # Advisory lock released, advances committed. Spawn the evaluations as
+    # background tasks -- never awaited here (the #1502 lock-wedge class).
+    dispatched = 0
+    for snap in to_dispatch:
+        if _spawn_evaluation(snap):
+            dispatched += 1
+    return dispatched
+
+
+async def _runner_loop() -> None:
+    """The forever loop: sleep one cadence, tick, repeat.
+
+    Sleep-then-tick so the first tick after process start is delayed by one
+    cadence -- letting the rest of the lifespan eager-init complete before the
+    loop touches the DB (mould:
+    :func:`meho_backplane.memory.expiry._sweeper_loop`). Per-tick ``try`` /
+    ``except`` so a transient failure (DB blip, advisory-lock query error) is
+    logged and the loop continues; ``CancelledError`` propagates so lifespan
+    shutdown stops the task cleanly.
+    """
+    interval = get_settings().sensor_runner_tick_interval_seconds
+    _log().info("sensor_runner_started", interval_seconds=interval)
+    while True:
+        await asyncio.sleep(get_settings().sensor_runner_tick_interval_seconds)
+        try:
+            await run_one_sensor_tick()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log().warning("sensor_runner_tick_failed", exc_info=True)
+
+
+def start_sensor_runner() -> asyncio.Task[None]:
+    """Start the background runner loop and return its task handle.
+
+    Registered in :func:`meho_backplane.main.lifespan` behind the
+    ``SENSOR_RUNNER_ENABLED`` setting. The returned task is cancelled on
+    lifespan shutdown; :func:`stop_sensor_runner` awaits the cancellation.
+    Returning the task keeps a strong reference alive so it is not GC'd
+    mid-flight (the "Task was destroyed but it is pending!" warning the
+    lifecycle test bars). Mould:
+    :func:`meho_backplane.memory.expiry.start_memory_expiry_sweeper`.
+    """
+    return asyncio.create_task(_runner_loop(), name="sensor-runner")
+
+
+async def stop_sensor_runner(task: asyncio.Task[None]) -> None:
+    """Cancel the runner loop + every outstanding evaluation, await their unwind.
+
+    Cancels the tick loop first, then every in-flight evaluation task so no
+    backgrounded op dispatch outlives the shutdown (leaving a "Task was
+    destroyed but it is pending!" warning or an in-flight session racing the
+    engine-pool teardown). Swallows the expected :class:`asyncio.CancelledError`
+    on each; any other exception during unwind propagates so a broken shutdown
+    is visible. Mould:
+    :func:`meho_backplane.memory.expiry.stop_memory_expiry_sweeper`.
+    """
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+    outstanding = [t for t in _IN_FLIGHT.values() if not t.done()]
+    for evaluation in outstanding:
+        evaluation.cancel()
+    for evaluation in outstanding:
+        with contextlib.suppress(asyncio.CancelledError):
+            await evaluation
+    _IN_FLIGHT.clear()

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -115,6 +115,7 @@ from meho_backplane.broadcast import (
     dispose_broadcast_client,
     get_broadcast_client,
 )
+from meho_backplane.checks.runner import start_sensor_runner, stop_sensor_runner
 from meho_backplane.connectors.registry import _eager_import_connectors, registered_product_tokens
 from meho_backplane.db.engine import dispose_engine, get_engine
 from meho_backplane.db.migrations import db_migration_probe
@@ -442,6 +443,7 @@ class _BackgroundTasks:
     grant_expiry: asyncio.Task[None] | None
     approval_expiry: asyncio.Task[None] | None
     scheduler: asyncio.Task[None] | None
+    sensor_runner: asyncio.Task[None] | None
     agent_run_reaper: asyncio.Task[None] | None
     event_drain: asyncio.Task[None] | None
     gateway_deadman: asyncio.Task[None] | None
@@ -491,6 +493,12 @@ def _start_background_tasks() -> _BackgroundTasks:
     scheduler: asyncio.Task[None] | None = None
     if settings.scheduler_enabled:
         scheduler = start_scheduler()
+    # Initiative #2416 (#2505) — deterministic sensor check-runner. Gated on
+    # SENSOR_RUNNER_ENABLED so operators running an external evaluator (or the
+    # test path without a runner) can opt out.
+    sensor_runner: asyncio.Task[None] | None = None
+    if settings.sensor_runner_enabled:
+        sensor_runner = start_sensor_runner()
     # G11.3-T4 #825 — gated on AGENT_RUN_REAPER_ENABLED so operators
     # running an external lease-reclaim mechanism (DBOS Transact, a
     # workflow engine) can disable the in-tree reaper without
@@ -519,6 +527,7 @@ def _start_background_tasks() -> _BackgroundTasks:
         grant_expiry=grant_expiry,
         approval_expiry=approval_expiry,
         scheduler=scheduler,
+        sensor_runner=sensor_runner,
         agent_run_reaper=agent_run_reaper,
         event_drain=event_drain,
         gateway_deadman=gateway_deadman,
@@ -539,6 +548,8 @@ async def _stop_background_tasks(tasks: _BackgroundTasks) -> None:
         await stop_event_drain(tasks.event_drain)
     if tasks.agent_run_reaper is not None:
         await stop_agent_run_reaper(tasks.agent_run_reaper)
+    if tasks.sensor_runner is not None:
+        await stop_sensor_runner(tasks.sensor_runner)
     if tasks.scheduler is not None:
         await stop_scheduler(tasks.scheduler)
     if tasks.approval_expiry is not None:

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1238,6 +1238,16 @@ class Settings(BaseModel):
     # shape so operators using an external scheduler can opt out.
     scheduler_tick_interval_seconds: int = Field(default=30, ge=1, le=3600)
     scheduler_enabled: bool = True
+    # Initiative #2416 (#2505) — deterministic sensor check-runner. The
+    # lifespan-owned interval-tick loop scans for due Sensor rows and evaluates
+    # each (dispatch → assertion → projection) with no LLM in the path.
+    # ``tick_interval`` bounds how often it scans; the default (10 s) supports
+    # the sub-minute interval cadence a Sensor may carry (sub-tick cadences
+    # quantize to this grid, documented on the runner module). ``enabled``
+    # mirrors the SCHEDULER_ENABLED shape so an operator running an external
+    # evaluator (or the test path without a runner) can opt out.
+    sensor_runner_enabled: bool = True
+    sensor_runner_tick_interval_seconds: int = Field(default=10, ge=1, le=3600)
     # G11.3-T2 #823 / G0.19-T2 #1478 — autonomous-agent credential
     # sourcing for the scheduler. ``run_scheduled`` (G11.2-T2 #1096)
     # wants ``(client_id, client_secret)``; the scheduler resolves
@@ -1770,6 +1780,12 @@ def get_settings() -> Settings:
         ),
         scheduler_enabled=parse_bool_env(
             os.environ.get("SCHEDULER_ENABLED", "true"),
+        ),
+        sensor_runner_tick_interval_seconds=int(
+            os.environ.get("SENSOR_RUNNER_TICK_INTERVAL_SECONDS", "10"),
+        ),
+        sensor_runner_enabled=parse_bool_env(
+            os.environ.get("SENSOR_RUNNER_ENABLED", "true"),
         ),
         scheduler_agent_secret_env_pattern=os.environ.get(
             "SCHEDULER_AGENT_SECRET_ENV_PATTERN",

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -344,6 +344,14 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                     # KeyError: 'KEYCLOAK_ISSUER_URL' (this test pins no env).
                     approval_expiry_enabled=False,
                     scheduler_enabled=False,
+                    # Initiative #2416 (#2505) added the sensor check-runner,
+                    # gated on SENSOR_RUNNER_ENABLED (default on). Pin it off —
+                    # a bare MagicMock attribute is truthy, so without this the
+                    # gate reads True and the real start_sensor_runner runs
+                    # _runner_loop, which reads the MagicMock
+                    # sensor_runner_tick_interval_seconds and blows up in
+                    # asyncio.sleep.
+                    sensor_runner_enabled=False,
                     agent_run_reaper_enabled=False,
                     event_drain_enabled=False,
                     # Initiative #2415 (#2501) added the gateway dead-man
@@ -380,6 +388,11 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                 "meho_backplane.main",
                 start_scheduler=MagicMock(),
                 stop_scheduler=AsyncMock(),
+                # #2505 — sensor check-runner. Defensive patch (the gate above
+                # is pinned off) so a future default flip can't smuggle the
+                # real runner (and its get_settings() tick read) back in.
+                start_sensor_runner=MagicMock(),
+                stop_sensor_runner=AsyncMock(),
                 start_agent_run_reaper=MagicMock(),
                 stop_agent_run_reaper=AsyncMock(),
                 start_event_drain=MagicMock(),
@@ -457,6 +470,11 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                     # sweeper and KeyError on KEYCLOAK_ISSUER_URL.
                     approval_expiry_enabled=False,
                     scheduler_enabled=False,
+                    # #2505 sensor check-runner — pin off; a bare MagicMock
+                    # attribute is truthy, which would start the real runner
+                    # (its _runner_loop reads the MagicMock tick interval and
+                    # blows up in asyncio.sleep). Same shape as the sibling.
+                    sensor_runner_enabled=False,
                     agent_run_reaper_enabled=False,
                     event_drain_enabled=False,
                     # #2501 gateway dead-man sweeper — pin off; a bare
@@ -488,6 +506,10 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                 "meho_backplane.main",
                 start_scheduler=MagicMock(),
                 stop_scheduler=AsyncMock(),
+                # #2505 sensor check-runner — defensive patch (see the sibling
+                # lifespan test) so the real runner can never start here.
+                start_sensor_runner=MagicMock(),
+                stop_sensor_runner=AsyncMock(),
                 start_agent_run_reaper=MagicMock(),
                 stop_agent_run_reaper=AsyncMock(),
                 start_event_drain=MagicMock(),

--- a/backend/tests/test_sensor_runner.py
+++ b/backend/tests/test_sensor_runner.py
@@ -1,0 +1,747 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the deterministic sensor check-runner (#2505).
+
+Initiative #2416 (parent goal #221), Task #2505. Coverage matrix mapped to the
+issue's acceptance criteria:
+
+* **Disabled via SENSOR_RUNNER_ENABLED=false** -- the setting resolves false so
+  the lifespan gate skips starting the task.
+* **Distinct advisory-lock key** -- the runner's key differs from the
+  scheduler's ``_SCHEDULER_ADVISORY_LOCK_KEY`` so the two loops never contend.
+* **At-most-once** -- a dispatch that raises still leaves ``next_fire_at``
+  advanced; an immediate second tick dispatches nothing more.
+* **Replica-safety** -- two concurrent ticks over one due sensor dispatch once.
+* **Both cadences advance** -- interval by exactly its interval; cron via
+  ``next_fire_after``.
+* **Corrupt cadence parks** -- an unparseable persisted cron parks the row and
+  is never re-claimed.
+* **Overlap guard + no lock-wedge** -- a still-running evaluation makes the next
+  tick skip dispatch (logging ``sensor_evaluation_overlap_skipped``), and the
+  tick returns while the evaluation is still pending.
+* **Identity** -- the dispatch runs as a synthetic per-tenant USER operator
+  whose ``sub`` is the sensor's ``identity_sub``.
+* **Failure mapping** -- non-``ok`` dispatch statuses and an evaluation timeout
+  persist ``unknown``; ``ok`` routes the payload into #2504's evaluator.
+* **Paused sensors** -- never claimed.
+* **Lifecycle** -- start/stop is clean and cancels outstanding evaluations.
+
+The tests run on the autouse SQLite-backed engine from :mod:`tests.conftest`.
+``dispatch`` is stubbed via monkeypatch on the runner module so no connector or
+network is hit (python_best_practices §14 -- no network in unit tests).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Callable, Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import structlog
+
+from meho_backplane.auth.operator import Operator, PrincipalKind
+from meho_backplane.checks.assertions import AssertionSpec
+from meho_backplane.checks.repository import (
+    advance_sensor_next_fire,
+    create_sensor,
+)
+from meho_backplane.checks.runner import (
+    _IN_FLIGHT,
+    _SENSOR_RUNNER_ADVISORY_LOCK_KEY,
+    reset_sensor_runner_state,
+    run_one_sensor_tick,
+    start_sensor_runner,
+    stop_sensor_runner,
+)
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Sensor, SensorCadenceKind, SensorStatus, Tenant
+from meho_backplane.scheduler.cron import next_fire_after
+from meho_backplane.scheduler.loop import _SCHEDULER_ADVISORY_LOCK_KEY
+from meho_backplane.settings import get_settings
+
+_TENANT = uuid.UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+# A threshold assertion that reads ``ok`` for a payload ``{"count": 3}``:
+# ``3 > 10`` is False, so no critical violation.
+_OK_ASSERTION: dict[str, Any] = AssertionSpec.model_validate(
+    {
+        "select": {"path": "$.count"},
+        "compare": {"type": "threshold", "op": "gt", "critical": 10},
+    }
+).model_dump(mode="json")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env vars :class:`Settings` requires; reset runner state."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    get_settings.cache_clear()
+    reset_sensor_runner_state()
+    yield
+    reset_sensor_runner_state()
+    get_settings.cache_clear()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+async def _seed_tenant(tenant_id: uuid.UUID = _TENANT) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if await session.get(Tenant, tenant_id) is None:
+            session.add(Tenant(id=tenant_id, slug=str(tenant_id)[:8], name="Tenant C"))
+            await session.commit()
+
+
+async def _create_interval_sensor(
+    *,
+    interval_seconds: int = 300,
+    identity_sub: str = "__sensor__",
+    assertion: dict[str, Any] | None = None,
+    tenant_id: uuid.UUID = _TENANT,
+    base: datetime | None = None,
+) -> uuid.UUID:
+    await _seed_tenant(tenant_id)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await create_sensor(
+            session,
+            tenant_id=tenant_id,
+            name=f"sensor-{uuid.uuid4().hex[:8]}",
+            connector_id="vmware-rest-9.0",
+            op_id="vmware.vm.list",
+            target=None,
+            params={},
+            assertion=assertion if assertion is not None else _OK_ASSERTION,
+            cadence_kind=SensorCadenceKind.INTERVAL,
+            interval_seconds=interval_seconds,
+            cron_expr=None,
+            timezone="UTC",
+            severity="critical",
+            for_seconds=0,
+            identity_sub=identity_sub,
+            created_by_sub="op-admin",
+            base=base,
+        )
+        await session.commit()
+        return row.id
+
+
+async def _create_cron_sensor(
+    *,
+    cron_expr: str = "*/5 * * * *",
+    timezone: str = "UTC",
+    tenant_id: uuid.UUID = _TENANT,
+    base: datetime,
+) -> uuid.UUID:
+    await _seed_tenant(tenant_id)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await create_sensor(
+            session,
+            tenant_id=tenant_id,
+            name=f"sensor-{uuid.uuid4().hex[:8]}",
+            connector_id="vmware-rest-9.0",
+            op_id="vmware.vm.list",
+            target=None,
+            params={},
+            assertion=_OK_ASSERTION,
+            cadence_kind=SensorCadenceKind.CRON,
+            interval_seconds=None,
+            cron_expr=cron_expr,
+            timezone=timezone,
+            severity="critical",
+            for_seconds=0,
+            identity_sub="__sensor__",
+            created_by_sub="op-admin",
+            base=base,
+        )
+        await session.commit()
+        return row.id
+
+
+async def _force_due(sensor_id: uuid.UUID, when: datetime) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        row.next_fire_at = when
+        await session.commit()
+
+
+async def _set_status(sensor_id: uuid.UUID, status: SensorStatus) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        row.status = status.value
+        await session.commit()
+
+
+async def _get_sensor(sensor_id: uuid.UUID) -> Sensor:
+    """Load a sensor and return it (no commit -- attrs stay accessible detached)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        return row
+
+
+def _aware(dt: datetime | None) -> datetime | None:
+    """Attach UTC to a naive datetime (aiosqlite drops tz on round-trip)."""
+    if dt is None:
+        return None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
+async def _drain_in_flight(timeout: float = 3.0) -> None:
+    """Await every outstanding evaluation task until the registry drains."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while _IN_FLIGHT and loop.time() < deadline:
+        tasks = list(_IN_FLIGHT.values())
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await asyncio.sleep(0)
+
+
+async def _wait_until(predicate: Callable[[], bool], timeout: float = 3.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate() and loop.time() < deadline:
+        await asyncio.sleep(0)
+    assert predicate(), "condition not met within timeout"
+
+
+def _ok_result(payload: dict[str, Any]) -> OperationResult:
+    return OperationResult(status="ok", op_id="vmware.vm.list", result=payload, duration_ms=1.0)
+
+
+# --------------------------------------------------------------------------- #
+# Settings gate + advisory-lock key
+# --------------------------------------------------------------------------- #
+
+
+def test_sensor_runner_disabled_setting_resolves_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SENSOR_RUNNER_ENABLED=false reads through to the settings flag.
+
+    The lifespan gate is ``if settings.sensor_runner_enabled:
+    start_sensor_runner()``; a false flag means no task is created.
+    """
+    monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    get_settings.cache_clear()
+    assert get_settings().sensor_runner_enabled is False
+    get_settings.cache_clear()
+
+
+def test_sensor_runner_enabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The runner is on by default (the shipped in-process evaluator)."""
+    monkeypatch.delenv("SENSOR_RUNNER_ENABLED", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    get_settings.cache_clear()
+    settings = get_settings()
+    assert settings.sensor_runner_enabled is True
+    assert settings.sensor_runner_tick_interval_seconds == 10
+    get_settings.cache_clear()
+
+
+def test_advisory_lock_key_differs_from_scheduler() -> None:
+    """The runner's advisory-lock key must not collide with the scheduler's."""
+    assert _SENSOR_RUNNER_ADVISORY_LOCK_KEY != _SCHEDULER_ADVISORY_LOCK_KEY
+    # Non-negative so it round-trips through asyncpg's signed bigint binding.
+    assert 0 <= _SENSOR_RUNNER_ADVISORY_LOCK_KEY <= 0x7FFF_FFFF_FFFF_FFFF
+
+
+# --------------------------------------------------------------------------- #
+# Cadence advance (value-assert, deterministic fire_instant)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_interval_cadence_advances_by_exact_interval() -> None:
+    """An interval sensor advances ``next_fire_at`` by exactly its interval."""
+    sensor_id = await _create_interval_sensor(interval_seconds=45)
+    fire_instant = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        advanced = await advance_sensor_next_fire(session, row, fire_instant=fire_instant)
+        assert advanced is not None
+        assert _aware(advanced.next_fire_at) == fire_instant + timedelta(seconds=45)
+
+
+@pytest.mark.asyncio
+async def test_cron_cadence_advances_via_next_fire_after() -> None:
+    """A cron sensor's advanced ``next_fire_at`` equals ``next_fire_after``."""
+    sensor_id = await _create_cron_sensor(
+        cron_expr="*/5 * * * *",
+        base=datetime(2026, 5, 25, 11, 0, 0, tzinfo=UTC),
+    )
+    fire_instant = datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        advanced = await advance_sensor_next_fire(session, row, fire_instant=fire_instant)
+        assert advanced is not None
+        assert _aware(advanced.next_fire_at) == next_fire_after("*/5 * * * *", fire_instant, "UTC")
+        assert _aware(advanced.next_fire_at) == datetime(2026, 5, 25, 12, 5, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_lost_advance_race_returns_none() -> None:
+    """A conditional advance loses to a claimer that already advanced the row.
+
+    The conditional ``WHERE next_fire_at=:previous`` is the single-fire guard on
+    the SKIP-LOCKED-less dialect: a second claimer holding a stale
+    ``next_fire_at`` matches zero rows and returns ``None`` (the other claimer
+    owns this tick).
+    """
+    sensor_id = await _create_interval_sensor(interval_seconds=60)
+    fire_instant = datetime(2026, 5, 25, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    # Session A loads the row at its current next_fire_at.
+    async with sessionmaker() as session_a:
+        row_a = await session_a.get(Sensor, sensor_id)
+        assert row_a is not None
+
+        # A concurrent claimer (session B) advances the same row first.
+        async with sessionmaker() as session_b:
+            row_b = await session_b.get(Sensor, sensor_id)
+            assert row_b is not None
+            advanced_b = await advance_sensor_next_fire(session_b, row_b, fire_instant=fire_instant)
+            assert advanced_b is not None
+            await session_b.commit()
+
+        # Session A still holds the stale next_fire_at; its conditional advance
+        # matches zero rows.
+        advanced_a = await advance_sensor_next_fire(session_a, row_a, fire_instant=fire_instant)
+        assert advanced_a is None
+
+
+# --------------------------------------------------------------------------- #
+# At-most-once + replica safety
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_at_most_once_dispatch_that_raises_advances_and_does_not_refire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dispatch that raises still advances ``next_fire_at``; a second tick is a no-op."""
+    calls = 0
+
+    async def _raising_dispatch(**_kwargs: Any) -> OperationResult:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("connector exploded")
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _raising_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    dispatched = await run_one_sensor_tick()
+    assert dispatched == 1
+    await _drain_in_flight()
+    assert calls == 1
+
+    # ``next_fire_at`` advanced past the claimed instant (into the future).
+    advanced = await _get_sensor(sensor_id)
+    next_fire = _aware(advanced.next_fire_at)
+    assert next_fire is not None
+    assert next_fire > datetime.now(UTC) - timedelta(seconds=10)
+
+    # An immediate second tick finds nothing due -> zero further dispatch.
+    dispatched_again = await run_one_sensor_tick()
+    await _drain_in_flight()
+    assert dispatched_again == 0
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_sensor_ticks_never_double_evaluate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two concurrent ticks over one due sensor dispatch exactly once."""
+    calls = 0
+
+    async def _counting_dispatch(**_kwargs: Any) -> OperationResult:
+        nonlocal calls
+        calls += 1
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _counting_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    results = await asyncio.gather(run_one_sensor_tick(), run_one_sensor_tick())
+    assert sum(results) == 1, f"expected exactly one dispatch, got {results}"
+    await _drain_in_flight()
+    assert calls == 1
+
+
+# --------------------------------------------------------------------------- #
+# Corrupt cadence parks
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_corrupt_cron_cadence_parks_and_is_not_reclaimed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unparseable persisted cron parks the row; it is never re-claimed."""
+    calls = 0
+
+    async def _counting_dispatch(**_kwargs: Any) -> OperationResult:
+        nonlocal calls
+        calls += 1
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _counting_dispatch)
+
+    sensor_id = await _create_cron_sensor(
+        cron_expr="*/5 * * * *",
+        base=datetime(2026, 5, 25, 12, 0, 0, tzinfo=UTC),
+    )
+    # Corrupt the persisted cron expression (bypassing the create validator)
+    # and force it due.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        row.cron_expr = "not a cron expr"
+        row.next_fire_at = datetime(2026, 1, 1, tzinfo=UTC)
+        await session.commit()
+
+    dispatched = await run_one_sensor_tick()
+    await _drain_in_flight()
+    assert dispatched == 0
+    assert calls == 0
+
+    parked = await _get_sensor(sensor_id)
+    assert parked.status == SensorStatus.PAUSED.value
+    assert parked.status_reason
+    assert "invalid_cadence" in parked.status_reason
+
+    # Paused row is never re-claimed on the next tick.
+    dispatched_again = await run_one_sensor_tick()
+    await _drain_in_flight()
+    assert dispatched_again == 0
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_paused_sensor_due_in_past_is_never_claimed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A paused sensor overdue in the past yields zero dispatches."""
+    calls = 0
+
+    async def _counting_dispatch(**_kwargs: Any) -> OperationResult:
+        nonlocal calls
+        calls += 1
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _counting_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=60)
+    await _force_due(sensor_id, datetime(2026, 1, 1, tzinfo=UTC))
+    await _set_status(sensor_id, SensorStatus.PAUSED)
+
+    dispatched = await run_one_sensor_tick()
+    await _drain_in_flight()
+    assert dispatched == 0
+    assert calls == 0
+
+
+# --------------------------------------------------------------------------- #
+# Identity
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_dispatch_runs_as_synthetic_tenant_user_operator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dispatch operator carries the sensor's identity_sub / tenant / USER kind."""
+    captured: dict[str, Any] = {}
+
+    async def _capturing_dispatch(*, operator: Operator, **_kwargs: Any) -> OperationResult:
+        captured["operator"] = operator
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _capturing_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    await run_one_sensor_tick()
+    await _drain_in_flight()
+
+    operator = captured["operator"]
+    assert isinstance(operator, Operator)
+    assert operator.sub == "__sensor__"
+    assert operator.tenant_id == _TENANT
+    assert operator.principal_kind is PrincipalKind.USER
+    assert operator.raw_jwt == ""
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uses_custom_identity_sub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sensor created with an explicit identity_sub dispatches under it."""
+    captured: dict[str, Any] = {}
+
+    async def _capturing_dispatch(*, operator: Operator, **_kwargs: Any) -> OperationResult:
+        captured["operator"] = operator
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _capturing_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300, identity_sub="svc:sensor-x")
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    await run_one_sensor_tick()
+    await _drain_in_flight()
+    assert captured["operator"].sub == "svc:sensor-x"
+
+
+# --------------------------------------------------------------------------- #
+# Failure mapping + ok routing
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_ok_dispatch_routes_payload_into_evaluator_and_persists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``status=='ok'`` feeds the payload to the evaluator and persists its outcome."""
+
+    async def _ok_dispatch(**_kwargs: Any) -> OperationResult:
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _ok_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    await run_one_sensor_tick()
+    await _drain_in_flight()
+
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "ok"
+    assert row.last_value == 3
+    assert row.last_evidence is not None
+    assert row.last_evidence["observed"] == 3
+    assert row.last_evaluated_at is not None
+    assert row.state_since is not None
+
+
+@pytest.mark.asyncio
+async def test_ok_dispatch_critical_state_persists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A payload violating the threshold persists ``critical`` (evaluator verdict)."""
+
+    async def _ok_dispatch(**_kwargs: Any) -> OperationResult:
+        return _ok_result({"count": 42})  # 42 > 10 -> critical
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _ok_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    await run_one_sensor_tick()
+    await _drain_in_flight()
+
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "critical"
+    assert row.last_value == 42
+
+
+@pytest.mark.parametrize("status", ["error", "denied", "awaiting_approval", "pending"])
+@pytest.mark.asyncio
+async def test_non_ok_dispatch_persists_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+) -> None:
+    """Any non-``ok`` dispatch status persists ``unknown`` with the status in evidence."""
+
+    async def _non_ok_dispatch(**_kwargs: Any) -> OperationResult:
+        return OperationResult(
+            status=status,
+            op_id="vmware.vm.list",
+            error="boom" if status in ("error", "denied") else None,
+            duration_ms=1.0,
+        )
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _non_ok_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    await run_one_sensor_tick()
+    await _drain_in_flight()
+
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "unknown"
+    assert row.last_evidence is not None
+    assert row.last_evidence["dispatch_status"] == status
+    assert row.last_evidence["reason"] == "dispatch_not_ok"
+
+
+@pytest.mark.asyncio
+async def test_evaluation_timeout_persists_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dispatch that outlasts the per-evaluation timeout persists ``unknown``."""
+    monkeypatch.setattr("meho_backplane.checks.runner._EVAL_TIMEOUT_SECONDS", 0.05)
+
+    async def _slow_dispatch(**_kwargs: Any) -> OperationResult:
+        await asyncio.sleep(5.0)
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _slow_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    await run_one_sensor_tick()
+    await _drain_in_flight()
+
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "unknown"
+    assert row.last_evidence is not None
+    assert row.last_evidence["reason"] == "evaluation_timeout"
+
+
+# --------------------------------------------------------------------------- #
+# Overlap guard + no lock-wedge (blocked dispatch)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_tick_returns_while_evaluation_pending_no_lock_wedge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run_one_sensor_tick`` returns while the evaluation task is still pending."""
+    gate = asyncio.Event()
+
+    async def _blocked_dispatch(**_kwargs: Any) -> OperationResult:
+        await gate.wait()
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _blocked_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    try:
+        dispatched = await run_one_sensor_tick()
+        assert dispatched == 1
+        task = _IN_FLIGHT[sensor_id]
+        assert task.done() is False
+    finally:
+        gate.set()
+        await _drain_in_flight()
+
+
+@pytest.mark.asyncio
+async def test_overlap_guard_skips_second_dispatch_and_logs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A still-running evaluation makes the next due tick skip dispatch + log it."""
+    gate = asyncio.Event()
+    calls = 0
+
+    async def _blocked_dispatch(**_kwargs: Any) -> OperationResult:
+        nonlocal calls
+        calls += 1
+        await gate.wait()
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _blocked_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    try:
+        # Tick 1 spawns the evaluation; wait until it is blocked in dispatch.
+        await run_one_sensor_tick()
+        await _wait_until(lambda: calls == 1)
+
+        # Force it due again; the second tick must skip the still-in-flight
+        # sensor and log the overlap.
+        await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+        with structlog.testing.capture_logs() as logs:
+            dispatched = await run_one_sensor_tick()
+
+        assert dispatched == 0
+        assert calls == 1
+        events = [entry.get("event") for entry in logs]
+        assert "sensor_evaluation_overlap_skipped" in events
+    finally:
+        gate.set()
+        await _drain_in_flight()
+
+
+# --------------------------------------------------------------------------- #
+# Lifecycle
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_sensor_runner_lifecycle_clean() -> None:
+    """The lifespan helpers create + cancel the loop task without GC warnings."""
+    task = start_sensor_runner()
+    assert not task.done()
+    await stop_sensor_runner(task)
+    assert task.done()
+    assert task.cancelled() or task.exception() is None
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_outstanding_evaluations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``stop_sensor_runner`` cancels + drains in-flight evaluation tasks."""
+    gate = asyncio.Event()
+
+    async def _blocked_dispatch(**_kwargs: Any) -> OperationResult:
+        await gate.wait()
+        return _ok_result({"count": 3})
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _blocked_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    await run_one_sensor_tick()
+    evaluation = _IN_FLIGHT[sensor_id]
+    assert not evaluation.done()
+
+    loop_task = start_sensor_runner()
+    try:
+        await stop_sensor_runner(loop_task)
+    finally:
+        gate.set()
+
+    assert evaluation.done()
+    assert not _IN_FLIGHT


### PR DESCRIPTION
## Summary

- Adds `meho_backplane.checks.runner` — the deterministic, no-LLM sensor
  check-runner that closes Initiative #2416's check layer. A lifespan-owned
  interval-tick loop claims every due `Sensor` (#2503), dispatches its `safe`
  op through the operations `dispatch()` seam under a synthetic per-tenant
  identity, feeds the payload to #2504's pure `evaluate_assertion`, and
  persists `{state, value, evidence, evaluated_at}` via `record_sensor_result`.
  No agent, no model call, no LLM on this path.
- One loop drives **both cadence kinds** — sub-minute `interval` on the tick
  grid, `>=1`-minute `cron` via the scheduler's `next_fire_after` — riding
  #804's belt-and-braces durability: `pg_try_advisory_lock` (under a **distinct**
  key from the scheduler's), `FOR UPDATE SKIP LOCKED` claim, and a conditional
  advance-before-dispatch. Evaluation is **at-most-once per scheduled instant**
  across replicas; a crashed or overlapping evaluation surfaces as staleness,
  never a double-fire.
- Evaluations run as tracked background tasks — **never awaited under the
  advisory lock** (the #1502 wedge class) — bounded by a concurrency semaphore
  + per-evaluation timeout and a per-sensor overlap guard. Any non-`ok`
  dispatch status or a timeout maps the sensor to `unknown`; a row whose
  persisted cadence no longer parses is parked to `paused` with a
  `status_reason`.
- Gated on `SENSOR_RUNNER_ENABLED` (default on), cadence via
  `SENSOR_RUNNER_TICK_INTERVAL_SECONDS` (default 10 s). **No migration, no new
  route** (OpenAPI snapshot unchanged).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/meho_backplane` — clean (653 files)
- [x] `pytest tests/test_sensor_runner.py` — 23 passed (new module)
- [x] `pytest tests/test_scheduler.py tests/test_memory_expiry.py tests/test_checks_admin.py tests/test_db_sensor.py` — green (mould + touched-module regression)
- [x] Full unit lane (`pytest -n 6 --dist loadscope`, helm-schema test deselected) — green
- [x] At-most-once: a dispatch that raises still advances `next_fire_at`; an immediate second tick dispatches nothing
- [x] Replica-safety: two concurrent `run_one_sensor_tick()` over one due sensor dispatch exactly once
- [x] Both cadences: interval advances by exactly its interval; cron via `next_fire_after`
- [x] Corrupt cron parks the row (`status='paused'` + `status_reason`), never re-claimed
- [x] Overlap guard skips the second dispatch + logs `sensor_evaluation_overlap_skipped`; the tick returns while the evaluation is still pending (no lock-wedge)
- [x] Identity: dispatch runs as a synthetic USER operator whose `sub` is the sensor's `identity_sub`, on the sensor's tenant
- [x] Failure mapping: `error`/`denied`/`awaiting_approval`/`pending` and an evaluation timeout each persist `unknown`; `ok` routes the payload into #2504's evaluator
- [x] Paused sensors due in the past are never claimed
- [x] Lifecycle: start/stop is clean (no "Task was destroyed" warnings) and cancels outstanding evaluations
- [x] `git diff` shows no change under `backend/alembic/versions/` and no change under `cli/`

## Out of scope

- Rollup semantics (worst-of fold, `unknown→degraded`, severity caps, `for:`
  hysteresis, `skip` derivation), the Dashboard entity, and `/ui/checks` — #2506.
- Investigator escalation on non-green — #2507 (wires its hook into this
  runner's persist path later; no hook seam is built here).
- A DB-level cross-replica in-flight marker / evaluation reaper — rejected by
  the issue (strands on crash; safe-read overlap cost below the noise floor).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2505


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated sensor check-runner that periodically evaluates due sensors and records their results.
  * Added safeguards to prevent duplicate evaluations across concurrent processes.
  * Invalid schedules are paused with an explanatory status.
  * Failed, unavailable, or timed-out evaluations are recorded as `unknown`.
  * Added configuration for enabling the runner and adjusting its check interval.

* **Tests**
  * Added coverage for scheduling, concurrency, failures, timeouts, identity handling, lifecycle management, and invalid schedules.

* **Documentation**
  * Documented the sensor check-runner under Unreleased changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->