### PR TITLE
feat(ui): in-flight spinners on console Run buttons (#2459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — in-flight spinners on console Run buttons (#2459)
+
+- The long-running action buttons on `/ui/retrieval` (Diagnostics Run, Run
+  eval, Run checklist) and `/ui/corpus` (Search Go) now show progress while a
+  request is in flight: the form declares `hx-indicator` targeting a
+  DaisyUI `htmx-indicator loading loading-spinner` span next to the button and
+  `hx-disabled-elt="find button[type=submit]"` so the button disables until the
+  fragment lands, following the existing kb-upload spinner precedent. An
+  `hx-disinherit="hx-disabled-elt hx-indicator"` guard keeps both attributes
+  from leaking onto descendant htmx requests in the swapped results region
+  (#2340). Operators no longer face a dead button with no feedback on
+  multi-second eval / checklist / ask runs.
+
 ### Fixed — dot-containing-slug preview selectors on /ui/kb (#2451)
 
 - The `/ui/kb` search result cards built the hover-preview `hx-target` and the

--- a/backend/src/meho_backplane/ui/templates/corpus/index.html
+++ b/backend/src/meho_backplane/ui/templates/corpus/index.html
@@ -67,6 +67,9 @@
           hx-target="#corpus-results"
           hx-swap="outerHTML"
           hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+          hx-indicator="#corpus-search-spinner"
+          hx-disabled-elt="find button[type=submit]"
+          hx-disinherit="hx-disabled-elt hx-indicator"
           class="flex flex-col gap-3 sm:flex-row sm:items-end"
           role="search"
           aria-label="Search the docs corpus"
@@ -157,6 +160,13 @@
             {{ icon("search") }}
             Go
           </button>
+          {#- In-flight feedback (#2459): the Ask pipeline can take many seconds;
+              the spinner shows progress and Go disables while in flight. -#}
+          <span
+            id="corpus-search-spinner"
+            class="htmx-indicator loading loading-spinner loading-sm text-primary self-center"
+            aria-label="Searching the corpus"
+          ></span>
         </form>
       {% elif entitlement_diagnostic %}
         {# A corpus EXISTS but the resolved session identity is missing the

--- a/backend/src/meho_backplane/ui/templates/retrieval/index.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/index.html
@@ -116,6 +116,9 @@
           hx-target="#retrieval-diagnostics-results"
           hx-swap="outerHTML"
           hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+          hx-indicator="#retrieval-diagnostics-spinner"
+          hx-disabled-elt="find button[type=submit]"
+          hx-disinherit="hx-disabled-elt hx-indicator"
           class="space-y-3"
           role="search"
           aria-label="Run a retrieval diagnostics query"
@@ -184,6 +187,15 @@
               {{ icon("search") }}
               Run
             </button>
+            {#- In-flight feedback (#2459): the form's hx-indicator toggles this
+                spinner's visibility while the request is in flight and
+                hx-disabled-elt disables the submit button; hx-disinherit keeps
+                both off any descendant htmx request in the results region. -#}
+            <span
+              id="retrieval-diagnostics-spinner"
+              class="htmx-indicator loading loading-spinner loading-sm text-primary self-center"
+              aria-label="Running the diagnostics query"
+            ></span>
           </div>
         </form>
       </div>
@@ -255,6 +267,9 @@
           hx-target="#retrieval-eval-results"
           hx-swap="outerHTML"
           hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+          hx-indicator="#retrieval-eval-spinner"
+          hx-disabled-elt="find button[type=submit]"
+          hx-disinherit="hx-disabled-elt hx-indicator"
           class="flex flex-wrap items-center justify-between gap-3"
           aria-label="Run the retrieval eval corpus"
         >
@@ -267,6 +282,13 @@
             {{ icon("gauge") }}
             Run eval
           </button>
+          {#- In-flight feedback (#2459): eval runs are multi-second; the spinner
+              shows progress and the submit button disables while in flight. -#}
+          <span
+            id="retrieval-eval-spinner"
+            class="htmx-indicator loading loading-spinner loading-sm text-primary self-center"
+            aria-label="Running the eval corpus"
+          ></span>
         </form>
       </div>
     </div>
@@ -294,6 +316,9 @@
           hx-target="#retrieval-retire-results"
           hx-swap="outerHTML"
           hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+          hx-indicator="#retrieval-retire-spinner"
+          hx-disabled-elt="find button[type=submit]"
+          hx-disinherit="hx-disabled-elt hx-indicator"
           class="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"
           aria-label="Run the retire-decision checklist"
         >
@@ -328,6 +353,13 @@
               {{ icon("shield-check") }}
               Run checklist
             </button>
+            {#- In-flight feedback (#2459): checklist runs scan every surface; the
+                spinner shows progress and the submit button disables in flight. -#}
+            <span
+              id="retrieval-retire-spinner"
+              class="htmx-indicator loading loading-spinner loading-sm text-primary self-center"
+              aria-label="Running the retire checklist"
+            ></span>
           </div>
         </form>
       </div>

--- a/backend/tests/test_ui_corpus.py
+++ b/backend/tests/test_ui_corpus.py
@@ -330,6 +330,13 @@ def test_corpus_index_renders_page_and_collections() -> None:
     assert CSRF_COOKIE_NAME in response.cookies
     assert "X-CSRF-Token" in body
     assert 'hx-post="/ui/corpus/search"' in body
+    # In-flight feedback on the Go button (#2459): spinner indicator + submit
+    # disable, with the disinherit guard so neither leaks to a child request.
+    assert 'hx-indicator="#corpus-search-spinner"' in body
+    assert 'hx-disabled-elt="find button[type=submit]"' in body
+    assert 'hx-disinherit="hx-disabled-elt hx-indicator"' in body
+    assert 'id="corpus-search-spinner"' in body
+    assert "htmx-indicator loading loading-spinner" in body
 
 
 def test_corpus_index_default_selects_sole_collection() -> None:

--- a/backend/tests/test_ui_retrieval.py
+++ b/backend/tests/test_ui_retrieval.py
@@ -325,6 +325,40 @@ def test_retrieval_index_renders_diagnostics_tab_active_and_empty_results() -> N
     assert 'hx-post="/ui/retrieval/diagnostics"' in body
 
 
+def test_run_buttons_carry_in_flight_spinner_and_disable_attrs() -> None:
+    """Each multi-second Run form wires hx-indicator + hx-disabled-elt (#2459).
+
+    The Diagnostics / Eval / Retire forms declare ``hx-indicator`` (pointing at
+    an ``htmx-indicator`` spinner span) and ``hx-disabled-elt`` targeting their
+    own submit button, plus an ``hx-disinherit`` guard so neither attribute
+    leaks onto a descendant htmx request in the swapped results region (#2340).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(tenant_id=_TENANT_A)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get("/ui/retrieval")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+
+    # Each Run form: indicator target + submit-button disable + disinherit guard.
+    for spinner_id in (
+        "retrieval-diagnostics-spinner",
+        "retrieval-eval-spinner",
+        "retrieval-retire-spinner",
+    ):
+        assert f'hx-indicator="#{spinner_id}"' in body
+        # The spinner span exists and carries the htmx-indicator class.
+        assert f'id="{spinner_id}"' in body
+    assert body.count('hx-disabled-elt="find button[type=submit]"') >= 3
+    assert body.count('hx-disinherit="hx-disabled-elt hx-indicator"') >= 3
+    assert body.count("htmx-indicator loading loading-spinner") >= 3
+
+
 # ---------------------------------------------------------------------------
 # POST /ui/retrieval/diagnostics -- successful fragment + per-signal breakdown
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Long-running console Run buttons gave zero in-flight feedback: **Diagnostics Run**, **Run eval**, **Run checklist** on `/ui/retrieval` and **Search Go** on `/ui/corpus`. The operator clicked, saw no change for several seconds, and could re-click or assume the tool was broken (#2459).
- Each form now declares `hx-indicator` targeting a DaisyUI `htmx-indicator loading loading-spinner` span beside the button and `hx-disabled-elt="find button[type=submit]"` so the button disables until the fragment lands — following the existing kb-upload spinner precedent.
- An `hx-disinherit="hx-disabled-elt hx-indicator"` guard keeps both attributes from leaking onto any descendant htmx request in the swapped results region (both are inherited attributes in htmx 2.0.9) — the #2340 inherited-selector leak the runbooks editor already guards against.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean on both touched test files
- [x] `pytest tests/test_ui_retrieval.py tests/test_ui_corpus.py` — 66 passed
- [x] New `test_run_buttons_carry_in_flight_spinner_and_disable_attrs` (retrieval) asserts `hx-indicator` + `hx-disabled-elt` + `hx-disinherit` + spinner span on each of the three retrieval Run forms
- [x] `test_corpus_index_renders_page_and_collections` extended to assert the same four attributes on the corpus Go form
- [x] Acceptance: those Run buttons show a progress spinner and disable while in flight; no hx-attribute inheritance leak (disinherit guard verified in-template + by test)

## Out of scope
- **Usage Analytics Run** button (`/ui/retrieval` Usage tab) has the same missing-spinner gap but was not named in this task's scope; recorded as an adjacent finding. Its aggregate query is sub-second, so the impact is lower than the four eval/checklist/ask/diagnostics buttons here.
- Sibling tasks #2461 / #2456 / #2457 / #2462 touch the corpus/retrieval **card bodies**; this PR edits only the **Run button** elements + the adjacent spinner span, so a rebase against those card edits stays clean.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2459
