### PR TITLE
feat(checks): checks.transition broadcast events + checks op-class on the tenant feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,12 +104,16 @@ connector-related release-notes line.
   uses for `approval.*`. Exactly one event per transition across
   replicas (the existing compare-and-swap claim is the dedupe) and no
   configurable floor: narrowing a feed is the consumer's job.
-  Publishing is fail-open — a Valkey outage logs
-  `checks_transition_broadcast_failed` and leaves the committed state
-  memo, the email notification, and the runner's persist path
-  untouched. The `/api/v1/checks/*` gateway op-ids
-  (`checks.assignment.put` / `.get`, `checks.results.post`) keep their
-  existing `write` / `read` / `other` classes. No migration, no new
+  Publishing is fail-open and leaves the committed state memo, the
+  email notification, and the runner's persist path untouched. A Valkey
+  outage is absorbed by the shared broadcast publisher and stays on its
+  existing feed-wide signals — the `broadcast_publish_failed` warning
+  and the `broadcast_publish_errors_total` counter; alert on those, not
+  on the new `checks_transition_broadcast_failed` warning, which fires
+  only if the event cannot be built before it reaches the publisher.
+  The `/api/v1/checks/*` gateway op-ids (`checks.assignment.put` /
+  `.get`, `checks.results.post`) are untouched and keep the `write` /
+  `read` / `write` classes their routes bind. No migration, no new
   settings. (#2720)
 
 ### Checks notifications — Dashboard email on state transitions (#2719)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Checks broadcast — transition events on the tenant feed (#2720)
+
+- Every claimed Dashboard rollup edge now publishes one
+  `checks.transition` event to the tenant broadcast feed, in **both**
+  directions — a watcher who saw a Dashboard go `critical` sees it
+  clear. The payload names the Dashboard (id + name) and the
+  `previous → new` states. Events carry a new `checks` op-class, so
+  `meho.broadcast.recent` / `meho.broadcast.watch` with
+  `filter.op_class=checks`, `GET /api/v1/feed?op_class=checks`, and
+  `/ui/broadcast/stream?op_class=checks` all narrow to check state
+  changes server-side — the same shape the approvals console already
+  uses for `approval.*`. Exactly one event per transition across
+  replicas (the existing compare-and-swap claim is the dedupe) and no
+  configurable floor: narrowing a feed is the consumer's job.
+  Publishing is fail-open — a Valkey outage logs
+  `checks_transition_broadcast_failed` and leaves the committed state
+  memo, the email notification, and the runner's persist path
+  untouched. The `/api/v1/checks/*` gateway op-ids
+  (`checks.assignment.put` / `.get`, `checks.results.post`) keep their
+  existing `write` / `read` / `other` classes. No migration, no new
+  settings. (#2720)
+
 ### Checks notifications — Dashboard email on state transitions (#2719)
 
 - A Dashboard can now name an operator to mail when its rollup crosses

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -174,6 +174,31 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
     }
 )
 
+#: Op-ids that classify as ``checks`` — the checks subsystem's own
+#: state-change events (#2720), published by
+#: :func:`~meho_backplane.checks.broadcast.publish_check_transition_event`
+#: rather than by the audit middleware.
+#:
+#: An explicit allowlist, **not** a ``checks.`` prefix branch, for two
+#: reasons. The ``/api/v1/checks/*`` gateway routes already own three
+#: shipped op-ids under that prefix (``checks.assignment.put`` /
+#: ``checks.assignment.get`` / ``checks.results.post``,
+#: :data:`meho_backplane.api.v1.checks._CHECKS_OP_IDS`), so:
+#:
+#: 1. A prefix branch would reclassify them out of ``write`` / ``read`` /
+#:    ``other``, splitting the historical meaning of ``audit_log.op_class``
+#:    at the deploy boundary and silently dropping the assignment write
+#:    out of any saved ``op_class=write`` query.
+#: 2. ``checks.results.post`` is the runner result-ingest data plane — one
+#:    call per runner per poll cycle, the highest-volume path in the
+#:    subsystem. Folding it into ``checks`` would bury the rare transition
+#:    edges this class exists to surface, defeating the
+#:    ``op_class=checks`` filter before it shipped.
+#:
+#: The allowlist is the same idiom :data:`_CREDENTIAL_MINT_OPS` uses for
+#: the same reason: an exact pin that beats a broader structural match.
+_CHECK_EVENT_OPS: Final[frozenset[str]] = frozenset({"checks.transition"})
+
 #: Op-id suffixes that imply mutation. Append to this tuple when a new
 #: write-shaped verb spelling lands. ``.put`` is the KV-v2 write verb
 #: (``vault.kv.put`` — G3.3-T1 #545); without it a secret write would
@@ -406,6 +431,19 @@ def classify_op(op_id: str) -> str:
        ``decision`` / the request id, never secret material), so it
        stays full-detail like ``other`` did -- see
        :data:`~meho_backplane.broadcast.overrides._SENSITIVE_OP_CLASSES`.
+    4c. ``checks`` — the checks subsystem's own state-change events
+       (:data:`_CHECK_EVENT_OPS`; today just ``checks.transition``,
+       emitted by
+       :func:`~meho_backplane.checks.broadcast.publish_check_transition_event`).
+       Its own class for the same reason ``approval`` has one: a feed
+       watcher filters ``op_class=checks`` server-side to follow
+       Dashboard rollup edges without reading every unclassified op.
+       Matched by **exact membership**, not by ``checks.`` prefix — the
+       ``/api/v1/checks/*`` gateway routes already own op-ids under that
+       prefix and must keep their ``write`` / ``read`` / ``other``
+       classes; see :data:`_CHECK_EVENT_OPS` for the full rationale.
+       Not sensitive (the payload is dashboard id / name / the two
+       states), so it stays full-detail.
     5. ``read`` / ``write`` — HTTP-method-prefixed ingested op IDs
        (e.g. ``GET:/api/v2.0/systeminfo``). ``GET:`` and ``HEAD:``
        map to ``read``; ``POST:``, ``PUT:``, ``PATCH:``, ``DELETE:``
@@ -454,6 +492,10 @@ def classify_op(op_id: str) -> str:
     'approval'
     >>> classify_op("approval.approved")
     'approval'
+    >>> classify_op("checks.transition")
+    'checks'
+    >>> classify_op("checks.assignment.put")
+    'write'
     >>> classify_op("GET:/api/v2.0/systeminfo")
     'read'
     >>> classify_op("DELETE:/api/v2.0/projects/myproj/repositories/myrepo")
@@ -481,6 +523,12 @@ def classify_op(op_id: str) -> str:
     # not sensitive, so it stays full-detail like the `other` fall-through.
     if op_id.startswith("approval."):
         return "approval"
+    # Checks-subsystem state-change events (checks.transition), so a feed
+    # watcher can filter op_class=checks for Dashboard rollup edges (#2720).
+    # Exact membership, not a `checks.` prefix: the /api/v1/checks/* gateway
+    # routes own op-ids under that prefix and keep their existing classes.
+    if op_id in _CHECK_EVENT_OPS:
+        return "checks"
     # Ingested ops use HTTP-method prefixes (e.g. "GET:/api/v2.0/systeminfo");
     # GET/HEAD are safe reads by HTTP semantics. The synthetic net.* probes
     # (#2406) ride the same arm: every net.* op is a non-mutating

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -179,21 +179,33 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
 #: :func:`~meho_backplane.checks.broadcast.publish_check_transition_event`
 #: rather than by the audit middleware.
 #:
-#: An explicit allowlist, **not** a ``checks.`` prefix branch, for two
-#: reasons. The ``/api/v1/checks/*`` gateway routes already own three
-#: shipped op-ids under that prefix (``checks.assignment.put`` /
+#: An explicit allowlist, **not** a ``checks.`` prefix branch. The
+#: ``/api/v1/checks/*`` gateway routes already own three shipped op-ids
+#: under that prefix (``checks.assignment.put`` /
 #: ``checks.assignment.get`` / ``checks.results.post``,
-#: :data:`meho_backplane.api.v1.checks._CHECKS_OP_IDS`), so:
+#: :data:`meho_backplane.api.v1.checks._CHECKS_OP_IDS`).
 #:
-#: 1. A prefix branch would reclassify them out of ``write`` / ``read`` /
-#:    ``other``, splitting the historical meaning of ``audit_log.op_class``
-#:    at the deploy boundary and silently dropping the assignment write
-#:    out of any saved ``op_class=write`` query.
-#: 2. ``checks.results.post`` is the runner result-ingest data plane — one
-#:    call per runner per poll cycle, the highest-volume path in the
-#:    subsystem. Folding it into ``checks`` would bury the rare transition
-#:    edges this class exists to surface, defeating the
-#:    ``op_class=checks`` filter before it shipped.
+#: What is *not* at risk is what those rows persist. All three routes
+#: bind an explicit ``audit_op_class`` contextvar (``write`` / ``read`` /
+#: ``write``), and
+#: :func:`~meho_backplane.broadcast.overrides.resolve_broadcast_detail`
+#: takes that ``op_class_override`` in preference to this function — the
+#: same value the audit row stores in ``payload["op_class"]``, which is
+#: what ``meho.audit.query`` filters on in SQL. So a prefix branch would
+#: not move a single stored class, and no saved ``op_class=write`` query
+#: would change its results.
+#:
+#: The hazard is on the **read** side. ``classify_op`` is re-run at render
+#: time against the stored op-id by the audit drawer
+#: (:mod:`meho_backplane.ui.routes.audit.routes`) and the broadcast event
+#: drawer (:mod:`meho_backplane.ui.routes.broadcast.event`), where it
+#: supplies the row's displayed class and badge and feeds
+#: :func:`~meho_backplane.ui.routes.broadcast.aggregate_gate.is_aggregate_only`.
+#: A prefix branch would therefore relabel every gateway row as
+#: ``checks`` — retroactively, because that class is derived on read
+#: rather than read back off the row — and would sweep in any future
+#: non-transition ``checks.*`` op-id by construction, diluting the class
+#: whose whole purpose is surfacing rare transition edges.
 #:
 #: The allowlist is the same idiom :data:`_CREDENTIAL_MINT_OPS` uses for
 #: the same reason: an exact pin that beats a broader structural match.
@@ -344,7 +356,13 @@ class BroadcastEvent(BaseModel):
     op_id: str
     #: One of ``"read"`` / ``"write"`` / ``"credential_read"`` /
     #: ``"credential_mint"`` / ``"credential_write"`` / ``"audit_query"``
-    #: / ``"other"``. Derived from :func:`classify_op` at publish time.
+    #: / ``"approval"`` / ``"checks"`` / ``"other"``. Usually derived
+    #: from :func:`classify_op` at publish time — but a route that binds
+    #: the ``audit_op_class`` contextvar overrides it:
+    #: :func:`~meho_backplane.broadcast.overrides.resolve_broadcast_detail`
+    #: takes ``op_class_override`` in preference to :func:`classify_op`,
+    #: and the same value is what the audit row persists under
+    #: ``payload["op_class"]``.
     op_class: str
     #: One of ``"ok"`` / ``"error"`` / ``"denied"``. The handler
     #: produces it; the broadcast publisher does not re-classify.
@@ -440,10 +458,11 @@ def classify_op(op_id: str) -> str:
        Dashboard rollup edges without reading every unclassified op.
        Matched by **exact membership**, not by ``checks.`` prefix — the
        ``/api/v1/checks/*`` gateway routes already own op-ids under that
-       prefix and must keep their ``write`` / ``read`` / ``other``
-       classes; see :data:`_CHECK_EVENT_OPS` for the full rationale.
-       Not sensitive (the payload is dashboard id / name / the two
-       states), so it stays full-detail.
+       prefix, and because this function is re-run at render time on the
+       stored op-id, a prefix branch would relabel their rows (historical
+       ones included) in the drawers; see :data:`_CHECK_EVENT_OPS` for
+       the full rationale. Not sensitive (the payload is dashboard id /
+       name / the two states), so it stays full-detail.
     5. ``read`` / ``write`` — HTTP-method-prefixed ingested op IDs
        (e.g. ``GET:/api/v2.0/systeminfo``). ``GET:`` and ``HEAD:``
        map to ``read``; ``POST:``, ``PUT:``, ``PATCH:``, ``DELETE:``

--- a/backend/src/meho_backplane/broadcast/history.py
+++ b/backend/src/meho_backplane/broadcast/history.py
@@ -142,12 +142,27 @@ _XRANGE_END: Final[str] = "+"
 #: filter when chasing a freshly-minted credential (e.g.
 #: ``harbor.robot.create``) or an unmapped HTTP route, which defeats
 #: the filter's purpose.
+#:
+#: ``checks`` (#2720) is the checks subsystem's own state-change class
+#: (``checks.transition``). It is listed because the enum is enforced:
+#: :mod:`meho_backplane.mcp.handlers` validates every tool call against
+#: the advertised ``inputSchema`` with ``jsonschema``, so an op_class
+#: absent from this tuple is a JSON-RPC ``-32602`` before the handler
+#: runs -- the filter would be unreachable from ``meho.broadcast.recent``
+#: / ``.watch``. Unlike the other members it never appears in
+#: ``audit_log.op_class``: the transition event is published outside the
+#: audit path (there is no audited operation behind a rollup edge), so a
+#: ``meho.audit.query`` narrowed to ``checks`` is always empty. The two
+#: tools share this tuple as one taxonomy by design
+#: (``tests/test_mcp_tools_list_shape_conventions.py`` pins them
+#: together).
 OP_CLASS_ENUM: Final[tuple[str, ...]] = (
     "read",
     "write",
     "credential_read",
     "credential_mint",
     "audit_query",
+    "checks",
     "other",
 )
 

--- a/backend/src/meho_backplane/checks/broadcast.py
+++ b/backend/src/meho_backplane/checks/broadcast.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``checks.transition`` broadcast events on the tenant feed (#2720).
+
+Task #2720 under Initiative #2716 (parent goal #221). The third consumer
+of #2507's compare-and-swap transition claim, beside the diagnose-only
+investigator (:mod:`meho_backplane.checks.investigate`) and the email
+notifier (:mod:`meho_backplane.checks.notify`): every claimed Dashboard
+rollup edge is published to ``meho:feed:{tenant_id}`` as one
+:class:`~meho_backplane.broadcast.events.BroadcastEvent` with op-id
+``checks.transition``.
+
+Why the claim is the publish point
+==================================
+
+The compare-and-swap in
+:func:`~meho_backplane.checks.investigate._claim_dashboard_transition`
+already returns to exactly one caller per edge, replica-safe. Publishing
+from the claim-win branch therefore inherits exactly-once-per-transition
+with no coordination here -- the same property the notifier gets, and the
+reason neither module needs a dedupe key.
+
+Both edge directions publish, unconditionally: a watcher who saw a
+Dashboard go ``critical`` must see it clear. Unlike the mail notifier
+there is no configured floor -- a feed event costs one ``XADD`` against a
+``MAXLEN ~`` -trimmed stream, so the filtering belongs to the consumer
+(``op_class=checks``), not to the producer.
+
+Not audit-derived
+=================
+
+Every other :class:`BroadcastEvent` producer sits downstream of an audit
+row and passes its id as ``audit_id`` (the field is documented as an FK
+to ``audit_log.id``). A rollup edge is not an audited operation -- it is
+derived state, folded from Sensor evaluations that were each audited on
+their own dispatch -- so there is no row to point at. The event carries
+:data:`_NO_AUDIT_ROW`, the nil UUID, rather than a fabricated id a
+consumer could not tell from a real one. The one surface that
+dereferences the field, the UI event drawer
+(``/ui/broadcast/event/{audit_id}``), already renders its not-found
+fragment for an id with no row, so the nil id degrades rather than
+breaks.
+
+``principal_sub`` is :data:`_CHECKS_PRINCIPAL_SUB` for the same reason:
+the edge has no operator behind it, and a Dashboard folds many Sensors
+that may each dispatch under a different ``identity_sub``, so attributing
+the edge to any one of them would be a lie. ``"__sensor__"`` is
+deliberately not reused -- that value is a *per-Sensor configurable
+dispatch identity*, not a subsystem identity.
+
+Failure posture
+===============
+
+Fail-open, twice over.
+:func:`~meho_backplane.broadcast.publisher.publish_event` already swallows
+every Valkey error (at-most-once delivery is the feed's documented
+contract), and this module wraps construction in a second guard so a
+malformed field or an import-time failure cannot reach the caller either.
+The publish is awaited inline rather than backgrounded: the claim is a
+rare edge, the fast broadcast client pins both its connect and read
+timeouts, and awaiting keeps the publish ordered with the claim that
+caused it. A broadcast outage must never convert a committed transition
+into a persist-path failure.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Final, cast
+
+import structlog
+
+from meho_backplane.broadcast.events import BroadcastEvent, classify_op
+from meho_backplane.broadcast.publisher import publish_event
+from meho_backplane.operations._audit import resolve_broadcast_lineage
+
+__all__ = ["CHECK_TRANSITION_OP_ID", "publish_check_transition_event"]
+
+
+#: Broadcast op-id for a claimed Dashboard rollup edge. Pinned in
+#: :data:`meho_backplane.broadcast.events._CHECK_EVENT_OPS` so
+#: :func:`~meho_backplane.broadcast.events.classify_op` maps it to the
+#: ``checks`` op-class; ``tests/test_checks_broadcast.py`` asserts the two
+#: cannot drift.
+CHECK_TRANSITION_OP_ID: Final[str] = "checks.transition"
+
+#: Principal recorded on a transition event. A subsystem identity, not an
+#: operator and not a Sensor's ``identity_sub`` -- see the module
+#: docstring.
+_CHECKS_PRINCIPAL_SUB: Final[str] = "__checks__"
+
+#: ``audit_id`` sentinel for an event with no audit row behind it. The nil
+#: UUID is self-describing: a consumer that joins on it finds nothing and
+#: can tell that from a stale id.
+_NO_AUDIT_ROW: Final[uuid.UUID] = uuid.UUID(int=0)
+
+
+def _log() -> structlog.typing.FilteringBoundLogger:
+    """Resolve the structlog logger per call (not a module-level proxy).
+
+    A module-level proxy caches its bound methods on first use under the
+    production ``cache_logger_on_first_use=True`` config, which orphans
+    them from a later :func:`structlog.testing.capture_logs`. Same
+    discipline as :mod:`meho_backplane.checks.notify`.
+    """
+    return cast("structlog.typing.FilteringBoundLogger", structlog.get_logger(__name__))
+
+
+async def publish_check_transition_event(
+    *,
+    tenant_id: uuid.UUID,
+    dashboard_id: uuid.UUID,
+    dashboard_name: str,
+    previous_state: str,
+    new_state: str,
+) -> None:
+    """Publish one ``checks.transition`` event for a claimed rollup edge.
+
+    **Never raises.** Called from the claim-win branch of
+    :func:`~meho_backplane.checks.investigate._process_transition`, which
+    runs on the check runner's result-persist path.
+
+    The payload carries server-derived values only -- the Dashboard id,
+    its operator-authored name (bounded at 128 chars by
+    :data:`meho_backplane.checks.dashboard_schemas._NAME_MAX_LENGTH` at
+    the create boundary), and the two states. No Sensor values, evidence,
+    or member names: the class is not sensitive precisely because the
+    payload stays at this altitude, and a consumer that wants the failing
+    members reads the Dashboard.
+
+    Args:
+        tenant_id: Owning tenant; selects the ``meho:feed:{tenant_id}``
+            stream, so the event is tenant-isolated by construction.
+        dashboard_id: The Dashboard whose rollup moved.
+        dashboard_name: Its display name, for a feed row that reads
+            without a lookup.
+        previous_state: Rollup state before the edge (``"ok"`` when the
+            memo was NULL).
+        new_state: Rollup state after the edge.
+    """
+    try:
+        lineage = resolve_broadcast_lineage()
+        op_class = classify_op(CHECK_TRANSITION_OP_ID)
+        event = BroadcastEvent(
+            event_id=uuid.uuid4(),
+            ts=datetime.now(UTC),
+            tenant_id=tenant_id,
+            principal_sub=_CHECKS_PRINCIPAL_SUB,
+            op_id=CHECK_TRANSITION_OP_ID,
+            op_class=op_class,
+            result_status="ok",
+            audit_id=_NO_AUDIT_ROW,
+            payload={
+                "op_class": op_class,
+                "result_status": "ok",
+                "dashboard_id": str(dashboard_id),
+                "dashboard_name": dashboard_name,
+                "previous_state": previous_state,
+                "new_state": new_state,
+            },
+            actor_sub=lineage.actor_sub,
+            agent_session_id=lineage.agent_session_id,
+            work_ref=lineage.work_ref,
+        )
+        await publish_event(event)
+    except Exception:
+        # Fail-open: the durable truth is the committed last_rollup_state
+        # memo. A feed miss must not fail the runner's persist path.
+        _log().warning(
+            "checks_transition_broadcast_failed",
+            dashboard_id=str(dashboard_id),
+            previous_state=previous_state,
+            new_state=new_state,
+            exc_info=True,
+        )

--- a/backend/src/meho_backplane/checks/broadcast.py
+++ b/backend/src/meho_backplane/checks/broadcast.py
@@ -52,11 +52,15 @@ dispatch identity*, not a subsystem identity.
 Failure posture
 ===============
 
-Fail-open, twice over.
+Fail-open, twice over, and the two halves log in different places.
 :func:`~meho_backplane.broadcast.publisher.publish_event` already swallows
 every Valkey error (at-most-once delivery is the feed's documented
-contract), and this module wraps construction in a second guard so a
-malformed field or an import-time failure cannot reach the caller either.
+contract) and never re-raises, so a transport failure surfaces on its own
+``broadcast_publish_failed`` warning and ``broadcast_publish_errors_total``
+counter, not here. This module wraps the body in a second guard so a
+malformed field or an unexpected lineage failure -- anything *before* the
+publish -- cannot reach the caller either; that is the only thing
+``checks_transition_broadcast_failed`` reports.
 The publish is awaited inline rather than backgrounded: the claim is a
 rare edge, the fast broadcast client pins both its connect and read
 timeouts, and awaiting keeps the publish ordered with the claim that

--- a/backend/src/meho_backplane/checks/investigate.py
+++ b/backend/src/meho_backplane/checks/investigate.py
@@ -119,6 +119,7 @@ from meho_backplane.agent.run import BudgetExceededError
 from meho_backplane.auth.agent_token import AgentTokenError
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.checks.assertions import CheckState
+from meho_backplane.checks.broadcast import publish_check_transition_event
 from meho_backplane.checks.dashboard_repository import members_by_dashboard
 from meho_backplane.checks.notify import (
     DashboardNotice,
@@ -373,12 +374,14 @@ async def _process_transition(
     back, so two Sensor outcomes landing together on one Dashboard produce exactly
     one of everything downstream.
 
-    A won claim has two independent consumers. A **worsening** transition into
+    A won claim has three independent consumers. A **worsening** transition into
     ``degraded`` / ``critical`` with at least one actively-failing member schedules
     a background investigation (unchanged). **Every** claimed edge, both
     directions, is handed to the #2719 notifier, which applies its own
     ``notify_min_state`` floor -- so a ``critical -> ok`` recovery mails the
-    all-clear without the investigator ever seeing it.
+    all-clear without the investigator ever seeing it -- and published to the
+    tenant broadcast feed as a ``checks.transition`` event (#2720), with no
+    floor at all.
     """
     now = now or datetime.now(UTC)
     sessionmaker = get_sessionmaker()
@@ -397,16 +400,26 @@ async def _process_transition(
             pending.append(claimed)
 
     # Claims committed under the per-(tenant, dashboard) lock; spawn the
-    # expensive work off the runner's persist path. Investigation and
-    # notification are independent consumers of one claim: the investigator
-    # keeps its worsening-and-actively-failing gate, the notifier decides for
-    # itself from the configured floor (both edge directions, #2719).
+    # expensive work off the runner's persist path. Investigation,
+    # notification and broadcast are independent consumers of one claim: the
+    # investigator keeps its worsening-and-actively-failing gate, the notifier
+    # decides for itself from the configured floor (both edge directions,
+    # #2719), and the feed event is unconditional (#2720) -- filtering a feed
+    # is the consumer's job. The publish is awaited (a bounded XADD) while the
+    # two expensive consumers are backgrounded.
     for claim in pending:
         if claim.worsening and claim.non_green:
             _schedule_investigation(
                 tenant_id=tenant_id, dashboard=claim.dashboard, members=claim.non_green
             )
         schedule_dashboard_notification(claim.notice)
+        await publish_check_transition_event(
+            tenant_id=tenant_id,
+            dashboard_id=claim.dashboard.dashboard_id,
+            dashboard_name=claim.dashboard.name,
+            previous_state=claim.dashboard.previous_state,
+            new_state=claim.dashboard.current_state,
+        )
 
 
 async def _claim_dashboard_transition(

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -302,6 +302,54 @@ class TestClassifyOp:
 
         assert "approval" not in _SENSITIVE_OP_CLASSES
 
+    def test_checks_transition_maps_to_checks(self) -> None:
+        """``checks.transition`` classifies as the dedicated ``checks`` class.
+
+        :func:`~meho_backplane.checks.broadcast.publish_check_transition_event`
+        emits this op-id on every claimed Dashboard rollup edge (#2720);
+        the class is what makes ``op_class=checks`` a usable server-side
+        filter on ``meho.broadcast.recent`` / ``.watch`` and the SSE
+        stream.
+        """
+        assert classify_op("checks.transition") == "checks"
+
+    @pytest.mark.parametrize(
+        ("op_id", "expected"),
+        [
+            ("checks.assignment.put", "write"),
+            ("checks.assignment.get", "read"),
+            ("checks.results.post", "other"),
+        ],
+    )
+    def test_gateway_checks_op_ids_keep_their_classes(self, op_id: str, expected: str) -> None:
+        """The ``/api/v1/checks/*`` op-ids are NOT swept into ``checks``.
+
+        Regression guard on the deliberate choice of an exact-membership
+        allowlist over a ``checks.`` prefix branch (#2720). A prefix match
+        would (a) split the historical meaning of ``audit_log.op_class``
+        at the deploy boundary -- rows written before say ``write``,
+        after say ``checks``, so a saved ``op_class=write`` query would
+        silently stop seeing the assignment write -- and (b) fold the
+        runner result-ingest data plane (one call per runner per poll)
+        into the class whose whole purpose is surfacing rare transition
+        edges.
+        """
+        assert classify_op(op_id) == expected
+
+    def test_checks_class_is_not_sensitive(self) -> None:
+        """The ``checks`` class broadcasts full detail (not aggregate-only).
+
+        The transition payload is a Dashboard id, its name, and the two
+        rollup states -- no params, no Sensor values, no evidence. Pins
+        the class out of
+        :data:`~meho_backplane.broadcast.overrides._SENSITIVE_OP_CLASSES`
+        so minting it did not accidentally opt the events into
+        aggregate-only redaction.
+        """
+        from meho_backplane.broadcast.overrides import _SENSITIVE_OP_CLASSES
+
+        assert "checks" not in _SENSITIVE_OP_CLASSES
+
     @pytest.mark.parametrize(
         ("op_id", "expected"),
         [

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -321,18 +321,29 @@ class TestClassifyOp:
             ("checks.results.post", "other"),
         ],
     )
-    def test_gateway_checks_op_ids_keep_their_classes(self, op_id: str, expected: str) -> None:
+    def test_gateway_checks_op_ids_are_not_swept_into_checks(
+        self, op_id: str, expected: str
+    ) -> None:
         """The ``/api/v1/checks/*`` op-ids are NOT swept into ``checks``.
 
         Regression guard on the deliberate choice of an exact-membership
-        allowlist over a ``checks.`` prefix branch (#2720). A prefix match
-        would (a) split the historical meaning of ``audit_log.op_class``
-        at the deploy boundary -- rows written before say ``write``,
-        after say ``checks``, so a saved ``op_class=write`` query would
-        silently stop seeing the assignment write -- and (b) fold the
-        runner result-ingest data plane (one call per runner per poll)
-        into the class whose whole purpose is surfacing rare transition
-        edges.
+        allowlist over a ``checks.`` prefix branch (#2720).
+
+        The values pinned here are what :func:`classify_op` returns **in
+        isolation**, which is not the same thing as the class those rows
+        ship with: all three routes bind an explicit ``audit_op_class``
+        (``write`` / ``read`` / ``write``), and both the audit write and
+        the broadcast publish honour that override in preference to
+        ``classify_op`` -- hence ``checks.results.post`` persisting
+        ``write`` while this function says ``other``.
+
+        What the pin protects is the **read** path. ``classify_op`` is
+        re-run at render time on the stored op-id by the audit and
+        broadcast event drawers, where it supplies the displayed class
+        and feeds ``is_aggregate_only``. A prefix branch would relabel
+        every gateway row there -- retroactively, since the class is
+        derived on read -- and would sweep in any future non-transition
+        ``checks.*`` op-id.
         """
         assert classify_op(op_id) == expected
 

--- a/backend/tests/test_checks_broadcast.py
+++ b/backend/tests/test_checks_broadcast.py
@@ -304,8 +304,15 @@ async def test_audit_id_is_the_nil_uuid(monkeypatch: pytest.MonkeyPatch) -> None
 async def test_publisher_failure_is_swallowed_and_logged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A raising publisher never reaches the caller; it logs and returns."""
-    _install_publisher(monkeypatch, exc=RuntimeError("valkey down"))
+    """A raising publish never reaches the caller; it logs and returns.
+
+    The injected failure stands in for what the guard actually covers: a
+    fault *before* the ``XADD``, e.g. lineage resolution or
+    ``BroadcastEvent`` validation. A Valkey outage never gets this far --
+    :func:`~meho_backplane.broadcast.publisher.publish_event` swallows it
+    and logs ``broadcast_publish_failed`` on its own.
+    """
+    _install_publisher(monkeypatch, exc=RuntimeError("event construction failed"))
 
     with capture_logs() as logs:
         await publish_check_transition_event(
@@ -368,16 +375,20 @@ async def test_concurrent_transitions_publish_exactly_one_event(
 
 
 @pytest.mark.asyncio
-async def test_publisher_outage_leaves_the_memo_and_the_mail_intact(
+async def test_broadcast_failure_leaves_the_memo_and_the_mail_intact(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A broadcast outage must not fail the persist seam or the notifier.
+    """A failing broadcast must not fail the persist seam or the notifier.
 
     The committed ``last_rollup_state`` memo is the durable truth; the
     feed is the at-most-once real-time view. This is the fail-open
-    contract the whole publish path is built on.
+    contract the whole publish path is built on. Raising at the publish
+    seam is the strongest form of the failure -- a real Valkey outage is
+    weaker still, since
+    :func:`~meho_backplane.broadcast.publisher.publish_event` swallows it
+    before this module's guard ever sees it.
     """
-    _install_publisher(monkeypatch, exc=RuntimeError("valkey down"))
+    _install_publisher(monkeypatch, exc=RuntimeError("broadcast unavailable"))
     mail = _install_transport(monkeypatch)
     monkeypatch.setattr(inv, "_schedule_investigation", lambda **_: None)
     await _seed_tenant()
@@ -396,13 +407,18 @@ async def test_publisher_outage_leaves_the_memo_and_the_mail_intact(
 
 
 @pytest.mark.asyncio
-async def test_no_claim_publishes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A persist that moves no rollup state publishes no event.
+async def test_second_persist_on_an_unchanged_rollup_does_not_republish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only the persist that moves the rollup state publishes.
 
-    The Dashboard is already ``critical`` in the memo, so the
-    compare-and-swap finds nothing to claim. Guards against the publish
-    being wired outside the claim-win branch, which would emit one event
-    per Sensor evaluation instead of one per edge.
+    The Dashboard starts with a NULL memo, so the first
+    ``investigate_on_transition`` wins a real ``ok -> critical`` claim and
+    publishes once. The second call finds the memo already ``critical``,
+    the compare-and-swap claims nothing, and the count must stay at one.
+    Guards against the publish being wired outside the claim-win branch,
+    which would emit one event per Sensor evaluation instead of one per
+    edge.
     """
     fake = _install_publisher(monkeypatch)
     _install_transport(monkeypatch)
@@ -412,7 +428,7 @@ async def test_no_claim_publishes_nothing(monkeypatch: pytest.MonkeyPatch) -> No
     await _seed_dashboard(name="prod-health", sensor_ids=[sid])
 
     await inv.investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
-    assert len(fake.events) == 1
+    assert len(fake.events) == 1, "the first persist claims the edge and publishes it"
 
     await inv.investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
     assert len(fake.events) == 1, "a no-op persist must not re-publish the edge"

--- a/backend/tests/test_checks_broadcast.py
+++ b/backend/tests/test_checks_broadcast.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``checks.transition`` broadcast publisher (#2720).
+
+Initiative #2716 (parent goal #221), Task #2720. Coverage:
+
+* **Event shape** -- op-id, op-class, tenant, principal, and the four
+  payload fields; plus the pin that the op-id the publisher emits is the
+  one :func:`~meho_backplane.broadcast.events.classify_op` recognises.
+* **Fail-open** -- a raising publisher never reaches the caller, and
+  emits the structured warning operators alert on.
+* **Integration through the persist seam** -- two raced
+  ``investigate_on_transition`` calls on one Dashboard publish exactly one
+  event (the compare-and-swap claim is the dedupe, same proof shape as
+  #2719's email test), the recovery edge back to ``ok`` publishes a
+  second, and a publisher outage leaves the memo committed and the mail
+  sent.
+
+:func:`~meho_backplane.broadcast.publisher.publish_event` is replaced by a
+recording fake in every test, so no Valkey connection is opened; the DB
+layer is real against the SQLite engine from :mod:`tests.conftest`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from structlog.testing import capture_logs
+
+import meho_backplane.checks.broadcast as checks_broadcast
+import meho_backplane.checks.investigate as inv
+import meho_backplane.checks.notify as notify
+from meho_backplane.broadcast.events import BroadcastEvent, classify_op
+from meho_backplane.broadcast.history import OP_CLASS_ENUM
+from meho_backplane.checks.broadcast import (
+    CHECK_TRANSITION_OP_ID,
+    publish_check_transition_event,
+)
+from meho_backplane.connectors.mail.transport import MailSendResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    CheckDashboard,
+    CheckDashboardSensor,
+    Sensor,
+    Tenant,
+)
+from meho_backplane.settings import get_settings
+
+_TENANT = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+_DASHBOARD = UUID("11111111-1111-1111-1111-111111111111")
+
+_ASSERTION: dict[str, Any] = {
+    "select": {"path": "$.count"},
+    "compare": {"type": "threshold", "op": "lt", "critical": 10},
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + doubles
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env :class:`Settings` requires so ``get_settings()`` constructs."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://kc.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_background_tasks() -> Iterator[None]:
+    """Clear the in-flight notification / investigation sets per test."""
+    yield
+    notify._NOTIFICATIONS.clear()
+    inv._INVESTIGATIONS.clear()
+
+
+class _RecordingPublisher:
+    """Stands in for ``publish_event``; records every event, optionally raises."""
+
+    def __init__(self, *, exc: Exception | None = None) -> None:
+        self.events: list[BroadcastEvent] = []
+        self._exc = exc
+
+    async def __call__(self, event: BroadcastEvent) -> None:
+        self.events.append(event)
+        if self._exc is not None:
+            raise self._exc
+
+
+def _install_publisher(
+    monkeypatch: pytest.MonkeyPatch, *, exc: Exception | None = None
+) -> _RecordingPublisher:
+    """Patch the publisher the checks module imported (not the source module)."""
+    fake = _RecordingPublisher(exc=exc)
+    monkeypatch.setattr(checks_broadcast, "publish_event", fake)
+    return fake
+
+
+class _RecordingTransport:
+    """Stands in for ``send_email`` so the notifier opens no SMTP session."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, *, to: list[str], subject: str, body: str) -> MailSendResult:
+        self.calls.append({"to": list(to), "subject": subject, "body": body})
+        return MailSendResult(sent=True)
+
+
+def _install_transport(monkeypatch: pytest.MonkeyPatch) -> _RecordingTransport:
+    fake = _RecordingTransport()
+    monkeypatch.setattr(notify, "send_email", fake)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# DB seeds (mirror tests/test_checks_notify.py)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant(tenant_id: UUID = _TENANT) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if await session.get(Tenant, tenant_id) is None:
+            session.add(Tenant(id=tenant_id, slug="tenant-bcast", name="Tenant Broadcast"))
+            await session.commit()
+
+
+async def _seed_sensor(*, name: str, last_state: str = "critical") -> UUID:
+    now = datetime.now(UTC)
+    sensor_id = uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Sensor(
+                id=sensor_id,
+                tenant_id=_TENANT,
+                name=name,
+                connector_id="vmware-rest-9.0",
+                op_id="vmware.vm.list",
+                target=None,
+                params={},
+                assertion=_ASSERTION,
+                status="active",
+                cadence_kind="interval",
+                interval_seconds=60,
+                cron_expr=None,
+                timezone="UTC",
+                next_fire_at=now + timedelta(seconds=60),
+                severity="critical",
+                for_seconds=0,
+                last_state=last_state,
+                last_value=7,
+                last_evidence={"observed": 7, "bound": 10},
+                last_evaluated_at=now - timedelta(seconds=30),
+                state_since=now - timedelta(hours=1),
+                identity_sub="__sensor__",
+                created_by_sub="op-admin",
+            )
+        )
+        await session.commit()
+    return sensor_id
+
+
+async def _seed_dashboard(
+    *,
+    name: str,
+    sensor_ids: list[UUID],
+    dashboard_id: UUID = _DASHBOARD,
+    notify_email: str | None = "oncall@example.com",
+) -> UUID:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            CheckDashboard(
+                id=dashboard_id,
+                tenant_id=_TENANT,
+                name=name,
+                description=None,
+                last_rollup_state=None,
+                notify_email=notify_email,
+                notify_min_state="critical",
+                created_by_sub="op-admin",
+            )
+        )
+        for sid in sensor_ids:
+            session.add(CheckDashboardSensor(dashboard_id=dashboard_id, sensor_id=sid))
+        await session.commit()
+    return dashboard_id
+
+
+async def _set_sensor_state(sensor_id: UUID, state: str) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        row.last_state = state
+        row.state_since = datetime.now(UTC) - timedelta(hours=1)
+        row.last_evaluated_at = datetime.now(UTC)
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Event shape
+# ---------------------------------------------------------------------------
+
+
+def test_op_id_is_the_one_classify_op_recognises() -> None:
+    """The publisher's op-id and the classifier's allowlist cannot drift.
+
+    The two live in different layers on purpose --
+    :mod:`meho_backplane.broadcast.events` must not import from
+    :mod:`meho_backplane.checks` -- so the literal is written twice. This
+    pins them together, the same way the op-class enum is pinned to the
+    tool schemas.
+    """
+    assert classify_op(CHECK_TRANSITION_OP_ID) == "checks"
+
+
+def test_checks_is_filterable_from_the_agent_surface() -> None:
+    """``checks`` is in the op_class filter vocabulary the MCP tools advertise.
+
+    ``inputSchema`` validation is jsonschema-enforced at the dispatcher,
+    so a class absent from :data:`OP_CLASS_ENUM` is a ``-32602`` before
+    the handler runs -- the class would be published but unreachable from
+    ``meho.broadcast.recent`` / ``.watch``.
+    """
+    assert "checks" in OP_CLASS_ENUM
+
+
+@pytest.mark.asyncio
+async def test_event_carries_the_edge_and_the_dashboard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One publish per call, with the documented op-id / class / payload."""
+    fake = _install_publisher(monkeypatch)
+
+    await publish_check_transition_event(
+        tenant_id=_TENANT,
+        dashboard_id=_DASHBOARD,
+        dashboard_name="prod-health",
+        previous_state="ok",
+        new_state="critical",
+    )
+
+    assert len(fake.events) == 1
+    event = fake.events[0]
+    assert event.kind == "operation"
+    assert event.op_id == "checks.transition"
+    assert event.op_class == "checks"
+    assert event.tenant_id == _TENANT
+    assert event.principal_sub == "__checks__"
+    assert event.result_status == "ok"
+    assert event.payload == {
+        "op_class": "checks",
+        "result_status": "ok",
+        "dashboard_id": str(_DASHBOARD),
+        "dashboard_name": "prod-health",
+        "previous_state": "ok",
+        "new_state": "critical",
+    }
+
+
+@pytest.mark.asyncio
+async def test_audit_id_is_the_nil_uuid(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No audit row backs a rollup edge, so the FK is the nil sentinel.
+
+    A fabricated id would be indistinguishable from a stale one to the UI
+    drawer, which resolves ``/ui/broadcast/event/{audit_id}`` against
+    ``audit_log``.
+    """
+    fake = _install_publisher(monkeypatch)
+
+    await publish_check_transition_event(
+        tenant_id=_TENANT,
+        dashboard_id=_DASHBOARD,
+        dashboard_name="prod-health",
+        previous_state="degraded",
+        new_state="ok",
+    )
+
+    assert fake.events[0].audit_id == UUID(int=0)
+
+
+# ---------------------------------------------------------------------------
+# Failure posture
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publisher_failure_is_swallowed_and_logged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising publisher never reaches the caller; it logs and returns."""
+    _install_publisher(monkeypatch, exc=RuntimeError("valkey down"))
+
+    with capture_logs() as logs:
+        await publish_check_transition_event(
+            tenant_id=_TENANT,
+            dashboard_id=_DASHBOARD,
+            dashboard_name="prod-health",
+            previous_state="ok",
+            new_state="critical",
+        )
+
+    warnings = [entry for entry in logs if entry["event"] == "checks_transition_broadcast_failed"]
+    assert len(warnings) == 1
+    assert warnings[0]["log_level"] == "warning"
+    assert warnings[0]["dashboard_id"] == str(_DASHBOARD)
+
+
+# ---------------------------------------------------------------------------
+# Integration through the persist seam
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_transitions_publish_exactly_one_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two raced persists on one Dashboard publish once -- the CAS claim dedupes.
+
+    Then a recovery to ``ok`` publishes a second event: the feed carries
+    both edge directions, so a watcher who saw the Dashboard redden sees
+    it clear.
+    """
+    fake = _install_publisher(monkeypatch)
+    _install_transport(monkeypatch)
+    monkeypatch.setattr(inv, "_schedule_investigation", lambda **_: None)
+    await _seed_tenant()
+    sid_a = await _seed_sensor(name="sensor-a", last_state="critical")
+    sid_b = await _seed_sensor(name="sensor-b", last_state="critical")
+    await _seed_dashboard(name="prod-health", sensor_ids=[sid_a, sid_b])
+
+    await asyncio.gather(
+        inv.investigate_on_transition(sensor_id=sid_a, tenant_id=_TENANT),
+        inv.investigate_on_transition(sensor_id=sid_b, tenant_id=_TENANT),
+    )
+
+    assert len(fake.events) == 1, "the compare-and-swap claim must dedupe the raced edge"
+    worsening = fake.events[0]
+    assert worsening.op_id == "checks.transition"
+    assert worsening.payload["dashboard_id"] == str(_DASHBOARD)
+    assert worsening.payload["dashboard_name"] == "prod-health"
+    assert worsening.payload["previous_state"] == "ok"
+    assert worsening.payload["new_state"] == "critical"
+
+    await _set_sensor_state(sid_a, "ok")
+    await _set_sensor_state(sid_b, "ok")
+    await inv.investigate_on_transition(sensor_id=sid_a, tenant_id=_TENANT)
+
+    assert len(fake.events) == 2, "the recovery edge must publish too"
+    assert fake.events[1].payload["previous_state"] == "critical"
+    assert fake.events[1].payload["new_state"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_publisher_outage_leaves_the_memo_and_the_mail_intact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broadcast outage must not fail the persist seam or the notifier.
+
+    The committed ``last_rollup_state`` memo is the durable truth; the
+    feed is the at-most-once real-time view. This is the fail-open
+    contract the whole publish path is built on.
+    """
+    _install_publisher(monkeypatch, exc=RuntimeError("valkey down"))
+    mail = _install_transport(monkeypatch)
+    monkeypatch.setattr(inv, "_schedule_investigation", lambda **_: None)
+    await _seed_tenant()
+    sid = await _seed_sensor(name="sensor-solo", last_state="critical")
+    await _seed_dashboard(name="prod-health", sensor_ids=[sid])
+
+    await inv.investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+    await notify._await_pending_notifications()
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(CheckDashboard, _DASHBOARD)
+        assert row is not None
+        assert row.last_rollup_state == "critical"
+    assert len(mail.calls) == 1, "the email notifier must be unaffected by a feed outage"
+
+
+@pytest.mark.asyncio
+async def test_no_claim_publishes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A persist that moves no rollup state publishes no event.
+
+    The Dashboard is already ``critical`` in the memo, so the
+    compare-and-swap finds nothing to claim. Guards against the publish
+    being wired outside the claim-win branch, which would emit one event
+    per Sensor evaluation instead of one per edge.
+    """
+    fake = _install_publisher(monkeypatch)
+    _install_transport(monkeypatch)
+    monkeypatch.setattr(inv, "_schedule_investigation", lambda **_: None)
+    await _seed_tenant()
+    sid = await _seed_sensor(name="sensor-solo", last_state="critical")
+    await _seed_dashboard(name="prod-health", sensor_ids=[sid])
+
+    await inv.investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+    assert len(fake.events) == 1
+
+    await inv.investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+    assert len(fake.events) == 1, "a no-op persist must not re-publish the edge"

--- a/backend/tests/test_mcp_tool_broadcast_recent.py
+++ b/backend/tests/test_mcp_tool_broadcast_recent.py
@@ -416,6 +416,60 @@ def test_filter_op_class_narrows_result(
     [TenantRole.OPERATOR],
     indirect=True,
 )
+def test_filter_op_class_checks_reaches_the_handler(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter.op_class="checks"`` narrows to ``checks.transition`` (#2720).
+
+    Posted as a full ``tools/call`` on purpose. The dispatcher validates
+    arguments against the advertised ``inputSchema`` with ``jsonschema``,
+    and ``filter.op_class`` carries an ``enum`` sourced from
+    :data:`~meho_backplane.broadcast.history.OP_CLASS_ENUM` -- so this
+    round-trip is what proves the class is reachable from the agent
+    surface at all, not merely that :func:`event_matches` compares
+    strings. A handler-level call would pass even with the class missing
+    from the enum.
+    """
+    client, _op = client_with_operator
+    transition = _make_event(
+        op_id="checks.transition",
+        op_class="checks",
+        principal_sub="__checks__",
+        payload={
+            "op_class": "checks",
+            "result_status": "ok",
+            "dashboard_id": "11111111-1111-1111-1111-111111111111",
+            "dashboard_name": "prod-health",
+            "previous_state": "ok",
+            "new_state": "critical",
+        },
+    )
+    unrelated = _make_event(op_id="vsphere.vm.list", op_class="read")
+    bc = get_broadcast_client()
+    with patch.object(
+        bc,
+        "xrange",
+        new=AsyncMock(
+            return_value=[
+                _xrange_entry(unrelated, "1747800000000-0"),
+                _xrange_entry(transition, "1747800001000-0"),
+            ],
+        ),
+    ):
+        resp = post_mcp(
+            client,
+            _tools_call("meho.broadcast.recent", {"filter": {"op_class": "checks"}}),
+        )
+    result = _result_dict(resp)
+    assert [e["op_id"] for e in result["events"]] == ["checks.transition"]
+    assert result["events"][0]["payload"]["new_state"] == "critical"
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
 def test_filter_principal_narrows_result(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:

--- a/docs/codebase/broadcast.md
+++ b/docs/codebase/broadcast.md
@@ -166,9 +166,10 @@ Three layers, separated for traceability:
     path. Matched by an **exact-membership allowlist**
     (`_CHECK_EVENT_OPS`), not by a `checks.` prefix: the
     `/api/v1/checks/*` gateway routes already own three op-ids under
-    that prefix (`checks.assignment.put` / `.get`, `checks.results.post`)
-    and keep their `write` / `read` / `other` classes. See
-    [`docs/codebase/checks-broadcast.md`](checks-broadcast.md).
+    that prefix (`checks.assignment.put` / `.get`, `checks.results.post`),
+    and because `classify_op` is re-run at render time in the drawers, a
+    prefix branch would relabel their rows — historical ones included.
+    See [`docs/codebase/checks-broadcast.md`](checks-broadcast.md).
   - `other` — full detail.
 
   `credential_read` and `audit_query` are *upgradeable*: a per-call or

--- a/docs/codebase/broadcast.md
+++ b/docs/codebase/broadcast.md
@@ -158,6 +158,17 @@ Three layers, separated for traceability:
   - `credential_write` (`vault.kv.put`, `vault.auth.userpass.write` /
     `.update_password`, `k8s.secret.create`, G11.7-T1 #1401) —
     **request params** carry the secret; aggregate-only.
+  - `approval` (`approval.*` lifecycle events, G10.7-T3 #1778) — full
+    detail; exists so the approvals console bell can filter the SSE
+    bridge server-side.
+  - `checks` (`checks.transition`, #2720) — full detail; the checks
+    subsystem's own state-change events, published outside the audit
+    path. Matched by an **exact-membership allowlist**
+    (`_CHECK_EVENT_OPS`), not by a `checks.` prefix: the
+    `/api/v1/checks/*` gateway routes already own three op-ids under
+    that prefix (`checks.assignment.put` / `.get`, `checks.results.post`)
+    and keep their `write` / `read` / `other` classes. See
+    [`docs/codebase/checks-broadcast.md`](checks-broadcast.md).
   - `other` — full detail.
 
   `credential_read` and `audit_query` are *upgradeable*: a per-call or

--- a/docs/codebase/checks-broadcast.md
+++ b/docs/codebase/checks-broadcast.md
@@ -32,7 +32,7 @@ consumer (`op_class=checks`), not to the producer.
 
 ## Control flow
 
-```
+```text
 runner persists a Sensor result
   → investigate_on_transition(sensor_id, tenant_id)          [never raises]
     → _process_transition
@@ -58,16 +58,30 @@ the event ordered with the claim that caused it.
 `classify_op` maps `checks.transition` to `checks` by **exact
 membership** in `_CHECK_EVENT_OPS`, not by a `checks.` prefix. The prefix
 is already occupied: `/api/v1/checks/*` binds `checks.assignment.put`,
-`checks.assignment.get`, and `checks.results.post` as audit op-ids. A
-prefix branch would
+`checks.assignment.get`, and `checks.results.post` as audit op-ids.
 
-1. split the historical meaning of `audit_log.op_class` at the deploy
-   boundary — rows written before say `write`, rows after say `checks`,
-   so a saved `op_class=write` query silently stops seeing the
-   assignment write; and
-2. fold the runner result-ingest data plane (one call per runner per poll
-   cycle, the subsystem's highest-volume path) into the class whose whole
-   purpose is surfacing rare transition edges.
+What those three rows *persist* is not at risk from a prefix branch.
+Each of the routes also binds an explicit `audit_op_class` contextvar
+(`write` / `read` / `write`), and `resolve_broadcast_detail` in
+`broadcast/overrides.py` takes that `op_class_override` in preference to
+`classify_op`. The same value is what the audit row stores in
+`payload["op_class"]`, and that stored value is what `meho.audit.query`
+filters on in SQL (`audit_query/query.py`). `classify_op` therefore never
+decides the gateway rows' class on the write path, and no saved
+`op_class=write` query would change its results.
+
+The hazard is on the **read** side. `classify_op` is re-run at render
+time against the stored op-id by the audit drawer
+(`ui/routes/audit/routes.py`) and the broadcast event drawer
+(`ui/routes/broadcast/event.py`), supplying the row's displayed class and
+badge and feeding `is_aggregate_only`. A prefix branch would therefore
+
+1. relabel every `/api/v1/checks/*` row in those drawers as `checks` —
+   retroactively, since the class is derived on read rather than read
+   back off the row, so there is no deploy boundary to reason about; and
+2. sweep in any future non-transition `checks.*` op-id by construction,
+   diluting the class whose whole purpose is surfacing rare transition
+   edges.
 
 `checks` is **not** sensitive: it is absent from
 `broadcast/overrides.py::_SENSITIVE_OP_CLASSES`, so events broadcast at
@@ -105,12 +119,23 @@ subsystem identity.
 
 ## Failure posture
 
-Fail-open twice over. `publish_event` already swallows every Valkey error
-(at-most-once delivery is the feed's documented contract), and
-`publish_check_transition_event` wraps construction in a second guard so
-a malformed field cannot reach the caller either. A swallowed failure
-logs `checks_transition_broadcast_failed` at warning with the dashboard
-id and both states.
+Fail-open twice over, and the two halves log in **different** places —
+which is what an operator wiring an alert needs to know.
+
+`publish_event` already swallows every Valkey error (at-most-once
+delivery is the feed's documented contract). It never re-raises, so a
+Valkey outage or a failing `XADD` does **not** reach this module's guard:
+it surfaces on the existing feed-wide signals, the
+`broadcast_publish_failed` warning and the `broadcast_publish_errors_total`
+counter, exactly as it does for every other publisher. Those are what a
+"transitions stopped reaching the feed" alert should watch.
+
+`publish_check_transition_event` wraps the whole body in a second guard
+purely so a failure *before* the publish — an unexpected lineage
+resolution or a `BroadcastEvent` validation error on a malformed field —
+cannot reach the caller either. That guard, and only that guard, logs
+`checks_transition_broadcast_failed` at warning with the dashboard id and
+both states. It is a construction-bug signal, not an outage signal.
 
 The durable truth is the committed `last_rollup_state` memo. A broadcast
 outage must never convert a committed transition into a persist-path
@@ -135,7 +160,11 @@ layers and pinned together by a test rather than shared as a constant.
   The filter vocabulary is single-sourced from `OP_CLASS_ENUM` across the
   broadcast and audit tools, and a transition has no audit row. An
   operator narrowing audit to `checks` gets an empty result; the checks
-  *gateway* rows are under `write` / `read` / `other`.
+  *gateway* rows are stored under `write` / `read` / `write`, the classes
+  their routes bind via `audit_op_class`. (The drawers *display*
+  `classify_op`'s answer instead, which is `write` / `read` / `other` —
+  a pre-existing read-vs-write divergence for any route binding an
+  explicit `audit_op_class`, not something this change introduces.)
 - **No rate limit, digest, or repeat suppression.** A flapping Dashboard
   publishes one event per real edge, matching the notifier's stance
   (#2716 scopes volume control out).

--- a/docs/codebase/checks-broadcast.md
+++ b/docs/codebase/checks-broadcast.md
@@ -1,0 +1,166 @@
+# Check transition broadcast events (`checks/broadcast.py`)
+
+## Overview
+
+Every claimed Dashboard rollup edge is published to the tenant broadcast
+feed (`meho:feed:{tenant_id}`) as one `BroadcastEvent` with op-id
+`checks.transition` and op-class `checks`. Feed watchers —
+`meho.broadcast.recent`, `meho.broadcast.watch`, `GET /api/v1/feed`, and
+`/ui/broadcast/stream?op_class=checks` — see check state changes the way
+they already see `approval.*` lifecycle events (#2720).
+
+This is the **third** independent consumer of #2507's transition claim,
+beside the diagnose-only investigator
+(`docs/codebase/checks-investigator.md`, worsening edges only) and the
+email notifier (`docs/codebase/checks-notifications.md`, both directions
+above a configured floor). None of the three knows about the others;
+all three read the same compare-and-swap on
+`check_dashboards.last_rollup_state`.
+
+Unlike the notifier, the publish has **no floor**. A feed event costs one
+`XADD` against a `MAXLEN ~`-trimmed stream, so narrowing belongs to the
+consumer (`op_class=checks`), not to the producer.
+
+## Key types
+
+- `publish_check_transition_event(*, tenant_id, dashboard_id,
+  dashboard_name, previous_state, new_state)` — the awaitable that builds
+  and publishes the event. **Never raises.**
+- `CHECK_TRANSITION_OP_ID` — the `"checks.transition"` literal.
+- `_CHECK_EVENT_OPS` (in `broadcast/events.py`) — the classifier's
+  allowlist, the other half of the op-id contract.
+
+## Control flow
+
+```
+runner persists a Sensor result
+  → investigate_on_transition(sensor_id, tenant_id)          [never raises]
+    → _process_transition
+      → _claim_dashboard_transition (advisory lock + CAS)     [per dashboard]
+        → _ClaimedTransition | None
+      → for each won claim:
+          _schedule_investigation(...)        [worsening + non-green only]
+          schedule_dashboard_notification(...)          [background task]
+          await publish_check_transition_event(...)     [inline, bounded]
+```
+
+The claim is the exactly-once token. Because publish sits on the
+claim-win branch, two replicas racing the same edge produce exactly one
+event with no dedupe key here — the same property the notifier inherits.
+
+The publish is **awaited inline** while the two expensive consumers are
+backgrounded. A claim is a rare edge, `XADD` is bounded by the fast
+broadcast client's pinned connect and read timeouts, and awaiting keeps
+the event ordered with the claim that caused it.
+
+## The `checks` op-class
+
+`classify_op` maps `checks.transition` to `checks` by **exact
+membership** in `_CHECK_EVENT_OPS`, not by a `checks.` prefix. The prefix
+is already occupied: `/api/v1/checks/*` binds `checks.assignment.put`,
+`checks.assignment.get`, and `checks.results.post` as audit op-ids. A
+prefix branch would
+
+1. split the historical meaning of `audit_log.op_class` at the deploy
+   boundary — rows written before say `write`, rows after say `checks`,
+   so a saved `op_class=write` query silently stops seeing the
+   assignment write; and
+2. fold the runner result-ingest data plane (one call per runner per poll
+   cycle, the subsystem's highest-volume path) into the class whose whole
+   purpose is surfacing rare transition edges.
+
+`checks` is **not** sensitive: it is absent from
+`broadcast/overrides.py::_SENSITIVE_OP_CLASSES`, so events broadcast at
+full detail. That is safe because the payload stays at Dashboard
+altitude — id, name, and the two states. No Sensor values, evidence, or
+member names ride the feed; a consumer that wants the failing members
+reads the Dashboard.
+
+`checks` is also listed in `broadcast/history.py::OP_CLASS_ENUM`. That
+tuple is not cosmetic: the MCP dispatcher validates every `tools/call`
+against the advertised `inputSchema` with `jsonschema`, and
+`filter.op_class` carries the enum, so a class missing from it is a
+JSON-RPC `-32602` before the handler runs. `meho.audit.query` shares the
+tuple as one taxonomy, where `checks` is always empty — see "Known
+issues" below.
+
+## Not audit-derived
+
+`BroadcastEvent.audit_id` is documented as an FK to `audit_log.id`, and
+every other publisher sits downstream of an audit row. A rollup edge is
+not an audited operation: it is derived state, folded from Sensor
+evaluations that were each audited on their own dispatch. So the event
+carries the **nil UUID** rather than a fabricated id a consumer could not
+distinguish from a real one. The one surface that dereferences the field
+— the UI event drawer at `/ui/broadcast/event/{audit_id}` — already
+renders its not-found fragment for an id with no row, so the nil id
+degrades rather than breaks.
+
+`principal_sub` is `"__checks__"` for the same reason: the edge has no
+operator behind it, and a Dashboard folds many Sensors that may each
+dispatch under a different `identity_sub`, so attributing the edge to any
+one of them would be a lie. `"__sensor__"` is deliberately not reused —
+that value is a per-Sensor *configurable dispatch identity*, not a
+subsystem identity.
+
+## Failure posture
+
+Fail-open twice over. `publish_event` already swallows every Valkey error
+(at-most-once delivery is the feed's documented contract), and
+`publish_check_transition_event` wraps construction in a second guard so
+a malformed field cannot reach the caller either. A swallowed failure
+logs `checks_transition_broadcast_failed` at warning with the dashboard
+id and both states.
+
+The durable truth is the committed `last_rollup_state` memo. A broadcast
+outage must never convert a committed transition into a persist-path
+failure, and must not affect the email notifier.
+
+## Dependencies
+
+- `meho_backplane.broadcast.events` — `BroadcastEvent`, `classify_op`.
+- `meho_backplane.broadcast.publisher` — `publish_event` (fail-open
+  `XADD`, `MAXLEN ~ 10000`).
+- `meho_backplane.operations._audit` — `resolve_broadcast_lineage`, so
+  the event carries the same actor / agent-session / work_ref lineage an
+  audit-driven event would.
+
+The dependency runs one way: `checks/` imports `broadcast/`, never the
+reverse. That is why the `checks.transition` literal is written in both
+layers and pinned together by a test rather than shared as a constant.
+
+## Known issues / boundaries
+
+- **`meho.audit.query` advertises `op_class=checks` but never matches.**
+  The filter vocabulary is single-sourced from `OP_CLASS_ENUM` across the
+  broadcast and audit tools, and a transition has no audit row. An
+  operator narrowing audit to `checks` gets an empty result; the checks
+  *gateway* rows are under `write` / `read` / `other`.
+- **No rate limit, digest, or repeat suppression.** A flapping Dashboard
+  publishes one event per real edge, matching the notifier's stance
+  (#2716 scopes volume control out).
+- **The UI feed palette and filter dropdown do not list `checks`.**
+  `OP_CLASS_BADGE_CLASSES` / `OP_CLASS_FILTER_OPTIONS` in
+  `ui/routes/broadcast/feed.py` also omit `approval` and
+  `credential_write`; unlisted classes fall back to `badge-ghost` and
+  remain reachable via an explicit `op_class` query parameter.
+- **No event-outbox routing and no durable event table.** The Valkey
+  stream plus its retention window is the carrier, exactly as for
+  `approval.*` (the outbox matcher is a no-op pending #826).
+
+## References
+
+- `backend/src/meho_backplane/checks/broadcast.py`
+- `backend/src/meho_backplane/checks/investigate.py` —
+  `_process_transition`, `_claim_dashboard_transition`
+- `backend/src/meho_backplane/broadcast/events.py` — `_CHECK_EVENT_OPS`,
+  `classify_op`
+- `backend/src/meho_backplane/broadcast/history.py` — `OP_CLASS_ENUM`
+- `backend/src/meho_backplane/api/v1/checks.py` — `_CHECKS_OP_IDS`, the
+  three gateway op-ids the allowlist exists to protect
+- `backend/tests/test_checks_broadcast.py`,
+  `backend/tests/test_broadcast_events.py`,
+  `backend/tests/test_mcp_tool_broadcast_recent.py`
+- `docs/codebase/broadcast.md`, `docs/codebase/checks-notifications.md`,
+  `docs/codebase/checks-investigator.md`
+- Mould: `operations/approval_queue.py::publish_approval_event`


### PR DESCRIPTION
## Summary

- Every claimed Dashboard rollup edge now publishes one
  `checks.transition` event to the tenant broadcast feed, in **both**
  directions — a watcher who saw a Dashboard go `critical` sees it clear.
  Publishing sits on #2719's compare-and-swap claim-win branch, so
  exactly-once-per-transition across replicas is inherited from the CAS,
  not re-implemented.
- New `checks` op-class on `classify_op`, so `meho.broadcast.recent` /
  `.watch` with `filter.op_class=checks`, `GET /api/v1/feed`, and
  `/ui/broadcast/stream?op_class=checks` all narrow to check state
  changes server-side — the shape the approvals console already uses for
  `approval.*`. No new consumer built here.
- Fail-open twice over, and the two halves log in **different** places:
  `publish_event` swallows Valkey errors and reports them on its existing
  feed-wide `broadcast_publish_failed` / `broadcast_publish_errors_total`
  signals (it never re-raises, so an outage never reaches this module),
  while the new publisher wraps its body in a second guard that logs
  `checks_transition_broadcast_failed` for a failure to *build* the event.
  Either way the committed `last_rollup_state` memo, the #2719 email, and
  the runner's persist path are untouched.
- No migration, no new settings, no console bell, no event-outbox
  routing, no durable event table — the Valkey stream is the carrier,
  exactly as for `approval.*`.

## Two AC details corrected

Both recorded in full on the issue
([comment](https://github.com/evoila/meho/issues/2720#issuecomment-5151571152));
neither changes what the task delivers. The item-1 rationale below is the
corrected one — see the follow-up section for what was wrong with the
original.

**1. Exact-membership allowlist, not a `checks.` prefix branch.** The
`checks.` prefix is already taken: `api/v1/checks.py` binds
`checks.assignment.put` / `.get` and `checks.results.post` as
`audit_op_id`s.

What is *not* at risk is what those rows persist. Each of the three
routes also binds an explicit `audit_op_class` contextvar (`write` /
`read` / `write`), and `resolve_broadcast_detail` takes that
`op_class_override` in preference to `classify_op`. The same value is
what the audit row stores in `payload["op_class"]`, and that stored value
is what `meho.audit.query` filters on in SQL — so `classify_op` never
decides the gateway rows' class on the write path, and no saved
`op_class=write` query would change its results.

The hazard is on the **read** side: `classify_op` is re-run at render
time against the stored op-id by the audit drawer and the broadcast event
drawer, supplying the displayed class and feeding `is_aggregate_only`. A
prefix branch would relabel every `/api/v1/checks/*` row there —
retroactively, since the class is derived on read rather than read back
off the row — and would sweep in any future non-transition `checks.*`
op-id by construction. Implemented with `_CHECK_EVENT_OPS`, the same
idiom `_CREDENTIAL_MINT_OPS` already uses in the same function.

**2. `broadcast_recent` did *not* pick the class up for free.**
`filter.op_class` carries `"enum": list(OP_CLASS_ENUM)` and
`mcp/handlers.py:337` validates every `tools/call` against the advertised
`inputSchema` with `jsonschema.Draft202012Validator` — verified against
the installed 4.26.0 that an out-of-enum value is rejected before the
handler runs. `checks` added to `OP_CLASS_ENUM`; the AC-4 test posts a
full `tools/call` rather than calling the handler, so the enum is what is
under test.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — 1382 files already formatted
- [x] `mypy src/` — 1 pre-existing darwin-only error
      (`connectors/net/icmp.py` `MSG_ERRQUEUE`); CI runs Linux
- [x] `code-quality.py --diff` — 0 blockers
- [x] **AC1** `classify_op("checks.transition") == "checks"` —
      `test_checks_transition_maps_to_checks`, plus the doctest and
      `test_gateway_checks_op_ids_are_not_swept_into_checks`, which pins
      what `classify_op` returns for the three gateway op-ids *in
      isolation* (`write` / `read` / `other`) — the drawer label, not the
      class those rows ship with (`write` / `read` / `write`, bound by
      their routes)
- [x] **AC2** forced `ok→critical` publishes exactly ONE event under two
      raced `investigate_on_transition` calls; recovery publishes the
      `critical→ok` event —
      `test_concurrent_transitions_publish_exactly_one_event`. Plus
      `test_second_persist_on_an_unchanged_rollup_does_not_republish`
      guarding against the publish being wired outside the claim-win
      branch
- [x] **AC3** raising publish seam → memo committed, mail still sent,
      `checks_transition_broadcast_failed` logged —
      `test_broadcast_failure_leaves_the_memo_and_the_mail_intact`,
      `test_publisher_failure_is_swallowed_and_logged`. The injected
      failure stands in for a *pre-publish* fault; a real Valkey outage is
      absorbed by `publish_event` and reports on
      `broadcast_publish_failed` / `broadcast_publish_errors_total`
      instead
- [x] **AC4** `meho.broadcast.recent` with `filter.op_class=checks`
      returns the event over a full JSON-RPC `tools/call` —
      `test_filter_op_class_checks_reaches_the_handler`
- [x] **AC5** no migration, no new settings; CHANGELOG bullet present
- [x] Backend suite green (`tests/`, minus two known-environmental
      network deselects and one pre-existing `test_ui_audit.py` teardown
      error reproduced on `main`)

## Out of scope

- Checks console notification bell / replacing the `/ui/checks` 30 s HTMX
  poll — enabled by this event, not built here.
- Event-outbox routing (matcher is a no-op pending #826) and any durable
  event table.
- #2721 (per-dashboard investigator prompt + emailed findings) is landing
  concurrently in the same area.

## Adjacent findings (not touched)

- `OP_CLASS_BADGE_CLASSES` / `OP_CLASS_FILTER_OPTIONS`
  (`ui/routes/broadcast/feed.py:104,121`) omit `approval`,
  `credential_write`, and now `checks`. Unlisted classes fall back to
  `badge-ghost` and stay reachable via an explicit query parameter, so
  nothing breaks — the UI dropdown just cannot name them. Same gap
  `approval` has had since #1778; worth one follow-up fixing all three.
- `meho.audit.query` shares `OP_CLASS_ENUM` as one taxonomy (pinned by
  `test_mcp_tools_list_shape_conventions.py`), so it now advertises an
  `op_class=checks` filter that is always empty — a transition has no
  audit row. Documented in the constant's docstring and in
  `docs/codebase/checks-broadcast.md`.
- `ui/routes/broadcast/aggregate_gate.py:104` states that `classify_op`
  "yields the same class the broadcast publisher computed". Untrue for
  any route binding an explicit `audit_op_class` — the same misconception
  that produced finding B2. Pre-existing and outside this PR's blast
  radius; worth a follow-up so the next author does not inherit it.
- `_process_transition` crosses the 60-line code-quality *warning*
  threshold (62) with the third claim consumer. Left alone on simplicity
  grounds — it blocks at 100, and splitting a three-consumer fan-out loop
  to reclaim two lines is churn for its own sake.

<!-- auto-implement-issue: fresh, iteration 1 -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-01)

Addressed the two blockers and the minor from review iteration 1.
**Prose only — no executable line under `src/` changed**; both blockers
were operator-facing contract accuracy, not implementation defects.
Verified with the targeted suites (`test_checks_broadcast.py`,
`test_broadcast_events.py`, `test_mcp_tool_broadcast_recent.py`, plus the
adjacent broadcast / checks / UI suites — 422 passed, 10 skipped) and the
full lint gates.

- **B1** `db2523a2` — `checks_transition_broadcast_failed` could never
  fire on the Valkey outage the CHANGELOG, the new doc, and the AC-3 line
  all named it for: `publish_event` swallows every transport exception,
  logs `broadcast_publish_failed`, increments
  `broadcast_publish_errors_total`, and returns. An operator following
  those release notes would have built a permanently silent alert. The
  two halves of the fail-open posture are now described separately in the
  CHANGELOG, `docs/codebase/checks-broadcast.md`, the
  `checks/broadcast.py` module docstring, and this PR body; the test that
  injected `RuntimeError("valkey down")` at the publish seam is renamed
  and reworded to say what it actually stands in for.
- **B2** `db2523a2` — `_CHECK_EVENT_OPS` kept (it is the right
  implementation), but both stated reasons were false and had spread to
  seven places. All three `/api/v1/checks/*` routes bind an explicit
  `audit_op_class`, which `resolve_broadcast_detail` honours over
  `classify_op`, and `meho.audit.query` filters the persisted
  `payload["op_class"]` in SQL — so neither the deploy-boundary split nor
  the result-ingest volume argument was possible, and the CHANGELOG's
  claim that `checks.results.post` "keeps" class `other` was false (it
  ships as `write`). Every rationale is re-anchored to the true hazard —
  `classify_op` is the read-time classifier in the audit and broadcast
  event drawers — across `events.py` (`_CHECK_EVENT_OPS` plus the
  `classify_op` step-4c docstring), the CHANGELOG,
  `docs/codebase/checks-broadcast.md`, `docs/codebase/broadcast.md`, the
  regression test's name and docstring, and this PR body.
  `BroadcastEvent.op_class` now enumerates `approval` and `checks` and
  records the `audit_op_class` override precedence.
- **m1** `db2523a2` — `test_no_claim_publishes_nothing` renamed to
  `test_second_persist_on_an_unchanged_rollup_does_not_republish`: its
  first call wins a real `None → critical` claim and must publish, which
  the old name and docstring denied. Assertions unchanged.

Not taken, matching the reviewer's own assessment and recorded as
adjacent findings above: the `OP_CLASS_BADGE_CLASSES` /
`OP_CLASS_FILTER_OPTIONS` gap, the `aggregate_gate.py:104` pre-existing
misconception, and `asyncio.gather` on the per-claim publishes. The
`_process_transition` line-count justification was corrected — #2721 does
not touch that function, so the restraint stands on simplicity grounds
alone.

<!-- auto-implement-issue: continue, iteration 1 -->

Closes #2720


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard check state changes now broadcast `checks.transition` events for both worsening and recovery transitions.
  * Events include Dashboard identity and previous and new states.
  * Broadcast streams and APIs support filtering by the `checks` operation category.
  * Concurrent processing prevents duplicate transition events.

* **Bug Fixes**
  * Broadcast service failures no longer interrupt state updates, email notifications, or runner persistence.

* **Documentation**
  * Added documentation for check transition events and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
