### PR TITLE
fix(ui): polish connector detail — labels, timestamps, edit-form layout (#170)

### DIFF
--- a/backend/src/meho_backplane/ui/static/src/app/connectors-feed.js
+++ b/backend/src/meho_backplane/ui/static/src/app/connectors-feed.js
@@ -112,8 +112,18 @@ document.addEventListener("alpine:init", () => {
     // ``YYYY-MM-DD HH:MM UTC`` (audit timestamps are UTC). Falls back to
     // the raw string on an unparseable value so a malformed frame never
     // blanks the row (mirrors ``broadcast-feed.js``'s ``formatTs``).
+    //
+    // ``occurred_at`` is UTC, but a suffix-less value (SQLite returns the
+    // ``DateTime(timezone=True)`` column without a ``+00:00`` offset) would
+    // be parsed as *local* time by ``new Date`` and then mislabelled by the
+    // ``getUTC*`` calls below in a non-UTC browser. Append ``Z`` when no
+    // timezone designator is present so the instant is always read as UTC.
     formatTs(ts) {
-      const d = new Date(ts);
+      if (!ts) {
+        return ts;
+      }
+      const hasTz = /[zZ]$|[+-]\d{2}:?\d{2}$/.test(ts);
+      const d = new Date(hasTz ? ts : ts + "Z");
       if (isNaN(d.getTime())) {
         return ts;
       }

--- a/backend/src/meho_backplane/ui/static/src/app/connectors-feed.js
+++ b/backend/src/meho_backplane/ui/static/src/app/connectors-feed.js
@@ -107,5 +107,29 @@ document.addEventListener("alpine:init", () => {
         this.events.length = this.cap;
       }
     },
+
+    // Render an ISO-8601 ``occurred_at`` as the console-standard
+    // ``YYYY-MM-DD HH:MM UTC`` (audit timestamps are UTC). Falls back to
+    // the raw string on an unparseable value so a malformed frame never
+    // blanks the row (mirrors ``broadcast-feed.js``'s ``formatTs``).
+    formatTs(ts) {
+      const d = new Date(ts);
+      if (isNaN(d.getTime())) {
+        return ts;
+      }
+      const pad = (n) => String(n).padStart(2, "0");
+      return (
+        d.getUTCFullYear() +
+        "-" +
+        pad(d.getUTCMonth() + 1) +
+        "-" +
+        pad(d.getUTCDate()) +
+        " " +
+        pad(d.getUTCHours()) +
+        ":" +
+        pad(d.getUTCMinutes()) +
+        " UTC"
+      );
+    },
   }));
 });

--- a/backend/src/meho_backplane/ui/templates/connectors/_recent_ops.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_recent_ops.html
@@ -95,7 +95,7 @@
           <time
             class="text-xs opacity-70 w-44 shrink-0"
             x-bind:datetime="ev.occurred_at"
-            x-text="ev.occurred_at"
+            x-text="formatTs(ev.occurred_at)"
           ></time>
           <span class="badge badge-outline badge-xs" x-text="ev.method"></span>
           <span class="font-mono text-xs truncate" x-text="ev.path"></span>

--- a/backend/src/meho_backplane/ui/templates/connectors/_target_form_fields.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_target_form_fields.html
@@ -41,7 +41,7 @@
 
 {%- macro error_for(field) -%}
   {%- if errors and field in errors -%}
-    <span class="label-text-alt text-error" role="alert" data-error-for="{{ field }}">
+    <span class="text-xs text-error" role="alert" data-error-for="{{ field }}">
       {{ errors[field] }}
     </span>
   {%- endif -%}
@@ -51,8 +51,8 @@
   {%- if errors and field in errors -%}{{ base }}{%- endif -%}
 {%- endmacro -%}
 
-<label class="form-control">
-  <span class="label-text">Name</span>
+<label class="flex flex-col gap-1">
+  <span class="text-sm font-medium">Name</span>
   <input
     type="text"
     name="name"
@@ -61,12 +61,12 @@
     maxlength="200"
     value="{{ field_value('name') }}"
     {% if mode == "edit" %}readonly{% endif %}
-    class="input input-bordered input-sm font-mono {{ error_class('name', 'input-error') }}"
+    class="input input-bordered input-sm font-mono w-full {{ error_class('name', 'input-error') }}"
     aria-label="Target name"
     {% if mode == "edit" %}aria-describedby="target-name-immutable-hint"{% endif %}
   />
   {% if mode == "edit" %}
-    <span id="target-name-immutable-hint" class="text-xs opacity-60 mt-1">
+    <span id="target-name-immutable-hint" class="text-xs opacity-60">
       Name is immutable. To rename, delete and re-create the target.
     </span>
   {% endif %}
@@ -74,12 +74,12 @@
 </label>
 
 <div class="grid gap-3 md:grid-cols-2">
-  <label class="form-control">
-    <span class="label-text">Product</span>
+  <label class="flex flex-col gap-1">
+    <span class="text-sm font-medium">Product</span>
     <select
       name="product"
       required
-      class="select select-bordered select-sm {{ error_class('product', 'select-error') }}"
+      class="select select-bordered select-sm w-full {{ error_class('product', 'select-error') }}"
       aria-label="Connector product"
     >
       <option value="" disabled {% if not field_value('product') %}selected{% endif %}>
@@ -94,12 +94,12 @@
     {{ error_for('product') }}
   </label>
 
-  <label class="form-control">
-    <span class="label-text">Auth model</span>
+  <label class="flex flex-col gap-1">
+    <span class="text-sm font-medium">Auth model</span>
     <select
       name="auth_model"
       required
-      class="select select-bordered select-sm {{ error_class('auth_model', 'select-error') }}"
+      class="select select-bordered select-sm w-full {{ error_class('auth_model', 'select-error') }}"
       aria-label="Auth model"
     >
       {%- set selected_auth = field_value('auth_model') or 'shared_service_account' -%}
@@ -114,8 +114,8 @@
 </div>
 
 <div class="grid gap-3 md:grid-cols-2">
-  <label class="form-control">
-    <span class="label-text">Host</span>
+  <label class="flex flex-col gap-1">
+    <span class="text-sm font-medium">Host</span>
     <input
       type="text"
       name="host"
@@ -123,22 +123,22 @@
       minlength="1"
       maxlength="512"
       value="{{ field_value('host') }}"
-      class="input input-bordered input-sm font-mono {{ error_class('host', 'input-error') }}"
+      class="input input-bordered input-sm font-mono w-full {{ error_class('host', 'input-error') }}"
       aria-label="Host"
       placeholder="host.example.internal"
     />
     {{ error_for('host') }}
   </label>
 
-  <label class="form-control">
-    <span class="label-text">Port <span class="opacity-60">(optional)</span></span>
+  <label class="flex flex-col gap-1">
+    <span class="text-sm font-medium">Port <span class="opacity-60">(optional)</span></span>
     <input
       type="number"
       name="port"
       min="1"
       max="65535"
       value="{{ field_value('port') }}"
-      class="input input-bordered input-sm {{ error_class('port', 'input-error') }}"
+      class="input input-bordered input-sm w-full {{ error_class('port', 'input-error') }}"
       aria-label="Port"
       placeholder="1-65535"
     />
@@ -146,44 +146,46 @@
   </label>
 </div>
 
-<label class="form-control">
-  <span class="label-text">Secret ref <span class="opacity-60">(optional)</span></span>
-  <input
-    type="text"
-    name="secret_ref"
-    maxlength="1024"
-    value="{{ field_value('secret_ref') }}"
-    class="input input-bordered input-sm font-mono {{ error_class('secret_ref', 'input-error') }}"
-    aria-label="Secret reference"
-    placeholder="secret/data/targets/&lt;name&gt;"
-    aria-describedby="target-secret-ref-hint"
-  />
-  <span id="target-secret-ref-hint" class="text-xs opacity-60 mt-1">
-    Vault path the connector reads credentials from.
-  </span>
-  {{ error_for('secret_ref') }}
-</label>
+<div class="grid gap-3 md:grid-cols-2">
+  <label class="flex flex-col gap-1">
+    <span class="text-sm font-medium">Secret ref <span class="opacity-60">(optional)</span></span>
+    <input
+      type="text"
+      name="secret_ref"
+      maxlength="1024"
+      value="{{ field_value('secret_ref') }}"
+      class="input input-bordered input-sm font-mono w-full {{ error_class('secret_ref', 'input-error') }}"
+      aria-label="Secret reference"
+      placeholder="secret/data/targets/&lt;name&gt;"
+      aria-describedby="target-secret-ref-hint"
+    />
+    <span id="target-secret-ref-hint" class="text-xs opacity-60">
+      Vault path the connector reads credentials from.
+    </span>
+    {{ error_for('secret_ref') }}
+  </label>
 
-<label class="form-control">
-  <span class="label-text">Aliases <span class="opacity-60">(comma-separated, optional)</span></span>
-  <input
-    type="text"
-    name="aliases"
-    maxlength="2048"
-    value="{{ field_value('aliases') }}"
-    class="input input-bordered input-sm {{ error_class('aliases', 'input-error') }}"
-    aria-label="Aliases"
-    placeholder="prod-cluster, primary"
-  />
-  {{ error_for('aliases') }}
-</label>
+  <label class="flex flex-col gap-1">
+    <span class="text-sm font-medium">Aliases <span class="opacity-60">(comma-separated, optional)</span></span>
+    <input
+      type="text"
+      name="aliases"
+      maxlength="2048"
+      value="{{ field_value('aliases') }}"
+      class="input input-bordered input-sm w-full {{ error_class('aliases', 'input-error') }}"
+      aria-label="Aliases"
+      placeholder="prod-cluster, primary"
+    />
+    {{ error_for('aliases') }}
+  </label>
+</div>
 
-<label class="form-control">
-  <span class="label-text">Notes <span class="opacity-60">(optional)</span></span>
+<label class="flex flex-col gap-1">
+  <span class="text-sm font-medium">Notes <span class="opacity-60">(optional)</span></span>
   <textarea
     name="notes"
     maxlength="8192"
-    class="textarea textarea-bordered min-h-[6rem] text-sm {{ error_class('notes', 'textarea-error') }}"
+    class="textarea textarea-bordered min-h-[6rem] w-full text-sm {{ error_class('notes', 'textarea-error') }}"
     aria-label="Notes"
     placeholder="Free-form operator notes."
   >{{ field_value('notes') }}</textarea>
@@ -199,5 +201,5 @@
     class="checkbox checkbox-sm"
     aria-label="VPN required"
   />
-  <span class="label-text">VPN required</span>
+  <span class="text-sm font-medium">VPN required</span>
 </label>

--- a/backend/src/meho_backplane/ui/templates/connectors/detail.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/detail.html
@@ -92,12 +92,15 @@
       >
         <div class="card-body space-y-2">
           <h2 class="card-title text-base">Properties</h2>
+          {#- Human-readable labels + hidden internal id (#170): the raw
+              UUID is operator-facing noise (name carries identity), and
+              ``created_at`` / ``updated_at`` render the console-standard
+              ``%Y-%m-%d %H:%M UTC`` with the ISO value kept in the
+              ``<time datetime>`` attribute. Timestamps are tz-aware UTC. -#}
           <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
-            <dt class="opacity-60">id</dt>
-            <dd class="font-mono text-xs">{{ target.id }}</dd>
-            <dt class="opacity-60">name</dt>
+            <dt class="opacity-60">Name</dt>
             <dd class="font-mono">{{ target.name }}</dd>
-            <dt class="opacity-60">aliases</dt>
+            <dt class="opacity-60">Aliases</dt>
             <dd>
               {% if target.aliases %}
                 {{ target.aliases | join(", ") }}
@@ -105,26 +108,30 @@
                 <span class="opacity-50">—</span>
               {% endif %}
             </dd>
-            <dt class="opacity-60">product</dt>
+            <dt class="opacity-60">Product</dt>
             <dd>{{ target.product }}</dd>
-            <dt class="opacity-60">host</dt>
+            <dt class="opacity-60">Host</dt>
             <dd class="font-mono">{{ target.host }}</dd>
-            <dt class="opacity-60">port</dt>
+            <dt class="opacity-60">Port</dt>
             <dd>{{ target.port if target.port is not none else "—" }}</dd>
-            <dt class="opacity-60">fqdn</dt>
+            <dt class="opacity-60">FQDN</dt>
             <dd>{{ target.fqdn or "—" }}</dd>
-            <dt class="opacity-60">auth_model</dt>
+            <dt class="opacity-60">Auth model</dt>
             <dd><span class="badge badge-ghost badge-xs">{{ target.auth_model }}</span></dd>
-            <dt class="opacity-60">vpn_required</dt>
+            <dt class="opacity-60">VPN required</dt>
             <dd>{{ "yes" if target.vpn_required else "no" }}</dd>
-            <dt class="opacity-60">secret_ref</dt>
+            <dt class="opacity-60">Secret ref</dt>
             <dd class="font-mono text-xs">{{ target.secret_ref or "—" }}</dd>
-            <dt class="opacity-60">preferred_impl_id</dt>
+            <dt class="opacity-60">Preferred impl</dt>
             <dd class="font-mono text-xs">{{ target.preferred_impl_id or "—" }}</dd>
-            <dt class="opacity-60">created_at</dt>
-            <dd class="text-xs">{{ target.created_at.isoformat() }}</dd>
-            <dt class="opacity-60">updated_at</dt>
-            <dd class="text-xs">{{ target.updated_at.isoformat() }}</dd>
+            <dt class="opacity-60">Created</dt>
+            <dd class="text-xs">
+              <time datetime="{{ target.created_at.isoformat() }}">{{ target.created_at.strftime("%Y-%m-%d %H:%M UTC") }}</time>
+            </dd>
+            <dt class="opacity-60">Updated</dt>
+            <dd class="text-xs">
+              <time datetime="{{ target.updated_at.isoformat() }}">{{ target.updated_at.strftime("%Y-%m-%d %H:%M UTC") }}</time>
+            </dd>
           </dl>
           {% if target.extras %}
             <details class="mt-2">


### PR DESCRIPTION
## Summary

Presentation cleanup of the connector **detail** view (`/ui/connectors/<name>`) — task **evoila-bosnia/meho-internal#170**.

- **Properties card** — humanized labels (`Name`, `Aliases`, `Product`, `Host`, `Port`, `FQDN`, `Auth model`, `VPN required`, `Secret ref`, `Preferred impl`, `Created`, `Updated`); dropped the raw internal UUID row (name carries identity); `created_at`/`updated_at` render `%Y-%m-%d %H:%M UTC` with the ISO value kept in the `<time datetime>` attribute (tz-aware UTC columns).
- **Recent operations** — the Alpine feed printed the raw ISO `occurred_at`. Added a `formatTs` method to the `connectorsRecentOps` component (UTC `YYYY-MM-DD HH:MM UTC`, raw-string fallback on unparseable input, mirroring `broadcast-feed.js`); rendered via `x-text`, keeping `x-bind:datetime` on the raw value.
- **Edit-target form** — migrated off daisyUI **v4** classes (`form-control`/`label-text`/`label-text-alt`, removed in v5, which is why labels/helper text overlapped). Now `flex flex-col gap-1` labels + `text-sm font-medium`; every control is `w-full`; **Name** and **Notes** are full-width; **Secret ref + Aliases** sit in a 2-col row like **Host/Port**; the field-error span uses `text-xs text-error`.

Presentation only — no change to the edit endpoint, the SSE feed contract, or connector behaviour.

## Test plan
- [x] `pytest tests/test_ui_connectors_view.py tests/test_ui_connectors_forms.py` — **66 passed**
- [x] Properties labels humanized + `id` row removed (visible in diff).
- [x] `created_at`/`updated_at` and Recent-ops timestamps show `%Y-%m-%d %H:%M UTC`; ISO retained in `datetime` attrs (Recent-ops verified live in the dev console).
- [x] Edit form: no label/helper overlap; controls `w-full`; Secret ref + Aliases paired; no `form-control`/`label-text`/`label-text-alt` class attributes remain.

## Out of scope
- Dead-class cleanup of other connector templates (registry / ingest / review-drawer) → the app-wide daisyUI-v5 migration.

Closes evoila-bosnia/meho-internal#170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Recent operation timestamps now display in a consistent UTC format.
  * Connector property labels are more readable, and internal identifiers are no longer shown.
  * Connector creation and update times now use clearer date and time formatting.
  * Connector target forms have improved spacing, labels, field widths, and inline error messaging.
  * Edit forms now provide clearer guidance when a connector name cannot be changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->