### PR TITLE
feat(ui): render proposed_effect structurally in the approvals modal (#2447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — structured proposed_effect rendering on /ui/approvals (#2447)
+
+- The `/ui/approvals` detail modal now renders the parked
+  `proposed_effect` envelope **structurally** instead of as one opaque
+  JSON blob: a `safety_level` badge + `op_class` chip in the header, a
+  warning banner when the connector identity may lack write permission
+  (`write_capability_warning`), an error banner when the preview builder
+  failed (`preview_unavailable` + `preview_error` — "blast radius
+  unknown"), a reason-keyed notice when no preview was populated
+  (deliberately-redacted credential write vs. connector-did-not-populate),
+  and a key-value table of the operation-specific fields (the bespoke
+  `preview`, else the generic redaction-safe `params_echo`). The full raw
+  envelope stays available behind a default-closed "Show raw JSON"
+  expander. Reviewers see the policy gate, the possible post-approval
+  denial, and the redaction posture at a glance. Template-only — the
+  render is generic (no per-`op_id` branching); op semantics already live
+  in the server-side preview builders (#2447).
+
 ### Added — doc-collection delete across REST/MCP/CLI (#2487)
 
 - A disabled, tenant-owned documentation collection can now be

--- a/backend/src/meho_backplane/ui/templates/approvals/_modal.html
+++ b/backend/src/meho_backplane/ui/templates/approvals/_modal.html
@@ -50,6 +50,22 @@
     error_message         -- str | None: a failed-decision human detail
 -#}
 {% from "_icons.html" import icon %}
+{#- Mirror of the ops-launcher ``safety_badge`` mold (``operations/_results.html``):
+    ``safety_level`` is the closed ``safe`` / ``caution`` / ``dangerous`` enum
+    stamped on every parked envelope (#1855). Colour-by-severity so a reviewer
+    scanning the modal reads the policy gate before the label -- error for
+    dangerous, warning for caution, ghost for safe. Kept local (not imported)
+    so the modal stays self-contained and StrictUndefined-safe -- the launcher
+    partial references launcher-only context at its top level. -#}
+{%- macro proposed_effect_safety_badge(level) -%}
+  {%- if level == "dangerous" -%}
+    <span class="badge badge-error badge-sm" title="Dangerous — irreversible or high-impact">{{ level }}</span>
+  {%- elif level == "caution" -%}
+    <span class="badge badge-warning badge-sm" title="Caution — state-changing">{{ level }}</span>
+  {%- else -%}
+    <span class="badge badge-ghost badge-sm" title="Safe — read or non-impacting">{{ level }}</span>
+  {%- endif -%}
+{%- endmacro -%}
 <dialog id="meho-approvals-modal" class="modal" aria-label="Review approval request">
   <div class="modal-box max-w-2xl">
     <div class="flex items-start justify-between gap-4">
@@ -133,9 +149,116 @@
       {% endif %}
     </dl>
 
+    {#- Structured render of the ``proposed_effect`` envelope (#2447). The
+        dispatcher stamps reviewer-oriented keys onto every parked op
+        (``operations/dispatcher.py:_build_proposed_effect``): ``safety_level``
+        (#1855), ``op_class`` + bespoke ``preview`` or generic redaction-safe
+        ``params_echo`` (#1856), ``preview_populated`` + ``preview_reason``
+        (#2332), ``preview_unavailable`` + ``preview_error`` (#1628), and a
+        top-level ``write_capability_warning`` when a permission preflight
+        says the write may be denied (#2331). Render each distinctly instead
+        of one opaque JSON blob; the full envelope stays available behind the
+        raw-JSON expander at the bottom. All keys are read via ``.get`` on the
+        real dict (StrictUndefined-safe: a missing key is a real ``None``,
+        never an ``Undefined``). No per-``op_id`` branching -- op semantics
+        already live in the server-side preview builders. -#}
+    {% set effect = request.proposed_effect or {} %}
     <div class="mt-3">
-      <p class="text-base-content/55 text-sm">Proposed effect</p>
-      <pre class="mt-1 max-h-48 overflow-auto rounded-box bg-base-200 p-3 font-mono text-xs [overflow-wrap:anywhere] whitespace-pre-wrap" aria-label="Proposed effect">{{ request.proposed_effect | tojson(indent=2) }}</pre>
+      <div class="flex items-center justify-between gap-3">
+        <p class="text-base-content/55 text-sm">Proposed effect</p>
+        <div class="flex items-center gap-2">
+          {% if effect.get("safety_level") %}
+            {{ proposed_effect_safety_badge(effect.get("safety_level")) }}
+          {% endif %}
+          {% if effect.get("op_class") %}
+            <span class="badge badge-ghost badge-sm font-mono" title="Operation class">{{ effect.get("op_class") }}</span>
+          {% endif %}
+        </div>
+      </div>
+
+      {% if effect.get("write_capability_warning") %}
+        {#- #2331: the permission preflight found the connector identity likely
+            lacks write capability. A warning, not a gate -- the approver may
+            know the policy is landing alongside. -#}
+        <div class="alert alert-warning mt-2" role="alert">
+          <div>
+            <h4 class="font-semibold text-sm">Write may be denied</h4>
+            <p class="text-xs opacity-90">
+              The connector identity may lack write permission — the approved
+              write may still be denied when it runs.
+            </p>
+          </div>
+        </div>
+      {% endif %}
+
+      {% if effect.get("preview_unavailable") %}
+        {#- #1628: the preview builder ran but faulted, so the blast radius
+            could not be resolved. Error-styled -- this is not a small action. -#}
+        <div class="alert alert-error mt-2" role="alert">
+          <div>
+            <h4 class="font-semibold text-sm">Blast radius unknown</h4>
+            <p class="text-xs opacity-90">
+              The preview builder failed, so the effect of this write is
+              unknown{% if effect.get("preview_error") %}:
+              <span class="font-mono">{{ effect.get("preview_error") }}</span>{% endif %}.
+            </p>
+          </div>
+        </div>
+      {% elif effect.get("preview_populated") is sameas false %}
+        {#- #2332: the envelope collapsed to the op-identity-only default. Name
+            WHY so a deliberately-redacted credential write reads distinctly
+            from a connector that simply never populated a preview. -#}
+        {% if effect.get("preview_reason") == "credential_write_redacted" %}
+          <div class="alert alert-warning mt-2" role="note">
+            <div>
+              <h4 class="font-semibold text-sm">Values deliberately redacted</h4>
+              <p class="text-xs opacity-90">
+                This is a credential-class write; its values are intentionally
+                withheld from the approval record. Treat as elevated risk.
+              </p>
+            </div>
+          </div>
+        {% elif effect.get("preview_reason") == "connector_did_not_populate" %}
+          <div class="alert mt-2" role="note">
+            <div>
+              <p class="text-xs opacity-90">
+                No preview was populated by the connector for this operation.
+              </p>
+            </div>
+          </div>
+        {% endif %}
+      {% endif %}
+
+      {#- The operation-specific fields: a bespoke ``preview`` when a builder
+          computed one, else the generic redaction-safe ``params_echo``. Render
+          the fields WITHIN that sub-dict as a table -- scalars inline, nested
+          values pretty-printed per row. -#}
+      {% set fields = effect.get("params_echo") or effect.get("preview") %}
+      {% if fields is mapping and fields %}
+        <div class="mt-2 overflow-auto rounded-box border border-base-300">
+          <table class="table table-xs" aria-label="Proposed effect fields">
+            <tbody>
+              {% for key, value in fields | dictsort %}
+                <tr>
+                  <th class="align-top font-mono font-normal text-base-content/55">{{ key }}</th>
+                  <td class="font-mono [overflow-wrap:anywhere]">
+                    {% if value is mapping or (value is sequence and value is not string) %}
+                      <pre class="whitespace-pre-wrap text-xs">{{ value | tojson(indent=2) }}</pre>
+                    {% else %}
+                      {{ value }}
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endif %}
+
+      <details class="mt-2">
+        <summary class="cursor-pointer text-xs text-base-content/55">Show raw JSON</summary>
+        <pre class="mt-1 max-h-48 overflow-auto rounded-box bg-base-200 p-3 font-mono text-xs [overflow-wrap:anywhere] whitespace-pre-wrap" aria-label="Proposed effect raw JSON">{{ request.proposed_effect | tojson(indent=2) }}</pre>
+      </details>
     </div>
 
     {% if request.status == "pending" and self_approval_blocked %}

--- a/backend/tests/test_ui_approvals.py
+++ b/backend/tests/test_ui_approvals.py
@@ -1324,6 +1324,195 @@ def test_detail_modal_pending_row_still_offers_decisions() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Detail modal -- structured proposed_effect envelope (#2447)
+# ---------------------------------------------------------------------------
+
+
+def _render_modal(effect: dict[str, object]) -> str:
+    """Seed a pending request with *effect* and return the rendered modal HTML."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_request(tenant_id=_TENANT_A, proposed_effect=effect)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(tenant_id=_TENANT_A, sub=_REVIEWER_SUB)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get(f"/ui/approvals/{rid}")
+
+    assert response.status_code == 200, response.text
+    return response.text
+
+
+def test_modal_bespoke_preview_renders_as_a_field_table() -> None:
+    """A populated bespoke ``preview`` (k8s.apply-style) renders as a table, not raw JSON."""
+    body = _render_modal(
+        {
+            "op_id": "k8s.apply",
+            "connector_id": "kubernetes-1.x",
+            "op_class": "config_write",
+            "preview": {
+                "kind": "Deployment",
+                "name": "web",
+                "namespace": "prod",
+                "resourceVersion": "421",
+            },
+            "preview_populated": True,
+            "safety_level": "caution",
+        }
+    )
+    # The preview fields land in a structured table, not one opaque blob.
+    assert 'aria-label="Proposed effect fields"' in body
+    table = body.split('aria-label="Proposed effect fields"')[1].split("</table>")[0]
+    assert "resourceVersion" in table
+    assert "web" in table
+    # The op_class chip is present.
+    assert ">config_write<" in body
+    # The raw envelope stays available but collapsed (no ``open`` attribute).
+    assert "Show raw JSON" in body
+    assert "<details open" not in body
+    assert 'aria-label="Proposed effect raw JSON"' in body
+
+
+def test_modal_generic_params_echo_renders_as_a_field_table() -> None:
+    """A generic ``params_echo`` (no bespoke builder) renders as a table too."""
+    body = _render_modal(
+        {
+            "op_id": "some.write.op",
+            "connector_id": "generic-1.x",
+            "op_class": "generic_write",
+            "params_echo": {"name": "widget", "replicas": 3},
+            "preview_populated": True,
+            "safety_level": "caution",
+        }
+    )
+    assert 'aria-label="Proposed effect fields"' in body
+    table = body.split('aria-label="Proposed effect fields"')[1].split("</table>")[0]
+    assert "widget" in table
+    assert "replicas" in table
+    assert "<details open" not in body
+
+
+def test_modal_credential_redacted_shows_elevated_risk_notice_and_no_table() -> None:
+    """An identifier-only credential-class envelope surfaces the redaction notice.
+
+    Synthetic envelope: since #2332 landed the bespoke vault KV builder,
+    live ``vault.kv.*`` no longer collapses to this shape -- but a
+    credential-class op *without* a bespoke builder still does, and the
+    reviewer surface must style the blind case as elevated risk.
+    """
+    body = _render_modal(
+        {
+            "op_id": "vault.kv.put",
+            "connector_id": "vault-1.x",
+            "safety_level": "dangerous",
+            "preview_populated": False,
+            "preview_reason": "credential_write_redacted",
+        }
+    )
+    assert "Values deliberately redacted" in body
+    assert "elevated risk" in body
+    assert 'role="note"' in body
+    # No field table -- there is neither a preview nor a params_echo.
+    assert 'aria-label="Proposed effect fields"' not in body
+    # Raw envelope still available, collapsed.
+    assert "Show raw JSON" in body
+    assert "<details open" not in body
+
+
+def test_modal_connector_did_not_populate_shows_a_plain_notice() -> None:
+    """A non-credential op with no populated preview shows the neutral notice."""
+    body = _render_modal(
+        {
+            "op_id": "some.op",
+            "connector_id": "generic-1.x",
+            "safety_level": "caution",
+            "preview_populated": False,
+            "preview_reason": "connector_did_not_populate",
+        }
+    )
+    assert "No preview was populated by the connector" in body
+    assert "elevated risk" not in body
+    assert 'aria-label="Proposed effect fields"' not in body
+
+
+def test_modal_write_capability_warning_renders_a_denial_alert() -> None:
+    """A ``write_capability_warning`` envelope renders a role=alert denial banner."""
+    body = _render_modal(
+        {
+            "op_id": "keycloak.user.create",
+            "connector_id": "keycloak-1.x",
+            "op_class": "config_write",
+            "preview": {"username": "alice"},
+            "preview_populated": True,
+            "safety_level": "caution",
+            "permission_preflight": {"will_be_denied": True, "missing": ["manage-users"]},
+            "write_capability_warning": "connector_identity_may_lack_write",
+        }
+    )
+    assert 'role="alert"' in body
+    warning = body.split("Write may be denied")[1].split("</div>")[0]
+    assert "may still be denied" in warning
+
+
+def test_modal_preview_unavailable_renders_blast_radius_unknown() -> None:
+    """A ``preview_unavailable`` envelope renders the error string + unknown copy."""
+    body = _render_modal(
+        {
+            "op_id": "argocd.app.sync",
+            "connector_id": "argocd-1.x",
+            "op_class": "config_write",
+            "preview_unavailable": True,
+            "preview_error": "connector timed out",
+            "preview_populated": False,
+            "safety_level": "caution",
+        }
+    )
+    assert "Blast radius unknown" in body
+    assert "connector timed out" in body
+    assert "the effect of this write is" in body
+    assert 'role="alert"' in body
+    # The failed-preview marker wins over the sparse-preview reason notice.
+    assert "No preview was populated" not in body
+
+
+def test_modal_dangerous_safety_level_is_an_error_badge() -> None:
+    """A ``dangerous`` ``safety_level`` renders a ``badge-error`` modifier.
+
+    Consistent with the ops-launcher ``safety_badge`` mold
+    (``operations/_results.html``).
+    """
+    body = _render_modal(
+        {
+            "op_id": "d.op",
+            "connector_id": "c-1.x",
+            "safety_level": "dangerous",
+            "preview_populated": False,
+            "preview_reason": "connector_did_not_populate",
+        }
+    )
+    badge = body.split("Proposed effect")[1].split("</div>")[0]
+    assert "badge-error" in badge
+    assert ">dangerous<" in badge
+
+
+def test_modal_caution_safety_level_is_a_warning_badge() -> None:
+    """A ``caution`` ``safety_level`` renders a ``badge-warning`` modifier."""
+    body = _render_modal(
+        {
+            "op_id": "c.op",
+            "connector_id": "c-1.x",
+            "safety_level": "caution",
+            "preview_populated": False,
+            "preview_reason": "connector_did_not_populate",
+        }
+    )
+    badge = body.split("Proposed effect")[1].split("</div>")[0]
+    assert "badge-warning" in badge
+    assert ">caution<" in badge
+
+
+# ---------------------------------------------------------------------------
 # params / params_hash never leak (#1827 -- a hard requirement)
 # ---------------------------------------------------------------------------
 

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -616,7 +616,7 @@ in-process (same in-process-audit binding the REST routes get).
 | `GET` | `/ui/approvals/badge` | Live **pending** count for the app-shell bell. Always `status='pending'` — it counts actionable work, not history. |
 | `GET` | `/ui/approvals` | Content-negotiated. A normal navigation (no `HX-Request`) → the **full-page console**: status tabs (Pending / Approved / Rejected / Expired / All), a `work_ref` filter, and the decision-history list. The bell's `hx-get` (`HX-Request: true`) → the existing pending **panel** modal fragment (unchanged). (G10.8-T #1827) |
 | `GET` | `/ui/approvals/list` | Decision-history partial — the HTMX swap target for the status tabs / `work_ref` filter / "Load more" offset pager. Reuses `list_pending(status=…, work_ref=…, offset=…)`; `tab=all` passes `status=None`. Pages with a real offset, not the badge's 50-row glance cap. (G10.8-T #1827) |
-| `GET` | `/ui/approvals/{id}` | Request-detail modal. A pending row offers Approve/Deny; a **decided** row renders read-only with a decision banner ("Approved/Rejected by X at T"). |
+| `GET` | `/ui/approvals/{id}` | Request-detail modal. A pending row offers Approve/Deny; a **decided** row renders read-only with a decision banner ("Approved/Rejected by X at T"). The `proposed_effect` envelope renders **structurally** (#2447), not as raw JSON (below). |
 | `POST` | `/ui/approvals/{id}/approve` | Approve in-process + re-dispatch the parked op + fail-open broadcast. |
 | `POST` | `/ui/approvals/{id}/reject` | Reject in-process + broadcast; the op never runs. |
 
@@ -639,6 +639,28 @@ of the open Pending tab without a reload. The decision **reason** lives on
 the `audit_log` decision row, not the `ApprovalRequest` row, so the
 history view shows who/when (`reviewed_by` / `decided_at`) but not the
 free-text reason (an `audit_log` read deferred to a follow-up).
+
+### Structured `proposed_effect` render in the modal (#2447)
+
+`approvals/_modal.html` renders the parked `proposed_effect` envelope
+**structurally** rather than as one opaque JSON `<pre>`: a `safety_level`
+badge (mirroring the ops-launcher `safety_badge` mold — error for
+`dangerous`, warning for `caution`) + an `op_class` chip in the header;
+a `role="alert"` warning banner when `write_capability_warning` is set
+(#2331); an error banner when `preview_unavailable` is true, carrying
+`preview_error` (#1628); a reason-keyed notice when `preview_populated`
+is false (`credential_write_redacted` → elevated-risk redaction copy,
+`connector_did_not_populate` → a neutral "no preview" note, #2332); and a
+key-value table of the operation-specific fields (the bespoke `preview`,
+else the generic redaction-safe `params_echo`, #1856). The full envelope
+stays available behind a default-closed `Show raw JSON` `<details>`. The
+render is **generic** — no per-`op_id` branching; op semantics already
+live in the server-side preview builders (`operations/_preview.py`), so
+the modal just projects whatever keys the dispatcher stamped. Every key
+is read via `.get` on the real dict, so a missing key degrades cleanly
+under `StrictUndefined`. Template-only: no route, projection, or schema
+change (`render.project_request_to_view` already passes `proposed_effect`
+through verbatim).
 
 ## Broadcast events (T5)
 


### PR DESCRIPTION
## Summary

- The `/ui/approvals` detail modal rendered the whole `proposed_effect` envelope as one raw-JSON `<pre>`, burying the reviewer-oriented keys the dispatcher already stamps on every parked op. This renders them **structurally**.
- Header: `safety_level` badge (mirrors the ops-launcher `safety_badge` mold — error for `dangerous`, warning for `caution`) + an `op_class` chip.
- Banners: `role="alert"` warning for a likely post-approval write denial (`write_capability_warning`, #2331); error banner for a failed preview builder (`preview_unavailable` + `preview_error` — "blast radius unknown", #1628); reason-keyed notice for an unpopulated preview (`credential_write_redacted` elevated-risk copy vs. `connector_did_not_populate` neutral note, #2332).
- A key-value table of the operation-specific fields (bespoke `preview`, else generic redaction-safe `params_echo`, #1856). Full raw envelope stays behind a default-closed **Show raw JSON** `<details>`.
- **Generic render — no per-`op_id` branching.** Op semantics already live in the server-side preview builders (`operations/_preview.py`); the modal just projects whatever keys the dispatcher stamped. Every key read via `.get` on the real dict so a missing key degrades cleanly under `StrictUndefined`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `pytest tests/test_ui_approvals.py` — 51 passed (10 new render tests)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] Bespoke `preview`, generic `params_echo`, and identifier-only `credential_write_redacted` envelopes each render the corresponding banner/table markup, with the raw JSON inside a `<details>` **without** `open`.
- [x] `write_capability_warning` → a `role="alert"` element naming the possible post-approval denial.
- [x] `preview_unavailable` + `preview_error` → error string + "blast radius unknown" copy.
- [x] `safety_level` badge modifier matches severity (`badge-error` for dangerous, `badge-warning` for caution).
- [x] Template-only: `ui/routes/approvals/routes.py` and `render.py` diff-empty (`render.project_request_to_view` already passes `proposed_effect` through). No OpenAPI regen needed (no route/schema change).

## Out of scope

- **Screenshots (AC #5):** rendering the DaisyUI/Tailwind visuals needs the live console asset pipeline, not available in the autonomous sandbox. The three envelope shapes' banner/table markup is instead asserted by the render tests; screenshots can be attached from a live console before merge.
- CLI parity (`cli/internal/cmd/approvals/show.go` also dumps raw JSON) — separate follow-up per the issue.
- Sibling #2446 builds on this `_modal.html` structure (kept clean/extensible).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2447
