### PR TITLE
fix(ui): unclip sidebar approvals badge by shrinking the operator chip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — unclip sidebar approvals badge (#2445)
+
+- The desktop sidebar's approvals-bell pending-count badge is no longer
+  clipped at the drawer edge. The badge is an absolute overlay on the bell
+  button (correct); the clip came from the account row overflowing the
+  `w-64` nav's content width — DaisyUI 5's `.btn { flex-shrink: 0 }` kept the
+  operator chip (avatar + mono `sub` label + chevron) at full width, so the
+  chip plus the fixed theme/bell buttons pushed the bell's right edge past
+  `:where(.drawer-side) { overflow-x: hidden }`. The operator chip now
+  absorbs the deficit: its flex wrapper and button carry `min-w-0` and the
+  button carries `shrink` (overriding the `.btn` rule) while the mono label
+  keeps `min-w-0 truncate` (ellipsis) and the avatar + chevron stay pinned
+  with `shrink-0`. A full-width Keycloak-`sub` operator label now truncates
+  instead of shoving the badge off-canvas, so the count is fully readable at
+  every `lg+` viewport width.
+
 ### Added — doc-collection delete across REST/MCP/CLI (#2487)
 
 - A disabled, tenant-owned documentation collection can now be

--- a/backend/src/meho_backplane/ui/templates/base.html
+++ b/backend/src/meho_backplane/ui/templates/base.html
@@ -279,12 +279,21 @@
                 </div>
               </div>
 
-              {# Account row: user menu (opens upward) + theme toggle #}
-              <div class="flex items-center justify-between">
-                <div class="relative" x-on:click.outside="userMenuOpen = false">
+              {# Account row: user menu (opens upward) + theme toggle.
+                 The operator chip absorbs any width deficit so the
+                 theme/bell buttons stay full-size and the approvals
+                 badge overlay is never pushed past the drawer's
+                 ``overflow-x: hidden`` clip (#2445): ``min-w-0`` on the
+                 flex wrapper lets it shrink below its content size, and
+                 ``shrink min-w-0 overflow-hidden`` on the chip button
+                 overrides DaisyUI 5's ``.btn { flex-shrink: 0 }`` so the
+                 chip — whose mono ``sub`` label already ``truncate``s —
+                 gives up space first. #}
+              <div class="flex items-center justify-between gap-1">
+                <div class="relative min-w-0" x-on:click.outside="userMenuOpen = false">
                   <button
                     type="button"
-                    class="btn btn-ghost h-auto min-h-0 gap-2 px-1.5 py-1.5"
+                    class="btn btn-ghost h-auto min-h-0 shrink gap-2 overflow-hidden px-1.5 py-1.5 min-w-0"
                     aria-haspopup="menu"
                     x-bind:aria-expanded="userMenuOpen.toString()"
                     x-on:click="userMenuOpen = !userMenuOpen"
@@ -297,9 +306,9 @@
                         session context is bound. The live role lives on
                         ``/ui/account`` (a fresh JWT verify) -- the chip
                         does not pay a per-page token verify to label it. -#}
-                    <span class="grid size-7 place-items-center rounded-full bg-base-content/8 font-mono text-[0.62rem] font-medium text-base-content/70 ring-1 ring-base-content/15">{% if session_operator_sub is not none %}{{ session_operator_sub[:2] | upper }}{% else %}OP{% endif %}</span>
-                    <span class="max-w-[7.5rem] truncate font-mono text-xs font-medium text-base-content/70" title="{% if session_operator_sub is not none %}{{ session_operator_sub }}{% else %}Operator{% endif %}">{% if session_operator_sub is not none %}{{ session_operator_sub }}{% else %}Operator{% endif %}</span>
-                    {{ icon("chevron-down", class="size-3 rotate-180 text-base-content/40") }}
+                    <span class="grid size-7 shrink-0 place-items-center rounded-full bg-base-content/8 font-mono text-[0.62rem] font-medium text-base-content/70 ring-1 ring-base-content/15">{% if session_operator_sub is not none %}{{ session_operator_sub[:2] | upper }}{% else %}OP{% endif %}</span>
+                    <span class="min-w-0 max-w-[7.5rem] truncate font-mono text-xs font-medium text-base-content/70" title="{% if session_operator_sub is not none %}{{ session_operator_sub }}{% else %}Operator{% endif %}">{% if session_operator_sub is not none %}{{ session_operator_sub }}{% else %}Operator{% endif %}</span>
+                    {{ icon("chevron-down", class="size-3 shrink-0 rotate-180 text-base-content/40") }}
                   </button>
                   <ul
                     class="menu menu-sm absolute bottom-full left-0 z-50 mb-2 w-48 rounded-box border border-base-content/10 bg-base-100 p-2 shadow-xl"

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -672,3 +672,106 @@ def test_forms_with_find_disabled_elt_disinherit_it() -> None:
         "the find selector leaks into the descendant request and htmx logs "
         f"'... returned no matches!': {sorted(set(offenders))}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Sidebar account-row overflow / approvals-badge clip (#2445)
+#
+# The approvals bell renders its pending-count badge as an absolute overlay
+# on the bell button (``approvals/_badge.html``); that overlay pattern is
+# correct. The bug was the sidebar *account row* overflowing horizontally:
+# DaisyUI 5's ``.btn`` sets ``flex-shrink: 0``, so the operator chip (avatar +
+# mono ``sub`` label + chevron) plus the two fixed theme/bell ``btn-square``
+# buttons exceeded the ``w-64`` nav's ~216px content width. The row overflowed
+# rightward, and the drawer-side's ``:where(.drawer-side){ overflow-x: hidden }``
+# clipped the bell's right portion and the entire badge at the sidebar edge --
+# identically at every ``lg+`` viewport because the sidebar is a fixed width.
+#
+# The fix lets the operator chip absorb the deficit instead of pushing the bell
+# off-canvas: the flex wrapper and the chip button carry ``min-w-0`` and the
+# button carries ``shrink`` (overriding ``.btn { flex-shrink: 0 }``), while the
+# mono label keeps ``min-w-0 truncate`` so it ellipsises and the avatar +
+# chevron stay pinned with ``shrink-0``. The theme/bell buttons are untouched,
+# so the badge overlay stays fully inside the visible sidebar.
+#
+# The console has no browser harness, so these server-side assertions pin the
+# load-bearing class contract on the raw ``base.html`` source (Jinja comments
+# stripped) so a future restyle cannot silently reintroduce the overflow.
+# ---------------------------------------------------------------------------
+
+#: The account-row operator-chip button is uniquely identified by its
+#: ``aria-haspopup="menu"`` (the only popup-menu trigger in ``base.html``).
+_OPERATOR_CHIP_BUTTON_RE = re.compile(
+    r'<button\b[^>]*aria-haspopup="menu"[^>]*>', re.IGNORECASE | re.DOTALL
+)
+
+
+def _base_html_source() -> str:
+    return _JINJA_COMMENT_RE.sub("", (templates_dir() / "base.html").read_text(encoding="utf-8"))
+
+
+def test_operator_chip_button_shrinks_below_its_content(ui_env: Environment) -> None:
+    """The account-row operator chip carries ``shrink`` + ``min-w-0`` (#2445).
+
+    DaisyUI 5's ``.btn`` sets ``flex-shrink: 0``; without an explicit
+    override the chip cannot give up space, so the account row overflows the
+    ``w-64`` nav and the drawer-side's ``overflow-x: hidden`` clips the
+    approvals-bell badge. The chip button must carry ``shrink`` (to beat the
+    ``.btn`` rule) and ``min-w-0`` (so it can shrink below its min-content).
+    """
+    source = _base_html_source()
+    m = _OPERATOR_CHIP_BUTTON_RE.search(source)
+    assert m is not None, "operator-chip user-menu button (aria-haspopup=menu) not found"
+    class_m = re.search(r'class="([^"]*)"', m.group(0))
+    assert class_m is not None, f"operator-chip button has no class attribute: {m.group(0)!r}"
+    chip_classes = class_m.group(1).split()
+    assert "shrink" in chip_classes, (
+        "operator-chip button must carry `shrink` to override DaisyUI 5's "
+        f"`.btn {{ flex-shrink: 0 }}`; classes: {chip_classes}"
+    )
+    assert "min-w-0" in chip_classes, (
+        "operator-chip button must carry `min-w-0` so it can shrink below its "
+        f"min-content instead of clipping the approvals badge; classes: {chip_classes}"
+    )
+
+
+def test_operator_chip_wrapper_and_label_allow_truncation() -> None:
+    """The chip's flex wrapper + mono label let the label truncate (#2445).
+
+    The chip button's flex wrapper (``div.relative``) needs ``min-w-0`` so it
+    can shrink within the account row, and the mono ``sub`` label needs
+    ``min-w-0 truncate`` so it ellipsises (its ``max-w-[7.5rem]`` cap alone
+    sets a flex min-width floor that would keep the row over-wide). This is
+    what makes the chip -- not the bell -- absorb the width deficit.
+    """
+    source = _base_html_source()
+    # The user-menu wrapper is the relative-positioned div that owns the
+    # click-outside close handler; it must be shrinkable.
+    assert re.search(
+        r'<div\b[^>]*class="[^"]*\bmin-w-0\b[^"]*"[^>]*x-on:click\.outside="userMenuOpen',
+        source,
+    ), "user-menu wrapper div must carry min-w-0 so the chip can shrink in the row"
+    # The mono sub label carries both min-w-0 and truncate on the same element.
+    labels_with_truncate = [
+        tag
+        for tag in re.findall(r"<span\b[^>]*>", source)
+        if "truncate" in tag and "font-mono" in tag and "max-w-[7.5rem]" in tag
+    ]
+    assert labels_with_truncate, "operator-sub mono label (truncate + max-w-[7.5rem]) not found"
+    for tag in labels_with_truncate:
+        assert "min-w-0" in tag, (
+            "the operator-sub label must carry min-w-0 alongside truncate so its "
+            f"ellipsis engages when the chip shrinks; tag: {tag!r}"
+        )
+
+
+def test_account_row_renders_both_bell_badge_targets(ui_env: Environment) -> None:
+    """Both bell instances still render their badge swap targets (#2445 AC #4).
+
+    The fix touches only the sidebar account row; the mobile top-bar bell must
+    render unchanged. Both bells expose their prefixed badge target so the
+    ``load`` / ``meho:approval-bump`` swap still lands the count.
+    """
+    html = ui_env.get_template("base.html").render(ready=True)
+    assert 'id="mobile-approvals-badge"' in html
+    assert 'id="sidebar-approvals-badge"' in html

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -775,6 +775,8 @@ def test_account_row_renders_both_bell_badge_targets(ui_env: Environment) -> Non
     html = ui_env.get_template("base.html").render(ready=True)
     assert 'id="mobile-approvals-badge"' in html
     assert 'id="sidebar-approvals-badge"' in html
+
+
 def test_kb_detail_code_block_is_theme_scoped(ui_env: Environment) -> None:
     """The ``/ui/kb/<slug>`` detail page themes code blocks for DaisyUI 5 (#2452).
 


### PR DESCRIPTION
## Summary

- The desktop sidebar's approvals-bell **pending-count badge rendered clipped** at the drawer edge. The badge is a correct absolute overlay on the bell button (`approvals/_badge.html`); the clip came from the **account row overflowing** the `w-64` nav's ~216px content width.
- DaisyUI 5's `.btn { flex-shrink: 0 }` pinned the operator chip (avatar + mono `sub` label + chevron) at full width, so the chip plus the two fixed theme/bell `btn-square`s pushed the bell's right portion — and the whole badge — past `:where(.drawer-side) { overflow-x: hidden }`, identically at every `lg+` width (fixed-width sidebar).
- **Fix (class-only):** the operator chip now absorbs the deficit. The flex wrapper (`div.relative`) and the chip button carry `min-w-0`, the button carries `shrink` (overrides the `.btn` rule), the mono `sub` label keeps `min-w-0 truncate` (ellipsis), and the avatar + chevron stay pinned with `shrink-0`. Theme/bell buttons untouched.
- No OpenAPI/schema change (template + CSS classes only); no migration.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (test file)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] `pytest tests/test_ui_templates.py tests/test_ui_approvals.py` — **85 passed**
- [x] **AC #1** — `grep -n 'shrink' base.html` shows the `aria-haspopup="menu"` operator-chip button carries `shrink` + `min-w-0` (line 296). New test `test_operator_chip_button_shrinks_below_its_content` pins it.
- [x] **AC #2** — new `test_ui_templates.py` tests pin the account-row class contract (chip button `shrink`/`min-w-0`; wrapper `min-w-0`; label `min-w-0 truncate`) so a restyle can't reintroduce the overflow.
- [x] **AC #4** — `test_account_row_renders_both_bell_badge_targets` asserts both `mobile-approvals-badge` and `sidebar-approvals-badge` targets still render (mobile bell unchanged).
- [ ] **AC #3 (screenshot)** — a rendered screenshot with a 36-char `sub` + `pending_count >= 1` at 1280px/1920px is not producible in the CI sandbox (no browser harness ships in this repo); the server-side class-contract tests above stand in, and the arithmetic (chip min-content now unbounded-below via `shrink`+`min-w-0`; theme/bell = ~68px stay `shrink-0`) guarantees the row fits 216px.

## Out of scope

- Widening the sidebar / moving the bell to a desktop top bar (desktop chrome is deliberately sidebar-only).
- The badge fragment + count path (`/ui/approvals/badge`, `_badge.html`) — both already correct.
- `docs/codebase/ui.md` + `approvals.md` are route/data-flow level and don't describe the account-row flex layout — verified unchanged.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2445
