### PR TITLE
docs(site): first Do-real-work guides — targets & secrets, first operations, sensors quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — docs-site Do-real-work guides: targets & secrets, first operations, sensors (#2673)
+
+- Land the first three *Do real work* task guides on the published
+  docs site (#2673): **Register targets and secrets** (`targets.yaml`
+  import incl. `tls_server_name`, the per-backend `secret_ref` shapes
+  with the Vault tenant-scope prefix and the GSM ref grammar,
+  probe-green verification, and a failure table built from the real
+  error strings), **Run your first operations** (the
+  discover → groups → search → preview → call ladder worked end to
+  end on the `k8s-1.x` typed connector, result-handle drill-in via
+  `result_query`, and what `safety_level` / `requires_approval` mean
+  at first contact), and **Watch your estate with sensors** (create,
+  dashboard rollup, break-and-triage across the five-state
+  vocabulary, the optional investigator, and the honest per-backend
+  background-credential matrix). Each guide ends with a
+  "what can go wrong here" section sourced from shipped error
+  messages rather than invented FAQs; the guides landing page now
+  sequences them and reserves the approvals & break-glass slot
+  (#2669). (#2673)
+
 ### Added — maturity drift guard in CI + generated maturity-index docs page (#2678)
 
 - Close the #2664 maturity program with its two enforcement pieces

--- a/docs-site/guides/first-operations.md
+++ b/docs-site/guides/first-operations.md
@@ -23,7 +23,10 @@ nothing, and writing no audit row.
     - A registered, probe-green target —
       [Register targets and secrets](targets-and-secrets.md). The
       examples below use the `lab-rke2` Kubernetes target from that
-      guide.
+      guide. On a GSM deployment with per-operator Workload Identity
+      Federation, credentialed probes report `reachable: false` or
+      `auth_failed` even when the target is fine — work the ladder
+      anyway and let a successful call (Step 4) stand in as the proof.
     - An **operator**-role session. Nothing in this guide needs
       tenant_admin.
 

--- a/docs-site/guides/first-operations.md
+++ b/docs-site/guides/first-operations.md
@@ -1,0 +1,249 @@
+# Run your first operations
+
+MEHO does not expose one tool per vendor operation — a vCenter alone
+would be thousands. Instead, every connector publishes its operations
+into one searchable catalog, and you (or your agent) reach them
+through a small, stable set of meta-tools: **discover the connector,
+list its operation groups, search for the operation, preview it,
+call it**. This guide walks that ladder once, end to end, against a
+typed Kubernetes connector — the same flow applies to every connector,
+including ones ingested from an OpenAPI spec.
+
+Every rung exists twice: as an MCP tool (for agents) and as a CLI verb
+(for operators). Both run the same dispatch path — policy, credential
+resolution, result reduction, audit.
+
+!!! note "Prerequisites"
+
+    - A registered, probe-green target —
+      [Register targets and secrets](targets-and-secrets.md). The
+      examples below use the `lab-rke2` Kubernetes target from that
+      guide.
+    - An **operator**-role session. Nothing in this guide needs
+      tenant_admin.
+
+## The ladder at a glance
+
+| Step | MCP tool | CLI |
+|---|---|---|
+| Find the connector | `meho.connector.list` | `meho connector list` |
+| List operation groups | `list_operation_groups` | `meho operation groups <connector_id>` |
+| Search operations | `search_operations` | `meho operation search <connector_id> "<query>"` |
+| Preview the request | `preview_operation` | — (REST/MCP only) |
+| Call | `call_operation` | `meho operation call <connector_id> <op_id>` |
+| Page a large result | `result_query` | — (MCP; agents drill in) |
+
+## Step 0 — find your connector id
+
+Operations are addressed by **`connector_id`**, which has the form
+`<impl_id>-<version>` — for example `k8s-1.x`, `vault-1.x`,
+`vmware-rest-9.0`. It is *not* the bare product name; a product can
+have several connector implementations, and the resolver picks one
+per target.
+
+```bash
+meho connector list
+```
+
+Pick the connector whose product matches your target. For the
+`lab-rke2` target (`product: k8s`), that is `k8s-1.x`.
+
+## Step 1 — list the operation groups
+
+Groups are the map of a connector's surface. Each carries a
+`when_to_use` hint, so you narrow hundreds of operations to a handful
+before searching.
+
+```bash
+meho operation groups k8s-1.x
+```
+
+Typical output shape: `inventory` (nodes, namespaces, versions),
+`workload` (pods, deployments, services), `logs`, `events`, `write`
+(mutating ops), each with an operation count.
+
+A group flagged `partial: true` is only partly enabled — an operator
+enabled specific operations rather than the whole group. Only the
+`enabled_op_count` operations in it are live; search will find exactly
+those.
+
+## Step 2 — search for the operation
+
+Search is hybrid lexical + semantic over the connector's *enabled*
+operations. Scope it to a group when you know one:
+
+```bash
+meho operation search k8s-1.x "pods that are not running" --group workload
+```
+
+Each hit carries the fields that matter before you call anything:
+
+- **`op_id`** — the handle you pass to call, e.g. `k8s.pod.list`.
+- **`safety_level`** — `safe`, `caution`, or `dangerous`.
+- **`requires_approval`** — whether a call parks for a second pair of
+  eyes instead of executing.
+
+Read those two flags on every hit **before** calling — see
+[Safety flags at first contact](#safety-flags-at-first-contact).
+
+## Step 3 — preview (when you want the wire truth)
+
+`preview_operation` resolves the exact operation + target + params a
+call would use and returns the literal would-be HTTP request —
+method, resolved path, query, and a redacted body — **without sending
+it**. It is the fastest way to diagnose a rejected write: re-issue the
+same arguments to preview and read back exactly what would go on the
+wire.
+
+Two honest limits:
+
+- It covers **spec-ingested HTTP operations**. A typed or composite
+  operation (like the Kubernetes ops here) has no single literal HTTP
+  request, so preview returns `status: "unavailable"` — that is the
+  expected answer, not a failure.
+- It is available over MCP and REST (`POST
+  /api/v1/operations/preview`); there is no CLI verb for it today.
+
+## Step 4 — call
+
+The worked example: find every pod in the cluster that is not
+`Running`.
+
+```bash
+meho operation call k8s-1.x k8s.pod.list \
+  --target lab-rke2 \
+  --params '{"all_namespaces": true, "field_selector": "status.phase!=Running"}'
+```
+
+The result envelope always has the same shape — `status`, `op_id`,
+`result`, `error`, `duration_ms`, `extras`. On success
+(`status: "ok"`), the payload here is rows of
+`{name, namespace, status, ready, restarts, age_seconds, node, ip}`
+plus a `total`:
+
+```json
+{
+  "status": "ok",
+  "op_id": "k8s.pod.list",
+  "result": {
+    "rows": [
+      {"name": "web-6f7d4b", "namespace": "demo", "status": "CrashLoopBackOff",
+       "ready": "0/1", "restarts": 17, "age_seconds": 5520,
+       "node": "rke2-w1", "ip": "10.42.0.31"}
+    ],
+    "total": 1
+  }
+}
+```
+
+Drill into the offender with the sibling read ops — same ladder, no
+new concepts:
+
+```bash
+meho operation call k8s-1.x k8s.pod.info \
+  --target lab-rke2 --params '{"pod_name": "web-6f7d4b", "namespace": "demo"}'
+
+meho operation call k8s-1.x k8s.logs \
+  --target lab-rke2 --params '{"pod_name": "web-6f7d4b", "namespace": "demo"}'
+
+meho operation call k8s-1.x k8s.event.list \
+  --target lab-rke2 --params '{"namespace": "demo"}'
+```
+
+Two conveniences worth knowing:
+
+- Frequently-used connectors also ship **shortcut verbs** that pre-bake
+  the connector id — `meho k8s pod list --target lab-rke2 --namespace
+  demo` dispatches the identical operation through the identical
+  governed path. Sugar only.
+- `--params` accepts inline JSON or `@<file>`; pass `work_ref` (MCP)
+  to stamp a change-ticket reference onto the audit row.
+
+## Large results: handles
+
+Set-shaped results are **automatically reduced server-side** above a
+threshold (more than 50 rows, or more than 4 KB serialized). You get
+a representative sample inline plus a **result handle** — never a
+multi-megabyte payload in your context. This is not opt-in and cannot
+be opted out of per call.
+
+When a result was reduced, its `fetch_more.drill_in` block tells you
+so — `available: true`, an `example_call`, and the handle's
+`expires_at`. Page through the full set with `result_query`:
+
+```json
+{"handle_id": "<uuid from the result>", "offset": 50, "limit": 100}
+```
+
+The envelope returns `rows`, `offset`, `limit`, `returned_rows`,
+`total_rows`, `stored_rows`, `truncated`. Notes that save you a
+confused hour:
+
+- Handles are **scoped to you** (operator + tenant) and expire. A
+  cross-operator read, an expired handle, and a nonexistent one are
+  indistinguishable: *"handle … is not readable: it does not exist,
+  has expired, or belongs to a different operator. Re-run the
+  operation to get a fresh handle."* That is isolation working, not a
+  bug.
+- `result_query` is the drill-in tool that ships today; aggregation
+  and export tools are on the roadmap but do not exist yet.
+- When `drill_in.available` is `false`, the full set was *not*
+  spilled (the `reason` field says why) — re-run the operation with
+  narrower params instead of hunting for a handle.
+
+## Safety flags at first contact
+
+Every operation carries two independent markers, set per-op when the
+connector is registered or reviewed:
+
+- **`safety_level`** — `safe` (read-class, executes under
+  default-allow), `caution`, or `dangerous` (write/destructive class,
+  subject to policy).
+- **`requires_approval`** — when `true`, calling the operation does
+  **not** execute it. The dispatcher durably parks it and returns:
+
+```json
+{
+  "status": "awaiting_approval",
+  "op_id": "k8s.delete",
+  "error": "awaiting_approval: 'k8s.delete' requires approval before execution",
+  "extras": {"error_code": "awaiting_approval", "approval_request_id": "<uuid>"}
+}
+```
+
+`awaiting_approval` is a first-class outcome, not an error. The gate
+is **server-side** — neither you nor an agent can opt out of it, and
+the classification keys on the operation, not on who is calling. The
+parked request is resolved on the operator surfaces:
+
+```bash
+meho approvals list
+meho approvals show <approval_request_id>
+meho approvals approve <approval_request_id> --reason "verified blast radius"
+meho approvals reject  <approval_request_id> --reason "wrong target"
+```
+
+By default you cannot approve your own request (the four-eyes rule),
+and parked requests expire on a TTL. The full story — including the
+audited single-operator break-glass — is the
+[approvals & break-glass guide](index.md#coming-to-this-section).
+
+Before approving *any* fan-out write: open the approval payload and
+verify the resolved object list first. An unconstrained filter is how
+a one-VM drill becomes a cluster-wide incident.
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| `-32602` with `data.reason: unknown_connector` | The `connector_id` names nothing registered — usually a bare product name (`k8s`) where `<impl_id>-<version>` (`k8s-1.x`) belongs. | `meho connector list`, copy the id verbatim. |
+| `-32602` with `data.reason: connector_not_ingested` | The connector is registered but its spec has not been ingested, so it has no operations yet. Recoverable: the error's `data.next_step.verb` carries the exact `meho connector ingest …` command to run. | Run the named command, then retry. |
+| `meho operation groups` returns an empty list | The connector exists but nothing is enabled yet — operations ship default-deny until reviewed/enabled. | `meho connector review <id>`, then enable groups or single ops (`meho connector enable-reads <id>` bulk-enables the read class). |
+| Search cannot find an operation you know exists | Search only indexes **enabled** operations; a disabled op is invisible by design. An unknown `--group` also silently narrows to zero hits (that is not an error). | Check enablement via `meho connector review`; drop the group filter. |
+| `status: "error"` with `invalid_params` | The params failed the operation's schema. **Do not retry the same arguments verbatim.** | Read `extras.validation_errors`, fix the shape (e.g. `k8s.pod.list` requires exactly one of `namespace` / `all_namespaces: true`), re-call. |
+| `status: "error"` with a `connector_error` / credential message | Dispatch reached the connector but the target's credential failed to resolve or was rejected. | Work the [targets & secrets failure table](targets-and-secrets.md#what-can-go-wrong-here) — the error strings there map one-to-one. |
+| `status: "denied"` | Policy refused the call for this principal — distinct from a missing approval. | Inspect the reason in `extras`; this is a grants/policy conversation, not a retry. |
+| `status: "awaiting_approval"` on what you expected to just run | The op carries `requires_approval` — working as designed. | See [Safety flags](#safety-flags-at-first-contact). |
+| `handle_not_found` from `result_query` | Handle expired, or it belongs to another operator/tenant. | Re-run the producing operation; page promptly. |
+
+**Next:** [Watch your estate with sensors](sensors-quickstart.md).

--- a/docs-site/guides/first-operations.md
+++ b/docs-site/guides/first-operations.md
@@ -9,9 +9,14 @@ call it**. This guide walks that ladder once, end to end, against a
 typed Kubernetes connector — the same flow applies to every connector,
 including ones ingested from an OpenAPI spec.
 
-Every rung exists twice: as an MCP tool (for agents) and as a CLI verb
-(for operators). Both run the same dispatch path — policy, credential
-resolution, result reduction, audit.
+Most rungs exist twice: as an MCP tool (for agents) and as a CLI verb
+(for operators) — preview and `result_query` are MCP/REST-only, as the
+table below shows. Where both surfaces exist they share one backplane
+rather than two implementations. The rung that *dispatches* — `call` —
+runs the full path: policy gate, credential resolution, result
+reduction, audit. Preview deliberately stops short of it: it resolves
+the request and hands it back, skipping the policy gate, sending
+nothing, and writing no audit row.
 
 !!! note "Prerequisites"
 

--- a/docs-site/guides/index.md
+++ b/docs-site/guides/index.md
@@ -1,13 +1,34 @@
 # Do real work
 
-!!! note "Stub — content tracked by [evoila/meho#2673](https://github.com/evoila/meho/issues/2673)"
+You have a running backplane and a connected client. This section is
+the bridge from "connected" to "operating real infrastructure": each
+guide is a task-shaped, start-to-finish walk you can execute against a
+fresh deploy.
 
-This section will carry task-oriented guides for operating real
-infrastructure through MEHO:
+Work through the first three in order — each builds on the previous
+one:
 
-- Register targets and secrets.
-- First operations: search → preview → call.
-- Approvals and break-glass.
-- Sensors quickstart.
-- Later: topology, broadcast, memory / knowledge, audit forensics,
-  runbooks, scheduler, satellite gateway.
+| Guide | What you will have at the end |
+|---|---|
+| [Register targets and secrets](targets-and-secrets.md) | Your systems registered as targets, credentials staged in your secret store, and a green probe proving MEHO can reach and identify each one. |
+| [Run your first operations](first-operations.md) | The discover → search → preview → call ladder, exercised end to end against a real target, including how to page large results and what the safety flags mean. |
+| [Watch your estate with sensors](sensors-quickstart.md) | A sensor evaluating a real check on a schedule, a dashboard rolling it up, and a triage walk of the five-state vocabulary when something breaks. |
+
+## Coming to this section
+
+- **Approvals and break-glass** — what happens when an operation
+  requires a second pair of eyes, and the audited single-operator
+  escape hatches. Tracked by
+  [evoila/meho#2669](https://github.com/evoila/meho/issues/2669).
+- Later guides — topology, broadcast, memory / knowledge, audit
+  forensics, runbooks, scheduler, satellite gateway — land as the
+  evaluation program shows where the pain is.
+
+!!! tip "When a guide and your deploy disagree"
+
+    These guides are written against the product version this site
+    version documents (see the version selector). If a command or
+    error message differs on your deploy, check that your CLI and
+    backplane versions match the docs version you are reading —
+    then [file a docs issue](https://github.com/evoila/meho/issues):
+    a guide a fresh user cannot execute verbatim is a bug.

--- a/docs-site/guides/index.md
+++ b/docs-site/guides/index.md
@@ -11,7 +11,7 @@ one:
 | Guide | What you will have at the end |
 |---|---|
 | [Register targets and secrets](targets-and-secrets.md) | Your systems registered as targets, credentials staged in your secret store, and a green probe proving MEHO can reach and identify each one. |
-| [Run your first operations](first-operations.md) | The discover → search → preview → call ladder, exercised end to end against a real target, including how to page large results and what the safety flags mean. |
+| [Run your first operations](first-operations.md) | The discover → groups → search → preview → call ladder, exercised end to end against a real target, including how to page large results and what the safety flags mean. |
 | [Watch your estate with sensors](sensors-quickstart.md) | A sensor evaluating a real check on a schedule, a dashboard rolling it up, and a triage walk of the five-state vocabulary when something breaks. |
 
 ## Coming to this section

--- a/docs-site/guides/sensors-quickstart.md
+++ b/docs-site/guides/sensors-quickstart.md
@@ -103,9 +103,16 @@ meho sensor list
 ```
 
 There is deliberately **no update or pause verb** — a sensor is
-immutable after create ("edit" is delete + recreate), and `paused`
-happens only when the runner itself parks a persistently failing
-sensor.
+immutable after create ("edit" is delete + recreate). Nor is `paused`
+a self-protection you can wait for: the runner parks a sensor **only**
+when its stored cadence (`cron_expr` / `timezone`) no longer parses,
+stamping `status_reason` with `invalid_cadence:<error>`. There is no
+failure counter — a sensor that evaluates `critical` or `unknown`
+forever stays `active` forever. The way to stop one is to delete it:
+
+```bash
+meho sensor delete <uuid>
+```
 
 ## Step 3 — compose a dashboard
 
@@ -238,9 +245,9 @@ is also the sensors feature's road-to-GA tracker.
 | 422 `sensor_operation_not_found` | `(connector_id, op_id)` resolves to nothing — usually a bare product name as `connector_id`. | Use the `<impl_id>-<version>` form (`k8s-1.x`), and an `op_id` from `meho operation search`. |
 | 409 `sensor_name_conflict` | Sensor names are unique per tenant. | Rename or delete the old one. |
 | A plain 422 validation error *before* any of the codes above | Schema validation runs first: the comparator `type` must be one of `threshold` / `equals` / `in` / `bool` / `freshness` (not `gt`/`lt` — those are the threshold's `op`), the cadence must be exactly one of interval (5–86400 s) XOR cron, the assertion is capped at 8 KiB, and a `status` field in the body is rejected. | Fix the spec shape; the error names the field. |
-| Sensor stuck `unknown`, evidence says *"threshold comparator requires a number, found array"* | Your `select.path` points at a list (e.g. `$.rows`), not a scalar. | Select a scalar — `$.total` for list-shaped Kubernetes results — or add an `aggregate` (`count`, `max`, …) to the select. |
+| Sensor stuck `unknown`, evidence says *"selection is not a scalar, found array"* | Your `select.path` points at a list (e.g. `$.rows`), not a scalar. | Select a scalar — `$.total` for list-shaped Kubernetes results — or add an `aggregate` (`count`, `max`, …) to the select. |
 | Target-bound sensor `unknown` forever, dispatch error names a credential read | No background credential identity on this deploy — the table above. | Work [Sensors and your credential backend](#sensors-and-your-credential-backend). |
-| Sensor `unknown` though it was green a minute ago | Staleness: no fresh evaluation past `next_fire_at` + 60 s grace — runner down, or evaluations overlapping/parked. | Check the runner's health and the sensor's `status` (a parked sensor shows `paused` → rollup `skip`). |
+| Sensor `unknown` though it was green a minute ago | Staleness: no fresh evaluation past `next_fire_at` + 60 s grace — the runner is down, or the previous evaluation is still in flight and the overlap guard skipped this tick. | Check the runner's health. A *parked* sensor is a different symptom: it shows `paused` and rolls up `skip`, never `unknown`. |
 | Dashboard `unknown` with all members green | The dashboard has zero members — an empty member set rolls up `unknown` by rule. | Add members (delete + recreate the dashboard). |
 | A sensor keeps auto-running an op that is no longer harmless | The safe-only guard is **create-time only**. If a connector re-ingest changes a pinned op's safety class, existing sensors keep firing; the ingest result surfaces exactly which sensors are affected (`safety_changes`, warning `ingest_safety_class_changed`). | Re-audit the named sensors after any re-ingest that touches safety classes; delete the ones that no longer qualify. |
 

--- a/docs-site/guides/sensors-quickstart.md
+++ b/docs-site/guides/sensors-quickstart.md
@@ -148,9 +148,9 @@ tools today**.
 
 ## Step 4 — break something and watch
 
-Make one pod unschedulable in the watched cluster — point a
-deployment at a nonexistent image tag, or kill a node if the lab is
-yours to break:
+Push one pod out of `Running` in the watched cluster — point a
+deployment at a nonexistent image tag (it schedules, then sticks in
+`ImagePullBackOff`), or kill a node if the lab is yours to break:
 
 ```bash
 meho operation call k8s-1.x k8s.pod.list \

--- a/docs-site/guides/sensors-quickstart.md
+++ b/docs-site/guides/sensors-quickstart.md
@@ -1,0 +1,250 @@
+# Watch your estate with sensors
+
+Everything so far was interactive: you asked, MEHO answered. Sensors
+make the backplane watch on its own. A **sensor** pins one tuple —
+*operation + params + assertion + cadence + severity* — that a
+built-in runner evaluates on a schedule, entirely deterministically
+(no LLM in the loop). **Dashboards** compose sensors into a single
+rolled-up state, and an optional agent **investigator** can triage a
+dashboard the moment it goes red.
+
+This guide registers a sensor on the Kubernetes target from the
+previous guides, composes a dashboard, breaks something on purpose,
+and reads the result.
+
+!!! note "Prerequisites, roles, and maturity"
+
+    - A probe-green target and the operation ladder from
+      [Run your first operations](first-operations.md) — a sensor is
+      just an operation call on a timer.
+    - Creating sensors and dashboards requires **tenant_admin**; an
+      operator-role JWT gets `403 insufficient_role`. Listing and
+      reading need only operator.
+    - Sensors are **beta** — see the
+      [feature-maturity index](../reference/maturity.md) for what
+      that promise means and the road to GA.
+
+## The five states
+
+Every sensor evaluation lands in exactly one of five states — the
+same vocabulary everywhere (sensor projection, dashboard rollup, UI):
+
+| State | Meaning |
+|---|---|
+| `ok` | Evaluated; assertion passed. |
+| `degraded` | Evaluated; assertion failed at the *degraded* band. |
+| `critical` | Evaluated; assertion failed at the *critical* band. |
+| `unknown` | Could not be judged — the dispatch failed (most often credentials, see [the backend caveat](#sensors-and-your-credential-backend)), the value had the wrong type, or the sensor has gone stale (no evaluation past its due time plus a 60-second grace). |
+| `skip` | Not scheduled — the sensor is paused. |
+
+## Step 1 — pick a safe operation
+
+A sensor may only pin an operation whose `safety_level` is **`safe`**
+— the runner auto-executes on a schedule with nobody watching, so
+`caution`/`dangerous` ops are refused at create time (422
+`sensor_requires_safe_operation`). Find the op exactly as in the
+previous guide:
+
+```bash
+meho operation search k8s-1.x "list pods" --group workload
+# -> k8s.pod.list   safety_level=safe   requires_approval=false
+```
+
+Our check: *no pod in the cluster should be off `Running` phase*. The
+call we want the runner to repeat is the one you already ran by hand:
+`k8s.pod.list` with `{"all_namespaces": true, "field_selector":
+"status.phase!=Running"}` — a healthy estate returns `total: 0`.
+
+## Step 2 — create the sensor
+
+The **assertion** is a bounded two-part spec: one `select` (a path
+into the operation's result) feeding one typed comparator —
+`threshold`, `equals`, `in`, `bool`, or `freshness`. It is
+deliberately not a query language.
+
+```bash
+meho sensor create \
+  --name pods-not-running \
+  --connector-id k8s-1.x \
+  --op-id k8s.pod.list \
+  --target '{"name": "lab-rke2"}' \
+  --params '{"all_namespaces": true, "field_selector": "status.phase!=Running"}' \
+  --assertion '{"select": {"path": "$.total"},
+                "compare": {"type": "threshold", "op": "gt", "degraded": 0, "critical": 2}}' \
+  --cadence-kind interval --interval-seconds 60 \
+  --severity critical --for-seconds 120
+```
+
+Reading the assertion: select the result's `$.total`; the state goes
+non-green when `value <op> bound` is true — here `degraded` as soon as
+any pod is off-phase (`> 0`), `critical` at three or more (`> 2`).
+The more severe band wins.
+
+The other knobs:
+
+- `--cadence-kind interval --interval-seconds N` (5–86400) **or**
+  `--cadence-kind cron --cron-expr "*/5 * * * *"` with an optional
+  `--timezone` (IANA, default UTC). The runner ticks on a ~10-second
+  grid, so very short intervals quantize to it.
+- `--severity` (`degraded` | `critical`, default `critical`) is a
+  **cap** on what this sensor can contribute to a dashboard — a
+  `severity: degraded` sensor can never drive a dashboard critical.
+- `--for-seconds` is hold-time hysteresis: a failing state only
+  counts toward the rollup after it has held that long (recovery is
+  immediate). Our `120` means a single flapping pod won't page
+  anyone.
+
+Verify:
+
+```bash
+meho sensor list
+# ID          NAME              STATUS  LAST_STATE  CADENCE     NEXT_FIRE_AT          SEVERITY
+# <uuid>      pods-not-running  active  ok          every 60s   2026-07-31T09:21:12Z  critical
+```
+
+There is deliberately **no update or pause verb** — a sensor is
+immutable after create ("edit" is delete + recreate), and `paused`
+happens only when the runner itself parks a persistently failing
+sensor.
+
+## Step 3 — compose a dashboard
+
+```bash
+meho dashboard create --name estate-health \
+  --description "Lab estate, rollup of the deterministic checks" \
+  --sensor-id <uuid-from-sensor-list>
+```
+
+`--sensor-id` repeats for more members (membership is create-only).
+Read it back:
+
+```bash
+meho dashboard show <dashboard_id>
+```
+
+The dashboard's state is computed **on read**, worst-of its members,
+with these rules:
+
+- `skip` members are excluded from the fold; `unknown` members
+  contribute as `degraded` — a sensor that cannot evaluate is a
+  problem, not a pass.
+- Each member's contribution is capped at its `severity`.
+- A failing state inside its `for:` window contributes `ok` and shows
+  as *pending* in the member breakdown.
+- Zero members rolls up `unknown`; all-`skip` rolls up `skip`.
+
+The same view lives in the operator console at `/ui/checks` (list)
+and `/ui/checks/{dashboard_id}` (member breakdown). Dashboards have
+CLI, REST, and UI surfaces; sensors additionally have MCP tools
+(`meho.sensor.list` / `create` / `delete`) — **dashboards have no MCP
+tools today**.
+
+## Step 4 — break something and watch
+
+Make one pod unschedulable in the watched cluster — point a
+deployment at a nonexistent image tag, or kill a node if the lab is
+yours to break:
+
+```bash
+meho operation call k8s-1.x k8s.pod.list \
+  --target lab-rke2 \
+  --params '{"all_namespaces": true, "field_selector": "status.phase!=Running"}'
+# -> total: 1
+```
+
+Then watch the timeline unfold:
+
+1. Within the next interval the runner evaluates, the assertion
+   selects `$.total = 1`, and `last_state` flips to `degraded`
+   (`meho sensor list`); `state_since` records the flip.
+2. For the first 120 seconds (`--for-seconds`), the dashboard still
+   reads green and the member shows **pending** — that's the
+   hysteresis absorbing flaps.
+3. Once held past the window, `meho dashboard show` (and
+   `/ui/checks`) goes `degraded`. Escalate the break to three
+   off-phase pods and it crosses to `critical`.
+4. Fix the deployment. Recovery is immediate on the next evaluation —
+   no hold-time on the way back to `ok`.
+
+Each evaluation stores its evidence on the sensor's projection
+(`last_value`, `last_evidence`, `last_evaluated_at`) — enough to see
+*what* the assertion saw without a results-history table.
+
+## The investigator (optional deep tier)
+
+When a dashboard's rollup crosses from green into a non-green state,
+MEHO can fire a **diagnose-only** agent investigation: affected
+sensors are correlated through the topology graph so one underlying
+cause produces exactly one investigation, known-noise verdicts are
+suppressed, and the agent writes a structured finding — verdict,
+evidence, recommended action — into tenant memory
+(`checks-noise-<group-key>`), retrievable via `search_memory`.
+
+It is off until you opt in, and it has real prerequisites:
+
+- An **enabled agent definition named `checks-investigator`** in your
+  tenant (the name is configurable deploy-side). The
+  [tiered-triage example](https://github.com/evoila/meho/tree/main/examples/r1-tiered-triage)
+  is the mould — read-only toolset, writes need approval.
+- The agent runtime, which is **experimental** maturity — check the
+  [feature-maturity index](../reference/maturity.md) before leaning
+  on it.
+- Topology anchors for your targets (correlation degrades to
+  per-sensor findings without them).
+
+The investigator never executes a change: any write op its agent
+attempts parks in the approval queue like everyone else's.
+
+## Sensors and your credential backend
+
+The honest operational caveat: scheduled evaluations run in the
+background, with **no operator logged in** — so a sensor whose target
+needs credentials depends on your deploy having a *background
+credential identity*. Whether that exists depends on the credential
+backend:
+
+| Deploy | Target-bound sensors | What to do |
+|---|---|---|
+| Vault (default), no `checkRunner.*` configured | Evaluate **`unknown` forever** — the runner presents no identity Vault will honour. | Configure the check-runner service principal (`checkRunner.*` chart block) — but read the warning below first. |
+| GSM, platform identity (no per-operator WIF) | Work — reads run under MEHO's own service account. | Nothing. |
+| GSM, per-operator WIF, on GKE with pod identity | Work — background reads fall back to the pod's identity. | Nothing. |
+| GSM, per-operator WIF, on-prem (no pod identity) | Evaluate **`unknown` forever** without the runner principal. | Configure `checkRunner.*`. |
+
+Sensors on operations that read **no target credential** evaluate
+fine on every backend, with zero extra configuration.
+
+!!! warning "`checkRunner.*` on a Vault deploy widens background reads"
+
+    The check-runner principal is not a GSM-only knob. On a Vault
+    deploy it gives *all* background dispatch a token the documented
+    default Vault role will accept — which can read every target
+    credential in the policy's subtree. Bound the role before
+    enabling it:
+    [`docs/deploying.md`](https://github.com/evoila/meho/blob/main/docs/deploying.md)
+    and
+    [`docs/cross-repo/vault-provisioning.md` § Bounding the check-runner principal](https://github.com/evoila/meho/blob/main/docs/cross-repo/vault-provisioning.md).
+
+Long-unattended operation has one more open edge: durable machine
+credentials for background execution (the "still running on day 30"
+promise) are actively being hardened — tracked in
+[evoila/meho#2668](https://github.com/evoila/meho/issues/2668), which
+is also the sensors feature's road-to-GA tracker.
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| 422 `sensor_requires_safe_operation` | The pinned op is `caution`/`dangerous`. Sensors auto-execute unattended, so only `safe` ops qualify — by design. | Pick a read-class op; check `safety_level` on the search hit. |
+| 422 `sensor_operation_not_found` | `(connector_id, op_id)` resolves to nothing — usually a bare product name as `connector_id`. | Use the `<impl_id>-<version>` form (`k8s-1.x`), and an `op_id` from `meho operation search`. |
+| 409 `sensor_name_conflict` | Sensor names are unique per tenant. | Rename or delete the old one. |
+| A plain 422 validation error *before* any of the codes above | Schema validation runs first: the comparator `type` must be one of `threshold` / `equals` / `in` / `bool` / `freshness` (not `gt`/`lt` — those are the threshold's `op`), the cadence must be exactly one of interval (5–86400 s) XOR cron, the assertion is capped at 8 KiB, and a `status` field in the body is rejected. | Fix the spec shape; the error names the field. |
+| Sensor stuck `unknown`, evidence says *"threshold comparator requires a number, found array"* | Your `select.path` points at a list (e.g. `$.rows`), not a scalar. | Select a scalar — `$.total` for list-shaped Kubernetes results — or add an `aggregate` (`count`, `max`, …) to the select. |
+| Target-bound sensor `unknown` forever, dispatch error names a credential read | No background credential identity on this deploy — the table above. | Work [Sensors and your credential backend](#sensors-and-your-credential-backend). |
+| Sensor `unknown` though it was green a minute ago | Staleness: no fresh evaluation past `next_fire_at` + 60 s grace — runner down, or evaluations overlapping/parked. | Check the runner's health and the sensor's `status` (a parked sensor shows `paused` → rollup `skip`). |
+| Dashboard `unknown` with all members green | The dashboard has zero members — an empty member set rolls up `unknown` by rule. | Add members (delete + recreate the dashboard). |
+| A sensor keeps auto-running an op that is no longer harmless | The safe-only guard is **create-time only**. If a connector re-ingest changes a pinned op's safety class, existing sensors keep firing; the ingest result surfaces exactly which sensors are affected (`safety_changes`, warning `ingest_safety_class_changed`). | Re-audit the named sensors after any re-ingest that touches safety classes; delete the ones that no longer qualify. |
+
+**Where next:** compose sensors with the approvals workflow (a red
+dashboard, an investigator finding, a gated remediation) — the
+[approvals & break-glass guide](index.md#coming-to-this-section)
+covers the gated half.

--- a/docs-site/guides/targets-and-secrets.md
+++ b/docs-site/guides/targets-and-secrets.md
@@ -81,8 +81,9 @@ Mapping rules the importer applies:
   pin the CA *or* disable verification, never both.
 - Set **`tls_server_name`** whenever you reach an appliance by IP (or
   by an alias) while its certificate only carries the FQDN — without
-  it, dispatch fails TLS verification with an
-  `connector_tls_verify_failed` / "IP address mismatch" class error.
+  it, dispatch fails with `connector_tls_verify_failed`, carrying
+  Python's own *"IP address mismatch"* text inside
+  `extras.exception_message`.
 
 You can leave `secret_ref` out entirely — see the next section.
 
@@ -173,7 +174,7 @@ server-derived default is the Vault layout).
 ## Import and verify
 
 ```bash
-# 1. Preview — classifies every entry CREATE / UPDATE / SKIP, writes nothing:
+# 1. Preview — classifies every entry CREATE / UPDATE, writes nothing:
 meho targets import targets.yaml --dry-run
 
 # 2. Apply. Default mode aborts before any write if a name already exists:
@@ -231,7 +232,7 @@ Real failure modes, with the errors they actually produce:
 | Dispatch fails, `connector_error: VaultCredentialsReadError` — *"…is missing required field '…'"* | The secret exists but doesn't carry the field the connector needs (`username`/`password`, or `kubeconfig` for Kubernetes). | Re-stage the secret with the connector's field names. |
 | Dispatch fails, `connector_vault_forbidden` — Vault answered *permission denied* | Nine times out of ten the secret is staged at the wrong path, **not** a missing grant: the error reads like a policy problem but the ref simply doesn't match where you wrote the secret. The error names the expected path. | `vault kv put` the credential at the expected path. Do **not** widen the backplane's Vault policy — it is deploy-owned and re-applied on upgrade. |
 | Dispatch fails, `connector_auth_failed` (HTTP 401 at session establish) | The credential resolved but the vendor rejected it — usually a password rotated upstream while the store copy lagged. | Re-stage the current credential at the same path, then retry. |
-| Dispatch fails TLS: `connector_tls_verify_failed`, *"IP address mismatch"* | You reach the appliance by IP but its certificate only names the FQDN. | Set `tls_server_name: <cert-fqdn>` on the target and re-import with `--update`. |
+| Dispatch fails TLS: `extras.error_code` is `connector_tls_verify_failed` and `extras.exception_message` contains *"IP address mismatch"* (CPython `ssl` text relayed verbatim, not a MEHO string — MEHO's own summary says the chain "is not trusted") | You reach the appliance by IP but its certificate only names the FQDN. | Set `tls_server_name: <cert-fqdn>` on the target and re-import with `--update`. |
 | Probe shows `reachable: false` / `auth_failed` on a GSM deploy with per-operator Workload Identity Federation | Probes run under a system placeholder identity that cannot complete the per-operator token exchange, so credentialed-target probes cannot read the secret on that configuration. Reachability of *uncredentialed* endpoints still probes fine. | Known limitation — documented in [`docs/deploying.md`](https://github.com/evoila/meho/blob/main/docs/deploying.md); verify credentialed dispatch with a real operation call instead. |
 | Registration accepted, but *every* dispatch fails with a `no_connector` error naming the wrong thing | A `product` no connector implementation actually serves can slip through registration in some cases; the dispatch-time error then misattributes the cause. | Known issue, tracked in [evoila/meho#2701](https://github.com/evoila/meho/issues/2701). Re-check the target's `product` against the connector catalog. |
 

--- a/docs-site/guides/targets-and-secrets.md
+++ b/docs-site/guides/targets-and-secrets.md
@@ -1,0 +1,246 @@
+# Register targets and secrets
+
+A **target** is one system MEHO operates against — a Kubernetes API
+server, a vCenter, a Vault, a firewall. Registration gives the
+backplane three things: the coordinates to reach the system (`host`,
+`port`, TLS trust), the `product` token that selects which connector
+serves it, and a `secret_ref` — a *reference* into your credential
+store. MEHO never stores the credential itself; it resolves the
+reference at dispatch time, under an identity your store can audit.
+
+Until at least one target is registered and its probe is green, an
+agent session can discover operations but cannot act on anything —
+which is why this is the first guide.
+
+!!! note "Prerequisites and roles"
+
+    - A running backplane ([Install & operate](../install/index.md))
+      and an authenticated CLI session
+      ([Connect clients](../clients/index.md)):
+      `meho login https://meho.example.com`.
+    - Registration verbs (`import`, create, edit, delete) require the
+      **tenant_admin** role. Read verbs (`list`, `describe`, `probe`,
+      `discover`) need **operator**. If a step below answers
+      `403 insufficient_role`, that is your JWT's role, not a broken
+      deploy.
+
+## Choose a registration path
+
+| Path | What it is | When to use it |
+|---|---|---|
+| **CLI — `meho targets import`** | Bulk-import from a `targets.yaml` file you keep in version control. | The canonical path. Your target registry becomes a reviewable, re-runnable file. |
+| **Operator console — `/ui/connectors`** | Create/edit forms plus a paste-or-upload `targets.yaml` import with a preview table. | Console-first operators. Produces byte-identical writes to the CLI import. |
+| **REST — `POST /api/v1/targets`** | The API the other two paths call. | Automation that already speaks REST. |
+
+**There are no MCP tools for registering targets or staging secrets —
+deliberately.** Registration is an operator-trust decision, so it
+lives on the operator surfaces above; agents get the read-only
+`list_targets` tool and consume whatever you registered. This is also
+why the CLI is worth installing before your first agent session. If
+that boundary ever moves, the change will be tracked on the
+[feature-maturity index](../reference/maturity.md).
+
+## Write a `targets.yaml`
+
+The file is a `targets:` list. A minimal, realistic pair — a
+Kubernetes cluster and a VMware appliance that is reached by IP:
+
+```yaml
+targets:
+  - name: lab-rke2
+    product: k8s                    # registered product token — NOT "kubernetes"
+    host: rke2-api.lab.example.com
+    port: 6443
+    auth_model: shared_service_account
+    notes: RKE2 lab cluster, evaluation estate.
+
+  - name: lab-vcenter
+    product: vmware
+    host: 10.20.0.15                # reached by IP...
+    tls_server_name: vc01.lab.example.com   # ...but the cert's SAN is the FQDN
+    tls_ca_pin: |
+      -----BEGIN CERTIFICATE-----
+      ...internal CA, PEM...
+      -----END CERTIFICATE-----
+    notes: vCenter reached by IP; SNI + cert verification pinned to the SAN name.
+```
+
+Mapping rules the importer applies:
+
+- **Recognised top-level keys** map 1:1 to real columns: `name`,
+  `aliases`, `product`, `host`, `port`, `fqdn`, `secret_ref`,
+  `auth_model`, `vpn_required`, `notes`, `preferred_impl_id`,
+  `verify_tls`, `tls_ca_pin`, `tls_server_name`, `extras`.
+- **`name`, `product`, and `host` are required** and validated
+  locally before any HTTP request.
+- **Unknown keys are not errors** — they spill into the target's
+  `extras` JSON column, so you can carry your own annotations.
+- **`fingerprint` is server-managed** and dropped with a warning; the
+  probe verb is its only writer.
+- `verify_tls: false` and `tls_ca_pin` are mutually exclusive (422):
+  pin the CA *or* disable verification, never both.
+- Set **`tls_server_name`** whenever you reach an appliance by IP (or
+  by an alias) while its certificate only carries the FQDN — without
+  it, dispatch fails TLS verification with an
+  `connector_tls_verify_failed` / "IP address mismatch" class error.
+
+You can leave `secret_ref` out entirely — see the next section.
+
+## Stage the secret
+
+Every target that needs credentials carries a `secret_ref`. Which
+store it points at is decided by your deploy's credential backend
+(`vault`, the default, or `gsm` — see the
+[install trail](../install/index.md)).
+
+### Vault (default backend)
+
+The `secret_ref` is the **logical KV-v2 path relative to the `secret`
+mount** — never include the mount or the `/data/` segment. The
+canonical, enforced layout is per-tenant:
+
+```
+tenants/<tenant-id>/<target-name>
+```
+
+If you omit `secret_ref` at registration, **the server derives exactly
+that path for you**. The reliable recipe is therefore: register first,
+read the derived reference back, then stage the secret at it.
+
+```bash
+# 1. After import, read the derived reference:
+meho targets describe lab-vcenter
+#   ...
+#   secret_ref:        tenants/4f6f6f6f-.../lab-vcenter
+
+# 2. Stage the credential there with your own Vault tooling.
+#    The Vault CLI addresses the *wire* path, which prepends the mount:
+vault kv put secret/tenants/4f6f6f6f-.../lab-vcenter \
+  username=svc-meho password='...'
+```
+
+The two path notations trip everyone once, so:
+
+| Context | Path shape | Example |
+|---|---|---|
+| MEHO `secret_ref` | logical, no mount | `tenants/<tenant-id>/lab-vcenter` |
+| Vault CLI / API | mount-prefixed | `secret/tenants/<tenant-id>/lab-vcenter` |
+
+Rules the backplane enforces:
+
+- An explicitly supplied Vault `secret_ref` must stay **inside your
+  tenant subtree** (`tenants/<tenant-id>/…`). Anything else is
+  rejected at registration with a structured 422
+  (`secret_ref_outside_tenant_scope`) that names the expected path —
+  because your operator Vault identity could never read it at
+  dispatch anyway.
+- A mount- or API-shaped ref (`secret/data/…`, `kv/data/…`,
+  `data/…`) is rejected at read time: Vault inserts the `/data/`
+  segment itself, so a prefixed value double-resolves to a 404.
+- Most connectors expect the fields **`username`** and
+  **`password`**. Some want a different shape — the Kubernetes
+  connector reads a single field named **`kubeconfig`** holding the
+  kubeconfig YAML. The per-connector field contract is listed in each
+  connector's onboarding notes
+  ([`docs/cross-repo/`](https://github.com/evoila/meho/tree/main/docs/cross-repo)).
+
+```bash
+# Kubernetes example — one field, whole kubeconfig as the value:
+vault kv put secret/tenants/<tenant-id>/lab-rke2 \
+  kubeconfig=@rke2-kubeconfig.yaml
+```
+
+### Google Secret Manager (`credentialBackend: gsm`)
+
+The ref grammar is:
+
+```
+gsm:<project-id>/<secret-name>[/versions/<version>][#<field>]
+```
+
+- `gsm:my-project/lab-vcenter-creds` — latest version, whole payload.
+- `gsm:my-project/lab-vcenter-creds/versions/3` — pinned version.
+- `gsm:my-project/lab-vcenter-creds#password` — one field only.
+
+The secret's payload **must be a JSON object of named fields**, e.g.
+`{"username": "svc-meho", "password": "..."}` — the same field names
+the connector expects on Vault. A kubeconfig ref looks like
+`gsm:my-project/lab-rke2-kubeconfig#kubeconfig`.
+
+On a GSM deploy, set `secret_ref` explicitly in the YAML (the
+server-derived default is the Vault layout).
+
+## Import and verify
+
+```bash
+# 1. Preview — classifies every entry CREATE / UPDATE / SKIP, writes nothing:
+meho targets import targets.yaml --dry-run
+
+# 2. Apply. Default mode aborts before any write if a name already exists:
+meho targets import targets.yaml
+#   Applied: 2 created, 0 updated.
+
+# 3. Iterate later with --update: PATCHes existing names, creates new ones.
+#    The PATCH is sparse — fields your YAML omits are left untouched.
+meho targets import targets.yaml --update
+```
+
+Then probe. The probe invokes the connector matched to the target's
+`product`, live, and persists the resulting fingerprint:
+
+```bash
+meho targets probe lab-rke2
+```
+
+```text
+vendor:        kubernetes
+product:       rke2
+version:       v1.31.4+rke2r1
+reachable:     true
+probed_at:     2026-07-31T09:14:22Z
+probe_method:  GET /version
+```
+
+**Probe-green means `reachable: true` with the product/version
+identified.** (The fingerprint's `product` is what the connector
+*observed* — here the RKE2 distribution — which can be more specific
+than the `product` token you registered the target under.) The fingerprint is cached on the target row —
+`meho targets describe lab-rke2` shows it from then on without
+re-probing, and the connector resolver uses it to pick the right
+implementation version at dispatch time.
+
+Two useful companions:
+
+```bash
+meho targets list --product k8s     # everything registered, filterable
+meho targets discover k8s           # candidate systems a connector can see
+                                    # from an already-registered seed target
+```
+
+## What can go wrong here
+
+Real failure modes, with the errors they actually produce:
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| 422 at registration: *"target destination is not a public address; refusing it as a server-side request forgery risk…"* | The SSRF guard rejects private/internal addresses by default. The number-one surprise on on-prem first installs. | Add your internal ranges or hostnames to the chart's `config.targetSsrfAllowlist` (env `MEHO_TARGET_SSRF_ALLOWLIST`) and upgrade the release. |
+| 422 `unknown_product`, listing `valid_products` | The `product` token isn't one a registered connector advertises. Product tokens are exact — `k8s`, not `kubernetes`. | Pick a token from the error's `valid_products` list. |
+| 422 `secret_ref_outside_tenant_scope` | You supplied a Vault ref outside `tenants/<tenant-id>/…`. It would fail with "permission denied" at every dispatch. | Use the `expected_secret_ref` the error names — or omit `secret_ref` and take the server default. |
+| Probe exits with 501 — *"no connector registered for product=…"* | The target row is fine; no connector serves that product on this backplane version. Any cached fingerprint is left untouched. | Check the [connector catalog](https://github.com/evoila/meho/blob/main/docs/cross-repo/connector-catalog.md) for your version; for spec-ingested (generic) connectors, ingest one first. |
+| Dispatch fails, `connector_error: VaultCredentialsReadError` — *"…has a KV-v2 API-path-shaped secret_ref…"* | Your ref embeds the mount or a `data/` segment (`secret/data/…`). | Store the logical path only: `tenants/<tenant-id>/<name>`. |
+| Dispatch fails, `connector_error: VaultCredentialsReadError` — *"…is missing required field '…'"* | The secret exists but doesn't carry the field the connector needs (`username`/`password`, or `kubeconfig` for Kubernetes). | Re-stage the secret with the connector's field names. |
+| Dispatch fails, `connector_vault_forbidden` — Vault answered *permission denied* | Nine times out of ten the secret is staged at the wrong path, **not** a missing grant: the error reads like a policy problem but the ref simply doesn't match where you wrote the secret. The error names the expected path. | `vault kv put` the credential at the expected path. Do **not** widen the backplane's Vault policy — it is deploy-owned and re-applied on upgrade. |
+| Dispatch fails, `connector_auth_failed` (HTTP 401 at session establish) | The credential resolved but the vendor rejected it — usually a password rotated upstream while the store copy lagged. | Re-stage the current credential at the same path, then retry. |
+| Dispatch fails TLS: `connector_tls_verify_failed`, *"IP address mismatch"* | You reach the appliance by IP but its certificate only names the FQDN. | Set `tls_server_name: <cert-fqdn>` on the target and re-import with `--update`. |
+| Probe shows `reachable: false` / `auth_failed` on a GSM deploy with per-operator Workload Identity Federation | Probes run under a system placeholder identity that cannot complete the per-operator token exchange, so credentialed-target probes cannot read the secret on that configuration. Reachability of *uncredentialed* endpoints still probes fine. | Known limitation — documented in [`docs/deploying.md`](https://github.com/evoila/meho/blob/main/docs/deploying.md); verify credentialed dispatch with a real operation call instead. |
+| Registration accepted, but *every* dispatch fails with a `no_connector` error naming the wrong thing | A `product` no connector implementation actually serves can slip through registration in some cases; the dispatch-time error then misattributes the cause. | Known issue, tracked in [evoila/meho#2701](https://github.com/evoila/meho/issues/2701). Re-check the target's `product` against the connector catalog. |
+
+!!! tip "Prove the secret is readable — without printing it"
+
+    If Vault itself is registered as a MEHO target, dispatch the
+    metadata-only `vault.kv.versions` operation against the
+    credential's path instead of a read: it proves the path resolves
+    and the policy allows access while returning version numbers,
+    never values.
+
+**Next:** [Run your first operations](first-operations.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,11 @@ nav:
   - Start here: index.md
   - Install & operate: install/index.md
   - Connect clients: clients/index.md
-  - Do real work: guides/index.md
+  - Do real work:
+      - guides/index.md
+      - guides/targets-and-secrets.md
+      - guides/first-operations.md
+      - guides/sensors-quickstart.md
   - Reference:
       - reference/index.md
       # Generated from the feature-maturity registry by


### PR DESCRIPTION
## Summary

- Lands the first three *Do real work* task guides into the #2670 docs-site scaffold: **Register targets and secrets** (`docs-site/guides/targets-and-secrets.md`), **Run your first operations** (`docs-site/guides/first-operations.md`), and **Watch your estate with sensors** (`docs-site/guides/sensors-quickstart.md`), plus a rewritten guides landing page that sequences them and reserves the approvals & break-glass slot (#2669).
- Every command, tool name, flag, error string, and role requirement was verified against the shipped surfaces (Go CLI command definitions, MCP tool registrations, dispatcher/error-builder strings, checks/rollup code) — not the aspirational spec. The guides say plainly what does *not* exist: no MCP tools for target registration, no CLI preview verb, `result_query` as the only shipped read-back tool, no dashboard MCP tools, no sensor update/pause verbs.
- Ports the load-bearing operation-ladder discipline from the dogfood skill contracts into the product docs (discover → groups → search → inspect `safety_level`/`requires_approval` → preview → call), and carries the honest per-backend caveats: the sensors background-credential matrix (Vault `checkRunner.*` privilege warning, GSM WIF cases), the per-operator-WIF probe limitation, and the open #2668 tracker for long-unattended operation.
- Each guide ends with a "What can go wrong here" table sourced from the real error strings (`secret_ref_outside_tenant_scope`, the API-path-shaped-ref rejection, `connector_vault_forbidden`, `connector_auth_failed`, `connector_tls_verify_failed`, `unknown_connector` vs `connector_not_ingested`, `handle_not_found`, the sensor guard codes) rather than invented FAQs.

## Test plan

- [x] `uv run --project backend --no-sync mkdocs build --strict` — exit 0 (the same gate `docs-site.yml` runs on PRs; strict turns broken links / missing-nav pages into failures)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] AC 1 — three guides live under *Do real work*, each written to be executable start-to-finish by someone who has only read *Install & operate* + *Connect clients*: prerequisites and role requirements (`tenant_admin` vs `operator`) are stated up front on every guide; all commands verified against `cli/internal/cmd/*` definitions and MCP tool schemas. (Execution against a live fresh deploy is what eval S2/S3/S6 will measure — that program is the acceptance instrument, per #2665.)
- [x] AC 2 — the first-operations guide carries the search→preview→call ladder with a worked end-to-end example on the `k8s-1.x` **typed** connector (`k8s.pod.list` → `k8s.pod.info` → `k8s.logs`/`k8s.event.list`), including preview's honest `status: "unavailable"` answer for typed ops.
- [x] AC 3 — the pages exist at stable page-level addresses for eval scenarios S2 (`guides/targets-and-secrets/`), S3 (`guides/first-operations/`), S6 (`guides/sensors-quickstart/`). The #2665 scenario cards are deliberately not yet filed ("filed when scheduled"), so the reference from the eval side lands when they are — nothing in this repo can encode that today.
- [x] AC 4 — CHANGELOG `[Unreleased]` entry under the unique header `### Added — docs-site Do-real-work guides: targets & secrets, first operations, sensors (#2673)`

## Notes for review

- The issue asked to "link the roadmap item" for MCP target-registration tools. **No such roadmap issue exists** (searched open issues); rather than fabricate one, the guide states the CLI/UI-first boundary plainly and points at the feature-maturity index as the surface where any change would be tracked.
- `mkdocs.yml` nav and `CHANGELOG.md` edits are deliberately minimal and additive — sibling task #2671 edits the same files concurrently; merge order is the orchestrator's call.

## Out of scope

- Approvals & break-glass guide (#2669 — slot reserved on the landing page, first-contact semantics only in the first-operations guide).
- Topology / broadcast / runbooks / scheduler / gateway guides (follow-ups after eval round 1).
- Adjacent finding: `docs/architecture/mcp.md` and `docs/decisions/locked-decisions.md` still list `search_connectors` / `list_connectors` / `result_aggregate` / `result_export` / `result_describe` as if shipped; the guides deliberately do not repeat that, but the contributor docs could use a correction pass (not touched here — out of scope).
- Adjacent finding: `docs/cross-repo/kubernetes-onboarding.md` carries a stale worked example (`product: kubernetes`, API-path-shaped `secret_ref`) that the shipped validation now rejects; worth a follow-up fix.

<!-- auto-implement-issue: fresh, iteration 1 -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-07-31)

Addressed all five findings from the [iteration-1 review](https://github.com/evoila/meho/pull/2723#pullrequestreview). Every claim was re-verified against the shipped code before editing — no finding was taken on faith, and none was disputed.

- **B1** `39eeafea` — `paused` is not an auto-park for a persistently failing sensor. `park_sensor` has one call site (`checks/runner.py:533`), reached only from `except (InvalidCronExpressionError, InvalidTimezoneError)`; there is no failure counter under `checks/`. The paragraph now names the real trigger (an unparseable stored cadence, `status_reason` = `invalid_cadence:<error>`), states that a persistently failing sensor stays `active` forever, and gives the only remedy — `meho sensor delete`. The staleness row drops "parked" (`_derive_raw` maps `paused` → `skip` before the staleness branch, `checks/rollup.py:163-170`).
- **B2** `39eeafea` — symptom cell now quotes `selection is not a scalar, found array`, the string `evaluate.py:92-97` actually emits for a list selection without `aggregate`. The previously quoted `threshold comparator requires a number, found array` is unreachable: every `_aggregate` return is a scalar, so `_compare_threshold` never sees a list.
- **M1** `7aba4034` — "every rung exists twice" and the unconditional audit claim are both scoped now. Preview and `result_query` are named as MCP/REST-only (there is no preview verb under `cli/`), and the policy / credential-resolution / result-reduction / audit path is attributed to the rung that dispatches, with preview's exemption stated outright (`_request_preview.py:310-316`: never sends, never audits, policy gate deliberately skipped).
- **m1** `23f64ec7` — dropped `SKIP` from the dry-run comment; `buildLivePlan` (`import.go:598-619`) is the only plan producer and never populates `p.Skip`.
- **m2** `23f64ec7` — `"IP address mismatch"` attributed to its source at both sites (lines 85 and 234): CPython `ssl` text relayed inside `extras.exception_message`, distinct from MEHO's own `connector_tls_verify_failed` summary.

Gates re-run at `23f64ec7`: `mkdocs build --strict` exit 0 with zero warnings; `code-quality.py --diff` exit 0.

Not changed (recorded as adjacent findings, unchanged from the reviewer's own disposition): the `index.md` groups-rung omission, the "unschedulable" wording at `sensors-quickstart.md:146`, and the `connector_vault_forbidden` phrasing. Two pre-existing code issues the review surfaced — `connector_tls_verify_failed`'s remediation never naming `tls_server_name`, and `meho targets import --help` omitting `extras` from its recognised-key list — are code follow-ups, out of scope for a docs PR.

<!-- auto-implement-issue: continue, iteration 1 -->


Closes #2673


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guides for registering targets, staging secrets, performing connector operations, and monitoring sensors.
  * Documented verification, approvals, troubleshooting, failure scenarios, result inspection, and Kubernetes examples.
  * Expanded the “Do real work” navigation with a structured guide roadmap.
  * Added guidance for credential backends, dashboards, sensor behavior, and documentation version mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
