### PR TITLE
fix(deps): bump pyasn1 0.6.3 → 0.6.4 — three HIGH DoS CVEs (unblocks image scan gate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Security — pyasn1 0.6.4: three HIGH DoS CVEs in ASN.1 parsing
+
+- Bump the transitive `pyasn1` pin from 0.6.3 to 0.6.4, fixing
+  CVE-2026-59884, CVE-2026-59885, and CVE-2026-59886 — three HIGH
+  denial-of-service vulnerabilities via crafted BER input, ASN.1
+  OBJECT IDENTIFIER, and ASN.1 REAL values respectively. `pyasn1`
+  reaches the image through `pyasn1-modules`; no direct MEHO code
+  path parses attacker-supplied ASN.1, but the image scan gate
+  (trivy, CRITICAL/HIGH with fix available) rightly blocks a
+  release carrying it. Caught by the `image.yml` scan on `main`
+  after the 2026-08-01 merges.
+
 ### Checks investigator — operator prompt + emailed findings (#2721)
 
 - A Dashboard can now carry an `investigator_prompt`: operator context

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2218,11 +2218,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

The `image.yml` trivy scan (CRITICAL/HIGH, `ignore-unfixed`, `exit-code: 1`) is red on `main` HEAD `dfa1b3d7` — reproduced locally against the pushed digest. Findings:

| CVE | Severity | Package | Fixed in |
|---|---|---|---|
| CVE-2026-59884 | HIGH | pyasn1 0.6.3 | 0.6.4 |
| CVE-2026-59885 | HIGH | pyasn1 0.6.3 | 0.6.4 |
| CVE-2026-59886 | HIGH | pyasn1 0.6.3 | 0.6.4 |

All three are DoS via crafted ASN.1 (BER input / OBJECT IDENTIFIER / REAL values). `pyasn1` is transitive via `pyasn1-modules`. Fix is `uv lock --upgrade-package pyasn1` (0.6.4 satisfies the existing range) plus a CHANGELOG `Security` entry.

This is release-blocking for v0.26.0: a `v*` tag publishes whatever `main` is, and the scan gate correctly refuses an image carrying fixable HIGHs.

Aside for a follow-up (not this PR): the scan step is named "report-only" but runs with `exit-code: 1` — the name or the config should change so the next red run isn't misread as a flake.

## Type of change

- [x] Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)