### PR TITLE
docs(site): the five named deployment shapes, with rendered diagrams

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,13 @@ repos:
         # dragonflyoss/helm-charts) and the pre-commit-hooks#420
         # discussion. Without this exclude, any edit to a chart template
         # tries (and fails) to parse Go-template directives as YAML.
-        exclude: ^deploy/charts/.+/templates/.+\.ya?ml$
+        #
+        # mkdocs.yml is excluded for the same class of reason: the
+        # mermaid custom fence uses the `!!python/name:` tag Material
+        # documents, which yaml.safe_load (and therefore check-yaml)
+        # rejects. mkdocs.yml is validated far more strictly by the
+        # `mkdocs build --strict` check in docs-site.yml.
+        exclude: ^(deploy/charts/.+/templates/.+\.ya?ml|mkdocs\.yml)$
       - id: check-json
       - id: check-added-large-files
         args: [--maxkb=500]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,12 +105,12 @@ connector-related release-notes line.
   so a satellite-only enclave gets observation and not change
   automation; air-gapped estates cannot use cloud-hosted MCP clients at
   all; per-operator Workload Identity Federation obligates a
-  background-dispatch decision or credentialed sensors silently read
-  nothing; and multi-tenant MSP is labelled a **target shape**, not a
-  field-proven one. Every operational claim cites a public file in this
-  repository, listed in the page's own Sources section. Mermaid
-  rendering is enabled for the site via the documented Material
-  custom-fence config. (#2663)
+  background-dispatch decision or credentialed sensors evaluate
+  `unknown` forever; and multi-tenant MSP is labelled a **target
+  shape**, not a field-proven one. Every operational claim cites a
+  public file in this repository, listed in the page's own Sources
+  section. Mermaid rendering is enabled for the site via the
+  documented Material custom-fence config. (#2663)
 
 ### Added — docs-site Do-real-work guides: targets & secrets, first operations, sensors (#2673)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — docs site: the five named deployment shapes (#2663)
+
+- New **Deployment shapes** page on the docs site
+  (`docs-site/deployment-shapes.md`, under *Start here*): the five ways
+  real estates differ — flat LAN, segmented network with satellite
+  gateways, air-gapped, cloud-native without Vault (Google Secret
+  Manager), and multi-tenant MSP — each with a rendered component
+  diagram, a plain-language "pick this shape when", and the constraints
+  that actually decide the install. One chart, five topologies: the
+  page says so up front and then names what changes (address
+  allowlist, credential backend, tenancy) and what does not. Adopters
+  get the honest edges too: satellite gateways are read-only by design,
+  so a satellite-only enclave gets observation and not change
+  automation; air-gapped estates cannot use cloud-hosted MCP clients at
+  all; per-operator Workload Identity Federation obligates a
+  background-dispatch decision or credentialed sensors silently read
+  nothing; and multi-tenant MSP is labelled a **target shape**, not a
+  field-proven one. Every operational claim cites a public file in this
+  repository, listed in the page's own Sources section. Mermaid
+  rendering is enabled for the site via the documented Material
+  custom-fence config. (#2663)
+
 ### Added — maturity drift guard in CI + generated maturity-index docs page (#2678)
 
 - Close the #2664 maturity program with its two enforcement pieces

--- a/docs-site/deployment-shapes.md
+++ b/docs-site/deployment-shapes.md
@@ -78,18 +78,20 @@ This is the same posture in all five shapes, so it is stated once here
 rather than repeated below. Broadcast is a **Beta** feature — see the
 [feature maturity index](reference/maturity.md).
 
-### The chart fails at render time, not at runtime
+### The chart fails fast on invalid values
 
-Configuration is validated by the chart's JSON schema, so a
-mis-configured install fails during `helm template` / `helm install`
+Chart values are validated by the chart's JSON schema, so a
+schema-invalid install fails during `helm template` / `helm install`
 before anything runs. The clearest example: if none of `ingress.host`,
 `config.backplaneUrl`, or `config.mcpResourceUri` resolves, the chart
 refuses to render rather than deploying a silently unusable MCP
-endpoint. That is worth knowing before you start: a mistake in any
-shape below surfaces at install time with a remediation message, not as
-a healthy-looking pod that quietly does nothing.
-([`docs/deploying.md` § Deploy from cold](https://github.com/evoila/meho/blob/main/docs/deploying.md#deploy-from-cold--prerequisites-checklist),
-MCP-audience row.)
+endpoint. What the schema cannot check is everything outside the
+chart — the pgvector extension, database reachability, DNS, CA trust,
+and credential-backend permissions surface at migration or first boot
+instead, row by row in the cold-start checklist.
+([`docs/deploying.md` § Deploy from cold](https://github.com/evoila/meho/blob/main/docs/deploying.md#deploy-from-cold--prerequisites-checklist)
+— the MCP-audience row for the example, the rest of the table for what
+surfaces later.)
 
 ---
 

--- a/docs-site/deployment-shapes.md
+++ b/docs-site/deployment-shapes.md
@@ -1,0 +1,483 @@
+# Deployment shapes
+
+MEHO ships as **one Helm chart**. The five shapes below are not five
+products and not five installs — they are the five ways real estates
+differ: network topology, credential backend, and tenancy. Every shape
+runs the same chart with the same components; what changes is which
+network the backplane can dial, where credentials live, and how many
+customers share one release.
+
+Pick a shape before you start the install. It decides three things you
+cannot easily change later: which address ranges you allowlist, whether
+you need a credential store you don't already run, and whether any part
+of your estate needs a gateway rather than a route.
+
+## Which shape is yours?
+
+| If your estate looks like this | Your shape |
+|---|---|
+| One network segment; the cluster can dial every target directly | [Flat LAN](#flat-lan) |
+| Several management segments, and at least one enclave the cluster can never dial | [Segmented network with satellite gateways](#segmented-network-with-satellite-gateways) |
+| No internet egress at all; every artefact arrives by one-time transfer | [Air-gapped](#air-gapped) |
+| GKE or GCP-adjacent, and you would rather not run Vault | [Cloud-native without Vault](#cloud-native-without-vault-google-secret-manager) |
+| One MEHO release governing several *customers'* estates | [Multi-tenant MSP](#multi-tenant-msp-target-shape) |
+
+Air-gapped is the one shape that **composes** with the others: it adds
+an artefact-mirroring workstream on top of a flat-LAN, segmented, or
+cloud-native install rather than replacing it.
+
+## What every shape shares
+
+### The components
+
+| Component | Who provides it | Notes |
+|---|---|---|
+| MEHO backplane | MEHO — `ghcr.io/evoila/meho` | One Deployment from the chart at `oci://ghcr.io/evoila/meho-chart`. Agents reach it over MCP; operators reach it over the REST API with the `meho` CLI and the optional browser console. Both fronts share one governed dispatch path — policy, approvals, audit, result handling. |
+| Keycloak realm | You | The OIDC issuer. The backplane needs a confidential client plus the public `meho-cli` device-code client with audience mappers. |
+| PostgreSQL + pgvector | You | Operator-managed; the `vector` extension is pre-created once by a superuser, and the chart expects an `asyncpg` DSN. |
+| Valkey broadcast | MEHO — in-tree subchart | Installed by the same release. See the availability posture below. |
+| Credential backend | You | HashiCorp Vault KV-v2 (the default) **or** Google Secret Manager, selected with `config.credentialBackend`. |
+| Targets | You | The governed systems. Each is registered with an address, a *reference* into the credential backend — never the secret itself — and its TLS trust settings. |
+
+Prerequisites, the worked install commands, and the per-row verification
+checks for all of the above live in
+[`docs/deploying.md`](https://github.com/evoila/meho/blob/main/docs/deploying.md#deploy-from-cold--prerequisites-checklist);
+sanitized values files for the on-premises and Google-Secret-Manager
+archetypes live in
+[`deploy/values-examples/`](https://github.com/evoila/meho/tree/main/deploy/values-examples).
+
+### The private-address guard applies to every shape
+
+The backplane **default-denies** targets whose hostname resolves to a
+non-public address — loopback, RFC 1918, link-local, cloud metadata.
+Since MEHO exists to govern private infrastructure, essentially every
+production install has to name its own ranges in
+`config.targetSsrfAllowlist`, for example `"10.0.0.0/8,192.168.0.0/16"`.
+
+This is a scoped opt-in, never a global off-switch: an empty value keeps
+the guard fully on, and the intended posture is to list the ranges you
+actually manage. Plan the list before the first target registration —
+registering a target outside the allowlist is rejected, not warned
+about.
+([`docs/deploying.md` § Operational chart knobs](https://github.com/evoila/meho/blob/main/docs/deploying.md#operational-chart-knobs).)
+
+### Broadcast runs single-replica, with ephemeral streams
+
+The activity-broadcast bus is deliberately **one replica** in the
+current chart: no Sentinel sidecar ships with it, streams are ephemeral
+by design, and the chart's values schema *rejects* any replica count
+above 1 rather than letting you configure a topology that would not
+actually be highly available. A restart therefore loses unconsumed
+stream history, and highly-available broadcast is explicitly deferred.
+([`deploy/charts/meho/values.yaml`](https://github.com/evoila/meho/blob/main/deploy/charts/meho/values.yaml)
+`broadcast:` block and the matching
+[`values.schema.json`](https://github.com/evoila/meho/blob/main/deploy/charts/meho/values.schema.json)
+constraint.)
+
+This is the same posture in all five shapes, so it is stated once here
+rather than repeated below. Broadcast is a **Beta** feature — see the
+[feature maturity index](reference/maturity.md).
+
+### The chart fails at render time, not at runtime
+
+Configuration is validated by the chart's JSON schema, so a
+mis-configured install fails during `helm template` / `helm install`
+before anything runs. The clearest example: if none of `ingress.host`,
+`config.backplaneUrl`, or `config.mcpResourceUri` resolves, the chart
+refuses to render rather than deploying a silently unusable MCP
+endpoint. That is worth knowing before you start: a mistake in any
+shape below surfaces at install time with a remediation message, not as
+a healthy-looking pod that quietly does nothing.
+([`docs/deploying.md` § Deploy from cold](https://github.com/evoila/meho/blob/main/docs/deploying.md#deploy-from-cold--prerequisites-checklist),
+MCP-audience row.)
+
+---
+
+## Flat LAN
+
+The smallest production shape: one network segment, every target
+directly reachable from the cluster, one entry in the address
+allowlist.
+
+```mermaid
+flowchart TB
+  agent["Agent front (MCP client)"]
+  op["Operator front (CLI and browser console)"]
+  subgraph cluster["Kubernetes cluster, namespace meho"]
+    bp["MEHO backplane (shared dispatch path)"]
+    valkey["Valkey broadcast (single replica, ephemeral streams)"]
+  end
+  kc["Keycloak realm"]
+  pg["PostgreSQL + pgvector"]
+  vault["Vault KV-v2 (or Google Secret Manager)"]
+  subgraph lan["Flat LAN, one allowlist entry"]
+    t1["Target A"]
+    t2["Target B"]
+    tn["Target N"]
+  end
+  agent -->|"MCP, Bearer JWT"| bp
+  op -->|"REST API, Bearer JWT"| bp
+  agent -.->|"OIDC"| kc
+  op -.->|"device-code login"| kc
+  bp -.->|"validate issuer and audience"| kc
+  bp --> valkey
+  bp --> pg
+  bp -->|"credential reads"| vault
+  bp -->|"governed operations"| t1
+  bp --> t2
+  bp --> tn
+```
+
+**Pick this shape when:**
+
+- Your targets sit in one network segment that the cluster can already
+  reach.
+- You already run a Keycloak realm and either a Vault or Google Secret
+  Manager.
+- One team, one tenant, a handful of targets, interactive operators
+  only.
+
+**What it still costs you.** "Flat" is a network statement, not an
+install shortcut. Every cold-install prerequisite applies unchanged: the
+pgvector extension step, the `asyncpg` DSN, the Keycloak clients and
+mappers, an internal-CA trust bundle where your services use private
+certificates, and a pinned immutable image tag. A flat LAN is still
+private address space, so the allowlist entry above is mandatory —
+there is no shape in which it is optional.
+
+## Segmented network with satellite gateways
+
+The standard enterprise on-premises shape: several management segments,
+the backplane given network identity into each segment it can reach, and
+a **satellite gateway** inside each enclave it cannot.
+
+```mermaid
+flowchart TB
+  agent["Agent front (MCP client)"]
+  op["Operator front (CLI and browser console)"]
+  subgraph central["Central cluster, namespace meho"]
+    bp["MEHO backplane"]
+    valkey["Valkey broadcast (single replica)"]
+  end
+  kc["Keycloak realm"]
+  pg["PostgreSQL + pgvector"]
+  vault["Credential backend"]
+  subgraph segA["Segment A: directly reachable (allowlisted)"]
+    ta["Targets"]
+  end
+  subgraph segB["Segment B: reachable after routes, DNS and CA trust"]
+    tb["Targets"]
+  end
+  subgraph enclave["Enclave C: no inbound path from central"]
+    runner["Satellite gateway (read-only executor)"]
+    tc["Targets"]
+  end
+  agent --> bp
+  op --> bp
+  bp -.-> kc
+  bp --> valkey
+  bp --> pg
+  bp --> vault
+  bp -->|"governed operations"| ta
+  bp -->|"governed operations"| tb
+  runner -->|"outbound-only poll and report"| bp
+  runner -->|"read-only operations"| tc
+```
+
+**Pick this shape when:**
+
+- Two or more network segments sit between the cluster and the targets.
+- You can give the backplane routes, DNS resolution, and CA trust into
+  the management networks it *should* reach.
+- At least one zone — a NAT-ed site, a private control plane, a
+  no-inbound network — will never accept a connection from the central
+  cluster.
+
+**Satellite gateways are read-only by design — and that is a planning
+constraint, not a limitation to work around.** A gateway is a dumb
+executor of centrally authorised work. It runs the same container image
+in a different mode, holds no local database, broadcast bus, console, or
+MCP endpoint, and **dials outbound only** — it polls the central
+instance for its assignment, executes read-only operations locally
+against the same connector surface, and reports results back. All
+authorisation, approval, and audit stay central; a gateway never
+self-authorises.
+
+The consequence is worth stating plainly to whoever is planning the
+rollout: **an enclave served only by a satellite gateway gets
+observation, not change automation.** Write workflows require the
+central backplane to reach the target itself. Design the segment map
+around that before anyone promises otherwise. Implementation detail:
+[`docs/codebase/satellite-runner.md`](https://github.com/evoila/meho/blob/main/docs/codebase/satellite-runner.md).
+The satellite gateway is a **Beta** feature — see the
+[feature maturity index](reference/maturity.md).
+
+**Every reachable segment is its own small project.** Routes, DNS, CA
+trust, and one more entry in `config.targetSsrfAllowlist` per segment.
+Zones reachable only through a jump host or a remote-desktop gateway are
+outside all of this — classify them as observe-only and scope them out
+explicitly rather than discovering it mid-install.
+
+**Budget for the tail, not the registration.** In one field
+deployment, twenty-two targets were registered in two days; the access,
+trust, and routing work behind them ran for weeks afterwards. Target
+registration is the fast part of this shape. Per-segment network
+identity is the slow part, and it is where the calendar actually goes.
+
+## Air-gapped
+
+The no-egress shape: every artefact is mirrored into the estate once,
+signature-verified on the way in, and the platform then runs with no
+internet path at all.
+
+```mermaid
+flowchart TB
+  subgraph outside["Outside, one-time offline transfer"]
+    src["Published artefacts: backplane image, Helm chart, Valkey image"]
+  end
+  subgraph estate["Air-gapped estate, no internet egress"]
+    mirror["Local registry mirror (signatures verified at import)"]
+    subgraph cluster["Cluster, namespace meho"]
+      bp["MEHO backplane (default embedding model baked into the image)"]
+      valkey["Valkey broadcast (single replica)"]
+    end
+    kc["Keycloak realm"]
+    pg["PostgreSQL + pgvector"]
+    vault["Credential backend"]
+    local["Local MCP clients and the meho CLI"]
+    targets["Targets (allowlisted internal ranges)"]
+  end
+  src -->|"mirrored offline"| mirror
+  mirror -->|"image and chart pulls"| cluster
+  local --> bp
+  bp -.-> kc
+  bp --> valkey
+  bp --> pg
+  bp --> vault
+  bp -->|"governed operations"| targets
+```
+
+**Pick this shape when** your estate has no internet egress — or when
+registry pulls must go through a mirror you control. It adds a mirroring
+workstream to whichever of the other shapes describes your network; it
+does not change the architecture.
+
+**A default install needs no internet egress.** The default embedding
+model (`BAAI/bge-small-en-v1.5`) is baked into the container image:
+offline, version-locked, no model download and no cache volume. The
+caveat is one-directional — setting a **custom**
+`config.retrievalEmbeddingModel` makes the backplane download it at
+runtime, which is exactly what an air-gapped estate cannot do. Keep the
+default model.
+
+**Three artefacts have to be mirrored:**
+
+1. the backplane image, `ghcr.io/evoila/meho`;
+2. the Helm chart, `oci://ghcr.io/evoila/meho-chart`;
+3. the broadcast subchart's Valkey image, `valkey/valkey` — it comes
+   from Docker Hub, not from the MEHO registry, and it is the one people
+   forget.
+
+All three are cosign keyless-signed, so the mirror import step can
+verify provenance before anything enters the estate; the verification
+commands are in the
+[repository README](https://github.com/evoila/meho#verify-image--chart--cli-signatures).
+
+**Cloud-hosted AI clients do not work here, and cannot be made to.**
+A hosted MCP client has to reach your backplane over the public
+internet. An air-gapped estate has no such path by definition, so this
+shape is local MCP clients and the `meho` CLI only. Set that expectation
+during planning rather than at handover — it is the single most common
+air-gap surprise.
+
+## Cloud-native without Vault (Google Secret Manager)
+
+The GCP-native shape: no Vault anywhere. Target credentials live in
+Google Secret Manager and are read under GKE Workload Identity — no
+service-account JSON keys — while the governed estate itself stays on
+private RFC 1918 ranges behind a VPN or interconnect.
+
+```mermaid
+flowchart TB
+  agent["Agent front (MCP client)"]
+  op["Operator front (CLI and browser console)"]
+  subgraph gke["GKE cluster, namespace meho"]
+    bp["MEHO backplane (Workload Identity SA, no SA keys)"]
+    valkey["Valkey broadcast (single replica)"]
+  end
+  kc["Keycloak realm"]
+  pg["PostgreSQL + pgvector"]
+  gsm["Google Secret Manager"]
+  sts["Google STS (optional per-operator federation)"]
+  subgraph estate["RFC 1918 estate (VPN or interconnect)"]
+    targets["Targets (allowlisted private ranges)"]
+  end
+  agent --> bp
+  op --> bp
+  bp -.-> kc
+  bp --> valkey
+  bp --> pg
+  bp -->|"credential reads via Workload Identity"| gsm
+  bp -.->|"exchange operator JWT (optional)"| sts
+  bp -->|"governed operations"| targets
+```
+
+**Pick this shape when** you want out of running Vault, your platform is
+GKE or GCP-adjacent, and you would rather not couple "read a credential"
+to "be on a particular network" — a managed secret store removes that
+coupling, since where the store lives becomes a cloud decision instead
+of a network one.
+
+**Setting it up.** `config.credentialBackend: gsm` selects the backend;
+`vault.address` stays blank, because the chart schema requires it only
+for the Vault backend. The health check's federation proof then reads
+through Secret Manager instead of Vault. Worked example:
+[`values-gsm-example.yaml`](https://github.com/evoila/meho/blob/main/deploy/values-examples/values-gsm-example.yaml);
+narrative in
+[`docs/deploying.md` § GSM / Vault-free](https://github.com/evoila/meho/blob/main/docs/deploying.md#gsm--vault-free).
+
+**Three things to plan for:**
+
+- **The private-address guard still applies.** Cloud-hosted backplane,
+  private estate — the RFC 1918 ranges behind your VPN or interconnect
+  must be allowlisted exactly as they would be on-premises.
+- **Per-target IAM is real work.** The reading identity needs
+  `roles/secretmanager.secretAccessor` **on each target secret**. That is
+  least privilege working as intended, but it is a per-secret grant, not
+  a one-time project-level toggle, and it is the step most likely to be
+  discovered at first probe rather than during planning.
+  ([`docs/codebase/connectors-shared-vault-creds.md` § GCP Secret Manager backend](https://github.com/evoila/meho/blob/main/docs/codebase/connectors-shared-vault-creds.md#gcp-secret-manager-backend-gsm).)
+- **Per-operator attribution obligates a background-dispatch
+  decision.** Turning on Workload Identity Federation
+  (`gsm.workloadIdentityFederation.audience`) makes credential reads run
+  as the *calling operator*, so Google's own audit log names the human
+  rather than the platform service account. But scheduled work — sensor
+  evaluations and other callers with no operator behind them — has no
+  token to federate. On a cluster without ambient pod identity you must
+  configure the `checkRunner.*` principal, or credentialed sensors read
+  nothing, forever and silently. The full decision matrix is in
+  [`docs/deploying.md` § Per-operator WIF and background dispatch](https://github.com/evoila/meho/blob/main/docs/deploying.md#per-operator-wif-and-background-dispatch-2642).
+
+The Google Secret Manager backend is a **Beta** feature — see the
+[feature maturity index](reference/maturity.md).
+
+## Multi-tenant MSP (target shape)
+
+!!! warning "This is a target shape, not a field-proven one"
+
+    The platform's tenancy primitives are real and shipped —
+    per-tenant token claims, tenant-scoped credential namespaces,
+    tenant-scoped policy and audit. What has *not* happened yet is a
+    production multi-customer estate running on them. Read the diagram
+    below as the design the primitives support, and treat a
+    multi-customer engagement as pioneering work rather than a
+    repeat of something already done. This label is deliberate: MEHO
+    publishes a [feature maturity index](reference/maturity.md) so
+    adopters can tell shipped-and-proven from shipped-and-untested,
+    and this shape belongs on the honest side of that line.
+
+```mermaid
+flowchart TB
+  subgraph tenA["Tenant A"]
+    agentA["Agent (MCP, tenant A claims)"]
+    opA["Operators (CLI and console, tenant A claims)"]
+  end
+  subgraph tenB["Tenant B"]
+    agentB["Agent (MCP, tenant B claims)"]
+    opB["Operators (CLI and console, tenant B claims)"]
+  end
+  subgraph central["MSP-operated cluster, namespace meho"]
+    bp["MEHO backplane (tenant-scoped policy, audit, approvals)"]
+    valkey["Valkey broadcast (single replica, shared)"]
+  end
+  kc["Keycloak (per-tenant identity claims)"]
+  pg["PostgreSQL + pgvector"]
+  vault["Vault KV-v2 (per-tenant subtree)"]
+  subgraph estateA["Customer A estate"]
+    targetsA["Targets (tenant A)"]
+  end
+  subgraph estateB["Customer B estate"]
+    targetsB["Targets (tenant B)"]
+  end
+  agentA --> bp
+  opA --> bp
+  agentB --> bp
+  opB --> bp
+  bp -.-> kc
+  bp --> valkey
+  bp --> pg
+  bp --> vault
+  bp -->|"tenant-A-scoped operations"| targetsA
+  bp -->|"tenant-B-scoped operations"| targetsB
+```
+
+**Pick this shape only when** you genuinely need one MEHO release
+governing several *customers'* estates, with per-tenant identity,
+credentials, targets, policy, and audit scoping. A single organisation
+with several internal teams does not need this — that is one tenant with
+several roles.
+
+**Tenant identity rides on token claims.** Every principal carries
+tenant claims from your Keycloak realm, and on the Vault backend the KV
+tenant-scope guard pins credential references under
+`secret/tenants/{tenant_id}/` — default-on since v0.15.0. The per-tenant
+layout is a first-class platform contract, not something bolted on for
+service providers.
+([`docs/deploying.md` § Version-specific upgrade notes](https://github.com/evoila/meho/blob/main/docs/deploying.md#version-specific-upgrade-notes).)
+
+**Network reality multiplies per tenant.** Each customer estate brings
+its own segments, allowlist ranges, CA trust, and possibly its own
+enclaves — the
+[segmented shape](#segmented-network-with-satellite-gateways) applies
+*inside every tenant*, and the effort scales with the number of
+estates, not the number of MEHO releases.
+
+**Two honest gaps to weigh up front.** There is no shipped worked
+example for this shape — no per-tenant values file ships with the chart,
+so the first deployment writes it. And the broadcast bus described
+[above](#broadcast-runs-single-replica-with-ephemeral-streams) is shared
+across all tenants: a restart loses unconsumed stream history for every
+tenant at once, and there is no per-tenant broadcast isolation today.
+For a service provider that is a real posture conversation, not a
+footnote.
+
+## Next step
+
+Once you have picked a shape, follow the
+[install trail](install/index.md) — the prerequisites and the
+credential-backend decision there are the same in every shape; the
+allowlist, the segment map, and the mirroring workstream are the parts
+your shape decides.
+
+## Sources
+
+Every operational claim on this page traces to a file in this
+repository:
+
+- [`docs/deploying.md`](https://github.com/evoila/meho/blob/main/docs/deploying.md)
+  — cold-install prerequisites (pgvector, `asyncpg` DSN, Keycloak
+  clients, MCP audience, CA bundle, pinned tag, baked-in default
+  embedding model); the Vault and Google Secret Manager install paths;
+  per-operator Workload Identity Federation and background dispatch;
+  operational chart knobs including `config.targetSsrfAllowlist`;
+  version-specific upgrade notes including the Vault tenant-scope
+  guard.
+- [`deploy/charts/meho/values.yaml`](https://github.com/evoila/meho/blob/main/deploy/charts/meho/values.yaml)
+  and
+  [`values.schema.json`](https://github.com/evoila/meho/blob/main/deploy/charts/meho/values.schema.json)
+  — the `broadcast:` block: single replica, schema-rejected replica
+  counts above 1, ephemeral streams, and the Valkey image source.
+- [`deploy/values-examples/`](https://github.com/evoila/meho/tree/main/deploy/values-examples)
+  — the sanitized on-premises archetype
+  (`values-rdc-example.yaml`), the Google Secret Manager archetype
+  (`values-gsm-example.yaml`), and the local rehearsal overlay
+  (`values-kind.yaml`, explicitly *not* a functional federation
+  deploy).
+- [`docs/codebase/satellite-runner.md`](https://github.com/evoila/meho/blob/main/docs/codebase/satellite-runner.md)
+  — the satellite gateway's outbound-only, read-only, no-local-state
+  design.
+- [Repository README](https://github.com/evoila/meho#verify-image--chart--cli-signatures)
+  — cosign keyless verification for the image, chart, and CLI.
+- [Feature maturity index](reference/maturity.md) — the shipped tier of
+  broadcast, the satellite gateway, the Google Secret Manager backend,
+  and every other non-GA feature named above.

--- a/docs-site/deployment-shapes.md
+++ b/docs-site/deployment-shapes.md
@@ -360,8 +360,8 @@ narrative in
   rather than the platform service account. But scheduled work — sensor
   evaluations and other callers with no operator behind them — has no
   token to federate. On a cluster without ambient pod identity you must
-  configure the `checkRunner.*` principal, or credentialed sensors read
-  nothing, forever and silently. The full decision matrix is in
+  configure the `checkRunner.*` principal, or credentialed sensors
+  evaluate `unknown` forever. The full decision matrix is in
   [`docs/deploying.md` § Per-operator WIF and background dispatch](https://github.com/evoila/meho/blob/main/docs/deploying.md#per-operator-wif-and-background-dispatch-2642).
 
 The Google Secret Manager backend is a **Beta** feature — see the

--- a/docs-site/deployment-shapes.md
+++ b/docs-site/deployment-shapes.md
@@ -227,8 +227,8 @@ identity is the slow part, and it is where the calendar actually goes.
 ## Air-gapped
 
 The no-egress shape: every artefact is mirrored into the estate once,
-signature-verified on the way in, and the platform then runs with no
-internet path at all.
+the MEHO-published ones signature-verified on the way in, and the
+platform then runs with no internet path at all.
 
 ```mermaid
 flowchart TB
@@ -236,7 +236,7 @@ flowchart TB
     src["Published artefacts: backplane image, Helm chart, Valkey image"]
   end
   subgraph estate["Air-gapped estate, no internet egress"]
-    mirror["Local registry mirror (signatures verified at import)"]
+    mirror["Local registry mirror (MEHO artefacts signature-verified at import)"]
     subgraph cluster["Cluster, namespace meho"]
       bp["MEHO backplane (default embedding model baked into the image)"]
       valkey["Valkey broadcast (single replica)"]
@@ -278,10 +278,14 @@ default model.
    from Docker Hub, not from the MEHO registry, and it is the one people
    forget.
 
-All three are cosign keyless-signed, so the mirror import step can
-verify provenance before anything enters the estate; the verification
-commands are in the
+The two MEHO-published artefacts — the backplane image and the Helm
+chart — are cosign keyless-signed, so the mirror import step can verify
+their provenance before they enter the estate; the verification commands
+are in the
 [repository README](https://github.com/evoila/meho#verify-image--chart--cli-signatures).
+The Valkey image is an upstream third-party image from Docker Hub and
+carries no MEHO signature — mirror it under whatever provenance policy
+your registry already applies to third-party base images.
 
 **Cloud-hosted AI clients do not work here, and cannot be made to.**
 A hosted MCP client has to reach your backplane over the public

--- a/docs/codebase/docs-site.md
+++ b/docs/codebase/docs-site.md
@@ -95,6 +95,11 @@ deploy.
 
 - `mkdocs.yml` is strict: a page not referenced in `nav`, or any
   broken internal link, fails the build. Add new pages to `nav`.
+- Mermaid diagrams render natively via the Material custom-fence
+  config on `pymdownx.superfences` (#2671). That config uses the
+  `!!python/name:` YAML tag, which `yaml.safe_load` rejects —
+  `mkdocs.yml` is therefore excluded from the pre-commit `check-yaml`
+  hook (the strict mkdocs build validates it far harder anyway).
 - The deploy job needs the `workflow`-scoped credential story only at
   *merge* time (the file under `.github/workflows/` requires the
   `workflow` OAuth scope to push).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,9 @@ theme:
     - content.action.edit
 
 nav:
-  - Start here: index.md
+  - Start here:
+      - index.md
+      - Deployment shapes: deployment-shapes.md
   - Install & operate: install/index.md
   - Connect clients: clients/index.md
   - Do real work: guides/index.md
@@ -64,7 +66,16 @@ markdown_extensions:
   - admonition
   - toc:
       permalink: true
-  - pymdownx.superfences
+  # The mermaid custom fence is the documented Material way to render
+  # ```mermaid blocks natively (theme-aware, no external JS):
+  # https://squidfunk.github.io/mkdocs-material/reference/diagrams/
+  # The `!!python/name:` tag is mkdocs-specific YAML — see the
+  # check-yaml exclude in .pre-commit-config.yaml.
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.snippets:
       # Repo root first so site pages can embed selected contributor
       # files (e.g. `docs/deploying.md`) in place, without moving them.


### PR DESCRIPTION
## Summary

- Adds **Deployment shapes** (`docs-site/deployment-shapes.md`, under *Start here*) — the five materially different ways a real estate deploys MEHO: **flat LAN**, **segmented network with satellite gateways**, **air-gapped**, **cloud-native without Vault (Google Secret Manager)**, and **multi-tenant MSP**. Each shape gets a rendered mermaid component diagram, a plain-language "pick this shape when", and the constraints that actually decide the install.
- Framing is **one chart, five topologies**, so the shared parts — components and who provides them, the private-address guard, the broadcast posture, render-time schema validation — are stated once up front instead of five times. A reader picks a shape *before* the install trail, because that decision fixes which address ranges get allowlisted, whether a credential store they don't already run is needed, and whether any part of the estate needs a gateway rather than a route.
- **Leads with the edges rather than burying them:** satellite gateways are read-only by design, so a satellite-only enclave gets observation and not change automation; air-gapped estates cannot use cloud-hosted MCP clients at all, and no configuration changes that; per-operator Workload Identity Federation obligates a background-dispatch decision or credentialed Sensors silently read nothing; and **multi-tenant MSP is labelled a target shape, not a field-proven one** — consistent with the feature-maturity honesty discipline, rendered as a `!!! warning` admonition and linked to the maturity index.
- **Every operational claim links a public file in this repo**, collected in the page's own *Sources* section: `docs/deploying.md`, `deploy/charts/meho/values.yaml` + `values.schema.json`, `deploy/values-examples/`, `docs/codebase/satellite-runner.md`, `docs/codebase/connectors-shared-vault-creds.md`, and the README's signature-verification section.
- **Mermaid rendering is enabled site-wide** via the Material-documented `pymdownx.superfences` custom fence. That config uses the `!!python/name:` YAML tag, which `yaml.safe_load` rejects, so `mkdocs.yml` joins the chart templates in the pre-commit `check-yaml` exclude — the strict mkdocs build validates the file far harder anyway.

## Coordination with #2722 (task #2671)

Deliberate scope split, agreed on #2671 before this PR was written:

| Owner | Slice |
|---|---|
| #2671 / #2722 | Landing page, the **single-system** reference-architecture page (`architecture.md`), the continuous install trail, and its side-quest pages (credential backends, Keycloak realm, TLS, upgrades, kind quickstart) |
| **this PR** | The **five deployment-shape** page alongside it, in the same *Start here* nav region |

No file is written by both PRs except the three noted below, and **those three hunks are byte-identical to #2722's** so a three-way merge resolves them without a conflict in either merge order. Verified, not assumed — `git merge-tree` against `docs/2671-start-here-install-trail`:

- `.pre-commit-config.yaml` — **auto-merges clean** (identical hunk).
- `mkdocs.yml` `markdown_extensions` (the mermaid fence) — **auto-merges clean** (identical hunk).
- `docs/codebase/docs-site.md` mermaid gotcha bullet — **auto-merges clean** (identical hunk).

Three conflicts remain, all of the keep-both / take-the-superset kind, with no semantic ambiguity:

1. `mkdocs.yml` `nav` — this PR adds `Deployment shapes: deployment-shapes.md` under *Start here*; #2722 adds `Reference architecture: architecture.md` there and expands *Install & operate*. **Resolution: keep both nav lines.**
2. `docs/codebase/docs-site.md` — degenerate: this PR's gotcha bullets are a strict prefix of #2722's (which adds one more, about anchor-slug validation). **Resolution: take #2722's superset.**
3. `CHANGELOG.md` — both insert a block directly under `## [Unreleased]`. **Resolution: keep both blocks.**

This PR deliberately links **only** pages that exist on `main` today (`install/index.md`, `reference/maturity.md`) plus absolute GitHub URLs for in-repo files, so the strict build stays green regardless of whether #2722 has landed.

## Test plan

- [x] `mkdocs build --strict` — clean (a page missing from `nav` or any broken internal link fails the build)
- [x] Second strict build with `validation.links.anchors: warn` via an inheriting config — clean; all 14 in-page anchors resolve, verified by parsing the built HTML
- [x] Mermaid renders natively: the built `deployment-shapes/index.html` contains **5** `<pre class="mermaid">` blocks (one per shape), and `mermaid` is present in the Material 9.7.7 JS bundle — no external JS, no `extra_javascript`
- [x] The `!!! warning` honesty admonition on the MSP shape renders (`class="admonition warning"` in the built HTML)
- [x] `yaml.safe_load` failure on the new `mkdocs.yml` reproduced (`ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/name:...'`) — the `check-yaml` exclude is load-bearing, not speculative; the new regex was checked to exclude `mkdocs.yml` and chart templates while still checking `values.yaml`, `.pre-commit-config.yaml`, and workflow YAML
- [x] `git merge-tree` against `docs/2671-start-here-install-trail` — three trivial conflicts, enumerated above; the three shared hunks auto-merge
- [x] Every claim cross-checked against its cited source: the pgvector / `asyncpg` / Keycloak / MCP-audience / CA-bundle / pinned-tag / baked-in-embedding-model prerequisite rows; `config.targetSsrfAllowlist` semantics; the `broadcast:` single-replica cap (`values.schema.json` `minimum: 1, maximum: 1`) and ephemeral streams (`save ""` / `appendonly no` on an `emptyDir`-backed mount); the satellite runner's outbound-only, `safety_level == "safe"`, no-local-state design; the GSM backend's blank `vault.address`, per-secret `roles/secretmanager.secretAccessor`, and the background-dispatch matrix; the v0.15.0 Vault tenant-scope guard; cosign keyless signing for image + chart + CLI
- [x] Postulate check — no per-operation MCP tools and no vendor-specific tool names appear anywhere on the page; the agent front is described only as "agents reach it over MCP", with one shared governed dispatch path
- [x] Public-sources check — zero links to non-public repositories; zero references to internal decision records; the broadcast/HA posture is paraphrased from the chart's own public statements. Field evidence appears once, fully anonymized ("in one field deployment, twenty-two targets were registered in two days; the access, trust, and routing work behind them ran for weeks")
- [x] `docs/deploying.md` and `deploy/values-examples/README.md` are unchanged and remain valid — this page links *into* them as the deep-dive rather than restating them, so no orphaned duplicate guidance is created
- [x] Trailing-whitespace / final-newline / CRLF sweep on all five changed files; `code-quality.py --diff` clean
- [x] CHANGELOG `[Unreleased]` entry under a unique `###` header

## Out of scope

- The rest of #2671 — landing page, the single-system reference-architecture page, and the install trail (#2722).
- A public **sizing** page: named in the #2663 IA but unclaimed upstream, so effort/sizing language was deliberately kept off this page rather than smuggled in.
- Client-side setup and the MCP client matrix (#2672); task guides (#2673).
- Adjacent finding, not touched: `docs-site/index.md`'s "site at a glance" table and its *Start here* section preview still describe the section as under construction and do not mention this page. #2722 rewrites that landing page wholesale, so editing it here would collide for no benefit — whichever PR lands second should add the one-line pointer.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes evoila-bosnia/meho-internal#192


---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-01)

Addressed the review's single blocker (see the [inline thread](https://github.com/evoila/meho/pull/2725#discussion_r3693927561)):

- **B1** `9687e51b` — the air-gap shape claimed all three artefacts to mirror are cosign keyless-signed, citing the README's verification section. That section covers the image, the chart, and the CLI tarball; `valkey/valkey` is an upstream Docker Hub image this project neither builds nor signs, so no bundle for it can satisfy the README's identity regexps. The claim is now scoped to the two published artefacts, with the Valkey image stated as third-party and unsigned by MEHO, to be mirrored under the operator's own provenance policy for base images. The two softer echoes of the same over-claim — the shape's opening line and the mirror node in the component diagram — were tightened in the same commit. The Sources entry was already correctly scoped and is unchanged.

Deliberately not done: substituting Chainguard's Sigstore-signed `cgr.dev/chainguard/valkey`. It is a different image from the one the chart pulls; swapping it to rescue the sentence would silently change what gets deployed.

Nothing disputed, nothing deferred.

Re-verified after the fix: `mkdocs build --strict` clean, still 5 `<pre class="mermaid">` blocks on the page, trailing-whitespace / final-newline / CRLF sweep clean. The three hunks shared with #2722 were not touched and remain byte-identical, so the merge stays conflict-free in either order.

<!-- auto-implement-issue: continue, iteration 1 -->


---

## Follow-up (auto-implement-issue, iteration 2, 2026-08-01)

Iteration 2's review raised two findings, both the same species as B1 — a claim on the page that its own cited in-repo source contradicts. Both verified against the sources directly before editing, both fixed.

- **B2** `dced859d` — the section asserted a universal ("The chart fails at render time, not at runtime" / "a mistake in any shape below surfaces at install time"), citing `docs/deploying.md` § Deploy from cold. That table labels the MCP-audience row one of two *chart-handled* fixes, and four other rows in it document mistakes that surface after render: pgvector `permission denied to create extension "vector"` from the pre-install migration Job, a bare `postgresql://` DSN that fails at connect, the internal-CA trust bundle, and the first-boot `startupProbe` budget. Read `deploy/charts/meho/values.schema.json` to confirm the other direction: it constrains the shape of chart values only and cannot check that an extension exists, a database answers, DNS resolves, a CA is trusted, or a credential backend granted the read. The guarantee is now scoped to schema validation and names what the schema cannot check; the #2394 MCP-audience example is kept verbatim; the heading no longer asserts the universal on its own. ([inline thread](https://github.com/evoila/meho/pull/2725#discussion_r3693988118))
- **M1** `23a5210a` — "credentialed sensors read nothing, forever and silently" contradicted three in-repo sources, which all say the sensors evaluate a *visible* `unknown` forever (`docs/codebase/sensor.md:111-113`, `docs/deploying.md` § Per-operator WIF and background dispatch, and the shipped #2642 CHANGELOG entry). `unknown` is a first-class member of the shipped five-state vocabulary at `sensor.md:31`, so "silently" inverted the detection story — the failure is conspicuous on the dashboard, and that is the signal an operator diagnoses it by. Fixed with the repository's existing wording in both places: the page and the CHANGELOG entry. ([inline thread](https://github.com/evoila/meho/pull/2725#discussion_r3693988491))

Nothing disputed, nothing deferred.

Two notes on diff shape, both deliberate. The B2 citation parenthetical now reads "the MCP-audience row for the example, the rest of the table for what surfaces later" — same link, no new claim, but the citation had to stop pointing at one row once the paragraph drew on the rest of the table. The M1 CHANGELOG diff is five lines rather than two because the replacement phrase pushed one line to 79 characters in a paragraph the file hand-wraps at ≤71, so the paragraph tail is re-wrapped; no other content change.

Re-verified after the fixes: `mkdocs build --strict` exits 0 with no warnings, the page still emits 5 `<pre class="mermaid">` blocks, and a repository-wide grep for the old phrasings returns nothing. The B1 fix text, the keep-both CHANGELOG resolution (both `###` blocks under `## [Unreleased]`), and the three hunks shared with #2722 — the pre-commit config, the `mkdocs.yml` custom-fence block, and the docs-site codebase bullet — were all left untouched and verified byte-identical to the previous head.

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a deployment shapes guide covering five deployment topologies, including LAN, segmented, air-gapped, cloud-native, and multi-tenant environments.
  * Added diagrams, selection guidance, prerequisites, operational limitations, installation details, and topology-specific considerations.
  * Updated documentation navigation and Mermaid diagram rendering configuration.
  * Documented YAML validation considerations for the documentation build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
