### PR TITLE
fix(connectors): thread tls_server_name SNI into every session-establish request (#2398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — SNI on session-establish (#2398)
+
+- Every connector session-establish request now threads the target's
+  `tls_server_name` TLS SNI / certificate-verify name, matching the
+  dispatch path. Previously only the shared dispatch seams
+  (`_request_json` / `_post_json`) carried the SNI override from #2002,
+  so the hand-rolled login/token requests bypassed it: httpcore fell
+  back to `server_hostname = origin.host` and verified an appliance's
+  FQDN-SAN certificate against the registered IP, failing
+  `CERTIFICATE_VERIFY_FAILED` *before* auth. This blocked secure
+  (`verify_tls=true` + `tls_ca_pin`) registration of any by-IP endpoint
+  whose certificate pins an FQDN. The fix covers all six hand-rolled
+  session families — vmware `/api/session` (modern + legacy fallback +
+  shutdown revoke), `vcf_session_login` (vROps token/acquire, vRLI
+  sessions, SDDC `/v1/tokens`), NSX `/api/session/create`, VCFA
+  provider + tenant logins, proxmox ticket mint, keycloak admin token
+  grant — plus the profiled-connector logins (basic / form / json) and
+  the unauthenticated fingerprint probe. Behaviour is byte-identical
+  when `tls_server_name` is unset (empty extensions dict). (#2398)
+
 ### Added — operator-console OAuth chart values (#2594)
 
 - The Helm chart now renders the operator-console (`/ui/*`) browser

--- a/backend/src/meho_backplane/connectors/_shared/vcf_auth.py
+++ b/backend/src/meho_backplane/connectors/_shared/vcf_auth.py
@@ -546,6 +546,7 @@ async def vcf_session_login(
     payload_builder: SessionPayloadBuilder | None = None,
     token_extractor: SessionTokenExtractor,
     request_headers: dict[str, str] | None = None,
+    request_extensions: dict[str, Any] | None = None,
 ) -> str:
     """POST credentials to *path* and return the extracted session token.
 
@@ -572,6 +573,14 @@ async def vcf_session_login(
     * ``request_headers`` — optional headers to set on the POST (e.g.
       ``Content-Type: application/json``, ``Accept: application/json``).
       The client's default headers are not modified.
+    * ``request_extensions`` — optional per-request httpx ``extensions``
+      (evoila/meho#2398). Consumers pass
+      ``HttpConnector._request_extensions(target)`` so the session-login
+      handshake honours a target's ``tls_server_name`` SNI / cert-verify
+      override, exactly as the dispatch seams
+      (``_request_json`` / ``_post_json``) already do. ``None`` (the
+      default) normalises to an empty dict, so the login is dispatched
+      byte-identically when no override is set.
 
     Raises:
 
@@ -594,7 +603,9 @@ async def vcf_session_login(
     else:
         body = {"username": username, "password": password}
     try:
-        resp = await client.post(path, json=body, headers=request_headers)
+        resp = await client.post(
+            path, json=body, headers=request_headers, extensions=request_extensions or {}
+        )
         resp.raise_for_status()
     except httpx.HTTPStatusError as exc:
         message = (

--- a/backend/src/meho_backplane/connectors/keycloak/connector.py
+++ b/backend/src/meho_backplane/connectors/keycloak/connector.py
@@ -432,6 +432,7 @@ class KeycloakConnector(HttpConnector):
                     "Content-Type": "application/x-www-form-urlencoded",
                     "Accept": "application/json",
                 },
+                extensions=self._request_extensions(target),
             )
             resp.raise_for_status()
             payload = resp.json()

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -253,6 +253,7 @@ class NsxConnector(HttpConnector):
                 resp = await client.post(
                     _SESSION_CREATE_PATH,
                     data={_FORM_USERNAME_KEY: username, _FORM_PASSWORD_KEY: password},
+                    extensions=self._request_extensions(target),
                 )
                 resp.raise_for_status()
             except httpx.HTTPStatusError as exc:

--- a/backend/src/meho_backplane/connectors/profiled.py
+++ b/backend/src/meho_backplane/connectors/profiled.py
@@ -526,6 +526,12 @@ class ProfiledRestConnector(HttpConnector):
         """
         client = await self._http_client(target)
         request_headers = dict(spec.request_headers)
+        # #2398: thread the target's ``tls_server_name`` SNI / cert-verify
+        # override onto the login round-trip so a by-IP appliance whose
+        # cert pins an FQDN establishes its session under ``verify_tls=true``
+        # -- the same handling the dispatch seams already apply. Empty dict
+        # (the default when no override is set) is byte-identical to today.
+        extensions = self._request_extensions(target)
         if spec.login_credentials == "basic":
             basic_auth = spec.build_login_auth(auth, secret)
             if basic_auth is None:
@@ -535,10 +541,16 @@ class ProfiledRestConnector(HttpConnector):
                     f"{auth.scheme!r} declares login_credentials='basic' but its "
                     f"build_login_auth produced no credential pair"
                 )
-            return await client.post(path, headers=request_headers, auth=basic_auth)
+            return await client.post(
+                path, headers=request_headers, auth=basic_auth, extensions=extensions
+            )
         if spec.encoding == "form":
-            return await client.post(path, data=dict(body), headers=request_headers)
-        return await client.post(path, json=dict(body), headers=request_headers)
+            return await client.post(
+                path, data=dict(body), headers=request_headers, extensions=extensions
+            )
+        return await client.post(
+            path, json=dict(body), headers=request_headers, extensions=extensions
+        )
 
     @staticmethod
     def _session_spec(scheme: str) -> SessionSchemeSpec:
@@ -700,7 +712,10 @@ class ProfiledRestConnector(HttpConnector):
         through the pooled, TLS-trust-aware client without an auth header.
         """
         client = await self._http_client(target)
-        resp = await client.request("GET", path)
+        # #2398: honour the target's ``tls_server_name`` SNI / cert-verify
+        # override on the unauthenticated fingerprint probe too (empty dict
+        # when unset -- byte-identical to today).
+        resp = await client.request("GET", path, extensions=self._request_extensions(target))
         resp.raise_for_status()
         return resp.json()  # type: ignore[no-any-return]
 

--- a/backend/src/meho_backplane/connectors/proxmox/connector.py
+++ b/backend/src/meho_backplane/connectors/proxmox/connector.py
@@ -218,6 +218,7 @@ class ProxmoxConnector(HttpConnector):
             resp = await client.post(
                 _TICKET_PATH,
                 data={"username": creds.username, "password": creds.password},
+                extensions=self._request_extensions(target),
             )
             resp.raise_for_status()
             data = resp.json().get("data") or {}

--- a/backend/src/meho_backplane/connectors/sddc_manager/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/connector.py
@@ -296,6 +296,7 @@ class SddcManagerConnector(HttpConnector):
                 payload_builder=_sddc_login_body,
                 token_extractor=_extract_access_token,
                 request_headers=dict(_SESSION_REQUEST_HEADERS),
+                request_extensions=self._request_extensions(target),
             )
             if not is_system_operator(operator):
                 self._session_tokens[cache_key] = token

--- a/backend/src/meho_backplane/connectors/vcf_automation/_auth.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/_auth.py
@@ -110,6 +110,8 @@ async def vcfa_provider_login(
     client: httpx.AsyncClient,
     creds: dict[str, str],
     target: VcfAutomationTargetLike,
+    *,
+    request_extensions: dict[str, Any] | None = None,
 ) -> str:
     """POST the provider session-create endpoint and return the JWT.
 
@@ -119,6 +121,11 @@ async def vcfa_provider_login(
     the JWT is returned to the caller (which then writes the cache
     under the per-plane lock). Absence of the header on a 2xx response
     raises :exc:`RuntimeError` rather than caching an empty token.
+
+    ``request_extensions`` (evoila/meho#2398) carries the caller's
+    ``HttpConnector._request_extensions(target)`` so the login handshake
+    honours a target's ``tls_server_name`` SNI / cert-verify override;
+    ``None`` normalises to an empty dict (byte-identical when unset).
     """
     username, password = _require_username_password(creds, target.name, "provider")
     provider_username = getattr(target, "provider_username", None)
@@ -129,6 +136,7 @@ async def vcfa_provider_login(
             PROVIDER_SESSION_PATH,
             auth=(basic_user, password),
             headers={"Accept": PROVIDER_CLOUDAPI_ACCEPT},
+            extensions=request_extensions or {},
         )
         resp.raise_for_status()
     except httpx.HTTPStatusError as exc:
@@ -162,6 +170,8 @@ async def tenant_login(
     client: httpx.AsyncClient,
     creds: dict[str, str],
     target: VcfAutomationTargetLike,
+    *,
+    request_extensions: dict[str, Any] | None = None,
 ) -> str:
     """POST the tenant login endpoint and return the bearer token.
 
@@ -170,6 +180,11 @@ async def tenant_login(
     field when ``target.domain`` is set. The response body is
     ``{"token": "..."}``. Missing / empty ``token`` field on a 2xx
     response raises :exc:`RuntimeError`.
+
+    ``request_extensions`` (evoila/meho#2398) carries the caller's
+    ``HttpConnector._request_extensions(target)`` so the login handshake
+    honours a target's ``tls_server_name`` SNI / cert-verify override;
+    ``None`` normalises to an empty dict (byte-identical when unset).
     """
     username, password = _require_username_password(creds, target.name, "tenant")
     body: dict[str, str] = {"username": username, "password": password}
@@ -181,6 +196,7 @@ async def tenant_login(
             TENANT_SESSION_PATH,
             json=body,
             headers={"Accept": TENANT_ACCEPT, "Content-Type": TENANT_ACCEPT},
+            extensions=request_extensions or {},
         )
         resp.raise_for_status()
     except httpx.HTTPStatusError as exc:

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -312,7 +312,9 @@ class VcfAutomationConnector(HttpConnector):
                 self._credentials_loader, target, operator, override_ref
             )
             client = await self._http_client(target)
-            jwt = await vcfa_provider_login(client, creds, target)
+            jwt = await vcfa_provider_login(
+                client, creds, target, request_extensions=self._request_extensions(target)
+            )
             self._provider_tokens[cache_key] = jwt
             return jwt
 
@@ -361,7 +363,9 @@ class VcfAutomationConnector(HttpConnector):
                 self._credentials_loader, target, operator, None
             )
             client = await self._http_client(target)
-            token = await tenant_login(client, creds, target)
+            token = await tenant_login(
+                client, creds, target, request_extensions=self._request_extensions(target)
+            )
             self._tenant_tokens[cache_key] = token
             return token
 

--- a/backend/src/meho_backplane/connectors/vcf_logs/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/connector.py
@@ -409,6 +409,7 @@ class VcfLogsConnector(HttpConnector):
                     "Content-Type": "application/json",
                     "Accept": "application/json",
                 },
+                request_extensions=self._request_extensions(target),
             )
             self._session_tokens[cache_key] = token
             _log.info(

--- a/backend/src/meho_backplane/connectors/vcf_operations/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/connector.py
@@ -326,6 +326,7 @@ class VcfOperationsConnector(HttpConnector):
                     "Content-Type": "application/json",
                     "Accept": "application/json",
                 },
+                request_extensions=self._request_extensions(target),
             )
             self._session_tokens[cache_key] = token
             _log.info(

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -266,6 +266,14 @@ class VmwareRestConnector(HttpConnector):
         # for the rationale and source citations. Keyed on the same
         # tenant-unique tuple as ``_session_tokens``.
         self._session_paths: dict[tuple[str, str], str] = {}
+        # Per-target httpx ``extensions`` (the ``tls_server_name`` SNI /
+        # cert-verify override, evoila/meho#2398) captured at establish
+        # time, keyed on the same tenant-unique tuple. :meth:`aclose`
+        # replays it on the best-effort session-revoke DELETE, which has
+        # no ``Target`` in scope (it iterates cached tokens by key), so a
+        # by-IP appliance that pins its cert to an FQDN is revoked over
+        # the same SNI-corrected handshake the establish call used.
+        self._session_extensions: dict[tuple[str, str], dict[str, Any]] = {}
         self._session_lock = asyncio.Lock()
         self._session_loader: VsphereSessionLoader = (
             session_loader if session_loader is not None else load_session_credentials_from_vault
@@ -454,13 +462,14 @@ class VmwareRestConnector(HttpConnector):
                 "{'username': str, 'password': str}"
             ) from exc
         auth = (username, password)
-        resp = await client.post(SESSION_PATH_MODERN, auth=auth)
+        extensions = self._request_extensions(target)
+        resp = await client.post(SESSION_PATH_MODERN, auth=auth, extensions=extensions)
         established_path = SESSION_PATH_MODERN
         if resp.status_code == 404:
             # Modern endpoint not served (vcsim, very old vCenter,
             # or a reverse-proxy that hasn't been updated). Try the
             # legacy path before declaring failure.
-            resp = await client.post(SESSION_PATH_LEGACY, auth=auth)
+            resp = await client.post(SESSION_PATH_LEGACY, auth=auth, extensions=extensions)
             established_path = SESSION_PATH_LEGACY
         try:
             resp.raise_for_status()
@@ -489,6 +498,7 @@ class VmwareRestConnector(HttpConnector):
         token = _extract_session_token(resp.json(), target.name)
         self._session_tokens[cache_key] = token
         self._session_paths[cache_key] = established_path
+        self._session_extensions[cache_key] = extensions
         _log.info(
             "vsphere_session_established",
             target=target.name,
@@ -528,6 +538,7 @@ class VmwareRestConnector(HttpConnector):
         async with self._session_lock:
             self._session_tokens.pop(cache_key, None)
             self._session_paths.pop(cache_key, None)
+            self._session_extensions.pop(cache_key, None)
 
     async def fingerprint(
         self,
@@ -871,8 +882,10 @@ class VmwareRestConnector(HttpConnector):
         async with self._session_lock:
             tokens = dict(self._session_tokens)
             paths = dict(self._session_paths)
+            extensions_by_key = dict(self._session_extensions)
             self._session_tokens.clear()
             self._session_paths.clear()
+            self._session_extensions.clear()
         for cache_key, token in tokens.items():
             # ``_session_tokens`` is keyed on the tenant-unique
             # ``(tenant_id, target.id)`` tuple, while the shared
@@ -906,6 +919,7 @@ class VmwareRestConnector(HttpConnector):
                     "DELETE",
                     revoke_path,
                     headers={_SESSION_HEADER: token},
+                    extensions=extensions_by_key.get(cache_key, {}),
                 )
                 # Log non-2xx but don't raise — shutdown proceeds.
                 if resp.status_code >= 400:

--- a/backend/tests/test_connectors_keycloak_auth.py
+++ b/backend/tests/test_connectors_keycloak_auth.py
@@ -112,6 +112,7 @@ class _StubTarget:
     secret_ref: str | None = "rdc-hetzner-dc/keycloak/admin"
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
     extras: dict[str, Any] = field(default_factory=dict)
+    tls_server_name: str | None = None  # #2398: per-target TLS SNI / cert-verify name
     # Tenant-unique cache key components (#1642/#1672).
     id: UUID = field(default_factory=uuid4)
     tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
@@ -871,3 +872,29 @@ def test_read_ops_handler_attrs_resolve_to_bound_methods() -> None:
         assert "read-only" in op.tags
         # Every grouped op has a curated when_to_use (registration asserts this).
         assert op.group_key is not None and op.group_key in WHEN_TO_USE_BY_GROUP
+
+
+# ---------------------------------------------------------------------------
+# TLS SNI / cert-verify override on the admin token grant (#2398)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mint_admin_token_threads_sni_extension() -> None:
+    """#2398: the admin token grant POST carries the target's SNI override."""
+    connector = _make_connector()
+    target = _StubTarget(
+        name="keycloak-sni",
+        host="keycloak-sni.test.invalid",
+        tls_server_name="keycloak.corp.example",
+    )
+
+    async with respx.mock(base_url="https://keycloak-sni.test.invalid") as mock:
+        route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": _ADMIN_TOKEN, "expires_in": 60, "token_type": "Bearer"}
+        )
+        await connector._mint_admin_token(target, _make_operator())
+
+    assert route.called
+    assert route.calls[0].request.extensions["sni_hostname"] == "keycloak.corp.example"
+    await connector.aclose()

--- a/backend/tests/test_connectors_nsx_auth.py
+++ b/backend/tests/test_connectors_nsx_auth.py
@@ -84,6 +84,7 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    tls_server_name: str | None = None  # #2398: per-target TLS SNI / cert-verify name
     # Tenant-unique cache key components (#1642). Distinct ``id`` per
     # instance so two stub targets never collapse onto one cache entry.
     id: UUID = field(default_factory=uuid4)
@@ -832,4 +833,30 @@ async def test_fingerprint_without_operator_falls_back_to_system_operator() -> N
 
     assert len(captured) == 1
     assert captured[0].sub == SYSTEM_OPERATOR_SUB
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# TLS SNI / cert-verify override on session establish (#2398)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_create_threads_sni_extension() -> None:
+    """#2398: the form-encoded /api/session/create login carries the SNI override."""
+    connector = _make_connector()
+    target = _StubTarget(
+        name="nsx-sni",
+        host="nsx-sni.test.invalid",
+        port=443,
+        secret_ref="nsx/nsx-sni",
+        tls_server_name="nsx.corp.example",
+    )
+
+    async with respx.mock(base_url="https://nsx-sni.test.invalid") as mock:
+        route = mock.post("/api/session/create").respond(200, headers={"X-XSRF-TOKEN": "xsrf"})
+        await connector.auth_headers(target, operator=_make_operator())
+
+    assert route.called
+    assert route.calls[0].request.extensions["sni_hostname"] == "nsx.corp.example"
     await connector.aclose()

--- a/backend/tests/test_connectors_profiled_auth.py
+++ b/backend/tests/test_connectors_profiled_auth.py
@@ -64,6 +64,7 @@ class _StubTarget:
     port: int | None = 443
     secret_ref: str | None = "p/secret"
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    tls_server_name: str | None = None  # #2398: per-target TLS SNI / cert-verify name
     id: UUID = field(default_factory=uuid4)
     tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
 
@@ -1056,3 +1057,85 @@ def test_class_attribute_profile_is_used_when_not_injected() -> None:
     assert instance.profile is _StampedProfiled.profile
     assert instance.profile is not None
     assert instance.profile.auth.scheme == "basic"
+
+
+# ---------------------------------------------------------------------------
+# TLS SNI / cert-verify override on profiled logins + fingerprint probe (#2398)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_login_attempt_json_variant_threads_sni_extension() -> None:
+    """#2398: the JSON-body login variant (session_login) carries the SNI override."""
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="vrli", host="vrli.invalid", tls_server_name="vrli.corp.example")
+
+    async with respx.mock(base_url="https://vrli.invalid") as mock:
+        route = mock.post("/api/v2/sessions").respond(200, json={"sessionId": "s", "ttl": 1800})
+        await connector.auth_headers(target, operator=_operator())
+
+    assert route.called
+    assert route.calls[0].request.extensions["sni_hostname"] == "vrli.corp.example"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_login_attempt_basic_variant_threads_sni_extension() -> None:
+    """#2398: the HTTP-Basic login variant (session_login_basic) carries the SNI override."""
+    connector = _connector("session_login_basic", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="vc", host="vc.invalid", tls_server_name="vcenter.corp.example")
+
+    async with respx.mock(base_url="https://vc.invalid") as mock:
+        route = mock.post("/api/session").respond(200, json="sess-token")
+        await connector.auth_headers(target, operator=_operator())
+
+    assert route.called
+    assert route.calls[0].request.extensions["sni_hostname"] == "vcenter.corp.example"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_login_attempt_form_variant_threads_sni_extension() -> None:
+    """#2398: the form-encoded login variant (oauth2_mint) carries the SNI override."""
+    connector = _connector("oauth2_mint", {"client_id": "cid", "client_secret": "csec"})
+    target = _StubTarget(name="kc", host="kc.invalid", tls_server_name="keycloak.corp.example")
+
+    async with respx.mock(base_url="https://kc.invalid") as mock:
+        route = mock.post("/realms/master/protocol/openid-connect/token").respond(
+            200, json={"access_token": "tok-kc", "expires_in": 300}
+        )
+        await connector.auth_headers(target, operator=_operator())
+
+    assert route.called
+    assert route.calls[0].request.extensions["sni_hostname"] == "keycloak.corp.example"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_fingerprint_probe_threads_sni_extension() -> None:
+    """#2398: the unauthenticated fingerprint GET carries the SNI override."""
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="probe", host="probe.invalid", tls_server_name="probe.corp.example")
+
+    async with respx.mock(base_url="https://probe.invalid") as mock:
+        route = mock.get("/api/version").respond(200, json={"version": "1.0"})
+        await connector._get_unauthenticated_json(target, "/api/version")
+
+    assert route.called
+    assert route.calls[0].request.extensions["sni_hostname"] == "probe.corp.example"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_login_attempt_omits_sni_extension_when_unset() -> None:
+    """#2398 existing-behaviour: a profiled login with no override dispatches empty extensions."""
+    connector = _connector("session_login", {"username": "svc", "password": "pw"})
+    target = _StubTarget(name="vrli", host="vrli.invalid")  # tls_server_name=None
+
+    async with respx.mock(base_url="https://vrli.invalid") as mock:
+        route = mock.post("/api/v2/sessions").respond(200, json={"sessionId": "s", "ttl": 1800})
+        await connector.auth_headers(target, operator=_operator())
+
+    assert route.called
+    assert "sni_hostname" not in route.calls[0].request.extensions
+    await connector.aclose()

--- a/backend/tests/test_connectors_sddc_manager_auth.py
+++ b/backend/tests/test_connectors_sddc_manager_auth.py
@@ -89,6 +89,7 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    tls_server_name: str | None = None  # #2398: per-target TLS SNI / cert-verify name
     # Tenant-unique cache key components (#1642). Distinct ``id`` per
     # instance so two stub targets never collapse onto one cache entry.
     id: UUID = field(default_factory=uuid4)
@@ -887,4 +888,30 @@ async def test_fingerprint_without_operator_falls_back_to_system_operator() -> N
 
     assert len(captured) == 1
     assert captured[0].sub == SYSTEM_OPERATOR_SUB
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# TLS SNI / cert-verify override on the SDDC /v1/tokens login (#2398)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tokens_login_threads_sni_extension() -> None:
+    """#2398: the SDDC Manager /v1/tokens login POST carries the SNI override."""
+    connector = _make_connector()
+    target = _StubTarget(
+        name="sddc-sni",
+        host="sddc-sni.test.invalid",
+        port=443,
+        secret_ref="sddc/sddc-sni",
+        tls_server_name="sddc.corp.example",
+    )
+
+    async with respx.mock(base_url="https://sddc-sni.test.invalid") as mock:
+        route = mock.post(_TOKEN_PATH).respond(200, json={"accessToken": "tok-abc"})
+        await connector.auth_headers(target, operator=_make_operator())
+
+    assert route.called
+    assert route.calls[0].request.extensions["sni_hostname"] == "sddc.corp.example"
     await connector.aclose()

--- a/backend/tests/test_connectors_vcf_automation_auth.py
+++ b/backend/tests/test_connectors_vcf_automation_auth.py
@@ -110,6 +110,7 @@ class _StubTarget:
     domain: str | None = None
     provider_username: str | None = None
     provider_secret_ref: str | None = None
+    tls_server_name: str | None = None  # #2398: per-target TLS SNI / cert-verify name
     # Tenant-unique cache key components (#1642/#1672).
     id: UUID = field(default_factory=uuid4)
     tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
@@ -1060,3 +1061,52 @@ async def test_aclose_with_no_cached_sessions_is_a_noop() -> None:
     assert connector._clients == {}
     assert connector._provider_tokens == {}
     assert connector._tenant_tokens == {}
+
+
+# ---------------------------------------------------------------------------
+# TLS SNI / cert-verify override on both plane logins (#2398)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provider_login_threads_sni_extension() -> None:
+    """#2398: the provider-plane login POST carries the target's SNI override."""
+    connector = _make_connector()
+    target = _StubTarget(
+        name="vcfa-sni",
+        host="vcfa-sni.test.invalid",
+        port=443,
+        secret_ref="vcfa/vcfa-sni",
+        tls_server_name="vcfa.corp.example",
+    )
+
+    async with respx.mock(base_url="https://vcfa-sni.test.invalid") as mock:
+        login = mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt"}
+        )
+        await connector.auth_headers(target, operator=_make_operator(), path="/cloudapi/1.0.0/orgs")
+
+    assert login.called
+    assert login.calls[0].request.extensions["sni_hostname"] == "vcfa.corp.example"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tenant_login_threads_sni_extension() -> None:
+    """#2398: the tenant-plane login POST carries the target's SNI override."""
+    connector = _make_connector()
+    target = _StubTarget(
+        name="vcfa-sni-t",
+        host="vcfa-sni-t.test.invalid",
+        port=443,
+        secret_ref="vcfa/vcfa-sni-t",
+        tls_server_name="vcfa-tenant.corp.example",
+    )
+
+    async with respx.mock(base_url="https://vcfa-sni-t.test.invalid") as mock:
+        login = mock.post("/iaas/api/login").respond(200, json={"token": "t-tok"})
+        await connector.auth_headers(target, operator=_make_operator(), path="/iaas/api/projects")
+
+    assert login.called
+    assert login.calls[0].request.extensions["sni_hostname"] == "vcfa-tenant.corp.example"
+    await connector.aclose()

--- a/backend/tests/test_connectors_vcf_logs_auth.py
+++ b/backend/tests/test_connectors_vcf_logs_auth.py
@@ -107,6 +107,7 @@ class _StubTarget:
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
     provider: str | None = None
+    tls_server_name: str | None = None  # #2398: per-target TLS SNI / cert-verify name
     # Tenant-unique cache key components (#1642). Distinct ``id`` per
     # instance so two stub targets never collapse onto one cache entry.
     id: UUID = field(default_factory=uuid4)
@@ -746,3 +747,29 @@ def test_stub_target_satisfies_vcf_logs_target_like_protocol() -> None:
     explicit inheritance required.
     """
     assert isinstance(_TARGET_A, VcfLogsTargetLike)
+
+
+# ---------------------------------------------------------------------------
+# TLS SNI / cert-verify override on the vRLI sessions login (#2398)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sessions_login_threads_sni_extension() -> None:
+    """#2398: the vRLI /api/v2/sessions login POST carries the SNI override."""
+    connector = _make_connector()
+    target = _StubTarget(
+        name="vrli-sni",
+        host="vrli-sni.test.invalid",
+        port=443,
+        secret_ref="vrli/vrli-sni",
+        tls_server_name="vrli.corp.example",
+    )
+
+    async with respx.mock(base_url="https://vrli-sni.test.invalid") as mock:
+        route = mock.post("/api/v2/sessions").respond(200, json={"sessionId": "tok", "ttl": 1800})
+        await connector.auth_headers(target, operator=_make_operator())
+
+    assert route.called
+    assert route.calls[0].request.extensions["sni_hostname"] == "vrli.corp.example"
+    await connector.aclose()

--- a/backend/tests/test_connectors_vcf_operations_auth.py
+++ b/backend/tests/test_connectors_vcf_operations_auth.py
@@ -120,6 +120,7 @@ class _StubTarget:
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
     auth_source: str | None = None
+    tls_server_name: str | None = None  # #2398: per-target TLS SNI / cert-verify name
     # Tenant-unique cache key components (#1642). Distinct ``id`` per
     # instance so two stub targets never collapse onto one cache entry.
     id: UUID = field(default_factory=uuid4)
@@ -744,3 +745,33 @@ def test_stub_target_satisfies_protocol_at_runtime() -> None:
     """
     assert isinstance(_TARGET_A, VcfOperationsTargetLike)
     assert isinstance(_TARGET_WITH_AUTH_SOURCE, VcfOperationsTargetLike)
+
+
+# ---------------------------------------------------------------------------
+# TLS SNI / cert-verify override on the vROps token/acquire login (#2398)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_token_acquire_threads_sni_extension() -> None:
+    """#2398: the vROps token/acquire login POST carries the SNI override.
+
+    Proves the ``vcf_session_login`` consumer threads
+    ``self._request_extensions(target)`` through to the establish request.
+    """
+    connector = _make_connector()
+    target = _StubTarget(
+        name="vrops-sni",
+        host="vrops-sni.test.invalid",
+        port=443,
+        secret_ref="vrops/vrops-sni",
+        tls_server_name="vrops.corp.example",
+    )
+
+    async with respx.mock(base_url="https://vrops-sni.test.invalid") as mock:
+        route = mock.post(_ACQUIRE_PATH).respond(200, json=_acquire_response())
+        await connector.auth_headers(target, operator=_make_operator())
+
+    assert route.called
+    assert route.calls[0].request.extensions["sni_hostname"] == "vrops.corp.example"
+    await connector.aclose()

--- a/backend/tests/test_connectors_vcf_shared_auth.py
+++ b/backend/tests/test_connectors_vcf_shared_auth.py
@@ -559,6 +559,73 @@ async def test_vcf_session_login_payload_builder_takes_precedence(
 
 
 # ---------------------------------------------------------------------------
+# vcf_session_login — TLS SNI / cert-verify override threading (#2398)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vcf_session_login_threads_request_extensions_sni(
+    _client: httpx.AsyncClient,
+) -> None:
+    """``request_extensions`` reaches the login POST as httpx ``extensions``.
+
+    #2398: the three consumers (vROps token/acquire, vRLI sessions, SDDC
+    ``/v1/tokens``) pass ``HttpConnector._request_extensions(target)`` so a
+    by-IP appliance whose cert pins an FQDN establishes its session under
+    ``verify_tls=true``. httpcore resolves ``server_hostname =
+    request.extensions["sni_hostname"]``.
+    """
+    captured: dict[str, object] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured["extensions"] = dict(request.extensions)
+        return httpx.Response(200, json={}, headers={"sessionId": "tok"})
+
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").mock(side_effect=_capture)
+        await vcf_session_login(
+            _client,
+            "/api/v2/sessions",
+            username="admin",
+            password="p",
+            target_name="vrli-a",
+            token_extractor=lambda r: r.headers.get("sessionId"),
+            request_extensions={"sni_hostname": "vrli.corp.example"},
+        )
+
+    exts = captured["extensions"]
+    assert isinstance(exts, dict)
+    assert exts.get("sni_hostname") == "vrli.corp.example"
+
+
+@pytest.mark.asyncio
+async def test_vcf_session_login_default_omits_sni_extension(
+    _client: httpx.AsyncClient,
+) -> None:
+    """No ``request_extensions`` dispatches byte-identically (empty dict, #2398)."""
+    captured: dict[str, object] = {}
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured["extensions"] = dict(request.extensions)
+        return httpx.Response(200, json={}, headers={"sessionId": "tok"})
+
+    with respx.mock(base_url="https://vrli-a.test.invalid") as mock:
+        mock.post("/api/v2/sessions").mock(side_effect=_capture)
+        await vcf_session_login(
+            _client,
+            "/api/v2/sessions",
+            username="admin",
+            password="p",
+            target_name="vrli-a",
+            token_extractor=lambda r: r.headers.get("sessionId"),
+        )
+
+    exts = captured["extensions"]
+    assert isinstance(exts, dict)
+    assert "sni_hostname" not in exts
+
+
+# ---------------------------------------------------------------------------
 # vcf_session_login — failure modes
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_connectors_vmware_rest_auth.py
+++ b/backend/tests/test_connectors_vmware_rest_auth.py
@@ -135,6 +135,7 @@ class _StubTarget:
     port: int | None
     secret_ref: str
     auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    tls_server_name: str | None = None  # #2398: per-target TLS SNI / cert-verify name
     # Tenant-unique cache key components (#1642/#1672). Distinct ``id`` per
     # instance so two stub targets never collapse onto one cache entry.
     id: UUID = field(default_factory=uuid4)
@@ -891,3 +892,72 @@ async def test_aclose_with_no_cached_sessions_is_a_noop() -> None:
     await connector.aclose()
     assert connector._clients == {}
     assert connector._session_tokens == {}
+
+
+# ---------------------------------------------------------------------------
+# TLS SNI / cert-verify override on session establish + revoke (#2398)
+# ---------------------------------------------------------------------------
+
+
+_TARGET_SNI = _StubTarget(
+    name="vcenter-sni",
+    host="vcenter-sni.test.invalid",
+    port=443,
+    secret_ref="vsphere/vcenter-sni",
+    tls_server_name="vcenter.corp.example",
+)
+
+
+@pytest.mark.asyncio
+async def test_establish_and_revoke_thread_sni_extension_modern_path() -> None:
+    """#2398: the modern establish POST and the revoke DELETE carry the SNI override.
+
+    A by-IP appliance whose cert pins an FQDN must offer ``tls_server_name``
+    as the TLS SNI / cert-verify name on the login POST (before this fix the
+    login bypassed the ``_request_extensions`` seam and failed
+    ``CERTIFICATE_VERIFY_FAILED`` under ``verify_tls=true``) and on the
+    best-effort shutdown revoke DELETE, which has no ``Target`` in scope.
+    """
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://vcenter-sni.test.invalid") as mock:
+        post_route = mock.post("/api/session").respond(200, json="sni-token")
+        delete_route = mock.delete("/api/session").respond(204)
+        await connector.auth_headers(_TARGET_SNI, _make_operator())
+        await connector.aclose()
+
+    assert post_route.called
+    assert post_route.calls[0].request.extensions["sni_hostname"] == "vcenter.corp.example"
+    assert delete_route.called
+    assert delete_route.calls[0].request.extensions["sni_hostname"] == "vcenter.corp.example"
+
+
+@pytest.mark.asyncio
+async def test_establish_threads_sni_extension_on_legacy_fallback() -> None:
+    """#2398: the legacy-fallback establish POST also carries the SNI override."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-sni.test.invalid") as mock:
+        mock.post("/api/session").respond(404)
+        legacy_route = mock.post("/rest/com/vmware/cis/session").respond(200, json="legacy-sni")
+        await connector.auth_headers(_TARGET_SNI, _make_operator())
+
+    assert legacy_route.called
+    assert legacy_route.calls[0].request.extensions["sni_hostname"] == "vcenter.corp.example"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_establish_omits_sni_extension_when_unset() -> None:
+    """#2398 existing-behaviour: a target with no override dispatches with empty extensions."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-a.test.invalid") as mock:
+        post_route = mock.post("/api/session").respond(200, json="plain-token")
+        await connector.auth_headers(_TARGET_A, _make_operator())
+
+    assert post_route.called
+    assert "sni_hostname" not in post_route.calls[0].request.extensions
+    await connector.aclose()


### PR DESCRIPTION
## Summary

- Threads the per-target `tls_server_name` TLS SNI / certificate-verify name (from #2002) into **every connector session-establish request**, closing the gap where login / token-mint / probe / revoke requests bypassed the SNI-carrying `_request_json` / `_post_json` dispatch seams.
- Before this fix, an establish request on a by-IP endpoint fell back to `server_hostname = origin.host` and verified an appliance's FQDN-SAN cert against the registered IP → `CERTIFICATE_VERIFY_FAILED` **before** auth, blocking secure (`verify_tls=true` + `tls_ca_pin`) registration and making the #2395 vROps OpsToken fix unreachable on such targets.
- Behaviour is byte-identical when `tls_server_name` is unset (the helper returns an empty extensions dict).

### What changed

- **vmware_rest**: modern `/api/session` + legacy fallback POST + the shutdown session-revoke DELETE. The revoke loop has no `Target` in scope, so the establish extensions are captured into a `_session_extensions` dict keyed like `_session_tokens` / `_session_paths` and replayed at `aclose`.
- **`vcf_session_login`** grows a `request_extensions` parameter, threaded by its three consumers: vROps `token/acquire`, vRLI `sessions`, SDDC `/v1/tokens`.
- **NSX** `/api/session/create`, **proxmox** ticket mint, **keycloak** admin token grant — threaded directly via `self._request_extensions(target)`.
- **VCFA** `vcfa_provider_login` / `tenant_login` grow the same parameter, threaded by the connector for both planes.
- **profiled** `_login_attempt` (basic / form / json carriage) and the unauthenticated fingerprint probe use `self._request_extensions(target)`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors` — Success, no issues (205 files)
- [x] `pytest` on the nine touched connector auth suites — **323 passed**
- [x] Regression suites (vmware fingerprint/composites, profiled tristate, sddc dispatch, vcfa e2e, proxmox, http adapter) — **207 passed**
- [x] New respx mock-transport tests assert `request.extensions["sni_hostname"] == tls_server_name` on: vmware establish (modern + legacy fallback) + revoke DELETE; each `vcf_session_login` consumer (vROps / vRLI / SDDC); NSX; VCFA provider + tenant; proxmox ticket; keycloak admin token grant; profiled `_login_attempt` (basic / form / json) + fingerprint probe.
- [x] Existing-behaviour assertions: a target with `tls_server_name` unset dispatches with **no** `sni_hostname` extension (empty-dict contract) — asserted at the shared-helper, vmware, and profiled layers.
- [x] `code-quality.py --diff` — 0 blockers (all warnings pre-existing file/function-size debt on files this change only touched).

## Sweep completeness (acceptance criterion)

Every `client.post(` hit under `backend/src/meho_backplane/connectors/` now passes `extensions=` at session establish, except these documented, intentional exemptions:

- `github/session.py:588` — installation-token mint targets `api.github.com`; `tls_server_name` does not apply.
- `gcloud/connector.py:738` / `:744` — typed-dispatch seams against `*.googleapis.com` (out of scope per the issue; same class of gap but never blocks registration today — audit separately if a by-IP `tls_server_name` target ever reaches them).

## Out of scope (per the issue)

- Non-establish typed-dispatch / fingerprint seams on other families (argocd/loki/vcf_fleet fingerprints, keycloak/harbor typed verbs) — same class of gap, none blocks registration today.
- Infra remediation (pod DNS for nested-vCenter FQDNs) and flipping the sddc lab targets back to `verify_tls=true`.

Closes #2398


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TLS SNI and certificate-verification behavior for secure session establishment when connecting by IP or alternate hostnames.
  * Ensured the per-target TLS server name override is consistently applied across session establishment, login/token flows, unauthenticated probing, and session revocation (including legacy fallback paths).
  * Preserved existing behavior when no custom TLS server name is configured.

* **Tests**
  * Expanded unit test coverage to verify SNI handling across supported connector authentication and session flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->