### PR TITLE
feat(operations): scrub credential_read dispatch responses by default (#2467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — credential_read response scrub + reveal_secret opt-in (#2467)
+
+- `credential_read`-classified dispatch responses (`vault.kv.read` and
+  its `_CREDENTIAL_READ_OPS` siblings) are now key-name scrubbed before
+  they reach the `call_operation` caller: secret-named values in the
+  transport response are replaced with `[REDACTED:param_name]` while
+  non-secret siblings (`username`, `version`) survive. This closes the
+  gap where the connector-boundary redaction engine — which matches only
+  labelled secret shapes inside string leaves — passed a
+  `{"password": "<value>"}` dict through verbatim into an agent caller's
+  model-API transcript. A caller that must pipe the raw value onward
+  passes a reserved `params.reveal_secret=true`, which returns the raw
+  value and is stamped queryably on the audit row
+  (`payload['reveal_secret']`). The audit `raw_payload` keeps the raw
+  result in both cases — only the transport response is scrubbed
+  (mirrors the #2172 secret-handler posture). The scrub keys on the op
+  class, not the caller kind. Approved human flows keep working by
+  opting in: the `/ui` Vault console read (reveal-on-click) and CLI
+  `meho secret read` (pipe-only) both pass `reveal_secret=true`;
+  `secret.move` stays the recommended no-transit path. The reserved
+  `reveal_secret` flag is stripped before op-schema validation and
+  `params_hash`, so a scrubbed read and its reveal share one hash.
+
 ### Added — operator-console OAuth chart values (#2594)
 
 - The Helm chart now renders the operator-console (`/ui/*`) browser

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -72,6 +72,7 @@ __all__ = [
     "classify_op",
     "redact_payload",
     "scrub_broadcast_params",
+    "scrub_secret_named_values",
 ]
 
 
@@ -731,6 +732,32 @@ def _scrub_secret_named_keys(node: Any) -> tuple[Any, bool]:
             found = found or child_found
         return items, found
     return node, False
+
+
+def scrub_secret_named_values(node: Any) -> tuple[Any, bool]:
+    """Key-name-aware secret scrub for a caller-bound dispatch response.
+
+    Public entry to :func:`_scrub_secret_named_keys` (the same walk the
+    broadcast params scrub uses). Returns ``(scrubbed, secret_detected)``:
+    every mapping entry whose key is secret-shaped (``password``,
+    ``client_secret``, ``sessionToken``, ...) has its value subtree
+    replaced with :data:`_REDACTED_PARAM`.
+
+    The connector-boundary redaction engine (``dispatcher.py`` step 7a)
+    matches only *labelled* secret shapes inside string leaves, so a
+    ``credential_read`` response like ``{"data": {"password": "..."}}``
+    passes through it verbatim. The dispatcher runs this scrub on the
+    caller-bound response of a ``credential_read``-classified op by
+    default (#2467) so the raw value never reaches the ``call_operation``
+    caller / agent transcript; ``params.reveal_secret=true`` opts out.
+    The audit row keeps the raw result regardless (the raw payload is
+    captured before this scrub runs), mirroring the #2172 secret-handler
+    posture. Unlike :func:`scrub_broadcast_params` this does **not** run
+    the Tier-1 engine pass -- the boundary middleware already applied it
+    to the response, so this layer is only the structured-dict
+    key-name complement.
+    """
+    return _scrub_secret_named_keys(node)
 
 
 def scrub_broadcast_params(params: dict[str, Any]) -> tuple[dict[str, Any], bool]:

--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -476,7 +476,17 @@ register_mcp_tool(
                         "Operation-specific parameters. The dispatcher "
                         "validates against the operation's parameter_schema "
                         "before invoking the handler; unknown fields are "
-                        "rejected at the schema layer."
+                        "rejected at the schema layer. One reserved key is "
+                        "handled by the dispatcher itself and never reaches "
+                        "the op schema: `reveal_secret` (bool). A "
+                        "credential_read op (e.g. `vault.kv.read`) returns a "
+                        "key-name-scrubbed response by default -- secret "
+                        "values are replaced so they never enter this agent "
+                        "transcript. Pass `reveal_secret: true` ONLY when you "
+                        "must pipe the raw value onward; the raw value is "
+                        "then returned AND the reveal is stamped on the audit "
+                        "row. Prefer `secret.move` to relocate a credential "
+                        "without it transiting your context."
                     ),
                 },
                 "work_ref": {

--- a/backend/src/meho_backplane/operations/_audit.py
+++ b/backend/src/meho_backplane/operations/_audit.py
@@ -57,6 +57,7 @@ __all__ = [
     "publish_broadcast",
     "resolve_agent_session_id",
     "resolve_broadcast_lineage",
+    "reveal_secret_var",
     "run_id_var",
     "step_id_var",
     "work_ref_var",
@@ -182,6 +183,24 @@ work_ref_var: ContextVar[str | None] = ContextVar(
 #: for the nullable ``audit_log.policy_decision`` column.
 policy_decision_var: ContextVar[str | None] = ContextVar(
     "policy_decision",
+    default=None,
+)
+
+
+#: ContextVar carrying the ``reveal_secret`` opt-in for a ``credential_read``
+#: dispatch (#2467). Bound in
+#: :func:`~meho_backplane.operations.dispatcher.dispatch` with a
+#: token/finally reset scoping it to the dispatch -- the same
+#: bound-at-a-boundary / read-at-the-write-call-site discipline as
+#: :data:`policy_decision_var`. Read by :func:`_build_audit_payload`, which
+#: stamps ``payload["reveal_secret"]`` so "which credential reads returned a
+#: raw value vs. the default key-name-scrubbed response" is queryable on the
+#: audit row. ``True`` = caller opted into the raw value; ``False`` = the
+#: default scrubbed response was returned; ``None`` (the value for every
+#: non-credential_read dispatch, and for pre-gate usage errors) leaves the
+#: key absent.
+reveal_secret_var: ContextVar[bool | None] = ContextVar(
+    "reveal_secret",
     default=None,
 )
 
@@ -417,14 +436,37 @@ def _build_audit_payload(
         # a UUID-as-str, ``total_rows`` an int, ``sample_rows_returned``
         # an int) so the dict merges into the JSON payload verbatim.
         payload.update(handle_metadata)
-    # G11.4-T5 #1074 -- agent-run attribution. The session id mirror in
-    # the JSON payload is for the broadcast-event surface (consumers
-    # parse ``payload``); the canonical lineage key lives in the real
-    # ``audit_log.agent_session_id`` column (migration ``0014`` /
-    # G8.2-T1 #1009), written by :func:`write_audit_row`. ``model`` /
-    # ``provider`` / ``cost`` carry only in the payload -- the
-    # ``agent_run`` row holds the durable copy; this snapshot is the
-    # per-row attribution slice.
+    # Contextvar-bound lineage mirrors (agent-run attribution, runbook
+    # correlation, credential_read reveal choice) for the broadcast-event
+    # surface; the canonical values live in dedicated ``audit_log`` columns.
+    _apply_contextvar_lineage_mirrors(payload)
+    # Handler-bound extras last so a handler can intentionally override
+    # a default (e.g. a future per-op result_status override); the
+    # default keys are documented + load-bearing for audit consumers,
+    # so this layering is the explicit knob, not an accidental coupling.
+    payload.update(_resolve_audit_extras_from_contextvars())
+    return payload
+
+
+def _apply_contextvar_lineage_mirrors(payload: dict[str, Any]) -> None:
+    """Mirror the dispatch's contextvar-bound lineage keys into *payload*.
+
+    The canonical values live in dedicated ``audit_log`` columns (written
+    by :func:`write_audit_row`); these JSON-payload mirrors exist for the
+    broadcast-event surface, whose consumers parse ``payload`` rather than
+    the columns. Each key is present only when its contextvar is bound:
+
+    * agent-run attribution (G11.4-T5 #1074) -- ``agent_session_id`` plus
+      the ``model`` / ``provider`` / ``cost`` from the active
+      :class:`AgentRunAuditMeta` snapshot (the ``agent_run`` row holds the
+      durable copy; this is the per-row attribution slice);
+    * runbook correlation (G12.1-T2 #1294) -- ``run_id`` / ``step_id``,
+      ``None`` outside a runbook step execution;
+    * credential_read reveal choice (#2467) -- ``reveal_secret`` (bool),
+      bound only for a credential_read dispatch (``True`` = the caller
+      opted into the raw value, ``False`` = the default key-name-scrubbed
+      response), so the key stays absent for every other op.
+    """
     agent_session_id = agent_session_id_var.get()
     if agent_session_id is not None:
         payload["agent_session_id"] = str(agent_session_id)
@@ -441,23 +483,15 @@ def _build_audit_payload(
             # example) through verbatim. JSON-incompatible shapes are
             # the meta producer's responsibility, not this layer's.
             payload["agent_cost"] = str(meta.cost) if isinstance(meta.cost, Decimal) else meta.cost
-    # G12.1-T2 #1294 -- runbook correlation. The run_id / step_id mirrors in
-    # the JSON payload serve the broadcast-event surface (consumers parse
-    # ``payload``); the canonical columns live on ``audit_log.run_id`` /
-    # ``audit_log.step_id`` (migration ``0034`` / G12.1-T1 #1292), written
-    # by :func:`write_audit_row`. ``None`` outside a runbook step execution.
     run_id = run_id_var.get()
     if run_id is not None:
         payload["run_id"] = str(run_id)
     step_id = step_id_var.get()
     if step_id is not None:
         payload["step_id"] = step_id
-    # Handler-bound extras last so a handler can intentionally override
-    # a default (e.g. a future per-op result_status override); the
-    # default keys are documented + load-bearing for audit consumers,
-    # so this layering is the explicit knob, not an accidental coupling.
-    payload.update(_resolve_audit_extras_from_contextvars())
-    return payload
+    reveal_secret = reveal_secret_var.get()
+    if reveal_secret is not None:
+        payload["reveal_secret"] = reveal_secret
 
 
 def _resolve_target_id(target: Any) -> uuid.UUID | None:

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -224,6 +224,7 @@ import httpx
 import hvac.exceptions
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.broadcast.events import classify_op, scrub_secret_named_values
 from meho_backplane.broadcast.history import build_target_activity_advisory
 from meho_backplane.connectors import (
     OperationResult,
@@ -238,6 +239,7 @@ from meho_backplane.operations._audit import (
     audit_and_broadcast_safe,
     parent_audit_id_var,
     policy_decision_var,
+    reveal_secret_var,
 )
 from meho_backplane.operations._branches import (
     dispatch_composite,
@@ -628,6 +630,7 @@ async def _execute_and_audit(
     params: dict[str, Any],
     params_hash: str,
     started: float,
+    scrub_response: bool = False,
 ) -> OperationResult:
     """Run the source_kind branch, redact, reduce, audit, broadcast, return.
 
@@ -700,6 +703,7 @@ async def _execute_and_audit(
         audit_id=audit_id,
         redaction=redaction,
         started=started,
+        scrub_response=scrub_response,
     )
 
 
@@ -714,13 +718,27 @@ async def _reduce_and_audit_success(
     audit_id: uuid.UUID,
     redaction: RedactionMiddlewareResult,
     started: float,
+    scrub_response: bool = False,
 ) -> OperationResult:
     """Run the reducer on the redacted payload, write the success-path
     audit row, and wrap the reduced summary into the final
     :class:`OperationResult`. Extracted from :func:`_execute_and_audit`
     so the orchestrator stays under the code-quality function-size cap
     and the redaction/reduce/audit ordering stays the only thing this
-    helper expresses."""
+    helper expresses.
+
+    *scrub_response* (#2467) key-name-scrubs the caller-bound response of a
+    ``credential_read``-classified op (``vault.kv.read`` et al.) unless the
+    caller passed ``params.reveal_secret=true``. Only the redacted
+    (reducer / caller) copy is scrubbed; ``redaction.raw`` -- captured
+    before this point and written to the audit row -- keeps the raw secret,
+    mirroring the #2172 secret-handler posture. The connector-boundary
+    engine matched only labelled string leaves, so a ``{"password": "..."}``
+    dict value reached here intact; :func:`scrub_secret_named_values`
+    replaces it with the redaction sentinel."""
+    if scrub_response:
+        scrubbed_redacted, _ = scrub_secret_named_values(redaction.redacted)
+        redaction = redaction.model_copy(update={"redacted": scrubbed_redacted})
     serialised_manifest = manifest_to_audit_payload(redaction.manifest)
     reduced = await _reduce_or_error(
         op_id=op_id,
@@ -1923,6 +1941,19 @@ async def dispatch(
     gate is the only authorization path for an ordinary dispatch.
     """
     started = time.monotonic()
+    # #2467 -- ``reveal_secret`` is a MEHO dispatch control, not a connector
+    # op param. Strip it before hashing / schema validation / handler
+    # forwarding: a ``credential_read``-classified response is key-name
+    # scrubbed by default so the raw secret never reaches the caller / agent
+    # transcript, and returning the raw value requires this explicit opt-in
+    # (stamped on the audit row). Stripping keeps the flag off the op's
+    # ``additionalProperties: false`` schema, out of the handler's params,
+    # and out of ``params_hash`` -- so a scrubbed read and its reveal share
+    # one hash (the reveal choice is recorded separately on the audit row).
+    reveal_secret = bool(params.get("reveal_secret"))
+    if "reveal_secret" in params:
+        params = {key: value for key, value in params.items() if key != "reveal_secret"}
+    credential_read = classify_op(op_id) == "credential_read"
     params_hash = compute_params_hash(params)
     product, version, impl_id = parse_connector_id(connector_id)
 
@@ -1962,6 +1993,12 @@ async def dispatch(
     # child ``dispatch`` rebinds the var, and clears it for the next dispatch
     # reusing this task.
     _verdict_token = policy_decision_var.set(None)
+    # #2467 -- stamp the reveal choice on the credential_read audit row.
+    # Bound only for a credential_read op (True/False = raw / scrubbed
+    # response); every other dispatch binds ``None`` so the key stays absent.
+    # Same token/finally reset discipline as ``policy_decision_var`` so a
+    # composite parent's value is restored after a child dispatch rebinds it.
+    _reveal_token = reveal_secret_var.set(reveal_secret if credential_read else None)
     try:
         if not _approved:
             # G11.2-T3: async, three-state verdict (auto-execute / needs-approval
@@ -2075,6 +2112,11 @@ async def dispatch(
             params=params,
             params_hash=params_hash,
             started=started,
+            # #2467 -- scrub the caller-bound response of a credential_read
+            # op unless the caller opted into the raw value. The audit row
+            # keeps the raw result either way.
+            scrub_response=credential_read and not reveal_secret,
         )
     finally:
         policy_decision_var.reset(_verdict_token)
+        reveal_secret_var.reset(_reveal_token)

--- a/backend/src/meho_backplane/ui/routes/vault/routes.py
+++ b/backend/src/meho_backplane/ui/routes/vault/routes.py
@@ -395,7 +395,9 @@ async def _render_read(
             request, "vault/_secret.html", _no_connector_error_context()
         )
 
-    envelope = await _dispatch(operator, connector_id, _OP_READ, target, mount, path)
+    envelope = await _dispatch(
+        operator, connector_id, _OP_READ, target, mount, path, reveal_secret=True
+    )
     context: dict[str, Any] = {
         "error": None,
         "envelope": envelope,
@@ -439,6 +441,8 @@ async def _dispatch(
     target: str,
     mount: str,
     path: str,
+    *,
+    reveal_secret: bool = False,
 ) -> dict[str, Any]:
     """Call ``call_operation`` in-process for one KV op; return the envelope.
 
@@ -448,6 +452,15 @@ async def _dispatch(
     do not consume a target, so an unset target field is valid). ``mount``
     is omitted from ``params`` when blank so the connector applies its
     ``_DEFAULT_KV_MOUNT``.
+
+    *reveal_secret* opts this dispatch into the raw ``credential_read``
+    value (#2467). The dispatcher key-name-scrubs ``vault.kv.read``
+    responses by default so an agent transcript never receives the secret;
+    the Vault console is an explicit reveal-on-click operator surface, so
+    the read path passes ``reveal_secret=True`` to keep the secret reaching
+    the browser. The choice is stamped on the audit row, so a console reveal
+    is queryable. ``vault.kv.list`` / ``vault.kv.versions`` are value-free
+    and leave it ``False``.
 
     The structured envelope is returned verbatim -- ``ok`` (carrying the
     result / handle) / ``error`` / ``denied`` all ride inside it (the
@@ -461,6 +474,10 @@ async def _dispatch(
     clean_mount = mount.strip()
     if clean_mount:
         params["mount"] = clean_mount
+    if reveal_secret:
+        # #2467 -- opt this operator-initiated reveal-on-click read out of
+        # the default credential_read response scrub.
+        params["reveal_secret"] = True
     arguments: dict[str, Any] = {
         "connector_id": connector_id,
         "op_id": op_id,

--- a/backend/tests/test_credential_read_response_scrub.py
+++ b/backend/tests/test_credential_read_response_scrub.py
@@ -1,0 +1,388 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Default key-name scrub for credential_read dispatch responses (#2467).
+
+A ``credential_read``-classified op (``vault.kv.read`` et al.) returns the
+raw secret in its handler payload -- that is the op's documented contract.
+The connector-boundary redaction engine cannot mask it: it matches only
+*labelled* secret shapes inside string leaves, so a ``{"password": "..."}``
+dict value passes through verbatim and lands in the ``call_operation``
+caller's response (and, for an agent caller, its model-API transcript).
+
+These tests pin the hardened contract:
+
+* the caller-bound response of a ``credential_read`` op is key-name
+  scrubbed by default -- secret-named values are replaced, non-secret
+  siblings (``username``, ``version``) are preserved;
+* ``params.reveal_secret=true`` opts into the raw value AND stamps the
+  choice on the audit row (queryable), while ``reveal_secret`` never
+  reaches the op's ``parameter_schema`` (it is stripped as a dispatch
+  control) nor the ``params_hash``;
+* the audit row's ``raw_payload`` keeps the raw secret in BOTH cases --
+  the scrub only touches the transport response, mirroring the #2172
+  secret-handler posture;
+* a non-credential_read op is untouched and carries no ``reveal_secret``
+  stamp.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.broadcast.events import scrub_secret_named_values
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.settings import get_settings
+
+# Assembled from fragments so gitleaks' built-in rules don't false-positive
+# on the test source.
+_PASSWORD_SECRET = "hunter2" + "longenough"
+_REDACTED = "[REDACTED:param_name]"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+def _make_operator(*, principal_kind: PrincipalKind = PrincipalKind.USER) -> Operator:
+    return Operator(
+        sub="op-2467-test",
+        name="Test Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-000000002467"),
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+class _NoOpVaultConnector(Connector):
+    """Connector class satisfying the resolver lookup for the typed op."""
+
+    product = "vault"
+    version = "1.x"
+    impl_id = "vault"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+async def _module_vault_read_handler(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Module-level ``vault.kv.read`` stand-in returning a raw secret.
+
+    Mirrors the real handler's ``{"data": <secret dict>, "version": N}``
+    shape. ``reveal_secret`` must have been stripped by the dispatcher, so
+    it is asserted absent from the handler-visible params.
+    """
+    assert "reveal_secret" not in params, "reveal_secret must be stripped before the handler"
+    return {"data": {"password": _PASSWORD_SECRET, "username": "root"}, "version": 3}
+
+
+async def _register_vault_read(embedding_service: AsyncMock) -> None:
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.read",
+        handler=_module_vault_read_handler,
+        summary="Read a KV v2 secret.",
+        description="Read a secret.",
+        parameter_schema={
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+            "additionalProperties": False,
+        },
+        when_to_use=None,
+        embedding_service=embedding_service,
+    )
+
+
+async def _audit_row(op_id: str) -> AuditLog:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (await fresh.execute(select(AuditLog).where(AuditLog.path == op_id))).scalars().all()
+    assert len(rows) == 1, f"expected exactly one audit row for {op_id}, got {len(rows)}"
+    return rows[0]
+
+
+# ---------------------------------------------------------------------------
+# Scrubbed by default
+# ---------------------------------------------------------------------------
+
+
+async def test_credential_read_response_scrubbed_by_default(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """No ``reveal_secret`` -> the secret value is replaced; siblings survive."""
+    await _register_vault_read(stub_embedding_service)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id="vault-1.x",
+        op_id="vault.kv.read",
+        target=None,
+        params={"path": "app/db"},
+    )
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    # Secret-named value replaced; non-secret siblings preserved.
+    assert result.result["data"]["password"] == _REDACTED
+    assert result.result["data"]["username"] == "root"
+    assert result.result["version"] == 3
+    # The raw secret never reaches the caller-bound envelope.
+    assert _PASSWORD_SECRET not in result.model_dump_json()
+
+    # The audit row keeps the RAW secret (raw_payload), and stamps the
+    # scrubbed (reveal_secret=False) choice.
+    row = await _audit_row("vault.kv.read")
+    assert isinstance(row.raw_payload, dict)
+    assert row.raw_payload["data"]["password"] == _PASSWORD_SECRET
+    assert row.payload["reveal_secret"] is False
+
+
+async def test_credential_read_scrub_is_principal_independent(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """The scrub keys on the op class, not the caller kind (product decision).
+
+    The reported incident's caller was a service-account token driven by an
+    agent, so caller-kind gating would have missed it. A ``USER`` principal
+    (default-allow) reaches execution and is scrubbed just the same.
+    """
+    await _register_vault_read(stub_embedding_service)
+
+    result = await dispatch(
+        operator=_make_operator(principal_kind=PrincipalKind.USER),
+        connector_id="vault-1.x",
+        op_id="vault.kv.read",
+        target=None,
+        params={"path": "app/db"},
+    )
+    assert result.status == "ok", result.error
+    assert result.result["data"]["password"] == _REDACTED
+
+
+# ---------------------------------------------------------------------------
+# reveal_secret=true opt-in
+# ---------------------------------------------------------------------------
+
+
+async def test_reveal_secret_true_returns_raw_and_stamps_audit(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``reveal_secret=true`` -> raw value returned AND stamped on the audit row."""
+    await _register_vault_read(stub_embedding_service)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id="vault-1.x",
+        op_id="vault.kv.read",
+        target=None,
+        params={"path": "app/db", "reveal_secret": True},
+    )
+    assert result.status == "ok", result.error
+    # The caller opted in: the raw value comes back.
+    assert result.result["data"]["password"] == _PASSWORD_SECRET
+    assert result.result["data"]["username"] == "root"
+
+    row = await _audit_row("vault.kv.read")
+    # The reveal is queryable on the audit row.
+    assert row.payload["reveal_secret"] is True
+    # raw_payload keeps the raw secret (unchanged posture).
+    assert isinstance(row.raw_payload, dict)
+    assert row.raw_payload["data"]["password"] == _PASSWORD_SECRET
+
+
+async def test_reveal_secret_does_not_reach_op_schema_or_hash(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """``reveal_secret`` is a dispatch control: stripped before schema + hash.
+
+    The op schema is ``additionalProperties: false``; if ``reveal_secret``
+    were forwarded, dispatch would 422 with ``invalid_params``. And the
+    scrubbed read and its reveal must share one ``params_hash`` (the reveal
+    choice is recorded separately on the audit row, not in the hash).
+    """
+    await _register_vault_read(stub_embedding_service)
+    operator = _make_operator()
+
+    scrubbed = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.read",
+        target=None,
+        params={"path": "app/db"},
+    )
+    revealed = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.kv.read",
+        target=None,
+        params={"path": "app/db", "reveal_secret": True},
+    )
+    # Neither dispatch 422'd on the strict schema.
+    assert scrubbed.status == "ok", scrubbed.error
+    assert revealed.status == "ok", revealed.error
+
+    # Both audit rows share one params_hash despite the differing reveal.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == "vault.kv.read")))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 2
+    hashes = {row.payload["params_hash"] for row in rows}
+    assert len(hashes) == 1, "reveal choice must not perturb params_hash"
+
+
+# ---------------------------------------------------------------------------
+# Non-credential_read ops are untouched
+# ---------------------------------------------------------------------------
+
+
+async def _module_metadata_handler(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """A plain ``read`` op that happens to echo a secret-named field."""
+    return {"password": _PASSWORD_SECRET, "note": "not a credential_read op"}
+
+
+async def test_non_credential_read_op_is_not_scrubbed_or_stamped(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A ``read``-class op keeps its payload and carries no reveal stamp.
+
+    ``vault.kv.versions`` classifies ``read`` (metadata browse), not
+    ``credential_read`` -- the response scrub must not fire on it, and the
+    audit row must not carry a ``reveal_secret`` key.
+    """
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.versions",
+        handler=_module_metadata_handler,
+        summary="List KV metadata versions.",
+        description="Metadata only.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id="vault-1.x",
+        op_id="vault.kv.versions",
+        target=None,
+        params={"path": "app/db"},
+    )
+    assert result.status == "ok", result.error
+    # Not a credential_read op: the response is untouched by the #2467 scrub.
+    assert result.result["password"] == _PASSWORD_SECRET
+
+    row = await _audit_row("vault.kv.versions")
+    assert "reveal_secret" not in row.payload
+
+
+# ---------------------------------------------------------------------------
+# scrub_secret_named_values unit contract
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_secret_named_values_replaces_nested_secret() -> None:
+    scrubbed, found = scrub_secret_named_values(
+        {"data": {"password": _PASSWORD_SECRET, "username": "root"}, "version": 3}
+    )
+    assert found is True
+    assert scrubbed == {
+        "data": {"password": _REDACTED, "username": "root"},
+        "version": 3,
+    }
+
+
+def test_scrub_secret_named_values_passthrough_when_no_secret() -> None:
+    payload = {"keys": ["app/db", "app/api"], "count": 2}
+    scrubbed, found = scrub_secret_named_values(payload)
+    assert found is False
+    assert scrubbed == payload

--- a/cli/internal/cmd/secret/read.go
+++ b/cli/internal/cmd/secret/read.go
@@ -137,10 +137,15 @@ func runRead(
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), false)
 	}
 
-	// Same params `meho vault kv read` sends: mount + path. The field is
-	// extracted client-side, so it never crosses the wire and is not part
-	// of the audit row.
-	params := map[string]any{"mount": mount, "path": path}
+	// mount + path, plus reveal_secret: this verb's whole contract is to
+	// pipe the raw credential value onward, so it opts out of the
+	// dispatcher's default credential_read response scrub (#2467). Without
+	// it the backplane returns a key-name-scrubbed envelope and --field
+	// would extract the redaction sentinel instead of the secret. The
+	// dispatcher strips reveal_secret before validating against the op
+	// schema and stamps the reveal on the audit row (the field name is
+	// still extracted client-side, so it never crosses the wire).
+	params := map[string]any{"mount": mount, "path": path, "reveal_secret": true}
 	r, err := vaultConn.Call(cmd.Context(), backplaneURL, opKVRead, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, false)

--- a/cli/internal/cmd/secret/read_test.go
+++ b/cli/internal/cmd/secret/read_test.go
@@ -139,6 +139,11 @@ func TestSecretRead(t *testing.T) {
 	if captured.Params["mount"] != "secret" || captured.Params["path"] != "app/db" {
 		t.Errorf("params should carry mount+path; got %v", captured.Params)
 	}
+	// reveal_secret opts out of the default credential_read response scrub
+	// (#2467); without it the piped value would be the redaction sentinel.
+	if captured.Params["reveal_secret"] != true {
+		t.Errorf("params should carry reveal_secret=true (#2467); got %v", captured.Params)
+	}
 	if _, leaked := captured.Params["field"]; leaked {
 		t.Errorf("field must NOT cross the wire (client-side extraction); got %v", captured.Params)
 	}

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -255,6 +255,58 @@ crash) are caught and converted to a structured `connector_error`
 preserved — a redactor failure must not leak raw payloads through a
 500 with no audit record.
 
+### credential_read response scrub + `reveal_secret` opt-in (#2467)
+
+The Tier-1 engine matches only **labelled** secret shapes inside
+string leaves (`password=…`, `Bearer …`); a structured `{"password":
+"<value>"}` dict carries no label in the leaf, so the engine passes it
+through verbatim. That is the correct behaviour for most responses, but
+a `credential_read` op — `vault.kv.read` and its allowlist siblings
+(`broadcast/events.py:_CREDENTIAL_READ_OPS`) — returns exactly this
+shape: its documented contract is *to return the secret value*. Before
+#2467 that raw value reached the `call_operation` caller, and for an
+agent caller it landed in the model-API transcript.
+
+The dispatcher adds a second, structured-dict layer for
+`credential_read`-classified ops only:
+
+- `dispatch()` strips a reserved `params.reveal_secret` control flag
+  **before** hashing / schema validation / handler forwarding (the op
+  schemas are `additionalProperties: false`, so the flag would
+  otherwise 422). It then classifies the op (`classify_op(op_id) ==
+  "credential_read"`) and, unless the caller opted in, passes
+  `scrub_response=True` down to `_reduce_and_audit_success`.
+- `_reduce_and_audit_success` runs
+  `broadcast.events.scrub_secret_named_values` (the public entry to the
+  same key-name walk the broadcast params scrub uses) over
+  **`redaction.redacted` only** — the caller-bound copy. Secret-named
+  values become `[REDACTED:param_name]`; non-secret siblings
+  (`username`, `version`) survive. `redaction.raw`, captured before the
+  scrub, is untouched, so the audit `raw_payload` keeps the raw secret.
+  This mirrors the #2172 secret-handler posture: the ledger keeps the
+  raw result, the transport response does not.
+- The reveal choice is stamped on the audit row via
+  `reveal_secret_var` (a ContextVar bound with the same token/finally
+  discipline as `policy_decision_var`), read in `_build_audit_payload`
+  as `payload['reveal_secret']` (`True` = raw returned, `False` = the
+  default scrubbed response). Non-`credential_read` dispatches leave the
+  var `None`, so the key is absent — "which credential reads returned a
+  raw value" is queryable without a new column.
+
+The scrub keys on the **op class, not the caller kind**: the reported
+incident's caller was a backplane service-account token driven by an
+agent, so principal-kind gating would have missed it (and no
+`human_agent` principal kind exists). Approved human flows keep working
+by opting in at their two known call sites — the `/ui` Vault console BFF
+(`ui/routes/vault/routes.py`, reveal-on-click) and CLI `meho secret
+read` (`cli/internal/cmd/secret/read.go`, the pipe-only raw path) both
+pass `reveal_secret: true`, so their audit rows honestly record the
+reveal. `secret.move` remains the recommended no-transit path for piping
+a credential onward; `vault.kv.versions` is the metadata-only browse.
+`meho vault kv read` is deliberately **not** an opt-in site — its
+browse envelope now shows the scrubbed value; use `meho secret read` for
+the raw bytes.
+
 ### Audit columns
 
 Migration `0030` adds two nullable JSON columns to `audit_log`


### PR DESCRIPTION
## Summary
- **Default key-name scrub for `credential_read` dispatch responses.** A `credential_read` op (`vault.kv.read` + its `_CREDENTIAL_READ_OPS` siblings) returns the raw secret in its handler payload — its documented contract. The connector-boundary redaction engine matches only *labelled* secret shapes inside string leaves, so a `{"password": "<value>"}` dict value passed through verbatim into the `call_operation` caller's response (and, for an agent caller, its model-API transcript). The dispatcher now key-name scrubs the **caller-bound** response: secret-named values become `[REDACTED:param_name]`, non-secret siblings (`username`, `version`) survive.
- **`params.reveal_secret=true` opt-in, stamped on the audit row.** A caller that must pipe the raw value onward passes the reserved flag; the raw value is returned AND the choice is recorded queryably as `payload['reveal_secret']`. The flag is stripped before op-schema validation (`additionalProperties: false`) and before `params_hash`, so a scrubbed read and its reveal share one hash.
- **Audit `raw_payload` keeps the raw result** in both cases — only the transport response is scrubbed (mirrors the #2172 secret-handler posture). The scrub keys on the **op class, not the caller kind** (the incident caller was a service-account token driven by an agent, so principal-kind gating would have missed it).
- **Approved human flows opt in at their two known call sites:** the `/ui` Vault console read (reveal-on-click) and CLI `meho secret read` (pipe-only) both pass `reveal_secret=true`; their audit rows honestly record the reveal. `secret.move` stays the recommended no-transit path; `vault.kv.versions` is the metadata-only browse.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (all changed files)
- [x] `mypy` — clean (all changed source files)
- [x] `code-quality.py --diff` — 0 blockers (extracted `_apply_contextvar_lineage_mirrors` to keep `_build_audit_payload` under the size/complexity caps)
- [x] New `tests/test_credential_read_response_scrub.py` (10 cases): scrubbed-by-default, `reveal_secret=true` reveals + stamps audit, `raw_payload` keeps raw, reveal flag stripped from schema + hash (one shared `params_hash`), non-`credential_read` op untouched, `scrub_secret_named_values` unit contract — all pass
- [x] `test_operations_dispatcher.py`, `test_mcp_tools_operations.py`, `test_broadcast_credential_mint_dispatch.py`, `test_agent_audit_invocation.py`, `test_audit_work_ref.py`, `test_ui_vault.py`, broadcast/runbook lineage sweep — all green (refactored audit-lineage mirrors verified)
- [x] `go build ./...` + `go test ./internal/cmd/secret/...` + `go vet` — pass (CLI opt-in + updated assertion)
- [x] No OpenAPI drift (MCP tool description is JSON-RPC, not a FastAPI route; no REST model touched → no `snapshot-openapi` regen)

## Out of scope / notes
- `meho vault kv read` is **not** an opt-in site (per the product decision's two named sites) — its browse envelope now shows the scrubbed value; use `meho secret read` for the raw bytes. Flagged for maintainer awareness in case a `--reveal` flag is later wanted.
- Pre-existing (not caused here): `tests/test_connectors_vault.py::test_preflight_fail_soft_when_probe_raises` emits a teardown ERROR (test itself passes) on both this branch and pristine `main`.

Closes #2467
