### PR TITLE
feat(mcp): propagate feature maturity to tool descriptions, initialize.instructions, and OpenAPI x-maturity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,21 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — maturity labels on the MCP and REST surfaces (#2675)
+
+- Propagate the #2674 feature-maturity registry to the agent-facing
+  surfaces (#2675). MCP tools owned by a non-GA feature now carry a
+  `[beta]` / `[experimental]` prefix in their `tools/list`
+  descriptions (GA tools stay unprefixed) — resolved at registration
+  time from each tool's new `feature` declaration, never hardcoded
+  per tool. `initialize.instructions` gains a compact feature-maturity
+  band listing exactly the registry's non-GA features. The public
+  OpenAPI document (and the committed `cli/api/openapi.json`
+  snapshot) carries `x-maturity` on its tags, with per-operation
+  overrides where a tag spans tiers (the `connectors` tag's
+  spec-ingestion paths). All additive: no tool or route was renamed,
+  and schema shapes are untouched. (#2675)
+
 ### Added — feature-maturity registry: the single source of truth (#2674)
 
 - Extend `backend/src/meho_backplane/features.py` into the single

--- a/backend/src/meho_backplane/api/openapi_maturity.py
+++ b/backend/src/meho_backplane/api/openapi_maturity.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``x-maturity`` OpenAPI extension injection (#2675).
+
+Stamps the public OpenAPI document with feature-maturity tiers resolved
+from :data:`~meho_backplane.features.FEATURE_MATURITY` — the propagation
+surface the #2664 program requires on REST, mirroring the ``[beta]`` /
+``[experimental]`` MCP description prefixes. Two placements, both plain
+`specification extensions <https://spec.openapis.org/oas/v3.1.0#specification-extensions>`_
+(legal on the Tag Object and the Operation Object alike):
+
+* **Top-level ``tags``** — one entry per mapped route tag carrying
+  ``x-maturity``. FastAPI's app is constructed without ``openapi_tags``,
+  so this module owns the top-level ``tags`` array outright.
+* **Per-operation ``x-maturity``** — only where a tag spans tiers
+  (:data:`PATH_FEATURE_OVERRIDES`): today the ``connectors`` tag, whose
+  lifecycle verbs follow ``typed_connector_reads`` (GA) while the
+  spec-ingestion pipeline paths follow ``connector_ingest``
+  (experimental) — the same split the MCP ``meho.connector.*`` tools
+  encode.
+
+Mapping maintenance
+===================
+
+:data:`TAG_FEATURE` is the REST twin of the per-tool ``feature`` field
+on :class:`~meho_backplane.mcp.registry.ToolDefinition` and of
+:data:`~meho_backplane.features._READY_ENTRY_FEATURE`. Tags absent
+from it are **deliberately unclassified**: infrastructure surfaces
+(``health``, ``version``, ``mcp`` — the transport, whose tools carry
+their own per-tool labels, ``discovery``'s untagged siblings ``/`` and
+``/metrics``) and surfaces the provisional #2664 table does not
+classify (``conventions``, ``runbooks``). The BFF ``/ui*`` tags are
+excluded wholesale — the console's maturity surface is the #2677 badge
+chips, and the #2678 drift guard excludes ``/ui/*`` by prefix until the
+#2662 public/BFF split lands. Values are validated against the registry
+at import so a typo'd key fails at boot, not as a silently missing
+label.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from meho_backplane.features import FEATURE_MATURITY
+
+__all__ = [
+    "PATH_FEATURE_OVERRIDES",
+    "TAG_FEATURE",
+    "inject_maturity_extensions",
+]
+
+#: Route tag → :data:`FEATURE_MATURITY` key. See module docstring for
+#: the deliberately-unmapped set.
+TAG_FEATURE: Final[dict[str, str]] = {
+    "agent-grants": "agent_runtime",
+    "agent-principals": "agent_runtime",
+    "agents": "agent_runtime",
+    "approvals": "approvals",
+    "audit": "audit",
+    "auth": "auth_tenancy",
+    "broadcast": "broadcast",
+    "checks": "sensors",
+    "checks-dashboards": "sensors",
+    "connectors": "typed_connector_reads",
+    "discovery": "auth_tenancy",
+    "docs": "doc_collections",
+    "feed": "broadcast",
+    "gateway": "satellite_gateway",
+    "knowledge": "memory_knowledge",
+    "memory": "memory_knowledge",
+    "operations": "typed_connector_reads",
+    "retrieval": "memory_knowledge",
+    "runner-principals": "satellite_gateway",
+    "scheduler": "scheduler",
+    "sensors": "sensors",
+    "targets": "targets",
+    "topology": "topology",
+}
+
+#: Path → :data:`FEATURE_MATURITY` key, for paths whose feature differs
+#: from their tag's (#2675 "per-path where a tag spans tiers"). Today:
+#: the ``connectors`` tag's spec-ingestion pipeline paths, which follow
+#: ``connector_ingest`` while the tag-level default follows the
+#: lifecycle verbs' ``typed_connector_reads`` — the same per-verb split
+#: the ``meho.connector.*`` MCP tools declare.
+PATH_FEATURE_OVERRIDES: Final[dict[str, str]] = {
+    "/api/v1/connectors/ingest": "connector_ingest",
+    "/api/v1/connectors/ingest/jobs/{job_id}": "connector_ingest",
+    "/api/v1/connectors/{connector_id}/review": "connector_ingest",
+    "/api/v1/connectors/{connector_id}/groups/{group_key}": "connector_ingest",
+    "/api/v1/connectors/{connector_id}/operations/{op_id}": "connector_ingest",
+}
+
+
+def _validate_mapping() -> None:
+    """Fail at import on a mapping value the registry does not know.
+
+    Same loud-pre-traffic posture as the MCP registry's duplicate-name
+    guard: a typo'd feature key must never degrade to a silently
+    missing maturity label.
+    """
+    unknown = {
+        key
+        for key in (*TAG_FEATURE.values(), *PATH_FEATURE_OVERRIDES.values())
+        if key not in FEATURE_MATURITY
+    }
+    if unknown:
+        raise RuntimeError(
+            "openapi_maturity maps to feature keys absent from "
+            f"FEATURE_MATURITY: {sorted(unknown)!r}",
+        )
+
+
+_validate_mapping()
+
+#: HTTP methods that carry Operation Objects inside a Path Item. Path
+#: Items also hold non-operation keys (``parameters``, ``summary``,
+#: ``servers``), so iterating blindly over the dict would stamp
+#: extensions onto non-operation nodes.
+_OPERATION_METHODS: Final[frozenset[str]] = frozenset(
+    ("get", "put", "post", "delete", "options", "head", "patch", "trace"),
+)
+
+
+def inject_maturity_extensions(schema: dict[str, Any]) -> None:
+    """Stamp ``x-maturity`` onto *schema* in place.
+
+    Top-level ``tags`` entries are emitted only for mapped tags that
+    actually appear on an operation, so the document never advertises a
+    tag with no routes. Per-operation stamps come exclusively from
+    :data:`PATH_FEATURE_OVERRIDES`; an override path missing from the
+    document raises — a stale override after a route rename must fail
+    the snapshot-freshness gate loudly rather than silently un-label
+    the path.
+    """
+    paths: dict[str, Any] = schema.get("paths", {})
+
+    used_tags: set[str] = set()
+    for path_item in paths.values():
+        for method, operation in path_item.items():
+            if method in _OPERATION_METHODS and isinstance(operation, dict):
+                used_tags.update(operation.get("tags", ()))
+
+    schema["tags"] = [
+        {
+            "name": tag,
+            "x-maturity": FEATURE_MATURITY[TAG_FEATURE[tag]]["maturity"],
+        }
+        for tag in sorted(used_tags & TAG_FEATURE.keys())
+    ]
+
+    for path, feature in PATH_FEATURE_OVERRIDES.items():
+        path_item = paths.get(path)
+        if path_item is None:
+            raise RuntimeError(
+                f"PATH_FEATURE_OVERRIDES names {path!r} which is absent "
+                "from the OpenAPI document — update the override map "
+                "alongside the route change",
+            )
+        for method, operation in path_item.items():
+            if method in _OPERATION_METHODS and isinstance(operation, dict):
+                operation["x-maturity"] = FEATURE_MATURITY[feature]["maturity"]

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -60,6 +60,7 @@ from meho_backplane.agents import (
     start_grant_expiry_sweeper,
     stop_grant_expiry_sweeper,
 )
+from meho_backplane.api.openapi_maturity import inject_maturity_extensions
 from meho_backplane.api.v1.agent_grants import router as api_v1_agent_grants_router
 from meho_backplane.api.v1.agent_principals import (
     router as api_v1_agent_principals_router,
@@ -1165,6 +1166,10 @@ def build_openapi_schema() -> dict[str, object]:
         separate_input_output_schemas=app.separate_input_output_schemas,
     )
     _inject_target_product_enum(schema)
+    # #2675: stamp x-maturity (registry-resolved) onto the mapped tags
+    # and the spans-tiers path overrides; flows into the committed
+    # cli/api/openapi.json snapshot.
+    inject_maturity_extensions(schema)
     app.openapi_schema = schema
     return schema
 

--- a/backend/src/meho_backplane/mcp/maturity.py
+++ b/backend/src/meho_backplane/mcp/maturity.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Feature-maturity band for ``initialize.instructions`` (#2675).
+
+The MCP ``initialize`` response is the fresh agent session's first —
+and sometimes only — guidance surface (2026-07-21 grounding review §4).
+This module renders the one-paragraph maturity summary the #2664
+program requires there: which features are beta, which are
+experimental, and how the per-tool ``[beta]`` / ``[experimental]``
+description prefixes relate to it.
+
+The band is derived **entirely** from
+:data:`~meho_backplane.features.FEATURE_MATURITY` at import time —
+the registry is static module-level data, so the text never changes
+within a process lifetime and building it once is free. Reclassifying
+a feature (the v0.28 post-eval round) changes this band with zero
+edits here.
+
+Rendered as a delimited band in the same shape as
+:data:`~meho_backplane.conventions.preamble.BROADCAST_DISCIPLINE_BAND`
+(MEHO-authored trusted guidance — no guard prefix needed; delimiters
+exist for band separation and grep-friendliness). It is appended by
+:func:`meho_backplane.mcp.server._initialize` *after* the assembled
+tenant preamble rather than inside
+:func:`~meho_backplane.conventions.preamble.assemble_preamble` because
+the label contract is an MCP-surface concern (#2675), not a tenant-
+conventions concern — the conventions write-path feedback consumers of
+the preamble assembler must not see it.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from meho_backplane.features import FEATURE_MATURITY
+
+__all__ = [
+    "FEATURE_MATURITY_BAND",
+    "MATURITY_BLOCK_END",
+    "MATURITY_BLOCK_START",
+]
+
+#: Opening delimiter for the maturity band. Same positional-envelope
+#: shape as the broadcast-discipline band's delimiters.
+MATURITY_BLOCK_START: Final[str] = "<<FEATURE_MATURITY>>"
+
+#: Closing delimiter for the maturity band. Pairs with
+#: :data:`MATURITY_BLOCK_START`.
+MATURITY_BLOCK_END: Final[str] = "<<END_FEATURE_MATURITY>>"
+
+
+def _build_band() -> str:
+    """Render the maturity band from the registry.
+
+    Lists exactly the registry's non-GA features, tier by tier (sorted
+    for deterministic output — the registry is a plain dict and its
+    ordering is an editing artifact, not a contract). Returns ``""``
+    when every feature is GA so the ``initialize`` band-join drops the
+    band cleanly — the same empty-band convention the preamble
+    assembler uses.
+
+    Deliberately renders feature *keys only* — no ``target_ga`` and no
+    ``tracking`` URLs. Beyond compactness (the band rides in every
+    session's token budget), the tracking URLs name the
+    ``evoila/meho`` tracker, and ``initialize.instructions`` must stay
+    free of repo-identity tokens per the G0.13-T7 (#1137) forbidden-
+    token contract pinned in
+    :mod:`tests.test_mcp_initialize_instructions`.
+    """
+    beta = sorted(key for key, info in FEATURE_MATURITY.items() if info["maturity"] == "beta")
+    experimental = sorted(
+        key for key, info in FEATURE_MATURITY.items() if info["maturity"] == "experimental"
+    )
+    if not beta and not experimental:
+        return ""
+    lines = [
+        MATURITY_BLOCK_START,
+        "## Feature maturity",
+        "",
+        "MEHO features carry maturity tiers. Tools whose description "
+        "starts with [beta] or [experimental] belong to a pre-GA "
+        "feature; unprefixed tools are GA and carry the stability "
+        "promise.",
+    ]
+    if beta:
+        lines += [
+            "",
+            "Beta (works end-to-end, gaps known and tracked; may change "
+            "with deprecation notice): " + ", ".join(beta) + ".",
+        ]
+    if experimental:
+        lines += [
+            "",
+            "Experimental (may change or vanish; outside the 1.0 "
+            "stability promise): " + ", ".join(experimental) + ".",
+        ]
+    lines.append(MATURITY_BLOCK_END)
+    return "\n".join(lines)
+
+
+#: The maturity band appended to every ``initialize.instructions``
+#: payload. Static per process — see module docstring.
+FEATURE_MATURITY_BAND: Final[str] = _build_band()

--- a/backend/src/meho_backplane/mcp/registry.py
+++ b/backend/src/meho_backplane/mcp/registry.py
@@ -71,9 +71,10 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 import structlog
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.features import FEATURE_MATURITY
 
 __all__ = [
     "ResourceHandler",
@@ -219,6 +220,22 @@ class ToolDefinition(BaseModel):
     the connector enable model rather than a packaging/entitlement
     system. ``None`` (the default) means "no capability gate", so every
     existing tool keeps its role-only behaviour.
+
+    ``feature`` (#2675) names the tool's owning entry in
+    :data:`~meho_backplane.features.FEATURE_MATURITY` so
+    :func:`register_mcp_tool` can resolve the tool's maturity tier and
+    prefix non-GA descriptions with ``[beta]`` / ``[experimental]`` at
+    registration time — labels are never hardcoded per tool. The field
+    is **required with no default**: every registration site must either
+    name a registry key (validated — an unknown key raises at
+    construction, loud and pre-traffic like the duplicate-name guard) or
+    pass an explicit ``None``, which declares "this surface is
+    deliberately outside the maturity classification" (the
+    :data:`~meho_backplane.features._READY_ENTRY_FEATURE` ``mcp``-entry
+    precedent — e.g. ``meho.status``, a health mirror, and the runbooks
+    surface, which the provisional #2664 table does not classify).
+    Explicit ``None`` stays greppable for the #2678 drift guard.
+    MEHO-internal: dropped from the wire shape like the RBAC fields.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -226,11 +243,31 @@ class ToolDefinition(BaseModel):
     name: str = Field(min_length=1)
     description: str = Field(min_length=1)
     inputSchema: dict[str, Any]  # noqa: N815 — wire field is camelCase per MCP spec
+    feature: str | None
     title: str | None = None
     outputSchema: dict[str, Any] | None = None  # noqa: N815
     required_role: TenantRole = TenantRole.OPERATOR
     op_class: str = "read"
     required_capability: str | None = None
+
+    @field_validator("feature")
+    @classmethod
+    def _feature_key_known(cls, value: str | None) -> str | None:
+        """Reject feature keys absent from :data:`FEATURE_MATURITY`.
+
+        A typo'd key would otherwise silently resolve to "no maturity
+        label" — exactly the overstatement failure mode the #2664
+        program exists to prevent. ``None`` stays legal as the explicit
+        deliberately-unclassified declaration.
+        """
+        if value is not None and value not in FEATURE_MATURITY:
+            known = ", ".join(sorted(FEATURE_MATURITY))
+            raise ValueError(
+                f"unknown feature key {value!r}; must be one of [{known}] "
+                "or None (deliberately unclassified — see "
+                "meho_backplane.features.FEATURE_MATURITY / #2675)",
+            )
+        return value
 
     def to_wire(self) -> dict[str, Any]:
         """Serialise to the MCP wire shape, dropping MEHO-internal fields.
@@ -336,6 +373,31 @@ _RESOURCES: dict[str, tuple[ResourceTemplateDefinition, ResourceHandler]] = {}
 # ---------------------------------------------------------------------------
 
 
+def _with_maturity_prefix(definition: ToolDefinition) -> ToolDefinition:
+    """Return *definition* with its description carrying the maturity prefix.
+
+    #2675: non-GA tools advertise their tier as a ``[beta]`` /
+    ``[experimental]`` description prefix resolved from
+    :data:`~meho_backplane.features.FEATURE_MATURITY` — never hardcoded
+    per tool, so a registry retier relabels every surface with zero
+    tool-module edits. GA tools and deliberately-unclassified tools
+    (``feature=None``) return unchanged (same object, no copy). The
+    prefix is applied to the *stored* definition rather than in
+    :meth:`ToolDefinition.to_wire` so every description consumer — the
+    ``tools/list`` wire shape and the hosted-agent toolset bridge
+    (:mod:`meho_backplane.agent.toolset`), which reads
+    ``definition.description`` directly — sees one consistent label.
+    """
+    if definition.feature is None:
+        return definition
+    maturity = FEATURE_MATURITY[definition.feature]["maturity"]
+    if maturity == "ga":
+        return definition
+    return definition.model_copy(
+        update={"description": f"[{maturity}] {definition.description}"},
+    )
+
+
 def register_mcp_tool(definition: ToolDefinition, handler: ToolHandler) -> None:
     """Register a tool keyed by :attr:`ToolDefinition.name`.
 
@@ -344,10 +406,14 @@ def register_mcp_tool(definition: ToolDefinition, handler: ToolHandler) -> None:
     :class:`RuntimeError` (not a wire-error) because the registry is
     populated at module-import time; a duplicate is a configuration bug
     the operator must fix before the process accepts traffic.
+
+    The stored definition is the maturity-labelled variant produced by
+    :func:`_with_maturity_prefix` (#2675) — callers pass the plain
+    description; the registry owns the label.
     """
     if definition.name in _TOOLS:
         raise RuntimeError(f"MCP tool already registered: {definition.name!r}")
-    _TOOLS[definition.name] = (definition, handler)
+    _TOOLS[definition.name] = (_with_maturity_prefix(definition), handler)
     _log.info("mcp_tool_registered", name=definition.name)
 
 

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -88,6 +88,7 @@ from pydantic import BaseModel, ValidationError
 from meho_backplane import __version__
 from meho_backplane.auth.operator import Operator
 from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.mcp.maturity import FEATURE_MATURITY_BAND
 from meho_backplane.mcp.schemas import (
     INTERNAL_ERROR,
     INVALID_PARAMS,
@@ -338,54 +339,27 @@ def _log_protocol_version_mismatch(
     )
 
 
-async def _initialize(
-    operator: Operator,
-    params: dict[str, Any] | None,
-) -> InitializeResponse:
-    """Handle the ``initialize`` method per MCP 2025-06-18 §Initialization.
+async def _session_instructions(operator: Operator) -> str | None:
+    """Assemble the ``initialize.instructions`` payload for *operator*.
 
-    Returns a server-info + capabilities envelope, plus -- when the
-    operator's tenant has any ``kind='operational'`` conventions -- the
-    assembled session preamble in the spec-optional ``instructions``
-    field (G7.1-T4 #316). The preamble is built by
-    :func:`meho_backplane.conventions.preamble.assemble_preamble`:
+    G7.1-T4 (#316): the tenant session preamble built by
+    :func:`meho_backplane.conventions.preamble.assemble_preamble` —
     deterministic highest-``priority``-first packing wrapped in a
     delimited lower-trust block; when the packer drops entries to fit
     the token budget, the dropped slugs are logged at WARNING so the
     omission is loud (silent truncation of an operational rule is a
     safety bug per the issue body).
 
-    MEHO supports only :data:`PROTOCOL_VERSION` and always responds
-    with that — spec-compliant on the response side, but
-    indistinguishable from a silent upgrade for a client pinned to an
-    older revision. G0.14-T13 (#1202) closes the observability gap
-    via :func:`_log_protocol_version_mismatch`: a mismatched client
-    revision triggers a structured ``mcp_initialize_protocol_version_mismatch``
-    WARNING, while the response body stays unchanged. Multi-version
-    negotiation behaviour is tracked as explicit follow-up work,
-    gated on concrete operator demand.
+    #2675: the static feature-maturity band is appended after the
+    preamble — the fresh session's first guidance surface must state
+    which features are pre-GA and how the ``[beta]`` /
+    ``[experimental]`` tool-description prefixes relate. Appended here
+    (not inside the preamble assembler) because the label contract is
+    an MCP-surface concern; the conventions write-path feedback
+    consumers of the assembler must not see it. Both bands use the
+    empty-drops-cleanly join convention, so an all-GA registry
+    degrades to the preamble alone.
     """
-    # ``params or {}`` deliberately collapses ``None`` and ``{}``. Spec-
-    # aligned: a missing ``params`` field on the JSON-RPC request and an
-    # explicit empty params object are both equivalent to "no required
-    # fields supplied" for our purposes — :class:`InitializeRequest`'s
-    # validator will then surface a clean INVALID_PARAMS for the
-    # required-but-missing ``protocolVersion``.
-    try:
-        client_request = InitializeRequest.model_validate(params or {})
-    except ValidationError as exc:
-        raise McpInvalidParamsError(
-            f"initialize: {exc.error_count()} validation error(s)",
-        ) from exc
-
-    _log_protocol_version_mismatch(client_request, operator)
-
-    # G7.1-T4 (#316): assemble the operator's tenant session preamble
-    # from ``kind='operational'`` conventions and ship it as
-    # ``instructions`` per MCP 2025-06-18 §Initialization. Since G6.5-T6
-    # (#2546) every preamble carries the static broadcast-discipline
-    # band, so ``instructions`` is always populated (the ``or None``
-    # below stays as a defensive belt for the theoretical empty case).
     # Imported inside the function to break the import cycle (mcp.server
     # → conventions.preamble → db → ... → mcp.server). The cost of one
     # function-local import per ``initialize`` call is negligible (the
@@ -412,6 +386,50 @@ async def _initialize(
             tenant_id=str(operator.tenant_id),
             dropped_slugs=preamble.dropped_slugs,
         )
+    joined = "\n\n".join(band for band in (preamble.text, FEATURE_MATURITY_BAND) if band)
+    # Since G6.5-T6 (#2546) every preamble carries the static
+    # broadcast-discipline band, so the payload is always non-empty;
+    # the ``or None`` stays as a defensive belt for the theoretical
+    # empty case (the wire serializer then drops the field cleanly).
+    return joined or None
+
+
+async def _initialize(
+    operator: Operator,
+    params: dict[str, Any] | None,
+) -> InitializeResponse:
+    """Handle the ``initialize`` method per MCP 2025-06-18 §Initialization.
+
+    Returns a server-info + capabilities envelope, plus the assembled
+    session guidance in the spec-optional ``instructions`` field —
+    the tenant preamble (G7.1-T4 #316) followed by the feature-maturity
+    band (#2675); see :func:`_session_instructions` for the assembly
+    contract.
+
+    MEHO supports only :data:`PROTOCOL_VERSION` and always responds
+    with that — spec-compliant on the response side, but
+    indistinguishable from a silent upgrade for a client pinned to an
+    older revision. G0.14-T13 (#1202) closes the observability gap
+    via :func:`_log_protocol_version_mismatch`: a mismatched client
+    revision triggers a structured ``mcp_initialize_protocol_version_mismatch``
+    WARNING, while the response body stays unchanged. Multi-version
+    negotiation behaviour is tracked as explicit follow-up work,
+    gated on concrete operator demand.
+    """
+    # ``params or {}`` deliberately collapses ``None`` and ``{}``. Spec-
+    # aligned: a missing ``params`` field on the JSON-RPC request and an
+    # explicit empty params object are both equivalent to "no required
+    # fields supplied" for our purposes — :class:`InitializeRequest`'s
+    # validator will then surface a clean INVALID_PARAMS for the
+    # required-but-missing ``protocolVersion``.
+    try:
+        client_request = InitializeRequest.model_validate(params or {})
+    except ValidationError as exc:
+        raise McpInvalidParamsError(
+            f"initialize: {exc.error_count()} validation error(s)",
+        ) from exc
+
+    _log_protocol_version_mismatch(client_request, operator)
 
     # T3 (#248) registers tools/list, tools/call, resources/list,
     # resources/templates/list, resources/read — so the capabilities
@@ -430,7 +448,7 @@ async def _initialize(
             },
         ),
         serverInfo={"name": _SERVER_NAME, "version": __version__},
-        instructions=preamble.text or None,
+        instructions=await _session_instructions(operator),
     )
 
 

--- a/backend/src/meho_backplane/mcp/tools/agent_grants.py
+++ b/backend/src/meho_backplane/mcp/tools/agent_grants.py
@@ -134,6 +134,7 @@ async def _list_grants_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.grant.list",
         description=(
             "List agent permission grants for the operator's tenant "
@@ -188,6 +189,7 @@ async def _show_grant_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.grant.show",
         description=(
             "Fetch one agent permission grant by id (G11.2-T6). "
@@ -240,6 +242,7 @@ async def _create_grant_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.grant.create",
         description=(
             "Grant a permission to an agent principal (G11.2-T6). "
@@ -318,6 +321,7 @@ async def _elevate_grant_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.grant.elevate",
         description=(
             "Grant a time-bounded elevation to an agent principal (G11.2-T6). "
@@ -390,6 +394,7 @@ async def _revoke_grant_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.grant.revoke",
         description=(
             "Revoke (delete) a permission grant by id (G11.2-T6). "

--- a/backend/src/meho_backplane/mcp/tools/agent_principals.py
+++ b/backend/src/meho_backplane/mcp/tools/agent_principals.py
@@ -110,6 +110,7 @@ async def _list_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agent_principals.list",
         description=(
             "List agent principals registered for the operator's tenant "
@@ -191,6 +192,7 @@ async def _register_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agent_principals.register",
         description=(
             "Register a new agent principal for the operator's tenant "
@@ -275,6 +277,7 @@ async def _revoke_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agent_principals.revoke",
         description=(
             "Revoke an agent principal — kill switch (G11.2-T1 #815). "

--- a/backend/src/meho_backplane/mcp/tools/agent_runs.py
+++ b/backend/src/meho_backplane/mcp/tools/agent_runs.py
@@ -195,6 +195,7 @@ async def _run_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.run",
         description=(
             "Run a named agent for the operator's tenant (Initiative #802). "
@@ -280,6 +281,7 @@ async def _run_status_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.run_status",
         description=(
             "Poll an agent run's durable status by run_id (Initiative "
@@ -379,6 +381,7 @@ async def _list_runs_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.list_runs",
         description=(
             "List the operator's tenant's agent runs, newest first "

--- a/backend/src/meho_backplane/mcp/tools/agents.py
+++ b/backend/src/meho_backplane/mcp/tools/agents.py
@@ -117,6 +117,7 @@ async def _list_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.list",
         description=(
             "List agent definitions for the operator's tenant "
@@ -158,6 +159,7 @@ async def _show_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.show",
         description=(
             "Fetch one agent definition by name for the operator's "
@@ -224,6 +226,7 @@ async def _create_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.create",
         description=(
             "Create an agent definition for the operator's tenant "
@@ -334,6 +337,7 @@ async def _edit_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.edit",
         description=(
             "Apply a partial update to an agent definition by name "
@@ -404,6 +408,7 @@ async def _delete_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="agent_runtime",
         name="meho.agents.delete",
         description=(
             "Delete an agent definition by name for the operator's "

--- a/backend/src/meho_backplane/mcp/tools/approvals.py
+++ b/backend/src/meho_backplane/mcp/tools/approvals.py
@@ -240,6 +240,7 @@ async def _list_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="approvals",
         name="meho.approvals.list",
         description=(
             "List approval requests for your tenant (G11.2-T5 / #818). "
@@ -323,6 +324,7 @@ async def _get_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="approvals",
         name="meho.approvals.get",
         description=(
             "Inspect a single approval request by id (G11.2-T5 / #818). "
@@ -441,6 +443,7 @@ async def _approve_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="approvals",
         name="meho.approvals.approve",
         description=(
             "Approve a pending approval request (G11.2-T5 / #818; #1503; "
@@ -527,6 +530,7 @@ async def _reject_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="approvals",
         name="meho.approvals.reject",
         description=(
             "Reject a pending approval request (G11.2-T5 / #818). "

--- a/backend/src/meho_backplane/mcp/tools/audit.py
+++ b/backend/src/meho_backplane/mcp/tools/audit.py
@@ -499,6 +499,7 @@ async def _query_audit_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="audit",
         name=_TOOL_NAME,
         description=_TOOL_DESCRIPTION,
         inputSchema=_INPUT_SCHEMA,
@@ -633,6 +634,7 @@ async def _replay_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="audit",
         name=_REPLAY_TOOL_NAME,
         description=_REPLAY_TOOL_DESCRIPTION,
         inputSchema=_REPLAY_INPUT_SCHEMA,

--- a/backend/src/meho_backplane/mcp/tools/broadcast.py
+++ b/backend/src/meho_backplane/mcp/tools/broadcast.py
@@ -241,6 +241,7 @@ async def _handler_recent(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="broadcast",
         name="meho.broadcast.recent",
         description=(
             "Read the operator's tenant's recent broadcast events from "
@@ -649,6 +650,7 @@ async def _handler_announce(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="broadcast",
         name="meho.broadcast.announce",
         description=(
             "Publish an agent-authored announcement to the operator's "
@@ -1156,6 +1158,7 @@ async def _handler_watch(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="broadcast",
         name="meho.broadcast.watch",
         description=(
             "Long-poll the operator's tenant broadcast stream for new "

--- a/backend/src/meho_backplane/mcp/tools/broadcast_overrides.py
+++ b/backend/src/meho_backplane/mcp/tools/broadcast_overrides.py
@@ -147,6 +147,7 @@ async def _list_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="broadcast",
         name="meho.broadcast.overrides.list",
         description=(
             "List broadcast-detail override rules for the operator's "
@@ -219,6 +220,7 @@ async def _set_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="broadcast",
         name="meho.broadcast.overrides.set",
         description=(
             "Create a broadcast-detail override rule for the operator's "
@@ -307,6 +309,7 @@ async def _remove_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="broadcast",
         name="meho.broadcast.overrides.remove",
         description=(
             "Delete a broadcast-detail override rule by id for the "

--- a/backend/src/meho_backplane/mcp/tools/connector_admin.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_admin.py
@@ -418,6 +418,7 @@ async def _delete_handler(
 register_mcp_tool(
     definition=ToolDefinition(
         name="meho.connector.list",
+        feature="typed_connector_reads",
         description=(
             "List ingested connectors visible to the operator's tenant "
             "(plus built-in / global). Returns per-connector counts — "
@@ -463,6 +464,7 @@ register_mcp_tool(
 register_mcp_tool(
     definition=ToolDefinition(
         name="meho.connector.review",
+        feature="connector_ingest",
         description=(
             "Get the full review payload for one connector (groups + "
             "per-group operations + per-op flags). Use after "
@@ -504,6 +506,7 @@ register_mcp_tool(
 register_mcp_tool(
     definition=ToolDefinition(
         name="meho.connector.edit_group",
+        feature="connector_ingest",
         description=(
             "Edit one operation group's when_to_use prose or display "
             "name (tenant_admin only). Use after meho.connector.review "
@@ -541,6 +544,7 @@ register_mcp_tool(
 register_mcp_tool(
     definition=ToolDefinition(
         name="meho.connector.edit_op",
+        feature="connector_ingest",
         description=(
             "Edit one operation's per-op overrides (tenant_admin only). "
             "Editable fields: custom_description (operator-authored "
@@ -593,6 +597,7 @@ register_mcp_tool(
 register_mcp_tool(
     definition=ToolDefinition(
         name="meho.connector.enable",
+        feature="typed_connector_reads",
         description=(
             "Flip every group of a connector to review_status='enabled' "
             "(tenant_admin only). Cascades is_enabled=true to every "
@@ -628,6 +633,7 @@ register_mcp_tool(
 register_mcp_tool(
     definition=ToolDefinition(
         name="meho.connector.enable_reads",
+        feature="typed_connector_reads",
         description=(
             "Bulk-enable every read-class operation of a connector in "
             "one pass (tenant_admin only). Flips is_enabled=true on "
@@ -680,6 +686,7 @@ register_mcp_tool(
 register_mcp_tool(
     definition=ToolDefinition(
         name="meho.connector.disable",
+        feature="typed_connector_reads",
         description=(
             "Flip every group of a connector to "
             "review_status='disabled' (tenant_admin only). Cascades "
@@ -717,6 +724,7 @@ register_mcp_tool(
 register_mcp_tool(
     definition=ToolDefinition(
         name="meho.connector.delete",
+        feature="typed_connector_reads",
         description=(
             "Delete one connector (tenant_admin only): remove its "
             "operation_group + endpoint_descriptor rows under the "

--- a/backend/src/meho_backplane/mcp/tools/connector_ingest.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_ingest.py
@@ -577,6 +577,7 @@ _INGEST_DESCRIPTION: Final[str] = (
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="connector_ingest",
         name="meho.connector.ingest",
         description=_INGEST_DESCRIPTION,
         inputSchema={
@@ -671,6 +672,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="connector_ingest",
         name="meho.connector.ingest_status",
         description=(
             "Poll the durable status of an async connector-ingest job "

--- a/backend/src/meho_backplane/mcp/tools/doc_collections.py
+++ b/backend/src/meho_backplane/mcp/tools/doc_collections.py
@@ -312,6 +312,7 @@ async def _list_doc_collections_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="doc_collections",
         name="list_doc_collections",
         description=_LIST_DOC_COLLECTIONS_DESCRIPTION,
         inputSchema=_LIST_DOC_COLLECTIONS_INPUT_SCHEMA,

--- a/backend/src/meho_backplane/mcp/tools/doc_collections_create.py
+++ b/backend/src/meho_backplane/mcp/tools/doc_collections_create.py
@@ -231,6 +231,7 @@ async def _create_doc_collections_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="doc_collections",
         name=_CREATE_TOOL_NAME,
         description=_CREATE_DOC_COLLECTIONS_DESCRIPTION,
         inputSchema=_CREATE_DOC_COLLECTIONS_INPUT_SCHEMA,

--- a/backend/src/meho_backplane/mcp/tools/doc_collections_delete.py
+++ b/backend/src/meho_backplane/mcp/tools/doc_collections_delete.py
@@ -150,6 +150,7 @@ async def _delete_doc_collections_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="doc_collections",
         name=_DELETE_TOOL_NAME,
         description=_DELETE_DOC_COLLECTIONS_DESCRIPTION,
         inputSchema=_DELETE_DOC_COLLECTIONS_INPUT_SCHEMA,

--- a/backend/src/meho_backplane/mcp/tools/docs.py
+++ b/backend/src/meho_backplane/mcp/tools/docs.py
@@ -359,6 +359,7 @@ async def _run_search_fanout(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="doc_collections",
         name="search_docs",
         description=(
             "Search a vendor-document collection (product manuals, KB "
@@ -662,6 +663,7 @@ def _citation_payload(chunk: DocsChunk) -> dict[str, Any]:
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="doc_collections",
         name="ask_docs",
         description=(
             "Answer a vendor-reference question with a SYNTHESIZED, CITED "

--- a/backend/src/meho_backplane/mcp/tools/knowledge.py
+++ b/backend/src/meho_backplane/mcp/tools/knowledge.py
@@ -220,6 +220,7 @@ async def _add_to_knowledge_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="memory_knowledge",
         name="search_knowledge",
         description=(
             "Search the tenant's knowledge base for distilled operator "
@@ -299,6 +300,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="memory_knowledge",
         name="add_to_knowledge",
         description=(
             "Add a new entry to the tenant's knowledge base. Use when "

--- a/backend/src/meho_backplane/mcp/tools/meho_status.py
+++ b/backend/src/meho_backplane/mcp/tools/meho_status.py
@@ -59,6 +59,10 @@ async def _meho_status_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        # Deliberately unclassified (#2675): the reference tool mirrors
+        # /api/v1/health — infrastructure, not a classified feature
+        # (the _READY_ENTRY_FEATURE ``mcp``-entry precedent).
+        feature=None,
         name="meho.status",
         description=(
             "Returns the operator's identity (sub, name, email) plus the "

--- a/backend/src/meho_backplane/mcp/tools/memory.py
+++ b/backend/src/meho_backplane/mcp/tools/memory.py
@@ -433,6 +433,7 @@ async def _add_to_memory_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="memory_knowledge",
         name="search_memory",
         description=(
             "Search the operator's accessible memories (own user-scoped "
@@ -499,6 +500,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="memory_knowledge",
         name="add_to_memory",
         description=(
             "Add a new memory entry. Use when you (or the operator "

--- a/backend/src/meho_backplane/mcp/tools/memory_promote.py
+++ b/backend/src/meho_backplane/mcp/tools/memory_promote.py
@@ -173,6 +173,7 @@ async def _meho_memory_promote_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="memory_knowledge",
         name=_TOOL_NAME,
         description=(
             "Promote one memory to a strictly broader scope along the "

--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -160,6 +160,7 @@ async def _preview_operation_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="typed_connector_reads",
         name="list_operation_groups",
         description=(
             "List enabled operation groups for a connector. Each group "
@@ -296,6 +297,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="typed_connector_reads",
         name="search_operations",
         description=(
             "Hybrid BM25 + cosine retrieval over a connector's enabled "
@@ -393,6 +395,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="typed_connector_reads",
         name="call_operation",
         description=(
             "Invoke an operation. Use ONLY after `search_operations` has "
@@ -560,6 +563,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="typed_connector_reads",
         name="preview_operation",
         description=(
             "Preview an operation WITHOUT running it. Resolves the same "

--- a/backend/src/meho_backplane/mcp/tools/result_query.py
+++ b/backend/src/meho_backplane/mcp/tools/result_query.py
@@ -118,6 +118,7 @@ def _handle_not_found(handle_id: UUID) -> McpInvalidParamsError:
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="typed_connector_reads",
         name="result_query",
         description=(
             "Read rows back from a JSONFlux result handle. After "

--- a/backend/src/meho_backplane/mcp/tools/runbook_runs.py
+++ b/backend/src/meho_backplane/mcp/tools/runbook_runs.py
@@ -584,6 +584,10 @@ async def _list_runs_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        # Deliberately unclassified (#2675): the provisional #2664
+        # maturity table does not tier the runbooks feature (see the
+        # matching note in runbooks.py). Applies to every tool here.
+        feature=None,
         name="meho.runbook.start",
         description=_START_DESCRIPTION,
         inputSchema={
@@ -606,6 +610,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature=None,
         name="meho.runbook.next",
         description=_NEXT_DESCRIPTION,
         inputSchema={
@@ -634,6 +639,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature=None,
         name="meho.runbook.abort",
         description=_ABORT_DESCRIPTION,
         inputSchema={
@@ -658,6 +664,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature=None,
         name="meho.runbook.reassign",
         description=_REASSIGN_DESCRIPTION,
         inputSchema={
@@ -684,6 +691,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature=None,
         name="meho.runbook.list_runs",
         description=_LIST_DESCRIPTION,
         inputSchema={

--- a/backend/src/meho_backplane/mcp/tools/runbooks.py
+++ b/backend/src/meho_backplane/mcp/tools/runbooks.py
@@ -713,6 +713,12 @@ def _opacity_floor_denial() -> McpInvalidParamsError:
 
 register_mcp_tool(
     definition=ToolDefinition(
+        # Deliberately unclassified (#2675): the provisional #2664
+        # maturity table does not tier the runbooks feature. Applies to
+        # every meho.runbook.* tool in this module and its sibling
+        # runbook_runs.py; the #2678 drift guard forces the
+        # classification decision.
+        feature=None,
         name="meho.runbook.draft_template",
         description=_DRAFT_DESCRIPTION,
         inputSchema={
@@ -733,6 +739,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature=None,
         name="meho.runbook.edit_template",
         description=_EDIT_DESCRIPTION,
         inputSchema={
@@ -753,6 +760,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature=None,
         name="meho.runbook.publish_template",
         description=_PUBLISH_DESCRIPTION,
         inputSchema={
@@ -773,6 +781,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature=None,
         name="meho.runbook.deprecate_template",
         description=_DEPRECATE_DESCRIPTION,
         inputSchema={
@@ -793,6 +802,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature=None,
         name="meho.runbook.discard_template",
         description=_DISCARD_DESCRIPTION,
         inputSchema={
@@ -813,6 +823,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature=None,
         name="meho.runbook.list_templates",
         description=_LIST_DESCRIPTION,
         inputSchema={
@@ -847,6 +858,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature=None,
         name="meho.runbook.show_template",
         description=_SHOW_DESCRIPTION,
         inputSchema={

--- a/backend/src/meho_backplane/mcp/tools/scheduler.py
+++ b/backend/src/meho_backplane/mcp/tools/scheduler.py
@@ -158,6 +158,7 @@ async def _list_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="scheduler",
         name="meho.scheduler.list",
         description=(
             "List scheduled triggers for the operator's tenant "
@@ -274,6 +275,7 @@ async def _create_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="scheduler",
         name="meho.scheduler.create",
         description=(
             "Create one scheduled trigger under the operator's tenant "
@@ -415,6 +417,7 @@ async def _cancel_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="scheduler",
         name="meho.scheduler.cancel",
         description=(
             "Cancel one scheduled trigger by id (Initiative #804). "

--- a/backend/src/meho_backplane/mcp/tools/sensors.py
+++ b/backend/src/meho_backplane/mcp/tools/sensors.py
@@ -115,6 +115,7 @@ async def _list_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="sensors",
         name="meho.sensor.list",
         description=(
             "List sensors for the operator's tenant (Initiative #2416). "
@@ -221,6 +222,7 @@ async def _create_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="sensors",
         name="meho.sensor.create",
         description=(
             "Create one sensor under the operator's tenant (Initiative "
@@ -350,6 +352,7 @@ async def _delete_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="sensors",
         name="meho.sensor.delete",
         description=(
             "Hard-delete one sensor by id (Initiative #2416). Tenant_admin "

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -992,6 +992,7 @@ async def _list_edges_facet(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="topology",
         name=_QUERY_TOPOLOGY_NAME,
         description=_QUERY_TOPOLOGY_DESCRIPTION,
         inputSchema=_QUERY_TOPOLOGY_INPUT_SCHEMA,
@@ -1371,6 +1372,10 @@ async def _list_targets_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        # Registered in the topology family module, but the tool is the
+        # G0.3 targets meta-tool — its maturity follows the ``targets``
+        # registry entry, not Topology v2's.
+        feature="targets",
         name=_LIST_TARGETS_NAME,
         description=_LIST_TARGETS_DESCRIPTION,
         inputSchema=_LIST_TARGETS_INPUT_SCHEMA,
@@ -1639,6 +1644,7 @@ async def _annotate_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="topology",
         name=_ANNOTATE_TOOL_NAME,
         description=_ANNOTATE_DESCRIPTION,
         inputSchema=ANNOTATE_PARAMETER_SCHEMA,
@@ -1700,6 +1706,7 @@ async def _unannotate_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="topology",
         name=_UNANNOTATE_TOOL_NAME,
         description=_UNANNOTATE_DESCRIPTION,
         inputSchema=UNANNOTATE_PARAMETER_SCHEMA,

--- a/backend/src/meho_backplane/mcp/tools/topology_bulk_import.py
+++ b/backend/src/meho_backplane/mcp/tools/topology_bulk_import.py
@@ -171,6 +171,7 @@ async def _bulk_import_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="topology",
         name=_BULK_IMPORT_TOOL_NAME,
         description=_BULK_IMPORT_DESCRIPTION,
         inputSchema=BULK_IMPORT_TOOL_INPUT_SCHEMA,

--- a/backend/src/meho_backplane/mcp/tools/topology_create_node.py
+++ b/backend/src/meho_backplane/mcp/tools/topology_create_node.py
@@ -119,6 +119,7 @@ async def _create_node_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="topology",
         name=_CREATE_NODE_TOOL_NAME,
         description=_CREATE_NODE_DESCRIPTION,
         inputSchema=CREATE_NODE_PARAMETER_SCHEMA,

--- a/backend/src/meho_backplane/mcp/tools/topology_delete_node.py
+++ b/backend/src/meho_backplane/mcp/tools/topology_delete_node.py
@@ -99,6 +99,7 @@ async def _delete_node_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
+        feature="topology",
         name=_DELETE_NODE_TOOL_NAME,
         description=_DELETE_NODE_DESCRIPTION,
         inputSchema=DELETE_NODE_PARAMETER_SCHEMA,

--- a/backend/tests/test_maturity_propagation.py
+++ b/backend/tests/test_maturity_propagation.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Maturity propagation to the agent-facing surfaces (#2675).
+
+Three surfaces, one source of truth
+(:data:`~meho_backplane.features.FEATURE_MATURITY`):
+
+* **MCP tool descriptions** — non-GA tools carry a ``[beta]`` /
+  ``[experimental]`` prefix applied by
+  :func:`~meho_backplane.mcp.registry.register_mcp_tool`; GA and
+  deliberately-unclassified (``feature=None``) tools carry none.
+* **``initialize.instructions``** — the static
+  :data:`~meho_backplane.mcp.maturity.FEATURE_MATURITY_BAND` appended
+  after the assembled preamble (wire-level coverage lives in
+  :mod:`tests.test_mcp_initialize_instructions`; this module pins the
+  band's *content* contract).
+* **OpenAPI ``x-maturity``** — top-level tag entries plus the
+  spans-tiers per-operation overrides injected by
+  :func:`~meho_backplane.api.openapi_maturity.inject_maturity_extensions`.
+
+Every expectation here is **derived from the registry** — no
+hand-maintained expected-list (the #2675 acceptance criterion). A
+registry retier must flip these assertions' expectations automatically,
+never require an edit here.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from collections.abc import Iterator
+
+import pytest
+from pydantic import ValidationError
+
+import meho_backplane.mcp.registry as registry_module
+from meho_backplane.api.openapi_maturity import (
+    PATH_FEATURE_OVERRIDES,
+    TAG_FEATURE,
+)
+from meho_backplane.features import FEATURE_MATURITY
+from meho_backplane.main import app
+from meho_backplane.mcp.maturity import (
+    FEATURE_MATURITY_BAND,
+    MATURITY_BLOCK_END,
+    MATURITY_BLOCK_START,
+    _build_band,
+)
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+
+_NON_GA_PREFIXES = ("[beta] ", "[experimental] ")
+
+
+async def _noop_handler(_operator: object, _args: dict[str, object]) -> dict[str, object]:
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# MCP tool-description prefixes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def production_tools() -> Iterator[dict[str, ToolDefinition]]:
+    """Yield every production tool definition, freshly registered.
+
+    Python's import cache makes registration side effects one-shot per
+    process, so a prior test's ``clear_registries()`` leaves the tool
+    modules imported but the registry empty. Import-then-reload forces
+    every module body to re-execute against a cleared registry — the
+    same pattern as ``tests.mcp_test_fixtures.isolated_registry``, but
+    discovered via ``pkgutil`` so a future tool module is covered
+    without joining a hand-maintained list. Prior registry state is
+    restored on teardown.
+    """
+    tools_pkg = importlib.import_module("meho_backplane.mcp.tools")
+    modules = [
+        importlib.import_module(f"meho_backplane.mcp.tools.{name}")
+        for _finder, name, _ispkg in pkgutil.iter_modules(tools_pkg.__path__)
+    ]
+    saved_tools = dict(registry_module._TOOLS)
+    saved_resources = dict(registry_module._RESOURCES)
+    registry_module._TOOLS.clear()
+    for module in modules:
+        importlib.reload(module)
+    try:
+        yield {name: defn for name, (defn, _handler) in registry_module._TOOLS.items()}
+    finally:
+        registry_module._TOOLS.clear()
+        registry_module._TOOLS.update(saved_tools)
+        registry_module._RESOURCES.clear()
+        registry_module._RESOURCES.update(saved_resources)
+
+
+def test_every_tool_description_prefix_derives_from_the_registry(
+    production_tools: dict[str, ToolDefinition],
+) -> None:
+    """Non-GA tools carry exactly their tier's prefix; others carry none."""
+    assert production_tools, "no production tools registered — fixture broken"
+    for name, defn in production_tools.items():
+        expected_tier = None if defn.feature is None else FEATURE_MATURITY[defn.feature]["maturity"]
+        if expected_tier in (None, "ga"):
+            assert not defn.description.startswith(_NON_GA_PREFIXES), (
+                f"{name}: GA/unclassified tool must carry no maturity prefix"
+            )
+        else:
+            expected_prefix = f"[{expected_tier}] "
+            assert defn.description.startswith(expected_prefix), (
+                f"{name}: expected description prefix {expected_prefix!r} "
+                f"(feature {defn.feature!r})"
+            )
+            rest = defn.description.removeprefix(expected_prefix)
+            assert not rest.startswith(_NON_GA_PREFIXES), f"{name}: description is double-prefixed"
+
+
+def test_prefix_is_applied_at_registration_and_stays_off_the_wire_fields() -> None:
+    """Registration owns the label; ``feature`` never reaches the wire."""
+    non_ga_feature = next(key for key, info in FEATURE_MATURITY.items() if info["maturity"] != "ga")
+    ga_feature = next(key for key, info in FEATURE_MATURITY.items() if info["maturity"] == "ga")
+    tier = FEATURE_MATURITY[non_ga_feature]["maturity"]
+    saved = dict(registry_module._TOOLS)
+    registry_module._TOOLS.clear()
+    try:
+        for feature, tool_name in (
+            (non_ga_feature, "maturity.test.non_ga"),
+            (ga_feature, "maturity.test.ga"),
+            (None, "maturity.test.unclassified"),
+        ):
+            register_mcp_tool(
+                ToolDefinition(
+                    feature=feature,
+                    name=tool_name,
+                    description="Does a thing.",
+                    inputSchema={"type": "object"},
+                ),
+                _noop_handler,
+            )
+        non_ga_defn = registry_module._TOOLS["maturity.test.non_ga"][0]
+        assert non_ga_defn.description == f"[{tier}] Does a thing."
+        assert registry_module._TOOLS["maturity.test.ga"][0].description == "Does a thing."
+        assert (
+            registry_module._TOOLS["maturity.test.unclassified"][0].description == "Does a thing."
+        )
+        wire = non_ga_defn.to_wire()
+        assert wire["description"] == f"[{tier}] Does a thing."
+        assert "feature" not in wire
+    finally:
+        registry_module._TOOLS.clear()
+        registry_module._TOOLS.update(saved)
+
+
+def test_unknown_feature_key_is_rejected_at_construction() -> None:
+    """A typo'd feature key fails loudly instead of silently un-labelling."""
+    with pytest.raises(ValidationError, match="unknown feature key"):
+        ToolDefinition(
+            feature="not-a-feature",
+            name="maturity.test.bogus",
+            description="Does a thing.",
+            inputSchema={"type": "object"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# initialize.instructions maturity band
+# ---------------------------------------------------------------------------
+
+
+def test_band_lists_exactly_the_registrys_non_ga_features() -> None:
+    """Every non-GA key appears in the band; every GA key does not."""
+    assert FEATURE_MATURITY_BAND.startswith(MATURITY_BLOCK_START)
+    assert FEATURE_MATURITY_BAND.endswith(MATURITY_BLOCK_END)
+    for key, info in FEATURE_MATURITY.items():
+        if info["maturity"] == "ga":
+            assert key not in FEATURE_MATURITY_BAND, (
+                f"GA feature {key!r} must not be listed in the maturity band"
+            )
+        else:
+            assert key in FEATURE_MATURITY_BAND, (
+                f"non-GA feature {key!r} missing from the maturity band"
+            )
+
+
+def test_band_is_empty_when_every_feature_is_ga(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All-GA registry -> empty band, so the initialize join drops it."""
+    monkeypatch.setattr(
+        "meho_backplane.mcp.maturity.FEATURE_MATURITY",
+        {"everything": {"maturity": "ga"}},
+    )
+    assert _build_band() == ""
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI x-maturity
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def openapi_schema() -> dict[str, object]:
+    """Bust FastAPI's cache and generate a fresh document."""
+    app.openapi_schema = None
+    return app.openapi()
+
+
+def test_openapi_tags_carry_registry_derived_x_maturity(
+    openapi_schema: dict[str, object],
+) -> None:
+    """Each mapped, in-use tag advertises its feature's current tier."""
+    tags = openapi_schema["tags"]
+    assert isinstance(tags, list) and tags
+    by_name = {entry["name"]: entry for entry in tags}
+    for name, entry in by_name.items():
+        assert entry["x-maturity"] == FEATURE_MATURITY[TAG_FEATURE[name]]["maturity"]
+    # The BFF console tags are #2677's surface, not the public
+    # document's — never labelled here.
+    assert not [name for name in by_name if name.startswith("ui")]
+
+
+def test_openapi_spans_tiers_paths_carry_operation_level_x_maturity(
+    openapi_schema: dict[str, object],
+) -> None:
+    """Override paths exist and each operation carries its own tier."""
+    paths = openapi_schema["paths"]
+    assert isinstance(paths, dict)
+    for path, feature in PATH_FEATURE_OVERRIDES.items():
+        assert path in paths, f"override path {path!r} missing from the document"
+        expected = FEATURE_MATURITY[feature]["maturity"]
+        operations = [
+            op
+            for method, op in paths[path].items()
+            if method in {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+        ]
+        assert operations
+        for op in operations:
+            assert op["x-maturity"] == expected

--- a/backend/tests/test_mcp_audit.py
+++ b/backend/tests/test_mcp_audit.py
@@ -224,6 +224,7 @@ async def test_tools_call_post_gate_invalid_params_audits_as_denied_not_500(
 
     register_mcp_tool(
         ToolDefinition(
+            feature=None,
             name="test.post_gate_reject",
             description="Raises McpInvalidParamsError after the gates (test only).",
             inputSchema={"type": "object", "properties": {}, "additionalProperties": False},

--- a/backend/tests/test_mcp_capability_gating.py
+++ b/backend/tests/test_mcp_capability_gating.py
@@ -90,6 +90,7 @@ def _operator(
 def test_tool_to_wire_strips_required_capability() -> None:
     """``ToolDefinition.to_wire`` drops ``required_capability`` from the wire."""
     defn = ToolDefinition(
+        feature=None,
         name="docs.search",
         description="Capability-gated docs search",
         inputSchema={"type": "object", "properties": {}},
@@ -120,6 +121,7 @@ def test_resource_template_to_wire_strips_required_capability() -> None:
 def test_required_capability_defaults_to_none() -> None:
     """An undeclared ``required_capability`` defaults to ``None`` (no gate)."""
     defn = ToolDefinition(
+        feature=None,
         name="ungated.tool",
         description="A tool with no capability gate",
         inputSchema={"type": "object", "properties": {}},
@@ -170,6 +172,7 @@ def _register_one_gated_one_ungated() -> None:
 
     register_mcp_tool(
         ToolDefinition(
+            feature=None,
             name="ungated.tool",
             description="Always visible",
             inputSchema={"type": "object", "properties": {}},
@@ -179,6 +182,7 @@ def _register_one_gated_one_ungated() -> None:
     )
     register_mcp_tool(
         ToolDefinition(
+            feature=None,
             name="docs.search",
             description="Gated on the meho-docs capability",
             inputSchema={"type": "object", "properties": {}},
@@ -226,6 +230,7 @@ def test_capability_gate_is_orthogonal_to_role_gate(
 
     register_mcp_tool(
         ToolDefinition(
+            feature=None,
             name="admin.docs",
             description="Admin-only AND meho-docs gated",
             inputSchema={"type": "object", "properties": {}},
@@ -319,6 +324,7 @@ def gated_client(
             # present for this test only; clear at teardown.
             register_mcp_tool(
                 ToolDefinition(
+                    feature=None,
                     name="docs.search",
                     description="Gated on the meho-docs capability",
                     inputSchema={"type": "object", "properties": {}},

--- a/backend/tests/test_mcp_initialize_instructions.py
+++ b/backend/tests/test_mcp_initialize_instructions.py
@@ -43,6 +43,7 @@ from meho_backplane.conventions.preamble import (
 )
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Tenant, TenantConvention
+from meho_backplane.mcp.maturity import FEATURE_MATURITY_BAND, MATURITY_BLOCK_END
 from meho_backplane.mcp.schemas import PROTOCOL_VERSION
 from tests.mcp_test_fixtures import (
     client_with_operator,  # noqa: F401 — pytest-discovered fixture
@@ -77,12 +78,14 @@ async def test_initialize_instructions_omitted_for_empty_tenant(
     client_with_operator: tuple[TestClient, Operator],
     seeded_operator_tenant: None,
 ) -> None:
-    """Empty tenant -> ``instructions`` carries the broadcast-discipline band.
+    """Empty tenant -> ``instructions`` carries the two static bands.
 
     Since G6.5-T6 (#2546) the static broadcast-discipline band is
     injected into every assembled preamble, so even a tenant with no
-    operational conventions receives it. The ``instructions`` field is
-    therefore present and equals the band alone (no conventions block).
+    operational conventions receives it. #2675 appends the static
+    feature-maturity band after the preamble. The ``instructions``
+    field is therefore present and equals exactly those two bands (no
+    conventions block).
     """
     client, _op = client_with_operator
 
@@ -91,7 +94,7 @@ async def test_initialize_instructions_omitted_for_empty_tenant(
     body = response.json()
     assert "error" not in body
     instructions = body["result"]["instructions"]
-    assert instructions == BROADCAST_DISCIPLINE_BAND
+    assert instructions == f"{BROADCAST_DISCIPLINE_BAND}\n\n{FEATURE_MATURITY_BAND}"
     assert BLOCK_START not in instructions  # no conventions block
 
 
@@ -137,10 +140,14 @@ async def test_initialize_instructions_populated_for_seeded_tenant(
     assert instructions  # non-empty
     # Since G6.5-T6 (#2546) the always-on broadcast-discipline band
     # leads the preamble; the conventions block follows and (with no
-    # priming / catalogue) closes the text.
+    # priming / catalogue) closes the preamble text. #2675 appends the
+    # feature-maturity band after the preamble, so it now closes the
+    # instructions payload; the conventions delimiter still terminates
+    # its own band immediately before it.
     assert instructions.startswith(BROADCAST_BLOCK_START)
     assert BLOCK_START in instructions
-    assert instructions.endswith(BLOCK_END)
+    assert instructions.endswith(MATURITY_BLOCK_END)
+    assert f"{BLOCK_END}\n\n{FEATURE_MATURITY_BAND}" in instructions
     assert GUARD_PREFIX in instructions
     # Convention content is included verbatim.
     assert "RBAC is canonical" in instructions

--- a/backend/tests/test_mcp_inputschema_format_enforcement.py
+++ b/backend/tests/test_mcp_inputschema_format_enforcement.py
@@ -94,6 +94,7 @@ def _register_format_probe_tool() -> dict[str, list[dict[str, Any]]]:
 
     register_mcp_tool(
         ToolDefinition(
+            feature=None,
             name="test.format_probe",
             description="Synthetic tool asserting format enforcement",
             inputSchema={

--- a/backend/tests/test_mcp_registry.py
+++ b/backend/tests/test_mcp_registry.py
@@ -145,6 +145,7 @@ def test_register_mcp_tool_makes_it_callable_via_get_tool() -> None:
         return {"ok": True}
 
     defn = ToolDefinition(
+        feature=None,
         name="test.tool",
         description="A test tool",
         inputSchema={"type": "object", "properties": {}},
@@ -187,6 +188,7 @@ def test_to_wire_strips_top_level_combinators_but_keeps_them_on_input_schema() -
         "anyOf": [{"required": ["kind"]}],
     }
     defn = ToolDefinition(
+        feature=None,
         name="test.combinator",
         description="A tool whose schema carries top-level combinators",
         inputSchema=schema,
@@ -229,6 +231,7 @@ def test_register_mcp_tool_rejects_duplicate() -> None:
         return {}
 
     defn = ToolDefinition(
+        feature=None,
         name="dup.tool",
         description="dup",
         inputSchema={"type": "object"},
@@ -257,6 +260,7 @@ def _register_three_tools_at_varying_roles() -> None:
     ):
         register_mcp_tool(
             ToolDefinition(
+                feature=None,
                 name=name,
                 description=f"Tool requiring {role}",
                 inputSchema={"type": "object", "properties": {}},
@@ -337,6 +341,7 @@ def test_tools_call_dispatches_to_registered_handler(
 
     register_mcp_tool(
         ToolDefinition(
+            feature=None,
             name="test.echo",
             description="Echo arguments back",
             inputSchema={
@@ -411,6 +416,7 @@ def test_tools_call_malformed_arguments_returns_invalid_params(
 
     register_mcp_tool(
         ToolDefinition(
+            feature=None,
             name="test.requires_msg",
             description="A tool whose msg arg is required",
             inputSchema={
@@ -459,6 +465,7 @@ def test_tools_call_forbidden_for_under_privileged_operator(
 
     register_mcp_tool(
         ToolDefinition(
+            feature=None,
             name="ops_only.tool",
             description="Operator-only tool",
             inputSchema={"type": "object", "properties": {}},

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -3285,7 +3285,8 @@
               }
             }
           }
-        }
+        },
+        "x-maturity": "experimental"
       }
     },
     "/api/v1/connectors/ingest/jobs/{job_id}": {
@@ -3339,7 +3340,8 @@
               }
             }
           }
-        }
+        },
+        "x-maturity": "experimental"
       }
     },
     "/api/v1/connectors": {
@@ -3512,7 +3514,8 @@
               }
             }
           }
-        }
+        },
+        "x-maturity": "experimental"
       }
     },
     "/api/v1/connectors/{connector_id}/groups/{group_key}": {
@@ -3577,7 +3580,8 @@
               }
             }
           }
-        }
+        },
+        "x-maturity": "experimental"
       }
     },
     "/api/v1/connectors/{connector_id}/operations/{op_id}": {
@@ -3649,7 +3653,8 @@
               }
             }
           }
-        }
+        },
+        "x-maturity": "experimental"
       }
     },
     "/api/v1/connectors/{connector_id}/enable": {
@@ -29900,5 +29905,99 @@
         "description": "Closed enum of sort columns exposed in the URL.\n\nMirrors :data:`meho_backplane.topology.query._NODE_SORT_COLUMNS`\n-- redeclared at the route boundary so an out-of-range value\nfails Pydantic validation (422 with the candidate list in the\nerror context) before the substrate's defensive\n:class:`ValueError` guard runs. The enum's ``str`` mixin keeps\nthe template's ``{{ sort }}`` rendering / ``href`` building\nstable -- ``str(SortColumn.NAME)`` is ``\"name\"`` (not\n``\"_SortColumn.NAME\"``)."
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "agent-grants",
+      "x-maturity": "experimental"
+    },
+    {
+      "name": "agent-principals",
+      "x-maturity": "experimental"
+    },
+    {
+      "name": "agents",
+      "x-maturity": "experimental"
+    },
+    {
+      "name": "approvals",
+      "x-maturity": "ga"
+    },
+    {
+      "name": "audit",
+      "x-maturity": "ga"
+    },
+    {
+      "name": "auth",
+      "x-maturity": "ga"
+    },
+    {
+      "name": "broadcast",
+      "x-maturity": "beta"
+    },
+    {
+      "name": "checks",
+      "x-maturity": "beta"
+    },
+    {
+      "name": "checks-dashboards",
+      "x-maturity": "beta"
+    },
+    {
+      "name": "connectors",
+      "x-maturity": "ga"
+    },
+    {
+      "name": "discovery",
+      "x-maturity": "ga"
+    },
+    {
+      "name": "docs",
+      "x-maturity": "experimental"
+    },
+    {
+      "name": "feed",
+      "x-maturity": "beta"
+    },
+    {
+      "name": "gateway",
+      "x-maturity": "beta"
+    },
+    {
+      "name": "knowledge",
+      "x-maturity": "ga"
+    },
+    {
+      "name": "memory",
+      "x-maturity": "ga"
+    },
+    {
+      "name": "operations",
+      "x-maturity": "ga"
+    },
+    {
+      "name": "retrieval",
+      "x-maturity": "ga"
+    },
+    {
+      "name": "runner-principals",
+      "x-maturity": "beta"
+    },
+    {
+      "name": "scheduler",
+      "x-maturity": "beta"
+    },
+    {
+      "name": "sensors",
+      "x-maturity": "beta"
+    },
+    {
+      "name": "targets",
+      "x-maturity": "ga"
+    },
+    {
+      "name": "topology",
+      "x-maturity": "beta"
+    }
+  ]
 }

--- a/docs/codebase/feature-maturity.md
+++ b/docs/codebase/feature-maturity.md
@@ -47,13 +47,39 @@ registry, preserving the module's purity contract (pure function over
 a `Settings` snapshot; tests pin this in
 `test_builder_stays_pure_and_does_not_alias_the_registry`).
 
-`/ready` is the only consuming surface shipped so far; it carries the
-merged view for operator tooling. The remaining #2664 surfaces are
-planned consumers, not yet implemented: MCP registration (#2675), the
-CLI command-manifest builder (#2676), the `/ui` badge include (#2677),
-and the docs-site maturity-index generator plus CI drift guard (#2678)
-will all read `FEATURE_MATURITY` in-process — there is deliberately no
-dedicated REST read surface.
+Consuming surfaces shipped so far (all read `FEATURE_MATURITY`
+in-process — there is deliberately no dedicated REST read surface):
+
+- `/ready` — carries the merged view for operator tooling (#2674).
+- **MCP tool descriptions** (#2675) — every
+  `mcp/registry.py::ToolDefinition` declares a required `feature`
+  field (a registry key, or an explicit `None` for
+  deliberately-unclassified surfaces such as `meho.status` and the
+  runbooks family, which the provisional #2664 table does not
+  classify). `register_mcp_tool` prefixes non-GA descriptions with
+  `[beta]` / `[experimental]` at registration time; an unknown key
+  fails validation at construction.
+- **`initialize.instructions`** (#2675) —
+  `mcp/maturity.py::FEATURE_MATURITY_BAND` (a registry-derived static
+  band listing exactly the non-GA features) is appended after the
+  assembled preamble by `mcp/server.py::_session_instructions`. Keys
+  only — no tracking URLs, to honour the #1137 forbidden-token
+  contract.
+- **OpenAPI `x-maturity`** (#2675) —
+  `api/openapi_maturity.py::inject_maturity_extensions` stamps
+  top-level tag entries (mapping in `TAG_FEATURE`) plus per-operation
+  overrides where a tag spans tiers (`PATH_FEATURE_OVERRIDES`; today
+  the `connectors` tag's ingest-pipeline paths). Flows into the
+  committed `cli/api/openapi.json` snapshot. `/ui*` tags and
+  infrastructure tags (`health`, `version`, `mcp`) are deliberately
+  unmapped.
+
+Remaining #2664 surfaces, not yet implemented: the CLI
+command-manifest builder (#2676), the `/ui` badge include (#2677),
+and the docs-site maturity-index generator plus CI drift guard
+(#2678). The drift guard is where today's deliberately-unclassified
+surfaces (runbooks, `meho.status`, the `conventions` REST tag) get
+forced into an explicit classification decision.
 
 ## Dependencies
 
@@ -79,3 +105,6 @@ expectations from the registry so a retier never requires a test edit.
 - `backend/tests/test_features.py` — registry contract tests;
   `backend/tests/test_features_doc_consistency.py` — deploy-gate doc
   parity (unchanged by #2674).
+- `backend/tests/test_maturity_propagation.py` — #2675 surface tests;
+  every expectation derives from the registry (a retier never
+  requires a test edit).


### PR DESCRIPTION
## Summary

- Propagate the #2674 feature-maturity registry to the agent-facing surfaces, all resolved from `FEATURE_MATURITY` at registration/generation time — never hardcoded per tool or route.
- **MCP tool descriptions**: `ToolDefinition` gains a required `feature` field (a registry key, or an explicit `None` for deliberately-unclassified surfaces); `register_mcp_tool` prefixes non-GA descriptions with `[beta]` / `[experimental]` at registration. Unknown keys fail validation at construction. The prefix is applied to the stored definition so `tools/list` and the hosted-agent toolset bridge see one consistent label.
- **`initialize.instructions`**: a registry-derived `FEATURE_MATURITY_BAND` (new `mcp/maturity.py`) is appended after the assembled preamble by a new `_session_instructions` helper (extracted from `_initialize`, which had hit the 100-line quality gate). Keys only — no tracking URLs, honouring the #1137 forbidden-token contract on `instructions`.
- **OpenAPI `x-maturity`**: new `api/openapi_maturity.py` injects top-level tag entries (tag→feature mapping) plus per-operation overrides where a tag spans tiers (the `connectors` tag: lifecycle verbs follow `typed_connector_reads`/GA, spec-ingestion paths follow `connector_ingest`/experimental — mirroring the `meho.connector.*` MCP split). Wired into `build_openapi_schema` after the existing product-enum injection; `cli/api/openapi.json` snapshot regenerated in-PR (`make snapshot-openapi && make generate` — the generated Go client is byte-identical, `x-` extensions don't affect codegen).

## Mapping decisions worth review

- `list_targets` (registered in the topology module) maps to `targets` (GA), not `topology` — it is the G0.3 targets meta-tool.
- Deliberately unclassified (`feature=None` / unmapped tag): `meho.status` (health mirror), the runbooks family, and the REST `conventions`, `health`, `version`, `mcp` tags — the provisional #2664 table does not classify these surfaces, and inventing tiers here would be a classification decision above this task's pay grade. The explicit-`None` declarations stay greppable for the #2678 drift guard, which is where these get forced into a classification decision.
- The instructions band and the OpenAPI tags carry tier labels only (no `target_ga` / `tracking`) — compactness plus the #1137 token constraint; the full metadata stays on `/ready`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/` — clean except pre-existing `net/icmp.py` `MSG_ERRQUEUE` error (macOS-only; present on clean origin/main, CI runs Linux)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (37 pre-existing warnings in touched legacy files)
- [x] Full unit suite (`pytest -n 3 --dist loadscope --ignore=tests/integration --ignore=tests/migrations tests/`) — 10670 passed, 193 skipped, 2 failed: `test_connectors_net_icmp.py::test_trace_reaches_loopback` and `test_connectors_net_dns_lookup.py::test_chosen_resolver_queries_that_nameserver`, the known pre-existing macOS-only baseline (untouched by this change; green on Linux CI)
- [x] AC1 — every non-GA MCP tool prefixed, GA unprefixed: `tests/test_maturity_propagation.py::test_every_tool_description_prefix_derives_from_the_registry` derives expectations from the registry over all 79 registered tools (no hand-maintained list)
- [x] AC2 — `initialize.instructions` maturity summary: `test_band_lists_exactly_the_registrys_non_ga_features` + updated `tests/test_mcp_initialize_instructions.py` wire-level assertions
- [x] AC3 — OpenAPI `x-maturity` + snapshot regen: `test_openapi_tags_carry_registry_derived_x_maturity`, `test_openapi_spans_tiers_paths_carry_operation_level_x_maturity`; snapshot committed; #2644's wire schema-shape rule untouched (descriptions only; `_wire_safe_input_schema` unaffected, `tests/test_mcp_inputschema_format_enforcement.py` green)
- [x] AC4 — CHANGELOG `[Unreleased]` entry under a unique `###` header

## Out of scope

- CLI help rendering (#2676), /ui badges (#2677), drift guard + maturity-index page (#2678).
- Classifying runbooks / status / conventions in the registry — a #2664-table decision, flagged above for #2678.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2675


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added feature-maturity labels across MCP tools, session instructions, REST API tags, and selected operations.
  - Non-GA MCP capabilities now display their maturity tier, while unclassified and GA capabilities remain unchanged.
  - OpenAPI metadata now exposes maturity information for supported API areas.
  - Existing routes, tools, names, and schemas remain compatible.

- **Documentation**
  - Updated maturity documentation and changelog details, including supported surfaces and validation behavior.

- **Tests**
  - Added coverage validating maturity labels across MCP and OpenAPI interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->