### PR TITLE
feat(connectors): numeric days_to_expiry on net.tls_inspect for cert-expiry sensors

### DIFF
--- a/backend/src/meho_backplane/connectors/net/tls.py
+++ b/backend/src/meho_backplane/connectors/net/tls.py
@@ -47,6 +47,7 @@ import ipaddress
 import select
 import socket
 import time
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -135,13 +136,30 @@ _CHAIN_ITEM_SCHEMA: dict[str, Any] = {
         },
         "not_before": {"type": "string", "description": "ISO 8601 UTC notBefore."},
         "not_after": {"type": "string", "description": "ISO 8601 UTC notAfter."},
+        "days_to_expiry": {
+            "type": "number",
+            "description": (
+                "Days from probe time until notAfter (notAfter - now, in days); "
+                "negative once the cert has expired. Point a threshold assertion "
+                "at it for cert-expiry early warning."
+            ),
+        },
         "serial": {"type": "string", "description": "Serial number as a decimal string."},
         "self_signed": {
             "type": "boolean",
             "description": "True iff subject == issuer (a root or self-signed leaf).",
         },
     },
-    "required": ["subject", "issuer", "san", "not_before", "not_after", "serial", "self_signed"],
+    "required": [
+        "subject",
+        "issuer",
+        "san",
+        "not_before",
+        "not_after",
+        "days_to_expiry",
+        "serial",
+        "self_signed",
+    ],
     "additionalProperties": False,
 }
 
@@ -188,6 +206,14 @@ _NET_TLS_INSPECT_RESPONSE_SCHEMA: dict[str, Any] = {
             "type": ["string", "null"],
             "description": "Leaf notAfter (ISO 8601 UTC) for the common 'is it expiring' read.",
         },
+        "days_to_expiry": {
+            "type": ["number", "null"],
+            "description": (
+                "Leaf days-to-expiry (notAfter - probe time, in days; negative once "
+                "expired); null on a failed handshake. A {type: threshold, op: lt} "
+                "assertion pointed here expresses cert-expiry early warning."
+            ),
+        },
         "hostname_match": {
             "type": "boolean",
             "description": (
@@ -211,6 +237,7 @@ _NET_TLS_INSPECT_RESPONSE_SCHEMA: dict[str, Any] = {
         "chain",
         "leaf",
         "not_after",
+        "days_to_expiry",
         "hostname_match",
         "chain_complete",
     ],
@@ -220,21 +247,24 @@ _NET_TLS_INSPECT_RESPONSE_SCHEMA: dict[str, Any] = {
 _NET_TLS_INSPECT_WHEN_TO_USE = (
     "Inspect the full TLS certificate chain an endpoint presents — the "
     "openssl 's_client -showcerts' read: 'what cert does the load "
-    "balancer serve on 443?', 'is this appliance's cert expired or "
-    "self-signed?', 'did the server send the intermediate?'. Verification "
-    "is OFF, so a self-signed / expired / mismatched cert is inspected and "
-    "reported, never rejected — the cert is the answer. A refused, "
-    "timed-out, or non-TLS endpoint is a normal result, not an error. The "
-    "destination must be inside MEHO_NETDIAG_PROBE_ALLOWLIST."
+    "balancer serve on 443?', 'is this appliance's cert expired, expiring "
+    "soon, or self-signed?', 'did the server send the intermediate?'. Each "
+    "presented cert carries days_to_expiry (float days until notAfter, "
+    "negative once expired), so a threshold assertion warns N days before a "
+    "cert expires. Verification is OFF, so a self-signed / expired / "
+    "mismatched cert is inspected and reported, never rejected — the cert "
+    "is the answer. A refused, timed-out, or non-TLS endpoint is a normal "
+    "result, not an error. The destination must be inside "
+    "MEHO_NETDIAG_PROBE_ALLOWLIST."
 )
 
 _NET_TLS_INSPECT_LLM_INSTRUCTIONS: dict[str, Any] = {
     "when_to_use": (
         "Use to read the certificate chain a TLS endpoint presents "
         "(leaf, intermediates, root-if-sent) without trusting it: chain "
-        "completeness, per-cert validity window, self-signed flags, and "
-        "whether the leaf matches a hostname. Read-only: no application "
-        "bytes are sent."
+        "completeness, per-cert validity window and days-to-expiry (for "
+        "cert-expiry early warning), self-signed flags, and whether the "
+        "leaf matches a hostname. Read-only: no application bytes are sent."
     ),
     "parameter_hints": {
         "host": "Required. Hostname or IP literal. Must be allowlisted for probing.",
@@ -244,13 +274,15 @@ _NET_TLS_INSPECT_LLM_INSTRUCTIONS: dict[str, Any] = {
     },
     "output_shape": (
         "On a completed handshake: {'handshake': true, 'reason': null, "
-        "'chain': [{subject, issuer, san, not_before, not_after, serial, "
-        "self_signed}, ...] (leaf-first), 'leaf': <chain[0]>, "
-        "'hostname_match': <bool>, 'chain_complete': <bool>, 'protocol': "
-        "<str>, 'cipher': <str>, 'not_after': <leaf notAfter>, 'host', "
-        "'port', 'server_name'}. On a refused / timed-out / non-TLS "
-        "endpoint: the same keys with handshake=false, reason set, chain=[] "
-        "and leaf=null — still a successful (status=ok) op."
+        "'chain': [{subject, issuer, san, not_before, not_after, "
+        "days_to_expiry, serial, self_signed}, ...] (leaf-first), 'leaf': "
+        "<chain[0]>, 'hostname_match': <bool>, 'chain_complete': <bool>, "
+        "'protocol': <str>, 'cipher': <str>, 'not_after': <leaf notAfter>, "
+        "'days_to_expiry': <leaf days-to-expiry, float; negative once "
+        "expired>, 'host', 'port', 'server_name'}. On a refused / "
+        "timed-out / non-TLS endpoint: the same keys with handshake=false, "
+        "reason set, chain=[], leaf=null and days_to_expiry=null — still a "
+        "successful (status=ok) op."
     ),
 }
 
@@ -359,13 +391,17 @@ def _leaf_hostname_match(cert: x509.Certificate, server_name: str) -> bool:
     return common_name is not None and _dns_name_matches([common_name], name)
 
 
-def _cert_to_dict(cert: x509.Certificate) -> dict[str, Any]:
+def _cert_to_dict(cert: x509.Certificate, now: datetime) -> dict[str, Any]:
     """Flatten one presented certificate into the audit-safe report shape.
 
     ``serial`` is stringified (a serial is a large integer that a JS
     consumer would silently truncate as a JSON number); timestamps use the
     tz-aware ``*_utc`` accessors (naive ``not_valid_after`` is deprecated
-    in ``cryptography``).
+    in ``cryptography``). ``days_to_expiry`` is ``(not_after - now)`` in
+    days (negative once expired) — a numeric field a threshold assertion
+    can bite on for cert-expiry early warning, computed against a single
+    probe-time *now* the caller injects so every cert in one chain shares
+    the same reference instant.
     """
     return {
         "subject": cert.subject.rfc4514_string(),
@@ -373,6 +409,7 @@ def _cert_to_dict(cert: x509.Certificate) -> dict[str, Any]:
         "san": _san_dns_names(cert) + _san_ip_addresses(cert),
         "not_before": cert.not_valid_before_utc.isoformat(),
         "not_after": cert.not_valid_after_utc.isoformat(),
+        "days_to_expiry": (cert.not_valid_after_utc - now).total_seconds() / 86400.0,
         "serial": str(cert.serial_number),
         "self_signed": cert.subject == cert.issuer,
     }
@@ -391,6 +428,7 @@ def _failure(host: str, port: int, server_name: str, reason: str) -> dict[str, A
         "chain": [],
         "leaf": None,
         "not_after": None,
+        "days_to_expiry": None,
         "hostname_match": False,
         "chain_complete": False,
     }
@@ -516,7 +554,8 @@ async def net_tls_inspect(
         # an OSError, so both bases are caught here.
         return _failure(host, port, server_name, _connect_failure_reason(exc))
 
-    chain_dicts = [_cert_to_dict(cert) for cert in chain]
+    now = datetime.now(UTC)
+    chain_dicts = [_cert_to_dict(cert, now) for cert in chain]
     leaf = chain_dicts[0] if chain_dicts else None
     hostname_match = bool(chain) and _leaf_hostname_match(chain[0], server_name)
     chain_complete = bool(chain) and (chain[-1].subject == chain[-1].issuer)
@@ -532,6 +571,7 @@ async def net_tls_inspect(
         "chain": chain_dicts,
         "leaf": leaf,
         "not_after": leaf["not_after"] if leaf else None,
+        "days_to_expiry": leaf["days_to_expiry"] if leaf else None,
         "hostname_match": hostname_match,
         "chain_complete": chain_complete,
     }

--- a/backend/tests/test_connectors_net_tls_inspect.py
+++ b/backend/tests/test_connectors_net_tls_inspect.py
@@ -40,9 +40,12 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
+from jsonschema import Draft202012Validator
 from sqlalchemy import select
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.checks.assertions import AssertionSpec, SelectSpec, ThresholdCompare
+from meho_backplane.checks.evaluate import evaluate_assertion
 from meho_backplane.connectors.net import tls as net_tls
 from meho_backplane.connectors.net.allowlist import PROBE_ALLOWLIST_ENV
 from meho_backplane.connectors.net.tls import (
@@ -618,3 +621,122 @@ def test_dns_name_wildcard_matching() -> None:
     assert net_tls._dns_name_matches(["*.example.com"], "example.com") is False
     assert net_tls._dns_name_matches(["*.example.com"], "a.b.example.com") is False
     assert net_tls._dns_name_matches(["Host.Example.com"], "host.example.com.") is True
+
+
+# ---------------------------------------------------------------------------
+# days_to_expiry — numeric cert-expiry signal (#2772)
+# ---------------------------------------------------------------------------
+
+
+async def test_days_to_expiry_present_on_leaf_and_every_chain_entry(
+    monkeypatch: pytest.MonkeyPatch,
+    multi_cert_server: _TLSServer,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """Success results carry a float days_to_expiry top-level, on the leaf, and per cert."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    result = await _dispatch_inspect(
+        {"host": "127.0.0.1", "port": multi_cert_server.port, "server_name": _LEAF_CN}
+    )
+    assert result.status == "ok", result.error
+    body = result.result
+    # Every presented cert carries a float days_to_expiry.
+    assert all(isinstance(entry["days_to_expiry"], float) for entry in body["chain"])
+    # Top-level aliases the leaf (chain[0]), which carries the same value.
+    assert isinstance(body["days_to_expiry"], float)
+    assert body["days_to_expiry"] == body["leaf"]["days_to_expiry"]
+    assert body["days_to_expiry"] == body["chain"][0]["days_to_expiry"]
+    # The multi-cert leaf is minted valid for 365 days from _NOW.
+    assert body["days_to_expiry"] == pytest.approx(365, abs=2)
+
+
+def test_cert_to_dict_days_to_expiry_arithmetic() -> None:
+    """days_to_expiry == (not_after - now) / 86400; a past-dated cert is negative."""
+    now = datetime.datetime.now(datetime.UTC)
+    key = _new_key()
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, _LEAF_CN)])
+
+    future = _sign(_LEAF_CN, key, name, key, not_after=now + datetime.timedelta(days=100))
+    future_dict = net_tls._cert_to_dict(future, now)
+    expected = (future.not_valid_after_utc - now).total_seconds() / 86400.0
+    assert future_dict["days_to_expiry"] == pytest.approx(expected)
+    # X.509 stores validity at 1-second granularity, so ~100 within a hair.
+    assert future_dict["days_to_expiry"] == pytest.approx(100.0, abs=0.001)
+
+    past = _sign(
+        _LEAF_CN,
+        key,
+        name,
+        key,
+        not_before=now - datetime.timedelta(days=400),
+        not_after=now - datetime.timedelta(days=30),
+    )
+    past_dict = net_tls._cert_to_dict(past, now)
+    assert past_dict["days_to_expiry"] < 0
+    assert past_dict["days_to_expiry"] == pytest.approx(-30.0, abs=0.001)
+
+
+async def test_success_and_failure_results_validate_against_response_schema(
+    monkeypatch: pytest.MonkeyPatch,
+    multi_cert_server: _TLSServer,
+    _registered_tls_inspect_op: None,
+) -> None:
+    """Both a success and a failure body round-trip through the response schema."""
+    schema = net_tls._NET_TLS_INSPECT_RESPONSE_SCHEMA
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    success = await _dispatch_inspect(
+        {"host": "127.0.0.1", "port": multi_cert_server.port, "server_name": _LEAF_CN}
+    )
+    assert success.status == "ok", success.error
+    validator.validate(success.result)  # raises ValidationError on non-conformance
+
+    # Empty allowlist (the autouse env clears it) ⇒ a refused, cert-less failure.
+    monkeypatch.delenv(PROBE_ALLOWLIST_ENV, raising=False)
+    failure = await _dispatch_inspect({"host": "10.9.9.9", "port": 8443})
+    assert failure.status == "ok", failure.error
+    assert failure.result["handshake"] is False
+    assert failure.result["days_to_expiry"] is None
+    validator.validate(failure.result)
+
+
+@pytest.mark.parametrize(
+    "days_out,expected_state",
+    [(45, "ok"), (20, "degraded"), (3, "critical")],
+    ids=["ok-above-30", "degraded-7-to-30", "critical-below-7"],
+)
+async def test_days_to_expiry_threshold_sensor_bands_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    _registered_tls_inspect_op: None,
+    days_out: int,
+    expected_state: str,
+) -> None:
+    """A real tls_inspect result drives the classic 30/7 cert-expiry threshold sensor.
+
+    End-to-end through :func:`evaluate_assertion` with the existing machinery
+    only: ``{select: $.days_to_expiry, compare: threshold lt degraded=30
+    critical=7}`` — no new comparator. Bands: ``>30`` ⇒ ok, ``(7, 30]`` ⇒
+    degraded, ``≤7`` ⇒ critical.
+    """
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    now = datetime.datetime.now(datetime.UTC)
+    server = _self_signed_server(tmp_path, not_after=now + datetime.timedelta(days=days_out))
+    try:
+        result = await _dispatch_inspect(
+            {"host": "127.0.0.1", "port": server.port, "server_name": _LEAF_CN}
+        )
+    finally:
+        server.stop()
+    assert result.status == "ok", result.error
+    body = result.result
+
+    spec = AssertionSpec(
+        select=SelectSpec(path="$.days_to_expiry"),
+        compare=ThresholdCompare(type="threshold", op="lt", degraded=30, critical=7),
+    )
+    outcome = evaluate_assertion(spec, body, now=datetime.datetime.now(datetime.UTC))
+    assert outcome.state == expected_state
+    assert outcome.value == body["days_to_expiry"]

--- a/docs/codebase/connectors-net-diagnostics.md
+++ b/docs/codebase/connectors-net-diagnostics.md
@@ -286,15 +286,28 @@ Control flow (`connectors/net/tls.py`):
    by `select`-waiting under a single `deadline` derived from the
    clamped timeout, so a stalled peer cannot pin the worker thread.
 4. Each presented cert is flattened to
-   `{subject, issuer, san, not_before, not_after, serial, self_signed}`
-   (leaf-first). `serial` is stringified (a serial is a large integer a
-   JSON number consumer would truncate); timestamps use the tz-aware
-   `not_valid_*_utc` accessors.
+   `{subject, issuer, san, not_before, not_after, days_to_expiry, serial,
+   self_signed}` (leaf-first). `serial` is stringified (a serial is a
+   large integer a JSON number consumer would truncate); timestamps use
+   the tz-aware `not_valid_*_utc` accessors. `days_to_expiry` is
+   `(not_valid_after_utc - now) / 86400` as a float (negative once
+   expired), computed against a single probe-time `now = datetime.now(UTC)`
+   the handler captures once and threads into `_cert_to_dict`, so every
+   cert in one chain shares the same reference instant. This is the
+   module's only wall-clock read (its other clock use is `time.monotonic()`
+   for the handshake deadline).
 
 Derived top-level fields:
 
 - `leaf` — convenience alias for `chain[0]`; `not_after` — the leaf's,
   for the common "is it expiring" read.
+- `days_to_expiry` — the leaf's `days_to_expiry` (float; `null` on a
+  failed handshake). A **numeric** cert-expiry signal a `threshold`
+  assertion can bite on, added by #2772: `not_after` is an ISO string
+  (nothing to compare numerically) and `FreshnessCompare` is
+  past-oriented (`age = now - timestamp`, so a future `not_after` reads
+  `ok` until the cert has *already* expired). See the cert-expiry sensor
+  recipe below.
 - `hostname_match` — computed **independently** of the (disabled) stack
   verification: `server_name` vs the leaf SAN dNSNames (wildcard-aware,
   RFC 6125 single-leftmost-label), SAN iPAddresses for an IP
@@ -310,6 +323,29 @@ a reason code — `not_in_probe_allowlist` / `timeout` / `refused` /
 `dns_failure` / `unreachable` / `tls_error` — and `status="ok"`), and is
 `safety_level="safe"` + `requires_approval=False`. A completed handshake
 sends **no** application bytes.
+
+### Cert-expiry early-warning sensor (#2772)
+
+`days_to_expiry` makes the classic "warn at 30 days, page at 7"
+cert-expiry sensor expressible with the **existing** assertion machinery —
+no new comparator. Point a `threshold` assertion at the field:
+
+```json
+{
+  "select": {"path": "$.days_to_expiry"},
+  "compare": {"type": "threshold", "op": "lt", "degraded": 30, "critical": 7}
+}
+```
+
+`ThresholdCompare` (`checks/evaluate.py`) bands it — `op=lt` is a strict
+`<` and `critical` is checked before `degraded`, so the more-severe band
+wins: `days_to_expiry >= 30` ⇒ `ok`, `7 <= days_to_expiry < 30` ⇒
+`degraded`, `days_to_expiry < 7` ⇒ `critical`. Because the field is on
+every chain entry, `{"select": {"path": "$.chain[*].days_to_expiry",
+"aggregate": "min"}, ...}` watches the soonest-expiring cert in the chain
+(an intermediate included) with the same comparator. `FreshnessCompare`
+stays untouched and past-oriented; the two are complementary, not
+alternatives.
 
 ## ICMP cohort — `net.ping` / `net.trace` / `net.path_mtu` (T6, #2411)
 


### PR DESCRIPTION
## Summary

- Cert-expiry early warning was inexpressible on `net.tls_inspect`: the op reported cert validity only as the ISO string `not_after` (nothing numeric for `ThresholdCompare` to bite on), and `FreshnessCompare` is deliberately past-oriented (`age = now - timestamp`), so pointed at a future `not_after` it stays `ok` until the cert has **already** expired.
- Derives a numeric `days_to_expiry` float — `(not_after - now) / 86400`, negative once expired — on **every** presented cert (leaf + intermediates), plus a top-level alias of the leaf's value beside the existing top-level `not_after`. Computed against a single probe-time `now` the handler captures once and threads into `_cert_to_dict`, so a whole chain shares one reference instant (an intermediate-expiry sensor becomes possible for free).
- The failure shape carries `days_to_expiry: null`, and the response schema is extended in lockstep (staying `additionalProperties: false`) so `search_operations` surfaces the field.
- **No new comparator.** The classic "warn at 30 days, page at 7" sensor now works with the existing machinery end-to-end: `{select: {path: "$.days_to_expiry"}, compare: {type: threshold, op: lt, degraded: 30, critical: 7}}`. `FreshnessCompare` and everything under `checks/` are untouched.

## Test plan

All gates run in the worktree under `backend/` (the CI commands):

- [x] `uv run ruff check src/ tests/` — clean on the changed files
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — no issues in the changed files (`tls.py` verified clean in isolation). One unrelated pre-existing error in the untouched `connectors/net/icmp.py` (`socket.MSG_ERRQUEUE` is Linux-only; a macOS-local false positive that is green on CI's Linux runners).
- [x] `uv run pytest tests/test_connectors_net_tls_inspect.py` — **25 passed** (19 pre-existing + 6 new)

New tests, one per acceptance criterion:

- [x] **AC1 (presence + schema round-trip)** — `test_days_to_expiry_present_on_leaf_and_every_chain_entry` (float top-level, on leaf, on every chain entry) and `test_success_and_failure_results_validate_against_response_schema` (a real success **and** a real failure body validate against the updated `Draft202012Validator` schema; failure carries `null`).
- [x] **AC2 (arithmetic)** — `test_cert_to_dict_days_to_expiry_arithmetic`: `days_to_expiry == (not_after - now) / 86400` within tolerance; a past-dated cert yields a negative value.
- [x] **AC3 (E2E banding)** — `test_days_to_expiry_threshold_sensor_bands_end_to_end`: real `tls_inspect` results (certs minted 45 / 20 / 3 days out) drive the 30/7 threshold assertion through `evaluate_assertion` → `ok` / `degraded` / `critical`.
- [x] **AC4 (checks untouched)** — no diff under `checks/` (only `tls.py`, its test, and the doc changed).
- [x] **AC5 (docs)** — `docs/codebase/connectors-net-diagnostics.md` documents the field, its probe-time-`now` computation, and the cert-expiry sensor recipe (incl. the `$.chain[*].days_to_expiry` + `min` intermediate-watch variant).

## Out of scope

- A future-oriented `FreshnessCompare` mode — the reporter's named alternative; larger surface (comparator vocabulary) for the same outcome.
- #2771 (`http_probe` `reachable=false`) — the other half of the reporter's blocked critical tier.
- Chain *validation* (OCSP, revocation, trust) — `days_to_expiry` is arithmetic on an already-reported field, nothing more.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2772
