### PR TITLE
fix(connectors): honor an explicit http scheme on HttpConnector targets (#2587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — explicit http scheme on HttpConnector targets (#2587)
+
+- Every `HttpConnector`-based connector hardcoded `https` when building
+  the request URL, so a target against a plain-HTTP management API — e.g.
+  RabbitMQ's Management API on `15672`, HTTP unless the mgmt TLS listener
+  is enabled on `15671` — was unreachable (it probed
+  `WRONG_VERSION_NUMBER`). The transport scheme is now read from an opt-in
+  `scheme` key in `Target.extras` (`{"http", "https"}`, default `https`),
+  with scheme-correct default-port elision (`443`/`80`). Absent the key,
+  behaviour is byte-identical (https, `:443` elided). An invalid value is
+  refused with a clear error at dispatch rather than silently coerced, and
+  the scheme is never derived from `verify_tls` (certificate trust and
+  transport selection stay orthogonal). Same-origin redirect following
+  keys on the effective scheme, so an http target's benign trailing-slash
+  canonicalisation is still followed while an http→https hop is refused
+  as cross-origin.
+
 ## [0.24.0] - 2026-07-17
 
 This release **completes Broadcast v2 (Initiative #2543)** — the final

--- a/backend/src/meho_backplane/connectors/adapters/http.py
+++ b/backend/src/meho_backplane/connectors/adapters/http.py
@@ -215,6 +215,39 @@ _MAX_SAME_ORIGIN_REDIRECTS = 5
 
 
 _DEFAULT_PORTS = {"http": 80, "https": 443}
+_ALLOWED_SCHEMES = frozenset(_DEFAULT_PORTS)
+
+
+def _effective_scheme(target: Target) -> str:
+    """Return the transport scheme for *target* — ``https`` unless opted out.
+
+    Reads an optional ``scheme`` key from :attr:`Target.extras`. Absent (the
+    default for every existing target — ``extras`` is ``{}`` by default) →
+    ``https``, so behaviour stays byte-identical to before. Present → must be
+    exactly ``http`` or ``https``; anything else raises :exc:`ValueError` at
+    dispatch rather than being silently coerced, so a typo like ``htp`` fails
+    loud instead of falling back to https and masking the misconfiguration.
+
+    Honouring an explicit ``http`` is what lets an :class:`HttpConnector`
+    reach a plain-HTTP management API — RabbitMQ's Management API is HTTP on
+    ``15672`` (HTTPS only on ``15671`` when the mgmt TLS listener is enabled)
+    (evoila/meho#2587). The scheme is deliberately opt-in and is **never**
+    derived from ``verify_tls``: certificate trust and transport selection
+    are orthogonal, and deriving one from the other would silently change the
+    transport of every existing ``verify_tls=false`` target.
+    """
+    extras = getattr(target, "extras", None)
+    if not isinstance(extras, dict):
+        return "https"
+    scheme = extras.get("scheme", "https")
+    if scheme not in _ALLOWED_SCHEMES:
+        raise ValueError(
+            f"target {getattr(target, 'name', '?')!r} has an invalid "
+            f"extras.scheme {scheme!r}; expected one of {sorted(_ALLOWED_SCHEMES)}"
+        )
+    # Membership above guarantees a literal "http"/"https"; str() narrows the
+    # ``Any`` that flows in from the free-form ``extras`` dict for the typer.
+    return str(scheme)
 
 
 def _effective_port(url: httpx.URL) -> int | None:
@@ -496,8 +529,9 @@ class HttpConnector(Connector):
         return path
 
     def _base_url(self, target: Target) -> str:
-        scheme = "https"
-        port = f":{target.port}" if target.port and target.port != 443 else ""
+        scheme = _effective_scheme(target)
+        default_port = _DEFAULT_PORTS[scheme]
+        port = f":{target.port}" if target.port and target.port != default_port else ""
         return f"{scheme}://{target.host}{port}"
 
     def _request_extensions(self, target: Target) -> dict[str, Any]:

--- a/backend/tests/test_connectors_http_adapter.py
+++ b/backend/tests/test_connectors_http_adapter.py
@@ -63,6 +63,7 @@ from meho_backplane.connectors.adapters.http import HttpConnector as _HttpConnec
 from meho_backplane.connectors.adapters.http import (
     _build_ca_pinned_ssl_context,
     _ca_pin_digest,
+    _effective_scheme,
     _same_origin,
     _SameOriginRedirectClient,
 )
@@ -99,6 +100,7 @@ def _make_target(
     verify_tls: bool = True,
     tls_ca_pin: str | None = None,
     tls_server_name: str | None = None,
+    extras: dict[str, Any] | None = None,
 ) -> Any:
     """Return a minimal duck-typed Target stub.
 
@@ -111,6 +113,8 @@ def _make_target(
     construction path match a verifying, unpinned target.
     ``tls_server_name`` defaults to ``None`` (#2002) — no SNI / cert-verify
     override, so the dispatch derives the verification name from ``host``.
+    ``extras`` mirrors the model's NOT NULL ``{}`` default (#2587) — no
+    ``scheme`` key, so ``_base_url`` builds an ``https`` URL as before.
     """
     return types.SimpleNamespace(
         name=name,
@@ -122,6 +126,7 @@ def _make_target(
         verify_tls=verify_tls,
         tls_ca_pin=tls_ca_pin,
         tls_server_name=tls_server_name,
+        extras=extras if extras is not None else {},
     )
 
 
@@ -1300,3 +1305,129 @@ def test_same_origin_normalises_default_ports() -> None:
     assert _same_origin(base, plain_http) is False
     # A non-default explicit port is a genuinely different origin.
     assert _same_origin(base, non_default_port) is False
+
+
+# ---------------------------------------------------------------------------
+# Explicit http scheme on HttpConnector targets (#2587)
+# ---------------------------------------------------------------------------
+
+
+def test_base_url_defaults_to_https_and_elides_443() -> None:
+    """No ``extras.scheme`` → https, with the :443 default port elided."""
+    conn = _ConcreteHttpConnector()
+    target = _make_target(host="vc.example.com", port=443)
+    assert conn._base_url(target) == "https://vc.example.com"
+
+
+def test_base_url_honors_explicit_http_scheme_with_port() -> None:
+    """``extras={'scheme':'http'}`` + port 15672 → ``http://host:15672``.
+
+    The RabbitMQ Management API case: plain HTTP on a non-default port must
+    be reachable when the operator opts in via ``extras.scheme``.
+    """
+    conn = _ConcreteHttpConnector()
+    target = _make_target(host="rabbit.example.com", port=15672, extras={"scheme": "http"})
+    assert conn._base_url(target) == "http://rabbit.example.com:15672"
+
+
+def test_base_url_http_elides_default_port_80() -> None:
+    """An explicit http target on port 80 elides the default port."""
+    conn = _ConcreteHttpConnector()
+    target = _make_target(host="plain.example.com", port=80, extras={"scheme": "http"})
+    assert conn._base_url(target) == "http://plain.example.com"
+
+
+def test_base_url_explicit_https_is_identical_to_default() -> None:
+    """``extras={'scheme':'https'}`` behaves exactly like the implicit default."""
+    conn = _ConcreteHttpConnector()
+    explicit = _make_target(host="vc.example.com", port=443, extras={"scheme": "https"})
+    implicit = _make_target(host="vc.example.com", port=443)
+    assert conn._base_url(explicit) == conn._base_url(implicit) == "https://vc.example.com"
+
+
+def test_base_url_https_keeps_non_default_port() -> None:
+    """A non-default https port is preserved (regression guard on elision)."""
+    conn = _ConcreteHttpConnector()
+    target = _make_target(host="vc.example.com", port=8443, extras={"scheme": "https"})
+    assert conn._base_url(target) == "https://vc.example.com:8443"
+
+
+@pytest.mark.parametrize("bad_scheme", ["ftp", "htp", "HTTP", "ws", "", "tcp"])
+def test_base_url_rejects_invalid_scheme(bad_scheme: str) -> None:
+    """An invalid ``extras.scheme`` is refused at use, not silently coerced."""
+    conn = _ConcreteHttpConnector()
+    target = _make_target(extras={"scheme": bad_scheme})
+    with pytest.raises(ValueError, match=r"invalid.*extras\.scheme"):
+        conn._base_url(target)
+
+
+def test_effective_scheme_missing_extras_defaults_https() -> None:
+    """A target whose ``extras`` is absent/non-dict falls back to https."""
+    no_extras = types.SimpleNamespace(name="t")
+    assert _effective_scheme(no_extras) == "https"
+    non_dict = types.SimpleNamespace(name="t", extras=None)
+    assert _effective_scheme(non_dict) == "https"
+
+
+@pytest.mark.asyncio
+async def test_http_scheme_target_dispatches_over_http() -> None:
+    """End-to-end: an http-scheme target's request reaches the http origin.
+
+    Proves the scheme flows through ``_base_url`` into the pooled client and
+    onto the wire — a request against a plain-HTTP management endpoint on
+    :15672 is dispatched over ``http://``, not forced to ``https``.
+    """
+    conn = _ConcreteHttpConnector()
+    target = _make_target(host="rabbit.example.com", port=15672, extras={"scheme": "http"})
+
+    client = await conn._http_client(target)
+    assert str(client.base_url) == "http://rabbit.example.com:15672"
+
+    async with respx.mock(base_url="http://rabbit.example.com:15672") as mock:
+        route = mock.get("/api/overview").respond(200, json={"ok": True})
+        result = await conn._get_json(target, "/api/overview", operator=_make_operator("tok"))
+
+    assert result == {"ok": True}
+    assert route.called
+    assert route.calls[0].request.url.scheme == "http"
+    await conn.aclose()
+
+
+@pytest.mark.asyncio
+async def test_http_target_follows_same_origin_redirect_over_http() -> None:
+    """An http target's same-origin trailing-slash redirect is followed.
+
+    The same-origin redirect comparison keys on the *effective* scheme: an
+    http base URL follows a same-origin http canonicalisation, and a
+    scheme-upgrade to https is treated as cross-origin and refused (so no
+    credential is replayed across the http→https boundary).
+    """
+    seen: list[tuple[str, str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.scheme, request.url.path))
+        if request.url.path == "/api/whoami":
+            return httpx.Response(301, headers={"Location": "/api/whoami/"})
+        return httpx.Response(200, json={"user": "guest"})
+
+    transport = httpx.MockTransport(handler)
+    async with _SameOriginRedirectClient(
+        base_url="http://rabbit.example.com:15672",
+        transport=transport,
+    ) as client:
+        resp = await client.get("/api/whoami")
+
+    assert resp.status_code == 200
+    assert seen == [
+        ("GET", "http", "/api/whoami"),
+        ("GET", "http", "/api/whoami/"),
+    ]
+
+
+def test_same_origin_http_scheme_upgrade_is_cross_origin() -> None:
+    """An http→https redirect on the same host is a different origin."""
+    http_base = httpx.URL("http://rabbit.example.com:15672/api/whoami")
+    https_same_host = httpx.URL("https://rabbit.example.com:15672/api/whoami/")
+    http_same = httpx.URL("http://rabbit.example.com:15672/api/whoami/")
+    assert _same_origin(http_base, https_same_host) is False
+    assert _same_origin(http_base, http_same) is True

--- a/docs/codebase/connectors-rabbitmq.md
+++ b/docs/codebase/connectors-rabbitmq.md
@@ -149,6 +149,13 @@ never an exception. `probe` delegates to `fingerprint`.
 - **Read-only by design.** No write/admin ops (create/delete shovel,
   set policy, …) — those would be a separate approval-gated G3.x write
   surface, not part of this connector.
+- **Plain-HTTP brokers need `extras.scheme`.** `HttpConnector` dials
+  `https` by default, so a broker whose Management API is HTTP-only on
+  `15672` (the common default — HTTPS on `15671` only when the mgmt TLS
+  listener is enabled) is unreachable until the operator opts in by
+  setting `extras: {"scheme": "http"}` on the target (#2587). The scheme
+  is validated to `http`/`https` at dispatch and is orthogonal to
+  `verify_tls` (certificate trust vs. transport selection).
 
 ## References
 


### PR DESCRIPTION
## Summary
- `HttpConnector._base_url` hardcoded `https`, making every `HttpConnector`-based target against a plain-HTTP management API unreachable — concretely RabbitMQ's Management API on `15672` (HTTP unless the mgmt TLS listener is enabled on `15671`), which probed `WRONG_VERSION_NUMBER`.
- The transport scheme is now read from an opt-in `scheme` key in `Target.extras` (validated to `{"http","https"}`, default `https`) — exactly what the free-form `extras` escape hatch exists for, so no model change or migration.
- `_base_url` uses the effective scheme with scheme-correct default-port elision (`443`/https, `80`/http). The scheme is never derived from `verify_tls` — certificate trust and transport selection stay orthogonal, so no existing `verify_tls=false` target silently changes transport.
- The same-origin redirect comparison already keys on the base URL's scheme, so an http target's benign trailing-slash canonicalisation is still followed while an http→https hop is refused as cross-origin.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/.../adapters/http.py` — clean
- [x] `pytest tests/test_connectors_http_adapter.py` — 69 passed (11 new)
- [x] `pytest -k "rabbitmq or http_adapter"` — 116 passed
- [x] AC: `extras:{"scheme":"http"}` + port 15672 → `http://host:15672` probe/dispatch (`_base_url` unit + stubbed-transport request-path test)
- [x] AC: targets without the key are byte-identical (https, `:443` elision) — existing tests green
- [x] AC: invalid `extras.scheme` refused with a clear `ValueError` at use — parametrised test
- [x] AC: same-origin redirect follows the effective scheme — http trailing-slash 301 followed; http→https refused cross-origin
- [x] `code-quality.py --diff` — 0 blockers (4 pre-existing warnings on untouched functions)

## Out of scope
- A first-class `scheme` column / migration (revisit only if `extras` proves insufficient).
- Per-op scheme overrides; anything RabbitMQ-connector-specific (this unblocks the whole `HttpConnector` family).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2587
