### PR TITLE
fix(cli): default MCP redirect URIs to loopback (localhost + 127.0.0.1), drop invalid claude.ai callback

### DIFF
--- a/cli/internal/cmd/admin/keycloak/bootstrap.go
+++ b/cli/internal/cmd/admin/keycloak/bootstrap.go
@@ -66,8 +66,10 @@ type BootstrapOptions struct {
 	SkipUserProvisioning bool
 
 	// MCPRedirectURIs / MCPWebOrigins control the public MCP client's
-	// browser-flow allowlists. Defaults cover Claude.ai + localhost
-	// MCP Inspector.
+	// browser-flow allowlists. Defaults cover the loopback callbacks
+	// (localhost + 127.0.0.1, any port/path) that mcp-remote and Claude
+	// Code listen on — Keycloak matches redirect hosts literally, so
+	// both loopback forms are listed.
 	MCPRedirectURIs []string
 	MCPWebOrigins   []string
 
@@ -106,8 +108,8 @@ func (o BootstrapOptions) withDefaults() BootstrapOptions {
 	}
 	if len(o.MCPRedirectURIs) == 0 {
 		o.MCPRedirectURIs = []string{
-			"https://claude.ai/api/mcp/auth_callback",
 			"http://localhost:*",
+			"http://127.0.0.1:*",
 		}
 	}
 	if len(o.MCPWebOrigins) == 0 {

--- a/cli/internal/cmd/admin/keycloak/bootstrap_test.go
+++ b/cli/internal/cmd/admin/keycloak/bootstrap_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -813,6 +814,43 @@ func TestBootstrap_MCPClientHasStandardFlowAndPKCE(t *testing.T) {
 	}
 	if len(mcpClient.RedirectURIs) == 0 {
 		t.Errorf("MCP client must have at least one redirect URI")
+	}
+}
+
+// TestBootstrap_MCPClientDefaultRedirectURIsLoopbackOnly is the
+// regression contract for #2793: when no --mcp-redirect-uri is given,
+// withDefaults() must apply the loopback-only set covering both host
+// forms (localhost + 127.0.0.1). Keycloak matches redirect hosts
+// literally, so `http://localhost:*` alone does NOT cover the
+// `127.0.0.1` host that mcp-remote's `/oauth/callback` uses (#2666).
+// The dead claude.ai cloud callback — structurally unreachable for
+// internal-only MEHO (#2744) — must not be defaulted.
+func TestBootstrap_MCPClientDefaultRedirectURIsLoopbackOnly(t *testing.T) {
+	fake := newFakeKeycloak()
+	if _, _, err := runBootstrapOnce(t, fake, fullOpts()); err != nil {
+		t.Fatalf("Bootstrap: %v", err)
+	}
+	var mcpClient *clientRep
+	for _, c := range fake.clients {
+		if c.ClientID == "meho-mcp" {
+			mcpClient = c
+		}
+	}
+	if mcpClient == nil {
+		t.Fatalf("meho-mcp not found")
+	}
+
+	want := []string{"http://localhost:*", "http://127.0.0.1:*"}
+	if !slices.Equal(mcpClient.RedirectURIs, want) {
+		t.Errorf("default MCP redirect URIs = %v, want %v",
+			mcpClient.RedirectURIs, want)
+	}
+	for _, uri := range mcpClient.RedirectURIs {
+		if strings.Contains(uri, "claude.ai") {
+			t.Errorf("default MCP redirect URIs must not include a "+
+				"claude.ai cloud callback (internal-only MEHO can never "+
+				"exercise it); got %q", uri)
+		}
 	}
 }
 

--- a/cli/internal/cmd/admin/keycloak/keycloak.go
+++ b/cli/internal/cmd/admin/keycloak/keycloak.go
@@ -217,7 +217,7 @@ func newBootstrapClientsCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&skipUserProvisioning, "skip-user-provisioning", false,
 		"skip the group + user creation steps (use when users are externally-managed via federation / SCIM)")
 	cmd.Flags().StringSliceVar(&mcpRedirectURIs, "mcp-redirect-uri", nil,
-		"redirect URI(s) for the MCP browser-flow client (default: claude.ai callback + localhost)")
+		"redirect URI(s) for the MCP browser-flow client (default: loopback localhost + 127.0.0.1, any port/path)")
 	cmd.Flags().StringSliceVar(&mcpWebOrigins, "mcp-web-origin", nil,
 		"CORS web origin(s) for the MCP browser-flow client (default: `+` — allow the redirect-URI origins)")
 	cmd.Flags().BoolVar(&insecureSkipTLS, "insecure-skip-tls-verify", false,

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -1872,8 +1872,10 @@ agent-facing operation, and is **not** mirrored on the MCP surface.
      every other flow off).
   2. Public authorization-code+PKCE MCP client (default name
      `meho-mcp`, `standardFlowEnabled=true`,
-     `pkce.code.challenge.method=S256`, redirect URIs for Claude.ai +
-     localhost MCP Inspector).
+     `pkce.code.challenge.method=S256`, default redirect URIs for the
+     loopback callbacks `http://localhost:*` + `http://127.0.0.1:*`
+     that `mcp-remote` and Claude Code listen on — Keycloak matches
+     redirect hosts literally, so both loopback forms are listed).
   3. 5 protocol mappers cloned from the reference shape on
      `meho-backplane`, installed on **both** public clients:
      `audience-meho-backplane`, `meho-mcp-audience`, `tenant-id`,


### PR DESCRIPTION
## Summary

- `meho admin keycloak bootstrap`'s default MCP redirect allowlist becomes **loopback-only**: `http://localhost:*` + `http://127.0.0.1:*` (was `https://claude.ai/api/mcp/auth_callback` + `http://localhost:*`).
- Drops the dead `claude.ai` cloud callback — it's the remote Custom-Connector path that needs a publicly-reachable backplane, which internal-only MEHO never is (#2744), so it could never be exercised.
- Adds the `127.0.0.1` host twin: Keycloak matches redirect hosts **literally**, so `http://localhost:*` does not cover the `127.0.0.1` host that `mcp-remote`'s `/oauth/callback` uses. This closes the gap the #2666 smoke test patched by hand ("the bootstrap script should gain them permanently"). A fresh bootstrap now yields a client a VPN-connected Claude Desktop (`mcp-remote`) or Claude Code can use with no manual redirect edits.
- Coupled wording updated in three descriptive sites (struct comment, `--mcp-redirect-uri` help, `docs/codebase/cli.md`); new regression test pins the exact default set and the absence of any `claude.ai` entry.

## Idempotency (fresh vs. re-run — surfaced, not automated)

This changes the default for **fresh** bootstraps only. Already-provisioned realms are untouched until the next `bootstrap` run.

On a re-run the MCP client is reconciled **by client id** via a full-representation `PUT` (Keycloak replaces the client representation wholesale; `redirectUris` is always sent). So the redirect set a re-run lands is whatever that run computes:

- **Re-run without `--mcp-redirect-uri`** — `withDefaults()` supplies the new loopback set and the `PUT` replaces the client's redirect URIs with it. That means the stale `claude.ai` entry is dropped and the `127.0.0.1` twin added **as a side effect** — no separate manual removal step is needed; the next default re-run self-heals the realm.
- **Re-run with `--mcp-redirect-uri …`** — the client's redirect URIs become exactly that set.

A stale `claude.ai` entry left on a realm that is never re-bootstrapped is harmless (internal-only MEHO can never exercise that cloud callback), so no urgent migration is required either way.

> Note: the linked ticket framed re-runs as "won't strip an existing `claude.ai` entry." That's imprecise for the code as written — the reconcile is a full-rep replace, not a redirect-URI merge (the same behavior the reference shell script's `$existing * $desired` jq merge has, since `*` replaces arrays). The behavior above is what actually happens.

## Test plan

- [x] `git grep -nE "claude\.ai/api/mcp/auth_callback" cli/` — empty (acceptance).
- [x] `go test ./...` (full CLI module, `-race -cover`) — all packages pass.
- [x] New `TestBootstrap_MCPClientDefaultRedirectURIsLoopbackOnly` — asserts default set is exactly `[http://localhost:*, http://127.0.0.1:*]` and contains no `claude.ai` entry; passes.
- [x] `golangci-lint run` (v2.12.2, CI-pinned, `cli/.golangci.yml`) — 0 issues.
- [x] `gofmt -l` / `go vet` / `go build ./...` — clean.

## Out of scope

- The Custom-Connector **wording** in the MCP client purpose / `Description` / config-summary help (bootstrap.go L37/L317/L825) — sibling ticket #2792. Untouched here.
- `MCPWebOrigins` default (`+`) — unchanged.
- Realm-side migration of already-provisioned clients — surfaced above, not automated.
- Operator-facing manual `kcadm`/install recipes that mirror the old default set (`deploy/values-examples/README.md`, `docs-site/install/keycloak-realm.md`, `docs/cross-repo/mcp-client-setup.md`) still list the `claude.ai` recipe. Those are static hand-registration guides entangled with #2792's Custom-Connector wording, not the CLI default this ticket owns; left for a follow-up doc pass to avoid a collision with #2792.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * MCP authentication now supports loopback callbacks on both `localhost` and `127.0.0.1`, using any port or path.
  * Removed the default Claude.ai callback from MCP redirect URI configuration.
  * Updated setup guidance to reflect the new callback options and PKCE S256 configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->