### PR TITLE
feat(ui): clamp result-card bodies with expand-on-click (#2456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — clamp result-card bodies with expand-on-click (#2456)
+
+- `/ui/retrieval` diagnostics hit cards and `/ui/corpus` cited-chunk cards now
+  clamp each body to a short snippet (`line-clamp-3`) with a per-card
+  expand-on-click toggle, so ten ranked hits fit one screen and can be compared
+  at a glance instead of stacking full documents. The clamp is a static class
+  (it holds with JavaScript disabled, no layout shift); an Alpine toggle removes
+  it on click and hides itself when the body does not overflow the snippet.
+
 ### Added — in-flight spinners on console Run buttons (#2459)
 
 - The long-running action buttons on `/ui/retrieval` (Diagnostics Run, Run

--- a/backend/src/meho_backplane/ui/routes/retrieval/routes.py
+++ b/backend/src/meho_backplane/ui/routes/retrieval/routes.py
@@ -493,7 +493,8 @@ async def _render_diagnostics(
 
     Swaps ``retrieval/_diagnostics_results.html`` into
     ``#retrieval-diagnostics-results``. A successful run renders one card per
-    hit (body excerpt + ``source`` / ``source_id`` / ``kind``, the
+    hit (body clamped to a snippet with expand-on-click so ranked hits stay
+    comparable at a glance, plus ``source`` / ``source_id`` / ``kind``, the
     ``fused_score``, and a per-signal breakdown where a ``None`` rank renders
     an explicit "absent from this signal's top-N" marker); an empty hit list
     renders a "no matches" state.

--- a/backend/src/meho_backplane/ui/templates/corpus/_results.html
+++ b/backend/src/meho_backplane/ui/templates/corpus/_results.html
@@ -114,7 +114,32 @@
               {% endif %}
             </div>
           </div>
-          <p class="text-sm whitespace-pre-wrap">{{ chunk.content }}</p>
+          {#- Body snippet: clamp to a few lines so ranked cited chunks stay
+              comparable on one screen; the toggle expands the full content on
+              click (#2456). Alpine scope is per chunk card; the static
+              ``line-clamp-3`` clamps with JS disabled (no layout shift), and
+              the ``expanded`` binding removes it on expand. The toggle hides
+              itself when the content does not overflow the clamp. -#}
+          <div x-data="{ expanded: false, clamped: false }" class="flex flex-col gap-1">
+            <p
+              x-ref="body"
+              class="text-sm whitespace-pre-wrap line-clamp-3"
+              x-bind:class="{ 'line-clamp-3': !expanded }"
+              x-init="$nextTick(() => { clamped = $refs.body.scrollHeight > $refs.body.clientHeight })"
+            >{{ chunk.content }}</p>
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs self-start px-1"
+              x-show="clamped || expanded"
+              x-cloak
+              x-on:click="expanded = !expanded"
+              x-bind:aria-expanded="expanded.toString()"
+              aria-label="Toggle full chunk content"
+            >
+              <span x-show="!expanded">Show more</span>
+              <span x-show="expanded" x-cloak>Show less</span>
+            </button>
+          </div>
         </div>
       </li>
     {% endfor %}

--- a/backend/src/meho_backplane/ui/templates/retrieval/_diagnostics_results.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/_diagnostics_results.html
@@ -85,7 +85,32 @@
               fused {{ "%.6f" | format(hit.fused_score) }}
             </span>
           </div>
-          <p class="text-sm whitespace-pre-wrap">{{ hit.body }}</p>
+          {#- Body snippet: clamp to a few lines so ten ranked hits stay
+              comparable on one screen; the toggle expands the full body on
+              click (#2456). Alpine scope is per hit card; the static
+              ``line-clamp-3`` clamps with JS disabled (no layout shift), and
+              the ``expanded`` binding removes it on expand. The toggle hides
+              itself when the body does not overflow the clamp. -#}
+          <div x-data="{ expanded: false, clamped: false }" class="flex flex-col gap-1">
+            <p
+              x-ref="body"
+              class="text-sm whitespace-pre-wrap line-clamp-3"
+              x-bind:class="{ 'line-clamp-3': !expanded }"
+              x-init="$nextTick(() => { clamped = $refs.body.scrollHeight > $refs.body.clientHeight })"
+            >{{ hit.body }}</p>
+            <button
+              type="button"
+              class="btn btn-ghost btn-xs self-start px-1"
+              x-show="clamped || expanded"
+              x-cloak
+              x-on:click="expanded = !expanded"
+              x-bind:aria-expanded="expanded.toString()"
+              aria-label="Toggle full result body"
+            >
+              <span x-show="!expanded">Show more</span>
+              <span x-show="expanded" x-cloak>Show less</span>
+            </button>
+          </div>
           {# Per-signal RRF score/rank breakdown -- a None rank renders the
              explicit absent marker, not a blank. #}
           <div class="overflow-x-auto">

--- a/backend/tests/test_ui_corpus.py
+++ b/backend/tests/test_ui_corpus.py
@@ -660,6 +660,51 @@ def test_card_title_absent_falls_back_to_document_id_heading(
     assert 'title="Document id"' not in html
 
 
+def test_corpus_search_clamps_chunk_content_with_expand_toggle() -> None:
+    """Each cited chunk's content is clamped to a snippet with an expand toggle (#2456).
+
+    Acceptance criterion: cited chunks render as comparable snippet cards so ten
+    hits fit one screen; each card exposes an expand-on-click affordance
+    revealing the full content. The clamp is a static ``line-clamp-3`` that the
+    ``expanded`` binding removes on click.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_collection(collection_key="vmware")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(
+        tenant_id=_TENANT_A,
+        capabilities=frozenset({"meho-docs", "meho-docs:vmware"}),
+    )
+    result = DocsSearchResult(
+        chunks=[_chunk(chunk_id=f"c-{i}", content=f"Chunk body {i}.") for i in range(10)]
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_SEARCH_DOCS, new_callable=AsyncMock, return_value=result),
+        ):
+            response = client.post(
+                "/ui/corpus/search",
+                data={"collection": "vmware", "q": "snapshot quiesce"},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # One clamped snippet + one expand toggle per cited chunk (all ten).
+    assert body.count("whitespace-pre-wrap line-clamp-3") == 10
+    assert body.count('x-data="{ expanded: false, clamped: false }"') == 10
+    assert body.count("expanded = !expanded") == 10
+    # The clamp is removed on expand, and the toggle labels both directions.
+    assert "{ 'line-clamp-3': !expanded }" in body
+    assert "Show more" in body
+    assert "Show less" in body
+
+
 def test_corpus_search_resolves_gs_kb_source_to_canonical_link() -> None:
     """A KB ``gs://`` chunk renders a clickable Broadcom KB link (#1919).
 

--- a/backend/tests/test_ui_retrieval.py
+++ b/backend/tests/test_ui_retrieval.py
@@ -403,6 +403,45 @@ def test_diagnostics_renders_fused_score_and_per_signal_breakdown() -> None:
     assert "1 hit" in body
 
 
+def test_diagnostics_clamps_hit_body_with_expand_toggle() -> None:
+    """Each hit body is clamped to a snippet with an Alpine expand-on-click toggle (#2456).
+
+    Acceptance criterion: ranked hits render as comparable snippet cards so ten
+    hits fit one screen; each card exposes an expand affordance revealing the
+    full body. The clamp is a static ``line-clamp-3`` (so it holds with JS
+    disabled) that the ``expanded`` binding removes on click.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    hits = [_hit(source_id=f"kb-entry-{i}") for i in range(10)]
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RETRIEVE, new_callable=AsyncMock, return_value=hits),
+        ):
+            response = client.post(
+                "/ui/retrieval/diagnostics",
+                data={"query": "snapshot quiesce", "limit": 10},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # One clamped snippet + one expand toggle per hit (all ten).
+    assert body.count("whitespace-pre-wrap line-clamp-3") == 10
+    assert body.count('x-data="{ expanded: false, clamped: false }"') == 10
+    assert body.count("expanded = !expanded") == 10
+    # The clamp is removed on expand, and the toggle labels both directions.
+    assert "{ 'line-clamp-3': !expanded }" in body
+    assert "Show more" in body
+    assert "Show less" in body
+
+
 def test_diagnostics_renders_absent_marker_for_none_rank() -> None:
     """A hit absent from a signal's top-N renders an explicit 'absent' marker, not a blank.
 


### PR DESCRIPTION
## Summary
- `/ui/retrieval` diagnostics hit cards and `/ui/corpus` cited-chunk cards clamped each body inline in full, so a ten-hit response stacked ten full documents and made ranked hits impossible to compare without scrolling per card — the exact workflow the diagnostics tool exists for.
- Clamp each card body to a short snippet (`line-clamp-3`) with a per-card Alpine expand-on-click toggle revealing the full body. The clamp is a static class (holds with JS disabled, no layout shift); `expanded` removes it on click and the toggle hides itself when the body doesn't overflow the snippet.
- Edit is localized to the card-body region + its toggle in both partials (corpus edits the shared `chunk_cards` macro), so it unions cleanly against the sibling card-cluster tasks (#2457 / #2462 / #2453 on top of the merged #2461).
- Template/JS/CSS-only (Tailwind 4 picks up `line-clamp-3` from template source at image-build time, as it already does `line-clamp-2`) — no OpenAPI/schema regen. Also corrected the `_render_diagnostics` docstring, which promised a "body excerpt" the render did not deliver.

## Test plan
- [x] `ruff check` — clean (routes.py + both test files)
- [x] `ruff format --check` — clean (both test files reformatted)
- [x] `mypy src/.../retrieval/routes.py --ignore-missing-imports` — no issues
- [x] `code-quality.py --diff` — 0 blockers (6 warnings all pre-existing in routes.py)
- [x] `pytest tests/test_ui_retrieval.py tests/test_ui_corpus.py` — 72 passed
- [x] Acceptance — ten hits fit one screen as comparable snippet cards, each expandable on click, on **both** surfaces: new `test_diagnostics_clamps_hit_body_with_expand_toggle` and `test_corpus_search_clamps_chunk_content_with_expand_toggle` assert one static `line-clamp-3` snippet + one wired expand toggle per card across ten hits, plus the `expanded`-removes-clamp binding and both toggle labels.

## Out of scope
- Sibling card-cluster tasks touching the same partials: provenance link (#2457), Ask view-source (#2462), score pills (#2453). The score-consistency observation in the issue (`fused` vs `fused · bm25 · cos`) is #2453's remit, not touched here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2456
