### PR TITLE
fix(ui): readable badge-ghost+badge-outline in alert banners (#2460)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — badge-ghost+badge-outline contrast in alert banners (#2460)
+
+- The `/ui/retrieval` honesty-gap banners (Usage + Retire Checklist tabs)
+  render the counted `/mcp` search-surface labels
+  (`mcp:search_knowledge` / `_memory` / `_operations`) as badges that were
+  unreadable inside the coloured alert — near-black-on-near-black in
+  `meho-dark`, near-white-on-near-white in `meho-light`. The DaisyUI 5
+  `badge-ghost` + `badge-outline` combo resolves its text colour through
+  `badge-outline`'s `color: var(--badge-color)`; with no `badge-<color>`
+  modifier that variable is unset, so `color` falls back to inheritance and
+  inside the alert picks up the alert's `*-content` token on badge-ghost's
+  `base-200` surface. An unlayered `.alert .badge-ghost.badge-outline` rule
+  in `styles.css` now pins `base-content` on `base-200`, winning over the
+  layered DaisyUI declarations regardless of emission order; it is scoped to
+  `.alert` so the on-card badge usages are unaffected. CSS only. (#2460)
+
 ### Fixed — DaisyUI 5 code-block theming on /ui/kb (#2452)
 
 - KB entry code blocks (`/ui/kb/<slug>`) are now legible in both console

--- a/backend/src/meho_backplane/ui/static/src/styles.css
+++ b/backend/src/meho_backplane/ui/static/src/styles.css
@@ -287,6 +287,31 @@ body::after {
    ════════════════════════════════════════════════════════════════════ */
 
 /*
+ * badge-ghost + badge-outline inside a coloured alert (#2460).
+ *
+ * DaisyUI 5 emits `.badge-outline { color: var(--badge-color) }` after
+ * `.badge-ghost { color: var(--color-base-content) }` in the same cascade
+ * layer, so on the combined class the outline `color` wins by emission
+ * order. With no `badge-<color>` modifier `--badge-color` is unset, the
+ * declaration is invalid at computed-value time, and `color` falls back to
+ * inheritance. Inside `.alert-*` the inherited value is the alert's
+ * `*-content` token — near-black on badge-ghost's base-200 surface in
+ * meho-dark, near-white on base-200 in meho-light — so the honesty-gap
+ * `mcp:*` labels vanish in both themes.
+ *
+ * This unlayered author rule beats every layered DaisyUI declaration
+ * regardless of emission order, pinning an explicit themed foreground +
+ * surface pair so the badge reads as it does on plain cards (base-content
+ * on base-200) in both themes. Scoped to `.alert` so the ~15 on-card
+ * badge-ghost+badge-outline usages keep their inherited base-content colour.
+ */
+.alert .badge-ghost.badge-outline {
+  color: var(--color-base-content);
+  background-color: var(--color-base-200);
+  border-color: color-mix(in oklch, var(--color-base-content) 22%, transparent);
+}
+
+/*
  * Layered card: subtle vertical sheen, 1px low-contrast border,
  * a hairline top highlight, and a slow lift on hover. Used alongside
  * DaisyUI's `card` behavior classes. color-mix against base tokens

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -724,3 +724,55 @@ def test_kb_detail_code_block_is_theme_scoped(ui_env: Environment) -> None:
     # (c) no dead DaisyUI 4 variables survive.
     assert "var(--b2" not in style_block
     assert "var(--wa" not in style_block
+
+
+def test_alert_ghost_outline_badges_have_readable_contrast() -> None:
+    """styles.css pins readable contrast for badge-ghost+badge-outline in alerts (#2460).
+
+    DaisyUI 5 emits ``.badge-outline { color: var(--badge-color) }`` after
+    ``.badge-ghost { color: var(--color-base-content) }`` in the same cascade
+    layer, so on the combined class the outline ``color`` wins by emission
+    order. With no ``badge-<color>`` modifier ``--badge-color`` is unset, the
+    declaration is invalid at computed-value time, and ``color`` falls back to
+    inheritance. Inside a coloured ``.alert`` that inherited value is the
+    alert's ``*-content`` token (near-black on badge-ghost's base-200 in
+    meho-dark, near-white on base-200 in meho-light) -> unreadable. An
+    unlayered author rule must pin an explicit themed foreground + surface
+    pair that beats the layered DaisyUI declarations in both themes.
+    """
+    source = (static_src_dir() / "styles.css").read_text(encoding="utf-8")
+    # Collapse whitespace so the assertion is insensitive to formatting.
+    normalized = re.sub(r"\s+", " ", source)
+
+    rule_match = re.search(r"\.alert \.badge-ghost\.badge-outline \{([^}]*)\}", normalized)
+    assert rule_match is not None, (
+        "missing the unlayered .alert .badge-ghost.badge-outline contrast rule"
+    )
+    body = rule_match.group(1)
+    # Explicit themed foreground + surface so the badge stops inheriting the
+    # alert's *-content colour; base-content on base-200 contrasts in both themes.
+    assert "color: var(--color-base-content)" in body
+    assert "background-color: var(--color-base-200)" in body
+
+
+@pytest.mark.parametrize(
+    "partial",
+    ["_retire_results.html", "_usage_results.html"],
+)
+def test_retrieval_honesty_gap_badges_sit_inside_alert(partial: str) -> None:
+    """The honesty-gap ``mcp:*`` badges sit inside ``.alert`` so #2460's rule targets them.
+
+    Both retrieval partials render the counted-surface labels as
+    ``badge badge-ghost badge-outline`` spans inside the ``.alert.alert-info``
+    honesty-gap banner. The contrast fix lives in styles.css and is scoped to
+    ``.alert``; guard that these partials keep the combo inside the alert so
+    the rule keeps matching (a move onto a plain card would silently escape it).
+    """
+    source = (templates_dir() / "retrieval" / partial).read_text(encoding="utf-8")
+    alert_at = source.find("alert alert-info")
+    badge_at = source.find("badge badge-ghost badge-outline")
+    assert alert_at != -1, f"{partial}: expected an .alert.alert-info banner"
+    assert badge_at != -1, f"{partial}: expected the honesty-gap badge combo"
+    assert badge_at > alert_at, (
+        f"{partial}: honesty-gap badge combo must sit inside the alert banner"
+    )

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -3019,6 +3019,24 @@ is bound from `operator.sub` (`principal_sub=`) — there is no `tenant_filter`
   ordering (retrieval include before stubs; literal diagnostics before any param
   route) + dashboard tile.
 
+### Honesty-gap badge contrast (#2460)
+
+The T2 Usage + T3 Retire fragments render the counted `/mcp` search-surface
+labels (`mcp:search_knowledge` / `_memory` / `_operations`) as
+`badge badge-ghost badge-outline` spans **inside** the `.alert.alert-info`
+honesty-gap banner. In the DaisyUI 5 bundle `.badge-outline` and `.badge-ghost`
+are mutually-exclusive style variants emitted in the same cascade layer:
+`.badge-outline { color: var(--badge-color) }` wins by emission order, and with
+no `badge-<color>` modifier `--badge-color` is unset, so `color` falls back to
+inheritance. On a plain card that inherits `base-content` (readable), but inside
+a coloured alert it inherits the alert's `*-content` token — near-black on
+badge-ghost's `base-200` surface in `meho-dark`, near-white on `base-200` in
+`meho-light` — so the badges vanished in both themes. `styles.css` carries an
+unlayered `.alert .badge-ghost.badge-outline` rule (in the "Chrome + component
+voice" block) that beats the layered DaisyUI declarations regardless of emission
+order, pinning `base-content` on `base-200` so the labels read in both themes;
+it is scoped to `.alert` so the ~15 on-card usages keep their inherited colour.
+
 ## Vault console — confirm-gated writes (G10.18-T2 #1957)
 
 The mutating verbs over the T1 (#1956) read-only KV browser:


### PR DESCRIPTION
## Summary

- `/ui/retrieval` honesty-gap banners (Usage + Retire Checklist tabs) render the counted `/mcp` search-surface labels (`mcp:search_knowledge` / `_memory` / `_operations`) as `badge badge-ghost badge-outline` spans inside the `.alert.alert-info` banner, and they were unreadable in **both** themes: near-black-on-near-black in `meho-dark`, near-white-on-near-white in `meho-light`.
- Root cause is the DaisyUI 5 **combo**, not the theme. `.badge-outline`'s `color: var(--badge-color)` is emitted after `.badge-ghost`'s `color: var(--color-base-content)` in the same cascade layer, so the outline `color` wins by emission order. With no `badge-<color>` modifier `--badge-color` is unset → the declaration is invalid at computed-value time → `color` falls back to inheritance. Inside a coloured alert that inherited value is the alert's `*-content` token on badge-ghost's `base-200` surface (readable on a plain card, which inherits `base-content`).
- Fix: an **unlayered** `.alert .badge-ghost.badge-outline` rule in `styles.css` pinning `base-content` on `base-200` (+ a subtle border). Unlayered author CSS beats every layered DaisyUI declaration regardless of emission order, so the fix is robust to future bundle re-ordering; it is scoped to `.alert`, so the ~15 on-card combo usages keep their inherited colour (out of scope).

## Approach note (deviation from issue body)

The issue body suggested the smallest patch — swap `badge-ghost badge-outline` → `badge-neutral` on the two template lines (its AC #1 greps those files for the removed combo). Per the initiative #2495 root-cause note this PR instead fixes the **combo** with a distinct CSS rule and keeps the template classes. Rationale: the CSS rule fixes every present and future in-alert combo at once, preserves the intended ghost/outline look, and lives as a single source of truth in the theme-CSS area (distinct from the just-merged #2452 code-block rules). Acceptance is therefore verified as "`mcp:*` badges inside alert banners are readable in both themes", not the template-grep form.

## Test plan

- [x] `ruff check tests/test_ui_templates.py` — clean
- [x] `ruff format --check tests/test_ui_templates.py` — clean (formatted)
- [x] `mypy tests/test_ui_templates.py` — clean
- [x] `pytest tests/test_ui_templates.py` — 43 passed (3 new)
- [x] `test_alert_ghost_outline_badges_have_readable_contrast` — asserts styles.css carries the unlayered `.alert .badge-ghost.badge-outline` rule pinning `base-content` on `base-200`
- [x] `test_retrieval_honesty_gap_badges_sit_inside_alert[_retire_results.html / _usage_results.html]` — guards that both partials keep the combo inside the `.alert.alert-info` banner so the rule keeps matching
- [x] Contrast reasoning (no headless browser / `static/dist` in repo): meho-dark = base-content `oklch(93%)` on base-200 `oklch(14.5%)`; meho-light = base-content `oklch(22%)` on base-200 `oklch(97.3%)` — high contrast both ways.

## Out of scope

- The ~15 on-card `badge-ghost badge-outline` usages (readable today; the rule is `.alert`-scoped and leaves them untouched).
- #2452 (`/ui/kb` code-block theming) — separate mechanism, already merged; this rule is distinct from its `.kb-code` rules.
- Theme-variable changes in `styles.css`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2460
