### PR TITLE
fix(keycloak): default --mcp-client-id to meho-mcp

### DIFF
--- a/cli/internal/cmd/admin/keycloak/bootstrap.go
+++ b/cli/internal/cmd/admin/keycloak/bootstrap.go
@@ -35,7 +35,7 @@ type BootstrapOptions struct {
 
 	// MCPClientID is the public authorization-code+PKCE client name
 	// used by Claude.ai Custom Connector / MCP Inspector; defaults to
-	// "meho-mcp-client".
+	// "meho-mcp".
 	MCPClientID string
 
 	// BackplaneAudience is the confidential resource-server client's
@@ -90,7 +90,7 @@ func (o BootstrapOptions) withDefaults() BootstrapOptions {
 		o.CLIClientID = "meho-cli"
 	}
 	if o.MCPClientID == "" {
-		o.MCPClientID = "meho-mcp-client"
+		o.MCPClientID = "meho-mcp"
 	}
 	if o.BackplaneAudience == "" {
 		o.BackplaneAudience = "meho-backplane"
@@ -357,7 +357,7 @@ type Result struct {
 //  1. Public CLI device-code client (`meho-cli`)
 //  2. 5 protocol mappers cloned from the reference
 //  3. 4 default client scopes (basic / roles / web-origins / acr)
-//  4. Public MCP browser-flow client (`meho-mcp-client`)
+//  4. Public MCP browser-flow client (`meho-mcp`)
 //  5. Same 5 mappers + 4 default scopes on the MCP client, **plus**
 //     `offline_access` as an *optional* client scope (the CLI
 //     device-code client deliberately doesn't get it — see RDC Wall W7

--- a/cli/internal/cmd/admin/keycloak/bootstrap_test.go
+++ b/cli/internal/cmd/admin/keycloak/bootstrap_test.go
@@ -441,8 +441,8 @@ func TestBootstrap_FreshRealmCreatesEverything(t *testing.T) {
 	if res.CLIClientID != "meho-cli" {
 		t.Errorf("CLIClientID = %q, want meho-cli", res.CLIClientID)
 	}
-	if res.MCPClientID != "meho-mcp-client" {
-		t.Errorf("MCPClientID = %q, want meho-mcp-client", res.MCPClientID)
+	if res.MCPClientID != "meho-mcp" {
+		t.Errorf("MCPClientID = %q, want meho-mcp", res.MCPClientID)
 	}
 
 	// Each client has 5 mappers.
@@ -798,12 +798,12 @@ func TestBootstrap_MCPClientHasStandardFlowAndPKCE(t *testing.T) {
 	}
 	var mcpClient *clientRep
 	for _, c := range fake.clients {
-		if c.ClientID == "meho-mcp-client" {
+		if c.ClientID == "meho-mcp" {
 			mcpClient = c
 		}
 	}
 	if mcpClient == nil {
-		t.Fatalf("meho-mcp-client not found")
+		t.Fatalf("meho-mcp not found")
 	}
 	if mcpClient.StandardFlowEnabled == nil || !*mcpClient.StandardFlowEnabled {
 		t.Errorf("MCP client standardFlow should be on")
@@ -836,7 +836,7 @@ func TestBootstrap_MCPClientHasOfflineAccessOptionalScope(t *testing.T) {
 		switch c.ClientID {
 		case "meho-cli":
 			cliUUID = uuid
-		case "meho-mcp-client":
+		case "meho-mcp":
 			mcpUUID = uuid
 		}
 	}
@@ -844,7 +844,7 @@ func TestBootstrap_MCPClientHasOfflineAccessOptionalScope(t *testing.T) {
 		t.Fatalf("meho-cli client not found")
 	}
 	if mcpUUID == "" {
-		t.Fatalf("meho-mcp-client not found")
+		t.Fatalf("meho-mcp not found")
 	}
 
 	// MCP client: offline_access is attached as an OPTIONAL scope.
@@ -857,7 +857,7 @@ func TestBootstrap_MCPClientHasOfflineAccessOptionalScope(t *testing.T) {
 		}
 	}
 	if !foundOnMCP {
-		t.Errorf("meho-mcp-client missing optional scope offline_access; "+
+		t.Errorf("meho-mcp missing optional scope offline_access; "+
 			"got optionalScopes=%v", mcpOpt)
 	}
 
@@ -866,7 +866,7 @@ func TestBootstrap_MCPClientHasOfflineAccessOptionalScope(t *testing.T) {
 	// whether the client requested it).
 	for _, sid := range fake.defaultScopes[mcpUUID] {
 		if sid == "scope-offline-access" {
-			t.Errorf("meho-mcp-client has offline_access as DEFAULT — " +
+			t.Errorf("meho-mcp has offline_access as DEFAULT — " +
 				"must be optional only (else every browser-flow login " +
 				"mints a refresh token even when offline_access isn't " +
 				"requested)")

--- a/cli/internal/cmd/admin/keycloak/keycloak.go
+++ b/cli/internal/cmd/admin/keycloak/keycloak.go
@@ -9,7 +9,7 @@
 //  1. The public `meho-cli` device-code client + 5 protocol mappers
 //     + 4 default client scopes (`basic`, `roles`, `web-origins`,
 //     `acr`).
-//  2. The public `meho-mcp-client` authorization-code+PKCE client +
+//  2. The public `meho-mcp` authorization-code+PKCE client +
 //     the same 5 mappers + 4 default scopes.
 //  3. The `meho-admins` group.
 //  4. An admin user joined to `meho-admins` with a password.
@@ -99,7 +99,7 @@ func newBootstrapClientsCmd() *cobra.Command {
 		Long: "bootstrap-clients provisions every realm resource " +
 			"`meho login` and the MCP browser-flow onramp need:\n\n" +
 			"  * the public device-code client (default name `meho-cli`)\n" +
-			"  * the public authorization-code+PKCE MCP client (default name `meho-mcp-client`)\n" +
+			"  * the public authorization-code+PKCE MCP client (default name `meho-mcp`)\n" +
 			"  * 5 protocol mappers on each client (audience-meho-backplane, meho-mcp-audience, tenant-id, tenant-role, groups-claim)\n" +
 			"  * 4 default client scopes on each client (basic, roles, web-origins, acr) — including the load-bearing `basic` scope that carries the `sub` claim in Keycloak 25+\n" +
 			"  * the `meho-admins` top-level group\n" +
@@ -198,7 +198,7 @@ func newBootstrapClientsCmd() *cobra.Command {
 		"master-realm admin username (or set KEYCLOAK_ADMIN_USER)")
 	cmd.Flags().StringVar(&cliClientID, "cli-client-id", "meho-cli",
 		"public client_id for the device-code flow (matches chart's `config.keycloakCliClientId`)")
-	cmd.Flags().StringVar(&mcpClientID, "mcp-client-id", "meho-mcp-client",
+	cmd.Flags().StringVar(&mcpClientID, "mcp-client-id", "meho-mcp",
 		"public client_id for the MCP browser-flow client")
 	cmd.Flags().StringVar(&backplaneAudience, "backplane-audience", "meho-backplane",
 		"audience claim the `audience-meho-backplane` mapper emits (matches chart's `config.keycloakAudience`)")


### PR DESCRIPTION
## Summary

- `meho admin keycloak bootstrap-clients` still defaulted the public MCP browser-flow client id to the pre-rename `meho-mcp-client`. #2779 settled the canonical name as `meho-mcp` but scoped itself "docs-only, no code," explicitly deferring this CLI leg — so a fresh bootstrap run today provisions a client that contradicts the shipped docs.
- Aligns both defaults — `bootstrap.go` `withDefaults()` and the `keycloak.go` `--mcp-client-id` flag — to `meho-mcp`, plus the comments/help strings and the `bootstrap_test.go` assertions that pin them.
- Net: `grep -rn "meho-mcp-client" cli/` now returns empty; all 14 occurrences across the three files became `meho-mcp`.

## Idempotency behavior (surfaced, not papered over)

`bootstrap-clients` reconciles clients **by client id** (`bootstrap.go`, `reconcile MCP client %q`). Changing the default means a re-run against a realm that already holds an old `meho-mcp-client` (provisioned by an older CLI) will **create a new `meho-mcp` client rather than rename the existing one**. The stale `meho-mcp-client` is left in place.

**Operator action:** a one-time manual cleanup of the stale `meho-mcp-client` is expected on realms already bootstrapped by an older CLI. No rename/migration logic is added here — per the task, that stays out of scope unless a maintainer asks for it.

## Test plan

- [x] `grep -rn "meho-mcp-client" cli/` — empty (no matches)
- [x] `go build ./...` (cli module) — clean
- [x] `go test ./...` (cli module, `-race`) — all packages `ok`
- [x] `golangci-lint run` (v2.12.2, matching CI) — 0 issues
- [x] `gofmt -l` on the three changed files — clean

## Out of scope

- The CLI client id (`meho-cli` / `meho-backplane`) — untouched; only the MCP client default changed.
- The stale "Claude.ai Custom Connector" phrasing in the `bootstrap.go` L37 comment and L825 help string. It does not contain the `meho-mcp-client` literal (so it's outside this task's grep bar) and rewording user-facing help text is a separate correctness nit that needs a maintainer's call on the replacement wording — left as an adjacent finding, not fixed here.
- Any Keycloak realm-side migration of already-provisioned clients (see idempotency note above).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2783


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default MCP client identifier to `meho-mcp` across administrative setup and configuration.
  * Aligned bootstrap behavior and validation with the new client identifier.
  * Updated related documentation and command-line defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->