### PR TITLE
docs(cli): correct the stale targets write-verb framing

### DIFF
--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -1063,9 +1063,12 @@ wrap the targets registry routes from G0.3-T3 (#254), the G0.3-T1.5
 verb. The verbs are the operator-side surface for the per-tenant
 `targets` table — a fingerprinted catalog of vendor systems the
 operator manages (vCenter hosts, Vault instances, k8s clusters, …)
-that the G0.6 dispatcher resolves at `call` time. Write verbs
-(`create` / `update` / `delete`) are deferred; bulk import lands
-under G0.3-T6 (#257).
+that the G0.6 dispatcher resolves at `call` time. Registration and
+updates flow through `meho targets import` (POST for new rows, PATCH
+under `--update`); a standalone `create` verb was explicitly ruled out
+in favour of file-based import (#1574 / #1559). No standalone `delete`
+verb is surfaced yet, though the API supports `DELETE
+/api/v1/targets/{name}` (`tenant_admin`).
 
 ### Subcommands
 
@@ -1154,10 +1157,11 @@ the comment block on `httpDoer` for the rationale.
 
 ### Out of scope (v0.2)
 
-- Write verbs (`create` / `update` / `delete`). The API supports them
-  (require `tenant_admin`); the CLI surfaces them in a follow-up
-  task when operators ask. Bulk import via T6 (#257) lands in a
-  sibling PR.
+- Standalone `delete` verb. The API supports `DELETE
+  /api/v1/targets/{name}` (`tenant_admin`); the CLI surfaces it in a
+  follow-up task when operators ask. Create and update are already
+  covered by `meho targets import` (POST for new rows, PATCH under
+  `--update`), so no separate `create` / `update` verb is planned.
 - Auto-completion of target names. Operators type names; tab-completion
   would need a separate `cobra-complete`-style design pass.
 - Client-side caching. Every CLI invocation hits the API fresh — the


### PR DESCRIPTION
## Summary

Follow-up to #2581 (adjacent finding). `docs/codebase/cli.md` described the `targets` write verbs `create` / `update` / `delete` as "deferred" in two places, implying all three are still-planned CLI work. That framing is stale:

- **Create and update are already covered** by `meho targets import` — POST for new rows, PATCH under `--update`.
- **A standalone `create` verb was explicitly ruled out** in favour of file-based import (#1574 / #1559 retired the lingering references to it).
- **Only `delete` is genuinely unimplemented** on the CLI. The API supports `DELETE /api/v1/targets/{name}` (`tenant_admin`, `api/v1/targets.py:1424`) but no verb wraps it yet.

Both spots (the targets overview and the "Out of scope (v0.2)" note) now state this accurately.

## Test plan

- [x] Docs-only change; no code touched, no build/test gate applies.
- [x] `grep -nE "targets create|Write verbs.*deferred"` on `cli.md` → no remaining stale framing.
- [x] Backend write routes verified present — POST (`:1195`), PATCH (`:1329`), DELETE (`:1424`) in `backend/src/meho_backplane/api/v1/targets.py`.
- [x] CLI verb inventory verified — `targets.go` registers `list` / `describe` / `probe` / `import` / `discover`; no `create` / `update` / `delete`.

## Out of scope

- Adding a `meho targets delete` verb (the one genuinely-deferred item; would be its own task).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how target implementations are resolved when commands are executed.
  * Documented that importing targets supports creating new entries and updating existing ones.
  * Clarified that a standalone delete command is not currently available and is planned for a future update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->