### PR TITLE
fix(broadcast): widen OP_CLASS_ENUM to classify_op's full range; fix UI tables + stale aggregate_gate docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,26 @@ connector-related release-notes line.
   release carrying it. Caught by the `image.yml` scan on `main`
   after the 2026-08-01 merges.
 
+### Changed — op_class filter vocabulary widened to the full classifier range (#2731)
+
+- The `op_class` filter enum that `meho.broadcast.recent`,
+  `meho.broadcast.watch`, and `query_audit` advertise in their
+  `inputSchema` now spans **every** class the classifier can emit:
+  `credential_write` and `approval` join the previous seven values.
+  Additive but user-visible: filtering on either class used to be
+  rejected at the wire with `-32602` (the dispatcher validates
+  arguments against the advertised schema before the handler runs)
+  even though `approval.*` and `credential_write` events were already
+  on the feed; a schema-driven client that mirrors the enum sees two
+  new values. A test now pins the enum to the classifier's output
+  range so neither side can gain a class alone. The operator console's
+  feed dropdown and badge palette cover the full vocabulary too
+  (previously `approval` / `credential_write` / `checks` were
+  unlisted and reachable only by hand-typed query parameter). Note
+  `query_audit` narrowed to `approval` or `checks` always returns
+  empty — those classes exist only as broadcast events, not audit
+  rows. No migration, no new settings. (#2731)
+
 ### Checks investigator — operator prompt + emailed findings (#2721)
 
 - A Dashboard can now carry an `investigator_prompt`: operator context

--- a/backend/src/meho_backplane/broadcast/agent_events.py
+++ b/backend/src/meho_backplane/broadcast/agent_events.py
@@ -181,16 +181,15 @@ WORK_REF_MAX_CHARS: Final[int] = 256
 TTL_MIN_MINUTES: Final[int] = 1
 TTL_MAX_MINUTES: Final[int] = 1440
 
-#: The op-class an agent may *declare* it is about to run. Spans the
-#: full :func:`meho_backplane.broadcast.events.classify_op` output
-#: taxonomy -- deliberately wider than the recent/watch read-filter
-#: :data:`meho_backplane.broadcast.history.OP_CLASS_ENUM` (which omits
-#: ``credential_write`` / ``approval``): a *declaration* must be able to
-#: name the sensitive write classes precisely because those are the
-#: highest-crossfire operations to warn peers about, whereas the read
-#: filter narrows already-classified :class:`BroadcastEvent` rows. The
-#: value is trusted structured metadata (a bounded enum, not prose), so
-#: it is served UNWRAPPED.
+#: The op-class an agent may *declare* it is about to run: the
+#: :func:`meho_backplane.broadcast.events.classify_op` output taxonomy
+#: minus ``checks`` -- an agent never *plans* a ``checks``-class op
+#: because the only member (``checks.transition``) is system-emitted on
+#: a Dashboard rollup edge, not dispatched. The read-filter
+#: :data:`meho_backplane.broadcast.history.OP_CLASS_ENUM` spans the full
+#: taxonomy including ``checks`` (#2731), so the two enums differ by
+#: exactly that member. The value is trusted structured metadata (a
+#: bounded enum, not prose), so it is served UNWRAPPED.
 PlannedOpClass = Literal[
     "read",
     "write",

--- a/backend/src/meho_backplane/broadcast/history.py
+++ b/backend/src/meho_backplane/broadcast/history.py
@@ -135,33 +135,44 @@ DEFAULT_WINDOW_MINUTES: Final[int] = 30
 #: :mod:`~meho_backplane.api.v1.feed`.
 _XRANGE_END: Final[str] = "+"
 
-#: Allowed ``op_class`` filter values. The four values the issue body
-#: example listed (``read|write|credential_read|audit_query``) plus
-#: ``credential_mint`` and ``other`` -- :func:`classify_op` emits those
-#: too. Restricting to the four would force the caller to omit the
-#: filter when chasing a freshly-minted credential (e.g.
-#: ``harbor.robot.create``) or an unmapped HTTP route, which defeats
-#: the filter's purpose.
+#: Allowed ``op_class`` filter values -- exactly the classes
+#: :func:`classify_op` can return, no more and no fewer
+#: (``tests/test_broadcast_events.py`` pins the set equality, so a
+#: class cannot be added to one side without the other). The tuple is
+#: enforced, not cosmetic: :mod:`meho_backplane.mcp.handlers` validates
+#: every tool call against the advertised ``inputSchema`` with
+#: ``jsonschema``, so an op_class absent from here is a JSON-RPC
+#: ``-32602`` before the handler runs -- the class would be published
+#: on the feed but unreachable from ``meho.broadcast.recent`` /
+#: ``.watch`` / ``query_audit`` (#2731 closed that gap for
+#: ``credential_write`` and ``approval``).
 #:
-#: ``checks`` (#2720) is the checks subsystem's own state-change class
-#: (``checks.transition``). It is listed because the enum is enforced:
-#: :mod:`meho_backplane.mcp.handlers` validates every tool call against
-#: the advertised ``inputSchema`` with ``jsonschema``, so an op_class
-#: absent from this tuple is a JSON-RPC ``-32602`` before the handler
-#: runs -- the filter would be unreachable from ``meho.broadcast.recent``
-#: / ``.watch``. Unlike the other members it never appears in
-#: ``audit_log.op_class``: the transition event is published outside the
-#: audit path (there is no audited operation behind a rollup edge), so a
-#: ``meho.audit.query`` narrowed to ``checks`` is always empty. The two
-#: tools share this tuple as one taxonomy by design
-#: (``tests/test_mcp_tools_list_shape_conventions.py`` pins them
-#: together).
+#: Two members never appear as a *persisted* ``payload["op_class"]``,
+#: so a ``query_audit`` narrowed to them is always empty:
+#:
+#: * ``checks`` (#2720) -- the ``checks.transition`` event is published
+#:   outside the audit path (there is no audited operation behind a
+#:   rollup edge).
+#: * ``approval`` -- no audit row persists
+#:   ``payload["op_class"] == "approval"``: the approval REST routes
+#:   bind ``audit_op_class`` to ``read`` / ``write``
+#:   (``api/v1/approvals.py``), and the queue's own request/decision
+#:   rows persist no ``op_class`` key at all. (Drawers still *display*
+#:   ``approval`` for those routes' ``approval.*`` op-ids -- the
+#:   read-time classifier -- but ``query_audit`` filters on the
+#:   persisted key.)
+#:
+#: The broadcast and audit tools share this tuple as one taxonomy by
+#: design (``tests/test_mcp_tools_list_shape_conventions.py`` §14.1
+#: pins them together).
 OP_CLASS_ENUM: Final[tuple[str, ...]] = (
     "read",
     "write",
     "credential_read",
+    "credential_write",
     "credential_mint",
     "audit_query",
+    "approval",
     "checks",
     "other",
 )

--- a/backend/src/meho_backplane/ui/routes/broadcast/aggregate_gate.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/aggregate_gate.py
@@ -19,10 +19,15 @@ The gate has three parts:
   ``audit_log`` row. A cross-tenant id resolves to ``None`` identically
   to a non-existent id, so the tenant boundary is opaque (never leaked
   as a 403-vs-404 distinction).
-* :func:`resolve_op_id` -- recover the op id the publisher classified
-  on, falling back to the ``http.{method}:{path}`` heuristic the audit
-  middleware uses, so :func:`~meho_backplane.broadcast.classify_op`
-  yields the same class the broadcast publisher computed.
+* :func:`resolve_op_id` -- recover the op id for the drawer's
+  **read-time** classification via
+  :func:`~meho_backplane.broadcast.classify_op`, falling back to the
+  ``http.{method}:{path}`` heuristic the audit middleware uses. Note
+  the read-time class is not always the persisted one: a route that
+  binds an explicit ``audit_op_class`` contextvar persists that
+  override (honoured over ``classify_op`` by
+  :func:`~meho_backplane.broadcast.overrides.compute_effective_broadcast_detail`),
+  while the drawer re-derives from the op id.
 * :func:`is_aggregate_only` -- the verdict: honour the G6.3 resolver's
   recorded ``payload["broadcast_detail_effective"]`` when present,
   otherwise fall back to op-class membership in
@@ -93,7 +98,7 @@ async def fetch_audit_row(
 
 
 def resolve_op_id(row: AuditLog) -> str:
-    """Recover the op id for the row's sensitivity classification.
+    """Recover the op id for the row's read-time sensitivity classification.
 
     The audit middleware stamps the canonical op id into
     ``payload["op_id"]`` for connector-style routes. When absent
@@ -101,10 +106,17 @@ def resolve_op_id(row: AuditLog) -> str:
     publisher's own heuristic ``http.{method.lower()}:{path}`` -- the
     exact string
     :func:`meho_backplane.audit._resolve_op_id_and_class_override`
-    builds -- so :func:`classify_op` here yields the same class the
-    broadcast publisher computed. The ``:`` separator deliberately
-    avoids a route ending in ``.list`` being misread as a ``read`` verb
-    suffix (the publisher relies on the same guard).
+    builds. The ``:`` separator deliberately avoids a route ending in
+    ``.list`` being misread as a ``read`` verb suffix (the publisher
+    relies on the same guard).
+
+    :func:`classify_op` over this id is the **read-time** classifier
+    only -- it does not determine the persisted ``op_class``. A route
+    that binds an explicit ``audit_op_class`` contextvar (e.g. the
+    ``/api/v1/checks/*`` gateway routes) persists that binding, which
+    :func:`~meho_backplane.broadcast.overrides.compute_effective_broadcast_detail`
+    honours in preference to :func:`classify_op`; for such rows the
+    drawer's re-derived class can differ from the persisted one.
     """
     op_id = row.payload.get("op_id")
     if isinstance(op_id, str) and op_id:

--- a/backend/src/meho_backplane/ui/routes/broadcast/feed.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/feed.py
@@ -48,7 +48,8 @@ The event-row badge colour is keyed on the event's ``op_class`` via
 vocabulary (:func:`meho_backplane.broadcast.classify_op`) to DaisyUI
 badge variants, serialised into the page as JSON the Alpine row-builder
 reads. :data:`OP_CLASS_FILTER_OPTIONS` is the same vocabulary surfaced
-as the filter dropdown's options (``All`` plus the six classes).
+as the filter dropdown's options (``All`` plus every
+:data:`~meho_backplane.broadcast.OP_CLASS_ENUM` member).
 
 Tenant scoping
 ==============
@@ -73,6 +74,7 @@ from fastapi.responses import HTMLResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from meho_backplane.broadcast import OP_CLASS_ENUM
 from meho_backplane.db.engine import get_raw_session
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
@@ -95,37 +97,38 @@ IN_DOM_ROW_CAP: Final[int] = 1000
 
 #: Map from the closed ``op_class`` vocabulary
 #: (:func:`meho_backplane.broadcast.classify_op`) to DaisyUI badge
-#: variant classes. ``credential_read`` / ``credential_mint`` /
-#: ``audit_query`` -- the sensitive, aggregate-only classes per decision
-#: #3 -- get the warning palette so an operator scanning the feed reads
-#: the sensitivity at a glance; ``write`` is accent (mutation), ``read``
-#: is the neutral ghost, ``other`` falls back to ghost too. A class not
-#: in this map falls back to ``badge-ghost`` in the row builder.
+#: variant classes, covering every :data:`OP_CLASS_ENUM` member
+#: (``tests/test_ui_broadcast_feed.py`` pins the coverage). The
+#: secret-material and audit classes -- ``credential_read`` /
+#: ``credential_write`` / ``credential_mint`` -- get the warning
+#: palette so an operator scanning the feed reads the sensitivity at a
+#: glance; ``audit_query`` and the ``approval`` lifecycle events are
+#: informational (info); ``checks`` state transitions are primary so a
+#: rollup edge stands out from the op traffic around it; ``write`` is
+#: accent (mutation), ``read`` is the neutral ghost, ``other`` falls
+#: back to ghost too. A class not in this map falls back to
+#: ``badge-ghost`` in the row builder.
 OP_CLASS_BADGE_CLASSES: Final[dict[str, str]] = {
     "read": "badge-ghost",
     "write": "badge-accent",
     "credential_read": "badge-warning",
+    "credential_write": "badge-warning",
     "credential_mint": "badge-warning",
     "audit_query": "badge-info",
+    "approval": "badge-info",
+    "checks": "badge-primary",
     "other": "badge-ghost",
 }
 
-#: The op_class filter dropdown options (work item #3). The empty string
-#: is the "All" sentinel -- it maps to *no* ``op_class`` query parameter
-#: on the stream so every class streams. The rest are the closed
-#: vocabulary keys of :data:`OP_CLASS_BADGE_CLASSES`, surfaced in the
-#: order the Initiative #338 work-item #3 lists them (read / write /
-#: credential_read / audit_query / other) plus ``credential_mint``,
-#: which shares the same sensitive (aggregate-only) treatment and would
-#: otherwise be unfilterable.
-OP_CLASS_FILTER_OPTIONS: Final[tuple[str, ...]] = (
-    "read",
-    "write",
-    "credential_read",
-    "credential_mint",
-    "audit_query",
-    "other",
-)
+#: The op_class filter dropdown options (work item #3): the full closed
+#: vocabulary, single-sourced from :data:`OP_CLASS_ENUM` so the console
+#: can name every class the classifier emits and the two surfaces
+#: cannot drift (#2731 -- the previous literal tuple omitted
+#: ``credential_write`` / ``approval`` / ``checks``, leaving them
+#: reachable only by hand-typed query param). The empty string "All"
+#: sentinel is template-side -- it maps to *no* ``op_class`` query
+#: parameter on the stream so every class streams.
+OP_CLASS_FILTER_OPTIONS: Final[tuple[str, ...]] = OP_CLASS_ENUM
 
 #: Max targets surfaced in the filter dropdown. The dropdown is an
 #: eyeball-scan filter, not a paginated browser (operators with denser

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -497,6 +497,42 @@ class TestClassifyOp:
         """
         assert classify_op("audit.list") == "audit_query"
 
+    def test_op_class_enum_spans_the_full_classifier_range(self) -> None:
+        """``OP_CLASS_ENUM`` is exactly :func:`classify_op`'s output range (#2731).
+
+        The enum is the filter vocabulary the MCP tools advertise, and the
+        dispatcher's jsonschema validation makes it enforced: a class the
+        classifier emits but the enum omits is publishable yet unfilterable
+        (a ``-32602`` at the wire). That was the shipped state for
+        ``credential_write`` and ``approval``, and ``checks`` (#2720)
+        needed a manual enum edit to become reachable. The classifier's
+        range is extracted from its source (every ``return "<literal>"``),
+        so this fails when either side gains a member alone — no curated
+        op-id corpus to forget to extend.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from meho_backplane.broadcast import OP_CLASS_ENUM
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(classify_op)))
+        classifier_range = {
+            node.value.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Return)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        }
+        # Guard the extraction itself: a refactor that stops returning
+        # plain string literals would silently shrink the extracted set.
+        assert classifier_range, "extracted no return literals from classify_op"
+        assert set(OP_CLASS_ENUM) == classifier_range, (
+            f"OP_CLASS_ENUM and classify_op's range drifted: "
+            f"enum-only={sorted(set(OP_CLASS_ENUM) - classifier_range)}, "
+            f"classifier-only={sorted(classifier_range - set(OP_CLASS_ENUM))}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # redact_payload — AC #6, #7, #8 + edge cases

--- a/backend/tests/test_mcp_tool_broadcast_recent.py
+++ b/backend/tests/test_mcp_tool_broadcast_recent.py
@@ -470,6 +470,59 @@ def test_filter_op_class_checks_reaches_the_handler(
     [TenantRole.OPERATOR],
     indirect=True,
 )
+@pytest.mark.parametrize(
+    ("op_class", "op_id"),
+    [
+        ("approval", "approval.pending"),
+        ("credential_write", "vault.kv.put"),
+    ],
+)
+def test_filter_op_class_approval_and_credential_write_reach_the_handler(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    op_class: str,
+    op_id: str,
+) -> None:
+    """The two classes #2731 added to the enum narrow via full ``tools/call``.
+
+    ``approval.*`` events have been on the feed since the approvals work
+    and ``credential_write`` since G11.7-T1, but both were rejected with
+    ``-32602`` at the wire because ``OP_CLASS_ENUM`` omitted them — the
+    dispatcher validates arguments against the advertised ``inputSchema``
+    before the handler runs. Posted as a full ``tools/call`` for the same
+    reason as the ``checks`` test above: the enum is what is under test,
+    and a handler-level call would pass even with the class missing.
+    """
+    client, _op = client_with_operator
+    wanted = _make_event(
+        op_id=op_id,
+        op_class=op_class,
+        payload={"op_class": op_class, "result_status": "ok"},
+    )
+    unrelated = _make_event(op_id="vsphere.vm.list", op_class="read")
+    bc = get_broadcast_client()
+    with patch.object(
+        bc,
+        "xrange",
+        new=AsyncMock(
+            return_value=[
+                _xrange_entry(unrelated, "1747800000000-0"),
+                _xrange_entry(wanted, "1747800001000-0"),
+            ],
+        ),
+    ):
+        resp = post_mcp(
+            client,
+            _tools_call("meho.broadcast.recent", {"filter": {"op_class": op_class}}),
+        )
+    result = _result_dict(resp)
+    assert [e["op_id"] for e in result["events"]] == [op_id]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
 def test_filter_principal_narrows_result(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:

--- a/backend/tests/test_mcp_tool_query_audit.py
+++ b/backend/tests/test_mcp_tool_query_audit.py
@@ -251,6 +251,48 @@ def test_tools_call_since_24h_parses_to_tz_aware_datetime(
     [TenantRole.OPERATOR],
     indirect=True,
 )
+@pytest.mark.parametrize("op_class", ["approval", "credential_write"])
+def test_tools_call_op_class_approval_and_credential_write_pass_the_schema(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    op_class: str,
+) -> None:
+    """The two classes #2731 added to the enum reach the substrate.
+
+    ``query_audit.op_class`` advertises ``enum: [*OP_CLASS_ENUM, None]``
+    and the dispatcher validates every ``tools/call`` against the
+    ``inputSchema`` before the handler runs, so with the old seven-member
+    tuple these two values were a ``-32602`` at the wire. The full
+    JSON-RPC round-trip (not a handler-level call) is what proves the
+    enum widening — the filter itself is plain exact-match plumbing.
+    """
+    client, _op = client_with_operator
+    mock_query = AsyncMock(return_value=_empty_result())
+    with patch(_PATCH_TARGET, new=mock_query):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_audit",
+                    "arguments": {"op_class": op_class},
+                },
+            },
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" not in body, body
+    assert body["result"]["isError"] is False
+    filters = mock_query.await_args.args[0]
+    assert filters.op_class == op_class
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
 def test_tools_call_tenant_id_taken_from_operator_jwt(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:

--- a/backend/tests/test_ui_broadcast_feed.py
+++ b/backend/tests/test_ui_broadcast_feed.py
@@ -51,6 +51,7 @@ from fastapi.testclient import TestClient
 
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.broadcast import (
+    OP_CLASS_ENUM,
     BroadcastEvent,
     get_broadcast_blocking_client,
     get_broadcast_client,
@@ -78,6 +79,7 @@ from meho_backplane.ui.routes import build_router as build_ui_router
 from meho_backplane.ui.routes.broadcast.feed import (
     IN_DOM_ROW_CAP,
     OP_CLASS_BADGE_CLASSES,
+    OP_CLASS_FILTER_OPTIONS,
 )
 from meho_backplane.ui.routes.broadcast.stream import _ui_feed_generator
 from meho_backplane.ui.templating import reset_templating_for_testing
@@ -410,6 +412,28 @@ def test_feed_page_embeds_row_cap_and_badge_palette() -> None:
     for op_class, badge_class in OP_CLASS_BADGE_CLASSES.items():
         assert op_class in body
         assert badge_class in body
+
+
+def test_badge_and_filter_tables_cover_the_full_op_class_enum() -> None:
+    """Both UI lookup tables span exactly ``OP_CLASS_ENUM`` (#2731).
+
+    Before #2731 the two tables omitted ``approval`` /
+    ``credential_write`` / ``checks``: nothing broke — badges fell back
+    to ``badge-ghost`` and the classes stayed reachable by hand-typed
+    query param — but the filter dropdown could not name them. Set
+    equality (not superset) so a class removed from the enum cannot
+    linger as a dead dropdown option or badge entry either.
+    """
+    assert set(OP_CLASS_BADGE_CLASSES) == set(OP_CLASS_ENUM), (
+        f"OP_CLASS_BADGE_CLASSES drifted from OP_CLASS_ENUM: "
+        f"missing={sorted(set(OP_CLASS_ENUM) - set(OP_CLASS_BADGE_CLASSES))}, "
+        f"extra={sorted(set(OP_CLASS_BADGE_CLASSES) - set(OP_CLASS_ENUM))}"
+    )
+    assert set(OP_CLASS_FILTER_OPTIONS) == set(OP_CLASS_ENUM), (
+        f"OP_CLASS_FILTER_OPTIONS drifted from OP_CLASS_ENUM: "
+        f"missing={sorted(set(OP_CLASS_ENUM) - set(OP_CLASS_FILTER_OPTIONS))}, "
+        f"extra={sorted(set(OP_CLASS_FILTER_OPTIONS) - set(OP_CLASS_ENUM))}"
+    )
 
 
 def test_feed_page_carries_aggregate_only_placeholder_logic() -> None:

--- a/docs/codebase/api-shape-conventions.md
+++ b/docs/codebase/api-shape-conventions.md
@@ -891,10 +891,13 @@ tuple. The v0.8.0 drift was prose-only on `query_audit.op_class`
 (five values, missing `credential_mint`) vs JSON-enum on
 `meho.broadcast.recent`/`watch` (six values). Convention: one
 import, one tuple, one enum on every surface that filters on it.
-Adjacent finding (not in scope here): `tool_call` is a recent
-classify_op return value missing from `OP_CLASS_ENUM`; harmonising
-the broadcast tuple with the dispatcher classifier output is a
-follow-up.
+Issue #2731 completed the harmonisation the other way too: `OP_CLASS_ENUM`
+now spans exactly `classify_op`'s output range (the tuple had omitted
+`credential_write` / `approval`, so both classes were published on
+the feed but rejected with `-32602` at the wire), and
+`backend/tests/test_broadcast_events.py` pins the set equality by
+extracting the classifier's return literals — neither side can gain
+a member alone.
 
 ### §14.2 — Forward-cursor parameter named `cursor` everywhere
 

--- a/docs/codebase/checks-broadcast.md
+++ b/docs/codebase/checks-broadcast.md
@@ -168,11 +168,11 @@ layers and pinned together by a test rather than shared as a constant.
 - **No rate limit, digest, or repeat suppression.** A flapping Dashboard
   publishes one event per real edge, matching the notifier's stance
   (#2716 scopes volume control out).
-- **The UI feed palette and filter dropdown do not list `checks`.**
-  `OP_CLASS_BADGE_CLASSES` / `OP_CLASS_FILTER_OPTIONS` in
-  `ui/routes/broadcast/feed.py` also omit `approval` and
-  `credential_write`; unlisted classes fall back to `badge-ghost` and
-  remain reachable via an explicit `op_class` query parameter.
+- ~~**The UI feed palette and filter dropdown do not list `checks`.**~~
+  Resolved by #2731: `OP_CLASS_BADGE_CLASSES` covers every
+  `OP_CLASS_ENUM` member (`checks` badges as `badge-primary`) and
+  `OP_CLASS_FILTER_OPTIONS` is now single-sourced from `OP_CLASS_ENUM`;
+  a test pins both tables to the enum.
 - **No event-outbox routing and no durable event table.** The Valkey
   stream plus its retention window is the carrier, exactly as for
   `approval.*` (the outbox matcher is a no-op pending #826).


### PR DESCRIPTION
## Summary

- Widens `OP_CLASS_ENUM` from seven members to the full nine-class range
  `classify_op` can return, adding `credential_write` and `approval`.
  The enum is what `meho.broadcast.recent` / `meho.broadcast.watch` /
  `query_audit` advertise in their `inputSchema`, and the MCP dispatcher
  validates every `tools/call` against that schema before the handler
  runs — so both classes were published on the feed but rejected with
  `-32602` when used as a filter.
- Pins the two sides together structurally: a new test extracts
  `classify_op`'s return literals via `ast` and asserts set equality
  with `OP_CLASS_ENUM`, so neither side can gain a member alone (no
  curated op-id corpus to forget to extend).
- Fixes the two operator-console lookup tables: `OP_CLASS_BADGE_CLASSES`
  now covers every enum member (`credential_write` → `badge-warning`,
  `approval` → `badge-info`, `checks` → `badge-primary`) and
  `OP_CLASS_FILTER_OPTIONS` is single-sourced from `OP_CLASS_ENUM`, so
  the filter dropdown can name every class. A test pins both tables to
  the enum with set equality.
- Corrects the stale `aggregate_gate.py` docstrings (module +
  `resolve_op_id`): `classify_op` is the **read-time** classifier only;
  the persisted `op_class` comes from the route-bound `audit_op_class`
  binding when a route sets one, honoured by
  `broadcast/overrides.py::compute_effective_broadcast_detail`. This
  stale claim was the traced origin of a false rationale in #2729's
  release notes.
- Updates the entangled comment in `broadcast/agent_events.py` (it
  described the enum as omitting the two classes) and the two docs
  passages that recorded the gap as a known issue
  (`docs/codebase/api-shape-conventions.md` §14.1,
  `docs/codebase/checks-broadcast.md`).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (1383 files)
- [x] `mypy src/` — no new errors (the single reported error,
  `connectors/net/icmp.py:208` `MSG_ERRQUEUE`, is pre-existing on the
  untouched base and macOS-only; the attribute exists on Linux where CI
  runs)
- [x] AC1: `test_op_class_enum_spans_the_full_classifier_range` asserts
  set equality between `OP_CLASS_ENUM` and `classify_op`'s
  ast-extracted return literals — fails if either side gains a member
  alone
- [x] AC2: `meho.broadcast.recent` and `query_audit` accept
  `op_class=approval` and `op_class=credential_write` through full
  JSON-RPC `tools/call` round-trips (posted via `post_mcp`, so
  `mcp/handlers.py`'s jsonschema validation is on the path);
  `meho.broadcast.watch` shares the same tuple, pinned by the existing
  §14.1 shape-conventions test
- [x] AC3: `test_badge_and_filter_tables_cover_the_full_op_class_enum`
  pins both UI tables to the enum (set equality both directions)
- [x] AC4: `grep -n "classify_op"` on `aggregate_gate.py` shows only
  read-time-classifier statements, no persisted-class claim
- [x] AC5: CHANGELOG `[Unreleased]` gains a "Changed" section calling
  out the additive but user-visible `inputSchema` enum widening
- [x] AC6: full backend suite (`pytest -n 3 --dist loadscope -p no:cov
  --ignore=tests/integration tests/`) — green (result inlined below)
- [x] Affected test files (broadcast events / recent / query_audit / UI
  feed / shape conventions / checks broadcast / structured claims):
  257 passed, 4 skipped

## Out of scope

- `classify_op`'s classification rules and op-id bindings — untouched.
- `PlannedOpClass` (the `broadcast_announce` declaration enum) — its
  membership is a different contract (deliberately excludes `checks`,
  which is system-emitted, never agent-planned); only its stale
  comparison comment was updated.
- Backfilling / reclassifying historical `audit_log` rows.
- Pre-existing code-quality warnings in touched files (see adjacent
  findings in the run's result file).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2731


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `credential_write` and `approval` operation classes to broadcast and audit filters.
  * Updated operator-console feeds with badges and filtering for all supported classifications, including `checks`.

* **Bug Fixes**
  * Improved filtering consistency across broadcast and audit views.
  * Broadcast-only `approval` and `checks` events no longer appear in audit results.

* **Documentation**
  * Updated operation-class and broadcast documentation to reflect the complete classification vocabulary and current UI support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->