### PR TITLE
docs(changelog): roll [Unreleased] into v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,9 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
-### Changed
+## [0.27.0] - 2026-08-03
+
+### Breaking changes
 
 - **BREAKING: all 62 dotted `meho.*` MCP tool names renamed to
   underscore-only names** (`meho.broadcast.watch` →
@@ -192,6 +194,20 @@ connector-related release-notes line.
   | `meho.topology.create_node` | `meho_topology_create_node` |
   | `meho.topology.delete_node` | `meho_topology_delete_node` |
   | `meho.topology.unannotate` | `meho_topology_unannotate` |
+
+### Changed
+
+- MCP client-setup recipe corrected to the internal-only deployment
+  model: the backplane is never publicly exposed, so the cloud-brokered
+  claude.ai / Claude Desktop remote Custom Connector path (which
+  requires public reachability for the RFC 9728 metadata fetch) is
+  documented as not applicable and replaced by the local `mcp-remote`
+  stdio-shim setup for Claude Desktop; the Step-5 troubleshooting
+  guidance to "expose the backplane via a public ingress or a tunnel"
+  is reversed to keep-it-internal (#2744).
+- Docs-site Project section de-stubbed — feature-maturity model,
+  versioning policy, security posture, and roadmap pages are now real
+  content instead of placeholders (#2747).
 
 ## [0.26.0] - 2026-08-02
 


### PR DESCRIPTION
## What

Release-cutting PR for **v0.27.0**: rolls `[Unreleased]` into `## [0.27.0] - 2026-08-03` and leaves a fresh empty `[Unreleased]`.

## Version rationale

The #2745 MCP tool-name rename is a breaking contract change (62 tool names) → minor bump pre-1.0: **v0.27.0**.

## Completeness audit (mandatory step)

3 PRs merged since `v0.26.0`, all cited:

- #2748 — the breaking rename (bullet authored in the PR itself, retitled here under the established `### Breaking changes` heading so migrations surface above features)
- #2744 — MCP client-setup corrected to internal-only (backfilled)
- #2747 — docs-site Project section de-stub (backfilled)

## After merge

Tag `v0.27.0` on the merge commit (publishes image + chart + CLI), verify the three artefacts, then deploy to the lab and re-run the #2666 Claude Desktop smoke test — the gate this release unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release notes for version 0.27.0.
  - Documented renamed MCP tools and required migration steps.
  - Clarified audit identity updates and registry-wide conformance testing.
  - Corrected Claude client setup guidance for internal deployments.
  - Replaced placeholder project pages with substantive documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->