### PR TITLE
docs(changelog): roll [Unreleased] into v0.25.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-07-19
+
+This release lands the complete **v0.21/v0.22 dogfood-hardening cycle** —
+all of G0.32 (MCP wire contract, governance, connector-session and deploy
+docs; #2494) and all of G0.33 (operator-console walkthrough; #2495) — plus
+the full **G0.36 GSM-deploy hardening set** (#2592, including the
+check-runner target-resolution fix that made target-bound Sensors work),
+the check-layer follow-ups (#2575, #2576), the console/CLI visibility
+pages (`/ui/runners`, `/ui/sensors`, `meho dashboard`), the vmomi VI-JSON
+mount fix for vCenter 8.0.x (#2466), and the retirement of CodeRabbit
+from the development flow (#2601). 45 PRs; no new schema migrations (the
+Alembic chain stays at `0067`).
+
 ### Fixed — check-runner target resolution (#2595)
 
 - The in-process sensor check-runner
@@ -822,6 +835,16 @@ connector-related release-notes line.
 - Remove the CodeRabbit review step from the contribution flow; the
   in-house Claude review pass is the review of record on every PR
   (#2601)
+
+### Documentation — correct the stale `targets` write-verb framing (#2588)
+
+- `docs/codebase/cli.md` described the `create` / `update` / `delete` write
+  verbs as "deferred", implying they are still planned. In reality
+  registration and updates flow through `meho targets import` (POST for new
+  rows, PATCH under `--update`), and a standalone `create` verb was ruled out
+  in favour of file-based import (#1574 / #1559). Only `delete` has no CLI
+  surface yet. Both the overview and the "Out of scope (v0.2)" note are
+  rewritten to state this accurately.
 
 ## [0.24.0] - 2026-07-17
 


### PR DESCRIPTION
Cuts **v0.25.0**. Rolls every `[Unreleased]` bullet under `## [0.25.0] - 2026-07-19` (45 sections + narrative intro) and leaves a fresh empty `[Unreleased]`. Tag is pushed only after this merges.

## What ships
- **G0.32 (#2494) + G0.33 (#2495) complete** — the whole v0.21/v0.22 dogfood-hardening cycle (MCP wire contract, governance, connector-session, deploy docs; full console-walkthrough batch).
- **G0.36 (#2592) complete** — GSM-deploy hardening incl. the backend-gated secret_ref guard (#2585), console OAuth chart values (#2594), and the check-runner target-resolution fix (#2595) that makes target-bound Sensors functional.
- Check-layer follow-ups #2575/#2576; `/ui/runners` (#2589), `/ui/sensors` (#2591), `meho dashboard` verbs (#2590); vmomi VI-JSON mount fix for vCenter 8.0.x (#2466); CodeRabbit retired from the dev flow (#2601).

## Completeness audit
Every PR merged since `v0.24.0` carries a bullet citing its issue (verified via commit-body `Closes` mapping — 45/45). The one gap was **#2588** (merged ~1h after the v0.24.0 tag): backfilled here using the exact wording from **PR #2593**, which this PR supersedes — #2593 can be closed once this merges (its bullet would otherwise double up). No new migrations; Alembic head stays `0067`. No version files hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 0.25.0, summarizing hardening, deployment improvements, validation follow-ups, and console/CLI visibility updates.
  * Clarified CLI support and workflows for managing targets, including importing updates and the remaining delete limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->