### PR TITLE
feat(maturity): CI drift guard + generated maturity-index docs page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,27 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — maturity drift guard in CI + generated maturity-index docs page (#2678)
+
+- Close the #2664 maturity program with its two enforcement pieces
+  (#2678). A CI **drift guard**
+  (`backend/tests/test_maturity_surface_drift.py`) asserts every
+  user-facing surface — MCP tool, public REST operation,
+  server-advertised CLI command (a tripwire until `/api/v1/commands`
+  ships), `/ui` area — resolves to a feature-maturity registry entry,
+  so an unlabelled surface is a red build; infrastructure exemptions
+  are closed, rationale-carrying allowlists in the guard itself. The
+  docs site gains a generated **feature-maturity index** page
+  (`docs-site/reference/maturity.md`, rendered from the registry by
+  `backend/scripts/generate_maturity_index.py` with a freshness gate)
+  listing every non-GA feature's target milestone and tracking issue;
+  the `/ui` badge chips now deep-link to each feature's anchor on it.
+  The guard also forced the outstanding classification decisions: the
+  `meho.runbook.*` MCP tools and the `runbooks` REST tag join
+  `write_surfaces` (beta — their descriptions now carry the `[beta]`
+  prefix), the `conventions` REST tag joins `memory_knowledge`, and
+  `meho.status` is explicitly exempt infrastructure. (#2678)
+
 ### Added — maturity badge chips on the operator-console area headers (#2677)
 
 - Every non-GA `/ui` area header now renders a **Beta** / **Experimental**

--- a/backend/scripts/generate_maturity_index.py
+++ b/backend/scripts/generate_maturity_index.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Render the docs-site feature-maturity index from the registry (#2678).
+
+Emits ``docs-site/reference/maturity.md`` — the public per-feature
+road-to-prod-ready roadmap the #2664 program requires — entirely from
+:data:`meho_backplane.features.FEATURE_MATURITY`. The page is
+**committed**, not built on the fly: the docs-site CI job installs only
+the ``docs`` dependency group (``uv sync --locked --only-group docs``,
+see ``.github/workflows/docs-site.yml``), so an mkdocs hook importing
+``meho_backplane`` would drag the full backend dependency tree into
+every docs build and tag deploy. Instead this script regenerates the
+page inside the backend env, and the freshness gate in
+:mod:`tests.test_maturity_surface_drift` fails the unit lane whenever
+the committed page and the registry disagree — the same
+committed-derived-artifact shape as ``cli/api/openapi.json`` and its
+``cli-api-snapshot-freshness`` CI job.
+
+Per-feature headings are the **raw registry keys** (the Python-Markdown
+toc slugifier preserves them verbatim, underscores included), so the
+#2677 ``/ui`` badge chips can deep-link
+``…/reference/maturity/#<feature-key>`` — pinned by the anchor test in
+the same drift-guard module.
+
+Run from ``backend/``::
+
+    uv run python scripts/generate_maturity_index.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from meho_backplane.features import FEATURE_MATURITY, MaturityInfo
+
+#: Where the rendered page lands, relative to the repo root.
+INDEX_RELPATH = "docs-site/reference/maturity.md"
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Tier semantics + promotion entry criteria, verbatim from the #2664
+#: initiative. Static prose — the per-feature data around it is what
+#: derives from the registry.
+_TIER_CRITERIA: dict[str, str] = {
+    "ga": (
+        "Carries the 1.0 stability promise. Entry criteria: clean-room "
+        "eval score ≥ 4 for both usefulness and correctness; works on "
+        "both credential backends where applicable; contract surfaces "
+        "under the [#2662](https://github.com/evoila/meho/issues/2662) "
+        "stability gates; a docs task-guide page; no open P1s."
+    ),
+    "beta": (
+        "Works end-to-end somewhere real; gaps are known and tracked "
+        "on the feature's tracking issue (its promotion gate); "
+        "surfaces may change with a deprecation notice."
+    ),
+    "experimental": (
+        "May change or vanish without notice; sits outside the 1.0 "
+        "stability promise. No committed GA milestone unless stated."
+    ),
+}
+
+
+def _issue_ref(tracking_url: str) -> str:
+    """Render a tracking-issue URL as a ``[#N](url)`` markdown link."""
+    return f"[#{tracking_url.rstrip('/').rsplit('/', 1)[-1]}]({tracking_url})"
+
+
+def _tier_features(tier: str) -> list[tuple[str, MaturityInfo]]:
+    """The registry's entries for *tier*, sorted for deterministic output."""
+    return sorted((key, info) for key, info in FEATURE_MATURITY.items() if info["maturity"] == tier)
+
+
+def _non_ga_section(title: str, tier: str) -> list[str]:
+    """Render one non-GA tier: summary table + per-feature anchor sections."""
+    features = _tier_features(tier)
+    lines = [
+        f"## {title}",
+        "",
+        _TIER_CRITERIA[tier],
+        "",
+        "| Feature | Target GA | Gaps & promotion gate |",
+        "| --- | --- | --- |",
+    ]
+    for key, info in features:
+        target = info.get("target_ga") or "_none committed_"
+        lines.append(f"| [{key}](#{key}) | {target} | {_issue_ref(info['tracking'])} |")
+    for key, info in features:
+        target = info.get("target_ga")
+        lines += [
+            "",
+            f"### {key}",
+            "",
+            f"- **Tier:** {tier}",
+            "- **Target GA milestone:** "
+            + (target if target else "none committed — outside the 1.0 promise"),
+            "- **Gaps & promotion gate:** known gaps and the road to "
+            f"promotion are tracked in {_issue_ref(info['tracking'])}.",
+        ]
+    lines.append("")
+    return lines
+
+
+def render_maturity_index() -> str:
+    """Render the full maturity-index page from the registry."""
+    ga_features = _tier_features("ga")
+    lines = [
+        "<!--",
+        "  GENERATED FILE — do not edit by hand (#2678).",
+        "  Source of truth: backend/src/meho_backplane/features.py",
+        "  (FEATURE_MATURITY). Regenerate from backend/ with:",
+        "      uv run python scripts/generate_maturity_index.py",
+        "  The freshness gate in",
+        "  backend/tests/test_maturity_surface_drift.py fails CI when",
+        "  this page and the registry disagree.",
+        "-->",
+        "",
+        "# Feature maturity index",
+        "",
+        "Every MEHO feature carries an explicit maturity tier — **GA**, "
+        "**Beta**, or **Experimental** — declared once in the "
+        "feature-maturity registry ([`backend/src/meho_backplane/"
+        "features.py`](https://github.com/evoila/meho/blob/main/"
+        "backend/src/meho_backplane/features.py)) "
+        "and propagated to every surface you touch: `[beta]` / "
+        "`[experimental]` prefixes on MCP tool descriptions, "
+        "`x-maturity` in the REST OpenAPI document, CLI help labels, "
+        "and the `/ui` console's area badges (which link to this page). "
+        "This page is the road-to-prod-ready roadmap for every non-GA "
+        "feature: what tier it is in, the milestone it targets, and the "
+        "issue where its gaps and promotion gate are tracked.",
+        "",
+        "The classification is the provisional "
+        "[#2664](https://github.com/evoila/meho/issues/2664) table, "
+        "pending clean-room eval round 1 "
+        "([#2665](https://github.com/evoila/meho/issues/2665)).",
+        "",
+        "## GA features",
+        "",
+        _TIER_CRITERIA["ga"],
+        "",
+    ]
+    lines += [f"- `{key}`" for key, _info in ga_features]
+    lines.append("")
+    lines += _non_ga_section("Beta features", "beta")
+    lines += _non_ga_section("Experimental features", "experimental")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> None:
+    """Write the rendered page to :data:`INDEX_RELPATH`."""
+    target = _REPO_ROOT / INDEX_RELPATH
+    target.write_text(render_maturity_index(), encoding="utf-8")
+    print(f"wrote {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/meho_backplane/api/openapi_maturity.py
+++ b/backend/src/meho_backplane/api/openapi_maturity.py
@@ -27,15 +27,21 @@ Mapping maintenance
 on :class:`~meho_backplane.mcp.registry.ToolDefinition` and of
 :data:`~meho_backplane.features._READY_ENTRY_FEATURE`. Tags absent
 from it are **deliberately unclassified**: infrastructure surfaces
-(``health``, ``version``, ``mcp`` — the transport, whose tools carry
-their own per-tool labels, ``discovery``'s untagged siblings ``/`` and
-``/metrics``) and surfaces the provisional #2664 table does not
-classify (``conventions``, ``runbooks``). The BFF ``/ui*`` tags are
-excluded wholesale — the console's maturity surface is the #2677 badge
-chips, and the #2678 drift guard excludes ``/ui/*`` by prefix until the
-#2662 public/BFF split lands. Values are validated against the registry
-at import so a typo'd key fails at boot, not as a silently missing
-label.
+only (``health``, ``version``, ``mcp`` — the transport, whose tools
+carry their own per-tool labels, ``discovery``'s untagged siblings
+``/`` and ``/metrics``). The BFF ``/ui*`` tags are excluded wholesale
+— the console's maturity surface is the #2677 badge chips, and the
+#2678 drift guard (:mod:`tests.test_maturity_surface_drift`) excludes
+``/ui/*`` by prefix until the #2662 public/BFF split lands. Every
+other tag must map here — the drift guard is red otherwise, naming
+this module as the file to edit. The #2678 decisions for the two tags
+the provisional #2664 table left unclassified: ``conventions`` (the
+preamble knowledge packer) is a face of the memory/knowledge plane →
+``memory_knowledge``; ``runbooks`` drives writes through the run
+driver → ``write_surfaces`` — both matching the /ui area mapping in
+:mod:`meho_backplane.ui.maturity`. Values are validated against the
+registry at import so a typo'd key fails at boot, not as a silently
+missing label.
 """
 
 from __future__ import annotations
@@ -63,6 +69,7 @@ TAG_FEATURE: Final[dict[str, str]] = {
     "checks": "sensors",
     "checks-dashboards": "sensors",
     "connectors": "typed_connector_reads",
+    "conventions": "memory_knowledge",
     "discovery": "auth_tenancy",
     "docs": "doc_collections",
     "feed": "broadcast",
@@ -71,6 +78,7 @@ TAG_FEATURE: Final[dict[str, str]] = {
     "memory": "memory_knowledge",
     "operations": "typed_connector_reads",
     "retrieval": "memory_knowledge",
+    "runbooks": "write_surfaces",
     "runner-principals": "satellite_gateway",
     "scheduler": "scheduler",
     "sensors": "sensors",

--- a/backend/src/meho_backplane/mcp/tools/runbook_runs.py
+++ b/backend/src/meho_backplane/mcp/tools/runbook_runs.py
@@ -584,10 +584,10 @@ async def _list_runs_handler(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        # Deliberately unclassified (#2675): the provisional #2664
-        # maturity table does not tier the runbooks feature (see the
-        # matching note in runbooks.py). Applies to every tool here.
-        feature=None,
+        # Classified via the #2678 drift-guard decision (see the
+        # matching note in runbooks.py): the runbooks family dispatches
+        # writes → ``write_surfaces``. Applies to every tool here.
+        feature="write_surfaces",
         name="meho.runbook.start",
         description=_START_DESCRIPTION,
         inputSchema={
@@ -610,7 +610,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        feature=None,
+        feature="write_surfaces",
         name="meho.runbook.next",
         description=_NEXT_DESCRIPTION,
         inputSchema={
@@ -639,7 +639,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        feature=None,
+        feature="write_surfaces",
         name="meho.runbook.abort",
         description=_ABORT_DESCRIPTION,
         inputSchema={
@@ -664,7 +664,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        feature=None,
+        feature="write_surfaces",
         name="meho.runbook.reassign",
         description=_REASSIGN_DESCRIPTION,
         inputSchema={
@@ -691,7 +691,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        feature=None,
+        feature="write_surfaces",
         name="meho.runbook.list_runs",
         description=_LIST_DESCRIPTION,
         inputSchema={

--- a/backend/src/meho_backplane/mcp/tools/runbooks.py
+++ b/backend/src/meho_backplane/mcp/tools/runbooks.py
@@ -713,12 +713,14 @@ def _opacity_floor_denial() -> McpInvalidParamsError:
 
 register_mcp_tool(
     definition=ToolDefinition(
-        # Deliberately unclassified (#2675): the provisional #2664
-        # maturity table does not tier the runbooks feature. Applies to
-        # every meho.runbook.* tool in this module and its sibling
-        # runbook_runs.py; the #2678 drift guard forces the
-        # classification decision.
-        feature=None,
+        # Classification decision forced by the #2678 drift guard:
+        # runbooks are curated compositions driven through the run
+        # driver — they dispatch writes, so they follow the
+        # ``write_surfaces`` beta line, matching the /ui area mapping
+        # in :mod:`meho_backplane.ui.maturity`. Applies to every
+        # meho.runbook.* tool in this module and its sibling
+        # runbook_runs.py.
+        feature="write_surfaces",
         name="meho.runbook.draft_template",
         description=_DRAFT_DESCRIPTION,
         inputSchema={
@@ -739,7 +741,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        feature=None,
+        feature="write_surfaces",
         name="meho.runbook.edit_template",
         description=_EDIT_DESCRIPTION,
         inputSchema={
@@ -760,7 +762,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        feature=None,
+        feature="write_surfaces",
         name="meho.runbook.publish_template",
         description=_PUBLISH_DESCRIPTION,
         inputSchema={
@@ -781,7 +783,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        feature=None,
+        feature="write_surfaces",
         name="meho.runbook.deprecate_template",
         description=_DEPRECATE_DESCRIPTION,
         inputSchema={
@@ -802,7 +804,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        feature=None,
+        feature="write_surfaces",
         name="meho.runbook.discard_template",
         description=_DISCARD_DESCRIPTION,
         inputSchema={
@@ -823,7 +825,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        feature=None,
+        feature="write_surfaces",
         name="meho.runbook.list_templates",
         description=_LIST_DESCRIPTION,
         inputSchema={
@@ -858,7 +860,7 @@ register_mcp_tool(
 
 register_mcp_tool(
     definition=ToolDefinition(
-        feature=None,
+        feature="write_surfaces",
         name="meho.runbook.show_template",
         description=_SHOW_DESCRIPTION,
         inputSchema={

--- a/backend/src/meho_backplane/ui/maturity.py
+++ b/backend/src/meho_backplane/ui/maturity.py
@@ -51,9 +51,12 @@ from meho_backplane.features import FEATURE_MATURITY
 __all__ = ["MATURITY_INDEX_URL", "SURFACE_FEATURE", "surface_maturity"]
 
 #: The docs maturity-index page the chip links to. #2678 generates the
-#: page into the MkDocs site's Reference section; until it lands the
-#: URL is an accepted stub target (task acceptance criteria). ``latest``
-#: is the mike alias every tagged deploy re-points.
+#: page (``docs-site/reference/maturity.md``, rendered by
+#: ``backend/scripts/generate_maturity_index.py``) into the MkDocs
+#: site's Reference section; each chip deep-links to its feature's
+#: anchor — the page's per-feature headings are the raw registry keys,
+#: which the toc slugifier preserves verbatim (underscores included).
+#: ``latest`` is the mike alias every tagged deploy re-points.
 MATURITY_INDEX_URL = "https://evoila.github.io/meho/latest/reference/maturity/"
 
 #: Sidebar surface key (``active_surface``, as registered in
@@ -118,5 +121,5 @@ def surface_maturity(surface: str) -> MaturityBadge | None:
         "label": info["maturity"].capitalize(),
         "target_ga": info.get("target_ga"),
         "tracking": info.get("tracking"),
-        "href": MATURITY_INDEX_URL,
+        "href": f"{MATURITY_INDEX_URL}#{feature}",
     }

--- a/backend/src/meho_backplane/ui/templates/_maturity_badge.html
+++ b/backend/src/meho_backplane/ui/templates/_maturity_badge.html
@@ -14,7 +14,7 @@
   DaisyUI 5 classes only (the v4-in-v5 trap from the console-polish
   round): ``badge-soft`` is the v5 style modifier, verified against the
   vendored static/src/vendor/daisyui.js plugin. The chip links to the
-  docs maturity-index page (#2678 generates it; stub target until then)
+  docs maturity-index page at the feature's anchor (#2678 generates it)
   and carries the tier semantics as a native tooltip via ``title`` —
   no positioning wrapper inside the flex h1, and the link's purpose
   stays exposed to assistive tech.

--- a/backend/tests/test_maturity_surface_drift.py
+++ b/backend/tests/test_maturity_surface_drift.py
@@ -1,0 +1,331 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Maturity drift guard + docs maturity-index freshness gate (#2678).
+
+The #2664 program's enforcement piece: every user-facing surface — MCP
+tool, public REST operation, server-advertised CLI command, ``/ui``
+area — must resolve to a :data:`meho_backplane.features.FEATURE_MATURITY`
+key, so an unlabelled surface is a **red build**, not a silent gap. One
+test per surface class; each failure message names the unmapped surface
+and the file to edit.
+
+Deliberate infrastructure exemptions are **closed allowlists in this
+module** — adding a surface without classifying it means either mapping
+it to a registry key or adding it here with a written rationale, in the
+same diff the reviewer sees. Stale allowlist entries fail too (the
+guard asserts each exempted surface still exists), so exemptions cannot
+outlive the surface they excuse. The #2678 decisions that emptied the
+previous "deliberately unclassified" set:
+
+* the ``meho.runbook.*`` MCP tools and the ``runbooks`` REST tag →
+  ``write_surfaces`` (curated compositions driven through the run
+  driver dispatch writes — the same call :mod:`meho_backplane.ui.maturity`
+  already made for the ``/ui`` runbooks area);
+* the ``conventions`` REST tag → ``memory_knowledge`` (the preamble
+  knowledge packer is a face of the memory/knowledge plane, matching
+  the ``/ui`` conventions area);
+* ``meho.status`` stays unclassified **explicitly**: it mirrors
+  ``/api/v1/health`` — infrastructure, the same posture as the
+  ``health`` / ``version`` / ``mcp`` REST tags and the
+  ``_READY_ENTRY_FEATURE`` ``mcp`` entry.
+
+The ``/ui*`` surfaces are excluded from the REST class by path prefix:
+the console's maturity surface is the #2677 badge chips (guarded by
+:mod:`tests.test_ui_maturity_badge` plus the UI class below), and the
+prefix exclusion tightens automatically once the #2662 public/BFF
+OpenAPI split lands.
+
+This module also carries the freshness gate for the **generated docs
+maturity-index page** (``docs-site/reference/maturity.md``): the page
+is rendered from the registry by
+``backend/scripts/generate_maturity_index.py`` and committed, because
+the docs-site CI job installs only the ``docs`` dependency group and
+must not import the backend (see the script docstring). A registry
+edit therefore turns this gate red until the page is regenerated —
+same committed-derived-artifact shape as ``cli/api/openapi.json`` and
+its ``cli-api-snapshot-freshness`` job.
+
+Pattern precedent: :mod:`tests.test_truncate_list_drift` (registry
+introspection + source extraction so drift fails on the PR that
+introduces it, not a later unrelated one).
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+import re
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from scripts.generate_maturity_index import INDEX_RELPATH, render_maturity_index
+
+import meho_backplane.mcp.registry as registry_module
+from meho_backplane.api.openapi_maturity import PATH_FEATURE_OVERRIDES, TAG_FEATURE
+from meho_backplane.features import FEATURE_MATURITY
+from meho_backplane.main import app
+from meho_backplane.mcp.registry import ToolDefinition
+from meho_backplane.ui.maturity import SURFACE_FEATURE
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# ---------------------------------------------------------------------------
+# Closed infrastructure allowlists — every entry carries its rationale.
+# ---------------------------------------------------------------------------
+
+#: MCP tools that deliberately carry ``feature=None``. ``meho.status``
+#: mirrors ``/api/v1/health`` wire-identically — infrastructure, not a
+#: classified feature (the ``_READY_ENTRY_FEATURE`` ``mcp`` precedent).
+_MCP_INFRA_TOOLS = frozenset({"meho.status"})
+
+#: REST tags that never map to a feature: deploy/runtime visibility
+#: (``health``: /healthz, /ready, /api/v1/health; ``version``) and the
+#: MCP transport endpoint (``mcp``: /mcp — the tools it carries are
+#: labelled per-tool by the MCP class above).
+_REST_INFRA_TAGS = frozenset({"health", "version", "mcp"})
+
+#: Untagged public paths that never map to a feature: the root
+#: redirect and the Prometheus scrape endpoint.
+_REST_UNTAGGED_INFRA_PATHS = frozenset({"/", "/metrics"})
+
+#: ``active_surface`` keys that are console chrome, not feature areas:
+#: the account page (``/ui/account``). The dashboard passes no
+#: ``active_surface`` at all, so it never reaches the mapping.
+_UI_CHROME_SURFACES = frozenset({"account"})
+
+_OPERATION_METHODS = frozenset(
+    ("get", "put", "post", "delete", "options", "head", "patch", "trace"),
+)
+
+
+# ---------------------------------------------------------------------------
+# MCP tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def production_tools() -> Iterator[dict[str, ToolDefinition]]:
+    """Yield every production tool definition, freshly registered.
+
+    Same isolation shape as
+    :func:`tests.test_maturity_propagation.production_tools` (see its
+    docstring for why import-then-reload is needed); replicated here so
+    the two guard modules stay independently collectable.
+    """
+    tools_pkg = importlib.import_module("meho_backplane.mcp.tools")
+    modules = [
+        importlib.import_module(f"meho_backplane.mcp.tools.{name}")
+        for _finder, name, _ispkg in pkgutil.iter_modules(tools_pkg.__path__)
+    ]
+    saved_tools = dict(registry_module._TOOLS)
+    saved_resources = dict(registry_module._RESOURCES)
+    registry_module._TOOLS.clear()
+    for module in modules:
+        importlib.reload(module)
+    try:
+        yield {name: defn for name, (defn, _handler) in registry_module._TOOLS.items()}
+    finally:
+        registry_module._TOOLS.clear()
+        registry_module._TOOLS.update(saved_tools)
+        registry_module._RESOURCES.clear()
+        registry_module._RESOURCES.update(saved_resources)
+
+
+def test_every_mcp_tool_resolves_to_a_feature(
+    production_tools: dict[str, ToolDefinition],
+) -> None:
+    """Every registered MCP tool names a registry key or is exempt infra."""
+    assert production_tools, "no production tools registered — fixture broken"
+    unmapped = sorted(
+        name
+        for name, defn in production_tools.items()
+        if defn.feature is None and name not in _MCP_INFRA_TOOLS
+    )
+    assert not unmapped, (
+        f"MCP tools without a maturity classification: {unmapped}. Set "
+        "feature=<FEATURE_MATURITY key> on each ToolDefinition (the file "
+        "registering the tool under backend/src/meho_backplane/mcp/tools/), "
+        "or — only for genuine infrastructure — add the tool name to "
+        "_MCP_INFRA_TOOLS in this module with a rationale."
+    )
+    stale = sorted(_MCP_INFRA_TOOLS - production_tools.keys())
+    assert not stale, (
+        f"_MCP_INFRA_TOOLS entries no longer registered: {stale}. "
+        "Remove them from this module's allowlist."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public REST operations
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def openapi_schema() -> dict[str, Any]:
+    """Bust FastAPI's cache and generate a fresh document."""
+    app.openapi_schema = None
+    return app.openapi()
+
+
+def _public_operations(schema: dict[str, Any]) -> Iterator[tuple[str, str, dict[str, Any]]]:
+    """Yield ``(path, method, operation)`` for every non-BFF operation."""
+    for path, path_item in schema["paths"].items():
+        if path.startswith("/ui"):
+            # BFF console routes — #2677's surface; prefix exclusion
+            # tightens automatically after the #2662 public/BFF split.
+            continue
+        for method, operation in path_item.items():
+            if method in _OPERATION_METHODS and isinstance(operation, dict):
+                yield path, method, operation
+
+
+def test_every_public_rest_operation_resolves_to_a_feature(
+    openapi_schema: dict[str, Any],
+) -> None:
+    """Every public operation maps via tag or path override, or is infra."""
+    unmapped: list[str] = []
+    for path, method, operation in _public_operations(openapi_schema):
+        if path in PATH_FEATURE_OVERRIDES:
+            continue
+        tags = operation.get("tags", [])
+        if not tags:
+            if path not in _REST_UNTAGGED_INFRA_PATHS:
+                unmapped.append(f"{method.upper()} {path} (untagged)")
+        elif not any(tag in TAG_FEATURE for tag in tags) and not all(
+            tag in _REST_INFRA_TAGS for tag in tags
+        ):
+            unmapped.append(f"{method.upper()} {path} (tags={tags})")
+    assert not unmapped, (
+        f"public REST operations without a maturity classification: {unmapped}. "
+        "Map each operation's tag in TAG_FEATURE (or, where its tag spans "
+        "tiers, its path in PATH_FEATURE_OVERRIDES) in "
+        "backend/src/meho_backplane/api/openapi_maturity.py, or — only for "
+        "genuine infrastructure — extend _REST_INFRA_TAGS / "
+        "_REST_UNTAGGED_INFRA_PATHS in this module with a rationale."
+    )
+
+
+def test_rest_infra_allowlists_carry_no_stale_entries(
+    openapi_schema: dict[str, Any],
+) -> None:
+    """Exemptions cannot outlive the surfaces they excuse."""
+    used_tags = {
+        tag
+        for _path, _method, operation in _public_operations(openapi_schema)
+        for tag in operation.get("tags", [])
+    }
+    stale_tags = sorted(_REST_INFRA_TAGS - used_tags)
+    assert not stale_tags, f"_REST_INFRA_TAGS entries on no operation: {stale_tags}"
+    stale_paths = sorted(_REST_UNTAGGED_INFRA_PATHS - openapi_schema["paths"].keys())
+    assert not stale_paths, f"_REST_UNTAGGED_INFRA_PATHS not in the document: {stale_paths}"
+
+
+# ---------------------------------------------------------------------------
+# Server-advertised CLI commands
+# ---------------------------------------------------------------------------
+
+
+def test_cli_command_manifest_endpoint_is_still_unshipped() -> None:
+    """Tripwire: the manifest endpoint must land together with its guard.
+
+    ``GET /api/v1/commands`` (the CLI's server-driven discovery
+    endpoint, ``cli/internal/discovery/discovery.go``) is an unshipped
+    Goal #11 §5 coordination point — every backplane 404s it today and
+    the CLI falls back to its local command set, so there are no
+    server-advertised commands to classify yet (see
+    ``docs/codebase/feature-maturity.md``). This tripwire turns red on
+    the PR that ships the endpoint: extend this module with a manifest
+    class asserting every advertised command resolves its owning
+    feature from FEATURE_MATURITY (the ``maturity`` field the CLI
+    already renders, #2676), then retire this test.
+    """
+    manifest_routes = [
+        route.path  # type: ignore[attr-defined]
+        for route in app.routes
+        if getattr(route, "path", "") == "/api/v1/commands"
+    ]
+    assert not manifest_routes, (
+        "/api/v1/commands has landed: replace this tripwire with a drift "
+        "guard asserting every command the manifest advertises resolves to "
+        "a FEATURE_MATURITY key (see this test's docstring)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# /ui areas
+# ---------------------------------------------------------------------------
+
+_UI_ROUTES_DIR = _REPO_ROOT / "backend" / "src" / "meho_backplane" / "ui" / "routes"
+
+#: Matches the ``"active_surface": "<key>"`` context entries every /ui
+#: route passes for the sidebar highlight. Literal string values only —
+#: the single dynamic site (``stubs.py``'s ``stub.slug``) draws from
+#: ``_SURFACE_STUBS``, which is empty since every surface shipped its
+#: real router.
+_ACTIVE_SURFACE_RE = re.compile(r'"active_surface":\s*"([^"]+)"')
+
+
+def test_every_ui_area_surface_resolves_to_a_feature() -> None:
+    """Every ``active_surface`` a /ui route passes is mapped or chrome.
+
+    Complements :mod:`tests.test_ui_maturity_badge` (which pins
+    ``SURFACE_FEATURE`` ↔ ``base.html``'s sidebar exactly): this class
+    catches a new area *route* whose surface key joins neither the
+    mapping nor the sidebar.
+    """
+    surfaces: dict[str, list[str]] = {}
+    for source in sorted(_UI_ROUTES_DIR.rglob("*.py")):
+        for key in _ACTIVE_SURFACE_RE.findall(source.read_text(encoding="utf-8")):
+            surfaces.setdefault(key, []).append(str(source.relative_to(_REPO_ROOT)))
+    assert surfaces, "no active_surface literals found — extraction regex broken?"
+    unmapped = {
+        key: files
+        for key, files in surfaces.items()
+        if key not in SURFACE_FEATURE and key not in _UI_CHROME_SURFACES
+    }
+    assert not unmapped, (
+        f"/ui surfaces without a maturity classification: {unmapped}. Map "
+        "each key in SURFACE_FEATURE (backend/src/meho_backplane/ui/"
+        "maturity.py), or — only for console chrome — add it to "
+        "_UI_CHROME_SURFACES in this module with a rationale."
+    )
+    stale = sorted(_UI_CHROME_SURFACES - surfaces.keys())
+    assert not stale, f"_UI_CHROME_SURFACES entries on no route: {stale}"
+
+
+# ---------------------------------------------------------------------------
+# Generated docs maturity-index page
+# ---------------------------------------------------------------------------
+
+
+def test_maturity_index_page_is_fresh() -> None:
+    """The committed page equals the registry-rendered content."""
+    committed = (_REPO_ROOT / INDEX_RELPATH).read_text(encoding="utf-8")
+    assert committed == render_maturity_index(), (
+        f"{INDEX_RELPATH} is stale relative to FEATURE_MATURITY. "
+        "Regenerate it from backend/ with "
+        "`uv run python scripts/generate_maturity_index.py` and commit "
+        "the result."
+    )
+
+
+def test_maturity_index_page_anchors_every_non_ga_feature() -> None:
+    """The #2677 badge chips deep-link ``#<feature-key>``; the anchors
+    must exist. Per-feature headings are the raw registry keys, which
+    the Python-Markdown toc slugifier preserves verbatim (underscores
+    included), so a ``### <key>`` heading guarantees the anchor.
+    """
+    page = render_maturity_index()
+    missing = sorted(
+        key
+        for key, info in FEATURE_MATURITY.items()
+        if info["maturity"] != "ga" and f"\n### {key}\n" not in page
+    )
+    assert not missing, (
+        f"maturity-index page lacks anchor headings for: {missing} — "
+        "the /ui badge deep-links would 404. Fix "
+        "backend/scripts/generate_maturity_index.py."
+    )

--- a/backend/tests/test_maturity_surface_drift.py
+++ b/backend/tests/test_maturity_surface_drift.py
@@ -69,6 +69,7 @@ from meho_backplane.features import FEATURE_MATURITY
 from meho_backplane.main import app
 from meho_backplane.mcp.registry import ToolDefinition
 from meho_backplane.ui.maturity import SURFACE_FEATURE
+from meho_backplane.ui.routes.stubs import _SURFACE_STUBS
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -194,9 +195,7 @@ def test_every_public_rest_operation_resolves_to_a_feature(
         if not tags:
             if path not in _REST_UNTAGGED_INFRA_PATHS:
                 unmapped.append(f"{method.upper()} {path} (untagged)")
-        elif not any(tag in TAG_FEATURE for tag in tags) and not all(
-            tag in _REST_INFRA_TAGS for tag in tags
-        ):
+        elif not all(tag in TAG_FEATURE or tag in _REST_INFRA_TAGS for tag in tags):
             unmapped.append(f"{method.upper()} {path} (tags={tags})")
     assert not unmapped, (
         f"public REST operations without a maturity classification: {unmapped}. "
@@ -228,7 +227,9 @@ def test_rest_infra_allowlists_carry_no_stale_entries(
 # ---------------------------------------------------------------------------
 
 
-def test_cli_command_manifest_endpoint_is_still_unshipped() -> None:
+def test_cli_command_manifest_endpoint_is_still_unshipped(
+    openapi_schema: dict[str, Any],
+) -> None:
     """Tripwire: the manifest endpoint must land together with its guard.
 
     ``GET /api/v1/commands`` (the CLI's server-driven discovery
@@ -241,13 +242,15 @@ def test_cli_command_manifest_endpoint_is_still_unshipped() -> None:
     class asserting every advertised command resolves its owning
     feature from FEATURE_MATURITY (the ``maturity`` field the CLI
     already renders, #2676), then retire this test.
+
+    Detection goes through the generated OpenAPI document, not a scan
+    of ``app.routes``: on the locked FastAPI, ``include_router`` is
+    lazy — the included routes never surface in ``app.routes`` — so a
+    route-scan tripwire stays green on the realistic
+    ``app.include_router`` landing, while the OpenAPI paths always
+    carry the new endpoint.
     """
-    manifest_routes = [
-        route.path  # type: ignore[attr-defined]
-        for route in app.routes
-        if getattr(route, "path", "") == "/api/v1/commands"
-    ]
-    assert not manifest_routes, (
+    assert "/api/v1/commands" not in openapi_schema["paths"], (
         "/api/v1/commands has landed: replace this tripwire with a drift "
         "guard asserting every command the manifest advertises resolves to "
         "a FEATURE_MATURITY key (see this test's docstring)."
@@ -260,12 +263,13 @@ def test_cli_command_manifest_endpoint_is_still_unshipped() -> None:
 
 _UI_ROUTES_DIR = _REPO_ROOT / "backend" / "src" / "meho_backplane" / "ui" / "routes"
 
-#: Matches the ``"active_surface": "<key>"`` context entries every /ui
-#: route passes for the sidebar highlight. Literal string values only —
-#: the single dynamic site (``stubs.py``'s ``stub.slug``) draws from
-#: ``_SURFACE_STUBS``, which is empty since every surface shipped its
-#: real router.
-_ACTIVE_SURFACE_RE = re.compile(r'"active_surface":\s*"([^"]+)"')
+#: Matches the ``active_surface`` context entries every /ui route
+#: passes for the sidebar highlight, in both in-tree idioms: the dict
+#: literal (``"active_surface": "kb"``) and the item assignment
+#: (``context["active_surface"] = "audit"``). Literal string values
+#: only — the single dynamic site (``stubs.py``'s ``stub.slug``) draws
+#: from ``_SURFACE_STUBS``, whose emptiness the test below asserts.
+_ACTIVE_SURFACE_RE = re.compile(r'"active_surface"\s*(?::|\]\s*=)\s*"([^"]+)"')
 
 
 def test_every_ui_area_surface_resolves_to_a_feature() -> None:
@@ -276,6 +280,11 @@ def test_every_ui_area_surface_resolves_to_a_feature() -> None:
     catches a new area *route* whose surface key joins neither the
     mapping nor the sidebar.
     """
+    assert not _SURFACE_STUBS, (
+        "stubs.py re-grew dynamic surfaces — extend this guard to cover "
+        "their slugs (they render active_surface=stub.slug, which the "
+        "literal-matching regex cannot see)."
+    )
     surfaces: dict[str, list[str]] = {}
     for source in sorted(_UI_ROUTES_DIR.rglob("*.py")):
         for key in _ACTIVE_SURFACE_RE.findall(source.read_text(encoding="utf-8")):

--- a/backend/tests/test_ui_maturity_badge.py
+++ b/backend/tests/test_ui_maturity_badge.py
@@ -110,7 +110,10 @@ def test_resolver_derives_tier_from_registry() -> None:
             assert badge["label"] == info["maturity"].capitalize()
             assert badge["target_ga"] == info.get("target_ga")
             assert badge["tracking"] == info.get("tracking")
-            assert badge["href"] == MATURITY_INDEX_URL
+            # #2678: the chip deep-links to the feature's anchor on the
+            # generated maturity-index page (headings are raw registry
+            # keys, preserved verbatim by the toc slugifier).
+            assert badge["href"] == f"{MATURITY_INDEX_URL}#{feature}"
 
 
 def test_resolver_renders_nothing_for_unmapped_surfaces() -> None:
@@ -138,7 +141,7 @@ def test_badge_include_renders_from_registry() -> None:
         expected_class = "badge-info" if tier == "beta" else "badge-warning"
         assert expected_class in html, f"{surface}: wrong tier class"
         assert "badge-soft" in html
-        assert MATURITY_INDEX_URL in html, f"{surface}: index link missing"
+        assert f"{MATURITY_INDEX_URL}#{feature}" in html, f"{surface}: anchored index link missing"
 
 
 def test_retier_propagates_without_template_edits(

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -29948,6 +29948,10 @@
       "x-maturity": "ga"
     },
     {
+      "name": "conventions",
+      "x-maturity": "ga"
+    },
+    {
       "name": "discovery",
       "x-maturity": "ga"
     },
@@ -29978,6 +29982,10 @@
     {
       "name": "retrieval",
       "x-maturity": "ga"
+    },
+    {
+      "name": "runbooks",
+      "x-maturity": "beta"
     },
     {
       "name": "runner-principals",

--- a/docs-site/reference/maturity.md
+++ b/docs-site/reference/maturity.md
@@ -1,0 +1,125 @@
+<!--
+  GENERATED FILE — do not edit by hand (#2678).
+  Source of truth: backend/src/meho_backplane/features.py
+  (FEATURE_MATURITY). Regenerate from backend/ with:
+      uv run python scripts/generate_maturity_index.py
+  The freshness gate in
+  backend/tests/test_maturity_surface_drift.py fails CI when
+  this page and the registry disagree.
+-->
+
+# Feature maturity index
+
+Every MEHO feature carries an explicit maturity tier — **GA**, **Beta**, or **Experimental** — declared once in the feature-maturity registry ([`backend/src/meho_backplane/features.py`](https://github.com/evoila/meho/blob/main/backend/src/meho_backplane/features.py)) and propagated to every surface you touch: `[beta]` / `[experimental]` prefixes on MCP tool descriptions, `x-maturity` in the REST OpenAPI document, CLI help labels, and the `/ui` console's area badges (which link to this page). This page is the road-to-prod-ready roadmap for every non-GA feature: what tier it is in, the milestone it targets, and the issue where its gaps and promotion gate are tracked.
+
+The classification is the provisional [#2664](https://github.com/evoila/meho/issues/2664) table, pending clean-room eval round 1 ([#2665](https://github.com/evoila/meho/issues/2665)).
+
+## GA features
+
+Carries the 1.0 stability promise. Entry criteria: clean-room eval score ≥ 4 for both usefulness and correctness; works on both credential backends where applicable; contract surfaces under the [#2662](https://github.com/evoila/meho/issues/2662) stability gates; a docs task-guide page; no open P1s.
+
+- `approvals`
+- `audit`
+- `auth_tenancy`
+- `memory_knowledge`
+- `net_diagnostics`
+- `targets`
+- `typed_connector_reads`
+
+## Beta features
+
+Works end-to-end somewhere real; gaps are known and tracked on the feature's tracking issue (its promotion gate); surfaces may change with a deprecation notice.
+
+| Feature | Target GA | Gaps & promotion gate |
+| --- | --- | --- |
+| [broadcast](#broadcast) | v1.0.0 | [#2665](https://github.com/evoila/meho/issues/2665) |
+| [gsm_backend](#gsm_backend) | v1.0.0 | [#2667](https://github.com/evoila/meho/issues/2667) |
+| [satellite_gateway](#satellite_gateway) | v1.0.0 | [#2665](https://github.com/evoila/meho/issues/2665) |
+| [scheduler](#scheduler) | v1.0.0 | [#2668](https://github.com/evoila/meho/issues/2668) |
+| [sensors](#sensors) | v1.0.0 | [#2668](https://github.com/evoila/meho/issues/2668) |
+| [topology](#topology) | v1.0.0 | [#2665](https://github.com/evoila/meho/issues/2665) |
+| [ui_console](#ui_console) | v1.0.0 | [#2665](https://github.com/evoila/meho/issues/2665) |
+| [write_surfaces](#write_surfaces) | v1.0.0 | [#2665](https://github.com/evoila/meho/issues/2665) |
+
+### broadcast
+
+- **Tier:** beta
+- **Target GA milestone:** v1.0.0
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2665](https://github.com/evoila/meho/issues/2665).
+
+### gsm_backend
+
+- **Tier:** beta
+- **Target GA milestone:** v1.0.0
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2667](https://github.com/evoila/meho/issues/2667).
+
+### satellite_gateway
+
+- **Tier:** beta
+- **Target GA milestone:** v1.0.0
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2665](https://github.com/evoila/meho/issues/2665).
+
+### scheduler
+
+- **Tier:** beta
+- **Target GA milestone:** v1.0.0
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2668](https://github.com/evoila/meho/issues/2668).
+
+### sensors
+
+- **Tier:** beta
+- **Target GA milestone:** v1.0.0
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2668](https://github.com/evoila/meho/issues/2668).
+
+### topology
+
+- **Tier:** beta
+- **Target GA milestone:** v1.0.0
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2665](https://github.com/evoila/meho/issues/2665).
+
+### ui_console
+
+- **Tier:** beta
+- **Target GA milestone:** v1.0.0
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2665](https://github.com/evoila/meho/issues/2665).
+
+### write_surfaces
+
+- **Tier:** beta
+- **Target GA milestone:** v1.0.0
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2665](https://github.com/evoila/meho/issues/2665).
+
+## Experimental features
+
+May change or vanish without notice; sits outside the 1.0 stability promise. No committed GA milestone unless stated.
+
+| Feature | Target GA | Gaps & promotion gate |
+| --- | --- | --- |
+| [agent_runtime](#agent_runtime) | _none committed_ | [#2656](https://github.com/evoila/meho/issues/2656) |
+| [connector_ingest](#connector_ingest) | _none committed_ | [#2661](https://github.com/evoila/meho/issues/2661) |
+| [doc_collections](#doc_collections) | _none committed_ | [#2661](https://github.com/evoila/meho/issues/2661) |
+| [two_world_ops](#two_world_ops) | _none committed_ | [#2661](https://github.com/evoila/meho/issues/2661) |
+
+### agent_runtime
+
+- **Tier:** experimental
+- **Target GA milestone:** none committed — outside the 1.0 promise
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2656](https://github.com/evoila/meho/issues/2656).
+
+### connector_ingest
+
+- **Tier:** experimental
+- **Target GA milestone:** none committed — outside the 1.0 promise
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2661](https://github.com/evoila/meho/issues/2661).
+
+### doc_collections
+
+- **Tier:** experimental
+- **Target GA milestone:** none committed — outside the 1.0 promise
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2661](https://github.com/evoila/meho/issues/2661).
+
+### two_world_ops
+
+- **Tier:** experimental
+- **Target GA milestone:** none committed — outside the 1.0 promise
+- **Gaps & promotion gate:** known gaps and the road to promotion are tracked in [#2661](https://github.com/evoila/meho/issues/2661).

--- a/docs/codebase/feature-maturity.md
+++ b/docs/codebase/feature-maturity.md
@@ -54,11 +54,11 @@ in-process — there is deliberately no dedicated REST read surface):
 - **MCP tool descriptions** (#2675) — every
   `mcp/registry.py::ToolDefinition` declares a required `feature`
   field (a registry key, or an explicit `None` for
-  deliberately-unclassified surfaces such as `meho.status` and the
-  runbooks family, which the provisional #2664 table does not
-  classify). `register_mcp_tool` prefixes non-GA descriptions with
-  `[beta]` / `[experimental]` at registration time; an unknown key
-  fails validation at construction.
+  deliberately-unclassified infrastructure — today only `meho.status`,
+  the `/api/v1/health` mirror; #2678 classified the runbooks family
+  under `write_surfaces`). `register_mcp_tool` prefixes non-GA
+  descriptions with `[beta]` / `[experimental]` at registration time;
+  an unknown key fails validation at construction.
 - **`initialize.instructions`** (#2675) —
   `mcp/maturity.py::FEATURE_MATURITY_BAND` (a registry-derived static
   band listing exactly the non-GA features) is appended after the
@@ -72,17 +72,30 @@ in-process — there is deliberately no dedicated REST read surface):
   the `connectors` tag's ingest-pipeline paths). Flows into the
   committed `cli/api/openapi.json` snapshot. `/ui*` tags and
   infrastructure tags (`health`, `version`, `mcp`) are deliberately
-  unmapped.
+  unmapped; every other tag must map (drift-guarded, see below —
+  #2678 mapped `conventions` → `memory_knowledge` and `runbooks` →
+  `write_surfaces`, both matching the /ui area mapping).
 - **`/ui` area-header badge chips** (#2677) —
   `meho_backplane.ui.maturity` maps sidebar surfaces onto registry
   keys and a shared Jinja include renders the chip; see
   `docs/codebase/ui.md`.
 
-Remaining #2664 surface, not yet implemented: the docs-site
-maturity-index generator plus CI drift guard (#2678). The drift
-guard is where today's deliberately-unclassified surfaces (runbooks,
-`meho.status`, the `conventions` REST tag) get
-forced into an explicit classification decision.
+- **Docs maturity-index page + CI drift guard** (#2678) —
+  `docs-site/reference/maturity.md` is rendered entirely from the
+  registry by `backend/scripts/generate_maturity_index.py` and
+  **committed** (the docs-site CI job installs only the `docs`
+  dependency group and must not import the backend), with a freshness
+  gate in `backend/tests/test_maturity_surface_drift.py` that turns a
+  registry edit without regeneration into a red unit lane — the same
+  committed-derived-artifact shape as `cli/api/openapi.json`. The
+  same module is the **drift guard**: every MCP tool, public REST
+  operation (`/ui*` excluded by prefix until the #2662 public/BFF
+  split), and `/ui` area must resolve to a registry key; deliberate
+  infrastructure exemptions are closed allowlists in the guard with
+  written rationale and staleness checks. The server-advertised CLI
+  command class is a tripwire until `/api/v1/commands` ships (see
+  below). Per-feature page headings are the raw registry keys, so the
+  #2677 badge chips deep-link `…/reference/maturity/#<feature-key>`.
 
 The CLI's *client* half of #2676 is shipped:
 `cli/internal/discovery/discovery.go`'s `Command` carries a
@@ -95,7 +108,11 @@ which is an unshipped Goal #11 §5 coordination point: today every
 backplane 404s the manifest fetch and the CLI falls back to its
 local-only command set. When the endpoint lands, its builder resolves
 each advertised command's owning feature from `FEATURE_MATURITY` and
-emits the field the CLI already understands.
+emits the field the CLI already understands. The endpoint's absence
+is pinned by the #2678 tripwire
+(`test_cli_command_manifest_endpoint_is_still_unshipped`), so the PR
+that ships it must extend the drift guard with a real manifest class
+in the same diff.
 
 ## Dependencies
 
@@ -124,3 +141,8 @@ expectations from the registry so a retier never requires a test edit.
 - `backend/tests/test_maturity_propagation.py` — #2675 surface tests;
   every expectation derives from the registry (a retier never
   requires a test edit).
+- `backend/tests/test_maturity_surface_drift.py` — #2678 drift guard
+  (MCP / REST / CLI-manifest tripwire / UI classes) + the generated
+  maturity-index page's freshness and anchor gates;
+  `backend/tests/test_ui_maturity_badge.py` — #2677 badge chips,
+  including the per-feature anchor deep-link.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,12 @@ nav:
   - Install & operate: install/index.md
   - Connect clients: clients/index.md
   - Do real work: guides/index.md
-  - Reference: reference/index.md
+  - Reference:
+      - reference/index.md
+      # Generated from the feature-maturity registry by
+      # backend/scripts/generate_maturity_index.py (#2678); freshness
+      # is enforced by backend/tests/test_maturity_surface_drift.py.
+      - reference/maturity.md
   - Project: project/index.md
 
 markdown_extensions:


### PR DESCRIPTION
## Summary

- Closes the #2664 maturity program with its two enforcement pieces: a unit-lane **drift guard** (`backend/tests/test_maturity_surface_drift.py`) asserting every user-facing surface — MCP tool, public REST operation, server-advertised CLI command, `/ui` area — resolves to a `FEATURE_MATURITY` entry, and the generated **maturity-index docs page** (`docs-site/reference/maturity.md`) listing every non-GA feature with its gaps/promotion-gate tracking issue and target milestone, with per-feature anchors the #2677 `/ui` badge chips now deep-link to.
- The guard **forced the outstanding classification decisions** flagged by #2675: the `meho.runbook.*` MCP tools (12 registrations) and the `runbooks` REST tag join `write_surfaces` (beta — descriptions now carry the `[beta]` prefix), matching the call `ui/maturity.py` already made for the `/ui` runbooks area; the `conventions` REST tag joins `memory_knowledge` (same rationale as the `/ui` conventions area); `meho.status` stays deliberately unclassified as infrastructure, now on a **closed, rationale-carrying allowlist in the guard** (same posture as the `health`/`version`/`mcp` REST tags and the untagged `/` + `/metrics`). Allowlists carry staleness checks, so an exemption cannot outlive the surface it excuses.
- The index page is **committed and freshness-gated** rather than built by an mkdocs hook: the docs-site CI job installs only the `docs` dependency group (`uv sync --locked --only-group docs`) and must not import the backend, so the page is rendered by `backend/scripts/generate_maturity_index.py` inside the backend env and a unit-lane freshness test turns a registry edit without regeneration into a red build — the same committed-derived-artifact shape as `cli/api/openapi.json` and its `cli-api-snapshot-freshness` job. A registry edit changes the page with no manual docs edit (the gate names the exact regen command).
- The server-advertised CLI command class is a **tripwire**: `/api/v1/commands` is an unshipped Goal #11 §5 coordination point (every backplane 404s it — `docs/codebase/feature-maturity.md`), so there is no manifest to enumerate yet. `test_cli_command_manifest_endpoint_is_still_unshipped` turns red on the PR that ships the endpoint, forcing that PR to extend the guard with the real manifest class in the same diff.

## Deliberate test-break proof (per the task AC / #2664 DoD — reproduced locally, then reverted; not committed)

**Unmapped MCP tool** (temporarily set one runbook tool back to `feature=None`):

```
AssertionError: MCP tools without a maturity classification: ['meho.runbook.draft_template'].
Set feature=<FEATURE_MATURITY key> on each ToolDefinition (the file registering the tool under
backend/src/meho_backplane/mcp/tools/), or — only for genuine infrastructure — add the tool
name to _MCP_INFRA_TOOLS in this module with a rationale.
```

**Unmapped REST tag** (temporarily removed `conventions` from `TAG_FEATURE`):

```
AssertionError: public REST operations without a maturity classification:
["GET /api/v1/conventions (tags=['conventions'])", "POST /api/v1/conventions (tags=['conventions'])", ...].
Map each operation's tag in TAG_FEATURE (or, where its tag spans tiers, its path in
PATH_FEATURE_OVERRIDES) in backend/src/meho_backplane/api/openapi_maturity.py, ...
```

**Manifest endpoint tripwire** (injected a stub `GET /api/v1/commands` route in-process):

```
AssertionError: /api/v1/commands has landed: replace this tripwire with a drift guard
asserting every command the manifest advertises resolves to a FEATURE_MATURITY key ...
```

**Unmapped UI area** (temporarily renamed a route's `active_surface` literal):

```
AssertionError: /ui surfaces without a maturity classification:
{'flux-capacitor': ['backend/src/meho_backplane/ui/routes/account.py']}.
Map each key in SURFACE_FEATURE (backend/src/meho_backplane/ui/maturity.py), ...
```

## Test plan

- [x] `ruff check src/ tests/ scripts/` + `ruff format --check` — clean
- [x] `mypy src/` — clean apart from the pre-existing, untouched `connectors/net/icmp.py` `MSG_ERRQUEUE` error, a darwin-local artifact (the constant is Linux-only; CI runs ubuntu)
- [x] Full unit lane (`pytest -n 3 --dist loadscope --ignore=tests/integration --ignore=tests/migrations tests/`) — green locally
- [x] Drift guard green on current main state with full mapping; red on each surface class via the deliberate breaks above (AC 1)
- [x] Maturity-index page derives entirely from the registry: freshness gate (`test_maturity_index_page_is_fresh`) regenerates in-memory and compares; anchor gate (`test_maturity_index_page_anchors_every_non_ga_feature`) pins a `### <feature-key>` heading per non-GA feature (AC 2)
- [x] #2677 chips resolve to the generated page: `surface_maturity` href now `…/reference/maturity/#<feature-key>`; `test_ui_maturity_badge` pins the anchored href, and the toc slug behaviour (underscores preserved) was verified against the installed Python-Markdown toc extension (AC 3)
- [x] `mkdocs build --strict` — green with the new page in nav (AC: docs build generates/serves the page)
- [x] `cli/api/openapi.json` regenerated (`make snapshot-openapi` + `make generate`; Go client output unchanged apart from the snapshot) — keeps the `cli-api-snapshot-freshness` CI job green after the two new `x-maturity` tag entries; `go build ./... && go test ./...` green
- [x] CHANGELOG `[Unreleased]` entry under a unique `###` header (AC 4)
- [x] `python3 .claude/hooks/code-quality.py --diff` — pass

## Out of scope

- The #2662 OpenAPI public/BFF split — the guard excludes `/ui*` by path prefix and tightens automatically once the split lands (per the task body).
- Reclassification decisions (post-eval, v0.28) — this PR only classifies the surfaces the guard would otherwise leave undecidable, following the precedents already recorded in `ui/maturity.py`.
- Shipping `/api/v1/commands` — the tripwire documents exactly what that PR must add.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2678


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a generated feature maturity index covering GA, Beta, and Experimental capabilities.
  * Added direct links from maturity badges to each feature’s detailed documentation.
  * Added maturity classifications for conventions, runbooks, REST tags, and infrastructure status.

* **Documentation**
  * Expanded Reference navigation to include the maturity index.
  * Documented maturity criteria, milestones, promotion gates, and tracking information.

* **Bug Fixes**
  * Corrected maturity mappings so conventions and runbook tools display the appropriate classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-07-31)

Addressed all findings from review iteration 1 (COMMENT-state review of record; binding verdict REQUEST_CHANGES):

- **B1** `d450bc17` — the CLI-manifest tripwire now detects through the generated OpenAPI document (`"/api/v1/commands" not in openapi_schema["paths"]`, reusing the cache-busting `openapi_schema` fixture) instead of scanning `app.routes`: on the locked fastapi 0.140.0, `include_router` is lazy — router-included routes never surface in `app.routes` — so the previous scan provably could not fire on the realistic landing shape. The docstring records the mechanism choice. **Re-proof on the realistic shape** (`GET /api/v1/commands` registered on an `APIRouter` and landed via `app.include_router` in `main.py`, then reverted):

  ```
  FAILED tests/test_maturity_surface_drift.py::test_cli_command_manifest_endpoint_is_still_unshipped
  AssertionError: /api/v1/commands has landed: replace this tripwire with a drift guard
  asserting every command the manifest advertises resolves to a FEATURE_MATURITY key
  (see this test's docstring).
  ```

  After reverting the injection the module is back to 7 passed. (The original PR-body proof used an app-level route registration, which is exactly the shape B1 showed to be unrepresentative.)

- **M1** `d450bc17` — per-tag REST closed world: `elif not all(tag in TAG_FEATURE or tag in _REST_INFRA_TAGS for tag in tags)` — a multi-tag operation carrying an unknown tag no longer escapes on a mapped sibling tag. Strictly stronger than the previous any/all pair; green on the current surface (no mixed-tag non-`/ui` operations exist today). *(Adopts the CodeRabbit + Copilot findings on the same line.)*
- **M2** `d450bc17` — `_ACTIVE_SURFACE_RE` broadened to `r'"active_surface"\s*(?::|\]\s*=)\s*"([^"]+)"'`, matching both the dict-literal and the item-assignment idiom, so the four existing assignment call sites (`operations/routes.py:609`, `audit/routes.py:786`/`886`, `approvals/routes.py:506`) are on the guard's radar; all collect to mapped keys, so the guard stays green. *(Adopts Copilot's finding.)*
- **M3** `d450bc17` — the "stubs are empty" premise is now asserted: `test_every_ui_area_surface_resolves_to_a_feature` opens with `assert not _SURFACE_STUBS`, failing with a message that directs the guard be extended to cover stub slugs if `stubs.py` re-grows dynamic surfaces — the one exemption that lacked a staleness check now has one. *(Adopts CodeRabbit's finding.)*

No disputes, no deferrals. Verification re-run: `ruff check` / `ruff format --check` clean; `mypy src/` clean apart from the pre-existing darwin-local `icmp.py` `MSG_ERRQUEUE` artifact; drift-guard module 7/7 green; full unit lane green apart from the two pre-existing darwin-local `connectors/net` failures that reproduce on clean main.

<!-- auto-implement-issue: continue, iteration 1 -->
