### PR TITLE
docs(clients): add Connect clients section — CLI-first, MCP matrix, troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added
+
+- **Docs site — the *Connect clients* section** (#2672): a CLI-first
+  onboarding path plus the full internal-only MCP client matrix. New
+  pages cover the `meho` CLI (cosign-verified binary, device-code
+  login, internal-CA and split-DNS walls), Claude Desktop via the
+  `mcp-remote` stdio shim (the empirically-observed
+  [#2666](https://github.com/evoila/meho/issues/2666) flow, including
+  the underscore-tool-name and `structuredContent` build requirements
+  and the finding that `meho://` resources are not discoverable through
+  the shim), Claude Code (`.mcp.json` HTTP + loopback PKCE), the
+  generic `mcp-remote` static-token shim for clients that cannot carry
+  a `client_id`, and a symptom-first troubleshooting page promoting the
+  auth-wall matrix. Every page is internal-only with no public-exposure
+  guidance — the remote Custom Connector is documented as *not
+  applicable*. Also aligns the site + install pages onto the settled
+  `meho-mcp` public-client name.
+
 ### Fixed
 
 - **MCP tools declaring an `outputSchema` now emit conforming

--- a/docs-site/clients/claude-code.md
+++ b/docs-site/clients/claude-code.md
@@ -1,0 +1,85 @@
+# Claude Code
+
+Claude Code speaks MCP over **native HTTP** — no shim. You point a
+project-scoped `.mcp.json` at the backplane's `/mcp` route and pin the
+pre-registered `meho-mcp` public client; Claude Code runs the OAuth 2.1
+authorization-code + PKCE flow itself, listening on a loopback port for
+the callback. This is the pattern both MEHO dogfood repos run daily.
+
+Like every client in this section, Claude Code must run on a machine
+**on the internal network / VPN** — MEHO is internal-only.
+
+## Configure `.mcp.json`
+
+Add a `meho` server to the workspace `.mcp.json`. Claude Code reads it
+at session start; restart the session after edits:
+
+```json
+{
+  "mcpServers": {
+    "meho": {
+      "type": "http",
+      "url": "https://meho.example.com/mcp",
+      "oauth": {
+        "clientId": "meho-mcp",
+        "callbackPort": 8456,
+        "scopes": "mcp:read mcp:execute"
+      }
+    }
+  }
+}
+```
+
+- **`clientId: meho-mcp`** pins the pre-registered public client, so
+  Claude Code skips Dynamic Client Registration — which Keycloak's
+  Trusted Hosts policy blocks on any real realm (Wall W1 on the
+  [troubleshooting page](troubleshooting.md)).
+- **`callbackPort`** fixes the loopback port the authorization-code
+  callback returns to. It must match a registered redirect URI on the
+  `meho-mcp` client (next section).
+
+## One-time realm redirect URI
+
+Claude Code's callback path is **`/callback`**. With the `callbackPort`
+above, register this loopback redirect URI on the `meho-mcp` client:
+
+```
+http://localhost:8456/callback
+```
+
+(This is distinct from the `/oauth/callback` path the
+[Claude Desktop shim](claude-desktop.md#one-time-realm-redirect-uris)
+uses — a client used for both needs both.) Claude Code's flow also
+requests `offline_access` to obtain a refresh token, so the `meho-mcp`
+client must carry `offline_access` as an **optional** scope, or the
+authorization request fails with `invalid_scope` (Wall W7). Both are
+covered in [Keycloak realm setup](../install/keycloak-realm.md).
+
+## Internal-CA trust
+
+Claude Code runs on Node, which trusts only public CAs by default and
+**does not read the OS trust store**. On an internal-CA deploy, point
+Node at the CA bundle before starting Claude Code:
+
+```bash
+export NODE_EXTRA_CA_CERTS=/path/to/internal-ca.pem
+```
+
+Without it the OAuth discovery and token requests fail with a
+TLS/`unable to verify` error even though `curl` and `meho login`
+(which use the OS store) succeed from the same machine. Skip this on a
+publicly-trusted deploy.
+
+## Verify
+
+After restarting the session, Claude Code lists the `meho` server's
+tools. Confirm the connection with two calls:
+
+- **`meho_status`** — returns operator identity, Vault, and DB state.
+- **`list_targets`** — returns your registered targets.
+
+If the server shows as failed, or the browser never opens for the OAuth
+step, the [troubleshooting page](troubleshooting.md) maps the symptom —
+a DCR `403 Host not trusted` means the `clientId` was dropped from
+`.mcp.json`; an `invalid_scope` means the `offline_access` optional
+scope is missing.

--- a/docs-site/clients/claude-desktop.md
+++ b/docs-site/clients/claude-desktop.md
@@ -1,0 +1,145 @@
+# Claude Desktop
+
+Claude Desktop reaches an internal MEHO backplane through a **local
+[`mcp-remote`](https://github.com/geelen/mcp-remote) stdio→HTTP shim**
+that runs on your own VPN-connected machine. The shim runs the OAuth
+2.1 + PKCE flow against your internal Keycloak and forwards
+Streamable-HTTP calls to `/mcp`. This is the **only** Desktop path for
+an internal-only backplane.
+
+!!! danger "The remote Custom Connector is not applicable"
+
+    Claude Desktop's remote *Custom Connector* (Settings → Connectors →
+    add a `/mcp` URL) is brokered through Anthropic's cloud and requires
+    the backplane to be **publicly reachable**. MEHO is internal-only
+    and must never be publicly exposed, so that path does not apply — it
+    is not a TLS problem you can solve with a public certificate. Use
+    the shim below. See the
+    [Connect clients overview](index.md#remote-custom-connector-not-applicable)
+    for the full rationale.
+
+The configuration and findings on this page are the **empirically
+observed** result of the smoke test run against a standing internal
+deploy over VPN (issue
+[#2666](https://github.com/evoila/meho/issues/2666)) — not a
+design sketch.
+
+## Prerequisites
+
+- Claude Desktop on a machine **on the internal network / VPN**.
+- [Node.js](https://nodejs.org/) (for `npx`), which spawns the shim.
+- The `meho` CLI installed and `meho login` working from the same
+  machine ([The meho CLI](cli.md)) — it proves TLS trust and the realm
+  before you add the shim's moving parts.
+- The deployment's CA in your OS trust store **and** as a PEM file you
+  can point `NODE_EXTRA_CA_CERTS` at (Node does not read the OS store).
+- The realm's public **`meho-mcp`** OAuth client, with the shim's
+  loopback redirect URIs registered (next section).
+
+## One-time realm redirect URIs
+
+`mcp-remote`'s OAuth callback path is **`/oauth/callback`** — not the
+`/callback` that Claude Code and the bootstrap script use. On a fixed
+local port (below, `8456`), the `meho-mcp` client therefore needs
+**both** loopback forms as valid redirect URIs:
+
+```
+http://localhost:8456/oauth/callback
+http://127.0.0.1:8456/oauth/callback
+```
+
+`mcp-remote` tries `localhost` and its `127.0.0.1` twin, so register
+both. The port must match the one in the config below. The rest of the
+`meho-mcp` client shape (public PKCE client, five protocol mappers,
+four default scopes, `offline_access` optional) is in
+[Keycloak realm setup](../install/keycloak-realm.md).
+
+## Configure `claude_desktop_config.json`
+
+Add a **local stdio server** that runs the shim. This is the exact
+shape proven in the smoke test (`mcp-remote@0.1.38`):
+
+```json
+{
+  "mcpServers": {
+    "meho": {
+      "command": "npx",
+      "args": [
+        "-y", "mcp-remote@0.1.38",
+        "https://meho.example.com/mcp",
+        "8456",
+        "--static-oauth-client-info", "{\"client_id\": \"meho-mcp\"}",
+        "--static-oauth-client-metadata", "{\"scope\": \"mcp:read mcp:execute\"}"
+      ],
+      "env": { "NODE_EXTRA_CA_CERTS": "/path/to/internal-ca.pem" }
+    }
+  }
+}
+```
+
+- `8456` is the positional local callback port — it must match the
+  registered redirect URIs above.
+- `--static-oauth-client-info` pins the pre-registered public
+  `meho-mcp` client so the shim skips Dynamic Client Registration
+  (which Keycloak's Trusted Hosts policy blocks anyway).
+- `NODE_EXTRA_CA_CERTS` is only needed on an internal-CA deploy; drop it
+  if your backplane and Keycloak present publicly-trusted certificates.
+
+Restart Claude Desktop. On first use the shim opens a browser, you
+complete OAuth 2.1 + PKCE against the internal Keycloak (a static
+client, so no DCR wall), and tokens land in `~/.mcp-auth`, which the
+shim auto-refreshes.
+
+## What actually works — and the sharp edges
+
+The smoke test proved the transport end to end and surfaced three
+version-sensitive findings. All three are resolved on a current
+backplane; they are documented because they gate **which build you
+must pin**.
+
+### Pin a build with underscore tool names and structured results
+
+- **Tool names must be underscores.** Claude's frontend validates every
+  remote-MCP tool name against `^[a-zA-Z0-9_-]{1,64}$` and rejects the
+  whole toolset if any name fails — the older dotted names (`meho.status`)
+  failed *all-or-nothing*, so a conversation saw **zero** MEHO tools
+  even though Settings → Connectors listed them. The rename to
+  underscores (`meho_status`, `list_targets`, …) shipped in **v0.27.0**;
+  pin that release or later.
+- **`outputSchema`-declaring tools need conforming `structuredContent`.**
+  MCP 2025-06-18 makes structured results mandatory for a tool that
+  declares an `outputSchema`, and Claude's frontend enforces it. On a
+  build without the fix, the ~17 declaring tools (including the
+  narrow-waist `list_targets`, `query_topology`, `query_audit`) hard-fail
+  client-side with "Tool execution failed" while the server logs a clean
+  `200` and writes its audit row. `meho_status` — which declares no
+  schema — is unaffected. Pin a build carrying the fix (merged after
+  v0.27.0); on it, `list_targets` returns and renders in a conversation.
+
+### `meho://` resources are not discoverable through the shim
+
+`resources/list` returns **zero** concrete resources over the shim, so a
+discovery-driven client (Claude Desktop asks at the handshake) sees
+nothing to offer. The resource *templates* are published
+(`resources/templates/list` carries the docs-chunk template) and the
+read handler works — a raw `resources/read meho://tenant/<uuid>/info`
+returns the tenant bundle — but **unlisted-but-readable is not usable by
+a discovery-driven client**. Do not expect to browse `meho://` resources
+from a Desktop conversation; drive everything through the tools.
+
+## Verify
+
+From a Claude Desktop conversation, once the toolset attaches by its
+underscore names:
+
+- Ask it to run **`meho_status`** — it returns your operator identity
+  (sub / name / email), the Vault KV read result, DB migration state,
+  and the negotiated MCP protocol version.
+- Ask it to run **`list_targets`** — on a build with the
+  `structuredContent` fix, it returns your registered targets, rendered
+  in the conversation.
+
+If the tools do not attach, or a call fails, walk the
+[troubleshooting page](troubleshooting.md) — a rejected token, a name
+that failed validation, and a schema-conformance failure each present
+differently.

--- a/docs-site/clients/claude-desktop.md
+++ b/docs-site/clients/claude-desktop.md
@@ -92,10 +92,10 @@ shim auto-refreshes.
 
 ## What actually works — and the sharp edges
 
-The smoke test proved the transport end to end and surfaced three
-version-sensitive findings. All three are resolved on a current
-backplane; they are documented because they gate **which build you
-must pin**.
+The smoke test proved the transport end-to-end and surfaced three
+findings. **Two are build-gated** — fixed on a current backplane, but
+they dictate which build you must pin (below). **The third — resource
+discovery — is a standing limitation** with no fix yet.
 
 ### Pin a build with underscore tool names and structured results
 

--- a/docs-site/clients/cli.md
+++ b/docs-site/clients/cli.md
@@ -1,0 +1,168 @@
+# The `meho` CLI
+
+The `meho` CLI is a single static Go binary and the **starting point**
+for connecting to a backplane. It runs on a VPN-connected workstation,
+verifies TLS against your operating system's trust store, and
+authenticates with the OAuth 2.0 device-code flow — so it works on
+private networks with no browser redirect back to the client.
+
+Install it and log in before wiring any MCP client: registering targets
+and secrets happens only through the CLI (and the operator console /
+REST), never through MCP tools, so a useful agent session depends on
+this step having happened first.
+
+## Install the signed binary
+
+Releases ship as four platform tarballs plus a `SHA256SUMS` file at the
+[releases page](https://github.com/evoila/meho/releases). Each artefact
+carries a matching `.cosign.bundle` sigstore bundle — signed keyless
+via [cosign](https://docs.sigstore.dev/) (the GitHub Actions OIDC token
+is exchanged at Fulcio for a short-lived signing cert), so there is no
+public key to distribute. The canonical operator recipe is in the
+[CLI README § Verify signatures](https://github.com/evoila/meho/blob/main/cli/README.md#verify-signatures).
+
+Download the tarball and its checksums file:
+
+```bash
+TAG=<the release tag matching your backplane, e.g. v0.27.0>
+TARBALL=meho_${TAG#v}_linux_amd64.tar.gz   # or darwin_arm64, linux_arm64, darwin_amd64
+BASE=https://github.com/evoila/meho/releases/download/${TAG}
+
+curl -LO ${BASE}/${TARBALL}
+curl -LO ${BASE}/${TARBALL}.cosign.bundle
+curl -LO ${BASE}/SHA256SUMS
+curl -LO ${BASE}/SHA256SUMS.cosign.bundle
+```
+
+Verify the signatures with [cosign](https://docs.sigstore.dev/), then
+the checksums. The identity regex pins the signer to this repo's
+release workflow on a tag ref, so a bundle produced anywhere else fails
+the check:
+
+```bash
+IDENTITY='^https://github\.com/evoila/meho/\.github/workflows/cli-release\.yml@refs/tags/v.+$'
+ISSUER='https://token.actions.githubusercontent.com'
+
+# Verify the checksums file's signature once...
+cosign verify-blob \
+  --certificate-identity-regexp "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER" \
+  --bundle SHA256SUMS.cosign.bundle \
+  SHA256SUMS
+
+# ...then trust every tarball it covers via the checksums.
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+Unpack and install:
+
+```bash
+tar xzf ${TARBALL}
+sudo install -m 0755 meho /usr/local/bin/meho
+meho version
+```
+
+## Trust the deployment's CA
+
+Skip this if your backplane and Keycloak present publicly-trusted
+certificates.
+
+If they are signed by an **internal CA**, install that CA into your
+workstation's **operating-system trust store** first. The CLI is a Go
+binary — on macOS it reads the system keychain and **ignores the
+`SSL_CERT_FILE` environment variable entirely**, so the env-var trick
+that works on the backplane does not carry over here. The per-platform
+commands are on
+[TLS and ingress § Your workstation](../install/tls-ingress.md#your-workstation-os-trust-store).
+
+Verify from a fresh shell before logging in — `meho login` contacts
+**both** the backplane and Keycloak:
+
+```bash
+curl -sf https://meho.example.com/healthz
+curl -sf https://keycloak.example.com/realms/<realm>/.well-known/openid-configuration
+```
+
+## Log in
+
+```bash
+meho login https://meho.example.com
+```
+
+This runs the device-code flow: the CLI discovers the realm and the
+public `meho-cli` client id from the backplane's
+`/api/v1/auth-config` endpoint, prints a verification URL and code, you
+approve it in a browser as a realm user, and the resulting token is
+stored in your OS keyring (Keychain / Secret Service / Wincred).
+
+The CLI also writes the backplane URL to `~/.config/meho/config.json`
+(`$XDG_CONFIG_HOME/meho/config.json` when set) so later subcommands do
+not need the URL re-typed. That file holds **only** the backplane URL —
+no secret; the token lives in the keyring, or in a `0600`-mode
+`credentials.json` sibling on headless hosts where no keyring is
+available.
+
+Two useful overrides:
+
+- `meho login --client-id <id>` / `--issuer <url>` skip or override the
+  auto-discovered values — handy when a realm publishes several CLI
+  clients (`meho-cli-prod`, `meho-cli-staging`).
+- `MEHO_KEYRING_DISABLE=1 meho login …` forces the file backend even
+  where a keyring exists (see
+  [reading the raw token](#reading-the-raw-token)).
+
+Prove the whole chain end to end:
+
+```bash
+meho status
+```
+
+`meho status` calls `/api/v1/health` with the stored token, so a clean
+result confirms CLI, token, ingress, and backplane all agree.
+
+## Known walls
+
+Two workstation-side issues account for most first-login failures:
+
+- **Internal-CA trust.** `meho login` dying at its discovery probe with
+  `x509: certificate signed by unknown authority` means the
+  deployment's CA is not in your OS trust store — redo
+  [Trust the deployment's CA](#trust-the-deployments-ca). This is the
+  workstation twin of the backplane's own internal-CA trust problem.
+- **Split DNS.** If the backplane's hostname resolves to different
+  addresses inside and outside the VPN, a login started off-VPN (or
+  during a VPN-idle DNS flap) can blackhole the first lookup. Confirm
+  the host resolves to its internal address from the machine you are
+  logging in from; a temporary `/etc/hosts` pin to the internal VIP is
+  a reliable workaround while you sort DNS out.
+
+For realm-side login failures (`unauthorized_client`,
+`invalid_audience`, the `missing_sub` / `basic`-scope trap), the
+symptom-to-fix table is
+[Keycloak realm setup § If login fails](../install/keycloak-realm.md#if-login-fails),
+and the deeper cross-wall walk is the
+[troubleshooting page](troubleshooting.md).
+
+## Reading the raw token
+
+There is **no `meho ... --print-token` verb** — the CLI never prints
+the bearer token to stdout. When you genuinely need the raw JWT (to
+decode its claims, or to bake it into a shim — see
+[Other MCP clients](mcp-remote-shim.md)), force the file backend and
+read it from `credentials.json`:
+
+```bash
+MEHO_KEYRING_DISABLE=1 meho login https://meho.example.com
+
+# The file holds one entry per backplane; extract the access token:
+jq -r '.entries[].access_token' \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/meho/credentials.json"
+```
+
+## Where next
+
+- **[Register targets and secrets](../guides/targets-and-secrets.md)** —
+  the first real work, and why the CLI had to come first.
+- **[Connect an MCP client](index.md#the-mcp-client-matrix)** — add
+  Claude Desktop, Claude Code, or another client on top of the working
+  CLI.

--- a/docs-site/clients/cli.md
+++ b/docs-site/clients/cli.md
@@ -154,8 +154,11 @@ read it from `credentials.json`:
 ```bash
 MEHO_KEYRING_DISABLE=1 meho login https://meho.example.com
 
-# The file holds one entry per backplane; extract the access token:
-jq -r '.entries[].access_token' \
+# The file holds one entry per backplane; select the one you logged
+# into (extracting .entries[] unfiltered would print every backplane's
+# token):
+jq -r --arg url "https://meho.example.com" \
+  '.entries[] | select(.backplane_url == $url) | .access_token' \
   "${XDG_CONFIG_HOME:-$HOME/.config}/meho/credentials.json"
 ```
 

--- a/docs-site/clients/index.md
+++ b/docs-site/clients/index.md
@@ -1,16 +1,71 @@
 # Connect clients
 
-!!! note "Stub — content tracked by [evoila/meho#2672](https://github.com/evoila/meho/issues/2672)"
+You have a running backplane. This section wires operators and agents
+to it — **the CLI first**, then the MCP client matrix, then a
+symptom-first [troubleshooting page](troubleshooting.md) for the auth
+walls every first connection tends to hit.
 
-This section will cover connecting operators and agents to a running
-backplane — **CLI first**, then the MCP client matrix:
+!!! danger "MEHO is internal-only — never publicly exposed"
 
-- The `meho` CLI: static binary, `~/.config/meho/config.json`,
-  device-code login (works on private networks).
-- Claude Desktop / claude.ai Custom Connector (public-TLS path).
-- Claude Code (`.mcp.json` + PKCE).
-- The `mcp-remote` shim fallback.
-- The "4-wall" troubleshooting matrix for auth walls.
+    MEHO is a governance backplane for internal infrastructure. It is
+    deployed VPN-internal / behind an internal CA **by design** and
+    must **never** be placed on public DNS or a public ingress — not
+    even a short-lived copy. Every client below connects **from a
+    machine already on the internal network / VPN**. This rules out the
+    cloud-brokered **remote Custom Connector** (see
+    [below](#remote-custom-connector-not-applicable)); do not expose the
+    backplane to make it work.
 
-Until it lands, the client-setup material lives in-repo:
-[`docs/cross-repo/mcp-client-setup.md`](https://github.com/evoila/meho/blob/main/docs/cross-repo/mcp-client-setup.md).
+## Start with the CLI
+
+Even if your end goal is an agent in Claude Desktop or Claude Code,
+install and log in with the [`meho` CLI](cli.md) first. Two reasons:
+
+- **Registering targets and secrets has no MCP tools — deliberately.**
+  That is an operator-trust decision, so it lives on the CLI, the
+  operator console, and REST; agents get the read-only `list_targets`
+  tool and consume whatever you registered
+  ([Register targets and secrets](../guides/targets-and-secrets.md)).
+  Until at least one target exists, an agent session can discover
+  operations but cannot act — so the CLI is a prerequisite for a useful
+  agent session anyway.
+- The CLI is the fastest way to prove the realm, TLS trust, and token
+  chain are correct before you add an MCP client's moving parts on top.
+
+## The MCP client matrix
+
+All three MCP paths are **internal-only** — the client, or the local
+shim it spawns, runs on a VPN-connected machine and speaks Streamable
+HTTP to the backplane's `/mcp` route directly. Pick the row that
+matches your client:
+
+| Client | How it connects | Page |
+|---|---|---|
+| **Claude Desktop** | A local [`mcp-remote`](https://github.com/geelen/mcp-remote) stdio→HTTP shim runs the OAuth 2.1 + PKCE flow and forwards to `/mcp`. The only Desktop path for an internal-only backplane. | [Claude Desktop](claude-desktop.md) |
+| **Claude Code** | Native HTTP MCP with a loopback PKCE flow, pinned to the pre-registered `meho-mcp` public client. The pattern both dogfood repos run daily. | [Claude Code](claude-code.md) |
+| **Cursor and other clients that can't carry a `client_id`** | A generic `mcp-remote` stdio shim carrying a CLI-minted bearer token. | [Other MCP clients](mcp-remote-shim.md) |
+
+All three assume the realm already has the public `meho-mcp` OAuth
+client and the operator's workstation trusts the deployment's CA. The
+one-time realm work is in
+[Keycloak realm setup](../install/keycloak-realm.md); the CA-trust step
+is in [TLS and ingress](../install/tls-ingress.md#your-workstation-os-trust-store).
+
+## Remote Custom Connector — not applicable
+
+The **remote** claude.ai / Claude Desktop *Custom Connector* (pasting a
+`/mcp` URL into Settings → Connectors) is **not a supported path for
+MEHO**. Its connector backend runs in Anthropic's cloud, so it requires
+the backplane to be **publicly reachable** to fetch the RFC 9728
+metadata and run the OAuth handshake — a requirement MEHO, being
+internal-only, deliberately never meets. Reach Claude Desktop through
+the [`mcp-remote` shim](claude-desktop.md) instead, which runs on your
+own VPN-connected machine and exposes nothing.
+
+## When something breaks
+
+First connections fail in a small, well-mapped set of ways — a token
+that decodes but is rejected, an empty tool list, a client that never
+reaches the OAuth screen. The [troubleshooting page](troubleshooting.md)
+is symptom-first: find your error message, read the wall behind it, fix
+it.

--- a/docs-site/clients/mcp-remote-shim.md
+++ b/docs-site/clients/mcp-remote-shim.md
@@ -34,7 +34,8 @@ read the access token out of `credentials.json`:
 ```bash
 MEHO_KEYRING_DISABLE=1 meho login https://meho.example.com
 
-export MEHO_TOKEN="Bearer $(jq -r '.entries[].access_token' \
+export MEHO_TOKEN="Bearer $(jq -r --arg url https://meho.example.com \
+  '.entries[] | select(.backplane_url == $url) | .access_token' \
   "${XDG_CONFIG_HOME:-$HOME/.config}/meho/credentials.json")"
 ```
 

--- a/docs-site/clients/mcp-remote-shim.md
+++ b/docs-site/clients/mcp-remote-shim.md
@@ -38,9 +38,10 @@ export MEHO_TOKEN="Bearer $(jq -r '.entries[].access_token' \
   "${XDG_CONFIG_HOME:-$HOME/.config}/meho/credentials.json")"
 ```
 
-Keep the `Bearer ` prefix inside the variable — `mcp-remote`'s `--header`
-argument mishandles the space if you put it on the command line, so the
-value (space and all) must live in the environment.
+Keep the `Bearer ` prefix (and its trailing space) inside the variable:
+`mcp-remote` splits `--header` on the first colon into name and value,
+and its README documents stashing a space-containing value in the
+environment as the robust form for a bearer header.
 
 ## Point the client's stdio command at the shim
 
@@ -51,11 +52,11 @@ same:
 
 ```bash
 npx -y mcp-remote@0.1.38 https://meho.example.com/mcp \
-  --header "Authorization:${MEHO_TOKEN}" \
-  --allow-http=false
+  --header "Authorization:${MEHO_TOKEN}"
 ```
 
-Set `NODE_EXTRA_CA_CERTS=/path/to/internal-ca.pem` in the client's
+The backplane is HTTPS, so no `--allow-http` is needed. Set
+`NODE_EXTRA_CA_CERTS=/path/to/internal-ca.pem` in the client's
 environment for an internal-CA deploy — Node does not read the OS trust
 store. Because the header carries the token, `mcp-remote` performs no
 OAuth flow and needs no redirect URI on the realm.

--- a/docs-site/clients/mcp-remote-shim.md
+++ b/docs-site/clients/mcp-remote-shim.md
@@ -1,0 +1,81 @@
+# Other MCP clients (the `mcp-remote` static-token shim)
+
+Some MCP clients — Cursor as of this writing, and others — follow the
+RFC 9728 metadata trail correctly but **expose no `client_id` field**
+in their config. They then fall back to Dynamic Client Registration,
+which Keycloak's Trusted Hosts policy blocks, and the wire-up never
+completes. Pre-registering `meho-mcp` does not help: the client has
+nowhere to put the resulting id.
+
+The general-purpose workaround is a
+[`mcp-remote`](https://github.com/geelen/mcp-remote) stdio shim that
+carries a **pre-minted bearer token** instead of running OAuth. The
+client spawns the shim as a local stdio server; the shim injects the
+`Authorization` header and forwards Streamable-HTTP calls to `/mcp`.
+
+!!! warning "This is a stopgap, not the first-class path"
+
+    A pre-minted access token is **short-lived**. In this mode the shim
+    is *not* running the OAuth refresh flow, so when the token expires
+    every call fails until you re-mint it and restart the client. Prefer
+    a client that can carry a `client_id` — [Claude Code](claude-code.md),
+    or the OAuth-mode [Claude Desktop shim](claude-desktop.md), both of
+    which refresh automatically. Use the static-token shim only when the
+    client supports neither.
+
+Runs here, as everywhere in this section, from a machine **on the
+internal network / VPN**.
+
+## Mint a token
+
+There is no `--print-token` verb. Force the CLI's file token backend and
+read the access token out of `credentials.json`:
+
+```bash
+MEHO_KEYRING_DISABLE=1 meho login https://meho.example.com
+
+export MEHO_TOKEN="Bearer $(jq -r '.entries[].access_token' \
+  "${XDG_CONFIG_HOME:-$HOME/.config}/meho/credentials.json")"
+```
+
+Keep the `Bearer ` prefix inside the variable — `mcp-remote`'s `--header`
+argument mishandles the space if you put it on the command line, so the
+value (space and all) must live in the environment.
+
+## Point the client's stdio command at the shim
+
+Configure the client's MCP server as a local stdio command running
+`mcp-remote` with `--header`. The exact config key differs per client
+(`command` + `args`, an `mcp.json`, a settings pane); the command is the
+same:
+
+```bash
+npx -y mcp-remote@0.1.38 https://meho.example.com/mcp \
+  --header "Authorization:${MEHO_TOKEN}" \
+  --allow-http=false
+```
+
+Set `NODE_EXTRA_CA_CERTS=/path/to/internal-ca.pem` in the client's
+environment for an internal-CA deploy — Node does not read the OS trust
+store. Because the header carries the token, `mcp-remote` performs no
+OAuth flow and needs no redirect URI on the realm.
+
+## Verify
+
+Once the client attaches the toolset, run **`meho_status`** and
+**`list_targets`** — the same two-call check as every other client.
+A `401` with an `invalid_token` / `token_expired` detail almost always
+means the pre-minted token has expired: re-run the mint step and restart
+the client. The full set of token-rejection causes is on the
+[troubleshooting page](troubleshooting.md).
+
+## The cleaner long-term answer
+
+For clients on newer protocol versions, **Client ID Metadata Documents
+(CIMD)** dissolve this wall entirely — the `client_id` becomes an HTTPS
+URL the authorization server fetches, so neither DCR nor a pre-registered
+client is needed. CIMD shipped **experimental** in Keycloak 26.6.0 and
+is off by default; the realm-side recipe is in the
+[values-examples deep-dive § CIMD onramp](https://github.com/evoila/meho/blob/main/deploy/values-examples/README.md#cimd-onramp--no-pre-registered-client-keycloak--2660-experimental).
+It is out of scope for this page and pinned to a moving Keycloak
+feature — treat it as a preview.

--- a/docs-site/clients/troubleshooting.md
+++ b/docs-site/clients/troubleshooting.md
@@ -1,0 +1,189 @@
+# Troubleshooting auth walls
+
+First connections fail in a small, well-mapped set of ways. This page
+is **symptom-first**: match the error you see, read the wall behind it,
+apply the fix. The `W#` labels cross-reference the deployer recipe's
+[auth-onramp matrix](https://github.com/evoila/meho/blob/main/deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp),
+which carries the deepest realm-side detail.
+
+!!! note "Every client here is internal-only"
+
+    MEHO is never publicly exposed. If a client cannot reach the
+    backplane's `/.well-known/oauth-protected-resource` metadata, the
+    fix is to put the client (or its `mcp-remote` shim) **on the
+    VPN / internal network** — never to expose the backplane through a
+    public ingress or tunnel.
+
+## The client never reaches the OAuth screen
+
+**Symptom.** The `/mcp` call returns `401` with
+`WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource"`,
+but the client never opens a browser or shows a login.
+
+**Wall.** The client cannot fetch the `resource_metadata` URL, or the
+URL points at a host it cannot resolve.
+
+**Fix.** Confirm the client's machine reaches the backplane over the
+VPN, and that `BACKPLANE_URL` in the backplane ConfigMap resolves to the
+internal hostname clients actually use — if it is wrong, the metadata
+document advertises the wrong host.
+
+## DCR fails with `403 Host not trusted` (W1)
+
+**Symptom.**
+
+```json
+{"error":"insufficient_scope",
+ "error_description":"Policy 'Trusted Hosts' rejected request to
+  client-registration service. Details: Host not trusted."}
+```
+
+**Wall.** The client has no `client_id` in its config, so it attempted
+Dynamic Client Registration (RFC 7591). Keycloak's default Trusted Hosts
+policy ships with an empty whitelist, so anonymous DCR is disabled — the
+correct, secure response.
+
+**Fix.** Give the client a pre-registered `client_id`. [Claude Code](claude-code.md)
+takes it in `.mcp.json` (`oauth.clientId`); the
+[Claude Desktop shim](claude-desktop.md) takes it via
+`--static-oauth-client-info`. For a client that exposes neither, carry a
+token through the [static-token shim](mcp-remote-shim.md). Do **not**
+open DCR on a production realm to work around a per-client config gap.
+
+## Login start fails with `unauthorized_client` (W1)
+
+**Symptom.** The device-code or authorization request 401s with
+`{"error":"unauthorized_client", …}` before any browser approval.
+
+**Wall.** The flow ran against a **confidential** client (typically
+`meho-backplane`) that requires a secret the client cannot hold.
+
+**Fix.** Point the client at a **public** client — `meho-cli` for the
+CLI device-code flow, `meho-mcp` for MCP. See
+[Keycloak realm setup](../install/keycloak-realm.md).
+
+## Authorization request fails with `invalid_scope` naming `offline_access` (W7)
+
+**Symptom.** A browser-flow MCP client (Claude Code) 400s with
+`{"error":"invalid_scope","error_description":"Invalid scopes: … offline_access"}`;
+the Keycloak login page never appears.
+
+**Wall.** The client requested `offline_access` to obtain a refresh
+token, but the `meho-mcp` client does not have that scope assigned.
+
+**Fix.** Assign the realm's built-in `offline_access` scope to
+`meho-mcp` as an **optional** scope (not default — only flows that ask
+for a refresh token should mint one). `meho-cli` is deliberately not
+given it: the device-code CLI re-runs the device dance instead of
+holding a long-lived refresh token.
+
+## Token issues but every call 401s
+
+The token is minted, but the backplane rejects it on every call. From
+v0.3.2 the 401 body carries a **specific `detail` code** — read it
+first, then match the row:
+
+| `detail` code | What it means | Fix |
+|---|---|---|
+| `invalid_audience` | The token's `aud` does not include the MCP resource URI (`MCP_RESOURCE_URI`, i.e. `https://<host>/mcp`). | Confirm the `meho-mcp-audience` mapper is on the client that issues the operator's token (**W2**). A reverse proxy that rewrites the request path can also leave the audience pointing at the wrong URI — capture the issued token via the realm's introspection endpoint and read `aud`. |
+| `missing_sub` | The token has no `sub` claim. Keycloak 25+ moved `sub` into a mapper inside the `basic` client scope, and clients created via the admin REST API do not auto-inherit realm default scopes. RFC 9068 makes `sub` required, so rejection is correct — the opacity is the problem. | Assign `basic` (and `roles`, `web-origins`, `acr`) as **default** client scopes, then log out and back in (**W3** — the deepest wall). |
+| `missing_tenant_claim` / `missing_tenant_role_claim` | The `tenant-id` / `tenant-role` mapper is absent, so the backplane cannot place the caller in a tenant. | Add the tenant mappers (**W2**). Realm recipe: [Keycloak realm setup § mappers](../install/keycloak-realm.md#step-3-add-the-five-protocol-mappers). |
+| `invalid_issuer` | The token's `iss` does not match the configured realm. | Point the client at the same realm `KEYCLOAK_ISSUER_URL` names; a stale OAuth state from a previous realm can survive across config changes. |
+| `token_expired` / `token_not_yet_valid` | `exp` is in the past, or `nbf` in the future beyond leeway (clock skew). | Refresh the token; for `nbf`, sync the clock on the issuing or calling host. |
+| `signature_verification_failed` | The JWS does not verify against the issuer's published keys. | Confirm the token comes from the realm the backplane validates against. |
+| `invalid_token` | A structural failure with no more specific code — a truncated JWS, `alg: none`, or a `kid` absent from the JWKS. | Capture the raw `Authorization` value and confirm it is a three-segment RS256 JWS. |
+
+The diagnostic detail (expected audience, claim name, exception class)
+is in the backplane's **server log**, not the 401 body — that
+body-vs-log split is the deliberate info-leak boundary an
+unauthenticated 401 honours.
+
+## `meho login` times out before you can approve (W4)
+
+**Symptom.** `meho: token exchange failed: context deadline exceeded`,
+often before you have finished approving in the browser.
+
+**Wall.** Not the device-code TTL (10 minutes). An ambient **parent
+deadline** — a CI step timeout, an IDE task wrapper, an agent
+bash-tool timeout — truncates the approval wait.
+
+**Fix.** Run `meho login` in a real interactive terminal without a short
+wrapper deadline, or raise the wrapper timeout above the device-code
+lifetime.
+
+## `tools/list` returns an empty list
+
+**Symptom.** The client connects and authenticates, but no MEHO tools
+appear.
+
+**Wall.** The token's `tenant_role` claim is below the rank a tool
+requires (`read_only < operator < tenant_admin`), or the claim is
+missing entirely.
+
+**Fix.** Confirm the `tenant-role` mapper emits a role of at least
+`read_only`; walk back through the realm's tenant mappers
+([Keycloak realm setup](../install/keycloak-realm.md)).
+
+## The whole toolset is rejected (Claude Desktop)
+
+**Symptom.** Settings → Connectors lists the MEHO tools, but a
+conversation sees **none** of them; the UI names a tool-name pattern
+error like
+`String should match pattern '^[a-zA-Z0-9_-]{1,64}$'`.
+
+**Wall.** Claude's frontend validates every remote-MCP tool name against
+that pattern and rejects the **whole** toolset if any name fails. The
+older dotted names (`meho.status`) failed.
+
+**Fix.** Pin backplane **v0.27.0 or later**, where the tools were renamed
+to underscores (`meho_status`, `list_targets`, …). See
+[Claude Desktop § pinning a build](claude-desktop.md#pin-a-build-with-underscore-tool-names-and-structured-results).
+
+## A tool call fails with "Tool execution failed" but the server logged 200
+
+**Symptom.** A specific tool (e.g. `list_targets`, `query_topology`)
+fails client-side with "Tool execution failed", while the backplane logs
+a clean `200` and writes an audit row. `meho_status` works.
+
+**Wall.** The tool declares an `outputSchema`, and MCP 2025-06-18
+requires a conforming `structuredContent` result for such tools — which
+Claude's frontend enforces. A build without the fix omits it, so every
+schema-declaring tool hard-fails.
+
+**Fix.** Pin a backplane build carrying the `structuredContent` fix
+(merged after v0.27.0). Tools that declare no schema (`meho_status`) are
+unaffected.
+
+## Newly-shipped tools don't appear after a backplane upgrade
+
+**Symptom.** After upgrading the backplane, a new tool stays invisible;
+`tools/list` keeps returning the old catalog.
+
+**Wall.** The backplane advertises `tools.listChanged: false` (the
+registry is fixed at process start), so a client that cached the catalog
+at `initialize` has no signal to refetch.
+
+**Fix.** Re-initialize the client — restart it, or disconnect and
+reconnect the server. Also confirm the rollout actually cycled the
+process (`kubectl rollout status`, or check the `serverInfo.version`),
+since a new tool only exists in a new backplane process.
+
+## A successful call left no audit row
+
+**Symptom.** A tool call succeeded, but no `audit_log` row exists for it.
+
+**Wall.** The MCP audit writer fails closed — an unauditable call returns
+JSON-RPC `INTERNAL_ERROR` (-32603), so a *successful* call with no row
+means the row was rolled back mid-request, most often a transient DB
+connectivity issue.
+
+**Fix.** Check the backplane's structured logs for a
+`mcp_audit_write_failed` event carrying the exception class before
+suspecting the writer.
+
+## Going deeper
+
+- Realm-side recipe, end to end: [Keycloak realm setup](../install/keycloak-realm.md).
+- The full deployer auth-onramp matrix (per-audience capability claims,
+  advanced realm shapes): [values-examples deep-dive](https://github.com/evoila/meho/blob/main/deploy/values-examples/README.md#auth-onramp-recipe-cli--mcp).
+- Workstation TLS trust: [TLS and ingress](../install/tls-ingress.md#your-workstation-os-trust-store).

--- a/docs-site/clients/troubleshooting.md
+++ b/docs-site/clients/troubleshooting.md
@@ -91,7 +91,7 @@ first, then match the row:
 | `invalid_issuer` | The token's `iss` does not match the configured realm. | Point the client at the same realm `KEYCLOAK_ISSUER_URL` names; a stale OAuth state from a previous realm can survive across config changes. |
 | `token_expired` / `token_not_yet_valid` | `exp` is in the past, or `nbf` in the future beyond leeway (clock skew). | Refresh the token; for `nbf`, sync the clock on the issuing or calling host. |
 | `signature_verification_failed` | The JWS does not verify against the issuer's published keys. | Confirm the token comes from the realm the backplane validates against. |
-| `invalid_token` | A structural failure with no more specific code — a truncated JWS, `alg: none`, or a `kid` absent from the JWKS. | Capture the raw `Authorization` value and confirm it is a three-segment RS256 JWS. |
+| `invalid_token` | A structural failure with no more specific code — a truncated JWS, `alg: none`, or a `kid` absent from the JWKS. | Inspect the token **locally** — confirm it is a three-segment RS256 JWS (segment count, `alg`, `kid`). Treat the bearer as a live credential: decode it on your own machine and never paste it into a shared issue, log, or chat — redact it from any diagnostic you share. |
 
 The diagnostic detail (expected audience, claim name, exception class)
 is in the backplane's **server log**, not the 401 body — that

--- a/docs-site/install/index.md
+++ b/docs-site/install/index.md
@@ -136,7 +136,7 @@ backplane can be logged into, the realm needs:
    identity MEHO validates tokens against;
 2. a **public `meho-cli` client** with the device-code grant — what
    `meho login` uses;
-3. a **public `meho-mcp-client`** with authorization-code + PKCE —
+3. a **public `meho-mcp`** client with authorization-code + PKCE —
    what browser-capable MCP clients use;
 4. five **protocol mappers** and four **default client scopes** on the
    public clients, so issued tokens carry the claims MEHO validates;

--- a/docs-site/install/keycloak-realm.md
+++ b/docs-site/install/keycloak-realm.md
@@ -17,7 +17,7 @@ the end, then return to the trail.
 |---|---|---|
 | `meho-backplane` | Confidential client | The backplane itself — the audience it validates tokens for. If your realm does not have it yet, create it first: a confidential client with ID `meho-backplane` and no login flows enabled — it exists as the resource-server identity whose client ID is the token audience (`keycloak.audience` in the chart values). |
 | `meho-cli` | **Public** client, device-code grant | `meho login` |
-| `meho-mcp-client` | **Public** client, authorization-code + PKCE | Browser-capable MCP clients (Claude Desktop, MCP Inspector, …) |
+| `meho-mcp` | **Public** client, authorization-code + PKCE | Browser-capable MCP clients (Claude Desktop, MCP Inspector, …) |
 | 5 protocol mappers | On both public clients | Make issued tokens carry the claims the backplane validates |
 | 4 default client scopes | On both public clients | Including the `basic` scope that carries the mandatory `sub` claim |
 | A user in `meho-admins` | Realm user | The human who approves device-code logins and operates MEHO |
@@ -125,17 +125,17 @@ one. Create at least one user with:
 The user's email does not need to be verified for device-code login to
 complete.
 
-## The MCP client (`meho-mcp-client`)
+## The MCP client (`meho-mcp`)
 
 Browser-capable MCP clients authenticate with authorization-code +
 PKCE, which needs a second public client. Repeat Steps 2–4 with these
 differences:
 
-| Setting | `meho-mcp-client` | Why it differs |
+| Setting | `meho-mcp` | Why it differs |
 |---|---|---|
 | Standard flow (authorization-code + PKCE) | **On** | The MCP specification mandates OAuth 2.1 authorization-code + PKCE. |
 | Device grant | Off | Not used by MCP clients. |
-| Valid redirect URIs | `https://claude.ai/api/mcp/auth_callback`, `http://localhost:*` | Covers the Claude / claude.ai callback and localhost tools. |
+| Valid redirect URIs | **Loopback only** — `http://localhost:<port>/callback` (Claude Code) plus `http://localhost:<port>/oauth/callback` and its `http://127.0.0.1:<port>/oauth/callback` twin (the `mcp-remote` shim) | MEHO is internal-only, so there is **no** public `claude.ai` Custom-Connector redirect. `<port>` matches the client's configured callback port; the exact per-client values are in [Connect clients](../clients/index.md). |
 | PKCE challenge method | `S256` | Spec-required for public clients. |
 | `offline_access` client scope | Assign as **Optional** | Some MCP clients always request a refresh token; without the scope the authorization request fails with `invalid_scope`. Deliberately *not* given to `meho-cli` — the CLI re-runs the device dance instead of holding a long-lived refresh token. |
 
@@ -210,7 +210,7 @@ usually appear:
 | Token issued, every call 401s with `invalid_audience` / `missing_tenant_claim` / `missing_tenant_role_claim` | Missing protocol mappers | Step 3 — add all five, then log out and back in. |
 | Token issued, every call 401s with `invalid_token` or `missing_sub`; the decoded token has no `sub` | The `basic` scope is not a default scope on the client | Step 4 — assign it, re-login (existing tokens stay broken). |
 | `meho login` times out before you can approve | An ambient wrapper timeout (CI step, IDE task) shorter than the approval wait | Run `meho login` in a real terminal, or raise the wrapper timeout. |
-| MCP client fails with `invalid_scope` naming `offline_access` | The scope is not assigned on `meho-mcp-client` | Assign `offline_access` as an **optional** scope (see the MCP client table above). |
+| MCP client fails with `invalid_scope` naming `offline_access` | The scope is not assigned on `meho-mcp` | Assign `offline_access` as an **optional** scope (see the MCP client table above). |
 | `x509: certificate signed by unknown authority` | Workstation OS trust store missing your CA | Step 1 / [TLS and ingress](tls-ingress.md#your-workstation-os-trust-store). |
 
 A fuller, client-by-client troubleshooting page ships with the

--- a/docs-site/install/tls-ingress.md
+++ b/docs-site/install/tls-ingress.md
@@ -49,13 +49,16 @@ ingress:
     secretName: meho-tls
 ```
 
-A **publicly-trusted** certificate here keeps everything downstream
-simple (workstations and hosted MCP clients trust it out of the box).
-An **internal CA** works for the CLI and self-hosted clients — but
-note for later that hosted agent frontends (e.g. connecting claude.ai
-directly to your backplane) can only reach endpoints whose
-certificates chain to a public CA. The client-by-client picture lives
-in [Connect clients](../clients/index.md).
+A **publicly-trusted** certificate here keeps workstation trust simple
+— operator machines, and the local MCP shims they run, trust it out of
+the box with no OS-store import. An **internal CA** works just as well
+and is the norm: every MEHO client connects from the internal network
+/ VPN, so there is no cloud-brokered frontend in the picture (the
+remote claude.ai / Claude Desktop Custom Connector is **not
+applicable** — MEHO is never publicly exposed). The one extra step an
+internal CA adds — trusting it on each operator workstation — and the
+per-client trust picture are in
+[Connect clients](../clients/index.md).
 
 ## Your workstation: OS trust store
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,13 @@ nav:
       - TLS and ingress: install/tls-ingress.md
       - Upgrades: install/upgrades.md
       - Local kind quickstart: install/kind-quickstart.md
-  - Connect clients: clients/index.md
+  - Connect clients:
+      - clients/index.md
+      - The meho CLI: clients/cli.md
+      - Claude Desktop: clients/claude-desktop.md
+      - Claude Code: clients/claude-code.md
+      - Other MCP clients (mcp-remote shim): clients/mcp-remote-shim.md
+      - Troubleshooting auth walls: clients/troubleshooting.md
   - Do real work:
       - guides/index.md
       - guides/targets-and-secrets.md


### PR DESCRIPTION
## Summary

- Adds the published **Connect clients** section to the docs site
  (`docs-site/clients/`): a CLI-first onboarding page, the internal-only
  MCP client matrix (Claude Desktop via the `mcp-remote` shim, Claude
  Code native HTTP + loopback PKCE, and a generic static-token shim for
  clients that can't carry a `client_id`), and a symptom-first auth-wall
  troubleshooting page. Replaces the `clients/index.md` stub and wires
  every page into the `mkdocs.yml` nav.
- The Claude Desktop page matches the **empirically-observed** #2666
  shim flow: the exact `claude_desktop_config.json` (`mcp-remote@0.1.38`,
  port `8456`, `--static-oauth-client-info {"client_id":"meho-mcp"}`,
  `NODE_EXTRA_CA_CERTS`), the `/oauth/callback` + `127.0.0.1`-twin
  redirect-URI finding, and the two honest findings — underscore tool
  names (#2748, v0.27.0) and `structuredContent` conformance (#2774) as
  build requirements, and that `meho://` resources are **not
  discoverable** through the shim (#2746). Carries an explicit "remote
  Custom Connector — not applicable" note; no public-exposure guidance
  anywhere.
- Resolves the `meho-mcp-client` → `meho-mcp` naming drift across the
  **site** (the two `docs-site/install/` pages #2779 missed) so the
  settled name (#2779) is consistent site-wide.
- CHANGELOG `[Unreleased]` entry under a new `### Added` header.

## Test plan

- [x] `mkdocs build --strict` — clean (exit 0, no warnings; strict fails
      on broken links / pages-missing-from-nav, so all six new pages are
      nav-wired and all intra-site links resolve).
- [x] Code-quality diff gate — exit 0.
- [x] AC-1: pages live for all three MCP paths + the CLI path, all
      internal-only; Desktop page matches the #2666 flow incl. schema-
      tolerance + resource-visibility findings + the "not applicable"
      note.
- [x] AC-2: no `meho-mcp-client` remains in `docs-site/`; `meho-mcp`
      used consistently across site + values-examples (values-examples
      already settled by #2779).
- [x] AC-3: troubleshooting page covers every wall in the current matrix
      (W1 DCR/`unauthorized_client`, W2 audience/tenant claims, W3
      Keycloak-25 `basic`/`sub`, W4 login timeout, W7 `offline_access`)
      plus the MCP detail-code table, symptom-first.
- [x] AC-4: `[Unreleased]` entry under a unique `### Added` header.
- [x] Verified against source: the pages use the **real** token-read
      path (`MEHO_KEYRING_DISABLE=1 meho login` + `credentials.json`),
      not the non-existent `--print-token` flag; the `mcp-remote` flags
      and Claude Code `.mcp.json` shape are confirmed against the tool's
      README and the live adopter config.

## Out of scope (adjacent findings — recommend follow-up tickets)

- **CLI `bootstrap-clients` helper still defaults to `meho-mcp-client`.**
  `cli/internal/cmd/admin/keycloak/{keycloak,bootstrap}.go` (+ tests)
  default `--mcp-client-id` to `meho-mcp-client`. Changing it is a
  behavioral/code change with idempotency implications for existing
  deployments; #2779 deliberately scoped itself "no code" and left it.
  Left as a follow-up code ticket rather than sneaking a Go+test change
  into a docs PR.
- **`--print-token` is a non-existent flag referenced by in-repo docs.**
  `deploy/values-examples/README.md` (`meho status --print-token`) and
  `docs/cross-repo/mcp-client-setup.md` (`meho login --print-token`)
  reference a flag that does not exist anywhere in `cli/`. The new site
  pages use the real method instead; the in-repo docs should be scrubbed
  (or the flag implemented) in a separate ticket.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2672


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive client connection guidance for the CLI, Claude Desktop, Claude Code, and static-token MCP setups.
  * Added installation, authentication, TLS trust, verification, and troubleshooting instructions.
  * Clarified internal-network requirements and unsupported remote connector scenarios.
  * Renamed the MCP client to `meho-mcp` and updated setup instructions.
  * Organized the new content into a dedicated “Connect clients” documentation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->