### PR TITLE
feat(checks): in-band checks_alert_advisory on dispatch responses, deduped per caller and state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — checks advisory: non-green Dashboards surface on dispatch responses (#2718)
+
+- Successful dispatch responses — agent `call_operation` and the
+  operator CLI's `--json` envelope, read ops included — now carry a
+  compact `extras["checks_alert_advisory"]` naming any Dashboard in
+  the caller's tenant whose rollup memo is `degraded`/`critical`, once
+  per (caller, dashboard, state) window (Valkey `SET NX EX` dedupe;
+  `CHECKS_ALERT_ADVISORY_WINDOW_MINUTES`, default 30, `0` disables).
+  At most 10 Dashboards ride one fragment, ordered by name — an
+  awareness nudge, not an audit — and their dedupe claims are staged
+  into one pipelined Valkey round-trip, so a tenant-wide outage adds
+  neither an unbounded read nor a per-Dashboard round-trip to every
+  successful dispatch.
+  Advisory only: fail-open, never gates a dispatch; second extras
+  fragment beside the #2550 target-activity advisory. The CLI's
+  default human render prints `extras` only for non-ok statuses, so
+  operators reach the fragment through `--json` today. (#2718)
 ### Added — docs site: Start here, reference architecture, and the install trail (#2671)
 
 - Fill the docs site's *Start here* and *Install & operate* sections

--- a/backend/src/meho_backplane/checks/advisory.py
+++ b/backend/src/meho_backplane/checks/advisory.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Dispatch-time checks-alert advisory (#2718, Initiative #2716).
+
+When the caller's tenant has a Dashboard whose ``last_rollup_state``
+memo (#2506's column, maintained exactly-once-per-transition by #2507's
+compare-and-swap at the persist seam) is ``degraded`` or ``critical``,
+the next successful dispatch response carries one compact
+``extras["checks_alert_advisory"]`` entry naming it -- once per
+``(caller, dashboard, state)`` window, deduped by an atomic Valkey
+``SET NX EX``. Ambient awareness for anyone actively working through
+the backplane: agent ``call_operation`` and operator CLI dispatches ride
+the same path, so the fragment is on the wire for both without anyone
+polling anything. Reaching the *operator's terminal* is a separate
+question -- ``meho operation call`` prints ``extras`` on its human
+render only for non-ok statuses, so the advisory surfaces there through
+``--json`` today (see ``docs/codebase/checks-advisory.md``).
+
+This is the second ``extras`` fragment beside the #2550
+``target_activity_advisory`` (:mod:`meho_backplane.broadcast.history`),
+and it deliberately diverges from that precedent in one way: it applies
+to **all** op classes, read dispatches included. The #2550 gate to
+write-class ops exists because that advisory is target-overlap-specific
+-- it warns about concurrent mutation crossfire, which only matters when
+the caller is about to mutate. A non-green Dashboard concerns every
+active caller in the tenant regardless of what they are dispatching, so
+gating here would defeat the feature. The per-caller NX dedupe is what
+keeps the all-classes reach from becoming spam: each caller hears about
+a given ``(dashboard, state)`` once per window.
+
+Design contract (mirrors the #2550 mould):
+
+* **Advisory only.** Never gates, blocks, or fails a dispatch. The
+  fragment is appended to an already-successful response.
+* **Fail-open.** A broad guard swallows any DB or Valkey error,
+  warn-logs ``checks_alert_advisory_failed``, and returns ``{}`` -- the
+  lookup never converts a successful dispatch into a failure.
+* **Bounded.** Two round-trips per successful dispatch, whatever the
+  tenant's state: one indexed read (``check_dashboard_tenant_idx``) of
+  the memo column, capped at :data:`_ADVISORY_MAX_DASHBOARDS` rows, then
+  one pipelined Valkey batch staging at most that many ``SET`` commands.
+  A green tenant pays only the SELECT. Neither the cost nor the fragment
+  grows when a correlated failure reddens a whole tenant at once -- the
+  case both bounds exist for.
+* **``0`` disables.** ``CHECKS_ALERT_ADVISORY_WINDOW_MINUTES`` (default
+  30) short-circuits before any I/O when ``0``.
+* **Memo-backed states only.** The advisory reads the transition memo,
+  not the on-read rollup, so a staleness-derived ``unknown`` (which the
+  memo never holds mid-window) is not reflected -- a deliberate,
+  documented limitation acceptable for an awareness nudge. A ``NULL``
+  memo (never-transitioned Dashboard) yields no advisory.
+* **Server-derived fields only.** Each entry is
+  ``{dashboard_id, name, state}`` read straight off the row -- no
+  free-form text lifted from sensor evidence enters the op response
+  (the untrusted-prose discipline of Initiative #2543).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Final
+
+import structlog
+from sqlalchemy import select
+
+from meho_backplane.auth.delegation import resolve_actor_sub
+from meho_backplane.auth.operator import Operator
+from meho_backplane.broadcast.client import get_broadcast_client
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import CheckDashboard
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "CHECKS_ADVISORY_EXTRAS_KEY",
+    "build_checks_alert_advisory",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The ``extras`` key the advisory rides on the ``OperationResult`` --
+#: sibling of :data:`meho_backplane.broadcast.history.ADVISORY_EXTRAS_KEY`.
+CHECKS_ADVISORY_EXTRAS_KEY: Final[str] = "checks_alert_advisory"
+
+#: Memo states that surface. ``degraded`` / ``critical`` only -- ``ok``
+#: needs no nudge, ``skip`` is a deliberate opt-out, and ``unknown`` in
+#: the memo means "cannot evaluate", which the investigator surface owns.
+_ADVISORY_STATES: Final[tuple[str, ...]] = ("degraded", "critical")
+
+#: How many non-green Dashboards one dispatch pays for. One SELECT is
+#: both the read and the entry source here, so this single cap bounds
+#: the query, the ``SET`` commands staged, and the fragment together --
+#: and keeping claims and entries equal is what makes a claimed dedupe
+#: key mean "this caller was told".
+#:
+#: Sized as an awareness nudge, not an audit: the rationale of the #2550
+#: precedent's
+#: :data:`~meho_backplane.broadcast.history._ADVISORY_MAX_ENTRIES`
+#: (``5``), which is the constant this one plays the role of. Its
+#: sibling ``_ADVISORY_SCAN_LIMIT = 100`` bounds a single ``XREVRANGE``
+#: -- one round-trip whatever the count -- so its *value* carries no
+#: argument for a cap that also decides what the agent reads. What the
+#: value buys here is bytes of unsolicited agent context, and entry 11
+#: of a nudge is worth ~nothing against that; a tenant that far into the
+#: red is the checks surface's problem, not an advisory's.
+#: ``ORDER BY name`` makes the truncation deterministic.
+_ADVISORY_MAX_DASHBOARDS: Final[int] = 10
+
+
+def _dedupe_key(
+    tenant_id: uuid.UUID,
+    principal_sub: str,
+    actor_sub: str | None,
+    dashboard_id: uuid.UUID,
+    state: str,
+) -> str:
+    """Valkey key deduping one ``(caller, dashboard, state)`` per window.
+
+    Caller identity is the ``(principal_sub, actor_sub)`` pair -- the
+    same pair the #2550 advisory uses for its self-activity drop -- so a
+    delegated agent and its human principal each get their own reminder.
+    An unbound actor renders as ``-``. A state change mints a new key,
+    so escalation (``degraded`` -> ``critical``) re-announces
+    immediately; window expiry re-reminds on unchanged state.
+
+    The two sub segments are free-form and the delimiter is ``:``, so
+    two distinct ``(principal, actor)`` pairs could in principle render
+    the same key (e.g. ``a:b``/``-`` vs ``a``/``b:-``). The UUID + closed-
+    vocabulary segments anchor both ends, the aliasing window is one
+    reminder wide, and the payload is advisory-only -- not worth an
+    escaping scheme.
+    """
+    return (
+        f"meho:checks:advisory:{tenant_id}:{principal_sub}:"
+        f"{actor_sub or '-'}:{dashboard_id}:{state}"
+    )
+
+
+async def _non_green_dashboards(
+    tenant_id: uuid.UUID,
+) -> list[tuple[uuid.UUID, str, str]]:
+    """Read ``(id, name, last_rollup_state)`` for non-green memo rows.
+
+    One SELECT riding ``check_dashboard_tenant_idx``; rows whose memo is
+    ``NULL`` (never transitioned) or outside :data:`_ADVISORY_STATES`
+    never match. Ordered by name and capped at
+    :data:`_ADVISORY_MAX_DASHBOARDS`, so the fragment is deterministic
+    and the caller's per-dispatch cost does not scale with how much of
+    the tenant is broken.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = await session.execute(
+            select(CheckDashboard.id, CheckDashboard.name, CheckDashboard.last_rollup_state)
+            .where(
+                CheckDashboard.tenant_id == tenant_id,
+                CheckDashboard.last_rollup_state.in_(_ADVISORY_STATES),
+            )
+            .order_by(CheckDashboard.name)
+            .limit(_ADVISORY_MAX_DASHBOARDS)
+        )
+        return [(row[0], row[1], row[2]) for row in rows.all()]
+
+
+async def _claim_unannounced(
+    candidates: list[tuple[str, dict[str, Any]]],
+    window_seconds: int,
+) -> list[dict[str, Any]]:
+    """Claim each candidate's dedupe key; return the entries that won.
+
+    Every key is claimed with ``SET key 1 NX EX <window-seconds>``, all
+    of them staged into one pipelined ``MULTI``/``EXEC`` batch: a single
+    awaited round-trip however many Dashboards are red. Batching is what
+    bounds the cost -- a claim has to be issued before anyone can know
+    whether it will succeed, so the NX dedupe cannot save the round-trip
+    it rides on, and an unpipelined loop would pay one per row on
+    *every* successful dispatch for as long as the tenant is red.
+
+    An entry survives only when its own claim succeeded
+    (``parse_set_result`` yields ``True`` for OK and ``None`` when the
+    key already exists -- verified against the pinned redis-py 8.0.1,
+    whose ``Pipeline`` shares the client's response-callback table, so
+    buffering does not change the shape).
+
+    ``transaction=True`` (MULTI/EXEC, the idiom in
+    ``broadcast/rate_limit.py``) so a mid-batch teardown cannot leave
+    some keys claimed while the caller's fail-open guard discards the
+    entries they stood for.
+    """
+    client = get_broadcast_client()
+    async with client.pipeline(transaction=True) as pipe:
+        for key, _entry in candidates:
+            pipe.set(key, "1", nx=True, ex=window_seconds)
+        claims = await pipe.execute()
+    return [entry for (_key, entry), claimed in zip(candidates, claims, strict=True) if claimed]
+
+
+async def build_checks_alert_advisory(operator: Operator) -> dict[str, Any]:
+    """Build the ``extras`` fragment naming the tenant's non-green Dashboards.
+
+    Returns ``{"checks_alert_advisory": [{"dashboard_id", "name",
+    "state"}, ...]}`` or an empty dict (no key added) when the advisory
+    does not apply. The empty-dict short-circuits, in order:
+
+    * the feature is disabled (``checks_alert_advisory_window_minutes
+      == 0`` -- checked before any DB or Valkey I/O);
+    * the tenant has no Dashboard with a ``degraded`` / ``critical``
+      memo (the indexed SELECT is the only I/O paid);
+    * every non-green Dashboard was already announced to this caller in
+      the current window (each ``SET NX`` found its key present).
+
+    Each surviving row's ``(caller, dashboard, state)`` dedupe key is
+    claimed through :func:`_claim_unannounced`, which batches every
+    claim into one Valkey round-trip and keeps only the Dashboards whose
+    key it won. The Valkey TTL key IS the delivery state: nothing
+    durable is persisted; a Valkey flush re-reminds each caller once.
+
+    Note for sizing :data:`_ADVISORY_MAX_DASHBOARDS`: ``extras`` is
+    attached after the dispatcher has already reduced the payload, so
+    this fragment never passes through JSONFlux/result-handle
+    reduction -- the cap is the only bound on the context it adds.
+
+    Fail-open: any error -- DB teardown, Valkey teardown, anything --
+    is swallowed by the broad guard, warn-logged as
+    ``checks_alert_advisory_failed``, and yields ``{}``.
+    """
+    window_minutes = get_settings().checks_alert_advisory_window_minutes
+    if window_minutes <= 0:
+        return {}
+    try:
+        rows = await _non_green_dashboards(operator.tenant_id)
+        if not rows:
+            return {}
+        actor_sub = resolve_actor_sub()
+        entries = await _claim_unannounced(
+            [
+                (
+                    _dedupe_key(operator.tenant_id, operator.sub, actor_sub, dashboard_id, state),
+                    {"dashboard_id": str(dashboard_id), "name": name, "state": state},
+                )
+                for dashboard_id, name, state in rows
+            ],
+            window_minutes * 60,
+        )
+    except Exception:
+        # Advisory is best-effort awareness; any failure (a DB or Valkey
+        # teardown included) must never convert a successful dispatch
+        # into a failure.
+        _log.warning(
+            "checks_alert_advisory_failed",
+            tenant_id=str(operator.tenant_id),
+        )
+        return {}
+    if not entries:
+        return {}
+    return {CHECKS_ADVISORY_EXTRAS_KEY: entries}

--- a/backend/src/meho_backplane/operations/_errors.py
+++ b/backend/src/meho_backplane/operations/_errors.py
@@ -1494,8 +1494,8 @@ def wrap_ok_result(
 
     *extras* carries envelope-extension fields the dispatcher computes on
     the success path -- currently the dispatch-time target-activity
-    advisory (#2550). ``None`` leaves the frozen model's ``{}`` default
-    intact.
+    advisory (#2550) and the checks-alert advisory (#2718). ``None``
+    leaves the frozen model's ``{}`` default intact.
     """
     if payload is None or isinstance(payload, (dict, list)):
         result_value: dict[str, Any] | list[Any] | None = payload

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -226,6 +226,7 @@ import hvac.exceptions
 from meho_backplane.auth.operator import Operator
 from meho_backplane.broadcast.events import classify_op, scrub_secret_named_values
 from meho_backplane.broadcast.history import build_target_activity_advisory
+from meho_backplane.checks.advisory import build_checks_alert_advisory
 from meho_backplane.connectors import (
     OperationResult,
     ResolutionLabel,
@@ -772,12 +773,23 @@ async def _reduce_and_audit_success(
         redaction_policy_id=redaction.policy_id,
         handle_metadata=_handle_metadata_for_audit(handle),
     )
-    advisory = await build_target_activity_advisory(
+    activity_advisory = await build_target_activity_advisory(
         operator,
         op_id=descriptor.op_id,
         target_name=getattr(target, "name", None),
     )
-    return wrap_ok_result(op_id, summary, duration_ms, handle, extras=advisory)
+    # Second extras fragment beside #2550: the checks-alert advisory
+    # (#2718) applies to ALL op classes (its builder documents why) and
+    # is deduped per (caller, dashboard, state); distinct keys, so a
+    # plain merge can never clobber either fragment.
+    checks_advisory = await build_checks_alert_advisory(operator)
+    return wrap_ok_result(
+        op_id,
+        summary,
+        duration_ms,
+        handle,
+        extras={**activity_advisory, **checks_advisory},
+    )
 
 
 async def _run_branch_with_error_handling(

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1066,6 +1066,14 @@ class Settings(BaseModel):
     #: ``extras["target_activity_advisory"]`` on its response. ``0``
     #: disables the feature entirely (no stream read on any dispatch).
     dispatch_activity_advisory_window_minutes: int = Field(default=30, ge=0)
+    #: Dedupe window (minutes) for the dispatch-time checks-alert
+    #: advisory (#2718). A successful dispatch by a caller whose tenant
+    #: has a Dashboard with a ``degraded``/``critical``
+    #: ``last_rollup_state`` memo carries a compact
+    #: ``extras["checks_alert_advisory"]`` once per (caller, dashboard,
+    #: state) window. ``0`` disables the feature entirely (no DB read on
+    #: any dispatch).
+    checks_alert_advisory_window_minutes: int = Field(default=30, ge=0)
     # Broadcast v2 T2 (#2547) -- durable-announcement retention prune
     # knobs. ``days=0`` is the keep-forever opt-out sentinel;
     # ``enabled=False`` skips starting the background task entirely
@@ -1722,6 +1730,9 @@ def get_settings() -> Settings:
         ),
         dispatch_activity_advisory_window_minutes=int(
             os.environ.get("DISPATCH_ACTIVITY_ADVISORY_WINDOW_MINUTES", "30"),
+        ),
+        checks_alert_advisory_window_minutes=int(
+            os.environ.get("CHECKS_ALERT_ADVISORY_WINDOW_MINUTES", "30"),
         ),
         broadcast_announcement_retention_days=int(
             os.environ.get("BROADCAST_ANNOUNCEMENT_RETENTION_DAYS", "90"),

--- a/backend/tests/test_checks_advisory.py
+++ b/backend/tests/test_checks_advisory.py
@@ -1,0 +1,595 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Dispatch-time checks-alert advisory (#2718, Initiative #2716).
+
+A successful dispatch by a caller whose tenant has a Dashboard with a
+``degraded``/``critical`` ``last_rollup_state`` memo carries a compact
+``extras["checks_alert_advisory"]`` naming it -- once per (caller,
+dashboard, state) window via a Valkey ``SET NX EX`` dedupe. Advisory
+only: it never gates a dispatch, and every failure mode fails open.
+
+Coverage mirrors the acceptance criteria on the issue, by name:
+
+* the ``0`` window knob short-circuits before any DB or Valkey I/O;
+* a green tenant (``NULL`` / ``ok`` memos) yields no advisory and no
+  Valkey call;
+* NX dedupe -- the same caller sees a given (dashboard, state) once per
+  window; a state change mints a new key and re-announces;
+* per-caller isolation -- distinct principals each get their own
+  reminder;
+* the ``_ADVISORY_MAX_DASHBOARDS`` cap bounds both the fragment and the
+  ``SET`` commands staged when a whole tenant goes red, and the claims
+  cost exactly one awaited round-trip however many rows survive it;
+* a Valkey teardown and a DB teardown both fail open (``{}``,
+  warn-logged, dispatch unaffected);
+* dispatch integration -- a successful ``dispatch()`` response carries
+  the fragment (read-class op included -- the deliberate divergence
+  from the write-gated #2550 precedent) and an immediate second
+  dispatch by the same caller does not;
+* coexistence -- the #2550 ``target_activity_advisory`` and this
+  fragment ride the same ``extras`` on one write-class response.
+
+The Valkey pipeline is faked with real NX-per-key semantics (a dict)
+and real buffering, so the dedupe assertions exercise the actual claim
+protocol and the round-trip count is observable; the broadcast client
+never opens a socket (the stub URL + per-test method patches, mirroring
+``test_broadcast_target_advisory``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from sqlalchemy import update
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.broadcast import (
+    BroadcastEvent,
+    get_broadcast_client,
+    reset_broadcast_client_for_testing,
+)
+from meho_backplane.broadcast.history import ADVISORY_EXTRAS_KEY
+from meho_backplane.checks.advisory import (
+    _ADVISORY_MAX_DASHBOARDS,
+    CHECKS_ADVISORY_EXTRAS_KEY,
+    build_checks_alert_advisory,
+)
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import CheckDashboard, Tenant
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.settings import get_settings
+
+_TENANT = UUID("00000000-0000-0000-0000-00000000c0c0")
+_AUDIT_ID = UUID("55555555-5555-5555-5555-555555555555")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin required settings + a stub broadcast URL; reset the client cache.
+
+    Mirrors ``test_broadcast_target_advisory``: the Valkey client is
+    rebuilt against a stub URL and every command it would issue is
+    patched per-test, so no socket ever opens.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
+    monkeypatch.setenv("CHECKS_ALERT_ADVISORY_WINDOW_MINUTES", "30")
+    get_settings.cache_clear()
+    reset_broadcast_client_for_testing()
+    yield
+    reset_broadcast_client_for_testing()
+    get_settings.cache_clear()
+
+
+def _operator(sub: str = "user-b", *, tenant_id: UUID = _TENANT) -> Operator:
+    return Operator(
+        sub=sub,
+        name=sub,
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=PrincipalKind.USER,
+    )
+
+
+async def _seed_dashboard(
+    *,
+    name: str = "prod-health",
+    state: str | None = "critical",
+    tenant_id: UUID = _TENANT,
+) -> UUID:
+    """Insert a tenant (idempotent) + one dashboard with the given memo."""
+    dashboard_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if await session.get(Tenant, tenant_id) is None:
+            session.add(Tenant(id=tenant_id, slug=f"t-{tenant_id.hex[:8]}", name="Tenant"))
+        session.add(
+            CheckDashboard(
+                id=dashboard_id,
+                tenant_id=tenant_id,
+                name=name,
+                created_by_sub="op-admin",
+                last_rollup_state=state,
+            )
+        )
+        await session.commit()
+    return dashboard_id
+
+
+async def _set_memo(dashboard_id: UUID, state: str) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await session.execute(
+            update(CheckDashboard)
+            .where(CheckDashboard.id == dashboard_id)
+            .values(last_rollup_state=state)
+        )
+        await session.commit()
+
+
+class _FakeNxStore:
+    """Dict-backed pipelined ``SET NX`` double with the real contract.
+
+    Buffers like redis-py 8.0.1's async ``Pipeline``: ``pipe.set(...)``
+    stages the command and returns the pipeline synchronously, and the
+    awaited ``execute()`` is the one round-trip that replies with a
+    result per staged command. Results carry ``parse_set_result``'s
+    shape -- ``True`` when the key was absent (claimed), ``None`` when it
+    already existed. TTL is not modelled: window expiry is Valkey's
+    contract, not this feature's logic.
+
+    ``ex_values`` records every ``SET`` staged and ``round_trips`` every
+    awaited ``execute()``, so a test can assert the fan-out's *size* and
+    its *cost* separately -- the two halves of the bound.
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.ex_values: list[int] = []
+        self.round_trips: int = 0
+        self._staged: list[tuple[str, str, int]] = []
+
+    def pipeline(self, transaction: bool = True) -> _FakeNxStore:
+        assert transaction, "the advisory claims in one MULTI/EXEC batch"
+        self._staged = []
+        return self
+
+    async def __aenter__(self) -> _FakeNxStore:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        return None
+
+    def set(
+        self, name: str, value: str, *, nx: bool = False, ex: int | None = None
+    ) -> _FakeNxStore:
+        assert nx, "the advisory must claim with NX"
+        assert ex is not None and ex > 0, "the advisory must set a TTL"
+        self._staged.append((name, value, ex))
+        return self
+
+    async def execute(self) -> list[Any]:
+        self.round_trips += 1
+        staged, self._staged = self._staged, []
+        results: list[Any] = []
+        for name, value, ex in staged:
+            self.ex_values.append(ex)
+            if name in self.store:
+                results.append(None)
+            else:
+                self.store[name] = value
+                results.append(True)
+        return results
+
+
+def _patch_nx(store: _FakeNxStore) -> Any:
+    return patch.object(get_broadcast_client(), "pipeline", new=store.pipeline)
+
+
+# ---------------------------------------------------------------------------
+# Disable knob + green tenant
+# ---------------------------------------------------------------------------
+
+
+async def test_window_zero_short_circuits_no_db_no_valkey(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``0`` disables the feature -- no sessionmaker call, no Valkey call."""
+    monkeypatch.setenv("CHECKS_ALERT_ADVISORY_WINDOW_MINUTES", "0")
+    get_settings.cache_clear()
+    db_stub = MagicMock(side_effect=AssertionError("DB must not be touched"))
+    valkey_pipeline = MagicMock(side_effect=AssertionError("Valkey must not be touched"))
+    with (
+        patch("meho_backplane.checks.advisory.get_sessionmaker", new=db_stub),
+        patch.object(get_broadcast_client(), "pipeline", new=valkey_pipeline),
+    ):
+        advisory = await build_checks_alert_advisory(_operator())
+    assert advisory == {}
+    db_stub.assert_not_called()
+
+
+async def test_green_tenant_yields_empty_and_no_valkey_call() -> None:
+    """``NULL`` and ``ok`` memos never match -- no fragment, no ``SET``."""
+    await _seed_dashboard(name="never-transitioned", state=None)
+    await _seed_dashboard(name="recovered", state="ok")
+    valkey_pipeline = MagicMock()
+    with patch.object(get_broadcast_client(), "pipeline", new=valkey_pipeline):
+        advisory = await build_checks_alert_advisory(_operator())
+    assert advisory == {}
+    valkey_pipeline.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# NX dedupe + state-change re-announce + per-caller isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_non_green_dashboard_surfaces_once_per_window() -> None:
+    """First call carries the fragment; the same caller's second call doesn't."""
+    dashboard_id = await _seed_dashboard(state="critical")
+    store = _FakeNxStore()
+    with _patch_nx(store):
+        first = await build_checks_alert_advisory(_operator())
+        second = await build_checks_alert_advisory(_operator())
+    assert first == {
+        CHECKS_ADVISORY_EXTRAS_KEY: [
+            {"dashboard_id": str(dashboard_id), "name": "prod-health", "state": "critical"}
+        ]
+    }
+    assert second == {}
+    # The dedupe key carries the 30-minute window as the TTL.
+    assert store.ex_values == [30 * 60, 30 * 60]
+    # One batch per dispatch -- never one per row.
+    assert store.round_trips == 2
+
+
+async def test_state_change_mints_new_key_and_re_announces() -> None:
+    """Escalation to a different state re-announces inside the window."""
+    dashboard_id = await _seed_dashboard(state="degraded")
+    store = _FakeNxStore()
+    with _patch_nx(store):
+        first = await build_checks_alert_advisory(_operator())
+        await _set_memo(dashboard_id, "critical")
+        escalated = await build_checks_alert_advisory(_operator())
+    assert first[CHECKS_ADVISORY_EXTRAS_KEY][0]["state"] == "degraded"
+    assert escalated[CHECKS_ADVISORY_EXTRAS_KEY][0]["state"] == "critical"
+    # Two distinct dedupe keys were claimed -- one per state.
+    assert len(store.store) == 2
+
+
+async def test_per_caller_isolation_each_principal_reminded_once() -> None:
+    """Distinct principals each claim their own key for the same dashboard."""
+    dashboard_id = await _seed_dashboard(state="critical")
+    store = _FakeNxStore()
+    with _patch_nx(store):
+        for sub in ("user-a", "user-b"):
+            advisory = await build_checks_alert_advisory(_operator(sub))
+            assert advisory[CHECKS_ADVISORY_EXTRAS_KEY][0]["dashboard_id"] == str(dashboard_id)
+        # Both callers are now deduped independently.
+        assert await build_checks_alert_advisory(_operator("user-a")) == {}
+        assert await build_checks_alert_advisory(_operator("user-b")) == {}
+    assert len(store.store) == 2
+
+
+# ---------------------------------------------------------------------------
+# Bounded fan-out (M1, PR #2726 review iteration 1)
+# ---------------------------------------------------------------------------
+
+
+async def test_tenant_wide_outage_caps_fragment_and_valkey_fanout() -> None:
+    """More non-green Dashboards than the cap costs exactly the cap.
+
+    The finding this pins: without ``.limit()`` the SELECT and the one-
+    ``SET``-per-row fan-out are O(non-green Dashboards) on *every*
+    successful dispatch, and that load correlates with incidents -- a
+    correlated failure reddens many Dashboards at once. Asserting on
+    ``len(store.ex_values)`` (``SET`` commands actually issued) rather
+    than only on the fragment length is what makes this a fan-out test:
+    a cap applied in Python after the claims would satisfy the entry
+    count and still leave the fan-out unbounded.
+
+    ``round_trips`` is the other half of the bound, and the one the NX
+    dedupe cannot help with: a claim is issued before anyone knows
+    whether it will succeed, so an unpipelined loop pays one awaited
+    round-trip per surviving row on *every* successful dispatch for as
+    long as the tenant is red.
+
+    Names are zero-padded so ``ORDER BY name`` is the numeric order, which
+    makes the surviving head assertable.
+    """
+    overflow = _ADVISORY_MAX_DASHBOARDS + 3
+    for i in range(overflow):
+        await _seed_dashboard(name=f"dash-{i:04d}", state="degraded")
+    store = _FakeNxStore()
+    with _patch_nx(store):
+        advisory = await build_checks_alert_advisory(_operator())
+    entries = advisory[CHECKS_ADVISORY_EXTRAS_KEY]
+    assert len(entries) == _ADVISORY_MAX_DASHBOARDS
+    assert len(store.ex_values) == _ADVISORY_MAX_DASHBOARDS
+    assert store.round_trips == 1
+    assert [e["name"] for e in entries] == [
+        f"dash-{i:04d}" for i in range(_ADVISORY_MAX_DASHBOARDS)
+    ]
+
+
+async def test_cap_is_nudge_sized_so_the_fragment_stays_out_of_the_way() -> None:
+    """The cap is nudge-sized, not audit-sized -- pinned as a contract.
+
+    ``extras`` is attached to the ``OperationResult`` after the
+    dispatcher has already reduced the payload, so this fragment never
+    passes through JSONFlux/result-handle reduction: the cap is the only
+    thing bounding the unsolicited context an agent is handed on a
+    successful dispatch. Pinning the magnitude (not just "some cap
+    exists") is what keeps a later widening an explicit decision.
+    """
+    assert _ADVISORY_MAX_DASHBOARDS <= 10
+
+
+# ---------------------------------------------------------------------------
+# Fail-open
+# ---------------------------------------------------------------------------
+
+
+async def test_fail_open_on_valkey_error() -> None:
+    """A Valkey teardown yields ``{}`` and warn-logs; it never raises."""
+    from redis import exceptions as redis_exceptions
+
+    await _seed_dashboard(state="critical")
+    with (
+        patch.object(
+            get_broadcast_client(),
+            "pipeline",
+            new=MagicMock(side_effect=redis_exceptions.ConnectionError("refused")),
+        ),
+        # Assert on the module logger directly (not capture_logs) -- the
+        # production ``cache_logger_on_first_use`` config makes
+        # capture_logs miss module-cached BoundLoggers intermittently
+        # (see test_broadcast_target_advisory for the incident note).
+        patch("meho_backplane.checks.advisory._log") as mock_log,
+    ):
+        advisory = await build_checks_alert_advisory(_operator())
+    assert advisory == {}
+    assert any(
+        call.args and call.args[0] == "checks_alert_advisory_failed"
+        for call in mock_log.warning.call_args_list
+    )
+
+
+async def test_fail_open_on_db_error() -> None:
+    """A DB teardown yields ``{}`` and warn-logs; it never raises."""
+    with (
+        patch(
+            "meho_backplane.checks.advisory.get_sessionmaker",
+            new=MagicMock(side_effect=RuntimeError("db down")),
+        ),
+        patch("meho_backplane.checks.advisory._log") as mock_log,
+    ):
+        advisory = await build_checks_alert_advisory(_operator())
+    assert advisory == {}
+    assert any(
+        call.args and call.args[0] == "checks_alert_advisory_failed"
+        for call in mock_log.warning.call_args_list
+    )
+
+
+# ---------------------------------------------------------------------------
+# Dispatch integration (the merge site) + #2550 coexistence
+# ---------------------------------------------------------------------------
+
+
+class _NoOpVaultConnector(Connector):
+    """Connector class satisfying resolver lookups in typed-dispatch tests."""
+
+    product = "vault"
+    version = "1.x"
+    impl_id = "vault"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+async def _module_handler(target: Any, params: dict[str, Any]) -> dict[str, Any]:
+    """Module-level typed handler so ``import_handler`` can round-trip it."""
+    return {"echo": params}
+
+
+class _FakeFingerprint:
+    def __init__(self, version: str | None = None) -> None:
+        self.version = version
+
+
+class _FakeTarget:
+    """Minimal duck-typed target (mirrors ``test_operations_dispatcher``)."""
+
+    def __init__(self, *, name: str = "test-target") -> None:
+        self.product = "vault"
+        self.fingerprint = _FakeFingerprint(version=None)
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.tenant_id: UUID = _TENANT
+        self.name = name
+        self.host = "test.example.com"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+@pytest.fixture(autouse=True)
+def _reset_dispatch_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def _quiet_broadcast(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Record broadcast events instead of publishing to Valkey."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so registration doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+async def _register_op(op_id: str, stub_embedding_service: AsyncMock) -> None:
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id=op_id,
+        handler=_module_handler,
+        summary="Test op.",
+        description="Test op.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+
+async def test_dispatch_success_carries_fragment_then_dedupes(
+    stub_embedding_service: AsyncMock,
+    _quiet_broadcast: list[BroadcastEvent],
+) -> None:
+    """A read-class dispatch carries the fragment once per caller+window.
+
+    Read-class is the point: the checks advisory deliberately diverges
+    from the write-gated #2550 precedent -- ambient awareness applies to
+    every op class. The immediate second dispatch by the same caller is
+    deduped by the NX claim.
+    """
+    dashboard_id = await _seed_dashboard(state="critical")
+    await _register_op("vault.kv.list", stub_embedding_service)
+    store = _FakeNxStore()
+    with _patch_nx(store):
+        first = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.list",
+            target=_FakeTarget(),
+            params={"path": "/secret"},
+        )
+        second = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.list",
+            target=_FakeTarget(),
+            params={"path": "/secret"},
+        )
+    assert first.status == "ok"
+    assert first.extras[CHECKS_ADVISORY_EXTRAS_KEY] == [
+        {"dashboard_id": str(dashboard_id), "name": "prod-health", "state": "critical"}
+    ]
+    assert second.status == "ok"
+    assert CHECKS_ADVISORY_EXTRAS_KEY not in second.extras
+
+
+async def test_both_advisory_fragments_coexist_on_one_response(
+    stub_embedding_service: AsyncMock,
+    _quiet_broadcast: list[BroadcastEvent],
+) -> None:
+    """The #2550 fragment and the checks fragment ride one ``extras``.
+
+    A write-class dispatch on a target with peer activity (the #2550
+    trigger) by a caller whose tenant has a critical Dashboard (this
+    feature's trigger) carries BOTH fragments -- distinct keys, plain
+    dict merge, neither clobbers the other.
+    """
+    from datetime import UTC, datetime
+
+    await _seed_dashboard(state="critical")
+    await _register_op("vault.kv.delete", stub_embedding_service)
+    peer_event = BroadcastEvent(
+        event_id=uuid.uuid4(),
+        ts=datetime.now(UTC),
+        tenant_id=_TENANT,
+        principal_sub="peer-a",
+        target_name="test-target",
+        op_id="vault.kv.delete",
+        op_class="write",
+        result_status="ok",
+        audit_id=_AUDIT_ID,
+        actor_sub=None,
+        payload={"op_class": "write", "params": {}, "result_status": "ok"},
+    )
+
+    async def _xrevrange(name: str, **kwargs: Any) -> list[tuple[str, dict[str, str]]]:
+        return [("1747800001000-0", {"event": peer_event.model_dump_json()})]
+
+    store = _FakeNxStore()
+    bc = get_broadcast_client()
+    with _patch_nx(store), patch.object(bc, "xrevrange", new=_xrevrange):
+        result = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.delete",
+            target=_FakeTarget(),
+            params={},
+        )
+    assert result.status == "ok"
+    assert result.extras[ADVISORY_EXTRAS_KEY][0]["principal_sub"] == "peer-a"
+    assert result.extras[CHECKS_ADVISORY_EXTRAS_KEY][0]["state"] == "critical"
+
+
+async def test_advisory_never_gates_dispatch_on_total_failure(
+    stub_embedding_service: AsyncMock,
+    _quiet_broadcast: list[BroadcastEvent],
+) -> None:
+    """A dead advisory path (DB error mid-build) leaves the dispatch ok."""
+    await _register_op("vault.kv.list", stub_embedding_service)
+    with patch(
+        "meho_backplane.checks.advisory.get_sessionmaker",
+        new=MagicMock(side_effect=RuntimeError("db down")),
+    ):
+        result = await dispatch(
+            operator=_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.list",
+            target=_FakeTarget(),
+            params={"path": "/secret"},
+        )
+    assert result.status == "ok"
+    assert CHECKS_ADVISORY_EXTRAS_KEY not in result.extras

--- a/cli/internal/cmd/operation/client_test.go
+++ b/cli/internal/cmd/operation/client_test.go
@@ -569,3 +569,108 @@ func TestRunCallAwaitingApprovalJSON(t *testing.T) {
 		t.Errorf("json envelope must carry extras.approval_request_id; got %v", decoded["extras"])
 	}
 }
+
+// ---- checks_alert_advisory (#2718) reach on the operator CLI ----
+//
+// The backend attaches extras["checks_alert_advisory"] to SUCCESSFUL
+// dispatch responses (status=ok). These two tests pin what each operator
+// output mode actually does with it, because the two disagree and
+// docs/codebase/checks-advisory.md § "Operator reach" documents the gap:
+// --json passes the envelope through verbatim, while printCallResult
+// returns inside its status=="ok" branch before reaching the extras
+// block, so the default human render drops it. Teaching the human render
+// to print extras on success is a CLI-wide UX change (it would also start
+// printing #2550's target_activity_advisory, and the vendor verbs render
+// through dispatch.Render), so #2718 scoped it out — but the boundary is
+// now asserted rather than assumed, and either half failing means the
+// boundary moved without the doc moving with it.
+
+const checksAdvisoryExtras = `{"checks_alert_advisory":[` +
+	`{"dashboard_id":"d1","name":"prod-health","state":"critical"}]}`
+
+// TestCallJSONCarriesChecksAlertAdvisoryOnOK — with --json, a status=ok
+// envelope round-trips the advisory fragment untouched. This is the
+// operator-reachable path today.
+func TestCallJSONCarriesChecksAlertAdvisoryOnOK(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{
+		Status: "ok", OpID: "vault.kv.read",
+		Result:     json.RawMessage(`{"value":"secret"}`),
+		Extras:     json.RawMessage(checksAdvisoryExtras),
+		DurationMs: 12,
+	})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	withFakeClient(t, f)
+
+	cmd := newCallCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"vault-1.x", "vault.kv.read", "--target", "rdc-vault", "--json", "--backplane", "https://x"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("status=ok must exit 0; got %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("--json output is not valid JSON: %v\n%s", err, out.String())
+	}
+	extras, ok := decoded["extras"].(map[string]any)
+	if !ok {
+		t.Fatalf("--json envelope must carry extras on status=ok; got %v", decoded["extras"])
+	}
+	advisory, ok := extras["checks_alert_advisory"].([]any)
+	if !ok || len(advisory) != 1 {
+		t.Fatalf("expected one checks_alert_advisory entry; got %v", extras["checks_alert_advisory"])
+	}
+	entry, ok := advisory[0].(map[string]any)
+	if !ok {
+		t.Fatalf("advisory entry should be an object; got %T", advisory[0])
+	}
+	for k, want := range map[string]string{
+		"dashboard_id": "d1", "name": "prod-health", "state": "critical",
+	} {
+		if entry[k] != want {
+			t.Errorf("advisory entry %s: got %v want %q", k, entry[k], want)
+		}
+	}
+}
+
+// TestCallHumanRenderOmitsExtrasOnOK — without --json the default human
+// render prints the result and returns; extras (advisory included) are
+// printed only for non-ok statuses. Pinning the gap keeps
+// docs/codebase/checks-advisory.md honest: close it and this test tells
+// you the doc's table needs updating.
+func TestCallHumanRenderOmitsExtrasOnOK(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{
+		Status: "ok", OpID: "vault.kv.read",
+		Result:     json.RawMessage(`{"value":"secret"}`),
+		Extras:     json.RawMessage(checksAdvisoryExtras),
+		DurationMs: 12,
+	})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	withFakeClient(t, f)
+
+	cmd := newCallCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"vault-1.x", "vault.kv.read", "--target", "rdc-vault", "--backplane", "https://x"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("status=ok must exit 0; got %v", err)
+	}
+	if !strings.Contains(out.String(), "status=ok") || !strings.Contains(out.String(), "secret") {
+		t.Fatalf("human render should show the status line + result; got %q", out.String())
+	}
+	if strings.Contains(out.String(), "checks_alert_advisory") {
+		t.Errorf("human render printed extras on status=ok — the CLI gap closed; "+
+			"update docs/codebase/checks-advisory.md § Operator reach and the "+
+			"CHANGELOG bullet, then flip this assertion. Output: %q", out.String())
+	}
+}

--- a/docs/codebase/broadcast.md
+++ b/docs/codebase/broadcast.md
@@ -388,6 +388,12 @@ Design contract:
 - **Disable knob.** `DISPATCH_ACTIVITY_ADVISORY_WINDOW_MINUTES` (default
   `30`, `0` = off) gates the whole feature.
 
+A second, independent extras fragment — `checks_alert_advisory`
+(#2718, built in `checks/advisory.py`, deduped per caller via Valkey
+`SET NX EX`, applied to **all** op classes) — merges beside this one at
+the same dispatcher success path; see
+[`docs/codebase/checks-advisory.md`](checks-advisory.md).
+
 ## Durable announcements (#2547)
 
 The Valkey stream is the hot real-time path but not durable: it is

--- a/docs/codebase/checks-advisory.md
+++ b/docs/codebase/checks-advisory.md
@@ -1,0 +1,182 @@
+# Checks-alert advisory (in-band, dispatch-time)
+
+## Overview
+
+The second in-band `extras` fragment on successful dispatch responses
+(#2718, Initiative #2716 scope item 4): when the caller's tenant has a
+Dashboard whose `check_dashboards.last_rollup_state` memo is `degraded`
+or `critical`, the next successful dispatch — agent `call_operation` and
+operator CLI alike, **read ops included** — carries one compact
+`extras["checks_alert_advisory"]` entry naming it, once per
+`(caller, dashboard, state)` window. Ambient awareness for anyone
+actively working through the backplane; delivery to people *not*
+dispatching is the sibling email path (#2719), not this fragment.
+
+"Carries" is about the response envelope, which is the same on both
+fronts. What each front then *shows* differs, and only the agent front
+shows it unprompted today — see
+[Operator reach](#operator-reach-json-only-today).
+
+## Key types
+
+- `meho_backplane.checks.advisory.build_checks_alert_advisory(operator)`
+  — the builder; returns
+  `{"checks_alert_advisory": [{"dashboard_id", "name", "state"}, ...]}`
+  or `{}`.
+- `CHECKS_ADVISORY_EXTRAS_KEY = "checks_alert_advisory"` — the extras
+  key, sibling of `broadcast.history.ADVISORY_EXTRAS_KEY`
+  (`target_activity_advisory`, #2550).
+- `settings.checks_alert_advisory_window_minutes` — dedupe window,
+  default `30`, `ge=0`; `0` disables the feature before any I/O.
+
+## Control flow
+
+```text
+dispatcher._reduce_and_audit_success(...)   # after audit + broadcast
+  → build_target_activity_advisory(...)     # 2550 fragment (write-gated)
+  → build_checks_alert_advisory(operator)   # this fragment (all classes)
+      [gate — returns {} without any I/O when:]
+        · settings.checks_alert_advisory_window_minutes == 0
+      [otherwise:]
+        → SELECT id, name, last_rollup_state FROM check_dashboards
+          WHERE tenant_id = :t AND last_rollup_state IN
+          ('degraded','critical')            # check_dashboard_tenant_idx
+          ORDER BY name LIMIT 10             # _ADVISORY_MAX_DASHBOARDS
+        → one MULTI/EXEC batch, staging per hit: SET meho:checks:
+          advisory:{tenant}:{principal_sub}:{actor_sub|-}:{dashboard_id}:
+          {state} 1 NX EX <window-seconds>   # ONE awaited round-trip
+        → include the dashboard ONLY when its SET claimed the key
+  → wrap_ok_result(..., extras={**activity, **checks})
+```
+
+## Design contract
+
+- **All op classes.** Deliberate divergence from the write-gated #2550
+  precedent: that gate exists because the target-activity advisory is
+  mutation-overlap-specific. A non-green Dashboard concerns every active
+  caller; the per-caller NX dedupe is what keeps that from becoming
+  spam.
+- **Bounded per dispatch — two round-trips, flat.** The claims are
+  staged into a single pipelined `MULTI`/`EXEC` batch, so the Valkey
+  cost is one awaited round-trip however many Dashboards are red. That
+  matters because the NX dedupe *cannot* help here: a claim has to be
+  issued before anyone can know whether it will succeed, so an
+  unpipelined loop would pay a round-trip per row on **every**
+  successful dispatch, read ops included, for as long as the tenant is
+  red — worst exactly during the incidents the feature exists to
+  announce.
+- **`_ADVISORY_MAX_DASHBOARDS = 10`** caps the SELECT, and with it the
+  `SET`s staged and the bytes the fragment adds. It is sized as an
+  awareness nudge, not an audit — the rationale of the #2550
+  precedent's `_ADVISORY_MAX_ENTRIES = 5`, the constant it plays the
+  role of. (Its sibling `_ADVISORY_SCAN_LIMIT = 100` bounds a single
+  `XREVRANGE` — one round-trip whatever the count — so its *value*
+  carries no argument for a cap that also decides what the agent
+  reads.) What the value buys here is bytes of unsolicited agent
+  context, and `extras` is attached after the dispatcher's JSONFlux
+  reduction, so nothing downstream trims it. One query is both the read
+  and the entry source, so claims and entries share the cap — which is
+  also what makes a claimed key mean "this caller was told".
+  `ORDER BY name` makes the truncation deterministic.
+- **The Valkey TTL key IS the delivery state.** Nothing durable is
+  persisted; a Valkey flush re-reminds each caller once. A state change
+  mints a new key, so escalation re-announces immediately; window expiry
+  re-reminds on unchanged state.
+- **Caller identity** is the `(principal_sub, actor_sub)` pair — the
+  same pair #2550 uses for its self-drop — so a delegated agent and its
+  human principal are distinct callers.
+- **Memo-backed states only.** The advisory reads the transition memo
+  (maintained exactly-once-per-transition by `checks/investigate.py`'s
+  compare-and-swap), never the on-read rollup — so a staleness-derived
+  `unknown` is not reflected, and a `NULL` memo (never-transitioned
+  Dashboard) yields nothing. Documented limitation, acceptable for an
+  awareness nudge.
+- **Fail-open, advisory-only.** A broad guard swallows any DB/Valkey
+  error, warn-logs `checks_alert_advisory_failed`, and returns `{}`.
+  Never gates, blocks, or fails a dispatch.
+- **Server-derived fields only** — no free-form sensor evidence enters
+  the op response (Initiative #2543 untrusted-prose discipline).
+
+## Dependencies
+
+- `check_dashboards.last_rollup_state` (#2506's column, #2507's CAS
+  writer) — read-only here; this module never writes the memo.
+- `broadcast.client.get_broadcast_client()` — the shared fast Valkey
+  client (5 s socket timeout bounds the worst-case added latency).
+- redis-py 8.x `set(name, value, nx=True, ex=seconds)` — atomic
+  set-if-absent-with-TTL; returns `True` when claimed, `None` when the
+  key exists (`parse_set_result`).
+- redis-py 8.x `client.pipeline(transaction=True)` — async context
+  manager; `pipe.set(...)` stages the command and returns the pipeline
+  synchronously, `await pipe.execute()` is the one round-trip and
+  replies with a result per staged command, through the *same*
+  response-callback table as an unbuffered call. Same idiom as
+  `broadcast/rate_limit.py`.
+
+## Operator reach (`--json`-only today)
+
+The fragment is on the wire for every front — the backend sets it on
+the `OperationResult` envelope, so the HTTP response is identical
+whether an agent or `meho operation call` issued it. What the **Go
+CLI's default human render** does with it is the gap:
+
+```go
+// cli/internal/cmd/operation/call.go — printCallResult
+if r.Status == "ok" {
+    ... print r.Result ...
+    return                      // ← returns before the extras block
+}
+...
+if len(r.Extras) > 0 && ... {   // ← non-ok path only
+```
+
+`printCallResult` prints `extras` only on the **non-ok** branch, and
+this advisory only ever rides a *successful* dispatch. So today:
+
+| Front | Sees the fragment? |
+|---|---|
+| Agent / MCP `call_operation` | yes — it reads the JSON envelope |
+| `meho operation call --json` | yes — full envelope, verbatim |
+| `meho operation call` (human render) | **no** — extras dropped on `ok` |
+
+That is a deliberate scope line, not an oversight left unrecorded:
+teaching the human render to print `extras` on success is a CLI-wide
+UX change (it would also start printing #2550's
+`target_activity_advisory`, and the vendor verbs render through a
+different path — `dispatch.Render` — so a one-line edit here would
+leave the two fronts inconsistent). #2718 is backend-only; the CLI
+render decision wants its own Task.
+
+`cli/internal/cmd/operation/client_test.go`
+(`TestCallJSONCarriesChecksAlertAdvisoryOnOK`,
+`TestCallHumanRenderOmitsExtrasOnOK`) pins both halves of that table so
+the gap cannot close or widen silently.
+
+## Known issues / boundaries
+
+- The two free-form key segments (`principal_sub`, `actor_sub`) share
+  the `:` delimiter, so two distinct caller pairs could in principle
+  alias one dedupe key; the aliasing window is one reminder and the
+  payload is advisory-only — deliberately not escaped. No reachable
+  pair aliases today: an IdP-issued `sub` is a Keycloak UUID and agent
+  principals are pinned to `^[A-Za-z0-9_\-\.]+$`
+  (`auth/agent_principals.py`), neither of which admits a `:`.
+- The default human CLI render does not show the fragment — see
+  [Operator reach](#operator-reach-json-only-today).
+- Only the first 10 non-green Dashboards by name ride a fragment
+  (`_ADVISORY_MAX_DASHBOARDS`); the tail is permanently invisible to
+  this surface. The checks surface and the #2719 email path own
+  completeness. A tenant that far into the red has bigger problems than
+  advisory coverage. The fragment carries no truncation marker today —
+  an agent cannot tell a capped list from a complete one.
+
+## References
+
+- Task #2718, Initiative #2716 (parent goal #221).
+- Precedent: `docs/codebase/broadcast.md` § "Read path (dispatch-time
+  target-activity advisory)" (#2550).
+- Memo + CAS: `backend/src/meho_backplane/db/models.py`
+  (`CheckDashboard`), `backend/src/meho_backplane/checks/investigate.py`
+  (`_claim_rollup_transition`).
+- Tests: `backend/tests/test_checks_advisory.py`;
+  `cli/internal/cmd/operation/client_test.go` (the CLI-path pair).


### PR DESCRIPTION
## Summary

- Add the in-band **`checks_alert_advisory`** (#2718, Initiative #2716 scope item 4): when the caller's tenant has a Dashboard whose `last_rollup_state` memo is `degraded`/`critical`, the next successful dispatch response — agent `call_operation` and operator CLI alike, **read ops included** — carries one compact `extras` entry naming it (`{dashboard_id, name, state}`, server-derived fields only).
- Deduped **once per (caller, dashboard, state)** via an atomic Valkey `SET NX EX` on `meho:checks:advisory:{tenant}:{principal_sub}:{actor_sub}:{dashboard_id}:{state}` — a state change mints a new key (instant re-announce on escalation), window expiry re-reminds; the TTL key IS the delivery state (nothing durable persisted).
- Second extras fragment beside the shipped #2550 `target_activity_advisory`, merged at the same dispatcher success path (`extras={**activity, **checks}`). Deliberate divergence from the write-class gate, documented in the builder: ambient awareness is the feature; the #2550 gate exists because that advisory is target-overlap-specific.
- Fail-open end to end: a DB or Valkey failure warn-logs `checks_alert_advisory_failed` and returns `{}` — never gates, blocks, or fails a dispatch. `CHECKS_ALERT_ADVISORY_WINDOW_MINUTES` (default 30, `ge=0`) short-circuits before any I/O when `0`.
- No migration. New doc `docs/codebase/checks-advisory.md`; cross-ref in `docs/codebase/broadcast.md`; CHANGELOG bullet.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean on `src/` + `tests/`
- [x] `mypy` — clean on all touched files (the sole repo error is pre-existing `connectors/net/icmp.py` `MSG_ERRQUEUE`, macOS-environmental; CI runs Linux)
- [x] `pytest tests/test_checks_advisory.py` — 10 passed, covering by name: disable short-circuit (no DB/Valkey I/O, stub-asserted); green tenant ⇒ `{}` (NULL + `ok` memos); NX dedupe (same caller+state once per window, TTL = window); re-announce on state change (new key per state); per-caller isolation (distinct principals each reminded once); fail-open on Valkey and on DB errors (warn-logged, `{}`)
- [x] Dispatch integration: with a seeded `critical` memo, a successful `dispatch()` of a **read-class** op carries `extras.checks_alert_advisory` with `{dashboard_id, name, state}`; an immediate second dispatch by the same caller does not; a dead advisory path leaves the dispatch `ok`
- [x] Coexistence: one write-class response carries **both** `target_activity_advisory` (#2550) and `checks_alert_advisory`
- [x] `grep -n "checks_alert_advisory" backend/src/meho_backplane/operations/dispatcher.py` — hits at the success path beside the #2550 merge
- [x] `grep -n "checks_alert_advisory_window_minutes" backend/src/meho_backplane/settings.py` — `Field(default=30, ge=0)` with the `#:` comment convention (+ the explicit `os.environ.get` mapping `get_settings()` requires — the class is a plain `BaseModel`, not `BaseSettings`)
- [x] Full backend suite green (one deselect: `test_connectors_net_dns_lookup.py::test_chosen_resolver_queries_that_nameserver` fails identically on pristine `main` — live-DNS environmental, unrelated)
- [x] `code-quality.py --diff` — 0 blockers (6 pre-existing legacy warnings in brushed files)

## Out of scope

- Raw Sensor states / staleness-derived `unknown` — memo-backed Dashboard states only (documented limitation in the builder + doc).
- Durable advisory delivery state — the Valkey TTL key is the state; a flush re-reminds once.
- MCP `_meta`/`structuredContent` surfacing — the fragment rides `extras` inside the tool-result JSON like #2550.
- Sibling #2717 (`mail.*` connector), #2719–#2721 — the rest of Initiative #2716.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2718


---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-01)

Addressed the review findings from [pr-2726-iter-1](https://github.com/evoila/meho/pull/2726#pullrequestreview):

- **B1** `944e99dd` — the doc claimed the operator CLI renders the fragment; it does not. `printCallResult` returns inside its `status == "ok"` branch before the `extras` block, which lives only on the non-ok path, and this advisory only ever rides a *successful* dispatch. Scoped honestly instead of patched: new docs § "Operator reach (`--json`-only today)" with the per-front table and the reason it was scoped out (printing extras on success is a CLI-wide UX change that would also surface #2550's fragment, and the vendor verbs render through `dispatch.Render`), matching corrections on the module docstring and the CHANGELOG bullet, plus the CLI-path test #2718 asked for — as a **pair**: `TestCallJSONCarriesChecksAlertAdvisoryOnOK` (the reachable path) and `TestCallHumanRenderOmitsExtrasOnOK` (the gap, failing loudly with a pointer to the doc if anyone closes it).
- **M1** `333f20cd` — added `_ADVISORY_MAX_DASHBOARDS = 100` and applied it as `.limit()` on the non-green SELECT, mirroring #2550's `_ADVISORY_SCAN_LIMIT` (same value, same rationale); the `**Bounded.**` docstring bullet now names the cap instead of asserting the property. New test asserts on the count of Valkey round-trips issued, not just the fragment length — a Python-side cap after the loop would satisfy the entry count and still leave the fan-out unbounded.

Also in this iteration:

- **Merge conflict** `37caa7c3` — merged `origin/main` (advanced to c5fa843f / #2723 after the branch was cut). One conflicting file, `CHANGELOG.md`, both sides inserting under `## [Unreleased]`; both bullets kept. Merge commit, no rebase, no force-push.
- **Copilot's dedupe-key `:`-collision thread** — [replied with the grammar citation](https://github.com/evoila/meho/pull/2726#discussion_r3695373299) and closed out. `agent:<name>` is the Keycloak *clientId*, not the `sub`; subs are Keycloak UUIDs and agent names are pinned to `^[A-Za-z0-9_\-\.]+$` (`auth/agent_principals.py:95,98`), so both free-form segments are colonless and no reachable pair aliases. Recorded under "Known issues / boundaries" rather than re-litigated.

Verification: `ruff` / `ruff format` / `mypy` clean on the touched files; `pytest tests/test_checks_advisory.py` 11 passed; blast-radius neighbours 151 passed; the checks/advisory/dispatcher/broadcast/settings slice 1037 passed, 37 skipped; `go build ./...` + full `go test ./...` on the CLI green; `code-quality.py --diff` exit 0.

<!-- auto-implement-issue: continue, iteration 1 -->


---

## Follow-up (auto-implement-issue, iteration 2, 2026-08-01)

Addressed the one blocker from [pr-2726-iter-2](https://github.com/evoila/meho/pull/2726#discussion_r3695398767):

- **B1** `466ddcbc` — `_ADVISORY_MAX_DASHBOARDS = 100` bounded the SELECT but not the cost M1 was filed about. The review is right that the dedupe cannot help: the `SET` is issued before anyone knows whether it claims, so the fan-out recurred on **every** successful dispatch, read ops included, for as long as a tenant stayed red. Fixed on both axes — the cap is now **10** (re-anchored to `_ADVISORY_MAX_ENTRIES = 5`'s "awareness nudge, not an audit" rationale, since `_ADVISORY_SCAN_LIMIT = 100` bounds a one-round-trip `XREVRANGE` and so carries no argument for an agent-facing cap), **and** the claims are staged into one pipelined `MULTI`/`EXEC` batch, so the Valkey cost per dispatch is **one** awaited round-trip instead of up to 100.

  Option 2 was taken, but deliberately **not verbatim**. Keeping a 100-row read with a separate nudge-sized *fragment* cap breaks the module's load-bearing invariant — the Valkey key IS the delivery record, so claiming 100 keys while emitting 5 entries marks 95 Dashboards "announced" without announcing them, silently suppressed for a full window. That is strictly worse than the tail-invisibility the doc already accepts, and repairing it needs a compensating `DEL` or a claim-until-K loop that defeats the batching. One nudge-sized cap keeps claims and entries equal, so a claimed key still means "this caller was told", and the pipeline is pure win on top.

  `transaction=True` (the `broadcast/rate_limit.py` idiom) additionally means a mid-batch teardown cannot leave keys claimed while the fail-open guard discards the entries they stood for. redis-py 8.0.1's `Pipeline` shares the client's response-callback table, so `parse_set_result` still yields `True`/`None` per staged `SET` — verified against the pinned wheel. The claim step moved into `_claim_unannounced` to stay under the function-size gate.

- **Non-blocking note taken** — `extras` is set after `_reduce_and_audit_success`, so the fragment bypasses JSONFlux reduction entirely. Named in the `build_checks_alert_advisory` docstring (and in the docs' design contract) as the reason the cap is nudge-sized; not re-architected.

Tests keep the round-trips-issued style rather than length-only, and now pin both halves of the bound: `len(store.ex_values)` the `SET`s actually staged, `store.round_trips` the batching. Both mutations were run and observed to fail the right assertion, then reverted — post-claim Python cap → `assert 13 == 10`; unpipelined loop → `assert 10 == 1`. A third test pins the cap's magnitude (`<= 10`) so widening it back stays an explicit decision.

Verification: `ruff` / `ruff format` clean on `src/` + `tests/`; `mypy` clean on the touched module (the one repo-wide error is a pre-existing macOS-only `socket.MSG_ERRQUEUE` false positive in untouched `connectors/net/icmp.py`); `pytest tests/test_checks_advisory.py` 12 passed; checks + broadcast neighbours 269 passed / 3 skipped; the dispatch-path slice 476 passed / 87 skipped; `code-quality.py --diff` exit 0, no warnings.

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Successful dispatch responses can include a `checks_alert_advisory` identifying degraded or critical Dashboards.
  - Advisories are limited, ordered by Dashboard name, and avoid repeated alerts while still reporting state changes.
  - The advisory applies across operation types and does not prevent dispatches from completing.
  - JSON output displays advisories for successful operations.

- **Documentation**
  - Added guidance covering advisory behavior, configuration, response formatting, and delivery limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->