### PR TITLE
test(ingest): make the parse-offload guard measure the loop, not the clock

### DIFF
--- a/backend/tests/test_ingest_large_spec_event_loop.py
+++ b/backend/tests/test_ingest_large_spec_event_loop.py
@@ -99,6 +99,15 @@ _MAX_GAP_CEILING_S = 0.5
 #: after it — a starved loop would tick only a handful of times.
 _MIN_TICKS = 50
 
+#: Heartbeats that must land *inside* the injected 0.3 s parse block for
+#: the offload to count as proven. At the 10 ms cadence an idle runner
+#: delivers ~25-30; a regression (parse back on the loop) delivers 0,
+#: because the loop cannot run at all while the block holds. 5 sits an
+#: order of magnitude below the healthy count and infinitely above the
+#: regression count, so it tolerates a heavily contended runner without
+#: weakening what the test actually detects.
+_MIN_TICKS_DURING_BLOCK = 5
+
 
 def _synth_openapi_spec(op_count: int) -> str:
     """Build a structurally valid OpenAPI 3.1 spec with *op_count* GET ops.
@@ -192,7 +201,7 @@ def _service(monkeypatch: pytest.MonkeyPatch) -> IngestionPipelineService:
     return service
 
 
-async def _run_with_heartbeat(work: Awaitable[Any]) -> tuple[Any, list[float]]:
+async def _run_with_heartbeat(work: Awaitable[Any]) -> tuple[Any, list[tuple[float, float]]]:
     """Await *work* while a heartbeat coroutine measures event-loop gaps.
 
     The heartbeat re-arms an ``asyncio.sleep(interval)`` in a loop and
@@ -201,19 +210,31 @@ async def _run_with_heartbeat(work: Awaitable[Any]) -> tuple[Any, list[float]]:
     stretches the gap spanning it to ~= the block duration, because the
     sleep's callback cannot fire until the loop is free again. The gap
     series is the loop-lag signal the assertions read.
+
+    Returns ``(result, beats)`` where each beat is a
+    ``(wake_time, gap)`` pair. The wake timestamp is what lets a caller
+    attribute a gap to a *specific* window of the run — see
+    :func:`test_blocking_parse_stays_off_the_event_loop`, which needs to
+    distinguish "the loop was frozen while the parse ran" from "the
+    runner was busy at some unrelated point".
+
+    ``time.monotonic()`` rather than ``loop.time()``: the timestamps are
+    compared against marks taken on a ``to_thread`` worker, where there
+    is no running loop to ask. CPython's event loops use
+    ``time.monotonic()`` for ``loop.time()`` anyway, so this is the same
+    clock, just one that is legible from both sides.
     """
     stop = asyncio.Event()
     armed = asyncio.Event()
-    gaps: list[float] = []
+    beats: list[tuple[float, float]] = []
 
     async def _heartbeat() -> None:
-        loop = asyncio.get_running_loop()
         armed.set()
-        prev = loop.time()
+        prev = time.monotonic()
         while not stop.is_set():
             await asyncio.sleep(_HEARTBEAT_INTERVAL_S)
-            now = loop.time()
-            gaps.append(now - prev)
+            now = time.monotonic()
+            beats.append((now, now - prev))
             prev = now
 
     beat = asyncio.create_task(_heartbeat())
@@ -231,7 +252,7 @@ async def _run_with_heartbeat(work: Awaitable[Any]) -> tuple[Any, list[float]]:
     finally:
         stop.set()
         await beat
-    return result, gaps
+    return result, beats
 
 
 @pytest.mark.asyncio
@@ -250,7 +271,7 @@ async def test_nondryrun_large_spec_ingest_keeps_event_loop_responsive(
     service = _service(monkeypatch)
     spec = SpecSource(uri="spec:loadtest-large", content=_synth_openapi_spec(_OP_COUNT))
 
-    result, gaps = await _run_with_heartbeat(
+    result, beats = await _run_with_heartbeat(
         service.ingest(
             product=_PRODUCT,
             version=_VERSION,
@@ -260,6 +281,7 @@ async def test_nondryrun_large_spec_ingest_keeps_event_loop_responsive(
             dry_run=False,
         )
     )
+    gaps = [gap for _wake, gap in beats]
 
     # The full non-dry-run commit landed — every op persisted.
     assert result.ingestion.inserted_count == _OP_COUNT, result.ingestion
@@ -300,10 +322,18 @@ async def test_blocking_parse_stays_off_the_event_loop(
 
     real_parse = _pipeline_mod.parse_openapi_with_provenance
 
+    # Marks bounding the injected block, stamped from whichever context the
+    # parse actually runs in. They convert the assertions below from "was
+    # any gap large?" (which a busy runner can trip on its own) into "was
+    # the loop alive *while the block held*?" — the property under test.
+    block_window: list[float] = []
+
     def _blocking_parse(*args: Any, **kwargs: Any) -> Any:
         # Runs on the ``to_thread`` worker in the real code path; the
         # blocking sleep here therefore must not be visible to the loop.
+        block_window.append(time.monotonic())
         time.sleep(block_s)
+        block_window.append(time.monotonic())
         return real_parse(*args, **kwargs)
 
     monkeypatch.setattr(_pipeline_mod, "parse_openapi_with_provenance", _blocking_parse)
@@ -313,7 +343,7 @@ async def test_blocking_parse_stays_off_the_event_loop(
     # the run and the assertion isolates the parse-offload property.
     spec = SpecSource(uri="spec:loadtest-tiny", content=_synth_openapi_spec(3))
 
-    _result, gaps = await _run_with_heartbeat(
+    _result, beats = await _run_with_heartbeat(
         service.ingest(
             product=_PRODUCT,
             version=_VERSION,
@@ -324,17 +354,39 @@ async def test_blocking_parse_stays_off_the_event_loop(
         )
     )
 
-    worst = max(gaps)
-    assert worst < block_s / 2, (
-        f"event loop stalled for {worst:.3f}s while a {block_s}s parse ran; "
-        "the parse is not being offloaded to a thread (asyncio.to_thread regressed)"
+    assert len(block_window) == 2, "the patched parse did not run exactly once"
+    block_start, block_end = block_window
+
+    # Heartbeats that woke *inside* the block. If the ``to_thread`` hop were
+    # removed the loop would be frozen for the whole block and this would be
+    # empty; offloaded, the 10 ms cadence yields ~25-30.
+    #
+    # This is deliberately a presence-vs-absence signal rather than a
+    # gap-magnitude threshold. The previous assertion (`max(gaps) <
+    # block_s / 2`) inferred the property from how large the worst gap in
+    # the *entire run* was, which conflates two unrelated things: the loop
+    # being blocked by the parse, and the runner simply being busy. On a
+    # saturated CI runner ambient scheduling jitter alone reached 0.174 s
+    # and 1.522 s against that 0.15 s threshold, failing the test while the
+    # offload was working perfectly. Tick count degrades gracefully instead
+    # — a runner 5x slower still delivers ~5 ticks, against 0 for a real
+    # regression.
+    ticks_in_block = [gap for wake, gap in beats if block_start <= wake <= block_end]
+    assert len(ticks_in_block) >= _MIN_TICKS_DURING_BLOCK, (
+        f"only {len(ticks_in_block)} heartbeats landed inside the {block_s}s parse "
+        f"(need >= {_MIN_TICKS_DURING_BLOCK}); the loop was not free while the parse "
+        "ran, so the parse is not being offloaded (asyncio.to_thread regressed)"
     )
-    # The loop ticked repeatedly *while* the block ran — direct evidence the
-    # block was off-loop (a ~0.3 s block at 10 ms cadence yields ~25 ticks).
-    ticks_during_block = sum(1 for g in gaps if g < block_s / 2)
-    assert ticks_during_block >= 15, (
-        f"only {ticks_during_block} responsive ticks during the {block_s}s parse; "
-        "the loop was not free while the parse ran"
+
+    # Belt-and-braces: no single gap *overlapping* the block spanned it. An
+    # on-loop block produces exactly one such gap, >= block_s. Restricting
+    # to overlapping gaps keeps an unrelated stall elsewhere in the run
+    # (register pass, sqlite commit, a noisy neighbour) from failing this.
+    spanning = [gap for wake, gap in beats if wake > block_start and (wake - gap) < block_end]
+    worst_spanning = max(spanning, default=0.0)
+    assert worst_spanning < block_s, (
+        f"a {worst_spanning:.3f}s gap spanned the {block_s}s parse window; "
+        "the loop was frozen for the block's duration (asyncio.to_thread regressed)"
     )
 
 


### PR DESCRIPTION
`test_blocking_parse_stays_off_the_event_loop` failed twice during the open-PR sweep — on #2697 and #2685 — while the code it guards was working correctly:

```
AssertionError: event loop stalled for 0.174s while a 0.3s parse ran
AssertionError: event loop stalled for 1.522s while a 0.3s parse ran
```

Both were false positives from runner contention. I re-triggered 25 PRs at once, which saturated the self-hosted pool; ambient scheduling jitter alone passed the threshold.

## What was actually wrong

The assertion took `max(gaps)` over the **entire run** and required it under `block_s / 2` (0.15 s) — inferring *"the parse was offloaded"* from *"no gap anywhere was large"*. That conflates two unrelated things: the loop being blocked by the parse, and the runner simply being busy.

It also left a dead band. A real regression puts the parse on the loop and produces a gap of **≥ 0.3 s**. Anything in 0.15–0.30 s failed the test without implicating the `to_thread` hop at all — and that band is exactly where a contended runner's jitter lands.

## The fix

The property under test is narrower than what was being measured: *did the loop keep running while the block held?* So measure that directly.

The patched parse stamps its start/end, `_run_with_heartbeat` returns `(wake_time, gap)` pairs instead of bare gaps, and the assertion counts heartbeats landing inside the block window.

This converts a magnitude threshold into a **presence-vs-absence signal**, which is what makes it load-robust:

| | heartbeats inside the 0.3 s block |
|---|---|
| Offloaded (correct) | ~25–30 |
| Threshold | **5** |
| On-loop (regression) | **0** — the loop cannot run at all |

An order of magnitude below healthy, infinitely above a regression. A runner 5× slower still clears it.

A second assertion preserves the original intent as belt-and-braces — no single gap *overlapping* the window spans it — but scoped to overlapping gaps, so a stall elsewhere in the run (register pass, sqlite commit, noisy neighbour) no longer fails the test.

## Verification

**Mutation test — the guard still catches what it exists to catch.** Removing the `asyncio.to_thread` hop in `_register_one_spec` so the parse runs on the loop:

```
AssertionError: only 0 heartbeats landed inside the 0.3s parse (need >= 5);
the loop was not free while the parse ran, so the parse is not being
offloaded (asyncio.to_thread regressed)
```

Source restored afterwards; this PR touches **only the test file**.

**Flake check.** 5/5 passes unloaded, and 3/3 under 8 concurrent busy-loops — the condition that broke it in CI. `ruff check` and `ruff format --check` clean. (CI's mypy targets `files = ["src"]`, so test files aren't type-checked.)

## Not changed

`test_nondryrun_large_spec_ingest_keeps_event_loop_responsive` has a similar absolute ceiling (`_MAX_GAP_CEILING_S = 0.5`) with the same theoretical exposure. It did **not** flake in this sweep, and 0.5 s is a good deal more headroom than 0.15 s was, so I left it alone rather than rewriting a test that has not misbehaved. Worth revisiting if it ever does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened regression coverage for large-spec ingestion to verify the event loop remains responsive during non-dry-run processing.
  * Added timing-based checks confirming heartbeat activity continues throughout blocking parse operations.
  * Improved test reliability by replacing schedule-sensitive lag heuristics with deterministic blocking-window assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->