### PR TITLE
fix(cli): map tls_server_name to the targets-import column set (#2643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — CLI targets import tls_server_name (#2643)
+
+- `meho targets import` now maps a manifest's `tls_server_name` to the
+  real top-level column on `TargetCreate` / `TargetUpdate` instead of
+  spilling it into the `extras` JSONB blob. Before this fix the import
+  reported "1 updated", the descriptor looked complete, and the typed
+  column stayed `NULL` — so dispatch kept deriving the SNI /
+  cert-verification hostname from `host` and an appliance reached by IP
+  with an FQDN-only SAN failed with `connector_tls_verify_failed`
+  ("IP address mismatch"), the exact class the #2398 SNI fix shipped to
+  unblock. Operators who worked around it with `PATCH
+  /api/v1/targets/{name}` can drop the manual step and let the
+  repo-tracked `targets.yaml` be the source of truth again.
+
 ## [0.25.0] - 2026-07-19
 
 This release lands the complete **v0.21/v0.22 dogfood-hardening cycle** —

--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -68,6 +68,17 @@ type importDoc struct {
 // the descriptor. The server enforces their mutual exclusivity
 // (`verify_tls=false` ⊕ `tls_ca_pin`) and PEM validation with a 422,
 // which the import path surfaces via the existing error handling.
+//
+// #2002 amendment: `tls_server_name` is the third first-class TLS
+// column (per-target SNI / cert-verification hostname, decoupled from
+// `host`). It belongs in the same bucket for the same reason —
+// spilling it into `extras` leaves the typed column NULL, so dispatch
+// keeps deriving the SNI from `host` and an appliance reached by IP
+// with an FQDN-only SAN fails verification with
+// `connector_tls_verify_failed` even though the descriptor named the
+// right hostname. The column composes with `verify_tls` / `tls_ca_pin`
+// (no mutual-exclusion validator); the server caps it at 512 chars and
+// returns 422 on overflow, which the import path already surfaces.
 var knownTopLevel = map[string]struct{}{
 	"aliases":           {},
 	"auth_model":        {},
@@ -81,6 +92,7 @@ var knownTopLevel = map[string]struct{}{
 	"product":           {},
 	"secret_ref":        {},
 	"tls_ca_pin":        {},
+	"tls_server_name":   {},
 	"verify_tls":        {},
 	"vpn_required":      {},
 }
@@ -179,7 +191,8 @@ func newImportCmd() *cobra.Command {
 			"Mapping rules. Top-level columns recognised on the API's " +
 			"TargetCreate / TargetUpdate models are mapped 1:1: name, aliases, " +
 			"product, host, port, fqdn, secret_ref, auth_model, vpn_required, " +
-			"notes, preferred_impl_id, verify_tls, tls_ca_pin. Any other field " +
+			"notes, preferred_impl_id, verify_tls, tls_ca_pin, tls_server_name. " +
+			"Any other field " +
 			"is spilled into the `extras` JSONB column. `fingerprint` is " +
 			"server-managed and skipped with a warning if present in the YAML " +
 			"(the probe verb is the only legitimate writer).\n\n" +

--- a/cli/internal/cmd/targets/import_test.go
+++ b/cli/internal/cmd/targets/import_test.go
@@ -266,6 +266,99 @@ func TestMapEntryTLSTrustTopLevelStillSpillsUnknown(t *testing.T) {
 	}
 }
 
+func TestMapEntryTLSServerNameIsTopLevel(t *testing.T) {
+	t.Parallel()
+	// #2002 shipped tls_server_name as a first-class TargetCreate /
+	// TargetUpdate column: the per-target SNI / cert-verification
+	// hostname, decoupled from `host`. It must land in the body root,
+	// NOT in extras — spilling leaves the typed column NULL, dispatch
+	// keeps deriving the SNI from `host`, and an appliance reached by
+	// IP with an FQDN-only SAN fails with connector_tls_verify_failed
+	// despite the descriptor naming the right hostname (#2643).
+	body, warnings := mapEntry(map[string]any{
+		"name":            "vcf-sddc-manager",
+		"product":         "vmware-rest",
+		"host":            "10.20.30.40",
+		"tls_server_name": "sddc-manager.evba.lab",
+	})
+	if len(warnings) != 0 {
+		t.Errorf("warnings: got %v; want none", warnings)
+	}
+	if v, ok := body["tls_server_name"]; !ok || v != "sddc-manager.evba.lab" {
+		t.Errorf("tls_server_name top-level: got %v (present=%t); want sddc-manager.evba.lab", v, ok)
+	}
+	if extras, ok := body["extras"].(map[string]any); ok {
+		if _, leaked := extras["tls_server_name"]; leaked {
+			t.Errorf("tls_server_name leaked into extras: %v", extras)
+		}
+	}
+}
+
+func TestEntryToUpdateBodyTLSServerNameIsTopLevel(t *testing.T) {
+	t.Parallel()
+	// `meho targets import --update` routes through entryToUpdateBody.
+	// tls_server_name must reach the sparse PATCH body's top level so a
+	// descriptor re-import flips the typed column; an explicit null
+	// clears the override and returns the target to deriving the SNI
+	// from `host` (TargetUpdate's documented clear semantics).
+	body, _ := entryToUpdateBody(map[string]any{
+		"name":            "vcf-sddc-manager",
+		"tls_server_name": "sddc-manager.evba.lab",
+	})
+	if v, ok := body["tls_server_name"]; !ok || v != "sddc-manager.evba.lab" {
+		t.Errorf("tls_server_name top-level on update: got %v (present=%t); want sddc-manager.evba.lab", v, ok)
+	}
+	if extras, ok := body["extras"].(map[string]any); ok {
+		if _, leaked := extras["tls_server_name"]; leaked {
+			t.Errorf("tls_server_name leaked into extras on update: %v", extras)
+		}
+	}
+
+	cleared, _ := entryToUpdateBody(map[string]any{
+		"name":            "vcf-sddc-manager",
+		"tls_server_name": nil, // clearing the override is an explicit-null PATCH
+	})
+	v, ok := cleared["tls_server_name"]
+	if !ok {
+		t.Errorf("tls_server_name missing from update body; want top-level null: %v", cleared)
+	}
+	if v != nil {
+		t.Errorf("tls_server_name cleared value: got %v; want nil", v)
+	}
+}
+
+func TestMapEntryTLSServerNameStillSpillsUnknown(t *testing.T) {
+	t.Parallel()
+	// No-regression guard: adding tls_server_name to knownTopLevel must
+	// not change the extras-spill behaviour for genuinely-unknown keys,
+	// and it must compose with the sibling TLS-trust columns (the server
+	// has no mutual-exclusion validator between them).
+	body, _ := mapEntry(map[string]any{
+		"name":            "vcf-sddc-manager",
+		"product":         "vmware-rest",
+		"host":            "10.20.30.40",
+		"verify_tls":      true,
+		"tls_server_name": "sddc-manager.evba.lab",
+		"sso_realm":       "evba.lab", // unknown → spill
+	})
+	if v, ok := body["tls_server_name"]; !ok || v != "sddc-manager.evba.lab" {
+		t.Errorf("tls_server_name top-level: got %v (present=%t); want sddc-manager.evba.lab", v, ok)
+	}
+	if v, ok := body["verify_tls"]; !ok || v != true {
+		t.Errorf("verify_tls top-level: got %v (present=%t); want true", v, ok)
+	}
+	extras, ok := body["extras"].(map[string]any)
+	if !ok {
+		t.Fatalf("extras: got %T; want map[string]any (unknown key should spill)", body["extras"])
+	}
+	if extras["sso_realm"] != "evba.lab" {
+		t.Errorf("extras.sso_realm: got %v; want evba.lab", extras["sso_realm"])
+	}
+	if _, leaked := extras["tls_server_name"]; leaked {
+		t.Errorf("tls_server_name must not be in extras: %v", extras)
+	}
+}
+
 func TestMapEntryExplicitExtrasMergesWithSpilled(t *testing.T) {
 	t.Parallel()
 	body, _ := mapEntry(map[string]any{

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -2027,11 +2027,14 @@ output), `--backplane` (override the configured backplane URL).
 - **Known top-level columns** map 1:1 to the API's `TargetCreate` /
   `TargetUpdate` body fields: `name`, `aliases`, `product`, `host`,
   `port`, `fqdn`, `secret_ref`, `auth_model`, `vpn_required`,
-  `notes`, `preferred_impl_id`. The list in
+  `notes`, `preferred_impl_id`, `verify_tls`, `tls_ca_pin`,
+  `tls_server_name`. The list in
   `knownTopLevel` is the canonical reference; the
   Python-side mirror lives in
-  `backend/tests/test_api_v1_targets_import.py:_KNOWN_TOP_LEVEL` and
-  keeps drift detectable in CI.
+  `backend/tests/test_api_v1_targets_import.py:_KNOWN_TOP_LEVEL`,
+  which pins the pre-#1774 core set the consumer fixture exercises
+  (it carries none of the TLS columns, so the two sets agree on
+  every key that fixture can produce).
 - **`fingerprint`** is dropped silently with a warning log line.
   Server-managed per the G0.3-T1.5 (#477) amendment — the probe
   verb is the only legitimate writer, and the API rejects
@@ -2042,6 +2045,15 @@ output), `--backplane` (override the configured backplane URL).
 - **`preferred_impl_id`** is a real top-level column post-#477.
   Sent at the body root, not spilled into extras — the G0.6 #388
   resolver's tie-break ladder reads it.
+- **`verify_tls` / `tls_ca_pin` / `tls_server_name`** are the
+  per-target TLS columns (Initiative #1774's #1780 / #1784, plus
+  #2002's SNI override). All three go at the body root. Spilling any
+  of them into `extras` is silent misconfiguration: the typed column
+  keeps its default, the import still prints "1 updated", and the
+  operator only finds out at dispatch time — `tls_server_name`
+  specifically surfaces as `connector_tls_verify_failed` /
+  "IP address mismatch" on an appliance reached by IP whose leaf cert
+  carries an FQDN-only SAN (#2643).
 - **Every other key** spills into the `extras` JSONB column.
   Explicit `extras:` blocks in the YAML merge with spilled keys
   rather than overwriting them.

--- a/docs/cross-repo/targets-yaml.md
+++ b/docs/cross-repo/targets-yaml.md
@@ -394,6 +394,7 @@ of this section for the bug history (PR #362's review on issue
 | --- | --- | --- |
 | `name`, `aliases`, `product`, `host`, `port`, `fqdn`, `secret_ref`, `auth_model`, `vpn_required`, `notes` | top-level column | required: `name`, `product`, `host` |
 | `preferred_impl_id` | top-level column | G0.3-T1.5 (#477) amendment — G0.6 resolver tie-break override |
+| `verify_tls`, `tls_ca_pin`, `tls_server_name` | top-level column | per-target TLS trust (#1780 / #1784) and SNI / cert-verification hostname (#2002, mapped by #2643) — set `tls_server_name` to the cert's FQDN when the appliance is reached by IP |
 | `extras` (explicit block) | `extras` JSONB | merges with the spilled-extras map from unknown keys |
 | `fingerprint` | dropped with warning | server-managed; only the probe verb writes it |
 | any other key | spilled into `extras` JSONB | the consumer's `sso_realm`, `kubeconfig_field`, `account`, `project_id` land here |


### PR DESCRIPTION
## Summary

- `meho targets import` silently dropped `tls_server_name`: the CLI's `knownTopLevel` set never grew the key when #2002 added the column to `TargetCreate` / `TargetUpdate`, so a manifest key spilled into the `extras` JSONB blob. The import printed "1 updated", the descriptor looked complete, and the typed column stayed `NULL`.
- Dispatch then kept deriving the SNI / cert-verification hostname from `host`, so an appliance reached by IP with an FQDN-only SAN failed with `connector_tls_verify_failed` ("IP address mismatch") — the exact class the #2398 SNI fix shipped to unblock. Operators had to work around it with a manual `PATCH /api/v1/targets/{name}`, which the repo-tracked `targets.yaml` then couldn't express.
- Fix is one map entry, given the same treatment `verify_tls` (#1780) and `tls_ca_pin` (#1784) got: the key reaches the body root on both the POST (create) and the sparse PATCH (`--update`) shapes, and an explicit `tls_server_name: null` still clears the override.
- No client regeneration and no backend change: the generated REST client already carries `TlsServerName *string` on `TargetCreate` and `TargetUpdate`, and `backend/src/meho_backplane/targets/schemas.py` has had the column since #2002. The CLI map was the only gap.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l ./internal/` — no output
- [x] `go test ./...` (whole CLI module) — all packages ok
- [x] AC 1 — CREATE body carries it top-level: `TestMapEntryTLSServerNameIsTopLevel` (mirrors `import_test.go` `TestMapEntryTLSTrustKeysAreTopLevel`)
- [x] AC 2 — `--update` sends it top-level: `TestEntryToUpdateBodyTLSServerNameIsTopLevel` (mirrors `TestEntryToUpdateBodyTLSTrustKeysAreTopLevel`; also pins the explicit-null clear)
- [x] AC 3 — never leaks into `extras`, unknown keys still spill: `TestMapEntryTLSServerNameStillSpillsUnknown` (mirrors `TestMapEntryTLSTrustTopLevelStillSpillsUnknown`)
- [x] AC 4 — CHANGELOG `[Unreleased]` entry under the unique header `### Fixed — CLI targets import tls_server_name (#2643)`
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0

Local `golangci-lint` could not run (`the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25)` — a stale local binary, not a code finding); the `Go (golangci-lint + go test)` CI lane runs the pinned version. The diff adds no production code paths, and `_test.go` files are already excluded from `revive` / `errcheck` by `cli/.golangci.yml`.

## Docs

- `cli/internal/cmd/targets/import.go` — the verb's `--help` mapping line now lists `tls_server_name`.
- `docs/codebase/cli.md` — mapping-rules list + a bullet explaining why all three TLS columns must go top-level.
- `docs/cross-repo/targets-yaml.md` — the "Mapping rules at a glance" table had never recorded `verify_tls` / `tls_ca_pin` either; one row now covers all three.

## Out of scope

- **`version` is a second gap of the same class.** `TargetCreate` / `TargetUpdate` both carry the operator-asserted `version` column (G0.15-T6 #1215 — it flips the connector resolver from the wildcard fallback to the versioned connector), and it is *also* absent from `knownTopLevel`, so a manifest's `version:` spills into `extras` just as silently. This contradicts the issue body's "this is the only `TargetUpdate` field absent from the map" line. Left untouched here to keep the fix matching its ticket; worth a one-line follow-up issue.
- **The Python-side mirror lags.** `backend/tests/test_api_v1_targets_import.py:_KNOWN_TOP_LEVEL` is documented as the mirror of `knownTopLevel` but never grew the #1780/#1784 columns either. It is inert today (the pinned consumer fixture carries none of the TLS columns, verified by grep), and it is not an asserted equality check — so it does not detect this drift class. Untouched here per the "no backend change" scope; a real drift guard would be a better fix than adding a fourth key by hand.
- Import-plan diff display polish; any other missing-column audit.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2643


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `meho targets import` so `tls_server_name` is correctly applied to targets instead of being stored as extra data.
  - Prevented TLS verification failures caused by using an IP address when the certificate requires a hostname.
  - Preserved support for clearing `tls_server_name` and storing unrelated unknown fields as extras.

- **Documentation**
  - Clarified YAML import behavior for TLS settings, including certificate hostname and SNI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->