### PR TITLE
docs(changelog): track #2588 under [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,16 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Documentation — correct the stale `targets` write-verb framing (#2588)
+
+- `docs/codebase/cli.md` described the `create` / `update` / `delete` write
+  verbs as "deferred", implying they are still planned. In reality
+  registration and updates flow through `meho targets import` (POST for new
+  rows, PATCH under `--update`), and a standalone `create` verb was ruled out
+  in favour of file-based import (#1574 / #1559). Only `delete` has no CLI
+  surface yet. Both the overview and the "Out of scope (v0.2)" note are
+  rewritten to state this accurately.
+
 ## [0.24.0] - 2026-07-17
 
 This release **completes Broadcast v2 (Initiative #2543)** — the final


### PR DESCRIPTION
#2588 (`docs(cli): correct the stale targets write-verb framing`) merged to `main` after the v0.24.0 CHANGELOG roll (PR #2584), so it did not make v0.24.0 and had no `[Unreleased]` bullet. This adds one under **Documentation** so the next release's completeness audit picks it up.

Docs-only; no code, no version files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the CLI documentation to accurately describe target import and update workflows.
  * Clarified that new targets are added through file-based import, updates use the update option, and deletion has no CLI command.
  * Updated the overview and out-of-scope notes to reflect the current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->