### PR TITLE
docs(process): retire CodeRabbit from the dev flow — Claude review is the review of record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,12 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — retire CodeRabbit from the development flow
+
+- Remove the CodeRabbit review step from the contribution flow; the
+  in-house Claude review pass is the review of record on every PR
+  (#2601)
+
 ## [0.24.0] - 2026-07-17
 
 This release **completes Broadcast v2 (Initiative #2543)** — the final

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,8 +97,10 @@ target — coordinate via the consumer-side ticket.
    `Closes #<task-number>` (or `Refs #<n>` for partial work).
 6. **Push, open a PR** targeting `main` on `evoila/meho`.
 7. **CI must pass** — every required check is green; no overrides.
-8. **CodeRabbit review** posts automatically on every PR; address the
-   findings or document why a finding is wrong inline.
+8. **Claude review** is the review of record on every PR — the
+   in-house review pass (`/auto-review-pr` in auto-runs,
+   `/review-pr-slim` interactively); address the findings or document
+   why a finding is wrong inline.
 9. **Maintainer review** approves the human side. Reviews on
    `evoila/meho` are mandatory; reviews on `evoila-bosnia/meho-internal`
    PRs (planning-only, ADRs, governance docs) are best-effort because

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -1244,8 +1244,9 @@ surfaces in the workflow log so the operator knows to rotate.
 **v0.2 improvement on the horizon.** The PAT is the v0.1 expedient.
 A GitHub App + installation token would carry shorter-lived
 credentials (1-hour installation tokens vs PATs that live until
-manually rotated), and CodeRabbit consistently flags long-lived PATs
-as such. The GitHub App migration is tracked separately; v0.1 ships
+manually rotated), and long-lived PATs have repeatedly been flagged
+in review for exactly that. The GitHub App migration is tracked
+separately; v0.1 ships
 with the PAT because the rotation discipline is captured on the
 coordination tracker
 ([`docs/cross-repo/rke2-infra-coordination.md`](../cross-repo/rke2-infra-coordination.md))


### PR DESCRIPTION
Implements the `evoila/meho` half of #2601 (maintainer decision: eliminate CodeRabbit completely, rely on our own review).

- `CONTRIBUTING.md` step 8: CodeRabbit → the in-house Claude review pass as the review of record (human maintainer review in step 9 unchanged).
- `docs/codebase/backend.md`: reworded the one present-tense CodeRabbit reference to attribution-neutral.
- `CHANGELOG.md`: `[Unreleased]` entry under a unique header.

Deliberately untouched: historical attribution comments in `.github/workflows/chart.yml` / `cli-release.yml` (no behavioral content; editing workflows costs the `workflow` OAuth scope), CHANGELOG history, and code/test comments crediting past findings.

Companion PR on `meho-internal` strips the CodeRabbit dance from the five auto-run skills. Admin action that no PR can do: uninstall the CodeRabbit GitHub App from the repo settings.

Refs #2601

🤖 Generated with [Claude Code](https://claude.com/claude-code)