### PR TITLE
feat(checks): dashboard email notifications on rollup transitions, recovery included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Checks notifications — Dashboard email on state transitions (#2719)
+
+- A Dashboard can now name an operator to mail when its rollup crosses
+  a state edge. Two new create-time fields — `notify_email` (unset ⇒
+  notifications off, the state every existing Dashboard keeps) and
+  `notify_min_state` (`degraded` or `critical`, default `critical`) —
+  land on `POST /api/v1/checks/dashboards`, on the detail/list reads,
+  and on `meho dashboard create --notify-email --notify-min-state`.
+  **Recovery is notified too**: an edge mails when the worse of its two
+  states reaches the floor, so at `critical` a Dashboard falling to
+  `critical` pages and its return to `ok` sends the all-clear, while
+  `ok → degraded` stays silent — the same posture as Alertmanager's
+  `send_resolved`. The mail names the Dashboard, the `previous → new`
+  edge, and each non-green member with its last value and evidence.
+  Exactly one mail per transition across replicas (the existing
+  compare-and-swap claim is the dedupe), delivered through the #2717
+  `mail.*` transport, so `MAIL_RECIPIENT_ALLOWLIST` gates it and an
+  empty allowlist keeps it inert. Sends run off the check-runner's
+  persist path and never fail it: a refused or broken SMTP session is
+  logged (`checks_notify_failed`) and swallowed. The diagnose-only
+  investigator's worsening-only fire conditions are unchanged.
+  Requires migration `0068`. (#2719)
+
 ### Added — checks advisory: non-green Dashboards surface on dispatch responses (#2718)
 
 - Successful dispatch responses — agent `call_operation` and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,8 +104,9 @@ connector-related release-notes line.
   `ok → degraded` stays silent — the same posture as Alertmanager's
   `send_resolved`. The mail names the Dashboard, the `previous → new`
   edge, and each non-green member with its last value and evidence.
-  Exactly one mail per transition across replicas (the existing
-  compare-and-swap claim is the dedupe), delivered through the #2717
+  At most one notification attempt per claimed transition across
+  replicas (the existing compare-and-swap claim is the dedupe; a
+  failed send is not retried), delivered through the #2717
   `mail.*` transport, so `MAIL_RECIPIENT_ALLOWLIST` gates it and an
   empty allowlist keeps it inert. Sends run off the check-runner's
   persist path and never fail it: a refused or broken SMTP session is

--- a/backend/alembic/versions/0068_add_check_dashboard_notify.py
+++ b/backend/alembic/versions/0068_add_check_dashboard_notify.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``check_dashboards`` email-notification columns (#2719).
+
+Revision ID: 0068
+Revises: 0067
+Create Date: 2026-08-01
+
+Task #2719 under Initiative #2716 (parent goal #221). #2507's transition
+detector already compare-and-swaps ``check_dashboards.last_rollup_state``
+exactly once per rollup edge, but the claim reached no operator channel.
+These two columns are the per-Dashboard notification config the checks
+notifier (``meho_backplane.checks.notify``) reads on that claim:
+
+* ``notify_email`` -- ``text`` nullable. The single recipient address.
+  ``NULL`` (the backfilled state for every pre-#2719 Dashboard) means
+  notifications are **off** for that Dashboard, so the migration is
+  behaviour-preserving on its own: no existing row starts emailing.
+* ``notify_min_state`` -- ``text`` NOT NULL, server default ``'critical'``,
+  CHECK ``IN ('degraded', 'critical')``. The threshold an edge must reach
+  before mail is sent: an edge notifies when
+  ``max(rank(previous), rank(current)) >= rank(notify_min_state)``, so the
+  recovery edge back to ``ok`` sends the all-clear.
+
+The CHECK admits only the two *actionable* states, not the full five-state
+``CheckState`` vocabulary: ``ok`` as a floor would mail on every edge
+(including ``ok -> ok`` noise), and ``skip`` / ``unknown`` are not
+severities an operator can meaningfully set a threshold at. That is why
+this vocabulary is declared independently of ``CheckState`` rather than
+snapshotted from it (contrast ``0065``'s ``_ROLLUP_STATES``); the drift
+guard in ``tests.test_db_dashboard`` pins it against the ORM's copy, not
+against ``CheckState``.
+
+Why ``notify_min_state`` is NOT NULL with a server default: the notifier's
+threshold comparison reads a concrete state on every claimed edge, so
+"unset" would need a Python-side fallback duplicating the default in a
+second place. A ``'critical'`` server default backfills every pre-#2719
+row with the conservative choice (page only on the worst state) and
+matches the ``0057`` ``skip_count`` discipline.
+
+Why ``batch_alter_table``: the same portable cookbook ``0025`` / ``0051``
+use to add a CHECK-constrained column to an existing table. On PostgreSQL
+Alembic issues plain ``ALTER TABLE ADD COLUMN`` + ``ADD CONSTRAINT`` (no
+copy; PG 11+ adds a defaulted NOT NULL column without a rewrite); on
+SQLite it falls back to the table-recreate path, which is the only way
+SQLite adds a CHECK to an existing table. One batch block adds both
+columns and the constraint together, so SQLite recreates once.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the constraint and both columns inside one batch
+block, in reverse add order. Purely additive forward, so a ``helm
+rollback`` to a pre-0068 image (which never mentions the columns) is safe.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0068"
+down_revision: str | None = "0067"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Closed ``check_dashboards.notify_min_state`` vocabulary -- the two
+#: actionable states an operator can set a notification floor at. Inlined
+#: as a literal (never imported from :mod:`meho_backplane.db.models`)
+#: because Alembic must run against any historical revision's model graph;
+#: the drift guard in :mod:`tests.test_db_dashboard` asserts this tuple
+#: equals the ORM's.
+_NOTIFY_MIN_STATES: tuple[str, ...] = ("degraded", "critical")
+
+#: Backfill value for every pre-#2719 row: page only on the worst state.
+_NOTIFY_MIN_STATE_DEFAULT: str = "critical"
+
+
+def _check_in(column: str, values: tuple[str, ...]) -> str:
+    """Render a portable ``column IN ('a', 'b', ...)`` CHECK body."""
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"{column} IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Add the two notification columns + the ``notify_min_state`` CHECK."""
+    with op.batch_alter_table("check_dashboards") as batch_op:
+        batch_op.add_column(sa.Column("notify_email", sa.Text(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "notify_min_state",
+                sa.Text(),
+                nullable=False,
+                server_default=_NOTIFY_MIN_STATE_DEFAULT,
+            )
+        )
+        batch_op.create_check_constraint(
+            "ck_check_dashboards_notify_min_state",
+            _check_in("notify_min_state", _NOTIFY_MIN_STATES),
+        )
+
+
+def downgrade() -> None:
+    """Drop the CHECK + both columns added in :func:`upgrade` (reverse order)."""
+    with op.batch_alter_table("check_dashboards") as batch_op:
+        batch_op.drop_constraint("ck_check_dashboards_notify_min_state", type_="check")
+        batch_op.drop_column("notify_min_state")
+        batch_op.drop_column("notify_email")

--- a/backend/src/meho_backplane/api/v1/checks_dashboards.py
+++ b/backend/src/meho_backplane/api/v1/checks_dashboards.py
@@ -147,7 +147,11 @@ async def create_dashboard(
     ``tenant_admin`` only. ``body.tenant_id`` is optional: when set to a
     *different* tenant the create is cross-tenant and requires
     ``platform_admin`` (via ``authorize_tenant_scope``). A foreign / absent
-    sensor id is 422 ``sensor_not_found``; a duplicate name is 409.
+    sensor id is 422 ``sensor_not_found``; a duplicate name is 409. The
+    #2719 notification config (``notify_email`` / ``notify_min_state``) is
+    validated by :class:`DashboardCreate`, so a malformed address or an
+    out-of-vocabulary floor is FastAPI's own 422 envelope -- never a
+    delivery failure discovered on the first transition.
     """
     target_tenant = authorize_tenant_scope(operator, body.tenant_id)
     structlog.contextvars.bind_contextvars(

--- a/backend/src/meho_backplane/checks/dashboard_repository.py
+++ b/backend/src/meho_backplane/checks/dashboard_repository.py
@@ -69,19 +69,25 @@ async def create_dashboard(
     description: str | None,
     sensor_ids: Sequence[uuid.UUID],
     created_by_sub: str,
+    notify_email: str | None = None,
+    notify_min_state: str = "critical",
 ) -> CheckDashboard:
     """Insert a Dashboard row plus one membership row per *sensor_ids*.
 
     *sensor_ids* is trusted to be validated (every id exists under
     *tenant_id*) and de-duplicated by the caller -- this function does not
-    re-check, so a duplicate would trip the composite PK. Flushes so the row
-    ids are populated within the caller's transaction.
+    re-check, so a duplicate would trip the composite PK. *notify_email* /
+    *notify_min_state* are the #2719 notification config, already validated by
+    the wire schema. Flushes so the row ids are populated within the caller's
+    transaction.
     """
     row = CheckDashboard(
         id=uuid.uuid4(),
         tenant_id=tenant_id,
         name=name,
         description=description,
+        notify_email=notify_email,
+        notify_min_state=notify_min_state,
         created_by_sub=created_by_sub,
     )
     session.add(row)

--- a/backend/src/meho_backplane/checks/dashboard_schemas.py
+++ b/backend/src/meho_backplane/checks/dashboard_schemas.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 from meho_backplane.checks.assertions import CheckState
 from meho_backplane.db.models import SensorSeverity, SensorStatus
@@ -33,7 +33,14 @@ __all__ = [
     "DashboardListResponse",
     "DashboardMemberView",
     "DashboardRead",
+    "NotifyMinState",
 ]
+
+#: The notification floor an operator may set on a Dashboard (#2719) -- the
+#: wire twin of ``db.models._CHECK_DASHBOARD_NOTIFY_MIN_STATES``. Only the two
+#: actionable states: ``ok`` as a floor would mail on every edge, and
+#: ``skip`` / ``unknown`` are not severities a threshold is meaningful at.
+NotifyMinState = Literal["degraded", "critical"]
 
 #: Max length of an operator-supplied Dashboard name (mirrors the Sensor cap).
 _NAME_MAX_LENGTH = 128
@@ -60,6 +67,13 @@ class DashboardCreate(BaseModel):
 
     *tenant_id* (optional) lets a platform-admin caller target another
     tenant; the boundary enforces the RBAC via ``authorize_tenant_scope``.
+
+    ``notify_email`` / ``notify_min_state`` are the #2719 notification config,
+    set at create only like membership. Omitting ``notify_email`` leaves
+    notifications off for this Dashboard. The address is validated with
+    pydantic's ``EmailStr`` (``email-validator``), so a malformed one is a
+    boundary 422 rather than a delivery failure discovered hours later on the
+    first transition.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -68,6 +82,11 @@ class DashboardCreate(BaseModel):
     description: str | None = Field(default=None, max_length=_DESCRIPTION_MAX_LENGTH)
     sensor_ids: list[uuid.UUID] = Field(default_factory=list, max_length=_MAX_MEMBERS)
     tenant_id: uuid.UUID | None = None
+    #: Single recipient for transition mail; ``None`` disables notification.
+    notify_email: EmailStr | None = None
+    #: Floor an edge must reach before mail is sent, under
+    #: ``ok < degraded < critical`` applied to ``max(previous, current)``.
+    notify_min_state: NotifyMinState = "critical"
 
 
 class DashboardMemberView(BaseModel):
@@ -126,6 +145,13 @@ class DashboardRead(BaseModel):
     state: CheckState
     #: The transition-detection memo column (#2507); NULL until then.
     last_rollup_state: CheckState | None
+    #: The #2719 notification config as persisted. ``notify_email`` is typed
+    #: ``str`` rather than ``EmailStr`` on the read side deliberately: the
+    #: address was validated on the way in, and re-validating a stored value
+    #: on every read would turn a row that somehow got past the boundary into
+    #: a 500 on an unrelated list call.
+    notify_email: str | None
+    notify_min_state: NotifyMinState
     created_by_sub: str
     created_at: datetime
     updated_at: datetime

--- a/backend/src/meho_backplane/checks/dashboard_service.py
+++ b/backend/src/meho_backplane/checks/dashboard_service.py
@@ -56,6 +56,7 @@ from meho_backplane.checks.dashboard_schemas import (
     DashboardDetail,
     DashboardMemberView,
     DashboardRead,
+    NotifyMinState,
 )
 from meho_backplane.checks.rollup import (
     MemberEvaluation,
@@ -163,6 +164,8 @@ def _to_read(row: CheckDashboard, sensors: Sequence[Sensor], now: datetime) -> D
         member_count=len(sensors),
         state=state,
         last_rollup_state=cast("CheckState | None", row.last_rollup_state),
+        notify_email=row.notify_email,
+        notify_min_state=cast("NotifyMinState", row.notify_min_state),
         created_by_sub=row.created_by_sub,
         created_at=row.created_at,
         updated_at=row.updated_at,
@@ -182,6 +185,8 @@ def _to_detail(row: CheckDashboard, sensors: Sequence[Sensor], now: datetime) ->
         member_count=len(sensors),
         state=state,
         last_rollup_state=cast("CheckState | None", row.last_rollup_state),
+        notify_email=row.notify_email,
+        notify_min_state=cast("NotifyMinState", row.notify_min_state),
         created_by_sub=row.created_by_sub,
         created_at=row.created_at,
         updated_at=row.updated_at,
@@ -212,7 +217,10 @@ class CheckDashboardAdminService:
         Validates every ``payload.sensor_ids`` entry against the tenant's
         Sensors (a foreign / absent id -> :class:`SensorNotFoundError`),
         de-duplicates the membership list, inserts the Dashboard + memberships
-        in one transaction, and returns the freshly rolled-up detail.
+        in one transaction, and returns the freshly rolled-up detail. The
+        #2719 notification config (``notify_email`` / ``notify_min_state``)
+        rides the same create-only posture as membership -- both were already
+        validated by :class:`DashboardCreate` at the boundary.
 
         Raises:
             SensorNotFoundError: a referenced sensor id is not in the tenant.
@@ -239,6 +247,8 @@ class CheckDashboardAdminService:
                     description=payload.description,
                     sensor_ids=deduped,
                     created_by_sub=created_by_sub,
+                    notify_email=payload.notify_email,
+                    notify_min_state=payload.notify_min_state,
                 )
                 await session.commit()
             except IntegrityError as exc:

--- a/backend/src/meho_backplane/checks/investigate.py
+++ b/backend/src/meho_backplane/checks/investigate.py
@@ -43,6 +43,12 @@ unchanged states just maintain the memo. Every evaluation is processed (not only
 state changes) because a ``for:`` hold expiring flips a Dashboard non-green with
 no sensor-state change; the memo-equality check is the cheap exit.
 
+Since #2719 the won claim has a second, independent consumer:
+:mod:`meho_backplane.checks.notify` mails the Dashboard's configured recipient.
+That consumer acts on **both** edge directions (an operator paged for
+``critical`` needs the all-clear too) and applies its own per-Dashboard floor,
+so the worsening gate described above governs the investigator alone.
+
 Diagnose-only (the CRUX security property)
 ==========================================
 
@@ -114,6 +120,11 @@ from meho_backplane.auth.agent_token import AgentTokenError
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.checks.assertions import CheckState
 from meho_backplane.checks.dashboard_repository import members_by_dashboard
+from meho_backplane.checks.notify import (
+    DashboardNotice,
+    NotifyMember,
+    schedule_dashboard_notification,
+)
 from meho_backplane.checks.rollup import (
     MemberEvaluation,
     MemberState,
@@ -283,6 +294,25 @@ class _DashboardSnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class _ClaimedTransition:
+    """One rollup edge this caller won the compare-and-swap for (#2719).
+
+    Returned for **both** edge directions, because the claim has two
+    independent consumers: the investigator (worsening only) and the email
+    notifier (both directions -- an operator paged for ``critical`` needs the
+    all-clear too). :attr:`worsening` carries the direction so the routing in
+    :func:`_process_transition` stays a plain read of the claim rather than a
+    second rank computation, and :attr:`notice` is built inside the claim
+    transaction while the Dashboard row is live.
+    """
+
+    dashboard: _DashboardSnapshot
+    non_green: list[_MemberSnapshot]
+    worsening: bool
+    notice: DashboardNotice
+
+
+@dataclass(frozen=True, slots=True)
 class _CauseGroup:
     """One correlated cause: the Sensors a single investigation covers.
 
@@ -333,16 +363,22 @@ async def _process_transition(
     tenant_id: uuid.UUID,
     now: datetime | None,
 ) -> None:
-    """Recompute affected Dashboards, maintain the memo, spawn investigations.
+    """Recompute affected Dashboards, maintain the memo, route the claim.
 
     For every Dashboard containing *sensor_id*, :func:`_claim_dashboard_transition`
     atomically coalesces concurrent transitions per ``(tenant, dashboard)``: it
     folds the members through #2506's pure rollup against *now*, compares against
     the persisted ``last_rollup_state`` (NULL treated as ``ok``), and
-    compare-and-swaps the memo. A **worsening** transition into ``degraded`` /
-    ``critical`` with at least one actively-failing member schedules a background
-    investigation -- but only for the caller that *won* the swap, so two Sensor
-    outcomes landing together on one Dashboard fire exactly one investigation.
+    compare-and-swaps the memo. Only the caller that *won* the swap gets a claim
+    back, so two Sensor outcomes landing together on one Dashboard produce exactly
+    one of everything downstream.
+
+    A won claim has two independent consumers. A **worsening** transition into
+    ``degraded`` / ``critical`` with at least one actively-failing member schedules
+    a background investigation (unchanged). **Every** claimed edge, both
+    directions, is handed to the #2719 notifier, which applies its own
+    ``notify_min_state`` floor -- so a ``critical -> ok`` recovery mails the
+    all-clear without the investigator ever seeing it.
     """
     now = now or datetime.now(UTC)
     sessionmaker = get_sessionmaker()
@@ -352,7 +388,7 @@ async def _process_transition(
     if not dashboard_ids:
         return
 
-    pending: list[tuple[_DashboardSnapshot, list[_MemberSnapshot]]] = []
+    pending: list[_ClaimedTransition] = []
     for dashboard_id in dashboard_ids:
         claimed = await _claim_dashboard_transition(
             sessionmaker, tenant_id=tenant_id, dashboard_id=dashboard_id, now=now
@@ -361,11 +397,16 @@ async def _process_transition(
             pending.append(claimed)
 
     # Claims committed under the per-(tenant, dashboard) lock; spawn the
-    # expensive work off the runner's persist path.
-    for dashboard_snapshot, non_green in pending:
-        _schedule_investigation(
-            tenant_id=tenant_id, dashboard=dashboard_snapshot, members=non_green
-        )
+    # expensive work off the runner's persist path. Investigation and
+    # notification are independent consumers of one claim: the investigator
+    # keeps its worsening-and-actively-failing gate, the notifier decides for
+    # itself from the configured floor (both edge directions, #2719).
+    for claim in pending:
+        if claim.worsening and claim.non_green:
+            _schedule_investigation(
+                tenant_id=tenant_id, dashboard=claim.dashboard, members=claim.non_green
+            )
+        schedule_dashboard_notification(claim.notice)
 
 
 async def _claim_dashboard_transition(
@@ -374,8 +415,8 @@ async def _claim_dashboard_transition(
     tenant_id: uuid.UUID,
     dashboard_id: uuid.UUID,
     now: datetime,
-) -> tuple[_DashboardSnapshot, list[_MemberSnapshot]] | None:
-    """Atomically claim one Dashboard's worsening transition; ``None`` if not owned.
+) -> _ClaimedTransition | None:
+    """Atomically claim one Dashboard's rollup transition; ``None`` if not owned.
 
     Serialises concurrent evaluations of the same ``(tenant, dashboard)`` behind a
     transaction-scoped Postgres advisory lock (auto-released at commit; a no-op on
@@ -383,14 +424,18 @@ async def _claim_dashboard_transition(
     fold sees a settled, committed view, then compare-and-swaps the
     ``last_rollup_state`` memo in a single conditional ``UPDATE``. Only the caller
     whose swap actually moved the memo (:func:`_claim_rollup_transition` returns
-    ``True``) owns the transition and returns the briefing snapshot; a concurrent
-    caller that lost the swap returns ``None``. So exactly one investigation is
-    scheduled per green->non-green edge, correlated over the full membership --
-    both the duplicate-run and partial-correlation races the memo-then-check
-    sequence used to admit (#2575).
+    ``True``) owns the transition; a concurrent caller that lost the swap returns
+    ``None``. So exactly one investigation is scheduled per green->non-green edge,
+    correlated over the full membership -- both the duplicate-run and
+    partial-correlation races the memo-then-check sequence used to admit (#2575).
 
-    The snapshots are detached while the ORM rows are live (before commit) because
-    the backgrounded investigation opens its own sessions.
+    The claim is returned for **both** edge directions (#2719); the worsening
+    filter that used to live here now sits at the single routing site in
+    :func:`_process_transition`, unchanged in meaning.
+
+    The snapshots are detached while the ORM rows are live (before commit)
+    because the backgrounded investigation opens its own sessions and the
+    backgrounded notification opens none at all.
     """
     async with sessionmaker() as session:
         await _lock_dashboard_transition(
@@ -421,11 +466,17 @@ async def _claim_dashboard_transition(
             claimed = await _claim_rollup_transition(
                 session, dashboard_id, expected=previous_memo, new=current
             )
+        notice = _dashboard_notice(dashboard, dashboard_snapshot, non_green)
         await session.commit()
 
-    if worsening and claimed and non_green:
-        return dashboard_snapshot, non_green
-    return None
+    if not claimed:
+        return None
+    return _ClaimedTransition(
+        dashboard=dashboard_snapshot,
+        non_green=non_green,
+        worsening=worsening,
+        notice=notice,
+    )
 
 
 def _dashboard_transition_lock_key(tenant_id: uuid.UUID, dashboard_id: uuid.UUID) -> int:
@@ -555,6 +606,37 @@ def _dashboard_snapshot(
         slug=_slugify(dashboard.name),
         previous_state=previous,
         current_state=current,
+    )
+
+
+def _dashboard_notice(
+    dashboard: CheckDashboard,
+    snapshot: _DashboardSnapshot,
+    non_green: list[_MemberSnapshot],
+) -> DashboardNotice:
+    """Detach the claim into the notifier's input (#2719).
+
+    Built inside the claim transaction, while the ``check_dashboards`` row is
+    still live, because the recipient config (``notify_email`` /
+    ``notify_min_state``) lives on that row and the send runs on a background
+    task with no session of its own.
+    """
+    return DashboardNotice(
+        dashboard_id=snapshot.dashboard_id,
+        name=snapshot.name,
+        previous_state=snapshot.previous_state,
+        current_state=snapshot.current_state,
+        notify_email=dashboard.notify_email,
+        notify_min_state=dashboard.notify_min_state,
+        members=tuple(
+            NotifyMember(
+                name=m.name,
+                effective_state=m.effective_state,
+                last_value=m.last_value,
+                last_evidence=m.last_evidence,
+            )
+            for m in non_green
+        ),
     )
 
 

--- a/backend/src/meho_backplane/checks/notify.py
+++ b/backend/src/meho_backplane/checks/notify.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-Dashboard email notification on a claimed rollup transition (#2719).
+
+Task #2719 under Initiative #2716 (parent goal #221). #2507's transition
+detector (:mod:`meho_backplane.checks.investigate`) already compare-and-swaps
+``check_dashboards.last_rollup_state`` exactly once per rollup edge, replica-
+safe; until now that claim only ever reached the diagnose-only investigator.
+This module is the second, independent consumer of the same claim: it mails
+the Dashboard's configured recipient.
+
+Both edge directions notify
+===========================
+
+The investigator fires on a **worsening** edge only -- a recovery needs no
+diagnosis. Notification is the opposite: an operator who was paged for
+``critical`` needs the all-clear as much as the page. So the rule here is
+symmetric in the two states, keyed on the configured floor:
+
+    notify  <=>  max(rank(previous), rank(current)) >= rank(notify_min_state)
+
+under ``ok < degraded < critical``. With the default ``notify_min_state``
+of ``critical`` that means ``critical -> ok`` mails the all-clear (the
+``critical`` side clears the bar) while ``ok -> degraded`` stays silent
+(neither side does). Prometheus Alertmanager takes the same stance with
+``send_resolved``: the resolved notification is standard practice, not an
+extra.
+
+:data:`_NOTIFY_RANK` ranks ``unknown`` with ``degraded`` -- a Dashboard that
+cannot be evaluated is a degradation, matching the Initiative's
+``UNKNOWN -> degraded`` rollup cap -- and ranks ``skip`` with ``ok``, so a
+``skip`` edge never clears the bar **on its own**; ``critical -> skip``
+still mails, because the ``critical`` side does.
+
+Exactly-once, and the flap boundary
+===================================
+
+One mail per *claimed* edge. The claim is the compare-and-swap, so two
+replicas racing the same edge produce exactly one send with no coordination
+here. What that does **not** bound is a genuinely flapping Dashboard: a
+member Sensor going stale and back re-crosses ``critical <-> unknown``, and
+each crossing is a real edge, so each mails. There is deliberately no
+rate limit, digest, or repeat-suppression window in this Task (#2716
+scopes those out); the floor knob is the only volume control today.
+
+Failure posture
+===============
+
+Fire-and-forget, in two senses. The send runs as a tracked background task
+(:func:`schedule_dashboard_notification`) so a 30-second SMTP session
+cannot sit on the check-runner's result-persist path -- the same containment
+shape the investigator uses. And :func:`notify_dashboard_transition` never
+raises: a refused, unconfigured, or failed
+:func:`~meho_backplane.connectors.mail.transport.send_email` is logged as
+``checks_notify_failed`` and swallowed, contract parity with
+``investigate_on_transition``'s never-raise posture. A broken MTA must not
+convert a committed transition claim into a persist-path failure.
+
+Header safety
+=============
+
+A Dashboard name is operator-authored free text with no newline constraint
+at the database, and the transport's in-process entry point raises
+:class:`ValueError` on a subject carrying a line break (only the dispatched
+``mail.send`` path gets the single-line parameter screen). The subject
+built here therefore folds every control character out of the name, so a
+crafted name cannot inject an SMTP header. The body is a MIME payload, not
+headers, so its untrusted fragments (member names, last values, evidence)
+need no such fold -- only bounding, which :data:`_MAX_MEMBER_LINES` and
+:data:`_MAX_FIELD_CHARS` provide.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from typing import Final, cast
+
+import structlog
+
+from meho_backplane.connectors.mail.transport import send_email
+
+__all__ = [
+    "DashboardNotice",
+    "NotifyMember",
+    "notify_dashboard_transition",
+    "schedule_dashboard_notification",
+]
+
+
+#: Notification rank over the five-state check vocabulary. ``unknown`` ranks
+#: with ``degraded`` (cannot-evaluate is a degradation, the Initiative's
+#: rollup cap); ``skip`` ranks with ``ok`` so a deliberate opt-out never
+#: clears the bar by itself. Distinct from
+#: :data:`~meho_backplane.checks.investigate._FIRE_RANK`, which additionally
+#: requires the *current* state to be a firing target -- that asymmetry is
+#: exactly what keeps the investigator worsening-only while this notifier
+#: acts on both directions.
+_NOTIFY_RANK: Final[dict[str, int]] = {
+    "ok": 0,
+    "skip": 0,
+    "unknown": 1,
+    "degraded": 1,
+    "critical": 2,
+}
+
+#: How many non-green members one mail enumerates. A correlated failure can
+#: redden a whole Dashboard; the recipient needs the shape of the problem,
+#: not a 200-row dump (``dashboard_schemas._MAX_MEMBERS``).
+_MAX_MEMBER_LINES: Final[int] = 20
+
+#: Per-field character bound on the untrusted member fragments (last value,
+#: evidence). Bounds one adversarial or merely verbose Sensor payload from
+#: dominating the mail.
+_MAX_FIELD_CHARS: Final[int] = 200
+
+#: Per-process strong references to in-flight notification tasks. ``asyncio``
+#: holds only weak references to bare tasks, so without this set a
+#: fire-and-forget send could be garbage-collected mid-flight (the
+#: ``_INVESTIGATIONS`` rationale in
+#: :mod:`meho_backplane.checks.investigate`). The done-callback discards each
+#: entry on completion so a long-lived worker does not accumulate them.
+_NOTIFICATIONS: set[asyncio.Task[None]] = set()
+
+
+def _log() -> structlog.typing.FilteringBoundLogger:
+    """Resolve the structlog logger per call (not a module-level proxy).
+
+    A module-level proxy caches its bound methods on first use under the
+    production ``cache_logger_on_first_use=True`` config, which orphans them
+    from a later :func:`structlog.testing.capture_logs`. Resolving per call
+    reads the live config each time -- the discipline the check runner and
+    the investigator both follow.
+    """
+    return cast("structlog.typing.FilteringBoundLogger", structlog.get_logger(__name__))
+
+
+@dataclass(frozen=True, slots=True)
+class NotifyMember:
+    """One non-green member Sensor as the mail renders it.
+
+    A narrow, notifier-owned projection rather than a reuse of the
+    investigator's briefing snapshot: this module must not depend on
+    :mod:`meho_backplane.checks.investigate` (which imports *it*), and the
+    mail needs four fields where the briefing needs ten.
+    """
+
+    name: str
+    effective_state: str
+    last_value: object
+    last_evidence: dict[str, object] | None
+
+
+@dataclass(frozen=True, slots=True)
+class DashboardNotice:
+    """One claimed transition, detached for the background send.
+
+    Built while the ``check_dashboards`` row and its member Sensors are live
+    inside the claim transaction, so the background task never touches an
+    expired ORM object.
+    """
+
+    dashboard_id: uuid.UUID
+    name: str
+    previous_state: str
+    current_state: str
+    notify_email: str | None
+    notify_min_state: str
+    members: tuple[NotifyMember, ...]
+
+
+def _crosses_threshold(previous: str, current: str, min_state: str) -> bool:
+    """Return ``True`` iff this edge reaches the configured notification floor.
+
+    ``max(rank(previous), rank(current)) >= rank(min_state)`` -- symmetric in
+    the two states, which is what makes the recovery edge notify. An
+    out-of-vocabulary state ranks 0 rather than raising: the memo column is
+    CHECK-constrained, so this is unreachable defensive shaping, and a
+    notifier is the wrong place to fail loudly.
+    """
+    floor = _NOTIFY_RANK.get(min_state, _NOTIFY_RANK["critical"])
+    return max(_NOTIFY_RANK.get(previous, 0), _NOTIFY_RANK.get(current, 0)) >= floor
+
+
+def _single_line(value: str) -> str:
+    """Fold every control character out of *value* (subject-header safety)."""
+    return "".join(" " if ch.isspace() or not ch.isprintable() else ch for ch in value).strip()
+
+
+def _clip(value: object) -> str:
+    """Render *value* as a bounded single-line fragment for the mail body."""
+    text = " ".join(str(value).split())
+    if len(text) > _MAX_FIELD_CHARS:
+        return text[:_MAX_FIELD_CHARS] + "..."
+    return text
+
+
+def _subject(notice: DashboardNotice) -> str:
+    """Build the single-line subject.
+
+    An "all clear" prefix keys on *no member being non-green* rather than on
+    the edge improving: ``critical -> degraded`` improves but still has
+    failures to name, and the recipient's filter rule cares about whether
+    anything is still broken.
+    """
+    prefix = "" if notice.members else "all clear - "
+    name = _single_line(notice.name)
+    return f"[MEHO] {prefix}{name}: {notice.previous_state} -> {notice.current_state}"
+
+
+def _body(notice: DashboardNotice) -> str:
+    """Build the plain-text body: the edge, then the non-green members."""
+    lines = [
+        f"Dashboard: {notice.name}",
+        f"State: {notice.previous_state} -> {notice.current_state}",
+        "",
+    ]
+    if not notice.members:
+        lines.append("All clear - no member sensor is in a failing state.")
+        return "\n".join(lines) + "\n"
+
+    shown = notice.members[:_MAX_MEMBER_LINES]
+    lines.append(f"Non-green members ({len(notice.members)}):")
+    lines.append("")
+    for member in shown:
+        lines.append(f"- {_clip(member.name)} [{member.effective_state}]")
+        lines.append(f"    last value: {_clip(member.last_value)}")
+        lines.append(f"    evidence:   {_clip(member.last_evidence)}")
+    if len(notice.members) > len(shown):
+        lines.append("")
+        lines.append(f"({len(notice.members) - len(shown)} further member(s) not shown.)")
+    return "\n".join(lines) + "\n"
+
+
+async def _deliver(notice: DashboardNotice, recipient: str) -> None:
+    """Send one mail and record its outcome; swallow every failure.
+
+    Split out of :func:`notify_dashboard_transition` so that function reads
+    as the two gates it is, and so the never-raise guard wraps exactly the
+    I/O rather than the gates too.
+    """
+    try:
+        result = await send_email(
+            to=[recipient],
+            subject=_subject(notice),
+            body=_body(notice),
+        )
+    except Exception:
+        # Contract: a notification failure never reaches the persist seam.
+        _log().warning(
+            "checks_notify_failed",
+            dashboard_id=str(notice.dashboard_id),
+            reason="unexpected_error",
+            exc_info=True,
+        )
+        return
+
+    if not result.sent:
+        _log().warning(
+            "checks_notify_failed",
+            dashboard_id=str(notice.dashboard_id),
+            reason=result.reason,
+        )
+        return
+    _log().info(
+        "checks_notify_sent",
+        dashboard_id=str(notice.dashboard_id),
+        previous_state=notice.previous_state,
+        current_state=notice.current_state,
+        member_count=len(notice.members),
+    )
+
+
+async def notify_dashboard_transition(notice: DashboardNotice) -> None:
+    """Mail the Dashboard's recipient about one claimed transition.
+
+    Never raises. Short-circuits, in order:
+
+    * ``notify_email`` unset -- notifications are off for this Dashboard
+      (the state every pre-#2719 row backfills to);
+    * the edge does not reach ``notify_min_state`` (see
+      :func:`_crosses_threshold`).
+
+    Otherwise :func:`_deliver` runs one
+    :func:`~meho_backplane.connectors.mail.transport.send_email` call,
+    screened by the deployment-level recipient allowlist floor that function
+    owns.
+    """
+    if not notice.notify_email:
+        _log().info(
+            "checks_notify_skipped_unconfigured",
+            dashboard_id=str(notice.dashboard_id),
+        )
+        return
+    if not _crosses_threshold(notice.previous_state, notice.current_state, notice.notify_min_state):
+        _log().info(
+            "checks_notify_skipped_below_threshold",
+            dashboard_id=str(notice.dashboard_id),
+            previous_state=notice.previous_state,
+            current_state=notice.current_state,
+            notify_min_state=notice.notify_min_state,
+        )
+        return
+    await _deliver(notice, notice.notify_email)
+
+
+def schedule_dashboard_notification(notice: DashboardNotice) -> None:
+    """Spawn the send as a tracked fire-and-forget task.
+
+    Keeps the SMTP session off the check-runner's result-persist path: the
+    transport bounds one session at 30 seconds, and the persist path awaits
+    ``investigate_on_transition`` inline. ``notify_dashboard_transition``
+    swallows every exception, so the task cannot end in an unretrieved
+    exception; :class:`asyncio.CancelledError` still propagates so lifespan
+    shutdown tears the task down cleanly.
+    """
+    task = asyncio.create_task(
+        notify_dashboard_transition(notice),
+        name=f"checks-notify-{notice.dashboard_id}",
+    )
+    _NOTIFICATIONS.add(task)
+    task.add_done_callback(_NOTIFICATIONS.discard)
+
+
+async def _await_pending_notifications() -> None:
+    """Await all in-flight notification tasks -- a deterministic test seam.
+
+    Production spawns sends fire-and-forget; tests drain them before
+    asserting on the transport. Mirrors
+    :func:`meho_backplane.checks.investigate._await_pending_investigations`.
+    """
+    pending = [task for task in _NOTIFICATIONS if not task.done()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -6340,6 +6340,14 @@ class Sensor(Base):
 _CHECK_DASHBOARD_ROLLUP_STATES: tuple[str, ...] = get_args(CheckState)
 
 
+#: Closed ``check_dashboards.notify_min_state`` vocabulary (#2719) -- the
+#: notification floor an operator may set. Deliberately **not** derived from
+#: :data:`CheckState`: ``ok`` as a floor would mail on every edge, and
+#: ``skip`` / ``unknown`` are not severities a threshold is meaningful at.
+#: Only the two actionable states qualify.
+_CHECK_DASHBOARD_NOTIFY_MIN_STATES: tuple[str, ...] = ("degraded", "critical")
+
+
 class CheckDashboard(Base):
     """One named, tenant-scoped composition of Sensors (#2506).
 
@@ -6381,6 +6389,18 @@ class CheckDashboard(Base):
     # until #2507's hook maintains it. The CHECK admits NULL plus the
     # five-state vocabulary.
     last_rollup_state: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    # Email-notification config (#2719), read by ``checks.notify`` on every
+    # claimed transition. ``notify_email`` NULL means notifications are off
+    # for this Dashboard -- the backfilled state for every pre-#2719 row.
+    # ``notify_min_state`` is the threshold the edge must reach; NOT NULL so
+    # the notifier's rank comparison always reads a concrete state.
+    notify_email: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    notify_min_state: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="critical",
+        server_default="critical",
+    )
     created_by_sub: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -6414,6 +6434,11 @@ class CheckDashboard(Base):
         sa.CheckConstraint(
             _ck_in("last_rollup_state", _CHECK_DASHBOARD_ROLLUP_STATES),
             name="ck_check_dashboards_last_rollup_state",
+        ),
+        # ``notify_min_state`` over the two actionable states only (#2719).
+        sa.CheckConstraint(
+            _ck_in("notify_min_state", _CHECK_DASHBOARD_NOTIFY_MIN_STATES),
+            name="ck_check_dashboards_notify_min_state",
         ),
     )
 

--- a/backend/tests/migrations/test_migration_0068_add_check_dashboard_notify.py
+++ b/backend/tests/migrations/test_migration_0068_add_check_dashboard_notify.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0068_add_check_dashboard_notify``.
+
+Initiative #2716, Task #2719. Adds the per-Dashboard notification config the
+checks notifier reads on every claimed rollup transition:
+
+* ``notify_email`` -- ``text`` nullable; NULL means notifications are off,
+  so every pre-#2719 row backfills to "silent" and the migration is
+  behaviour-preserving on its own.
+* ``notify_min_state`` -- ``text`` NOT NULL, server default ``'critical'``,
+  CHECK ``IN ('degraded', 'critical')``.
+
+**Idempotency pinning (0049/0050/0053/0055 footgun).** Every forward /
+round-trip step targets this migration's **own** revision (``0068``) and its
+``down_revision`` (``0067``), never ``head`` -- so a future head migration
+cannot make ``upgrade("head")`` re-run this ``add_column`` on a table that
+already has it. SQLite is the test driver; the migration uses only generic
+DDL through ``batch_alter_table``, so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0068"
+_DOWN_REVISION = "0067"
+_NOTIFY_COLUMNS = ("notify_email", "notify_min_state")
+
+#: A pre-0068 ``check_dashboards`` row. SQLite does not enforce foreign keys
+#: by default, so no parent tenant row is needed. UUIDs are stored as 32-char
+#: hex (SQLAlchemy's ``Uuid`` on SQLite drops the dashes).
+_DASHBOARD_ID = "55555555555555555555555555555555"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0068.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _table_info(sync_url: str) -> list[tuple[str, bool]]:
+    """Return ``(column_name, is_nullable)`` pairs for ``check_dashboards``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(check_dashboards)")).all()
+    finally:
+        sync_eng.dispose()
+    return [(str(row[1]), int(row[3]) == 0) for row in rows]
+
+
+def _columns(sync_url: str) -> set[str]:
+    return {name for name, _ in _table_info(sync_url)}
+
+
+def _column_is_nullable(sync_url: str, column: str) -> bool:
+    for name, nullable in _table_info(sync_url):
+        if name == column:
+            return nullable
+    raise AssertionError(f"column {column!r} not present on check_dashboards")
+
+
+def _insert_pre_0068_dashboard(sync_url: str) -> None:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO check_dashboards "
+                    "(id, tenant_id, name, description, last_rollup_state, "
+                    "created_by_sub, created_at, updated_at) "
+                    "VALUES (:id, '11111111111111111111111111111111', 'prod', NULL, "
+                    "'critical', 'seed', "
+                    "'2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')"
+                ),
+                {"id": _DASHBOARD_ID},
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def test_upgrade_adds_notify_columns(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0068`` lands both columns with the right nullability."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    columns = _columns(sync_url)
+    for column in _NOTIFY_COLUMNS:
+        assert column in columns, f"migration 0068 must add check_dashboards.{column}"
+
+    assert _column_is_nullable(sync_url, "notify_email")
+    # notify_min_state is NOT NULL (server default 'critical') so the
+    # notifier's rank comparison always reads a concrete state.
+    assert not _column_is_nullable(sync_url, "notify_min_state")
+
+
+def test_existing_row_backfills_silent_and_critical(alembic_cfg: tuple[Config, str]) -> None:
+    """A row inserted at ``0067`` backfills NULL email + ``'critical'`` floor.
+
+    The behaviour-preserving property: no pre-#2719 Dashboard starts emailing
+    when the migration lands, because the recipient column is the off switch.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+    _insert_pre_0068_dashboard(sync_url)
+
+    command.upgrade(cfg, _REVISION)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text("SELECT notify_email, notify_min_state FROM check_dashboards WHERE id = :id"),
+                {"id": _DASHBOARD_ID},
+            ).one()
+    finally:
+        sync_eng.dispose()
+    assert row[0] is None, "pre-0068 rows must backfill with notifications off"
+    assert row[1] == "critical", "pre-0068 rows must backfill the conservative floor"
+
+
+def test_notify_min_state_check_rejects_out_of_vocabulary(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The CHECK admits only ``degraded`` / ``critical`` -- not ``ok``."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with pytest.raises(IntegrityError), sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO check_dashboards "
+                    "(id, tenant_id, name, notify_min_state, created_by_sub, "
+                    "created_at, updated_at) "
+                    "VALUES ('66666666666666666666666666666666', "
+                    "'11111111111111111111111111111111', 'bad', 'ok', 'seed', "
+                    "'2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')"
+                )
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0067"`` drops the columns; ``upgrade "0068"`` restores them.
+
+    Pinned to this migration's own revision on both legs (never ``head``) so a
+    future head migration cannot break the round-trip.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert set(_NOTIFY_COLUMNS) <= _columns(sync_url)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    remaining = _columns(sync_url)
+    for column in _NOTIFY_COLUMNS:
+        assert column not in remaining, f"downgrade must drop {column}"
+
+    command.upgrade(cfg, _REVISION)
+    assert set(_NOTIFY_COLUMNS) <= _columns(sync_url)

--- a/backend/tests/test_checks_dashboards.py
+++ b/backend/tests/test_checks_dashboards.py
@@ -497,3 +497,95 @@ async def test_rest_last_rollup_state_stays_null(client: TestClient) -> None:
         row = await session.get(CheckDashboard, UUID(dashboard_id))
         assert row is not None
         assert row.last_rollup_state is None
+
+
+# ---------------------------------------------------------------------------
+# Notification config (#2719)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rest_create_round_trips_notify_config(client: TestClient) -> None:
+    """The create body's notification config lands on the row and reads back."""
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    sid = await _seed_sensor(name="notify-sensor", last_state="ok")
+    key = make_rsa_keypair("kid-notify")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key)}"}
+        created = client.post(
+            "/api/v1/checks/dashboards",
+            json={
+                "name": "notified",
+                "sensor_ids": [str(sid)],
+                "notify_email": "oncall@example.com",
+                "notify_min_state": "degraded",
+            },
+            headers=headers,
+        )
+        assert created.status_code == 201, created.text
+        assert created.json()["notify_email"] == "oncall@example.com"
+        assert created.json()["notify_min_state"] == "degraded"
+
+        dashboard_id = created.json()["id"]
+        detail = client.get(f"/api/v1/checks/dashboards/{dashboard_id}", headers=headers)
+        assert detail.json()["notify_email"] == "oncall@example.com"
+        assert detail.json()["notify_min_state"] == "degraded"
+
+        listed = client.get("/api/v1/checks/dashboards", headers=headers)
+        row = next(d for d in listed.json()["dashboards"] if d["id"] == dashboard_id)
+        assert row["notify_email"] == "oncall@example.com"
+        assert row["notify_min_state"] == "degraded"
+
+    async with get_sessionmaker()() as session:
+        persisted = await session.get(CheckDashboard, UUID(dashboard_id))
+        assert persisted is not None
+        assert persisted.notify_email == "oncall@example.com"
+        assert persisted.notify_min_state == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_rest_create_defaults_notify_off_at_critical(client: TestClient) -> None:
+    """Omitting both fields leaves notifications off at the ``critical`` floor."""
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    key = make_rsa_keypair("kid-notify-default")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key)}"}
+        created = client.post(
+            "/api/v1/checks/dashboards",
+            json={"name": "quiet"},
+            headers=headers,
+        )
+        assert created.status_code == 201, created.text
+        assert created.json()["notify_email"] is None
+        assert created.json()["notify_min_state"] == "critical"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        pytest.param("notify_email", "not-an-address", id="malformed-email"),
+        pytest.param("notify_email", "oncall@", id="empty-domain"),
+        pytest.param("notify_min_state", "ok", id="floor-outside-vocabulary"),
+        pytest.param("notify_min_state", "warn", id="floor-not-a-state"),
+    ],
+)
+async def test_rest_create_rejects_invalid_notify_config(
+    client: TestClient, field: str, value: str
+) -> None:
+    """A malformed address or an out-of-vocabulary floor is a boundary 422."""
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    key = make_rsa_keypair("kid-notify-invalid")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key)}"}
+        result = client.post(
+            "/api/v1/checks/dashboards",
+            json={"name": f"bad-{field}-{value}", field: value},
+            headers=headers,
+        )
+        assert result.status_code == 422, result.text
+        # FastAPI's validation envelope names the offending field.
+        assert any(field in entry["loc"] for entry in result.json()["detail"])

--- a/backend/tests/test_checks_notify.py
+++ b/backend/tests/test_checks_notify.py
@@ -1,0 +1,523 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the Dashboard email notifier (#2719).
+
+Initiative #2716 (parent goal #221), Task #2719. Coverage:
+
+* **Threshold rule** -- the ``max(rank(previous), rank(current)) >=
+  rank(notify_min_state)`` matrix, including the ``critical -> ok``
+  all-clear, the ``ok -> degraded`` silence at ``min_state='critical'``,
+  ``unknown`` ranking with ``degraded``, and ``skip`` never clearing the
+  bar on its own.
+* **Unconfigured** -- a ``notify_email``-less Dashboard sends nothing.
+* **Failure posture** -- a ``sent=False`` transport result and a raising
+  transport are both swallowed; neither reaches the caller.
+* **Message content** -- the mail names the Dashboard, the edge, and the
+  non-green members; a recovery reads as an all-clear; a control-character
+  Dashboard name cannot inject an SMTP header.
+* **Integration through the persist seam** -- two raced
+  ``investigate_on_transition`` calls on one Dashboard produce exactly one
+  send (the compare-and-swap claim is the dedupe), and the recovery edge
+  back to ``ok`` produces a second one.
+
+:func:`~meho_backplane.connectors.mail.transport.send_email` is replaced by
+a recording fake in every test, so no SMTP session is opened; the DB layer
+is real against the SQLite engine from :mod:`tests.conftest`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from structlog.testing import capture_logs
+
+import meho_backplane.checks.investigate as inv
+import meho_backplane.checks.notify as notify
+from meho_backplane.checks.notify import (
+    DashboardNotice,
+    NotifyMember,
+    notify_dashboard_transition,
+)
+from meho_backplane.connectors.mail.transport import MailSendResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    CheckDashboard,
+    CheckDashboardSensor,
+    Sensor,
+    Tenant,
+)
+from meho_backplane.settings import get_settings
+
+_TENANT = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+_ASSERTION: dict[str, Any] = {
+    "select": {"path": "$.count"},
+    "compare": {"type": "threshold", "op": "lt", "critical": 10},
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + doubles
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env :class:`Settings` requires so ``get_settings()`` constructs."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://kc.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_notifications() -> Iterator[None]:
+    """Clear the in-flight notification / investigation sets per test."""
+    yield
+    notify._NOTIFICATIONS.clear()
+    inv._INVESTIGATIONS.clear()
+
+
+class _RecordingTransport:
+    """Stands in for ``send_email``; records every call, returns a preset."""
+
+    def __init__(
+        self,
+        *,
+        result: MailSendResult | None = None,
+        exc: Exception | None = None,
+    ) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._result = result or MailSendResult(sent=True)
+        self._exc = exc
+
+    async def __call__(self, *, to: list[str], subject: str, body: str) -> MailSendResult:
+        self.calls.append({"to": list(to), "subject": subject, "body": body})
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+def _install_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    **kwargs: Any,
+) -> _RecordingTransport:
+    fake = _RecordingTransport(**kwargs)
+    monkeypatch.setattr(notify, "send_email", fake)
+    return fake
+
+
+def _notice(
+    *,
+    previous: str = "ok",
+    current: str = "critical",
+    email: str | None = "oncall@example.com",
+    min_state: str = "critical",
+    members: tuple[NotifyMember, ...] = (),
+    name: str = "prod-health",
+) -> DashboardNotice:
+    return DashboardNotice(
+        dashboard_id=uuid4(),
+        name=name,
+        previous_state=previous,
+        current_state=current,
+        notify_email=email,
+        notify_min_state=min_state,
+        members=members,
+    )
+
+
+def _member(
+    name: str = "disk-space",
+    *,
+    state: str = "critical",
+    last_value: object = 3,
+    evidence: dict[str, object] | None = None,
+) -> NotifyMember:
+    return NotifyMember(
+        name=name,
+        effective_state=state,
+        last_value=last_value,
+        last_evidence=evidence if evidence is not None else {"observed": 3, "bound": 10},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers (integration through the persist seam)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant(tenant_id: UUID = _TENANT) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if await session.get(Tenant, tenant_id) is None:
+            session.add(Tenant(id=tenant_id, slug="tenant-notify", name="Tenant Notify"))
+            await session.commit()
+
+
+async def _seed_sensor(*, name: str, last_state: str = "critical") -> UUID:
+    now = datetime.now(UTC)
+    sensor_id = uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Sensor(
+                id=sensor_id,
+                tenant_id=_TENANT,
+                name=name,
+                connector_id="vmware-rest-9.0",
+                op_id="vmware.vm.list",
+                target=None,
+                params={},
+                assertion=_ASSERTION,
+                status="active",
+                cadence_kind="interval",
+                interval_seconds=60,
+                cron_expr=None,
+                timezone="UTC",
+                next_fire_at=now + timedelta(seconds=60),
+                severity="critical",
+                for_seconds=0,
+                last_state=last_state,
+                last_value=7,
+                last_evidence={"observed": 7, "bound": 10},
+                last_evaluated_at=now - timedelta(seconds=30),
+                state_since=now - timedelta(hours=1),
+                identity_sub="__sensor__",
+                created_by_sub="op-admin",
+            )
+        )
+        await session.commit()
+    return sensor_id
+
+
+async def _seed_dashboard(
+    *,
+    name: str,
+    sensor_ids: list[UUID],
+    last_rollup_state: str | None = None,
+    notify_email: str | None = "oncall@example.com",
+    notify_min_state: str = "critical",
+) -> UUID:
+    dashboard_id = uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            CheckDashboard(
+                id=dashboard_id,
+                tenant_id=_TENANT,
+                name=name,
+                description=None,
+                last_rollup_state=last_rollup_state,
+                notify_email=notify_email,
+                notify_min_state=notify_min_state,
+                created_by_sub="op-admin",
+            )
+        )
+        for sid in sensor_ids:
+            session.add(CheckDashboardSensor(dashboard_id=dashboard_id, sensor_id=sid))
+        await session.commit()
+    return dashboard_id
+
+
+async def _set_sensor_state(sensor_id: UUID, state: str) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        row.last_state = state
+        row.state_since = datetime.now(UTC) - timedelta(hours=1)
+        row.last_evaluated_at = datetime.now(UTC)
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Threshold rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("previous", "current", "min_state", "should_send"),
+    [
+        # The binding rule: max(rank(previous), rank(current)) >= rank(min).
+        pytest.param("ok", "critical", "critical", True, id="ok-to-critical-at-critical"),
+        pytest.param("critical", "ok", "critical", True, id="critical-to-ok-all-clear"),
+        pytest.param("ok", "degraded", "critical", False, id="ok-to-degraded-silent"),
+        pytest.param("degraded", "ok", "critical", False, id="degraded-to-ok-silent"),
+        pytest.param("ok", "degraded", "degraded", True, id="ok-to-degraded-at-degraded"),
+        pytest.param("degraded", "ok", "degraded", True, id="degraded-to-ok-all-clear"),
+        pytest.param("degraded", "critical", "critical", True, id="degraded-to-critical"),
+        pytest.param("critical", "degraded", "critical", True, id="critical-to-degraded"),
+        # unknown ranks with degraded.
+        pytest.param("ok", "unknown", "degraded", True, id="unknown-ranks-degraded"),
+        pytest.param("ok", "unknown", "critical", False, id="unknown-below-critical"),
+        # skip ranks with ok -- it never clears the bar on its own.
+        pytest.param("ok", "skip", "degraded", False, id="skip-never-fires-alone"),
+        pytest.param("skip", "ok", "critical", False, id="skip-to-ok-silent"),
+        pytest.param("critical", "skip", "critical", True, id="critical-to-skip-other-side"),
+    ],
+)
+async def test_threshold_matrix(
+    monkeypatch: pytest.MonkeyPatch,
+    previous: str,
+    current: str,
+    min_state: str,
+    should_send: bool,
+) -> None:
+    """The notify rule is symmetric in the two states and keyed on the floor."""
+    fake = _install_transport(monkeypatch)
+    await notify_dashboard_transition(
+        _notice(previous=previous, current=current, min_state=min_state)
+    )
+    assert (len(fake.calls) == 1) is should_send
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_dashboard_sends_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``notify_email`` NULL is the off switch -- the transport is never reached."""
+    fake = _install_transport(monkeypatch)
+    with capture_logs() as logs:
+        await notify_dashboard_transition(_notice(email=None))
+    assert fake.calls == []
+    assert any(entry["event"] == "checks_notify_skipped_unconfigured" for entry in logs)
+
+
+@pytest.mark.asyncio
+async def test_empty_email_string_is_also_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty-string recipient is treated as unset, not mailed to nobody."""
+    fake = _install_transport(monkeypatch)
+    await notify_dashboard_transition(_notice(email=""))
+    assert fake.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Failure posture
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_failure_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``sent=False`` refusal warn-logs its reason code and never raises."""
+    _install_transport(
+        monkeypatch,
+        result=MailSendResult(sent=False, reason="not_in_recipient_allowlist"),
+    )
+    with capture_logs() as logs:
+        await notify_dashboard_transition(_notice())
+    failed = [entry for entry in logs if entry["event"] == "checks_notify_failed"]
+    assert len(failed) == 1
+    assert failed[0]["reason"] == "not_in_recipient_allowlist"
+
+
+@pytest.mark.asyncio
+async def test_transport_exception_is_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unexpected transport exception is contained, not propagated."""
+    _install_transport(monkeypatch, exc=RuntimeError("socket exploded"))
+    with capture_logs() as logs:
+        await notify_dashboard_transition(_notice())
+    failed = [entry for entry in logs if entry["event"] == "checks_notify_failed"]
+    assert len(failed) == 1
+    assert failed[0]["reason"] == "unexpected_error"
+
+
+@pytest.mark.asyncio
+async def test_successful_send_logs_sent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A delivered mail records ``checks_notify_sent`` with the edge."""
+    _install_transport(monkeypatch)
+    with capture_logs() as logs:
+        await notify_dashboard_transition(_notice(previous="critical", current="ok"))
+    sent = [entry for entry in logs if entry["event"] == "checks_notify_sent"]
+    assert len(sent) == 1
+    assert sent[0]["previous_state"] == "critical"
+    assert sent[0]["current_state"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Message content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_alert_mail_names_dashboard_edge_and_members(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mail carries the Dashboard, the edge, and each non-green member."""
+    fake = _install_transport(monkeypatch)
+    await notify_dashboard_transition(
+        _notice(
+            previous="ok",
+            current="critical",
+            members=(
+                _member("disk-space", state="critical", last_value=3),
+                _member("cpu-load", state="degraded", last_value=91),
+            ),
+        )
+    )
+    call = fake.calls[0]
+    assert call["to"] == ["oncall@example.com"]
+    assert "prod-health" in call["subject"]
+    assert "ok -> critical" in call["subject"]
+    assert "all clear" not in call["subject"]
+    body = call["body"]
+    assert "Dashboard: prod-health" in body
+    assert "State: ok -> critical" in body
+    for fragment in ("disk-space", "[critical]", "cpu-load", "[degraded]", "91"):
+        assert fragment in body
+
+
+@pytest.mark.asyncio
+async def test_recovery_mail_is_an_all_clear(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no non-green member left the mail reads as the all-clear."""
+    fake = _install_transport(monkeypatch)
+    await notify_dashboard_transition(_notice(previous="critical", current="ok"))
+    call = fake.calls[0]
+    assert "all clear" in call["subject"]
+    assert "critical -> ok" in call["subject"]
+    assert "All clear" in call["body"]
+    assert "State: critical -> ok" in call["body"]
+
+
+@pytest.mark.asyncio
+async def test_subject_folds_control_characters_in_the_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CR/LF-bearing Dashboard name cannot inject an SMTP header."""
+    fake = _install_transport(monkeypatch)
+    await notify_dashboard_transition(_notice(name="prod\r\nBcc: attacker@evil.test"))
+    subject = fake.calls[0]["subject"]
+    assert "\r" not in subject
+    assert "\n" not in subject
+
+
+@pytest.mark.asyncio
+async def test_body_bounds_members_and_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The body caps the member list and clips each untrusted field."""
+    fake = _install_transport(monkeypatch)
+    members = tuple(
+        _member(f"sensor-{i:03d}", last_value="x" * 5000)
+        for i in range(notify._MAX_MEMBER_LINES + 5)
+    )
+    await notify_dashboard_transition(_notice(members=members))
+    body = fake.calls[0]["body"]
+    assert "sensor-000" in body
+    assert f"sensor-{notify._MAX_MEMBER_LINES:03d}" not in body
+    assert "further member(s) not shown" in body
+    assert "x" * (notify._MAX_FIELD_CHARS + 1) not in body
+
+
+# ---------------------------------------------------------------------------
+# Integration through the persist seam
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_transitions_send_exactly_one_mail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two raced persists on one Dashboard mail once -- the CAS claim dedupes.
+
+    Then a recovery to ``ok`` mails a second time: the notifier acts on both
+    edge directions, unlike the investigator's worsening-only gate.
+    """
+    fake = _install_transport(monkeypatch)
+    monkeypatch.setattr(inv, "_schedule_investigation", lambda **_: None)
+    await _seed_tenant()
+    sid_a = await _seed_sensor(name="sensor-a", last_state="critical")
+    sid_b = await _seed_sensor(name="sensor-b", last_state="critical")
+    dash = await _seed_dashboard(name="prod-health", sensor_ids=[sid_a, sid_b])
+
+    await asyncio.gather(
+        inv.investigate_on_transition(sensor_id=sid_a, tenant_id=_TENANT),
+        inv.investigate_on_transition(sensor_id=sid_b, tenant_id=_TENANT),
+    )
+    await notify._await_pending_notifications()
+
+    assert len(fake.calls) == 1, "the compare-and-swap claim must dedupe the raced edge"
+    assert "ok -> critical" in fake.calls[0]["subject"]
+    assert "sensor-a" in fake.calls[0]["body"]
+    assert "sensor-b" in fake.calls[0]["body"]
+
+    # Recovery: both members go green, the Dashboard folds back to ok.
+    await _set_sensor_state(sid_a, "ok")
+    await _set_sensor_state(sid_b, "ok")
+    await inv.investigate_on_transition(sensor_id=sid_a, tenant_id=_TENANT)
+    await notify._await_pending_notifications()
+
+    assert len(fake.calls) == 2, "the recovery edge must mail the all-clear"
+    assert "all clear" in fake.calls[1]["subject"]
+    assert "critical -> ok" in fake.calls[1]["subject"]
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(CheckDashboard, dash)
+        assert row is not None
+        assert row.last_rollup_state == "ok"
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_dashboard_sends_nothing_through_the_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Dashboard with no recipient transitions silently (the default row)."""
+    fake = _install_transport(monkeypatch)
+    monkeypatch.setattr(inv, "_schedule_investigation", lambda **_: None)
+    await _seed_tenant()
+    sid = await _seed_sensor(name="lonely", last_state="critical")
+    await _seed_dashboard(name="quiet", sensor_ids=[sid], notify_email=None)
+
+    await inv.investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+    await notify._await_pending_notifications()
+
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_send_failure_through_the_seam_never_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken MTA cannot convert a committed claim into a persist failure."""
+    _install_transport(monkeypatch, exc=RuntimeError("MTA down"))
+    monkeypatch.setattr(inv, "_schedule_investigation", lambda **_: None)
+    await _seed_tenant()
+    sid = await _seed_sensor(name="crit", last_state="critical")
+    dash = await _seed_dashboard(name="prod-health", sensor_ids=[sid])
+
+    await inv.investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+    await notify._await_pending_notifications()
+
+    # The memo still advanced: the claim is independent of delivery.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(CheckDashboard, dash)
+        assert row is not None
+        assert row.last_rollup_state == "critical"
+
+
+@pytest.mark.asyncio
+async def test_investigator_gate_is_unchanged_by_the_notify_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recovery edge notifies but never schedules an investigation."""
+    fake = _install_transport(monkeypatch)
+    fired: list[dict[str, Any]] = []
+    monkeypatch.setattr(inv, "_schedule_investigation", lambda **kw: fired.append(kw))
+    await _seed_tenant()
+    sid = await _seed_sensor(name="recovering", last_state="ok")
+    await _seed_dashboard(name="prod-health", sensor_ids=[sid], last_rollup_state="critical")
+
+    await inv.investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+    await notify._await_pending_notifications()
+
+    assert fired == [], "the improving edge must not reach the investigator"
+    assert len(fake.calls) == 1, "the improving edge must reach the notifier"

--- a/backend/tests/test_db_dashboard.py
+++ b/backend/tests/test_db_dashboard.py
@@ -13,6 +13,10 @@ Initiative #2416 (parent goal #221), Task #2506. Covers:
 * **Drift guards** -- the model constant and the migration's frozen literal
   both equal #2504's :data:`CheckState`, and the migration's CHECK body equals
   the ORM's. Mirrors :mod:`tests.test_db_sensor`.
+* **Notification columns (#2719)** -- ``notify_email`` / ``notify_min_state``
+  default to "off at ``critical``", the floor CHECK admits only the two
+  actionable states, and the model / wire-Literal / ``0068`` migration copies
+  of that vocabulary agree.
 """
 
 from __future__ import annotations
@@ -26,8 +30,10 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from meho_backplane.checks.assertions import CheckState
+from meho_backplane.checks.dashboard_schemas import NotifyMinState
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
+    _CHECK_DASHBOARD_NOTIFY_MIN_STATES,
     _CHECK_DASHBOARD_ROLLUP_STATES,
     CheckDashboard,
     Tenant,
@@ -155,30 +161,33 @@ async def test_unique_name_per_tenant_enforced() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _load_migration() -> object:
+def _load_migration_file(filename: str, module_name: str) -> object:
     import importlib.util
     from pathlib import Path
 
-    path = (
-        Path(__file__).resolve().parent.parent
-        / "alembic"
-        / "versions"
-        / "0065_create_check_dashboards.py"
-    )
-    spec = importlib.util.spec_from_file_location("_migration_0065", path)
+    path = Path(__file__).resolve().parent.parent / "alembic" / "versions" / filename
+    spec = importlib.util.spec_from_file_location(module_name, path)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-def _orm_check_body() -> str:
+def _load_migration() -> object:
+    return _load_migration_file("0065_create_check_dashboards.py", "_migration_0065")
+
+
+def _load_notify_migration() -> object:
+    return _load_migration_file("0068_add_check_dashboard_notify.py", "_migration_0068")
+
+
+def _orm_check_body(name: str = "ck_check_dashboards_last_rollup_state") -> str:
     from sqlalchemy import CheckConstraint
 
     for c in CheckDashboard.__table__.constraints:
-        if isinstance(c, CheckConstraint) and c.name == "ck_check_dashboards_last_rollup_state":
+        if isinstance(c, CheckConstraint) and c.name == name:
             return str(c.sqltext)
-    raise AssertionError("ck_check_dashboards_last_rollup_state not found on the ORM table")
+    raise AssertionError(f"{name} not found on the ORM table")
 
 
 def test_model_rollup_states_equal_checkstate() -> None:
@@ -200,3 +209,84 @@ def test_migration_check_body_equals_orm() -> None:
         migration._ROLLUP_STATES,  # type: ignore[attr-defined]
     )
     assert _orm_check_body() == rendered
+
+
+# ---------------------------------------------------------------------------
+# Notification columns (#2719)
+# ---------------------------------------------------------------------------
+
+
+def test_notify_min_states_are_the_two_actionable_states() -> None:
+    """The floor vocabulary is deliberately narrower than ``CheckState``.
+
+    ``ok`` as a floor would mail on every edge, and ``skip`` / ``unknown``
+    are not severities a threshold is meaningful at -- so this constant is
+    declared independently rather than snapshotted from ``CheckState``.
+    """
+    assert set(_CHECK_DASHBOARD_NOTIFY_MIN_STATES) == {"degraded", "critical"}
+    assert set(_CHECK_DASHBOARD_NOTIFY_MIN_STATES) < set(get_args(CheckState))
+
+
+def test_wire_notify_min_state_literal_matches_model() -> None:
+    """The wire ``NotifyMinState`` Literal equals the model's vocabulary."""
+    assert set(get_args(NotifyMinState)) == set(_CHECK_DASHBOARD_NOTIFY_MIN_STATES)
+
+
+def test_notify_migration_literal_matches_model() -> None:
+    """The 0068 migration's frozen tuple is a snapshot of the ORM's."""
+    migration = _load_notify_migration()
+    assert set(migration._NOTIFY_MIN_STATES) == set(  # type: ignore[attr-defined]
+        _CHECK_DASHBOARD_NOTIFY_MIN_STATES
+    )
+
+
+def test_notify_migration_check_body_equals_orm() -> None:
+    """The 0068 migration's rendered CHECK body equals the ORM constraint's."""
+    migration = _load_notify_migration()
+    rendered = migration._check_in(  # type: ignore[attr-defined]
+        "notify_min_state",
+        migration._NOTIFY_MIN_STATES,  # type: ignore[attr-defined]
+    )
+    assert _orm_check_body("ck_check_dashboards_notify_min_state") == rendered
+
+
+@pytest.mark.asyncio
+async def test_notify_columns_default_to_silent_critical() -> None:
+    """A row inserted without notification config defaults off at ``critical``."""
+    await _seed_tenant()
+    dashboard_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            CheckDashboard(
+                id=dashboard_id,
+                tenant_id=_TENANT,
+                name="defaults-notify",
+                created_by_sub="op-admin",
+            )
+        )
+        await session.commit()
+    async with sessionmaker() as session:
+        row = await session.get(CheckDashboard, dashboard_id)
+        assert row is not None
+        assert row.notify_email is None
+        assert row.notify_min_state == "critical"
+
+
+@pytest.mark.asyncio
+async def test_notify_min_state_check_rejects_out_of_vocabulary() -> None:
+    """``ck_check_dashboards_notify_min_state`` refuses a five-state value."""
+    await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            CheckDashboard(
+                id=uuid.uuid4(),
+                tenant_id=_TENANT,
+                name="bad-floor",
+                notify_min_state="ok",
+                created_by_sub="op-admin",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -8220,7 +8220,7 @@
           "checks-dashboards"
         ],
         "summary": "Create Dashboard",
-        "description": "Create one Dashboard under the operator's tenant.\n\n``tenant_admin`` only. ``body.tenant_id`` is optional: when set to a\n*different* tenant the create is cross-tenant and requires\n``platform_admin`` (via ``authorize_tenant_scope``). A foreign / absent\nsensor id is 422 ``sensor_not_found``; a duplicate name is 409.",
+        "description": "Create one Dashboard under the operator's tenant.\n\n``tenant_admin`` only. ``body.tenant_id`` is optional: when set to a\n*different* tenant the create is cross-tenant and requires\n``platform_admin`` (via ``authorize_tenant_scope``). A foreign / absent\nsensor id is 422 ``sensor_not_found``; a duplicate name is 409. The\n#2719 notification config (``notify_email`` / ``notify_min_state``) is\nvalidated by :class:`DashboardCreate`, so a malformed address or an\nout-of-vocabulary floor is FastAPI's own 422 envelope -- never a\ndelivery failure discovered on the first transition.",
         "operationId": "create_dashboard_api_v1_checks_dashboards_post",
         "parameters": [
           {
@@ -23502,6 +23502,21 @@
             "format": "uuid",
             "nullable": true,
             "title": "Tenant Id"
+          },
+          "notify_email": {
+            "type": "string",
+            "format": "email",
+            "nullable": true,
+            "title": "Notify Email"
+          },
+          "notify_min_state": {
+            "type": "string",
+            "enum": [
+              "degraded",
+              "critical"
+            ],
+            "title": "Notify Min State",
+            "default": "critical"
           }
         },
         "additionalProperties": false,
@@ -23510,7 +23525,7 @@
           "name"
         ],
         "title": "DashboardCreate",
-        "description": "Request body for ``POST /api/v1/checks/dashboards``.\n\nMembership is set at create only (no PUT; \"edit\" is delete + recreate,\nthe trigger-immutability posture). An empty ``sensor_ids`` is permitted --\na member-less Dashboard rolls up to ``unknown`` (the zero-member rule) --\nbut duplicates are de-duplicated by the service before insert. A foreign\nor absent sensor id is refused 422 ``sensor_not_found`` at the boundary.\n\n*tenant_id* (optional) lets a platform-admin caller target another\ntenant; the boundary enforces the RBAC via ``authorize_tenant_scope``."
+        "description": "Request body for ``POST /api/v1/checks/dashboards``.\n\nMembership is set at create only (no PUT; \"edit\" is delete + recreate,\nthe trigger-immutability posture). An empty ``sensor_ids`` is permitted --\na member-less Dashboard rolls up to ``unknown`` (the zero-member rule) --\nbut duplicates are de-duplicated by the service before insert. A foreign\nor absent sensor id is refused 422 ``sensor_not_found`` at the boundary.\n\n*tenant_id* (optional) lets a platform-admin caller target another\ntenant; the boundary enforces the RBAC via ``authorize_tenant_scope``.\n\n``notify_email`` / ``notify_min_state`` are the #2719 notification config,\nset at create only like membership. Omitting ``notify_email`` leaves\nnotifications off for this Dashboard. The address is validated with\npydantic's ``EmailStr`` (``email-validator``), so a malformed one is a\nboundary 422 rather than a delivery failure discovered hours later on the\nfirst transition."
       },
       "DashboardDetail": {
         "properties": {
@@ -23560,6 +23575,19 @@
             "nullable": true,
             "title": "Last Rollup State"
           },
+          "notify_email": {
+            "type": "string",
+            "nullable": true,
+            "title": "Notify Email"
+          },
+          "notify_min_state": {
+            "type": "string",
+            "enum": [
+              "degraded",
+              "critical"
+            ],
+            "title": "Notify Min State"
+          },
           "created_by_sub": {
             "type": "string",
             "title": "Created By Sub"
@@ -23591,6 +23619,8 @@
           "member_count",
           "state",
           "last_rollup_state",
+          "notify_email",
+          "notify_min_state",
           "created_by_sub",
           "created_at",
           "updated_at",
@@ -23768,6 +23798,19 @@
             "nullable": true,
             "title": "Last Rollup State"
           },
+          "notify_email": {
+            "type": "string",
+            "nullable": true,
+            "title": "Notify Email"
+          },
+          "notify_min_state": {
+            "type": "string",
+            "enum": [
+              "degraded",
+              "critical"
+            ],
+            "title": "Notify Min State"
+          },
           "created_by_sub": {
             "type": "string",
             "title": "Created By Sub"
@@ -23792,6 +23835,8 @@
           "member_count",
           "state",
           "last_rollup_state",
+          "notify_email",
+          "notify_min_state",
           "created_by_sub",
           "created_at",
           "updated_at"

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -141,6 +141,12 @@ const (
 	DailyUsageBucketSurfaceOperations DailyUsageBucketSurface = "operations"
 )
 
+// Defines values for DashboardCreateNotifyMinState.
+const (
+	DashboardCreateNotifyMinStateCritical DashboardCreateNotifyMinState = "critical"
+	DashboardCreateNotifyMinStateDegraded DashboardCreateNotifyMinState = "degraded"
+)
+
 // Defines values for DashboardDetailLastRollupState.
 const (
 	DashboardDetailLastRollupStateCritical DashboardDetailLastRollupState = "critical"
@@ -148,6 +154,12 @@ const (
 	DashboardDetailLastRollupStateOk       DashboardDetailLastRollupState = "ok"
 	DashboardDetailLastRollupStateSkip     DashboardDetailLastRollupState = "skip"
 	DashboardDetailLastRollupStateUnknown  DashboardDetailLastRollupState = "unknown"
+)
+
+// Defines values for DashboardDetailNotifyMinState.
+const (
+	DashboardDetailNotifyMinStateCritical DashboardDetailNotifyMinState = "critical"
+	DashboardDetailNotifyMinStateDegraded DashboardDetailNotifyMinState = "degraded"
 )
 
 // Defines values for DashboardDetailState.
@@ -184,6 +196,12 @@ const (
 	DashboardReadLastRollupStateOk       DashboardReadLastRollupState = "ok"
 	DashboardReadLastRollupStateSkip     DashboardReadLastRollupState = "skip"
 	DashboardReadLastRollupStateUnknown  DashboardReadLastRollupState = "unknown"
+)
+
+// Defines values for DashboardReadNotifyMinState.
+const (
+	DashboardReadNotifyMinStateCritical DashboardReadNotifyMinState = "critical"
+	DashboardReadNotifyMinStateDegraded DashboardReadNotifyMinState = "degraded"
 )
 
 // Defines values for DashboardReadState.
@@ -3419,12 +3437,24 @@ type DailyUsageBucketSurface string
 //
 // *tenant_id* (optional) lets a platform-admin caller target another
 // tenant; the boundary enforces the RBAC via “authorize_tenant_scope“.
+//
+// “notify_email“ / “notify_min_state“ are the #2719 notification config,
+// set at create only like membership. Omitting “notify_email“ leaves
+// notifications off for this Dashboard. The address is validated with
+// pydantic's “EmailStr“ (“email-validator“), so a malformed one is a
+// boundary 422 rather than a delivery failure discovered hours later on the
+// first transition.
 type DashboardCreate struct {
-	Description *string               `json:"description"`
-	Name        string                `json:"name"`
-	SensorIds   *[]openapi_types.UUID `json:"sensor_ids,omitempty"`
-	TenantId    *openapi_types.UUID   `json:"tenant_id"`
+	Description    *string                        `json:"description"`
+	Name           string                         `json:"name"`
+	NotifyEmail    *openapi_types.Email           `json:"notify_email"`
+	NotifyMinState *DashboardCreateNotifyMinState `json:"notify_min_state,omitempty"`
+	SensorIds      *[]openapi_types.UUID          `json:"sensor_ids,omitempty"`
+	TenantId       *openapi_types.UUID            `json:"tenant_id"`
 }
+
+// DashboardCreateNotifyMinState defines model for DashboardCreate.NotifyMinState.
+type DashboardCreateNotifyMinState string
 
 // DashboardDetail Response shape for “GET /api/v1/checks/dashboards/{id}“.
 //
@@ -3439,6 +3469,8 @@ type DashboardDetail struct {
 	MemberCount     int                             `json:"member_count"`
 	Members         []DashboardMemberView           `json:"members"`
 	Name            string                          `json:"name"`
+	NotifyEmail     *string                         `json:"notify_email"`
+	NotifyMinState  DashboardDetailNotifyMinState   `json:"notify_min_state"`
 	State           DashboardDetailState            `json:"state"`
 	TenantId        openapi_types.UUID              `json:"tenant_id"`
 	UpdatedAt       time.Time                       `json:"updated_at"`
@@ -3446,6 +3478,9 @@ type DashboardDetail struct {
 
 // DashboardDetailLastRollupState defines model for DashboardDetail.LastRollupState.
 type DashboardDetailLastRollupState string
+
+// DashboardDetailNotifyMinState defines model for DashboardDetail.NotifyMinState.
+type DashboardDetailNotifyMinState string
 
 // DashboardDetailState defines model for DashboardDetail.State.
 type DashboardDetailState string
@@ -3522,6 +3557,8 @@ type DashboardRead struct {
 	LastRollupState *DashboardReadLastRollupState `json:"last_rollup_state"`
 	MemberCount     int                           `json:"member_count"`
 	Name            string                        `json:"name"`
+	NotifyEmail     *string                       `json:"notify_email"`
+	NotifyMinState  DashboardReadNotifyMinState   `json:"notify_min_state"`
 	State           DashboardReadState            `json:"state"`
 	TenantId        openapi_types.UUID            `json:"tenant_id"`
 	UpdatedAt       time.Time                     `json:"updated_at"`
@@ -3529,6 +3566,9 @@ type DashboardRead struct {
 
 // DashboardReadLastRollupState defines model for DashboardRead.LastRollupState.
 type DashboardReadLastRollupState string
+
+// DashboardReadNotifyMinState defines model for DashboardRead.NotifyMinState.
+type DashboardReadNotifyMinState string
 
 // DashboardReadState defines model for DashboardRead.State.
 type DashboardReadState string

--- a/cli/internal/cmd/dashboard/create.go
+++ b/cli/internal/cmd/dashboard/create.go
@@ -19,7 +19,8 @@ import (
 // newCreateCmd returns the `meho dashboard create` command.
 //
 //	meho dashboard create --name N [--description D]
-//	  [--sensor-id ID ...] [--tenant T] [--json] [--backplane <url>]
+//	  [--sensor-id ID ...] [--notify-email A] [--notify-min-state S]
+//	  [--tenant T] [--json] [--backplane <url>]
 //
 // Role: tenant_admin.
 func newCreateCmd() *cobra.Command {
@@ -27,6 +28,8 @@ func newCreateCmd() *cobra.Command {
 		name              string
 		description       string
 		sensorIDs         []string
+		notifyEmail       string
+		notifyMinState    string
 		tenant            string
 		jsonOut           bool
 		backplaneOverride string
@@ -44,6 +47,14 @@ func newCreateCmd() *cobra.Command {
 			"empty member set is legal and rolls up 'unknown' (the zero-member " +
 			"rule); duplicate ids are de-duplicated server-side. --tenant " +
 			"targets another tenant (platform_admin cross-tenant create).\n\n" +
+			"--notify-email is the single address that receives one mail per " +
+			"rollup transition crossing --notify-min-state; leaving it unset " +
+			"keeps notifications off. --notify-min-state is degraded or " +
+			"critical (default critical): an edge notifies when the worse of " +
+			"its two states reaches the floor, so at 'critical' a recovery " +
+			"from critical back to ok sends the all-clear while ok -> " +
+			"degraded stays silent. Both are set at create only, like " +
+			"membership.\n\n" +
 			"A foreign / absent --sensor-id is refused 422 sensor_not_found; a " +
 			"duplicate name is refused 409.",
 		Args:          cobra.NoArgs,
@@ -54,6 +65,8 @@ func newCreateCmd() *cobra.Command {
 				Name:              name,
 				Description:       description,
 				SensorIDs:         sensorIDs,
+				NotifyEmail:       notifyEmail,
+				NotifyMinState:    notifyMinState,
 				Tenant:            tenant,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
@@ -64,6 +77,10 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&description, "description", "", "optional free-form description")
 	cmd.Flags().StringArrayVar(&sensorIDs, "sensor-id", nil,
 		"member sensor UUID (repeatable; empty set rolls up 'unknown')")
+	cmd.Flags().StringVar(&notifyEmail, "notify-email", "",
+		"address that receives transition mail (unset = notifications off)")
+	cmd.Flags().StringVar(&notifyMinState, "notify-min-state", "",
+		"notification floor: degraded or critical (server default: critical)")
 	cmd.Flags().StringVar(&tenant, "tenant", "",
 		"target tenant UUID (platform_admin cross-tenant create)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw DashboardDetail JSON instead of the human summary")
@@ -77,9 +94,20 @@ type createOptions struct {
 	Name              string
 	Description       string
 	SensorIDs         []string
+	NotifyEmail       string
+	NotifyMinState    string
 	Tenant            string
 	JSONOut           bool
 	BackplaneOverride string
+}
+
+// notifyMinStates is the closed --notify-min-state vocabulary, mirroring the
+// server's ck_check_dashboards_notify_min_state CHECK. Validated CLI-side so
+// a typo surfaces locally instead of after a 422 round-trip — the same
+// discipline the --sensor-id UUID parse follows.
+var notifyMinStates = []api.DashboardCreateNotifyMinState{
+	api.DashboardCreateNotifyMinStateDegraded,
+	api.DashboardCreateNotifyMinStateCritical,
 }
 
 func runCreate(cmd *cobra.Command, opts createOptions) error {
@@ -89,6 +117,9 @@ func runCreate(cmd *cobra.Command, opts createOptions) error {
 				"--sensor-id may be given at most %d times; got %d",
 				maxDashboardMembers, len(opts.SensorIDs))),
 			opts.JSONOut)
+	}
+	if err := validateNotifyMinState(opts.NotifyMinState); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
 	}
 	// Parse each --sensor-id CLI-side into a typed UUID so a malformed id
 	// surfaces locally rather than after a 422 round-trip.
@@ -146,11 +177,32 @@ func runCreate(cmd *cobra.Command, opts createOptions) error {
 	return nil
 }
 
+// validateNotifyMinState rejects a --notify-min-state outside the closed
+// server vocabulary. An empty value is legal and means "omit the field", so
+// the server's own default (critical) applies.
+func validateNotifyMinState(value string) error {
+	if value == "" {
+		return nil
+	}
+	for _, allowed := range notifyMinStates {
+		if value == string(allowed) {
+			return nil
+		}
+	}
+	return fmt.Errorf("--notify-min-state must be one of degraded, critical; got %q", value)
+}
+
 // buildCreateBody assembles the typed POST body. Pulled out so the
 // wire-shape rendering (pointer-or-omit semantics for the optional fields)
 // stays unit-testable without an httptest.Server. An empty member slice is
 // forwarded as an empty (non-nil) sensor_ids so the zero-member rule applies
 // deterministically rather than depending on the field being omitted.
+//
+// notify_min_state is omitted when the flag is unset so the server's default
+// stays the single source of that value; notify_email is omitted when unset
+// so the row keeps notifications off. An unset --notify-email leaves the
+// field nil rather than sending an empty openapi_types.Email, whose
+// MarshalJSON would reject the empty string before the request goes out.
 func buildCreateBody(
 	opts createOptions,
 	sensorIDs []openapi_types.UUID,
@@ -167,6 +219,14 @@ func buildCreateBody(
 	}
 	if tenantID != nil {
 		body.TenantId = tenantID
+	}
+	if opts.NotifyEmail != "" {
+		email := openapi_types.Email(opts.NotifyEmail)
+		body.NotifyEmail = &email
+	}
+	if opts.NotifyMinState != "" {
+		minState := api.DashboardCreateNotifyMinState(opts.NotifyMinState)
+		body.NotifyMinState = &minState
 	}
 	return body
 }

--- a/cli/internal/cmd/dashboard/dashboard.go
+++ b/cli/internal/cmd/dashboard/dashboard.go
@@ -17,10 +17,13 @@
 //     five-state rollup plus every member's raw/effective state — the CLI
 //     twin of /ui/checks/{dashboard_id}.
 //   - `meho dashboard create --name <n> [--description <d>]
-//     [--sensor-id <id> ...] [--tenant <id>] [--json]` — create one
+//     [--sensor-id <id> ...] [--notify-email <a>] [--notify-min-state <s>]
+//     [--tenant <id>] [--json]` — create one
 //     dashboard via POST /api/v1/checks/dashboards. Role: tenant_admin. An
 //     empty member set is legal and rolls up `unknown` (the zero-member
 //     rule); a foreign / absent sensor id is refused 422 `sensor_not_found`.
+//     `--notify-email` opts the dashboard into transition mail (#2719);
+//     `--notify-min-state` picks the floor an edge must reach.
 //   - `meho dashboard delete <dashboard_id> [--tenant <id>] [--json]` —
 //     DELETE /api/v1/checks/dashboards/{id}. Role: tenant_admin.
 //
@@ -368,6 +371,13 @@ func printDashboardSummary(w io.Writer, d *api.DashboardDetail) {
 	fmt.Fprintf(w, "%-18s %s\n", "state:", string(d.State))
 	if d.LastRollupState != nil {
 		fmt.Fprintf(w, "%-18s %s\n", "last_rollup_state:", string(*d.LastRollupState))
+	}
+	// Notification config (#2719). notify_min_state prints only alongside a
+	// configured recipient: without one the floor is inert, and showing it
+	// would read as "notifications are on at this threshold".
+	if email := derefString(d.NotifyEmail); email != "" {
+		fmt.Fprintf(w, "%-18s %s\n", "notify_email:", sanitizeCell(email))
+		fmt.Fprintf(w, "%-18s %s\n", "notify_min_state:", string(d.NotifyMinState))
 	}
 	fmt.Fprintf(w, "%-18s %d\n", "member_count:", d.MemberCount)
 	fmt.Fprintf(w, "%-18s %s\n", "created_by:", d.CreatedBySub)

--- a/cli/internal/cmd/dashboard/dashboard_test.go
+++ b/cli/internal/cmd/dashboard/dashboard_test.go
@@ -203,13 +203,26 @@ func TestBuildCreateBodyMinimal(t *testing.T) {
 	if body.TenantId != nil {
 		t.Errorf("tenant_id should stay nil when omitted; got %+v", body.TenantId)
 	}
+	// Both notification fields stay omitted so the row keeps notifications
+	// off and the server's own notify_min_state default applies.
+	if body.NotifyEmail != nil {
+		t.Errorf("notify_email should stay nil when omitted; got %+v", body.NotifyEmail)
+	}
+	if body.NotifyMinState != nil {
+		t.Errorf("notify_min_state should stay nil when omitted; got %+v", body.NotifyMinState)
+	}
 }
 
 func TestBuildCreateBodyFull(t *testing.T) {
 	tenantID := parseStubUUID(t, stubOtherTenant)
 	sensorIDs := []openapi_types.UUID{parseStubUUID(t, stubSensorID)}
 	body := buildCreateBody(
-		createOptions{Name: "prod-health", Description: "prod glance"},
+		createOptions{
+			Name:           "prod-health",
+			Description:    "prod glance",
+			NotifyEmail:    "oncall@example.com",
+			NotifyMinState: "degraded",
+		},
 		sensorIDs, &tenantID,
 	)
 	if body.Description == nil || *body.Description != "prod glance" {
@@ -221,6 +234,36 @@ func TestBuildCreateBodyFull(t *testing.T) {
 	}
 	if body.TenantId == nil || body.TenantId.String() != stubOtherTenant {
 		t.Errorf("tenant_id not forwarded; got %+v", body.TenantId)
+	}
+	if body.NotifyEmail == nil || string(*body.NotifyEmail) != "oncall@example.com" {
+		t.Errorf("notify_email not forwarded; got %+v", body.NotifyEmail)
+	}
+	if body.NotifyMinState == nil || string(*body.NotifyMinState) != "degraded" {
+		t.Errorf("notify_min_state not forwarded; got %+v", body.NotifyMinState)
+	}
+}
+
+func TestValidateNotifyMinState(t *testing.T) {
+	for _, ok := range []string{"", "degraded", "critical"} {
+		if err := validateNotifyMinState(ok); err != nil {
+			t.Errorf("validateNotifyMinState(%q) = %v; want nil", ok, err)
+		}
+	}
+	for _, bad := range []string{"ok", "warn", "CRITICAL", "unknown"} {
+		if err := validateNotifyMinState(bad); err == nil {
+			t.Errorf("validateNotifyMinState(%q) = nil; want an error", bad)
+		}
+	}
+}
+
+func TestRunCreateRejectsInvalidNotifyMinState(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{Name: "prod-health", NotifyMinState: "warn"})
+	if err == nil {
+		t.Fatalf("expected an error for an out-of-vocabulary --notify-min-state")
+	}
+	if !strings.Contains(stderr.String(), "notify-min-state") {
+		t.Errorf("expected the flag name in the refusal; got %q", stderr.String())
 	}
 }
 
@@ -794,6 +837,25 @@ func TestPrintDashboardSummaryHasAllKeys(t *testing.T) {
 	printDashboardSummary(&buf, &d)
 	out := buf.String()
 	for _, want := range []string{"id:", "tenant_id:", "name:", "state:", "member_count:", "created_at:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in summary; got %q", want, out)
+		}
+	}
+	// No recipient configured -> neither notification line renders.
+	if strings.Contains(out, "notify_") {
+		t.Errorf("unconfigured dashboard must not render notify lines; got %q", out)
+	}
+}
+
+func TestPrintDashboardSummaryRendersNotifyConfig(t *testing.T) {
+	d := fakeDashboardDetail(t)
+	email := "oncall@example.com"
+	d.NotifyEmail = &email
+	d.NotifyMinState = api.DashboardDetailNotifyMinState("degraded")
+	var buf bytes.Buffer
+	printDashboardSummary(&buf, &d)
+	out := buf.String()
+	for _, want := range []string{"notify_email:", "oncall@example.com", "notify_min_state:", "degraded"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in summary; got %q", want, out)
 		}

--- a/docs/codebase/checks-investigator.md
+++ b/docs/codebase/checks-investigator.md
@@ -54,6 +54,15 @@ rollup (no LLM), and the *deep tier* is the scheduled agent run.
    processed (not only state changes) because a `for:` hold expiring flips a
    Dashboard non-green with no sensor-state change; the memo-equality check is
    the cheap exit.
+
+   Since #2719 the claim is returned for **both** edge directions and the
+   worsening filter sits one level up, at the single routing site in
+   `_process_transition` — unchanged in meaning for the investigator. The
+   improving edge is returned because the email notifier
+   (`docs/codebase/checks-notifications.md`) consumes it, not discarded
+   because the investigator does not. The two consumers are independent:
+   the notifier applies its own per-Dashboard `notify_min_state` floor and
+   never reaches this module's correlation, suppression, or agent path.
 2. **Correlation** (`_correlate`). Each non-green member maps to its topology
    anchor via its registered target's name (`kind="target"`), and
    `topology.query.find_dependencies` returns the forward closure. Members

--- a/docs/codebase/checks-notifications.md
+++ b/docs/codebase/checks-notifications.md
@@ -25,7 +25,9 @@ notifier is inert — there is no path around the floor.
 
 - `notify_dashboard_transition(notice)` — the awaitable that applies the
   threshold rule, builds the message, and calls the transport. **Never
-  raises.**
+  raises** an ordinary exception; `asyncio.CancelledError` is a
+  `BaseException`, so it still propagates and a tracked task can be
+  cancelled at shutdown.
 - `schedule_dashboard_notification(notice)` — spawns the above as a
   tracked fire-and-forget `asyncio.Task`. What `investigate.py` calls.
 - `DashboardNotice` — the detached input: dashboard id, name, the
@@ -78,8 +80,9 @@ default floor of `critical`:
 | `ok -> unknown` | no | `unknown` ranks with `degraded` |
 | `critical -> skip` | yes | the `critical` side, not the `skip` side |
 
-At `notify_min_state='degraded'` the `degraded` rows above flip to yes;
-`skip` never clears the bar on its own at any floor.
+At `notify_min_state='degraded'` every `no` row above flips to yes —
+including `ok -> unknown`, since `unknown` shares rank 1 with
+`degraded`. `skip` never clears the bar on its own at any floor.
 
 ## Control flow
 
@@ -132,7 +135,9 @@ Fire-and-forget in two senses:
   task cannot be garbage-collected mid-flight;
   `_await_pending_notifications()` is the deterministic test drain.
 - **Never raises.** A refusal, an unconfigured SMTP block, a delivery
-  failure, or an unexpected exception is logged and swallowed. A broken
+  failure, or an unexpected exception is logged and swallowed.
+  `asyncio.CancelledError` is the deliberate exemption — it propagates,
+  so lifespan shutdown tears a tracked task down cleanly. A broken
   MTA cannot convert a committed transition claim into a persist-path
   failure — contract parity with `investigate_on_transition`.
 

--- a/docs/codebase/checks-notifications.md
+++ b/docs/codebase/checks-notifications.md
@@ -1,0 +1,184 @@
+# Dashboard email notifications (`checks/notify.py`)
+
+## Overview
+
+When a check Dashboard's five-state rollup crosses an edge,
+`meho_backplane.checks.notify` mails the Dashboard's configured
+recipient — **in both directions**. An operator paged for `critical`
+gets the all-clear when the Dashboard recovers, which is what Prometheus
+Alertmanager's `send_resolved` provides and what #2716 made a binding
+decision for this layer.
+
+The notifier is the second, independent consumer of #2507's transition
+claim. The first is the diagnose-only investigator
+(`docs/codebase/checks-investigator.md`), which fires on a **worsening**
+edge only. Both read the same compare-and-swap on
+`check_dashboards.last_rollup_state`; neither knows about the other.
+
+Delivery goes through the `mail.*` connector's shared
+`transport.send_email()` (`docs/codebase/connectors-mail.md`), so the
+deployment-level `MAIL_RECIPIENT_ALLOWLIST` floor applies here exactly as
+it does to an agent-dispatched `mail.send`. An empty allowlist means the
+notifier is inert — there is no path around the floor.
+
+## Key types
+
+- `notify_dashboard_transition(notice)` — the awaitable that applies the
+  threshold rule, builds the message, and calls the transport. **Never
+  raises.**
+- `schedule_dashboard_notification(notice)` — spawns the above as a
+  tracked fire-and-forget `asyncio.Task`. What `investigate.py` calls.
+- `DashboardNotice` — the detached input: dashboard id, name, the
+  `previous -> current` edge, the two config columns, and the non-green
+  members. Built inside the claim transaction while the ORM row is live.
+- `NotifyMember` — one non-green member as the mail renders it (name,
+  effective state, last value, last evidence). A notifier-owned
+  projection, not a reuse of the investigator's briefing snapshot: this
+  module must not import `investigate`, which imports *it*.
+- `_NOTIFY_RANK` — `ok`/`skip` = 0, `unknown`/`degraded` = 1,
+  `critical` = 2.
+
+## Configuration (per Dashboard, set at create only)
+
+Two columns on `check_dashboards`, added by migration `0068`:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `notify_email` | `text` NULL | The single recipient. **NULL = notifications off**, the state every pre-#2719 row backfills to. |
+| `notify_min_state` | `text` NOT NULL, default `'critical'`, CHECK `IN ('degraded','critical')` | The floor an edge must reach. |
+
+`notify_min_state`'s vocabulary is deliberately narrower than
+`CheckState`: `ok` as a floor would mail on every edge, and
+`skip` / `unknown` are not severities a threshold is meaningful at. The
+model, the wire `NotifyMinState` Literal, and the migration's frozen
+tuple are pinned against each other by drift guards in
+`tests/test_db_dashboard.py`.
+
+Both are set at Dashboard-create only — the same immutability posture as
+membership. There is no PATCH route; "edit" is delete + recreate.
+Surfaces: `POST /api/v1/checks/dashboards` (body fields, `EmailStr`-
+validated → 422 on a malformed address) and
+`meho dashboard create --notify-email --notify-min-state`.
+
+## The notify rule
+
+```
+notify  <=>  max(rank(previous), rank(current)) >= rank(notify_min_state)
+```
+
+Symmetric in the two states, which is what makes recovery notify. At the
+default floor of `critical`:
+
+| Edge | Mails? | Why |
+|---|---|---|
+| `ok -> critical` | yes | `critical` side clears the bar |
+| `critical -> ok` | yes | all-clear; the `critical` side still clears the bar |
+| `ok -> degraded` | no | neither side reaches `critical` |
+| `degraded -> ok` | no | same |
+| `ok -> unknown` | no | `unknown` ranks with `degraded` |
+| `critical -> skip` | yes | the `critical` side, not the `skip` side |
+
+At `notify_min_state='degraded'` the `degraded` rows above flip to yes;
+`skip` never clears the bar on its own at any floor.
+
+## Control flow
+
+1. **The claim** (`investigate._claim_dashboard_transition`). Unchanged
+   mechanism: per-`(tenant, dashboard)` advisory lock, member fold under
+   the lock, compare-and-swap of the memo. Since #2719 it returns a
+   `_ClaimedTransition` for **both** directions instead of discarding the
+   improving edge, carrying a prebuilt `DashboardNotice`.
+2. **Routing** (`investigate._process_transition`). The worsening filter
+   that used to live inside the claim now sits at this single site,
+   unchanged in meaning: `worsening and non_green` → investigator. Every
+   claimed edge → `schedule_dashboard_notification`.
+3. **Threshold + build + send** (`notify_dashboard_transition`). Unset
+   recipient short-circuits; then the rank rule; then one `send_email`.
+4. **Outcome logging.** `checks_notify_sent` (info) on delivery;
+   `checks_notify_failed` (warning, with the transport's stable reason
+   code) on a `sent=False` result or an unexpected exception;
+   `checks_notify_skipped_unconfigured` /
+   `checks_notify_skipped_below_threshold` (info) on the two
+   short-circuits. All four are at info or above because a claimed edge
+   is a rare event and "no mail arrived" is a question the log has to be
+   able to answer.
+
+## Message shape
+
+Subject: `[MEHO] <name>: <previous> -> <current>`, with an
+`all clear - ` prefix when no member is non-green.
+
+Body: the Dashboard name, the edge, then one block per non-green member
+(name, effective state, last value, last evidence). Capped at
+`_MAX_MEMBER_LINES` (20) members with an "N further member(s) not shown"
+footer, and each untrusted field clipped at `_MAX_FIELD_CHARS` (200).
+
+**Header safety.** A Dashboard name is operator-authored free text with
+no newline constraint at the database, and the transport's in-process
+entry point raises `ValueError` on a subject carrying a line break (only
+the dispatched `mail.send` path gets the single-line parameter screen).
+The subject therefore folds every control character out of the name, so
+a crafted name cannot inject an SMTP header. The body is a MIME payload,
+not headers, so its fragments need bounding rather than folding.
+
+## Failure posture
+
+Fire-and-forget in two senses:
+
+- **Off the persist path.** The send runs as a tracked background task,
+  because the transport bounds one SMTP session at 30 seconds and the
+  check runner awaits `investigate_on_transition` inline in
+  `_persist_outcome`. Strong references live in `_NOTIFICATIONS` so a
+  task cannot be garbage-collected mid-flight;
+  `_await_pending_notifications()` is the deterministic test drain.
+- **Never raises.** A refusal, an unconfigured SMTP block, a delivery
+  failure, or an unexpected exception is logged and swallowed. A broken
+  MTA cannot convert a committed transition claim into a persist-path
+  failure — contract parity with `investigate_on_transition`.
+
+Delivery and the claim are independent: the memo advances whether or not
+the mail lands. That is deliberate — re-deriving "did anyone get told"
+from the memo would mean re-mailing every unchanged evaluation.
+
+## Dependencies
+
+- `meho_backplane.connectors.mail.transport.send_email` — the only
+  delivery path.
+- `meho_backplane.checks.investigate` — imports this module (never the
+  reverse) and owns the claim.
+- `check_dashboards.notify_email` / `notify_min_state` — migration
+  `0068`.
+
+## Known issues / boundaries
+
+- **No flap suppression.** One mail per *claimed* edge. A member Sensor
+  going stale and back re-crosses `critical <-> unknown`, and each
+  crossing is a real edge, so each mails. There is deliberately no rate
+  limit, digest, or repeat-suppression window (#2716 scopes those out);
+  the floor knob is the only volume control today. A Sensor that flaps
+  at the runner cadence will mail at the runner cadence.
+- **One recipient per Dashboard.** No lists, no routing rules, no
+  per-Sensor recipients. More when a consumer asks.
+- **Deployment-level SMTP.** One MTA and one allowlist for the whole
+  backplane; there is no per-tenant mail config. A tenant admin can
+  therefore name a recipient the allowlist refuses, and learns about it
+  only from `checks_notify_failed` in the pod log.
+- **No delivery record.** Nothing durable says a mail was sent; the
+  structlog event is the whole trace. The `checks.transition` broadcast
+  event (#2720) is the queryable record of the edge itself.
+
+## References
+
+- `backend/src/meho_backplane/checks/notify.py`
+- `backend/src/meho_backplane/checks/investigate.py` —
+  `_process_transition`, `_claim_dashboard_transition`,
+  `_ClaimedTransition`, `_dashboard_notice`
+- `backend/alembic/versions/0068_add_check_dashboard_notify.py`
+- `backend/tests/test_checks_notify.py`,
+  `backend/tests/migrations/test_migration_0068_add_check_dashboard_notify.py`
+- `docs/codebase/connectors-mail.md`,
+  `docs/codebase/checks-investigator.md`,
+  `docs/codebase/checks-advisory.md`
+- Alertmanager `send_resolved` (the empirical anchor for notifying on
+  recovery):
+  <https://prometheus.io/docs/alerting/latest/configuration/#email_config>

--- a/docs/codebase/connectors-mail.md
+++ b/docs/codebase/connectors-mail.md
@@ -21,11 +21,16 @@ Two consumers share one implementation:
 
 - **Dispatch** — agents and operators reach `mail.send` through the
   normal `call_operation` path (policy + audit + broadcast).
-- **Direct import** — the checks notifier (#2719) imports
-  `transport.send_email()` and calls it in-process.
+- **Direct import** — the checks notifier (#2719,
+  `meho_backplane.checks.notify`) imports `transport.send_email()` and
+  calls it in-process on every claimed Dashboard rollup transition that
+  crosses the Dashboard's configured floor. See
+  `docs/codebase/checks-notifications.md`.
 
 Both run the identical recipient-allowlist floor and return-failures
-contract, because both are the same function.
+contract, because both are the same function. An empty
+`MAIL_RECIPIENT_ALLOWLIST` therefore makes Dashboard notification inert
+too, not just agent-initiated sends.
 
 ## Key types
 
@@ -133,7 +138,10 @@ assignment it would raise `ValueError` and surface as a
 `connector_error`. The screen is the schema, so it covers every
 dispatched call but not the direct-import path — an in-process caller
 such as the #2719 notifier is responsible for composing a single-line
-subject.
+subject. The checks notifier does exactly that: it folds every control
+character out of the operator-authored Dashboard name before building
+its subject (`checks/notify.py::_single_line`, see
+`docs/codebase/checks-notifications.md`).
 
 Malformed allowlist entries raise loudly at parse time rather than
 being silently kept: whitespace, more than one `@`, an empty local part


### PR DESCRIPTION
## Summary

- A Dashboard can now name an operator to mail when its rollup crosses a state edge. #2507's transition detector already compare-and-swapped `check_dashboards.last_rollup_state` exactly once per edge, replica-safe — this wires the second, independent consumer of that claim.
- **Recovery notifies too.** The rule is symmetric in the two states: `max(rank(previous), rank(current)) >= rank(notify_min_state)` under `ok < degraded < critical` (`unknown` ranks with `degraded`, `skip` with `ok`). At the default `critical` floor, `critical → ok` sends the all-clear while `ok → degraded` stays silent — the posture Alertmanager's `send_resolved` takes.
- **The investigator's worsening-only gate is untouched.** It moved from inside `_claim_dashboard_transition` to the single routing site in `_process_transition`, unchanged in meaning, so the claim can be returned for both directions. Investigation and notification are independent consumers of one claim; existing `investigate.py` tests pass unmodified.
- **Delivery goes through #2717's shared `send_email()`**, so `MAIL_RECIPIENT_ALLOWLIST` gates it exactly as it gates an agent-dispatched `mail.send` (empty allowlist ⇒ inert). Fire-and-forget in two senses: the send runs as a tracked background task so a 30 s SMTP session never sits on the check-runner's persist path, and `notify_dashboard_transition` never raises, so a broken MTA cannot convert a committed claim into a persist-path failure.

### Config (migration `0068`, create-only like membership)

| Column | Type | Meaning |
|---|---|---|
| `notify_email` | `text` NULL | Single recipient. **NULL = off** — the state every existing Dashboard backfills to, so the migration is behaviour-preserving. |
| `notify_min_state` | `text` NOT NULL, default `'critical'`, CHECK `IN ('degraded','critical')` | The floor an edge must reach. |

Surfaces: `POST /api/v1/checks/dashboards` body (`EmailStr`-validated → 422), detail/list reads, and `meho dashboard create --notify-email --notify-min-state`.

## Test plan

- [x] `ruff check` / `ruff format --check` on `src/` + `tests/` — clean
- [x] `mypy src/ --ignore-missing-imports` — clean apart from the pre-existing darwin-only `connectors/net/icmp.py:208 MSG_ERRQUEUE` (untouched by this PR)
- [x] `python3 .claude/hooks/code-quality.py --diff` — **0 blockers**, 4 warnings (all pre-existing file-size / function-size on `investigate.py` + `models.py`)
- [x] `pytest tests/` — **11154 passed, 450 skipped** (two known-environmental deselects on this host: `test_connectors_net_icmp.py::test_trace_reaches_loopback`, `test_connectors_net_dns_lookup.py::test_chosen_resolver_queries_that_nameserver`, both pre-existing on `main`)
- [x] `go build ./... && go vet ./... && go test -race -cover ./...` in `cli/` — clean
- [x] **Migration** — `uv run alembic heads` prints a single head (`0068`); exactly one new migration file; `grep 'upgrade(cfg, "head")'` in the per-migration test returns nothing (replay pinned to `0067 → 0068` on both legs)
- [x] **Threshold rule table** — `tests/test_checks_notify.py::test_threshold_matrix`, 13 cases incl. `critical→ok` all-clear, `ok→degraded` silent at `critical`, `unknown`-ranks-as-`degraded`, `skip` never firing alone, `critical→skip` firing on the other side
- [x] **Unconfigured skip** — `test_unconfigured_dashboard_sends_nothing` (+ the through-the-seam twin)
- [x] **Send failure swallowed** — `test_send_failure_is_swallowed`, `test_transport_exception_is_swallowed`, `test_send_failure_through_the_seam_never_raises` (memo still advances)
- [x] **CAS dedupe + recovery** — `test_concurrent_transitions_send_exactly_one_mail`: two raced `investigate_on_transition` calls ⇒ exactly ONE `send_email()`; a second after recovery to `ok`
- [x] **Investigator preserved** — `test_investigator_gate_is_unchanged_by_the_notify_hook` (improving edge notifies, never schedules an investigation); `tests/test_checks_investigate.py` green unmodified
- [x] **REST** — create round-trips both fields; defaults are off-at-`critical`; malformed email and out-of-vocabulary floor are both 422 (parametrized)
- [x] **Drift guards** — model / wire `NotifyMinState` Literal / `0068` frozen tuple all agree; CHECK bodies match (`tests/test_db_dashboard.py`)
- [x] `grep -n "schedule_dashboard_notification" backend/src/meho_backplane/checks/investigate.py` hits; `grep -c '"notify_email"' cli/api/openapi.json` = 5 (snapshot + typed client regenerated via `make snapshot-openapi && make generate`)
- [x] CHANGELOG bullet under `### Checks notifications — Dashboard email on state transitions (#2719)`

## Notes for review

- **Header safety.** A Dashboard name is operator-authored free text with no newline constraint at the DB, and the transport's in-process entry point raises `ValueError` on a subject with a line break (only the dispatched `mail.send` path gets the single-line parameter screen). `notify._single_line` folds every control character out of the name before building the subject; covered by `test_subject_folds_control_characters_in_the_name`.
- **`notify_min_state` is narrower than `CheckState` on purpose** — `ok` as a floor would mail on every edge, and `skip`/`unknown` are not severities a threshold is meaningful at. That is why the vocabulary is declared independently rather than snapshotted from `CheckState` (contrast `0065`'s `_ROLLUP_STATES`).
- **Read models type `notify_email` as `str`, not `EmailStr`** — the address is validated on the way in; re-validating a stored value on every read would turn one bad row into a 500 on an unrelated list call.
- **`--notify-email` becomes `openapi_types.Email` in the generated Go client** (first `format: email` in the spec). `buildCreateBody` omits the field when the flag is unset, because `Email.MarshalJSON` rejects the empty string.

## Out of scope

- The `checks.transition` broadcast event (#2720) and the in-band advisory (#2718, merged) — sibling tasks.
- Multiple recipients / routing rules / digests, and per-Sensor notification config.
- Any change to the investigator's fire conditions, briefing, or budget gating.

## Adjacent findings (recorded, not fixed)

- **No flap suppression.** One mail per *claimed* edge, so a member Sensor going stale and back re-crosses `critical ↔ unknown` and mails on each crossing. #2716 scopes rate limits / digests out; documented as a known boundary in `docs/codebase/checks-notifications.md` rather than built here.
- `checks/investigate.py` is 1325 lines and `db/models.py` 6483 (both far over the 600-line quality threshold) — pre-existing, warned by the diff-mode gate, untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2719


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboards can now send email notifications for qualifying check-state changes, including recoveries.
  * Configure a recipient and minimum severity (`degraded` or `critical`) through the REST API or CLI.
  * Dashboard details and CLI summaries display notification settings when configured.
* **Bug Fixes**
  * Notifications are deduplicated, delivered asynchronously, and do not interrupt check processing when email delivery fails.
* **Documentation**
  * Added guidance for configuring notification behavior, delivery, filtering, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->