### PR TITLE
fix(connectors): project class-less typed connectors as dispatchable typed (#2496)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — resolve_authoring_kind for class-less typed connectors (#2496)
+
+- The connector listing (`GET /api/v1/connectors`) and
+  `meho.connector.review` now report `net-probe-1.x` and
+  `secret-broker-1.x` as `kind="typed"` / `dispatchable=true` instead of
+  `ingested-shim` / `dispatchable=false`. These synthetic `net.*` /
+  `secret.*` connectors register module-level `source_kind='typed'`
+  handlers with no backing connector class, so
+  `resolve_authoring_kind`'s resolver replay missed and mislabeled them
+  as a catalog dead end even though the dispatcher routes them fine with
+  `connector_instance=None`. The projection now keys on the row's own
+  `source_kind` (ground truth from the descriptor rows) to recognize the
+  class-less typed mold, so a live operator no longer reads a working,
+  code-shipped connector as dead (#2468 finding 3a). Read-surface fix
+  only — no change to dispatch semantics.
+
 ### Added — topology delete_node guarded hard-delete (#2485)
 
 - A manually-seeded `graph_node` can now be removed via MCP

--- a/backend/src/meho_backplane/operations/ingest/connector_registration.py
+++ b/backend/src/meho_backplane/operations/ingest/connector_registration.py
@@ -948,6 +948,7 @@ def resolve_authoring_kind(
     product: str,
     version: str,
     enabled_operation_count: int,
+    has_code_shipped_op: bool = False,
 ) -> tuple[ConnectorAuthoringKind, bool]:
     """Project the connector's authoring-mode ``(kind, dispatchable)`` for the wire.
 
@@ -974,16 +975,31 @@ def resolve_authoring_kind(
       until an operator enables an op; ``profiled-but-unreviewed`` is
       that not-yet-cleared sub-state surfaced on the read surfaces.
 
-    Resolver misses / ties (:exc:`NoMatchingConnector`,
-    :exc:`AmbiguousConnectorResolution`) read as ``("ingested-shim",
-    False)``: no dispatchable class backs the row, which is operationally
-    the same dead end as a bare shim. Fail-soft — a read-surface
-    projection must never raise.
+    Resolver misses (:exc:`NoMatchingConnector`) split on
+    *has_code_shipped_op* (#2496):
 
-    *enabled_operation_count* is the connector's enabled-op rollup the
-    listing already aggregates (the ``is_enabled`` dispatchable subset,
-    #1636); it stands in for "has the review gate been cleared" without a
-    second DB round-trip.
+    * **True → class-less typed mold** → ``("typed", True)``. The
+      ``net.*`` / ``secret.*`` families register module-level
+      ``source_kind='typed'`` handlers and call neither
+      ``register_connector`` nor ``register_connector_v2``, so no class
+      resolves — yet the dispatcher routes them fine with
+      ``connector_instance=None``. Keying on the row's own
+      ``source_kind`` keeps the projection from drifting from what the
+      dispatcher actually does.
+    * **False → genuinely ingested catalog row** → ``("ingested-shim",
+      False)``. Every op is a raw ``source_kind='ingested'`` primitive
+      with no dispatch path — the same dead end as a bare shim.
+
+    Resolver ties (:exc:`AmbiguousConnectorResolution`) always read
+    ``("ingested-shim", False)`` regardless of the flag: a tie between
+    registered classes is a config error, not a dispatchable surface.
+    Fail-soft throughout — a read-surface projection must never raise.
+
+    *enabled_operation_count* is the ``is_enabled`` dispatchable-op
+    rollup (#1636), standing in for "review gate cleared" without a
+    second DB round-trip. *has_code_shipped_op* is the sibling rollup:
+    ``True`` when any descriptor row carries a code-shipped
+    ``source_kind`` (``'typed'`` / ``'composite'``).
     """
     from meho_backplane.connectors.resolver import (
         AmbiguousConnectorResolution,
@@ -993,12 +1009,27 @@ def resolve_authoring_kind(
 
     try:
         cls = resolve_connector(_EnableTimeTarget(product=product, version=version))
-    except (NoMatchingConnector, AmbiguousConnectorResolution) as exc:
+    except NoMatchingConnector:
+        if has_code_shipped_op:
+            _log.debug(
+                "authoring_kind_probe_classless_typed",
+                product=product,
+                version=version,
+            )
+            return "typed", True
         _log.debug(
             "authoring_kind_probe_unresolved",
             product=product,
             version=version,
-            reason=type(exc).__name__,
+            reason="NoMatchingConnector",
+        )
+        return "ingested-shim", False
+    except AmbiguousConnectorResolution:
+        _log.debug(
+            "authoring_kind_probe_unresolved",
+            product=product,
+            version=version,
+            reason="AmbiguousConnectorResolution",
         )
         return "ingested-shim", False
 

--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -347,12 +347,18 @@ async def _operation_count_by_connector(
     """Aggregate :class:`EndpointDescriptor` rows by connector triple.
 
     Returns a dict keyed on ``(tenant_id, product, version,
-    impl_id)`` whose values are ``{total, enabled}`` op counts.
-    ``enabled`` counts the rows whose per-op ``is_enabled`` flag is
-    set -- the dispatchable subset -- via the same portable ``CASE
+    impl_id)`` whose values are ``{total, enabled, code_shipped}`` op
+    counts. ``enabled`` counts the rows whose per-op ``is_enabled`` flag
+    is set -- the dispatchable subset -- via the same portable ``CASE
     WHEN`` SUM technique as :func:`_aggregate_groups_by_connector`,
     so an operator can tell how many of a connector's ops are
     actually callable vs ingested-but-disabled (G0.23-T5 / #1636).
+    ``code_shipped`` counts the rows whose ``source_kind`` is
+    ``"typed"`` / ``"composite"`` -- image-shipped ops with a real
+    dispatch path. It feeds :func:`resolve_authoring_kind`'s
+    class-less-typed reading (#2496): a ``net.*`` / ``secret.*`` row
+    has code-shipped ops but no backing connector class, so the resolver
+    misses even though the op dispatches fine.
 
     Counts every ``source_kind`` -- ``"ingested"`` (G0.7 spec-driven),
     ``"typed"`` (G3.x hand-coded via :func:`register_typed_operation`),
@@ -375,6 +381,12 @@ async def _operation_count_by_connector(
     enabled_case = func.sum(
         case((EndpointDescriptor.is_enabled.is_(True), 1), else_=0),
     ).label("enabled")
+    code_shipped_case = func.sum(
+        case(
+            (EndpointDescriptor.source_kind.in_(("typed", "composite")), 1),
+            else_=0,
+        ),
+    ).label("code_shipped")
     total = func.count(EndpointDescriptor.id).label("total")
 
     stmt = (
@@ -385,6 +397,7 @@ async def _operation_count_by_connector(
             EndpointDescriptor.impl_id,
             total,
             enabled_case,
+            code_shipped_case,
         )
         .where(
             (EndpointDescriptor.tenant_id.is_(None))
@@ -400,10 +413,11 @@ async def _operation_count_by_connector(
     result = await session.execute(stmt)
     counts: dict[tuple[UUID | None, str, str, str], dict[str, int]] = {}
     for row in result.all():
-        tenant_uuid, product, version, impl_id, total_v, enabled_v = row
+        tenant_uuid, product, version, impl_id, total_v, enabled_v, code_shipped_v = row
         counts[(tenant_uuid, product, version, impl_id)] = {
             "total": int(total_v or 0),
             "enabled": int(enabled_v or 0),
+            "code_shipped": int(code_shipped_v or 0),
         }
     return counts
 
@@ -572,6 +586,7 @@ async def _emit_db_backed_rows(
             product=product,
             version=version,
             enabled_operation_count=enabled_op_count,
+            has_code_shipped_op=op_counts.get("code_shipped", 0) > 0,
         )
         items.append(
             ConnectorListItem(

--- a/backend/src/meho_backplane/operations/ingest/service.py
+++ b/backend/src/meho_backplane/operations/ingest/service.py
@@ -141,19 +141,26 @@ _log = structlog.get_logger(__name__)
 def _authoring_kind_for_payload(
     scope: ConnectorScope,
     rendered_groups: list[ConnectorReviewGroup],
+    *,
+    has_code_shipped_op: bool,
 ) -> tuple[ConnectorAuthoringKind, bool]:
     """Project the review payload's ``(kind, dispatchable)`` for *scope* (#1979).
 
     The review gate (#1971) is "cleared" once any op is enabled; the
     enabled-op count is derived from the already-rendered groups so no
-    second DB round-trip is needed. Delegates the resolver replay + tier
-    mapping to :func:`resolve_authoring_kind`.
+    second DB round-trip is needed. *has_code_shipped_op* rides in from
+    the caller's loaded descriptor rows (their ``source_kind``) so the
+    class-less typed mold (``net.*`` / ``secret.*``) projects as
+    dispatchable typed rather than the ingested-shim dead end (#2496).
+    Delegates the resolver replay + tier mapping to
+    :func:`resolve_authoring_kind`.
     """
     enabled_op_count = sum(1 for group in rendered_groups for op in group.ops if op.is_enabled)
     return resolve_authoring_kind(
         product=scope.product,
         version=scope.version,
         enabled_operation_count=enabled_op_count,
+        has_code_shipped_op=has_code_shipped_op,
     )
 
 
@@ -507,7 +514,10 @@ class ReviewService:
             )
             for group in groups
         ]
-        kind, dispatchable = _authoring_kind_for_payload(scope, rendered_groups)
+        has_code_shipped_op = any(op.source_kind in ("typed", "composite") for op in ops)
+        kind, dispatchable = _authoring_kind_for_payload(
+            scope, rendered_groups, has_code_shipped_op=has_code_shipped_op
+        )
         grouped_op_count = sum(group.op_count for group in rendered_groups)
         # #125: count the full descriptor universe (the same one the
         # ``GET /api/v1/connectors`` listing counts) so ops not in a rendered

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -1135,6 +1135,80 @@ async def test_review_payload_surfaces_authoring_kind(
 
 
 @pytest.mark.asyncio
+async def test_list_surfaces_classless_typed_as_dispatchable(
+    client: TestClient,
+) -> None:
+    """The class-less typed mold reads ``typed`` / ``dispatchable=True`` (#2496).
+
+    ``net-probe-1.x`` / ``secret-broker-1.x`` register their ops as
+    module-level ``source_kind='typed'`` handlers and deliberately back
+    them with **no** connector class, so the resolver-replay in
+    :func:`resolve_authoring_kind` misses. The regression: that miss was
+    projected as ``kind='ingested-shim'`` / ``dispatchable=False``, so a
+    live operator concluded a working, code-shipped connector was dead
+    (#2468 finding 3a). The row carries code-shipped ops the dispatcher
+    routes with ``connector_instance=None``, so it must read as the typed
+    surface it is. Seeded as built-ins (``tenant_id IS NULL``) with no
+    class registered, mirroring the real image-time registration.
+    """
+    for product, version, impl_id in (
+        ("net", "1.x", "net-probe"),
+        ("secret", "1.x", "secret-broker"),
+    ):
+        await _seed_connector(
+            tenant_id=None,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            review_status="enabled",
+            op_is_enabled=True,
+            source_kind="typed",
+        )
+
+    key, token = _operator_token(tenant_id=uuid.uuid4())
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    items = {c["connector_id"]: c for c in response.json()["items"]}
+    for connector_id in ("net-probe-1.x", "secret-broker-1.x"):
+        item = items[connector_id]
+        assert item["state"] == "ingested"
+        assert item["kind"] == "typed", connector_id
+        assert item["dispatchable"] is True, connector_id
+
+
+@pytest.mark.asyncio
+async def test_review_payload_surfaces_classless_typed_as_dispatchable(
+    client: TestClient,
+) -> None:
+    """``GET /{id}/review`` reports the class-less typed mold as dispatchable typed (#2496).
+
+    The ``meho.connector.review`` surface (MCP) and this REST review
+    route share :func:`resolve_authoring_kind` via
+    :func:`_authoring_kind_for_payload`, so the projection fix must hold
+    on the review path too, not only the listing.
+    """
+    await _seed_connector(
+        tenant_id=None,
+        product="net",
+        version="1.x",
+        impl_id="net-probe",
+        review_status="enabled",
+        op_is_enabled=True,
+        source_kind="typed",
+    )
+    key, token = _operator_token(tenant_id=uuid.uuid4())
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors/net-probe-1.x/review", headers=_authed(token))
+    assert response.status_code == 200
+    body = response.json()
+    assert body["kind"] == "typed"
+    assert body["dispatchable"] is True
+
+
+@pytest.mark.asyncio
 async def test_list_class_only_entries_excluded_under_status_narrowing(
     client: TestClient,
     _registered_class_only_connectors: None,

--- a/backend/tests/test_operations_profile_stamp_gate.py
+++ b/backend/tests/test_operations_profile_stamp_gate.py
@@ -463,13 +463,42 @@ def test_resolve_authoring_kind_handcoded_is_typed() -> None:
 
 
 def test_resolve_authoring_kind_resolver_miss_reads_as_shim() -> None:
-    """No connector class resolves for the line → the dead-end ``ingested-shim`` reading."""
+    """No connector class + no code-shipped op → the dead-end ``ingested-shim`` reading."""
     from meho_backplane.operations.ingest.connector_registration import resolve_authoring_kind
 
+    # A genuinely ingested catalog row: every op is a raw ``source_kind=
+    # 'ingested'`` primitive, so ``has_code_shipped_op`` is False.
     kind, dispatchable = resolve_authoring_kind(
-        product="ghost", version="9.9", enabled_operation_count=3
+        product="ghost", version="9.9", enabled_operation_count=3, has_code_shipped_op=False
     )
     assert (kind, dispatchable) == ("ingested-shim", False)
+
+
+def test_resolve_authoring_kind_classless_typed_is_dispatchable() -> None:
+    """A class-less typed line (net.*/secret.* mold) reads ``typed`` / dispatchable (#2496).
+
+    The resolver misses (no ``register_connector_v2`` class backs the
+    synthetic ``net`` / ``secret`` products), but the row carries
+    code-shipped ``source_kind='typed'`` ops the dispatcher routes with
+    ``connector_instance=None``. The projection must recognize that mold
+    and not collapse it into the ingested-shim dead end.
+    """
+    from meho_backplane.operations.ingest.connector_registration import resolve_authoring_kind
+
+    # No connector class is registered for "net" (clear_registry ran in the
+    # fixture), so resolve_connector raises NoMatchingConnector — yet the
+    # code-shipped-op signal flips the reading to the dispatchable surface.
+    kind, dispatchable = resolve_authoring_kind(
+        product="net", version="1.x", enabled_operation_count=1, has_code_shipped_op=True
+    )
+    assert (kind, dispatchable) == ("typed", True)
+
+    # The signal only matters on the resolver-miss path; the enabled count
+    # is irrelevant to the class-less typed reading.
+    kind, dispatchable = resolve_authoring_kind(
+        product="secret", version="1.x", enabled_operation_count=0, has_code_shipped_op=True
+    )
+    assert (kind, dispatchable) == ("typed", True)
 
 
 def test_enable_time_warnings_empty_for_no_connector() -> None:

--- a/docs/codebase/connectors-net-diagnostics.md
+++ b/docs/codebase/connectors-net-diagnostics.md
@@ -496,6 +496,15 @@ audit (`raw_payload` = handler return) → broadcast (`read` class).
 - `safety_level="safe"` (agent-auto-runnable) is the chosen posture; the
   reviewed alternative `"caution"` (operators auto-run, agents do not)
   is a one-line change if a security review prefers it.
+- **Read-surface projection (#2496):** because `net.*` registers
+  module-level `source_kind='typed'` ops with **no** backing connector
+  class, `resolve_authoring_kind`'s resolver replay misses. It keys on
+  the row's own `source_kind` to recognize this class-less typed mold, so
+  the connector listing and `meho.connector.review` report
+  `net-probe-1.x` as `kind="typed"` / `dispatchable=true` rather than the
+  `ingested-shim` dead end. A prior projection bug read the miss as
+  non-dispatchable, so a live operator concluded the connector was dead
+  (#2468 finding 3a).
 
 ## References
 

--- a/docs/codebase/connectors-secret-broker.md
+++ b/docs/codebase/connectors-secret-broker.md
@@ -182,6 +182,12 @@ the posture and relies on the existing gate). The policy refinement
 - The `reason` param is recorded for the approver/audit trail but is not
   read by the handler; it is surfaced to the approver in the ref-only
   `proposed_effect` summary (#1579).
+- **Read-surface projection (#2496):** the synthetic `secret-broker-1.x`
+  identity has no connector class, so `resolve_authoring_kind`'s resolver
+  replay misses. It keys on the row's own `source_kind` to recognize this
+  class-less typed mold, so the connector listing and
+  `meho.connector.review` report `secret-broker-1.x` as `kind="typed"` /
+  `dispatchable=true` rather than the `ingested-shim` dead end.
 
 ## References
 


### PR DESCRIPTION
## Summary

- `resolve_authoring_kind` replayed the class-side resolver and read its `NoMatchingConnector` miss as `("ingested-shim", False)`. The synthetic `net.*` / `secret.*` connectors register **module-level** `source_kind='typed'` handlers with **no** backing connector class, so the resolver always missed for them — even though the dispatcher routes their ops fine with `connector_instance=None`. The listing and `meho.connector.review` therefore lied: `net-probe-1.x` / `secret-broker-1.x` showed `dispatchable=false` / `ingested-shim`, and a live v0.21.0 operator concluded a working, code-shipped connector was dead (#2468 finding 3a).
- Thread a ground-truth `has_code_shipped_op` signal (any descriptor row with `source_kind in ('typed','composite')`) from both read-surface callers (`list_ingested_connectors` aggregation + `ReviewService._render_payload`) into `resolve_authoring_kind`. On the resolver-miss path the flag splits the class-less typed mold (→ `typed` / dispatchable) from a genuinely ingested catalog row (→ `ingested-shim` / non-dispatchable). Ambiguous ties still read as the dead end.
- **Read-surface projection only** — no dispatch change, no wire-schema change (the signal rides internal aggregates / a function param, not a response model field), so no OpenAPI regen.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (3 source files)
- [x] Code-quality gate — 0 blockers (docstring trimmed to keep the function ≤100 lines)
- [x] **AC1** unit test pinning all three molds — `test_resolve_authoring_kind_classless_typed_is_dispatchable` (class-less typed → `("typed", True)`), plus the existing hand-coded (`typed`) and resolver-miss/ingested (`ingested-shim`) tests
- [x] **AC2** route tests on listing + review — `test_list_surfaces_classless_typed_as_dispatchable` and `test_review_payload_surfaces_classless_typed_as_dispatchable` assert `net-probe-1.x` / `secret-broker-1.x` report `kind="typed"` / `dispatchable=true`
- [x] **AC3** no dispatcher change — diff touches only the projection/read path + tests + docs/CHANGELOG
- [x] Full affected suites: `test_operations_profile_stamp_gate`, `test_operations_ingest_auth_scheme`, `test_api_v1_connectors_ingest`, `test_operations_ingest_review` (204 passed) + broader connector sweep (`mcp_tools_connector_admin`, `connectors_net_probe`, `connectors_secret_broker`, `ui_connectors_registry_list`, `operations_ingest_delete` — 110 passed)

## Out of scope

- The #2468 deployment/upgrade guide itself (this task exists so that guide doesn't document a bug as intended behaviour).
- Any change to dispatch semantics for module-level handlers.
- Goal #2247 no-ingested-row enforcement — projection fix only.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2496
