### PR TITLE
feat(backplane): feature-maturity registry with maturity/target_ga/tracking — single source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — feature-maturity registry: the single source of truth (#2674)
+
+- Extend `backend/src/meho_backplane/features.py` into the single
+  source of truth for feature maturity (#2664): `FEATURE_MATURITY`
+  classifies every user-facing feature as **GA / Beta / Experimental**
+  and, on non-GA entries, carries the `target_ga` milestone and the
+  `tracking` issue URL where its road to promotion lives. `/ready`'s
+  existing feature-gate entries now render the merged maturity fields
+  (additive — pre-existing fields are untouched). The classification
+  is the provisional #2664 table, pending clean-room eval round 1;
+  retiering a feature is a one-line registry edit that every labelled
+  surface (MCP #2675, CLI #2676, /ui #2677, docs #2678) will inherit.
+  (#2674)
+
 ### Added — versioned documentation site scaffold (#2670)
 
 - Stand up the published docs site: MkDocs Material sources under

--- a/backend/src/meho_backplane/features.py
+++ b/backend/src/meho_backplane/features.py
@@ -49,21 +49,23 @@ This module is also the **single source of truth for feature
 maturity** (#2664): :data:`FEATURE_MATURITY` maps every user-facing
 MEHO feature to its tier — ``ga`` / ``beta`` / ``experimental`` — plus,
 on non-GA entries, the ``target_ga`` milestone and the ``tracking``
-issue URL. Every maturity-labelled surface derives from this one dict:
+issue URL. Every maturity-labelled surface derives from this one dict.
+``/ready`` — the deploy-gate entries this module already emits merge
+the maturity fields in (see :data:`_READY_ENTRY_FEATURE`) — is the
+only consumer shipped so far; the remaining #2664 surfaces are
+planned, not yet implemented:
 
-* ``/ready`` — the deploy-gate entries this module already emits merge
-  the maturity fields in (see :data:`_READY_ENTRY_FEATURE`).
 * MCP tool-description prefixes + ``initialize.instructions`` summary
   and the OpenAPI ``x-maturity`` extension (#2675).
 * The CLI command-manifest ``maturity`` field (#2676).
 * The ``/ui`` area-header badge chips (#2677).
 * The generated docs maturity-index page + CI drift guard (#2678).
 
-Those consumers **import this module** (server-side render, tool
-registration, docs build) — deliberately no dedicated REST read
-surface: the smallest thing that serves every #2664 consumer is the
-module itself, and ``/ready`` already carries the merged view for
-operator tooling.
+Those planned consumers **will import this module** (server-side
+render, tool registration, docs build) — deliberately no dedicated
+REST read surface: the smallest thing that serves every #2664
+consumer is the module itself, and ``/ready`` already carries the
+merged view for operator tooling.
 
 Reclassifying a feature (the v0.28 post-eval round, Goal #2661) is a
 one-line data edit in :data:`FEATURE_MATURITY`; no surface-specific

--- a/backend/src/meho_backplane/features.py
+++ b/backend/src/meho_backplane/features.py
@@ -42,6 +42,38 @@ The audit-replay entry additionally exposes ``capture_mode`` —
 enforcement, ``"always"`` after. The shape is forward-compatible: T6
 flips this from ``"enforced"`` to ``"always"`` and adds nothing else.
 
+Feature-maturity registry (#2674)
+---------------------------------
+
+This module is also the **single source of truth for feature
+maturity** (#2664): :data:`FEATURE_MATURITY` maps every user-facing
+MEHO feature to its tier — ``ga`` / ``beta`` / ``experimental`` — plus,
+on non-GA entries, the ``target_ga`` milestone and the ``tracking``
+issue URL. Every maturity-labelled surface derives from this one dict:
+
+* ``/ready`` — the deploy-gate entries this module already emits merge
+  the maturity fields in (see :data:`_READY_ENTRY_FEATURE`).
+* MCP tool-description prefixes + ``initialize.instructions`` summary
+  and the OpenAPI ``x-maturity`` extension (#2675).
+* The CLI command-manifest ``maturity`` field (#2676).
+* The ``/ui`` area-header badge chips (#2677).
+* The generated docs maturity-index page + CI drift guard (#2678).
+
+Those consumers **import this module** (server-side render, tool
+registration, docs build) — deliberately no dedicated REST read
+surface: the smallest thing that serves every #2664 consumer is the
+module itself, and ``/ready`` already carries the merged view for
+operator tooling.
+
+Reclassifying a feature (the v0.28 post-eval round, Goal #2661) is a
+one-line data edit in :data:`FEATURE_MATURITY`; no surface-specific
+edits anywhere. The classification encoded here is the **provisional**
+one tabled in #2664, pending clean-room eval round 1 (#2665). Tier
+semantics (#2664 entry criteria): ``ga`` features carry the 1.0
+stability promise; ``beta`` works end-to-end somewhere real with known,
+tracked gaps and may change with deprecation notice; ``experimental``
+may change or vanish and sits outside the 1.0 promise.
+
 The module is **pure** — it reads :class:`~meho_backplane.settings.Settings`
 and returns a plain :class:`dict`. No I/O, no settings cache mutation,
 no environment lookup. Callers that need to test against a synthetic
@@ -61,15 +93,145 @@ References
   diagnostic-values + remediation + doc-reference shape.
 * Sibling: G0.14-T6 (#1147) flips ``audit_replay.capture_mode`` from
   ``"enforced"`` to ``"always"`` once it lands.
+* Maturity program: #2664 (initiative — classification table + entry
+  criteria), #2674 (this registry), #2675-#2678 (surface propagation),
+  Goal #2661 milestone plan (v0.28 reclassification, v1.0.0 GA set).
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal, NotRequired, TypedDict
 
 from meho_backplane.settings import Settings
 
-__all__ = ["build_features_block"]
+__all__ = [
+    "FEATURE_MATURITY",
+    "Maturity",
+    "MaturityInfo",
+    "build_features_block",
+]
+
+Maturity = Literal["ga", "beta", "experimental"]
+
+_TRACKER = "https://github.com/evoila/meho/issues"
+
+
+class MaturityInfo(TypedDict):
+    """One :data:`FEATURE_MATURITY` entry.
+
+    ``target_ga`` and ``tracking`` are present on non-GA entries only
+    (mirroring how ``docs`` is present only where a setup doc exists).
+    ``target_ga`` may be ``None`` on ``experimental`` entries: those sit
+    outside the 1.0 promise (#2664 entry criteria; several are explicit
+    1.0 non-goals in #2661), so advertising a committed milestone would
+    overstate exactly the way this program exists to prevent.
+    """
+
+    maturity: Maturity
+    target_ga: NotRequired[str | None]
+    tracking: NotRequired[str]
+
+
+#: The provisional #2664 classification. Keys are the canonical feature
+#: identifiers every surface (#2675-#2678) maps its tools / routes /
+#: commands / UI areas onto. Renaming a key is a cross-surface break;
+#: retiering one is a one-line edit here and nowhere else.
+#:
+#: ``tracking`` points at the open issue where the feature's road to
+#: promotion is visible today: the concrete gap issue where one exists
+#: (#2668 background-execution credential identity for sensors and the
+#: scheduler, #2667 first-class GSM chart values, #2656 the v0.25.0
+#: hosted-agent-run hardening line), the clean-room eval (#2665) for
+#: beta features whose promotion gate is the eval score itself, and the
+#: 1.0 Goal (#2661, which schedules the v0.28 re-triage) for
+#: experimental features with no committed path.
+FEATURE_MATURITY: dict[str, MaturityInfo] = {
+    # GA-track (provisional): the read/governance/knowledge plane the
+    # 2026-07-21 grounding review found provably working in the field.
+    "audit": {"maturity": "ga"},
+    "memory_knowledge": {"maturity": "ga"},
+    "targets": {"maturity": "ga"},
+    "typed_connector_reads": {"maturity": "ga"},
+    "net_diagnostics": {"maturity": "ga"},
+    "approvals": {"maturity": "ga"},
+    "auth_tenancy": {"maturity": "ga"},
+    # Beta: works end-to-end somewhere real; gaps known and tracked.
+    "sensors": {
+        "maturity": "beta",
+        "target_ga": "v1.0.0",
+        "tracking": f"{_TRACKER}/2668",
+    },
+    "topology": {
+        "maturity": "beta",
+        "target_ga": "v1.0.0",
+        "tracking": f"{_TRACKER}/2665",
+    },
+    "broadcast": {
+        "maturity": "beta",
+        "target_ga": "v1.0.0",
+        "tracking": f"{_TRACKER}/2665",
+    },
+    "scheduler": {
+        "maturity": "beta",
+        "target_ga": "v1.0.0",
+        "tracking": f"{_TRACKER}/2668",
+    },
+    "ui_console": {
+        "maturity": "beta",
+        "target_ga": "v1.0.0",
+        "tracking": f"{_TRACKER}/2665",
+    },
+    "write_surfaces": {
+        "maturity": "beta",
+        "target_ga": "v1.0.0",
+        "tracking": f"{_TRACKER}/2665",
+    },
+    "gsm_backend": {
+        "maturity": "beta",
+        "target_ga": "v1.0.0",
+        "tracking": f"{_TRACKER}/2667",
+    },
+    "satellite_gateway": {
+        "maturity": "beta",
+        "target_ga": "v1.0.0",
+        "tracking": f"{_TRACKER}/2665",
+    },
+    # Experimental: may change or vanish; outside the 1.0 promise.
+    "connector_ingest": {
+        "maturity": "experimental",
+        "target_ga": None,
+        "tracking": f"{_TRACKER}/2661",
+    },
+    "agent_runtime": {
+        "maturity": "experimental",
+        "target_ga": None,
+        "tracking": f"{_TRACKER}/2656",
+    },
+    "doc_collections": {
+        "maturity": "experimental",
+        "target_ga": None,
+        "tracking": f"{_TRACKER}/2661",
+    },
+    "two_world_ops": {
+        "maturity": "experimental",
+        "target_ga": None,
+        "tracking": f"{_TRACKER}/2661",
+    },
+}
+
+#: Which ``/ready`` entry maps to which :data:`FEATURE_MATURITY` key.
+#: The block keys are deploy-gate names (what needs wiring); the
+#: registry keys are feature names (what carries a promise) — they
+#: coincide only for ``agent_runtime``. The ``mcp`` entry is absent by
+#: design: it reports a build-time protocol constant, not a classified
+#: feature — individual MCP tools inherit maturity from their owning
+#: feature at registration time (#2675).
+_READY_ENTRY_FEATURE: dict[str, str] = {
+    "agent_runtime": "agent_runtime",
+    "ui_surface": "ui_console",
+    "audit_replay": "audit",
+    "approval_queue": "approvals",
+}
 
 
 def _agent_runtime_block(settings: Settings) -> dict[str, Any]:
@@ -279,24 +441,40 @@ def build_features_block(settings: Settings) -> dict[str, dict[str, Any]]:
     enablement section; renaming one is a wire-compat break for
     operator tooling that reads ``/ready``.
 
+    Every entry with a :data:`_READY_ENTRY_FEATURE` mapping additionally
+    carries the merged :data:`FEATURE_MATURITY` fields (#2674):
+    ``maturity`` always, plus ``target_ga`` / ``tracking`` on non-GA
+    features. The ``mcp`` entry carries none — see
+    :data:`_READY_ENTRY_FEATURE` for why. Additive only: operator
+    tooling keyed on the pre-#2674 fields is unaffected.
+
     Shape (verified by the issue body):
 
     .. code-block:: json
 
         {
-          "agent_runtime":  {"configured": <bool>, "missing_env": [...], "docs": "..."},
-          "ui_surface":     {"configured": <bool>, "missing_env": [...], "docs": "..."},
-          "audit_replay":   {"configured": true,   "capture_mode": "...", "missing_env": []},
+          "agent_runtime":  {"configured": <bool>, "missing_env": [...], "docs": "...",
+                             "maturity": "experimental", "target_ga": null,
+                             "tracking": "https://github.com/evoila/meho/issues/2656"},
+          "ui_surface":     {"configured": <bool>, "missing_env": [...], "docs": "...",
+                             "maturity": "beta", "target_ga": "v1.0.0",
+                             "tracking": "https://github.com/evoila/meho/issues/2665"},
+          "audit_replay":   {"configured": true,   "capture_mode": "...", "missing_env": [],
+                             "maturity": "ga"},
           "approval_queue": {"configured": <bool>, "depends_on": "agent_runtime",
                              "effective_posture": "four_eyes_enforced" |
-                                                  "single_operator_break_glass"},
+                                                  "single_operator_break_glass",
+                             "maturity": "ga"},
           "mcp":            {"configured": true,   "protocol_version": "...", "missing_env": []}
         }
     """
-    return {
+    block: dict[str, dict[str, Any]] = {
         "agent_runtime": _agent_runtime_block(settings),
         "ui_surface": _ui_surface_block(settings),
         "audit_replay": _audit_replay_block(),
         "approval_queue": _approval_queue_block(settings),
         "mcp": _mcp_block(),
     }
+    for entry_name, feature_key in _READY_ENTRY_FEATURE.items():
+        block[entry_name].update(FEATURE_MATURITY[feature_key])
+    return block

--- a/backend/tests/test_features.py
+++ b/backend/tests/test_features.py
@@ -37,7 +37,11 @@ from typing import Any
 
 import pytest
 
-from meho_backplane.features import FEATURE_MATURITY, build_features_block
+from meho_backplane.features import (
+    _READY_ENTRY_FEATURE,
+    FEATURE_MATURITY,
+    build_features_block,
+)
 from meho_backplane.settings import Settings
 
 
@@ -359,6 +363,18 @@ READY_ENTRY_FEATURE_CONTRACT = {
 }
 
 _ISSUE_URL_RE = re.compile(r"^https://github\.com/evoila/meho/issues/\d+$")
+
+
+def test_ready_entry_mapping_matches_the_contract() -> None:
+    """The module's mapping is the pinned contract, key for key.
+
+    The merge tests below derive their expectations from the mapping's
+    *values*, so a silent remap between value-identical registry
+    entries (``audit``/``approvals`` today; the #2665-tracked beta
+    group) would still pass them. Comparing the dicts directly pins
+    the mapping itself.
+    """
+    assert _READY_ENTRY_FEATURE == READY_ENTRY_FEATURE_CONTRACT
 
 
 def test_maturity_registry_covers_the_2664_classification() -> None:

--- a/backend/tests/test_features.py
+++ b/backend/tests/test_features.py
@@ -22,15 +22,22 @@ Coverage matrix (G0.14-T7 #1148):
   ``Settings.approval_allow_self_approval``: ``four_eyes_enforced``
   by default, ``single_operator_break_glass`` under the emergency
   ``APPROVAL_ALLOW_SELF_APPROVAL=true`` escape.
+* The feature-maturity registry (#2674) covers the #2664 propagation
+  plan, honours the tier-conditional field contract, merges into the
+  mapped ``/ready`` entries, and never leaks mutable state. Tier
+  values are asserted **structurally only** — reclassification must
+  remain a one-line registry edit.
 """
 
 from __future__ import annotations
 
+import copy
+import re
 from typing import Any
 
 import pytest
 
-from meho_backplane.features import build_features_block
+from meho_backplane.features import FEATURE_MATURITY, build_features_block
 from meho_backplane.settings import Settings
 
 
@@ -330,3 +337,155 @@ def test_every_feature_has_configured_bool(feature: str) -> None:
     """Each entry carries a ``configured: bool`` — the load-bearing field."""
     block = build_features_block(_settings_with())
     assert isinstance(block[feature]["configured"], bool)
+
+
+# ---------------------------------------------------------------------------
+# Feature-maturity registry (#2674)
+# ---------------------------------------------------------------------------
+
+# The /ready-entry → registry-key mapping is a wire contract: #2675-#2678
+# key their surface mappings on the registry names, and operator tooling
+# reads the merged fields off these /ready entries. Pinned here (rather
+# than imported from the module) so remapping an entry is a deliberate
+# two-touch change. Tier values are deliberately NOT pinned anywhere in
+# this file — reclassification must stay a one-line registry edit
+# (#2674 acceptance criterion), so every tier expectation below derives
+# from ``FEATURE_MATURITY`` itself.
+READY_ENTRY_FEATURE_CONTRACT = {
+    "agent_runtime": "agent_runtime",
+    "ui_surface": "ui_console",
+    "audit_replay": "audit",
+    "approval_queue": "approvals",
+}
+
+_ISSUE_URL_RE = re.compile(r"^https://github\.com/evoila/meho/issues/\d+$")
+
+
+def test_maturity_registry_covers_the_2664_classification() -> None:
+    """Every feature in the #2664 propagation plan has a registry entry.
+
+    The key set is the cross-surface contract: MCP tools (#2675), CLI
+    commands (#2676), /ui areas (#2677), and the docs index / drift
+    guard (#2678) all map onto these names. Renaming or dropping a key
+    breaks every consumer at once — this pin catches it at test time.
+    Adding a feature is an additive change here and in the registry.
+    """
+    assert set(FEATURE_MATURITY.keys()) == {
+        # GA-track
+        "audit",
+        "memory_knowledge",
+        "targets",
+        "typed_connector_reads",
+        "net_diagnostics",
+        "approvals",
+        "auth_tenancy",
+        # Beta
+        "sensors",
+        "topology",
+        "broadcast",
+        "scheduler",
+        "ui_console",
+        "write_surfaces",
+        "gsm_backend",
+        "satellite_gateway",
+        # Experimental
+        "connector_ingest",
+        "agent_runtime",
+        "doc_collections",
+        "two_world_ops",
+    }
+
+
+@pytest.mark.parametrize("feature_key", sorted(FEATURE_MATURITY.keys()))
+def test_registry_entry_shape(feature_key: str) -> None:
+    """Each entry honours the tier-conditional field contract.
+
+    * ``maturity`` is one of the three tiers.
+    * GA entries carry **neither** ``target_ga`` nor ``tracking`` —
+      same absent-not-null convention as ``docs`` on the /ready gates.
+    * Non-GA entries carry both: ``tracking`` is a concrete
+      ``evoila/meho`` issue URL (the road-to-promotion pointer #2678
+      renders), ``target_ga`` is a milestone string on beta entries
+      and may be ``None`` only on experimental ones (outside the 1.0
+      promise — no committed milestone to advertise).
+    """
+    entry = FEATURE_MATURITY[feature_key]
+    maturity = entry["maturity"]
+    assert maturity in {"ga", "beta", "experimental"}
+
+    if maturity == "ga":
+        assert "target_ga" not in entry
+        assert "tracking" not in entry
+        return
+
+    assert _ISSUE_URL_RE.match(entry["tracking"]), (
+        f"{feature_key}: tracking must be an evoila/meho issue URL, got {entry.get('tracking')!r}"
+    )
+    assert "target_ga" in entry
+    if maturity == "beta":
+        assert isinstance(entry["target_ga"], str) and entry["target_ga"]
+    else:
+        assert entry["target_ga"] is None or (
+            isinstance(entry["target_ga"], str) and entry["target_ga"]
+        )
+
+
+@pytest.mark.parametrize(
+    ("entry_name", "feature_key"),
+    sorted(READY_ENTRY_FEATURE_CONTRACT.items()),
+)
+def test_ready_entry_merges_registry_maturity_fields(entry_name: str, feature_key: str) -> None:
+    """Each mapped /ready entry renders its feature's maturity fields.
+
+    Expectations derive from the registry, not from hardcoded tiers:
+    retiering a feature must flip this surface with zero test edits.
+    The merge is exactly the registry entry — no extra fields, no
+    dropped fields.
+    """
+    block = build_features_block(_settings_with())
+    entry = block[entry_name]
+    for field, value in FEATURE_MATURITY[feature_key].items():
+        assert entry[field] == value, (
+            f"/ready entry {entry_name!r} renders {field}={entry.get(field)!r}; "
+            f"registry key {feature_key!r} says {value!r}"
+        )
+    if FEATURE_MATURITY[feature_key]["maturity"] == "ga":
+        assert "target_ga" not in entry
+        assert "tracking" not in entry
+
+
+def test_mcp_entry_carries_no_maturity_fields() -> None:
+    """The ``mcp`` entry reports a protocol constant, not a feature.
+
+    Individual MCP tools inherit maturity from their owning feature at
+    registration time (#2675); labelling the transport block itself
+    would double-count. If ``mcp`` ever becomes a classified feature,
+    add it to the registry and the entry mapping together.
+    """
+    block = build_features_block(_settings_with())
+    assert "maturity" not in block["mcp"]
+    assert "target_ga" not in block["mcp"]
+    assert "tracking" not in block["mcp"]
+
+
+def test_builder_stays_pure_and_does_not_alias_the_registry() -> None:
+    """Purity contract: repeatable output, no shared mutable state.
+
+    Two calls over equivalent :class:`Settings` snapshots return equal
+    blocks; mutating a returned entry leaks into neither the registry
+    nor a subsequent call's result. Guards against the tempting
+    ``block[name] = FEATURE_MATURITY[key]``-style aliasing bug — the
+    merge must copy fields into the per-call dict.
+    """
+    registry_snapshot = copy.deepcopy(FEATURE_MATURITY)
+
+    first = build_features_block(_settings_with())
+    second = build_features_block(_settings_with())
+    assert first == second
+
+    first["ui_surface"]["maturity"] = "mutated"
+    first["ui_surface"]["tracking"] = "https://example.invalid"
+
+    assert registry_snapshot == FEATURE_MATURITY
+    third = build_features_block(_settings_with())
+    assert third == second

--- a/docs/codebase/feature-maturity.md
+++ b/docs/codebase/feature-maturity.md
@@ -1,0 +1,80 @@
+# Feature-maturity registry
+
+## Overview
+
+`backend/src/meho_backplane/features.py` is the single source of truth
+for feature maturity (#2664 / #2674). `FEATURE_MATURITY` maps every
+user-facing MEHO feature to a tier — `ga` / `beta` / `experimental` —
+plus, on non-GA entries, the `target_ga` milestone and the `tracking`
+issue URL. Every surface that shows a maturity label derives from this
+one dict; reclassifying a feature is a one-line data edit here with no
+surface-specific changes anywhere (the v0.28 post-eval round in Goal
+#2661 depends on that property).
+
+Tier semantics (#2664 entry criteria): `ga` carries the 1.0 stability
+promise; `beta` works end-to-end somewhere real with known, tracked
+gaps and may change with deprecation notice; `experimental` may change
+or vanish and sits outside the 1.0 promise. The encoded classification
+is the **provisional** #2664 table, pending clean-room eval round 1
+(#2665).
+
+## Key types
+
+- `Maturity` — `Literal["ga", "beta", "experimental"]`.
+- `MaturityInfo` — `TypedDict` for one registry entry. `target_ga` and
+  `tracking` are `NotRequired`: absent on GA entries (same
+  absent-not-null convention as `docs` on the `/ready` gates);
+  `target_ga` may be `None` on experimental entries because several
+  are explicit 1.0 non-goals — advertising a committed milestone would
+  overstate maturity, the exact failure this program exists to fix.
+- `FEATURE_MATURITY: dict[str, MaturityInfo]` — the registry. Keys are
+  the canonical feature identifiers all consuming surfaces map onto;
+  renaming a key is a cross-surface break (pinned by
+  `test_maturity_registry_covers_the_2664_classification`).
+- `_READY_ENTRY_FEATURE` — maps the `/ready` features-block entries
+  (deploy-gate names) to registry keys (feature names). The `mcp`
+  entry is deliberately unmapped: it reports a build-time protocol
+  constant, not a classified feature — MCP tools inherit maturity from
+  their owning feature at registration time (#2675).
+
+## Control flow
+
+`build_features_block(settings)` builds the pre-existing deploy-gate
+entries, then merges the mapped registry entries' fields into them
+(`maturity` always; `target_ga` / `tracking` on non-GA). The merge
+copies into fresh per-call dicts — no aliasing of the module-level
+registry, preserving the module's purity contract (pure function over
+a `Settings` snapshot; tests pin this in
+`test_builder_stays_pure_and_does_not_alias_the_registry`).
+
+Other consumers import the module directly — there is deliberately no
+dedicated REST read surface. `/ready` carries the merged view for
+operator tooling; MCP registration (#2675), the CLI command manifest
+builder (#2676), the `/ui` badge include (#2677), and the docs-site
+maturity-index generator plus CI drift guard (#2678) all read
+`FEATURE_MATURITY` in-process.
+
+## Dependencies
+
+Stdlib `typing` (`Literal`, `TypedDict`, `NotRequired`) and
+`meho_backplane.settings.Settings` only. Nothing outside the module
+may re-declare tier values; tests assert tiers structurally and derive
+expectations from the registry so a retier never requires a test edit.
+
+## Known issues
+
+- The classification is provisional until eval round 1 (#2665) scores
+  it; the v0.28 reclassification (#2661 milestone plan) happens here.
+- `tracking` URLs point at the best open issue today (concrete gap
+  issues #2668 / #2667 / #2656, the eval #2665, or Goal #2661 for
+  experimental features with no committed path). When a dedicated
+  promotion-gate issue is filed for a feature, update its entry.
+
+## References
+
+- #2664 (initiative — classification table + entry criteria), #2674
+  (this registry), #2675-#2678 (surface propagation), #2661 (Goal —
+  milestone plan).
+- `backend/tests/test_features.py` — registry contract tests;
+  `backend/tests/test_features_doc_consistency.py` — deploy-gate doc
+  parity (unchanged by #2674).

--- a/docs/codebase/feature-maturity.md
+++ b/docs/codebase/feature-maturity.md
@@ -8,8 +8,8 @@ user-facing MEHO feature to a tier — `ga` / `beta` / `experimental` —
 plus, on non-GA entries, the `target_ga` milestone and the `tracking`
 issue URL. Every surface that shows a maturity label derives from this
 one dict; reclassifying a feature is a one-line data edit here with no
-surface-specific changes anywhere (the v0.28 post-eval round in Goal
-#2661 depends on that property).
+surface-specific changes anywhere (the v0.28 post-eval round in
+Goal #2661 depends on that property).
 
 Tier semantics (#2664 entry criteria): `ga` carries the 1.0 stability
 promise; `beta` works end-to-end somewhere real with known, tracked
@@ -34,8 +34,8 @@ is the **provisional** #2664 table, pending clean-room eval round 1
 - `_READY_ENTRY_FEATURE` — maps the `/ready` features-block entries
   (deploy-gate names) to registry keys (feature names). The `mcp`
   entry is deliberately unmapped: it reports a build-time protocol
-  constant, not a classified feature — MCP tools inherit maturity from
-  their owning feature at registration time (#2675).
+  constant, not a classified feature — MCP tools will inherit maturity
+  from their owning feature at registration time (#2675).
 
 ## Control flow
 
@@ -47,12 +47,13 @@ registry, preserving the module's purity contract (pure function over
 a `Settings` snapshot; tests pin this in
 `test_builder_stays_pure_and_does_not_alias_the_registry`).
 
-Other consumers import the module directly — there is deliberately no
-dedicated REST read surface. `/ready` carries the merged view for
-operator tooling; MCP registration (#2675), the CLI command manifest
-builder (#2676), the `/ui` badge include (#2677), and the docs-site
-maturity-index generator plus CI drift guard (#2678) all read
-`FEATURE_MATURITY` in-process.
+`/ready` is the only consuming surface shipped so far; it carries the
+merged view for operator tooling. The remaining #2664 surfaces are
+planned consumers, not yet implemented: MCP registration (#2675), the
+CLI command-manifest builder (#2676), the `/ui` badge include (#2677),
+and the docs-site maturity-index generator plus CI drift guard (#2678)
+will all read `FEATURE_MATURITY` in-process — there is deliberately no
+dedicated REST read surface.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- Extends `backend/src/meho_backplane/features.py` into the single source of truth for feature maturity (#2664): `FEATURE_MATURITY` classifies every user-facing feature as **ga / beta / experimental**; non-GA entries carry `target_ga` (milestone) and `tracking` (issue URL). The classification is the provisional #2664 table (GA-track read/governance plane; Beta with tracked gaps; Experimental outside the 1.0 promise).
- `/ready` renders the new fields: the existing deploy-gate entries merge their mapped registry entry in (`agent_runtime` → `agent_runtime`, `ui_surface` → `ui_console`, `audit_replay` → `audit`, `approval_queue` → `approvals`). Additive only — every pre-existing field is untouched. The `mcp` entry deliberately stays unlabelled: it reports a build-time protocol constant, not a classified feature; MCP tools inherit maturity from their owning feature at registration time (#2675).
- Read surface for the sibling tasks: consumers **import the module** (MCP registration #2675, CLI manifest builder #2676, `/ui` Jinja render #2677, docs-build generator + drift guard #2678 — all in-process). No new REST route, per the task's "prefer the smallest thing" directive — so no OpenAPI snapshot regen is needed (`/ready` has no response model and `health.py` is untouched, keeping its snapshot-embedded docstring stable).
- `tracking` points at real open issues: concrete gap issues where one exists (#2668 sensors/scheduler background credential identity, #2667 GSM chart values, #2656 hosted-agent hardening line), the clean-room eval (#2665) for beta features whose promotion gate is the eval score, and Goal #2661 (which schedules the v0.28 re-triage) for experimental features with no committed path. `target_ga` is `v1.0.0` on beta entries and `null` on experimental ones — several are explicit 1.0 non-goals in #2661, so advertising a committed milestone would overstate maturity.
- New `docs/codebase/feature-maturity.md` documents the registry contract; tests assert tier values **structurally only** (never pinned per feature), so a reclassification stays a one-line registry edit with zero test/surface edits.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean except the pre-existing darwin-only `socket.MSG_ERRQUEUE` error in `connectors/net/icmp.py` (identical on clean `main`; CI runs Linux where the attribute exists)
- [x] `pytest -n 3 --dist loadscope --ignore=tests/integration --ignore=tests/migrations tests/` — 10662 passed, 193 skipped; the only 2 failures (`test_trace_reaches_loopback`, `test_chosen_resolver_queries_that_nameserver`) reproduce identically on a clean `main` checkout (local macOS ICMP/DNS environment, not this change)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (1 warning: `features.py` now 481 lines, warn threshold 400)
- [x] AC "registry entries carry maturity/target_ga/tracking; tests cover shape + purity; `/ready` renders the new fields" — `test_registry_entry_shape`, `test_builder_stays_pure_and_does_not_alias_the_registry`, `test_ready_entry_merges_registry_maturity_fields` (expectations derived from the registry, not hardcoded)
- [x] AC "provisional #2664 classification encoded; retier is a one-line data change" — `test_maturity_registry_covers_the_2664_classification` pins the 19-key set only; no test pins a tier
- [x] AC "if a new route was added: snapshot regen" — n/a, no route added (verified `/ready` is snapshot-stable)
- [x] AC "CHANGELOG `[Unreleased]` entry under a unique `###` header" — `### Added — feature-maturity registry: the single source of truth (#2674)`

## Out of scope

- Propagation to MCP/REST (#2675), CLI (#2676), UI (#2677), docs/drift guard (#2678) — all Depends-on this PR.
- Reclassification decisions themselves (post-eval, v0.28).
- Adjacent findings: `features.py` at 481 lines is approaching the 600-line split threshold — #2675-#2678 should not grow it further; pre-existing darwin-only mypy/pytest baseline failures in the `net` connector noted above.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2674


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added feature maturity labels—GA, Beta, and Experimental—to applicable readiness information.
  - Non-GA features now include planned GA milestones and tracking references where available.
  - Maturity classifications are consistently reflected across supported CLI, UI, documentation, and readiness surfaces.

- **Documentation**
  - Added guidance explaining maturity levels, associated metadata, and how classifications are maintained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->