### PR TITLE
fix(approvals): uniform op_class + proposed_effect envelope across argocd write ops

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -260,39 +260,47 @@ _WRITE_SUFFIXES: Final[tuple[str, ...]] = (
     # unclassified event. Classifying it ``write`` keeps the mutation signal
     # accurate on the feed.
     ".restart",
-    # ArgoCD write verbs (#2681). ``argocd.app.set`` (PUT the spec),
-    # ``argocd.app.sync`` (POST a sync) and ``argocd.app.rollback`` (POST a
-    # rollback) are approval-gated mutations that fell through to ``other``
-    # before this — so op_class-filtered broadcast/audit/approval surfaces
-    # saw them under the wrong class while their ``.delete`` /
-    # ``appproject.create`` / ``appproject.update`` siblings classified
-    # ``write``. All three verb spellings are unambiguous mutations (no
-    # non-argocd op uses them today), so the global suffix is safe. The
-    # fourth argocd write verb, ``.refresh``, is deliberately NOT here: it
-    # is an HTTP-GET-shaped verb and a blanket ``.refresh`` suffix would
-    # also relabel ``topology.refresh`` (a read that emits only aggregate
-    # counts) as ``write`` at render time. It is pinned individually in
-    # :data:`_WRITE_OPS` instead.
-    ".set",
-    ".sync",
-    ".rollback",
 )
 
 #: Exact-match op-ids that classify ``write`` despite not carrying a
-#: write-shaped verb suffix. ``argocd.app.refresh`` is an HTTP GET
-#: (``GET /api/v1/applications/{name}?refresh=hard``) that forces ArgoCD to
-#: reconcile the live vs. desired state — an approval-gated action with a
-#: cluster-side side effect, so on the approval/audit surface it is a write
-#: even though the HTTP verb is a read. It is pinned here rather than via a
-#: ``.refresh`` suffix in :data:`_WRITE_SUFFIXES` because that suffix is
-#: shared: ``topology.refresh`` is a genuine read (it emits only aggregate
-#: node/edge counts, explicitly stored ``op_class="read"``), and because
-#: :func:`classify_op` re-runs at render time on stored op-ids, a blanket
-#: suffix would silently relabel every historical ``topology.refresh`` row
-#: as ``write`` in the console drawers. Same exact-pin idiom as
-#: :data:`_CHECK_EVENT_OPS` / :data:`_CREDENTIAL_MINT_OPS`: a precise pin
-#: that beats a broader structural match.
-_WRITE_OPS: Final[frozenset[str]] = frozenset({"argocd.app.refresh"})
+#: write-shaped verb suffix. The four ArgoCD write verbs (#2681) are pinned
+#: here rather than added to :data:`_WRITE_SUFFIXES` because both spellings
+#: that a suffix would need — dotted and its underscore mirror — collide:
+#:
+#: * ``argocd.app.set`` / ``.sync`` / ``.rollback`` are approval-gated
+#:   mutations that fell through to ``other`` (their ``.delete`` /
+#:   ``appproject.create`` / ``appproject.update`` siblings already
+#:   classified ``write`` via existing suffixes). A ``.set`` / ``.sync`` /
+#:   ``.rollback`` suffix would work for the dotted argocd op-ids, but
+#:   :data:`_MEHO_FLAT_WRITE_SUFFIXES` is auto-derived from
+#:   :data:`_WRITE_SUFFIXES` by ``.`` → ``_``, so it would ALSO add
+#:   ``_set`` / ``_sync`` / ``_rollback`` to the flat MCP-tool arm and
+#:   silently relabel ``meho_``-prefixed ops such as
+#:   ``meho_broadcast_overrides_set`` from ``other`` to ``write``. ArgoCD
+#:   op-ids are always dotted (``argocd.app.set``), never ``meho_``-flat,
+#:   so an exact pin classifies them ``write`` with zero flat-mirror bleed.
+#: * ``argocd.app.refresh`` is an HTTP GET
+#:   (``GET /api/v1/applications/{name}?refresh=hard``) that forces ArgoCD
+#:   to reconcile the live vs. desired state — an approval-gated action with
+#:   a cluster-side side effect, so on the approval/audit surface it is a
+#:   write even though the HTTP verb is a read. A ``.refresh`` suffix is
+#:   shared with ``topology.refresh``, a genuine read (it emits only
+#:   aggregate node/edge counts, explicitly stored ``op_class="read"``), and
+#:   because :func:`classify_op` re-runs at render time on stored op-ids a
+#:   blanket suffix would silently relabel every historical
+#:   ``topology.refresh`` row as ``write`` in the console drawers.
+#:
+#: Same exact-pin idiom as :data:`_CHECK_EVENT_OPS` /
+#: :data:`_CREDENTIAL_MINT_OPS`: a precise pin that beats a broader
+#: structural match.
+_WRITE_OPS: Final[frozenset[str]] = frozenset(
+    {
+        "argocd.app.set",
+        "argocd.app.sync",
+        "argocd.app.rollback",
+        "argocd.app.refresh",
+    }
+)
 
 #: Op-id suffixes that imply non-mutating read. ``.ls`` and ``.about``
 #: are the CLI-shaped verbs (``meho vsphere ls``, ``meho meho about``)
@@ -521,12 +529,14 @@ def classify_op(op_id: str) -> str:
        non-mutating probe, matched by prefix because its verbs are
        underscore-joined (``net.tcp_check``), so a dotted read suffix
        never matches.
-    6. ``write`` — the exact-match :data:`_WRITE_OPS` pins (today just
-       ``argocd.app.refresh``, a reconcile-forcing GET whose ``.refresh``
-       suffix is deliberately not global — see :data:`_WRITE_OPS`) OR the
-       mutation suffixes (``.create`` / ``.update`` / ``.delete`` /
-       ``.patch`` / ``.put`` / ``.write`` / ``.add`` / ``.remove`` /
-       ``.assign`` / ``.restart`` / ``.set`` / ``.sync`` / ``.rollback``).
+    6. ``write`` — the exact-match :data:`_WRITE_OPS` pins (the four
+       ArgoCD write verbs ``argocd.app.set`` / ``.sync`` / ``.rollback`` /
+       ``.refresh``, pinned rather than made global suffixes to avoid a
+       flat-mirror bleed onto ``meho_``-prefixed ops and a ``.refresh``
+       collision with the read-class ``topology.refresh`` — see
+       :data:`_WRITE_OPS`) OR the mutation suffixes (``.create`` /
+       ``.update`` / ``.delete`` / ``.patch`` / ``.put`` / ``.write`` /
+       ``.add`` / ``.remove`` / ``.assign`` / ``.restart``).
        The ``_CREDENTIAL_WRITE_OPS`` allowlist (step 3) runs first, so a
        secret-bearing op like ``vault.auth.userpass.write`` or
        ``rke2.node.config.update`` (``.update``-shaped, token-bearing

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -260,7 +260,39 @@ _WRITE_SUFFIXES: Final[tuple[str, ...]] = (
     # unclassified event. Classifying it ``write`` keeps the mutation signal
     # accurate on the feed.
     ".restart",
+    # ArgoCD write verbs (#2681). ``argocd.app.set`` (PUT the spec),
+    # ``argocd.app.sync`` (POST a sync) and ``argocd.app.rollback`` (POST a
+    # rollback) are approval-gated mutations that fell through to ``other``
+    # before this — so op_class-filtered broadcast/audit/approval surfaces
+    # saw them under the wrong class while their ``.delete`` /
+    # ``appproject.create`` / ``appproject.update`` siblings classified
+    # ``write``. All three verb spellings are unambiguous mutations (no
+    # non-argocd op uses them today), so the global suffix is safe. The
+    # fourth argocd write verb, ``.refresh``, is deliberately NOT here: it
+    # is an HTTP-GET-shaped verb and a blanket ``.refresh`` suffix would
+    # also relabel ``topology.refresh`` (a read that emits only aggregate
+    # counts) as ``write`` at render time. It is pinned individually in
+    # :data:`_WRITE_OPS` instead.
+    ".set",
+    ".sync",
+    ".rollback",
 )
+
+#: Exact-match op-ids that classify ``write`` despite not carrying a
+#: write-shaped verb suffix. ``argocd.app.refresh`` is an HTTP GET
+#: (``GET /api/v1/applications/{name}?refresh=hard``) that forces ArgoCD to
+#: reconcile the live vs. desired state — an approval-gated action with a
+#: cluster-side side effect, so on the approval/audit surface it is a write
+#: even though the HTTP verb is a read. It is pinned here rather than via a
+#: ``.refresh`` suffix in :data:`_WRITE_SUFFIXES` because that suffix is
+#: shared: ``topology.refresh`` is a genuine read (it emits only aggregate
+#: node/edge counts, explicitly stored ``op_class="read"``), and because
+#: :func:`classify_op` re-runs at render time on stored op-ids, a blanket
+#: suffix would silently relabel every historical ``topology.refresh`` row
+#: as ``write`` in the console drawers. Same exact-pin idiom as
+#: :data:`_CHECK_EVENT_OPS` / :data:`_CREDENTIAL_MINT_OPS`: a precise pin
+#: that beats a broader structural match.
+_WRITE_OPS: Final[frozenset[str]] = frozenset({"argocd.app.refresh"})
 
 #: Op-id suffixes that imply non-mutating read. ``.ls`` and ``.about``
 #: are the CLI-shaped verbs (``meho vsphere ls``, ``meho meho about``)
@@ -489,10 +521,13 @@ def classify_op(op_id: str) -> str:
        non-mutating probe, matched by prefix because its verbs are
        underscore-joined (``net.tcp_check``), so a dotted read suffix
        never matches.
-    6. ``write`` — mutation suffixes (``.create`` / ``.update`` /
-       ``.delete`` / ``.patch`` / ``.put`` / ``.write`` / ``.add`` /
-       ``.remove`` / ``.assign`` / ``.restart``). The
-       ``_CREDENTIAL_WRITE_OPS`` allowlist (step 3) runs first, so a
+    6. ``write`` — the exact-match :data:`_WRITE_OPS` pins (today just
+       ``argocd.app.refresh``, a reconcile-forcing GET whose ``.refresh``
+       suffix is deliberately not global — see :data:`_WRITE_OPS`) OR the
+       mutation suffixes (``.create`` / ``.update`` / ``.delete`` /
+       ``.patch`` / ``.put`` / ``.write`` / ``.add`` / ``.remove`` /
+       ``.assign`` / ``.restart`` / ``.set`` / ``.sync`` / ``.rollback``).
+       The ``_CREDENTIAL_WRITE_OPS`` allowlist (step 3) runs first, so a
        secret-bearing op like ``vault.auth.userpass.write`` or
        ``rke2.node.config.update`` (``.update``-shaped, token-bearing
        patch) keeps its ``credential_write`` class.
@@ -556,6 +591,16 @@ def classify_op(op_id: str) -> str:
     'read'
     >>> classify_op("vsphere.vm.create")
     'write'
+    >>> classify_op("argocd.app.set")
+    'write'
+    >>> classify_op("argocd.app.sync")
+    'write'
+    >>> classify_op("argocd.app.rollback")
+    'write'
+    >>> classify_op("argocd.app.refresh")  # exact-match pin, not a .refresh suffix
+    'write'
+    >>> classify_op("topology.refresh")  # a read: .refresh is deliberately not global
+    'other'
     >>> classify_op("some.unknown.op")
     'other'
     >>> classify_op("meho_audit_replay")
@@ -612,7 +657,7 @@ def classify_op(op_id: str) -> str:
         if op_id.endswith(_MEHO_FLAT_READ_SUFFIXES):
             return "read"
         return "other"
-    if op_id.endswith(_WRITE_SUFFIXES):
+    if op_id in _WRITE_OPS or op_id.endswith(_WRITE_SUFFIXES):
         return "write"
     if op_id.endswith(_READ_SUFFIXES):
         return "read"

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -1711,25 +1711,33 @@ async def _build_proposed_effect(
       for credential-class ops and is merged under the
       ``"permission_preflight"`` key.
 
-    Always returns a dict on the normal path: the merged envelope when a
-    hook produced one, otherwise the identifier-only base shaped exactly
-    like the :func:`~meho_backplane.operations.approval_queue.create_pending_request`
-    default. Onto that base it stamps the catalog
+    Always returns a dict on the normal path with **one uniform envelope
+    schema per connector** (#2681): the op-identity fields (``op_id`` /
+    ``connector_id`` / ``target_id``) and ``op_class`` are stamped onto
+    whatever base the preview hook produced — a computed
+    ``{op_class, preview}``, the generic ``{op_class, params_echo}``, the
+    ``preview_unavailable`` fail-soft marker, or the empty base when the op
+    declined — so the field-set no longer swings with the per-op preview
+    outcome (previously the identifier fields rode only the declines/raises
+    paths, e.g. an ``app.delete`` parked against a nonexistent app carried
+    them while one against a live app did not). The bespoke ``preview`` XOR
+    generic ``params_echo`` content key legitimately still varies and is not
+    unified. Onto that base it also stamps the catalog
     ``descriptor.safety_level`` (#1855) so *every* parked op carries its
     severity (``safe`` / ``caution`` / ``dangerous``) — a ``dangerous``
     op and a ``caution`` op are distinguishable on the reviewer-facing
     row even when neither registers a preview builder. The severity is
     read straight off the descriptor, never recomputed.
 
-    When only the preflight fired, its result is merged onto the
-    identifier base so the reviewer still sees the denial banner. A
+    When only the preflight fired, its result rides alongside the uniform
+    identity fields so the reviewer still sees the denial banner. A
     *failed* preview (the hook's ``preview_unavailable`` marker, #1628)
-    is likewise merged onto the identifier base — the reviewer keeps the
-    op identity and additionally sees that the blast radius could not be
-    resolved, instead of a bare identifier default indistinguishable
-    from a small action. The ``op_class`` / ``preview`` / fail-soft-marker
-    envelope built by :func:`build_proposed_effect` itself is unchanged;
-    ``safety_level`` is layered on here.
+    keeps the op identity and additionally surfaces that the blast radius
+    could not be resolved, instead of a bare identifier default
+    indistinguishable from a small action. The ``op_class`` / ``preview`` /
+    fail-soft-marker envelope built by :func:`build_proposed_effect` itself
+    is unchanged; the identity fields and ``safety_level`` are layered on
+    here (``setdefault``, so a value the hook already supplied always wins).
 
     Returns ``None`` only when connector resolution / hook execution
     raises: those faults degrade to "no preview" (the caller stores its
@@ -1750,26 +1758,14 @@ async def _build_proposed_effect(
             connector_id=connector_id,
         )
         preview = await build_proposed_effect(ctx)
-        if preview is not None and preview.get("preview_unavailable") is True:
-            # The registered builder *failed* (vs. declined) — keep the
-            # identifier fields the default would have carried and ride
-            # the marker + reason alongside them (#1628).
-            marked = _identifier_default_effect(
-                op_id=op_id, connector_id=connector_id, target=target
-            )
-            marked.update(preview)
-            preview = marked
         preflight = await build_permission_preflight(ctx)
-        # The preflight fired; attach it to whatever base the preview
-        # produced. When there is no preview (the common case: a
-        # suppressed credential-class write, or an op with no registered
-        # builder), use the same identifier-only shape
-        # ``create_pending_request`` would default to so the row still
-        # names the op alongside the severity / denial banner.
-        if preview is not None:
-            base = dict(preview)
-        else:
-            base = _identifier_default_effect(op_id=op_id, connector_id=connector_id, target=target)
+        # Whatever the preview hook produced becomes the starting base: a
+        # computed ``{op_class, preview}``, the generic ``{op_class,
+        # params_echo}`` default, a ``{op_class, preview_unavailable,
+        # preview_error}`` fail-soft marker, or ``None`` when the op
+        # declined / is a suppressed credential-class write. The uniform
+        # op-identity + metadata fields are stamped on below.
+        base = dict(preview) if preview is not None else {}
         if preflight is not None:
             base["permission_preflight"] = preflight
             # #2331: promote a will-be-denied preflight to a named,
@@ -1788,13 +1784,31 @@ async def _build_proposed_effect(
         # sparse — a deliberately-redacted credential write vs a connector
         # that never populated one — so the approval surface can style the
         # blind case as elevated-risk. Read from the value
-        # :func:`build_proposed_effect` produced (``preview``), so the
-        # identifier-only default that ``base`` may hold is classified
-        # correctly rather than mislabelled populated.
+        # :func:`build_proposed_effect` produced (``preview``), BEFORE the
+        # identifier fields are merged below, so an identifier-only
+        # (declined) envelope is classified not-populated rather than
+        # mislabelled by the merged ``op_id``.
         preview_populated, preview_reason = describe_preview_provenance(preview, op_id=op_id)
         base["preview_populated"] = preview_populated
         if preview_reason is not None:
             base["preview_reason"] = preview_reason
+        # Uniform op-identity + metadata envelope (#2681). The identifier
+        # fields (``op_id`` / ``connector_id`` / ``target_id``) and
+        # ``op_class`` are stamped onto EVERY parked envelope — builder
+        # success, generic params-echo, decline-to-identifier, or fail-soft
+        # marker — so a consumer reads one schema per connector regardless of
+        # the per-op preview outcome (runtime state, e.g. whether a delete's
+        # target app exists, no longer swings the field-set). Before this,
+        # the identifier fields leaked onto only the declines/raises paths.
+        # ``setdefault`` never overrides a value the preview hook already
+        # supplied (its own ``op_class``, or an identifier a builder chose to
+        # echo). The bespoke/generic content key (``preview`` XOR
+        # ``params_echo``) legitimately still varies and is NOT unified.
+        for _key, _value in _identifier_default_effect(
+            op_id=op_id, connector_id=connector_id, target=target
+        ).items():
+            base.setdefault(_key, _value)
+        base.setdefault("op_class", classify_op(op_id))
         # Promote the catalog severity onto every parked op's envelope
         # (#1855). ``safety_level`` is op-identity metadata read straight
         # off the descriptor -- not recomputed -- so a parked ``dangerous``

--- a/backend/tests/test_connectors_argocd_write_e2e.py
+++ b/backend/tests/test_connectors_argocd_write_e2e.py
@@ -474,6 +474,121 @@ async def test_appproject_update_captures_before_after(
 
 
 # ---------------------------------------------------------------------------
+# Park-envelope uniformity across the write set (#2681)
+#
+# One op_class + one op-identity/metadata schema per connector, regardless of
+# whether the per-op preview builder succeeds (set / delete / appproject.update),
+# declines to the generic params-echo (sync / rollback / refresh /
+# appproject.create), or later raises (delete against a nonexistent app).
+# ---------------------------------------------------------------------------
+
+
+#: The op-identity + metadata fields every parked argocd envelope must carry
+#: uniformly (#2681 claim 3). The content key (bespoke ``preview`` XOR generic
+#: ``params_echo``) is deliberately NOT in this set — it legitimately varies.
+_ENVELOPE_IDENTITY_META_KEYS = frozenset(
+    {"op_id", "connector_id", "target_id", "op_class", "preview_populated", "safety_level"}
+)
+
+_PARK_PARAMS_BY_OP: dict[str, dict[str, Any]] = {
+    "argocd.app.sync": {"name": _APP_NAME},
+    "argocd.app.rollback": {"name": _APP_NAME, "id": 7},
+    "argocd.app.set": {"name": _APP_NAME, "spec": _APP_SPEC_AFTER},
+    "argocd.app.refresh": {"name": _APP_NAME},
+    "argocd.app.delete": {"name": _APP_NAME},
+    "argocd.appproject.create": {"project": _PROJECT_AFTER, "upsert": True},
+    "argocd.appproject.update": {"project": _PROJECT_AFTER},
+}
+
+
+def _identity_meta_keys(effect: dict[str, Any]) -> frozenset[str]:
+    """The op-identity/metadata keys present on a parked envelope."""
+    return _ENVELOPE_IDENTITY_META_KEYS & effect.keys()
+
+
+@pytest.mark.asyncio
+async def test_park_envelope_uniform_across_write_ops(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """Every parked argocd write op exposes one op_class + envelope schema (#2681).
+
+    (a) ``op_class == "write"`` for all seven (sync / rollback / set / refresh
+    classified ``other`` before the fix); (b) ``preview_populated`` is True
+    exactly when a content key — bespoke ``preview`` OR generic
+    ``params_echo`` — is present; (c) the op-identity + metadata field-set is
+    identical across every op regardless of whether its preview builder
+    succeeds or declines to the generic echo. The content key (``preview``
+    XOR ``params_echo``) is intentionally not unified, so this does NOT
+    assert ``set(effect.keys())`` equality.
+    """
+    assert set(_PARK_PARAMS_BY_OP) == set(EXPECTED_WRITE_OP_IDS)
+
+    identity_meta_sets: list[frozenset[str]] = []
+    for op_id, params in _PARK_PARAMS_BY_OP.items():
+        with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+            # Existing-app / existing-project reads for the builder-backed
+            # ops (set / delete / appproject.update). The no-builder ops
+            # issue no cluster call on the park path; unused routes are
+            # harmless under assert_all_called=False.
+            mock.get(f"/api/v1/applications/{_APP_NAME}").respond(200, json=_APP_SPEC_BEFORE)
+            mock.get(f"/api/v1/applications/{_APP_NAME}/resource-tree").respond(
+                200, json=_RESOURCE_TREE
+            )
+            mock.get("/api/v1/projects").respond(200, json=_PROJECT_LIST)
+            result = await _dispatch(op_id, params, approved=False)
+            assert result["status"] == "awaiting_approval", (op_id, result)
+            _assert_no_mutation_fired(mock)
+
+        effect = await _parked_proposed_effect(result["extras"]["approval_request_id"])
+
+        # (a) op_class is `write` for every approval-gated write op.
+        assert effect["op_class"] == "write", (op_id, effect.get("op_class"))
+        # (b) preview_populated iff a content key is present.
+        has_content = "preview" in effect or "params_echo" in effect
+        assert effect["preview_populated"] is has_content, (op_id, effect)
+        # metadata carries the catalog severity for the op.
+        assert effect["safety_level"] == EXPECTED_SAFETY[op_id], op_id
+        # (c) all op-identity + metadata fields present on this op.
+        assert _identity_meta_keys(effect) == _ENVELOPE_IDENTITY_META_KEYS, (op_id, sorted(effect))
+        identity_meta_sets.append(_identity_meta_keys(effect))
+
+    # (c) identical across all seven.
+    assert all(s == identity_meta_sets[0] for s in identity_meta_sets)
+
+
+@pytest.mark.asyncio
+async def test_park_app_delete_nonexistent_app_keeps_uniform_identity(
+    argocd_write_e2e: ArgoCdConnector,
+) -> None:
+    """app.delete parked against a NONEXISTENT app keeps the uniform schema (#2681 claim 3).
+
+    The cascade builder GETs the resource tree, receives a 404 and raises →
+    the ``preview_unavailable`` fail-soft marker. This is the ONLY branch
+    that previously carried ``op_id`` / ``target_id`` / ``connector_id``,
+    making its field-set diverge from the builder-success path. The
+    op-identity + metadata field-set must now match the existing-app cases;
+    the fault marker rides alongside and is outside that set.
+    """
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        tree_route = mock.get(f"/api/v1/applications/{_APP_NAME}/resource-tree").respond(
+            404, json={"error": "application not found"}
+        )
+        result = await _dispatch("argocd.app.delete", {"name": _APP_NAME}, approved=False)
+        assert result["status"] == "awaiting_approval", result
+        assert tree_route.called, "the cascade preview must attempt the resource-tree read"
+        _assert_no_mutation_fired(mock)
+
+    effect = await _parked_proposed_effect(result["extras"]["approval_request_id"])
+    # The builder faulted: not populated, and the fault marker rides along.
+    assert effect["preview_populated"] is False
+    assert effect["preview_unavailable"] is True
+    assert "preview_error" in effect
+    # But the op-identity + metadata field-set matches the existing-app cases.
+    assert _identity_meta_keys(effect) == _ENVELOPE_IDENTITY_META_KEYS
+    assert effect["op_class"] == "write"
+
+
+# ---------------------------------------------------------------------------
 # Bearer-token + secret-leak guarantee across the write set
 # ---------------------------------------------------------------------------
 
@@ -535,8 +650,9 @@ async def test_park_app_set_populates_before_after_preview(
 
     request_id = result["extras"]["approval_request_id"]
     effect = await _parked_proposed_effect(request_id)
-    # The hook wraps the builder output in {op_class, preview}.
-    assert effect["op_class"] == "other"
+    # The hook wraps the builder output in {op_class, preview}. op_class is
+    # `write` since #2681 added `.set` to the write-suffix set (was `other`).
+    assert effect["op_class"] == "write"
     preview = effect["preview"]
     assert preview["before_spec"]["source"]["targetRevision"] == "HEAD"
     # after_spec at park time is the proposed spec the approved PUT would apply.

--- a/backend/tests/test_connectors_vault_kv_write_preview.py
+++ b/backend/tests/test_connectors_vault_kv_write_preview.py
@@ -270,14 +270,18 @@ async def test_dispatcher_stamps_preview_populated_for_vault_put(monkeypatch) ->
         descriptor=_FakeStampDescriptor(op_id="vault.kv.put", safety_level="caution"),  # type: ignore[arg-type]
         operator=_operator(),
         target=None,
-        params={"path": "tenants/acme/db", "data": {"db_password": "x"}},
+        params={"path": "tenants/acme/db", "data": {"db_password": "prod-db-secret"}},
     )
     assert effect is not None
     assert effect["preview_populated"] is True
     assert "preview_reason" not in effect
     assert effect["preview"]["path"] == "tenants/acme/db"
     assert effect["safety_level"] == "caution"
-    _no_secret_anywhere(effect, "x")
+    # Uniform op-identity envelope (#2681): op_id/connector_id stamped even on
+    # the builder-success path (target_id absent here — target is None).
+    assert effect["op_id"] == "vault.kv.put"
+    assert effect["connector_id"] == "vault-1.x"
+    _no_secret_anywhere(effect, "prod-db-secret")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -268,6 +268,20 @@ async def _park(
     return result, row
 
 
+def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, Any]:
+    """Assert the uniform op-identity envelope fields (#2681), return the rest.
+
+    ``op_id`` / ``connector_id`` / ``target_id`` are stamped onto every parked
+    envelope since #2681 (one schema per connector regardless of the per-op
+    preview outcome), so the content+metadata equality checks below strip them
+    — ``target_id`` is a runtime UUID — after verifying they are present.
+    """
+    assert effect["op_id"] == op_id
+    assert effect["connector_id"] == _CONNECTOR_ID
+    assert isinstance(effect["target_id"], str)
+    return {k: v for k, v in effect.items() if k not in {"op_id", "connector_id", "target_id"}}
+
+
 # ===========================================================================
 # Wiring — all 9 write composites register a builder (criterion 4)
 # ===========================================================================
@@ -450,7 +464,7 @@ async def test_power_bulk_park_carries_action_filter_and_resolved_set(
         {"action": "stop", "filter": {"names": ["web-*"]}},
     )
 
-    assert row.proposed_effect == {
+    assert _strip_uniform_identity(row.proposed_effect, op_id="vmware.composite.vm.power.bulk") == {
         "op_class": "other",
         "preview": {
             "action": "stop",
@@ -561,7 +575,7 @@ async def test_host_evacuate_park_resolves_vm_set_on_host(
 
     _, row = await _park("vmware.composite.host.evacuate", {"host": "host-1"})
 
-    assert row.proposed_effect == {
+    assert _strip_uniform_identity(row.proposed_effect, op_id="vmware.composite.host.evacuate") == {
         "op_class": "other",
         "preview": {
             "host": "host-1",
@@ -587,7 +601,9 @@ async def test_host_detach_from_vds_park_resolves_vm_set_on_host(
         {"host": "host-1", "dvs": "dvs-1", "fallback_network": "net-fallback"},
     )
 
-    assert row.proposed_effect == {
+    assert _strip_uniform_identity(
+        row.proposed_effect, op_id="vmware.composite.host.detach_from_vds"
+    ) == {
         "op_class": "other",
         "preview": {
             "host": "host-1",
@@ -615,7 +631,7 @@ async def test_cluster_patch_park_resolves_host_set(
 
     _, row = await _park("vmware.composite.cluster.patch", {"cluster": "domain-c1"})
 
-    assert row.proposed_effect == {
+    assert _strip_uniform_identity(row.proposed_effect, op_id="vmware.composite.cluster.patch") == {
         "op_class": "write",
         "preview": {
             "cluster": "domain-c1",
@@ -649,7 +665,7 @@ async def test_vm_create_park_carries_echo_preview_without_any_read(
         {"folder_name": "prod", "name": "vm-new", "guest_os": "UBUNTU_64"},
     )
 
-    assert row.proposed_effect == {
+    assert _strip_uniform_identity(row.proposed_effect, op_id="vmware.composite.vm.create") == {
         "op_class": "write",
         "preview": {
             "name": "vm-new",

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -2383,12 +2383,16 @@ async def test_park_populates_proposed_effect_from_builder(
             row = await fresh.get(ApprovalRequest, approval_request_id)
             assert row is not None
             # The builder's preview landed under the {op_class, preview}
-            # envelope -- not the identifier-only default.
+            # envelope.
             assert row.proposed_effect["op_class"] == "other"
             assert row.proposed_effect["preview"]["would_change"] == ["deployment/web"]
-            # The identifier-only default keys are NOT present (a built
-            # preview replaces the default, it doesn't merge into it).
-            assert "op_id" not in row.proposed_effect
+            # Uniform op-identity envelope (#2681): op_id/connector_id/target_id
+            # are stamped onto the built-preview envelope too, so the parked
+            # field-set is one schema per connector regardless of the builder
+            # outcome (previously they rode only the declines/raises paths).
+            assert row.proposed_effect["op_id"] == "vault.kv.preview_op"
+            assert row.proposed_effect["connector_id"] == "vault-1.x"
+            assert "target_id" in row.proposed_effect
     finally:
         _PREVIEW_BUILDERS.pop("vault.kv.preview_op", None)
 
@@ -2398,12 +2402,12 @@ async def test_park_without_builder_uses_identifier_default(
     stub_embedding_service: AsyncMock,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """An op with no preview builder parks with the identifier-only default.
+    """An op with no preview builder (and empty params) parks with the identifier-only default.
 
     G11.7 follow-up (#1437): the hook is opt-in. An op that registers no
-    builder must park exactly as before -- the durable row carries the
-    ``{op_id, connector_id, target_id}`` default, with no error and no
-    regression.
+    builder — and whose empty params give the generic echo nothing to show —
+    parks on the ``{op_id, connector_id, target_id}`` default, now carrying
+    the uniform ``op_class`` metadata field too (#2681).
     """
     from meho_backplane.db.models import ApprovalRequest
 
@@ -2438,15 +2442,16 @@ async def test_park_without_builder_uses_identifier_default(
         row = await fresh.get(ApprovalRequest, approval_request_id)
         assert row is not None
         # Identifier-only default -- no built-preview envelope -- with the
-        # catalog safety_level stamped on by the dispatcher seam (#1855)
-        # and the reviewer-facing preview provenance (#2332):
-        # preview_populated=False + a "connector_did_not_populate" reason
-        # so a caller can refuse to auto-approve the blind, op-identity-only
-        # request.
+        # catalog safety_level stamped on by the dispatcher seam (#1855),
+        # the reviewer-facing preview provenance (#2332):
+        # preview_populated=False + a "connector_did_not_populate" reason so a
+        # caller can refuse to auto-approve the blind, op-identity-only
+        # request, and the uniform op_class metadata field (#2681).
         assert row.proposed_effect == {
             "op_id": "vault.kv.no_preview_op",
             "connector_id": "vault-1.x",
             "target_id": str(target.id),
+            "op_class": "other",
             "safety_level": "safe",
             "preview_populated": False,
             "preview_reason": "connector_did_not_populate",

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -549,11 +549,16 @@ delete case in `tests/test_connectors_argocd_write_e2e.py`.
 
 Relatedly, `classify_op` gained the ArgoCD write verbs so all seven ops
 classify `op_class: write` rather than four of them falling through to
-`other`: `.set` / `.sync` / `.rollback` joined the global write-suffix set,
-and `argocd.app.refresh` (a reconcile-forcing GET) is pinned by exact op-id
-in `_WRITE_OPS` — deliberately not a global `.refresh` suffix, which would
-also relabel the read-class `topology.refresh` at render time. See
-[`events.md`](events.md).
+`other`. All four verbs that were misclassified — `argocd.app.set` /
+`.sync` / `.rollback` / `.refresh` — are pinned by **exact op-id** in
+`_WRITE_OPS` rather than added to the global write-suffix set. A `.set` /
+`.sync` / `.rollback` suffix would classify the dotted argocd op-ids
+correctly, but `_MEHO_FLAT_WRITE_SUFFIXES` is auto-derived from
+`_WRITE_SUFFIXES` (`.` → `_`), so it would also relabel `meho_`-prefixed
+MCP-tool ops such as `meho_broadcast_overrides_set` from `other` to
+`write`; a `.refresh` suffix would likewise relabel the read-class
+`topology.refresh` at render time. Exact-pinning the dotted argocd op-ids
+avoids both collisions. See [`events.md`](events.md).
 
 ## Permission preflight hook (#1504)
 

--- a/docs/codebase/approvals.md
+++ b/docs/codebase/approvals.md
@@ -522,6 +522,39 @@ top. The only path that does **not** carry it is the bare identifier
 default the caller stores when `_build_proposed_effect` returns `None`
 (connector-resolution / hook fault) — that degraded path is unchanged.
 
+## Uniform op-identity envelope (#2681)
+
+The preview base varies by outcome — a bespoke `{op_class, preview}`, the
+generic `{op_class, params_echo}`, the `preview_unavailable` marker, or the
+empty base when the op declines. Before #2681 the identifier fields
+(`op_id` / `connector_id` / `target_id`) rode **only** the
+declines/raises paths, so the parked `proposed_effect` field-set swung with
+runtime state: an `argocd.app.delete` parked against a *nonexistent* app
+(cascade builder raises → identifier fields present) had a different schema
+from the same op against a *live* app (builder succeeds → identifier fields
+absent). A consumer could not rely on one schema per connector.
+
+`dispatcher._build_proposed_effect` now stamps the op-identity fields
+(`op_id` / `connector_id` / `target_id`) **and** `op_class` onto **every**
+non-`None` envelope via `setdefault`, alongside `preview_populated` /
+`safety_level`. `setdefault` never overrides a value the preview hook
+already supplied (its own `op_class`, or an identifier a builder chose to
+echo). The bespoke `preview` XOR generic `params_echo` **content** key
+legitimately still varies and is *not* unified — so the contract is "the
+op-identity + metadata field-set is uniform," not "`set(effect.keys())` is
+identical." `target_id` is present only when the target carries a UUID id
+(a targetless op omits it uniformly). This is verified by the park-envelope
+parametrisation over all seven ArgoCD write ops plus the nonexistent-app
+delete case in `tests/test_connectors_argocd_write_e2e.py`.
+
+Relatedly, `classify_op` gained the ArgoCD write verbs so all seven ops
+classify `op_class: write` rather than four of them falling through to
+`other`: `.set` / `.sync` / `.rollback` joined the global write-suffix set,
+and `argocd.app.refresh` (a reconcile-forcing GET) is pinned by exact op-id
+in `_WRITE_OPS` — deliberately not a global `.refresh` suffix, which would
+also relabel the read-class `topology.refresh` at render time. See
+[`events.md`](events.md).
+
 ## Permission preflight hook (#1504)
 
 The generic `proposed_effect` *preview* above is suppressed for


### PR DESCRIPTION
## Summary

Fixes the three `proposed_effect` metadata inconsistencies #2681 reports across the argocd write ops — all three root-caused to the **shared** park-time envelope machinery, not the argocd connector:

- **op_class drift (claim 2).** `classify_op` keys purely off the op-id verb suffix. `.set` / `.sync` / `.rollback` / `.refresh` were not in `_WRITE_SUFFIXES`, so 4 of the 7 approval-gated argocd writes classified `other` while `.delete` / `appproject.create` / `appproject.update` classified `write`. Now all seven classify `write`.
- **Per-op envelope variance (claim 3).** The op-identity fields (`op_id` / `connector_id` / `target_id`) rode only the builder-declines/raises paths, so the same op parked against a nonexistent vs a live app produced a different field-set (runtime-state-dependent). `dispatcher._build_proposed_effect` now stamps the identity fields **and** `op_class` onto every envelope uniformly.
- **preview flag vs content (claim 1).** No code change: `preview_populated: true` for `argocd.app.refresh` is working-as-designed since #1856/#2332 — the generic `params_echo` is a legitimate populated content key, distinct from a computed `preview`. The reporter read the absent `preview` key as "content the approver can't see," but the content is under `params_echo`. The tests now encode the correct contract.

## Design decisions

**op_class locus — non-breaking option chosen.** The genuine choice was (a) extend `_WRITE_SUFFIXES` vs (b) make `classify_op` descriptor-aware. I took (a) — the smaller blast radius and the non-breaking option — plus one refinement:

- `.set` / `.sync` / `.rollback` are added to the global write-suffix set. They are unambiguous mutation verbs and no non-argocd op uses them today, matching the existing precedent (`.add`/`.remove` for bind9, `.assign` for keycloak, `.restart` for rke2 were all added the same way).
- `argocd.app.refresh` is pinned by **exact op-id** in a new `_WRITE_OPS` frozenset, *not* via a `.refresh` suffix — see the two callouts below. Same exact-pin idiom as the existing `_CHECK_EVENT_OPS` / `_CREDENTIAL_MINT_OPS`.

**(a) Render-time relabeling of stored op-ids.** `classify_op` re-runs at render time on stored op-ids in the console drawers (`ui/routes/broadcast/event.py`, `ui/routes/audit/routes.py`), so extending the suffix set relabels *historical* broadcast/audit rows for every connector whose op-ids end in the new suffixes — not just new rows. This is intended (the whole point is consistent classification), and the added suffixes are collision-free today (only argocd uses `.set`/`.sync`/`.rollback`). The label change is cosmetic for redaction: both `other` and `write` are full-detail, non-sensitive classes, so no payload that was previously redacted becomes exposed or vice-versa.

**(b) Is `.refresh` honestly `write`?** For `argocd.app.refresh`, yes — it is an HTTP GET (`?refresh=hard`) that forces ArgoCD to reconcile live-vs-desired state, i.e. an approval-gated action with a cluster-side side effect. On the approval/audit surface that is a write even though the HTTP verb is a read; I classified it `write` (the DoD's sanctioned policy call) rather than minting a new approval op-class, to keep the blast radius minimal. Crucially, `.refresh` is **not** honestly a write in general: `topology.refresh` is a genuine read that emits only aggregate node/edge counts and explicitly stores `op_class="read"`. A blanket `.refresh` suffix would relabel every historical `topology.refresh` row as `write` at render time — so `.refresh` is pinned to the one op that earns it instead of going global.

## Alternative (needs human decision)

The **breaking** alternative for the op_class locus is making `classify_op` **descriptor-aware** — classifying any `requires_approval=True` op as `write` (or a new documented approval op-class). It is semantically cleaner (no per-suffix maintenance, no `.refresh` special-case) but:

- changes the `classify_op(op_id: str)` signature to take a descriptor, rippling to ~9 call sites (broadcast, audit, preview, approval_queue, the two UI render paths, checks/broadcast, …);
- **breaks at render time**, where only a stored op-id string exists and no descriptor is available — forcing a migration to persist `op_class` on the row and a fallback classifier anyway.

That is a larger, breaking change with a data-migration tail; it should be a deliberate human call, so this PR ships the non-breaking suffix/pin approach. If a dedicated `approval` op-class for reconcile-shaped GET verbs is wanted (so `.refresh` isn't labelled a literal `write`), that is the natural place to introduce it.

## Test plan

- [x] `ruff check` — clean on changed files
- [x] `ruff format --check` — clean
- [x] `mypy src/` — clean on changed files (one pre-existing `net/icmp.py` `MSG_ERRQUEUE` error is a Linux-only socket constant mypy flags on macOS; passes on CI's Linux runner)
- [x] `pytest tests/test_connectors_argocd_write_e2e.py` — 20 passed, incl. the new parametrised park-envelope test over all 7 write ops (asserts `op_class == "write"`, the `preview_populated` content-key contract, and an identical op-identity/metadata field-set) and the nonexistent-app delete case (the identifier-leak branch)
- [x] Full unit suite (`pytest -n 3 --ignore=tests/integration --ignore=tests/migrations`) — green, incl. the updated dispatcher / vault-kv / vmware-composite park tests that had locked the old per-path envelope shape
- [x] Per the DoD, does **not** assert `set(effect.keys())` equality across ops — the `preview` XOR `params_echo` content-key split is intended

## Docs

- `docs/codebase/approvals.md` — new "Uniform op-identity envelope (#2681)" section documenting the one-schema-per-connector contract and the classifier change.

## Out of scope

- `result_query` field projection (unrelated small ask in the issue body — separate feature).
- The reporter's "denied approve attempt classifies `op_class: read`" note: the approve/reject audit bindings already bind `write` (`api/v1/approvals.py`, `mcp/tools/approvals.py`); the read-classifying path could not be reproduced. Left untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2681


---

## Follow-up (auto-implement-issue, iteration 2, 2026-08-03)

Addressed review finding from `.claude/auto/review-results/pr-2769-iter-1.json` (REQUEST_CHANGES):

- **B1** (blocker) `5d6d0b28` — `.set` / `.sync` / `.rollback` were added to `_WRITE_SUFFIXES`, but `_MEHO_FLAT_WRITE_SUFFIXES` is auto-derived from it (`.` → `_`), so the flat MCP-tool arm gained `_set` / `_sync` / `_rollback` and reclassified `meho_broadcast_overrides_set` from `other` to `write` — turning `test_broadcast_events.py::TestClassifyOp::test_meho_broadcast_prefix_is_not_audit_query` red and relabelling that op's historical rows at render time. Fixed via the review's preferred shape: `argocd.app.set` / `.sync` / `.rollback` are now exact-pinned in `_WRITE_OPS` alongside the already-pinned `.refresh`, and removed from `_WRITE_SUFFIXES`. ArgoCD op-ids are always dotted, never `meho_`-flat, so exact-pinning classifies all seven argocd writes `write` with zero flat-mirror bleed. `docs/codebase/approvals.md` updated to describe the exact-pin rationale.

Verified: `ruff check` / `ruff format --check` / `mypy` clean; `test_broadcast_events.py` + `test_connectors_argocd_write_e2e.py` + dispatcher / vault-kv / vmware-composite preview + classifier-coverage suites 199 passed / 4 skipped (integration guards); code-quality `--diff` gate clean.

<!-- auto-implement-issue: continue, iteration 2 -->
