### PR TITLE
fix(ui): legible retrieval Usage chips + non-overlapping Diagnostics form (#169)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/retrieval/_usage_results.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/_usage_results.html
@@ -76,7 +76,12 @@
           {% if report.counted_surfaces %}
             <div class="mt-1 flex flex-wrap gap-1">
               {% for surface in report.counted_surfaces %}
-                <span class="badge badge-ghost badge-outline font-mono">{{ surface }}</span>
+                {#- ``badge-neutral`` (solid neutral + neutral-content text),
+                    not ``badge-ghost``: a ghost badge's text inherits the
+                    ``alert-info`` surface colour and reads as near-invisible
+                    on the teal banner. Neutral is contrast-safe in both
+                    themes (#169). -#}
+                <span class="badge badge-neutral font-mono">{{ surface }}</span>
               {% endfor %}
             </div>
           {% endif %}

--- a/backend/src/meho_backplane/ui/templates/retrieval/index.html
+++ b/backend/src/meho_backplane/ui/templates/retrieval/index.html
@@ -125,10 +125,8 @@
           role="search"
           aria-label="Run a retrieval diagnostics query"
         >
-          <label class="form-control w-full">
-            <div class="label">
-              <span class="label-text">Query</span>
-            </div>
+          <label class="flex flex-col gap-1 w-full">
+            <span class="text-sm font-medium">Query</span>
             <textarea
               name="query"
               rows="2"
@@ -141,10 +139,8 @@
             >{{ query }}</textarea>
           </label>
           <div class="flex flex-col gap-3 sm:flex-row sm:items-end">
-            <label class="form-control w-full sm:w-48">
-              <div class="label">
-                <span class="label-text">Source <span class="opacity-50">(optional)</span></span>
-              </div>
+            <label class="flex flex-col gap-1 w-full sm:w-48">
+              <span class="text-sm font-medium">Source <span class="opacity-50">(optional)</span></span>
               {#- Source datalist (#2458): the tenant's distinct retrieval-visible
                   source namespaces, enumerated by a SELECT DISTINCT over the
                   ``documents`` table. ``list=`` keeps the input free-typing (kinds
@@ -160,6 +156,7 @@
                 placeholder="e.g. kb, memory"
                 class="input input-bordered w-full"
                 aria-label="Source filter"
+                aria-describedby="retrieval-source-help"
                 autocomplete="off"
               />
               <datalist id="retrieval-source-options">
@@ -167,18 +164,9 @@
                   <option value="{{ option }}"></option>
                 {% endfor %}
               </datalist>
-              <div class="label">
-                <span class="label-text-alt opacity-60">
-                  Retrieval sources only. Docs-corpus collections are a separate
-                  substrate &mdash; search them on
-                  <a href="/ui/corpus" class="link">/ui/corpus</a>, not here.
-                </span>
-              </div>
             </label>
-            <label class="form-control w-full sm:w-48">
-              <div class="label">
-                <span class="label-text">Kind <span class="opacity-50">(optional)</span></span>
-              </div>
+            <label class="flex flex-col gap-1 w-full sm:w-48">
+              <span class="text-sm font-medium">Kind <span class="opacity-50">(optional)</span></span>
               {#- Kind datalist (#2458): the tenant's distinct retrieval-visible
                   kinds from the same SELECT DISTINCT; a user-scoped memory kind
                   another principal owns is excluded (own-principal scoped). -#}
@@ -199,10 +187,8 @@
                 {% endfor %}
               </datalist>
             </label>
-            <label class="form-control w-full sm:w-32">
-              <div class="label">
-                <span class="label-text">Limit</span>
-              </div>
+            <label class="flex flex-col gap-1 w-full sm:w-32">
+              <span class="text-sm font-medium">Limit</span>
               <select
                 name="limit"
                 class="select select-bordered w-full"
@@ -227,6 +213,17 @@
               aria-label="Running the diagnostics query"
             ></span>
           </div>
+          {#- Source helper, full-width below the controls row (#169). Lived
+              inside the narrow ``sm:w-48`` Source column as a daisyUI-v4
+              ``label-text-alt``; that class is dead in v5 so the block flowed
+              inline and overlapped the adjacent controls. As a full-width note
+              it can no longer collide; the Source input references it via
+              ``aria-describedby``. -#}
+          <p id="retrieval-source-help" class="text-xs opacity-60">
+            Retrieval sources only. Docs-corpus collections are a separate
+            substrate &mdash; search them on
+            <a href="/ui/corpus" class="link">/ui/corpus</a>, not here.
+          </p>
         </form>
       </div>
     </div>
@@ -252,10 +249,8 @@
           class="flex flex-col gap-3 sm:flex-row sm:items-end"
           aria-label="Run a retrieval usage report"
         >
-          <label class="form-control w-full sm:w-48">
-            <div class="label">
-              <span class="label-text">Lookback window</span>
-            </div>
+          <label class="flex flex-col gap-1 w-full sm:w-48">
+            <span class="text-sm font-medium">Lookback window</span>
             <input
               type="text"
               name="since"
@@ -363,10 +358,8 @@
                   never sees this field, so the form they can submit carries no
                   ``tenant_filter`` and they stay own-tenant scoped. A forged
                   cross-tenant value still hits the backend 403. -#}
-              <label class="form-control w-full sm:w-80">
-                <div class="label">
-                  <span class="label-text">Tenant filter <span class="opacity-50">(platform admin)</span></span>
-                </div>
+              <label class="flex flex-col gap-1 w-full sm:w-80">
+                <span class="text-sm font-medium">Tenant filter <span class="opacity-50">(platform admin)</span></span>
                 <input
                   type="text"
                   name="tenant_filter"


### PR DESCRIPTION
## Summary

Fixes **task evoila-bosnia/meho-internal#169** — two presentation defects on `/ui/retrieval`.

- **Usage Analytics chips legible** — the `mcp:search_*` chips in the teal "REST excluded" `alert-info` banner used `badge-ghost`, whose text inherits the info surface colour and read as near-invisible on teal. Switched to `badge-neutral` (solid neutral + neutral-content text), contrast-safe in light **and** dark. The per-row table chip (on the default surface, where ghost is legible) is left unchanged.
- **Diagnostics form no longer overlaps** — the form used daisyUI **v4** classes (`form-control` / `label` / `label-text` / `label-text-alt`) that daisyUI v5 removed (compile to zero rules), so `form-control` stopped stacking its children and the Source field's `label-text-alt` helper flowed inline and collided with the Kind / Limit / Run controls. Migrated every label in the file to live utilities (`flex flex-col gap-1` + `text-sm font-medium`) and relocated the Source helper to a full-width note below the controls row, wired to the Source input via `aria-describedby`.

Presentation only — no change to HTMX wiring, datalists, CSRF, or form fields.

## Test plan
- [x] `pytest tests/test_ui_retrieval.py tests/test_retrieval_usage.py tests/test_retrieval_retire.py` — **137 passed**
- [x] Usage chips: `badge-neutral` on the info banner (visible in diff); legible in both themes.
- [x] Diagnostics: Source/Kind/Limit/Run + Source helper no longer overlap at `sm` and below; helper is a full-width block below the row.
- [x] No `form-control` / `label-text` / `label-text-alt` **class attributes** remain in `retrieval/index.html` or `_usage_results.html`.
- [x] Helper-text substring assertion (`test_ui_retrieval.py`) still holds — text preserved, only relocated.

## Scope note
Beyond the two reported defects, the Usage-tab and Retire-tab forms **in the same file** carried the same dead classes; I migrated them too so `index.html` is internally consistent and AC "no dead classes remain" holds. The ticket's deferred "app-wide daisyUI-v5 migration" refers to **other** template files (e.g. `topology/graph.html`, `timeline.html`, `_bulk_import_modal.html`), not other forms in this touched file. Those remain out of scope.

Closes evoila-bosnia/meho-internal#169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated retrieval diagnostics controls with a more consistent, accessible label and helper-text layout.
  * Refined counted-surface badges with a neutral solid style for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->