### PR TITLE
style(ingest): put `None` last in the custom_description unions (RUF036)

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/_internals.py
+++ b/backend/src/meho_backplane/operations/ingest/_internals.py
@@ -626,7 +626,7 @@ async def bulk_enable_read_ops(
 
 def validate_edit_op_args(
     *,
-    custom_description: str | None | _UnsetType,
+    custom_description: str | _UnsetType | None,
     safety_level: str | None,
     requires_approval: bool | None,
     is_enabled: bool | None,
@@ -664,7 +664,7 @@ def validate_edit_op_args(
 def apply_op_overrides(
     op_row: EndpointDescriptor,
     *,
-    custom_description: str | None | _UnsetType,
+    custom_description: str | _UnsetType | None,
     safety_level: str | None,
     requires_approval: bool | None,
     is_enabled: bool | None,

--- a/backend/src/meho_backplane/operations/ingest/service.py
+++ b/backend/src/meho_backplane/operations/ingest/service.py
@@ -614,7 +614,7 @@ class ReviewService:
         op_id: str,
         *,
         tenant_id: UUID | None,
-        custom_description: str | None | _UnsetType = _UNSET,
+        custom_description: str | _UnsetType | None = _UNSET,
         safety_level: Literal["safe", "caution", "dangerous"] | None = None,
         requires_approval: bool | None = None,
         is_enabled: bool | None = None,


### PR DESCRIPTION
Unblocks the dependabot ruff `0.15.21` → `0.16.0` bump (#2691).

ruff 0.16.0 enables **RUF036** (`` `None` not at the end of the type union``), which flags exactly three annotations on the edit-op description path:

```
src/meho_backplane/operations/ingest/_internals.py:629
src/meho_backplane/operations/ingest/_internals.py:667
src/meho_backplane/operations/ingest/service.py:617
```

All three are `str | None | _UnsetType` → `str | _UnsetType | None`. Union member order carries no semantic weight, so this is a pure reordering — precisely what `ruff check --fix` emits (the rule reports `3 fixable with the --fix option`). It is equally valid under the 0.15.21 currently pinned, so it lands independently of the bump.

## Why this is split out rather than pushed onto #2691

I did initially push it onto the dependabot branch, and that turned out to be the wrong shape for two reasons:

1. A non-dependabot commit on a dependabot branch stops `@dependabot rebase` from recreating it cleanly — and #2691 needs a rebase, since the other lockfile bumps that landed in this sweep made it conflict.
2. `require_last_push_approval` is on, so whoever pushes the fix can no longer approve the bump — leaving it stuck needing a third party for what is really a one-line lint change.

With this on main, #2691 recreates as a pure lockfile bump: green, and approvable normally.

## Verification

- Confirmed all three sites are the complete set — `grep -rn "None | _UnsetType" backend/src/` returns nothing after the change.
- The identical change was already proven against ruff 0.16.0 on the #2691 branch, where CI went fully green (20 SUCCESS / 7 SKIPPED, no failures) with the bump applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized public type annotations for custom descriptions.
  * No changes to runtime behavior or validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->