### PR TITLE
feat(connectors): mail.* typed connector — SMTP send as a reusable, agent-callable operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — Mail connector — SMTP send as a typed operation (#2717)
+
+- New synthetic `mail.*` typed connector on the `net.*` mould: one op,
+  `mail.send` (`connector_id` `mail-smtp-1.x`), delivering plain-text
+  email through a deployment-level SMTP block (`MAIL_SMTP_HOST/PORT`,
+  STARTTLS by default, implicit TLS on port 465, optional LOGIN auth
+  that only ever runs on an encrypted channel — stdlib `smtplib`, no
+  new dependency). `MAIL_RECIPIENT_ALLOWLIST`
+  (full addresses and/or domains) is the hard floor: empty ⇒ every
+  send refused (the connector is inert). Registered
+  `safety_level="caution"` + `requires_approval=False`, so operators
+  auto-run it while agent calls ride the policy gate's needs-approval
+  default. Refused/unconfigured/failed sends return
+  `{sent: false, reason}` with `status="ok"` (return-failures
+  contract); the audit row records recipients + subject, never the
+  body. The shared `send_email()` transport is the seam the checks
+  notifier (#2719) reuses. (#2717)
 ### Added — docs site: Start here, reference architecture, and the install trail (#2671)
 
 - Fill the docs site's *Start here* and *Install & operate* sections

--- a/backend/src/meho_backplane/connectors/mail/__init__.py
+++ b/backend/src/meho_backplane/connectors/mail/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.mail — SMTP send as a typed op (#2717, Initiative #2716).
+
+A **synthetic** connector subpackage on the ``net.*`` mould: no vendor
+connector backs it, so this package calls neither ``register_connector``
+nor ``register_connector_v2``. The ``mail.send`` handler is a
+module-level function the dispatcher routes to with
+``connector_instance=None`` / ``target=None`` — recipients are params,
+not a registered ``Target``.
+
+Importing the package (the lifespan's
+:func:`~meho_backplane.connectors.registry._eager_import_connectors`
+pass walks ``connectors/<product>/`` and imports each subpackage)
+queues the ``mail.send`` typed-op upsert onto the lifespan-driven
+registrar list via
+:func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`,
+so the ``endpoint_descriptor`` row lands before the first dispatch.
+
+The package's second export surface is
+:func:`~meho_backplane.connectors.mail.transport.send_email` — the
+shared transport the checks notifier (#2719) imports directly, so
+notification delivery and agent-initiated sends run the identical
+allowlist floor (``MAIL_RECIPIENT_ALLOWLIST``, empty ⇒ inert) and
+return-failures contract. See
+:mod:`meho_backplane.connectors.mail.ops`,
+:mod:`meho_backplane.connectors.mail.transport`, and
+:mod:`meho_backplane.connectors.mail.allowlist`.
+"""
+
+from meho_backplane.connectors.mail.ops import register_mail_typed_operations
+from meho_backplane.connectors.mail.transport import MailSendResult, send_email
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+register_typed_op_registrar(register_mail_typed_operations)
+
+__all__ = [
+    "MailSendResult",
+    "register_mail_typed_operations",
+    "send_email",
+]

--- a/backend/src/meho_backplane/connectors/mail/allowlist.py
+++ b/backend/src/meho_backplane/connectors/mail/allowlist.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recipient allowlist for the ``mail.*`` connector.
+
+``mail.send`` gives the backplane (and, through the normal policy path,
+an agent) an outward channel: it delivers operator-authored text to an
+arbitrary mailbox. Unbounded, that is an exfiltration and spam primitive.
+:attr:`~meho_backplane.settings.Settings.mail_recipient_allowlist`
+(``MAIL_RECIPIENT_ALLOWLIST``) is the single floor that scopes it — the
+same **inverted-default** shape as the ``net.*`` probe allowlist
+(``connectors/net/allowlist.py``): the parsed set is the **whole
+permitted recipient space**, and an **empty** value means **deny
+everything**, so the connector is inert until an operator deliberately
+opts recipients in. The floor applies to every caller of
+:func:`~meho_backplane.connectors.mail.transport.send_email` — the
+dispatch handler *and* the checks notifier (#2719) — so no code path
+can mail an unlisted recipient.
+
+Two entry shapes, comma-separated:
+
+* a full address (``oncall@example.com``) — matches that mailbox only;
+* a domain (``example.com``, leading ``@`` accepted) — matches every
+  mailbox at that domain.
+
+Matching is case-insensitive on the whole address. That folds the
+local part too — RFC 5321 technically leaves local-part case to the
+receiving host, but no practical mail system distinguishes
+``OnCall@`` from ``oncall@``, and a case-sensitive floor would turn
+an operator's capitalization habit into a silent refusal.
+
+There is deliberately no pattern/glob dimension (#1177: one closed-set
+config, no DSL) and no per-tenant allowlist — the SMTP block is
+deployment-level (one MTA, one floor), per task #2717's scope.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "RecipientNotAllowedError",
+    "assert_recipient_allowed",
+    "parse_recipient_allowlist",
+]
+
+
+class RecipientNotAllowedError(ValueError):
+    """A recipient address is not inside ``MAIL_RECIPIENT_ALLOWLIST``.
+
+    Subclasses :class:`ValueError`. The transport catches it and converts
+    it into the connector's structured refusal (``{"sent": false,
+    "reason": "not_in_recipient_allowlist"}``, dispatch ``status="ok"``)
+    — a refused send is a normal result, never a ``connector_*`` error
+    (the return-failures contract shared with ``net.*``).
+    """
+
+
+def _malformed_entry(entry: str) -> ValueError:
+    """Build the fail-loud error for an allowlist token that cannot be used."""
+    return ValueError(
+        f"MAIL_RECIPIENT_ALLOWLIST entry {entry!r} is not a valid "
+        "address or domain; fix the deployment configuration"
+    )
+
+
+def parse_recipient_allowlist() -> tuple[frozenset[str], frozenset[str]]:
+    """Parse ``mail_recipient_allowlist`` into ``(addresses, domains)``.
+
+    A token containing ``@`` in an interior position is a full address;
+    a token without one (or with only a leading ``@``) is a domain. Both
+    are lower-cased, and a trailing dot on a domain is stripped, so
+    matching is case-insensitive and FQDN-dot-tolerant (mirrors the
+    ``net.*`` hostname fold).
+
+    A token that is not a well-formed address or domain raises
+    :class:`ValueError` naming it — loud, because silently keeping an
+    unusable entry misreports the permitted recipient space the operator
+    explicitly opted in (same fail-fast posture as
+    ``net.allowlist.parse_probe_allowlist``). Rejected: whitespace,
+    more than one ``@``, an empty local part or domain part
+    (``foo@``, ``@``), and a domain that folds away to nothing
+    (``...``). The bare ``@`` case is the sharpest: it used to parse to
+    ``domains={""}``, which matches no address yet makes the allowlist
+    look non-empty — suppressing the "connector is inert" refusal
+    message that would otherwise tell the operator exactly what is
+    wrong.
+
+    Reads the live :class:`~meho_backplane.settings.Settings` singleton
+    per call; tests swap the value by mutating the env and clearing
+    ``get_settings``'s cache, like every other settings-backed surface.
+    """
+    addresses: set[str] = set()
+    domains: set[str] = set()
+    for token in get_settings().mail_recipient_allowlist.split(","):
+        entry = token.strip()
+        if not entry:
+            continue
+        if any(ch.isspace() for ch in entry) or entry.count("@") > 1:
+            raise _malformed_entry(entry)
+        folded = entry.lower()
+        if "@" in folded[1:]:
+            local, _, domain = folded.partition("@")
+            if not local or not domain:
+                raise _malformed_entry(entry)
+            addresses.add(folded)
+            continue
+        domain = folded.removeprefix("@").rstrip(".")
+        if not domain:
+            raise _malformed_entry(entry)
+        domains.add(domain)
+    return frozenset(addresses), frozenset(domains)
+
+
+def assert_recipient_allowed(address: str) -> None:
+    """Raise :class:`RecipientNotAllowedError` unless *address* is allowlisted.
+
+    Called by the transport on **every** recipient of a send, *before*
+    any SMTP connection opens. The decision is absolute membership in
+    :func:`parse_recipient_allowlist`'s parsed set:
+
+    * empty allowlist → always refuse (the connector is inert);
+    * a listed full address → allowed verbatim (case-insensitive);
+    * an address whose domain is listed → allowed.
+
+    An address the floor cannot positively parse — empty, containing
+    whitespace or control characters, or not exactly ``local@domain`` —
+    is **refused**, not guessed at: only a parseable address can match
+    the allowlist, which also keeps SMTP envelope injection (CR/LF in a
+    recipient) structurally impossible past this gate. The message never
+    echoes the parsed set (no recipient-space oracle).
+
+    Raises:
+        RecipientNotAllowedError: *address* is empty, malformed, not
+            covered by the allowlist, or the allowlist is empty.
+    """
+    addresses, domains = parse_recipient_allowlist()
+    if not addresses and not domains:
+        raise RecipientNotAllowedError(
+            "recipient refused: MAIL_RECIPIENT_ALLOWLIST is empty, so the "
+            "mail.* connector is inert; add the address or domain to mail"
+        )
+    candidate = address.strip().lower()
+    local, sep, domain = candidate.partition("@")
+    if (
+        not local
+        or not sep
+        or not domain
+        or "@" in domain
+        or any(ch.isspace() or not ch.isprintable() for ch in candidate)
+    ):
+        raise RecipientNotAllowedError(f"recipient refused: {address!r} is not a valid address")
+    if candidate in addresses or domain.rstrip(".") in domains:
+        return
+    raise RecipientNotAllowedError(
+        "recipient refused: address is not listed in MAIL_RECIPIENT_ALLOWLIST"
+    )

--- a/backend/src/meho_backplane/connectors/mail/ops.py
+++ b/backend/src/meho_backplane/connectors/mail/ops.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``mail.send`` typed op + registrar for the synthetic ``mail.*`` product.
+
+``mail.*`` is a **synthetic** typed-op product on the ``net.*`` mould
+(#2717): no vendor connector backs it, so the package calls neither
+``register_connector`` nor ``register_connector_v2``. The op is
+registered under the natural key
+``(product="mail", version="1.x", impl_id="mail-smtp")``, so the wire
+``connector_id`` is ``mail-smtp-1.x`` — which round-trips through
+:func:`~meho_backplane.operations._lookup.parse_connector_id` back to
+``("mail", "1.x", "mail-smtp")``. The handler is a **module-level**
+function, so the dispatcher resolves it with ``connector_instance=None``
+and ``target=None`` — recipients are params, not a registered
+``Target``.
+
+The handler is a thin adapter over
+:func:`~meho_backplane.connectors.mail.transport.send_email` — the
+single shared transport the checks notifier (#2719) also imports — so
+the recipient-allowlist floor, the unconfigured refusal, and the
+return-failures contract live in exactly one place. The handler's
+return dict carries the literal ``to``/``subject`` (never the body), so
+the durable audit row's ``raw_payload`` answers "who was mailed about
+what" without persisting message content.
+
+``safety_level="caution"`` + ``requires_approval=False``: sending mail
+is an outward-facing side effect, so operators (human/service
+principals, default-allow) auto-run it while agent principals land on
+the ``caution`` needs-approval default of the policy gate
+(:mod:`meho_backplane.auth.permissions`) — and the recipient allowlist
+is the hard floor either way.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
+from meho_backplane.connectors.mail.transport import send_email
+from meho_backplane.operations.typed_register import register_typed_operation
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "MAIL_SEND_PARAMETER_SCHEMA",
+    "mail_send",
+    "register_mail_typed_operations",
+]
+
+#: Every character :meth:`str.splitlines` treats as a line boundary,
+#: excluded from ``subject`` so the schema layer — not the transport —
+#: owns header-injection rejection.
+#:
+#: :class:`~email.message.EmailMessage` guards header assignment with
+#: ``len(value.splitlines()) > 1`` and raises :class:`ValueError`, which
+#: would escape :func:`~meho_backplane.connectors.mail.transport.send_email`
+#: as a ``connector_error`` and break the return-failures contract.
+#: ``splitlines`` breaks on far more than CR/LF (VT, FF, the three
+#: information separators, NEL, and the Unicode line/paragraph
+#: separators), so a ``[^\r\n]`` class would leave the hole half-open;
+#: this class is the exact complement of the stdlib guard, so a
+#: rejected subject is always ``invalid_params``.
+_SINGLE_LINE_PATTERN: Final[str] = r"^[^\r\n\v\f\x1c\x1d\x1e\x85\u2028\u2029]+$"
+
+MAIL_SEND_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "to": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 32,
+            "items": {
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 254,
+                "pattern": r"^[^@\s]+@[^@\s]+$",
+                "description": (
+                    "Recipient email address. Must be covered by "
+                    "MAIL_RECIPIENT_ALLOWLIST (full address or its "
+                    "domain) or the whole send is refused before any "
+                    "SMTP connection opens."
+                ),
+            },
+            "description": "Recipient addresses; one refused recipient refuses the whole send.",
+        },
+        "subject": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "pattern": _SINGLE_LINE_PATTERN,
+            "description": (
+                "Subject line (plain text, single line). A line break of "
+                "any kind is rejected as invalid_params — it would be a "
+                "header-injection attempt."
+            ),
+        },
+        "body": {
+            "type": "string",
+            "maxLength": 100_000,
+            "description": "Plain-text message body (no HTML, no attachments).",
+        },
+    },
+    "required": ["to", "subject", "body"],
+    "additionalProperties": False,
+}
+
+_MAIL_SEND_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "sent": {
+            "type": "boolean",
+            "description": "True iff the MTA accepted the message for delivery.",
+        },
+        "reason": {
+            "type": ["string", "null"],
+            "description": (
+                "Null on success; otherwise a failure code: "
+                "not_in_recipient_allowlist, smtp_unconfigured, "
+                "smtp_connect_error, smtp_auth_requires_tls, "
+                "smtp_auth_error, smtp_recipients_refused, smtp_error."
+            ),
+        },
+        "to": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "The requested recipients (audit-visible).",
+        },
+        "subject": {
+            "type": "string",
+            "description": "The subject line (audit-visible; the body is never persisted).",
+        },
+    },
+    "required": ["sent", "reason", "to", "subject"],
+    "additionalProperties": False,
+}
+
+_MAIL_SEND_WHEN_TO_USE = (
+    "Send a plain-text email to operator-allowlisted recipients from the "
+    "backplane's deployment-level SMTP block — e.g. to deliver an "
+    "investigation finding, a maintenance notice, or an alert summary to "
+    "an on-call mailbox. An outward-facing side effect: recipients must "
+    "be inside MAIL_RECIPIENT_ALLOWLIST, and a refused or failed send is "
+    "a normal result (sent=false with a reason), not an error."
+)
+
+_MAIL_SEND_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Use to deliver a short plain-text message to a human mailbox "
+        "when the operator has asked for email delivery. Recipients must "
+        "be allowlisted at the deployment level; do not retry a "
+        "not_in_recipient_allowlist, smtp_unconfigured, or "
+        "smtp_auth_requires_tls refusal — all three are deployment "
+        "configuration, not transient state."
+    ),
+    "parameter_hints": {
+        "to": "Required. 1-32 recipient addresses; every one must be allowlisted.",
+        "subject": (
+            "Required. Single-line subject (max 200 chars); a line break "
+            "of any kind is rejected as invalid_params."
+        ),
+        "body": "Required. Plain-text body; no HTML or attachments.",
+    },
+    "output_shape": (
+        "On success: {'sent': true, 'reason': null, 'to': [<str>], "
+        "'subject': <str>}. On a refused or failed send: {'sent': false, "
+        "'reason': '<not_in_recipient_allowlist|smtp_unconfigured|"
+        "smtp_connect_error|smtp_auth_requires_tls|smtp_auth_error|"
+        "smtp_recipients_refused|smtp_error>', 'to': [<str>], "
+        "'subject': <str>} — still a "
+        "successful (status=ok) op."
+    ),
+}
+
+
+async def mail_send(operator: Operator, target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Send one plain-text email through the shared transport.
+
+    Op-id: ``mail.send``. Synthetic typed op (no vendor connector,
+    ``target`` is always ``None``). The dispatcher has validated the
+    param schema, so ``to`` / ``subject`` / ``body`` are present and
+    well-typed.
+
+    Delegates to
+    :func:`~meho_backplane.connectors.mail.transport.send_email` (the
+    allowlist floor and refusal mapping live there) and adapts the
+    :class:`~meho_backplane.connectors.mail.transport.MailSendResult`
+    into the audit-visible payload: the returned dict carries the
+    literal ``to``/``subject`` — the durable audit row's ``raw_payload``
+    answer to "who was mailed" — and never the body.
+    """
+    to = [str(address) for address in params["to"]]
+    subject = str(params["subject"])
+    result = await send_email(to=to, subject=subject, body=str(params["body"]))
+    return {
+        "sent": result.sent,
+        "reason": result.reason,
+        "to": to,
+        "subject": subject,
+    }
+
+
+async def register_mail_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the ``mail.*`` typed ops into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list by the package
+    ``__init__`` (via ``register_typed_op_registrar``) and run by
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+    after the connector eager-import pass. Idempotent: a re-run against
+    unchanged text is a no-op for the embedding pipeline. Registers
+    ``mail.send`` (#2717) as ``caution`` + ``requires_approval=False``
+    — operators auto-run, agents ride the policy gate's needs-approval
+    default; the recipient allowlist is the hard floor either way.
+    """
+    await register_typed_operation(
+        product="mail",
+        version="1.x",
+        impl_id="mail-smtp",
+        op_id="mail.send",
+        handler=mail_send,
+        group_key="send",
+        when_to_use=_MAIL_SEND_WHEN_TO_USE,
+        summary="Send a plain-text email to allowlisted recipients via the deployment SMTP block.",
+        description=(
+            "Delivers a plain-text email through the deployment-level "
+            "SMTP configuration (MAIL_SMTP_HOST/PORT, STARTTLS or "
+            "implicit TLS on port 465, optional LOGIN auth that only "
+            "ever runs on an encrypted channel). Every "
+            "recipient must be inside MAIL_RECIPIENT_ALLOWLIST or the "
+            "send is refused before any SMTP connection opens (empty "
+            "allowlist ⇒ the connector is inert). An unconfigured SMTP "
+            "block, a refused recipient, or a delivery failure returns "
+            "sent=false with a stable reason code and status=ok — a "
+            "failed send is the product, never a connector error. The "
+            "message body is never persisted; the audit row records "
+            "recipients and subject only."
+        ),
+        parameter_schema=MAIL_SEND_PARAMETER_SCHEMA,
+        response_schema=_MAIL_SEND_RESPONSE_SCHEMA,
+        tags=["mail", "smtp", "send", "notify", "write"],
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions=_MAIL_SEND_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )

--- a/backend/src/meho_backplane/connectors/mail/transport.py
+++ b/backend/src/meho_backplane/connectors/mail/transport.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared SMTP send transport for the ``mail.*`` connector.
+
+:func:`send_email` is the **single implementation** every mail-sending
+path calls: the ``mail.send`` dispatch handler
+(:mod:`meho_backplane.connectors.mail.ops`) and the checks notifier
+(#2719) import this same function, so the recipient-allowlist floor and
+the return-failures contract hold on every path — there is no way to
+send mail from the backplane around them.
+
+Stdlib only (task #2717: no new dependency): :mod:`smtplib` +
+:class:`email.message.EmailMessage`. ``smtplib`` is blocking, so the
+whole SMTP session (connect → STARTTLS → login → send → quit) runs in
+one worker thread via :func:`asyncio.to_thread` — the socket is bound
+to the thread that opened it, so the session cannot be split across
+``to_thread`` hops.
+
+TLS shape (RFC 8314): port 465 selects **implicit TLS**
+(:class:`smtplib.SMTP_SSL` — the connection is TLS from the first
+byte, so the ``mail_smtp_starttls`` flag is moot there). Any other
+port opens plaintext via :class:`smtplib.SMTP` and, when
+``mail_smtp_starttls`` is set (default), upgrades with ``starttls()``
+followed by a fresh ``ehlo()`` — the RFC 3207 requirement to rediscover
+extensions on the encrypted channel. ``login()`` runs only when a
+username is configured (an internal relay commonly needs none) **and
+only on an encrypted channel**: ``smtplib.login()`` imposes no TLS
+precondition of its own, so AUTH LOGIN/PLAIN would put base64-wrapped —
+not encrypted — credentials on a cleartext socket. Turning
+``mail_smtp_starttls`` off on a non-465 port while a username is set is
+therefore a misconfiguration the session refuses
+(``smtp_auth_requires_tls``) rather than silently obeys; Prometheus
+Alertmanager takes the same stance with ``require_tls`` defaulting to
+true.
+
+Return-failures contract (mould parity with ``net.*``): a refused,
+unconfigured, or delivery-failed send is the **product**, not an error
+— the caller gets ``MailSendResult(sent=False, reason=<code>)`` and
+the dispatch stays ``status="ok"``. Only an unexpected bug propagates.
+Reason codes are stable:
+
+* ``not_in_recipient_allowlist`` — a recipient failed the allowlist
+  floor (including the empty-allowlist inert state).
+* ``smtp_unconfigured`` — ``mail_smtp_host`` or ``mail_from`` unset.
+* ``smtp_connect_error`` — TCP/TLS/greeting failure reaching the MTA
+  (:class:`smtplib.SMTPConnectError` or a raw socket-level
+  :class:`OSError` — refused, DNS failure, timeout).
+* ``smtp_auth_requires_tls`` — a username is configured but the
+  channel is still cleartext, so the session refuses rather than
+  handing the credentials to the wire (see above).
+* ``smtp_auth_error`` — :class:`smtplib.SMTPAuthenticationError`.
+* ``smtp_recipients_refused`` — the server rejected every recipient
+  (:class:`smtplib.SMTPRecipientsRefused`).
+* ``smtp_error`` — any other :class:`smtplib.SMTPException`.
+
+The ``except`` ordering below is load-bearing: ``SMTPException``
+subclasses :class:`OSError` (since Python 3.4), so the specific SMTP
+arms and the generic ``SMTPException`` arm must precede the ``OSError``
+arm or a refused login would misreport as a connect error.
+
+Logging discipline: structlog events carry host/port/reason only —
+never the password, never the message body. The recipient list and
+subject are the *handler's* audit answer (they ride the dispatch
+``raw_payload``), not the transport log's.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import smtplib
+from dataclasses import dataclass
+from email.message import EmailMessage
+from typing import Final
+
+import structlog
+
+from meho_backplane.connectors.mail.allowlist import (
+    RecipientNotAllowedError,
+    assert_recipient_allowed,
+)
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "MailSendResult",
+    "send_email",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Hard bound on the blocking SMTP session (connect + every command).
+#: Passed as ``timeout=`` to :class:`smtplib.SMTP` / ``SMTP_SSL`` so a
+#: hung MTA cannot pin a worker thread indefinitely. Internal constant,
+#: not a settings knob — no consumer has asked to tune it (#1177).
+_SMTP_TIMEOUT_SECONDS: Final[float] = 30.0
+
+#: Port that selects implicit TLS (:class:`smtplib.SMTP_SSL`) — the
+#: IANA submissions-over-TLS port (RFC 8314 §7.3).
+_IMPLICIT_TLS_PORT: Final[int] = 465
+
+
+@dataclass(frozen=True, slots=True)
+class MailSendResult:
+    """Outcome of one :func:`send_email` call.
+
+    ``sent=True`` ⇔ ``reason is None``. ``reason`` is one of the stable
+    codes documented in the module docstring.
+    """
+
+    sent: bool
+    reason: str | None = None
+
+
+def _send_sync(
+    msg: EmailMessage,
+    *,
+    host: str,
+    port: int,
+    starttls: bool,
+    username: str,
+    password: str,
+    from_addr: str,
+    to_addrs: list[str],
+) -> str | None:
+    """Run the blocking SMTP session; return a failure reason code or ``None``.
+
+    Executes on a worker thread (via :func:`asyncio.to_thread`) — every
+    line here may block on the socket. The ``with`` block issues
+    ``QUIT`` and closes the connection on every exit path
+    (:class:`smtplib.SMTP` is a context manager).
+
+    ``encrypted`` tracks whether the channel is confidential — true from
+    construction under implicit TLS, true again once ``starttls()``
+    returns. It gates ``login()`` at the call site rather than being
+    re-derived from ``starttls``/``port`` up front, so a later change to
+    how TLS is established cannot leave the credential guard behind.
+    """
+    try:
+        if port == _IMPLICIT_TLS_PORT:
+            client: smtplib.SMTP = smtplib.SMTP_SSL(host, port, timeout=_SMTP_TIMEOUT_SECONDS)
+            encrypted = True
+        else:
+            client = smtplib.SMTP(host, port, timeout=_SMTP_TIMEOUT_SECONDS)
+            encrypted = False
+        with client:
+            client.ehlo()
+            if starttls and port != _IMPLICIT_TLS_PORT:
+                client.starttls()
+                # RFC 3207: the pre-TLS EHLO response is void; rediscover
+                # the server's extensions on the encrypted channel.
+                client.ehlo()
+                encrypted = True
+            if username:
+                if not encrypted:
+                    return "smtp_auth_requires_tls"
+                client.login(username, password)
+            # Explicit envelope: the validated recipient list drives RCPT
+            # TO verbatim rather than being re-derived from the headers.
+            client.send_message(msg, from_addr=from_addr, to_addrs=to_addrs)
+    except smtplib.SMTPAuthenticationError:
+        return "smtp_auth_error"
+    except smtplib.SMTPRecipientsRefused:
+        return "smtp_recipients_refused"
+    except smtplib.SMTPConnectError:
+        return "smtp_connect_error"
+    except smtplib.SMTPException:
+        return "smtp_error"
+    except OSError:
+        # Raw socket-level connect failure (refused, DNS, timeout) —
+        # smtplib raises these un-wrapped from the constructor's connect.
+        return "smtp_connect_error"
+    return None
+
+
+async def send_email(*, to: list[str], subject: str, body: str) -> MailSendResult:
+    """Send one plain-text email through the deployment-level SMTP block.
+
+    The single shared transport for the ``mail.send`` typed op and the
+    checks notifier (#2719). Flow: screen **every** recipient against
+    the allowlist floor → refuse when the SMTP block is unconfigured →
+    build the :class:`~email.message.EmailMessage` → run the blocking
+    session on a worker thread.
+
+    The allowlist screen is all-or-nothing: one refused recipient
+    refuses the whole send. A partial send would make the audit row's
+    "who was mailed" answer wrong, and the callers' recipient lists are
+    short, operator-curated sets — not fan-out batches.
+
+    A failed send is returned, never raised (return-failures contract);
+    see the module docstring for the reason codes. A CR/LF-bearing
+    *recipient* cannot survive the allowlist parse, so it never reaches
+    the :class:`~email.message.EmailMessage` build on any path. A
+    *subject* carrying a line break is screened one layer up, by
+    ``mail.send``'s parameter schema
+    (``ops._SINGLE_LINE_PATTERN``, the exact complement of the stdlib
+    header guard): every dispatched call is rejected as
+    ``invalid_params`` before the handler runs. **Direct in-process
+    callers get no such screen** — passing a subject with a line break
+    raises :class:`ValueError` out of this function rather than
+    returning a result. Compose single-line subjects; the checks
+    notifier (#2719) builds its own from check metadata.
+    """
+    settings = get_settings()
+    try:
+        for recipient in to:
+            assert_recipient_allowed(recipient)
+    except RecipientNotAllowedError:
+        _log.info(
+            "mail.send.refused",
+            reason="not_in_recipient_allowlist",
+            host=settings.mail_smtp_host,
+            port=settings.mail_smtp_port,
+        )
+        return MailSendResult(sent=False, reason="not_in_recipient_allowlist")
+
+    if not settings.mail_smtp_host or not settings.mail_from:
+        _log.info("mail.send.refused", reason="smtp_unconfigured")
+        return MailSendResult(sent=False, reason="smtp_unconfigured")
+
+    msg = EmailMessage()
+    msg["From"] = settings.mail_from
+    msg["To"] = ", ".join(to)
+    msg["Subject"] = subject
+    msg.set_content(body)
+
+    reason = await asyncio.to_thread(
+        _send_sync,
+        msg,
+        host=settings.mail_smtp_host,
+        port=settings.mail_smtp_port,
+        starttls=settings.mail_smtp_starttls,
+        username=settings.mail_smtp_username,
+        password=settings.mail_smtp_password,
+        from_addr=settings.mail_from,
+        to_addrs=list(to),
+    )
+    if reason is not None:
+        _log.warning(
+            "mail.send.failed",
+            reason=reason,
+            host=settings.mail_smtp_host,
+            port=settings.mail_smtp_port,
+        )
+        return MailSendResult(sent=False, reason=reason)
+    _log.info(
+        "mail.send.delivered",
+        host=settings.mail_smtp_host,
+        port=settings.mail_smtp_port,
+        recipient_count=len(to),
+    )
+    return MailSendResult(sent=True, reason=None)

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1321,6 +1321,25 @@ class Settings(BaseModel):
     # ``CHECKS_INVESTIGATOR_AGENT`` / ``CHECKS_INVESTIGATION_POLL_TIMEOUT_SECONDS``.
     checks_investigator_agent: str = "checks-investigator"
     checks_investigation_poll_timeout_seconds: int = Field(default=600, ge=1, le=86400)
+    # #2717 (Initiative #2716) — mail.* typed connector: one deployment-level
+    # SMTP block shared by the agent-callable ``mail.send`` op and the checks
+    # notifier's ``send_email()`` transport. ``mail_smtp_host`` empty (the
+    # default) leaves the transport unconfigured — every send is refused with
+    # ``reason="smtp_unconfigured"`` (return-failures contract, never an
+    # exception). Port 465 selects implicit TLS (``smtplib.SMTP_SSL``,
+    # RFC 8314); any other port opens plaintext and upgrades via STARTTLS
+    # when ``mail_smtp_starttls`` is set. ``SMTP.login()`` runs only when a
+    # username is configured. ``mail_recipient_allowlist`` is the hard floor
+    # (the ``net.*`` allowlist mould, inverted default): comma-separated full
+    # addresses and/or recipient domains naming the entire permitted
+    # recipient space; empty ⇒ every send refused (the connector is inert).
+    mail_smtp_host: str = Field(default="")
+    mail_smtp_port: int = Field(default=587, gt=0, le=65535)
+    mail_smtp_starttls: bool = True
+    mail_smtp_username: str = Field(default="")
+    mail_smtp_password: str = Field(default="", repr=False)
+    mail_from: str = Field(default="")
+    mail_recipient_allowlist: str = Field(default="")
     # G11.3-T2 #823 / G0.19-T2 #1478 — autonomous-agent credential
     # sourcing for the scheduler. ``run_scheduled`` (G11.2-T2 #1096)
     # wants ``(client_id, client_secret)``; the scheduler resolves
@@ -1881,6 +1900,15 @@ def get_settings() -> Settings:
         checks_investigation_poll_timeout_seconds=int(
             os.environ.get("CHECKS_INVESTIGATION_POLL_TIMEOUT_SECONDS", "600"),
         ),
+        mail_smtp_host=os.environ.get("MAIL_SMTP_HOST", "").strip(),
+        mail_smtp_port=int(os.environ.get("MAIL_SMTP_PORT", "587")),
+        mail_smtp_starttls=parse_bool_env(
+            os.environ.get("MAIL_SMTP_STARTTLS", "true"),
+        ),
+        mail_smtp_username=os.environ.get("MAIL_SMTP_USERNAME", "").strip(),
+        mail_smtp_password=os.environ.get("MAIL_SMTP_PASSWORD", "").strip(),
+        mail_from=os.environ.get("MAIL_FROM", "").strip(),
+        mail_recipient_allowlist=os.environ.get("MAIL_RECIPIENT_ALLOWLIST", ""),
         scheduler_agent_secret_env_pattern=os.environ.get(
             "SCHEDULER_AGENT_SECRET_ENV_PATTERN",
             "MEHO_AGENT_SECRET_{client_id}",

--- a/backend/tests/test_connectors_mail.py
+++ b/backend/tests/test_connectors_mail.py
@@ -1,0 +1,849 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the mail.* SMTP-send connector — #2717 (Initiative #2716).
+
+Covers the connector's load-bearing contracts on the ``net.*`` mould:
+
+* ``mail.send`` is a **synthetic** targetless typed op: it dispatches
+  with ``target=None``, the wire ``connector_id`` ``mail-smtp-1.x``
+  round-trips through the parser, and the descriptor row carries
+  ``safety_level="caution"`` + ``requires_approval=False`` (operators
+  auto-run; agents ride the policy gate's needs-approval default).
+* The recipient allowlist ``MAIL_RECIPIENT_ALLOWLIST`` has **inverted**
+  semantics: empty ⇒ every send refused *before any SMTP connection
+  opens*; full-address and domain entries admit recipients.
+* The **return-failures contract**: allowlist-refused, unconfigured,
+  and every SMTP delivery failure return ``{sent: false, reason}`` with
+  dispatch ``status="ok"`` — never a ``connector_*`` error. Each
+  ``SMTPException`` subclass maps to its stable reason code.
+* STARTTLS + LOGIN sequencing: ``ehlo → starttls → ehlo → login →
+  send_message`` when configured; no ``login`` without a username; no
+  ``starttls`` when disabled; port 465 selects implicit TLS
+  (``SMTP_SSL``); and ``login`` never runs on a cleartext channel —
+  STARTTLS off plus a username refuses with
+  ``smtp_auth_requires_tls``.
+* Header injection is refused one layer above the transport: the
+  ``subject`` schema pattern is the exact complement of the stdlib
+  header guard, so a line break of any kind is ``invalid_params``
+  rather than a ``ValueError`` escaping as a ``connector_error``.
+* The durable audit row records ``to``/``subject`` via ``raw_payload``
+  and never the body.
+
+All SMTP traffic is stubbed by monkeypatching ``smtplib.SMTP`` /
+``SMTP_SSL`` as seen from the transport module — no test opens a
+socket. The autouse ``_default_database_url`` conftest fixture migrates
+the SQLite DB to head so the ``endpoint_descriptor`` /
+``operation_group`` / ``audit_log`` tables exist before the registrar
+runs.
+"""
+
+from __future__ import annotations
+
+import re
+import smtplib
+import socket
+from collections.abc import AsyncIterator, Iterator
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Any, ClassVar
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.mail import ops as mail_ops
+from meho_backplane.connectors.mail import transport as mail_transport
+from meho_backplane.connectors.mail.allowlist import (
+    RecipientNotAllowedError,
+    assert_recipient_allowed,
+    parse_recipient_allowlist,
+)
+from meho_backplane.connectors.mail.ops import register_mail_typed_operations
+from meho_backplane.connectors.mail.transport import MailSendResult, send_email
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations._lookup import parse_connector_id
+from meho_backplane.settings import get_settings
+
+_CONNECTOR_ID = "mail-smtp-1.x"
+_OP_ID = "mail.send"
+
+_MAIL_ENV_VARS = (
+    "MAIL_SMTP_HOST",
+    "MAIL_SMTP_PORT",
+    "MAIL_SMTP_STARTTLS",
+    "MAIL_SMTP_USERNAME",
+    "MAIL_SMTP_PASSWORD",
+    "MAIL_FROM",
+    "MAIL_RECIPIENT_ALLOWLIST",
+)
+
+
+# ---------------------------------------------------------------------------
+# Settings env + dispatcher isolation + SMTP stubbing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the minimal Settings env + reset dispatcher caches per test.
+
+    Every ``MAIL_*`` var starts unset: allowlist empty ⇒ connector
+    inert, host empty ⇒ transport unconfigured. Tests opt into config
+    via :func:`_configure_mail_env`.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    for var in _MAIL_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+    yield
+    get_settings.cache_clear()
+    reset_dispatcher_caches()
+
+
+def _configure_mail_env(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
+    """Set a working SMTP block + allowlist, then apply *overrides*.
+
+    ``get_settings`` is process-cached, so the cache is cleared after
+    every env mutation — the transport and allowlist read the live
+    singleton per call.
+    """
+    env = {
+        "MAIL_SMTP_HOST": "smtp.internal",
+        "MAIL_FROM": "meho@example.com",
+        "MAIL_RECIPIENT_ALLOWLIST": "example.com",
+    }
+    env.update(overrides)
+    for key, value in env.items():
+        if value == "":
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+    get_settings.cache_clear()
+
+
+class _RecordingSMTP:
+    """Stand-in for ``smtplib.SMTP`` recording the full session sequence."""
+
+    instances: ClassVar[list[_RecordingSMTP]]
+
+    def __init__(self, host: str, port: int, timeout: float | None = None) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.sent_messages: list[EmailMessage] = []
+        type(self).instances.append(self)
+
+    def __enter__(self) -> _RecordingSMTP:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.calls.append(("quit", ()))
+
+    def ehlo(self) -> None:
+        self.calls.append(("ehlo", ()))
+
+    def starttls(self, *, context: object | None = None) -> None:
+        self.calls.append(("starttls", ()))
+
+    def login(self, user: str, password: str) -> None:
+        self.calls.append(("login", (user, password)))
+
+    def send_message(
+        self,
+        msg: EmailMessage,
+        from_addr: str | None = None,
+        to_addrs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(("send_message", (from_addr, tuple(to_addrs or ()))))
+        self.sent_messages.append(msg)
+        return {}
+
+
+class _ExplodingSMTP:
+    """Fails the test if the transport ever opens an SMTP connection."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        raise AssertionError("smtplib.SMTP must not be constructed when the send is refused")
+
+
+@pytest.fixture
+def recording_smtp(monkeypatch: pytest.MonkeyPatch) -> type[_RecordingSMTP]:
+    """Patch both SMTP entrypoints with a per-test recording class."""
+
+    class _PerTestSMTP(_RecordingSMTP):
+        instances: ClassVar[list[_RecordingSMTP]] = []
+
+    monkeypatch.setattr(mail_transport.smtplib, "SMTP", _PerTestSMTP)
+    monkeypatch.setattr(mail_transport.smtplib, "SMTP_SSL", _PerTestSMTP)
+    return _PerTestSMTP
+
+
+@pytest.fixture
+def exploding_smtp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch both SMTP entrypoints to fail on any connection attempt."""
+    monkeypatch.setattr(mail_transport.smtplib, "SMTP", _ExplodingSMTP)
+    monkeypatch.setattr(mail_transport.smtplib, "SMTP_SSL", _ExplodingSMTP)
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def _registered_mail_op(stub_embedding_service: AsyncMock) -> AsyncIterator[None]:
+    """Upsert the ``mail.send`` descriptor row for dispatch-driving tests."""
+    await register_mail_typed_operations(embedding_service=stub_embedding_service)
+    yield
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt="fake.jwt.value",
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _dispatch_send(params: dict[str, Any]) -> OperationResult:
+    """Dispatch ``mail.send`` through the real targetless path.
+
+    ``target`` is ``None`` (synthetic product, no connector instance /
+    registered target); the handler is module-level. The op is
+    ``requires_approval=False`` and the caller a human operator, so the
+    policy gate auto-executes despite ``safety_level="caution"``.
+    """
+    return await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=_OP_ID,
+        target=None,
+        params=params,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic identity + registration posture + no-connector-class
+# ---------------------------------------------------------------------------
+
+
+def test_mail_connector_id_round_trips() -> None:
+    """The wire connector_id resolves to the registered natural key."""
+    assert parse_connector_id(_CONNECTOR_ID) == ("mail", "1.x", "mail-smtp")
+
+
+async def test_mail_send_registered_as_caution_ungated_typed_op(
+    _registered_mail_op: None,
+) -> None:
+    """The descriptor row carries the exact synthetic identity + posture.
+
+    ``caution`` + ``requires_approval=False``: operators auto-run the
+    outward-facing send while agent principals land on the policy
+    gate's needs-approval default — the allowlist is the floor either way.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.product == "mail",
+                EndpointDescriptor.version == "1.x",
+                EndpointDescriptor.impl_id == "mail-smtp",
+                EndpointDescriptor.op_id == _OP_ID,
+            )
+        )
+        row = result.scalar_one()
+    assert row.source_kind == "typed"
+    assert row.safety_level == "caution"
+    assert row.requires_approval is False
+
+
+def test_mail_connector_registers_no_connector_class() -> None:
+    """``mail`` is synthetic — no ``register_connector_v2`` anywhere under it."""
+    mail_pkg = Path(mail_ops.__file__).parent
+    sources = "\n".join(p.read_text() for p in mail_pkg.glob("*.py"))
+    assert "register_connector_v2(" not in sources
+    assert "register_connector(" not in sources
+
+
+# ---------------------------------------------------------------------------
+# Refusal floors — allowlist (inert when empty) and unconfigured transport
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_allowlist_refuses_before_any_smtp_connection(
+    monkeypatch: pytest.MonkeyPatch,
+    exploding_smtp: None,
+    _registered_mail_op: None,
+) -> None:
+    """Empty ``MAIL_RECIPIENT_ALLOWLIST`` ⇒ structured refusal, no connection.
+
+    The host is configured, so only the allowlist stands between the
+    dispatch and the (exploding) SMTP constructor — proving the refusal
+    happens before any connection.
+    """
+    _configure_mail_env(monkeypatch, MAIL_RECIPIENT_ALLOWLIST="")
+
+    result = await _dispatch_send({"to": ["oncall@example.com"], "subject": "s", "body": "b"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "sent": False,
+        "reason": "not_in_recipient_allowlist",
+        "to": ["oncall@example.com"],
+        "subject": "s",
+    }
+
+
+async def test_recipient_outside_allowlist_refuses_whole_send(
+    monkeypatch: pytest.MonkeyPatch,
+    exploding_smtp: None,
+) -> None:
+    """One unlisted recipient refuses the send even when others are listed."""
+    _configure_mail_env(monkeypatch)
+
+    result = await send_email(to=["oncall@example.com", "exfil@evil.test"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=False, reason="not_in_recipient_allowlist")
+
+
+async def test_unconfigured_host_refuses_with_smtp_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+    exploding_smtp: None,
+) -> None:
+    """Allowlisted recipient but no ``MAIL_SMTP_HOST`` ⇒ ``smtp_unconfigured``."""
+    _configure_mail_env(monkeypatch, MAIL_SMTP_HOST="")
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=False, reason="smtp_unconfigured")
+
+
+async def test_unconfigured_from_refuses_with_smtp_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+    exploding_smtp: None,
+) -> None:
+    """A host without ``MAIL_FROM`` is still an unconfigured transport."""
+    _configure_mail_env(monkeypatch, MAIL_FROM="")
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=False, reason="smtp_unconfigured")
+
+
+# ---------------------------------------------------------------------------
+# SMTP session shape — STARTTLS/login sequencing, implicit TLS, message body
+# ---------------------------------------------------------------------------
+
+
+async def test_starttls_and_login_run_in_sequence_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type[_RecordingSMTP],
+) -> None:
+    """Configured STARTTLS + auth ⇒ ehlo → starttls → ehlo → login → send.
+
+    The post-``starttls`` ``ehlo`` is the RFC 3207 re-discovery on the
+    encrypted channel; ``login`` runs only after it.
+    """
+    _configure_mail_env(
+        monkeypatch,
+        MAIL_SMTP_USERNAME="meho-mailer",
+        MAIL_SMTP_PASSWORD="s3cret",
+    )
+
+    result = await send_email(
+        to=["oncall@example.com"], subject="Disk alert", body="datastore at 91%"
+    )
+
+    assert result == MailSendResult(sent=True, reason=None)
+    (client,) = recording_smtp.instances
+    assert (client.host, client.port) == ("smtp.internal", 587)
+    assert client.timeout == mail_transport._SMTP_TIMEOUT_SECONDS
+    assert [name for name, _ in client.calls] == [
+        "ehlo",
+        "starttls",
+        "ehlo",
+        "login",
+        "send_message",
+        "quit",
+    ]
+    assert ("login", ("meho-mailer", "s3cret")) in client.calls
+    assert ("send_message", ("meho@example.com", ("oncall@example.com",))) in client.calls
+    (msg,) = client.sent_messages
+    assert msg["From"] == "meho@example.com"
+    assert msg["To"] == "oncall@example.com"
+    assert msg["Subject"] == "Disk alert"
+    assert msg.get_content() == "datastore at 91%\n"
+
+
+async def test_no_starttls_and_no_login_when_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type[_RecordingSMTP],
+) -> None:
+    """STARTTLS off + no username ⇒ plain ehlo → send, no upgrade, no auth."""
+    _configure_mail_env(monkeypatch, MAIL_SMTP_STARTTLS="false")
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=True, reason=None)
+    (client,) = recording_smtp.instances
+    assert [name for name, _ in client.calls] == ["ehlo", "send_message", "quit"]
+
+
+async def test_port_465_uses_implicit_tls_without_starttls(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type[_RecordingSMTP],
+) -> None:
+    """Port 465 (RFC 8314 SMTPS) connects via ``SMTP_SSL`` — no ``starttls``.
+
+    The starttls flag stays at its true default; implicit TLS makes the
+    upgrade moot, so the session must not attempt it.
+    """
+    monkeypatch.setattr(mail_transport.smtplib, "SMTP", _ExplodingSMTP)
+    _configure_mail_env(monkeypatch, MAIL_SMTP_PORT="465")
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=True, reason=None)
+    (client,) = recording_smtp.instances
+    assert client.port == 465
+    assert [name for name, _ in client.calls] == ["ehlo", "send_message", "quit"]
+
+
+async def test_plaintext_channel_refuses_auth_instead_of_logging_in(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type[_RecordingSMTP],
+) -> None:
+    """STARTTLS off + a username ⇒ refuse; never AUTH over cleartext.
+
+    ``smtplib.login()`` imposes no TLS precondition, and AUTH
+    LOGIN/PLAIN only base64-wraps the credentials — on a plaintext
+    socket they are readable on the wire. The misconfiguration is
+    refused (and the message is not sent) rather than silently obeyed.
+    """
+    _configure_mail_env(
+        monkeypatch,
+        MAIL_SMTP_STARTTLS="false",
+        MAIL_SMTP_USERNAME="meho-mailer",
+        MAIL_SMTP_PASSWORD="s3cret",
+    )
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=False, reason="smtp_auth_requires_tls")
+    (client,) = recording_smtp.instances
+    assert [name for name, _ in client.calls] == ["ehlo", "quit"]
+    assert "login" not in [name for name, _ in client.calls]
+    assert not client.sent_messages
+
+
+async def test_implicit_tls_admits_login_with_starttls_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type[_RecordingSMTP],
+) -> None:
+    """The guard tracks the channel, not the ``starttls`` flag.
+
+    Port 465 is encrypted from the first byte, so ``MAIL_SMTP_STARTTLS``
+    being off there is not a plaintext-auth case and ``login`` must
+    still run.
+    """
+    _configure_mail_env(
+        monkeypatch,
+        MAIL_SMTP_PORT="465",
+        MAIL_SMTP_STARTTLS="false",
+        MAIL_SMTP_USERNAME="meho-mailer",
+        MAIL_SMTP_PASSWORD="s3cret",
+    )
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=True, reason=None)
+    (client,) = recording_smtp.instances
+    assert [name for name, _ in client.calls] == ["ehlo", "login", "send_message", "quit"]
+
+
+async def test_dispatch_surfaces_plaintext_auth_refusal_as_status_ok(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type[_RecordingSMTP],
+    _registered_mail_op: None,
+) -> None:
+    """The new reason code rides the return-failures contract like the rest."""
+    _configure_mail_env(
+        monkeypatch,
+        MAIL_SMTP_STARTTLS="false",
+        MAIL_SMTP_USERNAME="meho-mailer",
+        MAIL_SMTP_PASSWORD="s3cret",
+    )
+
+    result = await _dispatch_send({"to": ["oncall@example.com"], "subject": "s", "body": "b"})
+
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "sent": False,
+        "reason": "smtp_auth_requires_tls",
+        "to": ["oncall@example.com"],
+        "subject": "s",
+    }
+
+
+def test_every_transport_reason_code_is_documented_in_the_response_schema() -> None:
+    """The op's advertised reason list stays in step with the transport.
+
+    The response schema and llm_instructions are what an agent reads to
+    decide whether a refusal is retryable, so a reason code the
+    transport can return but the descriptor never names is a silent
+    contract gap.
+    """
+    advertised = mail_ops._MAIL_SEND_RESPONSE_SCHEMA["properties"]["reason"]["description"]
+    instructions = mail_ops._MAIL_SEND_LLM_INSTRUCTIONS["output_shape"]
+    docstring = mail_transport.__doc__ or ""
+    for code in (
+        "not_in_recipient_allowlist",
+        "smtp_unconfigured",
+        "smtp_connect_error",
+        "smtp_auth_requires_tls",
+        "smtp_auth_error",
+        "smtp_recipients_refused",
+        "smtp_error",
+    ):
+        assert code in advertised, code
+        assert code in instructions, code
+        assert code in docstring, code
+
+
+# ---------------------------------------------------------------------------
+# Return-failures contract — every delivery failure maps to a reason code
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "exc,expected_reason",
+    [
+        (smtplib.SMTPAuthenticationError(535, b"authentication failed"), "smtp_auth_error"),
+        (
+            smtplib.SMTPRecipientsRefused({"oncall@example.com": (550, b"mailbox unavailable")}),
+            "smtp_recipients_refused",
+        ),
+        (smtplib.SMTPConnectError(421, b"service not available"), "smtp_connect_error"),
+        (smtplib.SMTPServerDisconnected("connection lost"), "smtp_error"),
+        (smtplib.SMTPException("malformed reply"), "smtp_error"),
+    ],
+    ids=["auth", "recipients-refused", "connect", "disconnected", "generic"],
+)
+async def test_smtp_exception_subclasses_map_to_reason_codes(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type[_RecordingSMTP],
+    exc: smtplib.SMTPException,
+    expected_reason: str,
+) -> None:
+    """Each ``SMTPException`` subclass maps to its stable reason, never raises.
+
+    Pins the except-arm ordering: ``SMTPException`` subclasses
+    ``OSError``, so a specific SMTP failure must not fall through to the
+    socket-level ``smtp_connect_error`` arm.
+    """
+    _configure_mail_env(monkeypatch)
+
+    def _raise(*_a: object, **_kw: object) -> None:
+        raise exc
+
+    monkeypatch.setattr(recording_smtp, "send_message", _raise)
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=False, reason=expected_reason)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ConnectionRefusedError("connection refused"),
+        socket.gaierror("name resolution failed"),
+        TimeoutError("timed out"),
+    ],
+    ids=["refused", "gaierror", "timeout"],
+)
+async def test_socket_level_connect_failures_map_to_smtp_connect_error(
+    monkeypatch: pytest.MonkeyPatch,
+    exc: OSError,
+) -> None:
+    """Raw ``OSError``s from the constructor's connect map to a reason code."""
+    _configure_mail_env(monkeypatch)
+
+    class _FailingConnectSMTP:
+        def __init__(self, *_a: object, **_kw: object) -> None:
+            raise exc
+
+    monkeypatch.setattr(mail_transport.smtplib, "SMTP", _FailingConnectSMTP)
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=False, reason="smtp_connect_error")
+
+
+async def test_send_success_returns_sent_true(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type[_RecordingSMTP],
+) -> None:
+    """The success path: MTA accepts ⇒ ``MailSendResult(sent=True, reason=None)``."""
+    _configure_mail_env(monkeypatch)
+
+    result = await send_email(to=["oncall@example.com"], subject="s", body="b")
+
+    assert result == MailSendResult(sent=True, reason=None)
+
+
+# ---------------------------------------------------------------------------
+# Shared-dispatcher parity — call_operation path + durable audit row
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_mail_send_returns_ok_and_writes_audit_row(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type[_RecordingSMTP],
+    _registered_mail_op: None,
+) -> None:
+    """Dispatching ``("mail-smtp-1.x", "mail.send")`` is status=ok + audited.
+
+    The durable audit row's ``raw_payload`` carries the literal
+    ``to``/``subject`` (the "who was mailed" answer) and never the
+    message body.
+    """
+    _configure_mail_env(monkeypatch)
+
+    result = await _dispatch_send(
+        {
+            "to": ["oncall@example.com"],
+            "subject": "Dashboard critical",
+            "body": "the secret-adjacent body text",
+        }
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result == {
+        "sent": True,
+        "reason": None,
+        "to": ["oncall@example.com"],
+        "subject": "Dashboard critical",
+    }
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (await session.execute(select(AuditLog))).scalars().all()
+    mail_rows = [r for r in rows if r.path == _OP_ID]
+    assert len(mail_rows) == 1
+    raw = mail_rows[0].raw_payload
+    assert raw is not None
+    assert raw["to"] == ["oncall@example.com"]
+    assert raw["subject"] == "Dashboard critical"
+    assert "body" not in raw
+
+
+# ---------------------------------------------------------------------------
+# Header-injection rejection — the schema, not the transport, refuses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        "alert\r\nBcc: evil@example.com",
+        "alert\nBcc: evil@example.com",
+        "alert\rBcc: evil@example.com",
+        "alert\vBcc: evil@example.com",
+        "alert\fBcc: evil@example.com",
+        "alert\x1cBcc: evil@example.com",
+        "alert\x1dBcc: evil@example.com",
+        "alert\x1eBcc: evil@example.com",
+        "alert\x85Bcc: evil@example.com",
+        "alert\u2028Bcc: evil@example.com",
+        "alert\u2029Bcc: evil@example.com",
+    ],
+    ids=["crlf", "lf", "cr", "vt", "ff", "fs", "gs", "rs", "nel", "ls", "ps"],
+)
+async def test_line_break_subject_is_invalid_params_not_connector_error(
+    monkeypatch: pytest.MonkeyPatch,
+    exploding_smtp: None,
+    _registered_mail_op: None,
+    subject: str,
+) -> None:
+    """A subject carrying any line break is refused by the parameter schema.
+
+    ``EmailMessage`` guards header assignment with
+    ``len(value.splitlines()) > 1`` and raises ``ValueError``, which
+    would escape ``send_email`` as a ``connector_error`` and break the
+    return-failures contract. The schema pattern is the exact complement
+    of that guard — so the dispatcher rejects the call at validation,
+    before the handler runs and before any SMTP connection opens.
+    """
+    _configure_mail_env(monkeypatch)
+
+    result = await _dispatch_send({"to": ["oncall@example.com"], "subject": subject, "body": "b"})
+
+    assert result.status == "error"
+    assert result.extras is not None
+    assert result.extras["error_code"] == "invalid_params"
+    assert any(err["validator"] == "pattern" for err in result.extras["validation_errors"])
+
+
+def test_subject_pattern_is_the_exact_complement_of_the_stdlib_guard() -> None:
+    """No subject the schema admits can make ``EmailMessage`` raise.
+
+    Sweeps the whole Unicode range rather than a hand-picked list: the
+    stdlib guard keys off :meth:`str.splitlines`, whose boundary set is
+    wider than CR/LF and has grown across Python versions. If a future
+    interpreter adds a boundary character, this test fails instead of
+    the contract silently reopening.
+    """
+    pattern = re.compile(mail_ops._SINGLE_LINE_PATTERN)
+    admitted_but_rejected = [
+        hex(codepoint)
+        for codepoint in range(0x110000)
+        if len(f"a{chr(codepoint)}b".splitlines()) > 1
+        and pattern.search(f"a{chr(codepoint)}b") is not None
+    ]
+    assert admitted_but_rejected == []
+
+    # …and the pattern is not so wide it refuses an ordinary subject.
+    for allowed in ("Disk alert", "datastore-01 at 91%", "Ärger: Füllstand", "a\tb"):
+        assert pattern.search(allowed) is not None
+
+
+async def test_single_line_subject_still_reaches_the_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    recording_smtp: type[_RecordingSMTP],
+    _registered_mail_op: None,
+) -> None:
+    """The pattern is a line-break guard only — normal subjects dispatch."""
+    _configure_mail_env(monkeypatch)
+
+    result = await _dispatch_send(
+        {"to": ["oncall@example.com"], "subject": "Ärger: 91% voll", "body": "b"}
+    )
+
+    assert result.status == "ok", result.error
+    (msg,) = recording_smtp.instances[0].sent_messages
+    assert msg["Subject"] == "Ärger: 91% voll"
+
+
+# ---------------------------------------------------------------------------
+# Allowlist unit behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_assert_recipient_allowed_empty_denies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MAIL_RECIPIENT_ALLOWLIST", raising=False)
+    get_settings.cache_clear()
+    with pytest.raises(RecipientNotAllowedError):
+        assert_recipient_allowed("oncall@example.com")
+
+
+def test_assert_recipient_allowed_full_address_and_domain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MAIL_RECIPIENT_ALLOWLIST", "oncall@ops.test, @example.com")
+    get_settings.cache_clear()
+    assert_recipient_allowed("oncall@ops.test")
+    assert_recipient_allowed("OnCall@Ops.Test")  # case-insensitive
+    assert_recipient_allowed("anyone@example.com")  # domain entry, leading @ accepted
+    assert_recipient_allowed("anyone@example.com.")  # trailing dot tolerated
+    with pytest.raises(RecipientNotAllowedError):
+        assert_recipient_allowed("other@ops.test")  # address entry ≠ domain grant
+    with pytest.raises(RecipientNotAllowedError):
+        assert_recipient_allowed("anyone@sub.example.com")  # no subdomain widening
+
+
+@pytest.mark.parametrize(
+    "recipient",
+    ["", "no-at-sign", "two@@example.com", "a@b@c", "evil@example.com\r\nBcc: x@y.z"],
+    ids=["empty", "no-at", "double-at", "two-ats", "crlf-injection"],
+)
+def test_assert_recipient_allowed_rejects_malformed_recipient(
+    monkeypatch: pytest.MonkeyPatch,
+    recipient: str,
+) -> None:
+    """An address the floor cannot positively parse is refused, not guessed."""
+    monkeypatch.setenv("MAIL_RECIPIENT_ALLOWLIST", "example.com")
+    get_settings.cache_clear()
+    with pytest.raises(RecipientNotAllowedError):
+        assert_recipient_allowed(recipient)
+
+
+@pytest.mark.parametrize(
+    "allowlist",
+    [
+        "bad entry@example.com",
+        "a@b@c",
+        "foo@",
+        "@",
+        "@example.com, foo@",
+        "...",
+        "@.",
+    ],
+    ids=[
+        "embedded-space",
+        "double-at",
+        "empty-domain",
+        "bare-at",
+        "one-good-one-bad",
+        "dots-only",
+        "at-dot",
+    ],
+)
+def test_parse_recipient_allowlist_rejects_malformed_entry(
+    monkeypatch: pytest.MonkeyPatch,
+    allowlist: str,
+) -> None:
+    """A malformed allowlist entry fails loud — never silently kept."""
+    monkeypatch.setenv("MAIL_RECIPIENT_ALLOWLIST", allowlist)
+    get_settings.cache_clear()
+    with pytest.raises(ValueError, match="MAIL_RECIPIENT_ALLOWLIST"):
+        assert_recipient_allowed("oncall@example.com")
+
+
+def test_bare_at_entry_no_longer_masks_the_inert_connector_diagnostic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lone ``@`` is a config error, not a silently-empty domain grant.
+
+    It used to parse to ``domains={""}``: matching nothing, yet
+    non-empty enough to route the refusal past the "allowlist is empty,
+    the connector is inert" branch — so the operator got the generic
+    "not listed" message for a typo that had disabled every send.
+    """
+    monkeypatch.setenv("MAIL_RECIPIENT_ALLOWLIST", "@")
+    get_settings.cache_clear()
+
+    with pytest.raises(ValueError, match="not a valid address or domain"):
+        parse_recipient_allowlist()
+
+
+def test_parse_recipient_allowlist_accepts_the_documented_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tightened validation still admits every documented entry form."""
+    monkeypatch.setenv(
+        "MAIL_RECIPIENT_ALLOWLIST", "OnCall@Ops.Test, @example.com, example.org, corp.test."
+    )
+    get_settings.cache_clear()
+
+    addresses, domains = parse_recipient_allowlist()
+
+    assert addresses == frozenset({"oncall@ops.test"})
+    assert domains == frozenset({"example.com", "example.org", "corp.test"})

--- a/docs/codebase/connectors-mail.md
+++ b/docs/codebase/connectors-mail.md
@@ -1,0 +1,187 @@
+# Mail connector (`connectors/mail`)
+
+## Overview
+
+The `mail.*` connector gives the backplane an **outward delivery
+channel**: one typed op, `mail.send`, that delivers a plain-text email
+through a deployment-level SMTP block. It is a **synthetic** connector
+on the `net.*` mould (#2717, Initiative #2716) — no vendor connector
+backs it, there is no `Connector` subclass, and the package calls
+neither `register_connector` nor `register_connector_v2`. The handler is
+a module-level function the dispatcher routes to with
+`connector_instance=None` / `target=None`; recipients are **params**,
+not a registered `Target`.
+
+The op is registered under the natural key
+`(product="mail", version="1.x", impl_id="mail-smtp")`, so the wire
+`connector_id` is `mail-smtp-1.x`, which round-trips through
+`parse_connector_id` back to `("mail", "1.x", "mail-smtp")`.
+
+Two consumers share one implementation:
+
+- **Dispatch** — agents and operators reach `mail.send` through the
+  normal `call_operation` path (policy + audit + broadcast).
+- **Direct import** — the checks notifier (#2719) imports
+  `transport.send_email()` and calls it in-process.
+
+Both run the identical recipient-allowlist floor and return-failures
+contract, because both are the same function.
+
+## Key types
+
+- `transport.MailSendResult` — frozen dataclass `{sent: bool,
+  reason: str | None}`; `sent=True` ⇔ `reason is None`.
+- `transport.send_email(*, to, subject, body)` — the single shared
+  async transport. Screens every recipient, refuses when unconfigured,
+  builds the `email.message.EmailMessage`, runs the blocking
+  `smtplib` session via `asyncio.to_thread` (the socket is bound to
+  the thread that opened it, so the whole session lives in one
+  `to_thread` hop).
+- `allowlist.assert_recipient_allowed(address)` /
+  `parse_recipient_allowlist()` — the recipient floor.
+- `ops.mail_send(operator, target, params)` — the dispatch handler; a
+  thin adapter returning the audit-visible payload.
+- `ops.register_mail_typed_operations` — the registrar, queued by the
+  package `__init__` via `register_typed_op_registrar`.
+
+## Control flow
+
+`mail.send(to, subject, body)`:
+
+1. every recipient is screened by `assert_recipient_allowed` **before
+   any SMTP connection opens** — all-or-nothing (one refused recipient
+   refuses the whole send, keeping the audit answer exact);
+2. an empty `MAIL_SMTP_HOST` or `MAIL_FROM` refuses with
+   `reason="smtp_unconfigured"`;
+3. the `EmailMessage` is built (plain text only) and the blocking SMTP
+   session runs on a worker thread: connect → `ehlo` → (`starttls` +
+   re-`ehlo` when enabled) → (`login` when a username is configured) →
+   `send_message` with an explicit envelope → `quit`;
+4. the handler returns `{sent, reason, to, subject}` — the durable
+   audit row's `raw_payload` records **who was mailed about what** and
+   never the message body.
+
+**TLS shape (RFC 8314):** port 465 selects implicit TLS
+(`smtplib.SMTP_SSL` — TLS from the first byte, `starttls` moot); any
+other port opens plaintext and upgrades via `starttls()` + re-`ehlo()`
+when `MAIL_SMTP_STARTTLS` is set (default true).
+
+**Credentials never ride a cleartext socket.** `_send_sync` carries an
+`encrypted` flag — true from construction under implicit TLS, true
+again once `starttls()` returns — and `login()` is gated on it.
+`smtplib.login()` imposes no TLS precondition of its own, so
+`MAIL_SMTP_STARTTLS=false` on a non-465 port with `MAIL_SMTP_USERNAME`
+set would otherwise put base64-wrapped (not encrypted) credentials on
+the wire. That combination is refused with
+`reason="smtp_auth_requires_tls"` instead — the same posture as
+Prometheus Alertmanager's `require_tls`, which defaults to true. The
+flag is checked at the `login()` call site rather than pre-computed
+from `starttls`/`port`, so a future change to how TLS is established
+cannot leave the guard behind.
+
+**Return-failures contract** (mould parity with `net.*`): a refused,
+unconfigured, or delivery-failed send is the **product**, not an error
+— dispatch `status="ok"` with `sent=false` and a stable reason code:
+
+| reason | trigger |
+|---|---|
+| `not_in_recipient_allowlist` | a recipient failed the floor (incl. empty allowlist / unparseable address) |
+| `smtp_unconfigured` | `MAIL_SMTP_HOST` or `MAIL_FROM` unset |
+| `smtp_connect_error` | `SMTPConnectError` or socket-level `OSError` (refused / DNS / timeout) |
+| `smtp_auth_requires_tls` | a username is configured but the channel is still cleartext |
+| `smtp_auth_error` | `SMTPAuthenticationError` |
+| `smtp_recipients_refused` | `SMTPRecipientsRefused` (server rejected every recipient) |
+| `smtp_error` | any other `SMTPException` |
+
+The `except` ordering in `transport._send_sync` is load-bearing:
+`SMTPException` subclasses `OSError` (since Python 3.4), so the SMTP
+arms must precede the socket-level `OSError` arm.
+
+## Configuration
+
+One deployment-level SMTP block (no per-tenant config, #2717 scope),
+all in `Settings` (`settings.py`, env-mapped in `get_settings`):
+
+| env var | default | meaning |
+|---|---|---|
+| `MAIL_SMTP_HOST` | `""` | MTA host; empty ⇒ transport unconfigured |
+| `MAIL_SMTP_PORT` | `587` | 465 ⇒ implicit TLS (`SMTP_SSL`) |
+| `MAIL_SMTP_STARTTLS` | `true` | upgrade via STARTTLS on non-465 ports; off + a username ⇒ `smtp_auth_requires_tls` |
+| `MAIL_SMTP_USERNAME` | `""` | `login()` runs only when set, and only on an encrypted channel |
+| `MAIL_SMTP_PASSWORD` | `""` | `repr=False`; never logged |
+| `MAIL_FROM` | `""` | From header + envelope sender; empty ⇒ unconfigured |
+| `MAIL_RECIPIENT_ALLOWLIST` | `""` | the hard floor; empty ⇒ inert |
+
+**Allowlist semantics** (inverted default, like
+`MEHO_NETDIAG_PROBE_ALLOWLIST`): comma-separated full addresses
+(`oncall@example.com`) and/or domains (`example.com`, leading `@`
+accepted) naming the **entire** permitted recipient space. Matching is
+case-insensitive on the whole address; a domain entry does **not**
+match subdomains. An address the parser cannot positively read as
+`local@domain` is refused — which also makes SMTP envelope injection
+(CR/LF in a recipient) structurally impossible past the gate. A
+*subject* carrying a line break is rejected one layer earlier, by
+`mail.send`'s parameter schema (`ops._SINGLE_LINE_PATTERN`), so the
+dispatch returns the structured validation error (`status="error"`,
+`extras["error_code"] == "invalid_params"`). The pattern excludes every
+character `str.splitlines()` treats as a boundary — not just CR/LF, but
+also VT, FF, the information separators, NEL, and U+2028/U+2029 —
+because that is exactly the set `EmailMessage` refuses
+(`len(value.splitlines()) > 1`). Rejecting it at the schema keeps the
+return-failures contract intact: were the value to reach header
+assignment it would raise `ValueError` and surface as a
+`connector_error`. The screen is the schema, so it covers every
+dispatched call but not the direct-import path — an in-process caller
+such as the #2719 notifier is responsible for composing a single-line
+subject.
+
+Malformed allowlist entries raise loudly at parse time rather than
+being silently kept: whitespace, more than one `@`, an empty local part
+or domain part (`foo@`, `@`), or a domain that folds away to nothing
+(`...`). A bare `@` is the case worth naming — it used to parse to
+`domains={""}`, matching no address while making the allowlist look
+non-empty, so a typo that had disabled every send reported as an
+ordinary "not listed" refusal instead of the "connector is inert"
+diagnostic.
+
+## Safety posture
+
+`safety_level="caution"` + `requires_approval=False`: human/service
+principals default-allow (operators and the checks notifier auto-run),
+while agent principals land on the policy gate's `caution` ⇒
+needs-approval default — and the ceiling keeps a permission row from
+loosening past needs-approval (`auth/permissions.py`). The recipient
+allowlist is the hard floor on every path either way.
+
+`classify_op("mail.send")` falls through to `other` (full-detail
+broadcast) — the broadcast payload carries recipients + subject, which
+are audit-visible by design.
+
+## Dependencies
+
+Stdlib only: `smtplib` + `email.message.EmailMessage` +
+`asyncio.to_thread` (no `aiosmtplib`; blocking SMTP on a worker thread
+is fine at alert-mail volume). Structured logging via `structlog` —
+events carry host/port/reason only, never the password or body.
+
+## Known issues
+
+- The SMTP session timeout is a module constant
+  (`transport._SMTP_TIMEOUT_SECONDS`, 30 s), not a settings knob — no
+  consumer has asked to tune it (#1177 substrate minimalism).
+- No HTML, attachments, templating, or per-tenant SMTP — explicitly out
+  of scope for #2717; further transports (Slack/PagerDuty/webhook) are
+  new connectors when a consumer asks.
+
+## References
+
+- `backend/src/meho_backplane/connectors/mail/` — package
+  (`transport.py`, `allowlist.py`, `ops.py`).
+- `backend/tests/test_connectors_mail.py` — contract coverage.
+- Mould: `backend/src/meho_backplane/connectors/net/` +
+  [`connectors-net-diagnostics.md`](connectors-net-diagnostics.md).
+- Task #2717; Initiative #2716 (checks alerting delivery); notifier
+  consumer #2719.
+- Python 3.14 `smtplib`:
+  <https://docs.python.org/3.14/library/smtplib.html>; RFC 8314
+  (implicit TLS on 465); RFC 3207 (STARTTLS re-EHLO).


### PR DESCRIPTION
## Summary

- Add the synthetic `mail.*` typed connector on the `net.*` mould: one op, `mail.send` (`connector_id` `mail-smtp-1.x`), registered via `register_typed_operation` with a module-level handler (`connector_instance=None`, `target=None` — recipients are params, not a `Target`).
- `transport.send_email()` is the single shared implementation (stdlib `smtplib` + `email.message.EmailMessage` via `asyncio.to_thread`, **no new dependency**) that both the dispatch handler and the checks notifier (#2719) call — the recipient-allowlist floor and the return-failures contract hold on every send path.
- `MAIL_RECIPIENT_ALLOWLIST` (full addresses and/or domains) is the inverted-default hard floor: empty ⇒ every send refused, connector inert. Unparseable recipients are refused, which also makes SMTP envelope injection structurally impossible; a CR/LF subject is rejected by `EmailMessage`'s own header guard.
- Deployment-level SMTP settings block (`MAIL_SMTP_HOST/PORT/STARTTLS/USERNAME/PASSWORD`, `MAIL_FROM`) with `repr=False` on the password; port 465 selects implicit TLS (`SMTP_SSL`, RFC 8314), other ports upgrade via `starttls()` + re-`ehlo()` (RFC 3207); `login()` only when a username is configured.
- Registered `safety_level="caution"` + `requires_approval=False`: operators (non-agent principals) auto-run; agent principals land on the policy gate's caution ⇒ needs-approval default with a needs-approval ceiling. Refused/unconfigured/failed sends return `{sent: false, reason}` with dispatch `status="ok"`; stable reason codes `not_in_recipient_allowlist` / `smtp_unconfigured` / `smtp_connect_error` / `smtp_auth_error` / `smtp_recipients_refused` / `smtp_error`. Audit `raw_payload` carries `to`/`subject`, never the body.
- New `docs/codebase/connectors-mail.md`; CHANGELOG `[Unreleased]` entry under `### Added — Mail connector — SMTP send as a typed operation`.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` (strict) — clean except pre-existing `net/icmp.py` `MSG_ERRQUEUE` (Linux-only constant flagged on macOS; file untouched, green in Linux CI)
- [x] `uv run pytest tests/test_connectors_mail.py -q` — 29 passed, covering by name: empty-allowlist refusal, unconfigured-host refusal, STARTTLS+login sequencing, per-`SMTPException`-subclass reason codes, success
- [x] Dispatch parity: `test_dispatch_mail_send_returns_ok_and_writes_audit_row` proves `("mail-smtp-1.x", "mail.send")` through the real dispatcher returns `status="ok"` and writes an audit row whose `raw_payload` has `to`/`subject` and no body
- [x] `grep -n 'safety_level="caution"' .../mail/ops.py` hits; `grep -rn smtplib .../mail/transport.py` hits; `grep -n "aiosmtplib\|smtp" backend/pyproject.toml` — no new dependency
- [x] `mail_smtp_password` carries `repr=False` in `settings.py`
- [x] No migration: nothing under `backend/alembic/versions/` in the diff
- [x] Full backend suite (`pytest -n 3 --dist loadscope --ignore=tests/integration --ignore=tests/migrations`) green apart from two pre-existing env-dependent `net.*` failures (`test_trace_reaches_loopback`, `test_chosen_resolver_queries_that_nameserver`) — both fail identically on untouched `main` on this macOS host (real-socket tests; green in Linux CI)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (2 warnings: pre-existing `settings.py` size; `send_email` at 71 lines, warn-level)

## Out of scope

- Checks notifier + `check_dashboards` columns (#2719), `checks.transition` broadcast events (#2720), in-band advisory (#2718), investigator prompt (#2721).
- HTML/templated mail, attachments, per-tenant SMTP config, Slack/PagerDuty/webhook transports, inbound mail, MCP/CLI convenience verbs.
- Adjacent finding (not changed): `classify_op("mail.send")` falls through to `other` (full-detail broadcast — payload is to/subject, audit-visible by design); a dedicated classification branch was deliberately not added here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2717

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a typed `mail.send` connector for sending plain-text email through configurable SMTP.
  * Added recipient and domain allowlisting, optional authentication, TLS support, and approval safeguards.
  * Added structured failure responses and privacy-conscious auditing of recipients and subjects.
  * Added deployment settings for SMTP configuration and sender details.

* **Documentation**
  * Added documentation covering configuration, safety behavior, error handling, and known limitations.

* **Tests**
  * Added comprehensive coverage for sending, validation, security controls, and SMTP failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-01)

Addressed the review findings from https://github.com/evoila/meho/pull/2724#pullrequestreview-4832689478:

- **B1** `df71e2f2` — DCO remediation commit for `21c57ff4` (retroactive `Signed-off-by`, no history rewrite, no force-push). Every commit added in this iteration is signed off.
- **B2** `9b386f99` — `subject` gains a schema `pattern`, so a line-break-bearing subject is rejected as `invalid_params` by the dispatcher instead of raising `ValueError` out of `send_email` as a `connector_error`. The transport docstring and `docs/codebase/connectors-mail.md` no longer document the hole as intended behaviour.
- **M1** `6cca4894` — `_send_sync` tracks channel encryption and refuses `login()` on a cleartext socket with a new stable reason code `smtp_auth_requires_tls`, documented in the transport module docstring, the op's response schema + `llm_instructions`, and the docs reason/config tables.
- **m1** `e722c441` — `parse_recipient_allowlist` now rejects `foo@`, `@`, and dots-only entries instead of silently keeping them.
- `26d4fc07` — merged `main` in after #2723 landed and conflicted on the `## [Unreleased]` CHANGELOG section. Both entries kept; merged rather than rebased because the branch is published and carries a posted review.

**B1 could not be closed — see [this comment](https://github.com/evoila/meho/pull/2724#issuecomment-5148340889).** The remediation commit is correct and pushed, but `dcoapp/app` ignores remediation commits unless `.github/dco.yml` on the *default branch* sets `allowRemediationCommits.individual: true`, and no such config exists in this repo. Closing it needs either that one-file PR on `main` or a rebase + force-push, neither of which an autonomous run may decide.

### Deviation from the punch list (one, deliberate)

**B2's pattern is wider than the `^[^\r\n]+$` the review specified.** `EmailMessage` guards header assignment with `len(value.splitlines()) > 1`, and `str.splitlines()` breaks on VT, FF, the three information separators, NEL, and U+2028/U+2029 in addition to CR/LF — verified empirically on the worktree's CPython 3.14.6. `^[^\r\n]+$` would have closed the reported case while leaving nine other characters able to raise `ValueError` out of the handler. The shipped pattern is the exact complement of the stdlib guard, and `test_subject_pattern_is_the_exact_complement_of_the_stdlib_guard` sweeps the whole Unicode range to assert no admitted subject can make `EmailMessage` raise — so a future interpreter widening `splitlines()` is a red build rather than a silently reopened contract.

### Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — 1375 files already formatted
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — only the pre-existing macOS-only `net/icmp.py:208 MSG_ERRQUEUE` error (Linux CI lane is green)
- [x] `pytest tests/test_connectors_mail.py` — 53 passed (was 29; +24 covering the four findings)
- [x] `pytest -n 3 --dist loadscope --ignore=tests/integration --ignore=tests/migrations tests/` — 10737 passed, 193 skipped, exit 0
- [x] `code-quality.py` — 0 blockers

<!-- auto-implement-issue: continue, iteration 1 -->
