### PR TITLE
docs(ci): point at the Docker Hub credential custody note; unstale the guard comment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,21 +251,33 @@ jobs:
         # org-level secrets security-scan.yml uses, provisioned at
         # the evoila org level (visibility `all`) with 1Password
         # vault custody — see meho-internal#74 for the regression
-        # context this addresses. Long-term, the in-cluster proxy
-        # cache from claude-rdc-hetzner-dc#463 retires this step.
+        # context this addresses, and meho-internal
+        # `docs/dockerhub-ci-credential-custody.md` for where the
+        # credential actually lives and how to rotate it (the vault
+        # and item names stay in the internal repo; this one is
+        # public). Long-term, the in-cluster proxy cache from
+        # claude-rdc-hetzner-dc#463 retires this step.
         #
         # The `if:` guard is what keeps Dependabot PRs green. A
         # Dependabot-triggered run reads the *Dependabot* secret store,
         # not the Actions one, so `secrets.DOCKERHUB_USERNAME` is empty
         # there — and `docker/login-action` hard-fails with "Username and
         # password required" instead of no-opping, which failed this job
-        # (and every other job carrying this step) on all ~18 open
+        # (and every other job carrying this step) on all 19 open
         # Dependabot PRs. Skipping the login is safe: every image above
         # resolves through the harbor.evba.lab proxy cache, so an
         # unauthenticated run still pulls — it only gives up the Docker
-        # Hub rate-limit headroom the login buys. Mirroring
-        # DOCKERHUB_USERNAME / DOCKERHUB_TOKEN into the repo's Dependabot
-        # secrets restores that headroom and makes this guard a no-op.
+        # Hub rate-limit headroom the login buys.
+        #
+        # DOCKERHUB_USERNAME / DOCKERHUB_TOKEN have since been mirrored
+        # into the *org-level* Dependabot secret store (visibility
+        # `all`, 2026-07-30), so on a Dependabot run this guard now
+        # evaluates true and the login proceeds as it does anywhere
+        # else. Keep the guard regardless: it is what stops a missing
+        # or rotated secret from hard-failing an entire job instead of
+        # degrading to unauthenticated pulls. If this step starts
+        # *skipping* on Dependabot PRs again, the org Dependabot secret
+        # is gone or expired — check there before touching the workflow.
         if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0
         with:


### PR DESCRIPTION
Comment-only change to the `docker/login-action` block in `ci.yml`. No behaviour changes — all four `if: env.DOCKERHUB_USERNAME != ''` guards are untouched.

Companion to evoila-bosnia/meho-internal#186.

## 1. The closing line had become false

It still read as a TODO:

> Mirroring `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` into the repo's Dependabot secrets restores that headroom and makes this guard a no-op.

Those secrets were mirrored into the **org-level** Dependabot store (visibility `all`) on 2026-07-30, so the sentence describes work that is already done *and* names the wrong scope (org, not repo).

Replaced with what's actually true, plus the operational tell that matters most for debugging this later: **because the step is guarded, a missing secret shows up as a skip, not a red X.** If it starts skipping on Dependabot PRs again, the org Dependabot secret is gone or expired — check there before touching the workflow. That failure mode is silent and non-obvious, which is exactly why it's worth writing down.

The existing note about keeping the guard stays: it's what stops a rotated or missing secret from hard-failing an entire job rather than degrading to unauthenticated pulls.

## 2. The custody pointer was a dead end

The comment cited `meho-internal#74` for "1Password vault custody". That issue covers the rate-limit diagnosis and never records **where the credential lives** — locating it during this sweep meant enumerating every 1Password vault, and the item turned out to be titled `meho-ci-evoila-org-secret` with no mention of Docker Hub anywhere.

Now points at meho-internal `docs/dockerhub-ci-credential-custody.md`, which carries the concrete `op://` reference, a verify-without-printing recipe, and the full rotation flow across all three stores.

**The vault and item names deliberately stay in the internal repo.** `evoila/meho` is public; naming internal secret-management structure here would be a gratuitous disclosure, and the public comment says as much so nobody "helpfully" inlines it later. Verified nothing leaked: `grep -rn "meho-x-vault\|meho-ci-evoila-org-secret\|dckr_pat"` across `.github/`, `backend/`, and `docs/` returns nothing.

## 3. Count correction

"~18 open Dependabot PRs" → 19, the actual number in the sweep.

## Verification

`ci.yml` parses (`YAML.load_file` round-trip); all 4 login guards present and unchanged; diff is 18 insertions / 6 deletions, comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)