### PR TITLE
fix(ui): tidy runbooks Start-a-Run dialog + format Params JSON (#176)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/runbooks/_start_modal.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_start_modal.html
@@ -62,15 +62,15 @@
         </div>
       {% endif %}
 
-      <label class="form-control">
-        <span class="label-text">Template slug</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Template slug</span>
         <input
           type="text"
           name="template_slug"
           list="runbook-run-published-slugs"
           required
           maxlength="256"
-          class="input input-bordered input-sm font-mono"
+          class="input input-bordered input-sm font-mono w-full"
           placeholder="e.g. drain-node"
           autocomplete="off"
           aria-describedby="runbook-run-start-slug-hint"
@@ -83,7 +83,7 @@
             <option value="{{ slug }}"></option>
           {% endfor %}
         </datalist>
-        <span id="runbook-run-start-slug-hint" class="text-xs opacity-60 mt-1">
+        <span id="runbook-run-start-slug-hint" class="text-xs opacity-60">
           {% if published_slugs %}
             Pick a published template or type its slug.
           {% else %}
@@ -92,50 +92,69 @@
         </span>
       </label>
 
-      <label class="form-control">
-        <span class="label-text">Target</span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Target</span>
         <input
           type="text"
           name="target"
           required
           maxlength="512"
-          class="input input-bordered input-sm font-mono"
+          class="input input-bordered input-sm font-mono w-full"
           placeholder="the run's subject -- host, cluster, cert thumbprint"
           autocomplete="off"
           aria-describedby="runbook-run-start-target-hint"
         />
-        <span id="runbook-run-start-target-hint" class="text-xs opacity-60 mt-1">
+        <span id="runbook-run-start-target-hint" class="text-xs opacity-60">
           Substituted into the steps as <code>${run.target}</code>.
         </span>
       </label>
 
-      <label class="form-control">
-        <span class="label-text">Params <span class="opacity-60">(optional, JSON object)</span></span>
+      {#- ``formatParams`` pretty-prints the Params JSON on blur so the
+          operator sees a readable, indented object instead of a one-line
+          blob (#176). Invalid / partial JSON is left exactly as typed —
+          the server (``_parse_json_object``) still validates and surfaces a
+          422/typed error, so formatting never eats an in-progress edit. -#}
+      <label
+        class="flex flex-col gap-1"
+        x-data="{
+          formatParams(el) {
+            const raw = el.value.trim();
+            if (!raw) { return; }
+            try {
+              el.value = JSON.stringify(JSON.parse(raw), null, 2);
+            } catch (e) {
+              /* invalid JSON: leave as typed; the server validates it */
+            }
+          }
+        }"
+      >
+        <span class="text-sm font-medium">Params <span class="opacity-60">(optional, JSON object)</span></span>
         <textarea
           name="params"
           maxlength="16384"
-          class="textarea textarea-bordered min-h-[8rem] font-mono text-sm"
+          class="textarea textarea-bordered min-h-[8rem] w-full font-mono text-sm"
           placeholder='{"namespace": "prod", "replicas": 3}'
           aria-describedby="runbook-run-start-params-hint"
+          x-on:blur="formatParams($event.target)"
         ></textarea>
-        <span id="runbook-run-start-params-hint" class="text-xs opacity-60 mt-1">
+        <span id="runbook-run-start-params-hint" class="text-xs opacity-60">
           A JSON object of <code>${run.params.X}</code> substitutions. Leave
           blank for none.
         </span>
       </label>
 
-      <label class="form-control">
-        <span class="label-text">Work ref <span class="opacity-60">(optional)</span></span>
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Work ref <span class="opacity-60">(optional)</span></span>
         <input
           type="text"
           name="work_ref"
           maxlength="512"
-          class="input input-bordered input-sm font-mono"
+          class="input input-bordered input-sm font-mono w-full"
           placeholder="gh:evoila/meho#9, a Jira key, a CR id"
           autocomplete="off"
           aria-describedby="runbook-run-start-work-ref-hint"
         />
-        <span id="runbook-run-start-work-ref-hint" class="text-xs opacity-60 mt-1">
+        <span id="runbook-run-start-work-ref-hint" class="text-xs opacity-60">
           The external change ticket this run executes under. Pinned on the
           run and every step's audit row.
         </span>

--- a/backend/src/meho_backplane/ui/templates/runbooks/_start_modal.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_start_modal.html
@@ -121,7 +121,14 @@
             const raw = el.value.trim();
             if (!raw) { return; }
             try {
-              el.value = JSON.stringify(JSON.parse(raw), null, 2);
+              const parsed = JSON.parse(raw);
+              /* Params must be a JSON object; leave arrays / scalars /
+                 null exactly as typed so the server surfaces the error
+                 rather than us tidying invalid input into place. */
+              if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                return;
+              }
+              el.value = JSON.stringify(parsed, null, 2);
             } catch (e) {
               /* invalid JSON: leave as typed; the server validates it */
             }

--- a/backend/tests/test_ui_runbook_runs_list.py
+++ b/backend/tests/test_ui_runbook_runs_list.py
@@ -639,6 +639,11 @@ def test_start_modal_renders_with_published_picker() -> None:
     # Published slug offered; draft slug withheld from the picker.
     assert '<option value="drain-node">' in body
     assert '<option value="draft-only">' not in body
+    # #176: form migrated off dead daisyUI-v4 classes, and the Params
+    # textarea carries the client-side JSON format-on-blur handler.
+    assert "form-control" not in body
+    assert "label-text" not in body
+    assert 'x-on:blur="formatParams($event.target)"' in body
 
 
 def test_start_modal_refreshes_csrf_cookie_matching_form_header() -> None:


### PR DESCRIPTION
## What

Two fixes to the runbooks **Start-a-Run** modal (`_start_modal.html`).

### Layout
The form used daisyUI v4 `form-control` + `label-text`, both removed in v5 (they compile to zero rules), so labels didn't stack over their inputs and helper text sat misaligned. Migrated every field — Template slug, Target, Params, Work ref — to:

- `flex flex-col gap-1` label wrappers
- `text-sm font-medium` labels
- helper notes as `text-xs opacity-60` blocks
- `w-full` on the controls (daisyUI v5 `.input`/`.textarea` cap their own width, so `w-full` is needed to fill the modal)

### Params JSON formatting
The **Params (optional, JSON object)** textarea now pretty-prints its JSON on blur via a small Alpine `formatParams` handler (`JSON.stringify(JSON.parse(v), null, 2)`), so the operator sees a readable indented object instead of a one-line blob. Invalid / in-progress JSON is left exactly as typed — and the handler only reformats a genuine JSON object (arrays, scalars, and `null` are left alone) — so the server's `_parse_json_object` still validates and surfaces the typed error, and formatting never eats an edit.

## Why
Reported in **evoila-bosnia/meho-internal#176** (subtask of the runbooks-view polish initiative **evoila-bosnia/meho-internal#175**).

## Scope / notes
Presentation + client-side formatting only — the start POST, params substitution, CSRF double-submit, and the published-slug datalist are unchanged. The start route echoes no field values on the typed-error re-render, so there is no server-side value to pretty-print today; that input-preservation gap is a separate concern noted for follow-up.

## Test
- `pytest tests/test_ui_runbook_runs_list.py` — 22 passed (adds a guard asserting no dead form classes render and the Params format-on-blur handler is present)
- `pytest tests/test_ui_runbooks_acceptance.py` — 2 passed

## Issue
Closing keywords don't cross repositories, so the reference below is a traceability link — the issue is closed manually on merge.

Closes evoila-bosnia/meho-internal#176