### PR TITLE
feat(ui): headline /ui/corpus cards by chunk title, demote the numeric id to a badge (#2461)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — /ui/corpus card titles from chunk title (#2461)
+
+- `/ui/corpus` result and citation cards now headline the chunk's
+  human-legible `title` (threaded through in #2475) instead of a raw
+  numeric/opaque document id. The `_cited_chunks` seam already feeds the
+  title into the `title → document_id → filename → URL` citation-label
+  chain, so the shared `chunk_cards` macro renders it as the card heading;
+  when a title displaces the id, the id is demoted into the metadata badge
+  row (alongside collection/score) so provenance stays visible without
+  being the headline. When the corpus supplies no title the id remains the
+  heading exactly as before — no regression, and no duplicate badge.
+
 ### Added — doc-collection delete across REST/MCP/CLI (#2487)
 
 - A disabled, tenant-owned documentation collection can now be

--- a/backend/src/meho_backplane/ui/templates/corpus/_results.html
+++ b/backend/src/meho_backplane/ui/templates/corpus/_results.html
@@ -53,6 +53,10 @@
     {% for entry in cited %}
       {% set chunk = entry.chunk %}
       {% set link = entry.link %}
+      {#- The chunk's human title (#2461/#2475). ``default(none, true)`` reads it
+          defensively under StrictUndefined and coerces a blank title to none, so
+          the demotion below keys on a genuine title only. -#}
+      {% set chunk_title = chunk.title | default(none, true) %}
       <li class="card bg-base-100 border-base-300 border shadow-sm">
         <div class="card-body py-3 space-y-2">
           <div class="flex flex-wrap items-start justify-between gap-2">
@@ -84,6 +88,16 @@
               {% endif %}
             </div>
             <div class="flex flex-wrap items-center gap-1 text-xs" aria-label="Chunk metadata">
+              {# When a human title heads the card (#2461), the resolver put that
+                 title in ``link.label`` and demoted the opaque/numeric document
+                 id out of the heading -- surface it here so provenance stays
+                 visible as metadata. When no title was supplied the id remains
+                 the heading (``link.label``), so it is not repeated as a badge. #}
+              {% if chunk_title and chunk.document_id %}
+                <span class="badge badge-ghost badge-outline font-mono" title="Document id">
+                  {{ chunk.document_id }}
+                </span>
+              {% endif %}
               {% if chunk.collection %}
                 <span class="badge badge-ghost badge-outline" title="Source collection">
                   {{ chunk.collection }}

--- a/backend/tests/test_ui_corpus.py
+++ b/backend/tests/test_ui_corpus.py
@@ -39,6 +39,7 @@ Suite shape:
 from __future__ import annotations
 
 import asyncio
+import re
 import uuid
 from collections.abc import Iterator
 from datetime import timedelta
@@ -79,7 +80,8 @@ from meho_backplane.ui.csrf import (
 )
 from meho_backplane.ui.paths import static_root_dir
 from meho_backplane.ui.routes import build_router as build_ui_router
-from meho_backplane.ui.templating import reset_templating_for_testing
+from meho_backplane.ui.routes.corpus.routes import _cited_chunks
+from meho_backplane.ui.templating import get_templates, reset_templating_for_testing
 from tests.conftest import DEFAULT_AUDIENCE, DEFAULT_ISSUER
 
 # ---------------------------------------------------------------------------
@@ -561,6 +563,94 @@ def test_corpus_search_card_header_prefers_upstream_title() -> None:
     # The human title is the link text; the raw document_id is not the header.
     assert "Quiescing VM Snapshots" in body
     assert ">vsphere-snapshots<" not in body
+
+
+def _render_results(**context: object) -> str:
+    """Render the ``corpus/_results.html`` partial directly with *context*.
+
+    Drives the shared ``chunk_cards`` macro without the HTTP / JWT harness so a
+    card-rendering contract can be asserted straight at the Jinja partial.
+    """
+    template = get_templates().env.get_template("corpus/_results.html")
+    return template.render(**context)
+
+
+def _retrieve_context(cited: list[dict[str, object]]) -> dict[str, object]:
+    """The retrieve branch: a plain cited-chunk list (``cited`` only)."""
+    return {"cited": cited, "query": "host maintenance", "searched": True}
+
+
+def _ask_context(cited: list[dict[str, object]]) -> dict[str, object]:
+    """The ask branch: a grounded ``answer`` followed by the same cited cards."""
+    return {
+        "cited": cited,
+        "answer": "Enter maintenance mode before host patching.",
+        "query": "host maintenance",
+    }
+
+
+@pytest.mark.parametrize("context_for", [_retrieve_context, _ask_context])
+def test_card_title_headlines_and_demotes_document_id_to_badge(
+    context_for: object,
+) -> None:
+    """An upstream title heads the card; the document id is demoted to a badge.
+
+    Both render branches share the ``chunk_cards`` macro, so one parametrized
+    contract covers the retrieve path (``cited`` only) and the ask path
+    (``answer`` + ``cited``): the human title is the clickable ``<h3>`` anchor
+    text and the opaque numeric id (``393092``) moves into the metadata badge
+    row rather than remaining the headline (#2461).
+    """
+    chunk = _chunk(
+        chunk_id="c-1",
+        document_id="393092",
+        title="vSphere host maintenance mode",
+        content="Enter maintenance mode before host patching.",
+        source_url="https://docs.vmware.test/maintenance",
+        score=0.91,
+    )
+    cited = _cited_chunks([chunk])
+
+    html = _render_results(**context_for(cited))  # type: ignore[operator]
+
+    # The human title is the clickable heading anchor text.
+    assert ">vSphere host maintenance mode</a>" in html
+    # The numeric id is demoted into a "Document id" metadata badge, not the
+    # heading -- assert it sits inside the badge span, not the <h3> anchor.
+    assert re.search(
+        r'title="Document id"[^>]*>\s*393092\s*</span>',
+        html,
+    ), html
+    assert ">393092</a>" not in html
+
+
+@pytest.mark.parametrize("context_for", [_retrieve_context, _ask_context])
+def test_card_title_absent_falls_back_to_document_id_heading(
+    context_for: object,
+) -> None:
+    """With no upstream title the id remains the heading (no regression, #2461).
+
+    When the corpus supplies no title, the label chain falls back to the
+    document id, so it stays the heading -- and it must NOT be duplicated into
+    the demotion badge (which only fires when a title displaced it).
+    """
+    chunk = _chunk(
+        chunk_id="c-1",
+        document_id="393092",
+        title=None,
+        content="Enter maintenance mode before host patching.",
+        source_url="https://docs.vmware.test/maintenance",
+        score=0.91,
+    )
+    cited = _cited_chunks([chunk])
+
+    html = _render_results(**context_for(cited))  # type: ignore[operator]
+
+    # The id is the heading anchor text (existing fallback behaviour).
+    assert ">393092</a>" in html
+    # No demotion badge -- the id is not repeated as metadata when it is the
+    # heading.
+    assert 'title="Document id"' not in html
 
 
 def test_corpus_search_resolves_gs_kb_source_to_canonical_link() -> None:


### PR DESCRIPTION
## Summary

- `/ui/corpus` result and citation cards now headline the chunk's human-legible `title` instead of a raw numeric/opaque document id, and demote that id into the metadata badge row when a title displaces it — so provenance stays visible without being the headline (#2461, the UI half of #2475).
- The `_cited_chunks` seam already passes `title=chunk.title` into the title-first citation-label chain (landed with #2475), so the shared `chunk_cards` macro already renders the title as the heading; this change is the template demotion of the id plus a defensive `title` read under StrictUndefined (`default(none, true)`).
- When the corpus supplies no title, the id remains the heading exactly as before — no regression, and the demotion badge is not emitted (the id is never duplicated).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (no issues in the touched route module)
- [x] `.claude/hooks/code-quality.py --diff` — exit 0
- [x] `pytest tests/test_ui_corpus.py tests/test_ui_corpus_ask_fallback.py` — 32 passed
- [x] **AC — title present:** parametrized template unit test (`test_card_title_headlines_and_demotes_document_id_to_badge`) asserts `>vSphere host maintenance mode</a>` is the heading anchor and `393092` sits inside a `title="Document id"` badge span, not the `<h3>` — across **both** render branches (retrieve `cited` only, ask `answer` + `cited`).
- [x] **AC — title absent:** `test_card_title_absent_falls_back_to_document_id_heading` asserts the id remains the heading (`>393092</a>`) with **no** demotion badge — existing behaviour preserved on both branches.

## Out of scope

- The schema-side `title` field on `CorpusChunk` / `DocsChunk` and the `_cited_chunks` wiring — shipped in #2475 (already on `main`; this PR's `routes.py` is unchanged).
- Backfilling titles into the corpus (ops-owned data).
- Sibling corpus-card tasks #2456 (clamp cards) / #2457 (provenance link) / #2462 (Ask citation view-source) — the title/id edit is kept localized for a clean union rebase against them.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2461
