### PR TITLE
fix(ui): make connector registry Product/Kind filters actually fire (#174)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/connectors/registry.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/registry.html
@@ -75,7 +75,7 @@
     hx-get="/ui/connectors/registry"
     hx-target="#registry-table-body"
     hx-swap="outerHTML"
-    hx-trigger="change from:find select"
+    hx-trigger="change"
     hx-include="closest form"
     hx-push-url="true"
     role="search"
@@ -83,14 +83,14 @@
     onsubmit="return false;"
   >
     <div class="card-body grid gap-3 md:grid-cols-3">
-      <label class="form-control">
-        <span class="label-text">Status</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Status</span>
         {# The ``all`` option is a REAL sentinel value, NOT ``value=""`` --
            the backend enum 422s on an out-of-range value and an empty
            string would make the swap silently no-op. #}
         <select
           name="status"
-          class="select select-bordered select-sm"
+          class="select select-bordered select-sm w-full"
           aria-label="Filter by review status"
         >
           {%- set status_options = [
@@ -106,8 +106,8 @@
           {% endfor %}
         </select>
       </label>
-      <label class="form-control">
-        <span class="label-text">Product</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Product</span>
         {# Same footgun-safe shape: the "all products" option omits the
            ``product`` filter by submitting an empty string, which the
            handler treats as "no narrowing" -- ``product`` is a plain
@@ -115,7 +115,7 @@
            safe here (it maps to ``None``), unlike the status enum. #}
         <select
           name="product"
-          class="select select-bordered select-sm"
+          class="select select-bordered select-sm w-full"
           aria-label="Filter by product"
         >
           <option value="">All products</option>
@@ -126,8 +126,8 @@
           {% endfor %}
         </select>
       </label>
-      <label class="form-control">
-        <span class="label-text">Kind</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Kind</span>
         {# Authoring-mode filter (#1980, fed by ConnectorListItem.kind / #1979).
            Same footgun-safe shape as Status: the ``all`` option is a REAL
            sentinel (never ``value=""``) because the ``_KindFilter`` enum 422s
@@ -135,7 +135,7 @@
            in-process (kind is not a backend service argument). #}
         <select
           name="kind"
-          class="select select-bordered select-sm"
+          class="select select-bordered select-sm w-full"
           aria-label="Filter by connector kind"
         >
           {%- set kind_options = [

--- a/backend/tests/test_ui_connectors_registry_list.py
+++ b/backend/tests/test_ui_connectors_registry_list.py
@@ -366,6 +366,36 @@ def test_registry_list_renders_rows() -> None:
     assert "ops: 2 / 2" not in body
 
 
+def test_registry_filter_form_triggers_on_any_select_change() -> None:
+    """#174: the filter form fires on ``change`` from every select.
+
+    The form previously used ``hx-trigger="change from:find select"``;
+    htmx's ``find <sel>`` resolves to the FIRST matching descendant, so
+    only the Status select fired the request — changing Product or Kind
+    was a silent no-op. The form must trigger on ``change`` at the form
+    level (the event bubbles from any of the three selects) so every
+    filter narrows the table.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_connector(tenant_id=_TENANT_A, review_status="staged")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.get("/ui/connectors/registry")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The first-descendant-only binding must be gone.
+    assert "from:find select" not in body
+    # The filter form triggers on a bubbled ``change`` from any select.
+    assert 'hx-trigger="change"' in body
+
+
 def test_registry_list_status_filter_all_sentinel_renders() -> None:
     """The ``?status=all`` sentinel renders 200 (never 422); a bad value 422s."""
     _seed_tenant(_TENANT_A, "tenant-a")


### PR DESCRIPTION
## Summary

Fixes **task evoila-bosnia/meho-internal#174** (child of Initiative #172). What was reported as a cosmetic issue turned out to be a **functional bug**: selecting **Product** or **Kind** in the registry filter did nothing to the table.

**Root cause (functional).** The filter form triggered on `hx-trigger="change from:find select"`. Per the htmx docs, `find <selector>` resolves to the **first** matching descendant — so the listener bound only the **Status** select. `change` events from **Product** and **Kind** were never wired to a request, so the table silently didn't narrow. (The topology filter reuses this pattern but has a single select, so it worked there; the registry has three.)

**Fix.** Trigger on `change` at the **form** level — a `change` bubbles from any of the three selects to the form, and `hx-include="closest form"` already sends all three values, so every filter now narrows the table. Server-side filtering (status / product / kind, incl. the `all` sentinel) was already correct and is unchanged.

**Also (the visual half).** Migrated the three filter labels off the daisyUI **v4** dead classes (`form-control` / `label-text`) to `flex flex-col gap-1` + `text-sm font-medium` with `w-full` selects, so the controls render as aligned label-over-select.

## Test plan
- [x] `pytest tests/test_ui_connectors_registry_list.py` — **17 passed** (incl. a new guard: the rendered filter form triggers on `change` and no longer carries `from:find select`)
- [x] Server-side status/product/kind narrowing already covered by existing tests — unchanged.
- [ ] **Manual:** on `/ui/connectors/registry`, changing Product or Kind now re-renders the table (the trigger is client-side htmx; verified by the source-anchored guard + htmx docs, best confirmed with a browser click).

## Notes
Scope grew from the ticket's "presentation" framing to include the functional trigger fix — that's the actual defect the reporter hit. htmx `find` semantics confirmed against https://htmx.org/attributes/hx-trigger/.

Closes evoila-bosnia/meho-internal#174

🤖 Generated with [Claude Code](https://claude.com/claude-code)