### PR TITLE
fix(corpus): restyle Register Collection modal to kb form language (#2464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,17 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — restyle Register Collection modal to kb form language (#2464)
+
+- The `/ui/corpus` **Register Collection** modal now speaks the same
+  form language as the `/ui/kb` "New entry" editor: a padding-less
+  box with a bordered header + close-circle button, the three fields
+  grouped into **Identity / Metadata / Backend** sections split by
+  dividers, `label py-0` label rows with a right-aligned hint, and a
+  bordered footer whose actions stay pinned while a long body scrolls.
+  The field set, submit contract, CSRF wiring, and per-field error
+  echo are unchanged — template-only. (#2464)
+
 ### Fixed — DaisyUI 5 code-block theming on /ui/kb (#2452)
 
 - KB entry code blocks (`/ui/kb/<slug>`) are now legible in both console

--- a/backend/src/meho_backplane/ui/templates/corpus/_register_modal.html
+++ b/backend/src/meho_backplane/ui/templates/corpus/_register_modal.html
@@ -11,6 +11,14 @@
   ``htmx:afterSwap`` so it shows without an extra click and dismisses on the
   close button / ESC / backdrop.
 
+  Layout (#2464): the box adopts the ``/ui/kb`` editor's form language --
+  a ``p-0`` box with a bordered header + close-circle button, padded
+  section rows (Identity / Metadata / Backend) split by
+  ``border-base-300`` dividers, ``label py-0`` label rows with a
+  right-aligned ``label-text-alt`` hint, and a bordered footer. The scroll
+  region lives between the pinned header and footer so long input never
+  pushes the actions off-screen.
+
   Submit contract: the form ``hx-post``s to
   ``/ui/corpus/collections/register``, swapping
   ``#corpus-collections-modal-container`` (``hx-swap="innerHTML"``).
@@ -57,12 +65,23 @@
 {%- endmacro -%}
 
 <dialog id="corpus-register-modal" class="modal">
-  <div class="modal-box max-w-2xl">
-    <h3 class="font-semibold text-lg" id="corpus-register-modal-title">Register collection</h3>
-    <p class="text-sm opacity-70 mt-1">
-      The collection starts at <code>provisioning</code>; probe it after
-      registering to make it searchable.
-    </p>
+  <div class="modal-box w-11/12 max-w-3xl p-0 overflow-hidden flex flex-col max-h-[90vh]">
+    {# ----- Header ----- #}
+    <div class="flex items-start justify-between gap-4 px-6 py-4 border-b border-base-300">
+      <div>
+        <h3 class="text-lg font-semibold" id="corpus-register-modal-title">Register collection</h3>
+        <p class="text-sm opacity-70 mt-1">
+          The collection starts at <code>provisioning</code>; probe it after
+          registering to make it searchable.
+        </p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-ghost btn-sm btn-circle"
+        aria-label="Close register collection modal"
+        onclick="document.getElementById('corpus-register-modal').close()"
+      >✕</button>
+    </div>
 
     {#- On a 422/409 the route returns this whole ``<dialog>`` re-rendered
         with per-field errors. Target the modal container (not the form) and
@@ -77,120 +96,161 @@
       hx-swap="innerHTML"
       hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
       hx-disabled-elt="find button[type=submit]"
-      class="space-y-3 py-2"
+      class="flex flex-col flex-1 min-h-0 overflow-hidden"
       aria-labelledby="corpus-register-modal-title"
     >
-      <label class="form-control">
-        <span class="label-text">Collection key</span>
-        <input
-          type="text"
-          name="collection_key"
-          required
-          minlength="1"
-          maxlength="128"
-          value="{{ field_value('collection_key') }}"
-          class="input input-bordered input-sm font-mono {{ error_class('collection_key', 'input-error') }}"
-          aria-label="Collection key"
-          placeholder="vmware"
-        />
-        {{ error_for('collection_key') }}
-      </label>
+      <div class="flex-1 min-h-0 overflow-y-auto">
+        {# ----- Identity section ----- #}
+        <div class="px-6 pt-4 pb-4 border-b border-base-300">
+          <div class="text-xs font-medium opacity-60 uppercase tracking-wide mb-3">Identity</div>
 
-      <div class="grid gap-3 md:grid-cols-2">
-        <label class="form-control">
-          <span class="label-text">Vendor</span>
-          <input
-            type="text"
-            name="vendor"
-            required
-            minlength="1"
-            maxlength="256"
-            value="{{ field_value('vendor') }}"
-            class="input input-bordered input-sm {{ error_class('vendor', 'input-error') }}"
-            aria-label="Vendor"
-            placeholder="VMware by Broadcom"
-          />
-          {{ error_for('vendor') }}
-        </label>
+          <label class="form-control">
+            <div class="label py-0">
+              <span class="label-text font-medium">Collection key</span>
+              <span class="label-text-alt opacity-60">required</span>
+            </div>
+            <input
+              type="text"
+              name="collection_key"
+              required
+              minlength="1"
+              maxlength="128"
+              value="{{ field_value('collection_key') }}"
+              class="input input-bordered input-sm font-mono {{ error_class('collection_key', 'input-error') }}"
+              aria-label="Collection key"
+              placeholder="vmware"
+            />
+            {{ error_for('collection_key') }}
+          </label>
 
-        <label class="form-control">
-          <span class="label-text">Products <span class="opacity-60">(comma-separated, optional)</span></span>
-          <input
-            type="text"
-            name="products"
-            maxlength="2048"
-            value="{{ field_value('products') }}"
-            class="input input-bordered input-sm {{ error_class('products', 'input-error') }}"
-            aria-label="Products"
-            placeholder="vsphere, nsx"
-          />
-          {{ error_for('products') }}
-        </label>
+          <div class="flex flex-wrap gap-4 mt-3">
+            <label class="form-control flex-1 min-w-48">
+              <div class="label py-0">
+                <span class="label-text font-medium">Vendor</span>
+                <span class="label-text-alt opacity-60">required</span>
+              </div>
+              <input
+                type="text"
+                name="vendor"
+                required
+                minlength="1"
+                maxlength="256"
+                value="{{ field_value('vendor') }}"
+                class="input input-bordered input-sm {{ error_class('vendor', 'input-error') }}"
+                aria-label="Vendor"
+                placeholder="VMware by Broadcom"
+              />
+              {{ error_for('vendor') }}
+            </label>
+
+            <label class="form-control flex-1 min-w-48">
+              <div class="label py-0">
+                <span class="label-text font-medium">Products</span>
+                <span class="label-text-alt opacity-60">comma-separated, optional</span>
+              </div>
+              <input
+                type="text"
+                name="products"
+                maxlength="2048"
+                value="{{ field_value('products') }}"
+                class="input input-bordered input-sm {{ error_class('products', 'input-error') }}"
+                aria-label="Products"
+                placeholder="vsphere, nsx"
+              />
+              {{ error_for('products') }}
+            </label>
+          </div>
+        </div>
+
+        {# ----- Metadata section ----- #}
+        <div class="px-6 pt-4 pb-4 border-b border-base-300">
+          <div class="text-xs font-medium opacity-60 uppercase tracking-wide mb-3">Metadata</div>
+
+          <div class="flex flex-wrap gap-4">
+            <label class="form-control flex-1 min-w-48">
+              <div class="label py-0">
+                <span class="label-text font-medium">Description</span>
+                <span class="label-text-alt opacity-60">optional</span>
+              </div>
+              <textarea
+                name="description"
+                maxlength="8192"
+                class="textarea textarea-bordered min-h-[4rem] text-sm {{ error_class('description', 'textarea-error') }}"
+                aria-label="Description"
+                placeholder="What this corpus covers."
+              >{{ field_value('description') }}</textarea>
+              {{ error_for('description') }}
+            </label>
+
+            <label class="form-control flex-1 min-w-48">
+              <div class="label py-0">
+                <span class="label-text font-medium">When to use</span>
+                <span class="label-text-alt opacity-60">optional</span>
+              </div>
+              <textarea
+                name="when_to_use"
+                maxlength="8192"
+                class="textarea textarea-bordered min-h-[4rem] text-sm {{ error_class('when_to_use', 'textarea-error') }}"
+                aria-label="When to use"
+                placeholder="Pick this collection for ... questions."
+              >{{ field_value('when_to_use') }}</textarea>
+              {{ error_for('when_to_use') }}
+            </label>
+          </div>
+        </div>
+
+        {# ----- Backend section ----- #}
+        <div class="px-6 pt-4 pb-4">
+          <div class="text-xs font-medium opacity-60 uppercase tracking-wide mb-3">Backend</div>
+
+          <label class="form-control">
+            <div class="label py-0">
+              <span class="label-text font-medium">Backend type</span>
+              <span class="label-text-alt opacity-60">required</span>
+            </div>
+            <input
+              type="text"
+              name="backend_type"
+              required
+              minlength="1"
+              maxlength="128"
+              value="{{ field_value('backend_type') }}"
+              class="input input-bordered input-sm font-mono {{ error_class('backend_type', 'input-error') }}"
+              aria-label="Backend type"
+              placeholder="corpus-http"
+              aria-describedby="corpus-backend-type-hint"
+            />
+            <span id="corpus-backend-type-hint" class="text-xs opacity-60 mt-1">
+              The search backend this collection routes to (validated against
+              the registered backends).
+            </span>
+            {{ error_for('backend_type') }}
+          </label>
+
+          <label class="form-control mt-3">
+            <div class="label py-0">
+              <span class="label-text font-medium">Backend ref</span>
+              <span class="label-text-alt opacity-60">JSON, optional</span>
+            </div>
+            <textarea
+              name="backend_ref"
+              maxlength="16384"
+              class="textarea textarea-bordered min-h-[5rem] font-mono text-xs {{ error_class('backend_ref', 'textarea-error') }}"
+              aria-label="Backend ref"
+              placeholder='{"endpoint": "https://corpus/v1/search"}'
+              aria-describedby="corpus-backend-ref-hint"
+            >{{ field_value('backend_ref') }}</textarea>
+            <span id="corpus-backend-ref-hint" class="text-xs opacity-60 mt-1">
+              Per-collection backend config the resolved adapter reads. Leave
+              blank for a backend that needs none.
+            </span>
+            {{ error_for('backend_ref') }}
+          </label>
+        </div>
       </div>
 
-      <label class="form-control">
-        <span class="label-text">Description <span class="opacity-60">(optional)</span></span>
-        <textarea
-          name="description"
-          maxlength="8192"
-          class="textarea textarea-bordered min-h-[4rem] text-sm {{ error_class('description', 'textarea-error') }}"
-          aria-label="Description"
-          placeholder="What this corpus covers."
-        >{{ field_value('description') }}</textarea>
-        {{ error_for('description') }}
-      </label>
-
-      <label class="form-control">
-        <span class="label-text">When to use <span class="opacity-60">(optional)</span></span>
-        <textarea
-          name="when_to_use"
-          maxlength="8192"
-          class="textarea textarea-bordered min-h-[4rem] text-sm {{ error_class('when_to_use', 'textarea-error') }}"
-          aria-label="When to use"
-          placeholder="Pick this collection for ... questions."
-        >{{ field_value('when_to_use') }}</textarea>
-        {{ error_for('when_to_use') }}
-      </label>
-
-      <label class="form-control">
-        <span class="label-text">Backend type</span>
-        <input
-          type="text"
-          name="backend_type"
-          required
-          minlength="1"
-          maxlength="128"
-          value="{{ field_value('backend_type') }}"
-          class="input input-bordered input-sm font-mono {{ error_class('backend_type', 'input-error') }}"
-          aria-label="Backend type"
-          placeholder="corpus-http"
-          aria-describedby="corpus-backend-type-hint"
-        />
-        <span id="corpus-backend-type-hint" class="text-xs opacity-60 mt-1">
-          The search backend this collection routes to (validated against
-          the registered backends).
-        </span>
-        {{ error_for('backend_type') }}
-      </label>
-
-      <label class="form-control">
-        <span class="label-text">Backend ref <span class="opacity-60">(JSON, optional)</span></span>
-        <textarea
-          name="backend_ref"
-          maxlength="16384"
-          class="textarea textarea-bordered min-h-[5rem] font-mono text-xs {{ error_class('backend_ref', 'textarea-error') }}"
-          aria-label="Backend ref"
-          placeholder='{"endpoint": "https://corpus/v1/search"}'
-          aria-describedby="corpus-backend-ref-hint"
-        >{{ field_value('backend_ref') }}</textarea>
-        <span id="corpus-backend-ref-hint" class="text-xs opacity-60 mt-1">
-          Per-collection backend config the resolved adapter reads. Leave
-          blank for a backend that needs none.
-        </span>
-        {{ error_for('backend_ref') }}
-      </label>
-
-      <div class="modal-action">
+      {# ----- Footer: actions ----- #}
+      <div class="flex items-center justify-end gap-3 px-6 py-4 border-t border-base-300">
         <button
           type="button"
           class="btn btn-sm btn-ghost"

--- a/backend/tests/test_ui_corpus_collections_table.py
+++ b/backend/tests/test_ui_corpus_collections_table.py
@@ -552,6 +552,51 @@ def test_register_modal_renders_for_tenant_admin() -> None:
     assert CSRF_COOKIE_NAME in response.cookies
 
 
+def test_register_modal_matches_kb_editor_form_language() -> None:
+    """The modal adopts the /ui/kb editor's form language (#2464).
+
+    Asserts the structural markers the kb ``_editor_modal.html`` uses so the
+    register modal reads as the same write surface: a padding-less box with a
+    bordered header + close-circle button, ``label py-0`` label rows with a
+    right-aligned ``label-text-alt`` hint, section dividers, and a bordered
+    footer. Purely cosmetic -- the field set and submit contract are covered
+    by the neighbouring render/create tests.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/corpus/collections/register")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Box: padding managed by sections, scroll-contained (kb editor line 68).
+    assert 'class="modal-box w-11/12 max-w-3xl p-0' in body
+    # Bordered header with a close-circle button (kb editor lines 70-77).
+    assert "border-b border-base-300" in body
+    assert "btn btn-ghost btn-sm btn-circle" in body
+    # kb-style label rows: label py-0 + font-medium label-text + alt hint.
+    assert 'class="label py-0"' in body
+    assert 'class="label-text font-medium"' in body
+    assert 'class="label-text-alt opacity-60"' in body
+    # Section grouping into Identity / Metadata / Backend, kb column-header style.
+    assert "text-xs font-medium opacity-60 uppercase tracking-wide" in body
+    for section in ("Identity", "Metadata", "Backend"):
+        assert f">{section}</div>" in body
+    # Bordered footer holding the actions (kb editor line 181).
+    assert "border-t border-base-300" in body
+    # No behaviour change: submit contract + field set are intact.
+    assert 'hx-post="/ui/corpus/collections/register"' in body
+    assert 'data-action="register-submit"' in body
+    for field in ("collection_key", "vendor", "products", "backend_type", "backend_ref"):
+        assert f'name="{field}"' in body
+
+
 def test_register_modal_rejects_operator_role_with_403() -> None:
     """An operator (non-admin) GET on the register modal is 403'd server-side."""
     _seed_tenant(_TENANT_A, "tenant-a")


### PR DESCRIPTION
## Summary
- Restyle the `/ui/corpus` **Register Collection** modal to speak the `/ui/kb` "New entry" editor's form language (#2464). The modal read as a cramped, differently styled write surface (`max-w-2xl`, `space-y-3` rows, no header/footer borders, no field grouping) next to the polished kb editor.
- The box is now a `p-0` `modal-box` with a bordered header + close-circle button, the fields grouped into **Identity / Metadata / Backend** sections split by `border-base-300` dividers, `label py-0` rows with a right-aligned `label-text-alt` hint, and a bordered footer whose actions stay pinned while a long body scrolls.
- **Cosmetic only** — field names, the `hx-post` submit contract, the form-scoped `X-CSRF-Token` header (#1693), per-field error echo, and the value round-trip are unchanged. This touches only the register modal template, leaving the corpus result-card templates (siblings #2461/#2456/#2457/#2462) untouched.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean on the touched test file.
- [x] `pytest tests/test_ui_corpus_collections_table.py` — 12 passed (incl. new `test_register_modal_matches_kb_editor_form_language`).
- [x] `pytest tests/test_ui_templates.py` — 40 passed (template compilation clean).
- [x] `code-quality.py --diff` — exit 0.
- [x] Acceptance — the modal matches the kb editor form language: new test asserts the kb markers (`modal-box w-11/12 max-w-3xl p-0`, bordered header, `btn btn-ghost btn-sm btn-circle`, `label py-0` + `label-text font-medium` + `label-text-alt opacity-60`, uppercase section headers for Identity/Metadata/Backend, `border-t`/`border-b border-base-300`) while re-asserting the unchanged submit contract + field set.

## Out of scope
- Corpus **result cards** (siblings #2461/#2456/#2457/#2462) — deliberately untouched so rebases stay clean.
- No route/handler/OpenAPI changes (template + test + CHANGELOG only).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2464


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Restyled the “Register Collection” modal to match the Docs KB editor form design.
  * Added clearer sections for Identity, Metadata, and Backend details.
  * Improved modal layout with a scrollable content area, pinned header and footer, consistent spacing, dividers, and dedicated close controls.
  * Existing fields, submission behavior, validation feedback, and security protections remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->