### PR TITLE
chore(governance): machine review identity + DCO remediation commits

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Configuration for the DCO GitHub App (https://github.com/apps/dco).
+# The app reads this file from the default branch only — changes take
+# effect after they land on `main`, not while the PR that edits them is
+# open.
+#
+# Why this file exists (#2733; decision record:
+# docs/decisions/automation-review-identity.md): the DCO app's
+# remediation-commit feature is opt-in and defaults to off. Without this
+# file, the only way to repair a commit that is missing its
+# `Signed-off-by` trailer is to rewrite the branch and force-push —
+# which destroys review anchors and cost two branch rewrites during the
+# Initiative #2716 run. With `individual: true`, the commit author can
+# instead push a follow-up remediation commit (per DCO 1.1) that applies
+# the sign-off retroactively, and the DCO check turns green without any
+# history rewrite.
+#
+# Deliberately NOT set:
+#
+#   require:
+#     members: false
+#
+# That option exempts org members' commits from the sign-off
+# requirement. Every commit on this repo keeps the requirement —
+# `git commit -s` remains mandatory (see CONTRIBUTING.md, "Developer
+# Certificate of Origin"); remediation is the repair path, not a waiver.
+
+allowRemediationCommits:
+  # The original commit author may push a follow-up signed-off commit
+  # applying their own sign-off retroactively.
+  individual: true
+  # Third-party remediation (someone else signing off on the author's
+  # behalf) stays disabled — least surface. Revisit only if an external
+  # contributor becomes unreachable mid-PR.
+  thirdParty: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,17 +151,25 @@ The [DCO bot](https://github.com/apps/dco) checks every PR on
 `evoila/meho`. A missing `Signed-off-by:` on any commit fails the
 `DCO` required check, which blocks merge under main branch protection.
 
-Backfilling a sign-off after-the-fact requires rewriting history — for
-a single missing commit:
+Backfilling a missed sign-off does **not** require rewriting history:
+[`.github/dco.yml`](./.github/dco.yml) enables the DCO app's
+*individual remediation commits* (see
+[`docs/decisions/automation-review-identity.md`](./docs/decisions/automation-review-identity.md)).
+Push a follow-up commit — itself signed off — whose body contains one
+line per unsigned commit, in exactly this form:
 
 ```bash
-git commit --amend --signoff
-git push --force-with-lease
+git commit -s --allow-empty \
+  -m "DCO remediation" \
+  -m "I, Your Name <your@email>, hereby add my Signed-off-by to this commit: <full-sha>"
 ```
 
-For a multi-commit PR, an interactive rebase with
-`git rebase --signoff <base>` re-signs every commit in the range. Both
-flows are noisy; the easier discipline is to make `-s` the default.
+The name/email must match the unsigned commit's author, and `<full-sha>`
+is that commit's hash. The DCO check re-runs and turns green without a
+force-push. Rewriting instead (`git commit --amend --signoff`, or
+`git rebase --signoff <base>` for a range, then
+`git push --force-with-lease`) still works but destroys review anchors
+on an open PR; the easier discipline is to make `-s` the default.
 
 There is no CLA. Apache 2.0 §5 ("inbound = outbound": contributions
 flow in under the same Apache 2.0 terms the project ships under) plus

--- a/docs/codebase/automation-review-identity.md
+++ b/docs/codebase/automation-review-identity.md
@@ -212,7 +212,9 @@ by automation. Record completion in the decision record's
    # See .claude/skills/op-cli/SKILL.md for the create-via-template shape.
    op item get meho-review-app --vault <vault> >/dev/null 2>&1 || \
      echo "create item meho-review-app in <vault> with fields client-id, private-key"
-   rm -P ~/Downloads/meho-review.*.private-key.pem
+   # Plain rm — secure-wipe flags are platform-specific (and moot on
+   # modern filesystems); if the deletion worries you, rotate the key.
+   rm ~/Downloads/meho-review.*.private-key.pem
    ```
 
 6. **Smoke-test the mint path:**

--- a/docs/codebase/automation-review-identity.md
+++ b/docs/codebase/automation-review-identity.md
@@ -1,0 +1,269 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Automation review identity — the `meho-review` GitHub App
+
+## Overview
+
+The autonomous review skills (`/auto-review-pr`, driven by the
+`/auto-implement-*` family in `evoila-bosnia/meho-internal`) post a
+binary APPROVE / REQUEST_CHANGES verdict on `evoila/meho` PRs. Those
+PRs are authored by a maintainer's identity, and GitHub refuses a
+formal review on your own PR — so without a second identity the
+verdict degrades to a comment and `reviewDecision` never leaves
+`REVIEW_REQUIRED` (#2733).
+
+The fix is a dedicated **GitHub App** the review skills authenticate as
+when submitting the formal review. The App is a real second party:
+its `APPROVE` flips `reviewDecision` to `APPROVED`, satisfying branch
+protection's `required_approving_review_count: 1` honestly.
+
+Decision record (why an App and not a PAT machine user, and the DCO
+choice): [`docs/decisions/automation-review-identity.md`](../decisions/automation-review-identity.md).
+
+Status: the repo-side contract below is landed; the App itself is
+provisioned by an org admin via the runbook at the end of this doc.
+Until that happens the skills run permanently in degraded mode (see
+"Degraded mode" below).
+
+## The identity
+
+| Property | Value |
+|---|---|
+| Kind | GitHub App (org-owned, `evoila`) |
+| Recommended name / slug | "MEHO Review" / `meho-review` |
+| Attribution on PRs | `meho-review[bot]` |
+| Webhook | none (the App is a credential, not a service) |
+| Installed on | `evoila/meho` only |
+| Token kind | installation access token, expires after 1 hour |
+
+Permissions (least privilege):
+
+| Permission | Level | Why |
+|---|---|---|
+| Pull requests | Read and write | submit `APPROVE` / `REQUEST_CHANGES` reviews and inline review comments |
+| Issues | Read and write | `auto-parked` label + PR-level comments (both go through the Issues API) |
+| Contents | Read-only | the App never pushes; commits stay under the maintainer identity |
+| Metadata | Read-only | mandatory baseline for every App |
+
+The App authors **no commits**. DCO therefore never applies to it;
+commit sign-off discipline (`git commit -s`) is unchanged, and the
+repair path for a missed trailer is a remediation commit per
+[`.github/dco.yml`](../../.github/dco.yml) — see
+[CONTRIBUTING.md](../../CONTRIBUTING.md), "Developer Certificate of
+Origin".
+
+## Secret custody
+
+Two secrets exist, both operator-held (never in the repo, never in CI
+secrets — the skills run on operator machines):
+
+| Secret | Where it lives | Notes |
+|---|---|---|
+| App private key (PEM) | 1Password item `meho-review-app`, field `private-key` | generated in the App's settings page; GitHub keeps no copy |
+| Client ID | same item, field `client-id` | not secret in itself, stored alongside for one-stop reads |
+
+Optional convenience fields on the same item: `app-id`,
+`installation-id` (the mint script auto-discovers the installation id,
+so this is cache, not contract).
+
+Canonical read pattern (see the `op-cli` conventions — no secret values
+on command lines):
+
+```bash
+op read "op://<vault>/meho-review-app/private-key" | \
+  scripts/setup/mint-review-app-token.sh \
+    --client-id "$(op read --no-newline "op://<vault>/meho-review-app/client-id")" \
+    --key-file -
+```
+
+## Token flow
+
+[`scripts/setup/mint-review-app-token.sh`](../../scripts/setup/mint-review-app-token.sh)
+turns the App credentials into a short-lived installation token:
+
+1. Builds an RS256-signed JWT (`iss` = client ID, `iat` = now − 60 s,
+   `exp` = now + 9 min — inside GitHub's 10-minute cap).
+2. Discovers the installation with
+   `GET /repos/<owner>/<repo>/installation` (default repo
+   `evoila/meho`, override with `--repo`).
+3. Mints the token with
+   `POST /app/installations/{installation_id}/access_tokens`.
+4. Prints **only** the token to stdout; all diagnostics go to stderr;
+   any failure exits non-zero with a specific reason (missing
+   dependency, unreadable key, JWT rejected, App not installed).
+
+The token expires after 1 hour — mint per review session, never store.
+
+Usage: scope the token to the single mutation, keep every read on the
+normal identity (installation tokens can hit "Resource not accessible
+by integration" on GraphQL reads, and `gh pr view` and friends use
+GraphQL):
+
+```bash
+MEHO_REVIEW_APP_TOKEN=$(op read "op://<vault>/meho-review-app/private-key" | \
+  scripts/setup/mint-review-app-token.sh \
+    --client-id "$(op read --no-newline "op://<vault>/meho-review-app/client-id")" \
+    --key-file -)
+
+# Formal review — the ONLY calls that use the App token:
+GH_TOKEN="$MEHO_REVIEW_APP_TOKEN" gh pr review <n> --repo evoila/meho \
+  --approve --body-file /tmp/review-summary.md
+# (or --request-changes; inline comments via
+#  GH_TOKEN=... gh api repos/evoila/meho/pulls/<n>/comments ...)
+```
+
+## How the skills select the identity
+
+Contract implemented by
+`evoila-bosnia/meho-internal/.claude/skills/auto-review-pr/SKILL.md`
+(review posting) and consumed by the orchestrators' merge gates:
+
+1. **Machine token present** (`MEHO_REVIEW_APP_TOKEN` set, or mintable
+   from the 1Password item via the script above) → post the review
+   formally under the App identity. `reviewDecision` flips; this is
+   the normal path.
+2. **Machine credential absent or invalid** → the mint step fails
+   loudly (non-zero exit, stderr reason). The skill then **degrades
+   explicitly**: it posts the verdict as a plain comment that opens
+   with a degraded-mode banner, records
+   `review_mode: "degraded-comment"` in its result file, and the
+   orchestrator's merge gate hands the merge to a human instead of
+   expecting `reviewDecision=APPROVED`.
+3. **Never** post a formal review attempt under the author identity
+   (GitHub 422s it), and **never** post a prose verdict styled as an
+   approval without the degraded banner.
+
+## Degraded mode
+
+Degraded mode is today's pre-#2733 behaviour, made explicit instead of
+implicit. The comment the skill posts opens with:
+
+> **DEGRADED MODE — machine review identity unavailable.** This
+> verdict is advisory prose, **not** a GitHub review;
+> `reviewDecision` is unchanged and branch protection is not
+> satisfied by this comment.
+
+followed by the normal review body. The result file's
+`review_mode: "degraded-comment"` field is the machine-readable twin.
+
+### Manual check for the fail-loud path
+
+Covers #2733's "with the credential absent or invalid, the skills fail
+loudly" criterion; run it whenever the token plumbing changes:
+
+```bash
+# 1. Absent credential: the mint script must exit non-zero with a
+#    usage error, printing nothing to stdout.
+scripts/setup/mint-review-app-token.sh; echo "exit=$?"   # expect exit=2, empty stdout
+
+# 2. Invalid credential: a syntactically valid but unregistered key
+#    must be rejected by GitHub, exit non-zero, empty stdout.
+openssl genrsa 2048 2>/dev/null | \
+  scripts/setup/mint-review-app-token.sh --client-id Iv1.deadbeef --key-file -
+echo "exit=$?"                                            # expect non-zero, empty stdout
+
+# 3. Degraded posting: run /auto-review-pr with no
+#    MEHO_REVIEW_APP_TOKEN and no 1Password item reachable; verify the
+#    posted comment opens with the degraded banner and
+#    gh pr view <n> --json reviewDecision is unchanged.
+```
+
+## Rotation
+
+- **Routine rotation** (or key compromise): App settings →
+  "Private keys" → *Generate a private key*; update the
+  `meho-review-app` 1Password item; **delete the old key** in the App
+  settings. Deleting the key invalidates JWT minting immediately;
+  already-minted installation tokens die within 1 hour on their own.
+- **Immediate revocation** of a live token:
+  `DELETE /installation/token` authenticated with that token.
+- **Losing the key entirely** is recoverable: generate a new key in the
+  App settings; nothing else changes (client ID and installation are
+  stable).
+
+## Provisioning runbook (org admin, one-time)
+
+Every step below needs `evoila` org-admin rights; none can be executed
+by automation. Record completion in the decision record's
+"Provisioning record" section.
+
+1. **Create the App** — <https://github.com/organizations/evoila/settings/apps/new>:
+   - GitHub App name: `MEHO Review`
+   - Homepage URL: `https://github.com/evoila/meho`
+   - **Uncheck** "Active" under Webhook.
+   - Repository permissions: Pull requests → *Read and write*;
+     Issues → *Read and write*; Contents → *Read-only*.
+     (Metadata: Read-only is added automatically.)
+   - "Where can this GitHub App be installed?" → *Only on this account*.
+   - Create.
+2. **Note the Client ID** from the App's *General* page.
+3. **Generate a private key** — *General* → "Private keys" →
+   *Generate a private key*; a `.pem` downloads.
+4. **Install the App** — *Install App* (left sidebar) → `evoila` →
+   *Only select repositories* → `evoila/meho` → Install.
+5. **Store the credentials** (then delete the downloaded `.pem`):
+
+   ```bash
+   # Per the op-cli template flow — do not put the key on a command line.
+   # Item: meho-review-app, fields: client-id, private-key.
+   # See .claude/skills/op-cli/SKILL.md for the create-via-template shape.
+   op item get meho-review-app --vault <vault> >/dev/null 2>&1 || \
+     echo "create item meho-review-app in <vault> with fields client-id, private-key"
+   rm -P ~/Downloads/meho-review.*.private-key.pem
+   ```
+
+6. **Smoke-test the mint path:**
+
+   ```bash
+   op read "op://<vault>/meho-review-app/private-key" | \
+     scripts/setup/mint-review-app-token.sh \
+       --client-id "$(op read --no-newline "op://<vault>/meho-review-app/client-id")" \
+       --key-file - | wc -c    # expect a non-zero length, no errors
+   ```
+
+7. **Verify the two-party property on a real PR** (#2733 acceptance
+   criterion 1): on any open PR authored by a maintainer,
+
+   ```bash
+   GH_TOKEN=$(op read "op://<vault>/meho-review-app/private-key" | \
+     scripts/setup/mint-review-app-token.sh \
+       --client-id "$(op read --no-newline "op://<vault>/meho-review-app/client-id")" \
+       --key-file -) \
+   gh pr review <n> --repo evoila/meho --approve --body "Provisioning smoke test (#2733)."
+   gh pr view <n> --repo evoila/meho --json reviewDecision   # expect "APPROVED"
+   ```
+
+   (Dismiss the smoke-test review afterwards if the PR is not actually
+   ready: PR → Reviews → *Dismiss review*.)
+
+8. **Complete the "Provisioning record"** in
+   [`docs/decisions/automation-review-identity.md`](../decisions/automation-review-identity.md)
+   and close out #2733's remaining acceptance criteria.
+
+## Known gaps
+
+- Until the runbook above is executed, every automated review runs in
+  degraded mode and merges keep needing a human click — unchanged from
+  the pre-#2733 status quo, but now labelled honestly.
+- `#2733` acceptance criteria 1–2 (live `reviewDecision` flip;
+  unattended `--auto-merge` run) are provable only post-provisioning.
+
+## References
+
+- Task [#2733](https://github.com/evoila/meho/issues/2733); decision
+  record [`docs/decisions/automation-review-identity.md`](../decisions/automation-review-identity.md).
+- [Authenticating as a GitHub App installation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation)
+  (installation tokens, 1-hour expiry, installation-id discovery).
+- [Generating a JWT for a GitHub App](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app)
+  (RS256, `iss` = client ID, 10-minute `exp` cap, 60-second `iat`
+  backdate).
+- [dcoapp/app](https://github.com/dcoapp/app) — `.github/dco.yml`
+  remediation-commit configuration.
+- Skill-side wiring: `evoila-bosnia/meho-internal`,
+  `.claude/skills/auto-review-pr/SKILL.md` (identity selection,
+  degraded banner) and
+  `.claude/skills/auto-implement-initiative/SKILL.md` (merge-gate
+  handling of `review_mode`).

--- a/docs/decisions/automation-review-identity.md
+++ b/docs/decisions/automation-review-identity.md
@@ -1,0 +1,177 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Automation review identity — GitHub App reviewer + DCO remediation commits (decision)
+
+**Status:** decided (repo side landed); **org-admin provisioning routed for
+human execution** (see "Provisioning record" below — deliberately not filled
+by this record)
+**Date:** 2026-08-04
+**Goal:** [#221](https://github.com/evoila/meho/issues/221)
+**Task:** [#2733](https://github.com/evoila/meho/issues/2733) (this decision +
+the accompanying config and docs)
+
+## The matter this records
+
+The autonomous implement/review skills run under a maintainer's own GitHub
+identity — the same identity that authors the PRs they review. GitHub
+refuses `APPROVE` / `REQUEST_CHANGES` on your own pull request (HTTP 422),
+so every automated review degrades to a `COMMENT`-state review carrying a
+prose `**Verdict:**` line. Verified across the whole of Initiative #2716
+(PRs #2724, #2726, #2728, #2729, #2730) and the earlier #2710–#2715
+series: every PR ended `mergeable=MERGEABLE`, all checks green, and
+`mergeStateStatus=BLOCKED` purely on `reviewDecision=REVIEW_REQUIRED`.
+
+Consequences of the status quo:
+
+1. **The two-party review property is not actually held.** Branch
+   protection asks for one approving review; what exists is a comment
+   written by automation running as the author. The manual merge click is
+   the only real second-party step, and it is not a review.
+2. `--auto-merge` on the orchestration skills can never complete a run
+   unattended.
+3. A reader skimming the PR sees "Verdict: APPROVE" and may reasonably
+   believe the PR carries an approval it does not.
+
+An adjacent symptom from the same root: commits created by automation
+lack `Signed-off-by` unless every worker remembers `git commit -s`, and
+with no `.github/dco.yml` the DCO app's remediation-commit path was
+disabled — two PRs in #2716 needed a branch rewrite and force-push to
+repair a missing trailer.
+
+## Decision 1 — reviewer identity: GitHub App, not a PAT machine user
+
+**Decided: a dedicated GitHub App** (recommended name "MEHO Review", slug
+`meho-review`, so reviews attribute to `meho-review[bot]`) is the identity
+the review skills authenticate as when posting a formal review verdict.
+
+Considered and rejected — **PAT-backed machine user**:
+
+- A machine user consumes an org seat and carries a long-lived personal
+  access token; the token is a standing credential with no built-in
+  expiry.
+- App installation tokens are short-lived (1 hour), minted on demand
+  from a private key, scoped to a single installation, and attribute
+  cleanly as `<slug>[bot]` in the PR timeline.
+- Source: [Authenticating as a GitHub App installation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation)
+  (`POST /app/installations/{installation_id}/access_tokens`, 1-hour
+  expiry).
+
+Properties the App identity restores:
+
+- `APPROVE` / `REQUEST_CHANGES` submissions succeed (the reviewer is not
+  the PR author), so `reviewDecision` reflects the automated review's
+  actual verdict and branch protection's
+  `required_approving_review_count: 1` is satisfied honestly.
+- The PR author identity (maintainer) and the reviewer identity (App) are
+  distinct accounts — GitHub's self-review guard is satisfied, not
+  routed around.
+
+Minimum permissions (least privilege): **Pull requests: Read and write**
+(submit reviews), **Issues: Read and write** (labels such as
+`auto-parked` and PR comments go through the Issues API),
+**Contents: Read-only** (the App pushes nothing), Metadata: Read-only
+(mandatory). No webhook.
+
+## Decision 2 — DCO: sign-off stays mandatory; remediation commits enabled
+
+The task offered a choice: have the machine identity sign its commits
+off automatically, or land `.github/dco.yml` enabling remediation
+commits. **Decided: both halves of the existing discipline stay, plus
+the repair path lands:**
+
+- `git commit -s` remains mandatory for every commit, human or
+  automation (CONTRIBUTING.md, "Developer Certificate of Origin"). The
+  review App authors no commits at all — it only posts reviews — so
+  "the App signs its commits" is moot by design.
+- [`.github/dco.yml`](../../.github/dco.yml) lands with
+  `allowRemediationCommits.individual: true`: a commit that slipped
+  through without its trailer is repaired by a follow-up remediation
+  commit (per DCO 1.1), never again by rewriting a published branch.
+- `thirdParty` remediation stays **disabled** (least surface), and
+  `require.members: false` is deliberately **not** set — exempting org
+  members would weaken the DCO property this repo relies on.
+- Config schema source: [dcoapp/app](https://github.com/dcoapp/app)
+  (reads `.github/dco.yml` from the default branch;
+  `allowRemediationCommits.individual` / `.thirdParty`).
+
+## Decision 3 — fail-loud degraded mode, never a fake approval
+
+When the machine credential is absent or invalid, the review skills must
+**fail loudly and degrade explicitly**:
+
+- The formal review submission is skipped (it would 422 anyway under the
+  author identity); the verdict is posted as a plain comment that opens
+  with an explicit **degraded-mode banner** stating that it is *not* a
+  GitHub approval and that `reviewDecision` is unchanged.
+- The machine-readable result file records
+  `review_mode: "degraded-comment"` so orchestrators know the merge gate
+  cannot pass on `reviewDecision` and must hand off to a human instead
+  of parking the PR as failed.
+- Under no circumstances does automation post a prose verdict styled to
+  read like a GitHub approval without the banner.
+
+The full contract — identity selection order, custody, rotation, the
+manual fail-loud check — lives in
+[`docs/codebase/automation-review-identity.md`](../codebase/automation-review-identity.md).
+
+## What this record does not decide
+
+- **Org-admin provisioning** (creating the App under the `evoila` org,
+  installing it on `evoila/meho`, generating and storing the private
+  key) is a human action. The copy-pasteable runbook is in
+  `docs/codebase/automation-review-identity.md`; the completion is
+  attested below.
+- Acceptance criteria #1 and #2 of #2733 (a real PR's `reviewDecision`
+  flipping; an unattended `--auto-merge` run) are verifiable only after
+  provisioning; they stay open on the task until then.
+
+## Consequences
+
+- Repo side (this decision's PR): `.github/dco.yml`,
+  `docs/codebase/automation-review-identity.md` (identity, permissions,
+  custody, rotation, runbook, degraded mode),
+  [`scripts/setup/mint-review-app-token.sh`](../../scripts/setup/mint-review-app-token.sh)
+  (installation-token minting, fail-loud), this record.
+- Skill side (`evoila-bosnia/meho-internal`,
+  `.claude/skills/auto-review-pr/SKILL.md` and
+  `auto-implement-initiative/SKILL.md`): the COMMENT-state fallback is
+  described as an explicitly degraded mode, and the formal-review path
+  authenticates via the App token when present.
+- Once provisioning completes, the "verdict-of-record overlay" the
+  orchestration skills apply for the self-review 422 case deletes
+  itself: formal `reviewDecision=APPROVED` is required again
+  (`.claude/skills/auto-implement/SKILL.md`, "Merge-gate reality").
+
+## Provisioning record
+
+**This section is deliberately left for the org admin to complete** after
+executing the runbook in
+[`docs/codebase/automation-review-identity.md`](../codebase/automation-review-identity.md).
+
+- **App created (name / slug):** _(to be completed)_
+- **Installed on:** _(to be completed — expected `evoila/meho`)_
+- **Secret custody location:** _(to be completed — expected 1Password
+  item `meho-review-app`)_
+- **Provisioned by / date:** _(to be completed)_
+- **AC verification (reviewDecision flipped on a real PR):** _(link to
+  the PR — to be completed)_
+
+Until this section is completed, the identity decision stands as
+**decided and routed**, not provisioned.
+
+## References
+
+- Task [#2733](https://github.com/evoila/meho/issues/2733); observed
+  failure runs: Initiative #2716 (PRs #2724, #2726, #2728, #2729,
+  #2730), earlier #2710–#2715.
+- [Authenticating as a GitHub App installation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation)
+  — installation access tokens, 1-hour lifetime.
+- [Generating a JWT for a GitHub App](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app)
+  — RS256, `iss` = client ID, `exp` ≤ 10 minutes.
+- [dcoapp/app](https://github.com/dcoapp/app) — `.github/dco.yml`
+  schema, remediation commits.
+- Precedent record with a human-completion section:
+  [`shipped-spec-provenance.md`](shipped-spec-provenance.md).

--- a/scripts/setup/mint-review-app-token.sh
+++ b/scripts/setup/mint-review-app-token.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# mint-review-app-token.sh — mint a short-lived GitHub App installation
+# token for the MEHO automation review identity (#2733).
+#
+# The autonomous review skills post their formal APPROVE /
+# REQUEST_CHANGES verdict under a dedicated GitHub App so the verdict
+# is a real second-party review (the PR author identity cannot approve
+# its own PR). This script turns the App's credentials into the
+# 1-hour installation token those skills export as GH_TOKEN for the
+# review-posting call — and nothing else.
+#
+# Flow (see docs/codebase/automation-review-identity.md):
+#   1. RS256-signed JWT: iss = client id, iat = now-60s, exp = now+9min
+#      (inside GitHub's 10-minute cap).
+#   2. GET /repos/<repo>/installation with the JWT -> installation id.
+#   3. POST /app/installations/<id>/access_tokens -> token.
+#
+# Output contract (load-bearing for callers):
+#   - stdout: the installation token, nothing else.
+#   - stderr: all diagnostics.
+#   - exit 0 only when a token was minted; any failure exits non-zero
+#     with a specific reason (fail-loud — the review skills treat a
+#     non-zero exit as "machine identity unavailable" and degrade
+#     explicitly; they never guess).
+#
+# Usage:
+#   mint-review-app-token.sh --client-id <id> --key-file <pem-path|->
+#                            [--repo owner/name]
+#
+#   Environment fallbacks: MEHO_REVIEW_APP_CLIENT_ID,
+#   MEHO_REVIEW_APP_KEY_FILE. --key-file - reads the PEM from stdin so
+#   the key never touches the filesystem:
+#
+#   op read "op://<vault>/meho-review-app/private-key" | \
+#     mint-review-app-token.sh --client-id "$CLIENT_ID" --key-file -
+
+set -euo pipefail
+
+API="https://api.github.com"
+REPO="evoila/meho"
+CLIENT_ID="${MEHO_REVIEW_APP_CLIENT_ID:-}"
+KEY_FILE="${MEHO_REVIEW_APP_KEY_FILE:-}"
+
+err() { printf 'mint-review-app-token: %s\n' "$*" >&2; }
+
+usage_exit() {
+  err "$1"
+  err "usage: mint-review-app-token.sh --client-id <id> --key-file <pem-path|-> [--repo owner/name]"
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --client-id) CLIENT_ID="${2:-}"; shift 2 ;;
+    --key-file)  KEY_FILE="${2:-}";  shift 2 ;;
+    --repo)      REPO="${2:-}";      shift 2 ;;
+    -h|--help)   usage_exit "help requested" ;;
+    *)           usage_exit "unknown argument: $1" ;;
+  esac
+done
+
+for dep in openssl curl jq; do
+  command -v "$dep" >/dev/null 2>&1 || { err "missing dependency: $dep"; exit 3; }
+done
+
+[ -n "$CLIENT_ID" ] || usage_exit "no client id (--client-id or MEHO_REVIEW_APP_CLIENT_ID)"
+[ -n "$KEY_FILE" ]  || usage_exit "no key file (--key-file or MEHO_REVIEW_APP_KEY_FILE)"
+
+# Materialize the key for openssl. stdin mode buffers into a 0600
+# temp file that is removed on every exit path.
+TMP_KEY=""
+cleanup() { [ -n "$TMP_KEY" ] && rm -f "$TMP_KEY"; }
+trap cleanup EXIT
+
+if [ "$KEY_FILE" = "-" ]; then
+  TMP_KEY="$(mktemp)"
+  chmod 600 "$TMP_KEY"
+  cat > "$TMP_KEY"
+  KEY_FILE="$TMP_KEY"
+fi
+
+[ -s "$KEY_FILE" ] || { err "key file is missing or empty: $KEY_FILE"; exit 4; }
+
+if ! openssl pkey -in "$KEY_FILE" -noout >/dev/null 2>&1; then
+  err "key file is not a readable private key (PEM expected)"
+  exit 4
+fi
+
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+now="$(date +%s)"
+iat=$((now - 60))
+exp=$((now + 540))
+
+header="$(printf '{"typ":"JWT","alg":"RS256"}' | b64url)"
+payload="$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$iat" "$exp" "$CLIENT_ID" | b64url)"
+signature="$(printf '%s.%s' "$header" "$payload" | \
+  openssl dgst -sha256 -sign "$KEY_FILE" -binary | b64url)"
+jwt="${header}.${payload}.${signature}"
+
+gh_api() {
+  # gh_api <method> <path> -> response body + '\n' + HTTP status on
+  # stdout (curl -w appends the status as the last line; callers split
+  # it back off — a function cannot export a variable across the
+  # command-substitution subshell boundary).
+  local method="$1" path="$2"
+  curl -sS -X "$method" \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer ${jwt}" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    -w '\n%{http_code}' \
+    "${API}${path}"
+}
+
+response="$(gh_api GET "/repos/${REPO}/installation")" || {
+  err "network failure discovering the installation on ${REPO}"
+  exit 5
+}
+status="${response##*$'\n'}"
+installation="${response%$'\n'*}"
+case "$status" in
+  200) ;;
+  401) err "GitHub rejected the App JWT (401) — wrong client id, wrong/rotated key, or clock skew"; exit 6 ;;
+  404) err "no App installation found on ${REPO} (404) — the App is not installed there, or the client id is unknown; see the provisioning runbook in docs/codebase/automation-review-identity.md"; exit 7 ;;
+  *)   err "unexpected HTTP ${status} discovering the installation on ${REPO}"; exit 8 ;;
+esac
+
+installation_id="$(printf '%s' "$installation" | jq -r '.id // empty')"
+[ -n "$installation_id" ] || { err "installation response carried no id"; exit 8; }
+
+response="$(gh_api POST "/app/installations/${installation_id}/access_tokens")" || {
+  err "network failure minting the token on installation ${installation_id}"
+  exit 5
+}
+status="${response##*$'\n'}"
+token_response="${response%$'\n'*}"
+[ "$status" = "201" ] || {
+  err "token mint failed with HTTP ${status} on installation ${installation_id}"
+  exit 9
+}
+
+token="$(printf '%s' "$token_response" | jq -r '.token // empty')"
+[ -n "$token" ] || { err "token response carried no token field"; exit 9; }
+
+expires_at="$(printf '%s' "$token_response" | jq -r '.expires_at // "unknown"')"
+err "minted installation token for ${REPO} (installation ${installation_id}), expires ${expires_at}"
+printf '%s\n' "$token"

--- a/scripts/setup/mint-review-app-token.sh
+++ b/scripts/setup/mint-review-app-token.sh
@@ -46,18 +46,22 @@ KEY_FILE="${MEHO_REVIEW_APP_KEY_FILE:-}"
 
 err() { printf 'mint-review-app-token: %s\n' "$*" >&2; }
 
+usage() {
+  printf 'usage: mint-review-app-token.sh --client-id <id> --key-file <pem-path|-> [--repo owner/name]\n'
+}
+
 usage_exit() {
   err "$1"
-  err "usage: mint-review-app-token.sh --client-id <id> --key-file <pem-path|-> [--repo owner/name]"
+  usage >&2
   exit 2
 }
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --client-id) CLIENT_ID="${2:-}"; shift 2 ;;
-    --key-file)  KEY_FILE="${2:-}";  shift 2 ;;
-    --repo)      REPO="${2:-}";      shift 2 ;;
-    -h|--help)   usage_exit "help requested" ;;
+    --client-id) [ $# -ge 2 ] || usage_exit "missing value for --client-id"; CLIENT_ID="$2"; shift 2 ;;
+    --key-file)  [ $# -ge 2 ] || usage_exit "missing value for --key-file";  KEY_FILE="$2";  shift 2 ;;
+    --repo)      [ $# -ge 2 ] || usage_exit "missing value for --repo";      REPO="$2";      shift 2 ;;
+    -h|--help)   usage; exit 0 ;;
     *)           usage_exit "unknown argument: $1" ;;
   esac
 done
@@ -107,9 +111,13 @@ gh_api() {
   # it back off — a function cannot export a variable across the
   # command-substitution subshell boundary).
   local method="$1" path="$2"
+  # The Authorization header is fed through a process-substitution FD,
+  # not argv — the JWT is a live credential and command lines are
+  # world-readable via ps (op-cli rule 1: never put a secret value on
+  # a command line). curl reads header lines from @file since 7.55.
   curl -sS -X "$method" \
     -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer ${jwt}" \
+    -H @<(printf 'Authorization: Bearer %s\n' "$jwt") \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     -w '\n%{http_code}' \
     "${API}${path}"


### PR DESCRIPTION
## Summary

- Lands the **repo-side half** of the dedicated machine identity for automated reviews: the decision record (GitHub App over PAT machine user), the DCO remediation-commit config, the identity/custody/rotation documentation with a copy-pasteable org-admin provisioning runbook, and the installation-token minting script the review skills will consume.
- `.github/dco.yml` enables **individual remediation commits** (dcoapp/app reads it from the default branch), so a missed `Signed-off-by` is repaired with a follow-up commit instead of a branch rewrite + force-push (two of those during Initiative #2716). Sign-off stays mandatory for every commit — `require.members: false` is deliberately not set.
- `scripts/setup/mint-review-app-token.sh` turns the App credentials (1Password item `meho-review-app`) into a 1-hour installation token: RS256 JWT (`iss` = client ID, `exp` = now+9 min), installation discovery via `GET /repos/{repo}/installation`, mint via `POST /app/installations/{id}/access_tokens`. Token on stdout only; every failure is loud (non-zero exit + specific stderr reason) so the skills degrade explicitly instead of faking an approval.
- Companion PR on `evoila-bosnia/meho-internal` updates `.claude/skills/auto-review-pr/SKILL.md` and `auto-implement-initiative/SKILL.md`: formal review posting under the App identity when the credential exists, and the COMMENT fallback re-framed as an **explicitly degraded mode** with a mandatory banner and `review_mode: "degraded-comment"` in the result file.

## Why not `Closes`

Creating the GitHub App under the `evoila` org, installing it on `evoila/meho`, and provisioning the private key are **org-admin actions** a human must perform (runbook: `docs/codebase/automation-review-identity.md`, "Provisioning runbook"). Acceptance criteria 1–2 of the task (a real PR's `reviewDecision` flipping; an unattended `--auto-merge` run) are verifiable only after that. This PR therefore **Refs** the task instead of closing it; the "Provisioning record" section of the decision record tracks the remaining human steps.

## Test plan

- [x] `bash -n` + `shellcheck` (via `uvx --from shellcheck-py`) — clean on the mint script
- [x] Fail-loud paths executed: no args → exit 2, empty stdout; unregistered client id + throwaway key → HTTP 404 → exit 7, empty stdout, actionable stderr; garbage key → exit 4
- [x] JWT construction verified offline: header/payload decode to `{"typ":"JWT","alg":"RS256"}` / `{iat, exp, iss}` with `exp − iat = 600 s`, RS256 signature round-trips `Verified OK` against the public key
- [x] `pre-commit run --files <changed>` — trailing-whitespace, end-of-file, check-yaml, private-key detect, gitleaks all pass
- [x] `.claude/hooks/code-quality.py --diff` — exit 0
- [x] All 24 relative links in the new/edited docs resolve
- [x] `.github/dco.yml` schema checked against dcoapp/app (`allowRemediationCommits.individual/thirdParty`); remediation-commit message format checked against the app's validation regex
- [x] Commit carries `Signed-off-by` (DCO) from the start

## Out of scope

- Org-admin provisioning (App creation, installation, key custody) — runbook shipped, human executes, decision record's "Provisioning record" attests.
- Skill wiring lives in `evoila-bosnia/meho-internal` (companion PR) — `.claude/` is gitignored on this repo by design.
- Weakening branch protection or standing admin/bypass merges — explicitly out of scope per the task.

<!-- auto-implement-issue: fresh, iteration 1 -->

Refs #2733


---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-04)

Addressed review findings from the iteration-1 review (degraded-comment mode, see `<!-- auto-review-pr-iter-1 -->`):

- **B1** `339dcfe8` — App JWT now reaches curl via a process-substitution FD, never argv (`ps`-visibility, op-cli rule 1); network path re-verified end to end (unknown-app probe still 404 → exit 7).
- **m1** `339dcfe8` — dangling option values now produce a loud usage error (exit 2) instead of a silent `shift` death.
- **m2** `339dcfe8` — `-h`/`--help` prints usage to stdout and exits 0, matching `scripts/soak/soak-harness.sh` / `scripts/acceptance/smoke.sh` convention.
- **m3** `671f3828` — provisioning runbook uses portable `rm`; secure-wipe noted as platform-specific, rotation as the real remedy.

Disputed: none. Deferred: none.

<!-- auto-implement-issue: continue, iteration 1 -->
