### PR TITLE
fix(dispatcher): name the target's product in the no_connector error

### DIFF
--- a/backend/src/meho_backplane/connectors/__init__.py
+++ b/backend/src/meho_backplane/connectors/__init__.py
@@ -43,6 +43,7 @@ from meho_backplane.connectors.resolver import (
     ResolutionLabel,
     resolve_connector,
     resolve_connector_or_label,
+    resolve_target_version,
 )
 from meho_backplane.connectors.schemas import (
     AuthModel,
@@ -99,6 +100,7 @@ __all__ = [
     "register_connector_v2",
     "resolve_connector",
     "resolve_connector_or_label",
+    "resolve_target_version",
     "shim_kind",
     "split_version",
     "validate_execution_profile",

--- a/backend/src/meho_backplane/connectors/resolver.py
+++ b/backend/src/meho_backplane/connectors/resolver.py
@@ -325,7 +325,7 @@ def resolve_connector(target: Any) -> type[Connector]:
             f"target has no product slug; cannot resolve a connector: target={target!r}"
         )
 
-    target_version = _resolve_target_version(target)
+    target_version = resolve_target_version(target)
     preferred_impl_id = getattr(target, "preferred_impl_id", None)
 
     candidates = _filter_candidates(product, target_version)
@@ -532,7 +532,7 @@ def _run_tie_break_ladder(
     return None, "ambiguous", candidates
 
 
-def _resolve_target_version(target: Any) -> str | None:
+def resolve_target_version(target: Any) -> str | None:
     """Pull the target's product version from fingerprint or operator hint.
 
     Two sources, in priority order:

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -929,7 +929,7 @@ class Target(Base):
     # can still be created and probed; once the probe succeeds the
     # authoritative ``fingerprint.version`` takes precedence at resolver
     # time (see
-    # :func:`~meho_backplane.connectors.resolver._resolve_target_version`).
+    # :func:`~meho_backplane.connectors.resolver.resolve_target_version`).
     # G0.15-T6 (#1215) ships this column to break the chicken-and-egg
     # the v0.7.0 dogfood surfaced (RDC #753, signal 6): every typed
     # connector except K8s required ``fingerprint.version`` to resolve,

--- a/backend/src/meho_backplane/operations/_errors.py
+++ b/backend/src/meho_backplane/operations/_errors.py
@@ -285,11 +285,20 @@ def result_ambiguous_target(
 def result_no_connector(
     op_id: str,
     product: str,
-    version: str,
+    version: str | None,
     duration_ms: float,
     exception_message: str | None = None,
 ) -> OperationResult:
     """Resolver miss -- no registered impl for *(product, version)*.
+
+    ``product`` / ``version`` name the **failing input** the resolver
+    rejected -- i.e. the *target's* registered product and the version
+    the resolver read off it (which may be ``None`` when the target
+    carries no fingerprint or operator-asserted version), **not** the
+    ``connector_id`` the caller passed. The dispatcher's connector_id
+    already resolved a valid descriptor before this builder is reached
+    (else ``result_unknown_op`` fires), so echoing it here would blame
+    the wrong input (evoila/meho#2701).
 
     ``exception_message`` (added by G0.14-T1 #1142) carries the
     :exc:`~meho_backplane.connectors.NoMatchingConnector` exception text

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -232,6 +232,7 @@ from meho_backplane.connectors import (
     ResolutionLabel,
     ResultHandle,
     resolve_connector_or_label,
+    resolve_target_version,
 )
 from meho_backplane.connectors._shared.vcf_auth import ConnectorAuthError
 from meho_backplane.connectors.base import Connector, shim_kind
@@ -2091,10 +2092,28 @@ async def dispatch(
             # faults, which only arise when a target *was* supplied).
             return result_target_required(op_id, _elapsed_ms(started))
         if resolution_error == "no_connector":
+            # #2701: the resolver miss is on the TARGET's product/version,
+            # not the ``connector_id`` the caller passed. That connector_id
+            # already resolved a valid descriptor at Step 2 (else
+            # ``result_unknown_op`` fired), so echoing its parsed
+            # ``(product, version)`` here names the wrong input and reads as
+            # "your connector_id is wrong" -- the exact misattribution that
+            # sent the reporter chasing connector ids. Name the target's
+            # registered product and the version the resolver actually read
+            # (which may be ``None``). Fall back to the connector_id pair
+            # only when there is no target product to name (e.g. an ingested
+            # op dispatched with ``target=None``).
+            target_product = getattr(target, "product", None)
+            if isinstance(target_product, str) and target_product:
+                miss_product = target_product
+                miss_version: str | None = resolve_target_version(target)
+            else:
+                miss_product = product
+                miss_version = version
             return result_no_connector(
                 op_id,
-                product,
-                version,
+                miss_product,
+                miss_version,
                 _elapsed_ms(started),
                 exception_message=exception_message,
             )

--- a/backend/tests/integration/test_connectors_k8s_e2e.py
+++ b/backend/tests/integration/test_connectors_k8s_e2e.py
@@ -338,7 +338,7 @@ async def k8s_e2e(
     # reads product + fingerprint["version"] + preferred_impl_id off it
     # exactly as a production probed target. fingerprint is a JSON dict
     # (the probe route persists FingerprintResult.model_dump(mode="json")
-    # to this column), so resolve_connector's _resolve_target_version
+    # to this column), so resolve_connector's resolve_target_version
     # reads it via .get("version"); the K8s connector advertises
     # supported_version_range=None so the version is not filtered on,
     # only echoed into the audit payload — same as the _K3sTarget stub.

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -692,6 +692,92 @@ async def test_dispatch_ingested_returns_no_connector_when_resolver_misses(
     assert "ghost" in result.extras["exception_message"]
 
 
+@pytest.mark.asyncio
+async def test_no_connector_error_names_target_product_not_connector_id(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """#2701: the ``no_connector`` error names the TARGET's product, not the caller's.
+
+    Reproduces the exact reported shape: the ``connector_id`` product
+    (``k8s``) resolves a valid descriptor, but the target is registered
+    under a *different*, unadvertised product (``kubernetes``) so the
+    resolver misses. The error must point at the failing input -- the
+    target's ``kubernetes`` -- and must not echo the caller's ``k8s`` as
+    the unsupported product (which read as "your connector_id is wrong").
+
+    The sibling ghost/ghost test above cannot catch this: there the
+    connector_id product and the target product are identical, so echoing
+    either one happens to be correct.
+    """
+    from datetime import UTC, datetime
+
+    from meho_backplane.db.models import EndpointDescriptor
+
+    # Descriptor lives under product ``k8s`` so the connector_id
+    # ``k8s-1.x`` lookup succeeds (Step 2). No connector advertises
+    # ``kubernetes``, so resolving the target misses (Step 5).
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product="k8s",
+        version="1.x",
+        impl_id="k8s",
+        op_id="GET:/api/2701-about",
+        source_kind="ingested",
+        method="GET",
+        path="/api/2701-about",
+        handler_ref=None,
+        summary="k8s about",
+        description="Ingested op under product k8s.",
+        tags=[],
+        parameter_schema={},
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=stub_embedding_service.encode_one.return_value,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+    operator = _make_operator()
+    # Target's registered product differs from the connector_id product;
+    # no version anywhere, so the resolver sees version=None.
+    target = _FakeTarget(product="kubernetes")
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="k8s-1.x",
+        op_id="GET:/api/2701-about",
+        target=target,
+        params={},
+    )
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("no_connector:")
+    # Names the target's product (the failing input) ...
+    assert "product='kubernetes'" in result.error
+    # ... and does NOT present the caller's connector_id product as the
+    # unsupported product (the misattribution #2701 is about).
+    assert "product='k8s'" not in result.error
+    # The version the resolver actually saw was None (no fingerprint,
+    # no operator-asserted version), not the connector_id's ``1.x``.
+    assert "version=None" in result.error
+    assert "version='1.x'" not in result.error
+    # Machine-readable extras align to the target, not the connector_id.
+    assert result.extras["error_code"] == "no_connector"
+    assert result.extras["product"] == "kubernetes"
+    assert result.extras["version"] is None
+
+
 # ---------------------------------------------------------------------------
 # G0.14-T1 (#1142): typed/composite resolver miss must surface
 # no_connector (matching the ingested branch), and the resolver's

--- a/docs/codebase/error-message-shape.md
+++ b/docs/codebase/error-message-shape.md
@@ -466,6 +466,23 @@ set).
   `valid_products: [...]` on miss (Option C: recovery-time net).
   Both layers share `registered_product_tokens()` as the
   source-of-truth so they cannot disagree.
+- **#2701** — the Part B residual of Signal 5: even after T3 #1144
+  rejects an unadvertised `product` at registration, a target that
+  predates the validation (or was backfilled around it) still fails
+  every dispatch, and the `no_connector` error named the **wrong
+  value** — it echoed the caller's `connector_id`-parsed
+  `(product, version)` (e.g. `product='k8s' version='1.x'`) instead
+  of the *target's* registered product the resolver actually rejected
+  (`product='kubernetes' version=None`), reading as "your connector_id
+  is wrong". This violates convention (a) (*name the specific value
+  involved*) at the site the whole convention exists for. The fix
+  swaps the dispatcher's `result_no_connector` call
+  (`operations/dispatcher.py`, connector-resolution step) to name
+  `target.product` and the version `resolve_target_version(target)`
+  read (which may be `None`), aligning `extras['product']` /
+  `extras['version']` to the target; it falls back to the connector_id
+  pair only when there is no target product to name. The register-time
+  reject (#1144) is unchanged; this is diagnosability-only.
 
 ## References
 


### PR DESCRIPTION
## Summary

- A target registered under a `product` no connector advertises (the classic
  `product: kubernetes` where the connector advertises `product: k8s`) misses
  at connector resolution on **every** dispatch. The residual `no_connector`
  error echoed the caller's `connector_id`-parsed `(product, version)` — e.g.
  `no implementation for product='k8s' version='1.x'` — i.e. the values the
  caller *passed*, not the target's product the resolver actually rejected.
  It read as "your `connector_id` is wrong" and sent the reporter chasing
  connector ids instead of the mis-registered target row.
- The fix names the **target's** registered product and the version the
  resolver read (which may be `None`) in the top-level `error` and aligns
  `extras['product']` / `extras['version']` to the target. It falls back to
  the `connector_id` pair only when there is no target product to name
  (e.g. an ingested op dispatched with `target=None`).
- Diagnosability-only. Register-time rejection of an unadvertised `product`
  already shipped (#1144); this is the Part B follow-on that makes the
  residual runtime failure name itself.
- `resolve_target_version` is promoted from private (`_resolve_target_version`)
  so the dispatcher names exactly the version the resolver saw, without
  duplicating the fingerprint-vs-operator-asserted priority logic.

## Test plan

- [x] New async dispatcher test `test_no_connector_error_names_target_product_not_connector_id`
      in the exact #2701 shape (connector_id product `k8s` ≠ target product
      `kubernetes`, descriptor lookup by `connector_id` succeeds, no connector
      advertises `kubernetes`). Asserts `error.startswith('no_connector:')`,
      `product='kubernetes'` in the error, `product='k8s'` **not** presented as
      the unsupported product, `version=None` (not the connector_id's `1.x`),
      and `extras['product'] == 'kubernetes'`. **Proven to fail on the
      pre-fix dispatcher and pass after** (reverted the call-site change and
      re-ran: 1 failed → restored → 3 passed).
- [x] `pytest tests/test_operations_dispatcher.py tests/test_operations_connector_error_redaction.py tests/test_connectors_resolver.py` — 96 passed
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (dispatcher, _errors, resolver, connectors/__init__) — Success, no issues
- [x] `docs/codebase/error-message-shape.md` updated — the #2701 note added as
      the Part B resolution of Signal 5 (the same `kubernetes`/`k8s` scenario
      already catalogued there).

## Alternative (needs human decision)

The core fix names the target's product (the DoD's non-breaking option a). Two
richer/more-invasive alternatives were deliberately **not** taken autonomously:

1. **"Did you mean 'k8s'?" near-match suggestion.** The issue asks for a
   suggestion clause. A string-distance near-match (`difflib`) against
   `registered_product_tokens()` does **not** catch the flagship case:
   `SequenceMatcher('kubernetes', 'k8s').ratio() ≈ 0.31`, well below any sane
   cutoff — `kubernetes`↔`k8s` is an abbreviation/alias relationship, not a
   typo. Delivering a real "did you mean 'k8s'?" needs a **curated alias map**
   (`kubernetes → k8s`), which is a new maintained data structure and a wider
   surface. Left out to keep this change surgical; easy to add on top if the
   team wants the alias table.

2. **Resolver alias / normalization so the mis-registered target actually
   resolves.** The issue floats "normalisation, a resolver alias set, or
   write-time rejection" as options. Making the resolver treat `kubernetes`
   as `k8s` would let the previously-broken row dispatch — a **behavior
   change**, not just a message change: it would silently repair (and thereby
   mask) a class of mis-registration that #1144 chose to reject loudly at
   write time. That is a policy call for a human, so it is out of scope here;
   this PR only makes the failure name itself.

## Out of scope

- **Part A — reject an unadvertised `product` at registration.** Already
  shipped in #1144 (`_canonicalise_and_validate_product` → structured 422
  `unknown_product`); untouched here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2701
