### PR TITLE
fix(ci): unblock merge gates — path-filtered license checks + Dependabot login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,12 @@ jobs:
     # the existing branch-protection required check stays satisfied.
     timeout-minutes: 25
     env:
+      # Surfaced as a job-level env var purely so the Docker Hub login
+      # step can test it in an `if:`. The `secrets` context is NOT
+      # available in a step-level `if:` (GitHub's context-availability
+      # table allows it in `with:` / `env:` / `run:` only), so reading
+      # the secret through `env` is what makes the guard evaluatable.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       # Route testcontainers pulls through the in-cluster Harbor proxy
       # cache (claude-rdc-hetzner-dc#463; project `dockerhub-proxy` public,
       # anonymous consumer auth, wired into runner DinD via
@@ -247,6 +253,20 @@ jobs:
         # vault custody — see meho-internal#74 for the regression
         # context this addresses. Long-term, the in-cluster proxy
         # cache from claude-rdc-hetzner-dc#463 retires this step.
+        #
+        # The `if:` guard is what keeps Dependabot PRs green. A
+        # Dependabot-triggered run reads the *Dependabot* secret store,
+        # not the Actions one, so `secrets.DOCKERHUB_USERNAME` is empty
+        # there — and `docker/login-action` hard-fails with "Username and
+        # password required" instead of no-opping, which failed this job
+        # (and every other job carrying this step) on all ~18 open
+        # Dependabot PRs. Skipping the login is safe: every image above
+        # resolves through the harbor.evba.lab proxy cache, so an
+        # unauthenticated run still pulls — it only gives up the Docker
+        # Hub rate-limit headroom the login buys. Mirroring
+        # DOCKERHUB_USERNAME / DOCKERHUB_TOKEN into the repo's Dependabot
+        # secrets restores that headroom and makes this guard a no-op.
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -550,6 +570,12 @@ jobs:
     timeout-minutes: 50
     continue-on-error: true
     env:
+      # Surfaced as a job-level env var purely so the Docker Hub login
+      # step can test it in an `if:`. The `secrets` context is NOT
+      # available in a step-level `if:` (GitHub's context-availability
+      # table allows it in `with:` / `env:` / `run:` only), so reading
+      # the secret through `env` is what makes the guard evaluatable.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       MEHO_TEST_PGVECTOR_IMAGE: harbor.evba.lab/dockerhub-proxy/pgvector/pgvector:pg16
       MEHO_TEST_VALKEY_IMAGE: harbor.evba.lab/dockerhub-proxy/valkey/valkey:8
       # vcsim release-tag pin — see the comment on the first
@@ -564,6 +590,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Docker Hub login (for testcontainers pulls)
+        # Empty-secret guard — see the python-tests job's login step for
+        # why Dependabot runs need it.
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -696,6 +725,12 @@ jobs:
     runs-on: meho-runners-ci
     timeout-minutes: 60
     env:
+      # Surfaced as a job-level env var purely so the Docker Hub login
+      # step can test it in an `if:`. The `secrets` context is NOT
+      # available in a step-level `if:` (GitHub's context-availability
+      # table allows it in `with:` / `env:` / `run:` only), so reading
+      # the secret through `env` is what makes the guard evaluatable.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       MEHO_TEST_PGVECTOR_IMAGE: harbor.evba.lab/dockerhub-proxy/pgvector/pgvector:pg16
       MEHO_TEST_VALKEY_IMAGE: harbor.evba.lab/dockerhub-proxy/valkey/valkey:8
       # vcsim release-tag pin — see the comment on the first
@@ -735,6 +770,12 @@ jobs:
         # integration subtree is the heaviest testcontainers consumer
         # (pgvector/valkey/k3d/vcsim), so authenticated pulls are
         # load-bearing here in particular.
+        # Empty-secret guard — see the python-tests job's login step for
+        # why Dependabot runs need it. This job pulls the most images, so
+        # it is the likeliest to feel the lost rate-limit headroom; that
+        # is an argument for mirroring the Dependabot secrets, not for
+        # letting the step hard-fail.
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -787,6 +828,12 @@ jobs:
     runs-on: meho-runners-ci
     timeout-minutes: 30
     env:
+      # Surfaced as a job-level env var purely so the Docker Hub login
+      # step can test it in an `if:`. The `secrets` context is NOT
+      # available in a step-level `if:` (GitHub's context-availability
+      # table allows it in `with:` / `env:` / `run:` only), so reading
+      # the secret through `env` is what makes the guard evaluatable.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       # The 3 forward-compat rollback tests spin up pgvector via
       # testcontainers; route the pull through the Harbor proxy cache like
       # the sibling jobs (never `:latest`).
@@ -802,6 +849,9 @@ jobs:
       - name: Docker Hub login (for testcontainers pulls)
         # Authenticated pulls avoid the shared-NAT Docker Hub anonymous
         # rate limit when the rollback tests spin up pgvector/pgvector:pg16.
+        # Empty-secret guard — see the python-tests job's login step for
+        # why Dependabot runs need it.
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -29,23 +29,24 @@ on:
       - '**/package.json'
       - '**/package-lock.json'
       - '.github/workflows/dependency-license-check.yml'
+  # NO `paths:` filter here — deliberately. `Python License Check` and
+  # `NPM License Check` are *required* status checks in branch
+  # protection, and GitHub leaves a required context Pending forever
+  # when its whole workflow is skipped by a path filter, which blocks
+  # the merge with no way to satisfy it. The narrowing moved to the
+  # `changes` job + job-level `if:` below, because a job skipped by its
+  # own `if:` reports **Success** and does satisfy the required check.
+  # This is exactly the shape ci.yml adopted in #2140 and documents at
+  # its own `changes` job; this workflow was never converted, so every
+  # PR that did not touch a manifest was structurally unmergeable.
   pull_request:
     branches: [main]
-    paths:
-      - '**/pyproject.toml'
-      - '**/package.json'
-      - '**/package-lock.json'
-      - '.github/workflows/dependency-license-check.yml'
   # Fires when a PR enters the GitHub merge queue. Required so the
-  # `Python License Check` and `NPM License Check` status contexts —
-  # required checks in branch protection — report against the
-  # synthesised merge commit, not just the PR head. Bare `merge_group:`
-  # is intentional: the `merge_group` event does not support `paths:`
-  # filtering (GitHub docs only allow `types:`), so the license jobs
-  # run on every queue admission. The `hashFiles()` guards on each
-  # step already make the jobs no-op when manifests are unchanged, so
-  # the redundant runs are cheap. Same rationale as ci.yml's
-  # merge_group trigger (#769).
+  # `Python License Check` and `NPM License Check` status contexts
+  # report against the synthesised merge commit, not just the PR head.
+  # The `changes` job emits `manifests=true` on every non-PR event, so
+  # the license jobs run on every queue admission. Same rationale as
+  # ci.yml's merge_group trigger (#769).
   merge_group:
   workflow_dispatch:
 
@@ -63,8 +64,55 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect manifest changes
+    # Emits `manifests=true` when a PR touches a dependency manifest, so
+    # the two required license jobs run only then. On push / merge_group
+    # / workflow_dispatch it emits `true` unconditionally, so the
+    # required checks are never left Pending on a non-PR event.
+    #
+    # This carries the narrowing that used to live in `on.pull_request.
+    # paths`. See the comment on that trigger above for why the filter
+    # cannot stay there for a *required* check.
+    runs-on: meho-runners-ci
+    timeout-minutes: 5
+    outputs:
+      manifests: ${{ steps.detect.outputs.manifests }}
+    steps:
+      - name: Checkout
+        # fetch-depth: 0 so the PR base commit is present for the
+        # three-dot diff below (the default shallow fetch would not
+        # reach the merge-base).
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Detect manifest changes
+        id: detect
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "non-PR event (${{ github.event_name }}) -> manifests=true"
+            echo "manifests=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          # Same file set the `on.pull_request.paths` filter used to
+          # name: any Python or npm dependency manifest, plus this
+          # workflow itself (so a change to the allow-list is always
+          # validated against the real dependency graph).
+          changed="$(git diff --name-only "${base}"...HEAD)"
+          if printf '%s\n' "${changed}" | grep -qE '(^|/)(pyproject\.toml|package\.json|package-lock\.json)$|^\.github/workflows/dependency-license-check\.yml$'; then
+            echo "manifest change detected -> manifests=true"
+            echo "manifests=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no manifest change -> manifests=false"
+            echo "manifests=false" >> "$GITHUB_OUTPUT"
+          fi
+
   python-licenses:
     name: Python License Check
+    needs: changes
+    if: needs.changes.outputs.manifests == 'true'
     runs-on: meho-runners-ci
     timeout-minutes: 10
     steps:
@@ -186,6 +234,8 @@ jobs:
 
   npm-licenses:
     name: NPM License Check
+    needs: changes
+    if: needs.changes.outputs.manifests == 'true'
     runs-on: meho-runners-ci
     timeout-minutes: 10
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,32 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — CI merge gates no longer block every PR
+
+- Two independent CI misconfigurations made most open PRs structurally
+  unmergeable, and both are fixed here. **First**, `Python License Check`
+  and `NPM License Check` are required status checks, but their workflow
+  was gated by `on.pull_request.paths` limited to dependency manifests.
+  GitHub leaves a required context *Pending forever* when its whole
+  workflow is skipped by a path filter — so every PR that did not touch a
+  `pyproject.toml` / `package.json` / `package-lock.json` could never
+  satisfy branch protection and could only land via an admin bypass. The
+  narrowing moved to a `changes` job plus a job-level `if:`, because a job
+  skipped by its own `if:` reports **Success** and does satisfy the
+  required check. This is the same shape `ci.yml` adopted in #2140 for the
+  migration gate and documents at its own `changes` job; the license
+  workflow was simply never converted. Which manifests trigger a real
+  license run is unchanged. **Second**, every Dependabot PR failed
+  `Python (ruff + mypy + pytest)` and `Python (integration testcontainers)`
+  at `docker/login-action` with `Username and password required`:
+  Dependabot-triggered runs read the *Dependabot* secret store rather than
+  the Actions one, so `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` resolve
+  empty and the action hard-fails instead of no-opping. All four login
+  steps now carry an empty-secret guard. Skipping the login is safe —
+  the testcontainers images all resolve through the `harbor.evba.lab`
+  proxy cache — it only forfeits the Docker Hub rate-limit headroom, which
+  mirroring those two secrets into the repo's Dependabot secrets restores.
+
 ### Fixed — agent bridge publishes wire-safe tool schemas (#2644)
 
 - Every `meho agents run` on provider `anthropic` died at model-init with


### PR DESCRIPTION
Supersedes #2703 (same fix; that branch's first commit was authored with a machine-local email and failed DCO, and history rewriting was not available — so this is a clean re-cut rather than a force-push).

Found while sweeping the 27 open PRs: **26 of them are unmergeable, for two unrelated CI-config reasons.** Neither is about the code in those PRs.

## 1. Required checks gated by `on.pull_request.paths` — blocks nearly every PR

`Python License Check` and `NPM License Check` are required status checks in branch protection. But `dependency-license-check.yml` gated them with `on.pull_request.paths` limited to dependency manifests.

GitHub leaves a required context **Pending forever** when its whole workflow is skipped by a path filter. So any PR that doesn't touch a `pyproject.toml` / `package.json` / `package-lock.json` can never satisfy branch protection. Confirmed against the 6 green UI PRs — those two contexts are simply absent from their check rollups while everything else is green.

The repo already solved this exact problem and wrote down why — `ci.yml`'s `changes` job, added in #2140:

> **WHY a `changes`-job + job-level `if:` and NOT `on.paths` (#2140):** GitHub treats a job skipped by its own `if:` as **Success** (it satisfies a required status check), whereas a whole workflow skipped by a path filter stays **Pending** and blocks merge.

`dependency-license-check.yml` was never converted. This PR converts it, mirroring that pattern. **Which manifests trigger a real license run is unchanged** — the same file set moved from the trigger's `paths:` into the `changes` job's diff check. The regex is anchored with `(^|/)` so `notes-package.json` doesn't false-positive; verified against positive and negative paths.

Side note: the old comments assume a merge queue (`merge_group:` was added so these contexts report against the queue's merge commit), but `required_merge_queue` is `null` on `main` and `allow_auto_merge` is `false` — no queue was ever enabled, so nothing was satisfying these contexts on PRs.

## 2. Dependabot runs can't reach the Actions secret store — blocks all 18 Dependabot PRs

Every Dependabot PR fails `Python (ruff + mypy + pytest)` and `Python (integration testcontainers)` at the same step:

```
##[error]Username and password required
```

That's `docker/login-action`. The job log shows `Secret source: Dependabot` — Dependabot-triggered runs read the *Dependabot* secret store, not the Actions one, so `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` resolve empty and the action **hard-fails rather than no-opping**. Nothing to do with the dependency bumps themselves.

All four login steps now carry an empty-secret guard.

**The guard reads the secret through a job-level `env` var, not `secrets` directly.** `${{ secrets.X != '' }}` in a step-level `if:` is an *invalid-workflow error*, not a working guard — the `secrets` context isn't available there (GitHub allows it in `with:` / `env:` / `run:` only). #2703 had exactly that bug and GitHub rejected the whole CI workflow with "This run likely failed because of a workflow file issue", which is how it surfaced.

Skipping the login is safe: every testcontainers image resolves through the `harbor.evba.lab` proxy cache, so unauthenticated runs still pull. What's forfeited is the Docker Hub rate-limit headroom — relevant mainly to the integration job, which pulls the most images.

**Follow-up worth doing separately:** mirror `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` into the repo's Dependabot secrets (Settings → Secrets and variables → Dependabot). That restores the headroom and makes the guard a no-op. The guard is still worth keeping — it's what stops a missing secret from hard-failing a whole job.

## Verification

- Both workflows parse; `ci.yml` job graph unchanged, license workflow now `changes → python-licenses / npm-licenses`.
- All four `python-*` jobs confirmed to carry both the job-level `DOCKERHUB_USERNAME` env and the `if: env.DOCKERHUB_USERNAME != ''` guard.
- Manifest-detection regex tested against positives (`backend/pyproject.toml`, `pyproject.toml`, `frontend/package.json`, `backend/package-lock.json`, the workflow itself) and negatives (`docs/pyproject.toml.md`, `notes-package.json`, `.github/workflows/ci.yml`, template/test files).
- On #2703, part 1 was already proven green before the `ci.yml` expression bug was found: `Detect manifest changes`, `Python License Check`, and `NPM License Check` all reported **SUCCESS** where previously they never reported at all.
- This PR touches `dependency-license-check.yml`, which is in the detected set — so the license jobs run for real here rather than skipping, making it self-validating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)