### PR TITLE
fix(targets): gate secret_ref tenant-scope guard on the vault backend (#2585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — GSM secret-ref registration guard (#2585)
+
+- Target registration on a `config.credentialBackend: gsm` deploy no
+  longer rejects valid `gsm:<project>/<secret>[#field]` secret_refs with
+  a Vault-worded `422 secret_ref_outside_tenant_scope`. The registration-
+  time tenant-scope gate (`POST`/`PATCH /api/v1/targets`) now only applies
+  to refs that resolve through the Vault credential backend — decided by
+  the same `split_credential_ref` resolver dispatch uses — so a GSM
+  install registers `gsm:` refs out of the box with **zero** `extraEnv`
+  overrides (`deploy/values-examples/values-gsm-example.yaml`). Vault
+  deploys are unchanged; a per-target `gsm:` override ref is likewise
+  passed through on a Vault-default deploy.
+
 ## [0.24.0] - 2026-07-17
 
 This release **completes Broadcast v2 (Initiative #2543)** — the final

--- a/backend/src/meho_backplane/api/v1/targets.py
+++ b/backend/src/meho_backplane/api/v1/targets.py
@@ -141,6 +141,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
+from meho_backplane.connectors._shared.credential_backend import split_credential_ref
 from meho_backplane.connectors._shared.vault_creds import DEFAULT_KV_MOUNT
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.registry import (
@@ -883,9 +884,27 @@ def _enforce_secret_ref_tenant_scope(
     unconfigured target fails dispatch with the existing actionable
     "no secret_ref configured" error, not a Vault denial.
 
+    The check only applies to refs that resolve through the **Vault**
+    credential backend. #2585 (Initiative #2592): the constraint is a
+    Vault KV path convention, so a ref bound to another store — a
+    ``gsm:<project>/<secret>`` ref, or any ref on a
+    ``CREDENTIAL_BACKEND=gsm`` deploy — has no Vault subtree to enforce
+    and is passed through untouched. Backend resolution reuses
+    :func:`~meho_backplane.connectors._shared.credential_backend.split_credential_ref`
+    with the deploy default, so the write-time gate's *applicability*
+    tracks the same backend dispatch resolves at read time
+    (:func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`).
+
     Raises a structured 422 (``kind="secret_ref_outside_tenant_scope"``)
     on violation; returns ``None`` otherwise.
     """
+    kind, _ = split_credential_ref(secret_ref, default_backend=get_settings().credential_backend)
+    if kind != "vault":
+        # Ref resolves through a non-Vault store (explicit ``gsm:`` scheme,
+        # or the deploy default on a GSM install) — the Vault tenant-subtree
+        # convention does not apply, so there is nothing to enforce.
+        return
+
     template = get_settings().vault_kv_tenant_scope_prefix.strip()
     if not template:
         # Guard disabled (mid-migration deploy) — no defined subtree to

--- a/backend/tests/test_api_v1_targets.py
+++ b/backend/tests/test_api_v1_targets.py
@@ -2685,3 +2685,91 @@ def test_create_target_secret_ref_gate_noop_when_guard_disabled(
         )
     assert response.status_code == 201
     assert response.json()["secret_ref"] == "secret/meho/unguarded"
+
+
+def test_create_target_accepts_gsm_secret_ref_on_gsm_backend(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``CREDENTIAL_BACKEND=gsm`` — a ``gsm:`` secret_ref registers cleanly.
+
+    #2585 (Initiative #2592): the tenant-scope gate enforces a Vault KV
+    path convention, so it must not fire on a GSM deploy where refs
+    resolve through GCP Secret Manager. A ``gsm:<project>/<secret>#field``
+    ref is stored verbatim — no ``VAULT_KV_TENANT_SCOPE_PREFIX=""``
+    ``extraEnv`` workaround required (``deploy/values-examples/values-gsm-example.yaml``).
+    """
+    monkeypatch.setenv("CREDENTIAL_BACKEND", "gsm")
+    get_settings.cache_clear()
+    gsm_ref = "gsm:my-gcp-project/vcf-logs#password"
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "vcf-logs-gsm",
+                "product": "ssh",
+                "host": "10.0.0.5",
+                "secret_ref": gsm_ref,
+            },
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+    assert response.json()["secret_ref"] == gsm_ref
+
+
+@pytest.mark.asyncio
+async def test_update_target_accepts_gsm_secret_ref_on_gsm_backend(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``CREDENTIAL_BACKEND=gsm`` — PATCH to a ``gsm:`` secret_ref is honoured.
+
+    #2585: the PATCH call site runs the same tenant-scope gate as POST, so
+    it must likewise pass through a GSM-backed ref untouched.
+    """
+    monkeypatch.setenv("CREDENTIAL_BACKEND", "gsm")
+    get_settings.cache_clear()
+    gsm_ref = "gsm:my-gcp-project/patched#password"
+    key = make_rsa_keypair("kid-A")
+    await _insert_target(name="patched-gsm", product="ssh", host="10.0.0.9", secret_ref=None)
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.patch(
+            "/api/v1/targets/patched-gsm",
+            json={"secret_ref": gsm_ref},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 200
+    assert response.json()["secret_ref"] == gsm_ref
+
+
+def test_create_target_gsm_scheme_ref_bypasses_gate_on_vault_backend(
+    client: TestClient,
+) -> None:
+    """A ``gsm:`` scheme ref resolves to GSM even on a Vault-default deploy.
+
+    #2585: the gate's applicability tracks the backend the ref *resolves
+    to* (via ``split_credential_ref``), not the deploy default. A
+    per-target ``gsm:`` override is a GSM credential regardless of
+    ``credential_backend``, so the Vault tenant-subtree convention does
+    not apply and the ref is stored verbatim — the guard stays fully
+    intact for schemeless / ``vault:`` refs (covered above).
+    """
+    gsm_ref = "gsm:my-gcp-project/override#password"
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "vault-deploy-gsm-override",
+                "product": "ssh",
+                "host": "10.0.0.5",
+                "secret_ref": gsm_ref,
+            },
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+    assert response.json()["secret_ref"] == gsm_ref

--- a/docs/codebase/connectors-vault-tenant-scope.md
+++ b/docs/codebase/connectors-vault-tenant-scope.md
@@ -283,6 +283,15 @@ boundary, and the empty-prefix opt-out makes the gate a no-op. Only an
 *explicit* ref is checked — the derived per-tenant default (#1723) and
 an explicit-null clear pass untouched.
 
+The gate only fires for refs that resolve through the **Vault** backend
+(#2585). Applicability is decided by `split_credential_ref` with the
+deploy default (`credential_backend`), the same resolver dispatch uses
+at read time — so a `gsm:<project>/<secret>` ref, or any ref on a
+`CREDENTIAL_BACKEND=gsm` deploy, has no Vault subtree to enforce and is
+stored verbatim. This is what lets a GSM install register `gsm:` refs
+without the `VAULT_KV_TENANT_SCOPE_PREFIX=""` `extraEnv` workaround
+(`deploy/values-examples/values-gsm-example.yaml`).
+
 A target that predates the gate (or a genuine Vault-policy drift) still
 surfaces at dispatch as the structured `connector_vault_forbidden`
 error (`result_connector_vault_forbidden` in `operations/_errors.py`,
@@ -318,6 +327,7 @@ no Vault login) and allows an in-namespace path unchanged.
 The #2091 write-time gate is covered in
 [`backend/tests/test_api_v1_targets.py`](../../backend/tests/test_api_v1_targets.py)
 (the "#2091 — secret_ref tenant-scope fail-fast" cluster: POST/PATCH
-reject, segment boundary, derived-default pass, guard-disabled no-op);
+reject, segment boundary, derived-default pass, guard-disabled no-op,
+plus the #2585 GSM-backend / `gsm:`-scheme pass-through cases);
 the dispatch-time `connector_vault_forbidden` mapping in
 [`backend/tests/test_operations_connector_vault_forbidden.py`](../../backend/tests/test_operations_connector_vault_forbidden.py).


### PR DESCRIPTION
## Summary
- On a `config.credentialBackend: gsm` deploy, target registration rejected **every** valid `gsm:<project>/<secret>[#field]` secret_ref with a Vault-worded `422 secret_ref_outside_tenant_scope` — the registration-time tenant-scope guard (`_enforce_secret_ref_tenant_scope`, `POST`/`PATCH /api/v1/targets`) was not gated on the credential backend.
- The guard enforces a **Vault KV path** convention, so it now only applies to refs that resolve through the Vault backend. Applicability is decided by `split_credential_ref(secret_ref, default_backend=settings.credential_backend)` — the same resolver dispatch uses at read time — so the write-time gate's applicability tracks the store the ref actually reads from.
- Result: a GSM install registers `gsm:` refs out of the box with **zero** `extraEnv` overrides; `deploy/values-examples/values-gsm-example.yaml` works as written. Vault deploys are byte-identical for schemeless / `vault:` refs.

## Deviation from the ticket (deliberate, more precise)
The ticket suggested gating on `settings.credential_backend == "vault"`. I gated on the **ref's resolved backend** via `split_credential_ref` instead — same one-conditional footprint, but strictly more correct: it also passes through a per-target `gsm:` override ref on a Vault-default deploy (previously wrongly `422`'d, since a scheme-prefixed ref overrides the backend per-target — see `settings.py` `credential_backend` docstring). No change to `connectors/vault/tenant_scope.py` or any `vault.kv.*` op guard (per the ticket's correction).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/api/v1/targets.py` — clean
- [x] `pytest tests/test_api_v1_targets.py` — 79 passed (incl. 3 new)
  - `test_create_target_accepts_gsm_secret_ref_on_gsm_backend` — POST + `CREDENTIAL_BACKEND=gsm` accepts `gsm:...#field`
  - `test_update_target_accepts_gsm_secret_ref_on_gsm_backend` — PATCH + `CREDENTIAL_BACKEND=gsm` accepts `gsm:...#field`
  - `test_create_target_gsm_scheme_ref_bypasses_gate_on_vault_backend` — `gsm:` override passes on the vault default
- [x] All existing `#2091` tenant-scope guard tests stay green (vault-backend behaviour unchanged)
- [x] `code-quality.py --diff` — 0 blockers

## Out of scope
- Promoting `vault_kv_tenant_scope_prefix` to a typed chart value (a Vault-deploy tuning concern).
- Runtime `vault.kv.*` guard changes (see the ticket's correction).
- The consolidated deploy guide (#2468).

## Adjacent findings
- `_enforce_secret_ref_tenant_scope` is now 96 lines (code-quality WARN >60; under the 100-line block limit). Growth is docstring + the small backend-resolution gate; not extracted to avoid a gratuitous helper. Pre-existing `probe_target` (108 lines) remains a legacy block flagged as not-in-this-diff.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2585


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GSM-backed `secret_ref` values are now accepted during target creation and updates.
  * GSM references are stored unchanged and no longer incorrectly rejected by Vault tenant-scope validation.
  * Vault-backed secret reference behavior remains unchanged.

* **Documentation**
  * Clarified when tenant-scope validation applies and removed the need for a configuration workaround with GSM references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->