### PR TITLE
ci(image): retire the expired RDC repository_dispatch notify

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -59,19 +59,6 @@
 #     accumulation on a stale base image (it is not a PR merge gate — the step
 #     is skipped on pull_request). SARIF results land both on the GitHub
 #     Security tab (Code scanning alerts) and as a 30-day workflow artefact.
-#
-# Cross-repo deploy trigger (Task #51):
-#   - After image push on main, the workflow POSTs a `repository_dispatch`
-#     event of type `meho-image-pushed` to evoila-bosnia/claude-rdc-hetzner-dc
-#     so the dogfooding consumer can roll forward its deploy without polling.
-#     The event shape (image, digest, tag, commit, ref) is the canonical
-#     handshake documented at `docs/cross-repo/rke2-infra-coordination.md`.
-#   - Cross-repo dispatch requires a PAT — the default GITHUB_TOKEN is scoped
-#     to this repo only. The PAT is stored as the `RDC_DISPATCH_TOKEN` secret
-#     (fine-grained, single-repo, `metadata: read` + `actions: write` on
-#     claude-rdc-hetzner-dc). The dispatch step is skipped (not failed) when
-#     the secret is missing, so a rotated/revoked PAT degrades gracefully —
-#     the image is still built, pushed, signed, and attested.
 
 name: image
 
@@ -117,13 +104,6 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: meho-runners-ci
     timeout-minutes: 45  # arm64 emulation under QEMU is 3-5x slower than native
-    env:
-      # Surfaced at the job level so the `Notify claude-rdc-hetzner-dc` step
-      # below can skip when the secret is unset. Secrets can't be referenced
-      # in `if:` directly (GitHub Actions docs, "Using secrets") — the
-      # documented pattern is to expose them via env and test `env.X != ''`.
-      # Missing/rotated PAT degrades to skip-not-fail (Task #51 AC #5).
-      RDC_DISPATCH_TOKEN: ${{ secrets.RDC_DISPATCH_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -353,92 +333,3 @@ jobs:
           path: trivy-results.sarif
           retention-days: 30
           if-no-files-found: error
-
-      - name: Notify claude-rdc-hetzner-dc (repository_dispatch)
-        # Cross-repo deploy trigger (Task #51). On every main-push that lands
-        # a new image, send a `meho-image-pushed` repository_dispatch event
-        # to the dogfooding consumer carrying the immutable digest. The
-        # consumer's `.github/workflows/meho-deploy.yml` (consumer-owned)
-        # listens for the event and rolls the rke2-infra lab forward.
-        #
-        # Gate (three conjuncts):
-        #   1. github.event_name == 'push'  — never PRs (no token, no need).
-        #   2. github.ref == 'refs/heads/main' — main only. Tag pushes
-        #      (v* releases) are out of scope for v0.1: the dogfooding
-        #      consumer tracks main, not tagged releases. The cross-repo
-        #      handshake at docs/cross-repo/rke2-infra-coordination.md
-        #      locks `client_payload.ref` to refs/heads/main.
-        #   3. env.RDC_DISPATCH_TOKEN != ''  — skip when the PAT is missing.
-        #      AC #5 requires graceful degradation: a rotated or revoked
-        #      token must not fail the workflow; downstream operators
-        #      monitor the consumer-side deploy independently. Secrets
-        #      cannot be referenced in `if:` directly, hence the
-        #      job-level env block above.
-        #
-        # Auth: cross-repo dispatches need a PAT (fine-grained, single-repo
-        # on claude-rdc-hetzner-dc, scoped to `metadata: read` +
-        # `contents: write`). `contents: write` is the permission the
-        # create-a-repository-dispatch-event endpoint requires for a
-        # fine-grained token — NOT `actions: write` (that covers
-        # workflow_dispatch / re-running runs, a different endpoint). A
-        # token minted with the wrong scope authenticates fine but the
-        # dispatch POST returns 403 "Resource not accessible by personal
-        # access token" (see the May 2026 incident on this step). The
-        # default GITHUB_TOKEN is scoped to this repo only and the API
-        # returns 404 if used cross-repo.
-        #
-        # Failure mode: fail-loud on PAT-present but dispatch fails. A 401
-        # (revoked/expired token), 403 (token present but under-scoped —
-        # missing `contents: write`), or 422 (bad payload shape) means the
-        # consumer never learns about the new image; silent swallow would
-        # leave the lab on a stale revision indefinitely. No
-        # `continue-on-error`.
-        #
-        # Payload shape is the canonical handshake from
-        # docs/cross-repo/rke2-infra-coordination.md (Section 3, "Event
-        # contract"). Top-level key cardinality (5) sits well under the
-        # GitHub API ceiling (10 keys, 64KB total). All values are strings;
-        # `-f` (raw-field) keeps gh from re-typing integers as JSON
-        # numbers — image digests, tags, and refs are all opaque strings.
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && env.RDC_DISPATCH_TOKEN != ''
-        env:
-          # `curl` reads the PAT via this var; the job-level
-          # RDC_DISPATCH_TOKEN is the PAT minted on
-          # claude-rdc-hetzner-dc.
-          RDC_TOKEN: ${{ env.RDC_DISPATCH_TOKEN }}
-          DIGEST: ${{ steps.build.outputs.digest }}
-          TAGS: ${{ steps.meta.outputs.tags }}
-        # Implementation note: the original step used `gh api`, but the
-        # gha-runner-scale-set image doesn't ship the `gh` CLI (exit 127:
-        # command not found, CI run 25684872120). curl IS preinstalled
-        # (it's used by the kubeconform install in chart.yml too).
-        # python3's json.dumps does the heavy lifting on payload escaping
-        # so multi-line TAGS (newline-separated tag list from
-        # docker/metadata-action) are encoded as valid JSON strings,
-        # preserving the exact semantics gh provided.
-        run: |
-          set -euo pipefail
-          PAYLOAD="$(python3 -c '
-          import json, os
-          print(json.dumps({
-              "event_type": "meho-image-pushed",
-              "client_payload": {
-                  "image": "ghcr.io/evoila/meho",
-                  "digest": os.environ["DIGEST"],
-                  "tag": os.environ["TAGS"],
-                  "commit": os.environ["GITHUB_SHA"],
-                  "ref": os.environ["GITHUB_REF"],
-              },
-          }))
-          ')"
-          # --fail-with-body: non-2xx → non-zero exit AND print response
-          # body so the workflow log shows whatever Fulcio/Rekor/GitHub
-          # said. Mirrors gh's behavior. -sS silences progress but keeps
-          # error output.
-          curl --fail-with-body -sS -X POST \
-            -H "Authorization: Bearer ${RDC_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Content-Type: application/json" \
-            -d "${PAYLOAD}" \
-            https://api.github.com/repos/evoila-bosnia/claude-rdc-hetzner-dc/dispatches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — retire the expired RDC image-push `repository_dispatch` notify
+
+- Remove the `Notify claude-rdc-hetzner-dc (repository_dispatch)` step from
+  `.github/workflows/image.yml` (and its now-dead job-level
+  `RDC_DISPATCH_TOKEN` env). The `RDC_DISPATCH_TOKEN` PAT is no longer being
+  renewed, so the step — gated on the secret being present, not valid — failed
+  loud on every `main`/tag push with a `401` while the image build / sign /
+  attest / scan / push all succeeded. MEHO no longer emits a `meho-image-pushed`
+  event; the consumer rolls forward by tracking new `ghcr.io/evoila/meho` tags /
+  the GitHub Releases feed. The cross-repo handshake docs are marked retired
+  (`docs/cross-repo/rke2-infra-coordination.md` §3, `docs/codebase/backend.md`).
+
 ### Fixed — Sensors & Dashboards v1 review fast-follow (#2505, #2507)
 
 - **Check-runner never-raises hardening (#2505):** a non-`TimeoutError` exception

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -1174,13 +1174,21 @@ a trailing comment: `anchore/sbom-action@…` (v0.24.0),
 `actions/upload-artifact@…` (v7.0.1). Renovate / Dependabot bumps
 these on the same review cadence as `sigstore/cosign-installer`.
 
-### Cross-repo deploy trigger (Task #51)
+### Cross-repo deploy trigger (Task #51) — RETIRED 2026-07-17
 
-After image push, sign, attest, and scan, `image.yml`'s final step
-fires a `repository_dispatch` event of type `meho-image-pushed` at
+> **Retired.** The `Notify claude-rdc-hetzner-dc (repository_dispatch)` step was
+> removed from `image.yml` in the post-v0.23.0 cleanup — the
+> `RDC_DISPATCH_TOKEN` PAT was not being renewed and the step failed loud on
+> every main/tag push (401). The image is still built, signed, attested, and
+> scanned on every main/tag push; the consumer now rolls forward by tracking new
+> GHCR tags / GitHub Releases rather than a pushed event. The rest of this
+> section describes the removed mechanism for historical reference.
+
+Formerly, after image push, sign, attest, and scan, `image.yml`'s final step
+fired a `repository_dispatch` event of type `meho-image-pushed` at
 [`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc)
 — the dogfooding consumer that operates MEHO against the rke2-infra
-lab cluster. The dispatch is the upstream half of the cross-repo
+lab cluster. The dispatch was the upstream half of the cross-repo
 handshake; the consumer-side listener (`.github/workflows/meho-deploy.yml`
 on the consumer) is consumer-owned per Goal #11's cross-repo deps.
 

--- a/docs/cross-repo/rke2-infra-coordination.md
+++ b/docs/cross-repo/rke2-infra-coordination.md
@@ -31,13 +31,12 @@ the consumer:
    can't merge. This is the per-PR ephemeral-cluster discipline MEHO.X
    never had — every G2.0–G2.6 PR closes the real-target feedback loop
    before merge against a real (not mocked) Kubernetes API.
-2. **`repository_dispatch` deploy trigger** (G2.7-T3, [#51](https://github.com/evoila-bosnia/meho-internal/issues/51)).
-   Every merge to `main` on `evoila/meho` builds, signs, and pushes a
-   new backplane image to GHCR, then dispatches a
-   `repository_dispatch` event to `evoila-bosnia/claude-rdc-hetzner-dc`
-   carrying the new image digest. The consumer side decides whether to
-   roll the dogfooding instance forward (currently: yes, on every
-   green merge).
+2. **`repository_dispatch` deploy trigger** (G2.7-T3, [#51](https://github.com/evoila-bosnia/meho-internal/issues/51))
+   — **RETIRED 2026-07-17** (see Section 3). Every merge to `main` on
+   `evoila/meho` still builds, signs, and pushes a new backplane image to GHCR,
+   but the producer no longer dispatches a `meho-image-pushed` event: the
+   `RDC_DISPATCH_TOKEN` PAT was not renewed. The consumer rolls forward by
+   tracking new GHCR tags / GitHub Releases instead.
 
 Both edges cross the rke2-infra cluster boundary, and both need the
 consumer side to provision auth + RBAC for the `evoila/meho` GitHub
@@ -239,17 +238,21 @@ to GitHub Actions, `kubectl auth can-i delete namespace default`
 returns `no` and `kubectl auth can-i delete namespace meho-ci-pr-1`
 returns `yes`. The Verification section below scripts both checks.
 
-### 3. `repository_dispatch` consumer workflow
+### 3. `repository_dispatch` consumer workflow — RETIRED 2026-07-17
 
-`evoila/meho`'s `main` push image workflow (G2.7-T3, #51) sends a
+> **Retired.** The producer-side `Notify claude-rdc-hetzner-dc
+> (repository_dispatch)` step was removed from
+> [`.github/workflows/image.yml`](../../.github/workflows/image.yml) in the
+> post-v0.23.0 cleanup: the `RDC_DISPATCH_TOKEN` PAT was not being renewed and
+> the step failed loud on every main/tag push (401). MEHO no longer pushes a
+> `meho-image-pushed` event. The consumer rolls forward by tracking new tags on
+> `ghcr.io/evoila/meho` / the [GitHub Releases](https://github.com/evoila/meho/releases)
+> feed (the image is still built, pushed, signed, and attested on every main/tag
+> push). The event contract below is kept for historical reference only.
+
+`evoila/meho`'s `main` push image workflow (G2.7-T3, #51) **formerly** sent a
 `repository_dispatch` event to
-`evoila-bosnia/claude-rdc-hetzner-dc` with the shape below. The
-producer-side step lives at the tail of
-[`.github/workflows/image.yml`](../../.github/workflows/image.yml)
-(`Notify claude-rdc-hetzner-dc (repository_dispatch)`); its
-implementation rationale is documented in
-[`docs/codebase/backend.md`](../codebase/backend.md) under
-"Cross-repo deploy trigger (Task #51)".
+`evoila-bosnia/claude-rdc-hetzner-dc` with the shape below.
 
 | Field | Value |
 | --- | --- |
@@ -368,7 +371,7 @@ mirror the acceptance criteria on
 | Coordination ticket filed on `evoila-bosnia/claude-rdc-hetzner-dc` | pending | RDC maintainers | Linked to this doc + Initiative [#48](https://github.com/evoila-bosnia/meho-internal/issues/48) |
 | kube-apiserver OIDC trust configured (Option A) **OR** `RDC_KUBECONFIG` secret stored (Option B) | pending | RDC maintainers | Prefer Option A; document choice on the coordination ticket |
 | Namespace-scoped RBAC enforcing `meho-ci-*` | pending | RDC maintainers | Includes the admission-policy half of the scoping (see Section 2) |
-| Consumer workflow listening for `meho-image-pushed` repository_dispatch | pending | RDC maintainers | Filename suggested `.github/workflows/meho-deploy.yml` |
+| ~~Consumer workflow listening for `meho-image-pushed` repository_dispatch~~ | retired | — | Producer step removed 2026-07-17 (RDC_DISPATCH_TOKEN not renewed); track GHCR tags / Releases instead |
 | `manifests/meho/{values-rdc.yaml,install.sh,smoke.sh,README.md}` landed | pending | RDC maintainers | Also tracked in Goal [#11](https://github.com/evoila-bosnia/meho-internal/issues/11) cross-repo deps |
 | `claude-rdc-hetzner-dc/CLAUDE.md` documents the MEHO event contract | pending | RDC maintainers | Mirror of this doc's Section 3 |
 


### PR DESCRIPTION
## Retire the expired RDC image-push `repository_dispatch` notify

The `RDC_DISPATCH_TOKEN` PAT is not being renewed. The
`Notify claude-rdc-hetzner-dc (repository_dispatch)` step in `image.yml` is gated
on the secret being **present** (`env.RDC_DISPATCH_TOKEN != ''`), not valid — so
with the token expired-but-present it ran and **failed loud with a 401 on every
`main`/tag push**. The image build / sign / attest / scan / push were unaffected
(the notify is the last step), but the run showed red.

This has been the standing non-gating red flagged at the last two releases
(v0.22.0, v0.23.0). Per maintainer decision (token won't be renewed), remove it.

### Changes
- **`.github/workflows/image.yml`** — delete the notify step, its dead job-level
  `RDC_DISPATCH_TOKEN` env block, and the cross-repo header-comment block.
  (No other step referenced the token; YAML re-validated.)
- **`docs/cross-repo/rke2-infra-coordination.md`** — mark §3 (the
  `meho-image-pushed` handshake) and its intro item + status-table row **retired**;
  the live per-PR smoke-coordination sections are untouched.
- **`docs/codebase/backend.md`** — mark the "Cross-repo deploy trigger (Task #51)"
  section retired (kept for historical reference).
- **`CHANGELOG.md`** — `[Unreleased]` note.

### Consumer impact
MEHO no longer emits a `meho-image-pushed` event. The image is still built,
signed, attested, scanned, and pushed to `ghcr.io/evoila/meho` on every main/tag
push — the consumer rolls forward by tracking new GHCR tags / the
[Releases](https://github.com/evoila/meho/releases) feed instead of a pushed
event.

### Follow-up (maintainer, out of band)
The now-unused `RDC_DISPATCH_TOKEN` **repo secret** can be deleted (admin action;
harmless to leave).

> ⚠️ Merging touches `.github/workflows/**` — needs `workflow` OAuth scope on the
> merging token (`gh auth refresh -h github.com -s workflow`); `--admin` alone
> does not bypass it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Image publishing workflows no longer send cross-repository deployment notifications.
  * Builds continue through image publishing, signing, attestation, vulnerability scanning, and report uploads.
  * Deployment consumers should track new container image tags or GitHub Releases instead.

* **Documentation**
  * Updated the changelog and coordination documentation to mark the previous dispatch-based deployment trigger as retired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->