### PR TITLE
feat(charts): typed netdiag.probeAllowlist chart value (#2518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,27 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — netdiag.probeAllowlist chart value (#2518)
+
+- **The `net.*` diagnostics probe allowlist is now a typed Helm chart
+  value** (#2518). v0.22.0 shipped the `net.*` diagnostics connector
+  (#2405) governed by `MEHO_NETDIAG_PROBE_ALLOWLIST` — an inverted,
+  fail-closed allowlist whose empty default keeps the connector **inert**
+  (every probe denied) — but the chart exposed no typed key for it: the
+  only way to set the env var was the untyped `extraEnv` passthrough,
+  which `values.schema.json` does not validate and `helm show values`
+  does not surface. A new `netdiag.probeAllowlist` value (schema-typed
+  optional string, default `""`) now renders into
+  `MEHO_NETDIAG_PROBE_ALLOWLIST` on the backplane ConfigMap — injected
+  into the container via the existing `envFrom.configMapRef` — so a
+  scoped probe allowlist (e.g. `"10.0.0.0/8,vcenter.lab.internal"`) is a
+  first-class, `helm show values`-discoverable setting. The default `""`
+  is a genuine no-op that keeps the connector inert (fail-closed), so
+  existing installs are unchanged. This mirrors #2240's typed
+  `config.targetSsrfAllowlist` treatment so both fail-closed allowlists
+  share one configuration shape. Chart-only — the allowlist parser is
+  untouched. (#2518)
+
 ## [0.24.0] - 2026-07-17
 
 This release **completes Broadcast v2 (Initiative #2543)** — the final

--- a/deploy/charts/meho/templates/configmap.yaml
+++ b/deploy/charts/meho/templates/configmap.yaml
@@ -116,6 +116,17 @@ data:
   # literals. See `deploy/charts/meho/values.yaml`
   # (`config.targetSsrfAllowlist`) and `docs/codebase/target-ssrf-guard.md`.
   MEHO_TARGET_SSRF_ALLOWLIST: {{ .Values.config.targetSsrfAllowlist | quote }}
+  # Initiative #2405 net.* diagnostics probe allowlist — the INVERTED
+  # sibling of the SSRF guard above: allow-only-what-is-listed, so the
+  # default `""` denies every probe (the connector is inert until an
+  # operator opts a range in). Read per probe from the environment by
+  # `backend/src/meho_backplane/connectors/net/allowlist.py`
+  # (`PROBE_ALLOWLIST_ENV`) — NOT via settings.py. Rendered
+  # unconditionally: the default `""` keeps the connector fail-closed.
+  # Comma-separated CIDRs / bare IPs / hostname literals. See
+  # `deploy/charts/meho/values.yaml` (`netdiag.probeAllowlist`) and
+  # `docs/codebase/connectors-net-diagnostics.md`.
+  MEHO_NETDIAG_PROBE_ALLOWLIST: {{ .Values.netdiag.probeAllowlist | quote }}
   # Async ingest-job watchdog budget (#2318, hardens #2275). #2275
   # time-boxes each background OpenAPI-ingest job in `asyncio.timeout(...)`
   # so a wedged pipeline can't sit at `status=running` until a pod restart;

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -85,6 +85,10 @@
         "pingGroupRange": {
           "type": "string",
           "description": "Optional '<low> <high>' GID range for the net.ipv4.ping_group_range pod sysctl enabling unprivileged ICMP-echo ping (net.ping). Empty (default) renders no sysctl and no pod-security change. Set only after a security review; see values.yaml for the safe-vs-unsafe sysctl and GID caveats."
+        },
+        "probeAllowlist": {
+          "type": "string",
+          "description": "Probe-destination allowlist for the net.* diagnostics connector (Initiative #2405), rendered into the MEHO_NETDIAG_PROBE_ALLOWLIST env var the connector reads per probe (backend/src/meho_backplane/connectors/net/allowlist.py, PROBE_ALLOWLIST_ENV; NOT via settings.py). Inverted, allow-only-what-is-listed semantics — the sibling of config.targetSsrfAllowlist but with the opposite default: the parsed set IS the whole permitted probe space, so an empty value denies every probe and the connector is inert until a range is opted in. Comma-separated CIDR ranges (10.0.0.0/8), bare IPs (192.168.7.10), and/or hostname literals (vcenter.lab.internal, matched verbatim); whitespace around commas is ignored. Default \"\" keeps the connector fail-closed — deliberately carrying no minLength so the empty default validates on every install. Because net.* ops are agent-auto-runnable (safety_level=\"safe\"), this is the sole floor on a network-vantage recon primitive: a scoped opt-in, never a global off-switch. A malformed CIDR fails loudly at runtime naming the offending token. See docs/codebase/connectors-net-diagnostics.md."
         }
       }
     },

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -108,8 +108,30 @@ netdiag:
   #   * Enabling it only widens who may open unprivileged ICMP *datagram*
   #     sockets in this pod; it does NOT grant `CAP_NET_RAW` or
   #     packet-crafting. `net.ping` remains allowlist-gated
-  #     (`MEHO_NETDIAG_PROBE_ALLOWLIST`) regardless.
+  #     (`netdiag.probeAllowlist`, below) regardless.
   pingGroupRange: ""
+  # -- Probe-destination allowlist for the `net.*` diagnostics connector
+  # (Initiative #2405). Unlike `config.targetSsrfAllowlist` (a scoped
+  # opt-OUT of a default-deny-non-public guard), this is an *inverted,
+  # allow-only-what-is-listed* floor: the parsed set is the WHOLE
+  # permitted probe space, so an empty value means **deny every probe**
+  # — the connector is inert until an operator opts a range in. It
+  # renders into the `MEHO_NETDIAG_PROBE_ALLOWLIST` env var the connector
+  # reads per probe (`backend/src/meho_backplane/connectors/net/allowlist.py`,
+  # `PROBE_ALLOWLIST_ENV`), NOT via settings.py. Comma-separated entries:
+  # CIDR ranges (`10.0.0.0/8`), bare IPs (`192.168.7.10`), and/or
+  # hostname literals (`vcenter.lab.internal`, matched verbatim — never
+  # resolved-then-matched, to stay TOCTOU-free); whitespace around commas
+  # is ignored.
+  #
+  # Default `""` keeps the connector inert (fail-closed) — a genuine
+  # no-op render that changes nothing on existing installs. Because
+  # `net.*` ops are agent-auto-runnable (`safety_level="safe"`), this
+  # allowlist is the sole floor on a network-vantage recon primitive:
+  # scope it to exactly the ranges/hosts operators must probe, never a
+  # global off-switch. A malformed CIDR fails loudly at runtime naming
+  # the offending token. See `docs/codebase/connectors-net-diagnostics.md`.
+  probeAllowlist: ""
 
 service:
   type: ClusterIP

--- a/docs/codebase/connectors-net-diagnostics.md
+++ b/docs/codebase/connectors-net-diagnostics.md
@@ -384,6 +384,22 @@ ICMP datagram sockets — it never grants `CAP_NET_RAW`. Empty (default)
 renders no sysctl. A privileged `CAP_NET_RAW` sidecar remains the
 documented escalation path (not implemented).
 
+The probe allowlist itself is a first-class chart value:
+`netdiag.probeAllowlist` in `values.yaml` renders into
+`MEHO_NETDIAG_PROBE_ALLOWLIST` on the backplane ConfigMap
+(`templates/configmap.yaml`), which the Deployment injects into the
+container via `envFrom.configMapRef` — so a populated value reaches
+`connectors/net/allowlist.py` with no `extraEnv` escape hatch. It is
+schema-typed in `values.schema.json` as a plain optional string:
+deliberately absent from any `required` list and carrying no `minLength`,
+so the safe default `""` validates on every install (and surfaces under
+`helm show values`). That default renders `MEHO_NETDIAG_PROBE_ALLOWLIST: ""`,
+which — given the inverted allow-only-what-is-listed semantics — keeps
+the connector **inert** (every probe denied). This mirrors the typed
+`config.targetSsrfAllowlist` treatment (#2240) so both fail-closed
+allowlists share one configuration shape, differing only in default
+posture. Chart-only — the allowlist parser is untouched.
+
 ## Broadcast classification
 
 `net.*` ops classify as `read` in the broadcast sensitivity taxonomy


### PR DESCRIPTION
Closes #2518

## Summary

Promotes `MEHO_NETDIAG_PROBE_ALLOWLIST` — the inverted, fail-closed allowlist governing the `net.*` diagnostics connector (Initiative #2405) — to a first-class `netdiag.probeAllowlist` Helm chart value, mirroring #2240's `config.targetSsrfAllowlist` treatment so both fail-closed allowlists share one configuration shape. Previously the env var was settable **only** via the untyped `extraEnv` passthrough (not schema-validated, not surfaced by `helm show values`).

## Changes

- **`values.yaml`** — add `netdiag.probeAllowlist: ""` (empty default keeps the connector inert / fail-closed) under the existing `netdiag` block, with a comment contrasting the *inverted, allow-only-what-is-listed* semantics against the SSRF guard's opt-out posture. Retarget the `pingGroupRange` SECURITY NOTE cross-reference at the typed key instead of the raw env var.
- **`templates/configmap.yaml`** — render `MEHO_NETDIAG_PROBE_ALLOWLIST` unconditionally, grouped next to `MEHO_TARGET_SSRF_ALLOWLIST`; the empty default is a genuine no-op.
- **`values.schema.json`** — schema-type `probeAllowlist` as an optional string (no `minLength`, so the empty default validates on every install).
- **`docs/codebase/connectors-net-diagnostics.md`** — document the deployment surface.

Chart-only — the allowlist parser (`connectors/net/allowlist.py`) is untouched. Mirrors #2240's file set (no `values-rdc-example.yaml` change: that example has no `netdiag` block).

## Verification

- `helm show values` lists `netdiag.probeAllowlist: ""`.
- `helm template` default renders `MEHO_NETDIAG_PROBE_ALLOWLIST: ""` (inert, fail-closed — unchanged posture).
- `helm template --set-string netdiag.probeAllowlist=10.0.0.0/8\,vcenter.lab.internal` renders `MEHO_NETDIAG_PROBE_ALLOWLIST: "10.0.0.0/8,vcenter.lab.internal"`.
- `values.schema.json` rejects a non-string value (`got boolean, want string`).
- `helm lint` passes clean with the required overrides supplied.

Parent goal: #221 · Parent initiative: #2592

🤖 Generated with [Claude Code](https://claude.com/claude-code)
