### PR TITLE
fix(ui): migrate runbooks New Runbook editor form off dead daisyUI-v4 classes (#177)

### DIFF
--- a/backend/src/meho_backplane/ui/templates/runbooks/_step_fields.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_step_fields.html
@@ -51,26 +51,20 @@
 
     {# ----- Step id + type ----- #}
     <div class="flex flex-wrap gap-4">
-      <label class="form-control flex-1 min-w-48">
-        <div class="label py-0">
-          <span class="label-text font-medium">Step id</span>
-          <span class="label-text-alt opacity-60">lowercase, hyphens, unique</span>
-        </div>
-        <input type="text" class="input input-bordered input-sm font-mono"
+      <label class="flex flex-col gap-1 flex-1 min-w-48">
+        <span class="text-sm font-medium">Step id</span>
+        <input type="text" class="input input-bordered input-sm font-mono w-full"
                x-model="step.id"
                pattern="[a-z][a-z0-9\-]{0,63}"
                placeholder="drain-node"
                autocomplete="off"
                x-bind:aria-label="'Step ' + (idx + 1) + ' id'" />
-        <div class="label py-0" x-show="stepIdError(idx)">
-          <span class="label-text-alt text-error" x-text="stepIdError(idx)"></span>
-        </div>
+        <span class="text-xs opacity-60">lowercase, hyphens, unique</span>
+        <span class="text-xs text-error" x-show="stepIdError(idx)" x-text="stepIdError(idx)"></span>
       </label>
-      <label class="form-control min-w-48">
-        <div class="label py-0">
-          <span class="label-text font-medium">Type</span>
-        </div>
-        <select class="select select-bordered select-sm" x-model="step.type"
+      <label class="flex flex-col gap-1 min-w-48">
+        <span class="text-sm font-medium">Type</span>
+        <select class="select select-bordered select-sm w-full" x-model="step.type"
                 x-bind:aria-label="'Step ' + (idx + 1) + ' type'">
           <option value="manual">manual</option>
           <option value="operation_call">operation_call</option>
@@ -79,33 +73,29 @@
     </div>
 
     {# ----- Step title ----- #}
-    <label class="form-control">
-      <div class="label py-0"><span class="label-text font-medium">Title</span></div>
-      <input type="text" class="input input-bordered input-sm"
+    <label class="flex flex-col gap-1">
+      <span class="text-sm font-medium">Title</span>
+      <input type="text" class="input input-bordered input-sm w-full"
              x-model="step.title" placeholder="Drain the node" autocomplete="off"
              x-bind:aria-label="'Step ' + (idx + 1) + ' title'" />
     </label>
 
     {# ----- operation_call: op_id + params ----- #}
     <div x-show="step.type === 'operation_call'" x-cloak class="space-y-3">
-      <label class="form-control">
-        <div class="label py-0">
-          <span class="label-text font-medium">Operation id</span>
-          <span class="label-text-alt opacity-60">registry op_id (free text)</span>
-        </div>
-        <input type="text" class="input input-bordered input-sm font-mono"
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Operation id</span>
+        <input type="text" class="input input-bordered input-sm font-mono w-full"
                x-model="step.op_id" placeholder="vmware.composite.vm.create"
                autocomplete="off"
                x-bind:aria-label="'Step ' + (idx + 1) + ' operation id'" />
+        <span class="text-xs opacity-60">registry op_id (free text)</span>
       </label>
-      <label class="form-control">
-        <div class="label py-0">
-          <span class="label-text font-medium">Params (JSON)</span>
-          <span class="label-text-alt opacity-60">${run.target} / ${run.params.X} only</span>
-        </div>
-        <textarea class="textarea textarea-bordered textarea-sm font-mono" rows="3"
+      <label class="flex flex-col gap-1">
+        <span class="text-sm font-medium">Params (JSON)</span>
+        <textarea class="textarea textarea-bordered textarea-sm font-mono w-full" rows="3"
                   x-model="step.params" placeholder="{}"
                   x-bind:aria-label="'Step ' + (idx + 1) + ' params'"></textarea>
+        <span class="text-xs opacity-60">${run.target} / ${run.params.X} only</span>
       </label>
     </div>
 
@@ -140,8 +130,8 @@
     <div class="border-base-300 border-t pt-3 space-y-3">
       <div class="flex flex-wrap items-end gap-4">
         <p class="text-xs font-semibold uppercase tracking-wide opacity-60">Verify</p>
-        <label class="form-control min-w-48">
-          <select class="select select-bordered select-sm" x-model="step.verify.type"
+        <label class="flex flex-col gap-1 min-w-48">
+          <select class="select select-bordered select-sm w-full" x-model="step.verify.type"
                   x-bind:aria-label="'Step ' + (idx + 1) + ' verify type'">
             <option value="confirm">confirm</option>
             <option value="operation_call">operation_call</option>
@@ -150,38 +140,34 @@
       </div>
 
       {# confirm: a single prompt #}
-      <label class="form-control" x-show="step.verify.type === 'confirm'">
-        <div class="label py-0"><span class="label-text font-medium">Prompt</span></div>
-        <input type="text" class="input input-bordered input-sm"
+      <label class="flex flex-col gap-1" x-show="step.verify.type === 'confirm'">
+        <span class="text-sm font-medium">Prompt</span>
+        <input type="text" class="input input-bordered input-sm w-full"
                x-model="step.verify.prompt" placeholder="Node drained?" autocomplete="off"
                x-bind:aria-label="'Step ' + (idx + 1) + ' verify prompt'" />
       </label>
 
       {# operation_call: op_id + params + expect #}
       <div x-show="step.verify.type === 'operation_call'" x-cloak class="space-y-3">
-        <label class="form-control">
-          <div class="label py-0"><span class="label-text font-medium">Operation id</span></div>
-          <input type="text" class="input input-bordered input-sm font-mono"
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Operation id</span>
+          <input type="text" class="input input-bordered input-sm font-mono w-full"
                  x-model="step.verify.op_id" placeholder="vmware.cert.status"
                  autocomplete="off"
                  x-bind:aria-label="'Step ' + (idx + 1) + ' verify operation id'" />
         </label>
-        <label class="form-control">
-          <div class="label py-0">
-            <span class="label-text font-medium">Params (JSON)</span>
-          </div>
-          <textarea class="textarea textarea-bordered textarea-sm font-mono" rows="2"
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Params (JSON)</span>
+          <textarea class="textarea textarea-bordered textarea-sm font-mono w-full" rows="2"
                     x-model="step.verify.params" placeholder="{}"
                     x-bind:aria-label="'Step ' + (idx + 1) + ' verify params'"></textarea>
         </label>
-        <label class="form-control">
-          <div class="label py-0">
-            <span class="label-text font-medium">Expect (JSON)</span>
-            <span class="label-text-alt opacity-60">structural-equality match</span>
-          </div>
-          <textarea class="textarea textarea-bordered textarea-sm font-mono" rows="2"
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Expect (JSON)</span>
+          <textarea class="textarea textarea-bordered textarea-sm font-mono w-full" rows="2"
                     x-model="step.verify.expect" placeholder="{}"
                     x-bind:aria-label="'Step ' + (idx + 1) + ' verify expect'"></textarea>
+          <span class="text-xs opacity-60">structural-equality match</span>
         </label>
       </div>
     </div>

--- a/backend/src/meho_backplane/ui/templates/runbooks/editor.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/editor.html
@@ -148,44 +148,37 @@
     <div class="card bg-base-100 border-base-300 border shadow-sm">
       <div class="card-body space-y-3 py-4">
         {% if mode == "new" %}
-        <label class="form-control">
-          <div class="label py-0">
-            <span class="label-text font-medium">Slug</span>
-            <span class="label-text-alt opacity-60">lowercase, dots/hyphens, required</span>
-          </div>
-          <input type="text" name="slug" class="input input-bordered input-sm font-mono"
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Slug</span>
+          <input type="text" name="slug" class="input input-bordered input-sm font-mono w-full"
                  x-model="slug" pattern="[a-z]([a-z0-9.\-]*[a-z0-9])?"
                  placeholder="rotate-cluster-cert" autocomplete="off" required
                  aria-label="Template slug" />
-          <div class="label py-0" x-show="slugError()">
-            <span class="label-text-alt text-error" x-text="slugError()"></span>
-          </div>
+          <span class="text-xs opacity-60">lowercase, dots/hyphens, required</span>
+          <span class="text-xs text-error" x-show="slugError()" x-text="slugError()"></span>
         </label>
         {% else %}
         {# Slug is locked on edit — the path is the source of truth. #}
         <input type="hidden" name="slug" value="{{ slug }}" />
         {% endif %}
 
-        <label class="form-control">
-          <div class="label py-0"><span class="label-text font-medium">Title</span></div>
-          <input type="text" name="title" class="input input-bordered input-sm"
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Title</span>
+          <input type="text" name="title" class="input input-bordered input-sm w-full"
                  x-model="title" placeholder="Rotate the cluster certificate"
                  autocomplete="off" required aria-label="Template title" />
         </label>
 
-        <label class="form-control">
-          <div class="label py-0"><span class="label-text font-medium">Description</span></div>
-          <textarea name="description" class="textarea textarea-bordered textarea-sm" rows="2"
+        <label class="flex flex-col gap-1">
+          <span class="text-sm font-medium">Description</span>
+          <textarea name="description" class="textarea textarea-bordered textarea-sm w-full" rows="2"
                     x-model="description" placeholder="What this runbook does and when to run it."
                     required aria-label="Template description"></textarea>
         </label>
 
-        <label class="form-control max-w-md">
-          <div class="label py-0">
-            <span class="label-text font-medium">Target kind</span>
-            <span class="label-text-alt opacity-60">optional</span>
-          </div>
-          <input type="text" name="target_kind" class="input input-bordered input-sm font-mono"
+        <label class="flex flex-col gap-1 max-w-md">
+          <span class="text-sm font-medium">Target kind <span class="opacity-60 font-normal">(optional)</span></span>
+          <input type="text" name="target_kind" class="input input-bordered input-sm font-mono w-full"
                  x-model="targetKind" placeholder="vmware.vcenter" autocomplete="off"
                  aria-label="Template target kind" />
         </label>

--- a/backend/tests/test_ui_runbooks_editor.py
+++ b/backend/tests/test_ui_runbooks_editor.py
@@ -391,6 +391,11 @@ def test_editor_new_admin_renders_200() -> None:
     assert "codemirror-bundle.min.js" in body
     # CSRF cookie set on render.
     assert CSRF_COOKIE_NAME in response.cookies
+    # #177: the editor form (editor.html + the _step_fields.html partial it
+    # includes) is migrated off dead daisyUI-v4 classes, which compile to
+    # zero rules in v5 and broke the label-over-input column.
+    assert "form-control" not in body
+    assert "label-text" not in body
 
 
 def test_editor_new_operator_forbidden_403() -> None:


### PR DESCRIPTION
## Summary
- The **New Runbook** editor form was cramped and misaligned: `editor.html` and the `_step_fields.html` partial it includes used daisyUI v4 `form-control` / `label-text` / `label-text-alt` + `<div class="label">` wrappers, all removed in v5 (zero compiled rules), so the label-over-input column collapsed and hint/error spans flowed inline.
- Migrated every field to `flex flex-col gap-1` label wrappers, `text-sm font-medium` labels, hint/error as `text-xs opacity-60` / `text-xs text-error` blocks below the field, and `w-full` controls (daisyUI v5 caps input/select/textarea width). `max-w-md` on Target kind and the `flex-1 min-w-48` step-row sizing are preserved.
- Presentation only — the create/edit POST, Alpine `x-model` step JSON + `syncSteps()`, slug validation, and CSRF double-submit are unchanged.

## Test plan
- [x] `ruff check` — clean
- [x] `pytest tests/test_ui_runbooks_editor.py tests/test_ui_runbooks_acceptance.py tests/test_ui_runbooks_lifecycle.py` — 57 passed
- [x] **Aligned, no overlap** — all fields stack label-over-input via `flex flex-col gap-1`; hint/error render as blocks below
- [x] **No dead classes remain** — grep clean in both files; render-guard test asserts `form-control`/`label-text` absent from `/ui/runbooks/new` (which includes `_step_fields.html`)
- [x] **No functional regression** — create + edit POST, `x-model` step JSON, slug validation, CSRF covered by the 57 passing tests

## Out of scope
- The Start a Run dialog (sibling task evoila-bosnia/meho-internal#176, PR #2696).
- `index.html` / `runs.html` / `_run_step.html` also carry the dead classes but belong to other runbooks surfaces — recorded as adjacent findings, not touched here.
- No change to runbook create/edit behaviour or the step schema.

## Issue
Implements initiative **evoila-bosnia/meho-internal#175**. Closing keywords don't cross repositories, so the reference below is a traceability link — the issue is closed manually on merge.

Closes evoila-bosnia/meho-internal#177