### PR TITLE
fix(ci): python-coverage — step-level pytest timeout so a hang can't flip the run to 'cancelled'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,12 +530,22 @@ jobs:
     #     Remove the label once validated; routine PRs never carry it.
     #   * NON-REQUIRED + whole-job continue-on-error (#1987 AC5) — it is NOT
     #     in branch protection's required contexts, AND continue-on-error
-    #     means a coverage OOM/timeout reports the JOB as success, so it
-    #     never fails the overall CI run conclusion. That matters twice: a
-    #     red coverage job must not block merge (it can't — push runs after
-    #     merge — but defence in depth), and it must not flip the CI run's
-    #     `conclusion` to `failure`, which would suppress quality-gate.yml's
-    #     `workflow_run` (it only runs on `conclusion == 'success'`).
+    #     means a coverage-job FAILURE (OOM, red tests, step timeout)
+    #     reports the JOB as success, so it never fails the overall CI run
+    #     conclusion. That matters twice: a red coverage job must not block
+    #     merge (it can't — push runs after merge — but defence in depth),
+    #     and it must not flip the CI run's `conclusion` to `failure`,
+    #     which would suppress quality-gate.yml's `workflow_run` (it only
+    #     runs on `conclusion == 'success'`).
+    #     CAUTION (#2800): continue-on-error absorbs *failure* only —
+    #     cancellation leaks through. A JOB-level `timeout-minutes` expiry
+    #     CANCELS the job, and the `cancelled` conclusion propagated to the
+    #     whole run (observed three times on 2026-08-04, run 30902356757),
+    #     suppressing quality-gate.yml exactly like a `failure` would and
+    #     tripping docs/RELEASING.md's "cancelled ≠ green" pre-flight.
+    #     Hence the hang backstop lives on the pytest STEP (step timeout →
+    #     step failure → job failure → absorbed); the job-level cap is only
+    #     the outer backstop — see the timeout-minutes comment below.
     #
     # WHY OFFLINE COMBINE + LOW PARALLELISM (the memory story, measured for
     # #1987; methodology = #1982's: systemd-run --user --scope, cgroup
@@ -576,10 +586,20 @@ jobs:
     # Move this `runs-on:` to the new pool once provisioned. Until then an OOM
     # skips one coverage upload; quality-gate.yml now makes that skip
     # fail-visible via an error annotation (#2513).
-    # ~36-min serial wall + headroom. This job is push-only and non-blocking,
-    # so a long wall is acceptable (it never gates a PR). The cap is a hang
-    # backstop, not a perf budget.
-    timeout-minutes: 50
+    # Two-layer timeout (#2800). The hang backstop is the pytest step's own
+    # `timeout-minutes: 45` (~36-min serial wall + creep headroom): a step
+    # timeout is a step FAILURE (the runner kills the process and annotates
+    # "timed out after 45 minutes"), which the whole-job continue-on-error
+    # absorbs — run conclusion stays `success`. This job-level cap is
+    # strictly the OUTER backstop for a wedged non-pytest step (checkout /
+    # uv sync / model warm — never observed; both 2026-08-04 hangs were in
+    # pytest). It must stay comfortably above step cap + pre-pytest setup
+    # (35–75 s observed) + combine/upload (~15 s) so the step timeout
+    # always fires first for a pytest hang — a job-level expiry CANCELS
+    # the job, and `cancelled` leaks past continue-on-error into the run
+    # conclusion. Neither cap is a perf budget: the job is push-only and
+    # non-blocking, so a long wall never gates a PR.
+    timeout-minutes: 55
     continue-on-error: true
     env:
       # Surfaced as a job-level env var purely so the Docker Hub login
@@ -644,6 +664,12 @@ jobs:
             uv run python -c "from meho_backplane.redaction import get_engines; get_engines('en')"
 
       - name: Pytest (unit) with offline coverage data
+        # Hang backstop ON THE STEP (#2800): a step timeout kills the
+        # process and marks the step FAILED, which the job's
+        # continue-on-error absorbs. A job-level timeout would instead
+        # cancel the job and flip the whole run conclusion to `cancelled`
+        # (see the job-level timeout-minutes comment above).
+        timeout-minutes: 45
         env:
           MEHO_REDACTION_SPACY_MODEL: en_core_web_sm
           # Each xdist worker is a subprocess; coverage's a1_coverage.pth hook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,13 +530,14 @@ jobs:
     #     Remove the label once validated; routine PRs never carry it.
     #   * NON-REQUIRED + whole-job continue-on-error (#1987 AC5) — it is NOT
     #     in branch protection's required contexts, AND continue-on-error
-    #     means a coverage-job FAILURE (OOM, red tests, step timeout)
-    #     reports the JOB as success, so it never fails the overall CI run
-    #     conclusion. That matters twice: a red coverage job must not block
-    #     merge (it can't — push runs after merge — but defence in depth),
-    #     and it must not flip the CI run's `conclusion` to `failure`,
-    #     which would suppress quality-gate.yml's `workflow_run` (it only
-    #     runs on `conclusion == 'success'`).
+    #     means a coverage-job FAILURE (OOM, red tests, step timeout) is
+    #     absorbed: the job itself still reports conclusion `failure` (jobs
+    #     API, observed on run 30925197316), but it never fails the overall
+    #     CI run conclusion. That matters twice: a red coverage job must not
+    #     block merge (it can't — push runs after merge — but defence in
+    #     depth), and it must not flip the CI run's `conclusion` to
+    #     `failure`, which would suppress quality-gate.yml's `workflow_run`
+    #     (it only runs on `conclusion == 'success'`).
     #     CAUTION (#2800): continue-on-error absorbs *failure* only —
     #     cancellation leaks through. A JOB-level `timeout-minutes` expiry
     #     CANCELS the job, and the `cancelled` conclusion propagated to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,18 @@ connector-related release-notes line.
   `audit_and_broadcast_safe` → `write_audit_row` → `_build_audit_payload`,
   applied uniformly to every error arm. The params-only broadcast frame is
   unchanged; the never-raises and audit-fail-open contracts are preserved.
+- **A hung coverage-job pytest can no longer flip the whole CI run to
+  `cancelled`** (#2800): the push-only `python-coverage` job's hang backstop
+  moves from the job-level `timeout-minutes` — whose expiry *cancels* the job,
+  and cancellation (unlike failure) leaks past `continue-on-error` into the run
+  conclusion, suppressing quality-gate.yml's `workflow_run` trigger and
+  tripping the release pre-flight's "cancelled ≠ green" gate (observed three
+  times on 2026-08-04, run 30902356757) — to a step-level `timeout-minutes: 45`
+  on the pytest step. A step timeout is a step *failure*, absorbed by the job's
+  `continue-on-error: true`, so the run conclusion stays `success` and a
+  skipped coverage upload stays loud via the #2513 missing-artifact
+  annotation. The job-level cap rises to 55 min as the strictly-outer
+  backstop; the job stays non-required and non-blocking (#1987 AC5).
 
 ### Security
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -67,7 +67,11 @@ Choose the bump from what's in `[Unreleased]`:
 - [ ] **"cancelled" ≠ "green".** A cancelled CI run is *inconclusive*,
   not a pass. Merge-storm concurrency cancellation (a later push
   cancels an in-flight run on the same ref) is the common cause, and a
-  cancelled run reads green-ish in a glance — it is not. If the latest
+  cancelled run reads green-ish in a glance — it is not. (A hung
+  `python-coverage` job is *no longer* a cause: since #2800 a pytest
+  hang trips the step-level timeout and degrades to an absorbed job
+  failure with run conclusion `success`, so a `cancelled` main run
+  means a genuine cancel.) If the latest
   `main` run for the tagged commit is `cancelled`, **re-run it and wait
   for a real `success`** before tagging:
 

--- a/docs/codebase/sonarcloud.md
+++ b/docs/codebase/sonarcloud.md
@@ -33,7 +33,12 @@ the ~8.3k-test suite and barely moves with xdist worker count — see #1987 for 
 peak-memory measurement table. The coverage job is **job-level
 `continue-on-error: true`** so an OOM degrades to "no coverage for this push" and
 never fails the CI run conclusion (which would also suppress this gate's
-`workflow_run` trigger).
+`workflow_run` trigger). A pytest *hang* degrades the same way: the pytest step
+carries its own `timeout-minutes: 45` (step timeout → step failure → absorbed),
+because `continue-on-error` absorbs failure only — a job-level timeout expiry
+*cancels* the job, and a `cancelled` run conclusion leaks through and suppresses
+this gate just like a failure would (#2800, observed 2026-08-04). The job-level
+cap (55 min) is only the outer backstop for a wedged non-pytest step.
 
 | Concern | Where |
 |---|---|
@@ -67,7 +72,8 @@ chip is the only symptom.
 **24.9%** — and it stayed collapsed for 3+ weeks. Root cause: the
 `python-coverage` job was OOM-killed / evicted (runner lost, null step
 conclusions) at ~47 min on the memory-limited `meho-runners-ci-heavy` pool —
-*before* its 50-min timeout, so raising `timeout-minutes` is a no-op. The unit
+*before* its then-50-min job timeout (since #2800: a 45-min pytest step timeout
+inside a 55-min job cap), so raising `timeout-minutes` is a no-op. The unit
 lane had already dropped `--cov` for the same OOM reason (#1982), so this
 dedicated job was the sole coverage producer and nothing else caught the gap.
 


### PR DESCRIPTION
## Summary

- A hang in the push-only `python-coverage` job no longer flips the whole CI run conclusion to `cancelled`. The hang backstop moves from the job-level `timeout-minutes` (expiry **cancels** the job; cancellation — unlike failure — leaks past `continue-on-error` into the run conclusion) to a **step-level `timeout-minutes: 45`** on the pytest step: step timeout → step **failure** → job failure → absorbed by the existing whole-job `continue-on-error: true` → run conclusion stays `success`, quality-gate.yml's `workflow_run` still fires, and a skipped coverage upload stays loud via the #2513 missing-artifact annotation.
- The job-level cap rises 50 → 55 min as the strictly-outer backstop for a wedged non-pytest step (never observed; both 2026-08-04 hangs were in pytest). Step cap 45 + observed pre-pytest setup (35–75 s) + combine/upload (~15 s) means the step timeout always fires first for a pytest hang.
- Incident driving this: run [30902356757](https://github.com/evoila/meho/actions/runs/30902356757) (2026-08-04, merge commit `da1cc71b`) — three attempts, all concluded `cancelled`, 2h10m with zero conclusive CI verdict on main while v0.28.0 pre-flight was blocked.
- ci.yml design-intent comments updated to name the cancelled-vs-failure distinction; `docs/codebase/sonarcloud.md` + `docs/RELEASING.md` pre-flight note updated; CHANGELOG bullet under `[Unreleased]` → Fixed.

## Semantics (verified 2026-08-04)

- `jobs.<job_id>.timeout-minutes` — "The maximum number of minutes to let a job run before GitHub **automatically cancels it**" (github/docs, workflow-syntax reference).
- `jobs.<job_id>.steps[*].timeout-minutes` — "The maximum number of minutes to run the step before **killing the process**" (ibid.); the resulting step conclusion is **Failed**: `actions/runner` `src/Runner.Worker/StepsRunner.cs` sets `step.ExecutionContext.Result = TaskResult.Failed` with the annotation "The action '…' has timed out after N minutes" when the job cancellation token is not requested.
- `jobs.<job_id>.continue-on-error` — "Prevents a workflow run from failing when a job **fails**" (ibid.) — failure-only absorption; a job-cancel leaks through. That is the bug this PR fixes.

## Test plan

- [x] YAML validity + structural assertions (job cap 55, step cap 45, `continue-on-error: true` intact, combine `if: always()` + upload `hashFiles` guard untouched) — `yaml.safe_load` script, pass
- [x] `ruff check` / `ruff format --check` — clean (no Python files in the diff)
- [x] `mypy src/` — 1 pre-existing darwin-only artifact (`socket.MSG_ERRQUEUE`, Linux-only attr; file untouched); Linux CI authoritative
- [x] code-quality gate (`code-quality.py --diff`) — pass
- [x] Branch protection's required contexts confirmed to not include `Python coverage (SonarCloud)`; not modified by this PR
- [x] **On-runner hang validation (AC2)** via the `ci-coverage-validate` label path on throwaway PR #2807 — **PROVEN** on run [30925197316](https://github.com/evoila/meho/actions/runs/30925197316): induced hang → pytest step conclusion `failure` with the runner's "has timed out after 2 minutes" annotation → coverage job `failure` absorbed by `continue-on-error` → run conclusion **`success`** (attempt 2; attempt 1 proved the step/job legs but its run conclusion was contaminated by an unrelated Go-job 10-min job-cap cancellation — a sibling instance of this same bug class, noted for separate triage). Combine warn-skip + upload skip (no-data chain) exercised live. Full evidence table in [this comment](https://github.com/evoila/meho/pull/2806#issuecomment-5181629349). Throwaway PR closed unmerged, branch deleted.

## No-data chain (AC3, reasoned for the main-push case)

Once a hang is a step failure: combine (`if: always()`) warn-skips when no `.coverage.*` exists (ci.yml), the upload's `hashFiles('backend/coverage.xml')` guard skips cleanly, run conclusion `success` lets quality-gate.yml fire, and its "Assert python-coverage artifact present (fail-visible)" step (#2513) emits the error annotation — loud instead of invisible behind a suppressed workflow.

## Out of scope

- Root cause of the pytest hang itself (runner-pool resourcing `TODO(ops)` at the job's `runs-on:`) — per issue.
- The by-design merge-storm concurrency cancel (attempt 3's cause) — correct behavior, stays.
- #2740 (trivy 'report-only' misnomer) — tracked separately (PR #2803).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2800

🤖 Generated with [Claude Code](https://claude.com/claude-code)
