### PR TITLE
fix(knowledge): theme /ui/kb code blocks for DaisyUI 5 (#2452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — DaisyUI 5 code-block theming on /ui/kb (#2452)
+
+- KB entry code blocks (`/ui/kb/<slug>`) are now legible in both console
+  themes. The detail and editor-preview templates pinned the code-block
+  background to the dead DaisyUI 4 `--b2` variable, so a near-white light
+  fallback applied in `meho-dark` too while text inherited the theme's
+  near-white `base-content` — unreadable. Backgrounds now derive from the
+  live `var(--color-base-200)` token, the query-term highlight uses
+  `color-mix(... var(--color-warning) ...)` instead of the dead `--wa`,
+  and `pygments_css()` emits theme-scoped token colours (dark `github-dark`
+  under `.kb-code`, light `default` under `[data-theme="meho-light"]`). The
+  same fix reaches the KB and runbooks editor live previews (shared
+  renderer). Template/CSS only. (#2452)
+
 ### Added — doc-collection delete across REST/MCP/CLI (#2487)
 
 - A disabled, tenant-owned documentation collection can now be

--- a/backend/src/meho_backplane/ui/routes/kb/render.py
+++ b/backend/src/meho_backplane/ui/routes/kb/render.py
@@ -71,17 +71,70 @@ __all__ = ["pygments_css", "render_markdown"]
 
 _lock = threading.Lock()
 
-#: Shared HtmlFormatter instance: ``nowrap=True`` emits bare ``<span>``
-#: tokens so the wrapping ``<pre><code>`` block is controlled by the
-#: highlight callback. ``cssclass`` is set to a non-default value so
-#: the generated style rules don't collide with DaisyUI's own ``.highlight``
-#: utility class. The CSS is emitted once via :func:`pygments_css` and
-#: injected as a ``<style>`` block in the entry-detail template.
+#: Shared HtmlFormatter instance used for the highlight callback:
+#: ``nowrap=True`` emits bare ``<span>`` tokens so the wrapping
+#: ``<pre><code>`` block is controlled by the highlight callback.
+#: ``cssclass`` is set to a non-default value so the generated style
+#: rules don't collide with DaisyUI's own ``.highlight`` utility class.
+#: The token *colours* are style-independent (the emitted spans carry
+#: only class names); the theme-scoped colour rules come from
+#: :data:`_PYGMENTS_CSS`.
 _FORMATTER = HtmlFormatter(nowrap=True, cssclass="kb-code")
 
-#: Cached CSS for the current pygments style. Generated once at module
-#: load; safe to embed in a ``<style>`` block.
-_PYGMENTS_CSS: str = _FORMATTER.get_style_defs(".kb-code")
+#: Pygments styles paired to the console's two DaisyUI 5 themes. The
+#: default/dark scope uses a dark-background style (light token colours);
+#: the ``meho-light`` scope keeps pygments' light ``default`` style (dark
+#: token colours). Both surfaces sit on ``var(--color-base-200)``, which
+#: the templates pin — so the code block follows the active theme instead
+#: of the dead DaisyUI 4 ``--b2`` variable that used to force a light
+#: background in both themes (#2452).
+_DARK_STYLE = "github-dark"
+_LIGHT_STYLE = "default"
+
+#: Selector the light-theme rules are scoped under. Higher specificity
+#: than the bare ``.kb-code`` default block, so it wins when the
+#: ``data-theme="meho-light"`` attribute is present and is inert
+#: otherwise.
+_LIGHT_SCOPE = '[data-theme="meho-light"] .kb-code'
+
+
+def _style_defs(style: str, scope: str, *, tokens_only: bool) -> str:
+    """Return pygments colour rules for *style*, scoped under *scope*.
+
+    The opaque container rule pygments emits (``<scope> { background:
+    ...; color: ... }``) is always dropped: the template owns the code
+    block background via ``var(--color-base-200)`` so it follows the
+    active theme, and keeping pygments' hard-coded background/foreground
+    would (a) fight the DaisyUI surface and (b) leak a light style's dark
+    text — or a dark style's light text — into the wrong theme.
+
+    ``tokens_only`` additionally drops the style-independent global rules
+    (``pre { line-height }``, ``td.linenos`` / ``span.linenos``) so the
+    second (light) block does not re-emit them; the first (dark) block
+    keeps them once.
+    """
+    defs = HtmlFormatter(nowrap=True, cssclass="kb-code", style=style).get_style_defs(scope)
+    container_prefix = f"{scope} {{ background:"
+    kept: list[str] = []
+    for line in defs.splitlines():
+        if line.startswith(container_prefix):
+            continue
+        if tokens_only and not line.startswith(scope):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+#: Cached, theme-scoped CSS for the ``kb-code`` formatter. Generated once
+#: at module load; safe to embed in a ``<style>`` block. Two blocks: the
+#: default/dark token colours under ``.kb-code`` and the light-theme
+#: overrides under ``[data-theme="meho-light"] .kb-code``.
+_PYGMENTS_CSS: str = "\n".join(
+    (
+        _style_defs(_DARK_STYLE, ".kb-code", tokens_only=False),
+        _style_defs(_LIGHT_STYLE, _LIGHT_SCOPE, tokens_only=True),
+    )
+)
 
 
 def _highlight_code(code: str, lang: str, attrs: str) -> str:
@@ -141,11 +194,15 @@ def render_markdown(body: str) -> Markup:
 
 
 def pygments_css() -> str:
-    """Return the CSS rules for the ``kb-code`` pygments formatter.
+    """Return the theme-scoped CSS rules for the ``kb-code`` formatter.
 
     Callers inject this into a ``<style>`` block in the entry-detail
-    template so code blocks render with the default pygments style.
-    The string is pure CSS (no ``<style>`` wrapper) so callers can
-    compose it with other inline styles as needed.
+    template. The string carries two token-colour rule sets: a
+    default/dark set under ``.kb-code`` and a ``[data-theme="meho-light"]
+    .kb-code`` override, so code blocks stay legible in both console
+    themes. The container background is deliberately omitted — the
+    template pins it to ``var(--color-base-200)`` so the block follows
+    the active theme. The string is pure CSS (no ``<style>`` wrapper) so
+    callers can compose it with other inline styles as needed.
     """
     return _PYGMENTS_CSS

--- a/backend/src/meho_backplane/ui/templates/kb/_editor_preview.html
+++ b/backend/src/meho_backplane/ui/templates/kb/_editor_preview.html
@@ -21,7 +21,7 @@
 {{ code_css | safe }}
 
 pre.kb-code {
-  background: var(--b2, #e5e7eb);
+  background: var(--color-base-200);
   border-radius: 0.375rem;
   padding: 0.75rem;
   overflow-x: auto;

--- a/backend/src/meho_backplane/ui/templates/kb/detail.html
+++ b/backend/src/meho_backplane/ui/templates/kb/detail.html
@@ -133,9 +133,12 @@
 <style>
 {{ code_css | safe }}
 
-/* Override highlight background to match DaisyUI base-200 */
+/* Code-block surface follows the active theme via DaisyUI 5's live
+   base-200 token; plain (unhighlighted) text inherits base-content so it
+   contrasts in both themes. Pygments token colours are theme-scoped in
+   ``code_css`` above. */
 pre.kb-code {
-  background: var(--b2, #e5e7eb);
+  background: var(--color-base-200);
   border-radius: 0.375rem;
   padding: 1rem;
   overflow-x: auto;
@@ -143,9 +146,9 @@ pre.kb-code {
   line-height: 1.5;
 }
 
-/* Query-term highlight */
+/* Query-term highlight — DaisyUI 5 warning token, softened to 40%. */
 mark.kb-term {
-  background-color: oklch(var(--wa) / 0.4);
+  background-color: color-mix(in oklch, var(--color-warning) 40%, transparent);
   padding: 0.1em 0.15em;
   border-radius: 0.2em;
 }

--- a/backend/src/meho_backplane/ui/templates/runbooks/_editor_preview.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_editor_preview.html
@@ -23,7 +23,7 @@
 {{ code_css | safe }}
 
 pre.kb-code {
-  background: var(--b2, #e5e7eb);
+  background: var(--color-base-200);
   border-radius: 0.375rem;
   padding: 0.75rem;
   overflow-x: auto;

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -672,3 +672,55 @@ def test_forms_with_find_disabled_elt_disinherit_it() -> None:
         "the find selector leaks into the descendant request and htmx logs "
         f"'... returned no matches!': {sorted(set(offenders))}"
     )
+
+
+def test_kb_detail_code_block_is_theme_scoped(ui_env: Environment) -> None:
+    """The ``/ui/kb/<slug>`` detail page themes code blocks for DaisyUI 5 (#2452).
+
+    Regression guard for the dead-variable bug: the code-block ``<style>``
+    block must (a) carry both a default/dark-scoped ``.kb-code`` pygments
+    rule set AND a ``[data-theme="meho-light"]``-scoped override so token
+    colours follow the active theme, (b) pin the surface background to the
+    live ``var(--color-base-200)`` token, and (c) contain none of the dead
+    DaisyUI 4 ``--b2`` / ``--wa`` variables that forced a light background
+    (and dropped the query-term highlight) in both themes.
+    """
+    import datetime
+    import re
+    import types
+
+    from meho_backplane.ui.routes.kb.render import pygments_css, render_markdown
+
+    entry = types.SimpleNamespace(
+        slug="theme-demo",
+        metadata={},
+        updated_at=datetime.datetime(2026, 7, 19, 12, 0, 0),
+    )
+    body = "```python\nx = 1\n```\n\nunlabeled fence:\n\n```\nplain text\n```\n"
+    html = ui_env.get_template("kb/detail.html").render(
+        ready=True,
+        entry=entry,
+        rendered_body=render_markdown(body),
+        code_css=pygments_css(),
+        source_path=None,
+        body_hash=None,
+    )
+
+    match = re.search(r"<style>.*?</style>", html, re.S)
+    assert match is not None, "kb/detail.html rendered no inline <style> block"
+    style_block = match.group(0)
+
+    # (a) both theme scopes present in the pygments token rules.
+    assert re.search(r"(?m)^\.kb-code \.\w", style_block), (
+        "default/dark-scoped .kb-code pygments rule set missing"
+    )
+    assert '[data-theme="meho-light"] .kb-code .' in style_block, (
+        "light-theme-scoped .kb-code pygments rule set missing"
+    )
+
+    # (b) surface background follows the active theme via a live token.
+    assert "background: var(--color-base-200)" in style_block
+
+    # (c) no dead DaisyUI 4 variables survive.
+    assert "var(--b2" not in style_block
+    assert "var(--wa" not in style_block

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -695,7 +695,13 @@ The renderer singleton lives in `meho_backplane.ui.routes.kb.render`.
 A module-level `threading.Lock` guards the shared `MarkdownIt` instance
 (not thread-safe for concurrent `render()` calls). The pygments CSS is
 generated once at module load and injected as an inline `<style>` block
-in the entry-detail template.
+in the entry-detail template. It is emitted **theme-scoped** (#2452): a
+default/dark token set under `.kb-code` (pygments `github-dark`) plus a
+`[data-theme="meho-light"] .kb-code` override (pygments `default`), with
+pygments' own opaque container background stripped so the block sits on
+the live `var(--color-base-200)` surface the template pins — code blocks
+stay legible in both `meho-dark` and `meho-light` instead of forcing a
+light background via the dead DaisyUI 4 `--b2` variable.
 
 ## KB editor modal + mobile reflow (G10.2-T3 #872)
 


### PR DESCRIPTION
## Summary
- Fixes unreadable `/ui/kb/<slug>` code blocks in the default `meho-dark` theme. The detail + editor-preview templates pinned the code-block background to `var(--b2, #e5e7eb)` — `--b2` is DaisyUI 4 naming and is dead in this DaisyUI 5 bundle, so the near-white light fallback applied in **both** themes while text inherited the theme's near-white `base-content`.
- Backgrounds now derive from the live `var(--color-base-200)` token (theme-following); the `mark.kb-term` query-term highlight replaces the dead `--wa` with `color-mix(in oklch, var(--color-warning) 40%, transparent)`.
- `pygments_css()` now emits **theme-scoped** token colours: a default/dark set (`github-dark`) under `.kb-code` plus a `[data-theme="meho-light"] .kb-code` override (`default`), with pygments' opaque container background/foreground stripped so it never fights the DaisyUI surface or leaks the wrong theme's text colour.
- The shared KB renderer carries the same fix to the KB and runbooks editor live previews. Template/CSS only — no OpenAPI surface touched.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean (render.py, test_ui_templates.py)
- [x] `mypy src/.../kb/render.py` — clean
- [x] `code-quality.py --diff` — no agent-introduced violations
- [x] **AC1** `grep -rn "var(--b2\|var(--wa" backend/src/meho_backplane/ui/templates/` → no matches
- [x] **AC2** new unit test `test_kb_detail_code_block_is_theme_scoped` renders `kb/detail.html` and asserts the `<style>` block carries both a default/dark-scoped `.kb-code` rule set AND a `[data-theme="meho-light"]`-scoped one, plus `var(--color-base-200)` and no dead vars
- [x] `pytest tests/test_ui_templates.py tests/test_ui_kb_editor.py tests/test_ui_kb_search.py tests/test_ui_runbooks_editor.py` — all pass
- [ ] **AC3/AC4** browser screenshots on both themes — verified by construction (dark: base-200 `oklch(14.5%)` vs base-content `oklch(93%)`; light: base-200 `oklch(97.3%)` vs base-content `oklch(22%)` — high contrast in both, following the active theme) + the AC2 structural test. Headless-browser screenshots run in a maintainer environment.

## Out of scope
- `runbooks/detail.html` code blocks (no own `pre.kb-code` background) improve for free via the shared renderer (themed tokens; transparent on the base-100 card) but were not given an explicit base-200 surface — adjacent finding, not edited to keep the diff localized.
- Restoring `prose` typography styling; badge-ghost/badge-outline contrast (sibling #2460).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2452


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Knowledge Base and runbook code-block readability in both dark and light themes.
  * Updated code-block backgrounds and search-term highlights to use current theme styling.
  * Applied consistent theming to editor live previews.

* **Documentation**
  * Documented the theme-specific code-block styling behavior.

* **Tests**
  * Added regression coverage for dark/light code-block themes and updated styling tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->