### PR TITLE
feat(topology): MCP bulk_import (free dry-run, gated apply) + superseded on annotate return

### DIFF
--- a/backend/src/meho_backplane/connectors/topology/ops.py
+++ b/backend/src/meho_backplane/connectors/topology/ops.py
@@ -63,6 +63,8 @@ from typing import TYPE_CHECKING, Any
 from meho_backplane.connectors.topology.schemas import (
     ANNOTATE_PARAMETER_SCHEMA,
     ANNOTATE_RESPONSE_SCHEMA,
+    BULK_IMPORT_PARAMETER_SCHEMA,
+    BULK_IMPORT_RESPONSE_SCHEMA,
     CREATE_NODE_PARAMETER_SCHEMA,
     CREATE_NODE_RESPONSE_SCHEMA,
     UNANNOTATE_PARAMETER_SCHEMA,
@@ -71,7 +73,12 @@ from meho_backplane.connectors.topology.schemas import (
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import GraphNode
 from meho_backplane.operations.typed_register import register_typed_operation
-from meho_backplane.topology.annotate import NodeRef, annotate_edge, unannotate_edge
+from meho_backplane.topology.annotate import NodeRef, annotate_edge_with_plan, unannotate_edge
+from meho_backplane.topology.bulk_import import (
+    build_bulk_import_rows,
+    bulk_import_edges,
+    serialize_bulk_result,
+)
 from meho_backplane.topology.nodes import create_or_get_node
 
 if TYPE_CHECKING:
@@ -80,11 +87,13 @@ if TYPE_CHECKING:
 
 __all__ = [
     "TOPOLOGY_ANNOTATE_OP_ID",
+    "TOPOLOGY_BULK_IMPORT_OP_ID",
     "TOPOLOGY_CREATE_NODE_OP_ID",
     "TOPOLOGY_GRAPH_CONNECTOR_ID",
     "TOPOLOGY_UNANNOTATE_OP_ID",
     "register_topology_graph_operations",
     "topology_annotate",
+    "topology_bulk_import",
     "topology_create_node",
     "topology_unannotate",
 ]
@@ -99,6 +108,7 @@ TOPOLOGY_GRAPH_CONNECTOR_ID = "topology-graph-1.x"
 TOPOLOGY_ANNOTATE_OP_ID = "topology.annotate"
 TOPOLOGY_CREATE_NODE_OP_ID = "topology.create_node"
 TOPOLOGY_UNANNOTATE_OP_ID = "topology.unannotate"
+TOPOLOGY_BULK_IMPORT_OP_ID = "topology.bulk_import"
 
 _GROUP_KEY = "graph"
 _GROUP_WHEN_TO_USE = (
@@ -136,7 +146,7 @@ async def topology_annotate(
     """
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
-        edge = await annotate_edge(
+        plan = await annotate_edge_with_plan(
             session,
             operator,
             NodeRef(str(params["from_name"]), params.get("from_node_kind")),
@@ -145,6 +155,7 @@ async def topology_annotate(
             note=params.get("note"),
             evidence_url=params.get("evidence_url"),
         )
+        edge = plan.edge
         # Re-load the endpoint nodes for the response shape. The service
         # returns the edge only; mapping back to the human-readable
         # `(kind, name)` pair is this shim's job.
@@ -162,6 +173,12 @@ async def topology_annotate(
     props = edge.properties or {}
     raw_conflicts = props.get("conflicts_with")
     conflicts = list(raw_conflicts) if isinstance(raw_conflicts, list) else []
+    # `superseded` (#2539): the auto edges this assertion displaced.
+    # Already computed inside the write and stamped on the shared audit /
+    # broadcast payload (`annotate._audit_payload`) — surfacing it on the
+    # return is a shape change, not a new query. It equals the audit
+    # payload's list by construction.
+    superseded = [str(s) for s in plan.audit_payload.get("superseded", [])]
     return {
         "edge_id": str(edge.id),
         "from": {
@@ -177,6 +194,7 @@ async def topology_annotate(
         "kind": edge.kind,
         "source": edge.source,
         "conflicts": conflicts,
+        "superseded": superseded,
     }
 
 
@@ -252,6 +270,33 @@ async def topology_unannotate(
             to_ref=to_ref,
         )
     return {"edge_id": str(removed_id)}
+
+
+async def topology_bulk_import(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Apply a batch of curated ``graph_edge`` assertions atomically.
+
+    Op-id: ``topology.bulk_import``. Targetless typed op — the **apply**
+    half of ``meho.topology.bulk_import`` (#2539). Only the gated apply
+    path dispatches here; the free dry-run plan calls the service
+    directly from the MCP front and never reaches the dispatcher. The
+    dispatcher has already validated *params* against
+    :data:`~meho_backplane.connectors.topology.schemas.BULK_IMPORT_PARAMETER_SCHEMA`
+    (``rows`` only — no ``dry_run``), so this handler always applies.
+
+    The whole batch lives in one transaction: a validation failure on
+    any row rolls the whole thing back
+    (:class:`~meho_backplane.topology.bulk_import.BulkImportValidationError`
+    propagates to the dispatcher's ``connector_error`` envelope, which
+    the MCP shim maps to -32602). Per-row audit + broadcast fire one per
+    applied row inside the service, mirroring the single-edge annotate.
+    """
+    rows = build_bulk_import_rows(params["rows"])
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await bulk_import_edges(session, operator, rows, dry_run=False)
+    return serialize_bulk_result(result)
 
 
 # ---------------------------------------------------------------------------
@@ -355,6 +400,44 @@ _OPERATION_SPECS: tuple[dict[str, Any], ...] = (
                 "from_name": "Triple selector, with kind + to_name.",
             },
             "output_shape": "{'edge_id': '<removed-uuid>'}",
+        },
+    },
+    {
+        "op_id": TOPOLOGY_BULK_IMPORT_OP_ID,
+        "handler": topology_bulk_import,
+        "summary": "Apply a batch of curated graph_edge assertions atomically.",
+        "description": (
+            "Applies up to 1000 curated `graph_edge` assertions in one "
+            "all-or-nothing transaction — a single invalid row rolls the "
+            "whole batch back. This is the apply half of the "
+            "`meho.topology.bulk_import` tool; the free dry-run plan is a "
+            "read-shaped service call that never dispatches here. Each "
+            "row is one `topology.annotate` (both endpoints must already "
+            "exist). Tenant-scoped automatically. Agent-principal calls "
+            "park the whole batch as one approval request; human "
+            "tenant_admin calls execute immediately."
+        ),
+        "parameter_schema": BULK_IMPORT_PARAMETER_SCHEMA,
+        "response_schema": BULK_IMPORT_RESPONSE_SCHEMA,
+        "tags": ["topology", "write", "curated-edge", "bulk"],
+        "llm_instructions": {
+            "when_to_use": (
+                "Seed a whole cross-system inventory in one atomic pass "
+                "instead of looping single annotate calls. Dry-run first "
+                "to see the per-row plan, then apply."
+            ),
+            "parameter_hints": {
+                "rows": (
+                    "Required. Array of {from_name, kind, to_name, "
+                    "from_node_kind?, to_node_kind?, note?, evidence_url?} "
+                    "objects; 1-1000 rows."
+                ),
+            },
+            "output_shape": (
+                "{'dry_run', 'created', 'updated', 'conflicts', 'rows': "
+                "[{index, action, edge_id, from_name, from_kind, to_name, "
+                "to_kind, kind, superseded, conflicts}]}"
+            ),
         },
     },
 )

--- a/backend/src/meho_backplane/connectors/topology/schemas.py
+++ b/backend/src/meho_backplane/connectors/topology/schemas.py
@@ -27,6 +27,10 @@ from meho_backplane.db.models import (
 __all__ = [
     "ANNOTATE_PARAMETER_SCHEMA",
     "ANNOTATE_RESPONSE_SCHEMA",
+    "BULK_IMPORT_MAX_EDGES",
+    "BULK_IMPORT_PARAMETER_SCHEMA",
+    "BULK_IMPORT_RESPONSE_SCHEMA",
+    "BULK_IMPORT_TOOL_INPUT_SCHEMA",
     "CREATE_NODE_PARAMETER_SCHEMA",
     "CREATE_NODE_RESPONSE_SCHEMA",
     "UNANNOTATE_PARAMETER_SCHEMA",
@@ -175,8 +179,20 @@ ANNOTATE_RESPONSE_SCHEMA: dict[str, Any] = {
             "type": "array",
             "items": {"type": "string"},
         },
+        "superseded": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": (
+                "Ids of the `source='auto'` edges this assertion displaced "
+                "(§6 class 1 — same kind, different endpoint). The auto row "
+                "is stamped `properties.superseded_by=<this edge id>` and "
+                "drops out of traversal until this curated edge is removed. "
+                "Empty on a pair no probe covers. Matches the audit / "
+                "broadcast payload's `superseded` list exactly."
+            ),
+        },
     },
-    "required": ["edge_id", "from", "to", "kind", "source", "conflicts"],
+    "required": ["edge_id", "from", "to", "kind", "source", "conflicts", "superseded"],
 }
 
 UNANNOTATE_PARAMETER_SCHEMA: dict[str, Any] = {
@@ -354,4 +370,127 @@ CREATE_NODE_RESPONSE_SCHEMA: dict[str, Any] = {
         "was_created": {"type": "boolean"},
     },
     "required": ["node_id", "kind", "name", "source", "was_created"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Bulk import (#2539) — batch curated-edge authoring for the agent surface.
+# ---------------------------------------------------------------------------
+
+#: Boundary ceiling on the number of edge rows one ``meho.topology.
+#: bulk_import`` call accepts. Mirrors the REST boundary cap
+#: (``api/v1/topology._BULK_IMPORT_MAX_EDGES`` = 1000) so the two fronts
+#: reject an oversized batch identically. The service layer
+#: (:func:`~meho_backplane.topology.bulk_import.bulk_import_edges`) is
+#: unbounded by design — the size guard belongs at each front boundary.
+BULK_IMPORT_MAX_EDGES = 1000
+
+#: Per-row shape is exactly one single-edge annotate's params
+#: (``from_name`` / ``kind`` / ``to_name`` + the optional kind pins,
+#: note, evidence_url). Reusing :data:`ANNOTATE_PARAMETER_SCHEMA`
+#: verbatim keeps the row grammar and the single-edge grammar from
+#: drifting — a bulk row is definitionally one annotate.
+_BULK_IMPORT_ROWS_PROPERTY: dict[str, Any] = {
+    "type": "array",
+    "minItems": 1,
+    "maxItems": BULK_IMPORT_MAX_EDGES,
+    "items": ANNOTATE_PARAMETER_SCHEMA,
+    "description": (
+        "The edges to import, in source order. Each row is one "
+        "`meho.topology.annotate` call's params: `from_name`, `kind`, "
+        "`to_name` are required; `from_node_kind` / `to_node_kind` pin "
+        "an ambiguous endpoint; `note` / `evidence_url` are optional "
+        f"free text. Between 1 and {BULK_IMPORT_MAX_EDGES} rows — an "
+        "oversized batch is rejected at the tool boundary before any "
+        "service call runs. Both endpoints of every row must already "
+        "exist as `graph_node` rows; seed them with "
+        "`meho.topology.create_node` first."
+    ),
+}
+
+#: Typed-op parameter schema (apply path only): the ``rows`` array with
+#: no ``dry_run`` — the dispatched op is always the apply, so the
+#: ``ApprovalRequest`` an agent parks carries exactly the batch to apply
+#: and nothing else. The MCP front routes the free dry-run away from
+#: dispatch, so ``dry_run`` never reaches this schema.
+BULK_IMPORT_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {"rows": _BULK_IMPORT_ROWS_PROPERTY},
+    "required": ["rows"],
+    "additionalProperties": False,
+}
+
+#: MCP tool inputSchema: the ``rows`` array plus the ``dry_run`` toggle.
+#: ``dry_run`` defaults to ``true`` — the safe, read-shaped plan is the
+#: default; an agent opts into the gated apply explicitly with
+#: ``dry_run=false``.
+BULK_IMPORT_TOOL_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": _BULK_IMPORT_ROWS_PROPERTY,
+        "dry_run": {
+            "type": "boolean",
+            "default": True,
+            "description": (
+                "When true (the default), returns the per-row "
+                "create/update/conflict plan without writing anything "
+                "and without parking — the free, read-shaped propose "
+                "step. When false, applies the whole batch atomically "
+                "(all-or-nothing): a human tenant_admin executes "
+                "immediately, an agent principal parks the batch as one "
+                "`ApprovalRequest` for a human to approve."
+            ),
+        },
+    },
+    "required": ["rows"],
+    "additionalProperties": False,
+}
+
+#: Response shape for both the dry-run plan and the applied result —
+#: mirrors :class:`~meho_backplane.topology.bulk_import.BulkImportResult`
+#: and the REST ``POST /edges/bulk`` body. ``edge_id`` is null on
+#: dry-run rows (no row exists yet) and on the rare post-commit reload
+#: miss; ``superseded`` / ``conflicts`` echo the §6 marker arrays.
+BULK_IMPORT_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "dry_run": {"type": "boolean"},
+        "created": {"type": "integer"},
+        "updated": {"type": "integer"},
+        "conflicts": {"type": "integer"},
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "index": {"type": "integer"},
+                    "action": {
+                        "type": "string",
+                        "enum": ["create", "update", "conflict"],
+                    },
+                    "edge_id": {"type": ["string", "null"]},
+                    "from_name": {"type": "string"},
+                    "from_kind": {"type": "string"},
+                    "to_name": {"type": "string"},
+                    "to_kind": {"type": "string"},
+                    "kind": {"type": "string"},
+                    "superseded": {"type": "array", "items": {"type": "string"}},
+                    "conflicts": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": [
+                    "index",
+                    "action",
+                    "edge_id",
+                    "from_name",
+                    "from_kind",
+                    "to_name",
+                    "to_kind",
+                    "kind",
+                    "superseded",
+                    "conflicts",
+                ],
+            },
+        },
+    },
+    "required": ["dry_run", "created", "updated", "conflicts", "rows"],
 }

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -1463,6 +1463,7 @@ _TOPOLOGY_WRITE_INVALID_PARAM_EXCEPTIONS: Final[frozenset[str]] = frozenset(
     {
         "AmbiguousNodeError",
         "AutoEdgeDeletionError",
+        "BulkImportValidationError",
         "InvalidEdgeKindError",
         "InvalidNodeKindError",
         "NodeNotFoundError",
@@ -1594,14 +1595,15 @@ _ANNOTATE_DESCRIPTION: Final[str] = (
     "curated-only kind: `authenticates-via`, `depends-on`, "
     "`replicates-to`, `backed-up-by`, `routes-via`, `policy-binds`.\n\n"
     "Returns `{edge_id, from: {id, kind, name}, to: {id, kind, name}, "
-    'kind, source: "curated", conflicts: [<edge-id>...]}`. `conflicts` '
-    "lists edges of an incompatible kind over the same endpoint pair — "
-    "a diagnostic; the recovery flow is to `meho.topology.unannotate` "
-    "this edge. (Auto edges displaced by this annotation are stamped "
-    "`properties.superseded_by` on the database row and recorded in the "
-    "audit/broadcast payload, but are not surfaced on the tool's return "
-    "shape — inspect them with `query_topology {kind: edges}` if needed.)"
-    "\n\n"
+    'kind, source: "curated", conflicts: [<edge-id>...], superseded: '
+    "[<edge-id>...]}`. `conflicts` lists edges of an incompatible kind "
+    "over the same endpoint pair — a diagnostic; the recovery flow is to "
+    "`meho.topology.unannotate` this edge. `superseded` lists the "
+    "`source='auto'` edges this annotation displaced (same kind, "
+    "different endpoint): each is stamped `properties.superseded_by` on "
+    "its database row and drops out of traversal until this curated edge "
+    "is removed. Both lists match the audit/broadcast payload exactly "
+    "and are empty on a pair no probe covers.\n\n"
     "AGENT PRINCIPALS: the write does not execute immediately — it "
     "parks as a durable approval request and the tool returns "
     "`{status: awaiting_approval, approval_request_id, ...}`. A human "

--- a/backend/src/meho_backplane/mcp/tools/topology_bulk_import.py
+++ b/backend/src/meho_backplane/mcp/tools/topology_bulk_import.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho.topology.bulk_import`` — batch curated-edge authoring for agents.
+
+Task #2539 (Initiative #2533). Gives the agent surface the
+propose→plan→apply loop humans already have on the REST / CLI / console
+bulk-import fronts. Before this tool an agent seeding a cross-system
+inventory looped single ``meho.topology.annotate`` calls with no
+pre-apply plan and no way to approve the batch in one shot.
+
+Two behaviours on one tool, split on ``dry_run``:
+
+* ``dry_run=true`` (the default) — the free, read-shaped **plan** step.
+  The front calls
+  :func:`~meho_backplane.topology.bulk_import.bulk_import_edges` with
+  ``dry_run=True`` directly (no dispatch, no policy gate): it resolves
+  every endpoint, classifies each row create / update / conflict, writes
+  nothing, and returns the per-row plan. Never parks. A validation
+  failure surfaces every row's diagnostic together on the -32602
+  ``error.data`` member — the same "fix the whole file in one pass"
+  shape the REST front's ``422 invalid_bulk`` gives.
+* ``dry_run=false`` — the gated **apply**. The front dispatches the
+  ``topology.bulk_import`` typed op (registered by
+  :mod:`meho_backplane.connectors.topology.ops`) through
+  :func:`~meho_backplane.mcp.tools.topology.dispatch_topology_write`, so
+  the exact same #2537 substrate that gates the single writes gates the
+  batch: an AGENT principal parks the whole batch as **one**
+  :class:`~meho_backplane.db.models.ApprovalRequest` carrying the batch
+  params, and a human ``tenant_admin`` executes immediately. On approve,
+  the stored batch applies atomically (all-or-nothing transaction).
+
+Why the two paths are not both dispatched: the dry-run is read-shaped
+and must never park, but the typed op carries the agents-park safety
+dial — routing dry-run through it would park an agent's harmless plan
+request. So dry-run bypasses the dispatcher and the apply-only typed op
+carries no ``dry_run`` param (the parked request is exactly the batch to
+apply).
+
+Why no JSONFlux result handle: the topology MCP surface bounds
+set-shaped responses with a hard row cap, not a handle —
+``query_topology`` returns up to 1000 edges inline. The dry-run plan is
+capped at :data:`~meho_backplane.connectors.topology.schemas.BULK_IMPORT_MAX_EDGES`
+rows at the tool boundary (``inputSchema`` ``maxItems``), so it follows
+the same convention its sibling read tool established.
+
+Why a separate module: mirrors ``topology_create_node.py`` — the
+registry auto-discovers every module under ``meho_backplane.mcp.tools``,
+so a fifth topology tool registers without growing
+``mcp/tools/topology.py`` further past the 600-line file guidance.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.topology.ops import TOPOLOGY_BULK_IMPORT_OP_ID
+from meho_backplane.connectors.topology.schemas import (
+    BULK_IMPORT_MAX_EDGES,
+    BULK_IMPORT_RESPONSE_SCHEMA,
+    BULK_IMPORT_TOOL_INPUT_SCHEMA,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.mcp.tools.topology import dispatch_topology_write, with_parked_shape
+from meho_backplane.topology.bulk_import import (
+    BulkImportValidationError,
+    build_bulk_import_rows,
+    bulk_import_edges,
+    serialize_bulk_result,
+    serialize_bulk_validation_error,
+)
+
+__all__: list[str] = []
+
+
+_BULK_IMPORT_TOOL_NAME: Final[str] = "meho.topology.bulk_import"
+
+
+_BULK_IMPORT_DESCRIPTION: Final[str] = (
+    "Batch-assert curated `graph_edge` rows in one atomic pass "
+    "(tenant_admin only). The agent-surface equivalent of the REST / "
+    "CLI / console bulk import: seed a whole cross-system inventory "
+    "declaratively instead of looping single `meho.topology.annotate` "
+    "calls. Each row is one annotate's params — `{from_name, kind, "
+    "to_name, from_node_kind?, to_node_kind?, note?, evidence_url?}` — "
+    f"and a batch is 1 to {BULK_IMPORT_MAX_EDGES} rows. Tenant-scoped "
+    "automatically.\n\n"
+    "REQUIRES: both endpoints of every row must already exist as "
+    "`graph_node` rows in the tenant. A row naming a missing endpoint "
+    "fails validation; seed endpoints first with "
+    "`meho.topology.create_node`.\n\n"
+    "PROPOSE THEN APPLY:\n"
+    "  1. `dry_run: true` (the DEFAULT) returns the per-row plan "
+    "(`action` is `create` / `update` / `conflict`) and writes "
+    "nothing. It never parks — use it freely to preview the batch and "
+    "catch validation errors. A failing batch returns -32602 with every "
+    "row's diagnostic on `error.data.errors` so you fix the whole set "
+    "in one pass.\n"
+    "  2. `dry_run: false` applies the whole batch in one all-or-"
+    "nothing transaction (a single invalid row rolls everything back). "
+    "AGENT PRINCIPALS: the apply does not execute immediately — the "
+    "whole batch parks as ONE durable approval request and the tool "
+    "returns `{status: awaiting_approval, approval_request_id, ...}`; a "
+    "human operator approves it and all rows land atomically with the "
+    "exact proposed params. Human tenant_admin calls apply "
+    "immediately.\n\n"
+    "Returns `{dry_run, created, updated, conflicts, rows: [{index, "
+    "action, edge_id, from_name, from_kind, to_name, to_kind, kind, "
+    "superseded, conflicts}]}`. `edge_id` is null on dry-run rows (no "
+    "row exists yet). `superseded` lists auto edges the row would "
+    "displace; `conflicts` lists incompatible-kind edges over the same "
+    "endpoint pair (§6 diagnostics). Node bulk import is out of scope — "
+    "this seeds edges only, matching the underlying service."
+)
+
+
+async def _bulk_import_dry_run(
+    operator: Operator, rows_params: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Run the free, read-shaped plan pass and return it (never parks).
+
+    Calls the service validation pass directly — no dispatch, no policy
+    gate — so an agent's harmless preview is not gated. A
+    :class:`BulkImportValidationError` becomes a -32602 carrying every
+    row's structured diagnostic on ``error.data``.
+    """
+    rows = build_bulk_import_rows(rows_params)
+    sessionmaker = get_sessionmaker()
+    try:
+        async with sessionmaker() as session:
+            result = await bulk_import_edges(session, operator, rows, dry_run=True)
+    except BulkImportValidationError as exc:
+        raise McpInvalidParamsError(
+            str(exc),
+            data=serialize_bulk_validation_error(exc),
+        ) from exc
+    return serialize_bulk_result(result)
+
+
+async def _bulk_import_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Route a ``meho.topology.bulk_import`` call: dry-run direct, apply gated.
+
+    ``dry_run`` defaults to true (see the inputSchema). The free dry-run
+    calls the service directly; the gated apply dispatches the
+    ``topology.bulk_import`` typed op through
+    :func:`~meho_backplane.mcp.tools.topology.dispatch_topology_write`
+    with only ``rows`` (no ``dry_run``), so the parked
+    :class:`~meho_backplane.db.models.ApprovalRequest` carries exactly
+    the batch to apply. The tool boundary already enforced the 1-to-
+    :data:`BULK_IMPORT_MAX_EDGES` row bound via the inputSchema
+    ``minItems`` / ``maxItems``, so an oversized batch never reaches this
+    handler (rejected as -32602, the REST-422 analogue).
+    """
+    dry_run = bool(arguments.get("dry_run", True))
+    rows_params: list[dict[str, Any]] = arguments["rows"]
+    if dry_run:
+        return await _bulk_import_dry_run(operator, rows_params)
+    # Gated apply — dispatch the apply-only typed op. dispatch_topology_write
+    # returns the executed plan (human) or the awaiting_approval envelope
+    # (agent park), and maps BulkImportValidationError → -32602.
+    return await dispatch_topology_write(
+        operator, TOPOLOGY_BULK_IMPORT_OP_ID, {"rows": rows_params}
+    )
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name=_BULK_IMPORT_TOOL_NAME,
+        description=_BULK_IMPORT_DESCRIPTION,
+        inputSchema=BULK_IMPORT_TOOL_INPUT_SCHEMA,
+        outputSchema=with_parked_shape(BULK_IMPORT_RESPONSE_SCHEMA),
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class="write",
+    ),
+    handler=_bulk_import_handler,
+)

--- a/backend/src/meho_backplane/topology/annotate.py
+++ b/backend/src/meho_backplane/topology/annotate.py
@@ -117,6 +117,7 @@ __all__ = [
     "UnannotateSelectorError",
     "annotate_edge",
     "annotate_edge_in_txn",
+    "annotate_edge_with_plan",
     "unannotate_edge",
 ]
 
@@ -710,6 +711,41 @@ async def annotate_edge(
             kinds and no ``kind`` was pinned on the
             :class:`NodeRef`.
     """
+    plan = await annotate_edge_with_plan(
+        session,
+        operator,
+        from_ref,
+        kind,
+        to_ref,
+        note=note,
+        evidence_url=evidence_url,
+    )
+    return plan.edge
+
+
+async def annotate_edge_with_plan(
+    session: AsyncSession,
+    operator: Operator,
+    from_ref: NodeRef,
+    kind: str,
+    to_ref: NodeRef,
+    *,
+    note: str | None = None,
+    evidence_url: str | None = None,
+) -> AnnotatePlan:
+    """Same as :func:`annotate_edge`, but return the full :class:`AnnotatePlan`.
+
+    :func:`annotate_edge` returns only the :class:`GraphEdge` row, which
+    is all its human-front callers (REST / UI) need. A caller that also
+    needs the §6 diagnostics the write produced — the ``superseded`` /
+    ``conflicts`` id lists the write stamped, which live on
+    ``plan.audit_payload`` rather than on the curated edge's own
+    properties — calls this variant instead. The MCP ``topology.annotate``
+    typed-op handler uses it so it can surface ``superseded`` on the tool
+    return shape (#2539) without a second query. Identical transaction /
+    broadcast semantics: one ``session.begin()`` block, one fail-open
+    broadcast publish after commit.
+    """
     async with session.begin():
         plan = await annotate_edge_in_txn(
             session,
@@ -728,7 +764,7 @@ async def annotate_edge(
         target_name=plan.target_name,
         payload=plan.audit_payload,
     )
-    return plan.edge
+    return plan
 
 
 @dataclass(frozen=True, slots=True)

--- a/backend/src/meho_backplane/topology/bulk_import.py
+++ b/backend/src/meho_backplane/topology/bulk_import.py
@@ -48,7 +48,7 @@ back a successful batch.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
 from sqlalchemy import select
@@ -82,7 +82,10 @@ __all__ = [
     "BulkImportRow",
     "BulkImportRowError",
     "BulkImportValidationError",
+    "build_bulk_import_rows",
     "bulk_import_edges",
+    "serialize_bulk_result",
+    "serialize_bulk_validation_error",
 ]
 
 _log = structlog.get_logger(__name__)
@@ -706,3 +709,88 @@ def _materialise_apply_rows(
             )
         )
     return out
+
+
+# ---------------------------------------------------------------------------
+# Front adapters (shared by the MCP dry-run front and the typed-op apply
+# handler so the two paths coerce input + serialise output identically).
+# ---------------------------------------------------------------------------
+
+
+def build_bulk_import_rows(rows: list[dict[str, Any]]) -> list[BulkImportRow]:
+    """Coerce a list of param dicts into :class:`BulkImportRow` objects.
+
+    Each dict is one single-edge annotate's params (the row grammar is
+    :data:`~meho_backplane.connectors.topology.schemas.ANNOTATE_PARAMETER_SCHEMA`):
+    ``from_name`` / ``kind`` / ``to_name`` plus the optional
+    ``from_node_kind`` / ``to_node_kind`` pins and ``note`` /
+    ``evidence_url``. Shared by the ``meho.topology.bulk_import`` MCP
+    front (dry-run) and the ``topology.bulk_import`` typed-op handler
+    (apply) so the two paths build identical rows from identical input.
+    """
+    return [
+        BulkImportRow(
+            from_ref=NodeRef(str(row["from_name"]), row.get("from_node_kind")),
+            kind=str(row["kind"]),
+            to_ref=NodeRef(str(row["to_name"]), row.get("to_node_kind")),
+            note=row.get("note"),
+            evidence_url=row.get("evidence_url"),
+        )
+        for row in rows
+    ]
+
+
+def serialize_bulk_result(result: BulkImportResult) -> dict[str, Any]:
+    """Render a :class:`BulkImportResult` into the JSON wire shape.
+
+    Matches
+    :data:`~meho_backplane.connectors.topology.schemas.BULK_IMPORT_RESPONSE_SCHEMA`.
+    Shared by the dry-run and apply fronts so both return the same
+    envelope.
+    """
+    return {
+        "dry_run": result.dry_run,
+        "created": result.created,
+        "updated": result.updated,
+        "conflicts": result.conflicts,
+        "rows": [
+            {
+                "index": row.index,
+                "action": row.action,
+                "edge_id": row.edge_id,
+                "from_name": row.from_name,
+                "from_kind": row.from_kind,
+                "to_name": row.to_name,
+                "to_kind": row.to_kind,
+                "kind": row.kind,
+                "superseded": row.superseded,
+                "conflicts": row.conflicts,
+            }
+            for row in result.rows
+        ],
+    }
+
+
+def serialize_bulk_validation_error(exc: BulkImportValidationError) -> dict[str, Any]:
+    """Render a :class:`BulkImportValidationError` into the structured detail shape.
+
+    Mirrors the REST ``422 invalid_bulk`` body
+    (``api/v1/topology.bulk_import_edges_route``) so the MCP front can
+    surface every row's failure together on the ``error.data`` member of
+    a JSON-RPC -32602 — the same "fix the whole file in one pass"
+    diagnostic the REST front gives.
+    """
+    return {
+        "error": "invalid_bulk",
+        "errors": [
+            {
+                "index": e.index,
+                "error": e.error,
+                "message": e.message,
+                "name": e.name,
+                "kind": e.kind,
+                "kinds": e.kinds,
+            }
+            for e in exc.errors
+        ],
+    }

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -210,6 +210,7 @@ def isolated_registry() -> Iterator[None]:
         runbook_runs,
         runbooks,
         topology,
+        topology_bulk_import,
         topology_create_node,
     )
     from meho_backplane.mcp.tools import broadcast as broadcast_tools
@@ -271,6 +272,14 @@ def isolated_registry() -> Iterator[None]:
     importlib.reload(doc_collections_create_tool)
     importlib.reload(topology)
     importlib.reload(topology_create_node)
+    # #2539: the batch curated-edge authoring tool
+    # (``meho.topology.bulk_import``) lives in its own module (mirroring
+    # topology_create_node) so ``mcp.tools.topology`` does not grow past
+    # the 600-line guidance; it joins the reload list for the same reason
+    # every other tool module does -- the autouse ``clear_registries()``
+    # above would otherwise leave it unregistered in any test file that
+    # imports this fixture after the first one runs in the process.
+    importlib.reload(topology_bulk_import)
     # G12.2-T4 (#1298): the runbook template MCP tools
     # (``meho.runbook.*_template`` x 6) join the reload list for the same
     # reason every other tool module does -- the autouse

--- a/backend/tests/test_mcp_tools_topology_annotate.py
+++ b/backend/tests/test_mcp_tools_topology_annotate.py
@@ -428,6 +428,9 @@ async def test_annotate_creates_curated_edge_and_emits_audit_plus_broadcast(
     assert payload["kind"] == "authenticates-via"
     assert payload["source"] == "curated"
     assert payload["conflicts"] == []
+    # #2539: superseded is now an additive return key; empty on a pair
+    # no probe covers (no competing auto edge to displace).
+    assert payload["superseded"] == []
     assert uuid.UUID(payload["edge_id"])  # valid UUID
 
     # One curated row in the tenant — the service primitive owns the upsert.
@@ -469,6 +472,61 @@ async def test_annotate_creates_curated_edge_and_emits_audit_plus_broadcast(
 
     # Exactly one broadcast event (the service-level emission).
     assert publish_mock.await_count == 1
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_annotate_return_superseded_matches_audit_payload(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """#2539: the annotate return's ``superseded`` equals the audit payload's list.
+
+    Seed an ``source='auto'`` edge (A depends-on B), then assert a
+    curated edge over the same ``from`` + same ``kind`` to a *different*
+    endpoint (A depends-on C). The §6 same-kind/different-endpoint scan
+    stamps ``superseded_by`` on the auto edge and records its id on the
+    shared audit / broadcast payload. The tool return now surfaces that
+    same list — the acceptance criterion asserts they are equal.
+    """
+    client, _op = client_with_operator
+    a_id = await _seed_node(kind="service", name="svc-a")
+    b_id = await _seed_node(kind="database", name="db-b")
+    await _seed_node(kind="database", name="db-c")
+    auto_edge_id = await _seed_auto_edge(from_id=a_id, to_id=b_id, kind="depends-on")
+
+    with patch(_PUBLISH_PATCH, new=AsyncMock()):
+        response = _annotate_call(
+            client,
+            60,
+            {"from_name": "svc-a", "kind": "depends-on", "to_name": "db-c"},
+        )
+
+    body = response.json()
+    assert body["result"]["isError"] is False, body
+    payload = json.loads(body["result"]["content"][0]["text"])
+    # The curated assertion displaced exactly the seeded auto edge.
+    assert payload["superseded"] == [str(auto_edge_id)]
+
+    # ... and that list is byte-identical to the one on the service's
+    # audit payload (the ids already existed there pre-#2539 — this task
+    # only surfaced them on the return).
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        from sqlalchemy import select
+
+        service_row = (
+            (
+                await session.execute(
+                    select(AuditLog).where(
+                        AuditLog.path == "topology.annotate",
+                        AuditLog.method == "ANNOTATE",
+                    )
+                )
+            )
+            .scalars()
+            .one()
+        )
+    assert service_row.payload["superseded"] == payload["superseded"]
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
@@ -1070,16 +1128,16 @@ def test_annotate_description_scopes_auto_kind_warning_to_actual_conflict() -> N
 
 
 def test_annotate_description_matches_actual_response_shape() -> None:
-    """The annotate description must not advertise response fields the handler
-    does not populate (B1 regression on PR #654).
+    """The annotate description must advertise exactly the response fields
+    the handler populates (B1 regression on PR #654).
 
-    The handler returns ``edge_id / from / to / kind / source / conflicts``;
-    earlier iterations also claimed ``superseded: [<auto-edge-id>...]`` on
-    the response shape, but ``annotate_edge`` only stamps that on the
-    auto-edge ``properties`` and on the audit/broadcast payload — it
-    never surfaces it on the return value. Description-vs-impl drift
-    here is load-bearing for an LLM agent reading the description as
-    the API contract.
+    Since #2539 the handler returns ``edge_id / from / to / kind /
+    source / conflicts / superseded`` — ``superseded`` is now an additive
+    return key surfacing the auto edges the assertion displaced (the ids
+    already computed on the audit/broadcast payload; MCP authoring parity
+    with the REST/CLI fronts). Description-vs-impl drift here is
+    load-bearing for an LLM agent reading the description as the API
+    contract.
     """
     entry = get_tool("meho.topology.annotate")
     assert entry is not None
@@ -1092,19 +1150,12 @@ def test_annotate_description_matches_actual_response_shape() -> None:
     declared = set(executed_shape.get("properties", {}).keys())
     # outputSchema is the canonical contract — anything the description
     # *names* as a response key must be in it.
-    assert declared == {"edge_id", "from", "to", "kind", "source", "conflicts"}
+    assert declared == {"edge_id", "from", "to", "kind", "source", "conflicts", "superseded"}
     assert parked_shape["properties"]["status"] == {"const": "awaiting_approval"}
     # Belt-and-suspenders: the literal "Returns `{...}`" clause names
-    # only the keys above.
+    # the keys above, including the new `superseded` list.
     assert "Returns `{edge_id, from:" in desc
-    # `superseded` is the substrate-side §6 marker
-    # (`properties.superseded_by` on the displaced auto-edge row +
-    # audit payload field), never a response key on this tool. The
-    # description may *mention*
-    # the mechanism in parenthetical guidance but must not advertise it
-    # as a returned key.
-    assert "superseded: [<auto-edge-id>...]" not in desc
-    assert "superseded_by" in desc  # parenthetical reference to the substrate mechanism remains
+    assert "superseded: [<edge-id>...]" in desc
 
 
 def test_unannotate_description_names_auto_refusal() -> None:

--- a/backend/tests/test_mcp_tools_topology_bulk_import.py
+++ b/backend/tests/test_mcp_tools_topology_bulk_import.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""MCP-front tests for ``meho.topology.bulk_import`` (#2539, Initiative #2533).
+
+Coverage (the MCP-level half — the batch service is covered in
+:mod:`tests.test_topology_bulk_import`; the agent-park / approve-execute
+loop is covered in :mod:`tests.test_topology_ops_approval`):
+
+* Registration — ``required_role=TENANT_ADMIN`` + ``op_class='write'``;
+  hidden from a non-admin ``tools/list``.
+* Free dry-run — ``dry_run`` defaults to true; returns the per-row
+  create/update/conflict plan, writes nothing (no ``graph_edge`` rows,
+  no service audit rows), never parks.
+* Human apply — a human tenant_admin ``dry_run=false`` applies the whole
+  batch immediately (T3 dial inherited), landing every edge.
+* Validation-failing batch — a row naming a missing endpoint surfaces
+  every row's diagnostic together on the -32602 ``error.data`` (the
+  REST ``422 invalid_bulk`` analogue) and writes nothing.
+* Boundary cap — a batch over 1000 rows is rejected at the tool
+  boundary (inputSchema ``maxItems``), the MCP analogue of the REST
+  422 the ``_BULK_IMPORT_MAX_EDGES`` guard raises.
+
+The happy paths exercise the SQLite-migrated test DB end-to-end (same
+shape :mod:`tests.test_mcp_tools_topology_create_node` uses).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.topology.schemas import BULK_IMPORT_MAX_EDGES
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, GraphEdge, GraphNode, Tenant
+from meho_backplane.mcp.registry import get_tool
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+# Broadcast publisher patch — the apply path fans out one event per row
+# through the shared annotate helper.
+_PUBLISH_PATCH = "meho_backplane.topology.annotate.publish_event"
+_TOOL_NAME = "meho.topology.bulk_import"
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def _seeded_tenant() -> AsyncIterator[None]:
+    """Insert the operator's :class:`Tenant` row so endpoint resolution finds it."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(Tenant(id=OPERATOR_TENANT_ID, slug="op-tenant", name="Op Tenant"))
+    yield
+
+
+async def _seed_node(*, kind: str, name: str) -> uuid.UUID:
+    """Insert one ``graph_node`` row in the operator's tenant; return its id."""
+    sessionmaker = get_sessionmaker()
+    node_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            GraphNode(
+                id=node_id,
+                tenant_id=OPERATOR_TENANT_ID,
+                kind=kind,
+                name=name,
+                target_id=None,
+                properties={},
+                discovered_by="test",
+                first_seen=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+    return node_id
+
+
+def _bulk_import_call(client: TestClient, call_id: int, arguments: dict[str, Any]) -> Any:
+    return client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": _TOOL_NAME, "arguments": arguments},
+        },
+    )
+
+
+async def _count_edges() -> int:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(GraphEdge).where(GraphEdge.tenant_id == OPERATOR_TENANT_ID)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    return len(rows)
+
+
+async def _count_service_audit_rows() -> int:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(AuditLog).where(
+                        AuditLog.path == "topology.annotate",
+                        AuditLog.method == "ANNOTATE",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    return len(rows)
+
+
+# ---------------------------------------------------------------------------
+# Registration + RBAC
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_import_tool_registers_with_tenant_admin_and_write() -> None:
+    """The tool lands with TENANT_ADMIN gate + write op_class."""
+    entry = get_tool(_TOOL_NAME)
+    assert entry is not None, f"{_TOOL_NAME} not registered"
+    defn, _handler = entry
+    assert defn.required_role == TenantRole.TENANT_ADMIN
+    assert defn.op_class == "write"
+    # dry_run defaults to true — the safe read-shaped plan is the default.
+    assert defn.inputSchema["properties"]["dry_run"]["default"] is True
+    # The rows array carries the boundary cap.
+    assert defn.inputSchema["properties"]["rows"]["maxItems"] == BULK_IMPORT_MAX_EDGES
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_bulk_import_hidden_from_non_admin_tools_list(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An operator-role session does not see the admin tool in ``tools/list``."""
+    client, _op = client_with_operator
+    response = client.post("/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert _TOOL_NAME not in names
+
+
+# ---------------------------------------------------------------------------
+# Free dry-run plan — no writes, never parks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_bulk_import_default_dry_run_returns_plan_and_writes_nothing(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """``dry_run`` omitted → plan returned, zero edges + zero service audit rows."""
+    client, _op = client_with_operator
+    await _seed_node(kind="service", name="svc-a")
+    await _seed_node(kind="database", name="db-b")
+
+    response = _bulk_import_call(
+        client,
+        10,
+        {"rows": [{"from_name": "svc-a", "kind": "depends-on", "to_name": "db-b"}]},
+    )
+
+    body = response.json()
+    assert body["result"]["isError"] is False, body
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["dry_run"] is True
+    assert payload["created"] == 1
+    assert payload["rows"][0]["action"] == "create"
+    assert payload["rows"][0]["edge_id"] is None  # nothing created yet
+    assert payload["rows"][0]["from_name"] == "svc-a"
+    assert payload["rows"][0]["to_name"] == "db-b"
+
+    # The read-shaped plan wrote nothing: no edge, no service audit row.
+    assert await _count_edges() == 0
+    assert await _count_service_audit_rows() == 0
+
+
+# ---------------------------------------------------------------------------
+# Human apply — immediate, atomic, all rows land
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_bulk_import_human_apply_lands_all_edges(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """A human tenant_admin ``dry_run=false`` applies the whole batch immediately."""
+    client, _op = client_with_operator
+    await _seed_node(kind="service", name="svc-a")
+    await _seed_node(kind="database", name="db-b")
+    await _seed_node(kind="database", name="db-c")
+
+    with patch(_PUBLISH_PATCH, new=AsyncMock()):
+        response = _bulk_import_call(
+            client,
+            20,
+            {
+                "dry_run": False,
+                "rows": [
+                    {"from_name": "svc-a", "kind": "depends-on", "to_name": "db-b"},
+                    {"from_name": "svc-a", "kind": "depends-on", "to_name": "db-c"},
+                ],
+            },
+        )
+
+    body = response.json()
+    assert body["result"]["isError"] is False, body
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["dry_run"] is False
+    assert payload["created"] == 2
+    # Applied rows carry real edge ids.
+    assert all(uuid.UUID(r["edge_id"]) for r in payload["rows"])
+    assert await _count_edges() == 2
+
+
+# ---------------------------------------------------------------------------
+# Validation failure — every row's diagnostic surfaced, nothing written
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_bulk_import_validation_failure_surfaces_per_row_diagnostics(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """A dry-run batch with a missing endpoint → -32602 with per-row errors, no writes."""
+    client, _op = client_with_operator
+    await _seed_node(kind="service", name="svc-a")
+
+    response = _bulk_import_call(
+        client,
+        30,
+        {
+            "rows": [
+                {"from_name": "svc-a", "kind": "depends-on", "to_name": "ghost-db"},
+            ]
+        },
+    )
+
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    data = body["error"]["data"]
+    assert data["error"] == "invalid_bulk"
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["index"] == 0
+    assert data["errors"][0]["error"] == "node_not_found"
+    # Nothing written.
+    assert await _count_edges() == 0
+    assert await _count_service_audit_rows() == 0
+
+
+# ---------------------------------------------------------------------------
+# Boundary cap — over-1000 rows rejected before the handler runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_bulk_import_over_cap_rejected_at_boundary(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A batch over the 1000-row cap fails the inputSchema maxItems (-32602)."""
+    client, _op = client_with_operator
+    oversized = [
+        {"from_name": f"svc-{i}", "kind": "depends-on", "to_name": f"db-{i}"}
+        for i in range(BULK_IMPORT_MAX_EDGES + 1)
+    ]
+    response = _bulk_import_call(client, 40, {"rows": oversized})
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_bulk_import_empty_batch_rejected_at_boundary(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An empty ``rows`` array fails the inputSchema minItems (-32602)."""
+    client, _op = client_with_operator
+    response = _bulk_import_call(client, 41, {"rows": []})
+    assert response.json()["error"]["code"] == INVALID_PARAMS

--- a/backend/tests/test_topology_ops_approval.py
+++ b/backend/tests/test_topology_ops_approval.py
@@ -56,6 +56,7 @@ from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.connectors.schemas import OperationResult
 from meho_backplane.connectors.topology.ops import (
     TOPOLOGY_ANNOTATE_OP_ID,
+    TOPOLOGY_BULK_IMPORT_OP_ID,
     TOPOLOGY_CREATE_NODE_OP_ID,
     TOPOLOGY_GRAPH_CONNECTOR_ID,
     TOPOLOGY_UNANNOTATE_OP_ID,
@@ -72,6 +73,7 @@ from meho_backplane.db.models import (
 )
 from meho_backplane.main import app
 from meho_backplane.mcp.tools.topology import _annotate_handler
+from meho_backplane.mcp.tools.topology_bulk_import import _bulk_import_handler
 from meho_backplane.mcp.tools.topology_create_node import _create_node_handler
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.settings import get_settings
@@ -418,7 +420,15 @@ async def test_mcp_front_human_immediate_agent_parked(
     await _seed_node(kind="database", name="db-payments")
 
     executed = await _annotate_handler(human, dict(_ANNOTATE_PARAMS))
-    assert set(executed) == {"edge_id", "from", "to", "kind", "source", "conflicts"}
+    assert set(executed) == {
+        "edge_id",
+        "from",
+        "to",
+        "kind",
+        "source",
+        "conflicts",
+        "superseded",
+    }
     assert executed["source"] == "curated"
     assert await _fetch_approval_rows() == []
 
@@ -434,6 +444,118 @@ async def test_mcp_front_human_immediate_agent_parked(
     assert uuid.UUID(parked["approval_request_id"]) == rows[0].id
     edges = await _fetch_edges()
     assert [e.kind for e in edges] == ["depends-on"], "agent park must not write"
+
+
+# ---------------------------------------------------------------------------
+# Bulk import (#2539) — dry-run never parks; apply rides the same gate
+# ---------------------------------------------------------------------------
+
+_BULK_ROWS: list[dict[str, Any]] = [
+    {"from_name": "svc-payments", "kind": "depends-on", "to_name": "db-payments"},
+]
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_agent_dry_run_returns_plan_no_park(
+    _registered_topology_ops: None,
+    _seeded_tenant: None,
+) -> None:
+    """An AGENT dry-run returns the per-row plan immediately with no park.
+
+    The free dry-run is read-shaped: the MCP front calls the service
+    directly (no dispatch, no policy gate), so an agent's harmless
+    preview never creates an ApprovalRequest row and never writes.
+    """
+    await _seed_edge_endpoints()
+    agent = _make_operator("agent:proposer", principal_kind=PrincipalKind.AGENT)
+
+    plan = await _bulk_import_handler(agent, {"dry_run": True, "rows": list(_BULK_ROWS)})
+
+    assert plan["dry_run"] is True
+    assert plan["created"] == 1
+    assert plan["rows"][0]["action"] == "create"
+    assert plan["rows"][0]["edge_id"] is None
+    assert await _fetch_approval_rows() == []
+    assert await _fetch_edges() == []
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_agent_apply_parks_one_request_and_writes_nothing(
+    _registered_topology_ops: None,
+    _seeded_tenant: None,
+) -> None:
+    """An AGENT ``dry_run=false`` parks the whole batch as ONE pending request.
+
+    The apply dispatches the ``topology.bulk_import`` typed op through
+    the #2537 gate; the caution floor parks the agent. The single
+    tenant-wide (``target_id`` NULL) pending row stores the exact batch
+    params for the by-id resume, and no edge is written.
+    """
+    await _seed_edge_endpoints()
+    agent = _make_operator("agent:proposer", principal_kind=PrincipalKind.AGENT)
+
+    parked = await _bulk_import_handler(agent, {"dry_run": False, "rows": list(_BULK_ROWS)})
+
+    assert parked["status"] == "awaiting_approval"
+    assert parked["op_id"] == TOPOLOGY_BULK_IMPORT_OP_ID
+    rows = await _fetch_approval_rows()
+    assert len(rows) == 1
+    assert rows[0].status == ApprovalRequestStatus.PENDING.value
+    assert rows[0].op_id == TOPOLOGY_BULK_IMPORT_OP_ID
+    assert rows[0].target_id is None
+    # The parked params are exactly the batch — no dry_run smuggled in.
+    assert rows[0].params == {"rows": _BULK_ROWS}
+    assert await _fetch_edges() == []
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_decide_executes_parked_batch_atomically(
+    _registered_topology_ops: None,
+    _seeded_tenant: None,
+) -> None:
+    """A four-eyes ``/decide`` applies the parked batch; all rows land once."""
+    await _seed_edge_endpoints()
+    await _seed_node(kind="database", name="db-analytics")
+    agent = _make_operator("agent:proposer", principal_kind=PrincipalKind.AGENT)
+    batch = {
+        "dry_run": False,
+        "rows": [
+            {"from_name": "svc-payments", "kind": "depends-on", "to_name": "db-payments"},
+            {"from_name": "svc-payments", "kind": "depends-on", "to_name": "db-analytics"},
+        ],
+    }
+    parked = await _bulk_import_handler(agent, batch)
+    assert parked["status"] == "awaiting_approval"
+    assert await _fetch_edges() == []
+
+    response = _decide(
+        uuid.UUID(parked["approval_request_id"]),
+        decider_sub="operator:decider",
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["dispatch_status"] == "ok"
+
+    edges = await _fetch_edges()
+    assert len(edges) == 2
+    assert all(e.source == "curated" for e in edges)
+
+
+@pytest.mark.asyncio
+async def test_bulk_import_human_apply_immediate_no_approval_row(
+    _registered_topology_ops: None,
+    _seeded_tenant: None,
+) -> None:
+    """A human ``dry_run=false`` applies immediately: edge written, zero approval rows."""
+    await _seed_edge_endpoints()
+    human = _make_operator("operator:human")
+
+    applied = await _bulk_import_handler(human, {"dry_run": False, "rows": list(_BULK_ROWS)})
+
+    assert applied["dry_run"] is False
+    assert applied["created"] == 1
+    assert uuid.UUID(applied["rows"][0]["edge_id"])
+    assert len(await _fetch_edges()) == 1
+    assert await _fetch_approval_rows() == []
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -149,7 +149,11 @@ admin meta-tool `meho.topology.create_node` in
 `mcp/tools/topology.py` from accreting further past the 600-line
 guidance; the registry auto-discovers either way) that closes the
 empty-tenant bootstrap gap — same `tenant_admin` / `write` shape as
-the annotate pair.
+the annotate pair. #2539 added a fourth admin meta-tool
+`meho.topology.bulk_import` (own module `mcp/tools/topology_bulk_import.py`,
+same separate-module reason) — batch curated-edge authoring for the
+agent surface, closing the MCP half of the propose→plan→apply loop the
+REST / CLI / console bulk-import fronts already had.
 
 Since #2537 the three MCP write handlers no longer call the service
 primitives directly: they route through `operations.dispatch()` with
@@ -165,13 +169,36 @@ returns a `{status: awaiting_approval, approval_request_id, ...}`
 envelope; the write executes with the stored params when a human
 approves from any approvals surface), while a human tenant_admin rides
 the default-allow branch and executes immediately — same UX as before.
-The typed-op handlers unwrap params and call `annotate_edge` /
-`create_or_get_node` / `unannotate_edge` unchanged; domain errors come
+The typed-op handlers unwrap params and call `annotate_edge_with_plan` /
+`create_or_get_node` / `unannotate_edge` / `bulk_import_edges` unchanged;
+domain errors come
 back as `connector_error` results whose `exception_class` the MCP shim
 (`dispatch_topology_write` in `mcp/tools/topology.py`) maps back to
 JSON-RPC `-32602`. Each gated MCP write therefore produces one extra
 audit row (`method="DISPATCH"`, `path=<op_id>`, with
-`policy_decision`) alongside the service-level row. The REST + UI
+`policy_decision`) alongside the service-level row.
+
+`meho.topology.bulk_import` (#2539) is the one two-behaviour tool. Its
+`dry_run` param splits the path: `dry_run=true` (the default,
+read-shaped) calls `bulk_import_edges(dry_run=True)` **directly** — no
+dispatch, no gate — so an agent's harmless plan preview never parks; a
+`BulkImportValidationError` becomes a -32602 whose `error.data` carries
+every row's diagnostic (the REST `422 invalid_bulk` analogue).
+`dry_run=false` dispatches the apply-only typed op `topology.bulk_import`
+(registered with `rows` alone — no `dry_run`, so the parked
+`ApprovalRequest` holds exactly the batch to apply) through the same
+gate: an AGENT parks the whole batch as one request, a human applies
+immediately, and approve-time re-dispatch applies all rows in the
+service's all-or-nothing transaction. The 1000-row cap is enforced at
+the tool boundary via the `inputSchema` `maxItems` (mirroring the REST
+`_BULK_IMPORT_MAX_EDGES` guard); like `query_topology`'s inline edge
+list, the plan is returned inline under a hard row cap rather than a
+JSONFlux handle. `meho.topology.annotate`'s return shape gained a
+`superseded` list (#2539): the ids of the auto edges the assertion
+displaced — already stamped on the shared audit / broadcast payload, so
+surfacing them on the return is a shape change, not a new query (the
+handler reads `plan.audit_payload["superseded"]` from
+`annotate_edge_with_plan`, the plan-returning sibling of `annotate_edge`). The REST + UI
 write fronts are human-only surfaces and keep calling the service
 primitives directly. The three write ops are also discoverable /
 dispatchable through the generic agent meta-tools (`search_operations`


### PR DESCRIPTION
## Summary
- New `meho.topology.bulk_import` MCP tool (tenant_admin, own module) closes the agent-surface half of the propose→plan→apply loop the REST/CLI/console bulk-import fronts already had. `dry_run` defaults to true and calls the service validation pass directly — read-shaped, never parks; `dry_run=false` dispatches the new apply-only targetless typed op `topology.bulk_import` through the **same #2537 approval substrate** the single writes use (agent parks the whole batch as one `ApprovalRequest`; human tenant_admin applies immediately; approve re-dispatch applies all rows atomically). No second queue, no new endpoints.
- A validation-failing dry-run batch surfaces every row's diagnostic together on the -32602 `error.data` (the REST `422 invalid_bulk` analogue). The 1000-row cap is enforced at the tool boundary via the inputSchema `maxItems`.
- `meho.topology.annotate`'s return shape gains a `superseded` list — the ids of the auto edges the assertion displaced. Those ids already existed on the shared audit/broadcast payload, so this is an additive return-shape change, not a new query (handler now reads `plan.audit_payload["superseded"]` via `annotate_edge_with_plan`, a plan-returning sibling that leaves the wide `annotate_edge` caller base untouched). Omission caveat dropped from the description.

## Design notes
- **Dry-run bypasses dispatch on purpose:** the typed op carries the agents-park safety dial, so routing a harmless preview through it would park an agent. Dry-run calls the service directly; the apply-only typed op carries no `dry_run` param, so the parked request is exactly the batch to apply.
- **No JSONFlux handle:** the topology MCP surface bounds set-shaped responses with a hard row cap, not a handle (`query_topology` returns up to 1000 edges inline). The dry-run plan follows the same convention, capped at 1000 rows at the boundary.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (one pre-existing unrelated `icmp.py` platform error)
- [x] `pytest` — 227 passed across bulk_import (MCP + substrate), ops_approval, annotate (MCP + substrate), create_node, REST topology, mcp_server/topology tools
- [x] Agent dry-run returns plan with no ApprovalRequest, writes nothing; agent apply parks one pending request; four-eyes approve applies the batch atomically; human apply immediate
- [x] annotate return `superseded` asserted byte-equal to the audit payload's list
- [x] batch >1000 rows and empty batch rejected at the tool boundary (-32602)
- [x] code-quality gate — 0 blockers

## Out of scope
- Node bulk import (edges-only, matching the service). New REST/CLI surface (exists).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2539
