### PR TITLE
feat(cli): meho login --print-token — emit raw access token + fix 12 phantom-flag doc refs

### DIFF
--- a/cli/internal/cmd/login.go
+++ b/cli/internal/cmd/login.go
@@ -35,6 +35,7 @@ func newLoginCmd() *cobra.Command {
 		scopes            []string
 		insecureAllowHTTP bool
 		resolveEntries    []string
+		printToken        bool
 	)
 
 	cmd := &cobra.Command{
@@ -135,12 +136,22 @@ func newLoginCmd() *cobra.Command {
 				return err
 			}
 
-			// Prompter renders the verification URL + user code to
-			// stdout. Output discipline: this is a prompt, not an
-			// error, so it goes to stdout (per Goal #11 §5 + matches
-			// `gh auth login`, `flux bootstrap` behaviour).
+			// Prompter renders the verification URL + user code for
+			// the operator. Output discipline: a prompt is not an
+			// error, so by default it goes to stdout (per Goal #11 §5,
+			// matching `gh auth login` / `flux bootstrap`). Under
+			// --print-token, stdout is reserved exclusively for the
+			// freshly minted access token so a subshell capture
+			// (`TOKEN=$(meho login --print-token <url>)`) sees only the
+			// credential; every operator-facing line — this prompt, the
+			// success message, the migration nudge — is diverted to
+			// stderr. This mirrors status.go's redaction posture: the
+			// live bearer never reaches stdout unless the operator asks
+			// for exactly it.
 			out := cmd.OutOrStdout()
-			prompter := stdoutPrompter(out)
+			errOut := cmd.ErrOrStderr()
+			humanOut := humanWriter(out, errOut, printToken)
+			prompter := stdoutPrompter(humanOut)
 
 			// Build the detached device-flow context. Inherits values
 			// from parentCtx (so future oauth2.HTTPClient injections
@@ -179,12 +190,20 @@ func newLoginCmd() *cobra.Command {
 			// the operator can supply --backplane explicitly on the
 			// next invocation.
 			if err := auth.SaveConfig(auth.Config{BackplaneURL: backplaneURL}); err != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(),
+				fmt.Fprintf(errOut,
 					"warning: failed to persist backplane URL to config file: %v\n", err)
 			}
 
-			fmt.Fprintf(out, "Logged in to %s; token stored in %s.\n", backplaneURL, store.Describe())
-			printMigrationNudge(out)
+			fmt.Fprintf(humanOut, "Logged in to %s; token stored in %s.\n", backplaneURL, store.Describe())
+			printMigrationNudge(humanOut)
+
+			// --print-token contract: the freshly minted bearer is the
+			// only thing written to real stdout, so it can be captured
+			// with `TOKEN=$(meho login --print-token <url>)`.
+			// printAccessToken is the sole writer to stdout on this path.
+			if printToken {
+				printAccessToken(out, stored.AccessToken)
+			}
 			return nil
 		},
 	}
@@ -202,6 +221,11 @@ func newLoginCmd() *cobra.Command {
 		"pin a host to an IP for the flow, mirroring `curl --resolve <host>:<port>:<ip>` "+
 			"(split-DNS escape hatch when the Keycloak host doesn't resolve). Repeat for multiple hosts. "+
 			"TLS SNI/Host use the real hostname, so certificate validation is unaffected")
+	cmd.Flags().BoolVar(&printToken, "print-token", false,
+		"after a successful login, print ONLY the access token to stdout (every other line — the "+
+			"device-code prompt, the success message, warnings — goes to stderr) so it can be captured "+
+			"with 'TOKEN=$(meho login --print-token <backplane-url>)'. WARNING: the value is a live bearer "+
+			"credential — never log it or paste it into shared channels")
 	return cmd
 }
 
@@ -419,4 +443,29 @@ func stdoutPrompter(w io.Writer) auth.DeviceFlowPrompter {
 		fmt.Fprintf(w, "Waiting for authorisation…\n")
 		return nil
 	}
+}
+
+// humanWriter selects where operator-facing chrome — the device-code
+// prompt, the success line, the migration nudge — is written. On the
+// default path that is stdout. Under --print-token, stdout is reserved
+// exclusively for the access token, so chrome is diverted to stderr;
+// this keeps `TOKEN=$(meho login --print-token <url>)` free of any
+// bytes but the credential. Extracted to package scope so the routing
+// decision is unit-testable in isolation, matching the discipline
+// status.go applies to its own token-redaction helper.
+func humanWriter(stdout, stderr io.Writer, printToken bool) io.Writer {
+	if printToken {
+		return stderr
+	}
+	return stdout
+}
+
+// printAccessToken writes tok to w followed by exactly one newline and
+// nothing else. It is the only function that writes to stdout on the
+// `meho login --print-token` path, so the stdout contract lives here:
+// piped output is `wc -l == 1` and a `$(...)` capture yields exactly
+// the token. Mirrors status.go's redactJWTLike — exposed at package
+// scope so a unit test can pin the exact stdout shape.
+func printAccessToken(w io.Writer, tok string) {
+	fmt.Fprintln(w, tok)
 }

--- a/cli/internal/cmd/login_test.go
+++ b/cli/internal/cmd/login_test.go
@@ -214,10 +214,55 @@ func TestResolveAuthConfigDiscoveryFailureMentionsFlags(t *testing.T) {
 func TestLoginCommandHelpListsFlags(t *testing.T) {
 	cmd := newLoginCmd()
 	out := cmd.UsageString()
-	for _, want := range []string{"--issuer", "--client-id", "--scope", "--resolve"} {
+	for _, want := range []string{"--issuer", "--client-id", "--scope", "--resolve", "--print-token"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("usage missing flag %s:\n%s", want, out)
 		}
+	}
+}
+
+// TestLoginPrintTokenEmitsExactlyTheToken pins the --print-token stdout
+// contract (#2782 AC #1 / #3): on the print path stdout must carry the
+// access token and nothing else, so `TOKEN=$(meho login --print-token
+// <url>)` captures the bare credential and `... | wc -l` is exactly 1.
+// printAccessToken is the sole writer to stdout on that path, so pinning
+// its output pins the contract — mirroring status_test.go's redaction
+// test, which pins the isolated redaction helper rather than driving the
+// whole command.
+func TestLoginPrintTokenEmitsExactlyTheToken(t *testing.T) {
+	const token = "eyJ.PRINT-TOKEN-TEST.SIGNATURE"
+	var stdout bytes.Buffer
+	printAccessToken(&stdout, token)
+
+	got := stdout.String()
+	// `$(...)` strips trailing newlines — the captured value must be
+	// the token verbatim.
+	if capd := strings.TrimRight(got, "\n"); capd != token {
+		t.Errorf("subshell-captured stdout = %q, want %q", capd, token)
+	}
+	// `... | wc -l` must be exactly 1.
+	if n := strings.Count(got, "\n"); n != 1 {
+		t.Errorf("stdout newline count = %d, want 1", n)
+	}
+	// Nothing but the token + one newline may reach stdout.
+	if got != token+"\n" {
+		t.Errorf("stdout = %q, want exactly the token followed by one newline", got)
+	}
+}
+
+// TestLoginHumanWriterDivertsChromeUnderPrintToken pins the other half
+// of the stdout contract: every operator-facing line (prompt, success
+// message, migration nudge, warnings) is routed through humanWriter,
+// which must send it to stderr under --print-token so it never
+// contaminates the captured token — and to stdout otherwise, preserving
+// the default login UX.
+func TestLoginHumanWriterDivertsChromeUnderPrintToken(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if w := humanWriter(&stdout, &stderr, true); w != &stderr {
+		t.Error("--print-token must divert chrome to stderr so stdout carries only the token")
+	}
+	if w := humanWriter(&stdout, &stderr, false); w != &stdout {
+		t.Error("default login must keep operator-facing output on stdout")
 	}
 }
 

--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -582,7 +582,7 @@ jq -n --rawfile pin /path/to/appliance-ca.pem \
   '{name:"vcf-logs-lab", product:"vmware-rest", host:"vrli.nested.lab",
     auth_model:"shared_service_account", tls_ca_pin:$pin}' \
 | curl -sf -X POST https://meho.example.com/api/v1/targets \
-    -H "Authorization: Bearer $(meho status --print-token)" \
+    -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
     -H 'Content-Type: application/json' -d @-
 
 # Rotate the pin (e.g. the appliance cert was re-issued): PATCH the new
@@ -590,12 +590,12 @@ jq -n --rawfile pin /path/to/appliance-ca.pem \
 # client-pool cache key, so the old client is never reused.
 jq -n --rawfile pin /path/to/new-appliance-ca.pem '{tls_ca_pin:$pin}' \
 | curl -sf -X PATCH https://meho.example.com/api/v1/targets/vcf-logs-lab \
-    -H "Authorization: Bearer $(meho status --print-token)" \
+    -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
     -H 'Content-Type: application/json' -d @-
 
 # Clear the pin (the CA is now in the global bundle, say): send null.
 curl -sf -X PATCH https://meho.example.com/api/v1/targets/vcf-logs-lab \
-  -H "Authorization: Bearer $(meho status --print-token)" \
+  -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
   -H 'Content-Type: application/json' \
   -d '{"tls_ca_pin": null}'
 ```
@@ -616,7 +616,7 @@ settable on both create and update (the route is `tenant_admin`-only):
 ```bash
 # Create a target with verification off (self-signed lab appliance).
 curl -sf -X POST https://meho.example.com/api/v1/targets \
-  -H "Authorization: Bearer $(meho status --print-token)" \
+  -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
   -H 'Content-Type: application/json' \
   -d '{
         "name": "vcf-logs-lab",
@@ -628,7 +628,7 @@ curl -sf -X POST https://meho.example.com/api/v1/targets \
 
 # Flip an existing target back to secure once its CA is in the bundle.
 curl -sf -X PATCH https://meho.example.com/api/v1/targets/vcf-logs-lab \
-  -H "Authorization: Bearer $(meho status --print-token)" \
+  -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
   -H 'Content-Type: application/json' \
   -d '{"verify_tls": true}'
 ```
@@ -878,12 +878,12 @@ array, e.g. `["meho-docs", "meho-docs:vmware"]`.
 
 **Verify the claim is present on the audience that's failing.** Decode the
 token each surface validates and confirm both the audience and the
-capability. Using `meho status --print-token` (the CLI/REST audience):
+capability. Using `meho login --print-token` (the CLI/REST audience):
 
 ```bash
 # 1. The capabilities claim carries the per-collection key on the REST/UI
 #    audience token. (jwt-cli `jwt decode`, or jq over the base64 payload.)
-meho status --print-token \
+meho login --print-token https://meho.example.com \
   | jwt decode --json - \
   | jq '{aud: .payload.aud, capabilities: .payload.capabilities}'
 # Expect aud to include "meho-backplane" AND capabilities to include
@@ -893,7 +893,7 @@ meho status --print-token \
 # 2. Probe the REST surface directly: a 403 names the missing claim + the
 #    identity it checked, so you can grant exactly that capability.
 curl -s -X POST https://meho.example.com/api/v1/search_docs \
-  -H "Authorization: Bearer $(meho status --print-token)" \
+  -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
   -H 'Content-Type: application/json' \
   -d '{"query":"x","collection":"vmware"}' | jq .detail
 # {
@@ -1304,7 +1304,7 @@ meho login https://meho.evba.lab
 # Logged in to https://meho.evba.lab; token stored in keyring.
 
 # 3. Authenticated REST call succeeds.
-curl -sf -H "Authorization: Bearer $(meho status --print-token)" \
+curl -sf -H "Authorization: Bearer $(meho login --print-token https://meho.evba.lab)" \
   https://meho.evba.lab/api/v1/health
 # {"status": "ok"}
 

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -482,7 +482,9 @@ Authorization Grant (RFC 8628). End-to-end shape:
 4. **Prompt.** The CLI prints the verification URL and `user_code` to
    stdout. The operator opens the URL on any device with a browser,
    signs in, and approves the request. (Browser auto-launch is
-   deferred to a future Task per the v0.1 scope.)
+   deferred to a future Task per the v0.1 scope.) Under `--print-token`
+   this prompt is written to stderr instead, so stdout stays reserved
+   for the token — see step 7.
 5. **Polling.** `Config.DeviceAccessToken` polls the token endpoint
    at the IdP-supplied `interval`, honouring RFC 8628's
    `authorization_pending` and `slow_down` semantics. The polling
@@ -522,6 +524,22 @@ Authorization Grant (RFC 8628). End-to-end shape:
 6. **Persistence.** The access token plus issuer, client_id,
    refresh token (captured for v0.2), and id_token are persisted to
    a backend chosen at runtime — see below.
+7. **Token print (`--print-token`).** After persistence, when the
+   operator passed `--print-token`, the CLI writes the freshly minted
+   access token — and nothing else — to stdout, followed by a single
+   newline, then returns. Every other line the command emits (the
+   device-code prompt, the success message, the migration nudge, the
+   config-persist warning) is diverted to stderr for the whole run, so
+   `TOKEN=$(meho login --print-token <url>)` captures exactly the
+   bearer and `meho login --print-token <url> | wc -l` is `1`. This is
+   the coherent home for raw-token retrieval — `meho status` redacts
+   the token by design (see "Bearer redaction" below), so the flag
+   lives on `login`, not `status`. Two helpers keep the contract
+   auditable and unit-testable: `humanWriter` routes operator-facing
+   chrome to stderr, and `printAccessToken` is the sole writer to
+   stdout on this path. The value is a live credential, so `--help`
+   carries a do-not-log caution and the flag is off by default.
+   Precedent: `gcloud auth print-access-token`, `gh auth token`.
 
 ### Token storage
 

--- a/docs/cross-repo/mcp-client-setup.md
+++ b/docs/cross-repo/mcp-client-setup.md
@@ -118,7 +118,7 @@ The remote Custom Connector path (paste a `/mcp` URL into claude.ai → Settings
 # Obtain a token via the realm's preferred flow — for the dogfood
 # consumer, `meho login` is the simplest path; for direct Keycloak
 # device-code, `kcadm.sh` works too.
-TOKEN=$(meho login --print-token)
+TOKEN=$(meho login --print-token https://meho.example.com)
 
 # List tools (smoke test).
 npx @modelcontextprotocol/inspector --cli \


### PR DESCRIPTION
## Summary

- Add `--print-token` to `meho login`: after a successful device-code flow it writes **only** the freshly minted access token to stdout (one trailing newline), diverting every other line — the device-code prompt, the success message, the migration nudge, warnings — to stderr, so `TOKEN=$(meho login --print-token <url>)` captures exactly the bearer (precedent: `gcloud auth print-access-token`, `gh auth token`).
- Mirrors, rather than weakens, `status.go`'s redaction posture: `meho status` still redacts the token by design, so raw-token retrieval is homed on `login`. Default `meho login` output is byte-identical when the flag is off; `--help` carries a live-credential caution.
- Two small package-scope helpers keep the stdout contract auditable and unit-tested: `humanWriter` (routes chrome to stderr) and `printAccessToken` (the sole stdout writer on this path).
- Repoints all 12 phantom-flag doc references at the real flag: the 9 `meho status --print-token` sites in `deploy/values-examples/README.md` switch **command** to `meho login --print-token <url>`; `docs/cross-repo/mcp-client-setup.md` (3×) and `docs/codebase/cli.md` are updated to match.

## Test plan

- [x] `go test ./...` (CLI module) — all packages pass
- [x] `golangci-lint run` (v2.12.2, the "Go (golangci-lint + go test)" CI gate) — 0 issues
- [x] `gofmt -l` — clean
- [x] New unit test `TestLoginPrintTokenEmitsExactlyTheToken` — asserts stdout is exactly the token (`wc -l == 1`, `$(...)`-capture equals the token); mirrors `status_test.go`'s redaction test
- [x] New unit test `TestLoginHumanWriterDivertsChromeUnderPrintToken` — asserts chrome routes to stderr under the flag, stdout otherwise
- [x] `--print-token` added to the help-surface guard `TestLoginCommandHelpListsFlags`
- [x] Binary smoke: `meho login --help` shows the bool flag with the do-not-log caution and no bogus value placeholder; `meho login --print-token` (no URL) still errors via `ExactArgs(1)`
- [x] `grep -rn "status --print-token" deploy/ docs/` → empty
- [x] Every `print-token` reference in the two docs is `meho login --print-token`

## Out of scope / notes

- Not adding `--print-token` to `meho status` — `status` intentionally redacts the token; `login` is the coherent home (per the task).
- The `values-examples` curl snippets keep the author's original inline `$(...)` form, now switched to `meho login`. A capture-once refactor (`TOKEN=$(meho login --print-token <url>)` reused across the block, avoiding a re-auth per call) would be a nicer UX but is a larger structural rewrite than the task's "switch command" scope — noted for a possible follow-up.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2782
