### PR TITLE
fix(mcp): name canonical inputSchema arg in -32602 error labels (#2480)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — canonical arg names in MCP error labels (#2480)
+
+- **`meho.broadcast.recent` and `meho.connector.ingest_status` `-32602`
+  validation messages now name the canonical inputSchema property the
+  caller passed** (#2480). A malformed cursor on `broadcast.recent`
+  labelled the field `since:` (the deprecated alias / internal arg
+  name) rather than the canonical `cursor:` (#1358); the message is now
+  `cursor:`-labelled whichever alias the caller sent. A malformed job id
+  on `connector.ingest_status` said `handle must be a valid job id`,
+  naming a "handle" concept absent from the tool's inputSchema; it now
+  says `job_id must be a valid UUID`. Wire-facing labels that point
+  callers (and LLM agents, for whom the error text is a corrective
+  signal) at a field they never wrote are fixed to name the property
+  they did write.
+
 ### Fixed — connector_not_found -32602 across MCP handlers (#2481)
 
 - **All seven `meho.connector.*` tools that take a `connector_id` now

--- a/backend/src/meho_backplane/broadcast/history.py
+++ b/backend/src/meho_backplane/broadcast/history.py
@@ -242,8 +242,13 @@ def _iso8601_to_min_cursor(raw: str) -> str:
     try:
         parsed = datetime.fromisoformat(iso_normalised)
     except ValueError as exc:
+        # The wire-facing label names ``cursor`` -- the canonical MCP
+        # forward-cursor parameter (#1358) -- not the internal ``since``
+        # arg name, so the -32602 the sole wire consumer (the MCP
+        # ``broadcast.recent`` handler) re-raises points callers at the
+        # inputSchema property they actually passed.
         raise InvalidSinceError(
-            f"since: not a valid ISO-8601 timestamp or Valkey stream cursor: {raw!r}",
+            f"cursor: not a valid ISO-8601 timestamp or Valkey stream cursor: {raw!r}",
         ) from exc
     if parsed.tzinfo is None:
         # Treat a naive timestamp as UTC explicitly; otherwise

--- a/backend/src/meho_backplane/mcp/tools/connector_ingest.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_ingest.py
@@ -475,7 +475,7 @@ async def _ingest_status_handler(
     poll endpoint also returns.
 
     An unknown / cross-tenant / malformed handle surfaces as JSON-RPC
-    ``-32602`` (``handle must be a valid job id (UUID)`` /
+    ``-32602`` (``job_id must be a valid UUID`` /
     ``ingest_job_not_found``) — the closest spec-blessed shape for
     "bad input" / "not found", matching the connector-ingest error
     convention.
@@ -484,7 +484,7 @@ async def _ingest_status_handler(
     try:
         job_id = UUID(raw)
     except (ValueError, TypeError, AttributeError) as exc:
-        raise McpInvalidParamsError("handle must be a valid job id (UUID)") from exc
+        raise McpInvalidParamsError("job_id must be a valid UUID") from exc
     registry = get_job_registry()
     try:
         job = await registry.get(

--- a/backend/tests/test_mcp_tool_broadcast_recent.py
+++ b/backend/tests/test_mcp_tool_broadcast_recent.py
@@ -305,7 +305,8 @@ def test_since_invalid_iso_rejects_with_domain_error() -> None:
     :class:`McpInvalidParamsError` (the MCP handler maps the domain
     error to ``-32602`` upstream). The end-to-end MCP wire test for the
     same condition lives at
-    :func:`test_invalid_since_iso_returns_invalid_params_at_wire` below.
+    :func:`test_invalid_cursor_returns_invalid_params_labelled_cursor`
+    below.
     """
     with pytest.raises(InvalidSinceError, match="not a valid ISO-8601"):
         parse_since("not-a-real-timestamp")
@@ -316,26 +317,40 @@ def test_since_invalid_iso_rejects_with_domain_error() -> None:
     [TenantRole.OPERATOR],
     indirect=True,
 )
-def test_invalid_since_iso_returns_invalid_params_at_wire(
+def test_invalid_cursor_returns_invalid_params_labelled_cursor(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """A garbled ``since`` from a wire client surfaces as JSON-RPC -32602.
+    """A garbled cursor surfaces as -32602 labelled with the canonical arg.
 
     The shared helper raises :class:`InvalidSinceError`; the MCP handler
     catches that domain error and re-raises it as
     :class:`McpInvalidParamsError`, which the dispatcher renders as
-    ``-32602``. Locks the contract: the helper's split from MCP error
-    vocabulary doesn't leak Pyhton exception names to wire clients.
+    ``-32602``. Locks two contracts: the helper's split from MCP error
+    vocabulary doesn't leak Python exception names to wire clients, and
+    the wire label names the canonical ``cursor`` inputSchema property
+    (#1358, #2480) -- not the internal ``since`` arg -- whichever alias
+    the caller passed. A bare UUID is neither a Valkey stream id nor an
+    ISO-8601 timestamp, so it exercises the parse-failure branch.
     """
     client, _op = client_with_operator
-    resp = post_mcp(
-        client,
-        _tools_call("meho.broadcast.recent", {"since": "garbled"}),
-    )
-    body = resp.json()
-    assert "error" in body
-    assert body["error"]["code"] == INVALID_PARAMS
-    assert "since" in body["error"]["message"].lower()
+    bad = "550e8400-e29b-41d4-a716-446655440000"
+
+    def message_for(arg: str) -> str:
+        resp = post_mcp(
+            client,
+            _tools_call("meho.broadcast.recent", {arg: bad}),
+        )
+        body = resp.json()
+        assert "error" in body
+        assert body["error"]["code"] == INVALID_PARAMS
+        return str(body["error"]["message"])
+
+    canonical = message_for("cursor")
+    assert canonical.lower().startswith("cursor:")
+
+    # The deprecated ``since`` alias normalises to the same value and so
+    # yields the identical ``cursor:``-labelled message.
+    assert message_for("since") == canonical
 
 
 def test_parse_since_default_is_now_minus_30m() -> None:

--- a/backend/tests/test_mcp_tools_connector_ingest.py
+++ b/backend/tests/test_mcp_tools_connector_ingest.py
@@ -1006,7 +1006,9 @@ async def test_ingest_status_malformed_handle_is_invalid_params() -> None:
     op = build_operator(TenantRole.TENANT_ADMIN)
     with pytest.raises(McpInvalidParamsError) as caught:
         await ci_mod._ingest_status_handler(op, {"job_id": "not-a-uuid"})
-    assert "valid job id" in str(caught.value).lower()
+    # The label names the canonical ``job_id`` inputSchema arg (#2480),
+    # not the internal "handle" concept.
+    assert "job_id" in str(caught.value)
 
 
 async def test_ingest_status_cross_tenant_is_not_found(


### PR DESCRIPTION
## Summary

- **`meho.broadcast.recent`** and **`meho.connector.ingest_status`** emitted `-32602` validation messages that labelled the offending field by an internal/legacy name instead of the canonical inputSchema property the caller passed — sending callers (and LLM agents, for whom the error text is a corrective signal) hunting for a field they never wrote.
- Broadcast: the malformed-cursor label is relabelled `since:` → **`cursor:`** (the canonical forward-cursor name, #1358) at `broadcast/history.py`'s `InvalidSinceError` — the sole wire consumer is the MCP handler, which normalises both the `cursor` and deprecated `since` aliases into one value, so the message is identical whichever alias the caller sent.
- Connector ingest: `handle must be a valid job id (UUID)` → **`job_id must be a valid UUID`** at `connector_ingest.py:487`, naming the tool's actual `job_id` inputSchema arg instead of a "handle" concept absent from it.
- Error-string-label fix only; no behavior change, no REST/OpenAPI surface touched.

## Test plan

- [x] `ruff check` — clean (4 touched files)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (2 touched source files)
- [x] `pytest tests/test_mcp_tool_broadcast_recent.py tests/test_broadcast_history.py` + the malformed-handle test — 49 passed, 4 skipped
- [x] **AC1** — `broadcast.recent {"cursor": "<uuid>"}` returns `-32602` starting with `cursor:`; the deprecated `since` alias with the same bad value yields the identical message (`test_invalid_cursor_returns_invalid_params_labelled_cursor`, PASSED)
- [x] **AC2** — `connector.ingest_status {"job_id": "not-a-uuid"}` returns `-32602` naming `job_id` (`test_ingest_status_malformed_handle_is_invalid_params`, PASSED)
- [x] **AC3** sweep — `grep -rn "since:" backend/src/meho_backplane/broadcast/ backend/src/meho_backplane/mcp/` shows no remaining wire-facing label naming an absent field (only `since: str | None` param annotations, `history.py` internals, and topology's own `since` inputSchema description); `grep -rn '"handle' backend/src/.../connector_ingest.py` is empty
- [x] **AC4** — CHANGELOG `[Unreleased]` carries the `### Fixed — canonical arg names in MCP error labels (#2480)` bullet
- [x] `code-quality.py --diff` — 0 blockers (16 warnings, all pre-existing debt in touched files)

## Out of scope

- Arg renames / list-row mirrors (#2471 family-wide pass) — already merged.
- `broadcast.watch`'s `since_cursor` arg (different verb, no shared path).
- REST `/api/v1/feed` validator messages (already cursor-based).
- Broadcast row `id`-is-a-stream-cursor finding (#2479).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation error messages to use the canonical `cursor` and `job_id` field names.
  * Updated broadcast history errors for invalid cursor values.
  * Improved ingest status errors for malformed job IDs.

* **Documentation**
  * Added changelog entries describing the corrected validation labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->