### PR TITLE
fix(mcp): emit conforming structuredContent for outputSchema-declaring tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,28 @@ connector-related release-notes line.
 
 ### Fixed
 
+- **MCP tools declaring an `outputSchema` now emit conforming
+  `structuredContent`** (#2774). MCP 2025-06-18 §Tools/Output Schema
+  mandates structured results for declaring tools, and Claude's frontend
+  enforces it client-side — all 17 declaring tools (12 on v0.27.0:
+  `query_audit`, `meho_audit_replay`, the doc-collections trio,
+  `query_topology`, `list_targets`, and the five topology writes; plus
+  the five operation/JSONFlux tools that declared since) hard-failed in
+  Claude Desktop with "Tool execution failed" while the server logged
+  200 and wrote its audit row. The `tools/call` dispatcher now emits the
+  handler's result as `structuredContent` alongside the serialised text
+  block (the spec's backwards-compatibility shape); a new registry-wide
+  test family validates every declaring tool's real handler payload
+  against its declared schema (companion to the #2745 name-conformance
+  guard). The sweep also corrected drifted declarations:
+  `query_audit`'s schema now covers its `shape="tree"` replay envelope
+  (a `oneOf` flat|replay union — the old declaration made every tree
+  result violate the published contract), `call_operation`'s schema now
+  names the always-present JSONFlux `handle` field, and
+  `create_doc_collections`'s schema now lists the full collection wire
+  model. Payload shapes are unchanged — additive `structuredContent` +
+  schema corrections only.
+
 - MCP session-lineage honesty: `/status` (`GET /api/v1/health`) now
   reports `mcp_session_id_capture: "when_negotiated"` instead of the
   misleading `"always"` — a session id is captured only when the client

--- a/backend/src/meho_backplane/mcp/handlers.py
+++ b/backend/src/meho_backplane/mcp/handlers.py
@@ -19,7 +19,9 @@ This module wires the registry primitives in
   tool list per MCP 2025-06-18 §Listing Tools.
 * ``tools/call`` — :func:`handle_tools_call`. Validates arguments
   against the tool's ``inputSchema`` (jsonschema), dispatches to the
-  registered handler, packs the result into the MCP ``content`` array.
+  registered handler, packs the result into the MCP ``content`` array
+  (plus ``structuredContent`` for tools declaring an ``outputSchema``,
+  #2774).
 * ``resources/list`` — :func:`handle_resources_list`. Returns the
   list of concrete (non-templated) resources. v0.2 ships only templated
   resources, so this always returns an empty list — present for spec
@@ -227,8 +229,18 @@ async def handle_tools_call(
 
     Handler return value is packed into the MCP ``content`` array as
     a single ``text`` block containing the JSON-serialised dict, per
-    spec §Tools/Tool Result. Structured content (``structuredContent``
-    field) is a future polish.
+    spec §Tools/Tool Result. When the tool declares an ``outputSchema``,
+    the same dict is additionally emitted as ``structuredContent``
+    (#2774): MCP 2025-06-18 §Tools/Output Schema mandates that a tool
+    declaring an ``outputSchema`` "MUST return structured results that
+    conform to this schema", and Claude's frontend enforces it
+    client-side — without the field, every declaring tool hard-fails
+    in Claude Desktop with "Tool execution failed" while the server
+    logs 200. The text block stays alongside per the spec's
+    backwards-compatibility recommendation. Conformance of each
+    declaring handler's payload to its schema is machine-checked in
+    ``tests/test_mcp_output_schema_conformance.py`` (emission-time in
+    tests, not per-request in prod).
 
     Audit row writing
     -----------------
@@ -350,13 +362,20 @@ async def handle_tools_call(
         status_code = 200
 
         # MCP §Tool Result: every successful tools/call response carries a
-        # ``content`` array. v0.2 ships unstructured content only — a single
-        # text block with the JSON-serialised result. Structured content
-        # (``structuredContent``) lands when a downstream tool needs it.
-        return {
+        # ``content`` array — a single text block with the JSON-serialised
+        # result. A tool that declares an ``outputSchema`` MUST also return
+        # the dict as ``structuredContent`` (MCP 2025-06-18 §Tools/Output
+        # Schema; #2774) — Claude's frontend enforces this client-side, so
+        # omitting it hard-fails every declaring tool in Claude Desktop
+        # while the server logs 200. The text block is kept alongside per
+        # the spec's backwards-compatibility recommendation.
+        response: dict[str, Any] = {
             "content": [{"type": "text", "text": json.dumps(result)}],
             "isError": False,
         }
+        if defn.outputSchema is not None:
+            response["structuredContent"] = result
+        return response
     except McpInvalidParamsError:
         # Class-wide audit-status correction (#1481). A tool handler can
         # raise ``McpInvalidParamsError`` *after* all the explicit

--- a/backend/src/meho_backplane/mcp/registry.py
+++ b/backend/src/meho_backplane/mcp/registry.py
@@ -209,8 +209,13 @@ class ToolDefinition(BaseModel):
 
     ``inputSchema`` is a JSON Schema 2020-12 object the handler validates
     incoming ``tools/call.arguments`` against. ``outputSchema`` is
-    optional; when present the handler's return value is also validated
-    against it (T4 reference tool wires this).
+    optional; when present the dispatcher emits the handler's return
+    value as ``structuredContent`` alongside the serialised text block
+    (MCP 2025-06-18 §Tools/Output Schema — a declaring tool MUST return
+    conforming structured results; #2774). Conformance is validated at
+    emission time in tests
+    (``tests/test_mcp_output_schema_conformance.py``), not per-request
+    in prod.
 
     ``required_capability`` (G4.5-T1) is an optional second gating axis
     *orthogonal* to ``required_role``. When set, the tool is filtered out

--- a/backend/src/meho_backplane/mcp/tools/audit.py
+++ b/backend/src/meho_backplane/mcp/tools/audit.py
@@ -497,33 +497,86 @@ async def _query_audit_handler(
     return result.model_dump(mode="json")
 
 
+#: Envelope of a session replay — the ``{root, session_id, tenant_id,
+#: row_count}`` shape :func:`_build_replay_response` returns. Shared by
+#: the ``meho_audit_replay`` outputSchema and the ``shape="tree"``
+#: branch of ``query_audit``'s outputSchema so the two declarations
+#: cannot drift from the single builder they both describe (#2774).
+_REPLAY_OUTPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "root": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "Session-root ReplayNode forest ascending by "
+                "timestamp. See "
+                "`meho_backplane.audit_query.schemas.ReplayNode` "
+                "for the per-node field set (AuditEntry + depth + "
+                "children)."
+            ),
+        },
+        "session_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The replayed agent_session_id.",
+        },
+        "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The tenant boundary the replay ran under.",
+        },
+        "row_count": {
+            "type": "integer",
+            "description": "Total node count in the returned tree.",
+        },
+    },
+    "required": ["root", "session_id", "tenant_id", "row_count"],
+}
+
+
 register_mcp_tool(
     definition=ToolDefinition(
         feature="audit",
         name=_TOOL_NAME,
         description=_TOOL_DESCRIPTION,
         inputSchema=_INPUT_SCHEMA,
+        # Tagged union (#2774): the flat filter path returns
+        # ``{rows, next_cursor}``; the ``shape="tree"`` self-session
+        # path returns the replay envelope. The pre-#2774 declaration
+        # required ``rows`` / ``next_cursor`` unconditionally, so every
+        # ``shape="tree"`` result violated the declared contract — a
+        # spec-conforming client validating structuredContent (MCP
+        # 2025-06-18 §Tools/Output Schema) would reject it. Same
+        # ``oneOf`` idiom as the topology writes' executed/parked union
+        # (``with_parked_shape``).
         outputSchema={
             "type": "object",
-            "properties": {
-                "rows": {
-                    "type": "array",
-                    "items": {"type": "object"},
-                    "description": (
-                        "AuditEntry rows sorted by timestamp descending. "
-                        "See `meho_backplane.audit_query.schemas.AuditEntry` "
-                        "for the per-row field set."
-                    ),
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "rows": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "description": (
+                                "AuditEntry rows sorted by timestamp descending. "
+                                "See `meho_backplane.audit_query.schemas.AuditEntry` "
+                                "for the per-row field set."
+                            ),
+                        },
+                        "next_cursor": {
+                            "type": ["string", "null"],
+                            "description": (
+                                "Opaque forward-pagination cursor. Null when the "
+                                "page is the end of the matching set."
+                            ),
+                        },
+                    },
+                    "required": ["rows", "next_cursor"],
                 },
-                "next_cursor": {
-                    "type": ["string", "null"],
-                    "description": (
-                        "Opaque forward-pagination cursor. Null when the "
-                        "page is the end of the matching set."
-                    ),
-                },
-            },
-            "required": ["rows", "next_cursor"],
+                _REPLAY_OUTPUT_SCHEMA,
+            ],
         },
         required_role=TenantRole.OPERATOR,
         op_class="audit_query",
@@ -638,37 +691,7 @@ register_mcp_tool(
         name=_REPLAY_TOOL_NAME,
         description=_REPLAY_TOOL_DESCRIPTION,
         inputSchema=_REPLAY_INPUT_SCHEMA,
-        outputSchema={
-            "type": "object",
-            "properties": {
-                "root": {
-                    "type": "array",
-                    "items": {"type": "object"},
-                    "description": (
-                        "Session-root ReplayNode forest ascending by "
-                        "timestamp. See "
-                        "`meho_backplane.audit_query.schemas.ReplayNode` "
-                        "for the per-node field set (AuditEntry + depth + "
-                        "children)."
-                    ),
-                },
-                "session_id": {
-                    "type": "string",
-                    "format": "uuid",
-                    "description": "The replayed agent_session_id.",
-                },
-                "tenant_id": {
-                    "type": "string",
-                    "format": "uuid",
-                    "description": "The tenant boundary the replay ran under.",
-                },
-                "row_count": {
-                    "type": "integer",
-                    "description": "Total node count in the returned tree.",
-                },
-            },
-            "required": ["root", "session_id", "tenant_id", "row_count"],
-        },
+        outputSchema=_REPLAY_OUTPUT_SCHEMA,
         required_role=TenantRole.TENANT_ADMIN,
         op_class="audit_query",
     ),

--- a/backend/src/meho_backplane/mcp/tools/doc_collections_create.py
+++ b/backend/src/meho_backplane/mcp/tools/doc_collections_create.py
@@ -171,6 +171,15 @@ _CREATE_DOC_COLLECTIONS_OUTPUT_SCHEMA: Final[dict[str, Any]] = {
         "when_to_use": {"type": ["string", "null"]},
         "backend": {"type": "object"},
         "status": {"type": "string"},
+        # The payload is the full `DocCollection` wire model
+        # (`project_doc_collection(...).model_dump(mode="json")`); the
+        # four fields below were missing from the declared properties
+        # (#2774 schema-honesty sweep). All are always present — null /
+        # empty on a fresh registration.
+        "last_ingested_at": {"type": ["string", "null"]},
+        "doc_count": {"type": ["integer", "null"]},
+        "readiness": {"type": ["object", "null"]},
+        "extras": {"type": "object"},
         "created_at": {"type": "string"},
         "updated_at": {"type": "string"},
     },

--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -536,6 +536,21 @@ register_mcp_tool(
                 },
                 "error": {"type": ["string", "null"]},
                 "duration_ms": {"type": "number"},
+                # ``handle`` was missing from the declared properties
+                # (#2774 schema-honesty sweep): the payload is
+                # ``OperationResult.model_dump`` verbatim, which always
+                # carries the JSONFlux spill signal — null when the
+                # response was inlined, a ResultHandle object when the
+                # full set-shaped payload is addressable via
+                # ``result_query`` instead.
+                "handle": {
+                    "type": ["object", "null"],
+                    "description": (
+                        "JSONFlux result handle. Non-null when the raw "
+                        "response was set-shaped and spilled out-of-band; "
+                        "drill in via `result_query` with `handle_id`."
+                    ),
+                },
                 "extras": {"type": "object"},
             },
             "required": ["status", "op_id", "duration_ms"],

--- a/backend/tests/test_mcp_output_schema_conformance.py
+++ b/backend/tests/test_mcp_output_schema_conformance.py
@@ -1,0 +1,749 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-tool payload conformance to declared MCP ``outputSchema`` (#2774).
+
+MCP 2025-06-18 §Tools/Output Schema: a declaring tool **MUST** return
+structured results conforming to its schema; clients SHOULD validate.
+Claude's frontend enforces this — a non-conforming (or absent)
+``structuredContent`` hard-fails the call client-side while the server
+logs 200. Before this suite the declared schemas had never been
+exercised against real payloads (the ``query_audit`` ``shape="tree"``
+drift was found exactly this way), so every scenario here drives a
+**real handler result** through the full ``tools/call`` dispatcher and
+validates the emitted ``structuredContent`` against the declared
+schema with the same Draft 2020-12 validator + format checker the
+input side uses.
+
+Companion files ("machine-check the Anthropic contract" family, after
+#2644 / #2745):
+
+* ``tests/test_mcp_structured_content.py`` — dispatcher emission rules,
+  schema well-formedness, and the pinned declaring-tool roster.
+* ``tests/test_published_tool_schema_shape.py`` — input-schema shape.
+
+Coverage is total by construction:
+:func:`test_every_declaring_tool_has_a_conformance_scenario` fails when
+a registry tool declares an ``outputSchema`` without a scenario here.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import jsonschema
+import pytest
+from fastapi.testclient import TestClient
+
+import meho_backplane.mcp.tools.result_query as result_query_module
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.connectors.result_handle_store import SpilledWindow
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import GraphNode, Tenant
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.main import app
+from meho_backplane.mcp import registry as mcp_registry
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.topology.schemas import TopologyEdge, TopologyEdgeEndpoint
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    client_with_operator,  # noqa: F401 -- pytest-discovered fixture
+    isolated_registry,  # noqa: F401 -- pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 -- pytest-discovered autouse fixture
+    seed_doc_collection,
+    seeded_operator_tenant,  # noqa: F401 -- pytest-discovered fixture
+)
+
+_DOCS_CAPABILITY = "meho-docs"
+
+#: Patch sites for the fail-open broadcast publishers inside the
+#: topology write services (the writes themselves are real).
+_PUBLISH_ANNOTATE = "meho_backplane.topology.annotate.publish_event"
+_PUBLISH_NODES = "meho_backplane.topology.nodes.publish_event"
+_PUBLISH_DELETE = "meho_backplane.topology.node_delete.publish_event"
+
+#: Tools covered by a scenario in this file. Compared against the live
+#: registry by :func:`test_every_declaring_tool_has_a_conformance_scenario`.
+_COVERED_TOOLS: frozenset[str] = frozenset(
+    {
+        "call_operation",
+        "create_doc_collections",
+        "delete_doc_collections",
+        "list_doc_collections",
+        "list_operation_groups",
+        "list_targets",
+        "meho_audit_replay",
+        "meho_topology_annotate",
+        "meho_topology_bulk_import",
+        "meho_topology_create_node",
+        "meho_topology_delete_node",
+        "meho_topology_unannotate",
+        "preview_operation",
+        "query_audit",
+        "query_topology",
+        "result_query",
+        "search_operations",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _call(
+    client: TestClient,
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    headers: dict[str, str] | None = None,
+    req_id: int = 1,
+) -> Any:
+    return post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+        headers=headers,
+    )
+
+
+def _assert_conforms(tool_name: str, response: Any) -> dict[str, Any]:
+    """Assert a successful tools/call response conforms to the declared schema.
+
+    Returns the ``structuredContent`` payload for scenario-specific
+    follow-up assertions. Validation runs with the same pinned
+    Draft 2020-12 validator + format checker the input side uses
+    (``handlers.handle_tools_call``), so ``format: uuid`` in a declared
+    schema is load-bearing here too.
+    """
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" not in body, body
+    result = body["result"]
+    assert result["isError"] is False, result
+    assert "structuredContent" in result, (
+        f"{tool_name}: declaring tool emitted no structuredContent (#2774)"
+    )
+    structured = result["structuredContent"]
+    assert structured == json.loads(result["content"][0]["text"])
+    entry = mcp_registry.get_tool(tool_name)
+    assert entry is not None, f"missing MCP tool registration: {tool_name!r}"
+    schema = entry[0].outputSchema
+    assert schema is not None, f"{tool_name}: expected an outputSchema"
+    jsonschema.validate(
+        instance=structured,
+        schema=schema,
+        cls=jsonschema.Draft202012Validator,
+        format_checker=jsonschema.Draft202012Validator.FORMAT_CHECKER,
+    )
+    return structured
+
+
+async def _seed_tenant() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(Tenant(id=OPERATOR_TENANT_ID, slug="op-tenant", name="Op Tenant"))
+
+
+async def _seed_node(*, kind: str, name: str, source: str = "curated") -> uuid.UUID:
+    node_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            GraphNode(
+                id=node_id,
+                tenant_id=OPERATOR_TENANT_ID,
+                kind=kind,
+                name=name,
+                target_id=None,
+                source=source,
+                properties={},
+                discovered_by="test",
+                first_seen=datetime.now(UTC),
+                last_seen=datetime.now(UTC),
+            ),
+        )
+    return node_id
+
+
+async def _seed_target(name: str, product: str, host: str) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(
+            TargetORM(
+                tenant_id=OPERATOR_TENANT_ID,
+                name=name,
+                aliases=[],
+                product=product,
+                host=host,
+                port=443,
+                secret_ref="targets/conformance",
+                auth_model="shared_service_account",
+            ),
+        )
+
+
+def _custom_operator(
+    *,
+    role: TenantRole,
+    capabilities: frozenset[str] = frozenset(),
+    principal_kind: PrincipalKind = PrincipalKind.USER,
+) -> Operator:
+    return Operator(
+        sub="op-conformance",
+        name="Conformance",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=OPERATOR_TENANT_ID,
+        tenant_role=role,
+        capabilities=capabilities,
+        principal_kind=principal_kind,
+    )
+
+
+@pytest.fixture
+def custom_client(
+    request: pytest.FixtureRequest,
+) -> Iterator[tuple[TestClient, Operator]]:
+    """``TestClient`` bound to an :class:`Operator` built from the param.
+
+    Param is the ``Operator``-kwargs dict for :func:`_custom_operator` —
+    the shared ``client_with_operator`` cannot express capabilities or
+    an agent ``principal_kind`` (its ``build_operator`` accepts role +
+    ``platform_admin`` only), and the doc-collections capability gate
+    and the approval-parking dial both hang off those fields.
+    """
+    op = _custom_operator(**request.param)
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            yield client, op
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+
+
+# ---------------------------------------------------------------------------
+# Coverage completeness
+# ---------------------------------------------------------------------------
+
+
+def test_every_declaring_tool_has_a_conformance_scenario() -> None:
+    """Every outputSchema-declaring tool on the registry is covered here.
+
+    The declaring roster itself is pinned in
+    ``tests/test_mcp_structured_content.py``; this guard closes the
+    other half — a declaration without a real-payload scenario is an
+    untested client-enforced contract, which is exactly how the 12
+    original tools shipped hard-failing in Claude Desktop (#2774).
+    """
+    declaring = {
+        defn.name
+        for defn, _handler in mcp_registry._TOOLS.values()
+        if defn.outputSchema is not None
+    }
+    uncovered = declaring - _COVERED_TOOLS
+    assert not uncovered, (
+        f"declaring tool(s) {sorted(uncovered)} have no payload-conformance "
+        "scenario: add one to this file and extend _COVERED_TOOLS"
+    )
+    stale = _COVERED_TOOLS - declaring
+    assert not stale, (
+        f"covered tool(s) {sorted(stale)} no longer declare an outputSchema: "
+        "drop their scenarios and shrink _COVERED_TOOLS"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Audit family
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_audit_flat_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Flat filter path: real substrate query → ``{rows, next_cursor}``."""
+    client, _op = client_with_operator
+    payload = _assert_conforms("query_audit", _call(client, "query_audit", {}))
+    assert payload["rows"] == []
+    assert payload["next_cursor"] is None
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_audit_tree_shape_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``shape="tree"`` returns the replay envelope — the #2774 drift case.
+
+    The pre-#2774 declaration required ``{rows, next_cursor}``
+    unconditionally, so every tree-shaped result violated the published
+    contract; the widened ``oneOf`` (flat | replay) is validated here
+    against a real self-session replay.
+    """
+    client, _op = client_with_operator
+    session_id = str(uuid.uuid4())
+    response = _call(
+        client,
+        "query_audit",
+        {"shape": "tree", "agent_session_id": session_id},
+        headers={"Mcp-Session-Id": session_id},
+    )
+    payload = _assert_conforms("query_audit", response)
+    assert payload["session_id"] == session_id
+    assert payload["root"] == []
+    assert payload["row_count"] == 0
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_meho_audit_replay_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    client, op = client_with_operator
+    session_id = str(uuid.uuid4())
+    payload = _assert_conforms(
+        "meho_audit_replay",
+        _call(client, "meho_audit_replay", {"session_id": session_id}),
+    )
+    assert payload["tenant_id"] == str(op.tenant_id)
+    assert payload["row_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Doc-collections family (capability-gated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "custom_client",
+    [
+        {
+            "role": TenantRole.OPERATOR,
+            "capabilities": frozenset({_DOCS_CAPABILITY, "meho-docs:vmware"}),
+        }
+    ],
+    indirect=True,
+)
+async def test_list_doc_collections_conforms(
+    custom_client: tuple[TestClient, Operator],
+) -> None:
+    client, _op = custom_client
+    await seed_doc_collection(collection_key="vmware")
+    payload = _assert_conforms("list_doc_collections", _call(client, "list_doc_collections", {}))
+    assert [c["collection_key"] for c in payload["collections"]] == ["vmware"]
+
+
+@pytest.mark.parametrize(
+    "custom_client",
+    [
+        {
+            "role": TenantRole.TENANT_ADMIN,
+            "capabilities": frozenset({_DOCS_CAPABILITY}),
+        }
+    ],
+    indirect=True,
+)
+async def test_create_doc_collections_conforms(
+    custom_client: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    client, _op = custom_client
+    payload = _assert_conforms(
+        "create_doc_collections",
+        _call(
+            client,
+            "create_doc_collections",
+            {
+                "collection_key": "vmware",
+                "vendor": "VMware by Broadcom",
+                "products": ["vsphere", "nsx"],
+                "backend": {
+                    "type": "corpus-http",
+                    "ref": {"endpoint": "https://corpus.test/v1/search"},
+                },
+            },
+        ),
+    )
+    assert payload["collection_key"] == "vmware"
+    assert payload["status"] == "provisioning"
+
+
+@pytest.mark.parametrize(
+    "custom_client",
+    [
+        {
+            "role": TenantRole.TENANT_ADMIN,
+            "capabilities": frozenset({_DOCS_CAPABILITY}),
+        }
+    ],
+    indirect=True,
+)
+async def test_delete_doc_collections_conforms(
+    custom_client: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,  # noqa: F811
+) -> None:
+    client, _op = custom_client
+    await seed_doc_collection(
+        collection_key="vmware", status="disabled", tenant_id=OPERATOR_TENANT_ID
+    )
+    payload = _assert_conforms(
+        "delete_doc_collections",
+        _call(client, "delete_doc_collections", {"collection_key": "vmware"}),
+    )
+    assert payload == {"collection_key": "vmware"}
+
+
+# ---------------------------------------------------------------------------
+# JSONFlux read-back
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_result_query_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Window read-back over a stubbed store; handler shaping is real."""
+    client, _op = client_with_operator
+    handle_id = uuid.uuid4()
+    rows = [{"i": i} for i in range(8)]
+
+    class _StubStore:
+        async def fetch_window(
+            self,
+            *,
+            tenant_id: uuid.UUID,
+            operator_sub: str,
+            handle_id: uuid.UUID,
+            offset: int,
+            limit: int,
+        ) -> SpilledWindow:
+            window = rows[offset : offset + limit]
+            return SpilledWindow(
+                rows=window,
+                total_rows=len(rows),
+                stored_rows=len(rows),
+                truncated=False,
+            )
+
+    monkeypatch.setattr(result_query_module, "get_result_handle_store", lambda: _StubStore())
+    payload = _assert_conforms(
+        "result_query",
+        _call(client, "result_query", {"handle_id": str(handle_id), "limit": 5}),
+    )
+    assert payload["returned_rows"] == 5
+    assert payload["total_rows"] == 8
+
+
+# ---------------------------------------------------------------------------
+# Operations family
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_list_operation_groups_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Real listing of the lifespan-registered vault connector's groups."""
+    client, _op = client_with_operator
+    payload = _assert_conforms(
+        "list_operation_groups",
+        _call(client, "list_operation_groups", {"connector_id": "vault-1.x"}),
+    )
+    assert any(g["group_key"] == "kv" for g in payload["groups"])
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_search_operations_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Real hybrid search over the lifespan-registered vault ops."""
+    client, _op = client_with_operator
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+
+    async def _fake_get_embedding_service() -> Any:
+        return service
+
+    monkeypatch.setattr(
+        "meho_backplane.operations._search.get_embedding_service",
+        _fake_get_embedding_service,
+    )
+    payload = _assert_conforms(
+        "search_operations",
+        _call(
+            client,
+            "search_operations",
+            {"connector_id": "vault-1.x", "query": "read a secret"},
+        ),
+    )
+    assert isinstance(payload["hits"], list)
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_call_operation_ok_envelope_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Real end-to-end dispatch: a governed topology write through
+    ``call_operation`` returns the full ``OperationResult`` envelope
+    (including the always-present ``handle`` key the pre-#2774 schema
+    omitted)."""
+    client, _op = client_with_operator
+    with patch(_PUBLISH_NODES, new=AsyncMock()):
+        response = _call(
+            client,
+            "call_operation",
+            {
+                "connector_id": "topology-graph-1.x",
+                "op_id": "topology.create_node",
+                "params": {"kind": "vault-role", "name": "conf-call-op"},
+            },
+        )
+    payload = _assert_conforms("call_operation", response)
+    assert payload["status"] == "ok", payload
+    assert "handle" in payload
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_preview_operation_unavailable_envelope_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A typed op has no literal HTTP request: ``status="unavailable"``.
+
+    A first-class non-ok envelope — exactly the kind of result shape a
+    client-side validator rejects when the schema only imagined the
+    happy path.
+    """
+    client, _op = client_with_operator
+    payload = _assert_conforms(
+        "preview_operation",
+        _call(
+            client,
+            "preview_operation",
+            {"connector_id": "topology-graph-1.x", "op_id": "topology.create_node"},
+        ),
+    )
+    assert payload["status"] == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Topology reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_untracked_closure_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Closure kind on an untracked anchor: the ``node_untracked`` envelope."""
+    client, _op = client_with_operator
+    payload = _assert_conforms(
+        "query_topology",
+        _call(client, "query_topology", {"kind": "dependents", "target": "ghost"}),
+    )
+    assert payload["status"] == "node_untracked"
+    assert payload["nodes"] == []
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_edges_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Edges facet: the ``{kind, edges}`` envelope with a real edge row.
+
+    The ``list_edges`` substrate itself is PG-only (its window SQL
+    raises ``OperationalError`` on the SQLite test DB — the existing
+    topology suite patches it for the same reason), so the substrate is
+    stubbed at the tool's import site with a real
+    :class:`~meho_backplane.topology.schemas.TopologyEdge`; the
+    handler's ``model_dump`` shaping is what this scenario pins.
+    """
+    client, _op = client_with_operator
+    edge = TopologyEdge(
+        id=uuid.uuid4(),
+        from_endpoint=TopologyEdgeEndpoint(id=uuid.uuid4(), kind="service", name="svc-x"),
+        to_endpoint=TopologyEdgeEndpoint(id=uuid.uuid4(), kind="database", name="db-y"),
+        kind="depends-on",
+        source="curated",
+        properties={},
+        last_seen=datetime.now(UTC),
+    )
+    with patch(
+        "meho_backplane.mcp.tools.topology.list_edges",
+        new=AsyncMock(return_value=[edge]),
+    ):
+        payload = _assert_conforms(
+            "query_topology", _call(client, "query_topology", {"kind": "edges"})
+        )
+    assert payload["kind"] == "edges"
+    assert payload["edges"][0]["kind"] == "depends-on"
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+async def test_list_targets_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    client, _op = client_with_operator
+    await _seed_tenant()
+    await _seed_target("rdc-vault", "vault", "vault.example")
+    await _seed_target("rdc-vcenter", "vmware", "vc.example")
+    payload = _assert_conforms("list_targets", _call(client, "list_targets", {}))
+    assert [t["name"] for t in payload["targets"]] == ["rdc-vault", "rdc-vcenter"]
+    assert payload["next_cursor"] is None
+
+
+# ---------------------------------------------------------------------------
+# Topology writes (executed branch — human tenant_admin)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_topology_annotate_and_unannotate_conform(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    client, _op = client_with_operator
+    await _seed_tenant()
+    await _seed_node(kind="service", name="svc-x")
+    await _seed_node(kind="database", name="db-y")
+    with patch(_PUBLISH_ANNOTATE, new=AsyncMock()):
+        annotated = _assert_conforms(
+            "meho_topology_annotate",
+            _call(
+                client,
+                "meho_topology_annotate",
+                {"from_name": "svc-x", "kind": "depends-on", "to_name": "db-y"},
+            ),
+        )
+        assert annotated["source"] == "curated"
+        removed = _assert_conforms(
+            "meho_topology_unannotate",
+            _call(
+                client,
+                "meho_topology_unannotate",
+                {"edge_id": annotated["edge_id"]},
+                req_id=2,
+            ),
+        )
+    assert removed == {"edge_id": annotated["edge_id"]}
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_topology_create_node_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    client, _op = client_with_operator
+    with patch(_PUBLISH_NODES, new=AsyncMock()):
+        payload = _assert_conforms(
+            "meho_topology_create_node",
+            _call(
+                client,
+                "meho_topology_create_node",
+                {"kind": "vault-role", "name": "conf-node"},
+            ),
+        )
+    assert payload["was_created"] is True
+    assert payload["source"] == "curated"
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_topology_delete_node_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    client, _op = client_with_operator
+    await _seed_tenant()
+    node_id = await _seed_node(kind="vault-role", name="doomed", source="curated")
+    with patch(_PUBLISH_DELETE, new=AsyncMock()):
+        payload = _assert_conforms(
+            "meho_topology_delete_node",
+            _call(client, "meho_topology_delete_node", {"node_id": str(node_id)}),
+        )
+    assert payload == {"node_id": str(node_id), "kind": "vault-role", "name": "doomed"}
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_topology_bulk_import_dry_run_and_apply_conform(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Both faces of the tool: the free dry-run plan and the real apply."""
+    client, _op = client_with_operator
+    await _seed_tenant()
+    await _seed_node(kind="service", name="svc-a")
+    await _seed_node(kind="database", name="db-b")
+    rows = [{"from_name": "svc-a", "kind": "depends-on", "to_name": "db-b"}]
+
+    plan = _assert_conforms(
+        "meho_topology_bulk_import",
+        _call(client, "meho_topology_bulk_import", {"rows": rows}),
+    )
+    assert plan["dry_run"] is True
+    assert plan["rows"][0]["edge_id"] is None
+
+    with patch(_PUBLISH_ANNOTATE, new=AsyncMock()):
+        applied = _assert_conforms(
+            "meho_topology_bulk_import",
+            _call(
+                client,
+                "meho_topology_bulk_import",
+                {"rows": rows, "dry_run": False},
+                req_id=2,
+            ),
+        )
+    assert applied["dry_run"] is False
+    assert applied["created"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Topology writes (parked branch — agent principal)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "custom_client",
+    [
+        {
+            "role": TenantRole.TENANT_ADMIN,
+            "principal_kind": PrincipalKind.AGENT,
+        }
+    ],
+    indirect=True,
+)
+async def test_topology_annotate_parked_branch_conforms(
+    custom_client: tuple[TestClient, Operator],
+) -> None:
+    """An agent-principal write parks: the ``awaiting_approval`` oneOf branch.
+
+    The parked envelope is a first-class success result (MCP-wise it is
+    ``isError: false``), so it must validate against the declared
+    ``oneOf`` union exactly like the executed shape.
+    """
+    client, _op = custom_client
+    await _seed_tenant()
+    await _seed_node(kind="service", name="svc-x")
+    await _seed_node(kind="database", name="db-y")
+    payload = _assert_conforms(
+        "meho_topology_annotate",
+        _call(
+            client,
+            "meho_topology_annotate",
+            {"from_name": "svc-x", "kind": "depends-on", "to_name": "db-y"},
+        ),
+    )
+    assert payload["status"] == "awaiting_approval"
+    assert uuid.UUID(payload["approval_request_id"])

--- a/backend/tests/test_mcp_structured_content.py
+++ b/backend/tests/test_mcp_structured_content.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Dispatcher-level guards for MCP ``structuredContent`` emission (#2774).
+
+MCP 2025-06-18 §Tools/Output Schema: a tool that declares an
+``outputSchema`` **MUST** return structured results that conform to it,
+and SHOULD keep the serialised JSON in a ``TextContent`` block for
+backwards compatibility. Claude's frontend enforces the MUST client-side
+— before #2774 every declaring tool hard-failed in Claude Desktop with
+"Tool execution failed" while the backplane logged 200 and wrote its
+audit row (the third Anthropic-conformance class after #2644's
+schema-shape 400s and #2745's tool-name-pattern rejection).
+
+Three guard families live here:
+
+* **Emission** — ``handle_tools_call`` packs the handler's dict as
+  ``structuredContent`` alongside the text block for a declaring tool,
+  with the two byte-identical; a tool without an ``outputSchema`` gets
+  no ``structuredContent`` key (nothing to conform to, no wire bloat).
+* **Schema well-formedness** — every declared ``outputSchema`` is a
+  valid JSON Schema 2020-12 document whose root is ``type: object``
+  (``structuredContent`` is defined as a JSON object, so a non-object
+  root could never validate any result).
+* **Declaring-set pin** — the exact set of declaring tools is pinned so
+  a new declaration cannot land without a per-tool payload-conformance
+  scenario in ``tests/test_mcp_output_schema_conformance.py`` (the
+  companion file that validates real handler results against the
+  declared schemas).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import jsonschema
+import pytest
+
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.mcp import registry as mcp_registry
+from meho_backplane.mcp.registry import ToolDefinition
+from tests.mcp_test_fixtures import (
+    client_with_operator,  # noqa: F401 -- pytest-discovered fixture
+    isolated_registry,  # noqa: F401 -- pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 -- pytest-discovered autouse fixture
+)
+
+#: Every tool on the registry that declares an ``outputSchema``. Pinned
+#: exactly: adding a declaration without extending this set (AND adding a
+#: payload-conformance scenario in
+#: ``tests/test_mcp_output_schema_conformance.py``) fails
+#: ``test_declaring_tool_set_is_pinned`` with instructions. The issue
+#: (#2774) counted 12 on v0.27.0; five operation/JSONFlux tools declared
+#: schemas between v0.27.0 and this pin.
+EXPECTED_DECLARING_TOOLS: frozenset[str] = frozenset(
+    {
+        "call_operation",
+        "create_doc_collections",
+        "delete_doc_collections",
+        "list_doc_collections",
+        "list_operation_groups",
+        "list_targets",
+        "meho_audit_replay",
+        "meho_topology_annotate",
+        "meho_topology_bulk_import",
+        "meho_topology_create_node",
+        "meho_topology_delete_node",
+        "meho_topology_unannotate",
+        "preview_operation",
+        "query_audit",
+        "query_topology",
+        "result_query",
+        "search_operations",
+    }
+)
+
+
+def _declaring_tools() -> dict[str, ToolDefinition]:
+    """Every registered tool with a non-None ``outputSchema``, by name."""
+    return {
+        defn.name: defn
+        for defn, _handler in mcp_registry._TOOLS.values()
+        if defn.outputSchema is not None
+    }
+
+
+# ---------------------------------------------------------------------------
+# Declaring-set pin + schema well-formedness
+# ---------------------------------------------------------------------------
+
+
+def test_declaring_tool_set_is_pinned() -> None:
+    """The set of outputSchema-declaring tools matches the pinned roster.
+
+    A new declaration is a new client-enforced contract (MCP 2025-06-18:
+    declaring tools MUST return conforming structured results). Landing
+    one requires (a) extending :data:`EXPECTED_DECLARING_TOOLS` and (b)
+    adding a payload-conformance scenario to
+    ``tests/test_mcp_output_schema_conformance.py`` so the contract is
+    machine-checked against a real handler result before a conforming
+    client (Claude Desktop) is the first thing to validate it.
+    """
+    declaring = set(_declaring_tools())
+    unexpected = declaring - EXPECTED_DECLARING_TOOLS
+    missing = EXPECTED_DECLARING_TOOLS - declaring
+    assert not unexpected, (
+        f"new outputSchema declaration(s) {sorted(unexpected)}: add each to "
+        "EXPECTED_DECLARING_TOOLS and add a payload-conformance scenario in "
+        "tests/test_mcp_output_schema_conformance.py"
+    )
+    assert not missing, (
+        f"tool(s) {sorted(missing)} dropped their outputSchema declaration: "
+        "remove them from EXPECTED_DECLARING_TOOLS and from the conformance "
+        "scenarios (dropping a declaration is spec-legal — see #2774)"
+    )
+
+
+def test_every_declared_output_schema_is_valid_2020_12() -> None:
+    """Every declared ``outputSchema`` is a well-formed 2020-12 schema.
+
+    ``jsonschema.validate`` at test time (and any client-side validator)
+    would raise ``SchemaError`` on a malformed document — which reads as
+    a tool failure, not a schema bug. Check the schemas themselves.
+    """
+    for name, defn in sorted(_declaring_tools().items()):
+        schema = defn.outputSchema
+        assert schema is not None
+        jsonschema.Draft202012Validator.check_schema(schema)
+        # MCP §Tools/Structured Content: structuredContent is a JSON
+        # *object*. A non-object root could never validate any result.
+        assert schema.get("type") == "object", (
+            f"{name}: outputSchema root must be type 'object', got {schema.get('type')!r}"
+        )
+
+
+def test_output_schema_survives_to_wire() -> None:
+    """``to_wire`` publishes the declared ``outputSchema`` verbatim.
+
+    The client-side validation contract only exists because the schema
+    is published on ``tools/list``; a wire-shape regression that drops
+    or mutates it would silently disarm every conforming client's
+    validation (and orphan the structuredContent this suite pins).
+    """
+    for name, defn in sorted(_declaring_tools().items()):
+        wire = defn.to_wire()
+        assert wire.get("outputSchema") == defn.outputSchema, (
+            f"{name}: to_wire() must publish outputSchema verbatim"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher emission
+# ---------------------------------------------------------------------------
+
+
+def _tools_call(
+    client: Any,
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    req_id: int = 1,
+) -> Any:
+    return post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_declaring_tool_result_carries_matching_structured_content(
+    client_with_operator: Any,  # noqa: F811 — pytest indirect fixture
+) -> None:
+    """A declaring tool's result carries ``structuredContent`` == text block.
+
+    ``meho_topology_create_node`` is the cheapest declaring tool (no
+    seeding required — the node insert is the operation). The spec's
+    backwards-compatibility recommendation makes the text block and the
+    structured object the same document; byte-identical equality is the
+    strictest honest pin.
+    """
+    client, _op = client_with_operator
+    response = _tools_call(
+        client,
+        "meho_topology_create_node",
+        {"kind": "vault-role", "name": "structured-content-pin"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" not in body, body
+    result = body["result"]
+    assert result["isError"] is False
+    assert "structuredContent" in result, (
+        "outputSchema-declaring tool returned no structuredContent — "
+        "hard-fails every conforming MCP client (#2774)"
+    )
+    assert result["structuredContent"] == json.loads(result["content"][0]["text"])
+
+
+def test_non_declaring_tool_result_has_no_structured_content(
+    client_with_operator: Any,  # noqa: F811 — pytest indirect fixture
+) -> None:
+    """A tool without an ``outputSchema`` gets no ``structuredContent`` key.
+
+    Emission is gated on the declaration: doubling every payload for
+    the ~60 non-declaring tools would bloat the wire for no contract
+    gain, and ``meho_status`` (no declaration) is the proven-working
+    Desktop round-trip shape the #2666 smoke run measured.
+    """
+    client, _op = client_with_operator
+    response = _tools_call(client, "meho_status", {})
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" not in body, body
+    result = body["result"]
+    assert result["isError"] is False
+    assert "structuredContent" not in result

--- a/docs/codebase/mcp.md
+++ b/docs/codebase/mcp.md
@@ -255,6 +255,42 @@ Two molds apply, by where the mismatch sits:
 The native key is never removed (the #1612 precedent keeps both), so a
 consumer reading either name keeps working.
 
+## Structured tool results (`structuredContent`, #2774)
+
+`handle_tools_call` (`mcp/handlers.py`) packs every successful result
+as a single JSON-serialised `text` content block. When the called
+tool's `ToolDefinition` declares an `outputSchema`, the handler's dict
+is **additionally** emitted as `structuredContent` — MCP 2025-06-18
+§Tools/Output Schema mandates that a declaring tool "MUST return
+structured results that conform to this schema", and Claude's frontend
+enforces it client-side: before #2774 every declaring tool hard-failed
+in Claude Desktop with a bare "Tool execution failed" while the server
+logged 200 and wrote its audit row (found by the #2666 Desktop smoke
+re-run; the third Anthropic-conformance class after #2644 and #2745).
+The text block stays alongside per the spec's backwards-compatibility
+recommendation, byte-identical to the structured object. Tools without
+an `outputSchema` get no `structuredContent` key — nothing to conform
+to, no wire bloat.
+
+Conformance is validated at **emission time in tests, not per-request
+in prod**:
+
+* `tests/test_mcp_structured_content.py` — emission rules, schema
+  well-formedness (valid Draft 2020-12, `type: object` root), the
+  pinned declaring-tool roster, and `to_wire` publishing the schema
+  verbatim.
+* `tests/test_mcp_output_schema_conformance.py` — every declaring
+  tool's **real handler payload** driven through the full dispatcher
+  and validated against its declared schema, including the non-happy
+  first-class shapes (`awaiting_approval` parked writes,
+  `status="unavailable"` previews, the `query_audit` `shape="tree"`
+  replay envelope — the drift #2774 actually found, fixed by widening
+  that schema to a `oneOf` flat|replay union).
+
+A tool that cannot honestly declare its output shape should drop the
+declaration (spec-legal — proven by the ~60 non-declaring tools)
+rather than publish a schema its payloads violate.
+
 ## Audit URI redaction for query-bearing resources
 
 The `resources/read` dispatcher


### PR DESCRIPTION
## Summary

- **Emit `structuredContent` for every MCP tool that declares an `outputSchema`.** MCP 2025-06-18 §Tools/Output Schema mandates that a declaring tool "MUST return structured results that conform to this schema", and Claude's frontend enforces it client-side — all 17 declaring tools (the 12 found live on v0.27.0 by the #2666 Desktop smoke re-run, plus 5 operation/JSONFlux tools that declared since) hard-failed in Claude Desktop with "Tool execution failed" while the server logged 200 and wrote its audit row. `handle_tools_call` now packs the handler's dict as `structuredContent` alongside the existing serialised-text block (the spec's backwards-compatibility recommendation); non-declaring tools are unchanged (no wire bloat, and `meho_status` is the proven-working shape).
- **Registry-wide conformance test family** (companion to the #2745 name-conformance guard): `test_mcp_structured_content.py` pins the declaring roster, emission rules, and schema well-formedness; `test_mcp_output_schema_conformance.py` drives a **real handler payload** for every declaring tool through the full dispatcher and validates the emitted `structuredContent` against the declared schema — including the first-class non-happy shapes (parked `awaiting_approval` writes, `status="unavailable"` previews). Coverage is total by construction: a new declaration without a scenario fails CI.
- **Drifted declarations corrected (schemas fixed, payloads untouched):** `query_audit`'s schema required `{rows, next_cursor}` unconditionally, so every `shape="tree"` result (the replay envelope `{root, session_id, tenant_id, row_count}`) violated the published contract — widened to a `oneOf` flat|replay union (same idiom as the topology writes' executed/parked union), with the replay envelope now shared single-source with `meho_audit_replay`. `call_operation`'s schema omitted the always-present JSONFlux `handle` field; `create_doc_collections`'s schema omitted four always-present fields of the collection wire model. Also fixed a stale `registry.py` docstring claiming runtime output validation that never existed.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy` — clean on all touched modules (one pre-existing platform-only error in `connectors/net/icmp.py` on macOS: `socket.MSG_ERRQUEUE` is Linux-only; CI runs Linux)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (4 warnings, all pre-existing legacy debt in `audit.py` / `operations.py`, both already over the size limit on main)
- [x] New suites: `pytest tests/test_mcp_structured_content.py tests/test_mcp_output_schema_conformance.py` — 25 passed, all 17 declaring tools exercised with real dispatcher round-trips
- [x] Full unit sweep: `pytest tests/ --ignore=tests/integration --ignore=tests/acceptance` — passing
- [ ] AC-3 (live Desktop verification of `list_targets` + `meho_status` + one `query_topology` call, recorded on #2666) — requires the VPN-internal deploy + `mcp-remote` shim; runs post-merge as part of the #2666 program, not from CI

## Out of scope

- Adding `outputSchema` to the other ~60 non-declaring tools (explicitly out of scope per the issue).
- The #2746 findings (resources listing, `meho_status` identity fields, `serverInfo.version`).
- `mcp/tools/audit.py` / `mcp/tools/operations.py` file-size legacy debt (pre-existing warnings, noted as adjacent findings).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2774

🤖 Generated with [Claude Code](https://claude.com/claude-code)
