### PR TITLE
feat(ui): remove raw retrieval score pills from /ui/kb search cards (#2453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,16 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Removed — raw retrieval score pills from search cards (#2453)
+
+- `/ui/kb` search result cards no longer render the raw retrieval score pills
+  (`fused` / `bm25` / `cos`). The near-zero RRF fused values read as "bad" to a
+  non-expert operator even for a top hit, and the score tuple is beta plumbing
+  on an end-user surface. Per-signal score inspection is unaffected — it lives on
+  `/ui/retrieval` Diagnostics (#1888), which renders a strictly richer per-signal
+  score/rank breakdown. No toggle, no bucketed label (both would add a tunable
+  the substrate-minimalism rule rejects).
+
 ### Changed — clamp result-card bodies with expand-on-click (#2456)
 
 - `/ui/retrieval` diagnostics hit cards and `/ui/corpus` cited-chunk cards now

--- a/backend/src/meho_backplane/ui/templates/kb/_results.html
+++ b/backend/src/meho_backplane/ui/templates/kb/_results.html
@@ -21,8 +21,10 @@
 
   Layout:
     * Non-empty query: DaisyUI card-grid of result cards, each showing
-      slug, score pills (fused / BM25 / cosine), preview snippet, and
-      hover-preview trigger + detail link.
+      slug, preview snippet, and hover-preview trigger + detail link.
+      Raw retrieval score pills (fused / BM25 / cosine) were removed
+      (#2453) -- per-signal score inspection lives on /ui/retrieval
+      Diagnostics (_diagnostics_results.html, #1888), not the KB surface.
     * Empty query: table of slug + kind + indexed_at for browsing.
     * Empty state: friendly empty-state card.
 -#}
@@ -56,34 +58,6 @@
                     aria-label="View entry {{ hit.slug }}"
                   >{{ hit.slug }}</a>
                 </h3>
-                {# Score pills #}
-                <div class="flex flex-wrap gap-1 text-xs" aria-label="Relevance scores">
-                  <span
-                    class="badge badge-primary badge-outline"
-                    title="Fused RRF score"
-                    aria-label="Fused score {{ '%.3f' | format(hit.fused_score) }}"
-                  >
-                    fused {{ "%.3f" | format(hit.fused_score) }}
-                  </span>
-                  {% if hit.bm25_score is not none %}
-                    <span
-                      class="badge badge-ghost badge-outline"
-                      title="BM25 lexical score"
-                      aria-label="BM25 score {{ '%.3f' | format(hit.bm25_score) }}"
-                    >
-                      bm25 {{ "%.3f" | format(hit.bm25_score) }}
-                    </span>
-                  {% endif %}
-                  {% if hit.cosine_score is not none %}
-                    <span
-                      class="badge badge-ghost badge-outline"
-                      title="Cosine semantic score"
-                      aria-label="Cosine score {{ '%.4f' | format(hit.cosine_score) }}"
-                    >
-                      cos {{ "%.4f" | format(hit.cosine_score) }}
-                    </span>
-                  {% endif %}
-                </div>
               </div>
               {# Snippet preview #}
               <p class="text-sm opacity-70 line-clamp-2">{{ hit.snippet }}</p>

--- a/backend/tests/test_ui_kb_search.py
+++ b/backend/tests/test_ui_kb_search.py
@@ -352,7 +352,13 @@ def test_kb_index_htmx_returns_fragment_only() -> None:
 
 
 def test_kb_search_post_returns_hits() -> None:
-    """``POST /ui/kb/search`` with a query returns ranked result cards."""
+    """``POST /ui/kb/search`` with a query returns ranked result cards.
+
+    The raw retrieval score pills (fused / BM25 / cosine) were removed
+    from the KB search cards (#2453) -- per-signal score inspection lives
+    on /ui/retrieval Diagnostics, not the end-user KB surface. The cards
+    still render (slug + snippet); the score tuple no longer appears.
+    """
     _seed_tenant(_TENANT_A, "tenant-a")
     session_id = _seed_session_sync(tenant_id=_TENANT_A)
     csrf = _csrf_token(session_id)
@@ -377,16 +383,16 @@ def test_kb_search_post_returns_hits() -> None:
 
     assert response.status_code == 200, response.text
     body = response.text
-    # Both hits rendered.
+    # Both hits rendered as cards.
     assert "vcenter-snapshots" in body
     assert "linux-perf" in body
-    # Score pills.
-    assert "fused" in body
-    assert "0.900" in body
-    # BM25 pill present for first hit only.
-    assert "bm25" in body
-    # Cosine pill present.
-    assert "cos" in body
+    # Score pills are gone: neither the container, the per-signal labels,
+    # nor the formatted score values appear on the KB search cards.
+    assert 'aria-label="Relevance scores"' not in body
+    assert "Fused score" not in body
+    assert "BM25 score" not in body
+    assert "Cosine score" not in body
+    assert "0.900" not in body
 
 
 def test_kb_search_post_empty_query_returns_list() -> None:


### PR DESCRIPTION
## Summary

- Remove the raw retrieval score pills (`fused` / `bm25` / `cos`) from the `/ui/kb` search result cards. Product decision (#2453): the near-zero RRF fused values read as "bad" to a non-expert operator even for a top hit, and the score tuple is beta plumbing exposed on an end-user surface.
- The author/debug need is already served — strictly better — by `/ui/retrieval` Diagnostics (#1888), which renders the full per-signal score/rank breakdown. No toggle and no bucketed "strong/fair/weak" label (both add a per-user tunable / threshold heuristic the substrate-minimalism rule rejects).
- Template-only: the pill block is removed from `kb/_results.html`; the `KbEntrySearchHit` model still carries `fused_score` / `bm25_score` / `cosine_score`, consumed unchanged by the Diagnostics surface.
- Surgical removal — only the score-pill `<div>` is deleted; the header wrapper + title/snippet/preview regions are untouched (clean union with the parallel card-body cluster: #2456 clamp, #2457 provenance, #2462 Ask view-source).

## Test plan

- [x] `uv run pytest tests/test_ui_kb_search.py` — 25 passed. The pinned `test_kb_search_post_returns_hits` now asserts the score pills are **absent** (no `aria-label="Relevance scores"`, no `Fused/BM25/Cosine score` labels, no `0.900` value) while the cards still render (slug + snippet).
- [x] `uv run pytest tests/test_ui_templates.py tests/test_ui_retrieval.py` — 92 passed (StrictUndefined render safety; `/ui/retrieval` Diagnostics breakdown untouched and still green).
- [x] `ruff format --check` + `ruff check` on the changed test — clean.

## Acceptance criteria

- [x] Raw retrieval score pills are gone from the `/ui/kb` search cards (`kb/_results.html` pill block removed).
- [x] The pinned test (`test_kb_search_post_returns_hits`) updated to assert their absence.

## Out of scope

- `/ui/corpus` cited-chunk `score` pill and `/ui/retrieval` Diagnostics breakdown — different surfaces, not this issue; Diagnostics is the deliberate author/debug home for per-signal scores.
- Backend context still passes the scores (harmless; shared model consumed by Diagnostics).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2453
