### PR TITLE
feat(chart): render operator-console OAuth env from first-class values (#2594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,27 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — operator-console OAuth chart values (#2594)
+
+- The Helm chart now renders the operator-console (`/ui/*`) browser
+  BFF OAuth settings from first-class values, so a chart-only deploy
+  can enable the console without hand-rolling Secrets and `extraEnv`
+  `valueFrom`. Set `config.uiKeycloakClientId` (plain, rendered as
+  `UI_KEYCLOAK_CLIENT_ID`) and `uiConsole.enabled: true` +
+  `uiConsole.secretName` (a Secret holding the `meho-web` client
+  secret and the session encryption key, wired into
+  `UI_KEYCLOAK_CLIENT_SECRET` / `UI_SESSION_ENCRYPTION_KEY` via
+  `secretKeyRef`). Previously these three env vars had no chart values,
+  so a browser-console deploy hit `503 ui_oauth_not_configured` with no
+  chart-level way to configure it. Enabling the console is
+  all-or-nothing (the schema requires the client_id + secret name under
+  `uiConsole.enabled: true`); leaving it disabled is the default and
+  keeps the console cleanly dark with no effect on `/api/*` or the
+  `meho login` CLI. The GSM/no-Vault enablement recipe (confidential
+  web client + session key + the two secrets) is documented in
+  `deploy/values-examples/README.md` and the realm-side
+  `docs/cross-repo/keycloak-web-client.md` (#2594).
+
 ## [0.24.0] - 2026-07-17
 
 This release **completes Broadcast v2 (Initiative #2543)** — the final

--- a/deploy/charts/meho/templates/configmap.yaml
+++ b/deploy/charts/meho/templates/configmap.yaml
@@ -47,6 +47,17 @@ data:
   # actionable public-client error rather than silently misusing
   # `KEYCLOAK_AUDIENCE` (the confidential resource-server id).
   KEYCLOAK_CLI_CLIENT_ID: {{ .Values.config.keycloakCliClientId | quote }}
+  # #2594 (Goal #336) — public client_id of the confidential `meho-web`
+  # client the operator-console browser BFF login runs its OAuth 2.1
+  # authorization-code grant against. Unconditionally emitted so the
+  # env-var contract stays stable; the console gate
+  # (`meho_backplane.features._ui_surface_block`) needs this AND the two
+  # `uiConsole` secrets (`UI_KEYCLOAK_CLIENT_SECRET` /
+  # `UI_SESSION_ENCRYPTION_KEY`, wired via secretKeyRef in the Deployment)
+  # non-empty, so an empty value here keeps the console cleanly disabled
+  # (`503 ui_oauth_not_configured`) without touching `/api/*` or the CLI's
+  # `KEYCLOAK_CLI_CLIENT_ID` device-code flow.
+  UI_KEYCLOAK_CLIENT_ID: {{ .Values.config.uiKeycloakClientId | quote }}
   KEYCLOAK_JWKS_CACHE_TTL_SECONDS: {{ .Values.config.keycloakJwksCacheTtlSeconds | quote }}
   KEYCLOAK_JWT_LEEWAY_SECONDS: {{ .Values.config.keycloakJwtLeewaySeconds | quote }}
   # Emitted only for a Vault-backend install (Initiative #2227). A

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -120,6 +120,32 @@ spec:
                   name: {{ include "meho.keycloakAdminSecretName" . | quote }}
                   key: {{ .Values.keycloakAdmin.clientSecret.secretKey | quote }}
             {{- end }}
+            {{- if .Values.uiConsole.enabled }}
+            # #2594 (Goal #336) — operator-console browser BFF confidential
+            # credentials. Wired only when `uiConsole.enabled: true`. Both
+            # are confidential and use `secretKeyRef` (never plaintext) —
+            # `UI_KEYCLOAK_CLIENT_SECRET` is the `meho-web` client secret
+            # carried on the server-side token-endpoint POST;
+            # `UI_SESSION_ENCRYPTION_KEY` is the Fernet key the BFF
+            # encrypts the session cookie with. The public `client_id`
+            # (`UI_KEYCLOAK_CLIENT_ID`) is plain config from the ConfigMap.
+            # The schema requires `uiConsole.secretName` under
+            # `enabled: true`, so the referenced Secret name is never
+            # empty here. Unset → `GET /ui/auth/login` returns
+            # `503 ui_oauth_not_configured`
+            # (`meho_backplane.features._ui_surface_block`), no effect on
+            # `/api/*` or the CLI.
+            - name: UI_KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.uiConsole.secretName | quote }}
+                  key: {{ .Values.uiConsole.clientSecretKey | quote }}
+            - name: UI_SESSION_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.uiConsole.secretName | quote }}
+                  key: {{ .Values.uiConsole.sessionEncryptionKey | quote }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             # Operator-supplied extra env vars (full EnvVar shape — accepts
             # `value` or `valueFrom`). Most common use: pointing

--- a/deploy/charts/meho/templates/tests/test-ui-console-config.yaml
+++ b/deploy/charts/meho/templates/tests/test-ui-console-config.yaml
@@ -1,0 +1,107 @@
+{{- /*
+  #2594 (Goal #336) — helm test that asserts the operator-console
+  (`/ui/*`) browser BFF OAuth credentials make it from chart values to
+  the backplane container's env at the right shape:
+
+    * `UI_KEYCLOAK_CLIENT_ID` resolves to the plain
+      `config.uiKeycloakClientId` (ConfigMap-sourced) value.
+    * `UI_KEYCLOAK_CLIENT_SECRET` resolves via `secretKeyRef` (never
+      plaintext) to `uiConsole.secretName` / `uiConsole.clientSecretKey`.
+    * `UI_SESSION_ENCRYPTION_KEY` resolves via `secretKeyRef` to
+      `uiConsole.secretName` / `uiConsole.sessionEncryptionKey`.
+
+  These are exactly the three env vars
+  `meho_backplane.features._ui_surface_block` gates the console on — so a
+  passing test proves an operator who set the three values gets a console
+  that clears the gate instead of `503 ui_oauth_not_configured`.
+
+  Renders only when `uiConsole.enabled` — the gate the test covers. A
+  deploy that leaves the console disabled exercises the (verified-elsewhere)
+  no-render path and this Pod is not what proves it.
+
+  Triggered via `helm test <release>`. The Pod is annotated with
+  `helm.sh/hook: test` so it's NOT part of the release manifest —
+  `helm uninstall` cleans it up implicitly. It uses `printenv` to inspect
+  its own resolved env (it does NOT call Keycloak — that would need a real
+  realm the helm-test lane doesn't ship). The shape assertion is what
+  `secretKeyRef` resolution proves: Kubernetes' admission controller
+  refuses to start a Pod whose `secretKeyRef.name` / `.key` doesn't
+  resolve, so a started Pod already mounted a real Secret payload.
+*/}}
+{{- if .Values.uiConsole.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "meho.fullname" . }}-test-ui-console-config
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ include "meho.serviceAccountName" . }}
+  containers:
+    - name: ui-console-env-check
+      # Minimal busybox-class image; only `sh` + `printenv` are needed.
+      # Matches the test-agent-runtime-config / test-pgvector posture.
+      image: busybox:1.37
+      imagePullPolicy: IfNotPresent
+      env:
+        # Mirror the backplane's own env wiring so this Pod sees the exact
+        # same resolved values. Any drift between the chart's wiring and
+        # this Pod's would fail the check below, surfacing the regression
+        # before the operator does.
+        - name: UI_KEYCLOAK_CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "meho.fullname" . }}-config
+              key: UI_KEYCLOAK_CLIENT_ID
+        - name: UI_KEYCLOAK_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.uiConsole.secretName | quote }}
+              key: {{ .Values.uiConsole.clientSecretKey | quote }}
+        - name: UI_SESSION_ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.uiConsole.secretName | quote }}
+              key: {{ .Values.uiConsole.sessionEncryptionKey | quote }}
+      command:
+        - sh
+        - -c
+        - |
+          set -eu
+          # Each `printenv` exits non-zero when the env var is missing,
+          # which surfaces as the Pod's exit code and bubbles up through
+          # `helm test`. The values themselves are not logged — printing a
+          # real client secret / session key to the test pod's stdout would
+          # leak it in CI logs for any production-shaped deploy.
+          printenv UI_KEYCLOAK_CLIENT_ID >/dev/null \
+            || { echo "FAIL: UI_KEYCLOAK_CLIENT_ID not resolved (config.uiKeycloakClientId wiring regressed)"; exit 1; }
+          printenv UI_KEYCLOAK_CLIENT_SECRET >/dev/null \
+            || { echo "FAIL: UI_KEYCLOAK_CLIENT_SECRET not resolved (chart secretKeyRef wiring regressed)"; exit 1; }
+          printenv UI_SESSION_ENCRYPTION_KEY >/dev/null \
+            || { echo "FAIL: UI_SESSION_ENCRYPTION_KEY not resolved (chart secretKeyRef wiring regressed)"; exit 1; }
+          # The client_id may legitimately be an empty string only when the
+          # console is disabled; but this Pod renders only under
+          # `uiConsole.enabled: true`, where the schema requires
+          # config.uiKeycloakClientId non-empty — so a non-empty value is
+          # part of the contract this test proves.
+          [ -n "${UI_KEYCLOAK_CLIENT_ID}" ] \
+            || { echo "FAIL: UI_KEYCLOAK_CLIENT_ID is empty while the console is enabled (schema/render regression)"; exit 1; }
+          echo "OK: operator-console OAuth env vars resolved (UI_KEYCLOAK_CLIENT_ID + secretKeyRef client_secret + session key)"
+      resources:
+        limits:
+          cpu: 100m
+          memory: 32Mi
+        requests:
+          cpu: 10m
+          memory: 16Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+{{- end }}

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -282,6 +282,10 @@
           "type": "string",
           "pattern": "^(|[0-9]+(\\.[0-9]+)?)$",
           "description": "Async ingest-job watchdog budget override, in seconds, rendered into the `INGEST_JOB_TIMEOUT_SECONDS` env var the backplane reads once at import (`_load_ingest_job_timeout_seconds`, `backend/src/meho_backplane/operations/ingest/jobs.py`; #2318, hardens #2275) — NOT via settings.py. Optional override for the #2275 async-ingest watchdog that time-boxes each background OpenAPI-ingest job in `asyncio.timeout(...)` so a wedged pipeline can't sit at `status=running` until a pod restart: raise it for a slow shared executor / very large spec fleet. Value is an empty string or a decimal number of seconds. Default `\"\"` — deliberately absent from `config.required` and carrying no `minLength` so the empty default validates on every install — omits the env (the ConfigMap guards the render with `{{ if }}`) so the backend's own 30-min default applies silently; an always-rendered empty string would hit `float(\"\")` and log a spurious `ingest_job_timeout_env_invalid` warning on every boot, the trap the sibling `targetSsrfAllowlist` sidesteps only because its empty value is a valid no-op. A non-finite (`inf`/`nan`), non-positive, or malformed value that slips the pattern is rejected at the backend, which warns and falls back to 30 min — a misconfigured budget can never disable the watchdog. See `docs/codebase/spec-ingestion.md`."
+        },
+        "uiKeycloakClientId": {
+          "type": "string",
+          "description": "Public `client_id` of the confidential `meho-web` client the operator-console (`/ui/*`) browser BFF login runs its OAuth 2.1 authorization-code grant against (#2594, Goal #336), rendered unconditionally as the `UI_KEYCLOAK_CLIENT_ID` env var. NOT a secret (the confidential `client_secret` + session key are wired via `secretKeyRef` from `uiConsole.secretName`). Default `\"\"` — deliberately absent from `config.required` and carrying no `minLength` so a chassis-only / API-only install validates with the browser console left dark; the console gate (`meho_backplane.features._ui_surface_block`) needs this AND the two `uiConsole` secrets non-empty, so an empty value here keeps `/ui/auth/login` at `503 ui_oauth_not_configured` without touching `/api/*` or the `meho login` CLI. When `uiConsole.enabled: true` the root-level `allOf` requires this non-empty — the console is all-or-nothing. See `docs/cross-repo/keycloak-web-client.md`."
         }
       }
     },
@@ -440,6 +444,43 @@
                 "pattern": "^https?://"
               },
               "clientId": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      ]
+    },
+    "uiConsole": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Operator-console (`/ui/*`) browser BFF confidential credentials (#2594, Goal #336). When `enabled: true`, the chart wires `UI_KEYCLOAK_CLIENT_SECRET` (the confidential `meho-web` client secret) and `UI_SESSION_ENCRYPTION_KEY` (the BFF session-cookie Fernet key) into the backplane Deployment via `secretKeyRef` — never plaintext — both sourced from the single `secretName` Secret under the `clientSecretKey` / `sessionEncryptionKey` keys, mirroring the `postgres.credentialsSecret` by-name reference. The public `client_id` is the plain `config.uiKeycloakClientId` env. The schema enforces a non-empty `secretName` under `enabled: true`, and the root-level `allOf` additionally requires a non-empty `config.uiKeycloakClientId` — so a half-configured console fails at `helm install` rather than 503-ing at first browser login. `meho_backplane.features._ui_surface_block` enforces the same `all-three-non-empty` posture at app startup. When `enabled: false` (the default), no env is rendered and `GET /ui/auth/login` returns `503 ui_oauth_not_configured` with no effect on `/api/*` or the `meho login` CLI — same posture as a chart that doesn't ship this block.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "secretName": {
+          "type": "string",
+          "description": "Name of the Kubernetes Secret holding BOTH the confidential web client secret (under `clientSecretKey`) and the session encryption key (under `sessionEncryptionKey`). Referenced by name only — provisioning is the consumer's responsibility (a GSM-synced ExternalSecret, a sealed-secret, or a directly-applied Secret for a no-Vault deploy). Empty when `uiConsole.enabled: true` fails the schema."
+        },
+        "clientSecretKey": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Key within `secretName` whose value is the confidential `meho-web` client secret, wired into `UI_KEYCLOAK_CLIENT_SECRET`. Defaults to `client_secret`."
+        },
+        "sessionEncryptionKey": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Key within `secretName` whose value is the url-safe base64 32-byte Fernet session-cookie encryption key, wired into `UI_SESSION_ENCRYPTION_KEY`. Defaults to `session_encryption_key`."
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "enabled": { "const": true } },
+            "required": ["enabled"]
+          },
+          "then": {
+            "required": ["secretName"],
+            "properties": {
+              "secretName": { "type": "string", "minLength": 1 }
             }
           }
         }
@@ -926,6 +967,29 @@
           }
         },
         "required": ["gsm"]
+      }
+    },
+    {
+      "description": "When the operator console is enabled (`uiConsole.enabled: true`), the browser BFF login needs a non-empty public `client_id` as well as the confidential secret — so `config.uiKeycloakClientId` must be non-empty. This makes enabling the console all-or-nothing: a half-configured console (secret wired, client_id blank) fails at `helm install` rather than 503-ing at first login (#2594).",
+      "if": {
+        "properties": {
+          "uiConsole": {
+            "properties": { "enabled": { "const": true } },
+            "required": ["enabled"]
+          }
+        },
+        "required": ["uiConsole"]
+      },
+      "then": {
+        "properties": {
+          "config": {
+            "required": ["uiKeycloakClientId"],
+            "properties": {
+              "uiKeycloakClientId": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "required": ["config"]
       }
     }
   ],

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -369,6 +369,24 @@ config:
   # a warning and falls back to 30 min — a misconfigured budget can never
   # disable the watchdog. See `docs/codebase/spec-ingestion.md`.
   ingestJobTimeoutSeconds: ""
+  # -- Operator-console (`/ui/*`) OAuth client_id (#2594, Goal #336). The
+  # browser BFF login (`GET /ui/auth/login`) runs an OAuth 2.1
+  # authorization-code + PKCE grant server-side against the operator's
+  # Keycloak realm using a **confidential** web client (suggested name
+  # `meho-web`; see `docs/cross-repo/keycloak-web-client.md`). This is the
+  # public `client_id` of that client; it is NOT a secret and is rendered
+  # unconditionally as `UI_KEYCLOAK_CLIENT_ID` so the env-var contract
+  # stays stable across deploys. The console gate
+  # (`meho_backplane.features._ui_surface_block`) requires this AND the two
+  # `uiConsole` secrets non-empty, so the empty default keeps the browser
+  # console cleanly disabled (`GET /ui/auth/login` → `503
+  # ui_oauth_not_configured`) with NO effect on `/api/*` or the `meho
+  # login` CLI (which use `keycloakCliClientId` / `keycloakAudience`
+  # instead). Set this together with `uiConsole.enabled: true` +
+  # `uiConsole.secretName` to light up the console — the schema then
+  # requires all of them (the console is all-or-nothing). See
+  # `deploy/values-examples/README.md` § operator-console (browser BFF).
+  uiKeycloakClientId: ""
 
 # Memory layer (G5.2 #374). The backplane ships an in-process
 # memory-expiry sweeper that runs in the FastAPI lifespan and removes
@@ -638,6 +656,47 @@ keycloakAdmin:
     # `eso.keycloakAdmin` when that path is enabled, so operators who
     # opt into both don't have to reconcile names.
     secretKey: client_secret
+
+# Operator-console (`/ui/*`) OAuth confidential credentials (#2594,
+# Goal #336). The browser BFF login flow served at `/ui/auth/*` needs two
+# confidential values in addition to the plain `config.uiKeycloakClientId`:
+# the confidential web client's `client_secret` (carried on the
+# server-side token-endpoint POST) and a session-cookie encryption key
+# (Fernet key the BFF encrypts the session payload with). Both are
+# wired into the backplane container EXCLUSIVELY via `secretKeyRef` —
+# never a plaintext chart value — mirroring the Postgres DSN / Keycloak
+# admin-client-secret precedent. Point `secretName` at a Kubernetes
+# Secret holding both keys (a GSM/no-Vault deploy provisions it directly;
+# a Vault deploy syncs it via ESO). All rendered as env only when
+# `enabled: true`; unset (the default) leaves the console cleanly
+# disabled (`503 ui_oauth_not_configured` on `/ui/auth/login`) with no
+# effect on `/api/*` or the `meho login` CLI. See
+# `docs/cross-repo/keycloak-web-client.md` for the realm-side recipe and
+# `deploy/values-examples/README.md` for the GSM/no-Vault wiring.
+uiConsole:
+  # -- Whether to wire `UI_KEYCLOAK_CLIENT_SECRET` +
+  # `UI_SESSION_ENCRYPTION_KEY` into the backplane Deployment. Default
+  # `false`: the operator console stays disabled and the two env vars are
+  # not rendered. Flip to `true` and provide `secretName` (+ set
+  # `config.uiKeycloakClientId`) to enable the browser console — the
+  # schema requires both under `enabled: true`, so a half-configured
+  # console fails at `helm install` rather than 503-ing at first login.
+  enabled: false
+  # -- Name of the Kubernetes Secret holding BOTH the confidential web
+  # client secret and the session encryption key. Referenced by name only
+  # (like `postgres.credentialsSecret`) — provisioning is the consumer's
+  # responsibility (GSM-synced ExternalSecret, a sealed-secret, or a
+  # directly-applied Secret). Required and non-empty when
+  # `uiConsole.enabled: true`.
+  secretName: ""
+  # -- Key within `secretName` whose value is the confidential web
+  # client's `client_secret` (rendered into `UI_KEYCLOAK_CLIENT_SECRET`).
+  clientSecretKey: client_secret
+  # -- Key within `secretName` whose value is the session-cookie
+  # encryption key (rendered into `UI_SESSION_ENCRYPTION_KEY`). Generate a
+  # url-safe base64 32-byte Fernet key:
+  # `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`.
+  sessionEncryptionKey: session_encryption_key
 
 audit:
   # -- v0.1: audit rows written to PostgreSQL only. The S3 / object-store

--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -221,6 +221,81 @@ chart with both opt-ins on and greps for the `secretKeyRef` shape so
 a regression flipping `ANTHROPIC_API_KEY` to plaintext is rejected
 before merge.
 
+## Operator-console (browser BFF) OAuth wiring (#2594)
+
+The operator console (`/ui/*`, Goal #336) serves a Backend-for-Frontend
+login at `/ui/auth/*` that runs OAuth 2.1 authorization-code + PKCE
+against a **confidential** Keycloak client (`meho-web`). This is
+independent of the `/api/*` chassis JWT chain and the `meho login`
+device-code CLI — both of those work without any of the values below,
+so a chassis-only or API-only deploy leaves the console dark on
+purpose. The console is gated on three env vars, all non-empty
+(`meho_backplane.features._ui_surface_block`):
+
+| Env var | Chart value | Kind | Rendered by |
+| --- | --- | --- | --- |
+| `UI_KEYCLOAK_CLIENT_ID` | `config.uiKeycloakClientId` | plain | ConfigMap (always) |
+| `UI_KEYCLOAK_CLIENT_SECRET` | `uiConsole.secretName` @ `uiConsole.clientSecretKey` | `secretKeyRef` | Deployment (when `uiConsole.enabled`) |
+| `UI_SESSION_ENCRYPTION_KEY` | `uiConsole.secretName` @ `uiConsole.sessionEncryptionKey` | `secretKeyRef` | Deployment (when `uiConsole.enabled`) |
+
+Until all three are set, `GET /ui/auth/login` returns
+`503 ui_oauth_not_configured` and no console login is possible — with
+**no** effect on `/api/*` or the CLI. Enabling the console is
+all-or-nothing: with `uiConsole.enabled: true` the schema requires
+both `uiConsole.secretName` and `config.uiKeycloakClientId` non-empty,
+so a half-configured console fails at `helm install` rather than
+503-ing at first browser login.
+
+### Enablement recipe (GSM / no-Vault deploy)
+
+The realm-side steps (create the confidential `meho-web` client, pin
+PKCE, copy the client secret) live in
+[`docs/cross-repo/keycloak-web-client.md`](../../docs/cross-repo/keycloak-web-client.md).
+That doc's Step 3 writes the secret to a Vault path; a GSM/no-Vault
+deploy skips Vault and provisions a plain Kubernetes Secret instead —
+both the `client_secret` and the session encryption key go in **one**
+Secret under two keys:
+
+1. **Generate the session encryption key** (a url-safe base64 32-byte
+   Fernet key the BFF encrypts the session cookie with):
+
+   ```bash
+   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+   ```
+
+2. **Create the Secret** holding both confidential values. On GSM this
+   is typically a GSM-synced ExternalSecret; for a directly-applied
+   Secret:
+
+   ```bash
+   kubectl create secret generic meho-ui-oauth \
+     --from-literal=client_secret='<meho-web client secret from Keycloak>' \
+     --from-literal=session_encryption_key='<Fernet key from step 1>'
+   ```
+
+3. **Point the chart at it** (add to your values file):
+
+   ```yaml
+   config:
+     # public client_id of the confidential meho-web client
+     uiKeycloakClientId: meho-web
+   uiConsole:
+     enabled: true
+     secretName: meho-ui-oauth        # the Secret from step 2
+     clientSecretKey: client_secret   # key holding UI_KEYCLOAK_CLIENT_SECRET
+     sessionEncryptionKey: session_encryption_key  # key holding UI_SESSION_ENCRYPTION_KEY
+   ```
+
+`values-gsm-example.yaml` carries this block commented out — uncomment
+it once the Secret and realm-side client exist. Rotate the client
+secret by regenerating it on Keycloak, updating the Secret, and
+restarting the backplane pod (env is read at startup).
+
+The `helm test <release>` Pod
+(`templates/tests/test-ui-console-config.yaml`) asserts the three env
+vars resolve — the two `secretKeyRef` values and the plain client_id —
+when `uiConsole.enabled: true`.
+
 ## Internal-CA trust bundle (`extraVolumes` / `extraEnv`)
 
 The backplane connects to **Vault**, **Keycloak**, and **PostgreSQL**

--- a/deploy/values-examples/values-gsm-example.yaml
+++ b/deploy/values-examples/values-gsm-example.yaml
@@ -55,6 +55,26 @@ config:
   # Optional: impersonate a dedicated reader SA instead of reading directly
   # under the pod's Workload Identity ADC. Leave "" for direct ADC.
   gsmImpersonateSa: "" # e.g. meho-secret-reader@my-gcp-project.iam.gserviceaccount.com
+  # --- Operator console (/ui/*) OAuth (#2594, Goal #336) ---
+  # Public client_id of the confidential `meho-web` Keycloak client the
+  # browser BFF login runs its authorization-code grant against. Leave
+  # commented (empty) to keep the browser console disabled — /api/* and the
+  # `meho login` CLI are unaffected. Uncomment together with the uiConsole
+  # block below to light up the console. See
+  # deploy/values-examples/README.md § operator-console (browser BFF).
+  # uiKeycloakClientId: meho-web # CHANGE ME (client_id of the meho-web client)
+
+# Operator console (/ui/*) confidential OAuth credentials (#2594). On a
+# GSM/no-Vault deploy, provision ONE Kubernetes Secret holding both the
+# meho-web client secret and the session encryption key, then point the
+# chart at it here. Leave commented to keep the browser console disabled.
+# Recipe (Secret creation + session-key generation) is in
+# deploy/values-examples/README.md § operator-console (browser BFF).
+# uiConsole:
+#   enabled: true
+#   secretName: meho-ui-oauth # CHANGE ME (Secret with client_secret + session_encryption_key)
+#   clientSecretKey: client_secret
+#   sessionEncryptionKey: session_encryption_key
 
 gsm:
   enabled: true

--- a/docs/cross-repo/keycloak-web-client.md
+++ b/docs/cross-repo/keycloak-web-client.md
@@ -131,7 +131,21 @@ authorization URL, so the realm must accept this shape:
      works.
 4. **Save.**
 
-### Step 3 — Copy the client secret to Vault
+### Step 3 — Copy the client secret into a Secret the pod reads
+
+> **Chart-native wiring (#2594).** The Helm chart now renders all three
+> console env vars from first-class values — no hand-rolled `extraEnv`
+> `valueFrom` needed. Set `config.uiKeycloakClientId` (plain, →
+> `UI_KEYCLOAK_CLIENT_ID`) and `uiConsole.enabled: true` +
+> `uiConsole.secretName` pointing at a Kubernetes Secret holding the
+> client secret and the session key (→ `UI_KEYCLOAK_CLIENT_SECRET` /
+> `UI_SESSION_ENCRYPTION_KEY` via `secretKeyRef`). The Vault path below
+> is the recipe for a **Vault-backed** deploy; a **GSM / no-Vault**
+> deploy skips Vault entirely and provisions a plain Kubernetes Secret
+> (or a GSM-synced ExternalSecret) instead — the end-to-end recipe,
+> including generating the session encryption key, is in
+> [`deploy/values-examples/README.md`](../../deploy/values-examples/README.md)
+> § operator-console (browser BFF).
 
 1. On the `meho-web` client → **Credentials** tab.
 2. Copy the **Client secret** value. Treat this value as


### PR DESCRIPTION
## Summary
- The chart rendered **none** of the operator-console (`/ui/*`) OAuth settings, so a browser-console deploy hit `503 ui_oauth_not_configured` at runtime with no chart-level way to configure it (`features._ui_surface_block` gates on `UI_KEYCLOAK_CLIENT_ID`, `UI_KEYCLOAK_CLIENT_SECRET`, `UI_SESSION_ENCRYPTION_KEY` all non-empty).
- Adds `config.uiKeycloakClientId` (plain → `UI_KEYCLOAK_CLIENT_ID` in the ConfigMap, always) plus a `uiConsole` block whose `secretName` references one Secret holding the `meho-web` client secret + session key, wired into the pod env via `secretKeyRef` (mirrors the Postgres DSN / Keycloak admin-secret precedent) only when `uiConsole.enabled: true`.
- Enabling the console is all-or-nothing: the schema requires `uiConsole.secretName` + `config.uiKeycloakClientId` non-empty under `uiConsole.enabled: true`, so a half-configured console fails at `helm install` instead of 503-ing at first login. Disabled (default) keeps the console cleanly dark — no effect on `/api/*` or the `meho login` CLI.
- Documents the GSM/no-Vault enablement recipe (confidential web client + session key + the two secrets in one plain Secret) in `deploy/values-examples/README.md` and the realm-side `docs/cross-repo/keycloak-web-client.md`; adds a commented `uiConsole` example to `values-gsm-example.yaml`; ships a `helm test` Pod asserting the three env vars resolve.

## Test plan
- [x] `helm lint` — clean with console disabled (default CI overrides) **and** enabled (all three set)
- [x] `helm template` **without** the values → `UI_KEYCLOAK_CLIENT_ID: ""`, no secret env, no test pod (console cleanly disabled; no `/api/*` / CLI regression)
- [x] `helm template` **with** the three values → ConfigMap `UI_KEYCLOAK_CLIENT_ID`, Deployment `UI_KEYCLOAK_CLIENT_SECRET` + `UI_SESSION_ENCRYPTION_KEY` via `secretKeyRef`, test Pod rendered; render is valid YAML
- [x] `helm template` with `uiConsole.enabled=true` but `config.uiKeycloakClientId` unset → schema fails (`/config/uiKeycloakClientId: minLength want 1`) — fail-closed
- [x] `helm show values` lists `config.uiKeycloakClientId` + `uiConsole.{secretName,clientSecretKey,sessionEncryptionKey}`
- [x] Existing regression guards intact: `MCP_RESOURCE_URI`/`BACKPLANE_URL` derivation (#633), agent/keycloakAdmin `secretKeyRef` wiring + no-leak (#1363), `values-gsm-example.yaml` templates cleanly
- [x] `values.schema.json` is valid JSON

## Out of scope
- Surfacing the unconfigured-console state at `/ready` (issue lists it as "optional") — deferred; the runtime 503 + `/ready` feature block already enumerate the missing env.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2594
