### PR TITLE
feat(checks): evaluation-loop watchdog + queryable runner liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,24 @@ connector-related release-notes line.
 
 ### Added
 
+- **Checks evaluation-loop watchdog + queryable runner liveness**
+  (#2763): the sensor runner now stamps every completed tick, and a
+  sibling watchdog task detects the loop going quiet — no completed
+  tick for `SENSOR_RUNNER_STALL_AFTER_TICKS` (new setting, default 6)
+  × the tick interval emits a structured `checks_scheduler_stalled`
+  log plus a `checks.scheduler_stalled` broadcast event (op-class
+  `checks`, once per continuous stall, fanned out to every tenant with
+  an active Sensor); the first completed tick after a stall emits
+  `checks_scheduler_recovered` carrying the stall duration. Both
+  `GET /api/v1/health` and `GET /api/v1/health/live` now carry a
+  `sensor_runner` liveness facet (`seconds_since_last_tick`,
+  `stalled`, `stall_threshold_seconds`; `null` when
+  `SENSOR_RUNNER_ENABLED=false`) so an external prober — the
+  dead-man's-switch consumer — catches a stalled evaluation loop in
+  minutes instead of discovering it from a wall of degraded
+  dashboards. Motivated by a 37-minute fleet-wide silent stall on
+  v0.26.0 that recurred on v0.27.0.
+
 - **Docs site — the *Connect clients* section** (#2672): a CLI-first
   onboarding path plus the full internal-only MCP client matrix. New
   pages cover the `meho` CLI (cosign-verified binary, device-code

--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -86,6 +86,7 @@ from pydantic import BaseModel, ConfigDict
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
+from meho_backplane.checks.watchdog import sensor_runner_liveness
 from meho_backplane.connectors._shared.credential_backend import (
     UnknownCredentialBackendError,
     resolve_credential_backend,
@@ -190,6 +191,31 @@ class DbStatus(BaseModel):
     migrated: bool | None
 
 
+class SensorRunnerStatus(BaseModel):
+    """Liveness of this process's sensor evaluation loop (#2763).
+
+    The queryable half of the checks-runner watchdog: an external prober
+    ("how we monitor the monitoring") alerts when
+    ``seconds_since_last_tick`` exceeds ``stall_threshold_seconds`` — or
+    simply on ``stalled``, which is that comparison server-side.
+    ``stalled`` is derived live from the in-process tick stamp on every
+    read (never from the watchdog task's emission latch), so it stays
+    truthful even if the watchdog task itself has died.
+
+    ``seconds_since_last_tick`` is ``None`` only in the window between
+    process start and runner start — once the lifespan is up it is
+    always a number. The value is per-process: each replica reports its
+    own loop, which is exactly the failure mode observed (one process's
+    loop coroutine going quiet).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    seconds_since_last_tick: float | None
+    stalled: bool
+    stall_threshold_seconds: float
+
+
 class HealthResponse(BaseModel):
     """``GET /api/v1/health`` response body.
 
@@ -220,6 +246,13 @@ class HealthResponse(BaseModel):
     :func:`~meho_backplane.mcp.server.mcp_session_id_capture_mode`
     helper so both surfaces stay consistent).
 
+    ``sensor_runner`` (#2763) carries the checks evaluation-loop's
+    liveness (:class:`SensorRunnerStatus`), and is ``None`` exactly
+    when ``SENSOR_RUNNER_ENABLED=false`` — a deliberately disabled
+    runner must not read as stalled. The ``None`` default keeps
+    response decoders generated against the pre-#2763 shape working;
+    the handler always populates it on an enabled runner.
+
     ``mcp_protocol_version`` (G0.14-T13 #1202) reports the server's
     pinned :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`.
     Mirrors the ``mcp_session_id_capture`` precedent: single-field
@@ -238,6 +271,7 @@ class HealthResponse(BaseModel):
     db: DbStatus
     mcp_session_id_capture: str
     mcp_protocol_version: str = PROTOCOL_VERSION
+    sensor_runner: SensorRunnerStatus | None = None
 
 
 class LivenessResponse(BaseModel):
@@ -252,12 +286,21 @@ class LivenessResponse(BaseModel):
     :class:`HealthResponse` route so a low-privilege monitoring
     principal can never drive a per-operator Vault credential
     federation from the liveness path.
+
+    ``sensor_runner`` (#2763) rides here as well as on the deep check:
+    the external prober that watches the evaluation loop is precisely
+    the ``read_only`` monitoring principal this route exists for, and
+    polling the deep route instead would federate a Vault credential
+    and write an audit row per poll. The facet honours this handler's
+    constraints — an in-memory clock read; no connector, no credential,
+    no secret.
     """
 
     model_config = ConfigDict(frozen=True)
 
     operator: OperatorIdentity
     db: DbStatus
+    sensor_runner: SensorRunnerStatus | None = None
 
 
 router = APIRouter(prefix="/api/v1", tags=["health"])
@@ -475,6 +518,24 @@ async def _probe_federation(operator: Operator, log: Any) -> VaultStatus:
     return await _probe_backend_federation(operator, log, backend_kind)
 
 
+def _sensor_runner_status() -> SensorRunnerStatus | None:
+    """Map the watchdog's liveness view onto the wire model.
+
+    ``None`` when ``SENSOR_RUNNER_ENABLED=false`` — the facet's absence
+    *is* the "deliberately disabled" signal, distinct from a present
+    facet with a stale stamp (#2763 acceptance: a disabled runner must
+    not read as stalled).
+    """
+    if not get_settings().sensor_runner_enabled:
+        return None
+    liveness = sensor_runner_liveness()
+    return SensorRunnerStatus(
+        seconds_since_last_tick=liveness.seconds_since_last_tick,
+        stalled=liveness.stalled,
+        stall_threshold_seconds=liveness.stall_threshold_seconds,
+    )
+
+
 async def build_health_response(operator: Operator) -> HealthResponse:
     """Assemble the :class:`HealthResponse` for a validated operator.
 
@@ -500,6 +561,7 @@ async def build_health_response(operator: Operator) -> HealthResponse:
         db=DbStatus(migrated=db_probe_result.ok),
         mcp_session_id_capture=mcp_session_id_capture_mode(),
         mcp_protocol_version=PROTOCOL_VERSION,
+        sensor_runner=_sensor_runner_status(),
     )
 
 
@@ -527,6 +589,7 @@ async def liveness(
             email=operator.email,
         ),
         db=DbStatus(migrated=db_probe_result.ok),
+        sensor_runner=_sensor_runner_status(),
     )
 
 

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -175,9 +175,11 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
 )
 
 #: Op-ids that classify as ``checks`` — the checks subsystem's own
-#: state-change events (#2720), published by
-#: :func:`~meho_backplane.checks.broadcast.publish_check_transition_event`
-#: rather than by the audit middleware.
+#: state-change events, published by
+#: :mod:`meho_backplane.checks.broadcast` rather than by the audit
+#: middleware: the Dashboard rollup edge (#2720,
+#: ``publish_check_transition_event``) and the evaluation-loop watchdog's
+#: stall/recovery pair (#2763, ``publish_scheduler_liveness_event``).
 #:
 #: An explicit allowlist, **not** a ``checks.`` prefix branch. The
 #: ``/api/v1/checks/*`` gateway routes already own three shipped op-ids
@@ -209,7 +211,13 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
 #:
 #: The allowlist is the same idiom :data:`_CREDENTIAL_MINT_OPS` uses for
 #: the same reason: an exact pin that beats a broader structural match.
-_CHECK_EVENT_OPS: Final[frozenset[str]] = frozenset({"checks.transition"})
+_CHECK_EVENT_OPS: Final[frozenset[str]] = frozenset(
+    {
+        "checks.transition",
+        "checks.scheduler_stalled",
+        "checks.scheduler_recovered",
+    }
+)
 
 #: Op-id suffixes that imply mutation. Append to this tuple when a new
 #: write-shaped verb spelling lands. ``.put`` is the KV-v2 write verb
@@ -506,9 +514,10 @@ def classify_op(op_id: str) -> str:
        stays full-detail like ``other`` did -- see
        :data:`~meho_backplane.broadcast.overrides._SENSITIVE_OP_CLASSES`.
     4c. ``checks`` — the checks subsystem's own state-change events
-       (:data:`_CHECK_EVENT_OPS`; today just ``checks.transition``,
-       emitted by
-       :func:`~meho_backplane.checks.broadcast.publish_check_transition_event`).
+       (:data:`_CHECK_EVENT_OPS`; ``checks.transition`` from #2720's
+       :func:`~meho_backplane.checks.broadcast.publish_check_transition_event`
+       plus #2763's ``checks.scheduler_stalled`` /
+       ``checks.scheduler_recovered`` watchdog pair).
        Its own class for the same reason ``approval`` has one: a feed
        watcher filters ``op_class=checks`` server-side to follow
        Dashboard rollup edges without reading every unclassified op.

--- a/backend/src/meho_backplane/checks/broadcast.py
+++ b/backend/src/meho_backplane/checks/broadcast.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``checks.transition`` broadcast events on the tenant feed (#2720).
+"""Checks-subsystem broadcast events on the tenant feed (#2720, #2763).
 
 Task #2720 under Initiative #2716 (parent goal #221). The third consumer
 of #2507's compare-and-swap transition claim, beside the diagnose-only
@@ -9,7 +9,11 @@ investigator (:mod:`meho_backplane.checks.investigate`) and the email
 notifier (:mod:`meho_backplane.checks.notify`): every claimed Dashboard
 rollup edge is published to ``meho:feed:{tenant_id}`` as one
 :class:`~meho_backplane.broadcast.events.BroadcastEvent` with op-id
-``checks.transition``.
+``checks.transition``. #2763 added a second producer on the same mould:
+the evaluation-loop watchdog's ``checks.scheduler_stalled`` /
+``checks.scheduler_recovered`` liveness events
+(:func:`publish_scheduler_liveness_event`, driven by
+:mod:`meho_backplane.checks.watchdog`).
 
 Why the claim is the publish point
 ==================================
@@ -80,7 +84,13 @@ from meho_backplane.broadcast.events import BroadcastEvent, classify_op
 from meho_backplane.broadcast.publisher import publish_event
 from meho_backplane.operations._audit import resolve_broadcast_lineage
 
-__all__ = ["CHECK_TRANSITION_OP_ID", "publish_check_transition_event"]
+__all__ = [
+    "CHECK_TRANSITION_OP_ID",
+    "SCHEDULER_RECOVERED_OP_ID",
+    "SCHEDULER_STALLED_OP_ID",
+    "publish_check_transition_event",
+    "publish_scheduler_liveness_event",
+]
 
 
 #: Broadcast op-id for a claimed Dashboard rollup edge. Pinned in
@@ -89,6 +99,15 @@ __all__ = ["CHECK_TRANSITION_OP_ID", "publish_check_transition_event"]
 #: ``checks`` op-class; ``tests/test_checks_broadcast.py`` asserts the two
 #: cannot drift.
 CHECK_TRANSITION_OP_ID: Final[str] = "checks.transition"
+
+#: Broadcast op-ids for the evaluation-loop watchdog (#2763): the runner's
+#: tick loop went quiet past the stall threshold / completed its first
+#: tick after a detected stall. Pinned in ``_CHECK_EVENT_OPS`` exactly
+#: like :data:`CHECK_TRANSITION_OP_ID` (exact membership, never a
+#: ``checks.`` prefix match); ``tests/test_checks_watchdog.py`` asserts
+#: the pins cannot drift.
+SCHEDULER_STALLED_OP_ID: Final[str] = "checks.scheduler_stalled"
+SCHEDULER_RECOVERED_OP_ID: Final[str] = "checks.scheduler_recovered"
 
 #: Principal recorded on a transition event. A subsystem identity, not an
 #: operator and not a Sensor's ``identity_sub`` -- see the module
@@ -177,5 +196,68 @@ async def publish_check_transition_event(
             dashboard_id=str(dashboard_id),
             previous_state=previous_state,
             new_state=new_state,
+            exc_info=True,
+        )
+
+
+async def publish_scheduler_liveness_event(
+    *,
+    tenant_id: uuid.UUID,
+    op_id: str,
+    detail: dict[str, object],
+) -> None:
+    """Publish one evaluation-loop liveness event (#2763) to a tenant feed.
+
+    **Never raises.** Called by :mod:`meho_backplane.checks.watchdog` on
+    the stall-detection edge (:data:`SCHEDULER_STALLED_OP_ID`, fanned out
+    per tenant with an active Sensor) and from the runner's tick path on
+    the first completed tick after a stall
+    (:data:`SCHEDULER_RECOVERED_OP_ID`).
+
+    Same anatomy as :func:`publish_check_transition_event`, for the same
+    reasons: ``principal_sub`` is :data:`_CHECKS_PRINCIPAL_SUB` (a stall
+    has no operator behind it), ``audit_id`` is :data:`_NO_AUDIT_ROW` (a
+    quiet loop is a *non*-operation — there is no audit row to point at),
+    and the payload stays at subsystem altitude — clock deltas and the
+    configured threshold, never Sensor values or member names.
+
+    Args:
+        tenant_id: Feed to address; the watchdog owns the fan-out policy.
+        op_id: :data:`SCHEDULER_STALLED_OP_ID` or
+            :data:`SCHEDULER_RECOVERED_OP_ID`.
+        detail: Numeric context merged into the payload
+            (``seconds_since_last_tick`` / ``stall_threshold_seconds`` /
+            ``tick_interval_seconds`` on stall, ``stalled_for_seconds``
+            on recovery).
+    """
+    try:
+        lineage = resolve_broadcast_lineage()
+        op_class = classify_op(op_id)
+        event = BroadcastEvent(
+            event_id=uuid.uuid4(),
+            ts=datetime.now(UTC),
+            tenant_id=tenant_id,
+            principal_sub=_CHECKS_PRINCIPAL_SUB,
+            op_id=op_id,
+            op_class=op_class,
+            result_status="ok",
+            audit_id=_NO_AUDIT_ROW,
+            payload={
+                "op_class": op_class,
+                "result_status": "ok",
+                **detail,
+            },
+            actor_sub=lineage.actor_sub,
+            agent_session_id=lineage.agent_session_id,
+            work_ref=lineage.work_ref,
+        )
+        await publish_event(event)
+    except Exception:
+        # Fail-open: the loop's liveness truth is the in-process stamp the
+        # watchdog reads. A feed miss must not reach the watchdog loop or
+        # the runner's tick path.
+        _log().warning(
+            "checks_scheduler_broadcast_failed",
+            op_id=op_id,
             exc_info=True,
         )

--- a/backend/src/meho_backplane/checks/runner.py
+++ b/backend/src/meho_backplane/checks/runner.py
@@ -137,6 +137,7 @@ from meho_backplane.checks.repository import (
     park_sensor,
     record_sensor_result,
 )
+from meho_backplane.checks.watchdog import note_tick_completed, reset_watchdog_state
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Sensor
 from meho_backplane.operations.dispatcher import dispatch
@@ -221,10 +222,12 @@ def _eval_semaphore() -> asyncio.Semaphore:
 def reset_sensor_runner_state() -> None:
     """Drop all per-process runner state (test seam).
 
-    Clears the in-flight registry, the lazily-built semaphore, and the
-    check-runner principal's cached token, so a fresh test starts with no
-    leftover tasks, a semaphore bound to its own event loop, and no token
-    minted against another test's settings. Mirrors
+    Clears the in-flight registry, the lazily-built semaphore, the
+    check-runner principal's cached token, and the #2763 watchdog's
+    tick-stamp/stall state, so a fresh test starts with no leftover
+    tasks, a semaphore bound to its own event loop, no token minted
+    against another test's settings, and no stall latched from a prior
+    test's clock. Mirrors
     :func:`meho_backplane.db.engine.reset_engine_for_testing`'s role as an
     explicit reset for module-level state.
     """
@@ -232,6 +235,7 @@ def reset_sensor_runner_state() -> None:
     global _EVAL_SEMAPHORE
     _EVAL_SEMAPHORE = None
     reset_check_runner_token_cache()
+    reset_watchdog_state()
 
 
 @dataclass(frozen=True, slots=True)
@@ -515,7 +519,20 @@ async def run_one_sensor_tick() -> int:
     backgrounded evaluation per claimed row (subject to the overlap guard). The
     tick never awaits the evaluations, so it returns promptly and the lock is
     held for the DB work only.
+
+    Every *completed* tick -- including the lock-not-acquired no-op -- stamps
+    the #2763 watchdog via :func:`~meho_backplane.checks.watchdog.note_tick_completed`
+    (which also emits the recovery event when a stall was flagged, and never
+    raises). A tick that raises deliberately does not stamp: a loop that fails
+    every tick is a stalled evaluation plane and must trip the watchdog.
     """
+    dispatched = await _claim_and_spawn_due()
+    await note_tick_completed()
+    return dispatched
+
+
+async def _claim_and_spawn_due() -> int:
+    """The tick body: claim + advance under the lock, then spawn evaluations."""
     now = datetime.now(UTC)
     to_dispatch: list[_SensorSnapshot] = []
     sessionmaker = get_sessionmaker()

--- a/backend/src/meho_backplane/checks/watchdog.py
+++ b/backend/src/meho_backplane/checks/watchdog.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Evaluation-loop watchdog for the sensor check-runner (#2763).
+
+The one outage the checks plane structurally cannot alert on is its own:
+when :func:`~meho_backplane.checks.runner._runner_loop` goes quiet, no
+evaluations run, no transitions fire, and the notifier stays silent — a
+37-minute fleet-wide stall (v0.26.0, recurring on v0.27.0) surfaced only
+because an operator happened to read a dashboard. This module gives the
+loop a liveness signal of its own: the runner stamps every completed
+tick, an independent watchdog task detects "no tick completed for
+``SENSOR_RUNNER_STALL_AFTER_TICKS`` x the tick interval" and emits a
+structured log plus a ``checks.scheduler_stalled`` broadcast event, and
+the health surface exposes the staleness for an external prober — the
+Prometheus ``Watchdog``/dead-man's-switch division: MEHO surfaces the
+signal, the external prober consumes it.
+
+Why an in-process stamp, not a persisted fleet-level one
+========================================================
+
+Every replica runs :func:`~meho_backplane.checks.runner.run_one_sensor_tick`;
+the per-tick advisory lock decides who claims the due batch. A tick that
+finds the lock held still *completes* — so on every healthy replica the
+stamp refreshes each cadence, and it goes stale exactly when the observed
+failure mode (the loop coroutine going quiet in one process) occurs. A
+persisted fleet-level stamp would cost a DB write per tick and would
+*mask* a single wedged replica behind its healthy siblings; the
+per-process stamp is the signal that matches the failure. The health
+facet is served by the same process whose loop it reports on, so each
+replica answers for itself.
+
+Why a separate task
+===================
+
+The runner loop cannot watch itself — it is the thing that dies. The
+watchdog is a sibling asyncio task (same lifespan gate,
+``SENSOR_RUNNER_ENABLED``) that only reads the stamp and compares
+clocks. It shares the runner's fate on whole-event-loop starvation, but
+that failure mode is what the *external* prober against the health facet
+catches (its symptom: the facet goes stale or unreachable).
+
+Re-emission policy: once per continuous stall
+=============================================
+
+A stall emits exactly one ``checks_scheduler_stalled`` log + one
+``checks.scheduler_stalled`` event per affected tenant, however long the
+stall lasts. The watchdog keeps returning ``True`` while stalled but
+does not re-emit; the next completed tick emits the paired
+``checks_scheduler_recovered`` carrying the stall duration and re-arms
+the detector. One stall, one stalled/recovered pair — an external
+consumer never has to dedupe.
+
+Recovery is emitted from the tick path, not the watchdog
+========================================================
+
+:func:`note_tick_completed` (called by ``run_one_sensor_tick`` on every
+completed tick) emits the recovery the instant the loop proves itself
+alive — zero detection latency and no dependency on the watchdog task
+still running. The stall duration is measured from the last completed
+tick before the stall (the reference the detector tripped on), matching
+the "gap between batches" number an operator reconstructs from the
+audit ledger.
+
+Tenant fan-out
+==============
+
+Broadcast feeds are per-tenant (``meho:feed:{tenant_id}``); a stall is
+platform-wide. The stalled event fans out to every tenant with at least
+one active Sensor — each of them is blind while the loop is quiet — and
+the recovered event goes to exactly the tenants the stalled event went
+to (the set is captured at detection), so the pair always matches even
+when sensors are created or deleted mid-stall. The structured log lines
+are process-level and emitted regardless of tenant fan-out.
+
+Failure posture
+===============
+
+Fail-open, the ``checks_transition_broadcast_failed`` posture (#2720):
+state updates commit first, then emission; a failing tenant query or
+publish warn-logs ``checks_watchdog_emit_failed`` and never reaches the
+runner's tick path or kills the watchdog loop. The health facet derives
+staleness live from the stamp on every read — it keeps working even if
+the watchdog task itself has died.
+
+Deliberately **no** ``/ready`` probe: flipping readiness on a stalled
+evaluation loop would pull the whole API pod out of the load balancer
+over a monitoring-plane outage. The health facet is the queryable
+surface; reacting to it belongs to the external prober.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import cast
+
+import structlog
+from sqlalchemy import select
+
+from meho_backplane.checks.broadcast import (
+    SCHEDULER_RECOVERED_OP_ID,
+    SCHEDULER_STALLED_OP_ID,
+    publish_scheduler_liveness_event,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Sensor, SensorStatus
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "SensorRunnerLiveness",
+    "evaluate_stall_watchdog",
+    "note_tick_completed",
+    "reset_watchdog_state",
+    "sensor_runner_liveness",
+    "start_checks_watchdog",
+    "stop_checks_watchdog",
+]
+
+#: When the last completed runner tick finished, per process. Stamped by
+#: :func:`note_tick_completed` on every completed tick (including
+#: lock-not-acquired no-op ticks — see the module docstring).
+_LAST_TICK_COMPLETED_AT: datetime | None = None
+
+#: Watchdog start instant — the staleness reference until the first tick
+#: completes, so a runner that never manages a single tick still trips
+#: the detector instead of hiding behind a ``None`` stamp.
+_BASELINE: datetime | None = None
+
+#: The staleness reference the detector tripped on, while a stall is
+#: flagged; ``None`` when the loop is healthy. Doubles as the
+#: once-per-stall latch and the recovery event's duration origin.
+_STALLED_SINCE: datetime | None = None
+
+#: Tenants the stalled event was addressed to, captured at detection so
+#: the recovered event goes to exactly the same feeds.
+_STALL_TENANTS: tuple[uuid.UUID, ...] = ()
+
+
+def _log() -> structlog.typing.FilteringBoundLogger:
+    """Resolve the structlog logger per call (not a module-level proxy).
+
+    Same discipline as :mod:`meho_backplane.checks.runner`: a module-level
+    proxy caches its bound methods on first use under the production
+    ``cache_logger_on_first_use=True`` config, orphaning them from a later
+    :func:`structlog.testing.capture_logs`.
+    """
+    return cast("structlog.typing.FilteringBoundLogger", structlog.get_logger(__name__))
+
+
+@dataclass(frozen=True, slots=True)
+class SensorRunnerLiveness:
+    """Point-in-time liveness view of this process's sensor-runner loop.
+
+    ``seconds_since_last_tick`` is ``None`` only when neither a completed
+    tick nor a watchdog start has happened in this process (the runner is
+    enabled but not started — early startup, or a test path driving ticks
+    directly). ``stalled`` is derived live from the stamp against the
+    threshold on every read, deliberately **not** from the watchdog's
+    emission latch, so a dead watchdog task cannot blind the health facet.
+    """
+
+    seconds_since_last_tick: float | None
+    stalled: bool
+    stall_threshold_seconds: float
+
+
+def reset_watchdog_state() -> None:
+    """Drop all per-process watchdog state (test seam).
+
+    Called from :func:`meho_backplane.checks.runner.reset_sensor_runner_state`
+    so the runner test fixtures reset both modules in one place.
+    """
+    global _LAST_TICK_COMPLETED_AT, _BASELINE, _STALLED_SINCE, _STALL_TENANTS
+    _LAST_TICK_COMPLETED_AT = None
+    _BASELINE = None
+    _STALLED_SINCE = None
+    _STALL_TENANTS = ()
+
+
+def _stall_threshold_seconds() -> float:
+    """Quiet time that counts as a stall: ``stall_after_ticks x tick interval``.
+
+    Both factors are deployment settings (``SENSOR_RUNNER_STALL_AFTER_TICKS``,
+    default 6, and ``SENSOR_RUNNER_TICK_INTERVAL_SECONDS``, default 10 —
+    60 s by default), re-read per call so a settings-cache reset takes
+    effect without a restart. The threshold scales with the tick grid,
+    matching the reporter's "N x cadence" framing.
+    """
+    settings = get_settings()
+    return float(
+        settings.sensor_runner_stall_after_ticks * settings.sensor_runner_tick_interval_seconds
+    )
+
+
+def _staleness_reference() -> datetime | None:
+    """The instant staleness is measured from: last completed tick, else start."""
+    if _LAST_TICK_COMPLETED_AT is not None:
+        return _LAST_TICK_COMPLETED_AT
+    return _BASELINE
+
+
+def sensor_runner_liveness(now: datetime | None = None) -> SensorRunnerLiveness:
+    """Compute the loop's current liveness for the health surface.
+
+    Pure read — no emission, no state change, no I/O — so the health
+    route can call it on every request. *now* is injectable for
+    deterministic tests and defaults to the real clock.
+    """
+    check_at = now if now is not None else datetime.now(UTC)
+    threshold = _stall_threshold_seconds()
+    reference = _staleness_reference()
+    if reference is None:
+        return SensorRunnerLiveness(
+            seconds_since_last_tick=None,
+            stalled=False,
+            stall_threshold_seconds=threshold,
+        )
+    quiet_seconds = (check_at - reference).total_seconds()
+    return SensorRunnerLiveness(
+        seconds_since_last_tick=quiet_seconds,
+        stalled=quiet_seconds > threshold,
+        stall_threshold_seconds=threshold,
+    )
+
+
+async def _active_sensor_tenant_ids() -> list[uuid.UUID]:
+    """Distinct tenants holding at least one active Sensor (own session)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = await session.scalars(
+            select(Sensor.tenant_id).where(Sensor.status == SensorStatus.ACTIVE.value).distinct()
+        )
+        return list(rows)
+
+
+async def note_tick_completed(now: datetime | None = None) -> None:
+    """Stamp a completed runner tick; emit recovery if a stall was flagged.
+
+    Called by :func:`~meho_backplane.checks.runner.run_one_sensor_tick` on
+    every completed tick. **Never raises**: the stamp and the stall-latch
+    clear commit before any emission, and the emission block is guarded,
+    so a broadcast or logging failure cannot fail the tick that proved
+    the loop alive. *now* is injectable for deterministic tests.
+    """
+    global _LAST_TICK_COMPLETED_AT, _STALLED_SINCE, _STALL_TENANTS
+    stamp = now if now is not None else datetime.now(UTC)
+    stalled_since = _STALLED_SINCE
+    notified = _STALL_TENANTS
+    _LAST_TICK_COMPLETED_AT = stamp
+    if stalled_since is None:
+        return
+    _STALLED_SINCE = None
+    _STALL_TENANTS = ()
+    stalled_for = (stamp - stalled_since).total_seconds()
+    try:
+        _log().warning(
+            "checks_scheduler_recovered",
+            stalled_for_seconds=stalled_for,
+        )
+        for tenant_id in notified:
+            await publish_scheduler_liveness_event(
+                tenant_id=tenant_id,
+                op_id=SCHEDULER_RECOVERED_OP_ID,
+                detail={"stalled_for_seconds": stalled_for},
+            )
+    except Exception:
+        _log().warning(
+            "checks_watchdog_emit_failed",
+            op_id=SCHEDULER_RECOVERED_OP_ID,
+            exc_info=True,
+        )
+
+
+async def evaluate_stall_watchdog(now: datetime | None = None) -> bool:
+    """One watchdog check. Returns ``True`` while the loop reads as stalled.
+
+    Detection edge (quiet time first exceeds the threshold): set the
+    once-per-stall latch, emit the ``checks_scheduler_stalled`` log, and
+    fan the ``checks.scheduler_stalled`` event out to every tenant with
+    an active Sensor. Subsequent checks during the same stall return
+    ``True`` without re-emitting. The latch is set *before* the emission
+    block so a failing tenant query or publish (warn-logged, fail-open)
+    still arms the recovery pair. *now* is injectable for deterministic
+    tests.
+    """
+    global _STALLED_SINCE, _STALL_TENANTS
+    check_at = now if now is not None else datetime.now(UTC)
+    reference = _staleness_reference()
+    if reference is None:
+        return False
+    threshold = _stall_threshold_seconds()
+    quiet_seconds = (check_at - reference).total_seconds()
+    if quiet_seconds <= threshold:
+        return False
+    if _STALLED_SINCE is not None:
+        return True
+    _STALLED_SINCE = reference
+    tick_interval = get_settings().sensor_runner_tick_interval_seconds
+    _log().error(
+        "checks_scheduler_stalled",
+        seconds_since_last_tick=quiet_seconds,
+        stall_threshold_seconds=threshold,
+        tick_interval_seconds=tick_interval,
+    )
+    try:
+        tenants = tuple(await _active_sensor_tenant_ids())
+        _STALL_TENANTS = tenants
+        for tenant_id in tenants:
+            await publish_scheduler_liveness_event(
+                tenant_id=tenant_id,
+                op_id=SCHEDULER_STALLED_OP_ID,
+                detail={
+                    "seconds_since_last_tick": quiet_seconds,
+                    "stall_threshold_seconds": threshold,
+                    "tick_interval_seconds": tick_interval,
+                },
+            )
+    except Exception:
+        _log().warning(
+            "checks_watchdog_emit_failed",
+            op_id=SCHEDULER_STALLED_OP_ID,
+            exc_info=True,
+        )
+    return True
+
+
+async def _watchdog_loop() -> None:
+    """The forever loop: sleep one runner cadence, check the stamp, repeat.
+
+    Rides the runner's own tick interval (re-read per iteration, like the
+    runner loop) rather than a cadence of its own — the check is one
+    in-memory clock comparison, and a finer grid would not tighten the
+    detection bound below ``threshold + one interval``. Per-check ``try``
+    / ``except`` so a transient failure is logged and the loop continues;
+    ``CancelledError`` propagates so lifespan shutdown stops the task
+    cleanly (memory-expiry / gateway-deadman mould).
+    """
+    _log().info(
+        "checks_watchdog_started",
+        interval_seconds=get_settings().sensor_runner_tick_interval_seconds,
+        stall_threshold_seconds=_stall_threshold_seconds(),
+    )
+    while True:
+        await asyncio.sleep(get_settings().sensor_runner_tick_interval_seconds)
+        try:
+            await evaluate_stall_watchdog()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log().warning("checks_watchdog_check_failed", exc_info=True)
+
+
+def start_checks_watchdog() -> asyncio.Task[None]:
+    """Start the watchdog loop and return its task handle.
+
+    Registered in :func:`meho_backplane.main.lifespan` behind the same
+    ``SENSOR_RUNNER_ENABLED`` gate as the runner it watches — a watchdog
+    with its own kill switch is how the stall class stays invisible.
+    Sets the staleness baseline to *now* so the pre-first-tick window is
+    graced but a loop that never completes a tick still trips. Returning
+    the task keeps a strong reference alive (the "Task was destroyed but
+    it is pending!" class the lifecycle tests bar).
+    """
+    global _BASELINE
+    _BASELINE = datetime.now(UTC)
+    return asyncio.create_task(_watchdog_loop(), name="checks-watchdog")
+
+
+async def stop_checks_watchdog(task: asyncio.Task[None]) -> None:
+    """Cancel the watchdog loop and await its unwind.
+
+    Swallows the expected :class:`asyncio.CancelledError`; anything else
+    raised during unwind propagates so a broken shutdown is visible.
+    Mould: :func:`meho_backplane.gateway.deadman.stop_gateway_deadman_sweeper`.
+    """
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -124,6 +124,7 @@ from meho_backplane.broadcast.announcement_retention import (
     stop_announcement_retention_sweeper,
 )
 from meho_backplane.checks.runner import start_sensor_runner, stop_sensor_runner
+from meho_backplane.checks.watchdog import start_checks_watchdog, stop_checks_watchdog
 from meho_backplane.connectors.registry import _eager_import_connectors, registered_product_tokens
 from meho_backplane.db.engine import dispose_engine, get_engine
 from meho_backplane.db.migrations import db_migration_probe
@@ -453,6 +454,7 @@ class _BackgroundTasks:
     approval_expiry: asyncio.Task[None] | None
     scheduler: asyncio.Task[None] | None
     sensor_runner: asyncio.Task[None] | None
+    sensor_watchdog: asyncio.Task[None] | None
     agent_run_reaper: asyncio.Task[None] | None
     event_drain: asyncio.Task[None] | None
     gateway_deadman: asyncio.Task[None] | None
@@ -514,6 +516,14 @@ def _start_background_tasks() -> _BackgroundTasks:
     sensor_runner: asyncio.Task[None] | None = None
     if settings.sensor_runner_enabled:
         sensor_runner = start_sensor_runner()
+    # #2763 — evaluation-loop watchdog. Same gate as the runner it
+    # watches, never its own: a watchdog with an independent kill switch
+    # is how the silent-stall class stays invisible. Started right after
+    # the runner so the staleness baseline is set before the first
+    # cadence sleep elapses.
+    sensor_watchdog: asyncio.Task[None] | None = None
+    if settings.sensor_runner_enabled:
+        sensor_watchdog = start_checks_watchdog()
     # G11.3-T4 #825 — gated on AGENT_RUN_REAPER_ENABLED so operators
     # running an external lease-reclaim mechanism (DBOS Transact, a
     # workflow engine) can disable the in-tree reaper without
@@ -544,6 +554,7 @@ def _start_background_tasks() -> _BackgroundTasks:
         approval_expiry=approval_expiry,
         scheduler=scheduler,
         sensor_runner=sensor_runner,
+        sensor_watchdog=sensor_watchdog,
         agent_run_reaper=agent_run_reaper,
         event_drain=event_drain,
         gateway_deadman=gateway_deadman,
@@ -564,6 +575,8 @@ async def _stop_background_tasks(tasks: _BackgroundTasks) -> None:
         await stop_event_drain(tasks.event_drain)
     if tasks.agent_run_reaper is not None:
         await stop_agent_run_reaper(tasks.agent_run_reaper)
+    if tasks.sensor_watchdog is not None:
+        await stop_checks_watchdog(tasks.sensor_watchdog)
     if tasks.sensor_runner is not None:
         await stop_sensor_runner(tasks.sensor_runner)
     if tasks.scheduler is not None:

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1313,6 +1313,15 @@ class Settings(BaseModel):
     # evaluator (or the test path without a runner) can opt out.
     sensor_runner_enabled: bool = True
     sensor_runner_tick_interval_seconds: int = Field(default=10, ge=1, le=3600)
+    # #2763 — evaluation-loop watchdog. A stall is "no completed runner tick
+    # for stall_after_ticks x tick_interval_seconds" (default 6 x 10 s = 60 s);
+    # the threshold scales with the tick grid so a deployment that slows the
+    # cadence widens the stall window with it. Floor of 2: a threshold at or
+    # below one tick interval would flag every ordinary sleep-then-tick gap.
+    # The watchdog itself has no enable flag -- it starts and stops with
+    # SENSOR_RUNNER_ENABLED (a watchdog with its own kill switch is how the
+    # silent-stall class stays invisible).
+    sensor_runner_stall_after_ticks: int = Field(default=6, ge=2, le=1000)
     # #2642 (G0.37) — the in-process check-runner's own service-principal
     # identity for background dispatch. Both empty (the default) keeps
     # today's behaviour bit-for-bit: the runner's synthetic operator carries
@@ -1913,6 +1922,9 @@ def get_settings() -> Settings:
         ),
         sensor_runner_enabled=parse_bool_env(
             os.environ.get("SENSOR_RUNNER_ENABLED", "true"),
+        ),
+        sensor_runner_stall_after_ticks=int(
+            os.environ.get("SENSOR_RUNNER_STALL_AFTER_TICKS", "6"),
         ),
         check_runner_client_id=os.environ.get("CHECK_RUNNER_CLIENT_ID", "").strip(),
         check_runner_client_secret=os.environ.get("CHECK_RUNNER_CLIENT_SECRET", "").strip(),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -321,6 +321,27 @@ def _default_retrieval_model_cache_dir(
 
 
 @pytest.fixture(autouse=True)
+def _reset_checks_watchdog_state() -> Iterator[None]:
+    """Clear the #2763 watchdog's per-process state around every test.
+
+    :mod:`meho_backplane.checks.watchdog` keeps module-level liveness
+    state (last-tick stamp, start baseline, stall latch). Any app-boot
+    test whose lifespan runs with the default ``SENSOR_RUNNER_ENABLED``
+    starts the runner + watchdog and stamps that state; without this
+    sweep a later test's health-response assertion would see the stale
+    stamp (worse: a long-lived xdist worker could age it past the stall
+    threshold and flip ``stalled`` mid-suite). Both brackets, so a test
+    neither inherits nor bequeaths a stamp — the same hygiene
+    ``reset_sensor_runner_state`` gives the runner's own module state.
+    """
+    from meho_backplane.checks.watchdog import reset_watchdog_state
+
+    reset_watchdog_state()
+    yield
+    reset_watchdog_state()
+
+
+@pytest.fixture(autouse=True)
 def _stub_descriptor_embedding(
     monkeypatch: pytest.MonkeyPatch,
     request: pytest.FixtureRequest,

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -366,6 +366,15 @@ def test_happy_path_returns_full_federation_response(
         "db": {"migrated": True},
         "mcp_session_id_capture": "when_negotiated",
         "mcp_protocol_version": PROTOCOL_VERSION,
+        # #2763: the runner is enabled by default but this TestClient never
+        # runs the lifespan, so no tick has stamped and no baseline is set —
+        # the facet reads unknown-not-stalled (the enabled-but-not-started
+        # shape; the conftest autouse reset guarantees a clean slate).
+        "sensor_runner": {
+            "seconds_since_last_tick": None,
+            "stalled": False,
+            "stall_threshold_seconds": 60.0,
+        },
     }
 
     # Vault was hit with the configured role / mount and the operator's
@@ -716,3 +725,120 @@ def test_mcp_protocol_version_reports_server_pinned_revision(
 
     assert response.status_code == 200
     assert response.json()["mcp_protocol_version"] == PROTOCOL_VERSION
+
+
+# ---------------------------------------------------------------------------
+# #2763 — sensor_runner liveness facet
+# ---------------------------------------------------------------------------
+
+
+def test_sensor_runner_facet_healthy_when_stamp_is_fresh(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recently completed tick reads as healthy on ``GET /api/v1/health``.
+
+    Acceptance criterion (#2763): the health response carries the
+    checks-runner liveness facet so an external prober can watch the
+    evaluation loop. The tick stamp is injected directly onto the
+    watchdog module (the stamp-writing path is covered by
+    ``tests/test_checks_watchdog.py``; this test owns the route surface).
+    """
+    from datetime import UTC, datetime, timedelta
+
+    import meho_backplane.checks.watchdog as watchdog
+
+    monkeypatch.setattr(
+        watchdog,
+        "_LAST_TICK_COMPLETED_AT",
+        datetime.now(UTC) - timedelta(seconds=1),
+    )
+    key = _make_rsa_keypair("kid-runner-healthy")
+    token = _mint_token(key, sub="op-runner-healthy")
+    _install_fake_vault(monkeypatch, version=1)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    facet = response.json()["sensor_runner"]
+    assert facet["stalled"] is False
+    assert facet["stall_threshold_seconds"] == 60.0
+    assert 0.0 <= facet["seconds_since_last_tick"] < 30.0
+
+
+def test_sensor_runner_facet_stalled_when_stamp_is_stale(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stamp older than the stall threshold reads ``stalled: true``.
+
+    The facet derives staleness live from the stamp on every request —
+    no watchdog-task involvement — so the external prober catches a
+    stall even if the watchdog task itself died with the loop.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    import meho_backplane.checks.watchdog as watchdog
+
+    monkeypatch.setattr(
+        watchdog,
+        "_LAST_TICK_COMPLETED_AT",
+        datetime.now(UTC) - timedelta(seconds=120),
+    )
+    key = _make_rsa_keypair("kid-runner-stalled")
+    token = _mint_token(key, sub="op-runner-stalled")
+    _install_fake_vault(monkeypatch, version=1)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    facet = response.json()["sensor_runner"]
+    assert facet["stalled"] is True
+    assert facet["seconds_since_last_tick"] >= 120.0
+
+
+def test_sensor_runner_facet_absent_when_runner_disabled(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``SENSOR_RUNNER_ENABLED=false`` → ``sensor_runner: null``, never stalled.
+
+    Acceptance criterion (#2763): a deliberately disabled runner must not
+    read as stalled. The ancient stamp injected here would read as a
+    deep stall on an enabled runner; with the runner disabled the facet
+    is absent entirely.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    import meho_backplane.checks.watchdog as watchdog
+
+    monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    get_settings.cache_clear()
+    monkeypatch.setattr(
+        watchdog,
+        "_LAST_TICK_COMPLETED_AT",
+        datetime.now(UTC) - timedelta(hours=6),
+    )
+    key = _make_rsa_keypair("kid-runner-disabled")
+    token = _mint_token(key, sub="op-runner-disabled")
+    _install_fake_vault(monkeypatch, version=1)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["sensor_runner"] is None

--- a/backend/tests/test_api_v1_health_split.py
+++ b/backend/tests/test_api_v1_health_split.py
@@ -216,6 +216,17 @@ def test_read_only_liveness_returns_200_without_vault_touch(
             "email": "monitor@example.com",
         },
         "db": {"migrated": True},
+        # #2763: the runner-liveness facet rides the low-privilege
+        # liveness route — an in-memory clock read honouring this
+        # handler's no-Vault/no-connector constraint — so the external
+        # prober that watches the evaluation loop polls here, not the
+        # per-poll-Vault-federating deep check. No lifespan ran, so it
+        # reads the enabled-but-not-started shape.
+        "sensor_runner": {
+            "seconds_since_last_tick": None,
+            "stalled": False,
+            "stall_threshold_seconds": 60.0,
+        },
     }
     assert probe_mock.await_count == 0
     assert dispatch_mock.await_count == 0

--- a/backend/tests/test_checks_watchdog.py
+++ b/backend/tests/test_checks_watchdog.py
@@ -1,0 +1,508 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the sensor evaluation-loop watchdog (#2763).
+
+Coverage mapped to the issue's acceptance criteria:
+
+* **Stall detection, clock-injected** -- no completed tick for more than
+  ``SENSOR_RUNNER_STALL_AFTER_TICKS x tick interval`` yields exactly one
+  structured ``checks_scheduler_stalled`` log and exactly one
+  ``checks.scheduler_stalled`` broadcast event per affected tenant
+  (once-per-continuous-stall re-emission policy), classified ``checks``
+  by exact ``_CHECK_EVENT_OPS`` membership.
+* **Recovery** -- the first completed tick after a detected stall emits
+  ``checks_scheduler_recovered`` (log + event) carrying the stall
+  duration, to exactly the tenants the stalled event was addressed to.
+* **Fail-open** -- an injected broadcast failure during stall/recovery
+  emission is swallowed with a warn log and the runner keeps ticking
+  (proved through the real ``run_one_sensor_tick`` seam).
+* **Liveness derivation** -- the health facet's staleness view is
+  derived live from the tick stamp, never from the watchdog's emission
+  latch, and reads unknown-not-stalled before the runner has started.
+
+All clock-sensitive paths inject ``now`` -- no ``asyncio.sleep``-driven
+timing anywhere (python_best_practices §14). The DB layer is real
+against the autouse SQLite engine from :mod:`tests.conftest`;
+``publish_event`` is replaced by a recording fake so no Valkey
+connection is opened (same seam as ``tests/test_checks_broadcast.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import update
+from structlog.testing import capture_logs
+
+import meho_backplane.checks.broadcast as checks_broadcast
+import meho_backplane.checks.watchdog as watchdog
+from meho_backplane.broadcast.events import (
+    _CHECK_EVENT_OPS,
+    BroadcastEvent,
+    classify_op,
+)
+from meho_backplane.checks.assertions import AssertionSpec
+from meho_backplane.checks.broadcast import (
+    SCHEDULER_RECOVERED_OP_ID,
+    SCHEDULER_STALLED_OP_ID,
+)
+from meho_backplane.checks.repository import create_sensor
+from meho_backplane.checks.runner import reset_sensor_runner_state, run_one_sensor_tick
+from meho_backplane.checks.watchdog import (
+    evaluate_stall_watchdog,
+    note_tick_completed,
+    sensor_runner_liveness,
+    start_checks_watchdog,
+    stop_checks_watchdog,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Sensor, SensorCadenceKind, SensorStatus, Tenant
+from meho_backplane.settings import get_settings
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_TENANT_B = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+_T0 = datetime(2026, 8, 4, 10, 0, 0, tzinfo=UTC)
+
+#: Default threshold under the fixture env: 6 ticks x 10 s.
+_THRESHOLD = timedelta(seconds=60)
+
+_ASSERTION: dict[str, Any] = AssertionSpec.model_validate(
+    {
+        "select": {"path": "$.count"},
+        "compare": {"type": "threshold", "op": "gt", "critical": 10},
+    }
+).model_dump(mode="json")
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env :class:`Settings` requires; reset runner + watchdog state."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    get_settings.cache_clear()
+    reset_sensor_runner_state()
+    yield
+    reset_sensor_runner_state()
+    get_settings.cache_clear()
+
+
+class _RecordingPublisher:
+    """Stands in for ``publish_event``; records every event, optionally raises."""
+
+    def __init__(self, *, exc: Exception | None = None) -> None:
+        self.events: list[BroadcastEvent] = []
+        self._exc = exc
+
+    async def __call__(self, event: BroadcastEvent) -> None:
+        self.events.append(event)
+        if self._exc is not None:
+            raise self._exc
+
+
+def _install_publisher(
+    monkeypatch: pytest.MonkeyPatch, *, exc: Exception | None = None
+) -> _RecordingPublisher:
+    """Patch the publisher the checks-broadcast module imported."""
+    fake = _RecordingPublisher(exc=exc)
+    monkeypatch.setattr(checks_broadcast, "publish_event", fake)
+    return fake
+
+
+async def _seed_active_sensor(tenant_id: uuid.UUID) -> None:
+    """One tenant row + one active interval Sensor under it."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if await session.get(Tenant, tenant_id) is None:
+            session.add(Tenant(id=tenant_id, slug=str(tenant_id)[:8], name="T"))
+            await session.commit()
+    async with sessionmaker() as session:
+        await create_sensor(
+            session,
+            tenant_id=tenant_id,
+            name=f"sensor-{uuid.uuid4().hex[:8]}",
+            connector_id="vmware-rest-9.0",
+            op_id="vmware.vm.list",
+            target=None,
+            params={},
+            assertion=_ASSERTION,
+            cadence_kind=SensorCadenceKind.INTERVAL,
+            interval_seconds=300,
+            cron_expr=None,
+            timezone="UTC",
+            severity="critical",
+            for_seconds=0,
+            identity_sub="__sensor__",
+            created_by_sub="op-test",
+        )
+        await session.commit()
+
+
+async def _pause_all_sensors(tenant_id: uuid.UUID) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await session.execute(
+            update(Sensor)
+            .where(Sensor.tenant_id == tenant_id)
+            .values(status=SensorStatus.PAUSED.value)
+        )
+        await session.commit()
+
+
+def _events_for(fake: _RecordingPublisher, op_id: str) -> list[BroadcastEvent]:
+    return [event for event in fake.events if event.op_id == op_id]
+
+
+# --------------------------------------------------------------------------- #
+# Classifier pins
+# --------------------------------------------------------------------------- #
+
+
+def test_scheduler_op_ids_are_pinned_in_check_event_ops() -> None:
+    """The two watchdog op-ids and the classifier allowlist cannot drift."""
+    assert SCHEDULER_STALLED_OP_ID in _CHECK_EVENT_OPS
+    assert SCHEDULER_RECOVERED_OP_ID in _CHECK_EVENT_OPS
+    assert classify_op(SCHEDULER_STALLED_OP_ID) == "checks"
+    assert classify_op(SCHEDULER_RECOVERED_OP_ID) == "checks"
+
+
+# --------------------------------------------------------------------------- #
+# Stall detection (clock-injected)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_stall_past_threshold_emits_log_and_event_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Quiet past N x interval => one stalled log + one event per tenant."""
+    fake = _install_publisher(monkeypatch)
+    await _seed_active_sensor(_TENANT_A)
+    await note_tick_completed(now=_T0)
+
+    check_at = _T0 + _THRESHOLD + timedelta(seconds=1)
+    with capture_logs() as logs:
+        assert await evaluate_stall_watchdog(now=check_at) is True
+
+    stalled_logs = [entry for entry in logs if entry["event"] == "checks_scheduler_stalled"]
+    assert len(stalled_logs) == 1
+    assert stalled_logs[0]["log_level"] == "error"
+    assert stalled_logs[0]["seconds_since_last_tick"] == pytest.approx(61.0)
+    assert stalled_logs[0]["stall_threshold_seconds"] == pytest.approx(60.0)
+
+    events = _events_for(fake, SCHEDULER_STALLED_OP_ID)
+    assert len(events) == 1
+    event = events[0]
+    assert event.tenant_id == _TENANT_A
+    assert event.op_class == "checks"
+    assert event.principal_sub == "__checks__"
+    assert event.audit_id == uuid.UUID(int=0)
+    assert event.payload["seconds_since_last_tick"] == pytest.approx(61.0)
+    assert event.payload["stall_threshold_seconds"] == pytest.approx(60.0)
+    assert event.payload["tick_interval_seconds"] == 10
+
+
+@pytest.mark.asyncio
+async def test_continuing_stall_does_not_re_emit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Once per continuous stall: later checks return True but stay silent."""
+    fake = _install_publisher(monkeypatch)
+    await _seed_active_sensor(_TENANT_A)
+    await note_tick_completed(now=_T0)
+
+    first = _T0 + _THRESHOLD + timedelta(seconds=1)
+    assert await evaluate_stall_watchdog(now=first) is True
+    with capture_logs() as logs:
+        assert await evaluate_stall_watchdog(now=first + timedelta(minutes=10)) is True
+
+    assert [entry for entry in logs if entry["event"] == "checks_scheduler_stalled"] == []
+    assert len(_events_for(fake, SCHEDULER_STALLED_OP_ID)) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("quiet_seconds", [59.0, 60.0])
+async def test_quiet_at_or_below_threshold_is_not_a_stall(
+    monkeypatch: pytest.MonkeyPatch, quiet_seconds: float
+) -> None:
+    """The threshold is exclusive: exactly N x interval is still healthy."""
+    fake = _install_publisher(monkeypatch)
+    await note_tick_completed(now=_T0)
+
+    check_at = _T0 + timedelta(seconds=quiet_seconds)
+    with capture_logs() as logs:
+        assert await evaluate_stall_watchdog(now=check_at) is False
+
+    assert [entry for entry in logs if entry["event"] == "checks_scheduler_stalled"] == []
+    assert fake.events == []
+
+
+@pytest.mark.asyncio
+async def test_no_reference_at_all_is_not_a_stall(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No tick and no watchdog start => nothing to measure from, no stall."""
+    fake = _install_publisher(monkeypatch)
+    assert await evaluate_stall_watchdog(now=_T0) is False
+    assert fake.events == []
+
+
+@pytest.mark.asyncio
+async def test_never_ticked_runner_trips_from_the_start_baseline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loop that never completes a single tick still trips the detector."""
+    fake = _install_publisher(monkeypatch)
+    await _seed_active_sensor(_TENANT_A)
+    task = start_checks_watchdog()
+    await stop_checks_watchdog(task)
+    baseline = watchdog._BASELINE
+    assert baseline is not None
+
+    assert await evaluate_stall_watchdog(now=baseline + timedelta(seconds=59)) is False
+    assert await evaluate_stall_watchdog(now=baseline + _THRESHOLD + timedelta(seconds=1)) is True
+    assert len(_events_for(fake, SCHEDULER_STALLED_OP_ID)) == 1
+
+
+@pytest.mark.asyncio
+async def test_stall_threshold_scales_with_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SENSOR_RUNNER_STALL_AFTER_TICKS x SENSOR_RUNNER_TICK_INTERVAL_SECONDS."""
+    monkeypatch.setenv("SENSOR_RUNNER_TICK_INTERVAL_SECONDS", "30")
+    monkeypatch.setenv("SENSOR_RUNNER_STALL_AFTER_TICKS", "4")
+    get_settings.cache_clear()
+    fake = _install_publisher(monkeypatch)
+    await _seed_active_sensor(_TENANT_A)
+    await note_tick_completed(now=_T0)
+
+    assert await evaluate_stall_watchdog(now=_T0 + timedelta(seconds=120)) is False
+    assert await evaluate_stall_watchdog(now=_T0 + timedelta(seconds=121)) is True
+    assert sensor_runner_liveness(now=_T0).stall_threshold_seconds == pytest.approx(120.0)
+    assert fake.events  # the 121 s check emitted
+
+
+# --------------------------------------------------------------------------- #
+# Tenant fan-out
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_fan_out_targets_active_sensor_tenants_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stalled events go to tenants with >=1 active Sensor; paused-only stays dark."""
+    fake = _install_publisher(monkeypatch)
+    await _seed_active_sensor(_TENANT_A)
+    await _seed_active_sensor(_TENANT_B)
+    await _pause_all_sensors(_TENANT_B)
+    await note_tick_completed(now=_T0)
+
+    assert await evaluate_stall_watchdog(now=_T0 + _THRESHOLD + timedelta(seconds=5)) is True
+
+    stalled = _events_for(fake, SCHEDULER_STALLED_OP_ID)
+    assert [event.tenant_id for event in stalled] == [_TENANT_A]
+
+
+@pytest.mark.asyncio
+async def test_recovery_goes_to_the_tenants_the_stall_went_to(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stalled/recovered pair matches even when tenants change mid-stall."""
+    fake = _install_publisher(monkeypatch)
+    await _seed_active_sensor(_TENANT_A)
+    await note_tick_completed(now=_T0)
+    assert await evaluate_stall_watchdog(now=_T0 + _THRESHOLD + timedelta(seconds=5)) is True
+
+    # A tenant that gains its first sensor mid-stall was never told about
+    # the stall -- it must not receive a recovery either.
+    await _seed_active_sensor(_TENANT_B)
+    await note_tick_completed(now=_T0 + timedelta(minutes=10))
+
+    recovered = _events_for(fake, SCHEDULER_RECOVERED_OP_ID)
+    assert [event.tenant_id for event in recovered] == [_TENANT_A]
+
+
+# --------------------------------------------------------------------------- #
+# Recovery
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_first_tick_after_stall_emits_recovered_with_duration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recovery log + event carry the stall duration; the latch re-arms."""
+    fake = _install_publisher(monkeypatch)
+    await _seed_active_sensor(_TENANT_A)
+    await note_tick_completed(now=_T0)
+    assert await evaluate_stall_watchdog(now=_T0 + _THRESHOLD + timedelta(seconds=1)) is True
+
+    recover_at = _T0 + timedelta(minutes=37)
+    with capture_logs() as logs:
+        await note_tick_completed(now=recover_at)
+
+    recovered_logs = [entry for entry in logs if entry["event"] == "checks_scheduler_recovered"]
+    assert len(recovered_logs) == 1
+    assert recovered_logs[0]["log_level"] == "warning"
+    assert recovered_logs[0]["stalled_for_seconds"] == pytest.approx(37 * 60.0)
+
+    events = _events_for(fake, SCHEDULER_RECOVERED_OP_ID)
+    assert len(events) == 1
+    assert events[0].tenant_id == _TENANT_A
+    assert events[0].op_class == "checks"
+    assert events[0].payload["stalled_for_seconds"] == pytest.approx(37 * 60.0)
+
+    # Latch cleared: the next quiet window is a fresh stall with fresh events.
+    assert await evaluate_stall_watchdog(now=recover_at + timedelta(seconds=30)) is False
+    assert await evaluate_stall_watchdog(now=recover_at + _THRESHOLD + timedelta(seconds=1)) is True
+    assert len(_events_for(fake, SCHEDULER_STALLED_OP_ID)) == 2
+
+
+@pytest.mark.asyncio
+async def test_healthy_tick_emits_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The no-stall hot path is silent: stamp only, no events, no logs."""
+    fake = _install_publisher(monkeypatch)
+    with capture_logs() as logs:
+        await note_tick_completed(now=_T0)
+        await note_tick_completed(now=_T0 + timedelta(seconds=10))
+    assert fake.events == []
+    assert [e for e in logs if e["event"].startswith("checks_scheduler")] == []
+
+
+# --------------------------------------------------------------------------- #
+# Fail-open (through the runner seam)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_broadcast_failure_during_stall_and_recovery_never_breaks_the_tick(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising publisher warn-logs and the runner keeps ticking (#2763 AC)."""
+    fake = _install_publisher(monkeypatch, exc=RuntimeError("valkey down"))
+    await _seed_active_sensor(_TENANT_A)
+    await note_tick_completed(now=_T0)
+
+    with capture_logs() as logs:
+        assert await evaluate_stall_watchdog(now=_T0 + _THRESHOLD + timedelta(seconds=1)) is True
+    assert [e for e in logs if e["event"] == "checks_scheduler_broadcast_failed"]
+
+    # The real tick seam: recovery emission fails too, the tick still
+    # completes, stamps, and clears the latch.
+    with capture_logs() as logs:
+        dispatched = await run_one_sensor_tick()
+    assert dispatched == 0
+    assert [e for e in logs if e["event"] == "checks_scheduler_broadcast_failed"]
+    assert [e for e in logs if e["event"] == "checks_scheduler_recovered"]
+    liveness = sensor_runner_liveness()
+    assert liveness.seconds_since_last_tick is not None
+    assert liveness.seconds_since_last_tick < 5.0
+    assert watchdog._STALLED_SINCE is None
+    # Both emission attempts reached the publisher before it raised.
+    assert _events_for(fake, SCHEDULER_STALLED_OP_ID)
+    assert _events_for(fake, SCHEDULER_RECOVERED_OP_ID)
+
+
+@pytest.mark.asyncio
+async def test_tenant_query_failure_is_swallowed_and_still_latches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing fan-out query warn-logs; the latch still arms the recovery pair."""
+    fake = _install_publisher(monkeypatch)
+    await note_tick_completed(now=_T0)
+
+    async def _boom() -> list[uuid.UUID]:
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(watchdog, "_active_sensor_tenant_ids", _boom)
+    with capture_logs() as logs:
+        assert await evaluate_stall_watchdog(now=_T0 + _THRESHOLD + timedelta(seconds=1)) is True
+
+    assert [e for e in logs if e["event"] == "checks_watchdog_emit_failed"]
+    assert watchdog._STALLED_SINCE is not None
+    assert fake.events == []
+
+
+# --------------------------------------------------------------------------- #
+# Liveness view (health facet substrate)
+# --------------------------------------------------------------------------- #
+
+
+def test_liveness_before_any_reference_reads_unknown_not_stalled() -> None:
+    liveness = sensor_runner_liveness(now=_T0)
+    assert liveness.seconds_since_last_tick is None
+    assert liveness.stalled is False
+    assert liveness.stall_threshold_seconds == pytest.approx(60.0)
+
+
+@pytest.mark.asyncio
+async def test_liveness_derives_stalled_live_without_the_watchdog_flag() -> None:
+    """The facet trips on the stamp alone -- a dead watchdog task cannot blind it."""
+    await note_tick_completed(now=_T0)
+    healthy = sensor_runner_liveness(now=_T0 + timedelta(seconds=30))
+    assert healthy.stalled is False
+    assert healthy.seconds_since_last_tick == pytest.approx(30.0)
+
+    stalled = sensor_runner_liveness(now=_T0 + _THRESHOLD + timedelta(seconds=1))
+    assert stalled.stalled is True
+    assert stalled.seconds_since_last_tick == pytest.approx(61.0)
+    # No evaluate_stall_watchdog ran: the emission latch is untouched.
+    assert watchdog._STALLED_SINCE is None
+
+
+@pytest.mark.asyncio
+async def test_run_one_sensor_tick_stamps_the_liveness_view() -> None:
+    assert sensor_runner_liveness().seconds_since_last_tick is None
+    await run_one_sensor_tick()
+    liveness = sensor_runner_liveness()
+    assert liveness.seconds_since_last_tick is not None
+    assert liveness.seconds_since_last_tick < 5.0
+
+
+# --------------------------------------------------------------------------- #
+# Lifecycle
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_watchdog_clean() -> None:
+    """Start/stop unwinds without pending-task warnings; baseline is set."""
+    task = start_checks_watchdog()
+    assert watchdog._BASELINE is not None
+    assert not task.done()
+    await stop_checks_watchdog(task)
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_watchdog_loop_survives_a_failing_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising check is warn-logged and the loop keeps running."""
+    monkeypatch.setenv("SENSOR_RUNNER_TICK_INTERVAL_SECONDS", "1")
+    get_settings.cache_clear()
+
+    calls = 0
+
+    async def _boom(now: datetime | None = None) -> bool:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("check exploded")
+
+    monkeypatch.setattr(watchdog, "evaluate_stall_watchdog", _boom)
+    task = start_checks_watchdog()
+    try:
+        with capture_logs() as logs:
+            for _ in range(400):
+                await asyncio.sleep(0.01)
+                if calls >= 2:
+                    break
+    finally:
+        await stop_checks_watchdog(task)
+
+    assert calls >= 2
+    assert [e for e in logs if e["event"] == "checks_watchdog_check_failed"]

--- a/backend/tests/test_checks_watchdog.py
+++ b/backend/tests/test_checks_watchdog.py
@@ -21,9 +21,11 @@ Coverage mapped to the issue's acceptance criteria:
   derived live from the tick stamp, never from the watchdog's emission
   latch, and reads unknown-not-stalled before the runner has started.
 
-All clock-sensitive paths inject ``now`` -- no ``asyncio.sleep``-driven
-timing anywhere (python_best_practices §14). The DB layer is real
-against the autouse SQLite engine from :mod:`tests.conftest`;
+All stall/recovery *logic* is exercised with injected clocks
+(python_best_practices §14); the only real sleeps are in the
+loop-lifecycle tests, which drive the watchdog loop's own cadence and
+poll for completion rather than assert on wall-clock timing. The DB
+layer is real against the autouse SQLite engine from :mod:`tests.conftest`;
 ``publish_event`` is replaced by a recording fake so no Valkey
 connection is opened (same seam as ``tests/test_checks_broadcast.py``).
 """

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -310,6 +310,38 @@ def test_checks_notify_suppression_window_env_override_takes_effect(
         get_settings.cache_clear()
 
 
+def test_sensor_runner_stall_after_ticks_defaults_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset ``SENSOR_RUNNER_STALL_AFTER_TICKS`` → the 6-tick default (#2763)."""
+    _base_env(monkeypatch)
+    monkeypatch.delenv("SENSOR_RUNNER_STALL_AFTER_TICKS", raising=False)
+    get_settings.cache_clear()
+    try:
+        assert get_settings().sensor_runner_stall_after_ticks == 6
+    finally:
+        get_settings.cache_clear()
+
+
+def test_sensor_runner_stall_after_ticks_env_override_takes_effect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``SENSOR_RUNNER_STALL_AFTER_TICKS`` flows through ``get_settings()``.
+
+    The same inert-mapping trap the suppression-window round-trip pins:
+    ``Settings`` is a plain pydantic ``BaseModel``, so a field declared
+    without its hand-mapped env read would leave the documented watchdog
+    knob (#2763) a silent no-op.
+    """
+    _base_env(monkeypatch)
+    monkeypatch.setenv("SENSOR_RUNNER_STALL_AFTER_TICKS", "12")
+    get_settings.cache_clear()
+    try:
+        assert get_settings().sensor_runner_stall_after_ticks == 12
+    finally:
+        get_settings.cache_clear()
+
+
 def test_result_handle_max_spill_rows_defaults_when_env_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -24892,6 +24892,10 @@
             "type": "string",
             "title": "Mcp Protocol Version",
             "default": "2025-06-18"
+          },
+          "sensor_runner": {
+            "$ref": "#/components/schemas/SensorRunnerStatus",
+            "nullable": true
           }
         },
         "type": "object",
@@ -24902,7 +24906,7 @@
           "mcp_session_id_capture"
         ],
         "title": "HealthResponse",
-        "description": "``GET /api/v1/health`` response body.\n\n``mcp_session_id_capture`` (G0.14-T6 #1147) reports the deploy's\naudit-replay capture mode in a single field:\n\n* ``\"when_negotiated\"`` \u2014 a ``Mcp-Session-Id`` header is captured\n  into ``audit_log.agent_session_id`` only when the client\n  negotiated a session via the ``initialize`` handshake and echoes\n  the server-issued id; a header-less call is accepted and its row's\n  session id lands as NULL (invisible to session-lineage replay).\n  This is the default. It reads ``\"when_negotiated\"`` rather than\n  ``\"always\"`` because capture is not a guarantee \u2014 #2700 reported\n  the former ``\"always\"`` label as misleading, since header-less\n  callers stay out of lineage. Distinguish an empty forest from an\n  empty history via the replay surface's\n  ``excluded_null_session_count``.\n* ``\"enforced\"`` \u2014 capture works the same way **plus** a missing\n  header is a JSON-RPC ``-32600`` reject before any audit row is\n  written, so every accepted MCP call carries a session id. Flipped\n  on by ``MCP_REQUIRE_SESSION_ID=true`` in compliance deploys that\n  forbid header-less calls.\n\nThe field is the canonical operator-facing surface for the\ncapture state until T7 #1148's ``/ready`` features block ships\nthe richer enumeration (T7's ``audit_replay`` block pulls from\nthe same\n:func:`~meho_backplane.mcp.server.mcp_session_id_capture_mode`\nhelper so both surfaces stay consistent).\n\n``mcp_protocol_version`` (G0.14-T13 #1202) reports the server's\npinned :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`.\nMirrors the ``mcp_session_id_capture`` precedent: single-field\noperator visibility into the MCP layer's runtime state. The\nmatching ``mcp.protocol_version`` entry on ``/ready``'s features\nblock (see :func:`meho_backplane.features.build_features_block`)\nsurfaces the same value on the unauthenticated readiness probe so\na deploy operator can answer \"which MCP revision will this server\nnegotiate with my clients?\" without an authenticated GET."
+        "description": "``GET /api/v1/health`` response body.\n\n``mcp_session_id_capture`` (G0.14-T6 #1147) reports the deploy's\naudit-replay capture mode in a single field:\n\n* ``\"when_negotiated\"`` \u2014 a ``Mcp-Session-Id`` header is captured\n  into ``audit_log.agent_session_id`` only when the client\n  negotiated a session via the ``initialize`` handshake and echoes\n  the server-issued id; a header-less call is accepted and its row's\n  session id lands as NULL (invisible to session-lineage replay).\n  This is the default. It reads ``\"when_negotiated\"`` rather than\n  ``\"always\"`` because capture is not a guarantee \u2014 #2700 reported\n  the former ``\"always\"`` label as misleading, since header-less\n  callers stay out of lineage. Distinguish an empty forest from an\n  empty history via the replay surface's\n  ``excluded_null_session_count``.\n* ``\"enforced\"`` \u2014 capture works the same way **plus** a missing\n  header is a JSON-RPC ``-32600`` reject before any audit row is\n  written, so every accepted MCP call carries a session id. Flipped\n  on by ``MCP_REQUIRE_SESSION_ID=true`` in compliance deploys that\n  forbid header-less calls.\n\nThe field is the canonical operator-facing surface for the\ncapture state until T7 #1148's ``/ready`` features block ships\nthe richer enumeration (T7's ``audit_replay`` block pulls from\nthe same\n:func:`~meho_backplane.mcp.server.mcp_session_id_capture_mode`\nhelper so both surfaces stay consistent).\n\n``sensor_runner`` (#2763) carries the checks evaluation-loop's\nliveness (:class:`SensorRunnerStatus`), and is ``None`` exactly\nwhen ``SENSOR_RUNNER_ENABLED=false`` \u2014 a deliberately disabled\nrunner must not read as stalled. The ``None`` default keeps\nresponse decoders generated against the pre-#2763 shape working;\nthe handler always populates it on an enabled runner.\n\n``mcp_protocol_version`` (G0.14-T13 #1202) reports the server's\npinned :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`.\nMirrors the ``mcp_session_id_capture`` precedent: single-field\noperator visibility into the MCP layer's runtime state. The\nmatching ``mcp.protocol_version`` entry on ``/ready``'s features\nblock (see :func:`meho_backplane.features.build_features_block`)\nsurfaces the same value on the unauthenticated readiness probe so\na deploy operator can answer \"which MCP revision will this server\nnegotiate with my clients?\" without an authenticated GET."
       },
       "InCompare": {
         "properties": {
@@ -25432,6 +25436,10 @@
           },
           "db": {
             "$ref": "#/components/schemas/DbStatus"
+          },
+          "sensor_runner": {
+            "$ref": "#/components/schemas/SensorRunnerStatus",
+            "nullable": true
           }
         },
         "type": "object",
@@ -25440,7 +25448,7 @@
           "db"
         ],
         "title": "LivenessResponse",
-        "description": "``GET /api/v1/health/live`` response body.\n\nThe cheap, low-privilege liveness surface: operator identity (from\nthe already-validated JWT \u2014 zero extra cost) plus DB-migration\nliveness from\n:func:`~meho_backplane.db.migrations.db_migration_probe`. No Vault\nfield on purpose \u2014 this model must never grow one. The federation\nproof lives exclusively on the OPERATOR-gated\n:class:`HealthResponse` route so a low-privilege monitoring\nprincipal can never drive a per-operator Vault credential\nfederation from the liveness path."
+        "description": "``GET /api/v1/health/live`` response body.\n\nThe cheap, low-privilege liveness surface: operator identity (from\nthe already-validated JWT \u2014 zero extra cost) plus DB-migration\nliveness from\n:func:`~meho_backplane.db.migrations.db_migration_probe`. No Vault\nfield on purpose \u2014 this model must never grow one. The federation\nproof lives exclusively on the OPERATOR-gated\n:class:`HealthResponse` route so a low-privilege monitoring\nprincipal can never drive a per-operator Vault credential\nfederation from the liveness path.\n\n``sensor_runner`` (#2763) rides here as well as on the deep check:\nthe external prober that watches the evaluation loop is precisely\nthe ``read_only`` monitoring principal this route exists for, and\npolling the deep route instead would federate a Vault credential\nand write an audit row per poll. The facet honours this handler's\nconstraints \u2014 an in-memory clock read; no connector, no credential,\nno secret."
       },
       "ManualStep": {
         "properties": {
@@ -28050,6 +28058,31 @@
         ],
         "title": "SensorRead",
         "description": "Response shape for one ``sensor`` row.\n\nMirrors :class:`~meho_backplane.db.models.Sensor`'s column set,\nprojected to the wire types the JSON renderer can serialise. Includes\nthe latest-result projection (``last_state`` / ``last_value`` /\n``last_evidence`` / ``last_evaluated_at`` / ``state_since``) so the\nlist response carries the current status view (there is no REST\nGET-by-id -- the mould exposes none). ``frozen=True`` so a route\nhandler cannot mutate the row after returning it."
+      },
+      "SensorRunnerStatus": {
+        "properties": {
+          "seconds_since_last_tick": {
+            "type": "number",
+            "nullable": true,
+            "title": "Seconds Since Last Tick"
+          },
+          "stalled": {
+            "type": "boolean",
+            "title": "Stalled"
+          },
+          "stall_threshold_seconds": {
+            "type": "number",
+            "title": "Stall Threshold Seconds"
+          }
+        },
+        "type": "object",
+        "required": [
+          "seconds_since_last_tick",
+          "stalled",
+          "stall_threshold_seconds"
+        ],
+        "title": "SensorRunnerStatus",
+        "description": "Liveness of this process's sensor evaluation loop (#2763).\n\nThe queryable half of the checks-runner watchdog: an external prober\n(\"how we monitor the monitoring\") alerts when\n``seconds_since_last_tick`` exceeds ``stall_threshold_seconds`` \u2014 or\nsimply on ``stalled``, which is that comparison server-side.\n``stalled`` is derived live from the in-process tick stamp on every\nread (never from the watchdog task's emission latch), so it stays\ntruthful even if the watchdog task itself has died.\n\n``seconds_since_last_tick`` is ``None`` only in the window between\nprocess start and runner start \u2014 once the lifespan is up it is\nalways a number. The value is per-process: each replica reports its\nown loop, which is exactly the failure mode observed (one process's\nloop coroutine going quiet)."
       },
       "SensorSeverity": {
         "type": "string",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4231,6 +4231,13 @@ type HTTPValidationError struct {
 // :func:`~meho_backplane.mcp.server.mcp_session_id_capture_mode`
 // helper so both surfaces stay consistent).
 //
+// “sensor_runner“ (#2763) carries the checks evaluation-loop's
+// liveness (:class:`SensorRunnerStatus`), and is “None“ exactly
+// when “SENSOR_RUNNER_ENABLED=false“ — a deliberately disabled
+// runner must not read as stalled. The “None“ default keeps
+// response decoders generated against the pre-#2763 shape working;
+// the handler always populates it on an enabled runner.
+//
 // “mcp_protocol_version“ (G0.14-T13 #1202) reports the server's
 // pinned :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`.
 // Mirrors the “mcp_session_id_capture“ precedent: single-field
@@ -4263,6 +4270,23 @@ type HealthResponse struct {
 	// appear in a response body, and the :class:`Operator` model carries
 	// it for downstream Vault forward-auth only.
 	Operator OperatorIdentity `json:"operator"`
+
+	// SensorRunner Liveness of this process's sensor evaluation loop (#2763).
+	//
+	// The queryable half of the checks-runner watchdog: an external prober
+	// ("how we monitor the monitoring") alerts when
+	// ``seconds_since_last_tick`` exceeds ``stall_threshold_seconds`` — or
+	// simply on ``stalled``, which is that comparison server-side.
+	// ``stalled`` is derived live from the in-process tick stamp on every
+	// read (never from the watchdog task's emission latch), so it stays
+	// truthful even if the watchdog task itself has died.
+	//
+	// ``seconds_since_last_tick`` is ``None`` only in the window between
+	// process start and runner start — once the lifespan is up it is
+	// always a number. The value is per-process: each replica reports its
+	// own loop, which is exactly the failure mode observed (one process's
+	// loop coroutine going quiet).
+	SensorRunner *SensorRunnerStatus `json:"sensor_runner,omitempty"`
 
 	// Vault Federation-chain status for the deployment's credential backend.
 	//
@@ -4680,6 +4704,14 @@ type KindFilterValue string
 // :class:`HealthResponse` route so a low-privilege monitoring
 // principal can never drive a per-operator Vault credential
 // federation from the liveness path.
+//
+// “sensor_runner“ (#2763) rides here as well as on the deep check:
+// the external prober that watches the evaluation loop is precisely
+// the “read_only“ monitoring principal this route exists for, and
+// polling the deep route instead would federate a Vault credential
+// and write an audit row per poll. The facet honours this handler's
+// constraints — an in-memory clock read; no connector, no credential,
+// no secret.
 type LivenessResponse struct {
 	// Db Database migration status.
 	//
@@ -4701,6 +4733,23 @@ type LivenessResponse struct {
 	// appear in a response body, and the :class:`Operator` model carries
 	// it for downstream Vault forward-auth only.
 	Operator OperatorIdentity `json:"operator"`
+
+	// SensorRunner Liveness of this process's sensor evaluation loop (#2763).
+	//
+	// The queryable half of the checks-runner watchdog: an external prober
+	// ("how we monitor the monitoring") alerts when
+	// ``seconds_since_last_tick`` exceeds ``stall_threshold_seconds`` — or
+	// simply on ``stalled``, which is that comparison server-side.
+	// ``stalled`` is derived live from the in-process tick stamp on every
+	// read (never from the watchdog task's emission latch), so it stays
+	// truthful even if the watchdog task itself has died.
+	//
+	// ``seconds_since_last_tick`` is ``None`` only in the window between
+	// process start and runner start — once the lifespan is up it is
+	// always a number. The value is per-process: each replica reports its
+	// own loop, which is exactly the failure mode observed (one process's
+	// loop coroutine going quiet).
+	SensorRunner *SensorRunnerStatus `json:"sensor_runner,omitempty"`
 }
 
 // ManualStep A step the operator performs off-MEHO (SSH, web UI, console).
@@ -6410,6 +6459,27 @@ type SensorRead struct {
 
 // SensorReadLastState defines model for SensorRead.LastState.
 type SensorReadLastState string
+
+// SensorRunnerStatus Liveness of this process's sensor evaluation loop (#2763).
+//
+// The queryable half of the checks-runner watchdog: an external prober
+// ("how we monitor the monitoring") alerts when
+// “seconds_since_last_tick“ exceeds “stall_threshold_seconds“ — or
+// simply on “stalled“, which is that comparison server-side.
+// “stalled“ is derived live from the in-process tick stamp on every
+// read (never from the watchdog task's emission latch), so it stays
+// truthful even if the watchdog task itself has died.
+//
+// “seconds_since_last_tick“ is “None“ only in the window between
+// process start and runner start — once the lifespan is up it is
+// always a number. The value is per-process: each replica reports its
+// own loop, which is exactly the failure mode observed (one process's
+// loop coroutine going quiet).
+type SensorRunnerStatus struct {
+	SecondsSinceLastTick  *float32 `json:"seconds_since_last_tick"`
+	StallThresholdSeconds float32  `json:"stall_threshold_seconds"`
+	Stalled               bool     `json:"stalled"`
+}
 
 // SensorSeverity Worst dashboard state a failing assertion on a :class:`Sensor` may drive.
 //

--- a/docs/codebase/checks-broadcast.md
+++ b/docs/codebase/checks-broadcast.md
@@ -9,6 +9,17 @@ feed (`meho:feed:{tenant_id}`) as one `BroadcastEvent` with op-id
 `/ui/broadcast/stream?op_class=checks` — see check state changes the way
 they already see `approval.*` lifecycle events (#2720).
 
+The module also carries the evaluation-loop watchdog's liveness events
+(#2763): `checks.scheduler_stalled` (the runner's tick loop went quiet
+past the stall threshold; fanned out per tenant with an active Sensor)
+and `checks.scheduler_recovered` (first completed tick after a stall,
+carrying `stalled_for_seconds`), published via
+`publish_scheduler_liveness_event` on the same mould — `__checks__`
+principal, nil-UUID `audit_id`, fail-open
+(`checks_scheduler_broadcast_failed`). Producer-side mechanics live in
+`docs/codebase/checks-runner.md`; this page owns the op-id/classifier
+contract.
+
 This is the **third** independent consumer of #2507's transition claim,
 beside the diagnose-only investigator
 (`docs/codebase/checks-investigator.md`, worsening edges only) and the
@@ -26,9 +37,16 @@ consumer (`op_class=checks`), not to the producer.
 - `publish_check_transition_event(*, tenant_id, dashboard_id,
   dashboard_name, previous_state, new_state)` — the awaitable that builds
   and publishes the event. **Never raises.**
+- `publish_scheduler_liveness_event(*, tenant_id, op_id, detail)` — the
+  #2763 sibling for the watchdog's stall/recovery pair. **Never
+  raises.**
 - `CHECK_TRANSITION_OP_ID` — the `"checks.transition"` literal.
+- `SCHEDULER_STALLED_OP_ID` / `SCHEDULER_RECOVERED_OP_ID` — the
+  `"checks.scheduler_stalled"` / `"checks.scheduler_recovered"`
+  literals (#2763).
 - `_CHECK_EVENT_OPS` (in `broadcast/events.py`) — the classifier's
-  allowlist, the other half of the op-id contract.
+  allowlist (all three op-ids above), the other half of the op-id
+  contract.
 
 ## Control flow
 

--- a/docs/codebase/checks-runner.md
+++ b/docs/codebase/checks-runner.md
@@ -1,0 +1,163 @@
+# Sensor check-runner + evaluation-loop watchdog
+
+## Overview
+
+Two lifespan-owned background tasks drive the deterministic check layer's
+evaluation plane:
+
+- **The runner** (`checks/runner.py`, #2505) — a sleep-then-tick loop
+  (`SENSOR_RUNNER_TICK_INTERVAL_SECONDS`, default 10 s) that claims due
+  `Sensor` rows under a process-wide advisory lock, advances each row's
+  `next_fire_at` before dispatch, and spawns bounded background
+  evaluations (dispatch → assertion → latest-state projection). No LLM
+  anywhere on this path.
+- **The watchdog** (`checks/watchdog.py`, #2763) — a sibling task that
+  detects the runner loop going quiet and makes that outage observable.
+  It exists because a stalled evaluation loop is the one outage the
+  checks plane cannot alert on: no evaluations → no transitions → no
+  notifications (the v0.26.0 37-minute fleet-wide silent stall).
+
+Both start and stop together behind `SENSOR_RUNNER_ENABLED`. The
+watchdog deliberately has no enable flag of its own.
+
+## Key types
+
+- `run_one_sensor_tick()` (`checks/runner.py`) — one deterministic tick;
+  public test seam. Every *completed* tick (including the
+  advisory-lock-not-acquired no-op) calls `note_tick_completed()`; a
+  tick that raises does not — a loop failing every tick must read as
+  stalled.
+- `note_tick_completed(now=None)` (`checks/watchdog.py`) — stamps the
+  per-process "last tick completed at"; when a stall was flagged, emits
+  the recovery log + events and re-arms the detector. Never raises.
+- `evaluate_stall_watchdog(now=None)` — one watchdog check: quiet time
+  past the threshold trips the stall edge (log + events, once per
+  continuous stall) and returns `True` while stalled. Clock-injectable.
+- `sensor_runner_liveness(now=None)` → `SensorRunnerLiveness` — the
+  read-only view the health surface renders: `seconds_since_last_tick`,
+  `stalled`, `stall_threshold_seconds`. `stalled` is derived live from
+  the stamp, **not** from the watchdog's emission latch, so a dead
+  watchdog task cannot blind the facet.
+- `start_checks_watchdog()` / `stop_checks_watchdog()` — lifespan pair
+  (`main.py`, gated with the runner). Start sets the staleness baseline
+  so a runner that never completes a single tick still trips.
+- `reset_sensor_runner_state()` (`checks/runner.py`) also resets the
+  watchdog module state; a conftest autouse fixture clears it per test.
+
+## Control flow
+
+```text
+runner loop:  sleep(interval) → run_one_sensor_tick()
+                                  ├─ claim + advance + spawn evaluations
+                                  └─ note_tick_completed()
+                                       └─ stall flagged? → emit
+                                          checks_scheduler_recovered
+                                          (log + event, stall duration)
+
+watchdog loop: sleep(interval) → evaluate_stall_watchdog()
+                 quiet ≤ N × interval → healthy, return False
+                 quiet > N × interval, first time →
+                     error-log checks_scheduler_stalled
+                     fan checks.scheduler_stalled event out to every
+                       tenant with ≥1 active Sensor (set captured for
+                       the recovery pair)
+                 already flagged → True, no re-emission
+
+health read:   GET /api/v1/health · GET /api/v1/health/live
+                 sensor_runner_enabled=false → "sensor_runner": null
+                 else → live-derived SensorRunnerStatus
+```
+
+Detection latency is bounded by `threshold + one tick interval` (the
+watchdog rides the runner's own cadence; a finer grid would not tighten
+that bound).
+
+## Settings
+
+- `SENSOR_RUNNER_ENABLED` (default `true`) — gates runner **and**
+  watchdog.
+- `SENSOR_RUNNER_TICK_INTERVAL_SECONDS` (default 10) — both loops'
+  cadence.
+- `SENSOR_RUNNER_STALL_AFTER_TICKS` (default 6, min 2) — the stall
+  threshold is this × the tick interval (60 s by default). Scales with
+  the tick grid; the minimum of 2 keeps the threshold above the ordinary
+  sleep-then-tick gap.
+
+## Event kinds and log lines
+
+| Surface | Name | When |
+|---|---|---|
+| structlog `error` | `checks_scheduler_stalled` | stall detection edge |
+| structlog `warning` | `checks_scheduler_recovered` | first completed tick after a stall (carries `stalled_for_seconds`) |
+| structlog `warning` | `checks_watchdog_emit_failed` | fan-out query/publish block failed (fail-open) |
+| broadcast event | `checks.scheduler_stalled` | detection edge, per affected tenant |
+| broadcast event | `checks.scheduler_recovered` | recovery, to the same tenants |
+
+Both event op-ids are pinned in `broadcast/events.py::_CHECK_EVENT_OPS`
+(exact membership, never a `checks.` prefix match) and classify as
+op-class `checks`, so `broadcast_recent` / `broadcast_watch` /
+`/ui/broadcast/stream?op_class=checks` all see them. They ride the
+`publish_check_transition_event` mould: principal `__checks__`,
+nil-UUID `audit_id` (a quiet loop is a non-operation — there is no
+audit row to point at), fail-open publish
+(`checks_scheduler_broadcast_failed`). See
+`docs/codebase/checks-broadcast.md`.
+
+## The health facet
+
+`GET /api/v1/health` and `GET /api/v1/health/live` both carry
+`sensor_runner` (`SensorRunnerStatus`): `seconds_since_last_tick`,
+`stalled`, `stall_threshold_seconds`; the whole field is `null` exactly
+when `SENSOR_RUNNER_ENABLED=false` (a deliberately disabled runner must
+not read as stalled). The liveness route carries it because the
+external prober ("how we monitor the monitoring") is a `read_only`
+monitoring principal, and polling the deep check instead would federate
+a Vault credential and write an audit row per poll; the facet is an
+in-memory clock read, honouring that route's no-connector constraint.
+
+The division of labour is the Prometheus `Watchdog` /
+dead-man's-switch pattern: MEHO surfaces the liveness signal; the
+external prober alerts on it (`stalled == true`, or
+`seconds_since_last_tick > stall_threshold_seconds`).
+
+## Known issues / boundaries
+
+- **The stamp is per-process, deliberately.** No fleet-level persisted
+  stamp: it would cost a DB write per tick and mask a single wedged
+  replica behind healthy siblings. Each replica's health facet answers
+  for its own loop — which is the observed failure mode (one process's
+  loop coroutine going quiet). Fleet-level aggregation belongs to the
+  external prober hitting each replica.
+- **Whole-event-loop starvation takes the watchdog with it.** The
+  watchdog catches the runner coroutine going quiet while the process
+  stays otherwise alive (the reported shape — pod healthy, zero
+  restarts). If the entire event loop wedges, the health facet goes
+  stale/unreachable and the external prober is the detector.
+- **No `/ready` probe registration, deliberately.** Flipping readiness
+  on a monitoring-plane stall would pull the API pod out of the load
+  balancer — wrong blast radius. The facet is informational; reaction
+  policy belongs to the prober.
+- **Recovery events go to the tenant set captured at detection.** A
+  tenant whose first sensor was created mid-stall receives neither the
+  stalled nor the recovered event of that episode.
+- **A stall costs notification latency, not notifications.** On resume,
+  the first evaluations claim their CAS transition edges normally and
+  the notifier fires; the recovery event carries the stall window for
+  forensics (#2763 scoped retro-notification out).
+
+## References
+
+- `backend/src/meho_backplane/checks/runner.py`,
+  `backend/src/meho_backplane/checks/watchdog.py`,
+  `backend/src/meho_backplane/checks/broadcast.py`
+- `backend/src/meho_backplane/api/v1/health.py` (`SensorRunnerStatus`)
+- `backend/src/meho_backplane/main.py` (lifespan wiring)
+- `backend/tests/test_checks_watchdog.py`, `test_sensor_runner.py`,
+  `test_api_v1_health.py`
+- #2763 (watchdog), #2505 (runner), Initiative #2780, parent goal #221
+- Moulds: `gateway/deadman.py` (#2501 — the satellite-runner dead-man
+  switch, same lapse-detection shape at a different altitude),
+  `memory/expiry.py` (loop lifecycle)
+- Prometheus Watchdog / dead-man's-switch:
+  https://runbooks.prometheus-operator.dev/runbooks/general/watchdog/
+- `docs/codebase/sensor.md`, `checks-broadcast.md`, `checks-advisory.md`

--- a/docs/codebase/sensor.md
+++ b/docs/codebase/sensor.md
@@ -143,7 +143,8 @@ runner parking.
 ## References
 
 - Initiative #2416 (binding design), Task #2503, dependency #2504, parent
-  goal #221. Runner #2505, dashboard/rollup #2506, investigator #2507
-  build on this storage shape.
+  goal #221. Runner #2505 (see `docs/codebase/checks-runner.md`, which
+  also covers the #2763 evaluation-loop watchdog), dashboard/rollup
+  #2506, investigator #2507 build on this storage shape.
 - Mould: `ScheduledTrigger` (`db/models.py`), `scheduler/` service/repo/
   schemas, `docs/codebase/scheduler.md`.


### PR DESCRIPTION
## Summary

- **Watchdog (#2763 ask 1).** The sensor runner now stamps every *completed* tick in-process (`checks/watchdog.py::note_tick_completed`, called from `run_one_sensor_tick` — including the advisory-lock no-op path; a raising tick deliberately does not stamp). A sibling watchdog task, gated by the same `SENSOR_RUNNER_ENABLED`, trips when no tick completes for `SENSOR_RUNNER_STALL_AFTER_TICKS` (new setting, default 6, min 2) × `SENSOR_RUNNER_TICK_INTERVAL_SECONDS`: one structured `checks_scheduler_stalled` error log + one `checks.scheduler_stalled` broadcast event per tenant with an active Sensor. Re-emission policy pinned: **once per continuous stall**.
- **Recovery.** The first completed tick after a detected stall emits `checks_scheduler_recovered` (warning log + event) carrying `stalled_for_seconds`, addressed to exactly the tenants the stalled event went to (set captured at detection, so the pair always matches).
- **Queryable staleness (#2763 ask 2).** `GET /api/v1/health` **and** `GET /api/v1/health/live` carry a `sensor_runner` facet (`seconds_since_last_tick`, `stalled`, `stall_threshold_seconds`), `null` exactly when `SENSOR_RUNNER_ENABLED=false`. `stalled` is derived live from the stamp on every read — never from the watchdog's emission latch — so a dead watchdog task cannot blind the facet. The liveness route carries it because the external prober is a `read_only` monitoring principal, and polling the deep check would federate a Vault credential + write an audit row per poll; the facet is an in-memory clock read honouring that route's no-connector constraint.
- **Fail-open.** State updates commit before emission; a failing tenant query or publish warn-logs (`checks_watchdog_emit_failed` / `checks_scheduler_broadcast_failed`) and never breaks a tick or the watchdog loop — the `checks_transition_broadcast_failed` posture.

## Design decisions (the issue left these to the PR)

- **In-process stamp only, no fleet-level persisted stamp.** Every healthy replica's stamp refreshes each cadence (a lock-not-acquired tick still completes); the stamp goes stale exactly when the observed failure — one process's loop coroutine going quiet — occurs. A persisted fleet stamp would cost a DB write per tick and mask a wedged replica behind healthy siblings. Each replica's health facet answers for its own loop.
- **No `/ready` probe registration.** Flipping readiness on a monitoring-plane stall would pull the API pod from the load balancer — wrong blast radius. The health facet is the queryable floor; reaction policy belongs to the external prober (the Prometheus Watchdog / dead-man's-switch division the issue cites).
- **Event fan-out is per active-sensor tenant.** Broadcast feeds are tenant-scoped; a platform-wide stall blinds every tenant with sensors, so each of their feeds gets the event. The structured logs are process-level and emitted regardless.
- **New op-ids pinned by exact membership** in `_CHECK_EVENT_OPS` (`checks.scheduler_stalled` / `checks.scheduler_recovered`), never a `checks.` prefix — per the classifier's documented gateway-collision rationale. Events ride the `publish_check_transition_event` mould: `__checks__` principal, nil-UUID `audit_id` (a quiet loop is a non-operation), op-class `checks` (already in `OP_CLASS_ENUM` + UI badge tables).

## Test plan

- [x] `ruff check src/ tests/` + `ruff format --check` — clean
- [x] `mypy src/` — clean except the pre-existing darwin-only `icmp.py` `MSG_ERRQUEUE` artifact (present on clean `main`; Linux CI unaffected)
- [x] Full backend suite `pytest tests/ -n 3 --dist loadscope` — green
- [x] AC 1 — clock-injected stall test: one `checks_scheduler_stalled` log + one event per pinned policy, op-class `checks` membership pinned (`tests/test_checks_watchdog.py`)
- [x] AC 2 — recovery emits `checks_scheduler_recovered` with the stall duration; latch re-arms for the next stall
- [x] AC 3 — `/api/v1/health` facet: healthy, stalled, and `sensor_runner_enabled=false` cases (`tests/test_api_v1_health.py`); liveness-route shape in `test_api_v1_health_split.py`
- [x] AC 4 — injected broadcast failure swallowed with warn log, proven through the real `run_one_sensor_tick` seam; injected tenant-query failure also covered
- [x] AC 5 — docs: new `docs/codebase/checks-runner.md` (runner + watchdog: event kinds, settings, health facet, boundaries); `checks-broadcast.md` updated with the new op-ids
- [x] Settings env round-trips for `SENSOR_RUNNER_STALL_AFTER_TICKS` (the inert-mapping trap) in `tests/test_settings.py`
- [x] `cli/api/openapi.json` + `cli/internal/api/client.gen.go` regenerated (`make snapshot-openapi && make generate`); `go build ./...` + `go test ./...` green
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (warnings are pre-existing file-size debt)

## Out of scope (per the issue)

- Retro-notifying dashboards whose members transitioned while blind (resume claims the CAS edge normally; a stall costs notification latency, not the notification)
- Root-causing the original 37-minute stall; batch-spacing drift; the 5.6 s TCP-check duration observation
- A meta-sensor entity

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2763
