### PR TITLE
feat(ui): converge list-surface detail navigation (#2463)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed — converge list-surface detail navigation (#2463)
+
+- Every `/ui/*` page-nav list surface now offers the same detail-nav
+  affordance pair — a visibly-styled identity link (`link link-primary`)
+  where the row has an identity cell, plus a trailing `View` button —
+  so an operator never has to guess whether a cell is clickable. Corpus
+  Collections and Conventions gained a `View` button and actions column;
+  the Agents card grid gained a `View` link in `card-actions` rendered
+  for all roles (previously the card-actions held only a `can_write`-gated
+  toggle); the Agent-runs `run_id` cell is now a link to the run detail.
+- Identity-cell links that rendered as plain text until hover
+  (`link link-hover`) are normalised to the visible `link link-primary`
+  styling across Connectors, Memory (active + recently-expired cards),
+  Agents cards, Corpus Collections, and Conventions. Scheduler and
+  agent-grants rows keep their button-only affordance (no natural
+  identity column exists); drawer surfaces and the broadcast wall-monitor
+  row-click idiom are unchanged. The convention is recorded in
+  `docs/codebase/ui.md`.
+
 ### Changed — clamp result-card bodies with expand-on-click (#2456)
 
 - `/ui/retrieval` diagnostics hit cards and `/ui/corpus` cited-chunk cards now

--- a/backend/src/meho_backplane/ui/templates/agents/_cards.html
+++ b/backend/src/meho_backplane/ui/templates/agents/_cards.html
@@ -27,7 +27,7 @@
               <div class="flex items-start justify-between gap-2">
                 <a
                   href="/ui/agents/{{ agent.name | urlencode }}"
-                  class="link link-hover font-mono font-semibold break-all"
+                  class="link link-primary font-mono font-semibold break-all"
                 >
                   {{ agent.name }}
                 </a>
@@ -74,15 +74,18 @@
                 updated {{ agent.updated_at.isoformat() }}
               </div>
 
-              {# One-click enable / disable straight from the card, so a
-                 tenant_admin never has to open the detail view to flip an
-                 agent's state (#2347). It POSTs the flipped ``enabled`` to
-                 the same ``/ui/agents/{name}/toggle`` route the detail view
-                 uses; the 204 + ``HX-Redirect`` reloads the list with the
-                 new pill. Rendered for tenant_admins only (the top-level
-                 ``can_write``); the route re-checks the role server-side. #}
-              {% if can_write %}
-                <div class="card-actions justify-end pt-1">
+              {# Card actions. The View link drives page-nav to the per-agent
+                 detail view and is rendered for every role, matching the
+                 list-surface convention (visible identity link + View
+                 button). The one-click enable / disable toggle lets a
+                 tenant_admin flip an agent's state without opening the
+                 detail view (#2347): it POSTs the flipped ``enabled`` to the
+                 same ``/ui/agents/{name}/toggle`` route the detail view uses;
+                 the 204 + ``HX-Redirect`` reloads the list with the new pill.
+                 The toggle is gated on the top-level ``can_write`` (the route
+                 re-checks the role server-side); the View link is not. #}
+              <div class="card-actions justify-end pt-1">
+                {% if can_write %}
                   <button
                     type="button"
                     class="btn btn-xs btn-ghost"
@@ -95,8 +98,15 @@
                   >
                     {% if agent.enabled %}Disable{% else %}Enable{% endif %}
                   </button>
-                </div>
-              {% endif %}
+                {% endif %}
+                <a
+                  href="/ui/agents/{{ agent.name | urlencode }}"
+                  class="btn btn-xs btn-ghost"
+                  aria-label="View agent {{ agent.name }}"
+                >
+                  View
+                </a>
+              </div>
             </div>
           </article>
         </li>

--- a/backend/src/meho_backplane/ui/templates/agents/runs/_table_rows.html
+++ b/backend/src/meho_backplane/ui/templates/agents/runs/_table_rows.html
@@ -44,7 +44,13 @@
   {% if rows %}
     {% for row in rows %}
       <tr data-run-id="{{ row.run_id }}">
-        <td class="font-mono text-xs">{{ row.run_id[:8] }}…</td>
+        <td class="font-mono text-xs">
+          <a
+            href="/ui/agents/runs/{{ row.run_id }}"
+            class="link link-primary"
+            aria-label="View run {{ row.run_id }}"
+          >{{ row.run_id[:8] }}…</a>
+        </td>
         <td>
           <span class="badge {{ row.status_badge }} badge-sm">{{ row.status }}</span>
           {% if row.is_awaiting_approval %}

--- a/backend/src/meho_backplane/ui/templates/connectors/_table_rows.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_table_rows.html
@@ -44,7 +44,7 @@
         <td>
           <a
             href="/ui/connectors/{{ row.name | urlencode }}"
-            class="link link-hover font-mono"
+            class="link link-primary font-mono"
             aria-label="View detail for {{ row.name }}"
           >
             {{ row.name }}

--- a/backend/src/meho_backplane/ui/templates/conventions/_table.html
+++ b/backend/src/meho_backplane/ui/templates/conventions/_table.html
@@ -30,6 +30,7 @@
             <th scope="col">Title</th>
             <th scope="col">Kind</th>
             <th scope="col" class="text-right">Priority</th>
+            <th scope="col" class="sr-only">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -38,7 +39,7 @@
               <td class="font-mono break-all">
                 <a
                   href="/ui/conventions/{{ entry.slug | urlencode }}"
-                  class="link link-hover"
+                  class="link link-primary"
                   data-slug="{{ entry.slug }}"
                 >
                   {{ entry.slug }}
@@ -51,6 +52,15 @@
                 </span>
               </td>
               <td class="text-right font-mono">{{ entry.priority }}</td>
+              <td>
+                <a
+                  href="/ui/conventions/{{ entry.slug | urlencode }}"
+                  class="btn btn-ghost btn-xs"
+                  aria-label="View convention {{ entry.slug }}"
+                >
+                  View
+                </a>
+              </td>
             </tr>
           {% endfor %}
         </tbody>

--- a/backend/src/meho_backplane/ui/templates/corpus/_collections_table.html
+++ b/backend/src/meho_backplane/ui/templates/corpus/_collections_table.html
@@ -33,7 +33,7 @@
              readiness card + re-probe + enable/disable. #}
           <a
             href="/ui/corpus/collections/{{ row.collection_key | urlencode }}"
-            class="link link-hover"
+            class="link link-primary"
           >{{ row.collection_key }}</a>
         </td>
         <td>{{ row.vendor }}</td>
@@ -73,11 +73,20 @@
             <span class="opacity-50">never</span>
           {% endif %}
         </td>
+        <td>
+          <a
+            href="/ui/corpus/collections/{{ row.collection_key | urlencode }}"
+            class="btn btn-ghost btn-xs"
+            aria-label="View collection {{ row.collection_key }}"
+          >
+            View
+          </a>
+        </td>
       </tr>
     {% endfor %}
   {% else %}
     <tr>
-      <td colspan="6" class="text-center text-sm opacity-60 py-6">
+      <td colspan="7" class="text-center text-sm opacity-60 py-6">
         No collections registered for this tenant yet.
       </td>
     </tr>

--- a/backend/src/meho_backplane/ui/templates/corpus/collections.html
+++ b/backend/src/meho_backplane/ui/templates/corpus/collections.html
@@ -91,6 +91,7 @@
               <th>Status</th>
               <th>Docs</th>
               <th>Last ingested</th>
+              <th class="sr-only">Actions</th>
             </tr>
           </thead>
           {% include "corpus/_collections_table.html" %}

--- a/backend/src/meho_backplane/ui/templates/memory/_cards.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_cards.html
@@ -143,7 +143,7 @@
                 <h2 class="card-title text-base font-mono break-all">
                   <a
                     href="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}"
-                    class="link link-hover"
+                    class="link link-primary"
                   >{{ entry.slug }}</a>
                 </h2>
               </div>
@@ -234,7 +234,7 @@
                   <h3 class="card-title text-sm font-mono break-all">
                     <a
                       href="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}"
-                      class="link link-hover"
+                      class="link link-primary"
                     >{{ entry.slug }}</a>
                   </h3>
                 </div>

--- a/backend/tests/test_ui_agent_runs.py
+++ b/backend/tests/test_ui_agent_runs.py
@@ -262,6 +262,25 @@ def test_list_renders_run_row_for_operator() -> None:
     assert "toolset" not in body
 
 
+def test_list_run_id_cell_is_visible_identity_link() -> None:
+    """The run_id cell is a visible link to the run detail (#2463).
+
+    The identity cell (previously plain text) now links to the same run
+    URL as the trailing View button, styled ``link link-primary`` so the
+    cell is visibly clickable -- the page-nav list-surface convention.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    rid = _seed_run(tenant_id=_TENANT_A, status_value=AgentRunStatus.SUCCEEDED.value)
+    client = _client_for_tenant(_TENANT_A)
+    response = client.get("/ui/agents/runs")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Visible identity link on the run_id cell.
+    assert 'class="link link-primary"' in body
+    # Two hrefs per row point at the same run URL: the identity link + View.
+    assert body.count(f'href="/ui/agents/runs/{rid}"') == 2
+
+
 def test_list_renders_agent_name_column() -> None:
     """A run with a live definition shows the agent name in its row (#2472)."""
     _seed_tenant(_TENANT_A, "tenant-a")

--- a/backend/tests/test_ui_agents.py
+++ b/backend/tests/test_ui_agents.py
@@ -478,6 +478,37 @@ def test_list_card_hides_toggle_for_operator() -> None:
     assert "/ui/agents/on-agent/toggle" not in response.text
 
 
+def test_list_card_carries_view_link_and_visible_identity_for_operator() -> None:
+    """Each card offers the converged detail-nav pair, for every role (#2463).
+
+    The name heading is a visible ``link link-primary`` (not the invisible
+    ``link link-hover``) to the detail page, and ``card-actions`` carries a
+    ``View`` link -- rendered even for a non-admin operator (outside the
+    ``can_write`` toggle guard) so the affordance never depends on write
+    privileges.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_agent(tenant_id=_TENANT_A, name="on-agent", enabled=True)
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _operator_session(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/agents")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    # Visible identity link on the name heading (never the hover-only style).
+    assert 'class="link link-primary font-mono font-semibold break-all"' in body
+    assert "link link-hover" not in body
+    # A View link in card-actions to the detail page -- rendered for the
+    # operator despite the toggle being hidden (no write privileges).
+    assert 'data-action="toggle"' not in body  # toggle stays admin-only
+    assert 'aria-label="View agent on-agent"' in body
+    assert 'href="/ui/agents/on-agent"' in body
+
+
 # ---------------------------------------------------------------------------
 # Detail view
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_connectors_view.py
+++ b/backend/tests/test_ui_connectors_view.py
@@ -526,6 +526,29 @@ def test_list_full_page_renders_seeded_targets() -> None:
     assert CSRF_COOKIE_NAME in response.cookies
 
 
+def test_list_row_identity_cell_is_visible_link() -> None:
+    """The target-name cell links to the detail with visible styling (#2463).
+
+    The identity cell uses ``link link-primary`` (not the hover-only
+    ``link link-hover`` that rendered as plain text), matching the trailing
+    View button's target -- the page-nav list-surface convention.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="vmware-prod", product="vmware")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Visible identity link on the target-name cell (the row's identity
+    # cell no longer uses the hover-only style; the sort-header controls
+    # keep link-hover and are out of scope).
+    assert 'class="link link-primary font-mono"' in body
+    # Both the identity link and the trailing View button hit the detail URL.
+    assert body.count('href="/ui/connectors/vmware-prod"') == 2
+
+
 def test_list_handles_empty_inventory() -> None:
     """An empty tenant renders the "no targets" empty-state row."""
     _seed_tenant(_TENANT_A, "tenant-a")

--- a/backend/tests/test_ui_conventions_list.py
+++ b/backend/tests/test_ui_conventions_list.py
@@ -374,6 +374,42 @@ def test_list_kind_filter_narrows_table_but_banner_reflects_operational() -> Non
     assert 'data-dropped-slug="op-low"' in body
 
 
+def test_row_carries_visible_identity_link_and_view_button() -> None:
+    """Each convention row offers the converged detail-nav pair (#2463).
+
+    The slug cell links to the detail page with the visible
+    ``link link-primary`` styling (not the invisible ``link link-hover``),
+    and a trailing actions column carries a ``View`` button to the same
+    ``/ui/conventions/<slug>`` URL -- the page-nav list convention.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_convention(
+        tenant_id=_TENANT_A,
+        slug="confirm-first",
+        title="Confirm before applying",
+        body="Always confirm before applying a destructive change.",
+        kind=ConventionKind.OPERATIONAL,
+        priority=10,
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/conventions")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Visible identity link (never the hover-only styling).
+    assert 'class="link link-primary"' in body
+    assert "link link-hover" not in body
+    assert 'href="/ui/conventions/confirm-first"' in body
+    # Trailing View button to the same detail URL + its header cell.
+    assert 'class="btn btn-ghost btn-xs"' in body
+    assert 'aria-label="View convention confirm-first"' in body
+    assert 'class="sr-only">Actions</th>' in body
+
+
 def test_list_invalid_kind_returns_422() -> None:
     """A typoed kind query value 422s rather than collapsing to 'all'."""
     _seed_tenant(_TENANT_A, "tenant-a")

--- a/backend/tests/test_ui_corpus_collections_table.py
+++ b/backend/tests/test_ui_corpus_collections_table.py
@@ -300,6 +300,39 @@ def test_table_lists_unentitled_rows() -> None:
     assert 'hx-get="/ui/corpus/collections/register"' in body
 
 
+def test_row_carries_visible_identity_link_and_view_button() -> None:
+    """Each collection row offers the converged detail-nav pair (#2463).
+
+    The identity cell links to the detail page with the visible
+    ``link link-primary`` styling (not the invisible ``link link-hover``),
+    and the trailing actions column carries a ``View`` button to the same
+    URL -- the page-nav list-surface convention.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_collection(collection_key="vmware", tenant_id=_TENANT_A)
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/corpus/collections")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Visible identity link (never the hover-only styling).
+    assert 'class="link link-primary"' in body
+    assert "link link-hover" not in body
+    assert 'href="/ui/corpus/collections/vmware"' in body
+    # Trailing View button to the same detail URL + its header cell.
+    assert 'class="btn btn-ghost btn-xs"' in body
+    assert 'aria-label="View collection vmware"' in body
+    assert "View" in body
+    assert 'class="sr-only">Actions</th>' in body
+
+
 def test_table_renders_status_pill_for_each_lifecycle_state() -> None:
     """The status column renders a pill for each lifecycle state."""
     _seed_tenant(_TENANT_A, "tenant-a")

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -38,6 +38,38 @@ Locked decisions:
   (BFF) with `HttpOnly; Secure; SameSite=Strict` session cookie;
   tokens stay server-side.
 
+## List-surface detail-navigation convention (#2463)
+
+Every `/ui/*` **page-nav list surface** (a table or card grid whose rows
+navigate to a full-page detail view) offers the same detail-nav
+affordance pair, so an operator never has to guess whether a cell is
+clickable:
+
+- **Visible identity link.** Where the row has a natural identity cell
+  (slug / name / key / run_id), that cell is an `<a>` to the detail page
+  styled `link link-primary` — visibly coloured, **not** `link
+  link-hover` (which renders as plain text until hover, hiding the
+  affordance). Conforming exemplars: `kb/_results.html`,
+  `runbooks/_list.html`.
+- **View button.** A trailing actions column carries an
+  `<a class="btn btn-ghost btn-xs" aria-label="View …">View</a>` to the
+  same detail URL — in `card-actions` for card grids (e.g.
+  `memory/_cards.html`), rendered for **all** roles, never inside a
+  `can_write` guard.
+
+Sanctioned exceptions:
+
+- **Button-only, no identity column.** `/ui/scheduler` and
+  `/ui/agents/grants` carry no natural identity cell (the id lives only
+  in `data-*` attributes and the View href); their View button alone
+  satisfies the convention. Do **not** add a synthetic UUID column.
+- **Drawer lists.** Surfaces whose row detail opens an in-page drawer
+  rather than a full page (topology, audit, approvals history,
+  operations, connector registry Review, keycloak clients) converge on
+  an explicit button and are out of this convention's scope.
+- **Broadcast wall.** `broadcast/_event_row.html`'s whole-row click is a
+  deliberate wall-monitor idiom and stays.
+
 ## Key types
 
 | Module | Purpose |


### PR DESCRIPTION
## Summary

- Converges the row→detail navigation affordance across **every `/ui/*`
  page-nav list surface** onto the dominant convention: a **visibly-styled
  identity link** (`link link-primary`) on the identity cell **plus** a
  trailing **View button**. Before this, three patterns coexisted
  (identity-link + View, View-only, identity-only) and several identity
  cells used `link link-hover`, which renders as plain text until hover so
  operators didn't realise the cell was clickable.
- Corpus Collections and Conventions gained a `View` button + actions
  column; the Agents card grid gained a `View` link in `card-actions`
  rendered for **all** roles (previously `card-actions` held only the
  `can_write`-gated enable/disable toggle); the Agent-runs `run_id` cell is
  now a link to the run detail (two hrefs per row to the same URL).
- Hover-only identity styling normalised to `link link-primary` on
  Connectors, Memory (active + recently-expired cards), Agents cards,
  Corpus Collections, and Conventions.
- Scheduler and agent-grants rows are deliberately **unchanged** — they
  carry no natural identity column, so their View button alone satisfies
  the convention (adding a synthetic UUID column is explicitly out of
  scope). Drawer surfaces and the broadcast wall-monitor row-click idiom
  are untouched. The sanctioned patterns are recorded in
  `docs/codebase/ui.md`.

## Test plan

- [x] `pytest` — 145 passed across the 6 named UI suites
  (`test_ui_corpus_collections_table`, `test_ui_conventions_list`,
  `test_ui_agents`, `test_ui_agent_runs`, `test_ui_connectors_view`,
  `test_ui_memory_list`), each extended with a converged-affordance
  assertion (visible identity link + View affordance per surface).
- [x] `ruff format --check` + `ruff check` on the touched test files — clean.
- [x] code-quality `--diff` gate — clean.
- [x] AC1 grep: no `link link-hover` remains on the five identity-cell
  templates.
- [x] AC2: `grep -c View corpus/_collections_table.html` = 2, actions `<th>`
  added to `corpus/collections.html` + `conventions/_table.html`.
- [x] AC3: `scheduler/_table_rows.html` and `agents/grants/_rows.html`
  untouched (verified by diff).
- [x] AC5: row-nav convention note added to `docs/codebase/ui.md`.

## Out of scope

- `/ui/corpus` Ask-tab citation clickability (#2462) — sibling task, card
  surface.
- Score pills / result-card work (#2453, #2456) — result-card templates,
  not page-nav list rows.
- Scheduler / agent-grants synthetic identity column; drawer surfaces;
  broadcast wall row-click.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2463
