### PR TITLE
feat(ui): back /ui/retrieval Source/Kind inputs with tenant-scoped DISTINCT datalists (#2458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — Source/Kind datalists on /ui/retrieval (#2458)
+
+- The `/ui/retrieval` diagnostics Source and Kind filter inputs are now backed
+  by `<datalist>` suggestions enumerated from a tenant-scoped
+  `SELECT DISTINCT source, kind` over the operator's retrieval-visible
+  `documents` rows. An operator no longer has to guess valid filter values and
+  hit a silent zero-result — the offered values are exactly the ones the
+  in-process `retrieve` call can match. The inputs stay free-typing (kinds are
+  free-form by design), and the query carries the same tenant + per-principal
+  visibility predicate `retrieve` enforces, so no cross-tenant value and no
+  other principal's user-scoped memory kind leaks into the suggestions.
+- The Source field's help text now steers docs-corpus collection lookups to
+  `/ui/corpus`: those collections live on a different substrate that `retrieve`
+  never queries, so a collection name (e.g. `vmware`) can never be a retrieval
+  Source. That mismatch was the root of the "Source=`vmware` → 0 hits"
+  confusion.
+
 ### Changed — restyle Register Collection modal to kb form language (#2464)
 
 - The `/ui/corpus` **Register Collection** modal now speaks the same

--- a/backend/src/meho_backplane/retrieval/retriever.py
+++ b/backend/src/meho_backplane/retrieval/retriever.py
@@ -103,14 +103,21 @@ from typing import Any
 
 import structlog
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import select, text
+from sqlalchemy import or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Document
 from meho_backplane.retrieval.embedding import get_embedding_service
 
-__all__ = ["CANDIDATE_LIMIT", "RRF_K", "RetrievalHit", "retrieve"]
+__all__ = [
+    "CANDIDATE_LIMIT",
+    "RRF_K",
+    "RetrievalFacets",
+    "RetrievalHit",
+    "list_retrieval_facets",
+    "retrieve",
+]
 
 
 #: The ``documents.source`` value memory rows carry. Mirrors
@@ -757,3 +764,97 @@ def _coerce_uuid(value: Any) -> uuid.UUID:
     if isinstance(value, uuid.UUID):
         return value
     return uuid.UUID(str(value))
+
+
+class RetrievalFacets(BaseModel):
+    """The distinct ``source`` / ``kind`` values retrievable in a tenant.
+
+    Populates the ``/ui/retrieval`` diagnostics Source / Kind datalists (#2458)
+    so an operator selects a filter value the substrate actually holds instead
+    of guessing one that fails silently. The values are enumerated from the
+    same ``documents`` rows :func:`retrieve` reads, gated by the same
+    per-principal visibility predicate -- so a docs-corpus collection name (a
+    different substrate that ``retrieve`` never queries) can never appear, and a
+    user-scoped ``source='memory'`` ``kind`` another principal owns is excluded.
+
+    Both lists are sorted and de-duplicated. Frozen pydantic v2 model -- the
+    caller renders the values verbatim into ``<datalist>`` options.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sources: tuple[str, ...]
+    kinds: tuple[str, ...]
+
+
+async def list_retrieval_facets(
+    tenant_id: uuid.UUID,
+    *,
+    principal_sub: str | None = None,
+    session: AsyncSession | None = None,
+) -> RetrievalFacets:
+    """Enumerate the distinct retrieval-visible ``source`` / ``kind`` values.
+
+    Runs one ``SELECT DISTINCT source, kind FROM documents`` scoped to
+    *tenant_id* -- no cross-tenant row can contribute, mirroring the mandatory
+    tenant predicate every candidate query carries. When *principal_sub* is set
+    the same per-principal predicate the candidate queries enforce
+    (:data:`_PRINCIPAL_PREDICATE_SQL`) is applied, so a user-scoped
+    ``source='memory'`` row contributes its ``kind`` only to the principal that
+    wrote it; passing ``None`` (the opt-out the in-process callers use) admits
+    every row in the tenant.
+
+    Parameters
+    ----------
+    tenant_id
+        The querying tenant's UUID. Required -- there is no cross-tenant
+        enumeration surface, exactly as with :func:`retrieve`.
+    principal_sub
+        The authenticated caller's OIDC ``sub``. When set, user-scoped memory
+        kinds owned by a different principal are excluded from the result.
+    session
+        Optional caller-owned :class:`AsyncSession`. When ``None`` the helper
+        opens its own and closes on exit (the query is read-only, no commit).
+
+    Returns
+    -------
+    RetrievalFacets
+        Sorted, de-duplicated ``sources`` and ``kinds`` tuples. Empty tuples
+        when the tenant has no visible documents.
+    """
+    if session is None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as owned_session:
+            return await _select_facets(owned_session, tenant_id, principal_sub)
+    return await _select_facets(session, tenant_id, principal_sub)
+
+
+async def _select_facets(
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    principal_sub: str | None,
+) -> RetrievalFacets:
+    """Execute the tenant-scoped, per-principal-gated DISTINCT facet query.
+
+    The per-principal ``OR`` chain is the ``:principal_sub IS NOT NULL`` arm of
+    :data:`_PRINCIPAL_PREDICATE_SQL` expressed through the ORM so the query
+    stays portable across the PG production engine and the SQLite test engine
+    (the raw ``metadata ->> 'user_sub'`` text extraction the candidate queries
+    inline is PG-only). ``doc_metadata['user_sub'].as_string()`` yields
+    ``JSON_EXTRACT`` on SQLite and ``->>`` on PostgreSQL; a missing ``user_sub``
+    resolves to NULL, so ``NULL == :principal_sub`` excludes the row -- matching
+    the candidate queries' deny-on-missing-``user_sub`` posture.
+    """
+    stmt = select(Document.source, Document.kind).where(Document.tenant_id == tenant_id).distinct()
+    if principal_sub is not None:
+        stmt = stmt.where(
+            or_(
+                Document.source != _MEMORY_SOURCE,
+                Document.kind.notin_(_USER_SCOPED_MEMORY_KINDS),
+                Document.doc_metadata["user_sub"].as_string() == principal_sub,
+            )
+        )
+    rows = (await session.execute(stmt)).all()
+    sources = sorted({source for source, _ in rows})
+    kinds = sorted({kind for _, kind in rows})
+    return RetrievalFacets(sources=tuple(sources), kinds=tuple(kinds))

--- a/backend/src/meho_backplane/ui/routes/retrieval/routes.py
+++ b/backend/src/meho_backplane/ui/routes/retrieval/routes.py
@@ -143,7 +143,9 @@ from meho_backplane.retrieval.retire import (
 )
 from meho_backplane.retrieval.retriever import (
     CANDIDATE_LIMIT,
+    RetrievalFacets,
     RetrievalHit,
+    list_retrieval_facets,
     retrieve,
 )
 from meho_backplane.retrieval.usage import (
@@ -243,30 +245,58 @@ async def _resolve_operator(session: UISessionContext) -> Operator:
     return operator
 
 
-async def _resolve_platform_admin_softly(session: UISessionContext) -> bool:
-    """Return ``operator.platform_admin`` for the page render, failing **soft**.
+async def _resolve_operator_softly(session: UISessionContext) -> Operator | None:
+    """Reconstruct the operator for the read-only page render, failing **soft**.
 
-    The retire tab renders the cross-tenant ``tenant_filter`` selector only for a
-    platform admin. Deciding that requires reconstructing the operator on the
-    read-only ``GET /ui/retrieval`` render, but the page must keep rendering even
-    when the JWT round-trip can't complete (a transient JWKS outage, a session
+    Two page-render concerns need the operator on the ``GET /ui/retrieval``
+    render: the retire tab's cross-tenant ``tenant_filter`` selector (shown only
+    to a platform admin) and the diagnostics Source / Kind datalists (#2458,
+    enumerated own-tenant + own-principal). Both must keep rendering even when
+    the JWT round-trip can't complete (a transient JWKS outage, a session
     revoked in the gap since the middleware check). So any failure projects to
-    ``False`` -- the selector is hidden -- mirroring the soft-hide posture
+    ``None`` -- the selector hides and the datalists render empty -- mirroring
+    the soft-hide posture
     :func:`~meho_backplane.ui.routes.connectors.operator.resolve_role_probe`
-    uses. The hide is only a UX hint: the ``POST`` handler reconstructs the
-    operator for real and :func:`~meho_backplane.auth.rbac.authorize_tenant_scope`
-    stays the server-side authority on every cross-tenant claim.
+    uses. The hide is only a UX hint: every ``POST`` handler reconstructs the
+    operator for real and the server-side authorities
+    (:func:`~meho_backplane.auth.rbac.authorize_tenant_scope`, the substrate's
+    own tenant + per-principal predicates) stay authoritative.
     """
     try:
-        operator = await _resolve_operator(session)
+        return await _resolve_operator(session)
     except Exception as exc:
         log.info(
-            "ui_retrieval_platform_admin_probe_unavailable",
+            "ui_retrieval_operator_probe_unavailable",
             session_id=str(session.session_id),
             reason=type(exc).__name__,
         )
-        return False
-    return operator.platform_admin
+        return None
+
+
+async def _load_retrieval_facets(operator: Operator | None) -> RetrievalFacets:
+    """Enumerate the tenant's distinct Source / Kind values for the datalists.
+
+    Fails **soft** to empty facets: a datalist is a discovery aid, not a gate,
+    so a DB hiccup (or an unresolved operator) must never 500 the read-only page
+    render. Delegates to
+    :func:`~meho_backplane.retrieval.retriever.list_retrieval_facets`, own-tenant
+    + own-principal scoped, so no cross-tenant source/kind leaks into the
+    suggestions and a user-scoped memory kind another principal owns is excluded
+    -- the values offered are exactly the ones the diagnostics ``retrieve`` call
+    can actually match.
+    """
+    if operator is None:
+        return RetrievalFacets(sources=(), kinds=())
+    try:
+        return await list_retrieval_facets(operator.tenant_id, principal_sub=operator.sub)
+    except Exception as exc:
+        log.info(
+            "ui_retrieval_facets_unavailable",
+            operator_sub=operator.sub,
+            tenant_id=str(operator.tenant_id),
+            reason=type(exc).__name__,
+        )
+        return RetrievalFacets(sources=(), kinds=())
 
 
 def _compute_query_hash(query: str) -> str:
@@ -445,7 +475,9 @@ async def _render_retrieval_index(
     re-checks server-side via ``authorize_tenant_scope``).
     """
     csrf_token = mint_csrf_token(str(session.session_id))
-    platform_admin = await _resolve_platform_admin_softly(session)
+    operator = await _resolve_operator_softly(session)
+    platform_admin = operator.platform_admin if operator is not None else False
+    facets = await _load_retrieval_facets(operator)
     context: dict[str, object] = {
         **_diagnostics_form_context(
             query="",
@@ -454,6 +486,13 @@ async def _render_retrieval_index(
             limit=_DEFAULT_LIMIT,
             csrf_token=csrf_token,
         ),
+        # Source / Kind diagnostics datalists (#2458): the distinct
+        # retrieval-visible values so an operator picks a filter the substrate
+        # holds instead of guessing. Page-render only -- the POST diagnostics
+        # fragment re-renders only the results region, not the form, so these
+        # are not threaded through ``_diagnostics_form_context``.
+        "source_options": facets.sources,
+        "kind_options": facets.kinds,
         "hits": [],
         "searched": False,
         "candidate_limit": CANDIDATE_LIMIT,

--- a/backend/src/meho_backplane/ui/templates/retrieval/index.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/index.html
@@ -35,6 +35,8 @@
     query           -- str: current query (empty on first render)
     source          -- str: current source filter (empty on first render)
     kind            -- str: current kind filter (empty on first render)
+    source_options  -- tuple[str]: distinct retrieval-visible sources (datalist)
+    kind_options    -- tuple[str]: distinct retrieval-visible kinds (datalist)
     limit           -- int: current limit selection
     limit_options   -- tuple[int]: the limit selector's options
     hits            -- list[RetrievalHit]: empty on first render
@@ -143,31 +145,59 @@
               <div class="label">
                 <span class="label-text">Source <span class="opacity-50">(optional)</span></span>
               </div>
+              {#- Source datalist (#2458): the tenant's distinct retrieval-visible
+                  source namespaces, enumerated by a SELECT DISTINCT over the
+                  ``documents`` table. ``list=`` keeps the input free-typing (kinds
+                  are free-form by design) while offering the real values, so an
+                  operator no longer guesses a namespace that silently returns 0
+                  hits. Empty on the initial render when the corpus is empty. -#}
               <input
                 type="text"
                 name="source"
                 value="{{ source }}"
                 maxlength="64"
+                list="retrieval-source-options"
                 placeholder="e.g. kb, memory"
                 class="input input-bordered w-full"
                 aria-label="Source filter"
                 autocomplete="off"
               />
+              <datalist id="retrieval-source-options">
+                {% for option in source_options %}
+                  <option value="{{ option }}"></option>
+                {% endfor %}
+              </datalist>
+              <div class="label">
+                <span class="label-text-alt opacity-60">
+                  Retrieval sources only. Docs-corpus collections are a separate
+                  substrate &mdash; search them on
+                  <a href="/ui/corpus" class="link">/ui/corpus</a>, not here.
+                </span>
+              </div>
             </label>
             <label class="form-control w-full sm:w-48">
               <div class="label">
                 <span class="label-text">Kind <span class="opacity-50">(optional)</span></span>
               </div>
+              {#- Kind datalist (#2458): the tenant's distinct retrieval-visible
+                  kinds from the same SELECT DISTINCT; a user-scoped memory kind
+                  another principal owns is excluded (own-principal scoped). -#}
               <input
                 type="text"
                 name="kind"
                 value="{{ kind }}"
                 maxlength="64"
+                list="retrieval-kind-options"
                 placeholder="e.g. kb-entry"
                 class="input input-bordered w-full"
                 aria-label="Kind filter"
                 autocomplete="off"
               />
+              <datalist id="retrieval-kind-options">
+                {% for option in kind_options %}
+                  <option value="{{ option }}"></option>
+                {% endfor %}
+              </datalist>
             </label>
             <label class="form-control w-full sm:w-32">
               <div class="label">

--- a/backend/tests/test_ui_retrieval.py
+++ b/backend/tests/test_ui_retrieval.py
@@ -49,7 +49,7 @@ from fastapi.testclient import TestClient
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
-from meho_backplane.db.models import Tenant
+from meho_backplane.db.models import Document, Tenant
 from meho_backplane.retrieval.eval.result_models import EvalResult, SurfaceResult
 from meho_backplane.retrieval.retire import (
     CriterionResult,
@@ -179,6 +179,48 @@ def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session, session.begin():
             session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_document(
+    *,
+    tenant_id: uuid.UUID,
+    source: str,
+    kind: str,
+    source_id: str,
+    body: str = "seeded document body",
+    user_sub: str | None = None,
+) -> None:
+    """Insert one ``documents`` row so the datalist DISTINCT query sees it (#2458).
+
+    Seeds the substrate directly (no embedding service) with a fixed zero
+    vector; the facet query reads only ``source`` / ``kind`` / ``tenant_id`` /
+    ``metadata``. A ``user_sub`` populates ``metadata['user_sub']`` so the
+    per-principal memory-visibility predicate can be exercised.
+    """
+    metadata: dict[str, object] = {}
+    if user_sub is not None:
+        metadata["user_sub"] = user_sub
+    doc_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                Document(
+                    id=doc_id,
+                    tenant_id=tenant_id,
+                    source=source,
+                    source_id=source_id,
+                    kind=kind,
+                    body=body,
+                    body_hash=f"sha256:test:{doc_id}",
+                    embedding=[0.0] * 384,
+                    doc_metadata=metadata,
+                    tokens=len(body.split()),
+                ),
+            )
 
     asyncio.run(_do())
 
@@ -357,6 +399,123 @@ def test_run_buttons_carry_in_flight_spinner_and_disable_attrs() -> None:
     assert body.count('hx-disabled-elt="find button[type=submit]"') >= 3
     assert body.count('hx-disinherit="hx-disabled-elt hx-indicator"') >= 3
     assert body.count("htmx-indicator loading loading-spinner") >= 3
+
+
+# ---------------------------------------------------------------------------
+# GET /ui/retrieval -- Source / Kind datalists (#2458)
+# ---------------------------------------------------------------------------
+
+
+def test_index_source_kind_datalists_enumerate_distinct_visible_values() -> None:
+    """The Source / Kind inputs are backed by datalists of distinct visible values.
+
+    A ``SELECT DISTINCT source, kind`` over the tenant's retrieval-visible
+    ``documents`` rows populates the two ``<datalist>`` elements. Duplicate
+    (source, kind) rows collapse to one option, and the Source help text notes
+    docs-corpus collections are searched elsewhere.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(tenant_id=_TENANT_A, sub="op-42")
+    # Two kb rows (distinct source_id) collapse to a single kb / kb-entry option.
+    _seed_document(tenant_id=_TENANT_A, source="kb", kind="kb-entry", source_id="kb-1")
+    _seed_document(tenant_id=_TENANT_A, source="kb", kind="kb-entry", source_id="kb-2")
+    # A user-scoped memory row owned by this principal is visible to them.
+    _seed_document(
+        tenant_id=_TENANT_A,
+        source="memory",
+        kind="memory-user",
+        source_id="mem-1",
+        user_sub="op-42",
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get("/ui/retrieval")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Inputs are bound to their datalists.
+    assert 'list="retrieval-source-options"' in body
+    assert 'list="retrieval-kind-options"' in body
+    assert 'id="retrieval-source-options"' in body
+    assert 'id="retrieval-kind-options"' in body
+    # Distinct sources + kinds are offered as options.
+    assert '<option value="kb"></option>' in body
+    assert '<option value="memory"></option>' in body
+    assert '<option value="kb-entry"></option>' in body
+    assert '<option value="memory-user"></option>' in body
+    # DISTINCT collapses the two kb rows to one source option.
+    assert body.count('<option value="kb"></option>') == 1
+    # Source help text steers docs-corpus lookups to /ui/corpus, not here.
+    assert "/ui/corpus" in body
+    assert "Docs-corpus collections are a separate" in body
+
+
+def test_index_datalists_are_tenant_scoped() -> None:
+    """Values seeded under a different tenant never appear in the datalists.
+
+    The DISTINCT query is tenant-scoped, so another tenant's source/kind values
+    cannot leak into this operator's suggestions.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(tenant_id=_TENANT_A, sub="op-42")
+    _seed_document(tenant_id=_TENANT_A, source="kb", kind="kb-entry", source_id="a-1")
+    # Foreign-tenant rows with unmistakable source/kind values.
+    _seed_document(
+        tenant_id=_TENANT_B,
+        source="tenant-b-secret-source",
+        kind="tenant-b-secret-kind",
+        source_id="b-1",
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get("/ui/retrieval")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert '<option value="kb"></option>' in body
+    # No cross-tenant leak.
+    assert "tenant-b-secret-source" not in body
+    assert "tenant-b-secret-kind" not in body
+
+
+def test_index_datalists_exclude_other_principals_user_scoped_memory() -> None:
+    """A user-scoped memory row another principal owns is not offered (#1797 gate).
+
+    The datalists enumerate *retrieval-visible* rows, so a ``source='memory'``
+    user-scoped ``kind`` owned by a different ``user_sub`` is excluded -- the
+    operator would get 0 hits typing it, so it must not be suggested.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    operator = _operator(tenant_id=_TENANT_A, sub="op-42")
+    _seed_document(tenant_id=_TENANT_A, source="kb", kind="kb-entry", source_id="kb-1")
+    # A user-scoped memory row owned by a DIFFERENT principal -- not visible to op-42.
+    _seed_document(
+        tenant_id=_TENANT_A,
+        source="memory",
+        kind="memory-user",
+        source_id="mem-intruder",
+        user_sub="someone-else",
+    )
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        with patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator):
+            response = client.get("/ui/retrieval")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert '<option value="kb"></option>' in body
+    # The other principal's user-scoped memory row does not leak into either list.
+    assert '<option value="memory"></option>' not in body
+    assert '<option value="memory-user"></option>' not in body
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/retrieval.md
+++ b/docs/codebase/retrieval.md
@@ -73,6 +73,39 @@ Filter parameters narrow the candidate set in both signals symmetrically:
   {source:"memory"}` and the MCP retrieve resource returned other
   principals' user-scoped memories within the same tenant.
 
+### `list_retrieval_facets(...)` (`meho_backplane.retrieval.retriever`)
+
+Enumerates the distinct `source` / `kind` values retrievable in a
+tenant, for populating value-discovery affordances (the `/ui/retrieval`
+diagnostics Source / Kind datalists, #2458).
+
+```python
+async def list_retrieval_facets(
+    tenant_id: uuid.UUID,
+    *,
+    principal_sub: str | None = None,
+    session: AsyncSession | None = None,
+) -> RetrievalFacets
+```
+
+Runs one `SELECT DISTINCT source, kind FROM documents` scoped to
+`tenant_id` and gated by the **same** per-principal visibility predicate
+`retrieve` enforces: when `principal_sub` is set, a user-scoped
+`source='memory'` row (`memory-user` / `memory-user-tenant` /
+`memory-user-target`) contributes its value only to the principal that
+wrote it. The result is therefore exactly the set of values a diagnostics
+`retrieve` call could actually match — a docs-corpus collection name (a
+different substrate `retrieve` never queries) can never appear, and no
+cross-tenant or cross-principal value leaks into the suggestions.
+
+Returns a frozen `RetrievalFacets` with sorted, de-duplicated `sources`
+and `kinds` tuples. Unlike the candidate queries, the DISTINCT query is
+expressed through the ORM (`select(Document.source, Document.kind)` +
+`doc_metadata['user_sub'].as_string()`) so it stays portable across the
+PG production engine and the SQLite test engine — the raw
+`metadata ->> 'user_sub'` text extraction the candidate queries inline is
+PG-only.
+
 ### `RetrievalHit`
 
 Frozen Pydantic v2 model. Carries the projected `Document` row


### PR DESCRIPTION
## Summary
- Back the `/ui/retrieval` diagnostics **Source** and **Kind** filter inputs with `<datalist>` suggestions so operators pick real values instead of guessing free-text that fails silently (the `Source=vmware → 0 hits` confusion).
- Add `list_retrieval_facets()` to the retrieval substrate: one tenant-scoped `SELECT DISTINCT source, kind` over the `documents` table, gated by the **same** per-principal visibility predicate `retrieve()` enforces — so the offered values are exactly the ones a diagnostics run can match, with no cross-tenant or cross-principal leak.
- The DISTINCT query is expressed through the ORM (not the candidate queries' PG-only raw `metadata ->>` extraction) so it stays portable across the PG production engine and the SQLite test engine.
- The Source help text steers docs-corpus collection lookups to `/ui/corpus` (a different substrate `retrieve()` never queries). Inputs stay free-typing — kinds are free-form by design.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean on all touched files
- [x] `mypy` — clean (retriever.py + routes.py)
- [x] `pytest tests/test_ui_retrieval.py` — 45 passed (3 new + 42 existing)
- [x] **AC — datalist enumerates distinct visible values:** `test_index_source_kind_datalists_enumerate_distinct_visible_values` seeds kb + memory docs, asserts `<option>`s for `kb` / `memory` (source) and `kb-entry` / `memory-user` (kind), and that duplicate rows collapse to one option.
- [x] **AC — tenant scoping:** `test_index_datalists_are_tenant_scoped` asserts a foreign tenant's source/kind values never appear.
- [x] **AC — retrieval-visible only:** `test_index_datalists_exclude_other_principals_user_scoped_memory` asserts another principal's user-scoped memory row is excluded.
- [x] **AC — grep:** `list=` bindings present on the Source and Kind inputs; Source help text mentions docs-corpus collections → `/ui/corpus`.
- [x] Existing diagnostics fragment tests stay green (POST fragment re-renders only the results region, not the form, so no fragment change was needed).
- [x] `code-quality.py --diff` — 0 blockers (warnings all pre-existing).

## Out of scope
- Sibling card-cluster tasks (#2456 / #2457 / #2462 / #2453) edit the result-card bodies; this PR touches only the filter inputs + the datalist-populating query.
- No `/api/v1` endpoint and no OpenAPI-snapshot change: no `/ui/*` route added/renamed and the response stays `HTMLResponse`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2458
