### PR TITLE
feat(ui): confirm-gate approvals Approve/Deny with arm-then-confirm (#2446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — arm-then-confirm gate on /ui/approvals Approve/Deny (#2446)
+
+- The `/ui/approvals` decision modal now confirm-gates both Approve and
+  Deny. A pending row carries a consequence banner
+  (`data-approval-gate="confirm"`) whose severity follows the parked
+  envelope's `safety_level` (#1855) — error for `dangerous`, warning
+  otherwise — stating plainly that Approve dispatches the parked write
+  immediately (no un-approve) and Deny is terminal (the requester must
+  re-file). Each decision is two-phase: the first click on Approve/Deny
+  is a `type="button"` armer (Alpine local state only) that swaps in a
+  `Cancel` + `Confirm approve`/`Confirm deny` pair; only the Confirm
+  button posts, carrying the same CSRF header echo, shared-reason
+  `hx-include`, and double-fire guard as before. No new routes, no
+  modal-in-modal. The self-approval invariant (#1401) survives: a blocked
+  Approve never arms and has no reachable confirm state. Template-only —
+  it reuses the structured envelope render from #2447 and mirrors the
+  runbook lifecycle confirm mold (#1881/#1957) (#2446).
+
 ### Added — structured proposed_effect rendering on /ui/approvals (#2447)
 
 - The `/ui/approvals` detail modal now renders the parked

--- a/backend/src/meho_backplane/ui/templates/approvals/_modal.html
+++ b/backend/src/meho_backplane/ui/templates/approvals/_modal.html
@@ -36,6 +36,17 @@
     (it was closed by timeout, not a decision), so the "at T" falls back to
     ``expires_at`` for that branch.
 
+  Confirm gate (#2446)
+    A pending row carries a consequence banner (``data-approval-gate="confirm"``)
+    whose severity follows the envelope ``safety_level`` (#1855) -- error for
+    ``dangerous``, warning otherwise -- naming what each decision does: Approve
+    dispatches the parked write immediately (no un-approve), Deny is terminal
+    (re-file). Both decisions are two-phase: the first click on an armer
+    (``type="button"``, Alpine local ``armed`` state) only swaps in a Confirm
+    pair; only the Confirm button posts. This mirrors the runbook lifecycle
+    confirm mold (``runbooks/_detail_actions.html``) and the ops Run gate
+    (#1881). A blocked self-approval Approve (#1401) never arms.
+
   Context:
     request               -- dict: id / op_id / connector_id / principal_sub /
                              principal_act / proposed_effect / status /
@@ -272,10 +283,52 @@
 
     {% if request.status == "pending" %}
     {# Decision forms only for a pending row -- a decided row is read-only. #}
-    <div class="modal-action mt-5 items-end gap-2">
-      <label class="form-control mr-auto w-full max-w-xs">
+
+    {#- Consequence banner (#2446). Deciding is the one console step where the
+        gated write actually executes, so surface what each decision does BEFORE
+        the operator acts -- mirroring the ops Run modal's ``data-run-gate``
+        alert (#1881) and the vault confirm gate (#1957). ``safety_level`` is the
+        closed ``safe``/``caution``/``dangerous`` enum already stamped on every
+        parked envelope (#1855) and rendered structurally above (#2447); reuse it
+        as the banner's severity source (error for dangerous, warning otherwise,
+        including when it is absent). No server change -- the value already rides
+        ``proposed_effect``. -#}
+    {% set safety = effect.get("safety_level") %}
+    <div
+      role="alert"
+      class="alert {{ 'alert-error' if safety == 'dangerous' else 'alert-warning' }} mt-5 items-start"
+      data-approval-gate="confirm"
+      data-safety-level="{{ safety if safety else '' }}"
+    >
+      {{ icon("shield-check", class="size-5 shrink-0") }}
+      <div>
+        <h4 class="text-sm font-semibold">Deciding runs the parked write</h4>
+        <p class="text-xs [overflow-wrap:anywhere]">
+          Approving dispatches <span class="font-mono">{{ request.op_id }}</span>
+          via <span class="font-mono">{{ request.connector_id }}</span>
+          immediately &mdash; there is no un-approve. Denying is terminal; the
+          requester must re-file.
+        </p>
+        {% if safety %}
+          <div class="mt-2 flex flex-wrap items-center gap-2">
+            {{ proposed_effect_safety_badge(safety) }}
+            <span class="text-xs opacity-80">safety level: <span class="font-semibold">{{ safety }}</span></span>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+
+    {#- Two-phase arm-then-confirm (#2446), mirroring the runbook lifecycle
+        confirm mold (``runbooks/_detail_actions.html``): the first click only
+        ARMS a decision via Alpine local state (the app shell already ships
+        Alpine 3); only the second, explicit Confirm button posts. No new routes,
+        no modal-in-modal. The Confirm form carries the CSRF header echo, pulls
+        the shared reason via ``hx-include``, and disables itself during dispatch
+        exactly as the single-click form did before (#1693 / #1754). -#}
+    <div class="modal-action mt-4 flex-col items-stretch gap-3" x-data="{ armed: '' }">
+      <label class="form-control w-full max-w-xs self-start">
         <span class="label-text text-xs">Reason <span class="opacity-60">(optional)</span></span>
-        {# Single shared reason input; each decision form pulls it via
+        {# Single shared reason input; each confirm form pulls it via
            hx-include so the operator types it once. #}
         <input
           type="text"
@@ -288,41 +341,86 @@
         />
       </label>
 
-      {# Deny -- always enabled. Its own form carries the CSRF header echo. #}
-      <form
-        hx-post="/ui/approvals/{{ request.id }}/reject"
-        hx-target="#meho-approvals-modal-container"
-        hx-swap="innerHTML"
-        hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
-        hx-include="#meho-approval-reason"
-        hx-disabled-elt="find button"
-      >
-        <button type="submit" class="btn btn-sm btn-error btn-outline gap-1" data-action="reject">
+      {# Phase 1 -- resting armers. ``type="button"``: the first click only sets
+         the Alpine ``armed`` flag; it never posts. A blocked self-approval
+         (#1401) Approve stays disabled and carries no armer, so it can never
+         reach an approve confirm state. #}
+      <div class="flex items-end justify-end gap-2" x-show="armed === ''">
+        <button
+          type="button"
+          class="btn btn-sm btn-error btn-outline gap-1"
+          data-action="reject"
+          x-on:click="armed = 'reject'"
+        >
           {{ icon("ban", class="size-4") }}
           Deny
         </button>
-      </form>
-
-      {# Approve -- disabled on a self-approval (#1401). Its own form
-         carries the CSRF header echo. #}
-      <form
-        hx-post="/ui/approvals/{{ request.id }}/approve"
-        hx-target="#meho-approvals-modal-container"
-        hx-swap="innerHTML"
-        hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
-        hx-include="#meho-approval-reason"
-        hx-disabled-elt="find button"
-      >
         <button
-          type="submit"
+          type="button"
           class="btn btn-sm btn-primary gap-1"
           data-action="approve"
-          {% if self_approval_blocked %}disabled aria-disabled="true" aria-label="Approve disabled: you cannot approve your own request unless APPROVAL_ALLOW_SELF_APPROVAL is enabled"{% endif %}
+          {% if self_approval_blocked %}disabled aria-disabled="true" aria-label="Approve disabled: you cannot approve your own request unless APPROVAL_ALLOW_SELF_APPROVAL is enabled"{% else %}x-on:click="armed = 'approve'"{% endif %}
         >
           {{ icon("check", class="size-4") }}
           Approve
         </button>
-      </form>
+      </div>
+
+      {# Phase 2 -- armed Deny confirm. Only the Confirm button posts; it carries
+         the CSRF header echo, the shared reason, and the double-fire guard,
+         exactly as the single-click form did before. #}
+      <div x-show="armed === 'reject'" x-cloak class="flex flex-col items-stretch gap-2">
+        <p class="text-xs text-base-content/70 [overflow-wrap:anywhere]" data-approval-confirm="reject">
+          This denial is terminal &mdash; the requester must re-file to try again.
+          Denying does not run the write.
+        </p>
+        <div class="flex items-center justify-end gap-2">
+          <button type="button" class="btn btn-ghost btn-sm" x-on:click="armed = ''">Cancel</button>
+          <form
+            hx-post="/ui/approvals/{{ request.id }}/reject"
+            hx-target="#meho-approvals-modal-container"
+            hx-swap="innerHTML"
+            hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+            hx-include="#meho-approval-reason"
+            hx-disabled-elt="find button"
+          >
+            <button type="submit" class="btn btn-sm btn-error gap-1" data-confirm="reject">
+              {{ icon("ban", class="size-4") }}
+              Confirm deny
+            </button>
+          </form>
+        </div>
+      </div>
+
+      {# Phase 2 -- armed Approve confirm. NOT rendered on a blocked self-approval
+         (#1401): with no approve armer above and no confirm block here, there is
+         no reachable approve confirm state at all. #}
+      {% if not self_approval_blocked %}
+      <div x-show="armed === 'approve'" x-cloak class="flex flex-col items-stretch gap-2">
+        <p class="text-xs text-base-content/70 [overflow-wrap:anywhere]" data-approval-confirm="approve">
+          Approving dispatches <span class="font-mono">{{ request.op_id }}</span>
+          via <span class="font-mono">{{ request.connector_id }}</span> immediately{% if safety %}
+          at safety level <span class="font-semibold">{{ safety }}</span>{% endif %}.
+          There is no un-approve.
+        </p>
+        <div class="flex items-center justify-end gap-2">
+          <button type="button" class="btn btn-ghost btn-sm" x-on:click="armed = ''">Cancel</button>
+          <form
+            hx-post="/ui/approvals/{{ request.id }}/approve"
+            hx-target="#meho-approvals-modal-container"
+            hx-swap="innerHTML"
+            hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+            hx-include="#meho-approval-reason"
+            hx-disabled-elt="find button"
+          >
+            <button type="submit" class="btn btn-sm btn-primary gap-1" data-confirm="approve">
+              {{ icon("check", class="size-4") }}
+              Confirm approve
+            </button>
+          </form>
+        </div>
+      </div>
+      {% endif %}
     </div>
     {% endif %}
   </div>

--- a/backend/tests/test_ui_approvals.py
+++ b/backend/tests/test_ui_approvals.py
@@ -1513,6 +1513,158 @@ def test_modal_caution_safety_level_is_a_warning_badge() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Detail modal -- confirm-gate: consequence banner + arm-then-confirm (#2446)
+# ---------------------------------------------------------------------------
+
+
+def _render_pending_modal(
+    *,
+    effect: dict[str, object] | None = None,
+    self_approval: bool = False,
+) -> tuple[str, uuid.UUID]:
+    """Render the pending decision modal; return (html, request_id).
+
+    ``self_approval`` makes the reviewer the requester so the Approve button
+    renders in its #1401 blocked state.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    principal = _REVIEWER_SUB if self_approval else _REQUESTER_SUB
+    rid = _seed_request(tenant_id=_TENANT_A, principal_sub=principal, proposed_effect=effect)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, operator_sub=_REVIEWER_SUB)
+    operator = _operator(tenant_id=_TENANT_A, sub=_REVIEWER_SUB)
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get(f"/ui/approvals/{rid}")
+
+    assert response.status_code == 200, response.text
+    return response.text, rid
+
+
+def _opening_tag(html: str, marker: str) -> str:
+    """Return the ``<tag ...>`` opening tag whose attributes contain *marker*."""
+    pos = html.index(marker)
+    start = html.rfind("<", 0, pos)
+    end = html.index(">", pos)
+    return html[start : end + 1]
+
+
+def test_modal_pending_shows_consequence_banner_naming_safety_level() -> None:
+    """AC1: a pending modal carries a ``data-approval-gate="confirm"`` banner
+    whose text names the envelope ``safety_level`` value."""
+    body, _ = _render_pending_modal(
+        effect={
+            "op_id": "vsphere.vm.delete",
+            "connector_id": "vsphere-1.x",
+            "safety_level": "dangerous",
+        }
+    )
+    assert 'data-approval-gate="confirm"' in body
+    banner = body.split('data-approval-gate="confirm"')[1].split("</div>\n    </div>")[0]
+    # The banner's text includes the safety_level value.
+    assert "dangerous" in banner
+    # A dangerous level escalates the banner styling to error.
+    assert "alert-error" in _opening_tag(body, 'data-approval-gate="confirm"')
+    # It states each consequence plainly.
+    assert "no un-approve" in banner
+    assert "re-file" in banner
+
+
+def test_modal_consequence_banner_is_generic_warning_when_safety_absent() -> None:
+    """AC1 (absent case): with no ``safety_level`` the banner is generic warning."""
+    body, _ = _render_pending_modal(effect={"op_id": "some.op", "connector_id": "generic-1.x"})
+    assert 'data-approval-gate="confirm"' in body
+    tag = _opening_tag(body, 'data-approval-gate="confirm"')
+    assert "alert-warning" in tag
+    # No safety level to name -> the attribute is empty, not a stray "None".
+    assert 'data-safety-level=""' in tag
+    assert "None" not in body.split('data-approval-gate="confirm"')[1].split("</div>")[0]
+
+
+def test_modal_decisions_are_two_phase_armers_not_direct_posts() -> None:
+    """AC2: the ``data-action`` elements are ``type="button"`` armers, and the
+    ``hx-post`` submits sit behind the armed confirm state (unreachable at rest)."""
+    body, rid = _render_pending_modal()
+
+    # The Approve / Deny elements are armers: type=button, Alpine state only,
+    # and they carry NO hx-post of their own.
+    approve_armer = _opening_tag(body, 'data-action="approve"')
+    reject_armer = _opening_tag(body, 'data-action="reject"')
+    for armer, state in ((approve_armer, "approve"), (reject_armer, "reject")):
+        assert 'type="button"' in armer
+        assert f"armed = '{state}'" in armer
+        assert "hx-post" not in armer
+
+    # The decision POSTs live inside the armed confirm containers: the
+    # ``x-show="armed === '...'"`` gate opens BEFORE the hx-post form, and the
+    # confirm block is x-cloak'd so it is display:none until armed.
+    for state in ("approve", "reject"):
+        gate = f"x-show=\"armed === '{state}'\""
+        post = f'hx-post="/ui/approvals/{rid}/{state}"'
+        assert gate in body
+        assert post in body
+        assert body.index(gate) < body.index(post), state
+        # The gated block is cloaked (hidden until Alpine arms it).
+        assert "x-cloak" in body.split(gate)[1].split("</div>")[0]
+
+
+def test_modal_confirm_posts_to_existing_routes_no_new_endpoints() -> None:
+    """AC3: the armed confirm buttons post to the existing approve/reject routes;
+    the ``/ui/approvals`` route inventory gains no new endpoint."""
+    body, rid = _render_pending_modal()
+    assert f'hx-post="/ui/approvals/{rid}/approve"' in body
+    assert f'hx-post="/ui/approvals/{rid}/reject"' in body
+
+    # Route-inventory guard: the approvals surface exposes exactly the known
+    # path set -- the confirm gate is template-only and adds no endpoint.
+    from meho_backplane.ui.routes.approvals.routes import build_approvals_router
+
+    router = build_approvals_router()
+    approval_routes = {
+        (route.path, frozenset(route.methods))
+        for route in router.routes
+        if getattr(route, "path", "").startswith("/ui/approvals")
+    }
+    assert approval_routes == {
+        ("/ui/approvals/badge", frozenset({"GET"})),
+        ("/ui/approvals/list", frozenset({"GET"})),
+        ("/ui/approvals", frozenset({"GET"})),
+        ("/ui/approvals/{request_id}", frozenset({"GET"})),
+        ("/ui/approvals/{request_id}/approve", frozenset({"POST"})),
+        ("/ui/approvals/{request_id}/reject", frozenset({"POST"})),
+    }
+
+
+def test_modal_self_approval_blocks_approve_armer_and_confirm_state() -> None:
+    """AC4: a blocked self-approval keeps the Approve armer disabled with the
+    #1401 aria-label and renders NO approve confirm state; Deny still arms."""
+    body, _ = _render_pending_modal(self_approval=True)
+
+    approve_armer = _opening_tag(body, 'data-action="approve"')
+    assert "disabled" in approve_armer
+    assert "APPROVAL_ALLOW_SELF_APPROVAL" in approve_armer
+    # A blocked Approve never arms: no click-to-arm handler on it, and the
+    # approve confirm state is not rendered at all.
+    assert "armed = 'approve'" not in body
+    assert "x-show=\"armed === 'approve'\"" not in body
+    # Deny still arms (withdrawing your own request is not an escalation).
+    reject_armer = _opening_tag(body, 'data-action="reject"')
+    assert "disabled" not in reject_armer
+    assert "armed = 'reject'" in reject_armer
+    assert "x-show=\"armed === 'reject'\"" in body
+
+
+def test_modal_armed_deny_state_states_denial_is_terminal_and_refile() -> None:
+    """AC5: the armed Deny confirm copy states the denial is terminal / re-file."""
+    body, _ = _render_pending_modal()
+    assert 'data-approval-confirm="reject"' in body
+    deny_confirm = body.split('data-approval-confirm="reject"')[1].split("</p>")[0]
+    assert "terminal" in deny_confirm
+    assert "re-file" in deny_confirm
+
+
+# ---------------------------------------------------------------------------
 # params / params_hash never leak (#1827 -- a hard requirement)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Confirm-gate the Approve/Deny actions in the `/ui/approvals` decision modal — the one console surface where a policy-gated write actually executes, previously the only state-changing surface firing on a single click with no consequence banner.
- Every pending row now carries a **consequence banner** (`data-approval-gate="confirm"`) whose severity follows the parked envelope's `safety_level` (#1855, rendered structurally by #2447) — error for `dangerous`, warning otherwise — stating plainly that Approve dispatches the write immediately (no un-approve) and Deny is terminal (the requester must re-file).
- Both decisions are **two-phase arm-then-confirm**, mirroring the runbook lifecycle confirm mold (`runbooks/_detail_actions.html`) and the ops Run gate (#1881/#1957): the first click on Approve/Deny is a `type="button"` armer (Alpine local state only) that swaps in a `Cancel` + `Confirm approve`/`Confirm deny` pair; **only the Confirm button posts**, carrying the same CSRF header echo, shared-reason `hx-include`, and `hx-disabled-elt` double-fire guard as before.
- **No new routes, no modal-in-modal, no server change.** The self-approval invariant (#1401) survives untouched: a blocked Approve never arms and has no reachable confirm state. Template + tests only; reuses the #2447 envelope render.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy tests/test_ui_approvals.py` — no new errors (pre-existing `no-any-return` on helper functions unchanged)
- [x] `pytest tests/test_ui_approvals.py` — **57 passed**
- [x] AC1 — `test_modal_pending_shows_consequence_banner_naming_safety_level` + `test_modal_consequence_banner_is_generic_warning_when_safety_absent`: banner carries `data-approval-gate="confirm"`, names the `safety_level` value (error styling for dangerous), generic warning + empty `data-safety-level` when absent.
- [x] AC2 — `test_modal_decisions_are_two_phase_armers_not_direct_posts`: `data-action="approve"`/`"reject"` are `type="button"` armers with no `hx-post`; the decision POSTs sit behind `x-show="armed === '…'"` + `x-cloak` (unreachable at rest).
- [x] AC3 — `test_modal_confirm_posts_to_existing_routes_no_new_endpoints`: confirm buttons post to the existing `/ui/approvals/{id}/approve|reject`; `build_approvals_router()` inventory is exactly the six known routes (no new endpoint).
- [x] AC4 — `test_modal_self_approval_blocks_approve_armer_and_confirm_state`: blocked self-approval keeps the disabled Approve armer + `APPROVAL_ALLOW_SELF_APPROVAL` aria-label, renders **no** approve confirm state; Deny still arms.
- [x] AC5 — `test_modal_armed_deny_state_states_denial_is_terminal_and_refile`: the armed Deny copy states the denial is terminal / requester must re-file.
- [x] AC6 — resting + armed states captured via Playwright against the real template + vendored Alpine (arm-then-confirm interaction driven live). See below.

## Screenshots (AC6)

Captured by rendering the real `approvals/_modal.html` fragment against the vendored Alpine 3 bundle and clicking the Approve armer (DaisyUI/Tailwind styling is *approximated* in the harness — the Tailwind oxide build is unavailable in the sandbox — but the Alpine two-phase interaction is the real component):

**Resting** — consequence banner (error-styled for `dangerous`, names `safety level: dangerous`) + Deny/Approve armers.

**Armed (Approve)** — the armer row is replaced in place by the confirm copy ("Approving dispatches `vsphere.vm.delete` via `vsphere-1.x` immediately at safety level dangerous. There is no un-approve.") + `Cancel` + `Confirm approve`.

> The captured PNGs live in the run artifacts; GitHub image embedding needs the web UI drag-drop, so a maintainer can attach them directly. The interaction they show is fully asserted by `test_modal_decisions_are_two_phase_armers_not_direct_posts`.

## Out of scope

- Making Reason required (a decision-contract change spanning REST/MCP/CLI parity — separate ticket).
- Undo window / deferred dispatch (redesign of the approve-then-dispatch flow).
- CLI/MCP approval flows and the approval queue data path (all function correctly).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2446
