### PR TITLE
docs: relabel stale audit-replay capture_mode "always" → "when_negotiated" (#2700 follow-up)

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -223,9 +223,9 @@ docker logout ghcr.io && docker pull ghcr.io/evoila/meho:main    # -> succeeds
   unconditional. Pre-G0.15-T4 deploys (≤ v0.7.0) captured the header
   but never issued one, so audit rows from MCP clients that wait for
   a server-assigned id (the spec-compliant default) landed
-  `agent_session_id: null` regardless of the `capture_mode: "always"`
+  `agent_session_id: null` regardless of the `capture_mode: "when_negotiated"`
   advertisement; v0.7.1+ closes this gap. To confirm the deploy is
-  in the expected capture mode (`always` by default; `enforced` when
+  in the expected capture mode (`when_negotiated` by default; `enforced` when
   `MCP_REQUIRE_SESSION_ID=true`), inspect
   `GET /api/v1/health`'s `mcp_session_id_capture` field.
 
@@ -285,7 +285,7 @@ Walk the four gates in the order an operator hits them:
   (which also flips a missing header into a `-32600` reject before
   dispatch). The `/ready` `features.audit_replay.capture_mode` field
   exposes the current state — `"enforced"` pre-T6,
-  `"always"` post-T6. Operators tracking the audit-replay readiness
+  `"when_negotiated"` post-T6. Operators tracking the audit-replay readiness
   signal off `/ready` get a stable contract across the T6 transition.
   G0.15-T4 (#1213) added the **issuance** half — the server now
   emits `Mcp-Session-Id` on `initialize` per MCP 2025-06-18
@@ -293,7 +293,7 @@ Walk the four gates in the order an operator hits them:
   back on the capture side. Without issuance (≤ v0.7.0), spec-
   conforming MCP clients never sent the header and every row landed
   with `agent_session_id: null` despite `capture_mode` advertising
-  `"always"`; v0.7.1+ closes the inert-promise regression.
+  `"when_negotiated"`; v0.7.1+ closes the inert-promise regression.
 
 - [ ] **Approval queue** (agent-grant approval surface;
   `POST /api/v1/agents/grants` and the agent grant lifecycle). No
@@ -350,7 +350,7 @@ curl -s "https://<your-meho-host>/ready" | jq '.features'
 ```
 
 Every gate should read `"configured": true` (or
-`"capture_mode": "always"` for `audit_replay` post-T6) when fully
+`"capture_mode": "when_negotiated"` for `audit_replay` post-T6) when fully
 enabled. Any `"configured": false` with a non-empty `missing_env`
 list is an unfinished provisioning step — name the listed env vars
 into the pod's environment and re-deploy.
@@ -433,7 +433,7 @@ and whenever the migration Job or the `db` probe changes:
 [ ] 6. Deployed to rke2-infra; smoke-green
 [ ] 6a. Post-deploy enablement — for each gate in /ready features:
         configure the env vars per the cited Vault doc; verify gate
-        flips to configured (or capture_mode=always for audit_replay
+        flips to configured (or capture_mode=when_negotiated for audit_replay
         post-T6)
 [ ] 6b. Rollback drill (releases carrying a migration): broken-readiness
         upgrade auto-rolls-back; rolled-back pods reach Ready with

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -42,7 +42,7 @@ Per the spec's *Session Management* section, a server MAY assign a session id at
 - The dispatched response is HTTP 2xx **and** the JSON-RPC envelope has no `error` member — a failed initialize must not seed a session id.
 - The client did not already send an `Mcp-Session-Id` header inbound (a resume / replay attempt where the client carries an id is accepted lenient; MEHO does not overwrite the client's correlation key).
 
-Before G0.15-T4 #1213, MEHO captured the header end of the chain but never issued one. The visible symptom (`claude-rdc-hetzner-dc#753` finding 2) was every Claude Code MCP audit row landing with `agent_session_id: null` despite [`meho_status`](../../backend/src/meho_backplane/api/v1/health.py) / [`/ready.features.audit_replay.capture_mode`](../../backend/src/meho_backplane/api/v1/health.py) advertising `"always"` — both surfaces correctly reported the **capture** config; nothing populated the column because no client had a server-assigned session id to send back.
+Before G0.15-T4 #1213, MEHO captured the header end of the chain but never issued one. The visible symptom (`claude-rdc-hetzner-dc#753` finding 2) was every Claude Code MCP audit row landing with `agent_session_id: null` despite [`meho_status`](../../backend/src/meho_backplane/api/v1/health.py) / [`/ready.features.audit_replay.capture_mode`](../../backend/src/meho_backplane/api/v1/health.py) advertising `"when_negotiated"` — both surfaces correctly reported the **capture** config; nothing populated the column because no client had a server-assigned session id to send back.
 
 **Capture side.** On every `POST /mcp`, [`_bind_mcp_session_id`](../../backend/src/meho_backplane/mcp/server.py) binds an `mcp_session_id` structlog contextvar (G8.2-T2 #1010):
 

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -506,7 +506,7 @@ parity with the ``/api/v1/*`` chassis path and the MCP transport path.
   of the session walk naturally (no synthetic per-call uuid4 polluting
   the search). Operators can confirm the deploy's mode at
   `GET /api/v1/health`'s `mcp_session_id_capture` field
-  (`"always"` / `"enforced"`).
+  (`"when_negotiated"` / `"enforced"`).
 
 * **`op_id` / `op_class` glob filtering is JSON-path-based.** On PostgreSQL
   the `payload->>'op_id'` lookup runs over the JSONB column without an index


### PR DESCRIPTION
Closes #2773.

Docs-only. #2700 (via #2768) renamed the audit-replay `mcp_session_id_capture` value from the misleading `"always"` to `"when_negotiated"` on `/status` + `/ready` (`server.py:768`), but eight docs sites still narrated the old label. This relabels all of them: `docs/RELEASING.md` (6 sites), `docs/architecture/mcp.md` (1), `docs/codebase/audit_query.md` (1).

**Left intentionally untouched:** `error-message-shape.md:283` (the canonical record of the #2700 rename), `RELEASING.md:251` (example JSON showing a valid `"enforced"`), CHANGELOG, backend source.

**Verified** via the ticket's acceptance gates:
- word-boundary `always` grep across the 3 files → only unrelated hits remain (tag-publish, schema-read, 'Always roll', resources/list-empty, WHERE-clause prose)
- `grep '"always"' docs/ | grep capture` → only `error-message-shape.md:283`

No test changes (no doc-lint test pins these; backend already asserts `when_negotiated`).