### PR TITLE
docs(keycloak): drop stale Custom Connector framing from bootstrap-clients

### DIFF
--- a/cli/internal/cmd/admin/keycloak/bootstrap.go
+++ b/cli/internal/cmd/admin/keycloak/bootstrap.go
@@ -34,8 +34,9 @@ type BootstrapOptions struct {
 	CLIClientID string
 
 	// MCPClientID is the public authorization-code+PKCE client name
-	// used by Claude.ai Custom Connector / MCP Inspector; defaults to
-	// "meho-mcp".
+	// used by browser-flow MCP clients — the mcp-remote stdio shim
+	// (Claude Desktop), MCP Inspector, and Claude Code / Cursor
+	// (loopback PKCE); defaults to "meho-mcp".
 	MCPClientID string
 
 	// BackplaneAudience is the confidential resource-server client's
@@ -314,7 +315,7 @@ func (o BootstrapOptions) desiredMCPClient() *clientRep {
 	return &clientRep{
 		ClientID:                  o.MCPClientID,
 		Name:                      "MEHO MCP browser-OAuth-2.1 public client",
-		Description:               "Public OAuth client for OAuth 2.1 authorization-code + PKCE used by Claude.ai Custom Connector, MCP Inspector, and any browser-flow MCP client targeting <backplane-url>/mcp. Provisioned by `meho admin keycloak bootstrap-clients` (#791).",
+		Description:               "Public OAuth client for OAuth 2.1 authorization-code + PKCE used by browser-flow MCP clients (mcp-remote shim, MCP Inspector, Claude Code) targeting <backplane-url>/mcp. Provisioned by `meho admin keycloak bootstrap-clients` (#791).",
 		Enabled:                   boolPtr(true),
 		PublicClient:              boolPtr(true),
 		StandardFlowEnabled:       boolPtr(true),
@@ -822,6 +823,6 @@ func buildConfigKeySummary(opts BootstrapOptions) []string {
 		"# Surfaced via GET /api/v1/auth-config as `cli_client_id`;",
 		"# `meho login` resolves it automatically.",
 		"",
-		"MCP browser-flow client_id (paste into Claude.ai Custom Connector or MCP Inspector config): " + opts.MCPClientID,
+		"MCP browser-flow client_id (paste into your MCP client config — mcp-remote shim / MCP Inspector / Claude Code): " + opts.MCPClientID,
 	}
 }


### PR DESCRIPTION
## Summary

- Removes the stale "Claude.ai Custom Connector" framing from the three wording sites in `meho admin keycloak bootstrap-clients`: the `MCPClientID` struct comment, the registered Keycloak client **Description**, and the post-run operator help line.
- Replaces it with the real internal-only consumers — the `mcp-remote` stdio shim (Claude Desktop), MCP Inspector, and Claude Code / Cursor (loopback PKCE) — per the internal-only invariant established in #2744 and proven by the #2666 smoke test. The Custom Connector backend runs in Anthropic's cloud and needs a publicly reachable backplane, which MEHO never is.
- Wording only; no behavior change.

## Test plan

- [x] `git grep -nE "Custom Connector|[Cc]laude\.ai" cli/internal/cmd/admin/keycloak/` → returns **only** the redirect-URI-default sites owned by #2793 (bootstrap.go L70/L110, keycloak.go L220 — shifted down one line from L69/L109 because the struct-comment rewrite wraps to four lines; their content is untouched). None of the three reworded sites remain.
- [x] `gofmt -l cli/internal/cmd/admin/keycloak/bootstrap.go` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` (CLI module) — all packages pass (`keycloak` ok)
- [x] `golangci-lint run` (v2.12.2, matches CI pin) — 0 issues, full module and scoped to `./internal/cmd/admin/keycloak/...`

## Out of scope

- **Default redirect URIs** (`withDefaults` MCPRedirectURIs) and the comments/help describing them (bootstrap.go struct comment ~L70, `keycloak.go` `--mcp-redirect-uri` help ~L220) — a behavioral change tracked in #2793. This PR does not touch redirect behavior.
- The `meho-mcp` client id (settled in #2783).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2792
