### PR TITLE
fix(targets): decode the list envelope in import's existence check (#2577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — `targets import` reads the `{items, next_cursor}` list envelope (#2577)
+
+- `meho targets import` failed against every v0.21.0+ backplane — `--dry-run`
+  included — with `decode list response: json: cannot unmarshal object into Go
+  value of type []struct { Name string }`. The verb's pre-flight existence check
+  still decoded `GET /api/v1/targets` as the bare array it returned before
+  #2338 converged the route onto the `{items, next_cursor}` envelope, so the
+  import died before building a plan or writing anything. With `meho targets
+  create` retired (#1574), CLI target registration had no fallback.
+- The existence check now decodes the generated `api.TargetListResponse` and
+  pages on `next_cursor` instead of a page-length heuristic. Decoding the
+  generated type means a future list-shape change fails `go build` rather than
+  the operator's import: #2338 swept the sibling verbs by type and could not
+  see this file's private decoder, and #2383's follow-up audit checked
+  server-side tests only. The import's own doubles — the unit `fakeDoer` and
+  four end-to-end `httptest` servers — each minted their own bare-array body,
+  which is why the suite stayed green while the shipped verb was broken; they
+  now serve the same envelope the backplane emits.
+
 ### Changed — retire the expired RDC image-push `repository_dispatch` notify
 
 - Remove the `Notify claude-rdc-hetzner-dc (repository_dispatch)` step from

--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -433,6 +433,12 @@ func mapEntry(entry map[string]any) (map[string]any, []string) {
 // patch — the PR #362 regression that motivated the sparse-body
 // fix) or require per-field option plumbing for every patchable
 // column. The untyped path is the smaller blast radius for v0.2.
+//
+// That rationale covers request *bodies* only. Responses decode into
+// the generated types (see listExistingNames) — nothing about the
+// sparse-body contract requires a private response decoder, and #2577
+// is what one costs: a hand-rolled list decoder that #2338's
+// type-based sweep could not see.
 type httpDoer func(ctx context.Context, method, path string, body []byte) ([]byte, error)
 
 // httpError carries a non-2xx response from the import-path HTTP
@@ -644,6 +650,15 @@ func renderApplyResult(cmd *cobra.Command, p *plan, jsonOut bool) error {
 // listExistingNames fetches `GET /api/v1/targets` with full keyset
 // pagination and returns a set of target names in the operator's
 // tenant. Used by buildLivePlan to decide CREATE vs UPDATE.
+//
+// The page decodes into the generated `api.TargetListResponse` rather
+// than a decoder private to this file, so `make snapshot-openapi &&
+// make generate` propagates the next list-shape change into a build
+// failure here instead of a runtime one. #2338 converged this route
+// off a bare array onto the `{items, next_cursor}` envelope and swept
+// the sibling verbs by type; the private decoder that replaced was
+// invisible to that sweep and broke every import — dry-run included —
+// against a v0.21.0+ backplane (#2577).
 func listExistingNames(ctx context.Context, doer httpDoer) (map[string]struct{}, error) {
 	existing := map[string]struct{}{}
 	cursor := ""
@@ -656,26 +671,22 @@ func listExistingNames(ctx context.Context, doer httpDoer) (map[string]struct{},
 		if err != nil {
 			return nil, fmt.Errorf("list existing targets: %w", err)
 		}
-		var page []struct {
-			Name string `json:"name"`
-		}
+		var page api.TargetListResponse
 		if err := json.Unmarshal(raw, &page); err != nil {
 			return nil, fmt.Errorf("decode list response: %w", err)
 		}
-		if len(page) == 0 {
-			break
-		}
-		for _, t := range page {
+		for _, t := range page.Items {
 			existing[t.Name] = struct{}{}
 		}
-		// Keyset cursor is the last returned name. When the page is
-		// shorter than the limit we've consumed every row.
-		if len(page) < 500 {
-			break
+		// `next_cursor` is authoritative: the route over-fetches
+		// `limit + 1` so an extra row proves another page exists, which
+		// a page-length check cannot decide on an exact-multiple final
+		// page. Non-null implies a non-empty page, so this terminates.
+		if page.NextCursor == nil {
+			return existing, nil
 		}
-		cursor = page[len(page)-1].Name
+		cursor = *page.NextCursor
 	}
-	return existing, nil
 }
 
 // executePlan applies the plan: POST for each Create, PATCH for

--- a/cli/internal/cmd/targets/import_test.go
+++ b/cli/internal/cmd/targets/import_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -388,6 +389,81 @@ func TestDryRunPlanExistingRendersUpdateNewRendersCreate(t *testing.T) {
 	}
 }
 
+// TestListExistingNamesReadsTheListEnvelope pins #2577: the existence
+// check decodes the `{items, next_cursor}` envelope `GET
+// /api/v1/targets` has returned since #2338 converged it off the
+// v0.8.0 bare array. The bare-array subtest is the regression guard
+// proper — it is the body the pre-#2577 decoder wanted and the shipped
+// backplane no longer emits, so it must now be a hard decode error
+// rather than a silently-empty existence set (which would plan CREATE
+// for every existing target and fail apply on a 409).
+func TestListExistingNamesReadsTheListEnvelope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("envelope body yields the names", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeDoer{existing: []string{"rdc-vault", "rdc-vcenter"}}
+		got, err := listExistingNames(context.Background(), f.do)
+		if err != nil {
+			t.Fatalf("listExistingNames: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("names: %v; want rdc-vault + rdc-vcenter", got)
+		}
+		for _, want := range []string{"rdc-vault", "rdc-vcenter"} {
+			if _, ok := got[want]; !ok {
+				t.Errorf("missing %q from %v", want, got)
+			}
+		}
+	})
+
+	t.Run("bare-array body is a decode error", func(t *testing.T) {
+		t.Parallel()
+		bareArray := func(_ context.Context, _, _ string, _ []byte) ([]byte, error) {
+			return []byte(`[{"name": "rdc-vault"}]`), nil
+		}
+		got, err := listExistingNames(context.Background(), bareArray)
+		if err == nil {
+			t.Fatalf("bare-array body decoded cleanly into %v; want a decode error", got)
+		}
+		if !strings.Contains(err.Error(), "decode list response") {
+			t.Errorf("error = %v; want it to name the decode step", err)
+		}
+	})
+}
+
+// TestListExistingNamesPaginatesOnNextCursor pins that the walk is
+// driven by `next_cursor` rather than a page-length heuristic: three
+// names at one row per page must collect all three across three pages
+// and stop on the null cursor. The old `len(page) < limit` check
+// mis-decides the exact-multiple final page, which is why the route
+// over-fetches `limit + 1` and hands back an authoritative cursor.
+func TestListExistingNamesPaginatesOnNextCursor(t *testing.T) {
+	t.Parallel()
+	f := &fakeDoer{
+		existing: []string{"rdc-vault", "rdc-vcenter", "rdc-argocd"},
+		pageSize: 1,
+	}
+	got, err := listExistingNames(context.Background(), f.do)
+	if err != nil {
+		t.Fatalf("listExistingNames: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("names: %v; want all three across pages", got)
+	}
+	for _, want := range []string{"rdc-vault", "rdc-vcenter", "rdc-argocd"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("missing %q from %v", want, got)
+		}
+	}
+	// Three single-row pages: the third reports next_cursor null and
+	// ends the walk, so a fourth request would mean length-based
+	// termination crept back in.
+	if f.listPages != 3 {
+		t.Errorf("listPages = %d; want 3 (one per row, terminating on the null cursor)", f.listPages)
+	}
+}
+
 // --- buildLivePlan + listExistingNames ---------------------------------
 
 // fakeDoer records calls and serves canned responses. It substitutes
@@ -396,6 +472,7 @@ func TestDryRunPlanExistingRendersUpdateNewRendersCreate(t *testing.T) {
 // covered by cli/internal/auth's own tests.
 type fakeDoer struct {
 	existing  []string // names returned by listExistingNames
+	pageSize  int      // rows per list page; 0 serves every name at once
 	listPages int      // bumped each time the GET handler fires
 	creates   []recorded
 	updates   []recorded
@@ -410,17 +487,8 @@ type recorded struct {
 func (f *fakeDoer) do(_ context.Context, method, path string, body []byte) ([]byte, error) {
 	switch method {
 	case http.MethodGet:
-		// Pagination: any cursor query → empty second page.
-		if strings.Contains(path, "cursor=") {
-			return []byte(`[]`), nil
-		}
 		f.listPages++
-		out := []map[string]any{}
-		for _, n := range f.existing {
-			out = append(out, map[string]any{"name": n})
-		}
-		raw, _ := json.Marshal(out)
-		return raw, nil
+		return f.listPage(path)
 	case http.MethodPost:
 		f.creates = append(f.creates, recorded{Method: method, Path: path, Body: append([]byte(nil), body...)})
 		return []byte(`{}`), nil
@@ -429,6 +497,50 @@ func (f *fakeDoer) do(_ context.Context, method, path string, body []byte) ([]by
 		return []byte(`{}`), nil
 	}
 	return nil, &httpError{StatusCode: http.StatusMethodNotAllowed, Body: "fakeDoer: method " + method}
+}
+
+// listPage serves one keyset page of the `{items, next_cursor}`
+// envelope `GET /api/v1/targets` returns, mirroring the route's
+// contract rather than a shape convenient to the fake: rows are
+// ordered by name, `cursor` is exclusive (`name > cursor`), and
+// `next_cursor` is the page's last name when further rows remain and
+// null when they don't — the route proves "further rows" by
+// over-fetching `limit + 1`, never by page length. See
+// backend/src/meho_backplane/api/v1/targets.py:950-970.
+//
+// The fake serving the real envelope is the point: the bare-array
+// body this replaced is what let #2338 ship a broken import verb past
+// a green suite (#2577).
+func (f *fakeDoer) listPage(rawPath string) ([]byte, error) {
+	names := append([]string(nil), f.existing...)
+	sort.Strings(names)
+
+	u, err := url.Parse(rawPath)
+	if err != nil {
+		return nil, err
+	}
+	if cursor := u.Query().Get("cursor"); cursor != "" {
+		i := sort.SearchStrings(names, cursor)
+		if i < len(names) && names[i] == cursor {
+			i++
+		}
+		names = names[i:]
+	}
+
+	page := names
+	if f.pageSize > 0 && f.pageSize < len(names) {
+		page = names[:f.pageSize]
+	}
+
+	items := make([]map[string]any, 0, len(page))
+	for _, n := range page {
+		items = append(items, map[string]any{"name": n})
+	}
+	envelope := map[string]any{"items": items, "next_cursor": nil}
+	if len(names) > len(page) {
+		envelope["next_cursor"] = page[len(page)-1]
+	}
+	return json.Marshal(envelope)
 }
 
 func TestBuildLivePlanPartitionsCreateAndUpdate(t *testing.T) {
@@ -525,7 +637,7 @@ targets:
 			t.Errorf("dry-run issued a %s; want only GET", r.Method)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
+		_, _ = w.Write([]byte(`{"items":[],"next_cursor":null}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -570,7 +682,7 @@ targets:
 		}
 		w.Header().Set("Content-Type", "application/json")
 		// Existing tenant target with the same name → must plan UPDATE.
-		_, _ = w.Write([]byte(`[{"name":"rdc-vault"}]`))
+		_, _ = w.Write([]byte(`{"items":[{"name":"rdc-vault"}],"next_cursor":null}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -614,7 +726,7 @@ targets:
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
+		_, _ = w.Write([]byte(`{"items":[],"next_cursor":null}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -664,7 +776,7 @@ targets:
 		case http.MethodGet:
 			gets.Add(1)
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`[]`))
+			_, _ = w.Write([]byte(`{"items":[],"next_cursor":null}`))
 		default:
 			// Any POST/PATCH on the collection is a write — dry-run
 			// must never reach here.

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -2012,9 +2012,10 @@ targets registry (Initiative #224). The v0.2 surface ships:
 
 `import.go` implements `meho targets import <file>` with the
 flags called out in the issue body: `--update` (PATCH existing
-targets instead of erroring), `--dry-run` (print the plan; no API
-calls), `--json` (structured plan output), `--backplane` (override
-the configured backplane URL).
+targets instead of erroring), `--dry-run` (print the plan; one
+listing `GET`, zero writes — #1785 made the preview existence-aware,
+so it is read-only rather than offline), `--json` (structured plan
+output), `--backplane` (override the configured backplane URL).
 
 **Mapping rules.** The CLI parses the YAML as a generic
 `map[string]any` per entry and partitions every key:
@@ -2048,6 +2049,22 @@ in tenant). Default mode aborts the whole import on the first
 duplicate — operators have to re-run with `--update` to opt into
 PATCH semantics. The plan is built before *any* write fires, so a
 partial-conflict YAML never leaves the tenant half-imported.
+
+`listExistingNames` decodes that listing into the generated
+`api.TargetListResponse` (`{items, next_cursor}` per
+`docs/codebase/api-shape-conventions.md` §2) and walks pages until
+`next_cursor` is null. Both are load-bearing. The response type is
+generated, so a future list-shape change fails `go build` here
+instead of the operator's import; a decoder private to `import.go` is
+exactly what #2338 could not see when it converged this route off the
+bare array and swept the sibling verbs by type, and the import fake
+minting its own bare-array body is why the suite stayed green while
+`meho targets import` was hard-broken on every v0.21.0+ backplane
+(#2577). Termination follows `next_cursor` rather than page length
+because the route proves a further page by over-fetching `limit + 1`;
+page length cannot decide an exact-multiple final page. The write
+half of the verb deliberately stays untyped — see the sparse-PATCH
+contract below.
 
 **Sparse-PATCH contract.** The PATCH body for each updated entry
 is sparse: only keys present in the YAML appear, with `name` and


### PR DESCRIPTION
## Summary

- `meho targets import` was hard-broken against every v0.21.0+ backplane — `--dry-run` included — with `decode list response: json: cannot unmarshal object into Go value of type []struct { Name string }`. Its pre-flight existence check still decoded `GET /api/v1/targets` as the bare array the route returned before #2338 converged it onto the `{items, next_cursor}` envelope, so the import died before building a plan or writing anything. With `meho targets create` retired (#1574), CLI target registration had no fallback.
- `listExistingNames` now decodes the **generated** `api.TargetListResponse` and pages on `next_cursor`. Decoding the generated type is the design decision, not an incidental one: `make snapshot-openapi && make generate` regenerates it, so the next list-shape change fails `go build` here instead of an operator's import. Termination follows `next_cursor` because the route proves a further page by over-fetching `limit + 1` (`targets.py:958-969`); page length cannot decide an exact-multiple final page.
- **Why this shipped through two releases.** #1289 migrated `list`/`describe`/`probe`/`discover` onto the typed client but left `import` on hand-rolled HTTP. #2338 then swept every *typed* list consumer and structurally could not see this file's private decoder. #2383 fixed the one backend test #2338 missed and recorded the sweep as "scope-verified as the sole miss across all 7 converged endpoints" — that audit covered server-side tests only, so the Go client survived a second pass.
- **Why CI stayed green.** The verb's own doubles each minted their own bare-array body: the unit `fakeDoer` **and four end-to-end `httptest` servers**. No test could observe the shape the backplane actually emits. They now serve the real envelope — which makes the *pre-existing* dry-run test catch this class too.
- The untyped write path is deliberately unchanged: its sparse-PATCH rationale (#362) covers request *bodies*, not response decoding. The `httpDoer` comment now records that split.

## Test plan

- [x] `gofmt -l internal/` — clean
- [x] `go build ./...` — OK
- [x] `go vet ./...` — OK
- [x] `go test ./...` — 45/45 packages ok, exit 0
- [x] **AC1** decodes `api.TargetListResponse` — `grep '\[\]struct' cli/internal/cmd/targets/import.go` → none
- [x] **AC2** terminates on `NextCursor == nil` — `grep 'len(page) < 500'` → none
- [x] **AC3** doubles serve the envelope — no bare-array list body remains in the package
- [x] **AC4** regression test would have caught #2338 — **proven by experiment**: with `origin/main`'s `import.go` restored and the new tests kept, they fail with the reporter's verbatim error, `decode list response: json: cannot unmarshal object into Go value of type []struct { Name string "json:\"name\"" }`
- [x] **AC5** multi-page walk driven by `next_cursor` — `TestListExistingNamesPaginatesOnNextCursor` asserts 3 single-row pages and `listPages == 3`, so length-based termination cannot creep back
- [ ] **AC6** live v0.22.0+ backplane `--dry-run` — **not verified; no live backplane available to the implementing session.** The four end-to-end `runImport` tests now drive the real cobra path against an `httptest` server emitting the true envelope and produce a plan, and the shipped code fails those same tests with the operator's exact error — strong, but not a live deploy. **Please run `meho targets import <file> --dry-run` against the RDC backplane before closing.**
- [x] **AC8** CHANGELOG `[Unreleased]` entry under a distinct `### Fixed —` header

## Out of scope

- Migrating `authedDoer` / `executePlan` onto the generated typed client — the documented #362 sparse-body contract is a deliberate reason for the untyped write path.
- Re-adding a `meho targets create` verb (retired by #1574 / #1559).
- `conventions history` — checked and consistent, not a sibling defect: that route genuinely returns a bare list (`response_model=list[ConventionHistoryEntry]`, `api/v1/conventions.py:440`).

## Adjacent findings (not edited)

- `docs/codebase/cli.md:1067` still calls the write verbs `create`/`update`/`delete` "deferred"; `create` was in fact deliberately *retired* by #1574. Different section from the one this PR touches.

Closes #2577
