### PR TITLE
feat(checks): tiered-triage investigator wiring for dashboard non-green transitions (#2507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — tiered-triage investigator wiring (#2507)
+
+- Wire a **diagnose-only investigator** to Dashboard non-green transitions
+  (#2507). When a Dashboard's five-state rollup crosses from green into
+  `degraded` / `critical` — detected at the check-runner's result-persist seam
+  against the `last_rollup_state` memo #2506 reserved — the affected non-green
+  Sensors are correlated through the topology blast-radius graph so one
+  underlying cause produces exactly **one** investigation, tenant memory is
+  checked for a known-noise policy that suppresses re-escalation, and only
+  novel, non-suppressed groups fire a real, durable, budget-gated agent run via
+  `AgentInvoker.run_scheduled`. The investigator is **diagnose-only**: its
+  structured finding lands in the durable `agent_run` row and is written back
+  to memory (`checks-noise-<group-key>`) as the noise-suppression policy;
+  `recommended_action` is advisory text and any change op the agent attempts
+  parks in the existing approval queue — this wiring never executes one.
+  Opt-in per tenant by creating an enabled agent definition named
+  `checks-investigator` (`CHECKS_INVESTIGATOR_AGENT`); budget-gated and
+  kill-switchable through the invoker path. No migration (the memo column is
+  #2506's DDL). See `docs/codebase/checks-investigator.md`.
+
 ### Added — Dashboard entity + five-state rollup + /ui/checks (#2506)
 
 - Add the **Dashboard** entity (#2506): a named, tenant-scoped composition of

--- a/backend/src/meho_backplane/checks/investigate.py
+++ b/backend/src/meho_backplane/checks/investigate.py
@@ -1,0 +1,1096 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tiered-triage investigator wiring for Dashboard non-green transitions (#2507).
+
+Task #2507 under Initiative #2416 (parent goal #221). Productises the
+``examples/r1-tiered-triage`` mould against the deterministic check layer
+(#2503-#2506): when a Dashboard's five-state rollup crosses from green into a
+non-green state, correlate the affected non-green Sensors through the topology
+blast-radius graph so one underlying cause produces exactly **one**
+investigation, check tenant memory for a known-noise policy that suppresses
+re-escalation, and -- only for novel, non-suppressed groups -- fire a real,
+durable, budget-gated agent run via
+:meth:`~meho_backplane.agent.invocation.AgentInvoker.run_scheduled`.
+
+Where the mould goes
+====================
+
+The r1 harness (``examples/r1-tiered-triage/workflow.py``) drives an in-process
+``PydanticAgentRun`` whose *cheap tier* is an LLM classifier. Here the cheap
+tier is **replaced by the deterministic layer** (#2503-#2506): the check-runner
+(#2505) already evaluates every Sensor with no model in the path, and #2506's
+pure rollup fold already answers "is this Dashboard OK?". So there is no
+``invoke_agent`` hop -- the deep tier is invoked directly through the same
+production seam the cron scheduler uses (``scheduler/loop.py`` step 4), which
+gives, for free: the durable pollable ``agent_run`` row (agent-as-subject audit
+provenance), the pre-run budget gate + kill switch, bounded waiting, and
+``work_ref`` stamping.
+
+The trigger seam
+================
+
+There is no event machinery to ride (``kind=event`` trigger creation is refused
+until the #826 matcher lands, #2325) and #2506's rollup is read-path-only by
+decision, so the seam is a **hook at #2505's runner result-persist path**:
+:func:`investigate_on_transition` is called immediately after every
+``record_sensor_result`` persist. It recomputes the rollup for exactly the
+Dashboards containing the just-evaluated Sensor, compares against the
+``check_dashboards.last_rollup_state`` memo (#2506 shipped it UNWRITTEN and
+reserved for this Task; this hook is its only writer), and updates the memo.
+Only a **worsening** transition into a non-green state escalates -- improving or
+unchanged states just maintain the memo. Every evaluation is processed (not only
+state changes) because a ``for:`` hold expiring flips a Dashboard non-green with
+no sensor-state change; the memo-equality check is the cheap exit.
+
+Diagnose-only (the CRUX security property)
+==========================================
+
+This wiring **never executes a change op**. It reads topology, reads/writes
+tenant memory, and invokes a diagnose-only-configured agent whose structured
+finding (verdict, summary, evidence, suggested action) lands in the durable
+``agent_run`` row and is written back to memory as the noise-suppression policy.
+``recommended_action`` is persisted as text only. Any write op the *agent*
+itself attempts parks in the existing approval queue (#817) via the policy gate
+-- this module imports no operations dispatcher and calls no execution seam.
+
+Identity
+========
+
+Topology reads and memory read/write run under a synthetic per-tenant
+:class:`~meho_backplane.auth.operator.Operator` (:func:`_investigator_operator`),
+confined to the Sensor's own tenant -- no cross-tenant reach, no JWT forwarded,
+the #2505 runner precedent. The role is ``TENANT_ADMIN`` (not ``OPERATOR``)
+because the closed-loop noise-suppression policy is a **tenant-shared** memory
+write, and the memory RBAC matrix restricts ``TENANT``-scope writes to
+``tenant_admin`` (``memory/rbac.py``). This synthetic operator never dispatches
+an op; the actual agent run authenticates independently as its own principal
+via ``client_credentials`` (agent-as-subject), so no privilege elevation crosses
+into an execution path.
+
+Containment
+===========
+
+Every failure mode -- unconfigured agent, unresolved credentials, budget
+refusal, unparseable output, topology miss, task crash -- is contained so the
+runner's result-persist path never fails because of this hook. The expensive
+work (topology correlation + agent run) is a fire-and-forget :class:`asyncio.Task`
+anchored in a module-level strong-reference set, so the runner's persist path
+neither blocks nor raises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import cast
+
+import structlog
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    ValidationError,
+)
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.agent.invocation import (
+    AgentDisabledError,
+    AgentInvocationError,
+    AgentNotFoundError,
+    AgentRunOutcome,
+    AgentRunStatusView,
+    get_agent_invoker,
+)
+from meho_backplane.agent.run import BudgetExceededError
+from meho_backplane.auth.agent_token import AgentTokenError
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.checks.assertions import CheckState
+from meho_backplane.checks.dashboard_repository import members_by_dashboard
+from meho_backplane.checks.rollup import (
+    MemberEvaluation,
+    MemberState,
+    evaluate_member,
+    fold,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AgentDefinition,
+    AgentRun,
+    AgentRunStatus,
+    CheckDashboard,
+    CheckDashboardSensor,
+    Sensor,
+)
+from meho_backplane.memory.schemas import MemoryScope
+from meho_backplane.memory.service import MemoryService
+from meho_backplane.scheduler.credentials import (
+    AgentCredentialsUnresolvedError,
+    resolve_agent_credentials,
+)
+from meho_backplane.settings import get_settings
+from meho_backplane.topology.query import find_dependencies
+from meho_backplane.topology.resolvers import AmbiguousNodeError, NodeNotFoundError
+
+__all__ = [
+    "ChecksFinding",
+    "investigate_on_transition",
+    "run_investigation",
+]
+
+#: Slug prefix for every noise-suppression policy entry this wiring writes to
+#: tenant memory (mirrors ``POLICY_SLUG_PREFIX`` in the r1 mould). The suppress
+#: decision reads the entry's *metadata* (``re_escalate == false`` -> suppress),
+#: decided before any model call -- never body prose.
+_NOISE_SLUG_PREFIX = "checks-noise-"
+
+#: ``work_ref`` prefix stamped onto every fired ``agent_run`` -- the
+#: change-ticket reference the runs list filters on and the in-flight dedupe
+#: keys on. Shape: ``checks:<dashboard-slug>:<group-key>``. Unlike a memory
+#: slug, ``work_ref`` is a free Text column so ``:`` separators are legal.
+_WORK_REF_PREFIX = "checks"
+
+#: ``metadata.source`` stamp on every policy entry this wiring writes, so a
+#: later audit / promote sweep tells investigator-written entries from operator
+#: hand-edits or other automation.
+_MEMORY_SOURCE = "checks-investigator"
+
+#: The topology node ``kind`` a registered target manifests as
+#: (:data:`~meho_backplane.db.models.WELL_KNOWN_NODE_KINDS`); the correlation
+#: anchor lookup pins ``resolve_node`` on ``(tenant_id, "target", name)``.
+_TARGET_NODE_KIND = "target"
+
+#: Synthetic subject for the investigator's per-tenant operator -- the
+#: ``_system_operator`` mould with a dedicated sub so audit rows attribute the
+#: topology / memory reads to the check-investigator, not a real user.
+_INVESTIGATOR_SUB = "__checks_investigator__"
+
+#: Fixed poll cadence for the bounded post-``run_scheduled`` wait when a run
+#: outlives the sync timeout (converts to async). A dumb constant, same posture
+#: as the runner's fixed bounds.
+_POLL_INTERVAL_SECONDS = 5.0
+
+#: Server-side ``list_memories`` page cap for a suppression lookup -- one slug's
+#: entries never exceed one row (``(scope, slug)`` is unique), so a tiny cap is
+#: ample; the substring filter may over-match, hence the exact-slug check.
+_MEMORY_LOOKUP_LIMIT = 25
+
+#: The three non-terminal ``agent_run`` statuses. An in-flight run in any of
+#: these states for the same ``(tenant_id, work_ref)`` suppresses a duplicate
+#: fire (an ``awaiting_approval`` run is still in flight -- do not re-fire it).
+_NON_TERMINAL_STATUSES: tuple[AgentRunStatus, ...] = (
+    AgentRunStatus.PENDING,
+    AgentRunStatus.RUNNING,
+    AgentRunStatus.AWAITING_APPROVAL,
+)
+
+#: The three terminal ``agent_run`` statuses the bounded poll waits for.
+_TERMINAL_STATUSES: frozenset[AgentRunStatus] = frozenset(
+    {AgentRunStatus.SUCCEEDED, AgentRunStatus.FAILED, AgentRunStatus.CANCELLED}
+)
+
+#: Worsening-transition rank. Only ``degraded`` / ``critical`` are firing
+#: targets; ``ok`` / ``skip`` / ``unknown`` rank 0 (a Dashboard losing all
+#: members -> ``unknown`` or going all-paused -> ``skip`` is not a symptom to
+#: investigate). A transition fires iff ``rank[current] > rank[previous]`` and
+#: ``current`` is a firing target -- exactly the matrix on #2507.
+_FIRE_RANK: dict[str, int] = {
+    "ok": 0,
+    "skip": 0,
+    "unknown": 0,
+    "degraded": 1,
+    "critical": 2,
+}
+
+#: Characters not admitted by ``memory.schemas.SLUG_PATTERN``
+#: (``[A-Za-z0-9_\\-\\.]``). Runs collapse to a single ``-`` in :func:`_slugify`.
+_SLUGIFY_RE = re.compile(r"[^a-z0-9_.-]+")
+
+#: Per-process strong references to in-flight investigation tasks. ``asyncio``
+#: holds only weak references to bare tasks, so without this set a
+#: fire-and-forget investigation could be GC'd mid-flight (the run-store
+#: rationale in ``agent/invocation.py``). The done-callback discards each entry
+#: on completion so a long-lived worker does not accumulate finished tasks.
+_INVESTIGATIONS: set[asyncio.Task[None]] = set()
+
+
+def _log() -> structlog.typing.FilteringBoundLogger:
+    """Resolve the structlog logger per call (not a module-level proxy).
+
+    A module-level ``structlog.get_logger(__name__)`` proxy caches its bound
+    methods on first use under the production ``cache_logger_on_first_use=True``
+    config; a later :func:`structlog.testing.capture_logs` in the same worker
+    then cannot reach the orphaned closure, so log assertions flake under
+    pytest-xdist ``loadscope``. Resolving per call reads the live config each
+    time (the discipline #2505's runner adopted).
+    """
+    return cast("structlog.typing.FilteringBoundLogger", structlog.get_logger(__name__))
+
+
+class ChecksFinding(BaseModel):
+    """Structured output of one investigation run.
+
+    Mirrors the r1 ``PolicyDecision`` minus its model-chosen ``alert_class``
+    (suppression here keys on the deterministic topology group key, decided
+    before any model call). Because
+    :meth:`~meho_backplane.agent.invocation.AgentInvoker.run_scheduled` does not
+    synthesise a persisted ``output_schema`` into a Pydantic ``output_type``, the
+    terminal run's answer arrives as free text projected to ``{"text": ...}``;
+    this wiring parses that text into a :class:`ChecksFinding` caller-side.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    verdict: str = Field(pattern=r"^(benign|acknowledged|actionable)$")
+    re_escalate: bool
+    summary: str = Field(min_length=1)
+    evidence: list[str] = Field(default_factory=list)
+    recommended_action: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _MemberSnapshot:
+    """A detached view of one non-green member Sensor the briefing needs.
+
+    Captured while the member row is fresh in the transition session, so the
+    backgrounded investigation (which opens its own sessions) never touches an
+    expired ORM object.
+    """
+
+    sensor_id: uuid.UUID
+    name: str
+    connector_id: str
+    op_id: str
+    target: dict[str, object] | None
+    severity: str
+    raw_state: str
+    effective_state: str
+    last_value: object
+    last_evidence: dict[str, object] | None
+
+
+@dataclass(frozen=True, slots=True)
+class _DashboardSnapshot:
+    """A detached view of the transitioning Dashboard the briefing / work_ref need."""
+
+    dashboard_id: uuid.UUID
+    name: str
+    slug: str
+    previous_state: str
+    current_state: str
+
+
+@dataclass(frozen=True, slots=True)
+class _CauseGroup:
+    """One correlated cause: the Sensors a single investigation covers.
+
+    :attr:`key` is the deterministic group key (the deepest shared topology
+    node, else the lone Sensor's slug); it is both the ``work_ref`` group
+    segment and the noise-suppression slug suffix, so the two cannot drift.
+    """
+
+    key: str
+    members: tuple[_MemberSnapshot, ...]
+
+
+async def investigate_on_transition(
+    *,
+    sensor_id: uuid.UUID,
+    tenant_id: uuid.UUID,
+    now: datetime | None = None,
+) -> None:
+    """Detect Dashboard green->non-green transitions off one Sensor persist.
+
+    The public entry point #2505's runner calls immediately after every
+    ``record_sensor_result``. **Never raises** -- the runner's result-persist
+    path must not fail because of this hook. The in-band work (memo
+    compare-and-set) is cheap; the expensive investigation is spawned as a
+    fire-and-forget task so this call returns promptly.
+
+    Args:
+        sensor_id: The Sensor whose evaluation was just persisted.
+        tenant_id: The Sensor's tenant (every read/write here is scoped to it).
+        now: Injection point for the rollup's hysteresis clock; defaults to the
+            current instant (the read-path default #2506 uses).
+    """
+    try:
+        await _process_transition(sensor_id=sensor_id, tenant_id=tenant_id, now=now)
+    except Exception:
+        # Contract: never propagate to the runner's persist path.
+        _log().warning(
+            "checks_investigation_failed",
+            sensor_id=str(sensor_id),
+            tenant_id=str(tenant_id),
+            exc_info=True,
+        )
+
+
+async def _process_transition(
+    *,
+    sensor_id: uuid.UUID,
+    tenant_id: uuid.UUID,
+    now: datetime | None,
+) -> None:
+    """Recompute affected Dashboards, maintain the memo, spawn investigations.
+
+    For every Dashboard containing *sensor_id*: fold its members through #2506's
+    pure rollup against *now*, compare the result to the persisted
+    ``last_rollup_state`` (NULL treated as ``ok``), and write the memo when it
+    changed. A **worsening** transition into ``degraded`` / ``critical`` with at
+    least one actively-failing member schedules a background investigation.
+    """
+    now = now or datetime.now(UTC)
+    sessionmaker = get_sessionmaker()
+    pending: list[tuple[_DashboardSnapshot, list[_MemberSnapshot]]] = []
+    async with sessionmaker() as session:
+        dashboards = await _dashboards_for_sensor(session, tenant_id=tenant_id, sensor_id=sensor_id)
+        if not dashboards:
+            return
+        grouped = await members_by_dashboard(session, dashboard_ids=[d.id for d in dashboards])
+        for dashboard in dashboards:
+            members = grouped.get(dashboard.id, [])
+            evaluations = [(s, evaluate_member(_member_state(s), now)) for s in members]
+            current = fold([e for _, e in evaluations])
+            previous = dashboard.last_rollup_state or "ok"
+            if dashboard.last_rollup_state != current:
+                # Memo compare-and-set: the memo tracks the freshly computed
+                # state so a still-non-green Dashboard fires exactly once (on
+                # the edge), not every tick.
+                dashboard.last_rollup_state = current
+            if _is_worsening(previous, current):
+                non_green = [
+                    _member_snapshot(s, ev)
+                    for s, ev in evaluations
+                    if ev.effective_state not in ("ok", "skip")
+                ]
+                if non_green:
+                    pending.append((_dashboard_snapshot(dashboard, previous, current), non_green))
+        await session.commit()
+
+    # Memo writes committed; spawn the expensive work off the persist path.
+    for dashboard_snapshot, non_green in pending:
+        _schedule_investigation(
+            tenant_id=tenant_id, dashboard=dashboard_snapshot, members=non_green
+        )
+
+
+async def _dashboards_for_sensor(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    sensor_id: uuid.UUID,
+) -> list[CheckDashboard]:
+    """Return the tenant's Dashboards that reference *sensor_id*.
+
+    Reverse membership lookup over the association table, riding
+    ``check_dashboard_sensors_sensor_idx``. Tenant-scoped so a cross-tenant
+    membership can never surface another tenant's Dashboard.
+    """
+    stmt = (
+        select(CheckDashboard)
+        .join(CheckDashboardSensor, CheckDashboardSensor.dashboard_id == CheckDashboard.id)
+        .where(
+            CheckDashboardSensor.sensor_id == sensor_id,
+            CheckDashboard.tenant_id == tenant_id,
+        )
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+def _member_state(sensor: Sensor) -> MemberState:
+    """Project a ``sensor`` row into the fold-relevant :class:`MemberState`.
+
+    Mirrors ``dashboard_service._member_state`` -- replicated here rather than
+    imported so this module does not couple to a sibling's private helper.
+    ``last_state`` is CHECK-constrained to the five-state vocabulary at the DB,
+    so the narrowing cast is honest.
+    """
+    return MemberState(
+        last_state=cast(CheckState, sensor.last_state),
+        status=sensor.status,
+        severity=sensor.severity,
+        for_seconds=sensor.for_seconds,
+        last_evaluated_at=sensor.last_evaluated_at,
+        next_fire_at=sensor.next_fire_at,
+        state_since=sensor.state_since,
+    )
+
+
+def _member_snapshot(sensor: Sensor, evaluation: MemberEvaluation) -> _MemberSnapshot:
+    """Detach a non-green member Sensor into the briefing snapshot."""
+    return _MemberSnapshot(
+        sensor_id=sensor.id,
+        name=sensor.name,
+        connector_id=sensor.connector_id,
+        op_id=sensor.op_id,
+        target=sensor.target,
+        severity=sensor.severity,
+        raw_state=evaluation.raw_state,
+        effective_state=evaluation.effective_state,
+        last_value=sensor.last_value,
+        last_evidence=sensor.last_evidence,
+    )
+
+
+def _dashboard_snapshot(
+    dashboard: CheckDashboard, previous: str, current: str
+) -> _DashboardSnapshot:
+    """Detach the transitioning Dashboard into the briefing / work_ref snapshot."""
+    return _DashboardSnapshot(
+        dashboard_id=dashboard.id,
+        name=dashboard.name,
+        slug=_slugify(dashboard.name),
+        previous_state=previous,
+        current_state=current,
+    )
+
+
+def _is_worsening(previous: str, current: str) -> bool:
+    """Return ``True`` iff *current* is a strictly worse non-green state.
+
+    Fires on ``ok``/``skip`` -> ``degraded``/``critical`` and ``degraded`` ->
+    ``critical``; never on an improving edge (``critical`` -> ``degraded``), an
+    unchanged state, or a drop to ``unknown`` / ``skip``.
+    """
+    return _FIRE_RANK.get(current, 0) > _FIRE_RANK.get(previous, 0) and current in (
+        "degraded",
+        "critical",
+    )
+
+
+def _schedule_investigation(
+    *,
+    tenant_id: uuid.UUID,
+    dashboard: _DashboardSnapshot,
+    members: list[_MemberSnapshot],
+) -> None:
+    """Spawn the correlated investigation as a tracked fire-and-forget task."""
+    task = asyncio.create_task(
+        _guarded_investigation(tenant_id=tenant_id, dashboard=dashboard, members=members),
+        name=f"checks-investigate-{dashboard.dashboard_id}",
+    )
+    _INVESTIGATIONS.add(task)
+    task.add_done_callback(_INVESTIGATIONS.discard)
+
+
+async def _guarded_investigation(
+    *,
+    tenant_id: uuid.UUID,
+    dashboard: _DashboardSnapshot,
+    members: list[_MemberSnapshot],
+) -> None:
+    """Run one investigation with a top-level guard so a crash cannot leak.
+
+    ``CancelledError`` propagates so lifespan shutdown tears the task down
+    cleanly; any other exception is logged and swallowed (the containment
+    contract). Per-group errors are already contained inside
+    :func:`_investigate_group`; this is the belt-and-braces backstop.
+    """
+    try:
+        await run_investigation(tenant_id=tenant_id, dashboard=dashboard, members=members)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        _log().warning(
+            "checks_investigation_failed",
+            dashboard_id=str(dashboard.dashboard_id),
+            tenant_id=str(tenant_id),
+            exc_info=True,
+        )
+
+
+async def run_investigation(
+    *,
+    tenant_id: uuid.UUID,
+    dashboard: _DashboardSnapshot,
+    members: list[_MemberSnapshot],
+) -> None:
+    """Correlate the non-green members and investigate each cause group once.
+
+    Public so the runner-scheduled task and tests share one entry. Correlation
+    (topology forward-closure + union-find) collapses members sharing a common
+    cause into one group; each group is investigated at most once (suppression +
+    in-flight dedupe gate the actual agent fire).
+    """
+    operator = _investigator_operator(tenant_id)
+    groups = await _correlate(operator, members)
+    for group in groups:
+        await _investigate_group(operator, tenant_id, dashboard, group)
+
+
+async def _correlate(operator: Operator, members: list[_MemberSnapshot]) -> list[_CauseGroup]:
+    """Group members by shared topology closure; one group per common cause.
+
+    Each member maps to its topology anchor via its registered target's name
+    (``kind="target"``); :func:`find_dependencies` returns the forward closure.
+    Two members share a group iff their closures intersect (union-find handles
+    transitivity). A member whose anchor is unresolvable -- no ``name`` in the
+    target dict, or an untracked / ambiguous node (:class:`NodeNotFoundError` /
+    :class:`AmbiguousNodeError`, the expected state for every non-k8s target
+    today) -- has no closure and forms its own singleton, so correlation
+    degrades gracefully to per-Sensor investigations when topology has no data.
+    """
+    closures: dict[uuid.UUID, dict[tuple[str, str], int] | None] = {}
+    for member in members:
+        closures[member.sensor_id] = await _closure_for(operator, member)
+
+    ids = [m.sensor_id for m in members]
+    parent: dict[uuid.UUID, uuid.UUID] = {sid: sid for sid in ids}
+
+    def find(node: uuid.UUID) -> uuid.UUID:
+        root = node
+        while parent[root] != root:
+            root = parent[root]
+        while parent[node] != root:
+            parent[node], node = root, parent[node]
+        return root
+
+    def union(a: uuid.UUID, b: uuid.UUID) -> None:
+        parent[find(a)] = find(b)
+
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            ci, cj = closures[ids[i]], closures[ids[j]]
+            if ci is not None and cj is not None and (ci.keys() & cj.keys()):
+                union(ids[i], ids[j])
+
+    by_member = {m.sensor_id: m for m in members}
+    grouped: dict[uuid.UUID, list[_MemberSnapshot]] = {}
+    for sid in ids:
+        grouped.setdefault(find(sid), []).append(by_member[sid])
+
+    groups = [
+        _CauseGroup(key=_group_key(gmembers, closures), members=tuple(gmembers))
+        for gmembers in grouped.values()
+    ]
+    # Deterministic order (the determinism the AC asserts).
+    groups.sort(key=lambda g: g.key)
+    return groups
+
+
+async def _closure_for(
+    operator: Operator, member: _MemberSnapshot
+) -> dict[tuple[str, str], int] | None:
+    """Return the member's forward topology closure, or ``None`` when unresolved.
+
+    Keyed ``(kind, name) -> minimum depth``. ``None`` means "no anchor" -- the
+    member forms a singleton group. Every failure is a graceful ``None``: an
+    untracked / ambiguous anchor, or an unexpected topology error (logged).
+    """
+    anchor = _anchor_name(member.target)
+    if anchor is None:
+        return None
+    try:
+        nodes = await find_dependencies(operator, anchor, kind=_TARGET_NODE_KIND)
+    except (NodeNotFoundError, AmbiguousNodeError):
+        # The expected miss for every non-k8s / alias / target-less Sensor.
+        return None
+    except Exception:
+        _log().warning(
+            "checks_investigation_topology_error",
+            anchor=anchor,
+            tenant_id=str(operator.tenant_id),
+            exc_info=True,
+        )
+        return None
+    closure: dict[tuple[str, str], int] = {}
+    for node in nodes:
+        key = (node.kind, node.name)
+        if key not in closure or node.depth < closure[key]:
+            closure[key] = node.depth
+    return closure
+
+
+def _anchor_name(target: dict[str, object] | None) -> str | None:
+    """Extract the topology anchor name from a Sensor's dispatch target.
+
+    A Sensor references a registered target by name-or-alias under the ``name``
+    key (the canonical dispatch-target shape). Only a non-empty string ``name``
+    is a usable anchor; anything else (``None`` target, ``{"target_id": ...}``,
+    a blank name) yields ``None`` -> singleton path.
+    """
+    if isinstance(target, dict):
+        name = target.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    return None
+
+
+def _group_key(
+    members: list[_MemberSnapshot],
+    closures: dict[uuid.UUID, dict[tuple[str, str], int] | None],
+) -> str:
+    """Derive the deterministic key for one correlated group.
+
+    When the group's resolved closures share a common node, the key is that
+    shared node with the **maximal minimum depth** (the deepest common cause),
+    ties broken lexicographically by ``(kind, name)`` -- slugified. Otherwise
+    (a lone anchorless Sensor, or a transitively-linked group with no all-common
+    node) the key falls back to the smallest member Sensor slug, so a singleton
+    is keyed on its own Sensor (the AC's NodeNotFoundError case).
+    """
+    resolved = [closure for m in members if (closure := closures[m.sensor_id]) is not None]
+    if resolved:
+        common: set[tuple[str, str]] = set(resolved[0])
+        for closure in resolved[1:]:
+            common &= set(closure)
+        if common:
+
+            def _rank(node: tuple[str, str]) -> tuple[int, str, str]:
+                min_depth = min(c[node] for c in resolved if node in c)
+                # Largest min-depth first (negate), then (kind, name) ascending.
+                return (-min_depth, node[0], node[1])
+
+            best = min(common, key=_rank)
+            return _slugify(f"{best[0]}-{best[1]}")
+    return min(_sensor_group_key(m) for m in members)
+
+
+def _sensor_group_key(member: _MemberSnapshot) -> str:
+    """Deterministic singleton key for an anchorless / uncorrelated Sensor."""
+    return f"{_slugify(member.name)}-{member.sensor_id.hex[:8]}"
+
+
+def _slugify(value: str) -> str:
+    """Collapse *value* to the memory-slug alphabet (``[a-z0-9_.-]``).
+
+    Lower-cases, replaces runs of out-of-alphabet characters with ``-``, and
+    trims separators. Non-empty by construction so ``checks-noise-<key>`` always
+    satisfies ``memory.schemas.SLUG_PATTERN``.
+    """
+    slug = _SLUGIFY_RE.sub("-", value.strip().lower()).strip("-.")
+    return slug or "node"
+
+
+async def _investigate_group(
+    operator: Operator,
+    tenant_id: uuid.UUID,
+    dashboard: _DashboardSnapshot,
+    group: _CauseGroup,
+) -> None:
+    """Suppress / dedupe / invoke / persist for one correlated cause group.
+
+    Contains every failure so one group's problem never kills its siblings or
+    the task. Order matters: suppression and in-flight dedupe both short-circuit
+    **before** any agent fire, so a known-noise or already-running group records
+    zero invocations.
+    """
+    settings = get_settings()
+    group_key = group.key
+    work_ref = f"{_WORK_REF_PREFIX}:{dashboard.slug}:{group_key}"
+    memory = MemoryService()
+    try:
+        if await _is_suppressed(memory, operator, group_key):
+            _log().info(
+                "checks_investigation_suppressed",
+                work_ref=work_ref,
+                group_key=group_key,
+                tenant_id=str(tenant_id),
+            )
+            return
+        if await _has_in_flight_run(tenant_id, work_ref):
+            _log().info(
+                "checks_investigation_skipped_in_flight",
+                work_ref=work_ref,
+                tenant_id=str(tenant_id),
+            )
+            return
+
+        definition = await _load_investigator_definition(
+            tenant_id, settings.checks_investigator_agent
+        )
+        if definition is None:
+            _log().info(
+                "checks_investigator_unconfigured",
+                agent=settings.checks_investigator_agent,
+                tenant_id=str(tenant_id),
+            )
+            return
+        name, identity_ref = definition
+
+        try:
+            client_id, secret = await resolve_agent_credentials(identity_ref)
+        except AgentCredentialsUnresolvedError as exc:
+            _log().warning(
+                "checks_investigation_credentials_unresolved",
+                agent=name,
+                identity_ref=identity_ref,
+                reason=str(exc),
+                tenant_id=str(tenant_id),
+            )
+            return
+
+        outcome = await _fire_investigation(
+            name=name,
+            client_id=client_id,
+            secret=secret,
+            work_ref=work_ref,
+            briefing=_build_briefing(dashboard, group),
+            group_key=group_key,
+            tenant_id=tenant_id,
+        )
+        if outcome is None:
+            return
+
+        finding = await _await_finding(operator, outcome)
+        if finding is None:
+            return
+        await _persist_finding(memory, operator, group_key, finding, run_id=outcome.run_id)
+        _log().info(
+            "checks_investigation_recorded",
+            run_id=str(outcome.run_id),
+            group_key=group_key,
+            verdict=finding.verdict,
+            re_escalate=finding.re_escalate,
+            tenant_id=str(tenant_id),
+        )
+    except Exception:
+        _log().warning(
+            "checks_investigation_failed",
+            work_ref=work_ref,
+            tenant_id=str(tenant_id),
+            exc_info=True,
+        )
+
+
+async def _fire_investigation(
+    *,
+    name: str,
+    client_id: str,
+    secret: str,
+    work_ref: str,
+    briefing: str,
+    group_key: str,
+    tenant_id: uuid.UUID,
+) -> AgentRunOutcome | None:
+    """Invoke the investigator via ``run_scheduled``; ``None`` on a gated refusal.
+
+    Every budget / kill-switch / unconfigured / token failure is caught and
+    mapped to a structured log + a clean ``None`` (skip), so a refused fire never
+    crash-loops the runner. The budget gate refuses **before** any ``agent_run``
+    row is created (``budget_enforcement`` REFUSE-before-row contract).
+    """
+    invoker = get_agent_invoker()
+    try:
+        outcome = await invoker.run_scheduled(
+            name,
+            briefing,
+            agent_client_id=client_id,
+            agent_client_secret=SecretStr(secret),
+            work_ref=work_ref,
+        )
+    except BudgetExceededError as exc:
+        _log().warning(
+            "checks_investigation_budget_refused",
+            work_ref=work_ref,
+            reason=exc.reason,
+            tenant_id=str(tenant_id),
+        )
+        return None
+    except (AgentNotFoundError, AgentDisabledError) as exc:
+        # The definition vanished / was disabled between load and fire.
+        _log().info(
+            "checks_investigator_unconfigured",
+            agent=name,
+            reason=type(exc).__name__,
+            tenant_id=str(tenant_id),
+        )
+        return None
+    except (AgentInvocationError, AgentTokenError) as exc:
+        _log().warning(
+            "checks_investigation_failed",
+            work_ref=work_ref,
+            reason=type(exc).__name__,
+            tenant_id=str(tenant_id),
+        )
+        return None
+    _log().info(
+        "checks_investigation_started",
+        run_id=str(outcome.run_id),
+        work_ref=work_ref,
+        group_key=group_key,
+        tenant_id=str(tenant_id),
+    )
+    return outcome
+
+
+async def _is_suppressed(memory: MemoryService, operator: Operator, group_key: str) -> bool:
+    """Return ``True`` iff a known-noise policy suppresses re-escalation.
+
+    Reads the ``checks-noise-<group-key>`` tenant memory entry (if any) and
+    suppresses iff its metadata ``re_escalate`` is falsey. A missing entry (novel
+    red) or an ``re_escalate=true`` entry (still actionable) does not suppress.
+    Decided on metadata, never body prose, so no LLM call is needed to decide.
+    """
+    slug = f"{_NOISE_SLUG_PREFIX}{group_key}"
+    entries = await memory.list_memories(
+        operator,
+        scope=MemoryScope.TENANT,
+        slug_pattern=slug,
+        limit=_MEMORY_LOOKUP_LIMIT,
+    )
+    for entry in entries:
+        # slug_pattern is a substring filter; require the exact slug.
+        if entry.slug == slug:
+            return _is_falsey(entry.metadata.get("re_escalate"))
+    return False
+
+
+def _is_falsey(value: object) -> bool:
+    """Interpret a metadata ``re_escalate`` value as an explicit false.
+
+    Robust to the bool round-trip through the memory index and to a stringified
+    ``"false"`` an operator hand-edit might leave.
+    """
+    if value is False:
+        return True
+    return isinstance(value, str) and value.strip().lower() == "false"
+
+
+async def _has_in_flight_run(tenant_id: uuid.UUID, work_ref: str) -> bool:
+    """Return ``True`` iff a non-terminal run already covers this work_ref.
+
+    Rides ``agent_run_tenant_work_ref_idx`` on ``(tenant_id, work_ref)`` so a
+    second transition for the same correlated group does not duplicate an
+    in-flight investigation.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = (
+            select(AgentRun.id)
+            .where(
+                AgentRun.tenant_id == tenant_id,
+                AgentRun.work_ref == work_ref,
+                AgentRun.status.in_([s.value for s in _NON_TERMINAL_STATUSES]),
+            )
+            .limit(1)
+        )
+        return (await session.execute(stmt)).first() is not None
+
+
+async def _load_investigator_definition(tenant_id: uuid.UUID, name: str) -> tuple[str, str] | None:
+    """Return ``(name, identity_ref)`` for the tenant's enabled investigator agent.
+
+    ``None`` when no **enabled** definition with the well-known name exists in
+    the tenant -- the opt-in switch. A tenant enables the wiring by creating an
+    enabled ``AgentDefinition`` named ``checks-investigator`` (default); an
+    absent or disabled definition logs and skips.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        stmt = select(AgentDefinition.name, AgentDefinition.identity_ref).where(
+            AgentDefinition.tenant_id == tenant_id,
+            AgentDefinition.name == name,
+            AgentDefinition.enabled.is_(True),
+        )
+        row = (await session.execute(stmt)).first()
+        if row is None:
+            return None
+        return row.name, row.identity_ref
+
+
+def _build_briefing(dashboard: _DashboardSnapshot, group: _CauseGroup) -> str:
+    """Assemble the deterministic investigator briefing.
+
+    Three labelled sections (the briefing-builder mould from the r1 harness):
+    the transitioning Dashboard, the correlated non-green Sensors with their
+    evidence, and the correlation context. Instructs a JSON-only
+    :class:`ChecksFinding` answer so the caller-side parse is deterministic.
+    """
+    parts: list[str] = ["## Dashboard", ""]
+    parts.append(f"name: {dashboard.name}")
+    parts.append(f"transition: {dashboard.previous_state} -> {dashboard.current_state}")
+    parts.append(f"correlation_group: {group.key}")
+    parts.append("")
+    parts.append("## Correlated sensors")
+    parts.append("")
+    parts.append(
+        "These sensors are non-green and share a common topology cause; "
+        "investigate the ONE underlying cause, not each symptom."
+    )
+    for member in group.members:
+        parts.append("")
+        parts.append(f"- name: {member.name}")
+        parts.append(f"  state: {member.effective_state} (raw {member.raw_state})")
+        parts.append(f"  op: {member.connector_id} {member.op_id}")
+        parts.append(f"  last_value: {member.last_value!r}")
+        if member.last_evidence:
+            parts.append(f"  evidence: {member.last_evidence!r}")
+    parts.append("")
+    parts.append("## Output")
+    parts.append("")
+    parts.append(
+        "Investigate read-only, then answer with a single JSON object matching "
+        "ChecksFinding: {verdict: benign|acknowledged|actionable, re_escalate: "
+        "bool, summary: str, evidence: [str], recommended_action: str|null}. "
+        "Set re_escalate=false for benign/acknowledged so this correlated red is "
+        "suppressed until it recurs. recommended_action is advisory text only -- "
+        "any change op you attempt parks for operator approval and is never "
+        "executed by this wiring."
+    )
+    return "\n".join(parts)
+
+
+async def _await_finding(operator: Operator, outcome: AgentRunOutcome) -> ChecksFinding | None:
+    """Resolve *outcome* to a parsed :class:`ChecksFinding`, or ``None``.
+
+    A run terminal on return is parsed immediately; a run that converted to
+    async (outlived the sync timeout) is polled on a fixed cadence up to
+    ``checks_investigation_poll_timeout_seconds``. A non-``succeeded`` terminal,
+    a poll-deadline miss, or an unparseable answer yields ``None`` (the finding
+    is still durable on the run row; only the memory write-back is skipped).
+    """
+    status = outcome.status
+    output = outcome.output
+    if outcome.converted_to_async or status not in _TERMINAL_STATUSES:
+        resolved = await _poll_to_terminal(operator, outcome.run_id)
+        if resolved is None:
+            return None
+        status, output = resolved.status, resolved.output
+    if status is not AgentRunStatus.SUCCEEDED:
+        _log().info(
+            "checks_investigation_run_not_successful",
+            run_id=str(outcome.run_id),
+            status=status.value,
+        )
+        return None
+    return _parse_finding(output, run_id=outcome.run_id)
+
+
+async def _poll_to_terminal(operator: Operator, run_id: uuid.UUID) -> AgentRunStatusView | None:
+    """Bounded-poll a run until terminal; ``None`` on deadline.
+
+    Deep investigations routinely outlive the sync timeout, so
+    ``run_scheduled`` hands back a still-running handle. Poll the durable row on
+    a fixed cadence up to the configured deadline.
+    """
+    invoker = get_agent_invoker()
+    deadline = time.monotonic() + get_settings().checks_investigation_poll_timeout_seconds
+    while time.monotonic() < deadline:
+        await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+        view = await invoker.poll(operator, run_id)
+        if view.status in _TERMINAL_STATUSES:
+            return view
+    _log().warning("checks_investigation_poll_deadline", run_id=str(run_id))
+    return None
+
+
+def _parse_finding(output: dict[str, object] | None, *, run_id: uuid.UUID) -> ChecksFinding | None:
+    """Parse a terminal run's output into a :class:`ChecksFinding`, or ``None``.
+
+    ``run_scheduled`` projects a free-text answer as ``{"text": <json>}`` (it
+    does not map a stored ``output_schema`` to an ``output_type``), so the JSON
+    lives in ``output["text"]``; a genuinely structured dict is accepted
+    directly. A non-JSON / schema-mismatched answer logs
+    ``checks_investigation_unparseable`` and skips the write.
+    """
+    if not isinstance(output, dict):
+        _log().warning("checks_investigation_unparseable", run_id=str(run_id), reason="no_output")
+        return None
+    text = output.get("text")
+    try:
+        if isinstance(text, str):
+            return ChecksFinding.model_validate_json(text)
+        return ChecksFinding.model_validate(output)
+    except ValidationError:
+        _log().warning("checks_investigation_unparseable", run_id=str(run_id))
+        return None
+
+
+async def _persist_finding(
+    memory: MemoryService,
+    operator: Operator,
+    group_key: str,
+    finding: ChecksFinding,
+    *,
+    run_id: uuid.UUID,
+) -> None:
+    """Write the finding back to tenant memory as the noise-suppression policy.
+
+    Idempotent on ``(scope, slug)`` -- ``MemoryService.remember`` upserts, so a
+    re-investigation of the same group overwrites rather than duplicates. The
+    metadata carries the load-bearing suppression fields (``re_escalate``) plus
+    provenance (``source``, ``verdict``, ``run_id``).
+    """
+    await memory.remember(
+        operator,
+        MemoryScope.TENANT,
+        _render_finding_body(finding),
+        slug=f"{_NOISE_SLUG_PREFIX}{group_key}",
+        metadata={
+            "source": _MEMORY_SOURCE,
+            "verdict": finding.verdict,
+            "re_escalate": finding.re_escalate,
+            "run_id": str(run_id),
+        },
+    )
+
+
+def _render_finding_body(finding: ChecksFinding) -> str:
+    """Render a :class:`ChecksFinding` into the memory body (r1 render mould).
+
+    Fixed sections so a future read parses deterministically: verdict +
+    ``re_escalate`` header, ``## Summary``, optional ``## Evidence`` (fenced so
+    BM25 ranks the literal fragments), and ``## Recommended action`` only when
+    the verdict is ``actionable`` -- diagnose-only advisory text, never executed.
+    """
+    parts: list[str] = [
+        f"verdict: {finding.verdict}",
+        f"re_escalate: {str(finding.re_escalate).lower()}",
+        "",
+        "## Summary",
+        "",
+        finding.summary.rstrip(),
+    ]
+    if finding.evidence:
+        parts.append("")
+        parts.append("## Evidence")
+        parts.append("")
+        parts.extend(f"- `{line}`" for line in finding.evidence)
+    if finding.verdict == "actionable" and finding.recommended_action:
+        parts.append("")
+        parts.append("## Recommended action")
+        parts.append("")
+        parts.append(finding.recommended_action.rstrip())
+    parts.append("")
+    return "\n".join(parts)
+
+
+def _investigator_operator(tenant_id: uuid.UUID) -> Operator:
+    """Build the synthetic per-tenant operator the investigation runs reads as.
+
+    ``raw_jwt`` is empty (no token forwarded downstream) and the scope is
+    exactly *tenant_id* -- no cross-tenant reach, the #2505 runner precedent.
+    Role is ``TENANT_ADMIN`` because the closed-loop noise-suppression write is a
+    ``TENANT``-scoped (tenant-shared) memory write, which the memory RBAC matrix
+    restricts to ``tenant_admin``. This operator only reads topology and
+    reads/writes memory; it never dispatches an op -- the agent run authenticates
+    independently as its own principal, so no execution path inherits this role.
+    """
+    return Operator(
+        sub=_INVESTIGATOR_SUB,
+        name=None,
+        email=None,
+        raw_jwt="",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+async def _await_pending_investigations() -> None:
+    """Await all in-flight investigation tasks -- a deterministic test seam.
+
+    Production spawns investigations fire-and-forget; tests call this to drain
+    them before asserting on the invoker / memory. Mirrors the runner's
+    in-flight-drain discipline.
+    """
+    pending = [task for task in _INVESTIGATIONS if not task.done()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)

--- a/backend/src/meho_backplane/checks/runner.py
+++ b/backend/src/meho_backplane/checks/runner.py
@@ -108,6 +108,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.checks.assertions import AssertionOutcome, AssertionSpec
 from meho_backplane.checks.evaluate import evaluate_assertion
+from meho_backplane.checks.investigate import investigate_on_transition
 from meho_backplane.checks.repository import (
     advance_sensor_next_fire,
     claim_due_sensors,
@@ -331,7 +332,16 @@ async def _run_evaluation(snap: _SensorSnapshot) -> AssertionOutcome:
 
 
 async def _persist_outcome(snap: _SensorSnapshot, outcome: AssertionOutcome) -> None:
-    """Write *outcome* onto the sensor's latest-state projection (own session)."""
+    """Write *outcome* onto the sensor's latest-state projection (own session).
+
+    After the projection commits, hand off to #2507's transition detector: it
+    recomputes the rollup for the Dashboards holding this sensor, maintains the
+    ``last_rollup_state`` memo, and fires a diagnose-only investigator on a
+    green->non-green edge. The hook never raises (its contract), so the persist
+    path is unaffected by any investigation-side failure -- and it runs on every
+    result (not only state changes) because a ``for:`` hold expiring flips a
+    Dashboard non-green with no sensor-state change.
+    """
     evaluated_at = datetime.now(UTC)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
@@ -344,6 +354,7 @@ async def _persist_outcome(snap: _SensorSnapshot, outcome: AssertionOutcome) -> 
             evaluated_at=evaluated_at,
         )
         await session.commit()
+    await investigate_on_transition(sensor_id=snap.id, tenant_id=snap.tenant_id)
 
 
 async def _evaluate_and_record(snap: _SensorSnapshot) -> None:

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1248,6 +1248,17 @@ class Settings(BaseModel):
     # evaluator (or the test path without a runner) can opt out.
     sensor_runner_enabled: bool = True
     sensor_runner_tick_interval_seconds: int = Field(default=10, ge=1, le=3600)
+    # Initiative #2416 (#2507) — tiered-triage investigator wiring. A Dashboard
+    # green→non-green transition (detected at #2505's persist seam) fires a
+    # diagnose-only agent run via ``AgentInvoker.run_scheduled`` against the
+    # tenant's enabled definition whose name matches ``checks_investigator_agent``
+    # (opt-in: absent/disabled ⇒ the wiring logs and skips). A deep investigation
+    # routinely outlives ``agent_sync_timeout_seconds`` (converts to async), so
+    # ``checks_investigation_poll_timeout_seconds`` bounds the background poll that
+    # waits for the terminal finding before the memory write-back. Set via
+    # ``CHECKS_INVESTIGATOR_AGENT`` / ``CHECKS_INVESTIGATION_POLL_TIMEOUT_SECONDS``.
+    checks_investigator_agent: str = "checks-investigator"
+    checks_investigation_poll_timeout_seconds: int = Field(default=600, ge=1, le=86400)
     # G11.3-T2 #823 / G0.19-T2 #1478 — autonomous-agent credential
     # sourcing for the scheduler. ``run_scheduled`` (G11.2-T2 #1096)
     # wants ``(client_id, client_secret)``; the scheduler resolves
@@ -1786,6 +1797,13 @@ def get_settings() -> Settings:
         ),
         sensor_runner_enabled=parse_bool_env(
             os.environ.get("SENSOR_RUNNER_ENABLED", "true"),
+        ),
+        checks_investigator_agent=os.environ.get(
+            "CHECKS_INVESTIGATOR_AGENT",
+            "checks-investigator",
+        ),
+        checks_investigation_poll_timeout_seconds=int(
+            os.environ.get("CHECKS_INVESTIGATION_POLL_TIMEOUT_SECONDS", "600"),
         ),
         scheduler_agent_secret_env_pattern=os.environ.get(
             "SCHEDULER_AGENT_SECRET_ENV_PATTERN",

--- a/backend/tests/test_checks_investigate.py
+++ b/backend/tests/test_checks_investigate.py
@@ -1,0 +1,822 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the tiered-triage investigator wiring (#2507).
+
+Initiative #2416 (parent goal #221), Task #2507. Coverage:
+
+* **Transition detection** -- the ``last_rollup_state`` memo compare-and-set,
+  the worsening-transition matrix, and equality suppression.
+* **Correlation** -- topology forward-closure + union-find grouping (with
+  ``find_dependencies`` stubbed, since the recursive CTE is PG-only and the
+  correlation *logic* is what this Task owns), determinism, and the
+  ``NodeNotFoundError`` singleton fallback.
+* **One-cause-one-investigation** -- a correlated group fires exactly one
+  ``run_scheduled``.
+* **Suppression + in-flight dedupe** -- known-noise and already-running groups
+  record zero invocations.
+* **Closed loop** -- a terminal finding writes the noise-suppression policy;
+  unparseable output skips the write.
+* **Containment** -- budget refusal, an unconfigured agent, unresolved
+  credentials, and an investigation crash are all caught.
+* **Diagnose-only** -- the module imports no operations dispatcher.
+
+The :class:`~meho_backplane.agent.invocation.AgentInvoker` is replaced by a
+recording stub (``reset_agent_invoker_for_testing``) so no model is hit; the
+memory + DB layers are real against the SQLite engine from :mod:`tests.conftest`.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from structlog.testing import capture_logs
+
+import meho_backplane.checks.investigate as inv
+from meho_backplane.agent.invocation import (
+    AgentRunOutcome,
+    AgentRunStatusView,
+    reset_agent_invoker_for_testing,
+)
+from meho_backplane.agent.run import BudgetExceededError
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.checks.investigate import (
+    ChecksFinding,
+    investigate_on_transition,
+    run_investigation,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AgentDefinition,
+    AgentRun,
+    AgentRunStatus,
+    CheckDashboard,
+    CheckDashboardSensor,
+    Sensor,
+    Tenant,
+)
+from meho_backplane.memory.schemas import MemoryScope
+from meho_backplane.memory.service import MemoryService
+from meho_backplane.scheduler.credentials import AgentCredentialsUnresolvedError
+from meho_backplane.settings import get_settings
+from meho_backplane.topology.query import TopologyNode
+from meho_backplane.topology.resolvers import NodeNotFoundError
+
+_TENANT = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+_ASSERTION: dict[str, Any] = {
+    "select": {"path": "$.count"},
+    "compare": {"type": "threshold", "op": "lt", "critical": 10},
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env :class:`Settings` requires so ``get_settings()`` constructs."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://kc.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho")
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_investigator() -> Iterator[None]:
+    """Clear the invoker singleton + the in-flight investigation set per test."""
+    yield
+    reset_agent_invoker_for_testing(None)
+    inv._INVESTIGATIONS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant(tenant_id: UUID = _TENANT) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if await session.get(Tenant, tenant_id) is None:
+            session.add(Tenant(id=tenant_id, slug="tenant-a", name="Tenant A"))
+            await session.commit()
+
+
+async def _seed_sensor(
+    *,
+    name: str,
+    last_state: str = "critical",
+    severity: str = "critical",
+    for_seconds: int = 0,
+    status: str = "active",
+    tenant_id: UUID = _TENANT,
+    target: dict[str, object] | None = None,
+) -> UUID:
+    """Insert an active Sensor whose projection folds to *last_state* on read."""
+    now = datetime.now(UTC)
+    sensor_id = uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Sensor(
+                id=sensor_id,
+                tenant_id=tenant_id,
+                name=name,
+                connector_id="vmware-rest-9.0",
+                op_id="vmware.vm.list",
+                target=target,
+                params={},
+                assertion=_ASSERTION,
+                status=status,
+                cadence_kind="interval",
+                interval_seconds=60,
+                cron_expr=None,
+                timezone="UTC",
+                next_fire_at=now + timedelta(seconds=60),
+                severity=severity,
+                for_seconds=for_seconds,
+                last_state=last_state,
+                last_value=None,
+                last_evidence=None,
+                last_evaluated_at=now - timedelta(seconds=30),
+                state_since=now - timedelta(hours=1),
+                identity_sub="__sensor__",
+                created_by_sub="op-admin",
+            )
+        )
+        await session.commit()
+    return sensor_id
+
+
+async def _seed_dashboard(
+    *,
+    name: str,
+    sensor_ids: list[UUID],
+    last_rollup_state: str | None = None,
+    tenant_id: UUID = _TENANT,
+) -> UUID:
+    """Insert a Dashboard + memberships with an explicit memo state."""
+    dashboard_id = uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            CheckDashboard(
+                id=dashboard_id,
+                tenant_id=tenant_id,
+                name=name,
+                description=None,
+                last_rollup_state=last_rollup_state,
+                created_by_sub="op-admin",
+            )
+        )
+        for sid in sensor_ids:
+            session.add(CheckDashboardSensor(dashboard_id=dashboard_id, sensor_id=sid))
+        await session.commit()
+    return dashboard_id
+
+
+async def _seed_definition(
+    *,
+    name: str = "checks-investigator",
+    enabled: bool = True,
+    tenant_id: UUID = _TENANT,
+) -> None:
+    await _seed_tenant(tenant_id)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AgentDefinition(
+                tenant_id=tenant_id,
+                name=name,
+                identity_ref=f"agent:{name}",
+                model_tier="standard",
+                system_prompt="You investigate check dashboards.",
+                toolset={},
+                turn_budget=5,
+                output_schema=None,
+                enabled=enabled,
+                created_by_sub="seed-admin",
+            )
+        )
+        await session.commit()
+
+
+async def _seed_agent_run(*, work_ref: str, status: str, tenant_id: UUID = _TENANT) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            AgentRun(
+                id=uuid4(),
+                tenant_id=tenant_id,
+                identity_sub="agent:checks-investigator",
+                trigger="scheduled",
+                model_tier="standard",
+                status=status,
+                work_ref=work_ref,
+            )
+        )
+        await session.commit()
+
+
+async def _memo(dashboard_id: UUID) -> str | None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(CheckDashboard, dashboard_id)
+        assert row is not None
+        return row.last_rollup_state
+
+
+async def _agent_run_count(tenant_id: UUID = _TENANT) -> int:
+    from sqlalchemy import func, select
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(func.count()).select_from(AgentRun).where(AgentRun.tenant_id == tenant_id)
+        )
+        return int(result.scalar_one())
+
+
+def _admin_operator(tenant_id: UUID = _TENANT) -> Operator:
+    return Operator(
+        sub="op-admin",
+        name=None,
+        email=None,
+        raw_jwt="",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _StubInvoker:
+    """Records ``run_scheduled`` calls; returns a preset outcome or raises."""
+
+    def __init__(
+        self,
+        *,
+        outcome: AgentRunOutcome | None = None,
+        exc: Exception | None = None,
+        poll_views: list[Any] | None = None,
+    ) -> None:
+        self.calls: list[SimpleNamespace] = []
+        self._outcome = outcome
+        self._exc = exc
+        self._poll_views = list(poll_views or [])
+        self.poll_calls = 0
+
+    async def run_scheduled(
+        self,
+        name: str,
+        inputs: str,
+        *,
+        agent_client_id: str,
+        agent_client_secret: Any,
+        work_ref: str | None = None,
+    ) -> AgentRunOutcome:
+        self.calls.append(
+            SimpleNamespace(
+                name=name,
+                inputs=inputs,
+                work_ref=work_ref,
+                agent_client_id=agent_client_id,
+            )
+        )
+        if self._exc is not None:
+            raise self._exc
+        assert self._outcome is not None
+        return self._outcome
+
+    async def poll(self, operator: Operator, run_id: UUID) -> Any:
+        if not self._poll_views:
+            raise AssertionError("poll must not be called when the run is terminal")
+        self.poll_calls += 1
+        # Return each staged view once, then repeat the last (terminal) one.
+        index = min(self.poll_calls - 1, len(self._poll_views) - 1)
+        return self._poll_views[index]
+
+
+def _install_stub(**kwargs: Any) -> _StubInvoker:
+    stub = _StubInvoker(**kwargs)
+    reset_agent_invoker_for_testing(stub)  # type: ignore[arg-type]
+    return stub
+
+
+def _succeeded_outcome(finding: ChecksFinding, *, run_id: UUID | None = None) -> AgentRunOutcome:
+    return AgentRunOutcome(
+        run_id=run_id or uuid4(),
+        status=AgentRunStatus.SUCCEEDED,
+        output={"text": finding.model_dump_json()},
+        converted_to_async=False,
+    )
+
+
+def _node(kind: str, name: str, depth: int) -> TopologyNode:
+    return TopologyNode(
+        id=uuid4(), kind=kind, name=name, properties={}, depth=depth, via_edge_kind=None
+    )
+
+
+def _member(
+    name: str,
+    *,
+    target: dict[str, object] | None = None,
+    effective: str = "critical",
+    raw: str = "critical",
+) -> inv._MemberSnapshot:
+    return inv._MemberSnapshot(
+        sensor_id=uuid4(),
+        name=name,
+        connector_id="vmware-rest-9.0",
+        op_id="vmware.vm.list",
+        target=target,
+        severity="critical",
+        raw_state=raw,
+        effective_state=effective,
+        last_value=None,
+        last_evidence=None,
+    )
+
+
+def _dash(*, name: str = "prod", prev: str = "ok", cur: str = "critical") -> inv._DashboardSnapshot:
+    return inv._DashboardSnapshot(
+        dashboard_id=uuid4(),
+        name=name,
+        slug=inv._slugify(name),
+        previous_state=prev,
+        current_state=cur,
+    )
+
+
+def _patch_creds(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fake(identity_ref: str) -> tuple[str, str]:
+        return identity_ref, "secret"
+
+    monkeypatch.setattr(inv, "resolve_agent_credentials", _fake)
+
+
+# ---------------------------------------------------------------------------
+# Transition detection + memo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memo_maintained_and_equality_suppresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Memo tracks the computed state; a second identical evaluation is a no-op."""
+    fired: list[dict[str, Any]] = []
+    monkeypatch.setattr(inv, "_schedule_investigation", lambda **kw: fired.append(kw))
+    await _seed_tenant()
+    sid = await _seed_sensor(name="crit", last_state="critical")
+    dash = await _seed_dashboard(name="prod", sensor_ids=[sid], last_rollup_state=None)
+
+    await investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+    assert await _memo(dash) == "critical"
+    assert len(fired) == 1
+
+    fired.clear()
+    await investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+    assert await _memo(dash) == "critical"
+    assert fired == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("previous", "last_state", "expected_current", "should_fire"),
+    [
+        pytest.param(None, "critical", "critical", True, id="null-to-critical-fires"),
+        pytest.param("ok", "degraded", "degraded", True, id="ok-to-degraded-fires"),
+        pytest.param("degraded", "critical", "critical", True, id="degraded-to-critical-fires"),
+        pytest.param("critical", "degraded", "degraded", False, id="critical-to-degraded-no-fire"),
+        pytest.param("ok", "ok", "ok", False, id="ok-to-ok-no-fire"),
+    ],
+)
+async def test_transition_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    previous: str | None,
+    last_state: str,
+    expected_current: str,
+    should_fire: bool,
+) -> None:
+    """The worsening-transition matrix fires only on a green->worse-non-green edge."""
+    fired: list[dict[str, Any]] = []
+    monkeypatch.setattr(inv, "_schedule_investigation", lambda **kw: fired.append(kw))
+    await _seed_tenant()
+    sid = await _seed_sensor(name="s", last_state=last_state)
+    dash = await _seed_dashboard(name="d", sensor_ids=[sid], last_rollup_state=previous)
+
+    await investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+
+    assert await _memo(dash) == expected_current
+    assert (len(fired) == 1) is should_fire
+
+
+@pytest.mark.asyncio
+async def test_no_dashboard_is_noop() -> None:
+    """A Sensor in no Dashboard produces no work (the runner-tick common case)."""
+    await _seed_tenant()
+    sid = await _seed_sensor(name="lonely", last_state="critical")
+    stub = _install_stub()
+    await investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+    await inv._await_pending_investigations()
+    assert stub.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Correlation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_correlation_two_groups_and_determinism(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A + B share a dependency node, C does not -> two groups; keys deterministic."""
+    a = _member("a", target={"name": "anchor-a"})
+    b = _member("b", target={"name": "anchor-b"})
+    c = _member("c", target={"name": "anchor-c"})
+
+    closures = {
+        "anchor-a": [_node("target", "anchor-a", 0), _node("datastore", "shared", 1)],
+        "anchor-b": [_node("target", "anchor-b", 0), _node("datastore", "shared", 1)],
+        "anchor-c": [_node("target", "anchor-c", 0), _node("datastore", "other", 1)],
+    }
+
+    async def _fake_deps(operator: Operator, name: str, *, kind: str | None = None, **_: Any):
+        return closures[name]
+
+    monkeypatch.setattr(inv, "find_dependencies", _fake_deps)
+    operator = _admin_operator()
+
+    groups = await inv._correlate(operator, [a, b, c])
+    assert len(groups) == 2
+    grouped_names = {frozenset(m.name for m in g.members) for g in groups}
+    assert grouped_names == {frozenset({"a", "b"}), frozenset({"c"})}
+
+    keys_first = [g.key for g in groups]
+    keys_second = [g.key for g in await inv._correlate(operator, [a, b, c])]
+    assert keys_first == keys_second
+    # The A+B group is keyed on the deepest shared node.
+    ab_group = next(g for g in groups if {m.name for m in g.members} == {"a", "b"})
+    assert ab_group.key == "datastore-shared"
+
+
+@pytest.mark.asyncio
+async def test_correlation_untracked_anchor_is_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A member whose anchor raises NodeNotFoundError is keyed on its own slug."""
+    m = _member("lonely-vm", target={"name": "untracked"})
+
+    async def _fake_deps(operator: Operator, name: str, *, kind: str | None = None, **_: Any):
+        raise NodeNotFoundError(name)
+
+    monkeypatch.setattr(inv, "find_dependencies", _fake_deps)
+
+    groups = await inv._correlate(_admin_operator(), [m])
+    assert len(groups) == 1
+    assert groups[0].key == inv._sensor_group_key(m)
+
+
+# ---------------------------------------------------------------------------
+# Invocation path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_cause_one_investigation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Three correlated non-green Sensors fire exactly one run with a group work_ref."""
+    await _seed_definition()
+    _patch_creds(monkeypatch)
+    stub = _install_stub(
+        outcome=_succeeded_outcome(
+            ChecksFinding(verdict="acknowledged", re_escalate=False, summary="ok")
+        )
+    )
+
+    members = [
+        _member("a", target={"name": "anchor-a"}),
+        _member("b", target={"name": "anchor-b"}),
+        _member("c", target={"name": "anchor-c"}),
+    ]
+    shared = _node("datastore", "shared", 1)
+
+    async def _fake_deps(operator: Operator, name: str, *, kind: str | None = None, **_: Any):
+        return [_node("target", name, 0), shared]
+
+    monkeypatch.setattr(inv, "find_dependencies", _fake_deps)
+
+    dashboard = _dash(name="prod")
+    await run_investigation(tenant_id=_TENANT, dashboard=dashboard, members=members)
+
+    assert len(stub.calls) == 1
+    assert stub.calls[0].work_ref == "checks:prod:datastore-shared"
+
+
+@pytest.mark.asyncio
+async def test_in_flight_dedupe_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An existing RUNNING run for the same (tenant, work_ref) suppresses a re-fire."""
+    await _seed_definition()
+    _patch_creds(monkeypatch)
+    stub = _install_stub()
+    member = _member("solo", target=None)
+    group_key = inv._sensor_group_key(member)
+    await _seed_agent_run(work_ref=f"checks:prod:{group_key}", status=AgentRunStatus.RUNNING.value)
+
+    with capture_logs() as logs:
+        await run_investigation(tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[member])
+
+    assert stub.calls == []
+    assert any(e["event"] == "checks_investigation_skipped_in_flight" for e in logs)
+
+
+@pytest.mark.asyncio
+async def test_suppression_reescalate_false_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A known-noise memory entry (re_escalate=false) suppresses the fire."""
+    await _seed_definition()
+    _patch_creds(monkeypatch)
+    stub = _install_stub()
+    member = _member("solo", target=None)
+    group_key = inv._sensor_group_key(member)
+    await MemoryService().remember(
+        _admin_operator(),
+        MemoryScope.TENANT,
+        "verdict: benign\n",
+        slug=f"checks-noise-{group_key}",
+        metadata={"source": "checks-investigator", "re_escalate": False},
+    )
+
+    with capture_logs() as logs:
+        await run_investigation(tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[member])
+
+    assert stub.calls == []
+    assert any(e["event"] == "checks_investigation_suppressed" for e in logs)
+
+
+@pytest.mark.asyncio
+async def test_suppression_reescalate_true_invokes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An re_escalate=true entry does not suppress -- the investigation fires."""
+    await _seed_definition()
+    _patch_creds(monkeypatch)
+    stub = _install_stub(
+        outcome=_succeeded_outcome(
+            ChecksFinding(verdict="actionable", re_escalate=True, summary="still bad")
+        )
+    )
+    member = _member("solo", target=None)
+    group_key = inv._sensor_group_key(member)
+    await MemoryService().remember(
+        _admin_operator(),
+        MemoryScope.TENANT,
+        "verdict: actionable\n",
+        slug=f"checks-noise-{group_key}",
+        metadata={"source": "checks-investigator", "re_escalate": True},
+    )
+
+    await run_investigation(tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[member])
+    assert len(stub.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Closed loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_closed_loop_writes_policy_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A terminal ChecksFinding writes a noise-suppression policy to tenant memory."""
+    await _seed_definition()
+    _patch_creds(monkeypatch)
+    run_id = uuid4()
+    finding = ChecksFinding(
+        verdict="acknowledged",
+        re_escalate=False,
+        summary="Expected nightly maintenance window.",
+        evidence=["window 02:00-03:00 UTC"],
+    )
+    _install_stub(outcome=_succeeded_outcome(finding, run_id=run_id))
+    member = _member("solo", target=None)
+    group_key = inv._sensor_group_key(member)
+
+    await run_investigation(tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[member])
+
+    entries = await MemoryService().list_memories(
+        _admin_operator(),
+        scope=MemoryScope.TENANT,
+        slug_pattern=f"checks-noise-{group_key}",
+        limit=10,
+    )
+    entry = next(e for e in entries if e.slug == f"checks-noise-{group_key}")
+    assert entry.scope == MemoryScope.TENANT
+    assert entry.metadata["source"] == "checks-investigator"
+    assert entry.metadata["verdict"] == "acknowledged"
+    assert entry.metadata["re_escalate"] is False
+    assert entry.metadata["run_id"] == str(run_id)
+    assert "verdict: acknowledged" in entry.body
+    assert "## Summary" in entry.body
+
+
+@pytest.mark.asyncio
+async def test_converted_to_async_polls_then_persists(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run that outlived the sync timeout is polled to terminal, then persisted."""
+    await _seed_definition()
+    _patch_creds(monkeypatch)
+    monkeypatch.setattr(inv, "_POLL_INTERVAL_SECONDS", 0.001)
+    run_id = uuid4()
+    finding = ChecksFinding(verdict="benign", re_escalate=False, summary="transient blip")
+
+    def _view(status: AgentRunStatus, output: dict[str, object] | None) -> AgentRunStatusView:
+        return AgentRunStatusView(
+            run_id=run_id,
+            status=status,
+            turns=1,
+            provider="anthropic",
+            model="claude",
+            output=output,
+            error=None,
+        )
+
+    stub = _StubInvoker(
+        outcome=AgentRunOutcome(
+            run_id=run_id, status=AgentRunStatus.RUNNING, output=None, converted_to_async=True
+        ),
+        poll_views=[
+            _view(AgentRunStatus.RUNNING, None),
+            _view(AgentRunStatus.SUCCEEDED, {"text": finding.model_dump_json()}),
+        ],
+    )
+    reset_agent_invoker_for_testing(stub)  # type: ignore[arg-type]
+    member = _member("solo", target=None)
+    group_key = inv._sensor_group_key(member)
+
+    await run_investigation(tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[member])
+
+    assert stub.poll_calls >= 2
+    entries = await MemoryService().list_memories(
+        _admin_operator(),
+        scope=MemoryScope.TENANT,
+        slug_pattern=f"checks-noise-{group_key}",
+        limit=10,
+    )
+    assert any(e.slug == f"checks-noise-{group_key}" for e in entries)
+
+
+@pytest.mark.asyncio
+async def test_unparseable_output_skips_memory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-JSON terminal answer writes no memory and logs unparseable."""
+    await _seed_definition()
+    _patch_creds(monkeypatch)
+    _install_stub(
+        outcome=AgentRunOutcome(
+            run_id=uuid4(),
+            status=AgentRunStatus.SUCCEEDED,
+            output={"text": "not json at all"},
+            converted_to_async=False,
+        )
+    )
+    member = _member("solo", target=None)
+    group_key = inv._sensor_group_key(member)
+
+    with capture_logs() as logs:
+        await run_investigation(tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[member])
+
+    assert any(e["event"] == "checks_investigation_unparseable" for e in logs)
+    entries = await MemoryService().list_memories(
+        _admin_operator(),
+        scope=MemoryScope.TENANT,
+        slug_pattern=f"checks-noise-{group_key}",
+        limit=10,
+    )
+    assert [e for e in entries if e.slug == f"checks-noise-{group_key}"] == []
+
+
+# ---------------------------------------------------------------------------
+# Containment: budget, unconfigured, credentials, crash
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_budget_refused_leaves_no_run_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A budget/kill-switch refusal is caught; no agent_run row is created."""
+    await _seed_definition()
+    _patch_creds(monkeypatch)
+    _install_stub(exc=BudgetExceededError("global kill switch enabled"))
+
+    with capture_logs() as logs:
+        await run_investigation(
+            tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[_member("solo")]
+        )
+
+    assert any(e["event"] == "checks_investigation_budget_refused" for e in logs)
+    assert await _agent_run_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_agent_is_contained(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No enabled investigator definition -> logged + skipped, no invocation, no raise."""
+    await _seed_tenant()
+    _patch_creds(monkeypatch)
+    stub = _install_stub()
+
+    with capture_logs() as logs:
+        await run_investigation(
+            tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[_member("solo")]
+        )
+
+    assert stub.calls == []
+    assert any(e["event"] == "checks_investigator_unconfigured" for e in logs)
+
+
+@pytest.mark.asyncio
+async def test_disabled_agent_is_unconfigured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A disabled definition is treated as unconfigured (the enabled flag is the switch)."""
+    await _seed_definition(enabled=False)
+    _patch_creds(monkeypatch)
+    stub = _install_stub()
+
+    with capture_logs() as logs:
+        await run_investigation(
+            tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[_member("solo")]
+        )
+
+    assert stub.calls == []
+    assert any(e["event"] == "checks_investigator_unconfigured" for e in logs)
+
+
+@pytest.mark.asyncio
+async def test_credentials_unresolved_is_contained(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unresolved credentials are caught before any invocation."""
+    await _seed_definition()
+    stub = _install_stub()
+
+    async def _raise(identity_ref: str) -> tuple[str, str]:
+        raise AgentCredentialsUnresolvedError("no secret")
+
+    monkeypatch.setattr(inv, "resolve_agent_credentials", _raise)
+
+    with capture_logs() as logs:
+        await run_investigation(
+            tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[_member("solo")]
+        )
+
+    assert stub.calls == []
+    assert any(e["event"] == "checks_investigation_credentials_unresolved" for e in logs)
+
+
+@pytest.mark.asyncio
+async def test_investigation_crash_is_contained_and_memo_kept(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crash in the backgrounded investigation never propagates; the memo persists."""
+    await _seed_definition()
+    _patch_creds(monkeypatch)
+    _install_stub(exc=RuntimeError("boom"))
+    sid = await _seed_sensor(name="crit", last_state="critical")
+    dash = await _seed_dashboard(name="prod", sensor_ids=[sid], last_rollup_state="ok")
+
+    with capture_logs() as logs:
+        # Never raises (the runner's persist path contract) ...
+        await investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+        await inv._await_pending_investigations()
+
+    # ... the in-band memo write still committed ...
+    assert await _memo(dash) == "critical"
+    # ... and the background crash was contained + logged.
+    assert any(e["event"] == "checks_investigation_failed" for e in logs)
+
+
+# ---------------------------------------------------------------------------
+# Diagnose-only + settings guards
+# ---------------------------------------------------------------------------
+
+
+def test_module_never_imports_operations_dispatcher() -> None:
+    """The CRUX security property: this wiring imports no execution seam."""
+    source = inspect.getsource(inv)
+    assert "operations.dispatcher" not in source
+    assert "import dispatch" not in source
+
+
+def test_settings_fields_present() -> None:
+    """The two new settings fields carry the documented defaults."""
+    settings = get_settings()
+    assert settings.checks_investigator_agent == "checks-investigator"
+    assert settings.checks_investigation_poll_timeout_seconds == 600

--- a/docs/codebase/checks-investigator.md
+++ b/docs/codebase/checks-investigator.md
@@ -1,0 +1,180 @@
+# Tiered-triage investigator wiring (check dashboards)
+
+## Overview
+
+When a check Dashboard's five-state rollup crosses from green into a
+non-green state, `meho_backplane.checks.investigate` fires a **diagnose-only**
+agent investigation: it correlates the affected non-green Sensors through the
+topology blast-radius graph so one underlying cause produces exactly one
+investigation, checks tenant memory for a known-noise policy that suppresses
+re-escalation, and — only for novel, non-suppressed groups — runs a real,
+durable, budget-gated agent via
+`AgentInvoker.run_scheduled`. The investigator writes a structured finding
+plus an advisory suggested action; it **never executes a change op**.
+
+This productises the `examples/r1-tiered-triage` mould against the
+deterministic check layer (#2503–#2506): the *cheap tier* is the runner +
+rollup (no LLM), and the *deep tier* is the scheduled agent run.
+
+## Key types
+
+- `investigate_on_transition(*, sensor_id, tenant_id, now=None)` — the public
+  hook the check-runner (#2505) calls immediately after every
+  `record_sensor_result`. Never raises. Does the in-band memo work and spawns
+  the expensive investigation as a fire-and-forget task.
+- `run_investigation(*, tenant_id, dashboard, members)` — the awaitable
+  investigation: correlate → per cause-group (suppress / dedupe / invoke /
+  persist).
+- `ChecksFinding` — the structured investigation output parsed from the run's
+  terminal answer (`verdict`, `re_escalate`, `summary`, `evidence`,
+  `recommended_action`). Mirrors the r1 `PolicyDecision` minus the
+  model-chosen `alert_class` (suppression keys on the deterministic topology
+  group key instead).
+
+## Control flow
+
+1. **Transition detection** (in-band, `investigate_on_transition`). For each
+   Dashboard containing the just-evaluated Sensor, fold its members through
+   #2506's pure rollup against `now`, compare to the persisted
+   `check_dashboards.last_rollup_state` memo (NULL treated as `ok`), and write
+   the memo when it changed. #2506 shipped that memo column **unwritten** and
+   reserved for this hook — this is its only writer. Only a *worsening*
+   transition (`ok`/`skip` → `degraded`/`critical`, or `degraded` →
+   `critical`) with at least one actively-failing member schedules an
+   investigation; improving/unchanged/`unknown`/`skip` states just maintain
+   the memo. Every evaluation is processed (not only state changes) because a
+   `for:` hold expiring flips a Dashboard non-green with no sensor-state
+   change; the memo-equality check is the cheap exit.
+2. **Correlation** (`_correlate`). Each non-green member maps to its topology
+   anchor via its registered target's name (`kind="target"`), and
+   `topology.query.find_dependencies` returns the forward closure. Members
+   whose closures intersect are unioned into one cause group. The group key is
+   the deepest shared closure node (maximal minimum depth, ties broken by
+   `(kind, name)`), slugified — the deterministic key that is both the
+   `work_ref` group segment and the memory-slug suffix. A member whose anchor
+   is unresolvable — no `name` in the target dict, or an untracked / ambiguous
+   node (`NodeNotFoundError` / `AmbiguousNodeError`, the expected state for
+   every non-k8s target today, since only the Kubernetes connector overrides
+   `discover_topology`) — forms a singleton keyed on its own Sensor slug. So
+   correlation degrades gracefully to per-Sensor investigations when topology
+   has no data.
+3. **Suppression** (`_is_suppressed`). Read the `checks-noise-<group-key>`
+   tenant memory entry; suppress iff its metadata `re_escalate` is falsey. A
+   missing entry (novel red) or `re_escalate=true` (still actionable) does not
+   suppress. Decided on metadata only — no LLM call to decide.
+4. **In-flight dedupe** (`_has_in_flight_run`). A non-terminal `agent_run`
+   with the same `(tenant_id, work_ref)` suppresses a duplicate fire (rides
+   `agent_run_tenant_work_ref_idx`).
+5. **Invoke** (`_fire_investigation`). Resolve `(client_id, secret)` from the
+   definition's `identity_ref` (Vault-first, `resolve_agent_credentials`), then
+   `AgentInvoker.run_scheduled(name, briefing, work_ref=…)`. The budget gate +
+   kill switch are enforced before any row is created; a refusal
+   (`BudgetExceededError`), an unconfigured/disabled agent, unresolved
+   credentials, or a token failure is caught, logged, and skipped — never a
+   crash-loop.
+6. **Closed loop** (`_await_finding` → `_persist_finding`). A run terminal on
+   return is parsed immediately; one that converted to async is polled up to
+   `checks_investigation_poll_timeout_seconds`. A valid `ChecksFinding` is
+   written back to tenant memory as `checks-noise-<group-key>` (upsert on
+   `(scope, slug)`) with metadata `source` / `verdict` / `re_escalate` /
+   `run_id`, so a subsequent red for the same group with `re_escalate=false`
+   is suppressed without an LLM call.
+
+## Agent-name convention (opt-in per tenant)
+
+The wiring is **off** until a tenant creates an *enabled* agent definition
+whose name matches `Settings.checks_investigator_agent` (default
+`checks-investigator`). An absent or disabled definition logs
+`checks_investigator_unconfigured` and skips — the `enabled` flag is the
+on/off switch.
+
+Example create payload (derived from
+`examples/r1-tiered-triage/agent.deep-tier-investigator.json`; the read-only
+toolset + no write grants is the diagnose-only posture):
+
+```json
+{
+  "name": "checks-investigator",
+  "identity_ref": "agent:checks-investigator",
+  "model_tier": "deep",
+  "system_prompt": "You investigate check-dashboard non-green transitions. You receive one briefing per correlated cause group: the Dashboard, its transition, and the non-green member Sensors that share a common topology cause. Investigate the ONE underlying cause read-only, then answer with a single JSON object matching ChecksFinding: {verdict: benign|acknowledged|actionable, re_escalate: bool, summary: str, evidence: [str], recommended_action: str|null}. Set re_escalate=false for benign/acknowledged so this correlated red is suppressed until it recurs. recommended_action is advisory text only; any change op you attempt parks for operator approval and is never executed by this wiring.",
+  "toolset": {
+    "meta_tools": ["list_operation_groups", "search_operations", "call_operation"]
+  },
+  "turn_budget": 25,
+  "enabled": true
+}
+```
+
+Grant this principal `*.read` / `*.list` auto-execute and any `*.write`
+**needs-approval** (the `examples/r1-tiered-triage/permissions.json` mould).
+
+## Diagnose-only contract (the CRUX)
+
+This wiring never executes a change op:
+
+- `investigate.py` imports **no** operations dispatcher and calls no execution
+  seam (a unit test asserts `operations.dispatcher` is absent from the module
+  source).
+- `recommended_action` is persisted as memory text only.
+- Any write op the **agent** attempts is not executed by this wiring: the
+  policy gate parks it as a durable `ApprovalRequest`
+  (`operations/approval_queue.py`, #817) because the agent principal holds
+  `*.write` grants as needs-approval. Approval + execution is a separate,
+  operator-driven step (R2 territory), not this hook.
+
+The topology reads and memory read/write run under a synthetic per-tenant
+`Operator` confined to the Sensor's own tenant — no cross-tenant reach, the
+#2505 runner precedent. Its role is `TENANT_ADMIN` because the closed-loop
+noise-suppression policy is a **tenant-shared** memory write (the memory RBAC
+matrix restricts `TENANT`-scope writes to `tenant_admin`); that operator never
+dispatches an op, and the agent run authenticates independently as its own
+principal, so no execution path inherits the role.
+
+## Dependencies
+
+- `meho_backplane.checks.rollup` (#2506) — the pure five-state fold reused for
+  transition detection; `meho_backplane.checks.dashboard_repository` —
+  `members_by_dashboard`.
+- `meho_backplane.agent.invocation` — `AgentInvoker.run_scheduled` / `poll`,
+  the budget gate + kill switch, `work_ref` stamping.
+- `meho_backplane.scheduler.credentials` — Vault-first
+  `resolve_agent_credentials` (the same seam the cron scheduler uses).
+- `meho_backplane.topology.query.find_dependencies` — forward blast-radius
+  closure (PG-only recursive CTE; correlation degrades to singletons where
+  topology has no data).
+- `meho_backplane.memory.service.MemoryService` — the closed-loop suppression
+  channel (`remember` upsert on `(scope, slug)`).
+- No DB migration — the `last_rollup_state` memo column is #2506's DDL; this
+  hook is its only writer.
+
+## Known issues / boundaries
+
+- **No sensor→graph-node link for non-k8s targets.** Only the Kubernetes
+  connector discovers topology, so most Sensors fall to the singleton
+  (per-Sensor) path today; correlation grows automatically as more connectors
+  discover topology. Anchor resolution is exact-name only (no alias
+  resolution) — an alias-referencing target does not correlate.
+- **Concurrency.** Two members of one Dashboard evaluated near-simultaneously
+  can both detect a transition before either commits the memo; the memo
+  compare-and-set + the in-flight `work_ref` dedupe + the noise-suppression
+  memory layer make duplicate investigations rare and harmless (all
+  diagnose-only), but perfect single-fire under concurrency is not guaranteed.
+- **Trigger seam.** The runner-persist hook is the v1 seam because event
+  triggers are refused until the #826 matcher lands (#2325) and #2506's rollup
+  is read-path-only. Migrating to an event trigger when the matcher exists is
+  a separate task.
+- **Remote Sensors.** Investigation of remote / isolated-network Sensors
+  (#2415 gateway workload) is out of scope here (soft link).
+
+## References
+
+- Initiative #2416 (binding design), Task #2507, parent goal #221. Builds on
+  Sensor #2503, assertion evaluator #2504, runner #2505, dashboard/rollup
+  #2506.
+- Mould: `examples/r1-tiered-triage/workflow.py` (harness-persists rationale,
+  briefing builder, render/persist shape), `agent.deep-tier-investigator.json`
+  (definition payload), `permissions.json` (`*.write` needs-approval).
+- Seams: `agent/invocation.py` (`run_scheduled`), `scheduler/loop.py`
+  (step 4 caller), `scheduler/credentials.py`, `operations/budget_enforcement.py`,
+  `operations/approval_queue.py` (#817), `topology/query.py`.


### PR DESCRIPTION
## Summary

- Wires a **diagnose-only investigator** to check-Dashboard non-green transitions (#2507, final task of Initiative #2416). When a Dashboard's five-state rollup crosses from green into `degraded`/`critical` — detected at #2505's runner result-persist seam against the `last_rollup_state` memo #2506 reserved — the affected non-green Sensors are correlated through the topology blast-radius graph so **one underlying cause produces exactly one investigation**, tenant memory is checked for a known-noise policy, and only novel/non-suppressed groups fire a durable, budget-gated agent run via `AgentInvoker.run_scheduled`.
- **Diagnose-only (the CRUX):** the investigator writes a structured finding + an advisory suggested action to the durable `agent_run` row and back to memory (`checks-noise-<group-key>`) as the noise-suppression policy; `recommended_action` is text only, and any change op the agent attempts parks in the existing approval queue. `checks/investigate.py` imports **no** operations dispatcher and calls no execution seam (unit-tested).
- Productizes the `examples/r1-tiered-triage` mould against the deterministic check layer — no `invoke_agent` hop (the runner+rollup are the cheap tier), the deep tier is the same scheduled-agent seam the cron scheduler uses.
- Opt-in per tenant via an enabled `checks-investigator` agent definition (`CHECKS_INVESTIGATOR_AGENT`); budget-gated + kill-switchable through the invoker path. No DB migration (the memo column is #2506's DDL); no REST/CLI/MCP surface.

## Design notes

- **Trigger seam:** a hook at `checks/runner.py`'s persist path (`investigate_on_transition`) — event triggers are refused until the #826 matcher lands and #2506's rollup is read-path-only. The hook does the in-band memo compare-and-set and spawns the expensive investigation fire-and-forget so the runner's persist path never blocks or fails.
- **Correlation:** each non-green Sensor maps to its topology anchor (`kind="target"`) → `find_dependencies` closure → union-find; group key = deepest shared node (else the Sensor's own slug for the `NodeNotFoundError` singleton fallback, the expected case for non-k8s targets).
- **Identity:** a synthetic per-tenant `Operator` confined to the Sensor's tenant (the #2505 runner precedent). Role is `TENANT_ADMIN` because the closed-loop noise-suppression policy is a tenant-shared memory write (memory RBAC restricts `TENANT`-scope writes to `tenant_admin`); this operator never dispatches an op, and the agent run authenticates independently as its own principal.

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy src/meho_backplane` — clean (663 files)
- [x] `uv run pytest tests/test_checks_investigate.py` — 22 passed (memo + transition matrix, correlation + determinism, one-cause-one-investigation, in-flight dedupe, suppression, closed loop, unparseable, budget refusal, unconfigured/disabled/credentials containment, crash containment, diagnose-only guard, settings)
- [x] `uv run pytest tests/test_sensor_runner.py tests/test_checks_dashboards.py tests/test_checks_rollup.py tests/test_examples_r1_tiered_triage.py` — 65 passed (hook doesn't regress runner/dashboard/rollup/r1)
- [x] Full unit lane green (helm `test_no_mcp_env_keys_when_ingress_disabled_and_nothing_set` deselected, pre-existing)

## Out of scope

- Auto-remediation / executing `recommended_action` — parks via the existing approval queue (#817).
- Event-outbox/subscription trigger machinery (#826/#2325).
- Remote/isolated-network Sensors (#2415 gateway, soft link).

Closes #2507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic, diagnose-only investigations when dashboard health worsens from green to degraded or critical.
  * Correlates related causes, suppresses repeated noise, prevents duplicate runs, and records findings for future reference.
  * Added tenant opt-in configuration and configurable investigation polling timeout.

* **Documentation**
  * Added guidance covering investigation behavior, configuration, safeguards, and known limitations.

* **Tests**
  * Added comprehensive coverage for transitions, correlation, suppression, deduplication, failures, and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->