### PR TITLE
fix(connectors): report rke2 posture paths honestly on EACCES (#2698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — RKE2 posture reports an unreadable path honestly (#2698)
+
+- Stop `rke2.posture.show` reporting the RKE2 server join token **absent on
+  a node where it exists** (#2698). `stat` fails identically for a missing
+  file and for a parent directory it cannot traverse, and the handler read
+  only stdout — so on a stock hardened server node (`0700 root:root` on
+  `/var/lib/rancher/rke2/server/`, reached as a non-root SSH user) the op
+  answered `present: false` for a live join token. That is the unsafe
+  direction for the pre-rotation check: a runbook asking "is there a token
+  to rotate?" was told no. Each path now carries a three-state verdict —
+  `present`, `absent` (really not there) or `unknown` (undetermined, with a
+  `detail` naming the directory that must be traversable) — and `present`
+  is `null` rather than `false` whenever the answer is undetermined.
+  **Read the new `status` field, not the falsiness of `present`:** `null`
+  and `false` are both falsy and now mean different things. Root-
+  authenticated deploys are unaffected.
+- Fail the posture op closed when its probe cannot run at all — a node with
+  no `stat` binary or a broken shell now raises instead of reporting every
+  measured path as absent (#2698). The read tier previously ignored the
+  command's exit status entirely; it now applies the same discipline
+  `rke2.etcd-snapshot.save` already applies to its precondition guard.
+
 ### Fixed — background dispatch credential identity (#2642)
 
 - Give the in-process check-runner a **service-principal identity** so

--- a/backend/src/meho_backplane/connectors/rke2/ops_read.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_read.py
@@ -20,11 +20,38 @@ config surface without ever reading secret material:
 
 All measured paths are fixed constants in this module -- there is **no**
 operator-supplied path parameter, so there is no path-traversal or
-shell-injection surface. The single ``stat`` round-trip reports each
-existing path; paths absent from stdout are reported ``present: false``
-(``stat`` writes a diagnostic to stderr and skips them, which is exactly
-the "file not present" posture signal on an agent node with no server
-token).
+shell-injection surface.
+
+**Every path reports one of three states, never two (#2698).** ``stat``
+exits non-zero and writes to stderr for *both* a missing file (``ENOENT``)
+and a parent directory it cannot traverse (``EACCES``), so reading stdout
+alone cannot tell them apart. Collapsing both to ``present: false`` made
+the op lie in the unsafe direction: on a stock hardened server node the
+``0700 root:root`` ``/var/lib/rancher/rke2/server/`` directory hides a
+join token that *does* exist from a non-root SSH user, and a rotation
+runbook pre-checking with this op was told there was nothing to rotate.
+
+The probe therefore resolves each path individually and reports:
+
+* ``present`` / ``present: true`` -- ``stat`` succeeded; mode + owner/group
+  are real measurements.
+* ``absent`` / ``present: false`` -- ``stat`` failed **and** the parent
+  directory is traversable, so the path genuinely does not exist. This is
+  the "no server token" signal on an agent node.
+* ``unknown`` / ``present: null`` -- the parent directory cannot be
+  traversed (or no verdict came back for the path), so existence is
+  **undetermined**. An honest "could not determine" is strictly more
+  useful to an operator or agent than a confident wrong ``false``.
+
+Traversability is answered by the remote shell's own ``[ -x ]`` test
+rather than by parsing ``stat``'s diagnostic text -- the kernel is asked
+the actual question, so the verdict carries no dependency on coreutils
+message wording or the node's locale. A consequence worth stating: every
+real posture verdict now exits 0, so a **non-zero exit is unambiguously an
+infrastructure failure** (no ``stat`` on the node, broken shell) and
+raises :class:`Rke2PostureProbeError` instead of being silently reported
+as posture -- the same discipline ``ops_snapshot`` applies to its
+precondition guard.
 """
 
 from __future__ import annotations
@@ -42,8 +69,13 @@ __all__ = [
     "POSTURE_CONFIG_PATHS",
     "READ_OPS",
     "RKE2_TOKEN_PATH",
+    "STATUS_ABSENT",
+    "STATUS_PRESENT",
+    "STATUS_UNKNOWN",
+    "Rke2PostureProbeError",
+    "build_posture_probe_command",
     "parse_posture",
-    "parse_stat_output",
+    "parse_posture_probe_output",
     "rke2_posture_show",
 ]
 
@@ -63,6 +95,69 @@ POSTURE_CONFIG_PATHS: tuple[str, ...] = (
 #: token from (Initiative #2172).
 RKE2_TOKEN_PATH: str = "/var/lib/rancher/rke2/server/token"
 
+#: ``stat`` succeeded -- the path exists and its mode/owner/group are real
+#: measurements.
+STATUS_PRESENT: str = "present"
+
+#: ``stat`` failed *and* the parent directory is traversable, so the path
+#: genuinely does not exist (the agent-node "no server token" signal).
+STATUS_ABSENT: str = "absent"
+
+#: Existence is undetermined -- the parent directory cannot be traversed by
+#: the SSH user, or the probe returned no verdict for the path. Never
+#: reported as ``absent`` (#2698).
+STATUS_UNKNOWN: str = "unknown"
+
+#: Per-path probe markers. ``S`` carries a full ``stat`` line; ``A`` and
+#: ``U`` carry only the path.
+_MARKER_STAT: str = "S"
+_MARKER_ABSENT: str = "A"
+_MARKER_UNREADABLE: str = "U"
+
+#: Exit code the probe uses when the node has no ``stat`` binary. Any
+#: non-zero exit is an infrastructure failure, not a posture verdict.
+_PROBE_NO_STAT_EXIT: int = 127
+
+#: The per-path body of the probe, run once per measured path with ``$p``
+#: bound to it. ``stat`` first; on failure the parent directory's
+#: traversability (``[ -x ]`` -- the kernel's own answer, no reliance on
+#: ``stat``'s message wording or the node locale) decides ``absent`` vs
+#: ``unknown``. Kept as its own constant so the ``${p%/*}`` parameter
+#: expansion needs no brace-escaping at the f-string that assembles the
+#: command.
+_PROBE_BODY: str = (
+    "if o=$(stat -c '%n|%a|%U|%G' -- \"$p\" 2>/dev/null); "
+    f"then printf '{_MARKER_STAT}|%s\\n' \"$o\"; "
+    'elif [ -x "${p%/*}" ]; '
+    f"then printf '{_MARKER_ABSENT}|%s\\n' \"$p\"; "
+    f"else printf '{_MARKER_UNREADABLE}|%s\\n' \"$p\"; fi"
+)
+
+
+class Rke2PostureProbeError(RuntimeError):
+    """The posture probe itself failed to run (no ``stat``, broken shell).
+
+    Distinct from any posture verdict: the dispatcher maps it to a
+    ``connector_error`` result (the #986 discipline) so an infrastructure
+    failure is never served as a file-presence answer (#2698).
+    """
+
+
+def build_posture_probe_command(paths: tuple[str, ...]) -> str:
+    """Build the single-round-trip POSIX ``sh`` posture probe for *paths*.
+
+    Emits one marker line per path (see :func:`parse_posture_probe_output`).
+    Every path is ``shlex.quote``d, and the caller passes module constants
+    only -- there is no operator input in the command. The probe exits
+    ``0`` on every real verdict, so a non-zero exit means the probe could
+    not run at all.
+    """
+    quoted = " ".join(shlex.quote(path) for path in paths)
+    return (
+        f"command -v stat >/dev/null 2>&1 || exit {_PROBE_NO_STAT_EXIT}; "
+        f"for p in {quoted}; do {_PROBE_BODY}; done"
+    )
+
 
 def _normalise_mode(raw: str) -> str:
     """Left-pad a ``stat %a`` octal mode to 4 digits (``600`` -> ``0600``).
@@ -78,60 +173,96 @@ def _normalise_mode(raw: str) -> str:
     return stripped
 
 
-def parse_stat_output(stdout: str) -> dict[str, dict[str, str]]:
-    """Parse ``stat -c '%n|%a|%U|%G'`` stdout into a path -> attrs map.
+def parse_posture_probe_output(stdout: str) -> dict[str, dict[str, str | None]]:
+    """Parse the probe's marker lines into a path -> verdict map.
 
-    Each valid line is ``<path>|<octal-mode>|<owner>|<group>``. Lines
-    that do not split into exactly four ``|``-separated fields are
-    skipped (defensive against a stray banner line). Modes are
-    normalised to the 4-digit octal form.
+    Recognised lines are ``S|<path>|<octal-mode>|<owner>|<group>`` (stat
+    succeeded), ``A|<path>`` (absent) and ``U|<path>`` (parent not
+    traversable). Anything else is skipped -- defensive against a stray
+    banner line from a login shell, and a skipped path resolves to
+    ``unknown`` rather than ``absent``. Modes are normalised to the
+    4-digit octal form.
     """
-    result: dict[str, dict[str, str]] = {}
+    result: dict[str, dict[str, str | None]] = {}
     for line in stdout.splitlines():
         stripped = line.strip()
         if not stripped:
             continue
-        parts = stripped.split("|")
-        if len(parts) != 4:
+        marker, sep, rest = stripped.partition("|")
+        if not sep or not rest:
             continue
-        path, mode, owner, group = parts
-        result[path] = {
-            "mode": _normalise_mode(mode),
-            "owner": owner,
-            "group": group,
-        }
+        if marker == _MARKER_STAT:
+            parts = rest.split("|")
+            if len(parts) != 4:
+                continue
+            path, mode, owner, group = parts
+            result[path] = {
+                "status": STATUS_PRESENT,
+                "mode": _normalise_mode(mode),
+                "owner": owner,
+                "group": group,
+            }
+        elif marker in (_MARKER_ABSENT, _MARKER_UNREADABLE):
+            status = STATUS_ABSENT if marker == _MARKER_ABSENT else STATUS_UNKNOWN
+            result[rest] = {"status": status, "mode": None, "owner": None, "group": None}
     return result
 
 
-def _stat_entry(path: str, stat_map: dict[str, dict[str, str]]) -> dict[str, Any]:
-    """Build the per-path posture entry from the parsed ``stat`` map."""
-    info = stat_map.get(path)
-    if info is None:
-        return {"path": path, "present": False, "mode": None, "owner": None, "group": None}
+def _unknown_entry(path: str, detail: str) -> dict[str, Any]:
+    """Build the undetermined-existence entry for *path*."""
     return {
         "path": path,
-        "present": True,
+        "present": None,
+        "status": STATUS_UNKNOWN,
+        "mode": None,
+        "owner": None,
+        "group": None,
+        "detail": detail,
+    }
+
+
+def _stat_entry(path: str, probe_map: dict[str, dict[str, str | None]]) -> dict[str, Any]:
+    """Build the per-path posture entry from the parsed probe verdicts."""
+    info = probe_map.get(path)
+    if info is None:
+        return _unknown_entry(path, "the posture probe returned no verdict for this path")
+    if info["status"] == STATUS_UNKNOWN:
+        parent = path.rpartition("/")[0] or "/"
+        return _unknown_entry(
+            path,
+            f"the SSH user cannot traverse {parent}, so existence is undetermined; "
+            "the path may exist and be unreadable",
+        )
+    present = info["status"] == STATUS_PRESENT
+    return {
+        "path": path,
+        "present": present,
+        "status": info["status"],
         "mode": info["mode"],
         "owner": info["owner"],
         "group": info["group"],
+        "detail": None,
     }
 
 
 def parse_posture(
-    stat_map: dict[str, dict[str, str]],
+    probe_map: dict[str, dict[str, str | None]],
     config_paths: tuple[str, ...],
     token_path: str,
 ) -> dict[str, Any]:
-    """Compose the posture envelope from the parsed ``stat`` map.
+    """Compose the posture envelope from the parsed probe verdicts.
 
-    Returns ``{"config_files": [...], "token": {...}}``. Every config
-    entry and the token entry carry ``present`` plus (when present)
-    ``mode`` / ``owner`` / ``group``. The token entry additionally
-    carries ``redacted: true`` -- the token **value** is never read, only
-    its presence + mode, so no secret material appears in the envelope.
+    Returns ``{"config_files": [...], "token": {...}}``. Every entry
+    carries the same key set -- ``path`` / ``present`` / ``status`` /
+    ``mode`` / ``owner`` / ``group`` / ``detail`` -- so a consumer can
+    rely on one shape per path. ``present`` is ``null`` exactly when
+    ``status`` is ``unknown``, and ``detail`` says why. The token entry
+    additionally carries ``redacted: true`` -- the token **value** is
+    never read, only its presence + mode, so no secret material appears
+    in the envelope.
     """
-    config_files = [_stat_entry(path, stat_map) for path in config_paths]
-    token = _stat_entry(token_path, stat_map)
+    config_files = [_stat_entry(path, probe_map) for path in config_paths]
+    token = _stat_entry(token_path, probe_map)
     token["redacted"] = True
     return {"config_files": config_files, "token": token}
 
@@ -149,17 +280,34 @@ async def rke2_posture_show(
     param is consumed -- the measured paths are code constants, never
     operator input. Transport / auth failures propagate to the dispatcher,
     which maps them to a ``connector_error`` result (the #986 discipline);
-    a merely-absent file surfaces as ``present: false``, not an error.
+    a merely-absent file surfaces as ``present: false``, and a path whose
+    parent the SSH user cannot traverse surfaces as ``present: null`` /
+    ``status: unknown`` -- never as a confident ``false`` (#2698).
+
+    Raises :class:`Rke2PostureProbeError` when the probe exits non-zero.
+    The probe answers every real posture question with exit 0, so -- by
+    the same reasoning ``ops_snapshot`` applies to its precondition guard
+    -- a non-zero exit is a transport / shell / missing-``stat`` failure,
+    and serving it as posture would mislabel an infrastructure failure as
+    a file-presence verdict.
     """
     del params  # declared empty in schema; the measured paths are fixed
     paths = (*POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
-    quoted = " ".join(shlex.quote(path) for path in paths)
-    cmd = f"stat -c '%n|%a|%U|%G' -- {quoted}"
+    cmd = build_posture_probe_command(paths)
     proc = await connector._run_command(target, cmd, operator=operator)
+    exit_status = getattr(proc, "exit_status", None)
+    if exit_status not in (0, None):
+        stderr_raw = getattr(proc, "stderr", "")
+        stderr_txt = stderr_raw.strip()[:400] if isinstance(stderr_raw, str) else ""
+        hint = " (no `stat` on the node)" if exit_status == _PROBE_NO_STAT_EXIT else ""
+        raise Rke2PostureProbeError(
+            f"the RKE2 posture probe failed to run over SSH (exit {exit_status})"
+            f"{hint}: {stderr_txt or 'no stderr'}"
+        )
     stdout_raw = proc.stdout if hasattr(proc, "stdout") else ""
     stdout = stdout_raw if isinstance(stdout_raw, str) else ""
-    stat_map = parse_stat_output(stdout)
-    return parse_posture(stat_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
+    probe_map = parse_posture_probe_output(stdout)
+    return parse_posture(probe_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
 
 
 _RKE2_POSTURE_OP = Rke2Op(
@@ -167,11 +315,16 @@ _RKE2_POSTURE_OP = Rke2Op(
     handler_attr="posture_show",
     summary="Report RKE2 config-file modes + join-token presence (values redacted).",
     description=(
-        "Runs a single ``stat`` over the RKE2 config files under "
-        "``/etc/rancher/rke2/`` (``config.yaml`` and the admin kubeconfig "
-        "``rke2.yaml``) plus the on-disk server join token at "
+        "Runs a single ``stat``-based probe over the RKE2 config files "
+        "under ``/etc/rancher/rke2/`` (``config.yaml`` and the admin "
+        "kubeconfig ``rke2.yaml``) plus the on-disk server join token at "
         "``/var/lib/rancher/rke2/server/token``. Returns each path's "
-        "octal mode + owner/group and a ``present`` flag. The join-token "
+        "octal mode + owner/group and a three-state verdict: ``present``, "
+        "``absent`` (the file really is not there) or ``unknown`` (the "
+        "SSH user cannot traverse the parent directory, so existence is "
+        "undetermined -- typically a stock ``0700 root:root`` "
+        "``/var/lib/rancher/rke2/server/`` reached as a non-root user). "
+        "``unknown`` is never reported as ``absent``. The join-token "
         "entry reports presence + mode ONLY -- the token value is never "
         "read, so no secret material appears in the result. Use it to "
         "audit config-file permission drift (e.g. a world-readable "
@@ -192,12 +345,17 @@ _RKE2_POSTURE_OP = Rke2Op(
                     "type": "object",
                     "properties": {
                         "path": {"type": "string"},
-                        "present": {"type": "boolean"},
+                        "present": {"type": ["boolean", "null"]},
+                        "status": {
+                            "type": "string",
+                            "enum": [STATUS_PRESENT, STATUS_ABSENT, STATUS_UNKNOWN],
+                        },
                         "mode": {"type": ["string", "null"]},
                         "owner": {"type": ["string", "null"]},
                         "group": {"type": ["string", "null"]},
+                        "detail": {"type": ["string", "null"]},
                     },
-                    "required": ["path", "present"],
+                    "required": ["path", "present", "status"],
                     "additionalProperties": False,
                 },
             },
@@ -205,13 +363,18 @@ _RKE2_POSTURE_OP = Rke2Op(
                 "type": "object",
                 "properties": {
                     "path": {"type": "string"},
-                    "present": {"type": "boolean"},
+                    "present": {"type": ["boolean", "null"]},
+                    "status": {
+                        "type": "string",
+                        "enum": [STATUS_PRESENT, STATUS_ABSENT, STATUS_UNKNOWN],
+                    },
                     "mode": {"type": ["string", "null"]},
                     "owner": {"type": ["string", "null"]},
                     "group": {"type": ["string", "null"]},
+                    "detail": {"type": ["string", "null"]},
                     "redacted": {"type": "boolean"},
                 },
-                "required": ["path", "present", "redacted"],
+                "required": ["path", "present", "status", "redacted"],
                 "additionalProperties": False,
             },
         },
@@ -228,16 +391,26 @@ _RKE2_POSTURE_OP = Rke2Op(
             "permission modes of ``/etc/rancher/rke2/config.yaml`` and "
             "the admin kubeconfig ``rke2.yaml``, and whether the on-disk "
             "server join token exists (with its mode). The token VALUE is "
-            "never read -- only presence + mode. " + SSH_TRANSPORT_NOTE
+            "never read -- only presence + mode. Treat ``status: "
+            "unknown`` as 'not determined', NOT as 'absent': before "
+            "concluding a server node has no join token to rotate, "
+            "re-check under an identity that can traverse "
+            "``/var/lib/rancher/rke2/server/``. " + SSH_TRANSPORT_NOTE
         ),
         "parameter_hints": {},
         "output_shape": (
-            "``{config_files: [{path, present, mode, owner, group}], "
-            "token: {path, present, mode, owner, group, redacted: true}}``."
-            " ``mode`` is the 4-digit octal form (e.g. ``0600``). A path "
-            "that does not exist reports ``present: false`` with null "
-            "mode/owner/group. ``token.redacted`` is always true -- the "
-            "value is never fetched."
+            "``{config_files: [{path, present, status, mode, owner, group, "
+            "detail}], token: {..., redacted: true}}`` -- every entry "
+            "carries the same keys. ``mode`` is the 4-digit octal form "
+            "(e.g. ``0600``). ``status`` is ``present`` (measured), "
+            "``absent`` (``present: false`` -- the path really is not "
+            "there) or ``unknown`` (``present: null`` -- the parent "
+            "directory is not traversable by the SSH user, so existence "
+            "is undetermined; ``detail`` says why). ``present`` is null "
+            "exactly when ``status`` is ``unknown``, so a falsy check on "
+            "``present`` alone CANNOT distinguish absent from "
+            "undetermined -- branch on ``status``. ``token.redacted`` is "
+            "always true -- the value is never fetched."
         ),
     },
 )

--- a/backend/src/meho_backplane/connectors/rke2/ops_read.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_read.py
@@ -51,7 +51,9 @@ real posture verdict now exits 0, so a **non-zero exit is unambiguously an
 infrastructure failure** (no ``stat`` on the node, broken shell) and
 raises :class:`Rke2PostureProbeError` instead of being silently reported
 as posture -- the same discipline ``ops_snapshot`` applies to its
-precondition guard.
+precondition guard. When the peer reports *no* exit status at all, the
+output vouches for the run instead: one marker line per measured path
+means the probe finished, and anything less raises.
 """
 
 from __future__ import annotations
@@ -290,23 +292,38 @@ async def rke2_posture_show(
     -- a non-zero exit is a transport / shell / missing-``stat`` failure,
     and serving it as posture would mislabel an infrastructure failure as
     a file-presence verdict.
+
+    ``exit_status`` is ``None`` when the peer closed the channel without
+    sending an exit status at all (``asyncssh``'s documented third case,
+    alongside an int and ``-1`` for signal death). That is not proof of
+    failure -- some SSH implementations omit ``exit-status`` while still
+    delivering full output -- so completeness of the output decides: the
+    probe emits exactly one marker line per measured path, so a verdict
+    for every path is independent evidence that it ran to completion.
+    Missing verdicts with no exit status to vouch for the run raise,
+    because neither the run nor the paths can be accounted for.
     """
     del params  # declared empty in schema; the measured paths are fixed
     paths = (*POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
     cmd = build_posture_probe_command(paths)
     proc = await connector._run_command(target, cmd, operator=operator)
     exit_status = getattr(proc, "exit_status", None)
-    if exit_status not in (0, None):
+    stdout_raw = proc.stdout if hasattr(proc, "stdout") else ""
+    stdout = stdout_raw if isinstance(stdout_raw, str) else ""
+    probe_map = parse_posture_probe_output(stdout)
+    if exit_status != 0 and not (exit_status is None and probe_map.keys() >= set(paths)):
         stderr_raw = getattr(proc, "stderr", "")
         stderr_txt = stderr_raw.strip()[:400] if isinstance(stderr_raw, str) else ""
         hint = " (no `stat` on the node)" if exit_status == _PROBE_NO_STAT_EXIT else ""
+        if exit_status is None:
+            hint = (
+                " (no exit status reported, and the probe returned no verdict for "
+                f"{len(set(paths) - probe_map.keys())} of {len(paths)} measured paths)"
+            )
         raise Rke2PostureProbeError(
             f"the RKE2 posture probe failed to run over SSH (exit {exit_status})"
             f"{hint}: {stderr_txt or 'no stderr'}"
         )
-    stdout_raw = proc.stdout if hasattr(proc, "stdout") else ""
-    stdout = stdout_raw if isinstance(stdout_raw, str) else ""
-    probe_map = parse_posture_probe_output(stdout)
     return parse_posture(probe_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
 
 

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -7,15 +7,21 @@ Coverage matrix (per Task #2221 acceptance criteria):
 
 * :func:`parse_rke2_version` / :func:`parse_os_pretty_name` -- identity
   parsing from ``rke2 --version`` + ``/etc/os-release``.
-* :func:`parse_stat_output` / :func:`parse_posture` -- the posture
-  envelope: config-file modes + owner/group, missing paths reported
-  ``present: false``, and the redacted token entry.
+* :func:`parse_posture_probe_output` / :func:`parse_posture` -- the posture
+  envelope: config-file modes + owner/group, the three-state
+  present/absent/unknown verdict, and the redacted token entry.
+* Posture tri-state (#2698) -- a path whose parent the SSH user cannot
+  traverse reports ``present: null`` / ``status: unknown``, never a
+  confident ``present: false``; a genuinely missing file still reports
+  ``absent``; and a probe that could not run at all raises
+  :class:`Rke2PostureProbeError` instead of being served as posture.
 * Bound-method shims on :class:`Rke2SshConnector` -- ``about`` (identity)
   and ``posture_show`` (posture) run the correct plain-SSH commands and
   return the expected envelope shape.
-* Redaction invariant -- ``posture_show`` issues a single ``stat`` (never
-  a ``cat`` of the token path); the token entry carries ``redacted: true``
-  and no secret material bleeds into the result envelope or logs.
+* Redaction invariant -- ``posture_show`` issues a single ``stat``-based
+  probe (never a ``cat`` of the token path); the token entry carries
+  ``redacted: true`` and no secret material bleeds into the result
+  envelope or logs.
 * ``RKE2_OPS`` registration shape -- 6 ops: two read (``rke2.about`` /
   ``rke2.posture.show``, T1 #2221), three approval-gated write
   (``rke2.token.rotate`` T2 #2429, ``rke2.node.service.restart`` /
@@ -51,8 +57,13 @@ from meho_backplane.connectors.rke2.connector import (
 from meho_backplane.connectors.rke2.ops_read import (
     POSTURE_CONFIG_PATHS,
     RKE2_TOKEN_PATH,
+    STATUS_ABSENT,
+    STATUS_PRESENT,
+    STATUS_UNKNOWN,
+    Rke2PostureProbeError,
+    build_posture_probe_command,
     parse_posture,
-    parse_stat_output,
+    parse_posture_probe_output,
 )
 from meho_backplane.connectors.rke2.ops_snapshot import (
     SNAPSHOT_DEFAULT_DIR,
@@ -160,16 +171,33 @@ def test_parse_os_pretty_name_unquoted_and_absent() -> None:
 
 
 # ---------------------------------------------------------------------------
-# parse_stat_output
+# build_posture_probe_command / parse_posture_probe_output
 # ---------------------------------------------------------------------------
 
 
-def test_parse_stat_output_parses_and_normalises_mode() -> None:
+def test_build_posture_probe_command_covers_paths_and_never_cats() -> None:
+    cmd = build_posture_probe_command((*POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH))
+    for path in (*POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH):
+        assert path in cmd
+    # Reads modes only -- the token VALUE is never fetched.
+    assert "cat" not in cmd
+    # Fails closed when the node has no `stat`, rather than reporting
+    # every path absent (#2698).
+    assert "command -v stat" in cmd
+    assert "exit 127" in cmd
+    # Traversability is answered by the kernel, not by parsing stat's
+    # locale-dependent diagnostic text.
+    assert '[ -x "${p%/*}" ]' in cmd
+
+
+def test_parse_posture_probe_output_parses_and_normalises_mode() -> None:
     stdout = (
-        "/etc/rancher/rke2/config.yaml|600|root|root\n/etc/rancher/rke2/rke2.yaml|644|root|rke2\n"
+        "S|/etc/rancher/rke2/config.yaml|600|root|root\n"
+        "S|/etc/rancher/rke2/rke2.yaml|644|root|rke2\n"
     )
-    parsed = parse_stat_output(stdout)
+    parsed = parse_posture_probe_output(stdout)
     assert parsed["/etc/rancher/rke2/config.yaml"] == {
+        "status": STATUS_PRESENT,
         "mode": "0600",
         "owner": "root",
         "group": "root",
@@ -178,9 +206,17 @@ def test_parse_stat_output_parses_and_normalises_mode() -> None:
     assert parsed["/etc/rancher/rke2/rke2.yaml"]["mode"] == "0644"
 
 
-def test_parse_stat_output_skips_malformed_lines() -> None:
-    stdout = "garbage banner line\n/etc/rancher/rke2/config.yaml|600|root|root\n\n"
-    parsed = parse_stat_output(stdout)
+def test_parse_posture_probe_output_distinguishes_absent_from_unreadable() -> None:
+    stdout = f"A|/etc/rancher/rke2/rke2.yaml\nU|{RKE2_TOKEN_PATH}\n"
+    parsed = parse_posture_probe_output(stdout)
+    assert parsed["/etc/rancher/rke2/rke2.yaml"]["status"] == STATUS_ABSENT
+    assert parsed[RKE2_TOKEN_PATH]["status"] == STATUS_UNKNOWN
+    assert parsed[RKE2_TOKEN_PATH]["mode"] is None
+
+
+def test_parse_posture_probe_output_skips_malformed_lines() -> None:
+    stdout = "garbage banner line\nS|/etc/rancher/rke2/config.yaml|600|root|root\n\nS|truncated\n"
+    parsed = parse_posture_probe_output(stdout)
     assert set(parsed) == {"/etc/rancher/rke2/config.yaml"}
 
 
@@ -189,16 +225,25 @@ def test_parse_stat_output_skips_malformed_lines() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _verdict(status: str, mode: str | None = None) -> dict[str, str | None]:
+    """Build a parsed-probe verdict for *status* the way the probe would."""
+    if status == STATUS_PRESENT:
+        return {"status": status, "mode": mode, "owner": "root", "group": "root"}
+    return {"status": status, "mode": None, "owner": None, "group": None}
+
+
 def test_parse_posture_present_and_redacted_token() -> None:
-    stat_map = {
-        "/etc/rancher/rke2/config.yaml": {"mode": "0600", "owner": "root", "group": "root"},
-        "/etc/rancher/rke2/rke2.yaml": {"mode": "0600", "owner": "root", "group": "root"},
-        RKE2_TOKEN_PATH: {"mode": "0600", "owner": "root", "group": "root"},
+    probe_map = {
+        "/etc/rancher/rke2/config.yaml": _verdict(STATUS_PRESENT, "0600"),
+        "/etc/rancher/rke2/rke2.yaml": _verdict(STATUS_PRESENT, "0600"),
+        RKE2_TOKEN_PATH: _verdict(STATUS_PRESENT, "0600"),
     }
-    posture = parse_posture(stat_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
+    posture = parse_posture(probe_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
     cfg = {c["path"]: c for c in posture["config_files"]}
     assert cfg["/etc/rancher/rke2/config.yaml"]["present"] is True
+    assert cfg["/etc/rancher/rke2/config.yaml"]["status"] == STATUS_PRESENT
     assert cfg["/etc/rancher/rke2/config.yaml"]["mode"] == "0600"
+    assert cfg["/etc/rancher/rke2/config.yaml"]["detail"] is None
     # Token entry is present, carries its mode, and is explicitly redacted.
     token = posture["token"]
     assert token["path"] == RKE2_TOKEN_PATH
@@ -210,19 +255,66 @@ def test_parse_posture_present_and_redacted_token() -> None:
     assert "token" not in {k for c in posture["config_files"] for k in c}
 
 
-def test_parse_posture_missing_paths_report_absent() -> None:
-    # Agent node: no server token, config.yaml only.
-    stat_map = {
-        "/etc/rancher/rke2/config.yaml": {"mode": "0600", "owner": "root", "group": "root"},
+def test_parse_posture_absent_paths_report_absent() -> None:
+    # Agent node: no server token, no admin kubeconfig -- both genuinely
+    # missing, with a traversable parent, so `absent` is the honest answer.
+    probe_map = {
+        "/etc/rancher/rke2/config.yaml": _verdict(STATUS_PRESENT, "0600"),
+        "/etc/rancher/rke2/rke2.yaml": _verdict(STATUS_ABSENT),
+        RKE2_TOKEN_PATH: _verdict(STATUS_ABSENT),
     }
-    posture = parse_posture(stat_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
+    posture = parse_posture(probe_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
     cfg = {c["path"]: c for c in posture["config_files"]}
     assert cfg["/etc/rancher/rke2/rke2.yaml"]["present"] is False
+    assert cfg["/etc/rancher/rke2/rke2.yaml"]["status"] == STATUS_ABSENT
     assert cfg["/etc/rancher/rke2/rke2.yaml"]["mode"] is None
     token = posture["token"]
     assert token["present"] is False
+    assert token["status"] == STATUS_ABSENT
     assert token["mode"] is None
     assert token["redacted"] is True
+
+
+def test_parse_posture_unreadable_parent_is_unknown_not_absent() -> None:
+    """#2698: a 0700 root:root server dir must not read as 'no token'."""
+    probe_map = {
+        "/etc/rancher/rke2/config.yaml": _verdict(STATUS_PRESENT, "0600"),
+        "/etc/rancher/rke2/rke2.yaml": _verdict(STATUS_PRESENT, "0600"),
+        RKE2_TOKEN_PATH: _verdict(STATUS_UNKNOWN),
+    }
+    posture = parse_posture(probe_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
+    token = posture["token"]
+    # The load-bearing assertion: NOT False. A rotation pre-check must not
+    # be able to read this as "nothing to rotate".
+    assert token["present"] is None
+    assert token["status"] == STATUS_UNKNOWN
+    assert token["mode"] is None
+    assert token["redacted"] is True
+    # The detail names the directory the operator has to be able to traverse.
+    assert "/var/lib/rancher/rke2/server" in str(token["detail"])
+
+
+def test_parse_posture_path_with_no_verdict_is_unknown() -> None:
+    """A path the probe never reported on is undetermined, not absent."""
+    posture = parse_posture({}, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
+    for entry in (*posture["config_files"], posture["token"]):
+        assert entry["present"] is None
+        assert entry["status"] == STATUS_UNKNOWN
+        assert entry["detail"]
+
+
+def test_parse_posture_entries_share_one_key_set() -> None:
+    """One envelope shape per path, whatever the verdict."""
+    probe_map = {
+        "/etc/rancher/rke2/config.yaml": _verdict(STATUS_PRESENT, "0600"),
+        "/etc/rancher/rke2/rke2.yaml": _verdict(STATUS_ABSENT),
+        RKE2_TOKEN_PATH: _verdict(STATUS_UNKNOWN),
+    }
+    posture = parse_posture(probe_map, POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH)
+    expected = {"path", "present", "status", "mode", "owner", "group", "detail"}
+    for entry in posture["config_files"]:
+        assert set(entry) == expected
+    assert set(posture["token"]) == expected | {"redacted"}
 
 
 # ---------------------------------------------------------------------------
@@ -282,9 +374,9 @@ async def test_about_unreachable_raises_connector_error() -> None:
 
 
 _STAT_STDOUT_FULL = (
-    "/etc/rancher/rke2/config.yaml|600|root|root\n"
-    "/etc/rancher/rke2/rke2.yaml|600|root|root\n"
-    "/var/lib/rancher/rke2/server/token|600|root|root\n"
+    "S|/etc/rancher/rke2/config.yaml|600|root|root\n"
+    "S|/etc/rancher/rke2/rke2.yaml|600|root|root\n"
+    "S|/var/lib/rancher/rke2/server/token|600|root|root\n"
 )
 
 
@@ -294,16 +386,17 @@ async def test_posture_show_returns_redacted_envelope() -> None:
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.return_value = _proc(stdout=_STAT_STDOUT_FULL)
         result = await connector.posture_show(_TARGET, {})
-    # Single SSH round-trip; the command is a `stat`, never a `cat`.
+    # Single SSH round-trip; the command `stat`s, never `cat`s.
     mock_cmd.assert_awaited_once()
     cmd = mock_cmd.await_args.args[1]
-    assert cmd.startswith("stat -c '%n|%a|%U|%G' --")
+    assert "stat -c '%n|%a|%U|%G' --" in cmd
     assert "cat" not in cmd
     # Every measured path appears as a stat argument.
     for path in (*POSTURE_CONFIG_PATHS, RKE2_TOKEN_PATH):
         assert path in cmd
     # Envelope shape + redaction.
     assert result["token"]["present"] is True
+    assert result["token"]["status"] == STATUS_PRESENT
     assert result["token"]["mode"] == "0600"
     assert result["token"]["redacted"] is True
     cfg = {c["path"]: c for c in result["config_files"]}
@@ -313,15 +406,66 @@ async def test_posture_show_returns_redacted_envelope() -> None:
 @pytest.mark.asyncio
 async def test_posture_show_reports_missing_token_as_absent() -> None:
     connector = Rke2SshConnector()
-    # Agent node: config.yaml only in stat stdout (missing paths omitted).
-    stdout = "/etc/rancher/rke2/config.yaml|640|root|root\n"
+    # Agent node: config.yaml present, the other two genuinely missing
+    # behind a traversable parent.
+    stdout = (
+        "S|/etc/rancher/rke2/config.yaml|640|root|root\n"
+        "A|/etc/rancher/rke2/rke2.yaml\n"
+        f"A|{RKE2_TOKEN_PATH}\n"
+    )
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.return_value = _proc(stdout=stdout)
         result = await connector.posture_show(_TARGET, {})
     assert result["token"]["present"] is False
+    assert result["token"]["status"] == STATUS_ABSENT
     assert result["token"]["redacted"] is True
     cfg = {c["path"]: c for c in result["config_files"]}
     assert cfg["/etc/rancher/rke2/rke2.yaml"]["present"] is False
+
+
+@pytest.mark.asyncio
+async def test_posture_show_unreadable_token_dir_reports_unknown() -> None:
+    """#2698 regression: the observed server-A shape must not read 'absent'.
+
+    ``rke2.yaml`` is 0600 root:root and stats fine (the parent is
+    traversable); the token sits behind a 0700 root:root server dir, so its
+    existence is undetermined -- not false.
+    """
+    connector = Rke2SshConnector()
+    stdout = (
+        "S|/etc/rancher/rke2/config.yaml|600|root|root\n"
+        "S|/etc/rancher/rke2/rke2.yaml|600|root|root\n"
+        f"U|{RKE2_TOKEN_PATH}\n"
+    )
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=stdout)
+        result = await connector.posture_show(_TARGET, {})
+    token = result["token"]
+    assert token["present"] is None
+    assert token["status"] == STATUS_UNKNOWN
+    assert token["mode"] is None
+    assert token["redacted"] is True
+    # The config sanity signal still works — this is what isolates the
+    # cause to parent-directory traversal rather than "stat can't see
+    # root-owned files".
+    cfg = {c["path"]: c for c in result["config_files"]}
+    assert cfg["/etc/rancher/rke2/rke2.yaml"]["present"] is True
+    assert cfg["/etc/rancher/rke2/rke2.yaml"]["mode"] == "0600"
+
+
+@pytest.mark.asyncio
+async def test_posture_show_raises_when_probe_cannot_run() -> None:
+    """A non-zero probe exit is an infrastructure failure, never posture.
+
+    Same discipline as the snapshot precondition guard: the probe answers
+    every real verdict with exit 0, so a non-zero exit must not be served
+    as a file-presence answer (#2698).
+    """
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="", stderr="sh: stat: not found", exit_status=127)
+        with pytest.raises(Rke2PostureProbeError, match="no `stat` on the node"):
+            await connector.posture_show(_TARGET, {})
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -135,7 +135,7 @@ def _vault_secrets() -> Iterator[None]:
         yield
 
 
-def _proc(*, stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+def _proc(*, stdout: str = "", stderr: str = "", exit_status: int | None = 0) -> Any:
     """Construct an ``SSHCompletedProcess``-shaped stub."""
     proc = MagicMock()
     proc.stdout = stdout
@@ -465,6 +465,44 @@ async def test_posture_show_raises_when_probe_cannot_run() -> None:
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
         mock_cmd.return_value = _proc(stdout="", stderr="sh: stat: not found", exit_status=127)
         with pytest.raises(Rke2PostureProbeError, match="no `stat` on the node"):
+            await connector.posture_show(_TARGET, {})
+
+
+@pytest.mark.asyncio
+async def test_posture_show_accepts_complete_output_with_no_exit_status() -> None:
+    """``exit_status=None`` + a verdict per path is a complete run, not a failure.
+
+    ``asyncssh`` reports ``None`` when the peer closed the channel without
+    sending an exit status; some implementations omit it while still
+    delivering full output. The marker protocol gives independent evidence
+    the probe finished, so this must not fail a posture read that worked.
+    """
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_STAT_STDOUT_FULL, exit_status=None)
+        result = await connector.posture_show(_TARGET, {})
+    assert result["token"]["present"] is True
+    assert result["token"]["status"] == STATUS_PRESENT
+
+
+@pytest.mark.asyncio
+async def test_posture_show_raises_on_truncated_output_with_no_exit_status() -> None:
+    """No exit status AND missing verdicts: neither the run nor the paths add up."""
+    connector = Rke2SshConnector()
+    truncated = "S|/etc/rancher/rke2/config.yaml|600|root|root\n"
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=truncated, exit_status=None)
+        with pytest.raises(Rke2PostureProbeError, match="no exit status reported"):
+            await connector.posture_show(_TARGET, {})
+
+
+@pytest.mark.asyncio
+async def test_posture_show_raises_on_signal_death() -> None:
+    """asyncssh reports -1 when the remote process died on a signal."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_STAT_STDOUT_FULL, exit_status=-1)
+        with pytest.raises(Rke2PostureProbeError, match=r"exit -1"):
             await connector.posture_show(_TARGET, {})
 
 

--- a/backend/tests/test_connectors_rke2_e2e.py
+++ b/backend/tests/test_connectors_rke2_e2e.py
@@ -17,8 +17,12 @@ Acceptance criteria verified (Issue #2221)
   against a registered target returns ``status="ok"`` -- the connector +
   read-posture tier are dispatchable (AC1).
 * The posture result reports config-file modes + the join-token presence
-  with the token **value never present** (redacted); the ``stat`` command
-  is the only transport touched -- no ``cat`` of the token path (AC1/AC3).
+  with the token **value never present** (redacted); the ``stat`` probe is
+  the only transport touched -- no ``cat`` of the token path (AC1/AC3).
+* An undetermined join token (``present: null`` / ``status: unknown``,
+  #2698) survives the full dispatch stack -- the widened tri-state result
+  contract is neither rejected nor coerced by the reducer or the audit
+  write.
 """
 
 from __future__ import annotations
@@ -61,12 +65,16 @@ _CLIENT_PUB = _CLIENT_KEY.convert_to_public()
 
 _OS_RELEASE_FIXTURE = 'NAME="Ubuntu"\nPRETTY_NAME="Ubuntu 22.04.3 LTS"\nID=ubuntu\n'
 _RKE2_VERSION_FIXTURE = "rke2 version v1.29.3+rke2r1 (a1b2c3d)\ngo version go1.21.8\n"
-# stat -c '%n|%a|%U|%G' output: config.yaml + rke2.yaml + on-disk token.
-# The token line carries its MODE only -- the value is never read.
-_STAT_FIXTURE = (
-    "/etc/rancher/rke2/config.yaml|600|root|root\n"
-    "/etc/rancher/rke2/rke2.yaml|600|root|root\n"
-    "/var/lib/rancher/rke2/server/token|600|root|root\n"
+# Posture-probe output on a server node the SSH user can fully read:
+# config.yaml + rke2.yaml + on-disk token, each an ``S`` (stat-succeeded)
+# marker line. The token line carries its MODE only -- the value is never
+# read. The probe's per-path shell semantics (``S`` / ``A`` / ``U``) are
+# covered against a real POSIX shell elsewhere; this fake shell replays
+# recorded bytes, so it asserts the dispatch stack, not the shell.
+_PROBE_FIXTURE = (
+    "S|/etc/rancher/rke2/config.yaml|600|root|root\n"
+    "S|/etc/rancher/rke2/rke2.yaml|600|root|root\n"
+    "S|/var/lib/rancher/rke2/server/token|600|root|root\n"
 )
 # Precondition-guard sentinel for an embedded-etcd server node.
 _SNAPSHOT_GUARD_FIXTURE = "ok\n"
@@ -100,8 +108,9 @@ async def _fake_shell_process_factory(process: Any) -> None:
         response: str | None = _OS_RELEASE_FIXTURE
     elif cmd.startswith("rke2 --version"):
         response = _RKE2_VERSION_FIXTURE
-    elif cmd.startswith("stat -c '%n|%a|%U|%G'"):
-        response = _STAT_FIXTURE
+    elif cmd.startswith("command -v stat"):
+        # rke2.posture.show -- the per-path stat probe (#2698).
+        response = _PROBE_FIXTURE
     elif cmd.startswith("printf 'ACTIVE="):
         # rke2.token.rotate fingerprint preflight: server node, active,
         # patched version (1.29 is above the CVE-fix range).
@@ -349,6 +358,45 @@ async def test_rke2_e2e_posture_show_dispatches_ok_and_redacts(
     # Redaction: no token VALUE anywhere in the dispatch result.
     assert _TOKEN_VALUE_CANARY not in repr(result)
     assert "value" not in token
+
+
+@pytest.mark.asyncio
+async def test_rke2_e2e_posture_show_unknown_token_survives_dispatch(
+    rke2_e2e: _Rke2E2EBundle,
+    captured_events: list[Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An undetermined token reaches the caller as null, not false (#2698).
+
+    The reporter's server-A shape: ``rke2.yaml`` stats fine while the token
+    sits behind a ``0700 root:root`` parent. Driven through the full
+    ``call_operation`` stack because ``present: null`` is a widened result
+    contract -- this proves the dispatcher's reducer and the audit write
+    tolerate it rather than rejecting or coercing the tri-state.
+    """
+    del captured_events
+    monkeypatch.setattr(
+        "tests.test_connectors_rke2_e2e._PROBE_FIXTURE",
+        "S|/etc/rancher/rke2/config.yaml|600|root|root\n"
+        "S|/etc/rancher/rke2/rke2.yaml|600|root|root\n"
+        "U|/var/lib/rancher/rke2/server/token\n",
+    )
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": _CONNECTOR_ID,
+            "op_id": "rke2.posture.show",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"rke2.posture.show failed: {result.get('error')}"
+    token = result["result"]["token"]
+    assert token["present"] is None
+    assert token["status"] == "unknown"
+    assert token["detail"]
+    assert token["redacted"] is True
+    assert _TOKEN_VALUE_CANARY not in repr(result)
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -211,6 +211,18 @@ Two properties are load-bearing:
   extended to the read tier — previously the posture handler ignored
   `exit_status` entirely.
 
+`asyncssh` reports `exit_status` as `None` when the peer closed the channel
+without sending one at all (its documented third case, alongside an int and
+`-1` for signal death), so "not zero" and "failed" are not the same test.
+`None` is resolved from the output rather than assumed either way: the probe
+emits exactly one marker line per measured path, so a verdict for every path
+is independent evidence the run completed and the read is served. Missing
+verdicts with no exit status to vouch for the run raise — neither the run
+nor the unaccounted paths can be confirmed. Treating `None` as failure
+outright would break reads against SSH implementations that omit
+`exit-status` while still delivering full output; treating it as success
+outright would re-open the class this fix closes.
+
 A consumer must branch on `status`, not on the falsiness of `present`:
 `null` and `false` are both falsy but mean different things. Every entry
 carries the same key set (`path` / `present` / `status` / `mode` / `owner` /

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -24,7 +24,9 @@ T1 (#2221) ships the **connector scaffold + the read-only posture tier only**:
 - `rke2.posture.show` — the read-only posture tier. `stat`s the RKE2
   config-file modes under `/etc/rancher/rke2/` and the on-disk server
   join-token presence, **with the token value never read** (redacted by
-  construction).
+  construction). Each path carries a three-state verdict —
+  `present` / `absent` / `unknown` (#2698, see
+  [Posture tri-state](#posture-tri-state-2698)).
 
 Both `safety_level="safe"` / `requires_approval=false`.
 
@@ -96,12 +98,14 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
   `parse_os_pretty_name` (`PRETTY_NAME` from `/etc/os-release`).
 
 - **Posture handler + parsers** (`ops_read.py`) — `rke2_posture_show`
-  (the async handler), `parse_stat_output` (`stat -c '%n|%a|%U|%G'` stdout
-  → path→attrs map, mode normalised to the 4-digit octal form), and
-  `parse_posture` (composes the `{config_files, token}` envelope; the token
-  entry always carries `redacted: true`). `POSTURE_CONFIG_PATHS` and
-  `RKE2_TOKEN_PATH` are fixed code constants — there is **no** operator path
-  parameter, so no path-traversal / shell-injection surface.
+  (the async handler), `build_posture_probe_command` (assembles the
+  single-round-trip POSIX-`sh` per-path probe), `parse_posture_probe_output`
+  (marker lines → path→verdict map, mode normalised to the 4-digit octal
+  form), and `parse_posture` (composes the `{config_files, token}` envelope;
+  the token entry always carries `redacted: true`). `POSTURE_CONFIG_PATHS`
+  and `RKE2_TOKEN_PATH` are fixed code constants — there is **no** operator
+  path parameter, so no path-traversal / shell-injection surface.
+  `Rke2PostureProbeError` fires when the probe itself could not run.
 
 - **Op metadata** (`ops.py`) — `Rke2Op` frozen dataclass (mirrors
   `Bind9Op` / `HolodeckOp`), `SSH_TRANSPORT_NOTE` (the plain-SSH reminder
@@ -168,10 +172,57 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
 3. **Dispatch** — `POST /api/v1/operations/call` → `call_operation` resolves
    `connector_id="rke2-ssh-1.x"` + the target, runs the policy gate, and
    invokes the bound handler. `about` reuses `fingerprint` and asserts
-   reachability (#986); `posture_show` runs one `stat` round-trip and returns
+   reachability (#986); `posture_show` runs one probe round-trip and returns
    the redacted envelope. Transport/auth failures propagate to the
    dispatcher's `connector_error` branch; a merely-absent file surfaces as
-   `present: false`.
+   `present: false`, and an undeterminable one as `present: null`.
+
+## Posture tri-state (#2698)
+
+`stat` exits non-zero for **both** a missing file (`ENOENT`) and a parent
+directory it cannot traverse (`EACCES`), and writes the distinction only to
+stderr. The original handler read stdout alone, so both collapsed to
+`present: false`. On a stock hardened server node — `0700 root:root` on
+`/var/lib/rancher/rke2/server/`, reached as a non-root SSH user — the op
+therefore reported the join token **absent on a node where it exists**,
+which is the unsafe direction for an op whose stated job is "confirm the
+server token exists before rotating". A rotation runbook pre-checking with
+it was told there was nothing to rotate.
+
+The handler now issues one POSIX-`sh` probe that resolves each path
+individually and emits a marker line per path:
+
+| Marker | `status` | `present` | Meaning |
+| --- | --- | --- | --- |
+| `S\|<path>\|<mode>\|<owner>\|<group>` | `present` | `true` | `stat` succeeded; mode/owner/group are real measurements |
+| `A\|<path>` | `absent` | `false` | `stat` failed **and** the parent is traversable — genuinely not there (the agent-node "no server token" signal) |
+| `U\|<path>` | `unknown` | `null` | the parent cannot be traversed, so existence is undetermined; `detail` names the directory |
+
+Two properties are load-bearing:
+
+- **Traversability is answered by the remote shell's `[ -x ]` test**, not by
+  parsing `stat`'s diagnostic text — the kernel is asked the actual
+  question, so no verdict depends on coreutils message wording or the node's
+  locale.
+- **Every real verdict exits 0**, so a non-zero exit is unambiguously an
+  infrastructure failure (no `stat` on the node, broken shell) and raises
+  `Rke2PostureProbeError` rather than being served as posture. This is the
+  same reasoning `ops_snapshot` applies to its precondition guard, now
+  extended to the read tier — previously the posture handler ignored
+  `exit_status` entirely.
+
+A consumer must branch on `status`, not on the falsiness of `present`:
+`null` and `false` are both falsy but mean different things. Every entry
+carries the same key set (`path` / `present` / `status` / `mode` / `owner` /
+`group` / `detail`, plus `redacted` on the token) so there is one shape per
+path whatever the verdict.
+
+**Deliberately not done:** elevating the read with `sudo` the way
+`rke2.token.rotate` does. It would let the posture tier see inside a
+`0700 root:root` directory, but it makes a sudo credential a soft
+dependency of a *read* op — so the honest-reporting fix lands first and
+alone. Root-authenticated deploys (the common case, per the write tier's
+assumption) already report `present` because `stat` simply succeeds.
 
 ## Auth
 


### PR DESCRIPTION
## Summary

- `rke2.posture.show` reported the RKE2 server join token `present: false` on nodes where it exists. `stat` fails identically for `ENOENT` and for an untraversable parent (`EACCES`) and writes the distinction only to stderr; the handler read stdout alone, so both collapsed to a confident `false`. On a stock hardened server node (`0700 root:root` on `/var/lib/rancher/rke2/server/`, reached as a non-root SSH user) a pre-rotation check was told there was nothing to rotate — the unsafe direction.
- Each path now reports **`present` / `absent` / `unknown`**. `absent` means `stat` failed *and* the parent is traversable (so the agent-node "no server token" signal is preserved); `unknown` means the parent cannot be traversed, so existence is undetermined — `present: null`, with a `detail` naming the directory that has to be traversable.
- Traversability comes from the remote shell's own `[ -x ]` test, not from parsing `stat`'s diagnostic text, so no verdict depends on coreutils message wording or the node's locale.
- Every real verdict now exits 0, so a **non-zero exit is unambiguously an infrastructure failure** (no `stat` on the node, broken shell) and raises `Rke2PostureProbeError` rather than being served as posture. The read tier previously ignored `exit_status` entirely; `ops_snapshot.py` has applied exactly this reasoning to its precondition guard since #2448, and its comment names this hazard verbatim.

### Behaviour change worth reading

`present` is now `boolean | null`. **Branch on `status`, not on the falsiness of `present`** — `null` and `false` are both falsy and mean different things. The op `description`, `llm_instructions.output_shape` and `response_schema` all say so, and every entry carries one key set (`path` / `present` / `status` / `mode` / `owner` / `group` / `detail`, plus `redacted` on the token) whatever the verdict. Root-authenticated deploys are unaffected: `stat` simply succeeds.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean (1363 files)
- [x] `uv run mypy src/meho_backplane/connectors/rke2/` — clean (8 files)
- [x] `uv run pytest tests/test_connectors_rke2.py tests/test_connectors_rke2_e2e.py` — 74 passed
- [x] Full unit sweep as CI runs it (`-n 3 --dist loadscope`) — 10759 passed. The 4 failures are macOS-only and none of them import rke2: `net_icmp` (no `MSG_ERRQUEUE`/raw-socket loopback on darwin), `net_dns_lookup` (`OSError 49` binding `127.0.0.2`), `chart_mcp_resource_uri` (local `helm template` exits 1), plus the same `MSG_ERRQUEUE` attribute error under repo-wide `mypy src/`. All four reproduce identically without this change.
- [x] `code-quality.py --diff` — 0 blockers, 1 warning (`ops_read.py` at 423 lines vs the 400 warn / 600 block thresholds)
- [x] **Probe verified against a real POSIX shell** (Debian 13 / `dash`, non-root user), replicating the reporter's server-A:
  - token `0600 root:root` behind a `0700 root:root` parent → `U|…` = `unknown` (**the reported bug, now honest**), while `rke2.yaml` at `0600 root:root` still stats fine — reproducing the internal contradiction that isolated the cause to parent-directory traversal
  - agent node, traversable parent, no token → `A|…` = `absent` (legitimate signal preserved)
  - token present, traversable parent → `S|…|600|root|root`
  - root SSH user, `0700` parent → `present` (no elevation needed)
  - `stat` removed from the image → exit 127, **zero** verdict lines
- [x] Tri-state survives the full `call_operation` stack — new e2e test proves the reducer and audit write neither reject nor coerce `present: null`

## Out of scope

- **Elevating the read with `sudo`** — the reporter's second fix option, deliberately not done. It would let the posture tier see inside a `0700 root:root` directory, but it makes a sudo credential a soft dependency of a *read* op; the reporter ranked it second for the same reason. Recorded in `docs/codebase/connectors-rke2.md`.
- Sibling clean-room findings #2699 / #2700 / #2701 — each needs its own product decision.
- `ops_read.py` is now 423 lines, past the 400-line warn threshold (does not block). Splitting the probe out into its own module is a reasonable follow-up.
- Adjacent, not touched: the dispatcher's top-level `connector_error: <ExceptionClass>` string still hides the useful message in `extras.exception_message` — the shape #2701 complains about.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2698


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved RKE2 posture reporting for hardened or unreadable paths.
  - Distinguishes between present, absent, and undetermined results instead of incorrectly reporting inaccessible paths as absent.
  - Reports undetermined results with `present: null` and additional details.
  - Posture checks now fail safely when the required system probe cannot run.
  - Join-token values remain redacted and are never exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (iteration 2, 2026-07-30)

Addressed the CodeRabbit review finding on `ops_read.py`:

- **exit-status guard `None` hole** `2749e3f5` — the guard tested `not in (0, None)` (copied from `ops_snapshot`), so `exit_status is None` fell through to parsing stdout and the documented invariant went unenforced. `asyncssh.SSHChannel.get_exit_status` returns `None` whenever the peer closes the channel without sending one, so this was reachable in production. Rather than raise on `None` outright (which would break reads against SSH implementations that omit `exit-status` while delivering full output), the marker protocol now vouches for the run: `None` + a verdict for every measured path is served, `None` + missing verdicts raises. Signal death (`-1`) raises as before. Three new tests; rationale recorded in `docs/codebase/connectors-rke2.md`.

<!-- auto-implement-issue: continue, iteration 2 -->
