### PR TITLE
feat(ui): label result-card provenance + link kb hits to /ui/kb/<slug> (#2457)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,17 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — labelled click-through provenance on result cards (#2457)
+
+- The `/ui/retrieval` diagnostics hit cards now carry visible `Source` /
+  `Kind` / `Source id` captions on the provenance row, so an operator reads
+  the three badges as labelled provenance instead of guessing at anonymous
+  tags whose meaning lived only in hover `title` text. A hit whose source is
+  `kb` renders its `source_id` (which is the KB slug) as a same-tab link to
+  `/ui/kb/<slug>`, matching the KB surface; hits from sources without a
+  resolvable UI route keep the id as plain, selectable monospace text — never
+  a dead link.
+
 ### Changed — clamp result-card bodies with expand-on-click (#2456)
 
 - `/ui/retrieval` diagnostics hit cards and `/ui/corpus` cited-chunk cards now

--- a/backend/src/meho_backplane/ui/templates/retrieval/_diagnostics_results.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/_diagnostics_results.html
@@ -72,10 +72,29 @@
       <li class="card bg-base-100 border-base-300 border shadow-sm">
         <div class="card-body py-3 space-y-2">
           <div class="flex flex-wrap items-start justify-between gap-2">
+            {#- Provenance row: each badge carries a visible caption label so
+                its meaning is legible without hovering the ``title``. A kb hit
+                persists ``source_id=slug`` (kb/service.py), so its id badge
+                links to the KB entry detail page (same-tab, matching
+                kb/_results.html); sources without a resolvable UI route keep
+                the id as plain, selectable monospace text -- never a dead
+                link (#2457). -#}
             <div class="flex flex-wrap items-center gap-1 text-xs" aria-label="Hit provenance">
+              <span class="opacity-60">Source</span>
               <span class="badge badge-ghost badge-outline" title="Source namespace">{{ hit.source }}</span>
+              <span class="opacity-60">Kind</span>
               <span class="badge badge-ghost badge-outline" title="Document kind">{{ hit.kind }}</span>
-              <span class="badge badge-ghost badge-outline font-mono" title="Source id">{{ hit.source_id }}</span>
+              <span class="opacity-60">Source id</span>
+              {% if hit.source == "kb" %}
+                <a
+                  href="/ui/kb/{{ hit.source_id }}"
+                  class="badge badge-ghost badge-outline font-mono link link-primary"
+                  title="Open KB entry"
+                  aria-label="Open KB entry {{ hit.source_id }}"
+                >{{ hit.source_id }}</a>
+              {% else %}
+                <span class="badge badge-ghost badge-outline font-mono" title="Source id">{{ hit.source_id }}</span>
+              {% endif %}
             </div>
             <span
               class="badge badge-primary badge-outline"

--- a/backend/tests/test_ui_retrieval.py
+++ b/backend/tests/test_ui_retrieval.py
@@ -637,6 +637,78 @@ def test_diagnostics_renders_absent_marker_for_none_rank() -> None:
     assert "#1" in body
 
 
+def test_diagnostics_labels_provenance_and_links_kb_source_id() -> None:
+    """Provenance is labelled visibly and a kb hit's source_id links to its entry (#2457).
+
+    Acceptance criteria: the provenance row carries a visible ``Source id``
+    caption (not only a ``title=`` attribute), and a ``source == "kb"`` hit
+    renders its ``source_id`` as an anchor to ``/ui/kb/<source_id>`` (kb
+    documents persist ``source_id=slug``, so the id is the KB slug).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    hits = [_hit(source="kb", kind="kb-entry", source_id="quiesce-snapshots")]
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RETRIEVE, new_callable=AsyncMock, return_value=hits),
+        ):
+            response = client.post(
+                "/ui/retrieval/diagnostics",
+                data={"query": "snapshot", "limit": 10},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Provenance labels are rendered as visible captions, not hover-only.
+    assert ">Source</span>" in body
+    assert ">Kind</span>" in body
+    assert ">Source id</span>" in body
+    # A kb hit's source_id is a same-tab anchor to its KB entry detail page.
+    assert 'href="/ui/kb/quiesce-snapshots"' in body
+    assert ">quiesce-snapshots</a>" in body
+
+
+def test_diagnostics_non_kb_source_id_is_plain_text_never_a_dead_link() -> None:
+    """A non-kb hit keeps its source_id as plain text with no anchor (#2457).
+
+    Acceptance criterion: a memory hit (no resolvable ``/ui/kb`` route) must
+    not wrap its source_id in an anchor, and must never emit an ``href`` that
+    would 404 against the KB detail route.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    csrf = _csrf_token(session_id)
+    operator = _operator(tenant_id=_TENANT_A)
+    hits = [_hit(source="memory", kind="note", source_id="mem-scope-slug")]
+
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        client.cookies.set(CSRF_COOKIE_NAME, csrf)
+        with (
+            patch(_RESOLVE_OPERATOR, new_callable=AsyncMock, return_value=operator),
+            patch(_RETRIEVE, new_callable=AsyncMock, return_value=hits),
+        ):
+            response = client.post(
+                "/ui/retrieval/diagnostics",
+                data={"query": "recall", "limit": 10},
+                headers={CSRF_HEADER_NAME: csrf},
+            )
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The id is still shown, but as plain selectable text -- never a dead link.
+    assert "mem-scope-slug" in body
+    assert ">mem-scope-slug</a>" not in body
+    assert 'href="/ui/kb/mem-scope-slug"' not in body
+
+
 def test_diagnostics_empty_results_renders_no_matches_state() -> None:
     """A run returning zero hits renders the no-matches state, not an error."""
     _seed_tenant(_TENANT_A, "tenant-a")


### PR DESCRIPTION
## Summary

- On `/ui/retrieval` Diagnostics, the result cards' provenance row now carries visible `Source` / `Kind` / `Source id` captions, so an operator reads labelled provenance instead of three anonymous badges whose meaning lived only in hover `title` text.
- A hit whose `source == "kb"` renders its `source_id` (which is the KB slug — kb documents persist `source_id=slug`, `kb/service.py`) as a same-tab anchor to `/ui/kb/<slug>`, matching the KB surface (`kb/_results.html`).
- Sources without a resolvable UI route (e.g. memory) keep the `source_id` as plain, selectable monospace text — never a dead link.
- Template-only: the `/ui/kb/{slug}` detail route already exists, so nothing new lands on the wire (no OpenAPI regen).

## Test plan

- [x] `ruff check tests/test_ui_retrieval.py` — clean
- [x] `ruff format --check tests/test_ui_retrieval.py` — already formatted
- [x] `pytest tests/test_ui_retrieval.py` — 48 passed (46 pre-existing + 2 new)
- [x] AC1 — `test_diagnostics_labels_provenance_and_links_kb_source_id`: a seeded kb hit's fragment contains `href="/ui/kb/quiesce-snapshots"` on the source-id element.
- [x] AC2 — `test_diagnostics_non_kb_source_id_is_plain_text_never_a_dead_link`: a memory hit's fragment wraps its source_id in no anchor and emits no `/ui/kb/<slug>` href.
- [x] AC3 — `grep -n "Source id" _diagnostics_results.html` shows the label as a visible `<span>` caption (not only a `title=` attribute).
- [x] AC4 — existing diagnostics fragment tests stay green.

## Out of scope

- `/ui/corpus` titles/citations (sibling #2461 / #2462 / #2475) and the shared card-body cluster — edit kept localized to the provenance region so a serial rebase against siblings (#2453 score pills, #2462 Ask view-source) unions cleanly.
- Memory deep-linking (`/ui/memory/{scope}/{slug}`) deferred per the issue's out-of-scope note; the kb link is the load-bearing case.
- Adding URL/title fields to `RetrievalHit` — the substrate is unchanged.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2457
