### PR TITLE
fix(scheduler): close cross-tenant IDOR on the meho.scheduler.create MCP tool (parity with #2503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Security — scheduler MCP tool cross-tenant IDOR parity fix
+
+- Close a cross-tenant write IDOR on the `meho.scheduler.create` MCP tool: it
+  gated a cross-tenant `tenant_id` on tenant-admin *rank*, but the tool already
+  requires tenant_admin, so any tenant-admin could schedule a trigger into any
+  tenant. The handler now enforces the same shared `authorize_tenant_scope`
+  platform-admin seam its own REST route uses (the #1638 primitive) — a
+  non-platform-admin naming another tenant is refused with
+  `cross_tenant_requires_platform_admin`. Brings the MCP surface to parity with
+  the sibling Sensor MCP fix (#2503). Adds MCP regression tests (tenant-admin
+  refused cross-tenant; platform-admin allowed).
+
 ### Added — tiered-triage investigator wiring (#2507)
 
 - Wire a **diagnose-only investigator** to Dashboard non-green transitions

--- a/backend/src/meho_backplane/mcp/tools/scheduler.py
+++ b/backend/src/meho_backplane/mcp/tools/scheduler.py
@@ -60,9 +60,11 @@ import uuid
 from typing import Any, Final
 
 import structlog
+from fastapi import HTTPException
 from pydantic import ValidationError
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import authorize_tenant_scope
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.scheduler.schemas import (
@@ -212,18 +214,24 @@ async def _create_handler(
         payload = ScheduledTriggerCreate.model_validate(arguments)
     except ValidationError as exc:
         raise McpInvalidParamsError(f"invalid arguments: {exc}") from exc
-    # Cross-tenant admin: when payload.tenant_id is provided, route the
-    # create under that tenant -- but only for tenant_admin callers.
-    # Operator-role callers attempting cross-tenant create surface as
-    # invalid-params (mirrors the REST 403 contract). A silent drop
-    # would mis-place the trigger under the caller's own tenant and
-    # quietly break the cross-tenant admin path on the MCP transport
-    # (review M1 on PR #1128).
-    target_tenant = operator.tenant_id
-    if payload.tenant_id is not None:
-        if operator.tenant_role != TenantRole.TENANT_ADMIN:
-            raise McpInvalidParamsError("tenant_id_requires_tenant_admin")
-        target_tenant = payload.tenant_id
+    # Cross-tenant admin: a payload.tenant_id naming a *different* tenant
+    # crosses the tenant boundary, which is a platform-level capability --
+    # not something tenant-admin *rank* confers. Reuse the REST route's
+    # shared authz seam (authorize_tenant_scope, the #1638 cross-tenant
+    # IDOR primitive) rather than gating on rank: this tool already
+    # requires tenant_admin, so a rank check would be dead code and let
+    # any tenant-admin write a trigger into any tenant. authorize_tenant_scope
+    # returns the caller's own tenant for the same-tenant / null case and
+    # only allows a different tenant for operator.platform_admin.
+    try:
+        target_tenant = authorize_tenant_scope(operator, payload.tenant_id)
+    except HTTPException as exc:
+        # 403 cross_tenant_requires_platform_admin -> the MCP wire-error;
+        # the same detail token the REST caller sees (there is no MCP
+        # analogue for 403, so invalid-params is the closest shape). Mirrors
+        # meho_backplane.mcp.tools.broadcast_overrides._http_to_mcp.
+        detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+        raise McpInvalidParamsError(detail) from exc
     structlog.contextvars.bind_contextvars(
         audit_op_id=_SCHEDULER_OP_IDS["create"],
         audit_op_class="write",
@@ -266,14 +274,14 @@ register_mcp_tool(
             "Optional: timezone (IANA name, default 'UTC'), "
             "identity_sub (default '__scheduler__'), "
             "in_flight_policy ('fail_into_audit'|'resume', default "
-            "'fail_into_audit'), tenant_id (UUID; tenant_admin-only "
+            "'fail_into_audit'), tenant_id (UUID; platform-admin-only "
             "cross-tenant target), work_ref (change-ticket reference "
             "inherited by every dispatched run's audit rows). Invalid "
             "cron expression -> error with "
             "detail 'invalid_arguments'; unknown agent_definition_id -> "
             "'agent_definition_not_found'; a cron/one_off with no usable "
-            "inputs -> invalid arguments (422); non-admin passing tenant_id -> "
-            "'tenant_id_requires_tenant_admin'. Response: {trigger_id, "
+            "inputs -> invalid arguments (422); a non-platform-admin passing "
+            "another tenant's id -> 'cross_tenant_requires_platform_admin'. Response: {trigger_id, "
             "trigger: {...}}."
         ),
         inputSchema={
@@ -331,9 +339,9 @@ register_mcp_tool(
                     "format": "uuid",
                     "description": (
                         "Target tenant UUID for cross-tenant admin create "
-                        "(tenant_admin only; operator-role callers see "
-                        "'tenant_id_requires_tenant_admin'). When omitted "
-                        "or null, the trigger is created under the "
+                        "(platform-admin only; a non-platform-admin naming "
+                        "another tenant sees 'cross_tenant_requires_platform_admin'). "
+                        "When omitted or null, the trigger is created under the "
                         "caller's tenant."
                     ),
                 },

--- a/backend/tests/test_scheduler_admin.py
+++ b/backend/tests/test_scheduler_admin.py
@@ -1153,6 +1153,86 @@ async def test_mcp_create_rejects_event_trigger() -> None:
 
 
 @pytest.mark.asyncio
+async def test_mcp_create_cross_tenant_denied_for_non_platform_admin() -> None:
+    """A tenant-admin of A passing tenant_id=B via MCP is refused (cross-tenant IDOR).
+
+    meho.scheduler.create requires tenant_admin, so gating cross-tenant on
+    tenant_admin *rank* would be dead code -- any tenant-admin could schedule a
+    trigger into any tenant. Crossing the tenant boundary is a platform-level
+    capability; the MCP handler now enforces the SAME shared authz seam the REST
+    route uses (``authorize_tenant_scope``, the #1638 IDOR primitive), so a
+    non-platform tenant-admin is refused with
+    ``cross_tenant_requires_platform_admin`` and nothing is written to B.
+    """
+    from meho_backplane.mcp.server import McpInvalidParamsError
+    from meho_backplane.mcp.tools.scheduler import _create_handler  # type: ignore[attr-defined]
+
+    def_id = await _seed_agent_definition(tenant_id=_TENANT_B, name="mcp-cross-bot")
+    operator = Operator(
+        sub="a-admin",
+        raw_jwt="dummy",
+        tenant_id=_TENANT_A,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+    with pytest.raises(McpInvalidParamsError, match="cross_tenant_requires_platform_admin"):
+        await _create_handler(
+            operator,
+            {
+                "kind": "cron",
+                "agent_definition_id": str(def_id),
+                "cron_expr": "*/5 * * * *",
+                "inputs": {"prompt": "scheduled run"},
+                "tenant_id": str(_TENANT_B),
+            },
+        )
+    # And nothing was written into tenant B.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(ScheduledTrigger).where(ScheduledTrigger.tenant_id == _TENANT_B)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_mcp_create_cross_tenant_allowed_for_platform_admin() -> None:
+    """A platform-admin may create a scheduled trigger under another tenant via MCP."""
+    from meho_backplane.mcp.tools.scheduler import _create_handler  # type: ignore[attr-defined]
+
+    def_id = await _seed_agent_definition(tenant_id=_TENANT_B, name="mcp-cross-ok-bot")
+    operator = Operator(
+        sub="platform-op",
+        raw_jwt="dummy",
+        tenant_id=_TENANT_A,
+        tenant_role=TenantRole.TENANT_ADMIN,
+        platform_admin=True,
+    )
+    result = await _create_handler(
+        operator,
+        {
+            "kind": "cron",
+            "agent_definition_id": str(def_id),
+            "cron_expr": "*/5 * * * *",
+            "inputs": {"prompt": "scheduled run"},
+            "tenant_id": str(_TENANT_B),
+        },
+    )
+    created_id = uuid.UUID(result["trigger_id"])
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(select(ScheduledTrigger).where(ScheduledTrigger.id == created_id))
+        ).scalar_one()
+    assert row.tenant_id == _TENANT_B
+
+
+@pytest.mark.asyncio
 async def test_mcp_cancel_returns_not_found_for_cross_tenant() -> None:
     """meho.scheduler.cancel against a cross-tenant id surfaces as not found."""
     from meho_backplane.mcp.server import McpInvalidParamsError


### PR DESCRIPTION
## Summary

Brings the `meho.scheduler.create` MCP tool's cross-tenant authorization to parity with its own REST route, closing a cross-tenant write gap.

The MCP create handler resolved a caller-supplied `tenant_id` by gating on tenant-admin **rank** (`operator.tenant_role != TenantRole.TENANT_ADMIN`). But the tool's registration already requires `TENANT_ADMIN`, so that check was dead code — any tenant-admin could route a scheduled trigger into any tenant. Crossing the tenant boundary is a **platform-level** capability, not something tenant-admin rank confers.

The sibling **REST** route already enforces this correctly via the shared `authorize_tenant_scope` seam (the #1638 cross-tenant primitive; see `test_rest_tenant_admin_blocked_from_foreign_tenant_filter`). This change makes the MCP handler use the **same** seam — no hand-rolled second policy — exactly mirroring the Sensor MCP fix in **#2503**.

## Change

- `mcp/tools/scheduler.py::_create_handler` — replace the rank check with `authorize_tenant_scope(operator, payload.tenant_id)`, translating its `HTTPException` (403 `cross_tenant_requires_platform_admin`) to the MCP wire error via the established `_http_to_mcp` shape. Same-tenant / omitted `tenant_id` is unchanged; only a **different** tenant now requires `operator.platform_admin`.
- Tool description + `tenant_id` inputSchema text updated to the accurate contract (`platform-admin only` / `cross_tenant_requires_platform_admin`).

## Tests

- `test_mcp_create_cross_tenant_denied_for_non_platform_admin` — a tenant-admin of A passing tenant B's id is refused with `cross_tenant_requires_platform_admin`, and **nothing is written to B**.
- `test_mcp_create_cross_tenant_allowed_for_platform_admin` — a platform-admin may create under another tenant.

## Scope / completeness

The `create` handler is the **only** cross-tenant-capable MCP surface on this tool: `_list_handler` is tenant-scoped via the JWT (no cross-tenant argument) and `_cancel_handler` operates on `operator.tenant_id` (cross-tenant ids surface as not-found). No migration, no REST/OpenAPI change.

Gates green locally: ruff + format + mypy clean; `test_scheduler_admin.py` + `test_mcp_tools_list_shape_conventions.py` = 96 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a security issue that could allow unauthorized cross-tenant scheduled trigger creation.
  - Tenant administrators are now prevented from creating triggers for other tenants.
  - Platform administrators can continue to perform authorized cross-tenant scheduling.
  - Improved error messaging for unauthorized cross-tenant requests.
  - Added regression coverage for both allowed and denied scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->