### PR TITLE
feat(checks): flap-suppression window for dashboard notification email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,29 @@ connector-related release-notes line.
   investigator's worsening-only fire conditions are unchanged.
   Requires migration `0068`. (#2719)
 
+### Added — checks notifications: flap suppression window (#2732)
+
+- Dashboard transition email now carries a per-(dashboard, state)
+  **flap-suppression window**: the first crossing into a non-green
+  state mails, repeat crossings into the *same* state inside the window
+  are suppressed (Valkey `SET NX EX`, the #2718 advisory's idiom;
+  `CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES`, default 30, `0` restores
+  one-mail-per-edge). A member Sensor flapping `critical <-> unknown`
+  at the runner cadence — the stale-probe shape of the RDC lab — now
+  produces one mail per state per window instead of one per edge.
+  Escalation is never suppressed (a different state is a different
+  key), recovery is never suppressed **and resets the Dashboard's
+  windows** (an incident after an all-clear pages again immediately,
+  even when the recovery edge itself sat below the `notify_min_state`
+  floor), and the whole gate fails open — a Valkey error warn-logs and
+  the mail is sent, because a missed alert is worse than a duplicate.
+  Suppression bounds delivery only: the rollup memo, the
+  `checks.transition` broadcast event, and the investigator gate see
+  every edge. Finding email is deliberately exempt from both this
+  window and the `notify_min_state` floor (its volume control is the
+  investigator's budget-gated fire gate — decision recorded in
+  `docs/codebase/checks-notifications.md`). (#2732)
+
 ### Added — checks advisory: non-green Dashboards surface on dispatch responses (#2718)
 
 - Successful dispatch responses — agent `call_operation` and the

--- a/backend/src/meho_backplane/checks/investigate.py
+++ b/backend/src/meho_backplane/checks/investigate.py
@@ -674,6 +674,7 @@ def _dashboard_notice(
     task with no session of its own.
     """
     return DashboardNotice(
+        tenant_id=dashboard.tenant_id,
         dashboard_id=snapshot.dashboard_id,
         name=snapshot.name,
         previous_state=snapshot.previous_state,

--- a/backend/src/meho_backplane/checks/notify.py
+++ b/backend/src/meho_backplane/checks/notify.py
@@ -55,16 +55,46 @@ cannot be evaluated is a degradation, matching the Initiative's
 ``skip`` edge never clears the bar **on its own**; ``critical -> skip``
 still mails, because the ``critical`` side does.
 
-Exactly-once, and the flap boundary
-===================================
+Exactly-once, and the flap window
+=================================
 
 One mail per *claimed* edge. The claim is the compare-and-swap, so two
 replicas racing the same edge produce exactly one send with no coordination
-here. What that does **not** bound is a genuinely flapping Dashboard: a
+here. What that alone does not bound is a genuinely flapping Dashboard: a
 member Sensor going stale and back re-crosses ``critical <-> unknown``, and
-each crossing is a real edge, so each mails. There is deliberately no
-rate limit, digest, or repeat-suppression window in this Task (#2716
-scopes those out); the floor knob is the only volume control today.
+each crossing is a real edge. Since #2732 a per-``(tenant, dashboard,
+state)`` suppression window bounds *delivery*: the first crossing into a
+non-green state claims a Valkey ``SET NX EX`` key
+(:func:`_claim_suppression`, the #2718 advisory's idiom) and mails; repeat
+crossings into the **same** state inside the window lose the claim and are
+suppressed (``checks_notify_suppressed``). The window is
+``CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES`` (default 30); ``0`` disables
+suppression entirely and short-circuits before any Valkey call, restoring
+the pre-#2732 one-mail-per-edge behaviour.
+
+Three deliberate asymmetries keep the window from ever costing a page:
+
+* **Escalation is never suppressed.** A different state is a different
+  key, so ``degraded -> critical`` mails immediately after a recent
+  ``degraded`` notice.
+* **Recovery is never suppressed, and it resets the windows.** A crossing
+  into a rank-0 state (``ok`` / ``skip``) is exempt from the claim, and
+  it deletes the Dashboard's suppression keys (:func:`_clear_suppression`)
+  -- even when the recovery edge itself sits below the floor -- so the
+  incident *after* an all-clear is a new incident and its first crossing
+  mails, never inherits a half-spent window.
+* **Fail-open.** A Valkey error on claim or clear warn-logs
+  (``checks_notify_suppression_failed``) and the notification is sent --
+  a missed alert is worse than a duplicate.
+
+The window bounds **attempts**, not confirmed deliveries: the key is
+claimed before the send (atomic check-and-claim; claiming after would race
+a slow SMTP session against the next flap edge), so a send that fails
+inside a window is not retried on the next same-state edge. That matches
+the #2719 contract -- at most one notification attempt per claimed
+transition -- and the failure is warn-logged either way. Digests and
+batching remain out of scope (#2716); findings are not flap-suppressed --
+their volume control is the investigator's own fire gate.
 
 Failure posture
 ===============
@@ -108,7 +138,9 @@ from typing import Final, cast
 
 import structlog
 
+from meho_backplane.broadcast.client import get_broadcast_client
 from meho_backplane.connectors.mail.transport import send_email
+from meho_backplane.settings import get_settings
 
 __all__ = [
     "DashboardNotice",
@@ -136,6 +168,15 @@ _NOTIFY_RANK: Final[dict[str, int]] = {
     "degraded": 1,
     "critical": 2,
 }
+
+#: The states a flap-suppression window applies to -- exactly the rank>=1
+#: states of :data:`_NOTIFY_RANK`. A crossing into a rank-0 state (``ok`` /
+#: ``skip``) is a recovery for suppression purposes: it is never claimed
+#: (the all-clear always delivers) and it clears these keys so the next
+#: incident's first crossing mails. Enumerated as a tuple (not derived from
+#: the dict at call time) because :func:`_clear_suppression` deletes one key
+#: per entry and the vocabulary is CHECK-constrained at the database.
+_SUPPRESSIBLE_STATES: Final[tuple[str, ...]] = ("unknown", "degraded", "critical")
 
 #: How many non-green members one mail enumerates. A correlated failure can
 #: redden a whole Dashboard; the recipient needs the shape of the problem,
@@ -203,8 +244,13 @@ class DashboardNotice:
     Built while the ``check_dashboards`` row and its member Sensors are live
     inside the claim transaction, so the background task never touches an
     expired ORM object.
+
+    :attr:`tenant_id` exists for the #2732 suppression key -- the same
+    per-tenant prefix discipline the #2718 advisory key follows, and what
+    keeps the Valkey namespace greppable per tenant.
     """
 
+    tenant_id: uuid.UUID
     dashboard_id: uuid.UUID
     name: str
     previous_state: str
@@ -251,6 +297,76 @@ def _crosses_threshold(previous: str, current: str, min_state: str) -> bool:
     """
     floor = _NOTIFY_RANK.get(min_state, _NOTIFY_RANK["critical"])
     return max(_NOTIFY_RANK.get(previous, 0), _NOTIFY_RANK.get(current, 0)) >= floor
+
+
+def _suppression_key(tenant_id: uuid.UUID, dashboard_id: uuid.UUID, state: str) -> str:
+    """Valkey key bounding one ``(tenant, dashboard, state)`` per window (#2732).
+
+    Unlike the #2718 advisory's key there is no caller segment: the
+    notification's audience is the Dashboard's single configured recipient,
+    not whoever happens to dispatch. Every segment is a UUID or a
+    CHECK-constrained vocabulary word, so the ``:`` delimiter cannot alias
+    two keys.
+    """
+    return f"meho:checks:notify:{tenant_id}:{dashboard_id}:{state}"
+
+
+async def _claim_suppression(notice: DashboardNotice, window_seconds: int) -> bool:
+    """Claim this edge's suppression window; ``True`` iff the mail should send.
+
+    One atomic ``SET key 1 NX EX <window-seconds>`` (the #2718 advisory's
+    claim idiom, single key so no pipeline): ``True`` from redis-py 8.0.1's
+    ``parse_set_result`` means the key was absent and this notification owns
+    the window; ``None`` means a same-state notification already claimed it.
+    Claimed **before** the send -- an atomic check-and-claim -- because
+    claiming after would race a slow SMTP session against the next flap
+    edge and let both mail. The window therefore bounds attempts, not
+    confirmed deliveries (see the module docstring).
+
+    Fail-open: any Valkey error warn-logs ``checks_notify_suppression_failed``
+    and returns ``True`` -- a missed alert is worse than a duplicate.
+    """
+    key = _suppression_key(notice.tenant_id, notice.dashboard_id, notice.current_state)
+    try:
+        claimed = await get_broadcast_client().set(key, "1", nx=True, ex=window_seconds)
+    except Exception:
+        _log().warning(
+            "checks_notify_suppression_failed",
+            dashboard_id=str(notice.dashboard_id),
+            phase="claim",
+            exc_info=True,
+        )
+        return True
+    return bool(claimed)
+
+
+async def _clear_suppression(notice: DashboardNotice) -> None:
+    """Drop the Dashboard's suppression keys on a recovery crossing (#2732).
+
+    One ``DEL`` covering every suppressible state, so the incident after an
+    all-clear starts with fresh windows and its first non-green crossing
+    always mails. Runs on any rank-0 crossing -- before the floor gate --
+    because a below-floor recovery (``degraded -> ok`` at the default
+    ``critical`` floor) still ends the incident even though it sends no
+    mail of its own.
+
+    Fail-open like the claim: a Valkey error warn-logs and the notification
+    path continues -- worst case a stale window suppresses one repeat, it
+    never drops the current mail.
+    """
+    keys = [
+        _suppression_key(notice.tenant_id, notice.dashboard_id, state)
+        for state in _SUPPRESSIBLE_STATES
+    ]
+    try:
+        await get_broadcast_client().delete(*keys)
+    except Exception:
+        _log().warning(
+            "checks_notify_suppression_failed",
+            dashboard_id=str(notice.dashboard_id),
+            phase="clear",
+            exc_info=True,
+        )
 
 
 def _single_line(value: str) -> str:
@@ -363,7 +479,14 @@ async def notify_dashboard_transition(notice: DashboardNotice) -> None:
     * ``notify_email`` unset -- notifications are off for this Dashboard
       (the state every pre-#2719 row backfills to);
     * the edge does not reach ``notify_min_state`` (see
-      :func:`_crosses_threshold`).
+      :func:`_crosses_threshold`);
+    * a same-state notification already claimed this edge's flap window
+      (#2732, see :func:`_claim_suppression`; skipped entirely when the
+      window is ``0`` or the crossing is into a rank-0 state).
+
+    A rank-0 crossing (recovery) additionally clears the Dashboard's
+    suppression keys before the floor gate -- the incident is over whether
+    or not the recovery edge itself mails.
 
     Otherwise :func:`_deliver` runs one
     :func:`~meho_backplane.connectors.mail.transport.send_email` call,
@@ -376,6 +499,10 @@ async def notify_dashboard_transition(notice: DashboardNotice) -> None:
             dashboard_id=str(notice.dashboard_id),
         )
         return
+    window_minutes = get_settings().checks_notify_suppression_window_minutes
+    suppressible = notice.current_state in _SUPPRESSIBLE_STATES
+    if window_minutes > 0 and not suppressible:
+        await _clear_suppression(notice)
     if not _crosses_threshold(notice.previous_state, notice.current_state, notice.notify_min_state):
         _log().info(
             "checks_notify_skipped_below_threshold",
@@ -383,6 +510,19 @@ async def notify_dashboard_transition(notice: DashboardNotice) -> None:
             previous_state=notice.previous_state,
             current_state=notice.current_state,
             notify_min_state=notice.notify_min_state,
+        )
+        return
+    if (
+        window_minutes > 0
+        and suppressible
+        and not await _claim_suppression(notice, window_minutes * 60)
+    ):
+        _log().info(
+            "checks_notify_suppressed",
+            dashboard_id=str(notice.dashboard_id),
+            previous_state=notice.previous_state,
+            current_state=notice.current_state,
+            window_minutes=window_minutes,
         )
         return
     await _deliver(notice, notice.notify_email)
@@ -472,7 +612,12 @@ async def notify_finding(notice: FindingNotice) -> None:
     which is already far narrower than any state floor: a finding exists only
     when the edge worsened into a non-green state with an actively-failing
     member, the correlated cause was novel (not noise-suppressed), no run for
-    it was already in flight, and the budget gate admitted it.
+    it was already in flight, and the budget gate admitted it. #2732 re-put
+    the question and settled on keeping this shape -- the operator-surprise
+    tradeoff (finding mail about a ``degraded`` Dashboard reaching someone on
+    the default ``critical`` floor) is documented in
+    ``docs/codebase/checks-notifications.md``. The same fire gate is why the
+    #2732 flap-suppression window does not apply here either.
     """
     if not notice.recipient:
         _log().info(

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1074,6 +1074,15 @@ class Settings(BaseModel):
     #: state) window. ``0`` disables the feature entirely (no DB read on
     #: any dispatch).
     checks_alert_advisory_window_minutes: int = Field(default=30, ge=0)
+    #: Flap-suppression window (minutes) for Dashboard transition email
+    #: (#2732). The first crossing into a non-green state mails; repeat
+    #: crossings into the *same* state inside the window are suppressed
+    #: (Valkey ``SET NX EX`` per (tenant, dashboard, state)). A different
+    #: state mails immediately, and a recovery both mails and resets the
+    #: Dashboard's windows. ``0`` disables suppression entirely (one mail
+    #: per claimed edge, the pre-#2732 behaviour) and short-circuits
+    #: before any Valkey call.
+    checks_notify_suppression_window_minutes: int = Field(default=30, ge=0)
     # Broadcast v2 T2 (#2547) -- durable-announcement retention prune
     # knobs. ``days=0`` is the keep-forever opt-out sentinel;
     # ``enabled=False`` skips starting the background task entirely
@@ -1752,6 +1761,9 @@ def get_settings() -> Settings:
         ),
         checks_alert_advisory_window_minutes=int(
             os.environ.get("CHECKS_ALERT_ADVISORY_WINDOW_MINUTES", "30"),
+        ),
+        checks_notify_suppression_window_minutes=int(
+            os.environ.get("CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES", "30"),
         ),
         broadcast_announcement_retention_days=int(
             os.environ.get("BROADCAST_ANNOUNCEMENT_RETENTION_DAYS", "90"),

--- a/backend/tests/test_checks_notify.py
+++ b/backend/tests/test_checks_notify.py
@@ -20,6 +20,13 @@ Initiative #2716 (parent goal #221), Task #2719. Coverage:
   ``investigate_on_transition`` calls on one Dashboard produce exactly one
   send (the compare-and-swap claim is the dedupe), and the recovery edge
   back to ``ok`` produces a second one.
+* **Flap suppression (#2732)** -- one delivery per (dashboard, state) per
+  window with re-delivery after expiry, escalation and recovery exempt,
+  recovery resetting the windows (below-floor recovery included), the
+  fail-open Valkey posture on claim and clear, the ``0`` knob
+  short-circuiting before any Valkey call, the attempt-based claim, and
+  the same flap sequence suppressed through the persist seam while the
+  memo keeps advancing.
 * **Finding mail (#2721)** -- the second notice kind: verdict / summary /
   ``run_id`` / recommended action rendering, the unconfigured skip, both
   failure shapes (refused result and raising transport), header safety on
@@ -28,7 +35,11 @@ Initiative #2716 (parent goal #221), Task #2719. Coverage:
 
 :func:`~meho_backplane.connectors.mail.transport.send_email` is replaced by
 a recording fake in every test, so no SMTP session is opened; the DB layer
-is real against the SQLite engine from :mod:`tests.conftest`.
+is real against the SQLite engine from :mod:`tests.conftest`. The Valkey
+client behind the #2732 suppression window is replaced by
+:class:`_FakeSuppressionStore` (autouse) -- real ``SET NX EX`` semantics
+with a manually-advanced TTL clock, so window expiry is driven, not
+simulated by deleting keys -- and no socket ever opens.
 """
 
 from __future__ import annotations
@@ -95,6 +106,71 @@ def _reset_notifications() -> Iterator[None]:
     inv._INVESTIGATIONS.clear()
 
 
+class _FakeSuppressionStore:
+    """Valkey double for the #2732 flap window: ``SET NX EX`` + ``DEL``.
+
+    Models redis-py 8.0.1's awaited command shape (``set(..., nx=True,
+    ex=...)`` returns ``True`` when the key was absent and ``None`` when it
+    already existed -- ``parse_set_result``'s contract; ``delete(*names)``
+    returns the removed count) plus a **manually-advanced TTL clock**, so
+    the window-expiry assertion drives real key expiry through
+    :meth:`advance` instead of deleting keys behind the code's back.
+    """
+
+    def __init__(self) -> None:
+        self.now: float = 0.0
+        self.set_calls: list[tuple[str, int]] = []
+        self.deleted: list[str] = []
+        self.set_exc: Exception | None = None
+        self.delete_exc: Exception | None = None
+        self._store: dict[str, float] = {}
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+    def _purge(self) -> None:
+        self._store = {key: exp for key, exp in self._store.items() if exp > self.now}
+
+    async def set(
+        self, name: str, value: str, *, nx: bool = False, ex: int | None = None
+    ) -> bool | None:
+        if self.set_exc is not None:
+            raise self.set_exc
+        assert nx, "the suppression claim must be NX -- atomic check-and-claim"
+        assert ex is not None and ex > 0, "the suppression claim must carry the window TTL"
+        self.set_calls.append((name, ex))
+        self._purge()
+        if name in self._store:
+            return None
+        self._store[name] = self.now + ex
+        return True
+
+    async def delete(self, *names: str) -> int:
+        if self.delete_exc is not None:
+            raise self.delete_exc
+        self.deleted.extend(names)
+        self._purge()
+        removed = 0
+        for name in names:
+            if self._store.pop(name, None) is not None:
+                removed += 1
+        return removed
+
+
+@pytest.fixture(autouse=True)
+def suppression_store(monkeypatch: pytest.MonkeyPatch) -> _FakeSuppressionStore:
+    """Replace the notifier's Valkey client so no test ever opens a socket.
+
+    Autouse because the suppression window is on by default (30 minutes):
+    without this, every delivering test would attempt a real connection to
+    the settings-default Valkey -- and a developer's local instance would
+    leak claims across tests.
+    """
+    store = _FakeSuppressionStore()
+    monkeypatch.setattr(notify, "get_broadcast_client", lambda: store)
+    return store
+
+
 class _RecordingTransport:
     """Stands in for ``send_email``; records every call, returns a preset."""
 
@@ -132,9 +208,11 @@ def _notice(
     min_state: str = "critical",
     members: tuple[NotifyMember, ...] = (),
     name: str = "prod-health",
+    dashboard_id: UUID | None = None,
 ) -> DashboardNotice:
     return DashboardNotice(
-        dashboard_id=uuid4(),
+        tenant_id=_TENANT,
+        dashboard_id=dashboard_id or uuid4(),
         name=name,
         previous_state=previous,
         current_state=current,
@@ -531,6 +609,246 @@ async def test_investigator_gate_is_unchanged_by_the_notify_hook(
 
 
 # ---------------------------------------------------------------------------
+# Flap suppression (#2732)
+# ---------------------------------------------------------------------------
+
+
+_WINDOW_SECONDS = 30 * 60  # the settings default the fixture leaves in place
+
+
+@pytest.mark.asyncio
+async def test_flap_within_window_delivers_once_per_state(
+    monkeypatch: pytest.MonkeyPatch,
+    suppression_store: _FakeSuppressionStore,
+) -> None:
+    """``critical <-> unknown`` flapping mails once per distinct state per window.
+
+    The realistic flap shape: a member Sensor going stale and back derives
+    ``unknown`` and returns, so the Dashboard re-crosses the same two states.
+    Each repeat crossing inside the window is suppressed with a structured
+    log; once the window expires the same sequence delivers again.
+    """
+    fake = _install_transport(monkeypatch)
+    dash = uuid4()
+    flap = [
+        ("critical", "unknown"),
+        ("unknown", "critical"),
+        ("critical", "unknown"),
+        ("unknown", "critical"),
+    ]
+
+    with capture_logs() as logs:
+        for previous, current in flap:
+            await notify_dashboard_transition(
+                _notice(previous=previous, current=current, dashboard_id=dash)
+            )
+
+    assert ["-> unknown" in c["subject"] for c in fake.calls] == [True, False]
+    assert len(fake.calls) == 2, "one delivery per distinct state inside the window"
+    suppressed = [e for e in logs if e["event"] == "checks_notify_suppressed"]
+    assert len(suppressed) == 2
+    assert {e["current_state"] for e in suppressed} == {"unknown", "critical"}
+
+    suppression_store.advance(_WINDOW_SECONDS + 1)
+    for previous, current in flap:
+        await notify_dashboard_transition(
+            _notice(previous=previous, current=current, dashboard_id=dash)
+        )
+
+    assert len(fake.calls) == 4, "an expired window delivers the same states again"
+    assert all(ex == _WINDOW_SECONDS for _, ex in suppression_store.set_calls)
+
+
+@pytest.mark.asyncio
+async def test_escalation_is_never_suppressed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``critical`` page right after a ``degraded`` notice delivers both."""
+    fake = _install_transport(monkeypatch)
+    dash = uuid4()
+
+    await notify_dashboard_transition(
+        _notice(previous="ok", current="degraded", min_state="degraded", dashboard_id=dash)
+    )
+    await notify_dashboard_transition(
+        _notice(previous="degraded", current="critical", min_state="degraded", dashboard_id=dash)
+    )
+
+    assert len(fake.calls) == 2, "a different state is a different key -- never suppressed"
+    assert "-> degraded" in fake.calls[0]["subject"]
+    assert "-> critical" in fake.calls[1]["subject"]
+
+
+@pytest.mark.asyncio
+async def test_recovery_is_never_suppressed_and_resets_windows(
+    monkeypatch: pytest.MonkeyPatch,
+    suppression_store: _FakeSuppressionStore,
+) -> None:
+    """The all-clear always delivers, and it ends the incident's windows.
+
+    ``ok -> critical -> ok -> critical -> ok`` inside one window: every edge
+    mails. The second ``critical`` is a *new* incident (the recovery cleared
+    the keys), and the second all-clear is exempt from suppression outright.
+    """
+    fake = _install_transport(monkeypatch)
+    dash = uuid4()
+    for previous, current in [
+        ("ok", "critical"),
+        ("critical", "ok"),
+        ("ok", "critical"),
+        ("critical", "ok"),
+    ]:
+        await notify_dashboard_transition(
+            _notice(previous=previous, current=current, dashboard_id=dash)
+        )
+
+    assert len(fake.calls) == 4, "recovery must deliver and reset the flap windows"
+    assert suppression_store.deleted, "the recovery crossing clears the suppression keys"
+
+
+@pytest.mark.asyncio
+async def test_below_floor_recovery_still_resets_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recovery too quiet to mail still ends the incident.
+
+    At the default ``critical`` floor, ``degraded -> ok`` sends nothing --
+    but the next ``critical`` crossing is a new incident and must page, so
+    the clear runs before the floor gate, not behind it.
+    """
+    fake = _install_transport(monkeypatch)
+    dash = uuid4()
+    for previous, current in [
+        ("ok", "critical"),  # mails, claims the critical window
+        ("critical", "degraded"),  # mails (critical side), claims degraded
+        ("degraded", "ok"),  # below the critical floor: silent, but clears
+        ("ok", "critical"),  # new incident -- must mail again
+    ]:
+        await notify_dashboard_transition(
+            _notice(previous=previous, current=current, dashboard_id=dash)
+        )
+
+    subjects = [c["subject"] for c in fake.calls]
+    assert len(subjects) == 3
+    assert "-> critical" in subjects[0]
+    assert "-> degraded" in subjects[1]
+    assert "-> critical" in subjects[2], "the below-floor recovery must have reset the window"
+
+
+@pytest.mark.asyncio
+async def test_valkey_failure_on_claim_fails_open(
+    monkeypatch: pytest.MonkeyPatch,
+    suppression_store: _FakeSuppressionStore,
+) -> None:
+    """A Valkey teardown never drops a page -- deliver, warn, move on."""
+    fake = _install_transport(monkeypatch)
+    suppression_store.set_exc = RuntimeError("valkey down")
+
+    with capture_logs() as logs:
+        await notify_dashboard_transition(_notice())
+
+    assert len(fake.calls) == 1, "suppression is fail-open: the mail must be sent"
+    failed = [e for e in logs if e["event"] == "checks_notify_suppression_failed"]
+    assert len(failed) == 1
+    assert failed[0]["phase"] == "claim"
+
+
+@pytest.mark.asyncio
+async def test_valkey_failure_on_clear_fails_open(
+    monkeypatch: pytest.MonkeyPatch,
+    suppression_store: _FakeSuppressionStore,
+) -> None:
+    """A failing key clear never blocks the all-clear mail."""
+    fake = _install_transport(monkeypatch)
+    suppression_store.delete_exc = RuntimeError("valkey down")
+
+    with capture_logs() as logs:
+        await notify_dashboard_transition(_notice(previous="critical", current="ok"))
+
+    assert len(fake.calls) == 1
+    failed = [e for e in logs if e["event"] == "checks_notify_suppression_failed"]
+    assert len(failed) == 1
+    assert failed[0]["phase"] == "clear"
+
+
+@pytest.mark.asyncio
+async def test_window_zero_disables_and_skips_valkey(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``0`` restores one-mail-per-edge and short-circuits before any Valkey call."""
+    fake = _install_transport(monkeypatch)
+    monkeypatch.setenv("CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES", "0")
+    get_settings.cache_clear()
+    monkeypatch.setattr(
+        notify,
+        "get_broadcast_client",
+        lambda: pytest.fail("window 0 must not touch Valkey"),
+    )
+    dash = uuid4()
+
+    for _ in range(2):
+        await notify_dashboard_transition(_notice(dashboard_id=dash))
+    await notify_dashboard_transition(_notice(previous="critical", current="ok", dashboard_id=dash))
+
+    assert len(fake.calls) == 3, "no suppression and no clear when the window is 0"
+
+
+@pytest.mark.asyncio
+async def test_failed_send_still_claims_the_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The window bounds attempts, not confirmed deliveries.
+
+    The claim is atomic check-and-claim *before* the send (claiming after
+    would race a slow SMTP session against the next flap edge), so a failed
+    attempt is not retried by the next same-state crossing -- the #2719
+    one-attempt-per-claimed-transition contract, now per window.
+    """
+    fake = _install_transport(monkeypatch, exc=RuntimeError("MTA down"))
+    dash = uuid4()
+
+    with capture_logs() as logs:
+        await notify_dashboard_transition(_notice(dashboard_id=dash))
+        await notify_dashboard_transition(_notice(dashboard_id=dash))
+
+    assert len(fake.calls) == 1, "the second same-state edge is suppressed, not retried"
+    assert any(e["event"] == "checks_notify_failed" for e in logs)
+    assert any(e["event"] == "checks_notify_suppressed" for e in logs)
+
+
+@pytest.mark.asyncio
+async def test_flap_through_the_seam_is_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Suppression bounds delivery only -- the memo keeps advancing per edge.
+
+    A member flapping ``critical <-> degraded`` through the real persist
+    seam mails once per state; every edge still moves
+    ``last_rollup_state`` (the claim, the broadcast event, and the
+    investigator gate are deliberately untouched by #2732).
+    """
+    fake = _install_transport(monkeypatch)
+    monkeypatch.setattr(inv, "_schedule_investigation", lambda **_: None)
+    await _seed_tenant()
+    sid = await _seed_sensor(name="flappy", last_state="critical")
+    dash = await _seed_dashboard(name="prod-health", sensor_ids=[sid], notify_min_state="degraded")
+
+    for state in ("degraded", "critical", "degraded"):
+        await inv.investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+        await notify._await_pending_notifications()
+        await _set_sensor_state(sid, state)
+    await inv.investigate_on_transition(sensor_id=sid, tenant_id=_TENANT)
+    await notify._await_pending_notifications()
+
+    assert len(fake.calls) == 2, "one mail per distinct state inside the window"
+    assert "-> critical" in fake.calls[0]["subject"]
+    assert "-> degraded" in fake.calls[1]["subject"]
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(CheckDashboard, dash)
+        assert row is not None
+        assert row.last_rollup_state == "degraded", "the memo must advance on every edge"
+
+
+# ---------------------------------------------------------------------------
 # Finding mail (#2721)
 # ---------------------------------------------------------------------------
 
@@ -666,6 +984,41 @@ async def test_finding_mail_bounds_a_runaway_answer(
     assert "x" * (notify._MAX_FINDING_CHARS + 1) not in body
     assert body.count("\n- line-") == notify._MAX_EVIDENCE_LINES
     assert "5 further line(s) not shown." in body
+
+
+@pytest.mark.asyncio
+async def test_finding_mail_has_no_state_floor_and_no_flap_window(
+    monkeypatch: pytest.MonkeyPatch,
+    suppression_store: _FakeSuppressionStore,
+) -> None:
+    """The #2732 decision, pinned: finding mail gates on ``notify_email`` alone.
+
+    ``notify_min_state`` is a floor over a transition *edge* and a finding
+    is not an edge; the investigator's fire gate is the volume control. So
+    a finding about a Dashboard whose ``degraded`` incident never reached
+    the default ``critical`` transition floor still mails, and repeated
+    findings are not flap-suppressed -- no Valkey key is ever touched.
+    """
+    fake = _install_transport(monkeypatch)
+    dash = uuid4()
+
+    for _ in range(2):
+        await notify_finding(
+            FindingNotice(
+                dashboard_id=dash,
+                dashboard_name="prod-health",
+                run_id=uuid4(),
+                verdict="actionable",
+                summary="Sensor degraded below the paging floor.",
+                evidence=(),
+                recommended_action=None,
+                recipient="oncall@example.com",
+            )
+        )
+
+    assert len(fake.calls) == 2, "no floor and no window applies to finding mail"
+    assert suppression_store.set_calls == []
+    assert suppression_store.deleted == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -276,6 +276,40 @@ def test_vault_addr_set_env_is_preserved(
         get_settings.cache_clear()
 
 
+def test_checks_notify_suppression_window_defaults_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset ``CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES`` → the 30-minute default."""
+    _base_env(monkeypatch)
+    monkeypatch.delenv("CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES", raising=False)
+    get_settings.cache_clear()
+    try:
+        assert get_settings().checks_notify_suppression_window_minutes == 30
+    finally:
+        get_settings.cache_clear()
+
+
+def test_checks_notify_suppression_window_env_override_takes_effect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES`` flows through ``get_settings()``.
+
+    The #2732 acceptance criterion, and the `Settings` trap it exists
+    for: `Settings` is a plain pydantic ``BaseModel``, not
+    ``BaseSettings`` — ``get_settings()`` hand-maps every env var, so a
+    field declared without its mapping would be silently inert and the
+    documented operator knob a no-op. A full round-trip (env in, value
+    out) is the only shape that catches the missing mapping.
+    """
+    _base_env(monkeypatch)
+    monkeypatch.setenv("CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES", "0")
+    get_settings.cache_clear()
+    try:
+        assert get_settings().checks_notify_suppression_window_minutes == 0
+    finally:
+        get_settings.cache_clear()
+
+
 def test_result_handle_max_spill_rows_defaults_when_env_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/docs/codebase/checks-notifications.md
+++ b/docs/codebase/checks-notifications.md
@@ -115,16 +115,65 @@ including `ok -> unknown`, since `unknown` shares rank 1 with
    that used to live inside the claim now sits at this single site,
    unchanged in meaning: `worsening and non_green` → investigator. Every
    claimed edge → `schedule_dashboard_notification`.
-3. **Threshold + build + send** (`notify_dashboard_transition`). Unset
-   recipient short-circuits; then the rank rule; then one `send_email`.
+3. **Threshold + flap window + build + send**
+   (`notify_dashboard_transition`). Unset recipient short-circuits; a
+   recovery crossing clears the Dashboard's flap windows; then the rank
+   rule; then the #2732 suppression claim (see below); then one
+   `send_email`.
 4. **Outcome logging.** `checks_notify_sent` (info) on delivery;
    `checks_notify_failed` (warning, with the transport's stable reason
    code) on a `sent=False` result or an unexpected exception;
    `checks_notify_skipped_unconfigured` /
-   `checks_notify_skipped_below_threshold` (info) on the two
-   short-circuits. All four are at info or above because a claimed edge
-   is a rare event and "no mail arrived" is a question the log has to be
-   able to answer.
+   `checks_notify_skipped_below_threshold` /
+   `checks_notify_suppressed` (info) on the three short-circuits;
+   `checks_notify_suppression_failed` (warning, `phase` = `claim` or
+   `clear`) when Valkey misbehaves and the fail-open path runs. All are
+   at info or above because a claimed edge is a rare event and "no mail
+   arrived" is a question the log has to be able to answer.
+
+## Flap suppression (#2732)
+
+A member Sensor whose evaluation stops updating derives `unknown`
+(stale grace, `checks/rollup.py`) and returns to its real state when it
+evaluates again, so a Dashboard sitting at `critical` re-crosses
+`critical <-> unknown` — each crossing a genuine claimed edge. Since
+#2732 delivery (not the claim) is bounded by a per-`(tenant, dashboard,
+state)` window:
+
+- **Mechanism.** The first crossing into a non-green state claims a
+  Valkey key — `meho:checks:notify:<tenant>:<dashboard>:<state>`, one
+  atomic `SET NX EX`, the #2718 advisory's idiom (`checks/advisory.py`)
+  minus the caller segment (the audience is the Dashboard's one
+  configured recipient, not whoever dispatches). Repeat crossings into
+  the **same** state inside the window lose the claim and log
+  `checks_notify_suppressed`. The Valkey TTL key *is* the state —
+  nothing durable; a Valkey flush re-arms every window.
+- **Knob.** `CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES`, default 30.
+  `0` disables suppression entirely (one mail per claimed edge, the
+  pre-#2732 behaviour) and short-circuits before any Valkey call.
+  Deployment-level, like the SMTP block — not per Dashboard.
+- **Escalation is never suppressed.** A different state is a different
+  key: `degraded → critical` mails immediately after a recent
+  `degraded` notice.
+- **Recovery is never suppressed, and it resets the windows.** A
+  crossing into a rank-0 state (`ok`/`skip`) is exempt from the claim,
+  and it `DEL`s the Dashboard's three suppressible-state keys — even
+  when the recovery edge itself is below the floor and sends nothing
+  (`degraded → ok` at the default `critical` floor). The incident after
+  an all-clear is a new incident; its first crossing always mails.
+- **Fail-open.** Any Valkey error on claim or clear warn-logs
+  `checks_notify_suppression_failed` and the notification is sent. A
+  missed alert is worse than a duplicate.
+- **Attempt-based.** The key is claimed *before* the send (atomic
+  check-and-claim; claiming after would race a slow SMTP session
+  against the next flap edge), so a send that fails inside a window is
+  not retried by the next same-state crossing — the #2719
+  one-attempt-per-claimed-transition contract, per window. The failure
+  is warn-logged either way.
+- **Delivery only.** The memo compare-and-swap, the `checks.transition`
+  broadcast event (#2720), and the investigator's fire gate see every
+  edge, suppressed or not. Finding mail is not flap-suppressed — its
+  volume control is the investigator's fire gate.
 
 ## Message shape
 
@@ -172,6 +221,21 @@ edge worsened into a non-green state with an actively-failing member, the
 correlated cause was novel, no run for it was in flight, and the budget
 gate admitted it.
 
+#2721's review flagged the operator surprise in this and #2732 re-put
+the question; the decision is to **keep the no-floor shape**, and this
+paragraph is its record. The surprise, stated plainly: an operator on
+the default `critical` floor can receive finding mail about a
+`degraded` Dashboard whose transition mail was silent. That is
+intended — the floor tunes *paging* volume on a per-edge signal that
+can fire often, while a finding is a rare, budget-gated diagnosis that
+exists precisely because something worsened; a recipient who configured
+`notify_email` and an investigator wants the diagnosis. Gating it on
+the floor would silently discard completed investigations, and there is
+no separate per-Dashboard knob because no consumer has asked for one.
+For the same fire-gate reason, findings are exempt from the #2732 flap
+window (`test_finding_mail_has_no_state_floor_and_no_flap_window` pins
+both exemptions).
+
 ## Failure posture
 
 Fire-and-forget in two senses:
@@ -211,12 +275,15 @@ from the memo would mean re-mailing every unchanged evaluation.
 
 ## Known issues / boundaries
 
-- **No flap suppression.** One mail per *claimed* edge. A member Sensor
-  going stale and back re-crosses `critical <-> unknown`, and each
-  crossing is a real edge, so each mails. There is deliberately no rate
-  limit, digest, or repeat-suppression window (#2716 scopes those out);
-  the floor knob is the only volume control today. A Sensor that flaps
-  at the runner cadence will mail at the runner cadence.
+- **Suppression bounds repeats, not distinct states.** A Dashboard
+  cycling through *N* distinct non-green states mails once per state
+  per window — the window is per-`(dashboard, state)`, not
+  per-dashboard. Digests, batching, and grouping several Dashboards
+  into one mail remain out of scope (#2716).
+- **The window is attempt-based and ephemeral.** A send that fails
+  inside a window is not retried by the next same-state crossing, and a
+  Valkey flush (or failover to an empty replica) re-arms every window —
+  worst case one extra mail per state, never a dropped one.
 - **One recipient per Dashboard.** No lists, no routing rules, no
   per-Sensor recipients. More when a consumer asks.
 - **Deployment-level SMTP.** One MTA and one allowlist for the whole
@@ -237,10 +304,14 @@ from the memo would mean re-mailing every unchanged evaluation.
 
 ## References
 
-- `backend/src/meho_backplane/checks/notify.py`
+- `backend/src/meho_backplane/checks/notify.py` —
+  `_claim_suppression` / `_clear_suppression` / `_suppression_key` are
+  the #2732 flap-window seam
 - `backend/src/meho_backplane/checks/investigate.py` —
   `_process_transition`, `_claim_dashboard_transition`,
   `_ClaimedTransition`, `_dashboard_notice`, `_finding_notice`
+- `backend/src/meho_backplane/checks/advisory.py` — the `SET NX EX`
+  claim precedent the flap window follows
 - `backend/alembic/versions/0068_add_check_dashboard_notify.py`
 - `backend/tests/test_checks_notify.py`,
   `backend/tests/test_checks_investigate.py` (the finding mail through


### PR DESCRIPTION
## Summary

- Adds a per-(tenant, dashboard, state) **flap-suppression window** to Dashboard transition email: the first crossing into a non-green state claims a Valkey `SET NX EX` key (the #2718 advisory's idiom) and mails; repeat crossings into the same state inside the window are suppressed with a structured `checks_notify_suppressed` log. A member Sensor flapping `critical <-> unknown` (the stale-probe shape from the RDC lab) now produces one mail per state per window instead of one per edge.
- Window is `CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES` (default 30, the `checks_alert_advisory_window_minutes` shape); `0` disables suppression and short-circuits before any Valkey call. The `get_settings()` hand-mapping is covered by a round-trip test so a missing env mapping cannot be silently inert.
- Three delivery guarantees, all tested: **escalation is never suppressed** (different state = different key), **recovery is never suppressed and resets the Dashboard's windows** (a `DEL` on any rank-0 crossing, even a below-floor one, so the incident after an all-clear pages again immediately), and **fail-open** (any Valkey error warn-logs `checks_notify_suppression_failed` and the mail is sent — a missed alert is worse than a duplicate).
- Suppression bounds delivery only: the rollup memo CAS, the `checks.transition` broadcast event, and the investigator fire gate see every edge (proven through the persist seam). The window is attempt-based — claimed atomically before the send, so a slow SMTP session cannot race the next flap edge into a duplicate.
- Settles the #2721-review question: finding email deliberately keeps **no** `notify_min_state` floor and is exempt from the flap window (its volume control is the investigator's budget-gated fire gate); the decision, and the operator surprise it trades away, are recorded in `docs/codebase/checks-notifications.md` and pinned by `test_finding_mail_has_no_state_floor_and_no_flap_window`.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean except one pre-existing darwin-only error in `connectors/net/icmp.py` (`socket.MSG_ERRQUEUE` is Linux-only; file untouched; Linux CI is authoritative)
- [x] `pytest -n 3 --dist loadscope --ignore=tests/integration --ignore=tests/migrations tests/` — 10840 passed, 193 skipped; the only failures are two `net` connector tests needing real ICMP/DNS network access (`test_trace_reaches_loopback`, `test_chosen_resolver_queries_that_nameserver`) which fail identically on pristine `main` in this sandbox — zero `net` files in this diff
- [x] AC: `critical → unknown → critical → unknown` inside one window delivers once per distinct state; the same sequence after window expiry (driven through the fake's TTL clock, not by deleting keys) delivers again — `test_flap_within_window_delivers_once_per_state`
- [x] AC: escalation `degraded → critical` right after a `degraded` notice delivers both — `test_escalation_is_never_suppressed`
- [x] AC: recovery always delivers and resets the windows (below-floor recovery included) — `test_recovery_is_never_suppressed_and_resets_windows`, `test_below_floor_recovery_still_resets_windows`
- [x] AC: injected Valkey errors on claim and clear both fail open with a structured warning — `test_valkey_failure_on_claim_fails_open`, `test_valkey_failure_on_clear_fails_open`
- [x] AC: `0` disables suppression and never touches Valkey — `test_window_zero_disables_and_skips_valkey`
- [x] AC: env round-trip through `get_settings()` — `test_checks_notify_suppression_window_env_override_takes_effect` (+ default-value guard)
- [x] AC: the `notify_min_state`-for-findings decision — documented in `docs/codebase/checks-notifications.md` and pinned by `test_finding_mail_has_no_state_floor_and_no_flap_window`
- [x] Flap through the real persist seam suppressed while the memo advances — `test_flap_through_the_seam_is_suppressed`
- [x] Attempt-based window semantics pinned — `test_failed_send_still_claims_the_window`

## Out of scope

- Digests, batching, or grouping multiple dashboards into one mail (#2716 scope boundary, unchanged).
- The rollup's stale-grace derivation, the investigator fire gate, and the transition-detection CAS — all untouched (asserted through the seam test).
- Pre-existing darwin-only mypy finding in `connectors/net/icmp.py` (adjacent finding, not addressed here).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2732
