### PR TITLE
fix(connectors): mount vmware vmomi typed reads on VI-JSON /sdk/vim25/{release} (#2466)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,25 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — vmomi typed reads on VI-JSON base for vCenter 8.0.x (#2466)
+
+- The vmware typed reads that issue a vmomi (VI-JSON) method —
+  `RetrievePropertiesEx` (behind `vmware.host.usage`,
+  `vmware.host.network_uplinks`, `vmware.vm.info`, `vmware.object.collect`,
+  `vmware.tasks.recent`), `VsanQueryVcClusterHealthSummary` (behind
+  `vmware.host.vsan_health`), and the composite `QueryEvents` /
+  `QueryAvailablePerfMetric` / `QueryPerf` sub-ops — were mounted on the
+  vSphere Automation API (`/api`), so they returned HTTP 404 on vCenter
+  8.0.x (observed on a live 8.0.3 host in the v0.21.0 dogfood). They now
+  mount on the documented VI-JSON base `/sdk/vim25/{release}` — the
+  release-versioned endpoint vCenter serves since 8.0U1 — with `{release}`
+  derived per target from `GET /api/about` (e.g. `8.0.3` → `8.0.3.0`),
+  resolved once and cached. On a 404 there the read falls back once to the
+  `/api`-mounted form (the undocumented accommodation the 9.0.2 fleet
+  serves); when both 404 the degradation note names both attempted mounts
+  and the vCenter version instead of a bare 404. Legacy/vcsim targets
+  (session on `/rest`) are unchanged — no VI-JSON attempt (#2466).
+
 ### Added — view-source affordance on /ui/corpus Ask citations (#2462)
 
 - Every `/ui/corpus` citation is now openable. A citation whose source has no

--- a/backend/src/meho_backplane/connectors/vmware_rest/_mount.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/_mount.py
@@ -38,6 +38,18 @@ API_MOUNT_MODERN = "/api"
 API_MOUNT_LEGACY = "/rest"
 _KNOWN_API_MOUNT_PREFIXES = (f"{API_MOUNT_MODERN}/", f"{API_MOUNT_LEGACY}/")
 
+# Broadcom documents the VI-JSON (vmomi-over-JSON) wire base as
+# ``/sdk/vim25/{release}/{MoType}/{moId}/{method}`` — release-versioned,
+# available since vCenter 8.0U1 and unchanged on 9.x (vSphere Web
+# Services SDK programming guide, "Building JSON Request URLs"). This is
+# a *different* base from the vSphere Automation API mounts above: the
+# typed vmomi reads (``RetrievePropertiesEx``,
+# ``VsanQueryVcClusterHealthSummary``, ``QueryEvents``, ``QueryPerf`` …)
+# are served here, **not** under ``/api`` — an ``/api``-mounted vmomi
+# method 404s on vCenter 8.0.x (the ``/api`` form is an undocumented 9.x
+# accommodation, kept only as a fallback). See :func:`vmomi_mounted_path`.
+VI_JSON_MOUNT_PREFIX = "/sdk/vim25"
+
 # vSphere's list FilterSpec query params carry a ``filter.`` prefix on the
 # legacy ``/rest`` mount (``filter.datastores``, ``filter.hosts``, ...) but
 # are addressed by their bare name on the modern ``/api`` mount
@@ -49,9 +61,12 @@ __all__ = [
     "API_MOUNT_MODERN",
     "SESSION_PATH_LEGACY",
     "SESSION_PATH_MODERN",
+    "VI_JSON_MOUNT_PREFIX",
     "adapt_filter_params",
     "api_mount_for_session_path",
     "mounted_path",
+    "vmomi_mounted_path",
+    "vmomi_release_from_version",
 ]
 
 
@@ -115,3 +130,47 @@ def mounted_path(session_path: str, descriptor_path: str) -> str:
     mount = api_mount_for_session_path(session_path)
     normalised = descriptor_path if descriptor_path.startswith("/") else f"/{descriptor_path}"
     return f"{mount}{normalised}"
+
+
+def vmomi_release_from_version(version: str | None) -> str | None:
+    """Normalise a vCenter ``about.version`` to the VI-JSON ``{release}`` segment.
+
+    Broadcom's ``/sdk/vim25/{release}/...`` base takes a four-part
+    dotted-decimal release (``8.0.2.0``, ``9.0.0.0``); ``GET /api/about``
+    reports the three-part ``version`` (``8.0.3``). Pad the leading
+    numeric components to four with ``.0`` so ``8.0.3`` → ``8.0.3.0`` (an
+    already-four-part value passes through, a longer one is truncated).
+
+    Returns ``None`` when *version* is empty or has no leading numeric
+    component, so the caller falls back to the ``/api``-mounted vmomi form
+    rather than emitting a malformed ``/sdk/vim25//...`` path.
+    """
+    if not version:
+        return None
+    numeric: list[str] = []
+    for part in version.strip().split("."):
+        if part.isdigit():
+            numeric.append(part)
+        else:
+            break
+    if not numeric:
+        return None
+    while len(numeric) < 4:
+        numeric.append("0")
+    return ".".join(numeric[:4])
+
+
+def vmomi_mounted_path(release: str, descriptor_path: str) -> str:
+    """Mount a spec-relative vmomi method *descriptor_path* on the VI-JSON base.
+
+    Prefixes ``/{MoType}/{moId}/{method}`` with
+    ``/sdk/vim25/{release}`` — the documented VI-JSON wire base
+    (:data:`VI_JSON_MOUNT_PREFIX`) — so a typed vmomi read reaches the
+    endpoint vCenter 8.0.x actually serves instead of 404ing on the
+    Automation ``/api`` mount. *release* is the four-part segment from
+    :func:`vmomi_release_from_version`; *descriptor_path* is normalised to
+    a leading slash the same way :func:`mounted_path` normalises the
+    Automation form.
+    """
+    normalised = descriptor_path if descriptor_path.startswith("/") else f"/{descriptor_path}"
+    return f"{VI_JSON_MOUNT_PREFIX}/{release}{normalised}"

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -256,6 +256,15 @@ async def _read_sub_op(
     vi-json POST method-argument object (moid excluded -- it rides the
     path).
 
+    ``GET`` legs are vSphere Automation ``/vcenter/*`` paths, mounted on
+    ``/api`` / ``/rest`` via :meth:`VmwareRestConnector.mount_op_path`.
+    ``POST`` legs are vmomi (VI-JSON) methods (``QueryEvents`` /
+    ``QueryAvailablePerfMetric`` / ``QueryPerf``); they route through
+    :meth:`VmwareRestConnector._post_vmomi_json`, which mounts them on the
+    documented VI-JSON base ``/sdk/vim25/{release}`` (single ``/api``
+    fallback) so they resolve on vCenter 8.0.x instead of 404ing (#2466) —
+    no vmomi path reaches the bare ``/api`` mount.
+
     Returns the raw parsed JSON (``value``-envelope handling stays with
     the caller's :func:`_unwrap_value`). Transport / status failures raise
     :exc:`httpx.HTTPError`; load-bearing callers let it propagate (the
@@ -265,11 +274,11 @@ async def _read_sub_op(
     """
     method, _, path_template = op_id.partition(":")
     path = path_template.format(**path_params) if path_params else path_template
-    mounted = await connector.mount_op_path(target, path, operator)
     if method == "GET":
+        mounted = await connector.mount_op_path(target, path, operator)
         params = await connector.adapt_op_query(target, query, operator)
         return await connector._get_json(target, mounted, operator=operator, params=params)
-    return await connector._post_json(target, mounted, operator=operator, json=body)
+    return await connector._post_vmomi_json(target, path, operator=operator, json=body)
 
 
 async def cluster_drs_recommendations_composite(

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing >600-line connector (session
+# lifecycle + per-op mount hooks + 6 typed-op delegators accreted across
+# #2257/#2258/#2300/#2329/#2396/#2398); this change only adds the VI-JSON
+# vmomi transport seam (#2466). Splitting the module by responsibility is
+# separate refactor work, out of scope for a mount-path bug fix.
 
 """VmwareRestConnector — hand-rolled HttpConnector subclass for vSphere REST.
 
@@ -103,11 +108,14 @@ from meho_backplane.connectors.schemas import (
     ProbeResult,
 )
 from meho_backplane.connectors.vmware_rest._mount import (
+    API_MOUNT_LEGACY,
     SESSION_PATH_LEGACY,
     SESSION_PATH_MODERN,
     adapt_filter_params,
     api_mount_for_session_path,
     mounted_path,
+    vmomi_mounted_path,
+    vmomi_release_from_version,
 )
 from meho_backplane.connectors.vmware_rest.session import (
     VsphereSessionLoader,
@@ -274,6 +282,14 @@ class VmwareRestConnector(HttpConnector):
         # by-IP appliance that pins its cert to an FQDN is revoked over
         # the same SNI-corrected handshake the establish call used.
         self._session_extensions: dict[tuple[str, str], dict[str, Any]] = {}
+        # Per-target ``about.version`` (``GET /api/about``), resolved once
+        # and cached so the VI-JSON ``{release}`` segment
+        # (:meth:`_post_vmomi_json`) costs one probe per target rather than
+        # one per vmomi read. Keyed on the same tenant-unique tuple as
+        # ``_session_tokens``. ``None`` records "probe failed / no version"
+        # so the vmomi path falls back to the ``/api`` mount without
+        # re-probing on every call.
+        self._about_versions: dict[tuple[str, str], str | None] = {}
         self._session_lock = asyncio.Lock()
         self._session_loader: VsphereSessionLoader = (
             session_loader if session_loader is not None else load_session_credentials_from_vault
@@ -371,6 +387,103 @@ class VmwareRestConnector(HttpConnector):
         await self._session_token(target, operator)
         session_path = self._session_paths.get(target_cache_key(target), SESSION_PATH_MODERN)
         return adapt_filter_params(api_mount_for_session_path(session_path), query)
+
+    async def _post_vmomi_json(
+        self,
+        target: VsphereTargetLike,
+        vmomi_path: str,
+        *,
+        operator: Operator,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """POST a typed vmomi (VI-JSON) method on the documented ``/sdk/vim25`` base.
+
+        The vmomi method paths (``/{MoType}/{moId}/{method}`` —
+        ``RetrievePropertiesEx``, ``VsanQueryVcClusterHealthSummary``,
+        ``QueryEvents``, ``QueryPerf`` …) are served by vCenter under the
+        release-versioned VI-JSON base ``/sdk/vim25/{release}`` (Broadcom
+        Web Services SDK guide, "Building JSON Request URLs"), **not** the
+        vSphere Automation ``/api`` mount that :meth:`mount_op_path`
+        resolves for ``/vcenter/*`` paths. Mounting a vmomi method on
+        ``/api`` 404s on vCenter 8.0.x — the ``/api``-served form works
+        only on the 9.0.2 fleet as an undocumented accommodation, so it is
+        kept solely as a single fallback (#2466).
+
+        Resolution, off the target's established session:
+
+        * **legacy / vcsim** (session minted at ``/rest/...``): VI-JSON is
+          not served, so the vmomi method mounts on the legacy ``/rest``
+          form via :func:`._mount.mounted_path` — the pre-#2466 behaviour,
+          unchanged, so the vcsim integration lane stays green.
+        * **modern** (session minted at ``/api/session``): derive
+          ``{release}`` from ``GET /api/about`` (:meth:`_about_version`)
+          and POST ``/sdk/vim25/{release}{vmomi_path}``. On HTTP 404 there
+          (a deployment that does not serve VI-JSON at the derived
+          release), fall back **once** to the ``/api``-mounted form. When
+          the release can't be derived, skip straight to the ``/api`` form.
+
+        When both mounts 404, raises :exc:`RuntimeError` naming both
+        attempted URLs and the vCenter version, so a best-effort caller's
+        ``read_note`` is self-explanatory (``vi-json unavailable: POST
+        /sdk/vim25/8.0.3.0/... and /api/... both 404 on vCenter 8.0.3``)
+        rather than a bare 404. Non-404 failures (401 / 403 / 5xx /
+        transport) propagate unchanged — those are not "this mount isn't
+        served".
+        """
+        await self._session_token(target, operator)
+        session_path = self._session_paths.get(target_cache_key(target), SESSION_PATH_MODERN)
+        if api_mount_for_session_path(session_path) == API_MOUNT_LEGACY:
+            legacy_path = mounted_path(session_path, vmomi_path)
+            return await self._post_json(target, legacy_path, operator=operator, json=json)
+
+        api_path = mounted_path(session_path, vmomi_path)
+        version = await self._about_version(target, operator)
+        release = vmomi_release_from_version(version)
+        if release is None:
+            return await self._post_json(target, api_path, operator=operator, json=json)
+
+        vijson_path = vmomi_mounted_path(release, vmomi_path)
+        try:
+            return await self._post_json(target, vijson_path, operator=operator, json=json)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 404:
+                raise
+        # Single fallback to the /api-mounted vmomi form (the observed 9.x
+        # accommodation); if that also 404s, surface both attempts.
+        try:
+            return await self._post_json(target, api_path, operator=operator, json=json)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise RuntimeError(
+                    f"vi-json unavailable: POST {vijson_path} and {api_path} both 404 "
+                    f"on vCenter {version}"
+                ) from exc
+            raise
+
+    async def _about_version(self, target: VsphereTargetLike, operator: Operator) -> str | None:
+        """Return *target*'s ``about.version`` string, resolved once and cached.
+
+        Reads ``GET /api/about`` (the same probe :meth:`fingerprint` uses)
+        to obtain the ``version`` field that drives the VI-JSON
+        ``{release}`` segment in :meth:`_post_vmomi_json`. Cached per
+        tenant-unique ``target_cache_key`` so repeated vmomi reads share
+        one probe. Any transport / status / shape failure caches and
+        returns ``None`` — the vmomi caller then falls back to the ``/api``
+        mount rather than failing, and the failed probe is not retried on
+        every subsequent read.
+        """
+        cache_key = target_cache_key(target)
+        if cache_key in self._about_versions:
+            return self._about_versions[cache_key]
+        try:
+            payload = await self._get_json(target, "/api/about", operator=operator)
+        except (httpx.HTTPError, OSError, RuntimeError):
+            self._about_versions[cache_key] = None
+            return None
+        version = payload.get("version") if isinstance(payload, dict) else None
+        resolved = version if isinstance(version, str) and version else None
+        self._about_versions[cache_key] = resolved
+        return resolved
 
     async def _session_token(self, target: VsphereTargetLike, operator: Operator) -> str:
         """Return the cached session token for *target*, establishing one on first use.
@@ -539,6 +652,10 @@ class VmwareRestConnector(HttpConnector):
             self._session_tokens.pop(cache_key, None)
             self._session_paths.pop(cache_key, None)
             self._session_extensions.pop(cache_key, None)
+            # Drop the cached about-version too so an auth-recovery cycle
+            # re-probes ``GET /api/about`` — this also un-poisons a slot
+            # where an earlier probe cached ``None`` transiently.
+            self._about_versions.pop(cache_key, None)
 
     async def fingerprint(
         self,
@@ -886,6 +1003,7 @@ class VmwareRestConnector(HttpConnector):
             self._session_tokens.clear()
             self._session_paths.clear()
             self._session_extensions.clear()
+            self._about_versions.clear()
         for cache_key, token in tokens.items():
             # ``_session_tokens`` is keyed on the tenant-unique
             # ``(tenant_id, target.id)`` tuple, while the shared

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops.py
@@ -266,7 +266,6 @@ async def _read_host_usage_row(
     connector: VmwareRestConnector,
     operator: Operator,
     target: VsphereTargetLike,
-    props_path: str,
     host_moid: str,
     host_name: Any,
 ) -> dict[str, Any]:
@@ -282,9 +281,9 @@ async def _read_host_usage_row(
     """
     row: dict[str, Any] = {"id": host_moid, "name": host_name}
     try:
-        props_result = await connector._post_json(
+        props_result = await connector._post_vmomi_json(
             target,
-            props_path,
+            _RETRIEVE_PROPERTIES_PATH,
             operator=operator,
             json=build_host_usage_retrieve_params(host_moid),
         )
@@ -320,14 +319,16 @@ async def host_usage_impl(
        failure here raises and the dispatcher records it as a
        ``connector_error`` for the whole op.
     2. Per host: ``POST .../PropertyCollector/propertyCollector/RetrievePropertiesEx``
-       (mounted) reading ``summary.quickStats`` (CPU+memory load),
+       reading ``summary.quickStats`` (CPU+memory load),
        ``summary.hardware`` (capacity totals), and
        ``runtime.inMaintenanceMode``. Best-effort per host.
 
-    Both calls route through :meth:`VmwareRestConnector.mount_op_path`, so
-    the op lands on the ``/api`` (modern) or ``/rest`` (legacy / vcsim)
-    mount the target's session selected -- the same modern->legacy 404
-    fallback the session establish discovered.
+    The listing GET routes through
+    :meth:`VmwareRestConnector.mount_op_path` (``/api`` modern / ``/rest``
+    legacy). The vmomi ``RetrievePropertiesEx`` read routes through
+    :meth:`VmwareRestConnector._post_vmomi_json`, which mounts it on the
+    documented VI-JSON base ``/sdk/vim25/{release}`` (with a single ``/api``
+    fallback) so it resolves on vCenter 8.0.x instead of 404ing (#2466).
 
     Returns ``{"hosts": [{"id", "name", "quick_stats", "hardware",
     "in_maintenance_mode"}, ...]}``.
@@ -346,10 +347,6 @@ async def host_usage_impl(
             f"{_LIST_HOSTS_PATH!r}, got {type(entries).__name__}"
         )
 
-    # Resolve the mounted RetrievePropertiesEx path once -- host-independent
-    # and idempotent (the session establish it triggers is cached).
-    props_path = await connector.mount_op_path(target, _RETRIEVE_PROPERTIES_PATH, operator)
-
     hosts: list[dict[str, Any]] = []
     for entry in entries:
         if not isinstance(entry, dict):
@@ -360,9 +357,7 @@ async def host_usage_impl(
             # upstream malformation -- skip rather than abort.
             continue
         hosts.append(
-            await _read_host_usage_row(
-                connector, operator, target, props_path, host_moid, entry.get("name")
-            )
+            await _read_host_usage_row(connector, operator, target, host_moid, entry.get("name"))
         )
     _log.info("vmware_host_usage_read", target=target.name, host_count=len(hosts))
     return {"hosts": hosts}

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_network_uplinks.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_network_uplinks.py
@@ -184,7 +184,6 @@ async def _read_host_uplink_row(
     connector: VmwareRestConnector,
     operator: Operator,
     target: VsphereTargetLike,
-    props_path: str,
     host_moid: str,
     host_name: Any,
 ) -> dict[str, Any]:
@@ -198,9 +197,9 @@ async def _read_host_uplink_row(
     """
     row: dict[str, Any] = {"id": host_moid, "name": host_name}
     try:
-        props_result = await connector._post_json(
+        props_result = await connector._post_vmomi_json(
             target,
-            props_path,
+            _RETRIEVE_PROPERTIES_PATH,
             operator=operator,
             json=build_host_network_uplinks_retrieve_params(host_moid),
         )
@@ -236,13 +235,16 @@ async def host_network_uplinks_impl(
        failure here raises and the dispatcher records it as a
        ``connector_error`` for the whole op.
     2. Per host: ``POST .../PropertyCollector/propertyCollector/RetrievePropertiesEx``
-       (mounted) requesting ``config.network.pnic`` +
+       requesting ``config.network.pnic`` +
        ``config.network.proxySwitch`` on that single HostSystem object.
        Best-effort per host.
 
-    Both calls route through :meth:`VmwareRestConnector.mount_op_path`, so
-    the op lands on the ``/api`` (modern) or ``/rest`` (legacy / vcsim)
-    mount the target's session selected.
+    The listing GET routes through
+    :meth:`VmwareRestConnector.mount_op_path` (``/api`` modern / ``/rest``
+    legacy). The vmomi ``RetrievePropertiesEx`` read routes through
+    :meth:`VmwareRestConnector._post_vmomi_json`, which mounts it on the
+    documented VI-JSON base ``/sdk/vim25/{release}`` (with a single ``/api``
+    fallback) so it resolves on vCenter 8.0.x instead of 404ing (#2466).
 
     Returns ``{"hosts": [{"id", "name", "pnics", "proxy_switches"}, ...]}``.
     """
@@ -260,10 +262,6 @@ async def host_network_uplinks_impl(
             f"{_LIST_HOSTS_PATH!r}, got {type(entries).__name__}"
         )
 
-    # Resolve the mounted RetrievePropertiesEx path once -- host-independent
-    # and idempotent (the session establish it triggers is cached).
-    props_path = await connector.mount_op_path(target, _RETRIEVE_PROPERTIES_PATH, operator)
-
     hosts: list[dict[str, Any]] = []
     for entry in entries:
         if not isinstance(entry, dict):
@@ -274,9 +272,7 @@ async def host_network_uplinks_impl(
             # upstream malformation -- skip rather than abort.
             continue
         hosts.append(
-            await _read_host_uplink_row(
-                connector, operator, target, props_path, host_moid, entry.get("name")
-            )
+            await _read_host_uplink_row(connector, operator, target, host_moid, entry.get("name"))
         )
     _log.info("vmware_host_network_uplinks_read", target=target.name, host_count=len(hosts))
     return {"hosts": hosts}

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_vsan_health.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_host_vsan_health.py
@@ -138,21 +138,23 @@ async def host_vsan_health_impl(
        ``read_note`` recording why, rather than propagating the transport
        error.
 
-    The call routes through :meth:`VmwareRestConnector.mount_op_path`, so
-    the op lands on the ``/api`` (modern) or ``/rest`` (legacy / vcsim)
-    mount the target's session selected.
+    The call routes through
+    :meth:`VmwareRestConnector._post_vmomi_json`, which mounts the vmomi
+    method on the documented VI-JSON base ``/sdk/vim25/{release}`` (with a
+    single ``/api`` fallback) so ``VsanQueryVcClusterHealthSummary``
+    resolves on vCenter 8.0.x instead of 404ing (#2466); on legacy /
+    vcsim targets it stays on the ``/rest`` mount.
 
     Returns ``{"cluster": <moid>, "overall_health": <colour|null>,
     "groups": [...]}``.
     """
     cluster_moid = params["cluster"]
-    health_path = await connector.mount_op_path(target, _VSAN_QUERY_HEALTH_PATH, operator)
 
     out: dict[str, Any] = {"cluster": cluster_moid}
     try:
-        health_result = await connector._post_json(
+        health_result = await connector._post_vmomi_json(
             target,
-            health_path,
+            _VSAN_QUERY_HEALTH_PATH,
             operator=operator,
             json=build_vsan_query_health_params(cluster_moid),
         )

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_object_collect.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_object_collect.py
@@ -147,9 +147,13 @@ async def object_collect_impl(
     ingested descriptor):
 
     1. ``POST .../PropertyCollector/propertyCollector/RetrievePropertiesEx``
-       (mounted) requesting the caller's ``properties`` on the single
-       ``(type, moid)`` object. Load-bearing: a failure raises and the
-       dispatcher records it as a ``connector_error``.
+       requesting the caller's ``properties`` on the single ``(type,
+       moid)`` object, mounted on the documented VI-JSON base
+       ``/sdk/vim25/{release}`` via
+       :meth:`VmwareRestConnector._post_vmomi_json` (single ``/api``
+       fallback) so it resolves on vCenter 8.0.x instead of 404ing
+       (#2466). Load-bearing: a failure raises and the dispatcher records
+       it as a ``connector_error``.
 
     The size / depth bound is enforced upstream by ``parameter_schema``
     validation in the dispatcher, so by the time this runs ``params`` is
@@ -163,10 +167,9 @@ async def object_collect_impl(
     moid = params["moid"]
     properties: list[str] = list(params["properties"])
 
-    props_path = await connector.mount_op_path(target, _RETRIEVE_PROPERTIES_PATH, operator)
-    result = await connector._post_json(
+    result = await connector._post_vmomi_json(
         target,
-        props_path,
+        _RETRIEVE_PROPERTIES_PATH,
         operator=operator,
         json=build_object_collect_retrieve_params(mo_type, moid, properties),
     )

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_tasks_recent.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_tasks_recent.py
@@ -189,12 +189,15 @@ async def tasks_recent_impl(
     Reads, directly on the connector session (no ``dispatch_child``, no
     ingested descriptor):
 
-    1. ``POST .../RetrievePropertiesEx`` (mounted) reading
+    1. ``POST .../RetrievePropertiesEx`` reading
        ``TaskManager.recentTask`` -- the recent Task MoRefs.
-    2. ``POST .../RetrievePropertiesEx`` (mounted) reading ``Task.info``
+    2. ``POST .../RetrievePropertiesEx`` reading ``Task.info``
        on those MoRefs (capped at ``max_tasks``) -- a single round trip.
 
-    Both calls route through :meth:`VmwareRestConnector.mount_op_path`.
+    Both vmomi reads route through
+    :meth:`VmwareRestConnector._post_vmomi_json`, which mounts them on the
+    documented VI-JSON base ``/sdk/vim25/{release}`` (single ``/api``
+    fallback) so they resolve on vCenter 8.0.x instead of 404ing (#2466).
     Returns ``{"tasks": [{task, operation, entity, entity_type,
     entity_name, state, progress, cancelled, queue_time, start_time,
     complete_time, error_message}, ...]}``, most recent as vCenter orders
@@ -204,18 +207,20 @@ async def tasks_recent_impl(
     if not isinstance(max_tasks, int) or isinstance(max_tasks, bool) or max_tasks < 1:
         max_tasks = _DEFAULT_MAX_TASKS
 
-    props_path = await connector.mount_op_path(target, _RETRIEVE_PROPERTIES_PATH, operator)
-    recent_result = await connector._post_json(
-        target, props_path, operator=operator, json=build_recent_tasks_retrieve_params()
+    recent_result = await connector._post_vmomi_json(
+        target,
+        _RETRIEVE_PROPERTIES_PATH,
+        operator=operator,
+        json=build_recent_tasks_retrieve_params(),
     )
     task_moids = _extract_recent_task_moids(recent_result)[:max_tasks]
     if not task_moids:
         _log.info("vmware_tasks_recent_read", target=target.name, task_count=0)
         return {"tasks": []}
 
-    info_result = await connector._post_json(
+    info_result = await connector._post_vmomi_json(
         target,
-        props_path,
+        _RETRIEVE_PROPERTIES_PATH,
         operator=operator,
         json=build_task_info_retrieve_params(task_moids),
     )

--- a/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_vm_info.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/typed_ops_vm_info.py
@@ -267,15 +267,18 @@ async def vm_info_impl(
        resolve the name to a moid. Skipped when the caller supplies ``vm``
        directly.
     2. ``POST .../PropertyCollector/propertyCollector/RetrievePropertiesEx``
-       (mounted) reading the VirtualMachine's runtime power state, guest
+       reading the VirtualMachine's runtime power state, guest
        IP / hostname / Tools status, heartbeat, and per-datastore usage.
        Load-bearing: a failure here raises and the dispatcher records it
        as a ``connector_error`` -- unlike the per-host best-effort reads,
        this single-object read *is* the op.
 
-    Both calls route through :meth:`VmwareRestConnector.mount_op_path`, so
-    the op lands on the ``/api`` (modern) or ``/rest`` (legacy / vcsim)
-    mount the target's session selected.
+    The name-resolution listing GET routes through
+    :meth:`VmwareRestConnector.mount_op_path` (``/api`` modern / ``/rest``
+    legacy). The vmomi ``RetrievePropertiesEx`` read routes through
+    :meth:`VmwareRestConnector._post_vmomi_json`, which mounts it on the
+    documented VI-JSON base ``/sdk/vim25/{release}`` (single ``/api``
+    fallback) so it resolves on vCenter 8.0.x instead of 404ing (#2466).
 
     Returns a single flat row (see :data:`VMWARE_VM_INFO_OP`'s response
     schema).
@@ -284,10 +287,9 @@ async def vm_info_impl(
     if not isinstance(vm_moid, str):
         vm_moid = await _resolve_vm_moid_by_name(connector, operator, target, params["name"])
 
-    props_path = await connector.mount_op_path(target, _RETRIEVE_PROPERTIES_PATH, operator)
-    props_result = await connector._post_json(
+    props_result = await connector._post_vmomi_json(
         target,
-        props_path,
+        _RETRIEVE_PROPERTIES_PATH,
         operator=operator,
         json=build_vm_info_retrieve_params(vm_moid),
     )

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -140,14 +140,17 @@ def _register_vcenter_routes(mock: respx.MockRouter) -> None:
     ``GET /api/about`` (the fingerprint probe), ``DELETE /api/session``
     (the ``aclose`` revoke against the established path), plus the
     ``vmware.host.usage`` surface: ``GET /api/vcenter/host`` and the
-    per-host ``POST /api/PropertyCollector/propertyCollector/RetrievePropertiesEx``
-    (both mounted onto ``/api`` by :meth:`VmwareRestConnector.mount_op_path`).
+    per-host vmomi ``POST /sdk/vim25/9.0.0.0/PropertyCollector/propertyCollector/
+    RetrievePropertiesEx`` (the listing mounts onto ``/api`` via
+    :meth:`VmwareRestConnector.mount_op_path`; the vmomi read mounts onto the
+    documented VI-JSON ``/sdk/vim25/{release}`` base via ``_post_vmomi_json``,
+    release ``9.0.0.0`` derived from the ``about.version`` above; #2466).
     """
     mock.post("/api/session").respond(200, json=SESSION_TOKEN)
     mock.get("/api/about").respond(200, json=ABOUT_PAYLOAD)
     mock.delete("/api/session").respond(204)
     mock.get("/api/vcenter/host").respond(200, json=HOST_LISTING)
-    mock.post("/api/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
+    mock.post("/sdk/vim25/9.0.0.0/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
         side_effect=_retrieve_properties_response
     )
 
@@ -612,10 +615,12 @@ async def test_host_network_uplinks_over_modern_mount_returns_per_host_pnics(
         assert_all_mocked=False,
     ) as mock:
         mock.post("/api/session").respond(200, json=SESSION_TOKEN)
+        # The vmomi read derives its VI-JSON {release} from about.version (#2466).
+        mock.get("/api/about").respond(200, json=ABOUT_PAYLOAD)
         mock.get("/api/vcenter/host").respond(200, json=HOST_LISTING)
-        mock.post("/api/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
-            side_effect=_network_props_response
-        )
+        mock.post(
+            "/sdk/vim25/9.0.0.0/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+        ).mock(side_effect=_network_props_response)
         mock.delete("/api/session").respond(204)
         try:
             result = await connector.host_network_uplinks(_operator(), vcsim_target, {})
@@ -941,10 +946,12 @@ async def test_vm_info_over_modern_mount_returns_guest_signals(
         assert_all_mocked=False,
     ) as mock:
         mock.post("/api/session").respond(200, json=SESSION_TOKEN)
+        # The vmomi read derives its VI-JSON {release} from about.version (#2466).
+        mock.get("/api/about").respond(200, json=ABOUT_PAYLOAD)
         mock.get("/api/vcenter/vm").respond(200, json=[{"vm": "vm-9", "name": "hung-appliance"}])
-        mock.post("/api/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
-            side_effect=_vm_props
-        )
+        mock.post(
+            "/sdk/vim25/9.0.0.0/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+        ).mock(side_effect=_vm_props)
         mock.delete("/api/session").respond(204)
         try:
             result = await connector.vm_info(_operator(), vcsim_target, {"name": "hung-appliance"})
@@ -1076,9 +1083,11 @@ async def test_tasks_recent_over_modern_mount_returns_task_rows(
         assert_all_mocked=False,
     ) as mock:
         mock.post("/api/session").respond(200, json=SESSION_TOKEN)
-        mock.post("/api/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
-            side_effect=_tasks
-        )
+        # The vmomi read derives its VI-JSON {release} from about.version (#2466).
+        mock.get("/api/about").respond(200, json=ABOUT_PAYLOAD)
+        mock.post(
+            "/sdk/vim25/9.0.0.0/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+        ).mock(side_effect=_tasks)
         mock.delete("/api/session").respond(204)
         try:
             result = await connector.tasks_recent(_operator(), vcsim_target, {"max_tasks": 10})

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -70,10 +70,15 @@ def _make_operator() -> Operator:
 class _RecordingConnector:
     """Stub connector session that records sub-calls and serves canned JSON.
 
-    Stands in for :class:`VmwareRestConnector` on the direct-dispatch path:
-    the handlers call ``mount_op_path`` to resolve the live mount and then
-    ``_get_json`` / ``_post_json`` on the returned path. This double records
-    every call as ``{"method", "path", "query", "body"}`` and serves a
+    Stands in for :class:`VmwareRestConnector` on the direct-dispatch path.
+    GET (Automation ``/vcenter/*``) sub-ops call ``mount_op_path`` to
+    resolve the live mount and then ``_get_json`` on the returned path.
+    POST (vmomi VI-JSON) sub-ops call ``_post_vmomi_json`` with the
+    spec-relative path -- the connector's VI-JSON ``/sdk/vim25`` mount +
+    ``/api`` fallback is what that seam owns (#2466); the fake re-applies
+    ``mount_prefix`` for the recorded wire path so response keys stay in
+    the ``/api/...`` / ``/rest/...`` form. This double records every call
+    as ``{"method", "path", "query", "body", "vmomi"}`` and serves a
     response keyed either by the resolved (mounted) path or, in list form,
     sequentially -- the list form lets a test drive several calls to the
     same path (e.g. per-portgroup ``GET /api/vcenter/vm``) with distinct
@@ -117,7 +122,9 @@ class _RecordingConnector:
         operator: Operator,
         params: dict[str, Any] | None = None,
     ) -> Any:
-        self.calls.append({"method": "GET", "path": path, "query": params, "body": None})
+        self.calls.append(
+            {"method": "GET", "path": path, "query": params, "body": None, "vmomi": False}
+        )
         return self._serve(path)
 
     async def _post_json(
@@ -131,8 +138,28 @@ class _RecordingConnector:
         data: dict[str, Any] | None = None,
         extra_headers: dict[str, str] | None = None,
     ) -> Any:
-        self.calls.append({"method": "POST", "path": path, "query": None, "body": json})
+        self.calls.append(
+            {"method": "POST", "path": path, "query": None, "body": json, "vmomi": False}
+        )
         return self._serve(path)
+
+    async def _post_vmomi_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        json: dict[str, Any] | None = None,
+    ) -> Any:
+        # #2466: vmomi POST sub-ops route through the connector's VI-JSON
+        # mount seam, NOT mount_op_path. The handler passes the
+        # spec-relative path; the fake re-applies mount_prefix so the
+        # recorded wire path + response keys keep the pre-#2466 form.
+        mounted = f"{self._mount_prefix}{path}"
+        self.calls.append(
+            {"method": "POST", "path": mounted, "query": None, "body": json, "vmomi": True}
+        )
+        return self._serve(mounted)
 
     def _serve(self, path: str) -> Any:
         if isinstance(self._responses, dict):
@@ -920,7 +947,10 @@ async def test_every_read_composite_dispatches_directly_on_the_session() -> None
     ingested descriptor, no L2 pre-flight -- so the composites work on a
     fresh boot with zero catalog ingest. Each handler is exercised with a
     minimal happy-path stub and must (a) record at least one session call
-    and (b) mount every path it hit.
+    and (b) route each sub-op through the right seam -- GET Automation
+    sub-ops via ``mount_op_path``, POST vmomi sub-ops via the VI-JSON seam
+    (:meth:`_post_vmomi_json`), so no vmomi path reaches the bare
+    Automation mount (#2466).
     """
     handlers: tuple[tuple[Any, dict[str, Any], list[Any]], ...] = (
         (
@@ -942,7 +972,13 @@ async def test_every_read_composite_dispatches_directly_on_the_session() -> None
             connector=conn,  # type: ignore[arg-type]
         )
         assert conn.calls, f"{handler.__qualname__} issued no session sub-calls"
-        # Every session call went through a mount resolution.
-        assert len(conn.mount_calls) == len(conn.calls), (
-            f"{handler.__qualname__} bypassed mount_op_path on a sub-op"
+        get_calls = [c for c in conn.calls if c["method"] == "GET"]
+        # GET (Automation /vcenter) sub-ops resolve through mount_op_path.
+        assert len(conn.mount_calls) == len(get_calls), (
+            f"{handler.__qualname__} GET sub-op bypassed mount_op_path"
+        )
+        # POST (vmomi) sub-ops resolve through the VI-JSON seam, never the
+        # bare Automation mount (#2466).
+        assert all(c["vmomi"] for c in conn.calls if c["method"] == "POST"), (
+            f"{handler.__qualname__} vmomi sub-op bypassed _post_vmomi_json"
         )

--- a/backend/tests/test_connectors_vmware_rest_typed_host_network_uplinks.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_network_uplinks.py
@@ -116,7 +116,7 @@ class _FakeConnector:
         self.get_calls.append((path, params))
         return self._listing
 
-    async def _post_json(
+    async def _post_vmomi_json(
         self,
         target: Any,
         path: str,
@@ -124,6 +124,9 @@ class _FakeConnector:
         operator: Operator,
         json: dict[str, Any] | None = None,
     ) -> Any:
+        # The vmomi RetrievePropertiesEx read routes through the vmomi seam
+        # with the spec-relative path; the /sdk/vim25 mount is the
+        # connector's job (#2466).
         del target, operator
         assert json is not None
         self.post_calls.append((path, json))
@@ -208,13 +211,13 @@ async def test_lists_then_reads_props_per_host_mounted() -> None:
 
     out = await host_network_uplinks_impl(conn, _make_operator(), _Target(), {})
 
-    # Both the host listing and the PropertyCollector path were mounted.
-    assert conn.mount_calls[0] == "/vcenter/host"
-    assert "/PropertyCollector/propertyCollector/RetrievePropertiesEx" in conn.mount_calls
+    # The host listing was mounted (Automation /vcenter path); the per-host
+    # vmomi read routes through _post_vmomi_json with the spec-relative path.
+    assert conn.mount_calls == ["/vcenter/host"]
     assert conn.get_calls[0][0] == "/api/vcenter/host"
     assert len(conn.post_calls) == 2
     assert all(
-        path == "/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+        path == "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
         for path, _ in conn.post_calls
     )
     # The per-host property read requests the two host-network config paths.
@@ -262,18 +265,21 @@ async def test_lists_then_reads_props_per_host_mounted() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolves_mount_once_not_per_host() -> None:
-    """The RetrievePropertiesEx path is host-independent -- mount it once."""
+async def test_mounts_only_the_listing_via_mount_op_path() -> None:
+    """Only /vcenter/host is mounted via mount_op_path.
+
+    The per-host RetrievePropertiesEx read routes through the vmomi seam
+    (:meth:`_post_vmomi_json`) -- one POST per host -- so mount_op_path is
+    called exactly once (the listing), not per host (#2466).
+    """
     listing = [{"host": f"host-{i}", "name": f"esx-{i}"} for i in range(3)]
     props = {f"host-{i}": _retrieve_result(f"host-{i}", [], []) for i in range(3)}
     conn = _FakeConnector(listing=listing, props_by_host=props)
 
     await host_network_uplinks_impl(conn, _make_operator(), _Target(), {})
 
-    assert conn.mount_calls == [
-        "/vcenter/host",
-        "/PropertyCollector/propertyCollector/RetrievePropertiesEx",
-    ]
+    assert conn.mount_calls == ["/vcenter/host"]
+    assert len(conn.post_calls) == 3
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vmware_rest_typed_host_usage.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_usage.py
@@ -68,8 +68,10 @@ class _FakeConnector:
     """Records the transport calls ``host_usage_impl`` makes.
 
     Mirrors the surface of :class:`VmwareRestConnector` the handler uses:
-    :meth:`mount_op_path` (prefixes the live mount), :meth:`_get_json`
-    (the host listing), :meth:`_post_json` (per-host RetrievePropertiesEx).
+    :meth:`mount_op_path` (prefixes the live mount for the ``/vcenter/host``
+    listing), :meth:`_get_json` (the host listing), :meth:`_post_vmomi_json`
+    (per-host RetrievePropertiesEx — the VI-JSON ``/sdk/vim25`` mount is the
+    connector's job, so the handler passes the spec-relative path; #2466).
     """
 
     def __init__(
@@ -113,7 +115,7 @@ class _FakeConnector:
         self.get_calls.append((path, params))
         return self._listing
 
-    async def _post_json(
+    async def _post_vmomi_json(
         self,
         target: Any,
         path: str,
@@ -121,6 +123,9 @@ class _FakeConnector:
         operator: Operator,
         json: dict[str, Any] | None = None,
     ) -> Any:
+        # The handler now issues the vmomi read via _post_vmomi_json with
+        # the spec-relative path; the /sdk/vim25 mount + /api fallback is
+        # the connector's job (see the transport-level path tests, #2466).
         del target, operator
         assert json is not None
         self.post_calls.append((path, json))
@@ -197,15 +202,15 @@ async def test_host_usage_lists_then_reads_each_host_mounted() -> None:
 
     out = await host_usage_impl(conn, _make_operator(), _Target(), {})
 
-    # Both the host listing and the PropertyCollector path were mounted.
-    assert conn.mount_calls[0] == "/vcenter/host"
-    assert "/PropertyCollector/propertyCollector/RetrievePropertiesEx" in conn.mount_calls
+    # The host listing was mounted (Automation /vcenter path).
+    assert conn.mount_calls == ["/vcenter/host"]
     # The listing GET used the mounted (/api-prefixed) path.
     assert conn.get_calls[0][0] == "/api/vcenter/host"
-    # One RetrievePropertiesEx POST per host, all against the mounted path.
+    # One RetrievePropertiesEx POST per host via the vmomi seam, addressed
+    # by the spec-relative path (the /sdk/vim25 mount is the connector's job).
     assert len(conn.post_calls) == 2
     assert all(
-        path == "/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+        path == "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
         for path, _ in conn.post_calls
     )
 
@@ -230,8 +235,13 @@ async def test_host_usage_lists_then_reads_each_host_mounted() -> None:
 
 
 @pytest.mark.asyncio
-async def test_host_usage_resolves_mount_once_not_per_host() -> None:
-    """The RetrievePropertiesEx path is host-independent — mount it once."""
+async def test_host_usage_mounts_only_the_listing_via_mount_op_path() -> None:
+    """Only the /vcenter/host listing goes through mount_op_path.
+
+    The per-host RetrievePropertiesEx read routes through the vmomi seam
+    (:meth:`_post_vmomi_json`) — one POST per host — so mount_op_path is
+    called exactly once (the listing), not per host (#2466).
+    """
     listing = [{"host": f"host-{i}", "name": f"esx-{i}"} for i in range(3)]
     props = {
         f"host-{i}": _retrieve_result(f"host-{i}", _QS_FULL, _HW_FULL, False) for i in range(3)
@@ -240,12 +250,8 @@ async def test_host_usage_resolves_mount_once_not_per_host() -> None:
 
     await host_usage_impl(conn, _make_operator(), _Target(), {})
 
-    # Exactly two mount calls total: the host listing + one for the
-    # per-host property path (resolved once, reused across the 3 hosts).
-    assert conn.mount_calls == [
-        "/vcenter/host",
-        "/PropertyCollector/propertyCollector/RetrievePropertiesEx",
-    ]
+    assert conn.mount_calls == ["/vcenter/host"]
+    assert len(conn.post_calls) == 3
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vmware_rest_typed_host_vsan_health.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_host_vsan_health.py
@@ -40,9 +40,7 @@ from meho_backplane.connectors.vmware_rest.typed_ops_host_vsan_health import (
     host_vsan_health_impl,
 )
 
-_VSAN_PATH = (
-    "/api/VsanVcClusterHealthSystem/vsan-cluster-health-system/VsanQueryVcClusterHealthSummary"
-)
+_VSAN_PATH = "/VsanVcClusterHealthSystem/vsan-cluster-health-system/VsanQueryVcClusterHealthSummary"
 
 # ---------------------------------------------------------------------------
 # Fixtures / doubles
@@ -95,7 +93,7 @@ class _FakeConnector:
         self.mount_calls.append(path)
         return f"{self._mount_prefix}{path}"
 
-    async def _post_json(
+    async def _post_vmomi_json(
         self,
         target: Any,
         path: str,
@@ -103,6 +101,9 @@ class _FakeConnector:
         operator: Operator,
         json: dict[str, Any] | None = None,
     ) -> Any:
+        # vmomi VsanQueryVcClusterHealthSummary read via the vmomi seam;
+        # the handler passes the spec-relative path (the /sdk/vim25 mount
+        # is the connector's job, #2466).
         del target, operator
         assert json is not None
         self.post_calls.append((path, json))
@@ -162,10 +163,10 @@ async def test_queries_health_summary_for_cluster_mounted() -> None:
 
     out = await host_vsan_health_impl(conn, _make_operator(), _Target(), {"cluster": "domain-c123"})
 
-    # The singleton moId rides the mounted path; the cluster MoRef is the body arg.
-    assert conn.mount_calls == [
-        "/VsanVcClusterHealthSystem/vsan-cluster-health-system/VsanQueryVcClusterHealthSummary"
-    ]
+    # The vmomi read routes through _post_vmomi_json (not mount_op_path);
+    # the singleton moId rides the spec-relative path, the cluster MoRef is
+    # the body arg (#2466).
+    assert conn.mount_calls == []
     assert len(conn.post_calls) == 1
     path, body = conn.post_calls[0]
     assert path == _VSAN_PATH

--- a/backend/tests/test_connectors_vmware_rest_typed_object_collect.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_object_collect.py
@@ -70,7 +70,7 @@ class _FakeConnector:
         self.mount_calls.append(path)
         return f"{self._mount_prefix}{path}"
 
-    async def _post_json(
+    async def _post_vmomi_json(
         self,
         target: Any,
         path: str,
@@ -78,6 +78,9 @@ class _FakeConnector:
         operator: Operator,
         json: dict[str, Any] | None = None,
     ) -> Any:
+        # vmomi RetrievePropertiesEx read via the vmomi seam; the handler
+        # passes the spec-relative path (the /sdk/vim25 mount is the
+        # connector's job, #2466).
         del target, operator
         assert json is not None
         self.post_calls.append((path, json))
@@ -137,7 +140,10 @@ async def test_object_collect_reads_datastore_properties() -> None:
         {"type": "Datastore", "moid": "datastore-5", "properties": ["summary.freeSpace"]},
     )
 
-    assert conn.mount_calls == ["/PropertyCollector/propertyCollector/RetrievePropertiesEx"]
+    # The vmomi read routes through _post_vmomi_json (not mount_op_path);
+    # the handler addresses it by the spec-relative path (#2466).
+    assert conn.mount_calls == []
+    assert conn.post_calls[0][0] == "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
     assert out["type"] == "Datastore"
     assert out["moid"] == "datastore-5"
     assert out["properties"]["summary.freeSpace"] == 1073741824

--- a/backend/tests/test_connectors_vmware_rest_typed_tasks_recent.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_tasks_recent.py
@@ -71,7 +71,7 @@ class _FakeConnector:
         self.mount_calls.append(path)
         return f"{self._mount_prefix}{path}"
 
-    async def _post_json(
+    async def _post_vmomi_json(
         self,
         target: Any,
         path: str,
@@ -79,6 +79,9 @@ class _FakeConnector:
         operator: Operator,
         json: dict[str, Any] | None = None,
     ) -> Any:
+        # Both RetrievePropertiesEx reads route through the vmomi seam with
+        # the spec-relative path (the /sdk/vim25 mount is the connector's
+        # job, #2466).
         del target, operator
         assert json is not None
         self.post_calls.append((path, json))
@@ -163,9 +166,13 @@ async def test_tasks_recent_reads_recent_then_info() -> None:
 
     out = await tasks_recent_impl(conn, _make_operator(), _Target(), {})
 
-    # Both reads mounted, path resolved once (reused across the two POSTs).
-    assert conn.mount_calls == ["/PropertyCollector/propertyCollector/RetrievePropertiesEx"]
+    # Both reads route through the vmomi seam (not mount_op_path), each
+    # addressed by the spec-relative RetrievePropertiesEx path (#2466).
+    assert conn.mount_calls == []
     assert len(conn.post_calls) == 2
+    assert {p for p, _ in conn.post_calls} == {
+        "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+    }
 
     tasks = out["tasks"]
     assert [t["task"] for t in tasks] == ["task-1", "task-2"]

--- a/backend/tests/test_connectors_vmware_rest_typed_vm_info.py
+++ b/backend/tests/test_connectors_vmware_rest_typed_vm_info.py
@@ -109,7 +109,7 @@ class _FakeConnector:
         self.get_calls.append((path, params))
         return self._listing
 
-    async def _post_json(
+    async def _post_vmomi_json(
         self,
         target: Any,
         path: str,
@@ -117,6 +117,9 @@ class _FakeConnector:
         operator: Operator,
         json: dict[str, Any] | None = None,
     ) -> Any:
+        # vmomi RetrievePropertiesEx read via the vmomi seam; the handler
+        # passes the spec-relative path (the /sdk/vim25 mount is the
+        # connector's job, #2466).
         del target, operator
         assert json is not None
         self.post_calls.append((path, json))
@@ -186,10 +189,11 @@ async def test_vm_info_by_moid_skips_listing_and_reads_props() -> None:
 
     # Addressed by moid: no name->moid listing GET was issued.
     assert conn.get_calls == []
-    # Exactly one mounted PropertyCollector read.
-    assert conn.mount_calls == ["/PropertyCollector/propertyCollector/RetrievePropertiesEx"]
+    # Exactly one vmomi PropertyCollector read via the vmomi seam (not
+    # mount_op_path), addressed by the spec-relative path (#2466).
+    assert conn.mount_calls == []
     assert len(conn.post_calls) == 1
-    assert conn.post_calls[0][0] == "/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+    assert conn.post_calls[0][0] == "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
 
     assert out["vm"] == "vm-42"
     assert out["name"] == "hung-appliance"

--- a/backend/tests/test_connectors_vmware_rest_vmomi_mount.py
+++ b/backend/tests/test_connectors_vmware_rest_vmomi_mount.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the VI-JSON vmomi mount seam (#2466).
+
+vmomi (VI-JSON) methods — ``RetrievePropertiesEx``,
+``VsanQueryVcClusterHealthSummary``, ``QueryEvents``, ``QueryPerf`` … —
+are served by vCenter under the documented release-versioned base
+``/sdk/vim25/{release}/{MoType}/{moId}/{method}`` (Broadcom Web Services
+SDK guide, "Building JSON Request URLs"), available since vCenter 8.0U1.
+Mounting them under the vSphere Automation ``/api`` mount 404s on vCenter
+8.0.x; the ``/api`` form works only on the 9.0.2 fleet and is kept as a
+single fallback.
+
+These tests cover:
+
+* the pure ``{release}`` derivation + path build in ``._mount``;
+* :meth:`VmwareRestConnector._post_vmomi_json` against a real httpx
+  transport (respx): the ``/sdk/vim25/{release}`` URL construction, the
+  single ``/api`` 404 fallback, the both-404 diagnostic error, the legacy
+  ``/rest`` passthrough (no VI-JSON on vcsim), and the ``about``-version
+  caching.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vmware_rest import VmwareRestConnector, VsphereTargetLike
+from meho_backplane.connectors.vmware_rest._mount import (
+    vmomi_mounted_path,
+    vmomi_release_from_version,
+)
+
+_RETRIEVE_PROPERTIES_PATH = "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+_RETRIEVE_BODY: dict[str, Any] = {"specSet": [], "options": {}}
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers: release derivation + path build
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        # Three-part about.version pads to the four-part VI-JSON release.
+        ("8.0.3", "8.0.3.0"),
+        ("8.0.2", "8.0.2.0"),
+        ("8.0", "8.0.0.0"),
+        # Already four-part passes through (the 9.x fleet).
+        ("9.0.0.0", "9.0.0.0"),
+        ("9.0.2.1", "9.0.2.1"),
+        # No usable numeric prefix -> None (caller falls back to /api).
+        ("", None),
+        (None, None),
+        ("garbage", None),
+    ],
+)
+def test_vmomi_release_from_version(version: str | None, expected: str | None) -> None:
+    assert vmomi_release_from_version(version) == expected
+
+
+def test_vmomi_mounted_path_prefixes_the_documented_vi_json_base() -> None:
+    assert (
+        vmomi_mounted_path("8.0.3.0", _RETRIEVE_PROPERTIES_PATH)
+        == "/sdk/vim25/8.0.3.0/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+    )
+
+
+def test_vmomi_mounted_path_normalises_a_missing_leading_slash() -> None:
+    assert (
+        vmomi_mounted_path("9.0.0.0", "Task/task-1/Cancel")
+        == "/sdk/vim25/9.0.0.0/Task/task-1/Cancel"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Connector transport: _post_vmomi_json against a real httpx (respx) client
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str = "vc-8"
+    host: str = "vc-8.test.invalid"
+    port: int | None = 443
+    secret_ref: str = "vsphere/vc-8"
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-vmomi-mount",
+        name="Vmomi Mount Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _stub_loader(_target: VsphereTargetLike, _operator: Operator) -> dict[str, str]:
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _make_connector() -> VmwareRestConnector:
+    return VmwareRestConnector(session_loader=_stub_loader)
+
+
+def _patch_no_revoke_aclose(connector: VmwareRestConnector) -> None:
+    """Skip the session-revoke DELETE at teardown (mirrors the fingerprint tests)."""
+
+    async def _aclose() -> None:
+        connector._session_tokens.clear()
+        for client in connector._clients.values():
+            await client.aclose()
+        connector._clients.clear()
+
+    connector.aclose = _aclose  # type: ignore[method-assign]
+
+
+_BASE = "https://vc-8.test.invalid"
+_VIJSON_URL = "/sdk/vim25/8.0.3.0/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+_API_URL = "/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+
+
+@pytest.mark.asyncio
+async def test_modern_vmomi_read_mounts_on_sdk_vim25_release() -> None:
+    """about-version 8.0.3 -> the vmomi POST lands on /sdk/vim25/8.0.3.0/..."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=_BASE) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            mock.get("/api/about").respond(200, json={"version": "8.0.3"})
+            vijson = mock.post(_VIJSON_URL).respond(200, json={"objects": []})
+            result = await connector._post_vmomi_json(
+                _StubTarget(),
+                _RETRIEVE_PROPERTIES_PATH,
+                operator=_make_operator(),
+                json=_RETRIEVE_BODY,
+            )
+        assert vijson.called
+        assert vijson.call_count == 1
+        assert result == {"objects": []}
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_modern_vmomi_read_falls_back_once_to_api_on_404() -> None:
+    """A 404 on the /sdk/vim25 mount triggers exactly one /api fallback (AC #4)."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=_BASE) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            mock.get("/api/about").respond(200, json={"version": "8.0.3"})
+            vijson = mock.post(_VIJSON_URL).respond(404, json={})
+            api = mock.post(_API_URL).respond(200, json={"objects": ["fallback"]})
+            result = await connector._post_vmomi_json(
+                _StubTarget(),
+                _RETRIEVE_PROPERTIES_PATH,
+                operator=_make_operator(),
+                json=_RETRIEVE_BODY,
+            )
+        # Exactly one attempt on each mount: vi-json first, then the single
+        # /api fallback.
+        assert vijson.call_count == 1
+        assert api.call_count == 1
+        assert result == {"objects": ["fallback"]}
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_both_mounts_404_raises_diagnostic_naming_both_and_version() -> None:
+    """When both mounts 404 the error names both URLs + the vCenter version."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=_BASE) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            mock.get("/api/about").respond(200, json={"version": "8.0.3"})
+            mock.post(_VIJSON_URL).respond(404, json={})
+            mock.post(_API_URL).respond(404, json={})
+            with pytest.raises(RuntimeError) as excinfo:
+                await connector._post_vmomi_json(
+                    _StubTarget(),
+                    _RETRIEVE_PROPERTIES_PATH,
+                    operator=_make_operator(),
+                    json=_RETRIEVE_BODY,
+                )
+        message = str(excinfo.value)
+        assert "vi-json unavailable" in message
+        assert "/sdk/vim25/8.0.3.0/" in message
+        assert "/api/PropertyCollector/" in message
+        assert "8.0.3" in message
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_non_404_on_vijson_propagates_without_fallback() -> None:
+    """A 500 on the /sdk/vim25 mount is not a 'mount not served' signal -- propagate."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=_BASE, assert_all_called=False) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            mock.get("/api/about").respond(200, json={"version": "8.0.3"})
+            mock.post(_VIJSON_URL).respond(500, json={})
+            api = mock.post(_API_URL).respond(200, json={"objects": []})
+            with pytest.raises(httpx.HTTPStatusError):
+                await connector._post_vmomi_json(
+                    _StubTarget(),
+                    _RETRIEVE_PROPERTIES_PATH,
+                    operator=_make_operator(),
+                    json=_RETRIEVE_BODY,
+                )
+        # No fallback on a 5xx.
+        assert not api.called
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_legacy_session_uses_rest_mount_and_skips_vi_json() -> None:
+    """A vcsim/legacy target (session on /rest) reaches vmomi via /rest, no VI-JSON."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=_BASE, assert_all_called=False) as mock:
+            # Modern session endpoint 404s -> legacy fallback establishes.
+            mock.post("/api/session").respond(404, json={})
+            mock.post("/rest/com/vmware/cis/session").respond(200, json={"value": "tok"})
+            about = mock.get("/api/about").respond(200, json={"version": "8.0.3"})
+            vijson = mock.post(_VIJSON_URL).respond(200, json={})
+            rest = mock.post(
+                "/rest/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+            ).respond(200, json={"objects": ["rest"]})
+            result = await connector._post_vmomi_json(
+                _StubTarget(),
+                _RETRIEVE_PROPERTIES_PATH,
+                operator=_make_operator(),
+                json=_RETRIEVE_BODY,
+            )
+        assert result == {"objects": ["rest"]}
+        assert rest.call_count == 1
+        # Legacy path never probes about-version and never attempts VI-JSON.
+        assert not about.called
+        assert not vijson.called
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_about_version_goes_straight_to_api() -> None:
+    """When /api/about can't answer, the vmomi read uses the /api mount directly."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=_BASE, assert_all_called=False) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            mock.get("/api/about").respond(500, json={})
+            vijson = mock.post(_VIJSON_URL).respond(200, json={})
+            api = mock.post(_API_URL).respond(200, json={"objects": ["api"]})
+            result = await connector._post_vmomi_json(
+                _StubTarget(),
+                _RETRIEVE_PROPERTIES_PATH,
+                operator=_make_operator(),
+                json=_RETRIEVE_BODY,
+            )
+        assert result == {"objects": ["api"]}
+        assert api.call_count == 1
+        assert not vijson.called
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_about_version_resolved_once_and_cached_across_reads() -> None:
+    """The about-version probe runs once per target and is reused (AC caching)."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    target = _StubTarget()
+    try:
+        async with respx.mock(base_url=_BASE) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            about = mock.get("/api/about").respond(200, json={"version": "8.0.3"})
+            mock.post(_VIJSON_URL).respond(200, json={"objects": []})
+            await connector._post_vmomi_json(
+                target, _RETRIEVE_PROPERTIES_PATH, operator=_make_operator(), json=_RETRIEVE_BODY
+            )
+            await connector._post_vmomi_json(
+                target, _RETRIEVE_PROPERTIES_PATH, operator=_make_operator(), json=_RETRIEVE_BODY
+            )
+        # Two vmomi reads, one /api/about probe.
+        assert about.call_count == 1
+    finally:
+        await connector.aclose()

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -140,9 +140,12 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   (CPU/memory load, MHz/MB), `summary.hardware` (capacity totals:
   `cpu_mhz` per core, core/package/thread counts, `memory_size_bytes`),
   and `runtime.inMaintenanceMode` through a direct PropertyCollector
-  `RetrievePropertiesEx` on the connector session. Both calls are routed
-  through `mount_op_path` so they land on `/api` (modern) or `/rest`
-  (legacy/vcsim). The per-host property read is best-effort (a failed
+  `RetrievePropertiesEx` on the connector session. The host listing is
+  routed through `mount_op_path` (`/api` modern / `/rest` legacy); the
+  vmomi `RetrievePropertiesEx` read is routed through `_post_vmomi_json`,
+  which mounts it on the documented VI-JSON base `/sdk/vim25/{release}`
+  (see the VI-JSON mount section below) so it resolves on vCenter 8.0.x
+  instead of 404ing (`#2466`). The per-host property read is best-effort (a failed
   read nulls the detail with a `read_note`, mirroring
   `host_network_uplinks_composite`); the host listing is load-bearing.
   This op is why the plain REST host summary (liveness only) is not
@@ -605,6 +608,29 @@ they never park.
   header per `docs/vcenter-9.0/MANIFEST.md`. Two of the read
   composites (`event.tail`, `performance.summary`) call vi-json
   sub-ops; the other three call vCenter REST sub-ops only.
+- **VI-JSON mount for vmomi reads — `/sdk/vim25/{release}` (#2466)** —
+  vmomi (VI-JSON) methods (`RetrievePropertiesEx`,
+  `VsanQueryVcClusterHealthSummary`, `QueryEvents`,
+  `QueryAvailablePerfMetric`, `QueryPerf`) are served under the
+  documented release-versioned base
+  `/sdk/vim25/{release}/{MoType}/{moId}/{method}` (Broadcom Web Services
+  SDK guide, "Building JSON Request URLs"; available since vCenter 8.0U1,
+  same scheme on 9.x) — **not** the vSphere Automation `/api` mount that
+  `mount_op_path` resolves for `/vcenter/*` paths. Mounting a vmomi
+  method on `/api` 404s on vCenter 8.0.x (observed on a live 8.0.3 host).
+  `VmwareRestConnector._post_vmomi_json` owns this seam: for a
+  modern-session target it derives `{release}` from `GET /api/about`'s
+  `version` (`8.0.3` → `8.0.3.0`, resolved once and cached in
+  `_about_versions`), POSTs `/sdk/vim25/{release}{path}`, and on a 404
+  falls back **once** to the `/api`-mounted form (the undocumented
+  accommodation the 9.0.2 fleet serves); when both 404 the raised
+  `RuntimeError` names both attempted URLs + the vCenter version so a
+  best-effort caller's `read_note` is self-explanatory. Legacy/vcsim
+  targets (session on `/rest`) skip VI-JSON entirely and mount the vmomi
+  method on `/rest` (the pre-#2466 behaviour, so the vcsim integration
+  lane is unchanged). Every typed vmomi read and the composite vmomi
+  POST sub-ops route through `_post_vmomi_json`; only the vSphere
+  Automation `GET /vcenter/*` legs still use `mount_op_path`.
 - **All hand-authored composites shipped** — T5 (#508) ships 5 read;
   #2080 + #2135 add two more reads (`host.network_uplinks` /
   `host.vsan_health`, later re-shipped as typed ops in #2258); T6


### PR DESCRIPTION
## Summary

- vmware typed reads that issue a vmomi (VI-JSON) method — `RetrievePropertiesEx` (`host.usage`, `host.network_uplinks`, `vm.info`, `object.collect`, `tasks.recent`), `VsanQueryVcClusterHealthSummary` (`host.vsan_health`), and the composite `QueryEvents` / `QueryAvailablePerfMetric` / `QueryPerf` sub-ops — were mounted on the vSphere Automation `/api` mount and returned **HTTP 404 on vCenter 8.0.x** (observed on a live 8.0.3 host in the v0.21.0 dogfood).
- They now route through a new `VmwareRestConnector._post_vmomi_json` seam that mounts them on the **documented VI-JSON base `/sdk/vim25/{release}`** (Broadcom Web Services SDK guide, "Building JSON Request URLs"; served since vCenter 8.0U1, same scheme on 9.x). `{release}` is derived per target from `GET /api/about`'s `version` (`8.0.3` → `8.0.3.0`), resolved once and cached.
- On a 404 at the VI-JSON mount the read **falls back once** to the `/api`-mounted form (the accommodation the 9.0.2 fleet serves); when **both** 404 the raised error names both attempted URLs + the vCenter version so a best-effort caller's `read_note` is self-explanatory instead of a bare 404.
- **Legacy/vcsim targets** (session on `/rest`) skip VI-JSON entirely and keep the pre-existing `/rest` mount — that lane is unchanged. Only the vmomi URL construction changed; GET `/vcenter/*` Automation legs still use `mount_op_path`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (18 files)
- [x] `mypy src/.../vmware_rest/` — clean
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (pre-existing file/function-size warnings only)
- [x] **AC #4** — new `test_connectors_vmware_rest_vmomi_mount.py` (respx, real connector): about-version `8.0.3` → POST lands on `/sdk/vim25/8.0.3.0/PropertyCollector/propertyCollector/RetrievePropertiesEx`; a 404 there triggers exactly one `/api` fallback; both-404 raises a `RuntimeError` naming both mounts + `8.0.3`; legacy `/rest` passthrough (no VI-JSON); unresolvable about-version → `/api`; about probed once + cached; plus pure `vmomi_release_from_version` / `vmomi_mounted_path` cases.
- [x] **AC #5** — `test_connectors_vmware_rest_composites_read.py`: the mount-routing invariant now asserts every POST (vmomi) sub-op routes through `_post_vmomi_json` and no vmomi path reaches the bare Automation mount; GET Automation sub-ops still go through `mount_op_path`.
- [x] **AC #6** — `tests/integration/test_connectors_vmware_rest_vcsim.py` green (16 passed): modern-mount vmomi reads now assert `/sdk/vim25/9.0.0.0/...`; legacy `/rest` tests unchanged.
- [x] Full vmware sweep: `pytest -k vmware` → **329 passed, 11 skipped** (live-lab/container skips).
- [ ] **AC #1 / #3 (live 8.0.3)** — require a live vCenter 8.0.3 target (not available in the sandbox). Verified structurally via the respx transport tests that the reads now target `/sdk/vim25/{release}` and that a both-404 degrades with a `/sdk/vim25`-naming note.
- [x] **AC #2 (9.0.2 no-regression)** — the `*_over_modern_mount_*` integration tests (about `9.0.0.0`) confirm the modern mount returns non-null detail via `/sdk/vim25/9.0.0.0/...`.

## Out of scope

- vmomi **write** composites (`composites/_write.py`) still mount via `mount_op_path` — the issue scopes to the typed **reads**; the same seam can be extended to writes in a follow-up.
- Sibling task #2358 (retire ingested-curation across the 6 vmware modules) runs in parallel and touches these modules; this change is deliberately localized to the vmomi base-path/session mounting for a clean union rebase. Rebased onto #2398's SNI/`tls_server_name` threading already on `main`.

Closes #2466


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed typed VMware reads returning HTTP 404 errors on vCenter 8.0.x.
  * Added automatic version-aware routing with a one-time fallback for compatibility.
  * Improved error messages when both endpoint routes fail.
  * Preserved existing behavior for legacy and simulator environments.

* **Documentation**
  * Documented the updated VMware read routing and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->