### PR TITLE
feat(ingest): surface safety-class changes to Sensor-backed ops at connector re-ingest

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -21,6 +21,7 @@ from meho_backplane.operations.ingest.anthropic_client import (
     build_anthropic_ingest_llm_client,
 )
 from meho_backplane.operations.ingest.api_schemas import (
+    AffectedSensorModel,
     ConnectorListItem,
     ConnectorListResponse,
     ConnectorStatusFilter,
@@ -35,6 +36,7 @@ from meho_backplane.operations.ingest.api_schemas import (
     IngestJobStatusResponse,
     IngestRequest,
     IngestResponse,
+    SafetyChangeModel,
     SpecSource,
 )
 from meho_backplane.operations.ingest.boot_stamp import (
@@ -135,7 +137,9 @@ from meho_backplane.operations.ingest.pipeline import (
     default_llm_client_factory,
 )
 from meho_backplane.operations.ingest.register_ingested import (
+    AffectedSensor,
     IngestionResult,
+    SafetyChange,
     register_ingested_operations,
 )
 from meho_backplane.operations.ingest.schemas import (
@@ -146,6 +150,8 @@ from meho_backplane.operations.ingest.service import ReviewService
 
 __all__ = [
     "DEFAULT_GROUPING_BATCH_SIZE",
+    "AffectedSensor",
+    "AffectedSensorModel",
     "AmbiguousConnectorScopeError",
     "AnthropicMessagesLlmClient",
     "CatalogError",
@@ -196,6 +202,8 @@ __all__ = [
     "OpIdCollision",
     "ProductImplIdMismatch",
     "ReviewService",
+    "SafetyChange",
+    "SafetyChangeModel",
     "SafetyLevel",
     "SpecSource",
     "StructuredJsonLlmClient",

--- a/backend/src/meho_backplane/operations/ingest/_upsert.py
+++ b/backend/src/meho_backplane/operations/ingest/_upsert.py
@@ -43,10 +43,30 @@ from meho_backplane.retrieval.embedding import EmbeddingService
 _SPEC_TAG_PREFIX = "spec:"
 
 __all__ = [
+    "SafetyLevelChange",
     "UpsertContext",
     "build_upsert_context",
     "upsert_one_operation",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class SafetyLevelChange:
+    """A persisted row's ``safety_level`` changed on re-ingest (#2702).
+
+    Captured by :func:`upsert_one_operation` before either existing-row
+    update helper overwrites the field, on **both** update paths -- the
+    body hash covers embedding text (summary / description / tags), not
+    safety metadata, so the skip-re-embed branch can carry a safety
+    reclassification just as the re-embed branch can.
+    :func:`~meho_backplane.operations.ingest.register_ingested.register_ingested_operations`
+    joins these against pinned Sensors and surfaces the enriched result
+    on :class:`~meho_backplane.operations.ingest.register_ingested.IngestionResult`.
+    """
+
+    op_id: str
+    old_safety_level: str
+    new_safety_level: str
 
 
 @dataclass(frozen=True, slots=True)
@@ -274,16 +294,41 @@ def _build_new_descriptor(
     )
 
 
+def _capture_safety_change(
+    existing: EndpointDescriptor,
+    ctx: UpsertContext,
+) -> SafetyLevelChange | None:
+    """Record a ``safety_level`` diff before the update helpers overwrite it.
+
+    Runs on both existing-row paths (#2702): the body-hash skip check
+    covers only the embedding text, so a spec that reclassifies an op's
+    safety without touching its summary / description / tags reaches the
+    skip-re-embed branch -- and would previously overwrite the level
+    with no trace anywhere.
+    """
+    if existing.safety_level == ctx.proto.safety_level:
+        return None
+    return SafetyLevelChange(
+        op_id=ctx.proto.op_id,
+        old_safety_level=existing.safety_level,
+        new_safety_level=ctx.proto.safety_level,
+    )
+
+
 async def upsert_one_operation(
     session: AsyncSession,
     ctx: UpsertContext,
     *,
     embedding_service: EmbeddingService | None,
-) -> str:
+) -> tuple[str, SafetyLevelChange | None]:
     """Upsert one :class:`EndpointDescriptor` row from a parser proto.
 
-    Returns one of ``"inserted"`` / ``"updated"`` / ``"skipped"`` so
-    the caller can tally the counts for :class:`IngestionResult`. The
+    Returns ``(action, safety_change)``: *action* is one of
+    ``"inserted"`` / ``"updated"`` / ``"skipped"`` so the caller can
+    tally the counts for :class:`IngestionResult`; *safety_change* is a
+    :class:`SafetyLevelChange` when an existing row's ``safety_level``
+    was overwritten with a different value (#2702), ``None`` otherwise
+    (first-register rows have no previous value to diff against). The
     three branches (skip-re-embed / re-embed / first-register) live
     in dedicated helpers; this function is the orchestrator that
     chooses between them.
@@ -296,6 +341,8 @@ async def upsert_one_operation(
         # clash raises (see the helper for the normalization rationale).
         _check_cross_source_collision(existing, ctx)
 
+        safety_change = _capture_safety_change(existing, ctx)
+
         existing_text = build_embedding_text(
             summary=existing.summary or "",
             description=existing.description or "",
@@ -305,15 +352,15 @@ async def upsert_one_operation(
         if compute_embedding_text_hash(existing_text) == ctx.incoming_hash:
             _apply_skip_reembed(existing, ctx)
             await session.flush()
-            return "skipped"
+            return "skipped", safety_change
 
         embedding = await encode_endpoint_text(ctx.incoming_text, service=embedding_service)
         _apply_reembed_update(existing, ctx, embedding)
         await session.flush()
-        return "updated"
+        return "updated", safety_change
 
     embedding = await encode_endpoint_text(ctx.incoming_text, service=embedding_service)
     descriptor = _build_new_descriptor(ctx, embedding)
     session.add(descriptor)
     await session.flush()
-    return "inserted"
+    return "inserted", None

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -64,6 +64,7 @@ from meho_backplane.connectors.profile import AuthSchemeName
 from meho_backplane.operations.ingest.catalog import _compatibility_pattern_to_specifier
 
 __all__ = [
+    "AffectedSensorModel",
     "ConnectorListItem",
     "ConnectorListResponse",
     "ConnectorScope",
@@ -78,6 +79,7 @@ __all__ = [
     "IngestResponse",
     "IngestionResultModel",
     "NextStep",
+    "SafetyChangeModel",
     "SpecSource",
 ]
 
@@ -465,6 +467,39 @@ class IngestRequest(BaseModel):
         return normalized
 
 
+class AffectedSensorModel(BaseModel):
+    """Pydantic projection of
+    :class:`~meho_backplane.operations.ingest.register_ingested.AffectedSensor`.
+
+    Identity of one Sensor row pinning a reclassified op (#2702) —
+    enough for the operator to find and re-audit it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID
+    name: str
+    tenant_id: UUID
+
+
+class SafetyChangeModel(BaseModel):
+    """Pydantic projection of
+    :class:`~meho_backplane.operations.ingest.register_ingested.SafetyChange`.
+
+    One op whose persisted ``safety_level`` a re-ingest overwrote with
+    a different value (#2702), plus every Sensor pinning it — those
+    sensors keep auto-executing the op on schedule under the stale
+    create-time ``safe`` assumption until the operator re-audits them.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    op_id: str
+    old_safety_level: str
+    new_safety_level: str
+    affected_sensors: list[AffectedSensorModel] = Field(default_factory=list)
+
+
 class IngestionResultModel(BaseModel):
     """Pydantic projection of
     :class:`~meho_backplane.operations.ingest.register_ingested.IngestionResult`.
@@ -473,6 +508,9 @@ class IngestionResultModel(BaseModel):
     can stay framework-agnostic; this model is the wire-format twin
     the routes return. Fields mirror the dataclass one-for-one with
     an extra ``connector_id`` echo for round-trip clarity.
+    ``safety_changes`` (#2702) is additive with an empty-list default,
+    so pre-existing clients see no shape change on ingests that
+    reclassify nothing.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -483,6 +521,7 @@ class IngestionResultModel(BaseModel):
     skipped_count: int
     connector_registered: bool
     operations_grouped: bool
+    safety_changes: list[SafetyChangeModel] = Field(default_factory=list)
 
 
 class GroupingResultModel(BaseModel):

--- a/backend/src/meho_backplane/operations/ingest/pipeline.py
+++ b/backend/src/meho_backplane/operations/ingest/pipeline.py
@@ -94,8 +94,10 @@ from meho_backplane.operations.ingest._llm_grouping_internals import (
     build_connector_id,
 )
 from meho_backplane.operations.ingest.api_schemas import (
+    AffectedSensorModel,
     GroupingResultModel,
     IngestionResultModel,
+    SafetyChangeModel,
     SpecSource,
 )
 from meho_backplane.operations.ingest.catalog import (
@@ -121,6 +123,7 @@ from meho_backplane.operations.ingest.openapi import (
 )
 from meho_backplane.operations.ingest.register_ingested import (
     IngestionResult,
+    SafetyChange,
     register_ingested_operations,
 )
 from meho_backplane.operations.ingest.service import ReviewService
@@ -321,6 +324,19 @@ def _check_multi_spec_consistency(
         )
 
 
+def _safety_change_to_model(change: SafetyChange) -> SafetyChangeModel:
+    """Project one dataclass :class:`SafetyChange` into its wire model (#2702)."""
+    return SafetyChangeModel(
+        op_id=change.op_id,
+        old_safety_level=change.old_safety_level,
+        new_safety_level=change.new_safety_level,
+        affected_sensors=[
+            AffectedSensorModel(id=sensor.id, name=sensor.name, tenant_id=sensor.tenant_id)
+            for sensor in change.affected_sensors
+        ],
+    )
+
+
 class IngestionPipelineResult:
     """Bundled result of one :meth:`IngestionPipelineService.ingest` call.
 
@@ -364,6 +380,9 @@ class IngestionPipelineResult:
             skipped_count=self.ingestion.skipped_count,
             connector_registered=self.ingestion.connector_registered,
             operations_grouped=self.ingestion.operations_grouped,
+            safety_changes=[
+                _safety_change_to_model(change) for change in self.ingestion.safety_changes
+            ],
         )
         grouping_model: GroupingResultModel | None = None
         if self.grouping is not None:
@@ -943,6 +962,7 @@ class IngestionPipelineService:
         aggregated_inserted = 0
         aggregated_updated = 0
         aggregated_skipped = 0
+        aggregated_safety_changes: list[SafetyChange] = []
         connector_registered = False
 
         for spec in specs:
@@ -959,6 +979,7 @@ class IngestionPipelineService:
             aggregated_inserted += partial.inserted_count
             aggregated_updated += partial.updated_count
             aggregated_skipped += partial.skipped_count
+            aggregated_safety_changes.extend(partial.safety_changes)
             connector_registered = connector_registered or partial.connector_registered
 
         if execution_profile is not None:
@@ -980,6 +1001,7 @@ class IngestionPipelineService:
             skipped_count=aggregated_skipped,
             connector_registered=connector_registered,
             operations_grouped=False,
+            safety_changes=tuple(aggregated_safety_changes),
         )
 
     async def _register_one_spec(

--- a/backend/src/meho_backplane/operations/ingest/register_ingested.py
+++ b/backend/src/meho_backplane/operations/ingest/register_ingested.py
@@ -118,10 +118,14 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 import structlog
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Sensor
+from meho_backplane.operations.ingest._llm_grouping_internals import build_connector_id
 from meho_backplane.operations.ingest._upsert import (
+    SafetyLevelChange,
     build_upsert_context,
     upsert_one_operation,
 )
@@ -134,9 +138,46 @@ from meho_backplane.operations.ingest.schemas import EndpointDescriptorProto
 from meho_backplane.retrieval.embedding import EmbeddingService
 
 __all__ = [
+    "AffectedSensor",
     "IngestionResult",
+    "SafetyChange",
     "register_ingested_operations",
 ]
+
+
+@dataclass(frozen=True, slots=True)
+class AffectedSensor:
+    """A Sensor row pinning an op whose ``safety_level`` changed (#2702).
+
+    Identity-only projection (id / name / tenant_id) of
+    :class:`~meho_backplane.db.models.Sensor` -- enough for the
+    operator to find and re-audit the sensor, without dragging the
+    full ORM row into the frozen result.
+    """
+
+    id: UUID
+    name: str
+    tenant_id: UUID
+
+
+@dataclass(frozen=True, slots=True)
+class SafetyChange:
+    """One op whose persisted ``safety_level`` changed on re-ingest (#2702).
+
+    The sensor-enriched twin of
+    :class:`~meho_backplane.operations.ingest._upsert.SafetyLevelChange`:
+    carries the raw ``(op_id, old, new)`` diff plus every Sensor row --
+    any tenant -- pinning ``(connector_id, op_id)``. Those sensors keep
+    auto-executing the op on schedule under the stale create-time
+    ``safe`` assumption (the documented create-time-only trade-off in
+    ``checks/runner.py``), so surfacing them is the report-only half of
+    that platform-level concern.
+    """
+
+    op_id: str
+    old_safety_level: str
+    new_safety_level: str
+    affected_sensors: tuple[AffectedSensor, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -167,6 +208,12 @@ class IngestionResult:
         Always ``False`` in v0.2 -- the T3 LLM-grouping pass runs
         as a separate step after T2. Present on the result type so
         T3 + T5 can flip it without a schema change.
+    safety_changes:
+        One :class:`SafetyChange` per existing row whose
+        ``safety_level`` was overwritten with a different value by
+        this call (#2702), each carrying the Sensors pinning the
+        reclassified op. Empty on first ingests, dry runs, and
+        re-ingests that leave every op's safety class unchanged.
     """
 
     inserted_count: int
@@ -174,6 +221,7 @@ class IngestionResult:
     skipped_count: int
     connector_registered: bool
     operations_grouped: bool
+    safety_changes: tuple[SafetyChange, ...] = ()
 
 
 def _detect_op_id_collisions(
@@ -231,7 +279,7 @@ async def _run_upsert_loop(
     coords: _BatchCoordinates,
     operations: Sequence[EndpointDescriptorProto],
     embedding_service: EmbeddingService | None,
-) -> dict[str, int]:
+) -> tuple[dict[str, int], tuple[SafetyChange, ...]]:
     """Dispatch to :func:`_register_in_session` with the right session ownership.
 
     When *session* is provided, run the loop against it and defer
@@ -315,7 +363,9 @@ async def register_ingested_operations(
         :class:`IngestionResult` with per-action counts +
         ``connector_registered`` flag (was a new shim registered?) +
         ``operations_grouped`` flag (always ``False`` in v0.2; T3
-        runs grouping next).
+        runs grouping next) + ``safety_changes`` (#2702 — one entry
+        per existing row whose ``safety_level`` this call overwrote
+        with a different value, each naming the Sensors pinning it).
 
     Raises:
         OpIdCollision: Either (a) two operations in *operations* share an
@@ -345,7 +395,7 @@ async def register_ingested_operations(
         impl_id=impl_id,
         spec_source=spec_source,
     )
-    counts = await _run_upsert_loop(
+    counts, safety_changes = await _run_upsert_loop(
         session=session,
         coords=coords,
         operations=operations,
@@ -357,6 +407,7 @@ async def register_ingested_operations(
         skipped_count=counts["skipped"],
         connector_registered=connector_registered,
         operations_grouped=False,
+        safety_changes=safety_changes,
     )
 
 
@@ -415,6 +466,65 @@ def _preflight_and_register_class(
     )
 
 
+async def _collect_safety_changes(
+    session: AsyncSession,
+    *,
+    coords: _BatchCoordinates,
+    shifts: Sequence[SafetyLevelChange],
+    log: structlog.stdlib.BoundLogger,
+) -> tuple[SafetyChange, ...]:
+    """Join per-op safety diffs against pinned Sensors + warn per change (#2702).
+
+    One batched ``IN`` query for every reclassified ``op_id`` under the
+    operator-facing ``connector_id`` (the inverse of
+    :func:`~meho_backplane.operations.ingest.parser.parse_connector_id`,
+    rendered by :func:`build_connector_id`). Deliberately **not** tenant-
+    filtered: a built-in connector's descriptor rows serve every tenant's
+    Sensors, so any tenant's pinning row is affected -- each entry
+    carries its own ``tenant_id`` for triage. Runs inside the register
+    call's open transaction; it's a pure read, so it costs no extra
+    session and sees the just-flushed descriptor state.
+    """
+    if not shifts:
+        return ()
+    connector_id = build_connector_id(coords.product, coords.version, coords.impl_id)
+    stmt = (
+        select(Sensor)
+        .where(
+            Sensor.connector_id == connector_id,
+            Sensor.op_id.in_([shift.op_id for shift in shifts]),
+        )
+        .order_by(Sensor.name, Sensor.id)
+    )
+    sensors = (await session.execute(stmt)).scalars().all()
+    sensors_by_op: dict[str, list[AffectedSensor]] = {}
+    for sensor in sensors:
+        sensors_by_op.setdefault(sensor.op_id, []).append(
+            AffectedSensor(id=sensor.id, name=sensor.name, tenant_id=sensor.tenant_id)
+        )
+
+    changes: list[SafetyChange] = []
+    for shift in shifts:
+        affected = tuple(sensors_by_op.get(shift.op_id, ()))
+        changes.append(
+            SafetyChange(
+                op_id=shift.op_id,
+                old_safety_level=shift.old_safety_level,
+                new_safety_level=shift.new_safety_level,
+                affected_sensors=affected,
+            )
+        )
+        log.warning(
+            "ingest_safety_class_changed",
+            connector_id=connector_id,
+            op_id=shift.op_id,
+            old_safety_level=shift.old_safety_level,
+            new_safety_level=shift.new_safety_level,
+            affected_sensor_count=len(affected),
+        )
+    return tuple(changes)
+
+
 async def _register_in_session(
     session: AsyncSession,
     *,
@@ -422,11 +532,13 @@ async def _register_in_session(
     operations: Sequence[EndpointDescriptorProto],
     embedding_service: EmbeddingService | None,
     commit: bool,
-) -> dict[str, int]:
-    """Upsert every op in *operations* against *session*. Return action counts.
+) -> tuple[dict[str, int], tuple[SafetyChange, ...]]:
+    """Upsert every op in *operations* against *session*.
 
-    Split out from :func:`register_ingested_operations` so the public
-    function can branch on caller-owned-vs-helper-owned session
+    Returns ``(action_counts, safety_changes)``: the per-action tally
+    plus the sensor-enriched ``safety_level`` diffs the batch produced
+    (#2702). Split out from :func:`register_ingested_operations` so the
+    public function can branch on caller-owned-vs-helper-owned session
     without duplicating the loop body. ``commit=True`` commits **once
     after the whole batch**, so a mid-batch crash rolls the session
     back and leaves zero descriptor rows for the spec (#2273);
@@ -435,6 +547,7 @@ async def _register_in_session(
     log = structlog.get_logger(__name__)
     now = datetime.now(UTC)
     counts: dict[str, int] = {"inserted": 0, "updated": 0, "skipped": 0}
+    shifts: list[SafetyLevelChange] = []
 
     for proto in operations:
         ctx = build_upsert_context(
@@ -446,12 +559,14 @@ async def _register_in_session(
             proto=proto,
             now=now,
         )
-        action = await upsert_one_operation(
+        action, safety_shift = await upsert_one_operation(
             session,
             ctx,
             embedding_service=embedding_service,
         )
         counts[action] += 1
+        if safety_shift is not None:
+            shifts.append(safety_shift)
         log.debug(
             "ingested_operation_upserted",
             action=action,
@@ -461,6 +576,13 @@ async def _register_in_session(
             op_id=proto.op_id,
             spec_source=coords.spec_source,
         )
+
+    safety_changes = await _collect_safety_changes(
+        session,
+        coords=coords,
+        shifts=shifts,
+        log=log,
+    )
 
     if commit:
         # One commit per register call (= per spec): the batch is a single
@@ -476,9 +598,10 @@ async def _register_in_session(
         version=coords.version,
         impl_id=coords.impl_id,
         spec_source=coords.spec_source,
+        safety_change_count=len(safety_changes),
         **counts,
     )
-    return counts
+    return counts, safety_changes
 
 
 # Public surface intentionally limited to register_ingested_operations

--- a/backend/src/meho_backplane/operations/ingest/register_ingested.py
+++ b/backend/src/meho_backplane/operations/ingest/register_ingested.py
@@ -118,7 +118,7 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import ColumnElement, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_sessionmaker
@@ -478,29 +478,38 @@ async def _collect_safety_changes(
     One batched ``IN`` query for every reclassified ``op_id`` under the
     operator-facing ``connector_id`` (the inverse of
     :func:`~meho_backplane.operations.ingest.parser.parse_connector_id`,
-    rendered by :func:`build_connector_id`). Deliberately **not** tenant-
-    filtered: a built-in connector's descriptor rows serve every tenant's
-    Sensors, so any tenant's pinning row is affected -- each entry
-    carries its own ``tenant_id`` for triage. Runs inside the register
-    call's open transaction; it's a pure read, so it costs no extra
-    session and sees the just-flushed descriptor state.
+    rendered by :func:`build_connector_id`). Tenant scoping follows the
+    ingest's own scope: a tenant-scoped ingest (``coords.tenant_id``
+    set) overwrote only that tenant's descriptor rows, so the join
+    filters ``Sensor.tenant_id`` to match -- other tenants' sensors
+    resolve their own or the built-in rows (tenant-wins,
+    ``operations/_lookup.py``) and are unaffected; listing them would
+    leak foreign sensor identities over REST / job report / MCP. Only a
+    built-in / global ingest (``coords.tenant_id is None``) stays
+    unfiltered: the built-in rows serve every tenant's Sensors, so any
+    tenant's pinning row is affected -- each entry carries its own
+    ``tenant_id`` for triage. Runs inside the register call's open
+    transaction; it's a pure read, so it costs no extra session and
+    sees the just-flushed descriptor state.
     """
     if not shifts:
         return ()
     connector_id = build_connector_id(coords.product, coords.version, coords.impl_id)
+    conditions: list[ColumnElement[bool]] = [
+        Sensor.connector_id == connector_id,
+        Sensor.op_id.in_([shift.op_id for shift in shifts]),
+    ]
+    if coords.tenant_id is not None:
+        conditions.append(Sensor.tenant_id == coords.tenant_id)
     stmt = (
-        select(Sensor)
-        .where(
-            Sensor.connector_id == connector_id,
-            Sensor.op_id.in_([shift.op_id for shift in shifts]),
-        )
+        select(Sensor.id, Sensor.name, Sensor.tenant_id, Sensor.op_id)
+        .where(*conditions)
         .order_by(Sensor.name, Sensor.id)
     )
-    sensors = (await session.execute(stmt)).scalars().all()
     sensors_by_op: dict[str, list[AffectedSensor]] = {}
-    for sensor in sensors:
-        sensors_by_op.setdefault(sensor.op_id, []).append(
-            AffectedSensor(id=sensor.id, name=sensor.name, tenant_id=sensor.tenant_id)
+    for sensor_id, name, tenant_id, op_id in (await session.execute(stmt)).all():
+        sensors_by_op.setdefault(op_id, []).append(
+            AffectedSensor(id=sensor_id, name=name, tenant_id=tenant_id)
         )
 
     changes: list[SafetyChange] = []

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -2528,6 +2528,98 @@ paths:
     assert grouping["operations_assigned"] == 2
 
 
+def test_reingest_surfaces_safety_changes_in_response(
+    client: TestClient,
+    tmp_path: Any,
+) -> None:
+    """A re-ingest that reverts an operator's safety edit reports it (#2702).
+
+    End-to-end over the REST surface: ingest → operator PATCHes an op to
+    ``dangerous`` at review → re-ingest re-derives ``safe`` from the
+    verb heuristic and overwrites the edit. The response's additive
+    ``ingestion.safety_changes`` field names the ``(op_id, old, new)``
+    diff; the first ingest (nothing to diff against) serializes the
+    backward-compatible empty list.
+    """
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """openapi: 3.0.3
+info:
+  title: t
+  version: '1'
+paths:
+  /items:
+    get:
+      summary: list items
+      responses:
+        '200':
+          description: ok
+""",
+    )
+    propose_json = (
+        '[{"group_key": "items", "name": "Items", '
+        '"when_to_use": "Use these operations to manage items."}]'
+    )
+    assign_json = '{"GET:/items": "items"}'
+    set_llm_client_factory(
+        lambda: _StubLlmClient(
+            propose_response=propose_json,
+            assign_response=assign_json,
+        ),
+    )
+
+    tenant_id = uuid.uuid4()
+    key, token = _admin_token(tenant_id=tenant_id)
+    ingest_body: dict[str, Any] = {
+        "product": "reingest",
+        "version": "1.0",
+        "impl_id": "reingest-impl",
+        "specs": [{"uri": None}],  # filled in once the mock URL exists
+        "tenant_id": str(tenant_id),
+        "async": False,
+    }
+    with (
+        respx.mock as mock_router,
+        patch(
+            "meho_backplane.operations.ingest._upsert.encode_endpoint_text",
+            AsyncMock(return_value=[0.25] * 384),
+        ),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        spec_url = _register_spec_at_https(mock_router, spec_path, path="spec-reingest.yaml")
+        ingest_body["specs"] = [{"uri": spec_url}]
+
+        first = client.post(
+            "/api/v1/connectors/ingest",
+            json=ingest_body,
+            headers=_authed(token),
+        )
+        assert first.status_code == 200, first.text
+        assert first.json()["ingestion"]["safety_changes"] == []
+
+        edit = client.patch(
+            "/api/v1/connectors/reingest-impl-1.0/operations/GET:/items",
+            json={"safety_level": "dangerous"},
+            headers=_authed(token),
+        )
+        assert edit.status_code == 200, edit.text
+
+        second = client.post(
+            "/api/v1/connectors/ingest",
+            json=ingest_body,
+            headers=_authed(token),
+        )
+    assert second.status_code == 200, second.text
+    assert second.json()["ingestion"]["safety_changes"] == [
+        {
+            "op_id": "GET:/items",
+            "old_safety_level": "dangerous",
+            "new_safety_level": "safe",
+            "affected_sensors": [],
+        }
+    ]
+
+
 @pytest.mark.asyncio
 async def test_omitted_tenant_id_resolves_global_on_both_surfaces(
     client: TestClient,

--- a/backend/tests/test_mcp_tools_connector_ingest.py
+++ b/backend/tests/test_mcp_tools_connector_ingest.py
@@ -64,6 +64,7 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import all_connectors_v2, register_connector_v2
 from meho_backplane.mcp.server import McpInvalidParamsError
 from meho_backplane.operations.ingest import (
+    AffectedSensor,
     GroupingResult,
     IngestionPipelineResult,
     IngestionResult,
@@ -71,6 +72,7 @@ from meho_backplane.operations.ingest import (
     InvalidSpecError,
     LlmOutputInvalid,
     OpIdCollision,
+    SafetyChange,
     UncoveredVersionLabel,
     UnsupportedSpecError,
     UpstreamNotSpecError,
@@ -489,8 +491,84 @@ async def test_inline_default_returns_grouping(
     assert payload["ingestion"]["connector_id"] == "vmware-rest-9.0"
     assert payload["grouping"]["groups_created"] == 3
     assert "job_id" not in payload
+    # No safety reclassification → the additive #2702 field serializes
+    # as the backward-compatible empty list, not a missing key.
+    assert payload["ingestion"]["safety_changes"] == []
     [call] = fake.ingest_calls
     assert call["dry_run"] is False
+
+
+async def test_inline_ingest_surfaces_safety_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The MCP ingest payload carries the populated ``safety_changes`` field (#2702).
+
+    The pipeline result's dataclass ``SafetyChange`` entries (with their
+    pinning-Sensor identities) must survive the
+    ``to_api_models`` → ``model_dump(mode="json")`` projection the tool
+    returns — UUIDs as strings, sensors as nested objects.
+    """
+    sensor_id = uuid4()
+    tenant_id = uuid4()
+
+    class _ReclassifyingService(_FakeIngestionPipelineService):
+        async def ingest(self, **kwargs: Any) -> IngestionPipelineResult:
+            result = await super().ingest(**kwargs)
+            reclassified = IngestionResult(
+                inserted_count=0,
+                updated_count=0,
+                skipped_count=10,
+                connector_registered=False,
+                operations_grouped=True,
+                safety_changes=(
+                    SafetyChange(
+                        op_id="GET:/vms",
+                        old_safety_level="safe",
+                        new_safety_level="dangerous",
+                        affected_sensors=(
+                            AffectedSensor(
+                                id=sensor_id,
+                                name="vm-count-watch",
+                                tenant_id=tenant_id,
+                            ),
+                        ),
+                    ),
+                ),
+            )
+            return IngestionPipelineResult(
+                connector_id=result.connector_id,
+                ingestion=reclassified,
+                grouping=result.grouping,
+            )
+
+    fake = _ReclassifyingService()
+    monkeypatch.setattr(ci_mod, "IngestionPipelineService", fake)
+    op = build_operator(TenantRole.TENANT_ADMIN)
+
+    payload = await ci_mod._ingest_handler(
+        op,
+        {
+            "product": "vmware",
+            "version": "9.0",
+            "impl_id": "vmware-rest",
+            "specs": [{"uri": "docs:vcenter-9.0/vcenter.yaml"}],
+        },
+    )
+
+    assert payload["ingestion"]["safety_changes"] == [
+        {
+            "op_id": "GET:/vms",
+            "old_safety_level": "safe",
+            "new_safety_level": "dangerous",
+            "affected_sensors": [
+                {
+                    "id": str(sensor_id),
+                    "name": "vm-count-watch",
+                    "tenant_id": str(tenant_id),
+                }
+            ],
+        }
+    ]
 
 
 async def test_inline_content_threads_to_service_verbatim(

--- a/backend/tests/test_operations_ingest_safety_changes.py
+++ b/backend/tests/test_operations_ingest_safety_changes.py
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Safety-class change surfacing at connector re-ingest (#2702).
+
+Sibling of :mod:`tests.test_operations_register_ingested`, focused on
+the report-only affordance #2702 adds: a re-ingest that overwrites an
+existing row's ``safety_level`` with a different value must surface
+``(op_id, old, new)`` on :class:`IngestionResult.safety_changes`, name
+every Sensor pinning the reclassified op, and emit one structlog
+``ingest_safety_class_changed`` warning per change.
+
+Coverage matrix (the task's acceptance criteria):
+
+* Both existing-row update paths capture the diff -- the body hash
+  covers embedding text only, so the skip-re-embed branch (unchanged
+  summary / description / tags, changed safety) and the re-embed branch
+  (changed text + changed safety) each produce an entry.
+* Ops with unchanged safety are absent; an idempotent re-ingest and a
+  first ingest both yield ``safety_changes == ()``.
+* A Sensor row pinning ``(connector_id, op_id)`` of a reclassified op
+  is listed with its id / name / tenant_id; a sensor pinning an
+  *unchanged* op is not listed.
+* One ``ingest_safety_class_changed`` warning fires per change, keyed
+  with op_id, old, new, and the affected sensor count.
+
+The embedding service is mocked via the explicit ``embedding_service=``
+parameter (the same seam the register-ingested tests use) so no ONNX /
+fastembed dependency is pulled.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+import structlog.testing
+
+from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Sensor, SensorCadenceKind, Tenant
+from meho_backplane.operations.ingest import (
+    EndpointDescriptorProto,
+    IngestionResult,
+    register_ingested_operations,
+)
+from meho_backplane.settings import get_settings
+
+_ASSERTION = {
+    "select": {"path": "$.count"},
+    "compare": {"type": "threshold", "op": "lt", "critical": 10},
+}
+
+_CONNECTOR = {"product": "petstore", "version": "1.0", "impl_id": "petstore"}
+
+#: Operator-facing identifier the Sensor rows pin -- the inverse of
+#: ``parse_connector_id`` over the triple above (``<impl_id>-<version>``).
+_CONNECTOR_ID = "petstore-1.0"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_connector_registry() -> Iterator[None]:
+    """Reset the v2 connector registry between tests (auto-shim isolation)."""
+    clear_registry()
+    yield
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """An :class:`AsyncMock` standing in for :class:`EmbeddingService`."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.25] * 384
+    service.encode.return_value = [[0.25] * 384]
+    service.dimension = 384
+    return service
+
+
+def _proto(
+    op_id: str,
+    *,
+    summary: str = "Summary",
+    safety_level: str = "safe",
+) -> EndpointDescriptorProto:
+    """Parser-shaped proto with a controllable ``safety_level``.
+
+    Keeps summary / description / tags identical across calls unless the
+    test overrides ``summary``, so the body-hash branch taken (skip vs
+    re-embed) is chosen by the *summary* argument alone.
+    """
+    return EndpointDescriptorProto(
+        op_id=op_id,
+        method="GET",
+        path=f"/{op_id.split(':', 1)[1]}",
+        summary=summary,
+        description="Description",
+        tags=["pets"],
+        parameter_schema={"type": "object", "properties": {}},
+        response_schema={"type": "object"},
+        safety_level=safety_level,  # type: ignore[arg-type]
+        requires_approval=False,
+    )
+
+
+async def _register(
+    operations: list[EndpointDescriptorProto],
+    embedding_service: AsyncMock,
+) -> IngestionResult:
+    """One :func:`register_ingested_operations` call under the pinned triple."""
+    return await register_ingested_operations(
+        product=_CONNECTOR["product"],
+        version=_CONNECTOR["version"],
+        impl_id=_CONNECTOR["impl_id"],
+        spec_source="petstore.yaml",
+        operations=operations,
+        embedding_service=embedding_service,
+    )
+
+
+async def _seed_sensor(*, name: str, op_id: str) -> tuple[uuid.UUID, uuid.UUID]:
+    """Insert a tenant + a Sensor pinning ``(_CONNECTOR_ID, op_id)``.
+
+    Returns ``(tenant_id, sensor_id)``. Minimal-viable row per the
+    :class:`Sensor` model contract (interval cadence, threshold
+    assertion); the fields the surfacing reads are ``connector_id`` +
+    ``op_id`` + the identity triple (id / name / tenant_id).
+    """
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    sensor_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=f"t-{name}", name=f"Tenant {name}"))
+        await session.flush()
+        session.add(
+            Sensor(
+                id=sensor_id,
+                tenant_id=tenant_id,
+                name=name,
+                connector_id=_CONNECTOR_ID,
+                op_id=op_id,
+                assertion=_ASSERTION,
+                cadence_kind=SensorCadenceKind.INTERVAL.value,
+                interval_seconds=60,
+                created_by_sub="user-admin",
+            )
+        )
+        await session.commit()
+    return tenant_id, sensor_id
+
+
+# ---------------------------------------------------------------------------
+# Capture on both existing-row update paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safety_change_captured_on_skip_reembed_path(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Unchanged embedding text + changed safety_level → change captured.
+
+    The body hash covers summary / description / tags, not safety
+    metadata, so this re-ingest lands on the skip-re-embed branch --
+    the branch that previously overwrote ``safety_level`` with no trace.
+    """
+    await _register(
+        [_proto("GET:/pets"), _proto("GET:/owners")],
+        stub_embedding_service,
+    )
+
+    result = await _register(
+        [_proto("GET:/pets", safety_level="caution"), _proto("GET:/owners")],
+        stub_embedding_service,
+    )
+
+    assert result.skipped_count == 2
+    changes = result.safety_changes
+    assert [(c.op_id, c.old_safety_level, c.new_safety_level) for c in changes] == [
+        ("GET:/pets", "safe", "caution"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_safety_change_captured_on_reembed_path(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Changed embedding text + changed safety_level → change captured."""
+    await _register([_proto("GET:/pets")], stub_embedding_service)
+
+    result = await _register(
+        [_proto("GET:/pets", summary="Rewritten summary", safety_level="dangerous")],
+        stub_embedding_service,
+    )
+
+    assert result.updated_count == 1
+    changes = result.safety_changes
+    assert [(c.op_id, c.old_safety_level, c.new_safety_level) for c in changes] == [
+        ("GET:/pets", "safe", "dangerous"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unchanged_safety_yields_no_changes(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """First ingest and idempotent re-ingest both report zero changes."""
+    first = await _register([_proto("GET:/pets")], stub_embedding_service)
+    assert first.safety_changes == ()
+
+    rerun = await _register([_proto("GET:/pets")], stub_embedding_service)
+    assert rerun.safety_changes == ()
+
+
+# ---------------------------------------------------------------------------
+# Sensor join
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safety_change_lists_pinning_sensors_only(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A sensor on the reclassified op is listed; one on an unchanged op is not."""
+    await _register(
+        [_proto("GET:/pets"), _proto("GET:/owners")],
+        stub_embedding_service,
+    )
+    tenant_id, sensor_id = await _seed_sensor(name="pets-watch", op_id="GET:/pets")
+    await _seed_sensor(name="owners-watch", op_id="GET:/owners")
+
+    result = await _register(
+        [_proto("GET:/pets", safety_level="caution"), _proto("GET:/owners")],
+        stub_embedding_service,
+    )
+
+    [change] = result.safety_changes
+    assert change.op_id == "GET:/pets"
+    assert [(s.id, s.name, s.tenant_id) for s in change.affected_sensors] == [
+        (sensor_id, "pets-watch", tenant_id),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Structlog warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_warning_fires_per_change_with_sensor_count(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """One ``ingest_safety_class_changed`` warning per change, fully keyed."""
+    await _register(
+        [_proto("GET:/pets"), _proto("GET:/owners")],
+        stub_embedding_service,
+    )
+    await _seed_sensor(name="pets-watch", op_id="GET:/pets")
+
+    with structlog.testing.capture_logs() as logs:
+        await _register(
+            [
+                _proto("GET:/pets", safety_level="caution"),
+                _proto("GET:/owners", safety_level="dangerous"),
+            ],
+            stub_embedding_service,
+        )
+
+    warnings = [e for e in logs if e["event"] == "ingest_safety_class_changed"]
+    assert [
+        (
+            e["op_id"],
+            e["old_safety_level"],
+            e["new_safety_level"],
+            e["affected_sensor_count"],
+            e["log_level"],
+        )
+        for e in warnings
+    ] == [
+        ("GET:/pets", "safe", "caution", 1, "warning"),
+        ("GET:/owners", "safe", "dangerous", 0, "warning"),
+    ]
+    assert all(e["connector_id"] == _CONNECTOR_ID for e in warnings)

--- a/backend/tests/test_operations_ingest_safety_changes.py
+++ b/backend/tests/test_operations_ingest_safety_changes.py
@@ -21,6 +21,10 @@ Coverage matrix (the task's acceptance criteria):
 * A Sensor row pinning ``(connector_id, op_id)`` of a reclassified op
   is listed with its id / name / tenant_id; a sensor pinning an
   *unchanged* op is not listed.
+* Tenant scoping follows the ingest's scope: a tenant-scoped re-ingest
+  lists only the ingesting tenant's sensors (a foreign tenant's sensor
+  on the same ``(connector_id, op_id)`` is absent); a built-in / global
+  re-ingest stays unfiltered and lists every tenant's pinning sensors.
 * One ``ingest_safety_class_changed`` warning fires per change, keyed
   with op_id, old, new, and the affected sensor count.
 
@@ -118,6 +122,8 @@ def _proto(
 async def _register(
     operations: list[EndpointDescriptorProto],
     embedding_service: AsyncMock,
+    *,
+    tenant_id: uuid.UUID | None = None,
 ) -> IngestionResult:
     """One :func:`register_ingested_operations` call under the pinned triple."""
     return await register_ingested_operations(
@@ -126,24 +132,33 @@ async def _register(
         impl_id=_CONNECTOR["impl_id"],
         spec_source="petstore.yaml",
         operations=operations,
+        tenant_id=tenant_id,
         embedding_service=embedding_service,
     )
 
 
-async def _seed_sensor(*, name: str, op_id: str) -> tuple[uuid.UUID, uuid.UUID]:
-    """Insert a tenant + a Sensor pinning ``(_CONNECTOR_ID, op_id)``.
+async def _seed_sensor(
+    *,
+    name: str,
+    op_id: str,
+    tenant_id: uuid.UUID | None = None,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    """Insert a Sensor pinning ``(_CONNECTOR_ID, op_id)`` (+ its tenant).
 
-    Returns ``(tenant_id, sensor_id)``. Minimal-viable row per the
+    Returns ``(tenant_id, sensor_id)``. A fresh tenant is created unless
+    *tenant_id* names an existing one. Minimal-viable row per the
     :class:`Sensor` model contract (interval cadence, threshold
     assertion); the fields the surfacing reads are ``connector_id`` +
     ``op_id`` + the identity triple (id / name / tenant_id).
     """
     sessionmaker = get_sessionmaker()
-    tenant_id = uuid.uuid4()
+    create_tenant = tenant_id is None
+    tenant_id = tenant_id if tenant_id is not None else uuid.uuid4()
     sensor_id = uuid.uuid4()
     async with sessionmaker() as session:
-        session.add(Tenant(id=tenant_id, slug=f"t-{name}", name=f"Tenant {name}"))
-        await session.flush()
+        if create_tenant:
+            session.add(Tenant(id=tenant_id, slug=f"t-{name}", name=f"Tenant {name}"))
+            await session.flush()
         session.add(
             Sensor(
                 id=sensor_id,
@@ -250,6 +265,60 @@ async def test_safety_change_lists_pinning_sensors_only(
     assert change.op_id == "GET:/pets"
     assert [(s.id, s.name, s.tenant_id) for s in change.affected_sensors] == [
         (sensor_id, "pets-watch", tenant_id),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tenant_scoped_ingest_omits_foreign_tenant_sensors(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A tenant-scoped re-ingest lists only the ingesting tenant's sensors.
+
+    ``connector_id`` carries no tenant component, so a foreign tenant's
+    sensor pins the same ``(connector_id, op_id)`` -- but its descriptors
+    resolve that tenant's own (or the built-in) rows, which a
+    tenant-scoped ingest never touches. Listing it would both leak a
+    foreign sensor identity and report a sensor that was not affected.
+    """
+    tenant_a, sensor_a = await _seed_sensor(name="a-pets-watch", op_id="GET:/pets")
+    await _seed_sensor(name="b-pets-watch", op_id="GET:/pets")
+    await _register([_proto("GET:/pets")], stub_embedding_service, tenant_id=tenant_a)
+
+    result = await _register(
+        [_proto("GET:/pets", safety_level="caution")],
+        stub_embedding_service,
+        tenant_id=tenant_a,
+    )
+
+    [change] = result.safety_changes
+    assert change.op_id == "GET:/pets"
+    assert [(s.id, s.name, s.tenant_id) for s in change.affected_sensors] == [
+        (sensor_a, "a-pets-watch", tenant_a),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_global_ingest_lists_every_tenants_sensors(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A built-in / global re-ingest stays unfiltered across tenants.
+
+    The built-in rows serve every tenant's Sensors, so any tenant's
+    pinning row is affected and must be listed for triage.
+    """
+    await _register([_proto("GET:/pets")], stub_embedding_service)
+    tenant_a, sensor_a = await _seed_sensor(name="a-pets-watch", op_id="GET:/pets")
+    tenant_b, sensor_b = await _seed_sensor(name="b-pets-watch", op_id="GET:/pets")
+
+    result = await _register(
+        [_proto("GET:/pets", safety_level="caution")],
+        stub_embedding_service,
+    )
+
+    [change] = result.safety_changes
+    assert [(s.id, s.name, s.tenant_id) for s in change.affected_sensors] == [
+        (sensor_a, "a-pets-watch", tenant_a),
+        (sensor_b, "b-pets-watch", tenant_b),
     ]
 
 

--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -600,7 +600,9 @@ def _flaky_upsert_factory(
     real_upsert = _reg.upsert_one_operation
     calls = 0
 
-    async def flaky_upsert(session: AsyncSession, ctx: Any, *, embedding_service: Any) -> str:
+    async def flaky_upsert(
+        session: AsyncSession, ctx: Any, *, embedding_service: Any
+    ) -> tuple[str, Any]:
         nonlocal calls
         calls += 1
         if calls == fail_on_call and (should_fail is None or should_fail()):

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -19183,6 +19183,32 @@
         "title": "AbortRunResponse",
         "description": "Returned by ``meho.runbook.abort`` -- the terminal-state coordinates."
       },
+      "AffectedSensorModel": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "tenant_id"
+        ],
+        "title": "AffectedSensorModel",
+        "description": "Pydantic projection of\n:class:`~meho_backplane.operations.ingest.register_ingested.AffectedSensor`.\n\nIdentity of one Sensor row pinning a reclassified op (#2702) \u2014\nenough for the operator to find and re-audit it."
+      },
       "AgentDefinitionCreate": {
         "properties": {
           "name": {
@@ -25124,6 +25150,13 @@
           "operations_grouped": {
             "type": "boolean",
             "title": "Operations Grouped"
+          },
+          "safety_changes": {
+            "items": {
+              "$ref": "#/components/schemas/SafetyChangeModel"
+            },
+            "type": "array",
+            "title": "Safety Changes"
           }
         },
         "type": "object",
@@ -25136,7 +25169,7 @@
           "operations_grouped"
         ],
         "title": "IngestionResultModel",
-        "description": "Pydantic projection of\n:class:`~meho_backplane.operations.ingest.register_ingested.IngestionResult`.\n\nThe dataclass lives in :mod:`register_ingested` so the helper\ncan stay framework-agnostic; this model is the wire-format twin\nthe routes return. Fields mirror the dataclass one-for-one with\nan extra ``connector_id`` echo for round-trip clarity."
+        "description": "Pydantic projection of\n:class:`~meho_backplane.operations.ingest.register_ingested.IngestionResult`.\n\nThe dataclass lives in :mod:`register_ingested` so the helper\ncan stay framework-agnostic; this model is the wire-format twin\nthe routes return. Fields mirror the dataclass one-for-one with\nan extra ``connector_id`` echo for round-trip clarity.\n``safety_changes`` (#2702) is additive with an empty-list default,\nso pre-existing clients see no shape change on ingests that\nreclassify nothing."
       },
       "KbEntry": {
         "properties": {
@@ -27277,6 +27310,37 @@
         ],
         "title": "RunnerWorkItem",
         "description": "One centrally-authorized operation for the runner to execute.\n\nCarries the fields the runner needs to resolve and invoke a handler\nentirely locally: the dotted ``handler_ref`` (resolved via\n:func:`~meho_backplane.operations._handler_resolve.import_handler`),\nthe ``(product, version, impl_id)`` registry key used to rebind a\nbound-method handler against its connector instance, the validated\n``params``, the ``safety_level`` the runner re-checks (defence in\ndepth), the principal context, and the resolved target descriptor\n(``None`` for targetless synthetic ops such as ``net.*``)."
+      },
+      "SafetyChangeModel": {
+        "properties": {
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "old_safety_level": {
+            "type": "string",
+            "title": "Old Safety Level"
+          },
+          "new_safety_level": {
+            "type": "string",
+            "title": "New Safety Level"
+          },
+          "affected_sensors": {
+            "items": {
+              "$ref": "#/components/schemas/AffectedSensorModel"
+            },
+            "type": "array",
+            "title": "Affected Sensors"
+          }
+        },
+        "type": "object",
+        "required": [
+          "op_id",
+          "old_safety_level",
+          "new_safety_level"
+        ],
+        "title": "SafetyChangeModel",
+        "description": "Pydantic projection of\n:class:`~meho_backplane.operations.ingest.register_ingested.SafetyChange`.\n\nOne op whose persisted ``safety_level`` a re-ingest overwrote with\na different value (#2702), plus every Sensor pinning it \u2014 those\nsensors keep auto-executing the op on schedule under the stale\ncreate-time ``safe`` assumption until the operator re-audits them."
       },
       "ScheduledTriggerCreate": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -658,6 +658,17 @@ type AbortRunResponse struct {
 	State       *string            `json:"state,omitempty"`
 }
 
+// AffectedSensorModel Pydantic projection of
+// :class:`~meho_backplane.operations.ingest.register_ingested.AffectedSensor`.
+//
+// Identity of one Sensor row pinning a reclassified op (#2702) —
+// enough for the operator to find and re-audit it.
+type AffectedSensorModel struct {
+	Id       openapi_types.UUID `json:"id"`
+	Name     string             `json:"name"`
+	TenantId openapi_types.UUID `json:"tenant_id"`
+}
+
 // AgentDefinitionCreate POST body -- the inputs “create“ consumes. Pydantic v2 strict.
 //
 // “extra="forbid"“ rejects unknown fields with 422 (catches a client
@@ -4305,6 +4316,9 @@ type IngestJobStatusResponse struct {
 	// can stay framework-agnostic; this model is the wire-format twin
 	// the routes return. Fields mirror the dataclass one-for-one with
 	// an extra ``connector_id`` echo for round-trip clarity.
+	// ``safety_changes`` (#2702) is additive with an empty-list default,
+	// so pre-existing clients see no shape change on ingests that
+	// reclassify nothing.
 	Ingestion *IngestionResultModel         `json:"ingestion,omitempty"`
 	JobId     openapi_types.UUID            `json:"job_id"`
 	Product   *string                       `json:"product"`
@@ -4450,6 +4464,9 @@ type IngestResponse struct {
 	// can stay framework-agnostic; this model is the wire-format twin
 	// the routes return. Fields mirror the dataclass one-for-one with
 	// an extra ``connector_id`` echo for round-trip clarity.
+	// ``safety_changes`` (#2702) is additive with an empty-list default,
+	// so pre-existing clients see no shape change on ingests that
+	// reclassify nothing.
 	Ingestion IngestionResultModel `json:"ingestion"`
 }
 
@@ -4460,13 +4477,17 @@ type IngestResponse struct {
 // can stay framework-agnostic; this model is the wire-format twin
 // the routes return. Fields mirror the dataclass one-for-one with
 // an extra “connector_id“ echo for round-trip clarity.
+// “safety_changes“ (#2702) is additive with an empty-list default,
+// so pre-existing clients see no shape change on ingests that
+// reclassify nothing.
 type IngestionResultModel struct {
-	ConnectorId         string `json:"connector_id"`
-	ConnectorRegistered bool   `json:"connector_registered"`
-	InsertedCount       int    `json:"inserted_count"`
-	OperationsGrouped   bool   `json:"operations_grouped"`
-	SkippedCount        int    `json:"skipped_count"`
-	UpdatedCount        int    `json:"updated_count"`
+	ConnectorId         string               `json:"connector_id"`
+	ConnectorRegistered bool                 `json:"connector_registered"`
+	InsertedCount       int                  `json:"inserted_count"`
+	OperationsGrouped   bool                 `json:"operations_grouped"`
+	SafetyChanges       *[]SafetyChangeModel `json:"safety_changes,omitempty"`
+	SkippedCount        int                  `json:"skipped_count"`
+	UpdatedCount        int                  `json:"updated_count"`
 }
 
 // KbEntry One kb entry -- mirrors a row in the “documents“ table.
@@ -5722,6 +5743,20 @@ type RunnerWorkItem struct {
 	// would durably persist — a locked no-durable-artifact violation).
 	TargetDescriptor *ResolvedTargetDescriptor `json:"target_descriptor,omitempty"`
 	Version          *string                   `json:"version,omitempty"`
+}
+
+// SafetyChangeModel Pydantic projection of
+// :class:`~meho_backplane.operations.ingest.register_ingested.SafetyChange`.
+//
+// One op whose persisted “safety_level“ a re-ingest overwrote with
+// a different value (#2702), plus every Sensor pinning it — those
+// sensors keep auto-executing the op on schedule under the stale
+// create-time “safe“ assumption until the operator re-audits them.
+type SafetyChangeModel struct {
+	AffectedSensors *[]AffectedSensorModel `json:"affected_sensors,omitempty"`
+	NewSafetyLevel  string                 `json:"new_safety_level"`
+	OldSafetyLevel  string                 `json:"old_safety_level"`
+	OpId            string                 `json:"op_id"`
 }
 
 // ScheduledTriggerCreate Request body for “POST /api/v1/scheduler/triggers“.

--- a/docs/codebase/sensor.md
+++ b/docs/codebase/sensor.md
@@ -54,13 +54,16 @@ delete, the runner (#2505) owns claim/advance/park and the result write.
    `EndpointDescriptor` via `lookup_descriptor` (tenant-scoped, then
    global). No descriptor ⇒ 422 `sensor_operation_not_found`.
 3. **Safe-only guard**: `descriptor.safety_level != "safe"` ⇒ 422
-   `sensor_requires_safe_operation`. This is a create-time honesty guard,
-   not the security boundary — the dispatch-time policy gate
-   (`operations/dispatcher.dispatch`) still runs on every evaluation, so a
-   descriptor re-ingested harder later fails closed at dispatch. The
-   platform-level half of that trade-off is #2702: a connector re-ingest
+   `sensor_requires_safe_operation`. This is a create-time-only guard:
+   the dispatch-time policy gate (`operations/dispatcher.dispatch`)
+   still runs on every evaluation, but it does **not** re-validate
+   `safety_level` — a descriptor re-ingested to a less-safe level keeps
+   auto-executing on schedule (`checks/runner.py`, "Dispatch
+   identity"). The platform-level half of that trade-off — the
+   reporting/triage mitigation — is #2702: a connector re-ingest
    that overwrites a pinned op's `safety_level` surfaces the diff — with
-   every pinning sensor's id/name/tenant_id — on the ingest result's
+   each affected sensor's id/name/tenant_id, scoped to the ingest's
+   tenant for tenant-scoped ingests — on the ingest result's
    `safety_changes` field (REST / job report / MCP) and emits an
    `ingest_safety_class_changed` warning per change, so the operator
    knows which sensors to re-audit (see

--- a/docs/codebase/sensor.md
+++ b/docs/codebase/sensor.md
@@ -57,7 +57,14 @@ delete, the runner (#2505) owns claim/advance/park and the result write.
    `sensor_requires_safe_operation`. This is a create-time honesty guard,
    not the security boundary — the dispatch-time policy gate
    (`operations/dispatcher.dispatch`) still runs on every evaluation, so a
-   descriptor re-ingested harder later fails closed at dispatch.
+   descriptor re-ingested harder later fails closed at dispatch. The
+   platform-level half of that trade-off is #2702: a connector re-ingest
+   that overwrites a pinned op's `safety_level` surfaces the diff — with
+   every pinning sensor's id/name/tenant_id — on the ingest result's
+   `safety_changes` field (REST / job report / MCP) and emits an
+   `ingest_safety_class_changed` warning per change, so the operator
+   knows which sensors to re-audit (see
+   `docs/codebase/spec-ingestion.md`, `IngestionResult`).
 4. `create_sensor` inserts the row, materialising `next_fire_at`
    (`now + interval_seconds` for interval; `next_fire_after(cron_expr, …)`
    for cron) so #2505's claim query (`status='active' AND next_fire_at <= now`)

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -526,6 +526,27 @@ Carries per-call counts (`inserted_count`, `updated_count`,
 output. `operations_grouped` is always `False` in v0.2 — T3
 flips it after the LLM-grouping pass runs.
 
+`safety_changes` (#2702) is a tuple of frozen `SafetyChange`
+entries — one per **existing** row whose `safety_level` the call
+overwrote with a different value. Both existing-row update paths in
+`_upsert.py` capture the diff (the body hash covers embedding text,
+not safety metadata, so the skip-re-embed branch can carry a
+reclassification too). After the upsert loop,
+`_collect_safety_changes` joins the changed op_ids against `Sensor`
+rows pinning `(connector_id, op_id)` — deliberately **not**
+tenant-filtered, since a built-in connector's rows serve every
+tenant's Sensors — and attaches each pinning sensor's
+id / name / tenant_id as `AffectedSensor` entries. One structlog
+warning `ingest_safety_class_changed` fires per change (keyed with
+op_id, old, new, affected sensor count). The wire twin
+`SafetyChangeModel` rides `IngestionResultModel.safety_changes`
+(additive, `default_factory=list`), so the REST ingest response, the
+async job report, and the MCP `meho.connector.ingest` tool all carry
+it with no breaking shape change. Report-only: nothing is re-gated
+at dispatch and no Sensor is parked — this is the platform-level
+half of the create-time-only trade-off documented in
+`checks/runner.py` (see `docs/codebase/sensor.md`).
+
 ### `GenericRestConnector` (`ingest/connector_registration.py`)
 
 Auto-generated `HttpConnector` subclass synthesised on first ingest

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -533,10 +533,15 @@ overwrote with a different value. Both existing-row update paths in
 not safety metadata, so the skip-re-embed branch can carry a
 reclassification too). After the upsert loop,
 `_collect_safety_changes` joins the changed op_ids against `Sensor`
-rows pinning `(connector_id, op_id)` — deliberately **not**
-tenant-filtered, since a built-in connector's rows serve every
-tenant's Sensors — and attaches each pinning sensor's
-id / name / tenant_id as `AffectedSensor` entries. One structlog
+rows pinning `(connector_id, op_id)` and attaches each pinning
+sensor's id / name / tenant_id as `AffectedSensor` entries. The join
+follows the ingest's own tenant scope: a tenant-scoped ingest
+overwrote only that tenant's descriptor rows, so it filters
+`Sensor.tenant_id` to match — other tenants' sensors resolve their
+own or the built-in rows (tenant-wins, `operations/_lookup.py`) and
+listing them would leak foreign sensor identities. Only a built-in /
+global ingest (`tenant_id IS NULL`) is deliberately unfiltered,
+since the built-in rows serve every tenant's Sensors. One structlog
 warning `ingest_safety_class_changed` fires per change (keyed with
 op_id, old, new, affected sensor count). The wire twin
 `SafetyChangeModel` rides `IngestionResultModel.safety_changes`


### PR DESCRIPTION
## Summary
- A connector re-ingest previously overwrote `safety_level` unconditionally on both existing-row update paths in `_upsert.py`, with no trace anywhere — every Sensor pinning the reclassified op kept auto-executing it on schedule under its stale create-time `safe` assumption (the documented create-time-only trade-off in `checks/runner.py:78-84`).
- `upsert_one_operation` now captures `(op_id, old, new)` whenever an existing row's `safety_level` changes, on **both** the skip-re-embed and re-embed branches (the body hash covers embedding text, not safety metadata).
- `register_ingested_operations` joins the changed op_ids against `Sensor` rows pinning `(connector_id, op_id)` — one batched SQLAlchemy 2.0 `IN` query, deliberately not tenant-filtered since built-in connector rows serve every tenant's Sensors — and surfaces the enriched diffs as `IngestionResult.safety_changes` (frozen dataclasses), emitting one structlog `ingest_safety_class_changed` warning per change keyed with op_id, old, new, and affected sensor count.
- `IngestionResultModel` gains an additive `safety_changes: list[SafetyChangeModel] = Field(default_factory=list)` (Pydantic v2 nested models), so the REST ingest response, the async ingest job report, and the MCP `meho.connector.ingest` tool all inherit it with no breaking shape change. Report-only: no migration, no new column, no dispatch-path change, no Sensor auto-parking.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (1364 files)
- [x] `mypy src/` — clean on all touched modules; the only error is the pre-existing darwin-only `socket.MSG_ERRQUEUE` false positive in `connectors/net/icmp.py` (present on a clean tree; Linux CI passes)
- [x] `uv run pytest backend/tests -k safety_change` — 7 passed (new `tests/test_operations_ingest_safety_changes.py` + REST test)
- [x] Re-ingest with changed `safety_level` yields `safety_changes` naming `(op_id, old, new)` on both the skip-re-embed and re-embed paths; unchanged ops absent — `test_operations_ingest_safety_changes.py`
- [x] A Sensor pinning a reclassified op is listed with its id/name/tenant_id; a sensor pinning an unchanged op is not — `test_safety_change_lists_pinning_sensors_only`
- [x] REST ingest response carries populated `safety_changes` end-to-end (ingest → operator PATCHes op to `dangerous` → re-ingest reverts to heuristic `safe`) and serializes `[]` when nothing changed — `test_reingest_surfaces_safety_changes_in_response`
- [x] MCP ingest tool payload carries populated `safety_changes` through `to_api_models` → `model_dump(mode="json")` (UUIDs as strings, nested sensors) and `[]` on the no-change shape — `test_mcp_tools_connector_ingest.py`
- [x] One `ingest_safety_class_changed` warning per change, keyed with op_id/old/new/affected_sensor_count — `test_warning_fires_per_change_with_sensor_count`
- [x] Full unit sweep (`pytest -n 3 --dist loadscope --ignore=tests/integration --ignore=tests/migrations tests/`) — green

## Out of scope
- Re-gating `safety_level` at dispatch in the check-runner — the documented trade-off in `runner.py:78-84` stands.
- Typed-connector registration (`source_kind != "ingested"`).
- Auto-disabling/parking affected Sensors, broadcast events, or any UI surface (smallest operator-visible affordance first).
- The `identity_sub` validation gap on `sensor.create` (#2699).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2702


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ingestion reports now identify safety-level changes detected during connector re-ingestion.
  * Reports include the affected operation, previous and updated safety levels, and impacted sensors.
  * Safety-change details are available through REST, job reports, and the MCP ingestion tool.
  * Unchanged ingests continue to return an empty safety-change list.

* **Documentation**
  * Added guidance on reviewing safety changes and affected sensors after re-ingestion.

* **Tests**
  * Added coverage for safety changes, sensor scoping, idempotency, and report formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
---

## Follow-up (auto-implement-issue, iteration 1, 2026-07-30)

Addressed review findings from review 4820013609 (REQUEST_CHANGES of record):

- **B2** `d38339d8` — `_collect_safety_changes` now filters `Sensor.tenant_id == coords.tenant_id` when the ingest is tenant-scoped (unfiltered only for built-in/global ingests, `tenant_id IS NULL`); the query selects only the four projected columns instead of full `Sensor` rows. Docstring + `docs/codebase/spec-ingestion.md` updated; new tests prove a foreign tenant's sensor is absent on a tenant-scoped re-ingest and a global re-ingest still lists every tenant's sensors.
- **M1** `59813062` — `docs/codebase/sensor.md` no longer claims a reclassified op "fails closed at dispatch"; it states the create-time-only contract (`checks/runner.py`, Dispatch identity) with #2702's `safety_changes` reporting as the mitigation. Also resolves CodeRabbit's wording nitpick on the same lines.
- **B1** `4493e370` — `cd cli && make snapshot-openapi && make generate`; regenerated `cli/api/openapi.json` (+65 lines: `safety_changes`, `SafetyChangeModel`, `AffectedSensorModel`) and `cli/internal/api/client.gen.go` committed. `go build ./...` + `go test ./...` pass (Go 1.25.12, oapi-codegen pinned v2.5.0 via the Makefile).

Blocked (needs the PR author or a maintainer; not addressable without a history rewrite):

- **B3** — the pre-existing first commit `36a535b` lacks `Signed-off-by`, so the required DCO check stays red. All three new fix commits carry a matching `Signed-off-by`. The repo has no `.github/dco.yml`, so the DCO app accepts no remediation commit; its only documented remediation is a branch rebase with `--signoff` plus force-push, which this automation must not do. Options: the author rebases the branch with `--signoff` and force-pushes, or (since `enforce_admins` is off) an admin merges over the red check.

Verification: `ruff check` / `ruff format --check` clean; `mypy src/` clean except the pre-existing darwin-only `socket.MSG_ERRQUEUE` error in untouched `connectors/net/icmp.py`; full unit suite 10625 passed / 193 skipped with only the two known darwin-only pre-existing failures (icmp loopback trace, DNS resolver); `.claude/hooks/code-quality.py --diff` 0 blockers.

<!-- auto-implement-issue: continue, iteration 1 -->
