### PR TITLE
fix(checks)!: converge dashboards + sensors lists on {items} envelope (#2742)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,32 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Breaking changes — `GET /api/v1/checks/dashboards` + `GET /api/v1/sensors` converged on the `{items, next_cursor}` envelope (#2742)
+
+- **BREAKING.** The two check-plane `GET`-list routes that still wrapped
+  their list under a resource-named key now return the unified
+  `{items, next_cursor?}` list envelope
+  (`docs/codebase/api-shape-conventions.md` §2) — the same convention the
+  seven #2338 reference routes adopted, so the API no longer diverges from
+  its own standard on its newest routes. Both listings are unpaginated, so
+  `next_cursor` is always `null` (present so the field can grow a real
+  cursor later without a further breaking change). Both are now pinned by
+  the platform-wide contract test
+  (`backend/tests/test_api_v1_list_envelope_contract.py`) so the
+  divergence cannot recur. Affected endpoints and the wire-shape change
+  adopters must migrate:
+  - `GET /api/v1/checks/dashboards` — was `{"dashboards": [...]}` → now
+    `{"items": [...], "next_cursor": null}`.
+  - `GET /api/v1/sensors` — was `{"sensors": [...]}` → now
+    `{"items": [...], "next_cursor": null}`.
+
+  **Migration recipe.** Read the list from `response["items"]` instead of
+  the old key (`dashboards` / `sensors`); read `response["next_cursor"]`
+  for pagination (always `null` on these routes today). The bundled `meho`
+  CLI and the generated Go client already read the new envelope — this
+  change ships them together. The MCP `meho.sensors.*` tool payload is
+  unchanged (governed by its own conventions test, not §2).
+
 ### Added
 
 - **Checks evaluation-loop watchdog + queryable runner liveness**

--- a/backend/src/meho_backplane/api/v1/checks_dashboards.py
+++ b/backend/src/meho_backplane/api/v1/checks_dashboards.py
@@ -130,7 +130,7 @@ async def list_dashboards(
     service = CheckDashboardAdminService()
     dashboards = await service.list_(target_tenant, limit=limit, offset=offset)
     structlog.contextvars.bind_contextvars(audit_row_count=len(dashboards))
-    return DashboardListResponse(dashboards=list(dashboards))
+    return DashboardListResponse(items=list(dashboards))
 
 
 @router.post(

--- a/backend/src/meho_backplane/api/v1/sensors.py
+++ b/backend/src/meho_backplane/api/v1/sensors.py
@@ -140,7 +140,7 @@ async def list_sensors(
         offset=offset,
     )
     structlog.contextvars.bind_contextvars(audit_row_count=len(sensors))
-    return SensorListResponse(sensors=list(sensors))
+    return SensorListResponse(items=list(sensors))
 
 
 @router.post(

--- a/backend/src/meho_backplane/checks/dashboard_schemas.py
+++ b/backend/src/meho_backplane/checks/dashboard_schemas.py
@@ -194,12 +194,16 @@ class DashboardDetail(DashboardRead):
 
 
 class DashboardListResponse(BaseModel):
-    """Response envelope for ``GET /api/v1/checks/dashboards``.
+    """Unified list envelope for ``GET /api/v1/checks/dashboards``.
 
-    Wrapped in ``{"dashboards": [...]}`` so a future paging / cursor field
-    can land non-breakingly -- the same shape the Sensor list adopts.
+    The `{items, next_cursor}` shape codified in
+    ``docs/codebase/api-shape-conventions.md`` §2. The listing is not
+    cursor-paginated (``limit`` / ``offset`` truncate), so ``next_cursor``
+    is always ``None`` but present so the endpoint can grow pagination
+    later without a further breaking change.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    dashboards: list[DashboardRead]
+    items: list[DashboardRead]
+    next_cursor: str | None = None

--- a/backend/src/meho_backplane/checks/schemas.py
+++ b/backend/src/meho_backplane/checks/schemas.py
@@ -199,17 +199,19 @@ class SensorRead(BaseModel):
 
 
 class SensorListResponse(BaseModel):
-    """Response envelope for ``GET /api/v1/sensors``.
+    """Unified list envelope for ``GET /api/v1/sensors``.
 
-    Wrapped in ``{"sensors": [...]}`` so a future paging / cursor field
-    can land non-breakingly -- the same shape
-    :class:`~meho_backplane.scheduler.schemas.ScheduledTriggerListResponse`
-    adopted.
+    The `{items, next_cursor}` shape codified in
+    ``docs/codebase/api-shape-conventions.md`` §2. The listing is not
+    cursor-paginated (``limit`` / ``offset`` truncate), so ``next_cursor``
+    is always ``None`` but present so the endpoint can grow pagination
+    later without a further breaking change.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    sensors: list[SensorRead]
+    items: list[SensorRead]
+    next_cursor: str | None = None
 
 
 #: Re-exported sentinel status literal for query-string filter handling at

--- a/backend/tests/test_api_v1_list_envelope_contract.py
+++ b/backend/tests/test_api_v1_list_envelope_contract.py
@@ -134,6 +134,8 @@ _LIST_ENVELOPE_ENDPOINTS = [
     pytest.param("/api/v1/broadcast/overrides", None, id="broadcast-overrides"),
     pytest.param("/api/v1/runbooks/templates", "templates", id="runbook-templates"),
     pytest.param("/api/v1/runbooks/runs", "runs", id="runbook-runs"),
+    pytest.param("/api/v1/checks/dashboards", "dashboards", id="checks-dashboards"),
+    pytest.param("/api/v1/sensors", "sensors", id="sensors"),
 ]
 
 #: Bare path list for the schema / route-table checks (the parametrize

--- a/backend/tests/test_checks_admin.py
+++ b/backend/tests/test_checks_admin.py
@@ -610,13 +610,13 @@ async def test_rest_create_list_delete_round_trip(client: TestClient) -> None:
 
         listed = client.get("/api/v1/sensors", headers=headers)
         assert listed.status_code == 200
-        assert [s["id"] for s in listed.json()["sensors"]] == [sensor_id]
+        assert [s["id"] for s in listed.json()["items"]] == [sensor_id]
 
         deleted = client.delete(f"/api/v1/sensors/{sensor_id}", headers=headers)
         assert deleted.status_code == 204
         # Hard delete: repeat returns 404 and the list is empty.
         assert client.delete(f"/api/v1/sensors/{sensor_id}", headers=headers).status_code == 404
-        assert client.get("/api/v1/sensors", headers=headers).json()["sensors"] == []
+        assert client.get("/api/v1/sensors", headers=headers).json()["items"] == []
 
 
 @pytest.mark.asyncio
@@ -833,7 +833,7 @@ async def test_rest_tenant_scoping(client: TestClient) -> None:
         b_headers = {"Authorization": f"Bearer {_token(b_key, sub='b-admin', tenant_id=_TENANT_B)}"}
         listed = client.get("/api/v1/sensors", headers=b_headers)
         assert listed.status_code == 200
-        assert listed.json()["sensors"] == []
+        assert listed.json()["items"] == []
         result = client.delete(f"/api/v1/sensors/{entry_a.id}", headers=b_headers)
         assert result.status_code == 404
         assert result.json()["detail"] == "sensor_not_found"

--- a/backend/tests/test_checks_dashboards.py
+++ b/backend/tests/test_checks_dashboards.py
@@ -320,7 +320,7 @@ async def test_rest_create_list_delete_round_trip(client: TestClient) -> None:
 
         listed = client.get("/api/v1/checks/dashboards", headers=headers)
         assert listed.status_code == 200
-        rows = listed.json()["dashboards"]
+        rows = listed.json()["items"]
         assert [d["id"] for d in rows] == [dashboard_id]
         assert rows[0]["state"] == "ok"
 
@@ -394,7 +394,7 @@ async def test_rest_cross_tenant_dashboard_id_is_404(client: TestClient) -> None
         assert got.status_code == 404
         assert got.json()["detail"] == "dashboard_not_found"
         # And B's list does not include A's dashboard.
-        assert client.get("/api/v1/checks/dashboards", headers=b_headers).json()["dashboards"] == []
+        assert client.get("/api/v1/checks/dashboards", headers=b_headers).json()["items"] == []
 
 
 @pytest.mark.asyncio
@@ -534,7 +534,7 @@ async def test_rest_create_round_trips_notify_config(client: TestClient) -> None
         assert detail.json()["notify_min_state"] == "degraded"
 
         listed = client.get("/api/v1/checks/dashboards", headers=headers)
-        row = next(d for d in listed.json()["dashboards"] if d["id"] == dashboard_id)
+        row = next(d for d in listed.json()["items"] if d["id"] == dashboard_id)
         assert row["notify_email"] == "oncall@example.com"
         assert row["notify_min_state"] == "degraded"
 
@@ -619,7 +619,7 @@ async def test_rest_create_round_trips_investigator_prompt(client: TestClient) -
         assert detail.json()["investigator_prompt"] == prompt
 
         listed = client.get("/api/v1/checks/dashboards", headers=headers)
-        row = next(d for d in listed.json()["dashboards"] if d["id"] == dashboard_id)
+        row = next(d for d in listed.json()["items"] if d["id"] == dashboard_id)
         assert row["investigator_prompt"] == prompt
 
     async with get_sessionmaker()() as session:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -23648,20 +23648,25 @@
       },
       "DashboardListResponse": {
         "properties": {
-          "dashboards": {
+          "items": {
             "items": {
               "$ref": "#/components/schemas/DashboardRead"
             },
             "type": "array",
-            "title": "Dashboards"
+            "title": "Items"
+          },
+          "next_cursor": {
+            "type": "string",
+            "nullable": true,
+            "title": "Next Cursor"
           }
         },
         "type": "object",
         "required": [
-          "dashboards"
+          "items"
         ],
         "title": "DashboardListResponse",
-        "description": "Response envelope for ``GET /api/v1/checks/dashboards``.\n\nWrapped in ``{\"dashboards\": [...]}`` so a future paging / cursor field\ncan land non-breakingly -- the same shape the Sensor list adopts."
+        "description": "Unified list envelope for ``GET /api/v1/checks/dashboards``.\n\nThe `{items, next_cursor}` shape codified in\n``docs/codebase/api-shape-conventions.md`` \u00a72. The listing is not\ncursor-paginated (``limit`` / ``offset`` truncate), so ``next_cursor``\nis always ``None`` but present so the endpoint can grow pagination\nlater without a further breaking change."
       },
       "DashboardMemberView": {
         "properties": {
@@ -27883,20 +27888,25 @@
       },
       "SensorListResponse": {
         "properties": {
-          "sensors": {
+          "items": {
             "items": {
               "$ref": "#/components/schemas/SensorRead"
             },
             "type": "array",
-            "title": "Sensors"
+            "title": "Items"
+          },
+          "next_cursor": {
+            "type": "string",
+            "nullable": true,
+            "title": "Next Cursor"
           }
         },
         "type": "object",
         "required": [
-          "sensors"
+          "items"
         ],
         "title": "SensorListResponse",
-        "description": "Response envelope for ``GET /api/v1/sensors``.\n\nWrapped in ``{\"sensors\": [...]}`` so a future paging / cursor field\ncan land non-breakingly -- the same shape\n:class:`~meho_backplane.scheduler.schemas.ScheduledTriggerListResponse`\nadopted."
+        "description": "Unified list envelope for ``GET /api/v1/sensors``.\n\nThe `{items, next_cursor}` shape codified in\n``docs/codebase/api-shape-conventions.md`` \u00a72. The listing is not\ncursor-paginated (``limit`` / ``offset`` truncate), so ``next_cursor``\nis always ``None`` but present so the endpoint can grow pagination\nlater without a further breaking change."
       },
       "SensorRead": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3506,12 +3506,16 @@ type DashboardDetailNotifyMinState string
 // DashboardDetailState defines model for DashboardDetail.State.
 type DashboardDetailState string
 
-// DashboardListResponse Response envelope for “GET /api/v1/checks/dashboards“.
+// DashboardListResponse Unified list envelope for “GET /api/v1/checks/dashboards“.
 //
-// Wrapped in “{"dashboards": [...]}“ so a future paging / cursor field
-// can land non-breakingly -- the same shape the Sensor list adopts.
+// The `{items, next_cursor}` shape codified in
+// “docs/codebase/api-shape-conventions.md“ §2. The listing is not
+// cursor-paginated (“limit“ / “offset“ truncate), so “next_cursor“
+// is always “None“ but present so the endpoint can grow pagination
+// later without a further breaking change.
 type DashboardListResponse struct {
-	Dashboards []DashboardRead `json:"dashboards"`
+	Items      []DashboardRead `json:"items"`
+	NextCursor *string         `json:"next_cursor"`
 }
 
 // DashboardMemberView One member Sensor as rendered on a Dashboard detail read.
@@ -6373,14 +6377,16 @@ type SensorCreate struct {
 	Timezone *string                 `json:"timezone,omitempty"`
 }
 
-// SensorListResponse Response envelope for “GET /api/v1/sensors“.
+// SensorListResponse Unified list envelope for “GET /api/v1/sensors“.
 //
-// Wrapped in “{"sensors": [...]}“ so a future paging / cursor field
-// can land non-breakingly -- the same shape
-// :class:`~meho_backplane.scheduler.schemas.ScheduledTriggerListResponse`
-// adopted.
+// The `{items, next_cursor}` shape codified in
+// “docs/codebase/api-shape-conventions.md“ §2. The listing is not
+// cursor-paginated (“limit“ / “offset“ truncate), so “next_cursor“
+// is always “None“ but present so the endpoint can grow pagination
+// later without a further breaking change.
 type SensorListResponse struct {
-	Sensors []SensorRead `json:"sensors"`
+	Items      []SensorRead `json:"items"`
+	NextCursor *string      `json:"next_cursor"`
 }
 
 // SensorRead Response shape for one “sensor“ row.

--- a/cli/internal/cmd/dashboard/dashboard_test.go
+++ b/cli/internal/cmd/dashboard/dashboard_test.go
@@ -288,7 +288,7 @@ func TestRunListHappyPath(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		// Serve the real generated envelope shape, not a bare array (#2383).
 		_ = json.NewEncoder(w).Encode(api.DashboardListResponse{
-			Dashboards: []api.DashboardRead{fakeDashboardRead(t)},
+			Items: []api.DashboardRead{fakeDashboardRead(t)},
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -312,7 +312,7 @@ func TestRunListJSONGolden(t *testing.T) {
 	mux.HandleFunc("/api/v1/checks/dashboards", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(api.DashboardListResponse{
-			Dashboards: []api.DashboardRead{fakeDashboardRead(t)},
+			Items: []api.DashboardRead{fakeDashboardRead(t)},
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -329,11 +329,11 @@ func TestRunListJSONGolden(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("stdout not a DashboardListResponse: %v; %q", err, stdout.String())
 	}
-	if len(got.Dashboards) != 1 || got.Dashboards[0].Id.String() != stubDashboardID {
+	if len(got.Items) != 1 || got.Items[0].Id.String() != stubDashboardID {
 		t.Errorf("unexpected --json envelope; got %+v", got)
 	}
-	if string(got.Dashboards[0].State) != "ok" || got.Dashboards[0].MemberCount != 1 {
-		t.Errorf("rollup/member_count not round-tripped; got %+v", got.Dashboards[0])
+	if string(got.Items[0].State) != "ok" || got.Items[0].MemberCount != 1 {
+		t.Errorf("rollup/member_count not round-tripped; got %+v", got.Items[0])
 	}
 }
 
@@ -341,7 +341,7 @@ func TestRunListEmptyResponse(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/checks/dashboards", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(api.DashboardListResponse{Dashboards: nil})
+		_ = json.NewEncoder(w).Encode(api.DashboardListResponse{Items: nil})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/cli/internal/cmd/dashboard/list.go
+++ b/cli/internal/cmd/dashboard/list.go
@@ -180,13 +180,13 @@ func getList(
 // printListTable renders the dashboards as a compact table:
 // ID, NAME, STATE, MEMBERS, UPDATED_AT.
 func printListTable(w io.Writer, r *api.DashboardListResponse) {
-	if r == nil || len(r.Dashboards) == 0 {
+	if r == nil || len(r.Items) == 0 {
 		fmt.Fprintln(w, "no dashboards in this tenant")
 		return
 	}
 	fmt.Fprintf(w, "%-36s %-24s %-10s %-8s %s\n",
 		"ID", "NAME", "STATE", "MEMBERS", "UPDATED_AT")
-	for _, d := range r.Dashboards {
+	for _, d := range r.Items {
 		// Name carries operator-persisted free-form text; sanitize so
 		// terminal control chars / ANSI escapes can't affect the operator's
 		// terminal. The --json path (runList) serialises the raw value

--- a/cli/internal/cmd/sensor/list.go
+++ b/cli/internal/cmd/sensor/list.go
@@ -205,13 +205,13 @@ func getList(
 // printListTable renders the sensors as a compact table:
 // ID, NAME, STATUS, LAST_STATE, CADENCE, NEXT_FIRE_AT, SEVERITY.
 func printListTable(w io.Writer, r *api.SensorListResponse) {
-	if r == nil || len(r.Sensors) == 0 {
+	if r == nil || len(r.Items) == 0 {
 		fmt.Fprintln(w, "no sensors in this tenant")
 		return
 	}
 	fmt.Fprintf(w, "%-36s %-20s %-8s %-10s %-22s %-24s %s\n",
 		"ID", "NAME", "STATUS", "LAST_STATE", "CADENCE", "NEXT_FIRE_AT", "SEVERITY")
-	for _, s := range r.Sensors {
+	for _, s := range r.Items {
 		cadence := string(s.CadenceKind)
 		switch string(s.CadenceKind) {
 		case "interval":

--- a/cli/internal/cmd/sensor/sensor_test.go
+++ b/cli/internal/cmd/sensor/sensor_test.go
@@ -323,7 +323,7 @@ func TestRunListHappyPath(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(api.SensorListResponse{
-			Sensors: []api.SensorRead{fakeSensor(t, "interval")},
+			Items: []api.SensorRead{fakeSensor(t, "interval")},
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -343,7 +343,7 @@ func TestRunListEmptyResponse(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/sensors", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(api.SensorListResponse{Sensors: nil})
+		_ = json.NewEncoder(w).Encode(api.SensorListResponse{Items: nil})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()

--- a/docs/codebase/api-shape-conventions.md
+++ b/docs/codebase/api-shape-conventions.md
@@ -240,6 +240,21 @@ and asserts both the runtime body and the OpenAPI 200 schema are the
 resource-named list key). A new GET-list endpoint joins the convention
 by returning the envelope and being added to that test's registry.
 
+### Later convergences
+
+Two check-plane list routes shipped after #2338 still wrapped their list
+under a resource-named key, so the API diverged from its own standard on
+its newest routes. Both converged before consumers pinned the divergent
+shapes:
+
+| Endpoint | Response model | Was | Now |
+|---|---|---|---|
+| `GET /api/v1/checks/dashboards` | `DashboardListResponse` | `{"dashboards": [...]}` | `{"items": [...], "next_cursor": null}` |
+| `GET /api/v1/sensors` | `SensorListResponse` | `{"sensors": [...]}` | `{"items": [...], "next_cursor": null}` |
+
+Both are unpaginated (`next_cursor` always `null`) and are now in the
+contract-test registry, so a future regression is caught here (#2742).
+
 Sister-surface note: the MCP list tools call the service layer
 in-process and return their own list shapes (no HTTP `?envelope=` to
 forward), so they are unaffected by the REST wire-shape flip.


### PR DESCRIPTION
## Summary

- Converge the last two divergent check-plane GET-list routes —
  `GET /api/v1/checks/dashboards` and `GET /api/v1/sensors` — onto the §2
  `{items, next_cursor}` list envelope, matching the #2338 convention every
  other reference GET-list route already follows. Done now, before consumers
  pin the divergent shapes (this issue is field evidence of that cost).
- `DashboardListResponse.dashboards` / `SensorListResponse.sensors` become
  `items`, plus `next_cursor` (always `null` — both listings are
  unpaginated, present so a real cursor can land later non-breakingly).
- Both routes are added to `_LIST_ENVELOPE_ENDPOINTS` so the platform-wide
  contract test governs them and the divergence cannot recur.
- All in-repo consumers updated in lockstep: the regenerated OpenAPI
  snapshot (`cli/api/openapi.json`) + Go client (`client.gen.go`), and the
  bundled `meho dashboard list` / `meho sensor list` verbs + their tests.
  The `/ui` list views were already service-layer (in-process) reads, not
  REST-envelope decoders, so they need no change.

This is a **breaking change** to the wire shape; the CHANGELOG carries a
`### Breaking changes` entry (route, old → new, migration recipe) mirroring
the v0.21.0 (#2338) precedent, and `docs/codebase/api-shape-conventions.md`
§2 records the convergence.

## Test plan

- [x] `ruff check` + `ruff format --check` (7 touched files) — clean
- [x] `mypy` (4 changed modules) — `Success: no issues found`
- [x] **AC1** — `pytest backend/tests/test_api_v1_list_envelope_contract.py`
  green with both routes registered (11 passed: 9 runtime + OpenAPI-schema +
  route-registration); both routes return `{"items": [...], "next_cursor":
  null}`.
- [x] **AC2** — `grep -rn '"dashboards"\|"sensors"'
  backend/src/meho_backplane/checks/*schemas*.py` → no named-key list
  envelope remains.
- [x] **AC3** — `cli/api/openapi.json` + `client.gen.go` regenerated via
  `make -C cli snapshot-openapi && make -C cli generate` (idempotent — CI
  drift gate passes); `go test -race ./...` all green; `meho dashboard list`
  / `meho sensor list` decode the new envelope (real generated shapes, no
  hand-minted doubles — #2577).
- [x] **AC4** — CHANGELOG carries the `### Breaking changes` entry.
- [x] Blast radius — 378 passed across the full checks / sensor / dashboard /
  `ui_checks` backend suite; MCP `meho.sensors.*` payload verified unchanged
  (`test_mcp_tool_sensors.py`).
- [x] Code-quality diff gate (`.claude/hooks/code-quality.py --diff`) — pass.

## Out of scope

- The release-notes / deprecation-window **process** ask — initiative #2662.
- The MCP `meho.sensors.*` tool payload (`mcp/tools/sensors.py`) — governed
  by its own conventions test, deliberately left `{"sensors": [...]}`.
- The other pre-convention shapes the contract test's docstring already
  tracks for a future pass (`conventions/{slug}/history`, `topology/edges`,
  `approvals`, `agent/runs`, `doc-collections`).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2742
