### PR TITLE
fix(scheduler): split a dead Vault token from an under-scoped policy (#2652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,15 +100,19 @@ connector-related release-notes line.
   the operator verify policy, path pattern, and mount (all correct)
   before anyone thought to `vault token lookup` the token itself. The
   broker now fires the `auth/token/lookup-self` probe it already shipped
-  for #2328 on the write-failure path and carries the disposition on
+  for #2328 whenever Vault answers the write with a 403 — the one
+  ambiguous status — and carries the disposition on
   `SchedulerVaultBrokerError`; a dead token surfaces as
   `scheduler_vault_token_invalid: the scheduler Vault token is invalid or
   expired …` with the re-mint remediation on all four surfaces (the MCP
   `meho.agent_principals.register` `-32602` message, both REST register
   routes' 502 detail, and the `/ui/agents/principals` register banner),
   while a live-token-denied write keeps the existing policy-scope wording
-  unchanged. Diagnosis only — the write is not retried, and the
-  renew-on-use loop from #2328 is untouched.
+  unchanged. Only a 403 on the probe condemns the token: a sealed (503),
+  overloaded (429) or broken (500/502) Vault stays on the policy-scope
+  wording instead of ordering a re-mint mid-outage. Diagnosis only — the
+  write is not retried, and the renew-on-use loop from #2328 is
+  untouched.
   `docs/cross-repo/vault-provisioning.md` gains the dead-token row next
   to the under-scoped-policy row.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — scheduler Vault dead-token diagnostics (#2652)
+
+- Agent- and runner-principal registration now tells operators **which**
+  Vault fault they hit. A dead scheduler token (revoked, expired, or a
+  periodic token whose lease lapsed) and an under-scoped `meho-scheduler`
+  policy both make Vault answer the credential write with a 403, but
+  every surface named only the policy remediation — so a field report had
+  the operator verify policy, path pattern, and mount (all correct)
+  before anyone thought to `vault token lookup` the token itself. The
+  broker now fires the `auth/token/lookup-self` probe it already shipped
+  for #2328 on the write-failure path and carries the disposition on
+  `SchedulerVaultBrokerError`; a dead token surfaces as
+  `scheduler_vault_token_invalid: the scheduler Vault token is invalid or
+  expired …` with the re-mint remediation on all four surfaces (the MCP
+  `meho.agent_principals.register` `-32602` message, both REST register
+  routes' 502 detail, and the `/ui/agents/principals` register banner),
+  while a live-token-denied write keeps the existing policy-scope wording
+  unchanged. Diagnosis only — the write is not retried, and the
+  renew-on-use loop from #2328 is untouched.
+  `docs/cross-repo/vault-provisioning.md` gains the dead-token row next
+  to the under-scoped-policy row.
+
 ## [0.25.0] - 2026-07-19
 
 This release lands the complete **v0.21/v0.22 dogfood-hardening cycle** —

--- a/backend/src/meho_backplane/api/v1/agent_principals.py
+++ b/backend/src/meho_backplane/api/v1/agent_principals.py
@@ -67,7 +67,10 @@ from meho_backplane.auth.keycloak_admin import (
 )
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
-from meho_backplane.scheduler.vault_credentials import SchedulerVaultBrokerError
+from meho_backplane.scheduler.vault_credentials import (
+    SCHEDULER_VAULT_TOKEN_INVALID_DETAIL,
+    SchedulerVaultBrokerError,
+)
 
 __all__ = ["router"]
 
@@ -205,10 +208,18 @@ async def register_agent_principal(
         # (unreachable / denied). 502 upstream failure; the just-created
         # Keycloak client is already rolled back. (An *unset* token is not
         # an error — the service skips the write and the agent uses the
-        # env-var fallback.)
+        # env-var fallback.) The broker's ``lookup-self`` probe (#2652)
+        # says whether the token is dead — that case gets the
+        # gold-standard three-clause detail naming the re-mint, because
+        # its remediation *is* knowable; everything else keeps the bare
+        # ``scheduler_vault_write_error`` code.
         raise HTTPException(
             status_code=http_status.HTTP_502_BAD_GATEWAY,
-            detail="scheduler_vault_write_error",
+            detail=(
+                SCHEDULER_VAULT_TOKEN_INVALID_DETAIL
+                if exc.token_invalid
+                else "scheduler_vault_write_error"
+            ),
         ) from exc
     except ValueError as exc:
         raise HTTPException(

--- a/backend/src/meho_backplane/api/v1/runner_principals.py
+++ b/backend/src/meho_backplane/api/v1/runner_principals.py
@@ -71,7 +71,10 @@ from meho_backplane.auth.runner_principals import (
     RunnerPrincipalRead,
     RunnerPrincipalService,
 )
-from meho_backplane.scheduler.vault_credentials import SchedulerVaultBrokerError
+from meho_backplane.scheduler.vault_credentials import (
+    SCHEDULER_VAULT_TOKEN_INVALID_DETAIL,
+    SchedulerVaultBrokerError,
+)
 
 __all__ = ["router"]
 
@@ -198,10 +201,18 @@ async def register_runner_principal(
     except SchedulerVaultBrokerError as exc:
         # ``VAULT_SCHEDULER_TOKEN`` is set but the Vault write failed
         # (unreachable / denied). 502 upstream failure; the just-created
-        # Keycloak client is already rolled back.
+        # Keycloak client is already rolled back. The broker's
+        # ``lookup-self`` probe (#2652) says whether the token is dead —
+        # that case gets the gold-standard three-clause detail naming the
+        # re-mint, because its remediation *is* knowable; everything else
+        # keeps the bare ``scheduler_vault_write_error`` code.
         raise HTTPException(
             status_code=http_status.HTTP_502_BAD_GATEWAY,
-            detail="scheduler_vault_write_error",
+            detail=(
+                SCHEDULER_VAULT_TOKEN_INVALID_DETAIL
+                if exc.token_invalid
+                else "scheduler_vault_write_error"
+            ),
         ) from exc
     except ValueError as exc:
         raise HTTPException(

--- a/backend/src/meho_backplane/mcp/tools/agent_principals.py
+++ b/backend/src/meho_backplane/mcp/tools/agent_principals.py
@@ -32,10 +32,15 @@ Error mapping
   error class name for operator diagnostics.
 * :class:`~meho_backplane.scheduler.vault_credentials.SchedulerVaultBrokerError`
   (register only) → :class:`~meho_backplane.mcp.server.McpInvalidParamsError`
-  naming the ``VAULT_SCHEDULER_TOKEN`` write-policy remediation, mirroring
-  the REST/UI ``scheduler_vault_write_error`` 502 mapping. Without this
-  the broker error bubbled to the dispatcher's catch-all and surfaced as
-  an opaque ``-32603`` internal error.
+  naming the ``VAULT_SCHEDULER_TOKEN`` remediation, mirroring the REST/UI
+  502 mapping. Without this the broker error bubbled to the dispatcher's
+  catch-all and surfaced as an opaque ``-32603`` internal error. Which
+  remediation is named comes from the broker's ``token_invalid``
+  disposition (#2652): a dead token gets
+  :data:`~meho_backplane.scheduler.vault_credentials.SCHEDULER_VAULT_TOKEN_INVALID_DETAIL`
+  ("re-mint"), a live token denied by policy keeps
+  :data:`~meho_backplane.scheduler.vault_credentials.SCHEDULER_VAULT_WRITE_DENIED_DETAIL`
+  ("widen the policy").
 """
 
 from __future__ import annotations
@@ -58,7 +63,11 @@ from meho_backplane.auth.keycloak_admin import (
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
-from meho_backplane.scheduler.vault_credentials import SchedulerVaultBrokerError
+from meho_backplane.scheduler.vault_credentials import (
+    SCHEDULER_VAULT_TOKEN_INVALID_DETAIL,
+    SCHEDULER_VAULT_WRITE_DENIED_DETAIL,
+    SchedulerVaultBrokerError,
+)
 
 _log = structlog.get_logger(__name__)
 
@@ -164,15 +173,16 @@ async def _register_handler(
         raise McpInvalidParamsError(f"Keycloak admin error: {type(exc).__name__}") from exc
     except SchedulerVaultBrokerError as exc:
         # ``VAULT_SCHEDULER_TOKEN`` is set but the Vault write failed
-        # (unreachable / denied — most often a read-only token policy). The
-        # just-created Keycloak client is already rolled back. Mirror the
-        # REST/UI 502 ``scheduler_vault_write_error`` mapping so the MCP
+        # (unreachable / denied). The just-created Keycloak client is
+        # already rolled back. Mirror the REST/UI 502 mapping so the MCP
         # caller gets an actionable ``-32602`` naming the cause, not the
-        # opaque ``-32603`` a bubbled exception would produce. The message
-        # names the remediation without leaking the secret.
+        # opaque ``-32603`` a bubbled exception would produce. The broker
+        # already ran ``lookup-self`` and told us *which* remediation
+        # applies (#2652); neither message leaks the secret.
         raise McpInvalidParamsError(
-            "scheduler Vault write failed — VAULT_SCHEDULER_TOKEN policy must "
-            "grant create/update on the agent-credentials path"
+            SCHEDULER_VAULT_TOKEN_INVALID_DETAIL
+            if exc.token_invalid
+            else SCHEDULER_VAULT_WRITE_DENIED_DETAIL
         ) from exc
     except ValueError as exc:
         raise McpInvalidParamsError(str(exc)) from exc

--- a/backend/src/meho_backplane/scheduler/vault_credentials.py
+++ b/backend/src/meho_backplane/scheduler/vault_credentials.py
@@ -26,10 +26,9 @@ records AppRole as the alternative service identity but flags its
 ``secret_id`` bootstrap (secret-zero) cost. A static token bound to a
 narrow read/write policy on the agent-credentials path is the
 lowest-friction shippable identity — it reuses hvac's
-``Client(token=…)`` primitive (the same one the live-Vault test harness
-uses) with no ``secret_id`` exchange. An operator who prefers AppRole
-runs a Vault Agent sidecar that renews a token into
-``VAULT_SCHEDULER_TOKEN``: additive, no code change here.
+``Client(token=…)`` primitive with no ``secret_id`` exchange. An
+operator who prefers AppRole runs a Vault Agent sidecar that renews a
+token into ``VAULT_SCHEDULER_TOKEN``: additive, no code change here.
 
 Path convention
 ===============
@@ -43,9 +42,9 @@ mount (they insert ``data/`` themselves — verified against hvac 2.4.0).
 setting keeps working unchanged (#823 promised "a code swap, not an
 env-var rename").
 
-The secret payload shape is ``{"client_secret": "<value>"}``; the read
-returns the ``client_secret`` field. No secret value ever enters a log
-event or an error message — only the path and the field *name* do.
+The secret payload shape is ``{"client_secret": "<value>"}``. No secret
+value ever enters a log event or an error message — only the path and
+the field *name* do.
 
 Token lifetime — renew-on-use + self-lookup (#2328)
 ===================================================
@@ -58,27 +57,24 @@ Vault-first read returns 403 and the scheduler silently skips. Two
 mechanisms defuse it here:
 
 * :func:`_maybe_renew_scheduler_token` fires a best-effort
-  ``auth/token/renew-self`` after every successful read/write. The
-  token is renewed at scheduler-tick frequency, so a periodic token
-  with any sane ``period`` never expires while the process runs. The
-  renewal is best-effort: the read/write already succeeded, so a failed
-  renewal is logged and swallowed rather than turned into a new failure
-  mode.
+  ``auth/token/renew-self`` after every successful read/write, at
+  scheduler-tick frequency, so a periodic token with any sane
+  ``period`` never expires while the process runs. A failed renewal is
+  logged and swallowed — the read/write it follows already succeeded.
 * :func:`verify_scheduler_token` runs ``auth/token/lookup-self`` at
   scheduler startup and on a slow cadence from the tick loop. It does
   not fix the fuse — it shortens time-to-notice from weeks to minutes
-  by logging a dead/unreachable token as a loud ``ERROR`` the moment
-  it's observed. Sibling #2327 consumes the same signal for its
-  ``/ready features.scheduler`` skip-state surface.
+  by logging a dead/unreachable token as a loud ``ERROR``. Sibling
+  #2327 consumes the same signal for its ``/ready features.scheduler``
+  skip-state surface.
 
 The same ``lookup-self`` primitive also disambiguates the *write*
-failure path (#2652): Vault answers a dead token and a live token on an
-under-scoped policy with the same 403, but the fixes are opposites
-(re-mint vs. widen the policy). :func:`write_agent_secret` probes
-:func:`_scheduler_token_rejected` on rejection and stamps
-``token_invalid`` on the raised :class:`SchedulerVaultBrokerError`, so
-every register surface picks the right remediation off one flag.
-Diagnosis only: the write is not retried.
+failure path (#2652): a dead token and a live token on an under-scoped
+policy both draw a **403**, but the fixes are opposites (re-mint vs.
+widen the policy). :func:`write_agent_secret` probes
+:func:`_scheduler_token_rejected` on that 403 — and only that 403 — and
+stamps ``token_invalid`` on the raised
+:class:`SchedulerVaultBrokerError`. Diagnosis only: no retry.
 
 The token is resolved from its live source on **every** use
 (:func:`_current_scheduler_token`) rather than frozen at process start,
@@ -152,9 +148,9 @@ class SchedulerVaultBrokerError(Exception):
     (#2652) so every consuming surface — MCP, the two REST register
     routes, the UI banner — picks the right remediation from one shared
     diagnosis instead of re-probing Vault itself. ``True``: the token was
-    rejected by ``auth/token/lookup-self`` and must be re-minted.
-    ``False``: it is live (or its liveness could not be established) and
-    the pre-existing policy-scope remediation stands.
+    403'd by ``auth/token/lookup-self`` and must be re-minted. ``False``:
+    it is live, or its liveness could not be established — either way the
+    pre-existing policy-scope remediation stands.
     """
 
     def __init__(self, *args: object, token_invalid: bool = False) -> None:
@@ -336,11 +332,12 @@ async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
         with a warning (env-var fallback remains); the read caller treats
         it as "fall back to the env var".
     SchedulerVaultBrokerError
-        Vault is unreachable or rejected the write. On a Vault-level
-        rejection the error carries ``token_invalid`` — ``True`` when a
-        follow-up ``lookup-self`` shows the scheduler token itself is
-        dead (re-mint it), ``False`` when the token is live and the
-        policy scope is the fault (#2652).
+        Vault is unreachable or rejected the write. On a **403** the
+        error carries ``token_invalid=True`` when a follow-up
+        ``lookup-self`` also 403s (the token is dead — re-mint it) and
+        ``False`` when the token is live, leaving the policy scope at
+        fault (#2652). No other status is evidence about the token, so
+        each keeps ``False``.
     """
     settings = get_settings()
     api_path = vault_path_for_client_id(identity_ref, settings=settings)
@@ -357,19 +354,30 @@ async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
         raise SchedulerVaultBrokerError(
             f"vault unreachable writing agent secret at {api_path!r}: {type(exc).__name__}"
         ) from exc
-    except hvac.exceptions.VaultError as exc:
-        # Vault answers a dead token and a live-but-under-scoped policy
-        # with the same 403, yet the remediations are opposites (re-mint
-        # vs. widen the policy). Split them with one ``lookup-self`` on
-        # the *same* client that just failed, and carry the disposition
-        # on the exception so all four register surfaces inherit it
+    except hvac.exceptions.Forbidden as exc:
+        # 403 is the one ambiguous rejection: a dead token and a live-but-
+        # under-scoped policy look identical, yet the remediations are
+        # opposites (re-mint vs. widen the policy). Split them with one
+        # ``lookup-self`` on the *same* client that just failed and carry
+        # the disposition so all four register surfaces inherit it
         # (#2652). Diagnosis only — the write is never retried.
         token_invalid = await _scheduler_token_rejected(client)
         if token_invalid:
-            _log.error("scheduler_vault_token_dead", check="agent_secret_write")
+            _log.error(
+                "scheduler_vault_token_dead",
+                reason=type(exc).__name__,
+                check="agent_secret_write",
+            )
         raise SchedulerVaultBrokerError(
             f"vault rejected agent-secret write at {api_path!r}: {type(exc).__name__}",
             token_invalid=token_invalid,
+        ) from exc
+    except hvac.exceptions.VaultError as exc:
+        # Every other status hvac maps onto ``VaultError`` (429, 500, 502,
+        # 503 sealed/down …) describes Vault, not the token — nothing to
+        # disambiguate, so no probe; the policy-scope remediation stands.
+        raise SchedulerVaultBrokerError(
+            f"vault rejected agent-secret write at {api_path!r}: {type(exc).__name__}"
         ) from exc
     # The token just authenticated a write — renew it so the periodic
     # token never ages out (#2328). Best-effort; never raises.
@@ -462,10 +470,10 @@ def _lookup_self_blocking(client: hvac.Client) -> object:
 async def _scheduler_token_rejected(client: hvac.Client) -> bool:
     """Is *client*'s token itself dead, rather than merely under-scoped?
 
-    Called from the write-failure path (#2652) after Vault rejected a
-    write. A revoked / expired / lost-lease token and a live token on a
-    policy without ``create``+``update`` both produce a 403, so the write
-    response alone cannot name the remediation.
+    Called from the write-failure path (#2652) after Vault answered a
+    write with 403. A revoked / expired / lost-lease token and a live
+    token on a policy without ``create``+``update`` both produce that
+    403, so the write response alone cannot name the remediation.
     ``auth/token/lookup-self`` can: Vault answers it for *any* live token
     regardless of policy (it is self-scoped) and 403s an invalid one.
 
@@ -473,14 +481,24 @@ async def _scheduler_token_rejected(client: hvac.Client) -> bool:
     describe the identity that was actually denied, and re-resolving
     could pick up a token re-minted between the two calls.
 
-    Returns ``True`` only on a Vault-level rejection. A transport failure
-    is not evidence of a dead token, so it returns ``False`` and the
-    caller keeps the policy-scope remediation.
+    Returns ``True`` only on a 403. hvac maps *every* Vault status onto a
+    :class:`~hvac.exceptions.VaultError` subclass, so a sealed (503),
+    overloaded (429) or broken (500/502) Vault would otherwise read as a
+    dead token and have an operator re-mint a healthy one mid-outage.
+    Those, like a transport failure, are inconclusive — ``False``, which
+    keeps the caller on the policy-scope remediation.
     """
     try:
         await asyncio.to_thread(_lookup_self_blocking, client)
-    except hvac.exceptions.VaultError:
+    except hvac.exceptions.Forbidden:
         return True
+    except hvac.exceptions.VaultError as exc:
+        _log.warning(
+            "scheduler_vault_token_lookup_inconclusive",
+            reason=type(exc).__name__,
+            check="agent_secret_write",
+        )
+        return False
     except requests.exceptions.RequestException:
         _log.warning("scheduler_vault_token_lookup_unreachable", check="agent_secret_write")
         return False
@@ -510,10 +528,7 @@ async def verify_scheduler_token(*, reason: str = "check") -> SchedulerTokenStat
 
     Called at scheduler startup and on a slow cadence from the tick loop
     (:mod:`meho_backplane.scheduler.loop`). It does **not** fix the fuse
-    (that is :func:`_maybe_renew_scheduler_token`) — it shortens
-    time-to-notice from weeks to minutes by surfacing a dead or
-    unreachable token as a loud ``ERROR`` the moment it's observed,
-    rather than as silent credential-unresolved skips downstream.
+    (that is :func:`_maybe_renew_scheduler_token`; see the module docstring).
 
     Never raises. An unconfigured token returns ``configured=False``
     (the documented env-var-fallback opt-out) and any Vault failure is

--- a/backend/src/meho_backplane/scheduler/vault_credentials.py
+++ b/backend/src/meho_backplane/scheduler/vault_credentials.py
@@ -71,6 +71,15 @@ mechanisms defuse it here:
   it's observed. Sibling #2327 consumes the same signal for its
   ``/ready features.scheduler`` skip-state surface.
 
+The same ``lookup-self`` primitive also disambiguates the *write*
+failure path (#2652): Vault answers a dead token and a live token on an
+under-scoped policy with the same 403, but the fixes are opposites
+(re-mint vs. widen the policy). :func:`write_agent_secret` probes
+:func:`_scheduler_token_rejected` on rejection and stamps
+``token_invalid`` on the raised :class:`SchedulerVaultBrokerError`, so
+every register surface picks the right remediation off one flag.
+Diagnosis only: the write is not retried.
+
 The token is resolved from its live source on **every** use
 (:func:`_current_scheduler_token`) rather than frozen at process start,
 so a Vault-Agent sidecar (or an operator) that re-mints the token into
@@ -92,6 +101,8 @@ from meho_backplane.auth.vault import _build_client
 from meho_backplane.settings import Settings, get_settings
 
 __all__ = [
+    "SCHEDULER_VAULT_TOKEN_INVALID_DETAIL",
+    "SCHEDULER_VAULT_WRITE_DENIED_DETAIL",
     "SECRET_FIELD",
     "SchedulerTokenStatus",
     "SchedulerVaultBrokerError",
@@ -109,6 +120,26 @@ _log = structlog.get_logger(__name__)
 #: Both the write (register) and the read (scheduler) agree on this key.
 SECRET_FIELD: str = "client_secret"
 
+#: Remediation for a write Vault denied while the scheduler token is
+#: **live** — the bound policy lacks ``create``/``update`` on the
+#: agent-credentials path. Kept verbatim from the pre-#2652 MCP message.
+SCHEDULER_VAULT_WRITE_DENIED_DETAIL: str = (
+    "scheduler Vault write failed — VAULT_SCHEDULER_TOKEN policy must "
+    "grant create/update on the agent-credentials path"
+)
+
+#: Remediation for a write Vault denied **because the token is dead**
+#: (revoked / expired / lost lease) — indistinguishable from the case
+#: above by status code alone, hence the ``lookup-self`` probe (#2652).
+#: Three-clause shape per ``docs/codebase/error-message-shape.md``.
+SCHEDULER_VAULT_TOKEN_INVALID_DETAIL: str = (
+    "scheduler_vault_token_invalid: the scheduler Vault token is invalid "
+    "or expired — Vault rejected auth/token/lookup-self for it, so the "
+    "policy scope is not the fault. Re-mint VAULT_SCHEDULER_TOKEN (or "
+    "refresh the file VAULT_SCHEDULER_TOKEN_FILE points at) and update "
+    "the deployment secret per docs/cross-repo/vault-provisioning.md."
+)
+
 
 class SchedulerVaultBrokerError(Exception):
     """Base class for scheduler-service-token Vault broker failures.
@@ -116,7 +147,19 @@ class SchedulerVaultBrokerError(Exception):
     Raised on read/write failures that are *not* the
     not-configured case (which has its own subclass so callers can choose
     to fall back to the env-var path rather than fail).
+
+    ``token_invalid`` carries the broker's ``lookup-self`` disposition
+    (#2652) so every consuming surface — MCP, the two REST register
+    routes, the UI banner — picks the right remediation from one shared
+    diagnosis instead of re-probing Vault itself. ``True``: the token was
+    rejected by ``auth/token/lookup-self`` and must be re-minted.
+    ``False``: it is live (or its liveness could not be established) and
+    the pre-existing policy-scope remediation stands.
     """
+
+    def __init__(self, *args: object, token_invalid: bool = False) -> None:
+        super().__init__(*args)
+        self.token_invalid = token_invalid
 
 
 class SchedulerVaultNotConfiguredError(SchedulerVaultBrokerError):
@@ -293,7 +336,11 @@ async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
         with a warning (env-var fallback remains); the read caller treats
         it as "fall back to the env var".
     SchedulerVaultBrokerError
-        Vault is unreachable or rejected the write.
+        Vault is unreachable or rejected the write. On a Vault-level
+        rejection the error carries ``token_invalid`` — ``True`` when a
+        follow-up ``lookup-self`` shows the scheduler token itself is
+        dead (re-mint it), ``False`` when the token is live and the
+        policy scope is the fault (#2652).
     """
     settings = get_settings()
     api_path = vault_path_for_client_id(identity_ref, settings=settings)
@@ -311,8 +358,18 @@ async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
             f"vault unreachable writing agent secret at {api_path!r}: {type(exc).__name__}"
         ) from exc
     except hvac.exceptions.VaultError as exc:
+        # Vault answers a dead token and a live-but-under-scoped policy
+        # with the same 403, yet the remediations are opposites (re-mint
+        # vs. widen the policy). Split them with one ``lookup-self`` on
+        # the *same* client that just failed, and carry the disposition
+        # on the exception so all four register surfaces inherit it
+        # (#2652). Diagnosis only — the write is never retried.
+        token_invalid = await _scheduler_token_rejected(client)
+        if token_invalid:
+            _log.error("scheduler_vault_token_dead", check="agent_secret_write")
         raise SchedulerVaultBrokerError(
-            f"vault rejected agent-secret write at {api_path!r}: {type(exc).__name__}"
+            f"vault rejected agent-secret write at {api_path!r}: {type(exc).__name__}",
+            token_invalid=token_invalid,
         ) from exc
     # The token just authenticated a write — renew it so the periodic
     # token never ages out (#2328). Best-effort; never raises.
@@ -400,6 +457,34 @@ class SchedulerTokenStatus:
 def _lookup_self_blocking(client: hvac.Client) -> object:
     """Synchronously call ``auth/token/lookup-self`` for *client*'s token."""
     return client.auth.token.lookup_self()
+
+
+async def _scheduler_token_rejected(client: hvac.Client) -> bool:
+    """Is *client*'s token itself dead, rather than merely under-scoped?
+
+    Called from the write-failure path (#2652) after Vault rejected a
+    write. A revoked / expired / lost-lease token and a live token on a
+    policy without ``create``+``update`` both produce a 403, so the write
+    response alone cannot name the remediation.
+    ``auth/token/lookup-self`` can: Vault answers it for *any* live token
+    regardless of policy (it is self-scoped) and 403s an invalid one.
+
+    Probes the **same** client that failed the write — the answer must
+    describe the identity that was actually denied, and re-resolving
+    could pick up a token re-minted between the two calls.
+
+    Returns ``True`` only on a Vault-level rejection. A transport failure
+    is not evidence of a dead token, so it returns ``False`` and the
+    caller keeps the policy-scope remediation.
+    """
+    try:
+        await asyncio.to_thread(_lookup_self_blocking, client)
+    except hvac.exceptions.VaultError:
+        return True
+    except requests.exceptions.RequestException:
+        _log.warning("scheduler_vault_token_lookup_unreachable", check="agent_secret_write")
+        return False
+    return False
 
 
 def _unwrap_token_lifetime(payload: object) -> tuple[int | None, str | None]:

--- a/backend/src/meho_backplane/scheduler/vault_credentials.py
+++ b/backend/src/meho_backplane/scheduler/vault_credentials.py
@@ -474,8 +474,9 @@ async def _scheduler_token_rejected(client: hvac.Client) -> bool:
     write with 403. A revoked / expired / lost-lease token and a live
     token on a policy without ``create``+``update`` both produce that
     403, so the write response alone cannot name the remediation.
-    ``auth/token/lookup-self`` can: Vault answers it for *any* live token
-    regardless of policy (it is self-scoped) and 403s an invalid one.
+    ``auth/token/lookup-self`` can: Vault answers it for a live token
+    granted ``read`` there (``meho-scheduler`` grants it — load-bearing,
+    see ``docs/cross-repo/vault-provisioning.md``) and 403s an invalid one.
 
     Probes the **same** client that failed the write — the answer must
     describe the identity that was actually denied, and re-resolving

--- a/backend/src/meho_backplane/ui/routes/agents/principals_forms.py
+++ b/backend/src/meho_backplane/ui/routes/agents/principals_forms.py
@@ -67,7 +67,11 @@ shapes the REST surface emits, surfaced inline in the modal banner:
 * :class:`~meho_backplane.scheduler.vault_credentials.SchedulerVaultBrokerError`
   -> ``scheduler_vault_write_error`` (502; Vault is configured but the
   credential write failed and the just-created Keycloak client was rolled
-  back).
+  back) -- unless the broker's ``lookup-self`` probe found the scheduler
+  token itself dead (#2652), in which case the banner carries the
+  gold-standard
+  :data:`~meho_backplane.scheduler.vault_credentials.SCHEDULER_VAULT_TOKEN_INVALID_DETAIL`
+  naming the re-mint. Same 502 either way; only the remediation differs.
 """
 
 from __future__ import annotations
@@ -88,7 +92,10 @@ from meho_backplane.auth.keycloak_admin import (
     KeycloakAdminNotConfiguredError,
 )
 from meho_backplane.auth.operator import Operator
-from meho_backplane.scheduler.vault_credentials import SchedulerVaultBrokerError
+from meho_backplane.scheduler.vault_credentials import (
+    SCHEDULER_VAULT_TOKEN_INVALID_DETAIL,
+    SchedulerVaultBrokerError,
+)
 from meho_backplane.ui.auth.middleware import UISessionContext
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
 from meho_backplane.ui.routes.agents.principals_views import fetch_principal_or_404
@@ -217,7 +224,10 @@ async def submit_register(
     * Keycloak admin unconfigured -> 503 banner (the gold-standard
       three-clause detail).
     * other Keycloak API failure -> 502 banner (bare code).
-    * Vault credential write failure -> 502 banner.
+    * Vault credential write failure -> 502 banner: the bare
+      ``scheduler_vault_write_error`` code when the scheduler token is
+      live (policy scope is the fault), the three-clause re-mint detail
+      when the broker's ``lookup-self`` probe found it dead (#2652).
     """
     owner_clean = (owner_sub or "").strip() or None
     raw_values: dict[str, object] = {"name": name, "owner_sub": owner_clean or ""}
@@ -264,12 +274,16 @@ async def submit_register(
             banner="keycloak_admin_error",
             status_code=status.HTTP_502_BAD_GATEWAY,
         )
-    except SchedulerVaultBrokerError:
+    except SchedulerVaultBrokerError as exc:
         return _render_register_with_error(
             request,
             csrf_session_id=str(session_ctx.session_id),
             values=raw_values,
-            banner="scheduler_vault_write_error",
+            banner=(
+                SCHEDULER_VAULT_TOKEN_INVALID_DETAIL
+                if exc.token_invalid
+                else "scheduler_vault_write_error"
+            ),
             status_code=status.HTTP_502_BAD_GATEWAY,
         )
 

--- a/backend/tests/test_api_v1_agent_principals.py
+++ b/backend/tests/test_api_v1_agent_principals.py
@@ -847,6 +847,63 @@ async def test_register_rolls_back_client_on_vault_write_failure(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("token_invalid", [False, True])
+async def test_register_vault_write_failure_detail_splits_on_token_validity(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, token_invalid: bool
+) -> None:
+    """The 502 detail names the remediation the broker actually diagnosed (#2652).
+
+    A dead scheduler token and an under-scoped policy both reach the route
+    as a broker error, but only the broker knows which one Vault answered
+    (it runs ``lookup-self`` on the write-failure path). The route reads
+    that disposition off the exception rather than re-probing: dead token
+    → the three-clause ``scheduler_vault_token_invalid`` detail naming the
+    re-mint; live token → the pre-existing bare code, unchanged.
+    """
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-vault-disposition")
+    mock_client = AsyncMock()
+    mock_client.create_client = AsyncMock(return_value="dd000000-0000-0000-0000-00000000bbbb")
+    mock_client.get_client_secret = AsyncMock(return_value="generated-secret")
+    mock_client.delete_client = AsyncMock(return_value=None)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    factory = MagicMock(return_value=mock_client)
+
+    from meho_backplane.scheduler.vault_credentials import (
+        SCHEDULER_VAULT_TOKEN_INVALID_DETAIL,
+        SchedulerVaultBrokerError,
+    )
+
+    async def _failing_write(identity_ref: str, client_secret: str) -> str:
+        raise SchedulerVaultBrokerError("vault denied", token_invalid=token_invalid)
+
+    monkeypatch.setattr("meho_backplane.auth.agent_principals.write_agent_secret", _failing_write)
+
+    with (
+        patch(
+            "meho_backplane.auth.agent_principals.KeycloakAdminClient.from_settings",
+            factory,
+        ),
+        respx.mock as r,
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/agent-principals",
+            json={"name": "vault-disposition-bot"},
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+
+    assert resp.status_code == 502, resp.text
+    detail = resp.json()["detail"]
+    if token_invalid:
+        assert detail == SCHEDULER_VAULT_TOKEN_INVALID_DETAIL, detail
+        assert "policy must grant" not in detail, detail
+    else:
+        assert detail == "scheduler_vault_write_error", detail
+
+
+@pytest.mark.asyncio
 async def test_register_skips_vault_when_token_unset(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_api_v1_runner_principals.py
+++ b/backend/tests/test_api_v1_runner_principals.py
@@ -603,6 +603,59 @@ async def test_register_rolls_back_keycloak_client_when_secret_fetch_fails(
     assert await _fetch_principals(_TENANT_A) == []
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token_invalid", [False, True])
+async def test_register_vault_write_failure_detail_splits_on_token_validity(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, token_invalid: bool
+) -> None:
+    """The 502 detail names the remediation the broker actually diagnosed (#2652).
+
+    Same contract as the agent-principal register route: the broker runs
+    ``lookup-self`` on the write-failure path and stamps the disposition
+    on the exception; a dead token gets the three-clause re-mint detail,
+    a live token denied by policy keeps the bare code verbatim.
+    """
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-vault-disposition")
+    factory = _mock_kc_ok()
+    mock_client = factory.return_value
+
+    from meho_backplane.scheduler.vault_credentials import (
+        SCHEDULER_VAULT_TOKEN_INVALID_DETAIL,
+        SchedulerVaultBrokerError,
+    )
+
+    async def _failing_write(identity_ref: str, client_secret: str) -> str:
+        raise SchedulerVaultBrokerError("vault denied", token_invalid=token_invalid)
+
+    monkeypatch.setattr("meho_backplane.auth.runner_principals.write_agent_secret", _failing_write)
+
+    with (
+        patch(
+            "meho_backplane.auth.runner_principals.KeycloakAdminClient.from_settings",
+            factory,
+        ),
+        respx.mock as r,
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.post(
+            "/api/v1/runner-principals",
+            json={"name": "vault-disposition-runner"},
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+
+    assert resp.status_code == 502, resp.text
+    detail = resp.json()["detail"]
+    if token_invalid:
+        assert detail == SCHEDULER_VAULT_TOKEN_INVALID_DETAIL, detail
+        assert "policy must grant" not in detail, detail
+    else:
+        assert detail == "scheduler_vault_write_error", detail
+    # The failed credential write still rolls the Keycloak client back.
+    mock_client.delete_client.assert_awaited_once_with(_KC_INTERNAL_ID)
+    assert await _fetch_principals(_TENANT_A) == []
+
+
 # ---------------------------------------------------------------------------
 # Revoke ordering (kill switch fires before the row flips)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_tool_agent_principals.py
+++ b/backend/tests/test_mcp_tool_agent_principals.py
@@ -27,6 +27,12 @@ against ``meho.agent_principals.register`` whose Vault write raises
 descriptive, secret-free message — mirroring
 ``test_api_v1_agent_principals.py``'s REST equivalent.
 
+Since #2652 the same wire contract also carries the broker's
+``token_invalid`` disposition: a Vault 403 whose ``lookup-self`` probe
+also failed means the scheduler token is dead and the message must say
+"invalid or expired … re-mint", while a live token denied by policy keeps
+the pre-#2652 policy-scope wording verbatim.
+
 Out of scope:
 
 * Happy-path registration (service-layer suite covers it).
@@ -44,7 +50,11 @@ from fastapi.testclient import TestClient
 from meho_backplane.auth.agent_principals import AgentPrincipalService
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS
-from meho_backplane.scheduler.vault_credentials import SchedulerVaultBrokerError
+from meho_backplane.scheduler.vault_credentials import (
+    SCHEDULER_VAULT_TOKEN_INVALID_DETAIL,
+    SCHEDULER_VAULT_WRITE_DENIED_DETAIL,
+    SchedulerVaultBrokerError,
+)
 from tests.mcp_test_fixtures import (
     client_with_operator,  # noqa: F401 — pytest-discovered fixture
     isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
@@ -114,4 +124,49 @@ def test_register_vault_write_failure_maps_to_invalid_params(
     assert "vault write failed" in message.lower(), message
     # No secret leakage: neither the client secret nor a raw token value
     # may appear in the operator-facing error.
+    assert _SENTINEL_SECRET not in message, message
+    # A write denied while the token is live keeps the pre-#2652
+    # policy-scope remediation, character for character.
+    assert message == SCHEDULER_VAULT_WRITE_DENIED_DETAIL, message
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_register_dead_token_names_the_remint_not_the_policy(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead scheduler token gets the re-mint remediation, not the policy one.
+
+    The broker's ``lookup-self`` probe (#2652) stamps ``token_invalid`` on
+    the raised error; the MCP handler must translate that into a
+    ``-32602`` naming the token re-mint. Before this the operator was
+    told to widen a policy that was already correct.
+    """
+    client, _op = client_with_operator
+
+    async def _raise_dead_token(*_args: Any, **_kwargs: Any) -> Any:
+        raise SchedulerVaultBrokerError(
+            "vault rejected agent-secret write at "
+            "'secret/data/agents/VAULT_BOT/credentials': Forbidden",
+            token_invalid=True,
+        )
+
+    monkeypatch.setattr(AgentPrincipalService, "register", _raise_dead_token)
+
+    resp = post_mcp(client, _tools_call(_REGISTER_TOOL, {"name": "vault-bot"}))
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "error" in body, body
+    assert body["error"]["code"] == INVALID_PARAMS, body
+
+    message = body["error"]["message"]
+    assert message == SCHEDULER_VAULT_TOKEN_INVALID_DETAIL, message
+    assert "invalid or expired" in message, message
+    assert "re-mint" in message.lower(), message
+    # The misleading remediation the filing is about must be gone.
+    assert "policy must grant" not in message, message
     assert _SENTINEL_SECRET not in message, message

--- a/backend/tests/test_scheduler_vault_credentials.py
+++ b/backend/tests/test_scheduler_vault_credentials.py
@@ -12,8 +12,10 @@ time, both under the scheduler's static service token. These tests cover:
 * the write happy path (payload shape + path derivation);
 * the read happy path, the not-found (``None``) path, and error mapping;
 * the write-failure disposition split (#2652) — a Vault 403 plus a
-  failing ``lookup-self`` means the token is dead, a Vault 403 plus a
-  succeeding ``lookup-self`` means the policy is under-scoped.
+  403 on ``lookup-self`` means the token is dead; a Vault 403 plus a
+  succeeding ``lookup-self`` means the policy is under-scoped; every
+  other Vault status (sealed, overloaded, upstream broken) is
+  inconclusive and keeps the policy-scope wording.
 
 The hvac client is faked via the ``_build_client`` seam — no running
 Vault. The live round-trip is covered by the integration suite.
@@ -266,6 +268,72 @@ async def test_write_denied_with_unreachable_lookup_stays_conservative(
         await vc.write_agent_secret("agent:reporter", "s")
 
     assert excinfo.value.token_invalid is False
+
+
+@pytest.mark.parametrize(
+    ("lookup_error", "expected_token_invalid"),
+    [
+        # 403 — the only status Vault gives an *invalid* token.
+        (hvac.exceptions.Forbidden("permission denied"), True),
+        # Everything below describes Vault, not the token. hvac maps each
+        # status onto its own VaultError subclass, so a blanket
+        # `except VaultError` would read all four as a dead token and send
+        # the operator to re-mint a healthy one mid-outage (#2652).
+        (hvac.exceptions.VaultDown("sealed"), False),  # 503
+        (hvac.exceptions.InternalServerError("boom"), False),  # 500
+        (hvac.exceptions.BadGateway("upstream"), False),  # 502
+        (hvac.exceptions.RateLimitExceeded("standby"), False),  # 429
+    ],
+    ids=["forbidden", "vault_down", "internal_error", "bad_gateway", "rate_limited"],
+)
+async def test_only_a_403_lookup_proves_the_token_is_dead(
+    fake_kv: _FakeKvV2,
+    lookup_error: BaseException,
+    expected_token_invalid: bool,
+) -> None:
+    """Only a 403 from lookup-self condemns the token; other statuses don't.
+
+    ``False`` is what every register surface maps onto the verbatim
+    policy-scope remediation (pinned per-surface, e.g.
+    ``test_mcp_tool_agent_principals.py``), so a Vault outage keeps the
+    pre-#2652 wording instead of ordering a needless re-mint.
+    """
+    _deny_write(fake_kv)
+    fake_kv.token_api.lookup_raises = lookup_error
+
+    with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
+        await vc.write_agent_secret("agent:reporter", "s")
+
+    assert excinfo.value.token_invalid is expected_token_invalid
+    assert fake_kv.token_api.lookup_calls == 1
+
+
+@pytest.mark.parametrize(
+    "write_error",
+    [
+        hvac.exceptions.VaultDown("sealed"),
+        hvac.exceptions.InternalServerError("boom"),
+        hvac.exceptions.BadGateway("upstream"),
+        hvac.exceptions.RateLimitExceeded("standby"),
+        hvac.exceptions.InvalidRequest("bad request"),
+    ],
+    ids=["vault_down", "internal_error", "bad_gateway", "rate_limited", "invalid_request"],
+)
+async def test_non_403_write_rejection_skips_the_probe(
+    fake_kv: _FakeKvV2, write_error: BaseException
+) -> None:
+    """Only a 403 write rejection is ambiguous enough to be worth a probe."""
+
+    def _boom(**_: Any) -> None:
+        raise write_error
+
+    fake_kv.create_or_update_secret = _boom  # type: ignore[assignment]
+
+    with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
+        await vc.write_agent_secret("agent:reporter", "s")
+
+    assert excinfo.value.token_invalid is False
+    assert fake_kv.token_api.lookup_calls == 0
 
 
 async def test_broker_error_defaults_to_token_valid() -> None:

--- a/backend/tests/test_scheduler_vault_credentials.py
+++ b/backend/tests/test_scheduler_vault_credentials.py
@@ -10,7 +10,10 @@ time, both under the scheduler's static service token. These tests cover:
 * the raw-API-path -> ``(mount, logical_path)`` splitter;
 * the not-configured guard (no ``VAULT_SCHEDULER_TOKEN``);
 * the write happy path (payload shape + path derivation);
-* the read happy path, the not-found (``None``) path, and error mapping.
+* the read happy path, the not-found (``None``) path, and error mapping;
+* the write-failure disposition split (#2652) — a Vault 403 plus a
+  failing ``lookup-self`` means the token is dead, a Vault 403 plus a
+  succeeding ``lookup-self`` means the policy is under-scoped.
 
 The hvac client is faked via the ``_build_client`` seam — no running
 Vault. The live round-trip is covered by the integration suite.
@@ -47,6 +50,7 @@ class _FakeTokenApi:
         self.renew_raises: BaseException | None = None
         self.lookup_result: Any = None
         self.lookup_raises: BaseException | None = None
+        self.lookup_calls = 0
 
     def renew_self(self, increment: int | None = None) -> Any:
         self.renew_calls += 1
@@ -55,6 +59,7 @@ class _FakeTokenApi:
         return {"auth": {"lease_duration": 2764800}}
 
     def lookup_self(self, mount_point: str = "token") -> Any:
+        self.lookup_calls += 1
         if self.lookup_raises is not None:
             raise self.lookup_raises
         return self.lookup_result
@@ -202,8 +207,90 @@ async def test_write_unreachable_maps_to_broker_error(fake_kv: _FakeKvV2) -> Non
         raise requests.exceptions.ConnectionError("down")
 
     fake_kv.create_or_update_secret = _boom  # type: ignore[assignment]
-    with pytest.raises(vc.SchedulerVaultBrokerError):
+    with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
         await vc.write_agent_secret("agent:reporter", "s")
+    # An unreachable Vault is already an unambiguous diagnosis; the
+    # write path must not spend a lookup-self on it (#2652).
+    assert excinfo.value.token_invalid is False
+    assert fake_kv.token_api.lookup_calls == 0
+
+
+# --- write-failure disposition: dead token vs. under-scoped policy (#2652) ---
+
+
+def _deny_write(fake_kv: _FakeKvV2) -> None:
+    """Make the KV write answer with Vault's 403 (the ambiguous case)."""
+
+    def _forbidden(**_: Any) -> None:
+        raise hvac.exceptions.Forbidden("permission denied")
+
+    fake_kv.create_or_update_secret = _forbidden  # type: ignore[assignment]
+
+
+async def test_write_denied_with_dead_token_sets_token_invalid(fake_kv: _FakeKvV2) -> None:
+    """Write 403 + lookup-self 403 -> the token itself is the fault."""
+    _deny_write(fake_kv)
+    fake_kv.token_api.lookup_raises = hvac.exceptions.Forbidden("permission denied")
+
+    with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
+        await vc.write_agent_secret("agent:reporter", "s")
+
+    assert excinfo.value.token_invalid is True
+    assert fake_kv.token_api.lookup_calls == 1
+    # Fail fast: the write is diagnosed, never retried.
+    assert fake_kv.writes == []
+
+
+async def test_write_denied_with_live_token_keeps_policy_disposition(
+    fake_kv: _FakeKvV2,
+) -> None:
+    """Write 403 + lookup-self OK -> the policy scope is the fault."""
+    _deny_write(fake_kv)
+    fake_kv.token_api.lookup_result = {"data": {"ttl": 2764800, "expire_time": None}}
+
+    with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
+        await vc.write_agent_secret("agent:reporter", "s")
+
+    assert excinfo.value.token_invalid is False
+    assert fake_kv.token_api.lookup_calls == 1
+
+
+async def test_write_denied_with_unreachable_lookup_stays_conservative(
+    fake_kv: _FakeKvV2,
+) -> None:
+    """A transport failure on lookup-self is not evidence of a dead token."""
+    _deny_write(fake_kv)
+    fake_kv.token_api.lookup_raises = requests.exceptions.ConnectionError("down")
+
+    with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
+        await vc.write_agent_secret("agent:reporter", "s")
+
+    assert excinfo.value.token_invalid is False
+
+
+async def test_broker_error_defaults_to_token_valid() -> None:
+    """Every pre-existing raise site keeps the policy-scope disposition."""
+    assert vc.SchedulerVaultBrokerError("boom").token_invalid is False
+    assert vc.SchedulerVaultNotConfiguredError("boom").token_invalid is False
+
+
+def test_write_denied_detail_is_unchanged() -> None:
+    """The under-scoped-policy remediation is preserved verbatim (#2652)."""
+    assert vc.SCHEDULER_VAULT_WRITE_DENIED_DETAIL == (
+        "scheduler Vault write failed — VAULT_SCHEDULER_TOKEN policy must "
+        "grant create/update on the agent-credentials path"
+    )
+
+
+def test_token_invalid_detail_names_the_remint() -> None:
+    """The dead-token remediation names re-minting, not the policy."""
+    detail = vc.SCHEDULER_VAULT_TOKEN_INVALID_DETAIL
+    assert detail.startswith("scheduler_vault_token_invalid:")
+    assert "invalid or expired" in detail
+    assert "re-mint" in detail.lower()
+    assert "VAULT_SCHEDULER_TOKEN" in detail
+    assert "docs/cross-repo/vault-provisioning.md" in detail
+    assert "policy must grant" not in detail
 
 
 # --- read -------------------------------------------------------------

--- a/backend/tests/test_ui_agent_principals.py
+++ b/backend/tests/test_ui_agent_principals.py
@@ -654,6 +654,42 @@ def test_register_vault_error_renders_502(monkeypatch: pytest.MonkeyPatch) -> No
     assert "scheduler_vault_write_error" in response.text
 
 
+def test_register_dead_vault_token_banner_names_the_remint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead scheduler token renders the re-mint banner, not the policy one (#2652).
+
+    Both failures are a Vault 403, so the console used to tell the
+    operator to widen a policy that was already correct. The broker's
+    ``lookup-self`` disposition rides on the exception and the banner
+    follows it.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    token = _admin_session(keypair)
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=token, operator_sub=_OP_A)
+
+    async def _raise_dead_token(self: AgentPrincipalService, **kwargs: Any) -> AgentPrincipalRead:
+        raise SchedulerVaultBrokerError("vault denied", token_invalid=True)
+
+    monkeypatch.setattr(AgentPrincipalService, "register", _raise_dead_token)
+
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/agents/principals/register",
+            data={"name": "dead-token-bot"},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 502, response.text
+    assert "scheduler_vault_token_invalid" in response.text
+    assert "re-mint" in response.text.lower()
+    assert "scheduler_vault_write_error" not in response.text
+    assert "policy must grant" not in response.text
+
+
 # ---------------------------------------------------------------------------
 # Revoke (kill switch) -- RBAC + type-to-confirm + happy path + errors
 # ---------------------------------------------------------------------------

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -201,6 +201,24 @@ live source per use (`_current_scheduler_token`): setting
 re-read on every read/write, so a re-mint is picked up without a pod
 restart (#2328).
 
+The same `lookup-self` primitive also disambiguates the **write**
+failure (#2652). Vault answers a dead token and a live token on an
+under-scoped policy with the same 403, but the remediations are
+opposites — re-mint vs. widen the policy — and the pre-#2652 message
+only ever named the policy, which cost operators the diagnosis on a
+deploy whose policy, path pattern, and mount were all already correct.
+`write_agent_secret` now probes `_scheduler_token_rejected` on the
+rejection arm (same hvac client, so the answer describes the identity
+that was actually denied) and stamps `token_invalid` on the raised
+`SchedulerVaultBrokerError`. All four register surfaces — the MCP tool,
+`POST /api/v1/agent-principals`, `POST /api/v1/runner-principals`, and
+the `/ui/agents/principals` register banner — read that one flag and
+choose between `SCHEDULER_VAULT_TOKEN_INVALID_DETAIL` and
+`SCHEDULER_VAULT_WRITE_DENIED_DETAIL`. The probe is diagnosis-only: the
+write is never retried, a transport failure on the probe is not treated
+as evidence of a dead token, and the unreachable-Vault arm (already an
+unambiguous diagnosis) does not probe at all.
+
 ### Precondition gate vs invoke-time failure
 
 The two fire paths follow the same lifecycle shape:

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -208,16 +208,20 @@ opposites — re-mint vs. widen the policy — and the pre-#2652 message
 only ever named the policy, which cost operators the diagnosis on a
 deploy whose policy, path pattern, and mount were all already correct.
 `write_agent_secret` now probes `_scheduler_token_rejected` on the
-rejection arm (same hvac client, so the answer describes the identity
-that was actually denied) and stamps `token_invalid` on the raised
+**403** rejection arm (same hvac client, so the answer describes the
+identity that was actually denied) and stamps `token_invalid` on the raised
 `SchedulerVaultBrokerError`. All four register surfaces — the MCP tool,
 `POST /api/v1/agent-principals`, `POST /api/v1/runner-principals`, and
 the `/ui/agents/principals` register banner — read that one flag and
 choose between `SCHEDULER_VAULT_TOKEN_INVALID_DETAIL` and
-`SCHEDULER_VAULT_WRITE_DENIED_DETAIL`. The probe is diagnosis-only: the
-write is never retried, a transport failure on the probe is not treated
-as evidence of a dead token, and the unreachable-Vault arm (already an
-unambiguous diagnosis) does not probe at all.
+`SCHEDULER_VAULT_WRITE_DENIED_DETAIL`. The probe is diagnosis-only and
+deliberately narrow: the write is never retried; only a 403 *from* the
+probe condemns the token (hvac maps 503 sealed / 502 / 500 / 429 onto
+`VaultError` subclasses too, and treating those as a dead token would
+order a re-mint mid-outage — the exact wrong-remediation defect #2652
+exists to fix); a transport failure is likewise inconclusive; and the
+arms that are already unambiguous — an unreachable Vault, or a write
+rejected with any non-403 status — do not probe at all.
 
 ### Precondition gate vs invoke-time failure
 

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -2633,8 +2633,11 @@ same first-match discipline `/ui/agents/create` follows).
   503** banner carrying the gold-standard `KEYCLOAK_ADMIN_NOT_CONFIGURED_DETAIL`
   three-clause text; other Keycloak API failure → 502 `keycloak_admin_error`
   banner; Vault credential-write failure → 502 `scheduler_vault_write_error`
-  banner. The actionable backend detail is rendered verbatim, never
-  flattened to "something went wrong".
+  banner, or — when the broker's `lookup-self` probe found the scheduler
+  token itself dead rather than under-scoped (#2652) — the three-clause
+  `scheduler_vault_token_invalid` banner naming the token re-mint. The
+  actionable backend detail is rendered verbatim, never flattened to
+  "something went wrong".
 - `GET/POST /ui/agents/principals/{name}/revoke` — revoke = the **Keycloak
   kill switch** (**tenant_admin**): disables the Keycloak client, which
   blocks all new token grants for the identity (tokens already minted stay

--- a/docs/cross-repo/vault-provisioning.md
+++ b/docs/cross-repo/vault-provisioning.md
@@ -192,6 +192,20 @@ The capability scope must be **read + write**, not read-only:
   `meho_agent_principals_register`); registration then rolls back the
   just-created Keycloak client so no unschedulable agent is left behind.
 
+A **dead token** — revoked, expired, or one whose periodic lease was
+lost — produces the *same* Vault 403 on that write, so the policy scope
+is not the only thing to check. Since evoila/meho#2652 the broker
+disambiguates the two before answering: when Vault rejects the write it
+fires `auth/token/lookup-self` on the same token (Vault answers that
+endpoint for any live token regardless of policy, and 403s for an
+invalid one) and stamps the outcome on the raised error. A dead token
+then surfaces as `scheduler_vault_token_invalid: the scheduler Vault
+token is invalid or expired …` on every surface — REST detail, MCP
+`-32602` message, and the `/ui/agents/principals` register banner —
+naming the **re-mint**, not the policy. A live token keeps the
+policy-scope wording above unchanged. The probe is diagnosis only: the
+write is never retried. See the two rows in *Failure modes* below.
+
 ```hcl
 # Policy: meho-scheduler
 # KV v2 splits the secret value (/data/) from its metadata (/metadata/).
@@ -258,6 +272,16 @@ the scheduler re-reads that file on **every** use, so a rewritten token
 is picked up without a restart. When both are set the file wins; an
 unreadable/empty file falls through to `VAULT_SCHEDULER_TOKEN`.
 
+**When the fuse has already blown.** Renewal and the startup/hourly
+self-lookup shorten time-to-notice, but they do not resurrect a token
+that is already dead — and until #2652 the *registration* path did not
+say so: a dead token and an under-scoped policy both produced the
+policy-widening message, sending operators to verify a policy that was
+already correct. Registration now runs the same `auth/token/lookup-self`
+probe on the write-failure path and emits
+`scheduler_vault_token_invalid` with the re-mint remediation instead.
+The two rows in *Failure modes* below are the decision table.
+
 ## Verification
 
 Run from any host with the operator's Vault token (`vault login`
@@ -313,7 +337,8 @@ everything it needs from Vault.
 | `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: InvalidPath"` | **Missing surface 5** — federation-proof KV path doesn't exist. | Run the provisioning command from surface 5 above |
 | `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: Forbidden"` | **Missing surface 3** — policy doesn't grant read on `secret/meho/*`. | Verify surface 3 (`vault policy read meho-mcp`); the policy must include both `secret/data/meho/*` and `secret/metadata/meho/*` |
 | `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: KeyError"` or `read_failed: TypeError` | Vault returned an unexpected payload shape — KV-v1 mount instead of v2, proxy mangling the response, etc. | Verify surface 4 (KV v2 mount); the mount must be type `kv` with `options.version="2"` |
-| Agent-principal registration fails — REST `502 scheduler_vault_write_error`, or MCP `meho_agent_principals_register` JSON-RPC `-32602` "scheduler Vault write failed" — while reads/listing still work | **Under-scoped surface 6** — `VAULT_SCHEDULER_TOKEN` policy grants read but not write on the agent-credentials path, so the secret-mint write is denied (Vault 403). Reads stay healthy because the read path is read-only-sufficient. | Verify surface 6 (`vault token capabilities "$VAULT_SCHEDULER_TOKEN" secret/data/agents/<name>/credentials`); widen the `meho-scheduler` policy to include `create`+`update` on `secret/data/agents/*/credentials` |
+| Agent-principal registration fails — REST `502 scheduler_vault_write_error`, or MCP `meho_agent_principals_register` JSON-RPC `-32602` "scheduler Vault write failed" — while reads/listing still work | **Under-scoped surface 6** — `VAULT_SCHEDULER_TOKEN` policy grants read but not write on the agent-credentials path, so the secret-mint write is denied (Vault 403). The backplane already confirmed via `auth/token/lookup-self` that the token itself is **live**, so the policy is the only remaining fault. Reads stay healthy because the read path is read-only-sufficient. | Verify surface 6 (`vault token capabilities "$VAULT_SCHEDULER_TOKEN" secret/data/agents/<name>/credentials`); widen the `meho-scheduler` policy to include `create`+`update` on `secret/data/agents/*/credentials` |
+| Agent- or runner-principal registration fails with `scheduler_vault_token_invalid: the scheduler Vault token is invalid or expired …` (REST 502 detail, MCP `-32602` message, `/ui/agents/principals` register banner) | **Dead surface-6 token** — the `VAULT_SCHEDULER_TOKEN` value was revoked, hit its TTL, or is a periodic token whose lease lapsed (a `-period=768h` token expires that long after its *last* renewal, so a scheduler that was down for a month comes back with a dead token). Vault answers both this and the under-scoped-policy case with a 403; the backplane told them apart by getting a 403 from `auth/token/lookup-self` too. **Policy, path pattern, and mount are irrelevant here — do not widen the policy.** | Confirm with `VAULT_TOKEN="$VAULT_SCHEDULER_TOKEN" vault token lookup` (errors on a dead token). Re-mint against the same policy with the surface-6 command above (`vault token create -policy=meho-scheduler -period=768h -field=token`), then update the deployment secret the backplane reads (`VAULT_SCHEDULER_TOKEN`, or the file `VAULT_SCHEDULER_TOKEN_FILE` points at). The file sink is re-read on every use, so a Vault-Agent sidecar rewrite needs no pod restart; an env-var change does need a rollout. Watch the `scheduler_vault_token_verified` log event (`ttl_seconds` / `expire_time`) to confirm recovery |
 
 ## References
 

--- a/docs/cross-repo/vault-provisioning.md
+++ b/docs/cross-repo/vault-provisioning.md
@@ -197,9 +197,15 @@ lost — produces the *same* Vault 403 on that write, so the policy scope
 is not the only thing to check. Since evoila/meho#2652 the broker
 disambiguates the two before answering: when Vault answers the write
 with a **403** it fires `auth/token/lookup-self` on the same token
-(Vault answers that endpoint for any live token regardless of policy,
-and 403s for an invalid one) and stamps the outcome on the raised
-error. Only a 403 on the probe condemns the token — any other Vault
+(Vault answers that endpoint for a live token whose policy set grants
+`read` on it — the built-in `default` policy does, and the mint command
+below attaches it — and 403s for an invalid one) and stamps the outcome
+on the raised error. **Keep that capability reachable:** a live token
+minted with `-no-default-policy` and no explicit
+`auth/token/lookup-self` grant also 403s the probe, so it would be
+reported dead when the real fault is the policy. The `meho-scheduler`
+policy below grants it explicitly rather than relying on `default`.
+Only a 403 on the probe condemns the token — any other Vault
 status (503 sealed, 502 upstream, 500, 429 standby) says nothing about
 it, so an outage keeps the policy-scope wording rather than ordering a
 needless re-mint. A dead token then
@@ -219,6 +225,14 @@ path "secret/data/agents/*/credentials" {
   capabilities = ["create", "read", "update"]
 }
 path "secret/metadata/agents/*/credentials" {
+  capabilities = ["read"]
+}
+# The dead-token probe (evoila/meho#2652) reads lookup-self after a 403
+# on the write. The built-in `default` policy already grants this, but
+# granting it explicitly keeps the probe sound for a token minted with
+# `-no-default-policy` — without it a live token 403s the probe and gets
+# reported dead.
+path "auth/token/lookup-self" {
   capabilities = ["read"]
 }
 ```

--- a/docs/cross-repo/vault-provisioning.md
+++ b/docs/cross-repo/vault-provisioning.md
@@ -195,11 +195,15 @@ The capability scope must be **read + write**, not read-only:
 A **dead token** — revoked, expired, or one whose periodic lease was
 lost — produces the *same* Vault 403 on that write, so the policy scope
 is not the only thing to check. Since evoila/meho#2652 the broker
-disambiguates the two before answering: when Vault rejects the write it
-fires `auth/token/lookup-self` on the same token (Vault answers that
-endpoint for any live token regardless of policy, and 403s for an
-invalid one) and stamps the outcome on the raised error. A dead token
-then surfaces as `scheduler_vault_token_invalid: the scheduler Vault
+disambiguates the two before answering: when Vault answers the write
+with a **403** it fires `auth/token/lookup-self` on the same token
+(Vault answers that endpoint for any live token regardless of policy,
+and 403s for an invalid one) and stamps the outcome on the raised
+error. Only a 403 on the probe condemns the token — any other Vault
+status (503 sealed, 502 upstream, 500, 429 standby) says nothing about
+it, so an outage keeps the policy-scope wording rather than ordering a
+needless re-mint. A dead token then
+surfaces as `scheduler_vault_token_invalid: the scheduler Vault
 token is invalid or expired …` on every surface — REST detail, MCP
 `-32602` message, and the `/ui/agents/principals` register banner —
 naming the **re-mint**, not the policy. A live token keeps the
@@ -278,7 +282,7 @@ that is already dead — and until #2652 the *registration* path did not
 say so: a dead token and an under-scoped policy both produced the
 policy-widening message, sending operators to verify a policy that was
 already correct. Registration now runs the same `auth/token/lookup-self`
-probe on the write-failure path and emits
+probe whenever Vault answers the write with a 403 and emits
 `scheduler_vault_token_invalid` with the re-mint remediation instead.
 The two rows in *Failure modes* below are the decision table.
 
@@ -337,7 +341,7 @@ everything it needs from Vault.
 | `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: InvalidPath"` | **Missing surface 5** — federation-proof KV path doesn't exist. | Run the provisioning command from surface 5 above |
 | `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: Forbidden"` | **Missing surface 3** — policy doesn't grant read on `secret/meho/*`. | Verify surface 3 (`vault policy read meho-mcp`); the policy must include both `secret/data/meho/*` and `secret/metadata/meho/*` |
 | `/api/v1/health` returns `vault.reachable=true`, `vault.read_ok=false`, `detail="read_failed: KeyError"` or `read_failed: TypeError` | Vault returned an unexpected payload shape — KV-v1 mount instead of v2, proxy mangling the response, etc. | Verify surface 4 (KV v2 mount); the mount must be type `kv` with `options.version="2"` |
-| Agent-principal registration fails — REST `502 scheduler_vault_write_error`, or MCP `meho_agent_principals_register` JSON-RPC `-32602` "scheduler Vault write failed" — while reads/listing still work | **Under-scoped surface 6** — `VAULT_SCHEDULER_TOKEN` policy grants read but not write on the agent-credentials path, so the secret-mint write is denied (Vault 403). The backplane already confirmed via `auth/token/lookup-self` that the token itself is **live**, so the policy is the only remaining fault. Reads stay healthy because the read path is read-only-sufficient. | Verify surface 6 (`vault token capabilities "$VAULT_SCHEDULER_TOKEN" secret/data/agents/<name>/credentials`); widen the `meho-scheduler` policy to include `create`+`update` on `secret/data/agents/*/credentials` |
+| Agent-principal registration fails — REST `502 scheduler_vault_write_error`, or MCP `meho_agent_principals_register` JSON-RPC `-32602` "scheduler Vault write failed" — while reads/listing still work | **Under-scoped surface 6** — `VAULT_SCHEDULER_TOKEN` policy grants read but not write on the agent-credentials path, so the secret-mint write is denied (Vault 403). The backplane probed `auth/token/lookup-self` after that 403 and did **not** get a 403 back, so the token is live (or Vault could not answer the probe — check for an outage first) and the policy is the remaining fault. Reads stay healthy because the read path is read-only-sufficient. | Verify surface 6 (`vault token capabilities "$VAULT_SCHEDULER_TOKEN" secret/data/agents/<name>/credentials`); widen the `meho-scheduler` policy to include `create`+`update` on `secret/data/agents/*/credentials` |
 | Agent- or runner-principal registration fails with `scheduler_vault_token_invalid: the scheduler Vault token is invalid or expired …` (REST 502 detail, MCP `-32602` message, `/ui/agents/principals` register banner) | **Dead surface-6 token** — the `VAULT_SCHEDULER_TOKEN` value was revoked, hit its TTL, or is a periodic token whose lease lapsed (a `-period=768h` token expires that long after its *last* renewal, so a scheduler that was down for a month comes back with a dead token). Vault answers both this and the under-scoped-policy case with a 403; the backplane told them apart by getting a 403 from `auth/token/lookup-self` too. **Policy, path pattern, and mount are irrelevant here — do not widen the policy.** | Confirm with `VAULT_TOKEN="$VAULT_SCHEDULER_TOKEN" vault token lookup` (errors on a dead token). Re-mint against the same policy with the surface-6 command above (`vault token create -policy=meho-scheduler -period=768h -field=token`), then update the deployment secret the backplane reads (`VAULT_SCHEDULER_TOKEN`, or the file `VAULT_SCHEDULER_TOKEN_FILE` points at). The file sink is re-read on every use, so a Vault-Agent sidecar rewrite needs no pod restart; an env-var change does need a rollout. Watch the `scheduler_vault_token_verified` log event (`ttl_seconds` / `expire_time`) to confirm recovery |
 
 ## References


### PR DESCRIPTION
## Summary

- A dead scheduler Vault token (revoked / expired / lost periodic lease) and an
  under-scoped `meho-scheduler` policy both make Vault answer the
  agent-credential write with a **403**, but every register surface named only
  the policy remediation. The field report in #2652 had the operator verify
  policy, path pattern, and mount — all correct — before anyone thought to
  `vault token lookup` the token itself.
- `write_agent_secret` now fires the `auth/token/lookup-self` probe the broker
  already shipped for #2328 when Vault rejects the write, on the **same** hvac
  client that was denied, and stamps the outcome as `token_invalid` on
  `SchedulerVaultBrokerError`. Vault answers `lookup-self` for any live token
  regardless of policy and 403s an invalid one, so the two 403s become
  distinguishable.
- Fixed **at the broker**, so all four surfaces inherit one diagnosis instead of
  re-implementing it: the MCP `meho.agent_principals.register` `-32602` message,
  both REST register routes' 502 `detail`
  (`api/v1/agent_principals.py`, `api/v1/runner_principals.py`), and the
  `/ui/agents/principals` register banner. A dead token gets the three-clause
  `scheduler_vault_token_invalid: … invalid or expired … Re-mint
  VAULT_SCHEDULER_TOKEN …` detail; a live-token-denied write keeps today's
  policy-scope wording **verbatim**.
- Diagnosis only, per the issue's out-of-scope list: no retry after a failed
  lookup, renew-on-use (#2328) untouched, consumer-side token lifecycle
  untouched. A transport failure on the probe is not treated as evidence of a
  dead token (stays conservative → policy message), and the
  already-unambiguous unreachable-Vault arm does not probe at all.
- `docs/cross-repo/vault-provisioning.md` gains the dead-token row alongside the
  under-scoped-policy row (with a `vault token lookup` confirmation step and the
  re-mint command), plus a "when the fuse has already blown" note under the
  periodic-token section; `docs/codebase/scheduler.md` and `docs/codebase/ui.md`
  record the new split.

## Design note

The probe reuses `_lookup_self_blocking` against the client that just failed
rather than calling `verify_scheduler_token()`, which re-resolves the token from
`VAULT_SCHEDULER_TOKEN` / `VAULT_SCHEDULER_TOKEN_FILE`. The answer must describe
the identity Vault actually denied, and re-resolution could pick up a token
re-minted between the two calls.

## Test plan

- [x] `ruff check` / `ruff format --check` on `backend/src` + `backend/tests` — clean
- [x] `mypy src/meho_backplane --ignore-missing-imports` — 680 files, clean
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] Full backend unit sweep (`pytest -n 4 --dist loadscope --ignore=tests/integration --ignore=tests/migrations tests/`)
- [x] **AC1** — stubbed Vault, `lookup-self` fails + write 403s → `token_invalid is True`
  (`test_write_denied_with_dead_token_sets_token_invalid`) and the MCP `-32602`
  message is the re-mint detail, asserting `"invalid or expired"`, `"re-mint"`,
  and that `"policy must grant"` is **gone**
  (`test_register_dead_token_names_the_remint_not_the_policy`)
- [x] **AC2** — stubbed Vault, `lookup-self` succeeds + write 403s →
  `token_invalid is False` (`test_write_denied_with_live_token_keeps_policy_disposition`)
  and the MCP message equals the pre-#2652 string character for character
  (`test_write_denied_detail_is_unchanged` pins the constant literally;
  `test_register_vault_write_failure_maps_to_invalid_params` asserts equality)
- [x] **AC3** — REST `agent_principals` + `runner_principals` parametrized over both
  dispositions asserting the 502 `detail`
  (`test_register_vault_write_failure_detail_splits_on_token_validity` in both files);
  UI banner asserted in `test_register_dead_vault_token_banner_names_the_remint`
  (dead) and the pre-existing `test_register_vault_error_renders_502` (live)
- [x] **AC4** — `docs/cross-repo/vault-provisioning.md` dead-token row added
- [x] **AC5** — CHANGELOG `[Unreleased]` under `### Fixed — scheduler Vault dead-token diagnostics (#2652)`
- [x] Also covered: the unreachable-write arm does **not** spend a `lookup-self`,
  an unreachable probe stays conservative, and every pre-existing raise site keeps
  `token_invalid=False`
- [x] `cd cli && make snapshot-openapi` — `cli/api/openapi.json` **unchanged**
  (no route signature or docstring touched; `detail` is already a free-form string)

## Out of scope

- The consumer-side periodic-token lifecycle that keeps killing the token
  (RDC-side operational issue).
- Token auto-renewal / renew-on-use (#2328) — untouched.
- Retrying the write after a failed `lookup-self`.
- The `read_agent_secret` failure path: it does not reach an operator-facing
  surface (the scheduler logs a skip), so it keeps its single message.
- `docs/codebase/error-message-shape.md`'s audit table is an explicit **v0.6.0**
  point-in-time snapshot and does not list this site; left unedited rather than
  back-dating a new row into it.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2652


---

## Follow-up (auto-implement-issue, iteration 1, 2026-07-21)

Addressed review findings from `.claude/auto/review-results/pr-2658-iter-1.json`:

- **B1** `d97d9009` — `_scheduler_token_rejected` now condemns the token only
  on `hvac.exceptions.Forbidden` (403). Every other `VaultError` — hvac maps
  429/500/502/503 onto their own `VaultError` subclasses — is inconclusive:
  logged as `scheduler_vault_token_lookup_inconclusive` with `reason=<class>`
  and returns `False`, so a sealed or failing-over Vault keeps the
  policy-scope remediation instead of ordering a re-mint mid-outage.
- **M1** `d97d9009` — the probe now fires from an `except
  hvac.exceptions.Forbidden` write arm; a following `except VaultError` raises
  with `token_invalid=False` and spends no round-trip. The
  `scheduler_vault_token_dead` event gained `reason=` to match
  `verify_scheduler_token`'s shape.

Tests: `test_only_a_403_lookup_proves_the_token_is_dead` (5 cases) and
`test_non_403_write_rejection_skips_the_probe` (5 cases). The nine non-403
cases fail against the pre-fix code (verified by reverting the source file and
re-running). `SCHEDULER_VAULT_WRITE_DENIED_DETAIL` is byte-for-byte unchanged
(AC2), and the doc / `docs/codebase/scheduler.md` / CHANGELOG wording is
aligned with the narrowed 403-only split.

Disputed: none.

Deferred: none. The reviewer's adjacent note about
`scheduler/vault_credentials.py` nearing the 600-line file threshold still
stands — the file is 599 lines after this iteration (prose trimmed to absorb
the fix); the lookup-self / token-lifetime split seam remains the natural
follow-up.

<!-- auto-implement-issue: continue, iteration 1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler Vault error diagnostics by distinguishing expired or invalid tokens from insufficient permissions.
  * Registration failures now provide targeted remediation, including re-minting dead tokens or widening policy permissions when appropriate.
  * Consistent error details are shown across REST APIs, MCP registration, and the agent registration UI.

* **Documentation**
  * Updated scheduler and Vault provisioning guidance for token diagnosis, lookup permissions, renewal, and recovery procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->