### PR TITLE
ci(image): drop trivy 'report-only' misnomer, publish SARIF on scan failure

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -58,7 +58,10 @@
 #     fixed CVE fails the run as a red-main alarm against silent CVE
 #     accumulation on a stale base image (it is not a PR merge gate — the step
 #     is skipped on pull_request). SARIF results land both on the GitHub
-#     Security tab (Code scanning alerts) and as a 30-day workflow artefact.
+#     Security tab (Code scanning alerts) and as a 30-day workflow artefact —
+#     and, because the two upload steps are guarded on the scan step's outcome
+#     (not the default success() gate), they publish even when the scan FAILS,
+#     so a red run's CVE list is one click away instead of lost to the skip.
 
 name: image
 
@@ -277,7 +280,8 @@ jobs:
             --type spdxjson \
             "ghcr.io/evoila/meho@${DIGEST}"
 
-      - name: Vulnerability scan (trivy, report-only)
+      - name: Vulnerability scan (trivy — fails on fixable CRITICAL/HIGH)
+        id: trivy
         # trivy scans the pushed image (OS packages + language deps,
         # including the uv-installed Python wheels in /app/.venv). Emits
         # SARIF for upload to the GitHub Security tab.
@@ -313,7 +317,14 @@ jobs:
         # SARIF upload surfaces findings under repo -> Security -> Code
         # scanning alerts. Requires `security-events: write` at the job or
         # workflow level — granted in the top-level permissions block.
-        if: github.event_name != 'pull_request'
+        #
+        # Publish on a FAILED scan too — a red scan is exactly when the CVE
+        # list must reach the Security tab — but stay skipped when the scan
+        # step was SKIPPED (the pull_request path, where it never ran). A bare
+        # `if:` is implicitly success()-gated, so the previous condition
+        # dropped this upload on every red scan; the explicit `!cancelled()`
+        # opts out of that default and the outcome check restores the PR skip.
+        if: ${{ !cancelled() && steps.trivy.outcome != 'skipped' }}
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
         with:
           sarif_file: trivy-results.sarif
@@ -325,8 +336,10 @@ jobs:
       - name: Upload trivy SARIF as workflow artefact
         # Mirrors the SARIF upload as a downloadable artefact (30-day
         # retention) so operators can pull it via `gh run download` without
-        # needing Security-tab access.
-        if: github.event_name != 'pull_request'
+        # needing Security-tab access. Same fail-visible guard as the
+        # Security-tab upload above: publishes on a red scan, skips on the
+        # pull_request path where the scan step never ran.
+        if: ${{ !cancelled() && steps.trivy.outcome != 'skipped' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: trivy-results

--- a/backend/README.md
+++ b/backend/README.md
@@ -302,13 +302,15 @@ surfaced two ways:
    jq '.runs[0].results | length' trivy-results.sarif
    ```
 
-**v0.1 is report-only.** The workflow stays green even on critical CVEs — the
-deliberate split per Goal #11 is "scan now, gate later" so the team can
-establish a baseline before committing to a remediation policy. v0.2 will
-flip on a severity-based gate (likely `exit-code: 1` on `CRITICAL`) once the
-noise level is known. Until then, treat the Security tab as the working
-backlog: triage findings, file follow-ups, but do not expect builds to break
-on them.
+**The scan gates main/tag builds.** `exit-code: '1'` fails the run on any
+fixable CRITICAL/HIGH CVE — a red-main alarm against silent CVE accumulation
+on a stale base image (`ignore-unfixed: true` drops CVEs with no upstream
+fix). It runs post-push on main and tags only; the step is skipped on
+pull_request, so it is not a PR merge gate. Because the two SARIF uploads are
+guarded on the scan step's outcome rather than the default `success()` gate,
+a failing scan still publishes its findings to the Security tab and the
+30-day artefact — so a red run's CVE list is one click away. Treat a red run
+as "bump the base-image digest and re-push", not "this merge is blocked".
 
 ## What this skeleton intentionally omits
 

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -1178,7 +1178,7 @@ docker PR) and re-push", not "this merge is blocked".
 action in the new steps is SHA-pinned with the human-readable tag in
 a trailing comment: `anchore/sbom-action@…` (v0.24.0),
 `aquasecurity/trivy-action@…` (v0.36.0),
-`github/codeql-action/upload-sarif@…` (v4.35.4),
+`github/codeql-action/upload-sarif@…` (v4.37.3),
 `actions/upload-artifact@…` (v7.0.1). Renovate / Dependabot bumps
 these on the same review cadence as `sigstore/cosign-installer`.
 

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -1147,11 +1147,13 @@ Fulcio identity (`image.yml@<ref>`), so downstream `install.sh` (the
 dogfooding consumer) verifies the entire chain — image, build
 provenance, bill of materials — with one trust anchor.
 
-**Trivy report-only scan.** `aquasecurity/trivy-action` runs after the
-attestation step against the same digest. The scan emits SARIF
-covering OS packages + the locked Python deps inside `/app/.venv`,
-filtered to `CRITICAL,HIGH` with `ignore-unfixed: true` so the
-results list only actionable findings. SARIF is uploaded **twice**:
+**Trivy vulnerability scan (fails on fixable CRITICAL/HIGH).**
+`aquasecurity/trivy-action` runs after the attestation step against the
+same digest. The scan emits SARIF covering OS packages + the locked
+Python deps inside `/app/.venv`, filtered to `CRITICAL,HIGH` with
+`ignore-unfixed: true` so the results list only actionable findings.
+SARIF is uploaded **twice** (both uploads publish on a failing scan too —
+see the gate note below):
 
 - `github/codeql-action/upload-sarif` posts the report to the GitHub
   Security tab (Code scanning alerts, category `trivy-image-scan`).
@@ -1162,12 +1164,15 @@ results list only actionable findings. SARIF is uploaded **twice**:
   Security-tab access can still download the file via
   `gh run download`.
 
-**v0.1 is report-only by deliberate split.** `exit-code: '0'` keeps
-the workflow green regardless of findings. Goal #11 splits "scan
-runs" from "scan gates the build" so the team can establish a
-baseline noise level before committing to a remediation policy. v0.2
-will flip `exit-code` to fail on a defined severity threshold once
-the baseline is known and triage cadence is sustainable.
+**The scan gates main/tag runs (`exit-code: '1'`).** A fixable
+CRITICAL/HIGH finding fails the run — a red-main alarm against silent
+CVE accumulation on a stale base image, not a PR merge gate (the step
+is skipped on `pull_request`). Both SARIF uploads are gated on the scan
+step's `outcome` (`if: ${{ !cancelled() && steps.trivy.outcome != 'skipped' }}`)
+rather than the implicit `success()`, so a failing scan still lands its
+findings on the Security tab and the 30-day artefact instead of skipping
+the uploads. A red run means "bump the base-image digest (Dependabot
+docker PR) and re-push", not "this merge is blocked".
 
 **Action pin discipline (same rule as cosign).** Every third-party
 action in the new steps is SHA-pinned with the human-readable tag in


### PR DESCRIPTION
## Summary

- The trivy scan step was named `Vulnerability scan (trivy, report-only)` but runs with `exit-code: '1'` — it hard-fails main/tag builds on a fixable CRITICAL/HIGH CVE. The "report-only" misnomer twice invited reading a genuine red run as a flake (2026-08-01, 2026-08-04 incidents). Renamed to `Vulnerability scan (trivy — fails on fixable CRITICAL/HIGH)`.
- Both SARIF upload steps inherited the implicit `success()` gate (a bare `if:` with no status-check function is evaluated as `success() && …`), so on a red scan — exactly when the CVE list is needed — no SARIF reached the Security tab or the 30-day artefact. Gave the scan step `id: trivy` and gated both uploads on `if: ${{ !cancelled() && steps.trivy.outcome != 'skipped' }}` so they publish on a **failed** scan but stay skipped on the **pull_request** path (where the scan step never runs).
- Corrected three stale doc passages that still described the scan as report-only / `exit-code: '0'` / "stays green" (`backend/README.md`, `docs/codebase/backend.md`) — the exact misconception this change removes.
- **The gate is unchanged**: `exit-code: '1'`, `severity: CRITICAL,HIGH`, `limit-severities-for-sarif: true`, `ignore-unfixed: true`, and the scan step's `pull_request` skip are all untouched. This PR renames and un-skips uploads; it does not soften the gate.

## Why the `if:` is correct (fail vs skip vs cancel)

A deliberately-red `image` run isn't safe to trigger on `main`, so this is asserted by reading the rendered workflow and reasoning about `if:` evaluation. `steps.trivy.outcome` is one of `success | failure | cancelled | skipped` (GitHub Actions [steps context](https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context)); a step skipped by its own `if:` has `outcome == 'skipped'`. Because the expression contains a status-check function (`cancelled()`), the default `success()` gate is **not** auto-applied ([status check functions](https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions)).

| Event | trivy scan step | `trivy.outcome` | `!cancelled() && outcome != 'skipped'` | Upload steps |
|---|---|---|---|---|
| `pull_request` | skipped (its `if:` is false on PRs) | `skipped` | `true && false` → **false** | **skip** ✓ (PR path unchanged) |
| push, no fixable CVEs | runs, exits 0 | `success` | `true && true` → **true** | **run** ✓ |
| push, fixable CRITICAL/HIGH | runs, exits 1 | `failure` | `true && true` → **true** | **run** ✓ (the fix) |
| push, an earlier step failed | skipped (`success()` false) | `skipped` | `true && false` → **false** | **skip** ✓ (no SARIF to upload) |
| workflow cancelled | — | any | `false && …` → **false** | **skip** ✓ |

`aquasecurity/trivy-action@v0.36.0` writes the `output` SARIF file **before** applying `exit-code`, so `trivy-results.sarif` exists on a red scan — the upload steps have a file to publish, and `if-no-files-found: error` on the artefact step stays satisfied.

## Test plan

- [x] **AC1 — no "report-only" left**: `grep -n "report-only" .github/workflows/image.yml` → no match (exit 1). The only remaining repo-wide `report-only` hits are the unrelated `#2702` ingest affordance in `register_ingested.py` / its test.
- [x] **AC2 — both uploads carry a fail-true / skip-false `if:`**: both upload steps now use `if: ${{ !cancelled() && steps.trivy.outcome != 'skipped' }}` (see truth table above). `actionlint` (1.7.12) exits 0, which also confirms the `steps.trivy` reference resolves (it errors on undefined step ids).
- [x] **AC3 — a red scan produces the `trivy-results.sarif` artefact**: guaranteed by trivy-action writing the output before the non-zero exit, plus the `failure`-row upload above; artefact `retention-days: 30` unchanged.
- [x] **AC4 — gate behavior unchanged**: `exit-code: '1'`, `severity: CRITICAL,HIGH`, `limit-severities-for-sarif: true`, `ignore-unfixed: true`, and the `pull_request` skip are byte-for-byte unchanged (see diff).
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` → valid YAML; `git diff --check` → no trailing-whitespace/conflict markers.

## Out of scope (per the issue)

- The severity set, `ignore-unfixed`, and the exit-code gate itself (deliberate per the in-file rationale) — untouched.
- The PR-path skip on the scan step — preserved.
- SonarCloud / code-scanning alert triage (#2490's other children).

## Docs

Beyond the workflow, `backend/README.md` and `docs/codebase/backend.md` still asserted the scan was report-only with `exit-code: '0'` that "stays green even on critical CVEs" — inverted from the current workflow and the very misconception behind the incidents. Both are corrected to describe the hard gate + SARIF-on-failure behavior.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2740


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container image security scans now block main-branch and tag releases when fixable critical or high vulnerabilities are detected.
  * Scan results remain available in security reports and downloadable artifacts even when a scan fails.

* **Documentation**
  * Clarified scan behavior for pull requests, release workflows, and remediation of vulnerable base images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->