### PR TITLE
docs(values-examples): capture token once per curl recipe block

### DIFF
--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -574,6 +574,9 @@ genuine last resort it is framed as here.
 > target still trusts public CAs too.
 
 ```bash
+# Capture the token once and reuse it across the calls below.
+TOKEN=$(meho login --print-token https://meho.example.com)
+
 # Create a target that trusts a specific appliance CA — verification
 # stays ON (chain + hostname), against the pinned CA. PEM goes in the
 # tls_ca_pin field; --rawfile keeps the multi-line cert intact as a JSON
@@ -582,7 +585,7 @@ jq -n --rawfile pin /path/to/appliance-ca.pem \
   '{name:"vcf-logs-lab", product:"vmware-rest", host:"vrli.nested.lab",
     auth_model:"shared_service_account", tls_ca_pin:$pin}' \
 | curl -sf -X POST https://meho.example.com/api/v1/targets \
-    -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
+    -H "Authorization: Bearer $TOKEN" \
     -H 'Content-Type: application/json' -d @-
 
 # Rotate the pin (e.g. the appliance cert was re-issued): PATCH the new
@@ -590,12 +593,12 @@ jq -n --rawfile pin /path/to/appliance-ca.pem \
 # client-pool cache key, so the old client is never reused.
 jq -n --rawfile pin /path/to/new-appliance-ca.pem '{tls_ca_pin:$pin}' \
 | curl -sf -X PATCH https://meho.example.com/api/v1/targets/vcf-logs-lab \
-    -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
+    -H "Authorization: Bearer $TOKEN" \
     -H 'Content-Type: application/json' -d @-
 
 # Clear the pin (the CA is now in the global bundle, say): send null.
 curl -sf -X PATCH https://meho.example.com/api/v1/targets/vcf-logs-lab \
-  -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
+  -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"tls_ca_pin": null}'
 ```
@@ -614,9 +617,12 @@ and a WARN log line, exactly like the `verify_tls` toggle.
 settable on both create and update (the route is `tenant_admin`-only):
 
 ```bash
+# Capture the token once and reuse it across the calls below.
+TOKEN=$(meho login --print-token https://meho.example.com)
+
 # Create a target with verification off (self-signed lab appliance).
 curl -sf -X POST https://meho.example.com/api/v1/targets \
-  -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
+  -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{
         "name": "vcf-logs-lab",
@@ -628,7 +634,7 @@ curl -sf -X POST https://meho.example.com/api/v1/targets \
 
 # Flip an existing target back to secure once its CA is in the bundle.
 curl -sf -X PATCH https://meho.example.com/api/v1/targets/vcf-logs-lab \
-  -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
+  -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"verify_tls": true}'
 ```
@@ -881,9 +887,12 @@ token each surface validates and confirm both the audience and the
 capability. Using `meho login --print-token` (the CLI/REST audience):
 
 ```bash
+# Capture the token once and reuse it across the calls below.
+TOKEN=$(meho login --print-token https://meho.example.com)
+
 # 1. The capabilities claim carries the per-collection key on the REST/UI
 #    audience token. (jwt-cli `jwt decode`, or jq over the base64 payload.)
-meho login --print-token https://meho.example.com \
+echo "$TOKEN" \
   | jwt decode --json - \
   | jq '{aud: .payload.aud, capabilities: .payload.capabilities}'
 # Expect aud to include "meho-backplane" AND capabilities to include
@@ -893,7 +902,7 @@ meho login --print-token https://meho.example.com \
 # 2. Probe the REST surface directly: a 403 names the missing claim + the
 #    identity it checked, so you can grant exactly that capability.
 curl -s -X POST https://meho.example.com/api/v1/search_docs \
-  -H "Authorization: Bearer $(meho login --print-token https://meho.example.com)" \
+  -H "Authorization: Bearer $TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"query":"x","collection":"vmware"}' | jq .detail
 # {
@@ -1304,7 +1313,8 @@ meho login https://meho.evba.lab
 # Logged in to https://meho.evba.lab; token stored in keyring.
 
 # 3. Authenticated REST call succeeds.
-curl -sf -H "Authorization: Bearer $(meho login --print-token https://meho.evba.lab)" \
+TOKEN=$(meho login --print-token https://meho.evba.lab)
+curl -sf -H "Authorization: Bearer $TOKEN" \
   https://meho.evba.lab/api/v1/health
 # {"status": "ok"}
 


### PR DESCRIPTION
## Summary

- The auth-onramp curl recipes in `deploy/values-examples/README.md` embedded `$(meho login --print-token <host>)` inline in every curl's `Authorization: Bearer` header, re-invoking `meho login` once per call — redundant token work, and at worst re-triggering the device-code flow when no session is cached.
- Capture the token once per recipe block into `TOKEN` and reuse `$TOKEN`, matching the capture-once idiom already used in `docs/cross-repo/mcp-client-setup.md` (L121-136).
- Four recipe blocks updated (7 inline subshells removed); each block keeps its own host — three use `meho.example.com`, the connectivity-smoke block keeps `meho.evba.lab`. In the entitlement block, the `meho login --print-token | jwt decode` step now also reuses `$TOKEN` so the block logs in exactly once.

## Test plan

- [x] AC1 — `grep -nE 'Bearer \$\(meho login' deploy/values-examples/README.md` returns empty.
- [x] AC2 — each affected block declares `TOKEN=$(meho login --print-token <host>)` once (4 blocks) and reuses `$TOKEN` (7 `Bearer $TOKEN` usages); original hosts preserved.
- [x] AC3 — idiom matches `docs/cross-repo/mcp-client-setup.md` (capture-once).
- [x] AC4 — **n/a**: `deploy/values-examples/README.md` is not part of the mkdocs `docs_dir` (`docs-site/`); it is referenced only via absolute `github.com/.../blob/main/...` URLs, not mkdocs-internal links, and this change edits only `bash` code-block content (no headings/anchors/links), so `mkdocs build --strict` is unaffected.
- [x] No trailing whitespace introduced; EOF newline intact.

## Out of scope

- Any change beyond the inline→capture-once shape (no new flags, no auth-behavior change).
- `docs/cross-repo/mcp-client-setup.md` — already capture-once.
- The `meho login --print-token` implementation itself (#2782, merged).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2787
