### PR TITLE
fix(chart): roll backplane pod on configmap-only helm upgrades (#2586)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — configmap-roll pod annotation (#2586)
+
+- The backplane `Deployment` pod template now carries a `checksum/config`
+  annotation hashed from the rendered `configmap.yaml`. A `helm upgrade` that
+  changes only ConfigMap-rendered `config.*` (or `memory.*` / `topology.*` /
+  derived MCP/backplane) values now rolls the pod automatically instead of
+  requiring a manual `kubectl rollout restart`; an unchanged render keeps the
+  checksum stable, so there is no spurious pod churn.
+
 ## [0.24.0] - 2026-07-17
 
 This release **completes Broadcast v2 (Initiative #2543)** — the final

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -11,10 +11,20 @@ spec:
       {{- include "meho.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Roll the pod whenever the ConfigMap the backplane reads via
+        # `envFrom` (below) changes. Helm updates the ConfigMap object on a
+        # `config.*`-only upgrade, but the pod template is otherwise
+        # byte-identical, so without this the new environment never reaches
+        # the running pod until a manual `kubectl rollout restart` (#2586).
+        # Hashing the fully rendered configmap.yaml (the Helm howto pattern)
+        # means any change to what the pod consumes — config.*, memory.*,
+        # topology.*, or the derived MCP/backplane values — forces a rollout,
+        # while an unchanged render leaves the checksum stable (no churn).
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "meho.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}


### PR DESCRIPTION
## Summary

- Adds a `checksum/config` annotation to the backplane `Deployment`'s **pod template** (`spec.template.metadata.annotations`), hashed from the fully rendered `configmap.yaml` via the Helm howto pattern `{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}`.
- The pod reads its non-secret config from that ConfigMap via `envFrom`. Previously a `helm upgrade` changing only ConfigMap-rendered `config.*` values updated the ConfigMap object but left the pod template byte-identical, so the pod did not roll — the new environment only took effect after a manual `kubectl rollout restart` (#2586).
- Rendering is unconditional and still merges any operator `podAnnotations`.

## Test plan

- [x] `helm lint` (schema-override set) — `0 chart(s) failed`.
- [x] `helm template` renders (baseline, baseline-repeat, config-changed) — all succeed.
- [x] **AC1** — two renders differing only in one `config.*` value (`config.targetSsrfAllowlist`) produce **different** `checksum/config` values (`113ca532…` vs `03a888b4…`).
- [x] **AC2** — a repeated identical render produces the **same** `checksum/config` (`113ca532…` == `113ca532…`), so unchanged config causes no spurious rollout.
- [x] Annotation lands under the `Deployment` pod template; `podAnnotations.foo=bar` still merges alongside the checksum.
- [ ] kubeconform / helm-install+test lanes — run in CI (kubeconform not installed in the sandbox; the annotation add is schema-neutral).

## Out of scope

- Checksumming Secrets or other objects / workloads.
- Operator docs for the rollout behavior (deploy guide #2468 owns that).
- Sibling tasks #2518 / #2594 touch `values.yaml` / `configmap.yaml`; this PR only edits `deployment.yaml`'s pod-template annotations.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2586


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Helm upgrades now automatically restart pods when rendered configuration values change.
  * Prevented unnecessary pod restarts when configuration remains unchanged.
  * Preserved support for custom pod annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->