### PR TITLE
fix(checks): Sensors & Dashboards v1 review fast-follow (#2505, #2507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — Sensors & Dashboards v1 review fast-follow (#2505, #2507)
+
+- **Check-runner never-raises hardening (#2505):** a non-`TimeoutError` exception
+  from `dispatch()` now maps to an `unknown` outcome (`reason=dispatch_error`)
+  instead of escaping `_run_evaluation` and stranding the sensor's projection.
+  Corrected the dispatch-identity docstring, which over-claimed the safe-only
+  guarantee holds at dispatch — it is enforced at Sensor *create* time; the
+  runner does not re-validate `safety_level`.
+- **Investigator suppression + key collisions (#2507):** the noise-suppression
+  lookup now uses an exact `(scope, slug)` `recall` instead of a capped substring
+  query that could push the exact entry past its limit and silently fail to
+  suppress a known-noise cause. Work-refs and topology group keys now include the
+  dashboard id / a digest of the `(kind, name)` identity, so causes and dashboards
+  whose names slugify to the same string no longer share a suppression key or an
+  in-flight work-ref.
+
 ### Security — scheduler MCP tool cross-tenant IDOR parity fix
 
 - Close a cross-tenant write IDOR on the `meho.scheduler.create` MCP tool: it

--- a/backend/src/meho_backplane/checks/investigate.py
+++ b/backend/src/meho_backplane/checks/investigate.py
@@ -82,6 +82,7 @@ neither blocks nor raises.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import re
 import time
 import uuid
@@ -175,11 +176,6 @@ _INVESTIGATOR_SUB = "__checks_investigator__"
 #: outlives the sync timeout (converts to async). A dumb constant, same posture
 #: as the runner's fixed bounds.
 _POLL_INTERVAL_SECONDS = 5.0
-
-#: Server-side ``list_memories`` page cap for a suppression lookup -- one slug's
-#: entries never exceed one row (``(scope, slug)`` is unique), so a tiny cap is
-#: ample; the substring filter may over-match, hence the exact-slug check.
-_MEMORY_LOOKUP_LIMIT = 25
 
 #: The three non-terminal ``agent_run`` statuses. An in-flight run in any of
 #: these states for the same ``(tenant_id, work_ref)`` suppresses a duplicate
@@ -649,7 +645,10 @@ def _group_key(
                 return (-min_depth, node[0], node[1])
 
             best = min(common, key=_rank)
-            return _slugify(f"{best[0]}-{best[1]}")
+            # Append a digest of the original (kind, name) so two distinct
+            # topology causes that slugify to the same string do not share a
+            # suppression key (which would suppress one when the other is muted).
+            return f"{_slugify(f'{best[0]}-{best[1]}')}-{_identity_digest(best[0], best[1])}"
     return min(_sensor_group_key(m) for m in members)
 
 
@@ -669,6 +668,19 @@ def _slugify(value: str) -> str:
     return slug or "node"
 
 
+def _identity_digest(*parts: str) -> str:
+    """Short stable digest disambiguating a slug from its source identity.
+
+    ``_slugify`` is lossy (``prod/db`` and ``prod db`` collapse to the same
+    slug; a separator-only name becomes ``node``), so two distinct identities
+    can otherwise share a suppression key / ``work_ref``. Appending this digest
+    of the *original* parts makes the key collision-resistant while staying in
+    the ``[a-z0-9_.-]`` slug alphabet.
+    """
+    raw = "\x00".join(parts).encode("utf-8", "surrogatepass")
+    return hashlib.sha256(raw).hexdigest()[:8]
+
+
 async def _investigate_group(
     operator: Operator,
     tenant_id: uuid.UUID,
@@ -684,7 +696,10 @@ async def _investigate_group(
     """
     settings = get_settings()
     group_key = group.key
-    work_ref = f"{_WORK_REF_PREFIX}:{dashboard.slug}:{group_key}"
+    # Include the dashboard id so two dashboards whose names slugify to the same
+    # value do not collide on ``work_ref`` (which would coalesce their unrelated
+    # in-flight investigations); the readable slug is kept for operators.
+    work_ref = f"{_WORK_REF_PREFIX}:{dashboard.dashboard_id.hex[:8]}:{dashboard.slug}:{group_key}"
     memory = MemoryService()
     try:
         if await _is_suppressed(memory, operator, group_key):
@@ -830,17 +845,16 @@ async def _is_suppressed(memory: MemoryService, operator: Operator, group_key: s
     Decided on metadata, never body prose, so no LLM call is needed to decide.
     """
     slug = f"{_NOISE_SLUG_PREFIX}{group_key}"
-    entries = await memory.list_memories(
-        operator,
-        scope=MemoryScope.TENANT,
-        slug_pattern=slug,
-        limit=_MEMORY_LOOKUP_LIMIT,
-    )
-    for entry in entries:
-        # slug_pattern is a substring filter; require the exact slug.
-        if entry.slug == slug:
-            return _is_falsey(entry.metadata.get("re_escalate"))
-    return False
+    # Exact (scope, slug) lookup. A ``list_memories(slug_pattern=...)`` query is
+    # a *substring* filter capped at a limit, so an exact suppression entry can
+    # be pushed past the cap by unrelated slugs that merely contain this one --
+    # silently failing to suppress a known-noise cause (a needless agent run).
+    # ``recall`` resolves the single ``(TENANT, slug)`` entry the closed loop
+    # writes via ``remember`` (same scope + slug), with no cap to hide behind.
+    entry = await memory.recall(operator, MemoryScope.TENANT, slug)
+    if entry is None:
+        return False
+    return _is_falsey(entry.metadata.get("re_escalate"))
 
 
 def _is_falsey(value: object) -> bool:

--- a/backend/src/meho_backplane/checks/runner.py
+++ b/backend/src/meho_backplane/checks/runner.py
@@ -75,8 +75,12 @@ with ``sub=sensor.identity_sub`` (#2503's per-row column, default
 ``TenantRole.OPERATOR`` -- the topology-refresh ``_system_operator`` mould with
 the sub sourced from the row. ``principal_kind`` defaults to ``USER``, so
 :func:`~meho_backplane.operations._validate.policy_gate` auto-executes the
-``safe`` op (#2503's registration guard guarantees a sensor only ever
-references a ``safe`` op; the agent-credential path is never touched here and
+``safe`` op (#2503's registration guard enforces ``safe`` **at Sensor create
+time**; the runner does not re-validate ``safety_level`` at dispatch, matching
+the platform's default-allow-on-``requires_approval`` policy, so an op
+re-registered to a higher safety level *after* a Sensor is created would still
+run here -- a caution/dangerous escalation is a platform-level concern, not
+re-gated in the runner. The agent-credential path is never touched here and
 no agent run may exist on this path). A connector requiring an operator-context
 Vault credential read fails closed for a synthetic operator -- such a dispatch
 returns a structured error and the sensor reads ``unknown``; targets with
@@ -314,6 +318,12 @@ async def _run_evaluation(snap: _SensorSnapshot) -> AssertionOutcome:
             "evaluation_timeout",
             timeout_seconds=_EVAL_TIMEOUT_SECONDS,
         )
+    except Exception as exc:
+        # Never-raises contract: dispatch() is contracted not to raise, but a
+        # connector/transport bug must not strand the sensor's projection --
+        # map it to ``unknown``, not a crashed task. (asyncio.CancelledError is
+        # a BaseException, so cooperative cancellation still propagates.)
+        return _unknown_outcome("dispatch_error", error=str(exc))
 
     if result.status != "ok":
         return _unknown_outcome(

--- a/backend/tests/test_checks_investigate.py
+++ b/backend/tests/test_checks_investigate.py
@@ -482,9 +482,10 @@ async def test_correlation_two_groups_and_determinism(monkeypatch: pytest.Monkey
     keys_first = [g.key for g in groups]
     keys_second = [g.key for g in await inv._correlate(operator, [a, b, c])]
     assert keys_first == keys_second
-    # The A+B group is keyed on the deepest shared node.
+    # The A+B group is keyed on the deepest shared node, with a digest of the
+    # (kind, name) identity appended so slug-colliding causes stay distinct.
     ab_group = next(g for g in groups if {m.name for m in g.members} == {"a", "b"})
-    assert ab_group.key == "datastore-shared"
+    assert ab_group.key == f"datastore-shared-{inv._identity_digest('datastore', 'shared')}"
 
 
 @pytest.mark.asyncio
@@ -500,6 +501,20 @@ async def test_correlation_untracked_anchor_is_singleton(monkeypatch: pytest.Mon
     groups = await inv._correlate(_admin_operator(), [m])
     assert len(groups) == 1
     assert groups[0].key == inv._sensor_group_key(m)
+
+
+def test_slug_colliding_identities_get_distinct_keys() -> None:
+    """Slug-lossy identities must not share a suppression/work key: the identity
+    digest disambiguates causes that ``_slugify`` collapses to the same string."""
+    # `prod/db` and `prod db` both slugify to `prod-db`; names made only of
+    # out-of-alphabet characters both collapse to the `node` fallback -- the
+    # digest keeps all of them distinct.
+    assert inv._slugify("prod/db") == inv._slugify("prod db")
+    assert inv._slugify("///") == inv._slugify("@@@") == "node"
+    assert inv._identity_digest("host", "prod/db") != inv._identity_digest("host", "prod db")
+    assert inv._identity_digest("host", "///") != inv._identity_digest("host", "@@@")
+    # Stable across calls (deterministic keys).
+    assert inv._identity_digest("host", "prod/db") == inv._identity_digest("host", "prod/db")
 
 
 # ---------------------------------------------------------------------------
@@ -534,7 +549,12 @@ async def test_one_cause_one_investigation(monkeypatch: pytest.MonkeyPatch) -> N
     await run_investigation(tenant_id=_TENANT, dashboard=dashboard, members=members)
 
     assert len(stub.calls) == 1
-    assert stub.calls[0].work_ref == "checks:prod:datastore-shared"
+    # work_ref carries the dashboard id (collision-safe across same-slug dashboards)
+    # and the topology group_key carries a digest of the (kind, name) identity.
+    expected_group = f"datastore-shared-{inv._identity_digest('datastore', 'shared')}"
+    assert (
+        stub.calls[0].work_ref == f"checks:{dashboard.dashboard_id.hex[:8]}:prod:{expected_group}"
+    )
 
 
 @pytest.mark.asyncio
@@ -545,10 +565,14 @@ async def test_in_flight_dedupe_skips(monkeypatch: pytest.MonkeyPatch) -> None:
     stub = _install_stub()
     member = _member("solo", target=None)
     group_key = inv._sensor_group_key(member)
-    await _seed_agent_run(work_ref=f"checks:prod:{group_key}", status=AgentRunStatus.RUNNING.value)
+    dashboard = _dash(name="prod")
+    await _seed_agent_run(
+        work_ref=f"checks:{dashboard.dashboard_id.hex[:8]}:prod:{group_key}",
+        status=AgentRunStatus.RUNNING.value,
+    )
 
     with capture_logs() as logs:
-        await run_investigation(tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[member])
+        await run_investigation(tenant_id=_TENANT, dashboard=dashboard, members=[member])
 
     assert stub.calls == []
     assert any(e["event"] == "checks_investigation_skipped_in_flight" for e in logs)
@@ -569,6 +593,46 @@ async def test_suppression_reescalate_false_skips(monkeypatch: pytest.MonkeyPatc
         slug=f"checks-noise-{group_key}",
         metadata={"source": "checks-investigator", "re_escalate": False},
     )
+
+    with capture_logs() as logs:
+        await run_investigation(tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[member])
+
+    assert stub.calls == []
+    assert any(e["event"] == "checks_investigation_suppressed" for e in logs)
+
+
+@pytest.mark.asyncio
+async def test_suppression_exact_lookup_survives_substring_collisions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The exact suppression entry still fires even when many noise slugs contain
+    its key as a substring -- the old capped substring query could push the exact
+    entry past the limit and silently fail to suppress; the exact recall cannot."""
+    await _seed_definition()
+    _patch_creds(monkeypatch)
+    stub = _install_stub()
+    member = _member("solo", target=None)
+    group_key = inv._sensor_group_key(member)
+    exact_slug = f"checks-noise-{group_key}"
+    operator = _admin_operator()
+    memory = MemoryService()
+    await memory.remember(
+        operator,
+        MemoryScope.TENANT,
+        "verdict: benign\n",
+        slug=exact_slug,
+        metadata={"source": "checks-investigator", "re_escalate": False},
+    )
+    # Decoys whose slugs CONTAIN exact_slug as a substring -- these crowd out the
+    # exact entry under a capped substring query (30 > the former limit of 25).
+    for i in range(30):
+        await memory.remember(
+            operator,
+            MemoryScope.TENANT,
+            "noise\n",
+            slug=f"{exact_slug}-decoy-{i:02d}",
+            metadata={"source": "checks-investigator", "re_escalate": True},
+        )
 
     with capture_logs() as logs:
         await run_investigation(tenant_id=_TENANT, dashboard=_dash(name="prod"), members=[member])

--- a/backend/tests/test_sensor_runner.py
+++ b/backend/tests/test_sensor_runner.py
@@ -374,6 +374,31 @@ async def test_at_most_once_dispatch_that_raises_advances_and_does_not_refire(
 
 
 @pytest.mark.asyncio
+async def test_raising_dispatch_persists_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dispatch() that raises a non-timeout error persists ``unknown`` instead of
+    stranding the projection -- the ``_run_evaluation`` never-raises contract."""
+
+    async def _raising_dispatch(**_kwargs: Any) -> OperationResult:
+        raise RuntimeError("connector blew up")
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _raising_dispatch)
+
+    sensor_id = await _create_interval_sensor(interval_seconds=300)
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    await run_one_sensor_tick()
+    await _drain_in_flight()
+
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "unknown"
+    assert row.last_evidence is not None
+    assert row.last_evidence["reason"] == "dispatch_error"
+    assert "connector blew up" in row.last_evidence["error"]
+
+
+@pytest.mark.asyncio
 async def test_two_concurrent_sensor_ticks_never_double_evaluate(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Non-blocking review follow-ups from the #2416 check-layer PRs (#2505 check-runner, #2507 investigator). Each fix has a regression test.

## Fixes

**#2505 check-runner**
- **M2 — never-raises hardening** (`checks/runner.py::_run_evaluation`): the dispatch block caught only `TimeoutError`, so a non-timeout exception from `dispatch()` (a connector/transport bug) escaped a function whose contract is *"never raises"* and left the sensor's projection stale. Now `except Exception → unknown` (`reason=dispatch_error`). `asyncio.CancelledError` is a `BaseException`, so cooperative cancellation still propagates.
- **M1 — docstring accuracy** (`checks/runner.py`): the dispatch-identity docstring claimed #2503's guard means a sensor "only ever references a `safe` op". That guarantee is enforced at Sensor **create** time; the runner does not re-validate `safety_level` at dispatch (matching the platform's default-allow-on-`requires_approval` policy). Reworded to state that accurately — no behavior change.

**#2507 investigator** (`checks/investigate.py`)
- **Suppression correctness**: `_is_suppressed` used a capped substring `list_memories(slug_pattern=…)` query then filtered for the exact slug — an exact `checks-noise-<key>` entry could be pushed past the cap by unrelated slugs that merely contain it, silently failing to suppress a known-noise cause (a needless agent run). Switched to an exact `(scope, slug)` `recall`. (Removes the now-dead `_MEMORY_LOOKUP_LIMIT`.)
- **Collision-resistant keys**: `_slugify` is lossy (`prod/db` and `prod db` collapse; separator-only → `node`), so distinct causes/dashboards could share a suppression key or in-flight `work_ref`. `work_ref` now includes the dashboard id; the topology `group_key` now includes a stable digest of the `(kind, name)` identity. (The singleton/member key already carried `sensor_id`.)

## Deliberately deferred (not folded here)

- **Atomic coalesce of concurrent investigations** (CodeRabbit "Heavy lift", investigate.py#L380): a real concurrency hardening, but a DB-level atomic-claim redesign with bounded impact (worst case a duplicate *budget-gated, diagnose-only* run, or a first-pass investigation missing a concurrently-persisted member — self-corrects next tick). Deserves its own scoped task.
- **Parallel cause-group fan-out** (CodeRabbit "Performance", investigate.py#L525): parallelizing would let multiple groups pass the **budget gate** concurrently and over-fire; the serial loop is deliberately budget-safe. Kept serial.
- Three CodeRabbit **minors** (settings-fixture pin, two doc touch-ups): non-substantive; left out to keep the diff focused.

## Verification

ruff + format + mypy clean; the checks/sensor/investigate/dashboard/rollup suite is **299 passed** locally (incl. the new regression tests). No migration, no API/OpenAPI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensor evaluations now record an `unknown` result when unexpected dispatch errors occur, preventing stalled evaluations.
  * Investigation suppression now uses exact matches, avoiding false suppression from similar keys.
  * Dashboard investigations and in-flight work are uniquely tracked, preventing collisions between similarly named items.
  * Clarified dispatch safety behavior in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->