### PR TITLE
docs(site): de-stub the Project section — maturity, versioning, security, roadmap

### DIFF
--- a/docs-site/project/index.md
+++ b/docs-site/project/index.md
@@ -1,17 +1,54 @@
 # Project
 
-!!! note "Stub — feature-maturity program tracked by [evoila/meho#2664](https://github.com/evoila/meho/issues/2664)"
+How the MEHO project itself is run: what carries a stability promise,
+how versions and deprecations work, how to report a vulnerability, and
+where the roadmap lives.
 
-This section will document how the project itself is run:
+## Feature maturity
 
-- Versioning and deprecation policy.
-- Feature-maturity index — what is GA, Beta, Experimental, and each
-  non-GA surface's road to GA.
-- Security policy and coordinated disclosure
-  ([`SECURITY.md`](https://github.com/evoila/meho/blob/main/SECURITY.md)).
-- Roadmap.
+Every feature carries an explicit **GA / Beta / Experimental** tier,
+declared once in the feature-maturity registry and rendered on every
+surface (MCP tool descriptions, REST OpenAPI, CLI help, console
+badges). The full index — every non-GA feature, its gaps, target
+milestone, and tracking issue — is generated from the registry and
+lives at [Feature maturity index](../reference/maturity.md).
 
-Until it lands:
-[`CONTRIBUTING.md`](https://github.com/evoila/meho/blob/main/CONTRIBUTING.md)
-and the
-[release history](https://github.com/evoila/meho/releases).
+## Versioning and deprecation policy
+
+MEHO follows [SemVer](https://semver.org). The version lives only in
+the release tag; the backplane image, Helm chart, CLI tarballs, and
+this docs site all derive from it
+([release history](https://github.com/evoila/meho/releases)).
+
+Pre-1.0, breaking changes still ship in minors — each one carries a
+**migration recipe** in the release notes (the smallest concrete edit
+a v(N−1) client makes to keep working on v(N); see the *Breaking
+changes* convention in the
+[CHANGELOG](https://github.com/evoila/meho/blob/main/CHANGELOG.md)).
+The formal 1.0 stability promise — frozen contract surfaces, CI
+compatibility gates, and a deprecation window policy — is being built
+under [evoila/meho#2662](https://github.com/evoila/meho/issues/2662)
+and will be documented here when it lands.
+
+## Security policy
+
+Report vulnerabilities per
+[`SECURITY.md`](https://github.com/evoila/meho/blob/main/SECURITY.md)
+— coordinated disclosure, no public issue for an unpatched finding.
+Release artefacts (image, chart, CLI tarballs) are cosign-signed
+keyless under a common identity-claim format; verification commands
+ship in the release notes.
+
+## Roadmap
+
+The road to v1.0.0 is tracked as
+[evoila/meho#2661](https://github.com/evoila/meho/issues/2661):
+fresh-user install from these docs, Claude Desktop connectivity, the
+clean-room evaluation program, and the contract freeze. The goal map
+is public — `gh issue list --repo evoila/meho --label goal`.
+
+## Contributing
+
+Start with
+[`CONTRIBUTING.md`](https://github.com/evoila/meho/blob/main/CONTRIBUTING.md).
+Every commit needs a DCO `Signed-off-by` line (`git commit -s`).


### PR DESCRIPTION
## Description

Follow-up from the v0.26.0 docs-site stub audit. `docs-site/project/index.md` was the one stub whose tracker (#2664) closed without the page being filled — the other two stubs (`clients/` → #2672, `reference/` → #2662) remain correctly tracked and deliberately deferred.

This fills the Project section using only content that already exists:

- **Feature maturity** → links the generated `reference/maturity.md` index (#2678's generator; freshness CI-enforced).
- **Versioning & deprecation** → SemVer, tag-derived artefacts, the CHANGELOG's Breaking-changes migration-recipe convention; the formal 1.0 deprecation-window policy is explicitly deferred to #2662 and labeled as such.
- **Security policy** → SECURITY.md coordinated disclosure + cosign-keyless artefact signing.
- **Roadmap** → #2661.
- **Contributing** → CONTRIBUTING.md + DCO sign-off requirement.

`uv run --project backend --no-sync mkdocs build --strict` passes locally (same gate as CI).

## Type of change

- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the project-page placeholder with guidance on feature maturity, versioning, deprecation, security reporting, artifact signing, the v1.0 roadmap, and contribution requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->