### PR TITLE
docs(site): scaffold MkDocs Material site with mike versioning + Pages deploy on tag

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+# Documentation-site build check + versioned Pages deploy (#2670).
+#
+# Two jobs, two triggers:
+#   PR / merge queue : `mkdocs build --strict` — docs changes carry a
+#                      red/green check like any other change. `strict`
+#                      turns broken links and pages missing from nav
+#                      into build failures, so docs rot cannot land.
+#   push tag v*      : mike publishes the tag's docs under its
+#                      MAJOR.MINOR version (one docs version per minor
+#                      — a patch tag republishes its minor in place)
+#                      and moves the `latest` alias, onto the gh-pages
+#                      branch that GitHub Pages serves. The docs join
+#                      the image / chart / CLI as the fourth artefact a
+#                      `v*` tag publishes (docs/RELEASING.md).
+#
+# One-time setup (mirrors image.yml's GHCR-visibility precedent — a
+# maintainer does this once, CI cannot safely mutate repo settings):
+#   Settings → Pages → Source: "Deploy from a branch" →
+#   Branch: gh-pages / root. The gh-pages branch exists after the
+#   first tag-triggered run. The site then serves at
+#   https://evoila.github.io/meho/.
+#
+# mike's CI requirements (https://github.com/jimporter/mike):
+#   * the gh-pages branch must be fetched locally before deploying —
+#     mike commits the built site onto it;
+#   * a git committer identity must be configured — we use the
+#     github-actions[bot] identity, matching the commits GitHub's own
+#     actions produce.
+#
+# Docs toolchain versions are locked in backend/uv.lock (dependency
+# group `docs`), so Dependabot's existing `uv` ecosystem coverage keeps
+# mkdocs-material + mike current and this workflow reproducible.
+
+name: docs-site
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'mkdocs.yml'
+      - 'docs-site/**'
+      - 'backend/pyproject.toml'
+      - 'backend/uv.lock'
+      - '.github/workflows/docs-site.yml'
+  # Fires when a PR enters the merge queue, so the check can be made
+  # required in branch protection and still report against the
+  # synthesised merge commit. Bare `merge_group:` because the event
+  # does not support `paths:` filtering — same rationale as
+  # readme-version-check.yml (#769). The build is a strict mkdocs run
+  # (~seconds), so the redundant queue runs are negligible.
+  merge_group:
+  push:
+    # Tag-driven deploy only. Docs versions are cut per release, like
+    # the image / chart / CLI artefacts — a main push without a tag has
+    # no version to publish under. Pre-release tags (v1.0.0-rc.1)
+    # deploy under their minor (1.0): the rc docs *are* that minor's
+    # docs in progress.
+    tags: ['v*']
+  workflow_dispatch:
+
+# Read-only by default; the deploy job elevates to the minimum it
+# needs (contents: write, to push the gh-pages branch).
+permissions:
+  contents: read
+
+concurrency:
+  # Event-suffixed group key so pull_request / merge_group / tag runs
+  # don't collide; cancel-in-progress is scoped OFF for merge_group
+  # because a cancelled queue check fails the merge attempt. Same
+  # shape as readme-version-check.yml.
+  group: docs-site-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
+jobs:
+  build:
+    name: mkdocs build --strict
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+
+      - name: Install docs toolchain (locked)
+        run: uv sync --locked --only-group docs
+        working-directory: backend
+
+      - name: Build site (strict)
+        # --strict is redundant with `strict: true` in mkdocs.yml but
+        # keeps the gate explicit even if the config line moves.
+        run: uv run --project backend --no-sync mkdocs build --strict
+
+  deploy:
+    name: mike deploy (versioned Pages publish)
+    # Covers the tag push AND a manual workflow_dispatch pointed at a
+    # tag ref (re-publish after a transient failure). A dispatch on a
+    # branch ref only runs the build job above — there is no version
+    # to publish under.
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      # Serialise gh-pages pushes across tags — two near-simultaneous
+      # tag pushes would otherwise race mike's branch update. Never
+      # cancel a publish in flight.
+      group: docs-site-gh-pages
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Fetch gh-pages
+        # mike commits onto the local gh-pages ref. Absent on the very
+        # first deploy — mike then creates it — so guard the fetch on
+        # remote existence rather than swallowing all fetch errors.
+        run: |
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null; then
+            git fetch origin gh-pages --depth=1
+          fi
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9  # v9.0.0
+
+      - name: Install docs toolchain (locked)
+        run: uv sync --locked --only-group docs
+        working-directory: backend
+
+      - name: Deploy versioned docs
+        # One docs version per minor: v0.26.3 publishes as "0.26" and
+        # re-points `latest`. `--update-aliases` lets `latest` move
+        # off the previous minor; `set-default latest` (idempotent)
+        # makes the site root redirect to the newest docs.
+        # workflow_dispatch on a non-tag ref has no version to derive,
+        # so it only rebuilds the default: guard on the ref shape.
+        run: |
+          set -euo pipefail
+          case "${GITHUB_REF_NAME}" in
+            v[0-9]*)
+              VERSION=$(printf '%s' "${GITHUB_REF_NAME#v}" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
+              uv run --project backend --no-sync mike deploy --push --update-aliases "${VERSION}" latest
+              uv run --project backend --no-sync mike set-default --push latest
+              ;;
+            *)
+              echo "Ref '${GITHUB_REF_NAME}' is not a v* tag — nothing to deploy." >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -143,14 +143,17 @@ jobs:
         # so it only rebuilds the default: guard on the ref shape.
         run: |
           set -euo pipefail
+          # Require a full vMAJOR.MINOR prefix — a malformed tag (e.g.
+          # `v1-hotfix`) must fail loudly here, not publish a garbage
+          # entry in the public version selector.
           case "${GITHUB_REF_NAME}" in
-            v[0-9]*)
+            v[0-9]*.[0-9]*)
               VERSION=$(printf '%s' "${GITHUB_REF_NAME#v}" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
               uv run --project backend --no-sync mike deploy --push --update-aliases "${VERSION}" latest
               uv run --project backend --no-sync mike set-default --push latest
               ;;
             *)
-              echo "Ref '${GITHUB_REF_NAME}' is not a v* tag — nothing to deploy." >&2
+              echo "Ref '${GITHUB_REF_NAME}' is not a vMAJOR.MINOR[.PATCH] tag — nothing to deploy." >&2
               exit 1
               ;;
           esac

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ htmlcov/
 .venv/
 venv/
 
+# mkdocs build output (docs-site scaffold, #2670). Root-anchored so a
+# hypothetical nested `site/` package directory elsewhere stays
+# trackable.
+/site/
+
 # fastembed model snapshot pre-seeded into the backend Docker build context by
 # the chart.yml ``helm-test`` lane (restored from the unit lane's actions/cache
 # entry) so the model-bake layer skips the HuggingFace download (#1623). Only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,17 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — versioned documentation site scaffold (#2670)
+
+- Stand up the published docs site: MkDocs Material sources under
+  `docs-site/` (six-section navigation skeleton with stub pages; the
+  contributor `docs/` tree is untouched), mike-managed versioning (one
+  docs version per minor, `latest` alias), and a `docs-site.yml`
+  workflow that runs `mkdocs build --strict` on PRs and publishes to
+  GitHub Pages on every `v*` tag — the docs join the image / chart /
+  CLI as the fourth artefact a release tag publishes. README now links
+  the site as the primary documentation entry point. (#2670)
+
 ### Fixed — RKE2 posture reports an unreadable path honestly (#2698)
 
 - Stop `rke2.posture.show` reporting the RKE2 server join token **absent on

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@
 **Status:** Released — see the release badge above for the current version.
 The backplane image, Helm chart, and operator CLI are all shipped and cosign-signed.
 
+**Documentation:** <https://evoila.github.io/meho/> — the published,
+versioned docs site (install, client setup, task guides) and the primary
+entry point for operators. The `docs/` tree in this repo is the
+contributor-facing material behind it.
+
 ## The problem
 
 AI agents are getting good enough to *do* infrastructure work — roll a

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The backplane image, Helm chart, and operator CLI are all shipped and cosign-sig
 
 **Documentation:** <https://evoila.github.io/meho/> — the published,
 versioned docs site (install, client setup, task guides) and the primary
-entry point for operators. The `docs/` tree in this repo is the
-contributor-facing material behind it.
+entry point for operators. It builds from `docs-site/`; the `docs/` tree
+in this repo is separate, contributor-facing material.
 
 ## The problem
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -134,6 +134,15 @@ dev = [
     "testcontainers>=4.15.0",
     "types-jsonschema>=4.26.0.20260518",
 ]
+# Docs-site toolchain (#2670). Lives here — not in a separate docs
+# project — so the pins ride the existing uv.lock + Dependabot `uv`
+# ecosystem coverage. Non-default group: neither the Docker image
+# (`--no-dev`) nor a plain `uv sync` installs it; CI's docs job uses
+# `uv sync --locked --only-group docs`.
+docs = [
+    "mkdocs-material>=9.7.7",
+    "mike>=2.2.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -258,6 +258,28 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/56/4744bcd0c82184e80c52b0ac4076c261a8ffa1f1b343ff2f6e89ce0e1cef/backrefs-8.0.tar.gz", hash = "sha256:b556cd7d36c3a3a2f256b89590b176b8eddfb73bcfaee3a3ddd84ea66d21ce50", size = 7013081, upload-time = "2026-07-26T19:54:24.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/fd/9bf53b6a6f6f519ffaac765df2f2a25e5c2fc6d32cfd2b2747099e72c911/backrefs-8.0-py310-none-any.whl", hash = "sha256:4a627b817fd2dce43b79ab48da63613340509381cd8ce0897078a0bce79a2ab8", size = 380377, upload-time = "2026-07-26T19:54:17.457Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/29/4bd7ae72a2634da00379c2b3bcc5439e7c94620235c6afea8af15229a973/backrefs-8.0-py311-none-any.whl", hash = "sha256:f0c35cf0102ba6b6070c12a492be3c1c1d3f5839529784b9a9565d6d04569a01", size = 392169, upload-time = "2026-07-26T19:54:18.782Z" },
+    { url = "https://files.pythonhosted.org/packages/29/13/232505664e8e2a0c7a2eb0c505cfade9d715538f89a5d62bc4c272968f62/backrefs-8.0-py312-none-any.whl", hash = "sha256:87f0fae8c5f207fe9f4b2887efc71d42f4900ac78faa1af08d675ef303692dc5", size = 398084, upload-time = "2026-07-26T19:54:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/69/47a3dc20abc4fa5486655fde681bd55e63211b46c886d8c02223d6468431/backrefs-8.0-py313-none-any.whl", hash = "sha256:601ce68ca12385dbda06ce264406b4c4210cf5b79fd0fd627592365c92f29a88", size = 400040, upload-time = "2026-07-26T19:54:21.194Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/e5f9b68a5b0e939a2fb933a66c20180d0c9241bf8927f7a47fa48c1675e9/backrefs-8.0-py314-none-any.whl", hash = "sha256:9ec96efa080938be92323e8e730e57718c9c88eb15ad70bbef4e1766df591408", size = 411903, upload-time = "2026-07-26T19:54:23.221Z" },
+]
+
+[[package]]
 name = "blis"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -761,6 +783,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/7c/e8bdd653fb9b292a920b6568b3949176b8de98ad2f84fede2ce44bf318d9/genai_prices-0.0.70.tar.gz", hash = "sha256:62d495aa867bb360ea359866b01d89932365417ba3bd013e0ba7c1d884e09ef9", size = 81827, upload-time = "2026-07-07T18:11:03.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/34/09/02ec13cb9108862a514cf05ea10ff7f18e523698606ed2976e2cbfa484fa/genai_prices-0.0.70-py3-none-any.whl", hash = "sha256:c7cb9da4944860329450b086dad402f17237b7552165fd3b61b24e291d1ddb88", size = 84312, upload-time = "2026-07-07T18:11:02.373Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
 ]
 
 [[package]]
@@ -1301,6 +1335,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1418,6 +1461,10 @@ dev = [
     { name = "testcontainers" },
     { name = "types-jsonschema" },
 ]
+docs = [
+    { name = "mike" },
+    { name = "mkdocs-material" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1477,6 +1524,105 @@ dev = [
     { name = "ruff", specifier = ">=0.16.0" },
     { name = "testcontainers", specifier = ">=4.15.0" },
     { name = "types-jsonschema", specifier = ">=4.26.0.20260518" },
+]
+docs = [
+    { name = "mike", specifier = ">=2.2.0" },
+    { name = "mkdocs-material", specifier = ">=9.7.7" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
 ]
 
 [[package]]
@@ -1781,6 +1927,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pathable"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1864,6 +2019,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/18/f0/a5595c1e8c3ae44b9828cb2f0fa8155e5095ef04d6327b8f61cf44a3df85/pillow-12.3.0-cp315-cp315t-win32.whl", hash = "sha256:1657923d2d45afb66526e5b933e5b3052e6bdea196c90d3abb2424e18c77dae8", size = 6474384, upload-time = "2026-07-01T11:56:18.855Z" },
     { url = "https://files.pythonhosted.org/packages/e4/04/62bcd9f844984c5938d3b05264a61d797a29d3e0812341a8204af70bbdee/pillow-12.3.0-cp315-cp315t-win_amd64.whl", hash = "sha256:8cd2f7bdda092d99c9fc2fb7391354f306d01443d22785d0cbfafa2e2c8bb418", size = 7243537, upload-time = "2026-07-01T11:56:21.214Z" },
     { url = "https://files.pythonhosted.org/packages/3d/68/1f3066acedf37673694a7141381d8f811ae97f30d34413d236abe7d489f1/pillow-12.3.0-cp315-cp315t-win_arm64.whl", hash = "sha256:06ff022112bc9cbf83b60f8e028d94ad87b60621706487e65f673de61610ab59", size = 2567491, upload-time = "2026-07-01T11:56:23.506Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -2226,6 +2390,19 @@ crypto = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "11.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
 name = "pymongo"
 version = "4.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2266,6 +2443,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/b7/da07bae88f5a9506b4def6f2f4903cf4c3b8831e560dba8fa18ca08f758f/pyopenssl-26.3.0.tar.gz", hash = "sha256:589de7fae1c9ea670d18422ed00fc04da787bbde8e1454aea872aa57b49ad341", size = 182024, upload-time = "2026-06-12T20:28:07.458Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl", hash = "sha256:46367f8f66b92271e6d218da9c87607e1ef5a0bc5c8dea5bb3db82f395c385a3", size = 56008, upload-time = "2026-06-12T20:28:05.999Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -2399,6 +2585,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -3047,6 +3245,15 @@ wheels = [
 ]
 
 [[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
+]
+
+[[package]]
 name = "wasabi"
 version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3056,6 +3263,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/7c/34330a89da55610daa5f245ddce5aab81244321101614751e7537f125133/wasabi-1.1.3-py3-none-any.whl", hash = "sha256:f76e16e8f7e79f8c4c8be49b4024ac725713ab10cd7f19350ad18a8e3f71728c", size = 27880, upload-time = "2024-05-31T16:56:16.699Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]

--- a/docs-site/clients/index.md
+++ b/docs-site/clients/index.md
@@ -1,0 +1,16 @@
+# Connect clients
+
+!!! note "Stub — content tracked by [evoila/meho#2672](https://github.com/evoila/meho/issues/2672)"
+
+This section will cover connecting operators and agents to a running
+backplane — **CLI first**, then the MCP client matrix:
+
+- The `meho` CLI: static binary, `~/.config/meho/config.json`,
+  device-code login (works on private networks).
+- Claude Desktop / claude.ai Custom Connector (public-TLS path).
+- Claude Code (`.mcp.json` + PKCE).
+- The `mcp-remote` shim fallback.
+- The "4-wall" troubleshooting matrix for auth walls.
+
+Until it lands, the client-setup material lives in-repo:
+[`docs/cross-repo/mcp-client-setup.md`](https://github.com/evoila/meho/blob/main/docs/cross-repo/mcp-client-setup.md).

--- a/docs-site/guides/index.md
+++ b/docs-site/guides/index.md
@@ -1,0 +1,13 @@
+# Do real work
+
+!!! note "Stub — content tracked by [evoila/meho#2673](https://github.com/evoila/meho/issues/2673)"
+
+This section will carry task-oriented guides for operating real
+infrastructure through MEHO:
+
+- Register targets and secrets.
+- First operations: search → preview → call.
+- Approvals and break-glass.
+- Sensors quickstart.
+- Later: topology, broadcast, memory / knowledge, audit forensics,
+  runbooks, scheduler, satellite gateway.

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -1,0 +1,37 @@
+# Start here
+
+MEHO is a governance backplane for AI agents acting on infrastructure —
+policy-gated, audit-grade, MCP-native, Apache 2.0. It sits between MCP
+clients (Claude Desktop, Claude Code, Cursor, custom clients) and the
+infrastructure they operate against, so every operation passes through
+one governed seam: policy, just-in-time credentials, server-side result
+reduction, broadcast, and an immutable audit trail.
+
+!!! note "This site is under construction"
+
+    The scaffold you are looking at is live and versioned, but the
+    content is still being migrated. Each section below names what will
+    live there and links the task tracking it.
+
+## What this section will cover
+
+Tracked by [evoila/meho#2671](https://github.com/evoila/meho/issues/2671):
+
+- **What MEHO is** — the problem it solves and what it guarantees.
+- **Reference architecture** — backplane, Keycloak, Postgres + pgvector,
+  Valkey, Vault / Google Secret Manager, targets and connectors, agents
+  via MCP, operators via CLI and UI, satellite gateway.
+- **What 1.0 promises** — the honestly-scoped stability contract.
+
+## The site at a glance
+
+| Section | What will live there | Tracked by |
+|---|---|---|
+| [Install & operate](install/index.md) | Prerequisites, Helm install, credential backends, Keycloak realm setup, TLS, upgrades | [#2671](https://github.com/evoila/meho/issues/2671) |
+| [Connect clients](clients/index.md) | CLI first, then the MCP client matrix and troubleshooting | [#2672](https://github.com/evoila/meho/issues/2672) |
+| [Do real work](guides/index.md) | Task guides: targets & secrets, first operations, sensors | [#2673](https://github.com/evoila/meho/issues/2673) |
+| [Reference](reference/index.md) | Generated: MCP tools, REST API, CLI, env vars, Helm values, connector catalog | [#2662](https://github.com/evoila/meho/issues/2662) |
+| [Project](project/index.md) | Versioning & deprecation policy, feature maturity, security policy | [#2664](https://github.com/evoila/meho/issues/2664) |
+
+In the meantime, the in-repo material remains the source of truth:
+[github.com/evoila/meho](https://github.com/evoila/meho).

--- a/docs-site/install/index.md
+++ b/docs-site/install/index.md
@@ -1,0 +1,18 @@
+# Install & operate
+
+!!! note "Stub — content tracked by [evoila/meho#2671](https://github.com/evoila/meho/issues/2671)"
+
+This section will carry a **single continuous install trail** from
+empty cluster to running backplane, plus day-2 operation:
+
+- Prerequisites and sizing.
+- Helm install (chart at `oci://ghcr.io/evoila/meho-chart`).
+- Credential-backend decision: Vault vs Google Secret Manager.
+- Keycloak realm setup — bootstrap automation and the manual reference.
+- TLS and ingress.
+- Upgrades, backup / restore, observability.
+
+Until it lands, the install material lives in-repo:
+[`docs/deploying.md`](https://github.com/evoila/meho/blob/main/docs/deploying.md)
+and
+[`deploy/values-examples/`](https://github.com/evoila/meho/tree/main/deploy/values-examples).

--- a/docs-site/project/index.md
+++ b/docs-site/project/index.md
@@ -1,0 +1,17 @@
+# Project
+
+!!! note "Stub — feature-maturity program tracked by [evoila/meho#2664](https://github.com/evoila/meho/issues/2664)"
+
+This section will document how the project itself is run:
+
+- Versioning and deprecation policy.
+- Feature-maturity index — what is GA, Beta, Experimental, and each
+  non-GA surface's road to GA.
+- Security policy and coordinated disclosure
+  ([`SECURITY.md`](https://github.com/evoila/meho/blob/main/SECURITY.md)).
+- Roadmap.
+
+Until it lands:
+[`CONTRIBUTING.md`](https://github.com/evoila/meho/blob/main/CONTRIBUTING.md)
+and the
+[release history](https://github.com/evoila/meho/releases).

--- a/docs-site/reference/index.md
+++ b/docs-site/reference/index.md
@@ -1,0 +1,16 @@
+# Reference
+
+!!! note "Stub — generated reference lands with the contract-freeze work, [evoila/meho#2662](https://github.com/evoila/meho/issues/2662)"
+
+This section will be **generated from contract snapshots**, so it
+cannot drift from the product without a red build:
+
+- MCP tools — from the `tools/list` snapshot.
+- REST API — from the public OpenAPI snapshot.
+- CLI — from the server-driven command manifest.
+- Environment variables — from the backplane settings model.
+- Helm values — from `values.schema.json`.
+- Connector catalog — with per-connector maturity badges.
+
+It is deliberately not stubbed further: the pages appear when the
+snapshot tooling exists (v0.29 per the roadmap).

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -12,7 +12,7 @@ The `/release` skill walks these same steps interactively.
 ## What a release is
 
 A release is **a `v*` git tag**. The tag is the single source of truth
-for the version — three artefacts derive from it, all published
+for the version — four artefacts derive from it, all published
 automatically on the tag push:
 
 | Artefact | Where | Workflow | Version source |
@@ -20,10 +20,12 @@ automatically on the tag push:
 | Backplane image | `ghcr.io/evoila/meho:vX.Y.Z` | [`image.yml`](../.github/workflows/image.yml) | git tag |
 | Helm chart | `oci://ghcr.io/evoila/meho-chart` | [`chart.yml`](../.github/workflows/chart.yml) | chart workflow sets `version` + `appVersion` |
 | CLI tarballs + GitHub Release | [releases](https://github.com/evoila/meho/releases) | [`cli-release.yml`](../.github/workflows/cli-release.yml) | GoReleaser bakes `{{.Tag}}` into `version.Version` |
+| Docs site version | <https://evoila.github.io/meho/> | [`docs-site.yml`](../.github/workflows/docs-site.yml) | mike publishes the tag's `MAJOR.MINOR` + moves `latest` |
 
-All three trigger on `tags: ['v*']` (image/chart have **no** path filter
+All four trigger on `tags: ['v*']` (image/chart have **no** path filter
 on tags — a tag always publishes). `cli-release.yml` is **tag-only**: a
-main push never cuts a release.
+main push never cuts a release. Docs versions are cut **per minor** — a
+patch tag republishes its minor's docs in place.
 
 ## Versioning
 

--- a/docs/codebase/docs-site.md
+++ b/docs/codebase/docs-site.md
@@ -1,0 +1,109 @@
+# Docs site (MkDocs Material + mike)
+
+## Overview
+
+MEHO's published documentation site — <https://evoila.github.io/meho/>
+— is built with MkDocs Material from sources under `docs-site/` and
+versioned with [mike](https://github.com/jimporter/mike) on the
+`gh-pages` branch, which GitHub Pages serves. It was scaffolded by
+#2670 (initiative #2663); content migrates in under #2671 (start-here +
+install), #2672 (connect clients), and #2673 (do-real-work guides). The
+generated reference section lands with the #2662 contract snapshots.
+
+The site is the *operator/adopter-facing* documentation. The `docs/`
+tree (this directory's parent) remains the contributor-facing material
+and is deliberately not the site's source: pointing MkDocs at `docs/`
+would drag every internal walkthrough through the strict build and
+force nav curation of files that were never written for outsiders.
+
+## Key pieces
+
+| Piece | Where | Role |
+|---|---|---|
+| `mkdocs.yml` | repo root | Site config: Material theme (light/dark toggle), strict mode, nav skeleton, mike version provider |
+| `docs-site/` | repo root | Page sources; one directory per top-level nav section, `index.md` each |
+| `.github/workflows/docs-site.yml` | workflows | PR check (`mkdocs build --strict`) + tag-push deploy (mike → gh-pages) |
+| `backend/pyproject.toml` `[dependency-groups].docs` | backend | Locked toolchain pins (mkdocs-material, mike) riding `uv.lock` + Dependabot |
+| `gh-pages` branch | remote only | mike-managed publish target; never edited by hand |
+
+## Versioning model
+
+One docs version **per minor**, with a `latest` alias:
+
+- Tag `v0.26.3` → mike deploys version `0.26` and re-points `latest`
+  (`mike deploy --push --update-aliases 0.26 latest`).
+- A patch tag republishes its minor's docs in place — no per-patch
+  versions.
+- `mike set-default --push latest` keeps the site root redirecting to
+  the newest docs.
+- Material's version selector is enabled via `extra.version.provider:
+  mike` in `mkdocs.yml`; it reads mike's `versions.json` on gh-pages.
+- Pre-release tags (`v1.0.0-rc.1`) deploy under their minor (`1.0`) —
+  the rc docs are that minor's docs in progress.
+
+## Control flow (deploy)
+
+1. `v*` tag push triggers the `deploy` job (`docs-site.yml`).
+2. Job fetches `gh-pages` if it exists (mike commits onto the local
+   ref), configures the `github-actions[bot]` committer identity, and
+   installs the locked toolchain via `uv sync --locked --only-group
+   docs` in `backend/`.
+3. `mike deploy` builds the site (strict — `strict: true` in
+   `mkdocs.yml` applies to mike's internal build too) and pushes the
+   version + alias to `gh-pages`.
+4. GitHub Pages serves the branch. A job-level concurrency group
+   (`docs-site-gh-pages`, no cancel) serialises publishes so two tags
+   can't race the branch update.
+
+PRs touching the site (or the toolchain lock) get a `mkdocs build
+--strict` check instead; nothing deploys from PRs or main pushes.
+
+## Local development
+
+```bash
+cd backend && uv sync --locked --only-group docs && cd ..
+uv run --project backend --no-sync mkdocs serve   # live-reload preview
+uv run --project backend --no-sync mkdocs build --strict
+```
+
+`site/` (the build output) is gitignored.
+
+## Embedding contributor docs without moving them
+
+`pymdownx.snippets` is configured with the repo root on its
+`base_path`, so a site page can embed a contributor file in place:
+
+```markdown
+--8<-- "docs/deploying.md"
+```
+
+Use this when promoting existing material (e.g. `docs/deploying.md`,
+`docs/cross-repo/mcp-client-setup.md`) so the in-repo file stays the
+single source of truth. `check_paths: true` makes a missing snippet a
+build failure, not a silent empty include.
+
+## One-time setup
+
+GitHub Pages must be enabled once by a maintainer (CI cannot safely
+mutate repo settings — same custody rule as image.yml's GHCR
+visibility flip): **Settings → Pages → Deploy from a branch →
+`gh-pages` / root**. The branch exists after the first tag-triggered
+deploy.
+
+## Known issues / gotchas
+
+- `mkdocs.yml` is strict: a page not referenced in `nav`, or any
+  broken internal link, fails the build. Add new pages to `nav`.
+- The deploy job needs the `workflow`-scoped credential story only at
+  *merge* time (the file under `.github/workflows/` requires the
+  `workflow` OAuth scope to push).
+- mike owns `gh-pages` entirely — manual commits there will be
+  clobbered or cause non-fast-forward failures.
+
+## References
+
+- Initiative #2663 (information architecture), goal #2661.
+- `docs/RELEASING.md` — the docs site is the fourth tag-published
+  artefact.
+- mkdocs-material versioning guide:
+  <https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/>

--- a/docs/codebase/docs-site.md
+++ b/docs/codebase/docs-site.md
@@ -5,9 +5,10 @@
 MEHO's published documentation site — <https://evoila.github.io/meho/>
 — is built with MkDocs Material from sources under `docs-site/` and
 versioned with [mike](https://github.com/jimporter/mike) on the
-`gh-pages` branch, which GitHub Pages serves. It was scaffolded by
-#2670 (initiative #2663); content migrates in under #2671 (start-here +
-install), #2672 (connect clients), and #2673 (do-real-work guides). The
+`gh-pages` branch, which GitHub Pages serves. The scaffold landed with
+task #2670 (initiative #2663); content migrates in under #2671
+(start-here + install), #2672 (connect clients), and #2673
+(do-real-work guides). The
 generated reference section lands with the #2662 contract snapshots.
 
 The site is the *operator/adopter-facing* documentation. The `docs/`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,79 @@
+# MEHO published documentation site (#2670).
+#
+# Sources live in `docs-site/` — deliberately NOT `docs/`, which is the
+# contributor-facing tree (codebase walkthroughs, ADRs, runbooks) and
+# stays where it is. Selected contributor files can be embedded into
+# site pages without moving them via the `pymdownx.snippets` extension
+# (its `base_path` includes the repo root, so a page can do
+# `--8<-- "docs/deploying.md"` when a sibling task promotes content).
+#
+# Versioning is mike-managed (one docs version per minor, `latest`
+# alias); `.github/workflows/docs-site.yml` deploys on `v*` tag push
+# and runs `mkdocs build --strict` on PRs. `strict: true` below makes
+# every build — including mike's — fail on warnings (broken links,
+# pages missing from nav), so docs rot turns into a red build.
+
+site_name: MEHO
+site_description: >-
+  Governance backplane for AI agents acting on infrastructure —
+  policy-gated, audit-grade, MCP-native.
+site_url: https://evoila.github.io/meho/
+repo_url: https://github.com/evoila/meho
+repo_name: evoila/meho
+edit_uri: edit/main/docs-site/
+docs_dir: docs-site
+copyright: Copyright &copy; 2026 evoila Group — Apache 2.0
+
+strict: true
+
+theme:
+  name: material
+  palette:
+    # Light / dark toggle, following the OS preference on first visit.
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.footer
+    - navigation.top
+    - content.code.copy
+    - content.action.edit
+
+nav:
+  - Start here: index.md
+  - Install & operate: install/index.md
+  - Connect clients: clients/index.md
+  - Do real work: guides/index.md
+  - Reference: reference/index.md
+  - Project: project/index.md
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - pymdownx.superfences
+  - pymdownx.snippets:
+      # Repo root first so site pages can embed selected contributor
+      # files (e.g. `docs/deploying.md`) in place, without moving them.
+      base_path:
+        - .
+        - docs-site
+      check_paths: true
+
+plugins:
+  - search
+  - mike
+
+extra:
+  version:
+    # Renders Material's version selector, fed by mike's version index
+    # on the gh-pages branch.
+    provider: mike


### PR DESCRIPTION
## Summary

- Stands up the docs-site machinery from #2670: MkDocs Material sources under `docs-site/` with the six-section navigation skeleton (Start here / Install & operate / Connect clients / Do real work / Reference / Project), each stub naming what will live there and linking its tracking task. The contributor `docs/` tree is untouched; future content can embed existing files in place via `pymdownx.snippets` (repo root on `base_path`).
- mike-managed versioning: one docs version per minor, `latest` alias, published to the `gh-pages` branch. New `.github/workflows/docs-site.yml` runs `mkdocs build --strict` as a PR check and deploys on every `v*` tag — the docs become the fourth tag-published artefact (RELEASING.md table updated).
- Toolchain pins live in a non-default `docs` dependency group in `backend/pyproject.toml`, riding the existing `uv.lock` + Dependabot `uv` coverage (no second Python project). Docker image (`--no-dev`) and plain `uv sync` are unaffected; CI's `--all-groups` sync gains ~15 small pure-Python wheels.
- README links the site as the primary documentation entry point; `docs/codebase/docs-site.md` documents the machinery; CHANGELOG `[Unreleased]` entry added under its own `###` header.

## One-time follow-up after merge

GitHub Pages is not yet enabled on the repo (verified: `gh api repos/evoila/meho/pages` → 404). After the first tag-triggered deploy creates `gh-pages`, a maintainer enables **Settings → Pages → Deploy from a branch → `gh-pages` / root** (same one-time custody rule as image.yml's GHCR visibility flip; documented in the workflow header and `docs/codebase/docs-site.md`).

## Test plan

- [x] `uv lock` — additive-only (docs-group packages; no unrelated pin moves)
- [x] `uv sync --locked --only-group docs` — resolves on py3.14; prunes to docs toolchain only (what the CI job runs)
- [x] `uv run --project backend --no-sync mkdocs build --strict` — clean (six-section nav renders, no warnings)
- [x] Local `mike deploy --update-aliases 0.0 latest` smoke (no push) — version + alias committed to a local `gh-pages`, verified via `mike list`, branch deleted after
- [x] `ruff check` / `ruff format --check` — clean; `mypy src/` — only the pre-existing macOS-local `socket.MSG_ERRQUEUE` artifact (Linux-only attr; green in CI)
- [x] pytest smoke subset (settings/health/ci-checks: 93 passed) — no Python code changed; full sweep runs in CI
- [x] code-quality gate (`--diff`) — pass
- [x] No existing `docs/` file moved or modified except `docs/RELEASING.md` (table row) and the new `docs/codebase/docs-site.md`

## Out of scope

- All real content: #2671 (start-here + install), #2672 (connect clients), #2673 (do-real-work guides); generated reference lands with #2662 at v0.29.
- Making the `docs-site` check required in branch protection (workflow already fires on `merge_group` so it can be flipped later).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2670


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a versioned documentation site with installation, client, guides, project, and reference sections.
  * Added documentation version publishing for releases, including minor-version tracking and a `latest` version.
  * Added links to the documentation site from the README.

* **Documentation**
  * Added guidance for building, deploying, and contributing to the documentation site.
  * Expanded release documentation to cover documentation site publishing.
  * Added initial documentation section outlines and project information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-07-30)

Addressed review findings from the iteration-1 auto-review (review id 4821698005):

- **m1** `b67f6e4f` — deploy tag guard now requires a full vMAJOR.MINOR prefix; malformed tags fail loudly instead of publishing a garbage docs version
- **m2** `9a590249` — README names `docs-site/` as the published site's source; `docs/` described as separate contributor material
- **m3** `5a2666df` — `docs/codebase/docs-site.md` reflowed so the issue reference no longer opens a line (MD018 trap)

Disputed (see inline replies):

- **Copilot / gh-pages fetch** — mike 2.2.0 `update_from_upstream` syncs the local `gh-pages` ref from `origin/gh-pages`; the bare fetch is mike's documented CI recipe
- **CodeRabbit / paths-filter** — check is not required today; `readme-version-check.yml` is the repo's precedent for a required path-filtered check with a bare `merge_group` trigger

<!-- auto-implement-issue: continue, iteration 1 -->
