### PR TITLE
feat(cli): carry maturity through the command manifest and render it in help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — CLI command manifest carries feature maturity (#2676)
+
+- Teach the CLI's server-driven command manifest the `maturity` field
+  and render it in help output (#2676): a dynamic command advertised
+  by the backplane as **beta** or **experimental** now shows the
+  matching "(beta)" / "(experimental)" label after its short
+  description in `meho --help`. Additive and skew-safe in both
+  directions — a manifest without the field (backplane predating
+  #2674) and an unrecognized future tier both render unlabelled help.
+  Labels only: invoking a non-GA command is unchanged. The
+  `/api/v1/commands` endpoint itself remains an unshipped
+  coordination point (Goal #11 §5); until a backplane serves it, the
+  CLI's local-only fallback behaves exactly as before. (#2676)
+
 ### Added — feature-maturity registry: the single source of truth (#2674)
 
 - Extend `backend/src/meho_backplane/features.py` into the single

--- a/cli/internal/discovery/discovery.go
+++ b/cli/internal/discovery/discovery.go
@@ -58,6 +58,14 @@ type Command struct {
 	// Optional in the schema but populated by every realistic
 	// backplane.
 	Short string `json:"short,omitempty"`
+	// Maturity is the owning feature's tier from the backplane's
+	// feature-maturity registry (#2674): "beta" or "experimental".
+	// Omitted for GA commands — absence means "no maturity label",
+	// which also covers older backplanes that predate the field.
+	// Values other than the two known non-GA tiers render no label
+	// either, so a future tier never garbles help output on an
+	// older CLI (#2676).
+	Maturity string `json:"maturity,omitempty"`
 	// Subcommands are nested children. Optional; empty in v0.1.
 	Subcommands []Command `json:"subcommands,omitempty"`
 }
@@ -162,14 +170,38 @@ func Register(rootCmd *cobra.Command, manifest *CommandManifest) error {
 	return nil
 }
 
+// maturitySuffix maps a manifest maturity tier onto the help-text
+// label rendered after the command's short description. Only the
+// two known non-GA tiers produce a label; empty (GA / older
+// backplane) and unrecognized values render nothing, keeping help
+// output stable across version skew in both directions.
+func maturitySuffix(maturity string) string {
+	switch maturity {
+	case "beta":
+		return "(beta)"
+	case "experimental":
+		return "(experimental)"
+	default:
+		return ""
+	}
+}
+
 // buildCommand recursively turns a Command spec into a cobra
 // command. Each leaf RunE is the v0.1 placeholder; non-leaf
 // (sub-bearing) commands have no RunE so cobra prints the
 // subcommand help when invoked without an arg.
 func buildCommand(c Command) *cobra.Command {
+	short := c.Short
+	if suffix := maturitySuffix(c.Maturity); suffix != "" {
+		if short == "" {
+			short = suffix
+		} else {
+			short += " " + suffix
+		}
+	}
 	cmd := &cobra.Command{
 		Use:   c.Name,
-		Short: c.Short,
+		Short: short,
 		// SilenceUsage matches the rest of the CLI — operator errors
 		// shouldn't dump the usage wall.
 		SilenceUsage: true,

--- a/cli/internal/discovery/discovery_test.go
+++ b/cli/internal/discovery/discovery_test.go
@@ -25,7 +25,8 @@ func TestFetch_HappyPath(t *testing.T) {
             "commands": [
                 {"name": "k8s", "short": "Kubernetes operations",
                  "subcommands": [
-                    {"name": "deployment", "short": "Manage deployments"}
+                    {"name": "deployment", "short": "Manage deployments",
+                     "maturity": "beta"}
                  ]}
             ]
         }`))
@@ -46,6 +47,12 @@ func TestFetch_HappyPath(t *testing.T) {
 	}
 	if len(k8s.Subcommands) != 1 || k8s.Subcommands[0].Name != "deployment" {
 		t.Errorf("expected nested deployment subcommand: %+v", k8s.Subcommands)
+	}
+	if k8s.Maturity != "" {
+		t.Errorf("k8s carries no maturity key, expected empty, got %q", k8s.Maturity)
+	}
+	if k8s.Subcommands[0].Maturity != "beta" {
+		t.Errorf("deployment maturity: got %q, want %q", k8s.Subcommands[0].Maturity, "beta")
 	}
 }
 
@@ -143,6 +150,143 @@ func TestRegister_GraftsCommands(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Kubernetes operations") {
 		t.Errorf("--help output missing short description:\n%s", stdout.String())
+	}
+}
+
+// TestRegister_MaturitySuffixInHelp is the #2676 round-trip test:
+// a manifest carrying maturity tiers renders "(beta)" /
+// "(experimental)" after the short description in help output, GA
+// and unrecognized tiers render no label, and a label-only short
+// still surfaces for commands whose short is empty.
+func TestRegister_MaturitySuffixInHelp(t *testing.T) {
+	root := &cobra.Command{Use: "meho"}
+	manifest := &CommandManifest{Commands: []Command{
+		{Name: "sensor", Short: "Deterministic-check sensors", Maturity: "beta"},
+		{Name: "ingest", Short: "Spec ingestion", Maturity: "experimental"},
+		{Name: "audit", Short: "Audit queries", Maturity: "ga"},
+		{Name: "future", Short: "From a newer backplane", Maturity: "alpha-preview"},
+		{Name: "bare", Maturity: "beta"},
+		{
+			Name: "topology", Short: "Topology graph",
+			Subcommands: []Command{
+				{Name: "refresh", Short: "Refresh the graph", Maturity: "beta"},
+			},
+		},
+	}}
+	if err := Register(root, manifest); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("--help failed: %v", err)
+	}
+	help := stdout.String()
+	for _, want := range []string{
+		"Deterministic-check sensors (beta)",
+		"Spec ingestion (experimental)",
+	} {
+		if !strings.Contains(help, want) {
+			t.Errorf("--help missing %q:\n%s", want, help)
+		}
+	}
+	for _, unwanted := range []string{
+		"Audit queries (",
+		"From a newer backplane (",
+	} {
+		if strings.Contains(help, unwanted) {
+			t.Errorf("--help shows a maturity label it must not: %q\n%s", unwanted, help)
+		}
+	}
+
+	// Empty short + non-GA tier: the label alone is the short text.
+	var bare *cobra.Command
+	for _, c := range root.Commands() {
+		if c.Name() == "bare" {
+			bare = c
+		}
+	}
+	if bare == nil {
+		t.Fatal("bare subcommand not registered")
+	}
+	if bare.Short != "(beta)" {
+		t.Errorf("bare.Short: got %q, want %q", bare.Short, "(beta)")
+	}
+
+	// Nested subcommands inherit the same rendering via the
+	// recursive buildCommand walk.
+	stdout.Reset()
+	root.SetArgs([]string{"topology", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("topology --help failed: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Refresh the graph (beta)") {
+		t.Errorf("nested subcommand help missing beta label:\n%s", stdout.String())
+	}
+}
+
+// TestMaturity_WireRoundTrip drives the full path — httptest
+// backplane JSON → Fetch → Register → cobra help — for a manifest
+// carrying maturity, proving the wire field and the rendering agree
+// end to end (#2676 acceptance criterion).
+func TestMaturity_WireRoundTrip(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(Endpoint, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+            "commands": [
+                {"name": "sensor", "short": "Deterministic-check sensors",
+                 "maturity": "beta"}
+            ]
+        }`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	manifest, err := Fetch(context.Background(), srv.Client(), srv.URL)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	root := &cobra.Command{Use: "meho"}
+	if err := Register(root, manifest); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("--help failed: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Deterministic-check sensors (beta)") {
+		t.Errorf("--help missing wire-driven beta label:\n%s", stdout.String())
+	}
+}
+
+// TestRegister_NoMaturityNoSuffix pins the other direction of the
+// version skew: a manifest from a backplane that predates the
+// maturity field (#2674 not deployed) renders help output without
+// any label — byte-identical short descriptions.
+func TestRegister_NoMaturityNoSuffix(t *testing.T) {
+	root := &cobra.Command{Use: "meho"}
+	manifest := &CommandManifest{Commands: []Command{
+		{Name: "sensor", Short: "Deterministic-check sensors"},
+	}}
+	if err := Register(root, manifest); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("--help failed: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Deterministic-check sensors") {
+		t.Fatalf("--help missing short description:\n%s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Deterministic-check sensors (") {
+		t.Errorf("--help shows a label for a maturity-less manifest:\n%s", stdout.String())
 	}
 }
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -19,7 +19,12 @@ tarball and `SHA256SUMS` ships with a matching `.cosign.bundle`
 sigstore bundle (signature + Fulcio cert + Rekor proof) under the
 ADR 0006 identity-claim format. Server-driven subcommand discovery
 runs at every startup (empty manifest in v0.1; populated by
-post-Goal-2 backplanes without a CLI binary release).
+post-Goal-2 backplanes without a CLI binary release). Manifest
+commands may carry a `maturity` tier from the backplane's
+feature-maturity registry (#2674); the CLI renders "(beta)" /
+"(experimental)" after the short description in help output, and an
+absent or unrecognized tier renders no label — version skew in
+either direction degrades to unlabelled help (#2676).
 
 The v0.2 substrate adds several statically-registered subcommand
 trees alongside the discovery surface. All follow the same pattern:
@@ -309,8 +314,8 @@ cli/
     │   ├── suggest.go            # G5.3-T2 #609 — SuggestScope table + exported Scope* constants.
     │   └── suggest_test.go       # full mapping table including tenantConfigured branch and unknown-type fallback.
     ├── discovery/
-    │   ├── discovery.go       # /api/v1/commands manifest fetch + cobra graft.
-    │   └── discovery_test.go  # 200/404/transport/decode + collision tests.
+    │   ├── discovery.go       # /api/v1/commands manifest fetch + cobra graft + maturity help labels (#2676).
+    │   └── discovery_test.go  # 200/404/transport/decode + collision + maturity-label tests.
     ├── output/
     │   ├── format.go          # human + JSON formatters + structured exit codes.
     │   └── format_test.go     # human/JSON/exit-code pinning.

--- a/docs/codebase/feature-maturity.md
+++ b/docs/codebase/feature-maturity.md
@@ -55,6 +55,19 @@ and the docs-site maturity-index generator plus CI drift guard (#2678)
 will all read `FEATURE_MATURITY` in-process — there is deliberately no
 dedicated REST read surface.
 
+The CLI's *client* half of #2676 is shipped:
+`cli/internal/discovery/discovery.go`'s `Command` carries a
+`maturity` field (`"beta"` / `"experimental"`; omitted for GA) and
+`meho --help` renders the matching label after each dynamic command's
+short description — absent or unrecognized tiers render no label, so
+version skew in either direction degrades to unlabelled help. The
+server half stays gated on the `/api/v1/commands` endpoint itself,
+which is an unshipped Goal #11 §5 coordination point: today every
+backplane 404s the manifest fetch and the CLI falls back to its
+local-only command set. When the endpoint lands, its builder resolves
+each advertised command's owning feature from `FEATURE_MATURITY` and
+emits the field the CLI already understands.
+
 ## Dependencies
 
 Stdlib `typing` (`Literal`, `TypedDict`, `NotRequired`) and


### PR DESCRIPTION
## Summary

- The CLI's server-driven command manifest (`cli/internal/discovery`) now carries a per-command `maturity` field, and `meho --help` renders "(beta)" / "(experimental)" after the short description of non-GA dynamic commands (#2664 program, tiers from the #2674 `FEATURE_MATURITY` registry).
- Skew-safe in both directions: an absent field (backplane predating #2674) and an unrecognized future tier both render no label, preserving discovery's best-effort contract. Labels only — invoking a non-GA command is unchanged.
- Docs: `docs/codebase/cli.md` and `docs/codebase/feature-maturity.md` updated; CHANGELOG `[Unreleased]` entry added under its own `###` header.

## Premise correction (server side)

The issue's approach assumed a backplane manifest builder for `/api/v1/commands` exists to extend. It does not: the endpoint is an unshipped Goal #11 §5 coordination point — every backplane 404s the discovery fetch today and the CLI falls back to its local-only command set — and #2674 deliberately shipped no REST route. Consequently:

- There is no server-side manifest builder to teach maturity, and inventing the backplane's advertised-command set is that endpoint's own deferred design work, out of this task's scope.
- The `/api/v1/commands` response shape is not part of the backend OpenAPI document, so there is nothing to re-snapshot: `cli/api/openapi.json` and the generated client are unchanged, and the "CLI API snapshot freshness" check compares like-for-like against an untouched backend.
- The "help output against a #2674-carrying backplane" criterion is covered by the wire round-trip golden test (`TestMaturity_WireRoundTrip`: httptest-served maturity manifest → `Fetch` → `Register` → `--help` label), which is the same path a real manifest-serving backplane will exercise once the endpoint lands — its builder then resolves each command's owning feature from `FEATURE_MATURITY` and emits the field this CLI already understands.

## Test plan

- [x] `go test -race -cover ./...` (cli module) — all packages ok, `internal/discovery` at 89.5% coverage
- [x] `golangci-lint run` (v2.12.2, CI's pin) — 0 issues
- [x] `gofmt -l` / `go vet ./...` — clean
- [x] Manifest round-trip both skew directions — `TestMaturity_WireRoundTrip` (maturity carried → suffix rendered), `TestRegister_NoMaturityNoSuffix` (field absent → no suffix), `TestRegister_MaturitySuffixInHelp` (beta/experimental labelled; ga/unknown tiers unlabelled; nested subcommands; empty-short edge)
- [x] `TestFetch_HappyPath` extended — `maturity` decodes from the wire, absent key stays empty
- [x] Snapshot + generated client — no regeneration needed (backend untouched; endpoint not in the OpenAPI document), freshness check unaffected
- [x] CHANGELOG `[Unreleased]` entry under a unique `###` header
- [x] Code-quality gate (`code-quality.py --diff`) — pass

## Out of scope

- Server-side `/api/v1/commands` endpoint + manifest builder (unshipped Goal #11 §5 coordination point; see premise correction above).
- MCP/REST propagation (#2675), /ui badges (#2677), docs index + drift guard (#2678).
- Gating or warning on *use* of beta commands (labels only).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2676


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI help now labels dynamically discovered commands as **beta** or **experimental**.
  * Nested commands display maturity labels consistently.
  * Commands with missing, unknown, or generally available maturity remain unlabeled.
  * Command execution and local fallback behavior are unchanged.

* **Documentation**
  * Added documentation covering command maturity labels and current CLI support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->