### PR TITLE
feat(checks): sensor state-confirmation retries (soft/hard states) — commit + notify only after retry_times re-checks confirm

### DIFF
--- a/backend/alembic/versions/0070_add_sensor_confirmation_retries.py
+++ b/backend/alembic/versions/0070_add_sensor_confirmation_retries.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``sensor`` state-confirmation retry columns (#2799).
+
+Revision ID: 0070
+Revises: 0069
+Create Date: 2026-08-04
+
+Task #2799 under Initiative #2780 (parent goal #221). One transient bad
+reading flips a sensor's ``last_state`` on the very next evaluation, so a
+single flaky reading pages and its recovery pages again (the observed
+``capacity-physical`` one-minute flap). These four columns are the
+per-sensor confirmation config + the soft-state window
+``record_sensor_result`` holds an unconfirmed candidate in (Nagios
+soft/hard states):
+
+* ``retry_times`` -- ``integer`` NOT NULL, server default ``'0'``.
+  Consecutive confirming re-evaluations required after the first
+  differing reading before the new state commits. The ``'0'`` backfill
+  disables confirmation for every pre-#2799 row, so the migration is
+  behaviour-preserving on its own.
+* ``retry_backoff_seconds`` -- ``integer`` NOT NULL, server default
+  ``'15'``. Accelerated re-check spacing while a state is pending
+  (Nagios ``retry_interval``). Inert while ``retry_times`` is 0.
+* ``pending_state`` -- ``text`` nullable, CHECK over the ``CheckState``
+  vocabulary minus ``skip``. The held candidate state; NULL (the
+  backfilled state) means no confirmation window is open.
+* ``pending_count`` -- ``integer`` NOT NULL, server default ``'0'``.
+  How many consecutive readings have agreed on ``pending_state``.
+
+The CHECK excludes ``skip`` because ``skip`` is a rollup-side
+*derivation* for paused members (#2506), never an evaluation outcome --
+the evaluator cannot emit it, so it can never be a confirmation
+candidate. The vocabulary is frozen here as a literal (never imported
+from :mod:`meho_backplane.db.models`) because Alembic must run against
+any historical revision's model graph; the drift guard in
+:mod:`tests.test_db_sensor` asserts this tuple equals the ORM's
+``_SENSOR_PENDING_STATES``.
+
+Why NOT NULL + server default for the three counters: the commit gate in
+``record_sensor_result`` reads concrete values on every persist, so
+"unset" would need a Python-side fallback duplicating the default in a
+second place -- the same reasoning ``0068``'s ``notify_min_state``
+documents (and ``0057``'s ``skip_count`` before it).
+
+Why ``batch_alter_table``: the same portable cookbook ``0025`` / ``0051``
+/ ``0068`` use to add a CHECK-constrained column to an existing table.
+On PostgreSQL Alembic issues plain ``ALTER TABLE ADD COLUMN`` + ``ADD
+CONSTRAINT`` (no copy; PG 11+ adds a defaulted NOT NULL column without a
+rewrite); on SQLite it falls back to the table-recreate path, which is
+the only way SQLite adds a CHECK to an existing table. One batch block
+adds all four columns and the constraint together, so SQLite recreates
+once.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops the constraint and all four columns inside one
+batch block, in reverse add order. Purely additive forward, so a ``helm
+rollback`` to a pre-0070 image (which never mentions the columns) is
+safe.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0070"
+down_revision: str | None = "0069"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Closed ``sensor.pending_state`` vocabulary -- #2504's ``CheckState``
+#: minus ``skip``. Frozen as a literal; the drift guard in
+#: :mod:`tests.test_db_sensor` pins it against the ORM's
+#: ``_SENSOR_PENDING_STATES`` (itself derived from ``CheckState``).
+_SENSOR_PENDING_STATES: tuple[str, ...] = ("ok", "degraded", "critical", "unknown")
+
+
+def _check_in(column: str, values: tuple[str, ...]) -> str:
+    """Render a portable ``column IN ('a', 'b', ...)`` CHECK body."""
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"{column} IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Add the confirmation columns + the ``pending_state`` CHECK."""
+    with op.batch_alter_table("sensor") as batch_op:
+        batch_op.add_column(
+            sa.Column("retry_times", sa.Integer(), nullable=False, server_default="0")
+        )
+        batch_op.add_column(
+            sa.Column(
+                "retry_backoff_seconds",
+                sa.Integer(),
+                nullable=False,
+                server_default="15",
+            )
+        )
+        batch_op.add_column(sa.Column("pending_state", sa.Text(), nullable=True))
+        batch_op.add_column(
+            sa.Column("pending_count", sa.Integer(), nullable=False, server_default="0")
+        )
+        batch_op.create_check_constraint(
+            "ck_sensor_pending_state",
+            _check_in("pending_state", _SENSOR_PENDING_STATES),
+        )
+
+
+def downgrade() -> None:
+    """Drop the CHECK + all four columns added in :func:`upgrade` (reverse order)."""
+    with op.batch_alter_table("sensor") as batch_op:
+        batch_op.drop_constraint("ck_sensor_pending_state", type_="check")
+        batch_op.drop_column("pending_count")
+        batch_op.drop_column("pending_state")
+        batch_op.drop_column("retry_backoff_seconds")
+        batch_op.drop_column("retry_times")

--- a/backend/src/meho_backplane/checks/repository.py
+++ b/backend/src/meho_backplane/checks/repository.py
@@ -35,6 +35,7 @@ from meho_backplane.db.models import Sensor, SensorCadenceKind, SensorStatus
 from meho_backplane.scheduler.cron import next_fire_after
 
 __all__ = [
+    "accelerate_sensor_next_fire",
     "advance_sensor_next_fire",
     "claim_due_sensors",
     "create_sensor",
@@ -59,6 +60,8 @@ async def create_sensor(
     timezone: str,
     severity: str,
     for_seconds: int,
+    retry_times: int,
+    retry_backoff_seconds: int,
     identity_sub: str,
     created_by_sub: str,
     base: datetime | None = None,
@@ -107,6 +110,8 @@ async def create_sensor(
         next_fire_at=next_fire,
         severity=severity,
         for_seconds=for_seconds,
+        retry_times=retry_times,
+        retry_backoff_seconds=retry_backoff_seconds,
         identity_sub=identity_sub,
         created_by_sub=created_by_sub,
     )
@@ -136,13 +141,38 @@ async def record_sensor_result(
     evidence: dict[str, object],
     evaluated_at: datetime,
 ) -> bool:
-    """Update the latest-state projection for *sensor_id*; return state-changed.
+    """Update the latest-state projection for *sensor_id*; return state-committed.
 
-    Updates ``last_state`` / ``last_value`` / ``last_evidence`` /
-    ``last_evaluated_at``, and bumps ``state_since`` **only** when ``state``
-    differs from the row's current ``last_state`` -- so #2506's ``for:``
-    hold-time hysteresis can read how long the current state has held.
-    Returns ``True`` iff the state changed.
+    Updates ``last_value`` / ``last_evidence`` / ``last_evaluated_at`` on
+    every accepted result, and flips ``last_state`` / bumps ``state_since``
+    **only** when the new state is *confirmed* -- so #2506's ``for:``
+    hold-time hysteresis measures confirmed time. Returns ``True`` iff the
+    committed state changed.
+
+    **Confirmation gate (#2799, Nagios soft/hard states).** With
+    ``retry_times == 0`` (the default) every differing reading commits
+    immediately -- the pre-#2799 behaviour, bit for bit. With
+    ``retry_times > 0`` a reading that differs from the committed
+    ``last_state`` is held as a soft state instead:
+
+    * differs from ``pending_state`` too -> a new confirmation window
+      opens (``pending_state = outcome``, ``pending_count = 1``); an
+      escalation mid-window restarts the count on the new candidate.
+    * equals ``pending_state`` -> ``pending_count += 1``; once
+      ``pending_count > retry_times`` the state commits (``last_state``
+      flips, ``state_since`` bumps to this result's ``evaluated_at``)
+      and the window clears.
+    * equals the committed ``last_state`` (the candidate reverted) -> the
+      window clears without committing anything.
+
+    The gate is symmetric in both directions -- recovery to ``ok`` is
+    confirmed exactly like a degradation (deliberately unlike Nagios'
+    immediate hard recovery: the observed flap's second nuisance mail
+    *was* a flapping all-clear, the failure mode Prometheus grew
+    ``keep_firing_for`` for) -- and ``unknown`` participates like any
+    state, so a transient dispatch timeout cannot flip the sensor. The
+    gate lives here, not in the runner task, so the satellite-gateway
+    batch-post path is confirmed identically.
 
     **Monotonicity guard.** A result whose ``evaluated_at`` is not strictly
     newer than the row's recorded ``last_evaluated_at`` is ignored (returns
@@ -165,15 +195,35 @@ async def record_sensor_result(
     ):
         # Stale or duplicate result -- keep the newer projection intact.
         return False
-    changed = row.last_state != state
-    row.last_state = state
     row.last_value = value
     row.last_evidence = evidence
     row.last_evaluated_at = evaluated_at
-    if changed:
-        row.state_since = evaluated_at
+    if state == row.last_state:
+        # The committed state re-confirmed itself; any half-open
+        # confirmation window was a transient -- close it.
+        row.pending_state = None
+        row.pending_count = 0
+        await session.flush()
+        return False
+    if row.retry_times > 0:
+        if state != row.pending_state:
+            # First differing reading (or an escalation mid-window):
+            # open a fresh window on this candidate.
+            row.pending_state = state
+            row.pending_count = 1
+        else:
+            row.pending_count += 1
+        if row.pending_count <= row.retry_times:
+            # Soft state -- observed but unconfirmed. No commit, no
+            # transition for downstream consumers.
+            await session.flush()
+            return False
+    row.last_state = state
+    row.state_since = evaluated_at
+    row.pending_state = None
+    row.pending_count = 0
     await session.flush()
-    return changed
+    return True
 
 
 async def claim_due_sensors(
@@ -287,6 +337,58 @@ async def advance_sensor_next_fire(
     # without re-querying.
     row.next_fire_at = new_next
     return row
+
+
+async def accelerate_sensor_next_fire(
+    session: AsyncSession,
+    sensor_id: uuid.UUID,
+    *,
+    not_later_than: datetime,
+) -> bool:
+    """Pull ``next_fire_at`` forward to *not_later_than* if it is later.
+
+    The accelerated re-check half of #2799's confirmation retries: after a
+    pending (unconfirmed) result, the runner pulls the sensor's next fire
+    to ``evaluated_at + retry_backoff_seconds`` so the confirming
+    re-evaluation does not wait a full cadence. Implemented as one
+    conditional UPDATE (``WHERE next_fire_at > :accel``), i.e.
+    ``min(next_fire_at, accel)`` semantics done atomically:
+
+    * never *delays* a fire -- a row already scheduled sooner (or pulled
+      sooner by a concurrent writer) matches zero rows;
+    * only rides the existing claim/advance machinery -- the re-check is
+      an ordinary due row on the next tick, so the #804 at-most-once
+      discipline, the overlap guard, and replica-safety are untouched
+      (no in-process sleep loop that would die on ``stop_sensor_runner``
+      and pin ``_IN_FLIGHT``);
+    * ``status='active'`` guard so a row parked between the evaluation
+      and this persist is not resurrected onto the due index.
+
+    Returns ``True`` when the row was pulled forward, ``False`` when the
+    UPDATE matched nothing (already sooner, parked, or deleted).
+
+    ``synchronize_session=False``: the caller's session already holds the
+    row (``record_sensor_result`` loaded it), and the default ``'auto'``
+    strategy would evaluate the ``>`` predicate *Python-side* against the
+    in-memory attribute -- naive on the aiosqlite round-trip vs the aware
+    *not_later_than*, a ``TypeError``. The DB-side comparison is
+    dialect-consistent, and nothing reads the in-memory ``next_fire_at``
+    after this call (the session commits and closes).
+    """
+    stmt = (
+        update(Sensor)
+        .where(
+            Sensor.id == sensor_id,
+            Sensor.status == SensorStatus.ACTIVE.value,
+            Sensor.next_fire_at > not_later_than,
+        )
+        .values(next_fire_at=not_later_than)
+        .execution_options(synchronize_session=False)
+    )
+    result = await session.execute(stmt)
+    await session.flush()
+    rowcount: int = result.rowcount  # type: ignore[attr-defined]
+    return rowcount > 0
 
 
 async def park_sensor(

--- a/backend/src/meho_backplane/checks/runner.py
+++ b/backend/src/meho_backplane/checks/runner.py
@@ -116,7 +116,7 @@ import asyncio
 import contextlib
 import uuid
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import cast
 
 import structlog
@@ -132,6 +132,7 @@ from meho_backplane.checks.assertions import AssertionOutcome, AssertionSpec
 from meho_backplane.checks.evaluate import evaluate_assertion
 from meho_backplane.checks.investigate import investigate_on_transition
 from meho_backplane.checks.repository import (
+    accelerate_sensor_next_fire,
     advance_sensor_next_fire,
     claim_due_sensors,
     park_sensor,
@@ -425,13 +426,27 @@ async def _run_evaluation(snap: _SensorSnapshot) -> AssertionOutcome:
 async def _persist_outcome(snap: _SensorSnapshot, outcome: AssertionOutcome) -> None:
     """Write *outcome* onto the sensor's latest-state projection (own session).
 
+    When the persist leaves a confirmation window open (#2799 --
+    ``record_sensor_result`` held the reading as a pending soft state
+    instead of committing it), pull the row's ``next_fire_at`` to
+    ``min(next_fire_at, evaluated_at + retry_backoff_seconds)`` so the
+    confirming re-evaluation runs on the accelerated schedule. The
+    re-check then rides the existing claim/advance/overlap machinery
+    unchanged -- no in-process sleep loop (which would die on
+    :func:`stop_sensor_runner` and pin ``_IN_FLIGHT``), and effective
+    spacing quantizes up to the tick grid like any sub-tick cadence.
+    This acceleration is runner-local: satellite-posted results share
+    the same commit gate but re-check at their own posting cadence.
+
     After the projection commits, hand off to #2507's transition detector: it
     recomputes the rollup for the Dashboards holding this sensor, maintains the
     ``last_rollup_state`` memo, and fires a diagnose-only investigator on a
     green->non-green edge. The hook never raises (its contract), so the persist
     path is unaffected by any investigation-side failure -- and it runs on every
     result (not only state changes) because a ``for:`` hold expiring flips a
-    Dashboard non-green with no sensor-state change.
+    Dashboard non-green with no sensor-state change. An *unconfirmed*
+    reading never changes ``last_state``, so the fold the detector
+    recomputes sees no edge from it.
     """
     evaluated_at = datetime.now(UTC)
     sessionmaker = get_sessionmaker()
@@ -444,6 +459,16 @@ async def _persist_outcome(snap: _SensorSnapshot, outcome: AssertionOutcome) -> 
             evidence=outcome.evidence,
             evaluated_at=evaluated_at,
         )
+        # Identity-map read (record_sensor_result already loaded the row;
+        # a missing row means it was deleted mid-evaluation -- nothing to
+        # accelerate).
+        row = await session.get(Sensor, snap.id)
+        if row is not None and row.pending_state is not None:
+            await accelerate_sensor_next_fire(
+                session,
+                snap.id,
+                not_later_than=evaluated_at + timedelta(seconds=row.retry_backoff_seconds),
+            )
         await session.commit()
     await investigate_on_transition(sensor_id=snap.id, tenant_id=snap.tenant_id)
 

--- a/backend/src/meho_backplane/checks/schemas.py
+++ b/backend/src/meho_backplane/checks/schemas.py
@@ -71,6 +71,16 @@ _INTERVAL_SECONDS_MAX = 86400
 #: any realistic bounded assertion.
 _ASSERTION_MAX_SERIALIZED_BYTES = 8192
 
+#: Confirmation-retry bounds (#2799). ``retry_times`` is capped at 5 --
+#: Nagios deployments rarely exceed ``max_check_attempts`` 3-5, and each
+#: retry adds a full backoff to worst-case detection latency.
+#: ``retry_backoff_seconds`` is floored at 5 s (the same
+#: hammer-the-target floor as ``interval_seconds``) and capped at 300 s
+#: (a confirmation slower than that should just ride the cadence).
+_RETRY_TIMES_MAX = 5
+_RETRY_BACKOFF_SECONDS_MIN = 5
+_RETRY_BACKOFF_SECONDS_MAX = 300
+
 
 class SensorCreate(BaseModel):
     """Request body for ``POST /api/v1/sensors``.
@@ -117,6 +127,11 @@ class SensorCreate(BaseModel):
     timezone: Annotated[str, Field(max_length=_TIMEZONE_MAX_LENGTH)] = "UTC"
     severity: SensorSeverity = SensorSeverity.CRITICAL
     for_seconds: Annotated[int, Field(ge=0)] = 0
+    retry_times: Annotated[int, Field(ge=0, le=_RETRY_TIMES_MAX)] = 0
+    retry_backoff_seconds: Annotated[
+        int,
+        Field(ge=_RETRY_BACKOFF_SECONDS_MIN, le=_RETRY_BACKOFF_SECONDS_MAX),
+    ] = 15
     identity_sub: Annotated[str, Field(max_length=_IDENTITY_SUB_MAX_LENGTH)] = "__sensor__"
     tenant_id: uuid.UUID | None = None
 
@@ -187,11 +202,20 @@ class SensorRead(BaseModel):
     next_fire_at: datetime | None
     severity: SensorSeverity
     for_seconds: int
+    retry_times: int
+    retry_backoff_seconds: int
     last_state: Literal["ok", "degraded", "critical", "unknown", "skip"]
     last_value: Any
     last_evidence: dict[str, object] | None
     last_evaluated_at: datetime | None
     state_since: datetime | None
+    # Soft-state window (#2799): the unconfirmed candidate state (never
+    # ``skip`` -- a rollup-side derivation, not an evaluation outcome)
+    # and how many consecutive readings have agreed on it. Exposed so
+    # the pending window is observable, the way Prometheus exposes
+    # ``pending`` alerts via ``ALERTS``.
+    pending_state: Literal["ok", "degraded", "critical", "unknown"] | None
+    pending_count: int
     identity_sub: str
     created_by_sub: str
     created_at: datetime

--- a/backend/src/meho_backplane/checks/service.py
+++ b/backend/src/meho_backplane/checks/service.py
@@ -333,6 +333,8 @@ class SensorAdminService:
                     timezone=payload.timezone,
                     severity=payload.severity.value,
                     for_seconds=payload.for_seconds,
+                    retry_times=payload.retry_times,
+                    retry_backoff_seconds=payload.retry_backoff_seconds,
                     identity_sub=payload.identity_sub,
                     created_by_sub=created_by_sub,
                 )

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -6054,6 +6054,14 @@ _SENSOR_SEVERITIES: tuple[str, ...] = tuple(s.value for s in SensorSeverity)
 #: against them in :mod:`tests.test_db_sensor`.
 _SENSOR_LAST_STATES: tuple[str, ...] = get_args(CheckState)
 
+#: Closed ``sensor.pending_state`` vocabulary (#2799) -- ``CheckState``
+#: minus ``skip``: ``skip`` is a rollup-side *derivation* for paused
+#: members (#2506), never an evaluation outcome, so it can never be a
+#: confirmation candidate. Derived from :data:`CheckState` so the two
+#: cannot drift; migration ``0070`` records its own frozen literal and
+#: the drift guard in :mod:`tests.test_db_sensor` pins all three.
+_SENSOR_PENDING_STATES: tuple[str, ...] = tuple(s for s in get_args(CheckState) if s != "skip")
+
 #: Discriminated-union invariant for the cadence union: exactly one of
 #: ``interval_seconds`` / ``cron_expr`` carries the semantics, the other
 #: is NULL. Portable ``(cadence_kind = '...' AND col IS NOT NULL AND
@@ -6107,6 +6115,14 @@ class Sensor(Base):
     until an operator asks for history. The named write path is one
     repository function
     (:func:`~meho_backplane.checks.repository.record_sensor_result`).
+
+    #2799 extends the projection with a *soft-state* window
+    (``pending_state`` / ``pending_count``): because there is no history
+    table, the consecutive-confirmation counter the commit gate needs is
+    carried as columns on the row (the #2327 ``skip_count`` precedent),
+    not derived. ``state_since`` marks the *confirmed* transition
+    instant, so the ``for:`` hold measures confirmed time on top of
+    confirmation.
 
     Storage-only
     ------------
@@ -6221,6 +6237,27 @@ class Sensor(Base):
         default=0,
         server_default="0",
     )
+    # State-confirmation retries (#2799, Nagios ``max_check_attempts``):
+    # consecutive confirming re-evaluations required after the first
+    # differing reading before ``record_sensor_result`` commits the new
+    # state. 0 (the default) disables confirmation -- every reading
+    # commits immediately, the pre-#2799 behaviour.
+    retry_times: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default="0",
+    )
+    # Accelerated re-check spacing while a state is pending (#2799,
+    # Nagios ``retry_interval``). Seconds the runner pulls
+    # ``next_fire_at`` forward by after an unconfirmed reading;
+    # quantizes up to the runner tick grid like any sub-tick cadence.
+    retry_backoff_seconds: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=15,
+        server_default="15",
+    )
     # Latest-state projection (Decision D). ``last_state`` carries the
     # five-state vocabulary #2504's ``CheckState`` declares (default
     # ``unknown``); ``record_sensor_result`` touches ``state_since`` only
@@ -6252,6 +6289,25 @@ class Sensor(Base):
         DateTime(timezone=True),
         nullable=True,
         default=None,
+    )
+    # Soft-state window (#2799). When ``retry_times > 0`` and a reading
+    # differs from the committed ``last_state``, the candidate is held
+    # here (``pending_state`` + how many consecutive readings agreed)
+    # instead of flipping the projection; ``record_sensor_result``
+    # commits only once ``pending_count`` exceeds ``retry_times``. NULL
+    # / 0 on a sensor with no confirmation in flight. Exposed on
+    # ``SensorRead`` so the pending window is observable (the same
+    # reason Prometheus exposes ``pending`` via ``ALERTS``).
+    pending_state: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
+    pending_count: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default="0",
     )
     # Identity ``sub`` #2505's runner dispatches under -- the sensor
     # analogue of the trigger's ``__scheduler__`` sentinel.
@@ -6317,6 +6373,13 @@ class Sensor(Base):
         sa.CheckConstraint(
             _ck_in("last_state", _SENSOR_LAST_STATES),
             name="ck_sensor_last_state",
+        ),
+        # ``pending_state`` over ``CheckState`` minus ``skip`` (#2799).
+        # NULL passes an IN check (SQL three-valued logic), so the
+        # no-window-open state needs no explicit OR IS NULL clause.
+        sa.CheckConstraint(
+            _ck_in("pending_state", _SENSOR_PENDING_STATES),
+            name="ck_sensor_pending_state",
         ),
         # Cadence discriminated-union invariant -- see
         # :data:`_SENSOR_CADENCE_FIELDS_CHECK`.

--- a/backend/src/meho_backplane/mcp/tools/sensors.py
+++ b/backend/src/meho_backplane/mcp/tools/sensors.py
@@ -241,7 +241,11 @@ register_mcp_tool(
             "interval_seconds (5..86400) or cron_expr (+ optional timezone). "
             "Optional: target (dispatch target object), params (op params "
             "object), severity ('degraded'|'critical', default 'critical'), "
-            "for_seconds (hold-time hysteresis, default 0), identity_sub "
+            "for_seconds (hold-time hysteresis, default 0), retry_times "
+            "(consecutive confirming re-checks required before a state "
+            "change commits + notifies, 0..5, default 0 = off) with "
+            "retry_backoff_seconds (accelerated re-check spacing while "
+            "pending, 5..300, default 15), identity_sub "
             "(the sub the runner dispatches -- and audit-attributes -- each "
             "evaluation under; only the '__sensor__' sentinel (default) or "
             "your own sub is accepted, any other value is refused with "
@@ -305,6 +309,28 @@ register_mcp_tool(
                     "type": "integer",
                     "minimum": 0,
                     "description": "Hold-time hysteresis seconds (default 0).",
+                },
+                "retry_times": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 5,
+                    "description": (
+                        "Consecutive confirming re-evaluations required "
+                        "after the first differing reading before a state "
+                        "change commits + notifies (Nagios soft/hard "
+                        "states; default 0 = off, every reading commits "
+                        "immediately)."
+                    ),
+                },
+                "retry_backoff_seconds": {
+                    "type": "integer",
+                    "minimum": 5,
+                    "maximum": 300,
+                    "description": (
+                        "Accelerated re-check spacing in seconds while a "
+                        "state change is pending confirmation (default "
+                        "15; inert while retry_times is 0)."
+                    ),
                 },
                 "identity_sub": {
                     "type": "string",

--- a/backend/tests/migrations/test_migration_0070_add_sensor_confirmation_retries.py
+++ b/backend/tests/migrations/test_migration_0070_add_sensor_confirmation_retries.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0070_add_sensor_confirmation_retries``.
+
+Initiative #2780, Task #2799. Adds the per-sensor state-confirmation
+config + soft-state window the ``record_sensor_result`` commit gate reads:
+
+* ``retry_times`` -- ``integer`` NOT NULL, server default ``'0'``. The
+  ``'0'`` backfill disables confirmation for every pre-#2799 row, so the
+  migration is behaviour-preserving on its own.
+* ``retry_backoff_seconds`` -- ``integer`` NOT NULL, server default ``'15'``.
+* ``pending_state`` -- ``text`` nullable, CHECK over ``CheckState`` minus
+  ``skip``; NULL (the backfilled state) means no window is open.
+* ``pending_count`` -- ``integer`` NOT NULL, server default ``'0'``.
+
+**Idempotency pinning (0049/0050/0053/0055 footgun).** Every forward /
+round-trip step targets this migration's **own** revision (``0070``) and its
+``down_revision`` (``0069``), never ``head`` -- so a future head migration
+cannot make ``upgrade("head")`` re-run this ``add_column`` on a table that
+already has it. SQLite is the test driver; the migration uses only generic
+DDL through ``batch_alter_table``, so PG parity holds.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0070"
+_DOWN_REVISION = "0069"
+_CONFIRMATION_COLUMNS = (
+    "retry_times",
+    "retry_backoff_seconds",
+    "pending_state",
+    "pending_count",
+)
+
+#: A pre-0070 ``sensor`` row. SQLite does not enforce foreign keys by
+#: default, so no parent tenant row is needed. UUIDs are stored as 32-char
+#: hex (SQLAlchemy's ``Uuid`` on SQLite drops the dashes).
+_SENSOR_ID = "77777777777777777777777777777777"
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL (sync fixture)."""
+    db_path = tmp_path / "migration_0070.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _table_info(sync_url: str) -> list[tuple[str, bool]]:
+    """Return ``(column_name, is_nullable)`` pairs for ``sensor``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(sensor)")).all()
+    finally:
+        sync_eng.dispose()
+    return [(str(row[1]), int(row[3]) == 0) for row in rows]
+
+
+def _columns(sync_url: str) -> set[str]:
+    return {name for name, _ in _table_info(sync_url)}
+
+
+def _column_is_nullable(sync_url: str, column: str) -> bool:
+    for name, nullable in _table_info(sync_url):
+        if name == column:
+            return nullable
+    raise AssertionError(f"column {column!r} not present on sensor")
+
+
+def _insert_pre_0070_sensor(sync_url: str) -> None:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO sensor "
+                    "(id, tenant_id, name, connector_id, op_id, params, "
+                    "assertion, cadence_kind, interval_seconds, "
+                    "created_by_sub, created_at, updated_at) "
+                    "VALUES (:id, '11111111111111111111111111111111', "
+                    "'disk-space', 'vmware-rest-9.0', 'vmware.vm.list', "
+                    "'{}', '{}', 'interval', 60, 'seed', "
+                    "'2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')"
+                ),
+                {"id": _SENSOR_ID},
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def test_upgrade_adds_confirmation_columns(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade 0070`` lands all four columns with the right nullability."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    columns = _columns(sync_url)
+    for column in _CONFIRMATION_COLUMNS:
+        assert column in columns, f"migration 0070 must add sensor.{column}"
+
+    assert _column_is_nullable(sync_url, "pending_state")
+    # The config knobs + counter are NOT NULL (server defaults) so the
+    # commit gate always reads concrete values.
+    assert not _column_is_nullable(sync_url, "retry_times")
+    assert not _column_is_nullable(sync_url, "retry_backoff_seconds")
+    assert not _column_is_nullable(sync_url, "pending_count")
+
+
+def test_existing_row_backfills_confirmation_off(alembic_cfg: tuple[Config, str]) -> None:
+    """A row inserted at ``0069`` backfills retry_times=0 (confirmation off).
+
+    The behaviour-preserving property: no pre-#2799 sensor starts holding
+    soft states when the migration lands, because ``retry_times=0`` is the
+    off switch.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+    _insert_pre_0070_sensor(sync_url)
+
+    command.upgrade(cfg, _REVISION)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT retry_times, retry_backoff_seconds, pending_state, "
+                    "pending_count FROM sensor WHERE id = :id"
+                ),
+                {"id": _SENSOR_ID},
+            ).one()
+    finally:
+        sync_eng.dispose()
+    assert row[0] == 0, "pre-0070 rows must backfill with confirmation off"
+    assert row[1] == 15, "pre-0070 rows must backfill the default backoff"
+    assert row[2] is None, "no confirmation window may be open after backfill"
+    assert row[3] == 0
+
+
+def test_pending_state_check_rejects_skip(alembic_cfg: tuple[Config, str]) -> None:
+    """The CHECK admits ``CheckState`` minus ``skip`` -- not ``skip`` itself."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with pytest.raises(IntegrityError), sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO sensor "
+                    "(id, tenant_id, name, connector_id, op_id, params, "
+                    "assertion, cadence_kind, interval_seconds, pending_state, "
+                    "created_by_sub, created_at, updated_at) "
+                    "VALUES ('88888888888888888888888888888888', "
+                    "'11111111111111111111111111111111', 'bad', "
+                    "'vmware-rest-9.0', 'vmware.vm.list', '{}', '{}', "
+                    "'interval', 60, 'skip', 'seed', "
+                    "'2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')"
+                )
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade "0069"`` drops the columns; ``upgrade "0070"`` restores them.
+
+    Pinned to this migration's own revision on both legs (never ``head``) so a
+    future head migration cannot break the round-trip.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    assert set(_CONFIRMATION_COLUMNS) <= _columns(sync_url)
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    remaining = _columns(sync_url)
+    for column in _CONFIRMATION_COLUMNS:
+        assert column not in remaining, f"downgrade must drop {column}"
+
+    command.upgrade(cfg, _REVISION)
+    assert set(_CONFIRMATION_COLUMNS) <= _columns(sync_url)

--- a/backend/tests/test_checks_confirmation.py
+++ b/backend/tests/test_checks_confirmation.py
@@ -1,0 +1,576 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for sensor state-confirmation retries (#2799).
+
+Initiative #2780 (parent goal #221), Task #2799. Coverage matrix mapped
+to the issue's acceptance criteria:
+
+* **Commit gate** (``record_sensor_result``, driven directly -- the
+  satellite-gateway batch-post shape, no runner involved): a differing
+  reading opens a pending soft-state window; ``retry_times`` consecutive
+  confirming re-evaluations commit; a revert clears the window without
+  committing; an escalation mid-window restarts the count; recovery to
+  ``ok`` is confirmed symmetrically; ``unknown`` participates like any
+  state; the monotonicity guard rejects an out-of-order result before
+  any pending mutation; ``retry_times=0`` commits immediately (the
+  pre-#2799 behaviour).
+* **Accelerated re-check** (runner path): a pending persist pulls
+  ``next_fire_at`` to ``evaluated_at + retry_backoff_seconds``, never
+  later than the already-scheduled cadence instant, and a committed
+  (non-pending) persist does not touch the schedule.
+* **End-to-end suppression** (runner + rollup + transition detector):
+  a transient flake commits no state, claims no rollup edge, spawns no
+  notification; a genuine confirmed transition claims exactly one edge
+  and one notification; a flapping all-clear sends no recovery mail.
+
+``dispatch`` is stubbed on the runner module and the transition
+detector's notification / broadcast / investigation seams are replaced
+with recorders (patched at the usage location), so no connector, mail
+transport, or Valkey is hit.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+import meho_backplane.checks.investigate as inv
+from meho_backplane.checks.repository import create_sensor, record_sensor_result
+from meho_backplane.checks.runner import (
+    _IN_FLIGHT,
+    reset_sensor_runner_state,
+    run_one_sensor_tick,
+)
+from meho_backplane.connectors.schemas import OperationResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    CheckDashboard,
+    CheckDashboardSensor,
+    Sensor,
+    SensorCadenceKind,
+    Tenant,
+)
+from meho_backplane.settings import get_settings
+
+_TENANT = uuid.UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+
+#: ``count`` <= 10 -> ok, 10 < count <= 100 -> degraded, count > 100 ->
+#: critical -- one assertion whose payload drives all three states.
+_BANDED_ASSERTION: dict[str, Any] = {
+    "select": {"path": "$.count"},
+    "compare": {"type": "threshold", "op": "gt", "degraded": 10, "critical": 100},
+}
+
+_OK_PAYLOAD = {"count": 3}
+_DEGRADED_PAYLOAD = {"count": 42}
+_CRITICAL_PAYLOAD = {"count": 500}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env :class:`Settings` requires; reset runner state per test."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    get_settings.cache_clear()
+    reset_sensor_runner_state()
+    yield
+    reset_sensor_runner_state()
+    get_settings.cache_clear()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+async def _seed_tenant(tenant_id: uuid.UUID = _TENANT) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if await session.get(Tenant, tenant_id) is None:
+            session.add(Tenant(id=tenant_id, slug=str(tenant_id)[:8], name="Tenant D"))
+            await session.commit()
+
+
+async def _create_sensor(
+    *,
+    retry_times: int,
+    retry_backoff_seconds: int = 15,
+    interval_seconds: int = 300,
+) -> uuid.UUID:
+    await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await create_sensor(
+            session,
+            tenant_id=_TENANT,
+            name=f"sensor-{uuid.uuid4().hex[:8]}",
+            connector_id="vmware-rest-9.0",
+            op_id="vmware.vm.list",
+            target=None,
+            params={},
+            assertion=_BANDED_ASSERTION,
+            cadence_kind=SensorCadenceKind.INTERVAL,
+            interval_seconds=interval_seconds,
+            cron_expr=None,
+            timezone="UTC",
+            severity="critical",
+            for_seconds=0,
+            retry_times=retry_times,
+            retry_backoff_seconds=retry_backoff_seconds,
+            identity_sub="__sensor__",
+            created_by_sub="op-admin",
+        )
+        await session.commit()
+        return row.id
+
+
+async def _record(
+    sensor_id: uuid.UUID,
+    state: str,
+    evaluated_at: datetime,
+    *,
+    value: object = 0,
+) -> bool:
+    """Drive the shared commit gate directly (the gateway batch-post shape)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        committed = await record_sensor_result(
+            session,
+            sensor_id=sensor_id,
+            state=state,  # type: ignore[arg-type]
+            value=value,
+            evidence={"observed": value},
+            evaluated_at=evaluated_at,
+        )
+        await session.commit()
+        return committed
+
+
+async def _get_sensor(sensor_id: uuid.UUID) -> Sensor:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        return row
+
+
+async def _commit_state(
+    sensor_id: uuid.UUID,
+    state: str,
+    *,
+    base: datetime,
+    retry_times: int,
+) -> datetime:
+    """Confirm *state* onto the sensor (retry_times + 1 readings); return last ts."""
+    at = base
+    for i in range(retry_times + 1):
+        at = base + timedelta(seconds=i)
+        await _record(sensor_id, state, at)
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == state
+    return at
+
+
+def _aware(dt: datetime | None) -> datetime:
+    """Attach UTC to a naive datetime (aiosqlite drops tz on round-trip)."""
+    assert dt is not None
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
+async def _force_due(sensor_id: uuid.UUID, when: datetime) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        row.next_fire_at = when
+        await session.commit()
+
+
+async def _drain_in_flight(timeout: float = 3.0) -> None:
+    import asyncio
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while _IN_FLIGHT and loop.time() < deadline:
+        tasks = list(_IN_FLIGHT.values())
+        await asyncio.gather(*tasks, return_exceptions=True)
+        await asyncio.sleep(0)
+
+
+def _stub_dispatch(monkeypatch: pytest.MonkeyPatch, payload_ref: dict[str, Any]) -> None:
+    """Stub the runner's dispatch seam to return ``payload_ref['payload']``."""
+
+    async def _dispatch(**_kwargs: Any) -> OperationResult:
+        return OperationResult(
+            status="ok",
+            op_id="vmware.vm.list",
+            result=payload_ref["payload"],
+            duration_ms=1.0,
+        )
+
+    monkeypatch.setattr("meho_backplane.checks.runner.dispatch", _dispatch)
+
+
+async def _tick_with(
+    sensor_id: uuid.UUID,
+    payload_ref: dict[str, Any],
+    payload: dict[str, Any],
+) -> None:
+    """Force the sensor due, run one tick, and drain the evaluation."""
+    payload_ref["payload"] = payload
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+    await run_one_sensor_tick()
+    await _drain_in_flight()
+
+
+# --------------------------------------------------------------------------- #
+# Commit gate (repository level -- the shared, transport-agnostic seam)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_gate_holds_soft_state_then_commits_after_retry_times() -> None:
+    """retry_times=3: four consecutive differing readings commit exactly once."""
+    sensor_id = await _create_sensor(retry_times=3)
+    base = datetime(2026, 8, 4, 12, 0, 0, tzinfo=UTC)
+    committed_at = await _commit_state(sensor_id, "ok", base=base, retry_times=3)
+
+    outcomes: list[bool] = []
+    for i in range(1, 5):
+        at = committed_at + timedelta(seconds=i)
+        outcomes.append(await _record(sensor_id, "degraded", at, value=42))
+        row = await _get_sensor(sensor_id)
+        if i <= 3:
+            # Soft state: observed but not committed.
+            assert row.last_state == "ok"
+            assert row.pending_state == "degraded"
+            assert row.pending_count == i
+            # The observation projection still updates on every reading.
+            assert row.last_value == 42
+            assert _aware(row.last_evaluated_at) == at
+    assert outcomes == [False, False, False, True]
+
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "degraded"
+    # state_since is the commit-time evaluation, not the first soft reading.
+    assert _aware(row.state_since) == committed_at + timedelta(seconds=4)
+    assert row.pending_state is None
+    assert row.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_gate_transient_flap_never_commits() -> None:
+    """ok -> one degraded reading -> ok: last_state never leaves ok."""
+    sensor_id = await _create_sensor(retry_times=1)
+    base = datetime(2026, 8, 4, 12, 0, 0, tzinfo=UTC)
+    committed_at = await _commit_state(sensor_id, "ok", base=base, retry_times=1)
+    row = await _get_sensor(sensor_id)
+    state_since = row.state_since
+
+    assert await _record(sensor_id, "degraded", committed_at + timedelta(seconds=1)) is False
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "ok"
+    assert row.pending_state == "degraded"  # the window is observable...
+    assert row.pending_count == 1
+
+    assert await _record(sensor_id, "ok", committed_at + timedelta(seconds=2)) is False
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "ok"
+    assert row.pending_state is None  # ...and cleared on revert.
+    assert row.pending_count == 0
+    assert row.state_since == state_since  # the committed clock never moved
+
+
+@pytest.mark.asyncio
+async def test_gate_escalation_mid_window_restarts_count() -> None:
+    """degraded, degraded, critical restarts the count and commits critical."""
+    sensor_id = await _create_sensor(retry_times=2)
+    base = datetime(2026, 8, 4, 12, 0, 0, tzinfo=UTC)
+    at = await _commit_state(sensor_id, "ok", base=base, retry_times=2)
+
+    assert await _record(sensor_id, "degraded", at + timedelta(seconds=1)) is False
+    assert await _record(sensor_id, "degraded", at + timedelta(seconds=2)) is False
+    # Escalation: the candidate changes, the count restarts on critical.
+    assert await _record(sensor_id, "critical", at + timedelta(seconds=3)) is False
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "ok"  # degraded never committed
+    assert row.pending_state == "critical"
+    assert row.pending_count == 1
+
+    assert await _record(sensor_id, "critical", at + timedelta(seconds=4)) is False
+    assert await _record(sensor_id, "critical", at + timedelta(seconds=5)) is True
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "critical"
+    assert _aware(row.state_since) == at + timedelta(seconds=5)
+
+
+@pytest.mark.asyncio
+async def test_gate_recovery_is_confirmed_symmetrically() -> None:
+    """From committed critical, a lone ok reading commits nothing."""
+    sensor_id = await _create_sensor(retry_times=1)
+    base = datetime(2026, 8, 4, 12, 0, 0, tzinfo=UTC)
+    at = await _commit_state(sensor_id, "critical", base=base, retry_times=1)
+
+    assert await _record(sensor_id, "ok", at + timedelta(seconds=1)) is False
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "critical"
+    assert row.pending_state == "ok"
+
+    assert await _record(sensor_id, "critical", at + timedelta(seconds=2)) is False
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "critical"
+    assert row.pending_state is None
+
+
+@pytest.mark.asyncio
+async def test_gate_unknown_participates_like_any_state() -> None:
+    """A transient dispatch failure (unknown) cannot flip a confirmed sensor."""
+    sensor_id = await _create_sensor(retry_times=1)
+    base = datetime(2026, 8, 4, 12, 0, 0, tzinfo=UTC)
+    at = await _commit_state(sensor_id, "ok", base=base, retry_times=1)
+
+    assert await _record(sensor_id, "unknown", at + timedelta(seconds=1)) is False
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "ok"
+    assert row.pending_state == "unknown"
+
+    assert await _record(sensor_id, "ok", at + timedelta(seconds=2)) is False
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "ok"
+    assert row.pending_state is None
+
+
+@pytest.mark.asyncio
+async def test_gate_monotonicity_guard_rejects_before_pending_mutation() -> None:
+    """An out-of-order gateway result opens no window (rejected up front)."""
+    sensor_id = await _create_sensor(retry_times=1)
+    base = datetime(2026, 8, 4, 12, 0, 0, tzinfo=UTC)
+    committed_at = await _commit_state(sensor_id, "ok", base=base, retry_times=1)
+
+    stale = committed_at - timedelta(seconds=30)
+    assert await _record(sensor_id, "degraded", stale) is False
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "ok"
+    assert row.pending_state is None
+    assert row.pending_count == 0
+    assert _aware(row.last_evaluated_at) == committed_at  # projection intact
+
+
+@pytest.mark.asyncio
+async def test_gate_retry_times_zero_commits_immediately() -> None:
+    """The default is bit-for-bit today's behaviour: no window, instant commit."""
+    sensor_id = await _create_sensor(retry_times=0)
+    at = datetime(2026, 8, 4, 12, 0, 0, tzinfo=UTC)
+
+    assert await _record(sensor_id, "degraded", at, value=42) is True
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "degraded"
+    assert _aware(row.state_since) == at
+    assert row.pending_state is None
+    assert row.pending_count == 0
+
+
+# --------------------------------------------------------------------------- #
+# Accelerated re-check (runner path)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_pending_result_pulls_next_fire_to_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pending persist pulls next_fire_at to evaluated_at + backoff."""
+    payload_ref: dict[str, Any] = {"payload": _CRITICAL_PAYLOAD}
+    _stub_dispatch(monkeypatch, payload_ref)
+    sensor_id = await _create_sensor(retry_times=1, retry_backoff_seconds=15, interval_seconds=300)
+
+    await _tick_with(sensor_id, payload_ref, _CRITICAL_PAYLOAD)
+
+    row = await _get_sensor(sensor_id)
+    assert row.pending_state == "critical"  # unknown -> critical is held too
+    assert row.pending_count == 1
+    assert row.last_state == "unknown"
+    # Pulled to exactly evaluated_at + 15 s, far sooner than the 300 s cadence.
+    assert _aware(row.next_fire_at) == _aware(row.last_evaluated_at) + timedelta(seconds=15)
+
+
+@pytest.mark.asyncio
+async def test_pending_pull_never_delays_scheduled_fire(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """min() semantics: a backoff beyond the cadence instant is a no-op."""
+    payload_ref: dict[str, Any] = {"payload": _CRITICAL_PAYLOAD}
+    _stub_dispatch(monkeypatch, payload_ref)
+    sensor_id = await _create_sensor(retry_times=1, retry_backoff_seconds=300, interval_seconds=5)
+
+    before = datetime.now(UTC)
+    await _tick_with(sensor_id, payload_ref, _CRITICAL_PAYLOAD)
+
+    row = await _get_sensor(sensor_id)
+    assert row.pending_state == "critical"
+    # The claim advanced next_fire_at to ~before + 5 s; the 300 s backoff
+    # must not push it later.
+    assert _aware(row.next_fire_at) <= before + timedelta(seconds=7)
+
+
+@pytest.mark.asyncio
+async def test_committed_result_does_not_accelerate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """retry_times=0 commits immediately and leaves the cadence untouched."""
+    payload_ref: dict[str, Any] = {"payload": _CRITICAL_PAYLOAD}
+    _stub_dispatch(monkeypatch, payload_ref)
+    sensor_id = await _create_sensor(retry_times=0, retry_backoff_seconds=15, interval_seconds=300)
+
+    await _tick_with(sensor_id, payload_ref, _CRITICAL_PAYLOAD)
+
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "critical"
+    assert row.pending_state is None
+    # Still the full cadence away -- no accelerated pull happened.
+    delta = _aware(row.next_fire_at) - _aware(row.last_evaluated_at)
+    assert delta > timedelta(seconds=250)
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: rollup edge + notification gating (runner + detector)
+# --------------------------------------------------------------------------- #
+
+
+class _DetectorRecorders:
+    """Recording replacements for the transition detector's fan-out seams."""
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.notifications: list[Any] = []
+        self.published: list[dict[str, Any]] = []
+        self.investigations: list[Any] = []
+
+        def _notify(notice: Any) -> None:
+            self.notifications.append(notice)
+
+        async def _publish(**kwargs: Any) -> None:
+            self.published.append(kwargs)
+
+        def _investigate(**kwargs: Any) -> None:
+            self.investigations.append(kwargs)
+
+        # Patch at the usage location (the investigate module's globals).
+        monkeypatch.setattr(inv, "schedule_dashboard_notification", _notify)
+        monkeypatch.setattr(inv, "publish_check_transition_event", _publish)
+        monkeypatch.setattr(inv, "_schedule_investigation", _investigate)
+
+
+async def _seed_dashboard(sensor_id: uuid.UUID, *, memo: str) -> uuid.UUID:
+    dashboard_id = uuid.uuid4()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            CheckDashboard(
+                id=dashboard_id,
+                tenant_id=_TENANT,
+                name=f"dash-{uuid.uuid4().hex[:8]}",
+                description=None,
+                last_rollup_state=memo,
+                created_by_sub="op-admin",
+            )
+        )
+        session.add(CheckDashboardSensor(dashboard_id=dashboard_id, sensor_id=sensor_id))
+        await session.commit()
+    return dashboard_id
+
+
+async def _memo(dashboard_id: uuid.UUID) -> str | None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(CheckDashboard, dashboard_id)
+        assert row is not None
+        return row.last_rollup_state
+
+
+@pytest.mark.asyncio
+async def test_flake_suppressed_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ok -> one degraded reading -> ok: no edge claimed, no mail spawned."""
+    payload_ref: dict[str, Any] = {"payload": _OK_PAYLOAD}
+    _stub_dispatch(monkeypatch, payload_ref)
+    recorders = _DetectorRecorders(monkeypatch)
+
+    sensor_id = await _create_sensor(retry_times=1)
+    base = datetime.now(UTC) - timedelta(minutes=5)
+    await _commit_state(sensor_id, "ok", base=base, retry_times=1)
+    dashboard_id = await _seed_dashboard(sensor_id, memo="ok")
+
+    await _tick_with(sensor_id, payload_ref, _DEGRADED_PAYLOAD)
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "ok"
+    assert row.pending_state == "degraded"  # visible while pending...
+
+    await _tick_with(sensor_id, payload_ref, _OK_PAYLOAD)
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "ok"
+    assert row.pending_state is None  # ...then cleared
+
+    assert await _memo(dashboard_id) == "ok"  # no rollup edge was claimed
+    assert recorders.notifications == []  # no notification task spawned
+    assert recorders.published == []  # no transition event published
+    assert recorders.investigations == []
+
+
+@pytest.mark.asyncio
+async def test_confirmed_transition_claims_one_edge_one_mail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """retry_times=3: four degraded readings commit once -> one edge, one mail."""
+    payload_ref: dict[str, Any] = {"payload": _OK_PAYLOAD}
+    _stub_dispatch(monkeypatch, payload_ref)
+    recorders = _DetectorRecorders(monkeypatch)
+
+    sensor_id = await _create_sensor(retry_times=3, retry_backoff_seconds=15)
+    base = datetime.now(UTC) - timedelta(minutes=5)
+    await _commit_state(sensor_id, "ok", base=base, retry_times=3)
+    dashboard_id = await _seed_dashboard(sensor_id, memo="ok")
+
+    for _ in range(4):
+        await _tick_with(sensor_id, payload_ref, _DEGRADED_PAYLOAD)
+
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "degraded"
+    assert row.pending_state is None
+    assert _aware(row.state_since) == _aware(row.last_evaluated_at)  # commit-time
+    assert await _memo(dashboard_id) == "degraded"
+    assert len(recorders.notifications) == 1  # exactly one claimed edge
+    assert len(recorders.published) == 1
+    assert recorders.published[0]["previous_state"] == "ok"
+    assert recorders.published[0]["new_state"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_recovery_flap_sends_no_all_clear(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """From committed critical: one ok reading then critical -> no recovery mail."""
+    payload_ref: dict[str, Any] = {"payload": _CRITICAL_PAYLOAD}
+    _stub_dispatch(monkeypatch, payload_ref)
+    recorders = _DetectorRecorders(monkeypatch)
+
+    sensor_id = await _create_sensor(retry_times=1)
+    base = datetime.now(UTC) - timedelta(minutes=5)
+    await _commit_state(sensor_id, "critical", base=base, retry_times=1)
+    dashboard_id = await _seed_dashboard(sensor_id, memo="critical")
+
+    await _tick_with(sensor_id, payload_ref, _OK_PAYLOAD)
+    await _tick_with(sensor_id, payload_ref, _CRITICAL_PAYLOAD)
+
+    row = await _get_sensor(sensor_id)
+    assert row.last_state == "critical"
+    assert row.pending_state is None
+    assert await _memo(dashboard_id) == "critical"
+    assert recorders.notifications == []  # the observed nuisance all-clear
+    assert recorders.published == []

--- a/backend/tests/test_checks_watchdog.py
+++ b/backend/tests/test_checks_watchdog.py
@@ -143,6 +143,8 @@ async def _seed_active_sensor(tenant_id: uuid.UUID) -> None:
             timezone="UTC",
             severity="critical",
             for_seconds=0,
+            retry_times=0,
+            retry_backoff_seconds=15,
             identity_sub="__sensor__",
             created_by_sub="op-test",
         )

--- a/backend/tests/test_db_sensor.py
+++ b/backend/tests/test_db_sensor.py
@@ -21,8 +21,10 @@ Coverage matrix
 * **Cadence discriminated-union CHECK rejects malformed rows.**
 * **tenant FK enforced** + **unique (tenant_id, name) enforced.**
 * **Drift guards.** The model enums and the migration's frozen literals
-  agree; the migration's frozen CHECK bodies equal the ORM's; and the
-  ``ck_sensor_last_state`` value set equals #2504's :data:`CheckState`.
+  agree; the migration's frozen CHECK bodies equal the ORM's; the
+  ``ck_sensor_last_state`` value set equals #2504's :data:`CheckState`;
+  and migration ``0070``'s frozen ``pending_state`` vocabulary equals the
+  ORM's ``_SENSOR_PENDING_STATES`` (``CheckState`` minus ``skip``).
 
 The tests run against ``sqlite+aiosqlite`` via the shared engine the
 autouse ``_default_database_url`` fixture pre-migrates to head.
@@ -46,6 +48,7 @@ from meho_backplane.db.models import (
     _SENSOR_CADENCE_FIELDS_CHECK,
     _SENSOR_CADENCE_KINDS,
     _SENSOR_LAST_STATES,
+    _SENSOR_PENDING_STATES,
     _SENSOR_SEVERITIES,
     _SENSOR_STATUSES,
     Sensor,
@@ -125,7 +128,11 @@ async def test_interval_sensor_round_trip_persists_every_field() -> None:
                 next_fire_at=now,
                 severity=SensorSeverity.DEGRADED.value,
                 for_seconds=300,
+                retry_times=2,
+                retry_backoff_seconds=30,
                 last_state="ok",
+                pending_state="degraded",
+                pending_count=1,
                 created_by_sub="user-admin",
             )
         )
@@ -146,7 +153,11 @@ async def test_interval_sensor_round_trip_persists_every_field() -> None:
     assert row.cron_expr is None
     assert row.severity == "degraded"
     assert row.for_seconds == 300
+    assert row.retry_times == 2
+    assert row.retry_backoff_seconds == 30
     assert row.last_state == "ok"
+    assert row.pending_state == "degraded"
+    assert row.pending_count == 1
     assert row.status == "active"
 
 
@@ -213,6 +224,9 @@ async def test_orm_defaults_fire_on_sqlite() -> None:
         assert sensor.severity == SensorSeverity.CRITICAL.value
         assert sensor.last_state == "unknown"
         assert sensor.for_seconds == 0
+        assert sensor.retry_times == 0
+        assert sensor.retry_backoff_seconds == 15
+        assert sensor.pending_count == 0
         assert sensor.identity_sub == "__sensor__"
         assert sensor.timezone == "UTC"
         assert sensor.created_at is not None
@@ -227,6 +241,7 @@ async def test_orm_defaults_fire_on_sqlite() -> None:
     assert row.last_value is None
     assert row.last_evidence is None
     assert row.state_since is None
+    assert row.pending_state is None
 
 
 # ---------------------------------------------------------------------------
@@ -287,6 +302,29 @@ async def test_last_state_check_rejects_unknown() -> None:
             "cadence_kind": SensorCadenceKind.INTERVAL.value,
             "interval_seconds": 60,
             "last_state": "warn",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_pending_state_check_rejects_out_of_vocabulary() -> None:
+    await _seed_and_add(
+        {
+            "cadence_kind": SensorCadenceKind.INTERVAL.value,
+            "interval_seconds": 60,
+            "pending_state": "warn",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_pending_state_check_rejects_skip() -> None:
+    """``skip`` is a rollup-side derivation, never a confirmation candidate."""
+    await _seed_and_add(
+        {
+            "cadence_kind": SensorCadenceKind.INTERVAL.value,
+            "interval_seconds": 60,
+            "pending_state": "skip",
         }
     )
 
@@ -452,6 +490,30 @@ def test_migration_last_state_literal_matches_checkstate() -> None:
     """The migration's frozen ``last_state`` literal is a snapshot of ``CheckState``."""
     migration = _load_migration_by_name("0064_create_sensor")
     assert set(migration._SENSOR_LAST_STATES) == set(get_args(CheckState))  # type: ignore[attr-defined]
+
+
+def test_pending_states_equal_checkstate_minus_skip() -> None:
+    """``_SENSOR_PENDING_STATES`` is ``CheckState`` minus ``skip`` (#2799).
+
+    ``skip`` is #2506's rollup-side derivation for paused members, never an
+    evaluation outcome, so it can never be a confirmation candidate.
+    """
+    assert set(_SENSOR_PENDING_STATES) == set(get_args(CheckState)) - {"skip"}
+    pending_body = _orm_check_bodies()["ck_sensor_pending_state"]
+    for member in _SENSOR_PENDING_STATES:
+        assert f"'{member}'" in pending_body
+    assert "'skip'" not in pending_body
+
+
+def test_migration_0070_pending_states_literal_matches_model() -> None:
+    """Migration ``0070``'s frozen vocabulary + CHECK body equal the ORM's."""
+    migration = _load_migration_by_name("0070_add_sensor_confirmation_retries")
+    assert set(migration._SENSOR_PENDING_STATES) == set(_SENSOR_PENDING_STATES)  # type: ignore[attr-defined]
+    orm = _orm_check_bodies()
+    assert orm["ck_sensor_pending_state"] == migration._check_in(  # type: ignore[attr-defined]
+        "pending_state",
+        migration._SENSOR_PENDING_STATES,  # type: ignore[attr-defined]
+    )
 
 
 def test_migration_check_bodies_equal_orm() -> None:

--- a/backend/tests/test_sensor_runner.py
+++ b/backend/tests/test_sensor_runner.py
@@ -165,6 +165,8 @@ async def _create_interval_sensor(
     assertion: dict[str, Any] | None = None,
     tenant_id: uuid.UUID = _TENANT,
     base: datetime | None = None,
+    retry_times: int = 0,
+    retry_backoff_seconds: int = 15,
 ) -> uuid.UUID:
     await _seed_tenant(tenant_id)
     sessionmaker = get_sessionmaker()
@@ -184,6 +186,8 @@ async def _create_interval_sensor(
             timezone="UTC",
             severity="critical",
             for_seconds=0,
+            retry_times=retry_times,
+            retry_backoff_seconds=retry_backoff_seconds,
             identity_sub=identity_sub,
             created_by_sub="op-admin",
             base=base,
@@ -217,6 +221,8 @@ async def _create_cron_sensor(
             timezone=timezone,
             severity="critical",
             for_seconds=0,
+            retry_times=0,
+            retry_backoff_seconds=15,
             identity_sub="__sensor__",
             created_by_sub="op-admin",
             base=base,
@@ -1050,6 +1056,8 @@ async def _create_target_bound_sensor(
             timezone="UTC",
             severity="critical",
             for_seconds=0,
+            retry_times=0,
+            retry_backoff_seconds=15,
             identity_sub="__sensor__",
             created_by_sub="op-admin",
         )

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -27856,6 +27856,20 @@
             "title": "For Seconds",
             "default": 0
           },
+          "retry_times": {
+            "type": "integer",
+            "maximum": 5.0,
+            "minimum": 0.0,
+            "title": "Retry Times",
+            "default": 0
+          },
+          "retry_backoff_seconds": {
+            "type": "integer",
+            "maximum": 300.0,
+            "minimum": 5.0,
+            "title": "Retry Backoff Seconds",
+            "default": 15
+          },
           "identity_sub": {
             "type": "string",
             "maxLength": 256,
@@ -27976,6 +27990,14 @@
             "type": "integer",
             "title": "For Seconds"
           },
+          "retry_times": {
+            "type": "integer",
+            "title": "Retry Times"
+          },
+          "retry_backoff_seconds": {
+            "type": "integer",
+            "title": "Retry Backoff Seconds"
+          },
           "last_state": {
             "type": "string",
             "enum": [
@@ -28007,6 +28029,21 @@
             "format": "date-time",
             "nullable": true,
             "title": "State Since"
+          },
+          "pending_state": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "degraded",
+              "critical",
+              "unknown"
+            ],
+            "nullable": true,
+            "title": "Pending State"
+          },
+          "pending_count": {
+            "type": "integer",
+            "title": "Pending Count"
           },
           "identity_sub": {
             "type": "string",
@@ -28046,11 +28083,15 @@
           "next_fire_at",
           "severity",
           "for_seconds",
+          "retry_times",
+          "retry_backoff_seconds",
           "last_state",
           "last_value",
           "last_evidence",
           "last_evaluated_at",
           "state_since",
+          "pending_state",
+          "pending_count",
           "identity_sub",
           "created_by_sub",
           "created_at",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -385,6 +385,14 @@ const (
 	SensorReadLastStateUnknown  SensorReadLastState = "unknown"
 )
 
+// Defines values for SensorReadPendingState.
+const (
+	SensorReadPendingStateCritical SensorReadPendingState = "critical"
+	SensorReadPendingStateDegraded SensorReadPendingState = "degraded"
+	SensorReadPendingStateOk       SensorReadPendingState = "ok"
+	SensorReadPendingStateUnknown  SensorReadPendingState = "unknown"
+)
+
 // Defines values for SensorSeverity.
 const (
 	SensorSeverityCritical SensorSeverity = "critical"
@@ -6350,15 +6358,17 @@ type SensorCreate struct {
 	// Closed enum: widening it is a coordinated DB + model change so the
 	// enum, the :data:`_SENSOR_CADENCE_KINDS` literal, and migration
 	// ``0064``'s frozen tuple cannot drift.
-	CadenceKind     SensorCadenceKind       `json:"cadence_kind"`
-	ConnectorId     string                  `json:"connector_id"`
-	CronExpr        *string                 `json:"cron_expr"`
-	ForSeconds      *int                    `json:"for_seconds,omitempty"`
-	IdentitySub     *string                 `json:"identity_sub,omitempty"`
-	IntervalSeconds *int                    `json:"interval_seconds"`
-	Name            string                  `json:"name"`
-	OpId            string                  `json:"op_id"`
-	Params          *map[string]interface{} `json:"params,omitempty"`
+	CadenceKind         SensorCadenceKind       `json:"cadence_kind"`
+	ConnectorId         string                  `json:"connector_id"`
+	CronExpr            *string                 `json:"cron_expr"`
+	ForSeconds          *int                    `json:"for_seconds,omitempty"`
+	IdentitySub         *string                 `json:"identity_sub,omitempty"`
+	IntervalSeconds     *int                    `json:"interval_seconds"`
+	Name                string                  `json:"name"`
+	OpId                string                  `json:"op_id"`
+	Params              *map[string]interface{} `json:"params,omitempty"`
+	RetryBackoffSeconds *int                    `json:"retry_backoff_seconds,omitempty"`
+	RetryTimes          *int                    `json:"retry_times,omitempty"`
 
 	// Severity Worst dashboard state a failing assertion on a :class:`Sensor` may drive.
 	//
@@ -6413,23 +6423,27 @@ type SensorRead struct {
 	// Closed enum: widening it is a coordinated DB + model change so the
 	// enum, the :data:`_SENSOR_CADENCE_KINDS` literal, and migration
 	// ``0064``'s frozen tuple cannot drift.
-	CadenceKind     SensorCadenceKind       `json:"cadence_kind"`
-	ConnectorId     string                  `json:"connector_id"`
-	CreatedAt       time.Time               `json:"created_at"`
-	CreatedBySub    string                  `json:"created_by_sub"`
-	CronExpr        *string                 `json:"cron_expr"`
-	ForSeconds      int                     `json:"for_seconds"`
-	Id              openapi_types.UUID      `json:"id"`
-	IdentitySub     string                  `json:"identity_sub"`
-	IntervalSeconds *int                    `json:"interval_seconds"`
-	LastEvaluatedAt *time.Time              `json:"last_evaluated_at"`
-	LastEvidence    *map[string]interface{} `json:"last_evidence"`
-	LastState       SensorReadLastState     `json:"last_state"`
-	LastValue       interface{}             `json:"last_value"`
-	Name            string                  `json:"name"`
-	NextFireAt      *time.Time              `json:"next_fire_at"`
-	OpId            string                  `json:"op_id"`
-	Params          map[string]interface{}  `json:"params"`
+	CadenceKind         SensorCadenceKind       `json:"cadence_kind"`
+	ConnectorId         string                  `json:"connector_id"`
+	CreatedAt           time.Time               `json:"created_at"`
+	CreatedBySub        string                  `json:"created_by_sub"`
+	CronExpr            *string                 `json:"cron_expr"`
+	ForSeconds          int                     `json:"for_seconds"`
+	Id                  openapi_types.UUID      `json:"id"`
+	IdentitySub         string                  `json:"identity_sub"`
+	IntervalSeconds     *int                    `json:"interval_seconds"`
+	LastEvaluatedAt     *time.Time              `json:"last_evaluated_at"`
+	LastEvidence        *map[string]interface{} `json:"last_evidence"`
+	LastState           SensorReadLastState     `json:"last_state"`
+	LastValue           interface{}             `json:"last_value"`
+	Name                string                  `json:"name"`
+	NextFireAt          *time.Time              `json:"next_fire_at"`
+	OpId                string                  `json:"op_id"`
+	Params              map[string]interface{}  `json:"params"`
+	PendingCount        int                     `json:"pending_count"`
+	PendingState        *SensorReadPendingState `json:"pending_state"`
+	RetryBackoffSeconds int                     `json:"retry_backoff_seconds"`
+	RetryTimes          int                     `json:"retry_times"`
 
 	// Severity Worst dashboard state a failing assertion on a :class:`Sensor` may drive.
 	//
@@ -6459,6 +6473,9 @@ type SensorRead struct {
 
 // SensorReadLastState defines model for SensorRead.LastState.
 type SensorReadLastState string
+
+// SensorReadPendingState defines model for SensorRead.PendingState.
+type SensorReadPendingState string
 
 // SensorRunnerStatus Liveness of this process's sensor evaluation loop (#2763).
 //

--- a/cli/internal/cmd/sensor/create.go
+++ b/cli/internal/cmd/sensor/create.go
@@ -122,7 +122,8 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().IntVar(&retryTimes, "retry-times", 0,
 		"consecutive confirming re-checks required before a state change commits, 0..5 (default 0 = off)")
 	cmd.Flags().IntVar(&retryBackoffSeconds, "retry-backoff-seconds", 0,
-		"accelerated re-check spacing in seconds while a state change is pending, 5..300 (default 15)")
+		"accelerated re-check spacing in seconds while a state change is pending, 5..300 "+
+			"(omitted when unset; the server then applies its default of 15)")
 	cmd.Flags().StringVar(&targetArg, "target", "",
 		"optional dispatch-target JSON object (inline JSON, @<path>, or @-)")
 	cmd.Flags().StringVar(&paramsArg, "params", "",

--- a/cli/internal/cmd/sensor/create.go
+++ b/cli/internal/cmd/sensor/create.go
@@ -30,22 +30,24 @@ import (
 // Role: tenant_admin.
 func newCreateCmd() *cobra.Command {
 	var (
-		name              string
-		connectorID       string
-		opID              string
-		assertionArg      string
-		cadenceKind       string
-		intervalSeconds   int
-		cronExpr          string
-		timezone          string
-		severity          string
-		forSeconds        int
-		targetArg         string
-		paramsArg         string
-		identitySub       string
-		tenant            string
-		jsonOut           bool
-		backplaneOverride string
+		name                string
+		connectorID         string
+		opID                string
+		assertionArg        string
+		cadenceKind         string
+		intervalSeconds     int
+		cronExpr            string
+		timezone            string
+		severity            string
+		forSeconds          int
+		retryTimes          int
+		retryBackoffSeconds int
+		targetArg           string
+		paramsArg           string
+		identitySub         string
+		tenant              string
+		jsonOut             bool
+		backplaneOverride   string
 	)
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -64,10 +66,14 @@ func newCreateCmd() *cobra.Command {
 			"--timezone is the IANA zone for cron evaluation (default 'UTC'). " +
 			"--severity is the worst rollup state a failure drives " +
 			"(degraded|critical, default critical). --for-seconds is the " +
-			"hold-time hysteresis (default 0). --target / --params are " +
-			"optional JSON objects. --identity-sub overrides the default " +
-			"runner identity. --tenant targets another tenant (platform_admin " +
-			"cross-tenant).\n\nA non-safe op returns 422 " +
+			"hold-time hysteresis (default 0). --retry-times is the number " +
+			"of consecutive confirming re-checks required before a state " +
+			"change commits + notifies (0..5, default 0 = off; Nagios " +
+			"soft/hard states), spaced by --retry-backoff-seconds (5..300, " +
+			"default 15; inert while --retry-times is 0). --target / " +
+			"--params are optional JSON objects. --identity-sub overrides " +
+			"the default runner identity. --tenant targets another tenant " +
+			"(platform_admin cross-tenant).\n\nA non-safe op returns 422 " +
 			"sensor_requires_safe_operation; an unknown op 422 " +
 			"sensor_operation_not_found; a duplicate name 409 " +
 			"sensor_name_conflict.",
@@ -76,22 +82,24 @@ func newCreateCmd() *cobra.Command {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runCreate(cmd, createOptions{
-				Name:              name,
-				ConnectorID:       connectorID,
-				OpID:              opID,
-				AssertionArg:      assertionArg,
-				CadenceKind:       cadenceKind,
-				IntervalSeconds:   intervalSeconds,
-				CronExpr:          cronExpr,
-				Timezone:          timezone,
-				Severity:          severity,
-				ForSeconds:        forSeconds,
-				TargetArg:         targetArg,
-				ParamsArg:         paramsArg,
-				IdentitySub:       identitySub,
-				Tenant:            tenant,
-				JSONOut:           jsonOut,
-				BackplaneOverride: backplaneOverride,
+				Name:                name,
+				ConnectorID:         connectorID,
+				OpID:                opID,
+				AssertionArg:        assertionArg,
+				CadenceKind:         cadenceKind,
+				IntervalSeconds:     intervalSeconds,
+				CronExpr:            cronExpr,
+				Timezone:            timezone,
+				Severity:            severity,
+				ForSeconds:          forSeconds,
+				RetryTimes:          retryTimes,
+				RetryBackoffSeconds: retryBackoffSeconds,
+				TargetArg:           targetArg,
+				ParamsArg:           paramsArg,
+				IdentitySub:         identitySub,
+				Tenant:              tenant,
+				JSONOut:             jsonOut,
+				BackplaneOverride:   backplaneOverride,
 			})
 		},
 	}
@@ -111,6 +119,10 @@ func newCreateCmd() *cobra.Command {
 		"worst rollup state a failing assertion drives: degraded | critical (default critical)")
 	cmd.Flags().IntVar(&forSeconds, "for-seconds", 0,
 		"hold-time hysteresis in seconds a failing state must persist (default 0)")
+	cmd.Flags().IntVar(&retryTimes, "retry-times", 0,
+		"consecutive confirming re-checks required before a state change commits, 0..5 (default 0 = off)")
+	cmd.Flags().IntVar(&retryBackoffSeconds, "retry-backoff-seconds", 0,
+		"accelerated re-check spacing in seconds while a state change is pending, 5..300 (default 15)")
 	cmd.Flags().StringVar(&targetArg, "target", "",
 		"optional dispatch-target JSON object (inline JSON, @<path>, or @-)")
 	cmd.Flags().StringVar(&paramsArg, "params", "",
@@ -131,22 +143,24 @@ func newCreateCmd() *cobra.Command {
 }
 
 type createOptions struct {
-	Name              string
-	ConnectorID       string
-	OpID              string
-	AssertionArg      string
-	CadenceKind       string
-	IntervalSeconds   int
-	CronExpr          string
-	Timezone          string
-	Severity          string
-	ForSeconds        int
-	TargetArg         string
-	ParamsArg         string
-	IdentitySub       string
-	Tenant            string
-	JSONOut           bool
-	BackplaneOverride string
+	Name                string
+	ConnectorID         string
+	OpID                string
+	AssertionArg        string
+	CadenceKind         string
+	IntervalSeconds     int
+	CronExpr            string
+	Timezone            string
+	Severity            string
+	ForSeconds          int
+	RetryTimes          int
+	RetryBackoffSeconds int
+	TargetArg           string
+	ParamsArg           string
+	IdentitySub         string
+	Tenant              string
+	JSONOut             bool
+	BackplaneOverride   string
 }
 
 func runCreate(cmd *cobra.Command, opts createOptions) error {
@@ -171,6 +185,19 @@ func runCreate(cmd *cobra.Command, opts createOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf(
 				"--for-seconds must be non-negative; got %d", opts.ForSeconds)),
+			opts.JSONOut)
+	}
+	if opts.RetryTimes < 0 {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--retry-times must be non-negative; got %d", opts.RetryTimes)),
+			opts.JSONOut)
+	}
+	if opts.RetryBackoffSeconds < 0 {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--retry-backoff-seconds must be non-negative; got %d",
+				opts.RetryBackoffSeconds)),
 			opts.JSONOut)
 	}
 	// Per-cadence discriminator pre-check (the backend's Pydantic validator
@@ -298,6 +325,14 @@ func buildCreateBody(
 	if opts.ForSeconds > 0 {
 		fs := opts.ForSeconds
 		body.ForSeconds = &fs
+	}
+	if opts.RetryTimes > 0 {
+		rt := opts.RetryTimes
+		body.RetryTimes = &rt
+	}
+	if opts.RetryBackoffSeconds > 0 {
+		rb := opts.RetryBackoffSeconds
+		body.RetryBackoffSeconds = &rb
 	}
 	if target != nil {
 		t := map[string]interface{}(target)

--- a/cli/internal/cmd/sensor/sensor.go
+++ b/cli/internal/cmd/sensor/sensor.go
@@ -447,7 +447,14 @@ func printSensorSummary(w io.Writer, s *api.SensorRead) {
 	}
 	fmt.Fprintf(w, "%-22s %s\n", "severity:", string(s.Severity))
 	fmt.Fprintf(w, "%-22s %d\n", "for_seconds:", s.ForSeconds)
+	if s.RetryTimes > 0 {
+		fmt.Fprintf(w, "%-22s %d\n", "retry_times:", s.RetryTimes)
+		fmt.Fprintf(w, "%-22s %ds\n", "retry_backoff_seconds:", s.RetryBackoffSeconds)
+	}
 	fmt.Fprintf(w, "%-22s %s\n", "last_state:", string(s.LastState))
+	if s.PendingState != nil {
+		fmt.Fprintf(w, "%-22s %s (x%d)\n", "pending_state:", string(*s.PendingState), s.PendingCount)
+	}
 	if s.LastEvaluatedAt != nil {
 		fmt.Fprintf(w, "%-22s %s\n", "last_evaluated_at:", formatTime(s.LastEvaluatedAt))
 	}

--- a/cli/internal/cmd/sensor/sensor_test.go
+++ b/cli/internal/cmd/sensor/sensor_test.go
@@ -242,14 +242,16 @@ func TestListQueryParamsForwardsFilters(t *testing.T) {
 func TestBuildCreateBodyInterval(t *testing.T) {
 	body := buildCreateBody(
 		createOptions{
-			Name:            "disk",
-			ConnectorID:     "vmware-rest-9.0",
-			OpID:            "vmware.vm.list",
-			CadenceKind:     "interval",
-			IntervalSeconds: 60,
-			Severity:        "degraded",
-			ForSeconds:      300,
-			IdentitySub:     "svc",
+			Name:                "disk",
+			ConnectorID:         "vmware-rest-9.0",
+			OpID:                "vmware.vm.list",
+			CadenceKind:         "interval",
+			IntervalSeconds:     60,
+			Severity:            "degraded",
+			ForSeconds:          300,
+			RetryTimes:          2,
+			RetryBackoffSeconds: 30,
+			IdentitySub:         "svc",
 		},
 		mustAssertion(t, stubAssertion), nil, nil, nil,
 	)
@@ -270,6 +272,12 @@ func TestBuildCreateBodyInterval(t *testing.T) {
 	}
 	if body.ForSeconds == nil || *body.ForSeconds != 300 {
 		t.Errorf("for_seconds not forwarded; got %+v", body.ForSeconds)
+	}
+	if body.RetryTimes == nil || *body.RetryTimes != 2 {
+		t.Errorf("retry_times not forwarded; got %+v", body.RetryTimes)
+	}
+	if body.RetryBackoffSeconds == nil || *body.RetryBackoffSeconds != 30 {
+		t.Errorf("retry_backoff_seconds not forwarded; got %+v", body.RetryBackoffSeconds)
 	}
 	if body.IdentitySub == nil || *body.IdentitySub != "svc" {
 		t.Errorf("identity_sub not forwarded; got %+v", body.IdentitySub)
@@ -308,6 +316,13 @@ func TestBuildCreateBodyCron(t *testing.T) {
 	}
 	if body.TenantId == nil || body.TenantId.String() != stubOtherTenant {
 		t.Errorf("tenant_id not forwarded; got %+v", body.TenantId)
+	}
+	// Unset confirmation knobs stay omitted so the server defaults apply.
+	if body.RetryTimes != nil {
+		t.Errorf("retry_times should stay nil when unset; got %+v", body.RetryTimes)
+	}
+	if body.RetryBackoffSeconds != nil {
+		t.Errorf("retry_backoff_seconds should stay nil when unset; got %+v", body.RetryBackoffSeconds)
 	}
 }
 

--- a/docs/codebase/checks-advisory.md
+++ b/docs/codebase/checks-advisory.md
@@ -90,7 +90,11 @@ dispatcher._reduce_and_audit_success(...)   # after audit + broadcast
   compare-and-swap), never the on-read rollup — so a staleness-derived
   `unknown` is not reflected, and a `NULL` memo (never-transitioned
   Dashboard) yields nothing. Documented limitation, acceptable for an
-  awareness nudge.
+  awareness nudge. Since #2799, a sensor with `retry_times > 0` moves
+  the memo only after its confirmation window commits, so the advisory
+  reflects a fresh incident with up to `retry_times ×
+  (retry_backoff_seconds + one runner tick)` of added latency — the
+  cost of not nudging every caller about a one-reading flap.
 - **Fail-open, advisory-only.** A broad guard swallows any DB/Valkey
   error, warn-logs `checks_alert_advisory_failed`, and returns `{}`.
   Never gates, blocks, or fails a dispatch.

--- a/docs/codebase/checks-broadcast.md
+++ b/docs/codebase/checks-broadcast.md
@@ -32,6 +32,12 @@ Unlike the notifier, the publish has **no floor**. A feed event costs one
 `XADD` against a `MAXLEN ~`-trimmed stream, so narrowing belongs to the
 consumer (`op_class=checks`), not to the producer.
 
+Since #2799, a sensor with `retry_times > 0` commits a state change only
+after consecutive confirming re-checks (`docs/codebase/sensor.md`), so
+transient one-reading flaps never reach the rollup CAS — the feed sees
+**fewer raw edges**, each one a confirmed transition. No change to this
+module; the gate is upstream of the claim all three consumers share.
+
 ## Key types
 
 - `publish_check_transition_event(*, tenant_id, dashboard_id,

--- a/docs/codebase/checks-investigator.md
+++ b/docs/codebase/checks-investigator.md
@@ -63,6 +63,17 @@ rollup (no LLM), and the *deep tier* is the scheduled agent run.
    because the investigator does not. The two consumers are independent:
    the notifier applies its own per-Dashboard `notify_min_state` floor and
    never reaches this module's correlation, suppression, or agent path.
+
+   **What counts as an edge, since #2799:** on a sensor with
+   `retry_times > 0`, an unconfirmed (pending soft-state) evaluation
+   never changes the sensor's `last_state`, so the fold this hook
+   recomputes cannot see it — the memo CAS is a cheap no-op and no edge
+   is claimed. Only a *confirmed* sensor transition (or a `for:` hold
+   expiring / stale derivation, which are fold-side) can move the
+   rollup, so the investigator fires on confirmed edges only. The hook
+   still runs on every persist; confirmation just changes which
+   persists can produce an edge (`docs/codebase/sensor.md` §Result
+   recording).
 2. **Correlation** (`_correlate`). Each non-green member maps to its topology
    anchor via its registered target's name (`kind="target"`), and
    `topology.query.find_dependencies` returns the forward closure. Members

--- a/docs/codebase/checks-notifications.md
+++ b/docs/codebase/checks-notifications.md
@@ -175,6 +175,30 @@ state)` window:
   edge, suppressed or not. Finding mail is not flap-suppressed — its
   volume control is the investigator's fire gate.
 
+## Three anti-flap layers (#2799 composition)
+
+The delivery window above is one of three independent layers; they
+compose, none rediscovers another:
+
+1. **Confirmation retries (#2799, upstream of everything).** Per-sensor
+   `retry_times` × `retry_backoff_seconds`: `record_sensor_result`
+   commits a *sensor* state change only after consecutive confirming
+   re-checks (soft/hard states, `docs/codebase/sensor.md`). An
+   unconfirmed transition never reaches the projection, so the rollup
+   CAS, this notifier, the broadcaster, the investigator, and the
+   advisory are all gated for free — fewer, better edges arrive here.
+   This is what suppresses the observed one-flaky-reading incident: the
+   two nuisance mails were first crossings into *distinct* states,
+   which the #2732 window deliberately never suppresses.
+2. **`for_seconds` hold (#2506, fold-side).** Duration-based, at the
+   dashboard rollup read path: a confirmed-but-young failing state
+   contributes `ok` until it has held. Since #2799, `state_since` marks
+   the *confirmed* instant, so the hold measures confirmed time on top
+   of confirmation.
+3. **Delivery window (#2732, this file).** Bounds repeat *same-state*
+   mails per `(tenant, dashboard, state)`; claim-side consumers see
+   every edge. Unchanged by #2799 — it just sees fewer edges.
+
 ## Message shape
 
 Subject: `[MEHO] <name>: <previous> -> <current>`, with an

--- a/docs/codebase/checks-runner.md
+++ b/docs/codebase/checks-runner.md
@@ -49,6 +49,12 @@ watchdog deliberately has no enable flag of its own.
 ```text
 runner loop:  sleep(interval) → run_one_sensor_tick()
                                   ├─ claim + advance + spawn evaluations
+                                  │    evaluation → _persist_outcome:
+                                  │      record_sensor_result (commit gate)
+                                  │      pending window open? →
+                                  │        accelerate_sensor_next_fire
+                                  │        (next_fire_at := min(next_fire_at,
+                                  │         evaluated_at + retry_backoff_seconds))
                                   └─ note_tick_completed()
                                        └─ stall flagged? → emit
                                           checks_scheduler_recovered
@@ -71,6 +77,37 @@ health read:   GET /api/v1/health · GET /api/v1/health/live
 Detection latency is bounded by `threshold + one tick interval` (the
 watchdog rides the runner's own cadence; a finer grid would not tighten
 that bound).
+
+### Confirmation retries (#2799)
+
+A sensor with `retry_times > 0` does not commit a differing evaluation
+outcome on first sight: `record_sensor_result` holds it as a pending
+soft state (`pending_state` / `pending_count` on the row) and commits
+`last_state` / `state_since` only after `retry_times` consecutive
+confirming re-evaluations (Nagios soft/hard states; symmetric — recovery
+to `ok` is confirmed too, and `unknown` participates like any state).
+The runner's contribution is the **accelerated re-check**: when a
+persist leaves the window open, `_persist_outcome` pulls the row's
+`next_fire_at` to `min(next_fire_at, evaluated_at +
+retry_backoff_seconds)` (`accelerate_sensor_next_fire`, a conditional
+`UPDATE ... WHERE next_fire_at > :accel` — atomic min, never a delay).
+The re-check then rides the ordinary claim/advance/overlap machinery:
+no in-process sleep loop, so `stop_sensor_runner` and the at-most-once
+advance discipline are untouched, and effective spacing quantizes up to
+the tick grid like any sub-tick cadence.
+
+**Worst-case detection latency** for a genuine transition becomes
+`first differing reading + retry_times × (retry_backoff_seconds + one
+tick interval)` — each confirming re-check waits its backoff plus up to
+one tick of grid quantization (the same fire-time contract shape #2245
+states for the scheduler's 30 s grid).
+
+**Satellite asymmetry:** the commit gate lives in
+`record_sensor_result`, so satellite-gateway batch-posted results are
+confirmation-counted identically — but the accelerated re-fire is
+runner-local (`next_fire_at` is the central runner's clock; a satellite
+re-checks at its own posting cadence, so remote confirmation is paced
+by that cadence instead of `retry_backoff_seconds`).
 
 ## Settings
 
@@ -154,7 +191,8 @@ external prober alerts on it (`stalled == true`, or
 - `backend/src/meho_backplane/main.py` (lifespan wiring)
 - `backend/tests/test_checks_watchdog.py`, `test_sensor_runner.py`,
   `test_api_v1_health.py`
-- #2763 (watchdog), #2505 (runner), Initiative #2780, parent goal #221
+- #2763 (watchdog), #2505 (runner), #2799 (confirmation retries),
+  Initiative #2780, parent goal #221
 - Moulds: `gateway/deadman.py` (#2501 — the satellite-runner dead-man
   switch, same lapse-detection shape at a different altitude),
   `memory/expiry.py` (loop lifecycle)

--- a/docs/codebase/sensor.md
+++ b/docs/codebase/sensor.md
@@ -19,10 +19,17 @@ delete, the runner (#2505) owns claim/advance/park and the result write.
 
 ## Key types
 
-- `meho_backplane.db.models.Sensor` — the ORM row. 26 columns: identity
+- `meho_backplane.db.models.Sensor` — the ORM row. 30 columns: identity
   (`connector_id` + `op_id`), `params`/`target`, `assertion` (JSON), the
-  cadence union, `severity`/`for_seconds`, the latest-result projection,
-  and `status`/`status_reason`.
+  cadence union, `severity`/`for_seconds`, the confirmation knobs
+  `retry_times`/`retry_backoff_seconds` (#2799, create-only like every
+  other sensor knob), the latest-result projection (including the
+  soft-state window `pending_state`/`pending_count`), and
+  `status`/`status_reason`. `pending_state`'s CHECK admits `CheckState`
+  minus `skip` (`skip` is a rollup-side derivation, never an evaluation
+  outcome); `_SENSOR_PENDING_STATES` derives from `CheckState` and is
+  drift-guarded in `tests/test_db_sensor.py` against migration `0070`'s
+  frozen literal.
 - `SensorCadenceKind` (`interval` | `cron`), `SensorStatus`
   (`active` | `paused`), `SensorSeverity` (`degraded` | `critical`) —
   closed StrEnums with DB `CHECK`s. The five-state `last_state` vocabulary
@@ -86,10 +93,35 @@ delete, the runner (#2505) owns claim/advance/park and the result write.
    `sensor_name_conflict`.
 
 **Result recording** (`record_sensor_result`, called by #2505/#2507/#2415-T3):
-updates `last_state`/`last_value`/`last_evidence`/`last_evaluated_at` on
-every call, bumps `state_since` **only** when the state changes, and
-returns whether it changed. There is no results history table — the
-projection is the single source of current state (Decision D).
+updates `last_value`/`last_evidence`/`last_evaluated_at` on every
+accepted call, and commits `last_state`/`state_since` through the
+**confirmation gate** (#2799, Nagios soft/hard states):
+
+- `retry_times = 0` (default): every differing reading commits
+  immediately — the pre-#2799 behaviour, bit for bit.
+- `retry_times > 0`: a reading differing from the committed
+  `last_state` opens (or advances) the soft-state window —
+  `pending_state`/`pending_count` on the row. Same candidate again →
+  count increments; `pending_count > retry_times` → commit
+  (`last_state` flips, `state_since` = the commit-time `evaluated_at`)
+  and the window clears. A different candidate mid-window (escalation)
+  restarts the count; a reading equal to the committed state clears the
+  window without committing. Symmetric in both directions (recovery to
+  `ok` is confirmed too — deliberately unlike Nagios' immediate hard
+  recovery, because the observed flap's second nuisance mail was a
+  flapping all-clear); `unknown` participates like any state.
+
+The gate lives in the repository function — not the runner task — so
+runner-local and satellite-gateway batch-posted results are confirmed
+identically. Returns `True` iff the *committed* state changed. There is
+still no results history table — the projection (now including the
+soft-state window) is the single source of current state (**Decision D,
+annotated by #2799**: the consecutive-confirmation counter is carried
+as projection columns, the #2327 `skip_count` precedent, not derived
+from history). Downstream, `state_since` marks the *confirmed*
+transition instant, so a `for_seconds` hold measures confirmed time on
+top of confirmation — count-based commit gate first, duration-based
+fold hold second, two independent layers.
 
 **Delete** is a hard `DELETE` (no tombstone) — a sensor carries no
 fire-history the audit trail needs post-delete.
@@ -109,7 +141,8 @@ runner parking.
 - `meho_backplane.scheduler.cron` — `is_valid_cron_expr`, `resolve_timezone`,
   `next_fire_after` (shared with the scheduler).
 - `meho_backplane.operations._lookup` — descriptor resolution for the guard.
-- Migration `0064_create_sensor.py` (`down_revision="0063"`).
+- Migrations `0064_create_sensor.py` (`down_revision="0063"`) and
+  `0070_add_sensor_confirmation_retries.py` (#2799 columns).
 
 ## Known issues / boundaries
 


### PR DESCRIPTION
## Summary

- Adds per-sensor **state-confirmation retries** (Nagios soft/hard states): `retry_times` (0..5, default 0 = off) consecutive confirming re-evaluations are required after the first differing reading before a state change commits; `retry_backoff_seconds` (5..300, default 15) paces accelerated re-checks while a candidate is pending. Fixes the observed `capacity-physical` one-minute flap where one flaky `free_space` reading mailed `critical -> degraded` and `degraded -> ok` within a minute.
- The commit gate lives in `record_sensor_result` (`checks/repository.py`), so runner-local and satellite-gateway batch-posted results are confirmed identically; an unconfirmed reading never reaches the projection, so the rollup CAS, notifier, broadcaster, investigator, and advisory are gated upstream for free. Confirmation is symmetric (recovery to `ok` is confirmed too — the second nuisance mail was a flapping all-clear) and `unknown` participates like any state.
- Accelerated re-check is runner-local and restart-safe: a pending persist pulls `next_fire_at` to `min(next_fire_at, evaluated_at + retry_backoff_seconds)` via a conditional UPDATE (`accelerate_sensor_next_fire`) — no in-process sleep loops; the re-check rides the existing claim/advance/overlap machinery unchanged.
- Soft-state window is observable: new projection columns `pending_state` (CHECK over `CheckState` minus `skip`) + `pending_count`, exposed on `SensorRead` (the Prometheus `ALERTS`-pending rationale). All three transports accept the knobs: REST `SensorCreate`, MCP `meho_sensor_create` (inputSchema + description), Go CLI `--retry-times` / `--retry-backoff-seconds` (client regenerated via `make snapshot-openapi` + `make generate`).
- Migration `0070` follows the `0068` mould (`op.batch_alter_table('sensor')`, NOT NULL + server defaults, frozen inline vocabulary, reversible downgrade); `retry_times=0` backfill keeps every existing sensor behaviour-identical.

## Test plan

- [x] `ruff check src/ tests/` — clean; `ruff format --check` — clean
- [x] `mypy src/` — no issues in touched modules (one pre-existing darwin-only `socket.MSG_ERRQUEUE` complaint in untouched `connectors/net/icmp.py`; CI runs Linux where the symbol exists)
- [x] `pytest -n 3 --dist loadscope --ignore=tests/integration --ignore=tests/migrations tests/` — full unit suite green (AC: `retry_times=0` is behaviour-identical; only new-column plumbing in existing tests)
- [x] `pytest tests/migrations/` — green, including new `test_migration_0070_add_sensor_confirmation_retries.py` (columns + nullability, `retry_times=0` backfill, CHECK rejects `skip`, pinned downgrade→upgrade round-trip)
- [x] AC flake suppressed end-to-end: `test_flake_suppressed_end_to_end` — `ok -> degraded -> ok` with `retry_times=1`: `last_state` never leaves `ok`, no rollup edge claimed (memo unchanged), no notification spawned, `pending_state` visible then cleared
- [x] AC genuine transition: `test_gate_holds_soft_state_then_commits_after_retry_times` + `test_confirmed_transition_claims_one_edge_one_mail` — `retry_times=3`, four degraded readings commit exactly once; `state_since` = commit-time evaluation; one claimed edge, one mail; escalation restarts the count (`test_gate_escalation_mid_window_restarts_count`)
- [x] AC symmetric recovery: `test_gate_recovery_is_confirmed_symmetrically` + `test_recovery_flap_sends_no_all_clear`
- [x] AC accelerated pull: `test_pending_result_pulls_next_fire_to_backoff` (exactly `evaluated_at + backoff`), `test_pending_pull_never_delays_scheduled_fire` (min() semantics), `test_committed_result_does_not_accelerate`; existing runner tick tests green unchanged
- [x] AC gateway path: `test_gate_*` drive `record_sensor_result` directly, including the out-of-order `evaluated_at` monotonicity rejection before any pending mutation
- [x] AC transports: schema bounds via Pydantic (`ge/le`), MCP inputSchema (`additionalProperties: false` now admits the knobs), CLI `go build` + `go vet` + `gofmt` + full `go test ./...` green (wire-shape pins extended in `sensor_test.go`)
- [x] Docs updated: `docs/codebase/sensor.md` (Decision D annotation, commit rule, new columns), `checks-runner.md` (control flow + worst-case latency formula + satellite asymmetry), `checks-notifications.md` (three-layer composition with #2506/#2732), `checks-investigator.md` (what counts as an edge), `checks-broadcast.md` (fewer raw edges), `checks-advisory.md` (confirmation latency note)

## Out of scope

- #2756 (per-tick evidence retention) — open sibling on the same `record_sensor_result` seam; not landed on main, so its scope is not implemented here. Whichever lands second rebases keeping both semantics (pending evaluations still produce evidence rows).
- Nagios-style flap detection, Zabbix recovery-expression hysteresis, `for_seconds` semantics, the #2732 window, digests/batching, a sensor update/PATCH surface, and root-causing the triggering sensor's `$.datastores[0]` selection (per the ticket's out-of-scope list).
- Adjacent findings: `db/models.py` (6554 lines) and `mcp/tools/sensors.py` (418 lines) exceed the size warn thresholds pre-existing; `golangci-lint` unavailable locally (CI runs it).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2799

🤖 Generated with [Claude Code](https://claude.com/claude-code)
