### PR TITLE
fix(agent): publish wire-safe tool schemas from the broadcast bridge (#2644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — agent bridge publishes wire-safe tool schemas (#2644)
+
+- Every `meho agents run` on provider `anthropic` died at model-init with
+  `input_schema does not support oneOf, allOf, or anyOf at the top level`
+  and `turns: 0`, no matter what the agent's own toolset asked for —
+  reproducible with an empty toolset. The Anthropic Messages API validates
+  the whole `tools` array, so one malformed schema poisons the request
+  rather than just its own tool. The offender was `meho.broadcast.watch`:
+  its registered `inputSchema` carries a top-level `anyOf` enforcing the
+  `cursor` / `since_cursor` XOR, and the hosted-agent bridge deep-copied
+  the *registered* schema into the model-facing tool list, bypassing
+  `ToolDefinition.to_wire()` — which has stripped root-level combinators
+  since v0.6.0 for exactly this reason. The bridge now publishes the wire
+  shape at its single publish chokepoint, so every currently-bridged and
+  future-bridged tool inherits the guarantee. Nothing about the MCP surface
+  changes: the registered schema keeps its `anyOf`, `tools/call` keeps
+  validating both-or-neither cursor forms against it, and the deprecated
+  `since_cursor` alias is untouched. Scheduled runs, the approval-gated
+  agent-write flow, and operator-triggered runs all recover.
+  A new cross-surface sweep (`tests/test_published_tool_schema_shape.py`)
+  fails on any *published* schema — MCP wire copy or agent meta-tool —
+  whose root carries a combinator or is not `type: object`.
+
 ### Fixed — scheduler Vault dead-token diagnostics (#2652)
 
 - Agent- and runner-principal registration now tells operators **which**

--- a/backend/src/meho_backplane/agent/toolset_broadcast.py
+++ b/backend/src/meho_backplane/agent/toolset_broadcast.py
@@ -7,8 +7,9 @@ MEHO-hosted agents get the same three broadcast primitives external MCP
 clients already have — announce / recent / watch — so a hosted run is a
 first-class reader and writer on the tenant coordination feed rather than a
 mute participant. The agent front-end does NOT re-implement the tools: it
-reuses the exact ``(schema, handler)`` pairs the MCP surface registered in
-:mod:`meho_backplane.mcp.tools.broadcast`, resolved from the registry via
+reuses the handlers the MCP surface registered in
+:mod:`meho_backplane.mcp.tools.broadcast` verbatim and publishes the same
+wire schema those tools publish, both resolved from the registry via
 :func:`~meho_backplane.mcp.registry.get_tool`. The handlers already carry the
 #2544 structured claims, the #2545 actor/work_ref lineage projection, the
 #2546 announce rate limit, and the untrusted-prose envelope on reads
@@ -62,14 +63,32 @@ _RUN_SCOPED_ANNOUNCE_FIELDS: tuple[str, ...] = ("run_id", "work_ref")
 
 
 def _mcp_broadcast_tool(name: str) -> tuple[dict[str, Any], _MetaToolHandler]:
-    """Return a registered broadcast MCP tool's ``(inputSchema, handler)``.
+    """Return a registered broadcast MCP tool's ``(published schema, handler)``.
 
-    The schema is deep-copied so the agent surface can adapt it (e.g. drop
+    The schema comes from :meth:`~meho_backplane.mcp.registry.ToolDefinition.to_wire`,
+    not from the registered ``inputSchema``. ``to_wire`` strips the top-level
+    ``oneOf`` / ``allOf`` / ``anyOf`` the Anthropic Messages API rejects on a
+    tool's ``input_schema``; a bridged tool that carries one 400s the whole
+    ``tools`` array at model-init, so every hosted run dies before its first
+    turn regardless of what the run itself asked for (#2644 —
+    ``meho.broadcast.watch``'s ``cursor``/``since_cursor`` XOR was the
+    offender). Publishing the wire shape keeps the bridge on the same
+    chokepoint the MCP surface already goes through, so a future bridged tool
+    inherits the guarantee. The registered ``inputSchema`` is untouched and
+    keeps validating in :mod:`meho_backplane.mcp.handlers`; the agent path
+    relies on the handlers' own typed argument checks instead, which
+    ``pydantic_ai.Tool.from_schema`` requires anyway — it does not validate
+    arguments against the advertised schema.
+
+    The result is deep-copied so the agent surface can adapt it (e.g. drop
     the run-scoped announce fields) without mutating the dict the MCP
-    registry still serves to MCP clients. Missing registration is a hard
-    configuration bug — the side-effect import at module top should have
-    registered every broadcast tool — so it fails loud rather than silently
-    dropping the tool from the agent surface.
+    registry still serves to MCP clients. The copy is load-bearing:
+    ``to_wire`` returns the *same* ``inputSchema`` object when there is
+    nothing to strip, which is the case for announce and recent.
+
+    Missing registration is a hard configuration bug — the side-effect import
+    at module top should have registered every broadcast tool — so it fails
+    loud rather than silently dropping the tool from the agent surface.
     """
     entry = get_tool(name)
     if entry is None:  # pragma: no cover - defensive; import registers all three
@@ -78,7 +97,7 @@ def _mcp_broadcast_tool(name: str) -> tuple[dict[str, Any], _MetaToolHandler]:
             "is meho_backplane.mcp.tools.broadcast imported?"
         )
     definition, handler = entry
-    return copy.deepcopy(definition.inputSchema), handler
+    return copy.deepcopy(definition.to_wire()["inputSchema"]), handler
 
 
 def _model_retry_on_mcp_error(handler: _MetaToolHandler) -> _MetaToolHandler:
@@ -174,10 +193,11 @@ def build_broadcast_meta_tools() -> tuple[MetaToolSpec, ...]:
     """Build the three broadcast coordination meta-tools from the MCP tools.
 
     Each entry reuses the MCP handler verbatim (wrapped so handler-side
-    errors reach the model as :class:`ModelRetry`); the read tools reuse the
-    MCP ``inputSchema`` as-is, and announce reuses it minus the run-scoped
-    fields the wrapper injects. ``OPERATOR`` floor matches the MCP tools'
-    ``required_role`` — the same identity gate every broadcast surface uses.
+    errors reach the model as :class:`ModelRetry`); the read tools publish
+    the MCP tool's wire schema as-is, and announce publishes it minus the
+    run-scoped fields the wrapper injects. ``OPERATOR`` floor matches the MCP
+    tools' ``required_role`` — the same identity gate every broadcast surface
+    uses.
     """
     announce_schema, announce_handler = _mcp_broadcast_tool(_MCP_BROADCAST_ANNOUNCE)
     recent_schema, recent_handler = _mcp_broadcast_tool(_MCP_BROADCAST_RECENT)

--- a/backend/tests/test_agent_toolset_broadcast.py
+++ b/backend/tests/test_agent_toolset_broadcast.py
@@ -145,13 +145,47 @@ def test_broadcast_tools_require_operator_floor() -> None:
     ],
 )
 def test_read_tool_schema_matches_mcp(agent_name: str, mcp_name: str) -> None:
-    """The read tools advertise the exact MCP inputSchema (wire parity, AC2)."""
+    """The read tools advertise the exact MCP *wire* schema (wire parity, AC2).
+
+    Parity is against ``to_wire()["inputSchema"]``, not the registered
+    ``inputSchema``: the bridge publishes what MCP clients are served
+    (#2644), which is the registered schema minus any top-level JSON-Schema
+    combinator the Anthropic Messages API rejects.
+    """
     tools = resolve_agent_tools({"meta_tools": [agent_name]}, _make_operator())
     (tool,) = tools
     entry = get_tool(mcp_name)
     assert entry is not None
     definition, _handler = entry
-    assert tool.function_schema.json_schema == definition.inputSchema
+    assert tool.function_schema.json_schema == definition.to_wire()["inputSchema"]
+
+
+def test_watch_bridge_strips_anyof_but_registry_keeps_it() -> None:
+    """The bridged ``broadcast_watch`` schema drops the cursor XOR; MCP keeps it (#2644).
+
+    ``meho.broadcast.watch``'s registered ``inputSchema`` carries a top-level
+    ``anyOf`` so ``mcp/handlers.py``'s ``jsonschema.validate`` rejects a call
+    that supplies neither cursor spelling. That combinator 400s the Anthropic
+    Messages API when it reaches a tool's ``input_schema``, killing every
+    hosted run at model-init, so the agent bridge publishes the wire copy
+    instead. Both halves are asserted here because dropping either one is the
+    regression: strip it from the registry and server-side validation
+    narrows; publish it to the agent and every run dies.
+    """
+    tools = resolve_agent_tools({"meta_tools": ["broadcast_watch"]}, _make_operator())
+    (tool,) = tools
+    published = tool.function_schema.json_schema
+    assert "anyOf" not in published
+    # The parameters both cursor spellings live on survive the strip.
+    assert {"cursor", "since_cursor"} <= set(published["properties"])
+
+    entry = get_tool("meho.broadcast.watch")
+    assert entry is not None
+    registered = entry[0].inputSchema
+    assert registered["anyOf"] == [
+        {"required": ["cursor"]},
+        {"required": ["since_cursor"]},
+    ]
 
 
 def test_announce_schema_hides_run_scoped_fields() -> None:

--- a/backend/tests/test_mcp_tool_broadcast_watch.py
+++ b/backend/tests/test_mcp_tool_broadcast_watch.py
@@ -327,6 +327,26 @@ async def test_handler_rejects_both_cursor_and_since_cursor() -> None:
         )
 
 
+async def test_handler_rejects_neither_cursor_nor_since_cursor() -> None:
+    """Supplying neither cursor spelling rejects with -32602 at the handler (#2644).
+
+    The registered ``inputSchema``'s top-level ``anyOf`` catches this on the
+    MCP wire (``test_missing_since_cursor_rejects_with_invalid_params``), but
+    that combinator is stripped from every *published* schema — the MCP
+    ``tools/list`` copy and the agent bridge's copy alike — because the
+    Anthropic Messages API rejects it. The handler is therefore the surface
+    that has to reject the both-or-neither forms wherever no jsonschema layer
+    runs first, which is exactly the hosted-agent path
+    (``pydantic_ai.Tool.from_schema`` does not validate arguments against the
+    advertised schema).
+    """
+    op = build_operator(TenantRole.OPERATOR)
+    with pytest.raises(McpInvalidParamsError, match="cursor"):
+        await _handler_watch(op, {})
+    with pytest.raises(McpInvalidParamsError, match="cursor"):
+        await _handler_watch(op, {"timeout_ms": _WATCH_DEFAULT_TIMEOUT_MS})
+
+
 # ---------------------------------------------------------------------------
 # timeout_ms cap (schema + handler validation)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_published_tool_schema_shape.py
+++ b/backend/tests/test_published_tool_schema_shape.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Cross-surface guard on the shape of every tool schema MEHO *publishes* (#2644).
+
+The Anthropic Messages API requires each tool's ``input_schema`` to be a
+plain object schema at the root: a top-level ``oneOf`` / ``allOf`` / ``anyOf``
+is rejected outright, and because the API validates the whole ``tools`` array
+a single offender 400s every request in that session — not just calls to the
+offending tool. MEHO reaches that API through two publishers:
+
+* the **MCP surface**, where an MCP client (Claude Code, Inspector) forwards
+  each ``tools/list`` entry verbatim as a custom tool, and
+* the **hosted-agent surface**, where
+  :func:`~meho_backplane.agent.toolset.resolve_agent_tools` hands each
+  :class:`~meho_backplane.agent.meta_tool.MetaToolSpec`'s
+  ``parameter_schema`` to ``pydantic_ai.Tool.from_schema``, which forwards it
+  to the configured provider.
+
+Both publishers are swept here. The MCP half passes on arrival and is a
+regression guard: :meth:`~meho_backplane.mcp.registry.ToolDefinition.to_wire`
+has stripped top-level combinators since #905, so the only way to reintroduce
+one is to bypass ``to_wire`` — which is exactly what the agent bridge did
+until #2644 (it deep-copied the *registered* ``inputSchema``, republishing
+``meho.broadcast.watch``'s ``cursor``/``since_cursor`` XOR and killing every
+hosted Anthropic run at model-init with ``turns: 0``).
+
+**Registered schemas are deliberately out of scope.** Eight registered
+``inputSchema`` dicts carry a top-level combinator on purpose — it is the
+server-side validation layer ``mcp/handlers.py`` runs ``jsonschema.validate``
+against. Those stay; only the published copies are constrained. The design
+pins for that split live in ``tests/test_mcp_registry.py`` (``to_wire``
+strips, ``inputSchema`` keeps) and
+``tests/test_mcp_tools_list_shape_conventions.py`` (the watch XOR's exact
+registered shape).
+
+Related narrower guard: ``tests/test_mcp_tools_topology.py`` asserts the same
+combinator property over the RBAC-filtered ``tools/list`` view, from the
+topology tools' own #905 regression. This file is the cross-surface superset
+— it adds the agent catalog, the ``type: object`` root requirement, and the
+capability-gated tools an unprovisioned operator never sees.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from meho_backplane.agent.meta_tool import MetaToolSpec
+from meho_backplane.agent.toolset import _META_TOOL_CATALOG, resolve_agent_tools
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp import registry as mcp_registry
+from meho_backplane.mcp.registry import ToolDefinition
+from tests.mcp_test_fixtures import (
+    build_operator,
+    isolated_registry,  # noqa: F401 -- pytest-discovered autouse fixture
+    required_settings_env,  # noqa: F401 -- pytest-discovered autouse fixture
+)
+
+#: The JSON-Schema combinator keywords the Messages API rejects at the root of
+#: a tool's ``input_schema``. Nested occurrences (inside ``properties`` /
+#: ``items`` / ``$defs``) are legal and are not swept.
+_FORBIDDEN_ROOT_KEYS: tuple[str, ...] = ("oneOf", "allOf", "anyOf")
+
+
+def _root_violations(schema: dict[str, Any]) -> list[str]:
+    """Return the reasons *schema* is not a publishable ``input_schema``.
+
+    Empty list means the root is a plain object schema with no combinator —
+    the only shape the Messages API accepts.
+    """
+    reasons = [f"top-level {key}" for key in _FORBIDDEN_ROOT_KEYS if key in schema]
+    if schema.get("type") != "object":
+        reasons.append(f"root type is {schema.get('type')!r}, expected 'object'")
+    return reasons
+
+
+def _registered_tools() -> list[ToolDefinition]:
+    """Every tool in the MCP registry, unfiltered by role or capability.
+
+    Read from the registry mapping rather than
+    :func:`~meho_backplane.mcp.registry.all_tools_for` on purpose: that helper
+    is the RBAC + capability *filter*, so even a ``tenant_admin`` sweep would
+    silently skip the capability-gated ``meho-docs`` tools (and any future
+    gated tool) — the exact blind spot a completeness guard must not have.
+    There is no public unfiltered enumeration, and inventing one for a test is
+    not worth widening the registry's API surface.
+    """
+    return [defn for defn, _handler in mcp_registry._TOOLS.values()]
+
+
+def _agent_catalog() -> tuple[MetaToolSpec, ...]:
+    """The full agent meta-tool catalog, before any toolset/role intersection."""
+    return _META_TOOL_CATALOG
+
+
+def test_mcp_wire_schemas_are_publishable() -> None:
+    """No registered tool's ``to_wire()`` schema can reach the Messages API malformed."""
+    offenders = {
+        defn.name: reasons
+        for defn in _registered_tools()
+        if (reasons := _root_violations(defn.to_wire()["inputSchema"]))
+    }
+    assert offenders == {}, (
+        "MCP tools publish an input_schema the Anthropic Messages API rejects "
+        f"(a single offender 400s the whole tools array): {offenders}"
+    )
+
+
+def test_mcp_registry_sweep_is_not_vacuous() -> None:
+    """Guard the guard: an empty registry would make the sweep above pass trivially."""
+    assert len(_registered_tools()) > 50
+
+
+def test_agent_meta_tool_schemas_are_publishable() -> None:
+    """No agent meta-tool's ``parameter_schema`` can reach the Messages API malformed.
+
+    This is the half that regressed in #2644: the broadcast bridge published
+    the registered ``inputSchema`` instead of the wire copy, so
+    ``broadcast_watch`` shipped a top-level ``anyOf`` to every hosted run.
+    """
+    offenders = {
+        spec.name: reasons
+        for spec in _agent_catalog()
+        if (reasons := _root_violations(spec.parameter_schema))
+    }
+    assert offenders == {}, (
+        "agent meta-tools publish a parameter_schema the Anthropic Messages "
+        f"API rejects (a single offender 400s the whole run at model-init): {offenders}"
+    )
+
+
+def test_agent_catalog_sweep_is_not_vacuous() -> None:
+    """Guard the guard: the catalog must actually carry the tools being swept."""
+    names = {spec.name for spec in _agent_catalog()}
+    assert {"call_operation", "broadcast_watch"} <= names
+
+
+def test_default_toolset_assembles_only_publishable_schemas() -> None:
+    """The default (empty-toolset) agent loop registers Messages-API-legal tools.
+
+    The end-to-end shape of the #2644 bug: an agent run with an empty toolset
+    spec — no meta-tool allow-list, so the whole catalog — died at model-init
+    on ``tools.5.custom.input_schema``, which is ``broadcast_watch`` in catalog
+    order. This asserts against the objects the loop actually registers
+    (``pydantic_ai.Tool``), one step past the catalog sweep above, so a future
+    adapter that re-derived the schema on the way to ``Tool.from_schema``
+    would still be caught.
+    """
+    operator: Operator = build_operator(TenantRole.OPERATOR)
+    tools = resolve_agent_tools({}, operator)
+    assert tools, "the default toolset must register at least one tool"
+
+    offenders = {
+        tool.name: reasons
+        for tool in tools
+        if (reasons := _root_violations(tool.function_schema.json_schema))
+    }
+    assert offenders == {}, (
+        f"the default agent tool list carries schemas the Messages API rejects: {offenders}"
+    )

--- a/docs/codebase/agent-runtime.md
+++ b/docs/codebase/agent-runtime.md
@@ -171,11 +171,23 @@ registry's `get_tool`) and reuses the handlers verbatim, so the agent's wire
 shape — the #2544 structured claims, the #2545 actor/work_ref lineage, the
 #2546 announce rate limit, and the untrusted-prose envelope
 (`dump_event_wire`) on reads — is identical to every other surface's. The
-read tools reuse the MCP `inputSchema` unchanged; `broadcast_announce` reuses
+read tools publish the MCP tool's **wire** schema (`ToolDefinition.to_wire()`,
+not the registered `inputSchema`) unchanged; `broadcast_announce` publishes
 it minus `run_id` / `work_ref`, which the wrapper stamps from the ambient run
 context (`current_agent_run_id_var` + `work_ref_var`, the same ContextVars the
 audit writers and `approval_wait` read) so announcements auto-group under the
-run without the model self-reporting a spoofable id. Handler-side errors
+run without the model self-reporting a spoofable id. Publishing the wire copy
+rather than the registered schema is load-bearing (#2644): `to_wire()` strips
+the top-level `oneOf` / `allOf` / `anyOf` the Anthropic Messages API rejects
+on a tool's `input_schema`, and because that API validates the whole `tools`
+array a single offender 400s the run at model-init with `turns: 0` regardless
+of what the run itself asked for — `meho.broadcast.watch`'s
+`cursor` / `since_cursor` XOR was the one that bit. The registered
+`inputSchema` keeps its combinator and keeps validating in `mcp/handlers.py`;
+on the agent path the handlers' own typed argument checks are the guard
+(`pydantic_ai.Tool.from_schema` does not validate arguments against the
+advertised schema). `tests/test_published_tool_schema_shape.py` sweeps both
+publishers so a future bridged tool cannot regress it. Handler-side errors
 (`McpInvalidParamsError`, the announce `McpRateLimitedError`) are re-raised as
 `ModelRetry` so a bad argument or a rate-limit hands feedback to the model
 instead of aborting the run.


### PR DESCRIPTION
## Summary

- **Every `meho agents run` on provider `anthropic` died at model-init** with
  `status_code: 400 … tools.5.custom.input_schema: input_schema does not support oneOf,
  allOf, or anyOf at the top level` and `turns: 0` — independent of the agent's own
  toolset, reproducible with an empty toolset `{}`. The Messages API validates the whole
  `tools` array, so one malformed schema poisons the request rather than just its own tool.
- **Root cause was the hosted-agent bridge, not the tool.** `_mcp_broadcast_tool`
  (`agent/toolset_broadcast.py`) deep-copied the **registered** `inputSchema` into the
  model-facing tool list, bypassing `ToolDefinition.to_wire()` — which has stripped
  root-level `oneOf`/`allOf`/`anyOf` since #905 for exactly this reason. `meho.broadcast.watch`
  carries a top-level `anyOf` enforcing the `cursor`/`since_cursor` XOR, and it is
  index 5 in default catalog order, matching `tools.5` in the ops report.
- **Fix is one line at the single publish chokepoint:** the bridge now publishes
  `definition.to_wire()["inputSchema"]`. Fixing it at the tool's registered schema would
  have fixed one tool and left the seven combinator-carrying siblings latent; fixing it at
  the chokepoint covers every currently-bridged **and future-bridged** tool.
- **Nothing about the MCP surface changes.** Every registered `inputSchema` is untouched,
  so `mcp/handlers.py`'s `jsonschema.validate` still rejects both-or-neither cursor forms
  with `-32602`, the deprecated `since_cursor` alias survives, and both design pins
  (`test_mcp_registry.py:161`, `test_mcp_tools_list_shape_conventions.py:170`) still pass
  unmodified. The `deepcopy` stays — `_wire_safe_input_schema` returns the *same* object
  when there is nothing to strip (announce/recent), and `build_broadcast_meta_tools`
  mutates the announce copy.
- **New cross-surface sweep** (`tests/test_published_tool_schema_shape.py`) fails on any
  *published* schema — every MCP `to_wire()["inputSchema"]` **and** every agent
  `MetaToolSpec.parameter_schema` — whose root carries a combinator or is not
  `type: object`. The MCP half passes on arrival by design: it is a regression guard
  against bypassing `to_wire()` again, exactly as the bridge did.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — 1358 files already formatted
- [x] `uv run mypy src/` — no issues in 680 source files
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] Targeted suites — 221 passed, 4 skipped (the changed/new test files plus both
      mandated design-pin files, the existing topology combinator sweep, capability
      gating, and inputSchema format enforcement)
- [x] Full agent + MCP blast-radius slice (`pytest -n 3 tests/test_agent_*.py
      tests/test_mcp_*.py`) — 1072 passed, 12 skipped, 0 failed
- [x] **AC1** — the bridge-published `broadcast_watch` schema has no top-level `anyOf`;
      the registered `inputSchema` keeps it; the handler rejects both-or-neither cursor
      forms with `-32602`.
      `test_agent_toolset_broadcast.py::test_watch_bridge_strips_anyof_but_registry_keeps_it`
      (asserts both halves in one test) +
      `test_mcp_tool_broadcast_watch.py::test_handler_rejects_neither_cursor_nor_since_cursor`
      (new; the existing `test_handler_rejects_both_cursor_and_since_cursor` covers "both").
- [x] **AC2** — sweep over published schemas, both publishers.
      `test_published_tool_schema_shape.py::test_mcp_wire_schemas_are_publishable` (79
      registered tools, read unfiltered so capability-gated `meho-docs` tools are covered)
      + `::test_agent_meta_tool_schemas_are_publishable`. Both paired with
      `*_sweep_is_not_vacuous` guards so an empty registry/catalog cannot make them pass.
- [x] **AC3** — agent-loop assembly test.
      `test_published_tool_schema_shape.py::test_default_toolset_assembles_only_publishable_schemas`
      builds the default meta-tool list from an empty toolset spec and asserts every
      `pydantic_ai.Tool`'s advertised schema root is a plain object.
- [x] **AC4** — CHANGELOG `[Unreleased]` entry under the unique header
      `### Fixed — agent bridge publishes wire-safe tool schemas (#2644)`.
- [x] **Negative control** — reverted the one-line fix locally and confirmed all four
      new/updated assertions go red (`test_agent_meta_tool_schemas_are_publishable`,
      `test_default_toolset_assembles_only_publishable_schemas`,
      `test_read_tool_schema_matches_mcp[broadcast_watch]`,
      `test_watch_bridge_strips_anyof_but_registry_keeps_it`), then restored it. The
      guards are not vacuous.
- [x] Design pins re-run explicitly and unmodified:
      `test_mcp_registry.py::test_to_wire_strips_top_level_combinators_but_keeps_them_on_input_schema`,
      `test_mcp_tools_list_shape_conventions.py::test_broadcast_watch_required_anyof_accepts_either_alias`.

## Notes

- **The root `anyOf` was advertised but never enforced on the agent path.**
  `pydantic_ai.Tool.from_schema` documents that "schema validation of the arguments is
  skipped, but a custom `args_validator` will still run if provided" — and the bridge
  passes no `args_validator`. So stripping the combinator from the published schema
  removes zero enforcement from the hosted-agent path; the handler's own typed
  `cursor` check (`not isinstance(since_cursor, str) or not since_cursor`) is and always
  was the real guard there. It already existed; the new
  `test_handler_rejects_neither_cursor_nor_since_cursor` pins it so a future refactor
  can't quietly drop it now that no jsonschema layer backs it up on that path.
- **The sweep reads the registry mapping, not `all_tools_for()`, on purpose.**
  `all_tools_for` is the RBAC + capability *filter* — it is the `tools/list` view for a
  given operator, not an enumeration. Sweeping through it would silently skip the five
  capability-gated `meho-docs` tools (`list_doc_collections`, `create_doc_collections`,
  `delete_doc_collections`, `search_docs`, `ask_docs`) for any operator without that
  capability provisioned, and would skip any future gated tool the same way — exactly
  the blind spot a completeness guard must not inherit. There is no public unfiltered
  enumeration, and widening the registry's API surface for a test isn't worth it, so
  `_registered_tools()` reads the mapping directly with that reasoning in its docstring.
  Ruff does not select `SLF001` here, and the surrounding test files already import
  privates freely (`_handler_watch`, `_WATCH_MIN_TIMEOUT_MS`, `_input_schema`,
  `_mirror_grant_id`). Both sweeps are paired with `*_sweep_is_not_vacuous` guards so an
  empty registry or catalog can't make them pass silently.
- No OpenAPI/CLI regeneration: the change touches no routes and no REST schemas, and
  `broadcast_watch` does not appear in `cli/api/openapi.json`.
- `docs/codebase/agent-runtime.md` said the read tools "reuse the MCP `inputSchema`
  unchanged" — updated to the wire shape, with the reason.

## Out of scope

- Retiring the deprecated `since_cursor` alias (per the ticket).
- Any change to the watch handler's semantics, timeouts, or filter contract.
- Any change to registered `inputSchema` dicts or `mcp/handlers.py`'s validation layer.
- `tests/test_mcp_tools_topology.py`'s narrower #905 combinator sweep is left in place;
  the new file is a cross-surface superset and its module docstring records the
  relationship rather than deleting a working guard from an unrelated file.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2644
