### PR TITLE
docs(keycloak): align manual redirect-URI recipes to loopback default (drop claude.ai callback)

### DIFF
--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -975,7 +975,7 @@ client-shape contrast with `meho-cli`:
 | --- | --- | --- |
 | Standard flow (authorization-code + PKCE) | **On** | MCP 2025-06-18 mandates OAuth 2.1 authorization-code + PKCE for the `/mcp` path; the device grant is a CLI-only convenience. |
 | Device grant | Off | Not needed; MCP clients run the browser-redirect flow. |
-| Valid redirect URIs | `https://claude.ai/api/mcp/auth_callback`, `http://localhost:*` | Covers the Claude.ai Custom Connector and any localhost MCP Inspector. |
+| Valid redirect URIs | `http://localhost:*`, `http://127.0.0.1:*` | Loopback only — `localhost` for a local MCP Inspector / Claude Code, plus the `127.0.0.1` twin the `mcp-remote` shim needs (Keycloak matches redirect hosts literally, so `localhost` ≠ `127.0.0.1`). MEHO is internal-only, so there is **no** public `claude.ai` Custom-Connector redirect. |
 | Web origins | `+` (or a tight allow-list) | CORS for the browser flow. |
 | PKCE challenge method | `S256` | Spec-required for public-client PKCE. |
 | **Optional client scopes** | **`offline_access`** | Claude Code's MCP client **always** requests `offline_access` in its scope parameter to obtain a refresh token; if the scope isn't assigned on the client, Keycloak rejects the authorization request with `invalid_scope` (Wall #7). Assign as **optional** rather than default — only flows that ask for a refresh token (browser MCP clients) should mint one. The CLI device-code client deliberately doesn't get this scope (RFC 8628 device-code clients re-run the device dance instead of holding a long-lived refresh token; a stolen device-code refresh token has worse blast-radius than a fresh dance prompt). |

--- a/docs/cross-repo/mcp-client-setup.md
+++ b/docs/cross-repo/mcp-client-setup.md
@@ -65,8 +65,8 @@ kcadm.sh create clients -r <realm> -b '{
   "standardFlowEnabled": true,
   "directAccessGrantsEnabled": false,
   "redirectUris": [
-    "https://claude.ai/api/mcp/auth_callback",
-    "http://localhost:*"
+    "http://localhost:*",
+    "http://127.0.0.1:*"
   ],
   "webOrigins": ["+"],
   "attributes": {
@@ -77,10 +77,10 @@ kcadm.sh create clients -r <realm> -b '{
 # Attach the audience mapper from Step 1 to this client.
 ```
 
-`redirectUris` covers two patterns:
+`redirectUris` is loopback-only — MEHO is internal-only, so there is no public `claude.ai` Custom Connector redirect (see the callout at the top of this doc). Both loopback hosts are registered:
 
-- `https://claude.ai/api/mcp/auth_callback` for the Claude.ai Custom Connector flow.
 - `http://localhost:*` for MCP Inspector and other CLI / desktop clients that listen on an ephemeral local port.
+- `http://127.0.0.1:*` — the loopback twin the `mcp-remote` shim needs. Keycloak matches redirect hosts literally, so `localhost` and `127.0.0.1` are distinct and both must be registered.
 
 A future-proof alternative is to make this client a *Dynamic Client Registration* template once Keycloak's DCR support and the v0.2.next MEHO RFC 7591 work land; for v0.2, the static recipe above is the path.
 


### PR DESCRIPTION
## Summary

- Two manual Keycloak realm-setup recipes still registered the invalid `https://claude.ai/api/mcp/auth_callback` redirect URI and omitted the `127.0.0.1` loopback twin, contradicting the CLI default shipped in #2793 and the internal-only invariant (#2744). An operator following them by hand reintroduced exactly the cloud callback those changes removed.
- Aligns `deploy/values-examples/README.md` (the `meho-mcp` "Valid redirect URIs" table row) and `docs/cross-repo/mcp-client-setup.md` (the `redirectUris` JSON + its explanation) to the canonical loopback-only recipe already in `docs-site/install/keycloak-realm.md:138`.
- Both recipes now register `http://localhost:*` **and** `http://127.0.0.1:*` (Keycloak matches redirect hosts literally, so the two are distinct — #2666), drop the cloud callback, and carry the internal-only / `mcp-remote`-shim rationale in place of the old "Custom Connector" wording. This also resolves the self-contradiction in `mcp-client-setup.md`, whose prose already stated the remote Custom Connector does not apply to internal-only MEHO.

## Test plan

- [x] `git grep -n 'claude\.ai/api/mcp/auth_callback' deploy/ docs/` — empty (no manual recipe registers the cloud callback).
- [x] `deploy/values-examples/README.md` redirect-URI row lists loopback `localhost` + `127.0.0.1`, rationale is internal-only.
- [x] `docs/cross-repo/mcp-client-setup.md` `redirectUris` JSON + explanation list loopback `localhost` + `127.0.0.1`, consistent with the doc's own internal-only prose.
- [x] Both recipes consistent with `docs-site/install/keycloak-realm.md:138`.
- [x] `mkdocs build --strict` — passes (exit 0, no strict warnings).
- [x] `code-quality.py --diff` — pass.

## Out of scope

- `docs-site/install/keycloak-realm.md` — the canonical example, already correct; unchanged.
- The CIMD **Trusted domains** `*.claude.ai` reference in `deploy/values-examples/README.md` (~L1185) — a different feature (client-id-metadata-document domain allowlist, not redirect URIs).
- No CLI/code change (#2793 shipped it); no CHANGELOG entry (docs-only consistency fix, matching sibling docs PRs #2794/#2789).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2796
