### PR TITLE
fix(db): renumber graph_node.source migration to 0066 — duplicate revision id 0065 on main

### DIFF
--- a/backend/alembic/versions/0066_add_graph_node_source.py
+++ b/backend/alembic/versions/0066_add_graph_node_source.py
@@ -3,8 +3,8 @@
 
 """Add ``graph_node.source`` + backfill curated seeds (#2536).
 
-Revision ID: 0065
-Revises: 0064
+Revision ID: 0066
+Revises: 0065
 Create Date: 2026-07-16
 
 Initiative #2533 (Topology v2), Task #2536 (T2, the second and final
@@ -55,13 +55,24 @@ Reversibility contract
 
 ``downgrade()`` drops the CHECK and the column. The auto/curated
 distinction is lost (rows survive; the ``properties.seeded_by``
-convention remains recoverable), which restores the pre-0065 state
+convention remains recoverable), which restores the pre-0066 state
 exactly — no pre-check is needed because no row can violate the
 narrowed schema.
 
 The migration is self-contained: the source vocabulary is inlined
 (never imported from :mod:`meho_backplane.db.models`) because Alembic
 must run against any historical revision's model graph.
+
+Renumbering note (was ``0065``)
+-------------------------------
+
+This migration originally shipped as revision ``0065`` (PR #2562),
+colliding with ``0065_create_check_dashboards``; it was renumbered to
+``0066`` chaining after that revision. If you already applied it under
+the old id, fix your ``alembic_version`` bookkeeping by hand:
+``alembic stamp 0066`` if both 0065 migrations were applied, or apply
+``0065_create_check_dashboards`` manually and then stamp — the schema
+changes themselves are identical and need no replay.
 """
 
 from collections.abc import Sequence
@@ -70,8 +81,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0065"
-down_revision: str | None = "0064"
+revision: str = "0066"
+down_revision: str | None = "0065"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -1818,7 +1818,7 @@ class GraphEdgeKind(StrEnum):
 #: -- ``auto`` for probe-derived rows (T3 refresh), ``curated`` for
 #: operator-asserted ones (G9.2 edges; #2536 node seeds via
 #: :func:`meho_backplane.topology.nodes.create_or_get_node`). Shared
-#: between ``ck_graph_node_source`` (migration ``0065``) and
+#: between ``ck_graph_node_source`` (migration ``0066``) and
 #: ``ck_graph_edge_source`` (migration ``0007``) so the two halves of
 #: the curated-durability discipline cannot drift.
 _GRAPH_SOURCES: tuple[str, ...] = ("auto", "curated")
@@ -1893,7 +1893,7 @@ class GraphNode(Base):
       cascade-delete the topology data the agent may still want to
       reason about; the node lives on as a non-target row.
     * ``source`` -- Text NOT NULL DEFAULT ``'auto'`` with a DB-layer
-      ``CHECK source IN (...)`` constraint (migration ``0065``;
+      ``CHECK source IN (...)`` constraint (migration ``0066``;
       mirrors :attr:`GraphEdge.source` / ``ck_graph_edge_source``).
       ``auto`` for probe-derived rows (T3 refresh); ``curated`` for
       operator/agent-seeded rows

--- a/backend/tests/migrations/test_migration_0066_add_graph_node_source.py
+++ b/backend/tests/migrations/test_migration_0066_add_graph_node_source.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Behavioural tests for Alembic migration ``0065_add_graph_node_source``.
+"""Behavioural tests for Alembic migration ``0066_add_graph_node_source``.
 
 Initiative #2533 (Topology v2), Task #2536 (T2). The migration adds
 ``graph_node.source`` (``TEXT NOT NULL DEFAULT 'auto'``, CHECK
@@ -11,23 +11,23 @@ backfills ``source='curated'`` for rows carrying the manual-seed
 
 Coverage:
 
-* **Backfill** — a pre-0065 row with ``seeded_by`` in ``properties``
+* **Backfill** — a pre-0066 row with ``seeded_by`` in ``properties``
   lands as ``curated``; a probe-discovered row (no stamp) lands as
   ``auto``.
-* **Default** — a post-0065 insert that omits ``source`` gets
+* **Default** — a post-0066 insert that omits ``source`` gets
   ``'auto'`` from the server default.
-* **CHECK** — a post-0065 insert with an out-of-vocabulary ``source``
+* **CHECK** — a post-0066 insert with an out-of-vocabulary ``source``
   is rejected with :class:`IntegrityError`.
 * **Sibling-CHECK survival** — ``ck_graph_node_kind`` still rejects a
   malformed kind after the batch table rebuild (the SQLite batch-mode
   caveat migration ``0063`` pinned for the edge table, now pinned for
   the node table).
-* **Round-trip** — ``upgrade 0065`` → ``downgrade 0064`` (column gone)
-  → ``upgrade 0065`` is clean; the backfill replays identically.
+* **Round-trip** — ``upgrade 0066`` → ``downgrade 0065`` (column gone)
+  → ``upgrade 0066`` is clean; the backfill replays identically.
 
 **Idempotency pinning (0049/0050/0054/0055 footgun).** Every
 forward / round-trip step targets this migration's **own** revision
-(``0065``) and its ``down_revision`` (``0064``), never ``head`` — so a
+(``0066``) and its ``down_revision`` (``0065``), never ``head`` — so a
 future head migration cannot silently change what these tests
 exercise. SQLite is the test driver; the migration branches only on
 the backfill predicate (PG ``properties ? 'seeded_by'`` vs SQLite
@@ -54,8 +54,8 @@ from meho_backplane.db.engine import reset_engine_for_testing
 from meho_backplane.db.migrations import alembic_config
 from meho_backplane.settings import get_settings
 
-_REVISION = "0065"
-_DOWN_REVISION = "0064"
+_REVISION = "0066"
+_DOWN_REVISION = "0065"
 
 
 @pytest.fixture
@@ -64,7 +64,7 @@ def alembic_cfg(
     tmp_path: Path,
 ) -> Iterator[tuple[Config, str]]:
     """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
-    db_path = tmp_path / "migration_0065.db"
+    db_path = tmp_path / "migration_0066.db"
     async_url = f"sqlite+aiosqlite:///{db_path}"
     sync_url = f"sqlite:///{db_path}"
     monkeypatch.setenv("DATABASE_URL", async_url)
@@ -106,14 +106,14 @@ def _seed_tenant(sync_url: str) -> str:
     return tenant_id
 
 
-def _insert_node_pre_0065(
+def _insert_node_pre_0066(
     sync_url: str,
     tenant_id: str,
     *,
     name: str,
     properties: dict[str, Any],
 ) -> str:
-    """Insert a ``graph_node`` row at revision 0064 (no ``source`` column)."""
+    """Insert a ``graph_node`` row at revision 0065 (no ``source`` column)."""
     node_id = str(uuid.uuid4())
     eng = sa_create_engine(sync_url)
     try:
@@ -139,7 +139,7 @@ def _insert_node_pre_0065(
     return node_id
 
 
-def _insert_node_post_0065(
+def _insert_node_post_0066(
     sync_url: str,
     tenant_id: str,
     *,
@@ -147,7 +147,7 @@ def _insert_node_post_0065(
     kind: str = "vm",
     source: str | None = None,
 ) -> None:
-    """Insert a row post-0065; ``source=None`` omits the column (default)."""
+    """Insert a row post-0066; ``source=None`` omits the column (default)."""
     columns = "id, tenant_id, kind, name, properties, discovered_by, first_seen"
     values = ":id, :tenant_id, :kind, :name, '{}', 'source-test', :first_seen"
     params: dict[str, Any] = {
@@ -188,11 +188,11 @@ def _select_source(sync_url: str, node_id: str) -> str:
 def test_backfill_marks_seeded_rows_curated_and_probe_rows_auto(
     alembic_cfg: tuple[Config, str],
 ) -> None:
-    """The 0065 backfill keys on the ``properties.seeded_by`` stamp."""
+    """The 0066 backfill keys on the ``properties.seeded_by`` stamp."""
     cfg, sync_url = alembic_cfg
     command.upgrade(cfg, _DOWN_REVISION)
     tenant_id = _seed_tenant(sync_url)
-    seeded_id = _insert_node_pre_0065(
+    seeded_id = _insert_node_pre_0066(
         sync_url,
         tenant_id,
         name="manually-seeded",
@@ -202,7 +202,7 @@ def test_backfill_marks_seeded_rows_curated_and_probe_rows_auto(
             "seeded_at": "2026-01-01T00:00:00+00:00",
         },
     )
-    probe_id = _insert_node_pre_0065(
+    probe_id = _insert_node_pre_0066(
         sync_url,
         tenant_id,
         name="probe-discovered",
@@ -218,11 +218,11 @@ def test_backfill_marks_seeded_rows_curated_and_probe_rows_auto(
 def test_post_upgrade_insert_defaults_to_auto(
     alembic_cfg: tuple[Config, str],
 ) -> None:
-    """A post-0065 insert omitting ``source`` gets ``'auto'`` from the default."""
+    """A post-0066 insert omitting ``source`` gets ``'auto'`` from the default."""
     cfg, sync_url = alembic_cfg
     command.upgrade(cfg, _REVISION)
     tenant_id = _seed_tenant(sync_url)
-    _insert_node_post_0065(sync_url, tenant_id, name="defaulted")
+    _insert_node_post_0066(sync_url, tenant_id, name="defaulted")
 
     eng = sa_create_engine(sync_url)
     try:
@@ -244,16 +244,16 @@ def test_check_rejects_unknown_source(
     tenant_id = _seed_tenant(sync_url)
 
     with pytest.raises(IntegrityError):
-        _insert_node_post_0065(sync_url, tenant_id, name="bad-source", source="inferred")
+        _insert_node_post_0066(sync_url, tenant_id, name="bad-source", source="inferred")
 
-    _insert_node_post_0065(sync_url, tenant_id, name="ok-auto", source="auto")
-    _insert_node_post_0065(sync_url, tenant_id, name="ok-curated", source="curated")
+    _insert_node_post_0066(sync_url, tenant_id, name="ok-auto", source="auto")
+    _insert_node_post_0066(sync_url, tenant_id, name="ok-curated", source="curated")
 
 
 def test_sibling_kind_check_survives_batch_rebuild(
     alembic_cfg: tuple[Config, str],
 ) -> None:
-    """``ck_graph_node_kind`` still rejects a malformed kind post-0065.
+    """``ck_graph_node_kind`` still rejects a malformed kind post-0066.
 
     The SQLite batch-mode caveat: :func:`op.batch_alter_table` rebuilds
     the table, and only **named** CHECK constraints participate in the
@@ -265,13 +265,13 @@ def test_sibling_kind_check_survives_batch_rebuild(
     tenant_id = _seed_tenant(sync_url)
 
     with pytest.raises(IntegrityError):
-        _insert_node_post_0065(sync_url, tenant_id, name="bad-kind", kind="DNS-Record")
+        _insert_node_post_0066(sync_url, tenant_id, name="bad-kind", kind="DNS-Record")
 
 
 def test_downgrade_then_upgrade_round_trips(
     alembic_cfg: tuple[Config, str],
 ) -> None:
-    """``downgrade 0064`` drops the column; ``upgrade 0065`` replays the backfill.
+    """``downgrade 0065`` drops the column; ``upgrade 0066`` replays the backfill.
 
     Pinned to this migration's own revision on both legs (never
     ``head``). The seeded row's ``properties.seeded_by`` stamp survives
@@ -280,7 +280,7 @@ def test_downgrade_then_upgrade_round_trips(
     cfg, sync_url = alembic_cfg
     command.upgrade(cfg, _DOWN_REVISION)
     tenant_id = _seed_tenant(sync_url)
-    seeded_id = _insert_node_pre_0065(
+    seeded_id = _insert_node_pre_0066(
         sync_url,
         tenant_id,
         name="round-trip-seed",

--- a/backend/tests/test_checks_investigate.py
+++ b/backend/tests/test_checks_investigate.py
@@ -336,7 +336,13 @@ def _succeeded_outcome(finding: ChecksFinding, *, run_id: UUID | None = None) ->
 
 def _node(kind: str, name: str, depth: int) -> TopologyNode:
     return TopologyNode(
-        id=uuid4(), kind=kind, name=name, properties={}, depth=depth, via_edge_kind=None
+        id=uuid4(),
+        kind=kind,
+        name=name,
+        source="auto",
+        properties={},
+        depth=depth,
+        via_edge_kind=None,
     )
 
 


### PR DESCRIPTION
## Urgent hotfix — main is broken

**Defect 1 (migration collision):** two Alembic migrations on `main` share revision id `0065`, both with `down_revision = "0064"`:

- `0065_create_check_dashboards.py` — merged earlier at `af1cf960` (checks-dashboards work, #2506)
- `0065_add_graph_node_source.py` — merged later via **PR #2562** (task #2536, Initiative #2533)

On pristine `main`, `alembic upgrade head` fails with *"Revision 0065 is present more than once"* / multiple heads, which errors out conftest migration setup in **every pytest lane**.

**Defect 2 (schema/test drift, surfaced by this PR's first CI run):** #2562 also made `TopologyNode.source` a required field and updated every existing test constructor — except `tests/test_checks_investigate.py` (merged via #2569, whose CI predated the schema change), whose `_node` helper still built nodes without `source` → `ValidationError` once the pytest lane runs at all.

**Escape vector (both defects):** the CI run at #2562's merge commit was cancelled as superseded, so main's required checks never executed against the merged tree and neither breakage was caught.

## Fix (minimal)

1. Renumber the later-merged migration — `0065_add_graph_node_source.py` → `0066_add_graph_node_source.py` with `revision="0066"`, `down_revision="0065"` — chaining it after the checks-dashboards `0065`. `0065_create_check_dashboards.py` is untouched. Swept references:
   - migration test renamed to `test_migration_0066_add_graph_node_source.py`; `_REVISION="0066"` / `_DOWN_REVISION="0065"` + docstrings
   - `db/models.py` doc comments naming migration `0065` for `graph_node.source` now say `0066`
   - migration docstring gains a short renumbering note: anyone who already applied `0065_add_graph_node_source` under its old id should fix `alembic_version` via `alembic stamp` (schema changes are identical, no replay needed)
2. `tests/test_checks_investigate.py::_node` now passes `source="auto"`, matching every sibling test helper #2562 already updated.

## Verification

- `alembic heads` → exactly one head: `0066`
- fresh-DB `alembic upgrade head` replays `… → 0064 → 0065 (check_dashboards) → 0066 (graph_node_source)`
- `alembic downgrade 0065` then re-upgrade: clean, backfill replays identically
- full migrations suite: **314 passed**; `tests/test_checks_investigate.py`: **23 passed**
- ruff check + format clean on touched files

Refs #2536

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected migration sequencing to ensure database upgrades and downgrades proceed reliably.
  * Preserved graph node source defaults, validation, and backfill behavior during migration changes.

* **Tests**
  * Expanded migration coverage for source defaults, invalid values, backfills, and upgrade/downgrade round trips.
  * Confirmed existing graph node validation remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->