### PR TITLE
feat(mcp): unify list-row identifiers with sibling input args (#2471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,32 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — MCP identifier round-trips (#2471)
+
+- Unify list-row identifiers with the sibling verbs that consume them across
+  four MCP families, so the obvious round-trip
+  (`run_status(run_id=row.run_id)`, `grant.show(grant_id=row.id)`,
+  `scheduler.cancel(trigger_id=row.id)`, `list_runs(status=row.state)`) no
+  longer fails with `-32602`. Folds dogfood reports #2476 / #2477 / #2478 /
+  #2482.
+- **`meho.agents.run_status` now takes `run_id`** (the key `meho.agents.run`
+  and `meho.agents.list_runs` rows already return). The pre-#2471 `handle`
+  arg survives as a **deprecated alias** for one cycle — marked
+  `deprecated: true` in `tools/list`, guarded by the same `anyOf` +
+  handler-level XOR the approvals tools use; supplying both `run_id` and
+  `handle` rejects with `-32602` naming both. **Migration:** switch
+  `run_status` callers from `handle` to `run_id`; `handle` keeps working
+  until the alias is dropped.
+- Three additive response mirrors at the MCP wire boundary (REST surface and
+  shared Pydantic models untouched, native keys retained):
+  `meho.agents.grant.{list,show,create,elevate}` rows now carry `grant_id`
+  (== native `id`); `meho.scheduler.list` rows carry `trigger_id` (== native
+  `id`); `meho.runbook.list_runs` summaries carry `status` (== native
+  `state`). The runbook `status` list-filter is unchanged (§14.6).
+- Clarify the `template_slug` inputSchema description on the runbook template
+  verbs to state that responses carry both `template_slug` (mirror) and the
+  model-native `slug`, equal values (#2476) — no payload change.
+
 ### Fixed — `targets import` reads the `{items, next_cursor}` list envelope (#2577)
 
 - `meho targets import` failed against every v0.21.0+ backplane — `--dry-run`

--- a/backend/src/meho_backplane/mcp/tools/agent_grants.py
+++ b/backend/src/meho_backplane/mcp/tools/agent_grants.py
@@ -74,8 +74,23 @@ _GRANT_OP_IDS: Final[dict[str, str]] = {
 }
 
 
+def _mirror_grant_id(payload: dict[str, Any]) -> dict[str, Any]:
+    """Mirror the native ``id`` response key as ``grant_id``.
+
+    The row model :class:`AgentGrantRead` is shared with the REST route
+    ``GET /api/v1/agents/grants`` (#1612 kept shared models out of a
+    rename's scope), so the MCP handlers mirror the id at the wire
+    boundary instead: every grant row carries ``grant_id`` — the field
+    ``meho.agents.grant.show`` / ``meho.agents.grant.revoke`` accept
+    verbatim — alongside the model's native ``id``.
+    """
+    if "id" in payload:
+        payload["grant_id"] = payload["id"]
+    return payload
+
+
 def _row_to_dict(entry: AgentGrantRead) -> dict[str, Any]:
-    return entry.model_dump(mode="json")
+    return _mirror_grant_id(entry.model_dump(mode="json"))
 
 
 def _require_str(arguments: dict[str, Any], key: str) -> str:
@@ -122,7 +137,9 @@ register_mcp_tool(
         name="meho.agents.grant.list",
         description=(
             "List agent permission grants for the operator's tenant "
-            "(G11.2-T6). Returns {grants: [...]}. "
+            "(G11.2-T6). Returns {grants: [...]}; each row carries "
+            "`grant_id` (accepted verbatim by meho.agents.grant.show / "
+            ".revoke) alongside the model-native `id`. "
             "Optional principal_sub filters to one agent. "
             "include_expired=true includes past elevations."
         ),
@@ -174,7 +191,8 @@ register_mcp_tool(
         name="meho.agents.grant.show",
         description=(
             "Fetch one agent permission grant by id (G11.2-T6). "
-            "Returns the grant row or raises not-found."
+            "Returns the grant row (carrying both `grant_id` and the "
+            "model-native `id`) or raises not-found."
         ),
         inputSchema={
             "type": "object",
@@ -227,7 +245,9 @@ register_mcp_tool(
             "Grant a permission to an agent principal (G11.2-T6). "
             "verdict: auto-execute | needs-approval | deny. "
             "expires_at (ISO-8601 UTC) makes the grant time-bounded. "
-            "Omit expires_at for a permanent grant."
+            "Omit expires_at for a permanent grant. The created row "
+            "carries `grant_id` (accepted verbatim by "
+            "meho.agents.grant.show / .revoke) alongside the native `id`."
         ),
         inputSchema={
             "type": "object",
@@ -297,7 +317,9 @@ register_mcp_tool(
         description=(
             "Grant a time-bounded elevation to an agent principal (G11.2-T6). "
             "expires_at is required. The grant-expiry sweeper reverts the "
-            "agent to baseline automatically after the window ends."
+            "agent to baseline automatically after the window ends. The "
+            "created row carries `grant_id` (accepted verbatim by "
+            "meho.agents.grant.show / .revoke) alongside the native `id`."
         ),
         inputSchema={
             "type": "object",

--- a/backend/src/meho_backplane/mcp/tools/agent_runs.py
+++ b/backend/src/meho_backplane/mcp/tools/agent_runs.py
@@ -10,8 +10,8 @@ Two ``meho.agents.*`` tools that mirror the REST invocation routes
   server-side timeout and returns the final output; ``async=true`` (or a
   sync run that exceeds the timeout) returns a run handle. Role:
   ``operator``.
-* ``meho.agents.run_status`` — poll a run's durable status by handle. Role:
-  ``operator``.
+* ``meho.agents.run_status`` — poll a run's durable status by ``run_id``
+  (the deprecated ``handle`` alias is still accepted). Role: ``operator``.
 
 SSE streaming is REST-only: the MCP request/response shape has no
 streaming-events transport here, so an MCP caller that wants progress polls
@@ -61,6 +61,69 @@ _RUN_OP_IDS: Final[dict[str, str]] = {
     "status": "agent.run_status",
     "list": "agent.list_runs",
 }
+
+#: Canonical ``run_id`` schema fragment for ``meho.agents.run_status``.
+#: The row key ``meho.agents.run`` / ``meho.agents.list_runs`` return —
+#: so a value read off a run response round-trips into ``run_status``
+#: verbatim (§14.3 ``<noun>_id`` grammar; approvals precedent #1358).
+_RUN_ID_PROPERTY: Final[dict[str, Any]] = {
+    "type": "string",
+    "format": "uuid",
+    "minLength": 1,
+    "description": (
+        "Run UUID. Canonical name (G0.32 #2471) — the `run_id` key "
+        "`meho.agents.run` and `meho.agents.list_runs` return, matching "
+        "the `<noun>_id` convention used by every other MCP tool that "
+        "names a resource UUID."
+    ),
+}
+
+#: Deprecated ``handle`` alias kept for backward compat with the pre-#2471
+#: wire shape.
+_RUN_STATUS_LEGACY_HANDLE_PROPERTY: Final[dict[str, Any]] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "DEPRECATED alias for `run_id` (pre-#2471 wire shape). Accepted "
+        "for backward compatibility; new callers SHOULD use `run_id`. "
+        "Mutually exclusive with `run_id`; passing both rejects with "
+        "-32602."
+    ),
+    "deprecated": True,
+}
+
+#: Either alias satisfies the "run id required" constraint; the handler
+#: enforces the XOR.
+_RUN_STATUS_ID_ANYOF: Final[list[dict[str, Any]]] = [
+    {"required": ["run_id"]},
+    {"required": ["handle"]},
+]
+
+
+def _require_run_id(arguments: dict[str, Any]) -> uuid.UUID:
+    """Resolve the run UUID from the wire arguments.
+
+    Accepts the canonical ``run_id`` (G0.32 #2471) and the deprecated
+    ``handle`` (pre-#2471 wire shape) as aliases — exactly one must be
+    supplied. Passing both rejects with -32602. The ``<noun>_id`` rename
+    aligns ``meho.agents.run_status`` with the ``run_id`` key its sibling
+    ``meho.agents.run`` / ``meho.agents.list_runs`` already return, so a
+    value read off a run response round-trips verbatim; ``handle`` is
+    retained for one cycle so pre-#2471 callers continue to work.
+    """
+    canonical = arguments.get("run_id")
+    legacy = arguments.get("handle")
+    if canonical is not None and legacy is not None:
+        raise McpInvalidParamsError(
+            "pass either `run_id` (canonical) or `handle` (deprecated alias), not both",
+        )
+    raw = canonical if canonical is not None else legacy
+    if not isinstance(raw, str) or not raw:
+        raise McpInvalidParamsError("run_id is required and must be a non-empty UUID string")
+    try:
+        return uuid.UUID(raw)
+    except ValueError as exc:
+        raise McpInvalidParamsError("run_id must be a valid run id (UUID)") from exc
 
 
 def _require_name(arguments: dict[str, Any]) -> str:
@@ -190,13 +253,7 @@ async def _run_status_handler(
     operator: Operator,
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
-    raw = arguments.get("handle")
-    if not isinstance(raw, str) or not raw:
-        raise McpInvalidParamsError("handle is required and must be a non-empty string")
-    try:
-        run_id = uuid.UUID(raw)
-    except ValueError as exc:
-        raise McpInvalidParamsError("handle must be a valid run id (UUID)") from exc
+    run_id = _require_run_id(arguments)
     structlog.contextvars.bind_contextvars(
         audit_op_id=_RUN_OP_IDS["status"],
         audit_op_class="read",
@@ -221,23 +278,23 @@ register_mcp_tool(
     definition=ToolDefinition(
         name="meho.agents.run_status",
         description=(
-            "Poll an agent run's durable status by handle (Initiative "
+            "Poll an agent run's durable status by run_id (Initiative "
             "#802). Operator-level. Returns {run_id, status, turns, "
             "provider, model, output, error}; output/error are set once the "
             "run reaches a terminal state. Reads the durable run record, so "
-            "it works after the call that started the run returned. An "
-            "unknown / cross-tenant handle returns 'agent_run_not_found'."
+            "it works after the call that started the run returned. Pass the "
+            "`run_id` a `meho.agents.run` / `meho.agents.list_runs` row "
+            "returned (canonical name; G0.32 #2471) or the deprecated "
+            "`handle` alias. An unknown / cross-tenant run_id returns "
+            "'agent_run_not_found'."
         ),
         inputSchema={
             "type": "object",
             "properties": {
-                "handle": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "The run handle (run id, a UUID) to poll.",
-                },
+                "run_id": _RUN_ID_PROPERTY,
+                "handle": _RUN_STATUS_LEGACY_HANDLE_PROPERTY,
             },
-            "required": ["handle"],
+            "anyOf": _RUN_STATUS_ID_ANYOF,
             "additionalProperties": False,
         },
         required_role=TenantRole.OPERATOR,

--- a/backend/src/meho_backplane/mcp/tools/runbook_runs.py
+++ b/backend/src/meho_backplane/mcp/tools/runbook_runs.py
@@ -182,6 +182,22 @@ def _parse_run_id(tool: str, raw: Any) -> uuid.UUID:
         raise _to_invalid_params(tool, ValueError(f"invalid run_id: {raw!r}")) from exc
 
 
+def _mirror_run_status(payload: dict[str, Any]) -> dict[str, Any]:
+    """Mirror a run summary's native ``state`` response key as ``status``.
+
+    The ``RunSummary`` row model is REST-shared and mirrors the
+    ``runbook_runs.state`` DB column, so neither side can be renamed; the
+    ``meho.runbook.list_runs`` filter stays ``status`` (the surface-wide
+    ``*.list.status`` name pinned by §14.6). The MCP handler therefore
+    mirrors the value at the wire boundary: every run-summary row carries
+    ``status`` — the same vocabulary the ``status`` filter accepts —
+    alongside the model's native ``state`` (equal values).
+    """
+    if "state" in payload:
+        payload["status"] = payload["state"]
+    return payload
+
+
 # ---------------------------------------------------------------------------
 # Tool descriptions (the load-bearing UX)
 # ---------------------------------------------------------------------------
@@ -309,7 +325,10 @@ _LIST_DESCRIPTION: Final[str] = (
     "before considering meho.runbook.reassign.\n\n"
     "Returns RunSummary entries -- run-level state plus the current "
     "step's state (current_step_state: in_progress / failed), no step "
-    "contents. current_step_state='failed' means the step's verify did "
+    "contents. Each row carries its run-level state under both `state` "
+    "(model-native) and `status` (the same vocabulary the `status` "
+    "filter accepts), equal values. current_step_state='failed' means "
+    "the step's verify did "
     "not pass (answer no/escalate, or a mismatched operation_call "
     "result); the only forward path for that run is meho.runbook.abort. "
     "To see the current step body of an in-progress run you OWN, call "
@@ -555,7 +574,7 @@ async def _list_runs_handler(
         )
     except (ValidationError, *_INVALID_PARAMS_ERRORS) as exc:
         raise _to_invalid_params("meho.runbook.list_runs", exc) from exc
-    return {"runs": [summary.model_dump(mode="json") for summary in summaries]}
+    return {"runs": [_mirror_run_status(summary.model_dump(mode="json")) for summary in summaries]}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/meho_backplane/mcp/tools/runbooks.py
+++ b/backend/src/meho_backplane/mcp/tools/runbooks.py
@@ -402,7 +402,11 @@ _TEMPLATE_SLUG_PROPERTY: Final[dict[str, Any]] = {
         "lowercase letters, digits, hyphens, or dots. Example: "
         "'vcenter-9.0-cert-rotation'. REQUIRED. Canonical field name "
         "across all 12 runbook tools (#1612) — the same name "
-        "`meho.runbook.start` takes and every template response returns."
+        "`meho.runbook.start` takes. Template responses (show_template, "
+        "each list_templates summary) carry this id under both "
+        "`template_slug` (this canonical mirror) and the model-native "
+        "`slug`, equal values — either round-trips into "
+        "`meho.runbook.start` verbatim."
     ),
 }
 

--- a/backend/src/meho_backplane/mcp/tools/scheduler.py
+++ b/backend/src/meho_backplane/mcp/tools/scheduler.py
@@ -90,9 +90,24 @@ _SCHEDULER_OP_IDS: Final[dict[str, str]] = {
 }
 
 
+def _mirror_trigger_id(payload: dict[str, Any]) -> dict[str, Any]:
+    """Mirror the native ``id`` response key as ``trigger_id``.
+
+    The row model :class:`ScheduledTriggerRead` is shared with the REST
+    route ``/api/v1/scheduler/triggers``, so the MCP handler mirrors the
+    id at the wire boundary instead of renaming it: every trigger row
+    carries ``trigger_id`` — the field ``meho.scheduler.cancel`` accepts
+    verbatim, and the same top-level key ``meho.scheduler.create``
+    already returns — alongside the model's native ``id``.
+    """
+    if "id" in payload:
+        payload["trigger_id"] = payload["id"]
+    return payload
+
+
 def _row_to_dict(entry: ScheduledTriggerRead) -> dict[str, Any]:
     """Serialise a :class:`ScheduledTriggerRead` to the MCP wire dict."""
-    return entry.model_dump(mode="json")
+    return _mirror_trigger_id(entry.model_dump(mode="json"))
 
 
 def _require_trigger_id(arguments: dict[str, Any]) -> uuid.UUID:
@@ -147,7 +162,9 @@ register_mcp_tool(
         description=(
             "List scheduled triggers for the operator's tenant "
             "(Initiative #804). Operator-level read. Returns "
-            "{triggers: [trigger, ...]} sorted newest-first. "
+            "{triggers: [trigger, ...]} sorted newest-first; each row "
+            "carries `trigger_id` (accepted verbatim by "
+            "meho.scheduler.cancel) alongside the model-native `id`. "
             "Optional filters: kind ('cron'|'one_off'|'event'), "
             "status ('active'|'paused'|'cancelled'|'fired'), "
             "work_ref (exact-match change-ticket reference). "

--- a/backend/tests/test_mcp_tools_agent_runs.py
+++ b/backend/tests/test_mcp_tools_agent_runs.py
@@ -139,13 +139,31 @@ async def test_run_then_poll_round_trip(
     body = _result_dict(run)
     assert body["status"] == "succeeded"
     assert body["output"] == {"text": "triaged via mcp"}
-    handle = body["run_id"]
+    run_id = body["run_id"]
 
-    status = _call(client, "meho.agents.run_status", {"handle": handle}, rpc_id=2)
+    # Canonical: poll with the `run_id` the run row returned (#2471) —
+    # exercises the anyOf schema gate through the real dispatcher.
+    status = _call(client, "meho.agents.run_status", {"run_id": run_id}, rpc_id=2)
     status_body = _result_dict(status)
-    assert status_body["run_id"] == handle
+    assert status_body["run_id"] == run_id
     assert status_body["status"] == "succeeded"
     assert status_body["output"] == {"text": "triaged via mcp"}
+
+    # Deprecated alias: `handle` still resolves for pre-#2471 callers.
+    via_alias = _call(client, "meho.agents.run_status", {"handle": run_id}, rpc_id=3)
+    assert _result_dict(via_alias)["run_id"] == run_id
+
+    # Both aliases supplied -> -32602 naming both.
+    both = _call(
+        client,
+        "meho.agents.run_status",
+        {"run_id": run_id, "handle": run_id},
+        rpc_id=4,
+    )
+    both_body = both.json()
+    assert "error" in both_body
+    assert "run_id" in both_body["error"]["message"]
+    assert "handle" in both_body["error"]["message"]
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)

--- a/backend/tests/test_mcp_tools_list_shape_conventions.py
+++ b/backend/tests/test_mcp_tools_list_shape_conventions.py
@@ -49,6 +49,10 @@ from meho_backplane.mcp.tools import (  # noqa: F401
     scheduler,
     topology,
 )
+from meho_backplane.mcp.tools.agent_grants import _mirror_grant_id
+from meho_backplane.mcp.tools.runbook_runs import _mirror_run_status
+from meho_backplane.mcp.tools.runbooks import _mirror_template_slug
+from meho_backplane.mcp.tools.scheduler import _mirror_trigger_id
 
 
 def _tool_def(name: str) -> ToolDefinition:
@@ -216,6 +220,64 @@ def test_approvals_tools_expose_approval_request_id_canonical_name(
         {"required": ["id"]},
     ]
     assert "required" not in schema
+
+
+def test_run_status_exposes_run_id_canonical_name_with_handle_alias() -> None:
+    """`meho.agents.run_status` names its run UUID `run_id` (G0.32 #2471).
+
+    Convention §14.3: every MCP tool that names a resource UUID uses the
+    `<noun>_id` form. `run_status` was the sole remaining resource-UUID
+    input arg spelling it `handle` while its sibling `meho.agents.run` /
+    `meho.agents.list_runs` rows return `run_id` — so the obvious
+    round-trip `run_status(run_id=row.run_id)` failed. `run_id` is now
+    canonical; `handle` survives as a deprecated alias for one cycle,
+    guarded by the same `anyOf` + handler XOR the approvals tools use.
+    """
+    properties = _properties("meho.agents.run_status")
+    assert "run_id" in properties, (
+        f"meho.agents.run_status: missing canonical `run_id` (properties={sorted(properties)})"
+    )
+    assert properties["run_id"]["format"] == "uuid"
+    # The deprecated `handle` alias survives for backward compat.
+    assert "handle" in properties
+    assert properties["handle"].get("deprecated") is True
+    assert "deprecated" not in properties["run_id"]
+    # Either alias name satisfies the schema-level required check.
+    schema = _input_schema("meho.agents.run_status")
+    assert schema["anyOf"] == [
+        {"required": ["run_id"]},
+        {"required": ["handle"]},
+    ]
+    assert "required" not in schema
+
+
+def test_run_status_handler_resolves_run_id_xor_handle() -> None:
+    """The `run_id` ↔ `handle` XOR + canonical error strings are pinned.
+
+    §14.3 alias mold (approvals precedent #1358): the handler-level
+    resolver accepts either alias, rejects both-supplied with `-32602`
+    naming both, and speaks `run_id` in every error string.
+    """
+    from meho_backplane.mcp.server import McpInvalidParamsError
+    from meho_backplane.mcp.tools.agent_runs import _require_run_id
+
+    uuid_str = "11111111-1111-1111-1111-111111111111"
+    # Canonical resolves.
+    assert str(_require_run_id({"run_id": uuid_str})) == uuid_str
+    # Deprecated alias resolves.
+    assert str(_require_run_id({"handle": uuid_str})) == uuid_str
+    # Both supplied -> -32602 naming both.
+    with pytest.raises(McpInvalidParamsError) as both:
+        _require_run_id({"run_id": uuid_str, "handle": uuid_str})
+    assert "run_id" in str(both.value) and "handle" in str(both.value)
+    # Missing -> error speaks the canonical name.
+    with pytest.raises(McpInvalidParamsError) as missing:
+        _require_run_id({})
+    assert "run_id" in str(missing.value)
+    # Malformed -> error speaks the canonical name.
+    with pytest.raises(McpInvalidParamsError) as bad:
+        _require_run_id({"run_id": "not-a-uuid"})
+    assert "run_id" in str(bad.value)
 
 
 # ---------------------------------------------------------------------------
@@ -509,3 +571,61 @@ def test_runbook_run_tools_keep_template_slug_field(tool_name: str) -> None:
     properties = _properties(tool_name)
     assert "template_slug" in properties
     assert "slug" not in properties
+
+
+# ---------------------------------------------------------------------------
+# §14.10 — list-row identifiers mirror the qualified name the sibling verb
+#          accepts (alongside the model-native key)
+# ---------------------------------------------------------------------------
+#
+# Where a family's list-row model is REST-shared (so a field rename is off
+# the table), the MCP handler mirrors the identifier / state field at the
+# wire boundary: every row carries the qualified name its sibling verb
+# accepts (`grant_id`, `trigger_id`, `status`, `template_slug`) alongside
+# the model-native key (`id`, `state`, `slug`), equal values — so the
+# obvious round-trip `sibling(qualified=row.qualified)` works (G0.32
+# #2471; response-mirror precedent #1612).
+
+
+def test_grant_row_mirrors_id_as_grant_id_accepted_by_sibling_verbs() -> None:
+    """A grant row carries `grant_id` (== native `id`), accepted by show / revoke."""
+    row = _mirror_grant_id({"id": "grant-uuid", "principal_sub": "agent:x"})
+    assert row["grant_id"] == row["id"] == "grant-uuid"
+    # The sibling verbs require that exact key.
+    for tool_name in ("meho.agents.grant.show", "meho.agents.grant.revoke"):
+        assert "grant_id" in _properties(tool_name)
+        assert _input_schema(tool_name)["required"] == ["grant_id"]
+
+
+def test_scheduler_row_mirrors_id_as_trigger_id_accepted_by_cancel() -> None:
+    """A scheduler row carries `trigger_id` (== native `id`), accepted by cancel."""
+    row = _mirror_trigger_id({"id": "trigger-uuid", "kind": "cron"})
+    assert row["trigger_id"] == row["id"] == "trigger-uuid"
+    assert "trigger_id" in _properties("meho.scheduler.cancel")
+    assert _input_schema("meho.scheduler.cancel")["required"] == ["trigger_id"]
+
+
+@pytest.mark.parametrize("state", ("in_progress", "completed", "abandoned"))
+def test_runbook_run_row_mirrors_state_as_status_within_filter_enum(state: str) -> None:
+    """A run summary carries `status` (== native `state`), a `status`-filter member.
+
+    §14.6 keeps the `meho.runbook.list_runs` filter named `status`; the
+    row model keeps its native `state`. The mirror makes the row's
+    `status` value round-trippable into the filter — so each mirrored
+    value is a member of the `status` filter enum.
+    """
+    row = _mirror_run_status({"state": state, "run_id": "run-uuid"})
+    assert row["status"] == row["state"] == state
+    status_enum = _properties("meho.runbook.list_runs")["status"]["enum"]
+    assert state in status_enum
+
+
+def test_template_row_mirrors_slug_as_template_slug_both_present() -> None:
+    """A template row carries both `slug` (native) and `template_slug` (mirror).
+
+    #2476: the retained #1612 mirror means every template response carries
+    both keys with equal values — no payload change, description
+    clarification only (see `_TEMPLATE_SLUG_PROPERTY`).
+    """
+    row = _mirror_template_slug({"slug": "cert-rotation", "title": "Rotate"})
+    assert row["template_slug"] == row["slug"] == "cert-rotation"

--- a/docs/codebase/api-shape-conventions.md
+++ b/docs/codebase/api-shape-conventions.md
@@ -1004,6 +1004,58 @@ sibling). Template-verb responses still mirror the id as
 `list_templates` round-trips into `meho.runbook.start` verbatim. See
 also [`mcp.md`](mcp.md) §Tool naming grammar.
 
+### §14.10 — List rows mirror the qualified name the sibling verb accepts
+
+**Every list row carries the qualified identifier / state name its
+sibling `show` / `cancel` / `poll` / filter verb accepts, alongside
+the model-native key — so the obvious round-trip works verbatim.**
+
+A recurring papercut (G0.32 #2471, folding dogfood reports #2476 /
+#2477 / #2478 / #2482): a family's list row spelled its identifier or
+state one way while the sibling verb that consumes it required another,
+so `run_status(run_id=row.run_id)`, `grant.show(grant_id=row.id)`,
+`scheduler.cancel(trigger_id=row.id)`, and `list_runs(status=row.state)`
+each failed with `-32602`. The row models are REST-shared (or mirror a
+DB column), so a field rename is off the table — #1612 kept shared
+models out of a rename's scope.
+
+The convention closes the gap at the **MCP wire boundary** with two
+already-codified molds, picked by whether the mismatch is on an
+**input** or a **response**:
+
+* **Input mismatch → §14.3 canonical-name + deprecated-alias.** When
+  the offending name is an *input arg* (a resource UUID that violated
+  the `<noun>_id` grammar), rename it to the canonical `<noun>_id` and
+  keep the old name as a `deprecated: true` alias for one cycle, guarded
+  by a top-level `anyOf` (`[{required:[canonical]}, {required:[alias]}]`)
+  and a handler-level XOR resolver that names both on a both-supplied
+  `-32602` and speaks the canonical name in every error string. This is
+  the approvals `id`→`approval_request_id` mold (§14.3); #2471 applied
+  it to `meho.agents.run_status` (`handle`→`run_id`), the last
+  resource-UUID input arg violating the grammar.
+
+* **Response mismatch → additive mirror (native key stays).** When the
+  offending name is a *response key* on a REST-shared row, mirror it at
+  the wire boundary: the row carries **both** the model-native key and
+  the qualified name the sibling verb accepts, equal values. The REST
+  surface and the shared Pydantic model are untouched. This is the
+  `_mirror_template_slug` mold (#1612). #2471 added three more:
+  `meho.agents.grant.{list,show,create,elevate}` rows mirror `id` →
+  `grant_id` (accepted by `grant.show` / `grant.revoke`);
+  `meho.scheduler.list` rows mirror `id` → `trigger_id` (accepted by
+  `scheduler.cancel`, and the same key `scheduler.create` already
+  returns at top level); `meho.runbook.list_runs` run summaries mirror
+  `state` → `status`. The runbook filter itself stays `status` (§14.6
+  pins `*.list.status` surface-wide), so the mirror makes the row's
+  `status` value a member of the filter's own enum — a clean
+  round-trip without touching either the shared `RunSummary.state`
+  field or the filter name.
+
+Removing the native `id` / `state` / `slug` key from the mirrored
+response is explicitly **not** part of this convention — the #1612
+precedent keeps both, so a consumer reading either name keeps working.
+Tool descriptions state which key round-trips into which sibling verb.
+
 ### Code reference
 
 The pack of regression tests in

--- a/docs/codebase/mcp.md
+++ b/docs/codebase/mcp.md
@@ -203,6 +203,38 @@ The conventions are structurally pinned in
 (§14.9) and documented alongside the other tools/list shape rules in
 [`api-shape-conventions.md`](api-shape-conventions.md) §14.
 
+### List-row identifier mirrors (#2471)
+
+The `template_slug` response mirror generalises to a surface-wide rule
+(§14.10): **every list row carries the qualified name its sibling verb
+accepts, alongside the model-native key.** #2471 closed the last four
+mismatches — where a family's list row spelled its id/state one way
+while the sibling `show` / `cancel` / `poll` / filter verb required
+another, so the obvious round-trip failed with `-32602`.
+
+Two molds apply, by where the mismatch sits:
+
+* **Input arg** (a resource UUID off the `<noun>_id` grammar) →
+  canonical-name + deprecated-alias, the §14.3 approvals mold.
+  `meho.agents.run_status` took `handle`; #2471 renamed it to the
+  canonical `run_id` (the key its sibling `meho.agents.run` /
+  `meho.agents.list_runs` rows already return) and kept `handle` as a
+  `deprecated: true` alias for one cycle, guarded by an `anyOf` and a
+  handler-level XOR resolver that speaks `run_id` in every error string.
+* **Response key** on a REST-shared row → additive mirror, the
+  `_mirror_template_slug` mold. The row carries **both** the native key
+  and the qualified name, equal values; the REST surface and shared
+  Pydantic model are untouched. #2471 added `_mirror_grant_id` (`id` →
+  `grant_id` on `meho.agents.grant.{list,show,create,elevate}`),
+  `_mirror_trigger_id` (`id` → `trigger_id` on `meho.scheduler.list`),
+  and `_mirror_run_status` (`state` → `status` on
+  `meho.runbook.list_runs` summaries — the filter itself stays `status`
+  per §14.6, so the mirror makes the row value a member of the filter's
+  own enum).
+
+The native key is never removed (the #1612 precedent keeps both), so a
+consumer reading either name keeps working.
+
 ## Audit URI redaction for query-bearing resources
 
 The `resources/read` dispatcher


### PR DESCRIPTION
## Summary

- Four MCP families returned list rows whose identifier/state field name differed from the arg the sibling `show`/`cancel`/`poll`/filter verb required, so the obvious round-trip (`run_status(run_id=row.run_id)`, `grant.show(grant_id=row.id)`, `scheduler.cancel(trigger_id=row.id)`, `list_runs(status=row.state)`) failed with `-32602`. This closes all four using the two already-codified house molds. Folds dogfood reports #2476 / #2477 / #2478 / #2482.
- **One input rename (§14.3 approvals mold):** `meho.agents.run_status` now takes canonical `run_id`; the pre-#2471 `handle` survives as a `deprecated: true` alias, guarded by a top-level `anyOf` and a handler-level XOR resolver that names both on a both-supplied `-32602` and speaks `run_id` in every error string.
- **Three additive response mirrors at the MCP wire boundary** (REST surface + shared Pydantic models untouched, native keys retained): grant rows mirror `id`→`grant_id` on list/show/create/elevate; `scheduler.list` rows mirror `id`→`trigger_id`; `meho.runbook.list_runs` summaries mirror `state`→`status` (the list-filter stays `status` per §14.6, so the mirror makes the row value a member of the filter's own enum).
- **One description clarification (#2476):** the runbook `template_slug` inputSchema description now states responses carry both `template_slug` (mirror) and the model-native `slug`, equal values — no payload change.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on all touched files
- [x] `mypy` — no issues in the 5 touched source files
- [x] AC1 — `run_status` schema pin (`run_id` canonical + `handle` `deprecated: true` + `anyOf`) and handler XOR resolver pinned; functional round-trip polls with `run_id`, the `handle` alias, and asserts both-supplied → `-32602` naming both (`test_mcp_tools_agent_runs.py`, `test_mcp_tools_list_shape_conventions.py`)
- [x] AC2 — grant row `grant_id` / scheduler row `trigger_id` mirror pins + sibling verbs require those keys; `list_runs` row `status` is a member of the `status` filter enum
- [x] AC3 — runbook filter stays `status`, existing §14.6 tests green; every run summary carries both `state` and `status` with equal values (parametrized over all three state literals)
- [x] AC4 — `grep -rn '"handle"' backend/src/meho_backplane/mcp/tools/` matches only the deprecated-alias property + resolver + anyOf on `run_status`
- [x] AC5 — `api-shape-conventions.md` §14 (new §14.10) + `mcp.md` naming-grammar record the row-mirror rule; CHANGELOG `[Unreleased]` carries the `### Changed — MCP identifier round-trips (#2471)` bullet with the `handle`→`run_id` migration note
- [x] AC6 — `template_slug` description acknowledges both keys; a test asserts every template row carries both `slug` and `template_slug` with equal values
- [x] `pytest` — 128 passed across the affected MCP + UI suites (list-shape-conventions, agent_runs, agent_grants, runbook_runs, runbooks_templates, meho_status, approvals, agent_toolset, scheduler, ui_*); code-quality diff gate 0 blockers
- [x] No REST routes touched (MCP inputSchema is JSON-RPC) → no OpenAPI regen

## Out of scope

- REST/UI surfaces and shared Pydantic models (`AgentGrantRead.id`, `ScheduledTriggerRead.id`, `RunSummary.state`, template `slug` keep their names) — mirror-only, native keys retained per the #1612 precedent.
- Error-label canonicalization (#2480), broadcast `id`-cursor (#2479), `-32603` vs `-32602` taxonomy (#2481), new registry-level alias machinery (#1625 removed it).
- Adjacent findings: `agent_grants.py` / `agent_runs.py` / `scheduler.py` sit at 404 / 415 / 445 lines (code-quality warn >400, block >600) — pre-existing, not split in this change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2471
