### PR TITLE
fix(connectors): vmware fingerprint — vCenter-capable fallback chain (GET /api/about is ESXi-only)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -2,9 +2,10 @@
 # Copyright (c) 2026 evoila Group
 # code-quality-allow: file-size — pre-existing >600-line connector (session
 # lifecycle + per-op mount hooks + 6 typed-op delegators accreted across
-# #2257/#2258/#2300/#2329/#2396/#2398); this change only adds the VI-JSON
-# vmomi transport seam (#2466). Splitting the module by responsibility is
-# separate refactor work, out of scope for a mount-path bug fix.
+# #2257/#2258/#2300/#2329/#2396/#2398, the VI-JSON vmomi transport seam
+# #2466, and the vCenter-capable fingerprint fallback chain #2765).
+# Splitting the module by responsibility is separate refactor work, out
+# of scope for a probe-chain bug fix.
 
 """VmwareRestConnector — hand-rolled HttpConnector subclass for vSphere REST.
 
@@ -93,6 +94,7 @@ from typing import Any
 
 import httpx
 import structlog
+from defusedxml.ElementTree import ParseError, fromstring
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.cache_key import target_cache_key
@@ -123,7 +125,7 @@ from meho_backplane.connectors.vmware_rest.session import (
     load_session_credentials_from_vault,
 )
 
-__all__ = ["VmwareRestConnector", "product_from_line_id"]
+__all__ = ["VmwareRestConnector", "product_from_line_id", "service_versions_api_version"]
 
 _log = structlog.get_logger(__name__)
 
@@ -161,6 +163,81 @@ _SESSION_TOKEN_OBJECT_KEY = SESSION_TOKEN_OBJECT_KEY
 # through _post_json instead — see HttpConnector for the policy.
 # Lifted here so :meth:`auth_headers`-level callers can introspect.
 _IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+# Fingerprint probe chain (#2765). ``GET /api/about`` is the ESXi host
+# REST surface — vCenter's Automation API spec has no such path (its
+# only "about" is ``/api/vcenter/phm/about``) and answers HTTP 404 —
+# so on a 404 the probe falls back to the unauthenticated version-
+# discovery document at ``/sdk/vimServiceVersions.xml``, served by
+# both vCenter and ESXi since the SOAP era (it is how pyVim/govmomi
+# negotiate API versions), then best-effort enriches the result from
+# the authenticated appliance-version read only vCenter (VCSA) serves.
+_ABOUT_PATH = "/api/about"
+_ABOUT_PROBE = "GET /api/about"
+_SERVICE_VERSIONS_PATH = "/sdk/vimServiceVersions.xml"
+_SERVICE_VERSIONS_PROBE = "GET /sdk/vimServiceVersions.xml"
+_APPLIANCE_VERSION_PATH = "/api/appliance/system/version"
+_APPLIANCE_VERSION_PROBE = "GET /api/appliance/system/version"
+
+#: The ``vimServiceVersions.xml`` namespace entry whose ``<version>``
+#: carries the current vim25 API version (four-part, e.g. ``8.0.3.0``
+#: — the same value the VI-JSON ``/sdk/vim25/{release}`` base uses).
+_VIM25_NAMESPACE = "urn:vim25"
+
+
+def _xml_local_name(tag: str) -> str:
+    """Return *tag* without any ``{uri}`` XML-namespace prefix."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def service_versions_api_version(document: str) -> str | None:
+    """Extract the current vim25 API version from a ``vimServiceVersions.xml`` body.
+
+    The version-discovery document has the shape::
+
+        <namespaces version="1.0">
+          <namespace>
+            <name>urn:vim25</name>
+            <version>8.0.3.0</version>
+            <priorVersions><version>8.0.2.0</version>...</priorVersions>
+          </namespace>
+        </namespaces>
+
+    Older products serve a variant whose tags carry the
+    ``http://www.vmware.com/vi/versions`` XML namespace (the second
+    format pyVim's ``__VersionIsSupported`` handles); matching on the
+    tags' local names covers both. Only *direct* children of a
+    ``namespace`` element are read, so ``priorVersions`` entries never
+    shadow the current version.
+
+    Returns the ``urn:vim25`` entry's version, falling back to the
+    first namespace entry carrying one; ``None`` when the document is
+    malformed or yields no version — the caller treats that as "no
+    version discovered", never an exception.
+    """
+    try:
+        root = fromstring(document)
+    except ParseError:
+        return None
+    first_version: str | None = None
+    for element in root.iter():
+        if _xml_local_name(element.tag) != "namespace":
+            continue
+        name: str | None = None
+        version: str | None = None
+        for child in element:
+            local = _xml_local_name(child.tag)
+            if local == "name":
+                name = (child.text or "").strip()
+            elif local == "version":
+                version = (child.text or "").strip() or None
+        if version is None:
+            continue
+        if name == _VIM25_NAMESPACE:
+            return version
+        if first_version is None:
+            first_version = version
+    return first_version
 
 
 def product_from_line_id(line_id: str) -> str:
@@ -282,9 +359,11 @@ class VmwareRestConnector(HttpConnector):
         # by-IP appliance that pins its cert to an FQDN is revoked over
         # the same SNI-corrected handshake the establish call used.
         self._session_extensions: dict[tuple[str, str], dict[str, Any]] = {}
-        # Per-target ``about.version`` (``GET /api/about``), resolved once
-        # and cached so the VI-JSON ``{release}`` segment
-        # (:meth:`_post_vmomi_json`) costs one probe per target rather than
+        # Per-target version for the VI-JSON ``{release}`` segment
+        # (``GET /api/about``'s ``version``, or the vim25 API version
+        # from ``/sdk/vimServiceVersions.xml`` when ``/api/about`` 404s
+        # on vCenter, #2765), resolved once and cached so
+        # :meth:`_post_vmomi_json` costs one probe per target rather than
         # one per vmomi read. Keyed on the same tenant-unique tuple as
         # ``_session_tokens``. ``None`` records "probe failed / no version"
         # so the vmomi path falls back to the ``/api`` mount without
@@ -416,8 +495,9 @@ class VmwareRestConnector(HttpConnector):
           form via :func:`._mount.mounted_path` — the pre-#2466 behaviour,
           unchanged, so the vcsim integration lane stays green.
         * **modern** (session minted at ``/api/session``): derive
-          ``{release}`` from ``GET /api/about`` (:meth:`_about_version`)
-          and POST ``/sdk/vim25/{release}{vmomi_path}``. On HTTP 404 there
+          ``{release}`` via :meth:`_about_version` (``GET /api/about``,
+          falling back to the version-discovery document on vCenter,
+          #2765) and POST ``/sdk/vim25/{release}{vmomi_path}``. On HTTP 404 there
           (a deployment that does not serve VI-JSON at the derived
           release), fall back **once** to the ``/api``-mounted form. When
           the release can't be derived, skip straight to the ``/api`` form.
@@ -461,29 +541,67 @@ class VmwareRestConnector(HttpConnector):
             raise
 
     async def _about_version(self, target: VsphereTargetLike, operator: Operator) -> str | None:
-        """Return *target*'s ``about.version`` string, resolved once and cached.
+        """Return *target*'s version string for the VI-JSON ``{release}`` segment.
 
-        Reads ``GET /api/about`` (the same probe :meth:`fingerprint` uses)
-        to obtain the ``version`` field that drives the VI-JSON
-        ``{release}`` segment in :meth:`_post_vmomi_json`. Cached per
+        Reads ``GET /api/about`` (the same probe :meth:`fingerprint`
+        starts with) for its ``version`` field. When that endpoint
+        answers HTTP 404 — vCenter serves no ``/api/about`` (#2765) —
+        falls back to the unauthenticated version-discovery document's
+        vim25 API version, which is exactly the four-part value the
+        VI-JSON base is versioned by, so the ``{release}`` derivation
+        in :meth:`_post_vmomi_json` works on vCenter too. Cached per
         tenant-unique ``target_cache_key`` so repeated vmomi reads share
-        one probe. Any transport / status / shape failure caches and
-        returns ``None`` — the vmomi caller then falls back to the ``/api``
-        mount rather than failing, and the failed probe is not retried on
-        every subsequent read.
+        one probe. Any other transport / status / shape failure caches
+        and returns ``None`` — the vmomi caller then falls back to the
+        ``/api`` mount rather than failing, and the failed probe is not
+        retried on every subsequent read.
         """
         cache_key = target_cache_key(target)
         if cache_key in self._about_versions:
             return self._about_versions[cache_key]
+        resolved: str | None = None
         try:
-            payload = await self._get_json(target, "/api/about", operator=operator)
+            payload = await self._get_json(target, _ABOUT_PATH, operator=operator)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                resolved = await self._service_versions_or_none(target)
         except (httpx.HTTPError, OSError, RuntimeError):
-            self._about_versions[cache_key] = None
-            return None
-        version = payload.get("version") if isinstance(payload, dict) else None
-        resolved = version if isinstance(version, str) and version else None
+            resolved = None
+        else:
+            version = payload.get("version") if isinstance(payload, dict) else None
+            resolved = version if isinstance(version, str) and version else None
         self._about_versions[cache_key] = resolved
         return resolved
+
+    async def _fetch_service_versions_api_version(self, target: VsphereTargetLike) -> str | None:
+        """GET the version-discovery document and return its vim25 API version.
+
+        Issues a bare GET on the pooled per-target client — deliberately
+        not :meth:`_get_json`: the document is XML (not JSON) and both
+        vCenter and ESXi serve it without authentication (pyVim fetches
+        it pre-login), so injecting :meth:`auth_headers` would force a
+        session establish the read doesn't need. Transport / status
+        errors propagate to the caller, which decides reachability; a
+        200 whose body yields no parsable version returns ``None``.
+        """
+        client = await self._http_client(target)
+        resp = await client.get(_SERVICE_VERSIONS_PATH, extensions=self._request_extensions(target))
+        resp.raise_for_status()
+        return service_versions_api_version(resp.text)
+
+    async def _service_versions_or_none(self, target: VsphereTargetLike) -> str | None:
+        """Error-swallowing :meth:`_fetch_service_versions_api_version` wrapper.
+
+        For callers (the ``{release}`` derivation) where a failed
+        discovery read must degrade to "no version" rather than raise —
+        :meth:`_fingerprint_via_service_versions` by contrast needs the
+        error to report reachability truthfully, so it calls the
+        raising form directly.
+        """
+        try:
+            return await self._fetch_service_versions_api_version(target)
+        except (httpx.HTTPError, OSError):
+            return None
 
     async def _session_token(self, target: VsphereTargetLike, operator: Operator) -> str:
         """Return the cached session token for *target*, establishing one on first use.
@@ -662,7 +780,18 @@ class VmwareRestConnector(HttpConnector):
         target: VsphereTargetLike,
         operator: Operator | None = None,
     ) -> FingerprintResult:
-        """Canonical fingerprint built from ``GET /api/about``.
+        """Canonical fingerprint built from the #2765 probe chain.
+
+        ``GET /api/about`` first — the richest source, but it is the
+        ESXi host REST surface and vCenter answers HTTP 404. On that
+        404 (specifically — transport/auth failures keep the
+        unreachable arm) the probe falls back to the unauthenticated
+        ``/sdk/vimServiceVersions.xml`` version-discovery document,
+        best-effort enriched by ``GET /api/appliance/system/version``
+        (VCSA-only). ``probe_method`` always names the endpoint(s) that
+        produced the result. Pre-#2765 the probe stopped at
+        ``/api/about``, so every vCenter target permanently read
+        ``reachable=False``.
 
         The session token is fetched lazily by :meth:`auth_headers`
         (called transitively through :meth:`HttpConnector._request_json`).
@@ -693,19 +822,23 @@ class VmwareRestConnector(HttpConnector):
         # when no real operator is in scope.
         eff_operator = operator if operator is not None else synthesise_system_operator()
         try:
-            payload = await self._get_json(target, "/api/about", operator=eff_operator)
+            payload = await self._get_json(target, _ABOUT_PATH, operator=eff_operator)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                # vCenter serves no GET /api/about (#2765); a session
+                # was already established for the GET that 404'd, so
+                # the fallback's appliance read reuses it.
+                return await self._fingerprint_via_service_versions(target, eff_operator, probed_at)
+            return self._unreachable_fingerprint(
+                target, probed_at, _ABOUT_PROBE, f"{type(exc).__name__}: {exc}"
+            )
         except (httpx.HTTPError, OSError, RuntimeError) as exc:
             # RuntimeError catches the session-establish failures from
             # :meth:`_session_token` so an unauthenticatable target
             # surfaces as a clean ``reachable=False`` fingerprint
             # rather than propagating the wrapped exception.
-            return FingerprintResult(
-                vendor="vmware",
-                product="vcenter",
-                reachable=False,
-                probed_at=probed_at,
-                probe_method="GET /api/about",
-                extras={"error": f"{type(exc).__name__}: {exc}"},
+            return self._unreachable_fingerprint(
+                target, probed_at, _ABOUT_PROBE, f"{type(exc).__name__}: {exc}"
             )
         return FingerprintResult(
             vendor="vmware",
@@ -715,7 +848,7 @@ class VmwareRestConnector(HttpConnector):
             edition=payload.get("license_product_name"),
             reachable=True,
             probed_at=probed_at,
-            probe_method="GET /api/about",
+            probe_method=_ABOUT_PROBE,
             extras={
                 "uuid": payload.get("instance_uuid"),
                 "full_name": payload.get("full_name"),
@@ -723,6 +856,126 @@ class VmwareRestConnector(HttpConnector):
                 "api_type": payload.get("api_type"),
                 "os_type": payload.get("os_type"),
             },
+        )
+
+    async def _fingerprint_via_service_versions(
+        self,
+        target: VsphereTargetLike,
+        operator: Operator,
+        probed_at: datetime,
+    ) -> FingerprintResult:
+        """Fingerprint a target whose ``GET /api/about`` answered HTTP 404.
+
+        Chain steps 2 + 3 of #2765: read the unauthenticated
+        version-discovery document for the vim25 API version (enough
+        for ``reachable=True`` + a version), then best-effort enrich
+        from the authenticated appliance-version read. Only the
+        appliance surface identifies the product as vCenter by
+        observation; without it the result carries the target's
+        registered product — the discovery document alone cannot
+        distinguish vCenter from an older ESXi that predates the host
+        REST surface.
+        """
+        chain = f"{_ABOUT_PROBE} + {_SERVICE_VERSIONS_PROBE}"
+        about_extras = {"api_about": "HTTP 404 (endpoint is ESXi-only)"}
+        try:
+            api_version = await self._fetch_service_versions_api_version(target)
+        except (httpx.HTTPError, OSError) as exc:
+            return self._unreachable_fingerprint(
+                target, probed_at, chain, f"{type(exc).__name__}: {exc}", extras=about_extras
+            )
+        if api_version is None:
+            # A 200 with no parsable vim25 version is an answering
+            # socket, not a verified vSphere surface — some other web
+            # server on the target's port must not read as reachable.
+            return self._unreachable_fingerprint(
+                target,
+                probed_at,
+                chain,
+                "vimServiceVersions.xml answered but yielded no vim25 API version",
+                extras=about_extras,
+            )
+        appliance = await self._appliance_version(target, operator)
+        if appliance is None:
+            return FingerprintResult(
+                vendor="vmware",
+                product=getattr(target, "product", None) or "unknown",
+                version=api_version,
+                reachable=True,
+                probed_at=probed_at,
+                probe_method=_SERVICE_VERSIONS_PROBE,
+                extras={"api_version": api_version},
+            )
+        version = appliance.get("version")
+        build = appliance.get("build")
+        return FingerprintResult(
+            vendor="vmware",
+            # The appliance surface is served by VCSA only, so an
+            # answer here is observed evidence of vCenter — unlike
+            # the failure arms, this is not an assumption.
+            product="vcenter",
+            version=version if isinstance(version, str) and version else api_version,
+            build=build if isinstance(build, str) and build else None,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=f"{_SERVICE_VERSIONS_PROBE} + {_APPLIANCE_VERSION_PROBE}",
+            extras={
+                "api_version": api_version,
+                "product_name": appliance.get("product"),
+                "type": appliance.get("type"),
+            },
+        )
+
+    async def _appliance_version(
+        self, target: VsphereTargetLike, operator: Operator
+    ) -> dict[str, Any] | None:
+        """Best-effort authenticated ``GET /api/appliance/system/version`` read.
+
+        Returns the appliance ``VersionStruct`` payload (``version`` /
+        ``build`` / ``product`` / ``type`` / ...) — the authoritative
+        vCenter version source — or ``None`` on any failure: the
+        appliance surface is VCSA-only, so its absence (ESXi, vcsim, a
+        transient error mid-probe) must not turn an already-verified
+        reachable fingerprint red (#2765).
+        """
+        try:
+            payload = await self._get_json(target, _APPLIANCE_VERSION_PATH, operator=operator)
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            _log.debug(
+                "vsphere_appliance_version_unavailable",
+                target=target.name,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def _unreachable_fingerprint(
+        self,
+        target: VsphereTargetLike,
+        probed_at: datetime,
+        probe_method: str,
+        error: str,
+        extras: dict[str, Any] | None = None,
+    ) -> FingerprintResult:
+        """Build the ``reachable=False`` result for a failed probe chain.
+
+        ``product`` reports the target's *registered* product when the
+        concrete target model carries one, falling back to ``"unknown"``
+        — a failed probe observed nothing, so the previous hardcoded
+        ``"vcenter"`` could stamp a product the target never exhibited
+        (#2765). ``probe_method`` names every endpoint the chain
+        attempted so the operator can see how far it got.
+        """
+        merged: dict[str, Any] = {"error": error}
+        if extras:
+            merged.update(extras)
+        return FingerprintResult(
+            vendor="vmware",
+            product=getattr(target, "product", None) or "unknown",
+            reachable=False,
+            probed_at=probed_at,
+            probe_method=probe_method,
+            extras=merged,
         )
 
     async def probe(self, target: VsphereTargetLike) -> ProbeResult:

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -94,6 +94,7 @@ from typing import Any
 
 import httpx
 import structlog
+from defusedxml import DefusedXmlException
 from defusedxml.ElementTree import ParseError, fromstring
 
 from meho_backplane.auth.operator import Operator
@@ -213,11 +214,15 @@ def service_versions_api_version(document: str) -> str | None:
     Returns the ``urn:vim25`` entry's version, falling back to the
     first namespace entry carrying one; ``None`` when the document is
     malformed or yields no version — the caller treats that as "no
-    version discovered", never an exception.
+    version discovered", never an exception. ``DefusedXmlException``
+    (``EntitiesForbidden`` on an entity-bearing document; a
+    :exc:`ValueError`, not a :exc:`ParseError`) is caught alongside
+    ``ParseError`` — defusedxml *rejecting* a hostile document is the
+    same "no version discovered" outcome as failing to parse one.
     """
     try:
         root = fromstring(document)
-    except ParseError:
+    except (ParseError, DefusedXmlException):
         return None
     first_version: str | None = None
     for element in root.iter():

--- a/backend/tests/test_connectors_vmware_rest_fingerprint.py
+++ b/backend/tests/test_connectors_vmware_rest_fingerprint.py
@@ -17,6 +17,18 @@ Coverage matrix (per #498 acceptance criteria):
   ``ConnectError``, HTTP 401 from session, 5xx from ``/api/about``).
 * :meth:`probe` returns ``ok=True`` when fingerprint is reachable;
   ``ok=False`` with ``reason`` populated when not.
+
+Plus the #2765 vCenter-capable fallback chain (``GET /api/about`` is the
+ESXi host REST surface; vCenter 404s it):
+
+* a 404 on ``/api/about`` falls back to the unauthenticated
+  ``/sdk/vimServiceVersions.xml`` (``reachable=True`` + vim25 API
+  version), enriched by ``GET /api/appliance/system/version`` when the
+  appliance surface answers (``product="vcenter"`` + version/build);
+* both probes failing stays ``reachable=False`` with the error in
+  ``extras``; non-404 ``/api/about`` failures never enter the fallback;
+* the unreachable arm no longer hardcodes ``product="vcenter"`` — it
+  reports the target's registered product, else ``"unknown"``.
 """
 
 from __future__ import annotations
@@ -40,6 +52,7 @@ from meho_backplane.connectors.vmware_rest import (
     VsphereTargetLike,
     product_from_line_id,
 )
+from meho_backplane.connectors.vmware_rest.connector import service_versions_api_version
 
 # ---------------------------------------------------------------------------
 # Target stub — same shape as the auth-test module's stub
@@ -198,6 +211,10 @@ async def test_fingerprint_returns_unreachable_on_connect_error() -> None:
     # Vendor stays vmware so the operator can identify the failed
     # connector class without a separate lookup.
     assert result.vendor == "vmware"
+    # #2765: the unreachable arm no longer asserts product="vcenter" —
+    # nothing was observed, and the stub target carries no registered
+    # product, so the truthful value is "unknown".
+    assert result.product == "unknown"
     assert result.probe_method == "GET /api/about"
     assert "ConnectError" in result.extras["error"]
     await connector.aclose()
@@ -214,6 +231,7 @@ async def test_fingerprint_returns_unreachable_on_session_401() -> None:
         result = await connector.fingerprint(_TARGET)
 
     assert result.reachable is False
+    assert result.product == "unknown"  # #2765: no observed product on failure
     assert "401" in result.extras["error"]
     await connector.aclose()
 
@@ -245,6 +263,211 @@ async def test_fingerprint_returns_unreachable_on_about_5xx() -> None:
     assert result.reachable is False
     assert "503" in result.extras["error"]
     await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# #2765 — vCenter-capable fallback chain
+# ---------------------------------------------------------------------------
+
+#: The version-discovery document both vCenter and ESXi serve
+#: unauthenticated at /sdk/vimServiceVersions.xml (shape per pyVim's
+#: ``__VersionIsSupported`` parser and govmomi's simulator template).
+_SERVICE_VERSIONS_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<namespaces version="1.0">
+ <namespace>
+  <name>urn:vim25</name>
+  <version>8.0.3.0</version>
+  <priorVersions>
+   <version>8.0.2.0</version>
+   <version>7.0.3.0</version>
+  </priorVersions>
+ </namespace>
+</namespaces>
+"""
+
+#: ``GET /api/appliance/system/version`` body (appliance VersionStruct
+#: shape per the vSphere Automation SDK: version / product / build /
+#: type / summary / releasedate / install_time).
+_APPLIANCE_VERSION_PAYLOAD: dict[str, Any] = {
+    "version": "8.0.3.00000",
+    "build": "24022515",
+    "product": "VMware vCenter Server",
+    "type": "vCenter Server with an embedded Platform Services Controller",
+    "summary": "Patch for VMware vCenter Server 8.0",
+    "releasedate": "May 21, 2024",
+    "install_time": "2024-06-01T00:00:00.000Z",
+}
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_falls_back_to_service_versions_on_about_404() -> None:
+    """A 404 on /api/about + a served discovery document → reachable=True.
+
+    The vCenter shape (#2765): no /api/about, but the unauthenticated
+    version-discovery document answers. Without the appliance surface
+    (404 here) the fingerprint carries the vim25 API version and the
+    truthful probe_method; the stub target registers no product, so
+    product falls back to "unknown".
+    """
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="vc-session-token")
+        mock.get("/api/about").respond(404)
+        mock.get("/sdk/vimServiceVersions.xml").respond(
+            200, text=_SERVICE_VERSIONS_XML, headers={"content-type": "text/xml"}
+        )
+        mock.get("/api/appliance/system/version").respond(404)
+        result = await connector.fingerprint(_TARGET)
+
+    assert result.reachable is True
+    assert result.vendor == "vmware"
+    assert result.product == "unknown"
+    assert result.version == "8.0.3.0"
+    assert result.build is None
+    assert result.probe_method == "GET /sdk/vimServiceVersions.xml"
+    assert result.extras["api_version"] == "8.0.3.0"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_fallback_reports_registered_product_when_present() -> None:
+    """Without observed product evidence the target's registered product is used."""
+
+    @dataclass
+    class _ProductTarget(_StubTarget):
+        product: str = "vmware"
+
+    target = _ProductTarget(
+        name="vcenter-fp",
+        host="vcenter-fp.test.invalid",
+        port=443,
+        secret_ref="vsphere/vcenter-fp",
+    )
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="vc-session-token")
+        mock.get("/api/about").respond(404)
+        mock.get("/sdk/vimServiceVersions.xml").respond(200, text=_SERVICE_VERSIONS_XML)
+        mock.get("/api/appliance/system/version").respond(404)
+        result = await connector.fingerprint(target)
+
+    assert result.reachable is True
+    assert result.product == "vmware"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_fallback_enriches_from_appliance_version() -> None:
+    """With a session, the VCSA appliance read supplies version + build.
+
+    The appliance surface is vCenter-only, so an answer is observed
+    evidence for product="vcenter"; version/build come from the
+    authoritative appliance VersionStruct, and probe_method names both
+    endpoints that produced the result.
+    """
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="vc-session-token")
+        mock.get("/api/about").respond(404)
+        mock.get("/sdk/vimServiceVersions.xml").respond(200, text=_SERVICE_VERSIONS_XML)
+        mock.get("/api/appliance/system/version").respond(200, json=_APPLIANCE_VERSION_PAYLOAD)
+        result = await connector.fingerprint(_TARGET)
+
+    assert result.reachable is True
+    assert result.product == "vcenter"
+    assert result.version == "8.0.3.00000"
+    assert result.build == "24022515"
+    assert result.probe_method == (
+        "GET /sdk/vimServiceVersions.xml + GET /api/appliance/system/version"
+    )
+    assert result.extras["api_version"] == "8.0.3.0"
+    assert result.extras["product_name"] == "VMware vCenter Server"
+    assert result.extras["type"] == ("vCenter Server with an embedded Platform Services Controller")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_stays_unreachable_when_both_probes_fail() -> None:
+    """/api/about 404 + discovery document 404 → reachable=False with the error."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="vc-session-token")
+        mock.get("/api/about").respond(404)
+        mock.get("/sdk/vimServiceVersions.xml").respond(404)
+        result = await connector.fingerprint(_TARGET)
+
+    assert result.reachable is False
+    assert result.product == "unknown"
+    assert result.probe_method == "GET /api/about + GET /sdk/vimServiceVersions.xml"
+    assert "404" in result.extras["error"]
+    assert "404" in result.extras["api_about"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_when_discovery_document_unparsable() -> None:
+    """A 200 with no vim25 version (some other web server) is not reachable."""
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+
+    async with respx.mock(base_url="https://vcenter-fp.test.invalid") as mock:
+        mock.post("/api/session").respond(200, json="vc-session-token")
+        mock.get("/api/about").respond(404)
+        mock.get("/sdk/vimServiceVersions.xml").respond(200, text="<html>login page</html>")
+        result = await connector.fingerprint(_TARGET)
+
+    assert result.reachable is False
+    assert "no vim25 API version" in result.extras["error"]
+    await connector.aclose()
+
+
+@pytest.mark.parametrize(
+    ("document", "expected"),
+    [
+        # The modern un-namespaced shape (govmomi simulator template);
+        # priorVersions entries must not shadow the current version.
+        (_SERVICE_VERSIONS_XML, "8.0.3.0"),
+        # The XML-namespaced variant older products serve (the second
+        # format pyVim's __VersionIsSupported handles).
+        (
+            '<namespaces version="1.0" xmlns="http://www.vmware.com/vi/versions">'
+            "<namespace><name>urn:vim25</name><version>6.7.3</version></namespace>"
+            "</namespaces>",
+            "6.7.3",
+        ),
+        # vim25 entry wins over other namespace entries regardless of order.
+        (
+            '<namespaces version="1.0">'
+            "<namespace><name>urn:vim</name><version>2.5</version></namespace>"
+            "<namespace><name>urn:vim25</name><version>7.0.3.0</version></namespace>"
+            "</namespaces>",
+            "7.0.3.0",
+        ),
+        # No vim25 entry: fall back to the first entry carrying a version.
+        (
+            '<namespaces version="1.0">'
+            "<namespace><name>urn:vim</name><version>2.5</version></namespace>"
+            "</namespaces>",
+            "2.5",
+        ),
+        # No namespace entries / not the discovery document at all.
+        ('<namespaces version="1.0"></namespaces>', None),
+        ("<html>login page</html>", None),
+        # Malformed XML must yield None, never raise.
+        ("<namespaces><namespace>", None),
+        ("", None),
+    ],
+)
+def test_service_versions_api_version_parsing(document: str, expected: str | None) -> None:
+    assert service_versions_api_version(document) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_fingerprint.py
+++ b/backend/tests/test_connectors_vmware_rest_fingerprint.py
@@ -464,6 +464,16 @@ async def test_fingerprint_unreachable_when_discovery_document_unparsable() -> N
         # Malformed XML must yield None, never raise.
         ("<namespaces><namespace>", None),
         ("", None),
+        # An entity-bearing document makes defusedxml raise
+        # EntitiesForbidden (a DefusedXmlException — ValueError, not
+        # ParseError); the parser must treat the rejection as "no
+        # version discovered", never an exception.
+        (
+            "<!DOCTYPE namespaces [<!ENTITY x 'y'>]>"
+            '<namespaces version="1.0"><namespace><name>urn:vim25</name>'
+            "<version>&x;</version></namespace></namespaces>",
+            None,
+        ),
     ],
 )
 def test_service_versions_api_version_parsing(document: str, expected: str | None) -> None:

--- a/backend/tests/test_connectors_vmware_rest_vmomi_mount.py
+++ b/backend/tests/test_connectors_vmware_rest_vmomi_mount.py
@@ -290,6 +290,41 @@ async def test_unresolvable_about_version_goes_straight_to_api() -> None:
 
 
 @pytest.mark.asyncio
+async def test_about_404_derives_release_from_service_versions_document() -> None:
+    """On vCenter (/api/about 404s, #2765) the release comes from the discovery doc.
+
+    The vim25 API version in /sdk/vimServiceVersions.xml is the same
+    four-part value the VI-JSON base is versioned by, so the vmomi read
+    mounts on /sdk/vim25/{release} instead of dropping straight to the
+    /api form.
+    """
+    document = (
+        '<namespaces version="1.0"><namespace><name>urn:vim25</name>'
+        "<version>8.0.3.0</version></namespace></namespaces>"
+    )
+    connector = _make_connector()
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=_BASE, assert_all_called=False) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            mock.get("/api/about").respond(404)
+            mock.get("/sdk/vimServiceVersions.xml").respond(200, text=document)
+            vijson = mock.post(_VIJSON_URL).respond(200, json={"objects": ["vi-json"]})
+            api = mock.post(_API_URL).respond(200, json={"objects": ["api"]})
+            result = await connector._post_vmomi_json(
+                _StubTarget(),
+                _RETRIEVE_PROPERTIES_PATH,
+                operator=_make_operator(),
+                json=_RETRIEVE_BODY,
+            )
+        assert result == {"objects": ["vi-json"]}
+        assert vijson.call_count == 1
+        assert not api.called
+    finally:
+        await connector.aclose()
+
+
+@pytest.mark.asyncio
 async def test_about_version_resolved_once_and_cached_across_reads() -> None:
     """The about-version probe runs once per target and is reused (AC caching)."""
     connector = _make_connector()

--- a/backend/tests/test_connectors_vmware_rest_vmomi_mount.py
+++ b/backend/tests/test_connectors_vmware_rest_vmomi_mount.py
@@ -308,7 +308,7 @@ async def test_about_404_derives_release_from_service_versions_document() -> Non
         async with respx.mock(base_url=_BASE, assert_all_called=False) as mock:
             mock.post("/api/session").respond(200, json="tok")
             mock.get("/api/about").respond(404)
-            mock.get("/sdk/vimServiceVersions.xml").respond(200, text=document)
+            service_versions = mock.get("/sdk/vimServiceVersions.xml").respond(200, text=document)
             vijson = mock.post(_VIJSON_URL).respond(200, json={"objects": ["vi-json"]})
             api = mock.post(_API_URL).respond(200, json={"objects": ["api"]})
             result = await connector._post_vmomi_json(
@@ -318,6 +318,7 @@ async def test_about_404_derives_release_from_service_versions_document() -> Non
                 json=_RETRIEVE_BODY,
             )
         assert result == {"objects": ["vi-json"]}
+        assert service_versions.call_count == 1
         assert vijson.call_count == 1
         assert not api.called
     finally:

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -276,23 +276,48 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
 
 ### fingerprint() / probe()
 
-`fingerprint(target)` issues `GET /api/about` (auth headers injected
-lazily via the cached session token); the response payload populates
-the canonical `FingerprintResult`:
+`fingerprint(target)` runs the #2765 probe chain. `GET /api/about`
+first (auth headers injected lazily via the cached session token) —
+the richest source, but it is the **ESXi host REST surface**: vCenter's
+Automation API has no `/api/about` and answers HTTP 404, which
+pre-#2765 left every vCenter target permanently `reachable=False`.
 
-- `vendor="vmware"`
-- `product` — via `product_from_line_id(payload.product_line_id)`
-  (`vpx` → `vcenter`; `embeddedEsx`/`esx` → `esxi`; fall-through for
-  unknown values; `""`/`None` → `"unknown"`)
-- `version`, `build`, `edition` — straight from the payload
-- `extras` — `uuid`, `full_name`, `product_line_id`, `api_type`,
-  `os_type`
+1. `GET /api/about` answers 200 → the payload populates the canonical
+   `FingerprintResult` exactly as before:
+   - `vendor="vmware"`
+   - `product` — via `product_from_line_id(payload.product_line_id)`
+     (`vpx` → `vcenter`; `embeddedEsx`/`esx` → `esxi`; fall-through for
+     unknown values; `""`/`None` → `"unknown"`)
+   - `version`, `build`, `edition` — straight from the payload
+   - `extras` — `uuid`, `full_name`, `product_line_id`, `api_type`,
+     `os_type`
+2. `GET /api/about` answers **404 specifically** (not transport/auth
+   failures) → fall back to `GET /sdk/vimServiceVersions.xml`, the
+   unauthenticated version-discovery document both vCenter and ESXi
+   have served since the SOAP era (`service_versions_api_version`
+   parses the `urn:vim25` entry's current version; the request is a
+   bare client GET — no auth headers, no session). A parsed vim25 API
+   version → `reachable=True`, `version=<api version>`,
+   `probe_method="GET /sdk/vimServiceVersions.xml"`, `product` from
+   the target's registered product (else `"unknown"` — the document
+   alone cannot distinguish vCenter from a pre-REST ESXi).
+3. Best-effort enrichment: `GET /api/appliance/system/version`
+   (authenticated; the session from step 1's attempt is reused). The
+   appliance surface is VCSA-only, so an answer is observed evidence of
+   `product="vcenter"` and supplies the authoritative `version` +
+   `build`; `probe_method` then names both fallback endpoints. Any
+   failure here is swallowed (`_appliance_version` → `None`) — absence
+   must not turn a reachable fingerprint red.
 
 `probe(target)` delegates to `fingerprint()` and folds the boolean
 reachable flag into a `ProbeResult`. Failure modes (TCP `ConnectError`,
-TLS error, 401 from `/api/session`, 5xx from `/api/about`) surface as
-`reachable=False` with the exception class + message in
-`extras["error"]` / `ProbeResult.reason`.
+TLS error, 401 from `/api/session`, 5xx from `/api/about`, 404 on both
+`/api/about` and the discovery document) surface as `reachable=False`
+with the exception class + message in `extras["error"]` /
+`ProbeResult.reason`, and `probe_method` names every endpoint the chain
+attempted. The unreachable arm reports the target's **registered**
+product (else `"unknown"`) rather than asserting `"vcenter"` — a failed
+probe observed nothing (#2765).
 
 ### aclose()
 
@@ -619,9 +644,12 @@ they never park.
   `mount_op_path` resolves for `/vcenter/*` paths. Mounting a vmomi
   method on `/api` 404s on vCenter 8.0.x (observed on a live 8.0.3 host).
   `VmwareRestConnector._post_vmomi_json` owns this seam: for a
-  modern-session target it derives `{release}` from `GET /api/about`'s
-  `version` (`8.0.3` → `8.0.3.0`, resolved once and cached in
-  `_about_versions`), POSTs `/sdk/vim25/{release}{path}`, and on a 404
+  modern-session target it derives `{release}` via `_about_version` —
+  `GET /api/about`'s `version` (`8.0.3` → `8.0.3.0`), falling back on a
+  404 to the vim25 API version from `/sdk/vimServiceVersions.xml`
+  (vCenter serves no `/api/about`, #2765; the discovery document's
+  four-part value is exactly the VI-JSON release), resolved once and
+  cached in `_about_versions` — POSTs `/sdk/vim25/{release}{path}`, and on a 404
   falls back **once** to the `/api`-mounted form (the undocumented
   accommodation the 9.0.2 fleet serves); when both 404 the raised
   `RuntimeError` names both attempted URLs + the vCenter version so a


### PR DESCRIPTION
## Summary

- `VmwareRestConnector.fingerprint()` probed only `GET /api/about`, which is the **ESXi host REST surface** — vCenter answers 404, so every vCenter target permanently read `reachable=false`. The probe now runs the fallback chain from #2765: `/api/about` (kept first — richest for ESXi, regression-pinned) → on **404 specifically** the unauthenticated `GET /sdk/vimServiceVersions.xml` version-discovery document (`reachable=true` + the vim25 API version) → best-effort authenticated `GET /api/appliance/system/version` (VCSA-only; supplies authoritative `version`/`build` and observed `product="vcenter"`; any failure is swallowed so absence never turns a reachable fingerprint red).
- The unreachable arm no longer hardcodes `product="vcenter"` — it reports the target's registered product (else `"unknown"`), since a failed probe observed nothing. `probe_method` truthfully names every endpoint the chain used/attempted.
- Optional item from the issue implemented as a non-breaking internal improvement: `_about_version` reuses the same discovery read on an `/api/about` 404, so the VI-JSON `{release}` derivation (`/sdk/vim25/{release}`, #2466) now works on vCenter too — the discovery document's four-part vim25 version is exactly the VI-JSON release segment; the existing single `/api` fallback is unchanged.
- XML is parsed with `defusedxml` (in-repo idiom, pfsense connector precedent); the parser handles both the modern un-namespaced document and the older `http://www.vmware.com/vi/versions`-namespaced variant (both shapes verified against pyVim's `__VersionIsSupported` parser and govmomi's simulator template), and never lets `priorVersions` shadow the current version.

## Test plan

- [x] `ruff check src/ tests/` — clean; `ruff format --check` — clean
- [x] `mypy src/` — no issues in touched package (one pre-existing macOS-only `net/icmp.py` `MSG_ERRQUEUE` error exists on clean main; Linux CI unaffected)
- [x] `pytest tests/test_connectors_vmware_rest_fingerprint.py tests/test_connectors_vmware_rest_vmomi_mount.py` — 46 passed
- [x] AC1: 404 on `/api/about` + served discovery document → `reachable=True` with a version string and truthful `probe_method`; both failing stays `reachable=False` with the error in `extras` (`test_fingerprint_falls_back_to_service_versions_on_about_404`, `test_fingerprint_stays_unreachable_when_both_probes_fail`)
- [x] AC2: ESXi-shaped target (200 on `/api/about`) keeps today's exact fingerprint output — pre-existing pins `test_fingerprint_builds_canonical_shape_for_vcenter` / `test_fingerprint_maps_esxi_product_line_id` unchanged and green
- [x] AC3: with session credentials, the fingerprint carries `version` + `build` from `/api/appliance/system/version` (`test_fingerprint_fallback_enriches_from_appliance_version`; mocked — live verification against a lab vCenter noted as follow-up, no lab target reachable from CI)
- [x] AC4: unreachable arm reports registered product / `"unknown"`, never an unobserved `"vcenter"` (`test_fingerprint_returns_unreachable_on_connect_error`, `..._on_session_401`, `test_fingerprint_fallback_reports_registered_product_when_present`)
- [x] AC5: vcsim integration lane green — `pytest tests/integration/test_connectors_vmware_rest_vcsim.py` + full vmware suite + `test_targets_fingerprint.py` — 330 passed
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers

## Out of scope

- ESXi hosts as first-class targets / an `esxi` connector split; resolver preference changes (postulate 3 tie-breaking); vi-json mount-derivation rework beyond the `_about_version` reuse above (all per the issue's out-of-scope list).
- A target where **both** session endpoints 404 at establish (pre-8.5 shapes) still reads unreachable without entering the fallback — session-establish failures are wrapped `RuntimeError`s, not an `/api/about` 404; out of the supported `>=8.5` range.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2765

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved VMware vCenter detection when the standard `/api/about` endpoint is unavailable.
  - Added fallback version discovery through the vSphere service-version endpoint.
  - Supports optional appliance version details for richer environment identification.

- **Bug Fixes**
  - VMware connections can now resolve the correct VI-JSON release and mount successfully in more configurations.
  - Improved reporting for reachable systems, failed probes, and registered products.

- **Documentation**
  - Updated VMware REST connector documentation to describe fallback discovery and enhanced probe results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-04)

Addressed the CodeRabbit review finding (posted after the iteration-1 verdict):

- **CR1** `e342567a` — `service_versions_api_version` caught only `ParseError`; an entity-bearing discovery document raises `EntitiesForbidden` (a `DefusedXmlException` → `ValueError`, not a `ParseError`), which escaped the parser and broke its documented never-raises contract on both the fingerprint fallback and the `_about_version` `{release}` derivation. Now caught alongside `ParseError`, pinned by a new entity-declaration parser case.
- **CR-nit** `e342567a` — the vmomi-mount fallback test now asserts the discovery route is called exactly once, so the fallback contract is verified directly.

<!-- auto-implement-issue: continue, iteration 1 -->
