### PR TITLE
fix(connectors): classify net.http_probe transport failures through ExceptionGroup + TLS-phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,27 @@ connector-related release-notes line.
 
 ### Fixed
 
+- **`net.http_probe` classifies transport failures instead of
+  collapsing them to `unreachable`** (#2771). The reason classifier now
+  walks the whole `httpx.TransportError` tree — both the `__cause__`
+  chain and `ExceptionGroup` children (PEP 654) — so a dual-stack
+  (happy-eyeballs) connect failure, whose real per-attempt errors anyio
+  nests in an `ExceptionGroup`, is mapped to `refused` / `dns_failure` /
+  `tls_error` rather than the uninformative `unreachable` it used to
+  return. When several inner causes disagree the most actionable wins
+  (`tls_error` > `dns_failure` > `refused` > `timeout` > `unreachable`).
+  TLS-phase handshake failures that carry no `ssl.SSLError` — the peer
+  closes or sends an alert, which httpcore's `start_tls` maps to
+  `ConnectError` via `anyio.EndOfStream` / `anyio.BrokenResourceError` —
+  now read `tls_error` on `https` probes, so an endpoint behind a
+  private CA the chart trust bundle does not know is finally
+  distinguishable from an unreachable host. Every connection-level
+  failure also carries a new bounded, innermost-first `error_detail`
+  (`[{type, message}]`) exposing the actual mapped exception chain —
+  evidence the op previously discarded, forcing operators to offer an
+  instrumented repro. `anyio` is promoted to a declared direct
+  dependency (already present transitively via httpx).
+
 - **MCP tools declaring an `outputSchema` now emit conforming
   `structuredContent`** (#2774). MCP 2025-06-18 §Tools/Output Schema
   mandates structured results for declaring tools, and Claude's frontend

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,14 @@ dependencies = [
     "prometheus-client>=0.26.0",
     "authlib>=1.3",
     "httpx>=0.27",
+    # httpx's async transport (httpcore) runs on anyio; the
+    # net.http_probe diagnostic op imports it directly to classify
+    # TLS-phase connect failures — httpcore's start_tls maps
+    # anyio.EndOfStream / anyio.BrokenResourceError to ConnectError with
+    # no ssl.SSLError in the cause chain (#2771). Already present
+    # transitively via httpx; declared direct so the connector's runtime
+    # requirement is explicit (same pattern as dnspython / cryptography).
+    "anyio>=4.0",
     "hvac>=2.4.0",
     "sqlalchemy[asyncio]>=2.0.51",
     "asyncpg>=0.29",

--- a/backend/src/meho_backplane/connectors/net/http_probe.py
+++ b/backend/src/meho_backplane/connectors/net/http_probe.py
@@ -51,8 +51,10 @@ import hashlib
 import socket
 import ssl
 import time
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Final
 
+import anyio
 import httpx
 import structlog
 
@@ -209,6 +211,26 @@ _NET_HTTP_PROBE_RESPONSE_SCHEMA: dict[str, Any] = {
                 "allowlist and never dialed; else null."
             ),
         },
+        "error_detail": {
+            "type": ["array", "null"],
+            "description": (
+                "On a connection-level failure, the actual mapped "
+                "exception chain as innermost-first {type, message} "
+                "entries (bounded, each message truncated) — the "
+                "evidence behind the 'reason' code. Null on a clean "
+                "response or a pre-dial refusal (not_in_probe_allowlist "
+                "/ invalid_url). Never contains the response body."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "type": {"type": "string"},
+                    "message": {"type": "string"},
+                },
+                "required": ["type", "message"],
+                "additionalProperties": False,
+            },
+        },
         "url": {"type": "string", "description": "The initially requested URL (audit-visible)."},
         "method": {"type": "string", "description": "The HTTP method issued."},
     },
@@ -224,6 +246,7 @@ _NET_HTTP_PROBE_RESPONSE_SCHEMA: dict[str, Any] = {
         "body_sha256",
         "final_url",
         "blocked_redirect",
+        "error_detail",
         "url",
         "method",
     ],
@@ -266,7 +289,9 @@ _NET_HTTP_PROBE_LLM_INSTRUCTIONS: dict[str, Any] = {
         "reason='blocked_redirect', blocked_redirect=<host>, and the "
         "host is never dialed. A connection failure: reachable=false "
         "with reason (timeout|dns_failure|refused|tls_error|unreachable "
-        "|not_in_probe_allowlist). Every case is status=ok. Never a body."
+        "|not_in_probe_allowlist) plus error_detail (innermost-first "
+        "[{type, message}], bounded) as the evidence behind reason. "
+        "Every case is status=ok. Never a body."
     ),
 }
 
@@ -301,6 +326,7 @@ def _result(
     body_sha256: str | None = None,
     final_url: str | None = None,
     blocked_redirect: str | None = None,
+    error_detail: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """Build the flat result payload (every key present, nulls where N/A).
 
@@ -320,6 +346,7 @@ def _result(
         "body_sha256": body_sha256,
         "final_url": final_url,
         "blocked_redirect": blocked_redirect,
+        "error_detail": error_detail,
         "url": url,
         "method": method,
     }
@@ -401,28 +428,127 @@ async def _consume_body_size_and_hash(response: httpx.Response) -> tuple[int, st
     return size, hasher.hexdigest()
 
 
-def _reason_for_transport_error(exc: httpx.TransportError) -> str:
+#: Priority order for transport-failure reason codes when one failure
+#: surfaces several inner causes at once (e.g. a dual-stack probe whose
+#: IPv6 attempt was refused while the IPv4 attempt hit a TLS error). The
+#: most specific/actionable code wins; ``unreachable`` is the implicit
+#: floor returned when nothing above matches.
+_TRANSPORT_REASON_PRIORITY: Final[tuple[str, ...]] = (
+    "tls_error",
+    "dns_failure",
+    "refused",
+    "timeout",
+)
+#: Bounds on the ``error_detail`` evidence list — at most this many
+#: innermost exceptions, each message truncated to this many characters.
+_MAX_ERROR_DETAIL_ENTRIES: Final[int] = 6
+_MAX_ERROR_DETAIL_MESSAGE_CHARS: Final[int] = 200
+
+
+def _iter_exception_tree(exc: BaseException) -> Iterator[BaseException]:
+    """Yield *exc* and every exception reachable from it, each once.
+
+    Follows two edges: the ``__cause__`` chain (``raise X from Y`` — how
+    httpcore/httpx re-wrap the underlying OS/TLS error) and, for an
+    :class:`ExceptionGroup` / :class:`BaseExceptionGroup`, its
+    ``.exceptions`` children (PEP 654). anyio raises
+    ``OSError("All connection attempts failed") from ExceptionGroup(...)``
+    on a multi-address (happy-eyeballs) connect, so the real per-attempt
+    errors live in the group's children, not on ``__cause__`` — walking
+    both edges is what stops them collapsing to ``unreachable``. An
+    ``id``-based seen-set guards against ``__cause__`` cycles.
+    """
+    stack: list[BaseException] = [exc]
+    seen: set[int] = set()
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        yield node
+        if node.__cause__ is not None:
+            stack.append(node.__cause__)
+        if isinstance(node, BaseExceptionGroup):
+            stack.extend(node.exceptions)
+
+
+def _reason_for_transport_error(exc: httpx.TransportError, *, tls: bool) -> str:
     """Map an httpx transport error to a probe reason code.
 
-    Walks the exception's ``__cause__`` chain to the underlying OS/TLS
-    error so DNS, TLS, and connection-refused failures each get a
-    distinct code rather than collapsing to ``unreachable``.
+    Walks the whole exception tree (``__cause__`` **and**
+    ``ExceptionGroup`` children — see :func:`_iter_exception_tree`) and
+    classifies each node by type, so DNS, TLS, and connection-refused
+    failures each get a distinct code instead of collapsing to
+    ``unreachable``. When several inner causes disagree the most
+    specific/actionable wins, per :data:`_TRANSPORT_REASON_PRIORITY`
+    (``tls_error`` > ``dns_failure`` > ``refused`` > ``timeout`` >
+    ``unreachable``).
+
+    TLS-phase failures that carry **no** ``ssl.SSLError`` are caught too:
+    httpcore's ``start_tls`` maps ``anyio.EndOfStream`` and
+    ``anyio.BrokenResourceError`` to ``ConnectError`` when the peer
+    closes or sends an alert mid-handshake (verified against
+    httpcore 1.0.9 / anyio 4.13.0). ``EndOfStream`` is start_tls-only,
+    but ``BrokenResourceError`` is *also* mapped by ``connect_tcp`` — so
+    it only reads ``tls_error`` when *tls* is set (the probe URL was
+    ``https``); on plain HTTP there is no handshake to blame and it stays
+    ``unreachable``.
     """
-    cause: BaseException | None = exc
-    seen: set[int] = set()
-    while cause is not None and id(cause) not in seen:
-        seen.add(id(cause))
-        if isinstance(cause, ssl.SSLError):
-            return "tls_error"
-        if isinstance(cause, socket.gaierror):
-            return "dns_failure"
-        if isinstance(cause, ConnectionRefusedError):
-            return "refused"
-        cause = cause.__cause__
-    # No recognised inner cause — classify by the httpx type.
-    if isinstance(exc, httpx.ConnectTimeout | httpx.ReadTimeout | httpx.TimeoutException):
-        return "timeout"
+    reasons: set[str] = set()
+    for node in _iter_exception_tree(exc):
+        if isinstance(node, ssl.SSLError):
+            reasons.add("tls_error")
+        elif isinstance(node, socket.gaierror):
+            reasons.add("dns_failure")
+        elif isinstance(node, ConnectionRefusedError):
+            reasons.add("refused")
+        elif isinstance(node, TimeoutError):
+            reasons.add("timeout")
+        elif tls and isinstance(node, (anyio.EndOfStream, anyio.BrokenResourceError)):
+            reasons.add("tls_error")
+    if isinstance(exc, httpx.TimeoutException):
+        reasons.add("timeout")
+    for reason in _TRANSPORT_REASON_PRIORITY:
+        if reason in reasons:
+            return reason
     return "unreachable"
+
+
+def _exc_type_name(exc: BaseException) -> str:
+    """Readable type label for the evidence detail (``module.Qual``).
+
+    Drops the noisy ``builtins.`` prefix so a refused connect reads
+    ``ConnectionRefusedError`` rather than
+    ``builtins.ConnectionRefusedError``, while a library type keeps its
+    module (``anyio.EndOfStream``, ``httpx.ConnectError``) for
+    unambiguous attribution.
+    """
+    cls = type(exc)
+    if cls.__module__ in ("builtins", "__main__"):
+        return cls.__qualname__
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _error_detail(exc: BaseException) -> list[dict[str, str]]:
+    """Bounded, innermost-first ``[{type, message}]`` of *exc*'s tree.
+
+    The classifier collapses a failure to one closed-enum ``reason``;
+    this rides alongside it so a caller sees the *actual* mapped
+    exception chain without re-running the probe under instrumentation.
+    Innermost-first (the leaf cause is the most actionable), capped at
+    :data:`_MAX_ERROR_DETAIL_ENTRIES` entries with each message truncated
+    to :data:`_MAX_ERROR_DETAIL_MESSAGE_CHARS` — exception type + message
+    only, never the response body.
+    """
+    nodes = list(_iter_exception_tree(exc))
+    nodes.reverse()
+    detail: list[dict[str, str]] = []
+    for node in nodes[:_MAX_ERROR_DETAIL_ENTRIES]:
+        message = str(node)
+        if len(message) > _MAX_ERROR_DETAIL_MESSAGE_CHARS:
+            message = message[:_MAX_ERROR_DETAIL_MESSAGE_CHARS] + "..."
+        detail.append({"type": _exc_type_name(node), "message": message})
+    return detail
 
 
 async def _walk_redirects(
@@ -593,21 +719,23 @@ async def net_http_probe(operator: Operator, target: Any, params: dict[str, Any]
                 _walk_redirects(client=client, url=url, method=method, started=started),
                 timeout=timeout,
             )
-    except (TimeoutError, httpx.TimeoutException):
+    except (TimeoutError, httpx.TimeoutException) as exc:
         return _result(
             url=url,
             method=method,
             reachable=False,
             reason="timeout",
             timing_ms=_elapsed_ms(started),
+            error_detail=_error_detail(exc),
         )
     except httpx.TransportError as exc:
         return _result(
             url=url,
             method=method,
             reachable=False,
-            reason=_reason_for_transport_error(exc),
+            reason=_reason_for_transport_error(exc, tls=parsed.scheme == "https"),
             timing_ms=_elapsed_ms(started),
+            error_detail=_error_detail(exc),
         )
 
 
@@ -647,7 +775,10 @@ async def register_net_http_probe_operations(
             "⇒ the connector is inert). A refused, timed-out, DNS-failed, "
             "TLS-failed, or redirect-blocked probe returns reachable "
             "with a reason code and status=ok — a failed probe is the "
-            "product, never a connector error."
+            "product, never a connector error. A connection-level "
+            "failure also carries error_detail: the actual mapped "
+            "exception chain (innermost-first {type, message}, bounded) "
+            "behind the reason code."
         ),
         parameter_schema=NET_HTTP_PROBE_PARAMETER_SCHEMA,
         response_schema=_NET_HTTP_PROBE_RESPONSE_SCHEMA,

--- a/backend/tests/test_connectors_net_http_probe.py
+++ b/backend/tests/test_connectors_net_http_probe.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import socket
+import ssl
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -35,6 +37,8 @@ from typing import Any
 from unittest.mock import AsyncMock
 from uuid import UUID
 
+import anyio
+import httpx
 import pytest
 from sqlalchemy import select
 
@@ -265,6 +269,8 @@ async def test_probe_reports_surface_and_never_returns_a_body(
     assert body["body_size"] == len(b"hello-body")
     assert body["body_sha256"] == hashlib.sha256(b"hello-body").hexdigest()
     assert body["final_url"] == f"{srv.origin}/health"
+    # A clean response carries no failure evidence.
+    assert body["error_detail"] is None
 
 
 async def test_head_probe_reports_no_body_bytes(
@@ -448,6 +454,10 @@ async def test_connection_refused_is_ok_status_with_reason(
     assert body["reachable"] is False
     assert body["reason"] in {"refused", "unreachable"}
     assert body["status"] is None
+    # AC3: a connection-level failure carries the mapped exception chain
+    # as bounded innermost-first {type, message} evidence.
+    assert isinstance(body["error_detail"], list) and body["error_detail"]
+    assert all({"type", "message"} == set(entry) for entry in body["error_detail"])
 
 
 @pytest.mark.parametrize(
@@ -504,3 +514,171 @@ async def test_method_enum_rejects_non_head_get_at_schema_boundary(
     result = await _dispatch_probe({"url": "http://127.0.0.1/x", "method": "POST"})
     assert result.status == "error"
     assert result.extras.get("error_code") == "invalid_params"
+
+
+# ---------------------------------------------------------------------------
+# Transport-failure taxonomy (#2771): classify through ExceptionGroup
+# children + TLS-phase mappings instead of collapsing to 'unreachable'
+# ---------------------------------------------------------------------------
+
+_classify = net_http_probe_mod._reason_for_transport_error
+_detail = net_http_probe_mod._error_detail
+
+
+def _anyio_multi_connect_error(children: list[Exception]) -> httpx.ConnectError:
+    """Rebuild the anyio happy-eyeballs multi-address failure shape.
+
+    ``httpx.ConnectError ← OSError("All connection attempts failed") ←
+    ExceptionGroup(children)`` — exactly what anyio 4.13 raises when more
+    than one address (dual-stack A+AAAA) is tried and every attempt
+    fails, then httpcore/httpx re-wrap. The per-attempt errors live in
+    the group's ``.exceptions``, not on ``__cause__``.
+    """
+    group = ExceptionGroup("multiple connection attempts failed", children)
+    os_err = OSError("All connection attempts failed")
+    os_err.__cause__ = group
+    connect_err = httpx.ConnectError("All connection attempts failed")
+    connect_err.__cause__ = os_err
+    return connect_err
+
+
+@pytest.mark.parametrize(
+    ("children", "expected"),
+    [
+        pytest.param(
+            [ConnectionRefusedError(111, "refused"), ConnectionRefusedError(111, "refused")],
+            "refused",
+            id="dual-stack-refused",
+        ),
+        pytest.param(
+            [socket.gaierror(-2, "Name or service not known")],
+            "dns_failure",
+            id="gaierror",
+        ),
+        pytest.param([ssl.SSLError("handshake failure")], "tls_error", id="sslerror"),
+    ],
+)
+def test_group_children_are_classified_not_collapsed(
+    children: list[Exception], expected: str
+) -> None:
+    """A ConnectError whose real causes sit in an ExceptionGroup gets the
+    specific code (refused/dns_failure/tls_error), never 'unreachable'.
+
+    ``tls=False`` proves the classification comes from the group
+    children, not from the https TLS-phase hint.
+    """
+    assert _classify(_anyio_multi_connect_error(children), tls=False) == expected
+
+
+@pytest.mark.parametrize(
+    ("children", "expected"),
+    [
+        pytest.param(
+            [ConnectionRefusedError(111, "refused"), ssl.SSLError("alert")],
+            "tls_error",
+            id="tls-beats-refused",
+        ),
+        pytest.param(
+            [ConnectionRefusedError(111, "refused"), socket.gaierror(-2, "nxdomain")],
+            "dns_failure",
+            id="dns-beats-refused",
+        ),
+    ],
+)
+def test_priority_picks_most_actionable_when_children_disagree(
+    children: list[Exception], expected: str
+) -> None:
+    """Children disagreeing → priority tls_error > dns_failure > refused
+    > timeout > unreachable decides (the reporter's v6-refused +
+    v4-TLS-error case)."""
+    assert _classify(_anyio_multi_connect_error(children), tls=False) == expected
+
+
+@pytest.mark.parametrize(
+    "cert_error",
+    [
+        ssl.SSLCertVerificationError("certificate verify failed: unable to get local issuer"),
+        ssl.SSLError("certificate verify failed"),
+    ],
+)
+def test_untrusted_ca_classifies_tls_error(cert_error: ssl.SSLError) -> None:
+    """AC4: an https endpoint behind a private CA the trust bundle does
+    not know reads tls_error, whether the verify failure arrives as a
+    dual-stack group child or a direct ``__cause__``."""
+    assert _classify(_anyio_multi_connect_error([cert_error]), tls=True) == "tls_error"
+
+    direct = httpx.ConnectError("verify failed")
+    direct.__cause__ = cert_error
+    assert _classify(direct, tls=True) == "tls_error"
+
+
+@pytest.mark.parametrize("inner", [anyio.BrokenResourceError(), anyio.EndOfStream()])
+def test_tls_phase_stream_failure_on_https_is_tls_error(inner: Exception) -> None:
+    """AC2: a start_tls-phase failure (peer closed / sent an alert
+    mid-handshake) reaches us as a ConnectError wrapping anyio
+    BrokenResourceError / EndOfStream with no ssl.SSLError — on an https
+    probe that is tls_error, not unreachable."""
+    exc = httpx.ConnectError("")
+    exc.__cause__ = inner
+    assert _classify(exc, tls=True) == "tls_error"
+
+
+def test_broken_resource_on_plain_http_stays_unreachable() -> None:
+    """The scheme gate: httpcore's connect_tcp also maps
+    BrokenResourceError, so on a plain-HTTP probe (no handshake) it must
+    NOT read tls_error."""
+    exc = httpx.ConnectError("")
+    exc.__cause__ = anyio.BrokenResourceError()
+    assert _classify(exc, tls=False) == "unreachable"
+
+
+def test_plain_oserror_connect_failure_is_unreachable_not_tls() -> None:
+    """A generic connect OSError (e.g. EHOSTUNREACH 'no route to host')
+    on https stays unreachable — the TLS-phase logic must not sweep every
+    unrecognised https failure into tls_error."""
+    exc = httpx.ConnectError("")
+    exc.__cause__ = OSError(113, "No route to host")
+    assert _classify(exc, tls=True) == "unreachable"
+
+
+def test_cause_cycle_terminates() -> None:
+    """The id-based seen-set guards a ``__cause__`` cycle (no hang)."""
+    outer = httpx.ConnectError("outer")
+    inner = OSError("inner")
+    outer.__cause__ = inner
+    inner.__cause__ = outer
+    assert _classify(outer, tls=False) == "unreachable"
+
+
+def test_error_detail_is_innermost_first_bounded_and_shaped() -> None:
+    """AC3: error_detail is innermost-first {type, message} evidence."""
+    detail = _detail(
+        _anyio_multi_connect_error([ConnectionRefusedError(111, "Connection refused")])
+    )
+    assert detail
+    assert all(set(entry) == {"type", "message"} for entry in detail)
+    # Leaf cause first (most actionable), outer httpx wrapper last.
+    assert detail[0]["type"] == "ConnectionRefusedError"
+    assert detail[-1]["type"] == "httpx.ConnectError"
+
+
+def test_error_detail_caps_entries_and_truncates_messages() -> None:
+    """Deep chains and long messages are bounded so a probe result never
+    carries an unbounded exception dump."""
+    current: BaseException = OSError("x" * 500)
+    for _ in range(20):
+        wrapper = OSError("wrap")
+        wrapper.__cause__ = current
+        current = wrapper
+    detail = _detail(current)
+    assert len(detail) <= net_http_probe_mod._MAX_ERROR_DETAIL_ENTRIES
+    # Innermost (the long leaf message) is first and truncated.
+    assert detail[0]["message"].endswith("...")
+    assert len(detail[0]["message"]) <= net_http_probe_mod._MAX_ERROR_DETAIL_MESSAGE_CHARS + 3
+
+
+def test_response_schema_declares_error_detail() -> None:
+    """The evidence field is part of the documented result contract."""
+    schema = net_http_probe_mod._NET_HTTP_PROBE_RESPONSE_SCHEMA
+    assert "error_detail" in schema["properties"]
+    assert "error_detail" in schema["required"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1405,6 +1405,7 @@ version = "0.1.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "anyio" },
     { name = "asyncpg" },
     { name = "asyncssh" },
     { name = "authlib" },
@@ -1469,6 +1470,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.5" },
+    { name = "anyio", specifier = ">=4.0" },
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "asyncssh", specifier = ">=2.24.0,<3.0" },
     { name = "authlib", specifier = ">=1.3" },

--- a/docs/codebase/connectors-net-diagnostics.md
+++ b/docs/codebase/connectors-net-diagnostics.md
@@ -193,8 +193,37 @@ subject/issuer/`notAfter` (public identity, never private material);
 before the handler runs. Reason codes extend the T1 set with
 `invalid_url`, `blocked_redirect`, `too_many_redirects`, and `tls_error`.
 
+**Transport-failure classification (#2771).** A connection-level failure
+is mapped to its reason code by walking the caught `httpx.TransportError`
+*tree* — both the `__cause__` chain **and** any `ExceptionGroup`
+children (`.exceptions`, PEP 654) — not just `__cause__`. This matters
+because anyio's happy-eyeballs connect raises `OSError("All connection
+attempts failed") from ExceptionGroup(...)` on a multi-address (dual-stack
+A+AAAA) host, so the real per-attempt errors (`ConnectionRefusedError`,
+`socket.gaierror`, `ssl.SSLError`) sit in the group's children, invisible
+to a `__cause__`-only walk — which is why they used to collapse to
+`unreachable`. When several inner causes disagree, the most
+specific/actionable wins: `tls_error` > `dns_failure` > `refused` >
+`timeout` > `unreachable`. TLS-phase failures that carry **no**
+`ssl.SSLError` are also caught: httpcore's `start_tls` maps
+`anyio.EndOfStream` / `anyio.BrokenResourceError` to `ConnectError` when
+the peer closes or sends an alert mid-handshake; `EndOfStream` is
+start_tls-only, and `BrokenResourceError` is disambiguated by the probe
+scheme (it only reads `tls_error` on `https`, since `connect_tcp` also
+maps it). Every connection-level failure additionally carries
+`error_detail` — a bounded, innermost-first `[{type, message}]` of the
+mapped exception chain (exception type + message only, never the response
+body) — so a caller sees the actual inner error without re-running the
+probe under instrumentation. `error_detail` is `null` on a clean response
+or a pre-dial refusal (`not_in_probe_allowlist` / `invalid_url`).
+
 Because it issues an HTTP request, `net.http_probe` adds **`httpx`** to
-the family's dependency surface (already a project dep — no new dep).
+the family's dependency surface (already a project dep). It also imports
+**`anyio`** directly (httpx's async transport backend) to `isinstance`
+the TLS-phase stream exceptions above; anyio is already present
+transitively via httpx and is now declared a direct dependency in
+`backend/pyproject.toml` so the requirement is explicit (same pattern as
+`dnspython` / `cryptography`).
 
 ## `net.ntp_check` — clock offset/skew + stratum (T5, #2410)
 
@@ -462,8 +491,12 @@ audit (`raw_payload` = handler return) → broadcast (`read` class).
   declared runtime dependency (the handler imports `cryptography.x509`
   directly).
 - `net.http_probe`: `httpx` (already a project dependency) for the HTTP
-  request and its `network_stream` TLS extension — no **new** runtime
-  dependency is added.
+  request and its `network_stream` TLS extension, plus **`anyio`**
+  (httpx's async backend, promoted from transitive to a declared direct
+  dependency, #2771) — imported to `isinstance` the TLS-phase stream
+  exceptions (`anyio.EndOfStream` / `anyio.BrokenResourceError`) when
+  classifying a transport failure. No **new** package enters the resolved
+  set (anyio was already installed via httpx).
 - `net.dns_lookup`: **dnspython** (ISC-licensed, already present
   transitively via `email-validator` / `pymongo`; pinned direct in
   `backend/pyproject.toml` so the connector's requirement is explicit) —


### PR DESCRIPTION
## Summary

- `net.http_probe` no longer collapses every connection-level failure to
  `reason="unreachable"`. The classifier now walks the **whole**
  `httpx.TransportError` tree — `__cause__` **and** `ExceptionGroup`
  children (PEP 654) — so a dual-stack (happy-eyeballs) connect failure,
  whose real per-attempt errors anyio nests in an `ExceptionGroup`
  (`OSError("All connection attempts failed") from ExceptionGroup(...)`),
  is mapped to `refused` / `dns_failure` / `tls_error`. When inner causes
  disagree, the most actionable wins: `tls_error` > `dns_failure` >
  `refused` > `timeout` > `unreachable`.
- **TLS-phase** handshake failures that carry no `ssl.SSLError` (peer
  closes / sends an alert — httpcore's `start_tls` maps
  `anyio.EndOfStream` / `anyio.BrokenResourceError` to `ConnectError`)
  now read `tls_error` on `https` probes. `EndOfStream` is
  start_tls-exclusive; `BrokenResourceError` is scheme-gated because
  `connect_tcp` also maps it (verified against httpcore 1.0.9 /
  anyio 4.13.0). A plain `OSError` connect failure (e.g. `EHOSTUNREACH`)
  still reads `unreachable`.
- Failure results now carry **`error_detail`** — a bounded,
  innermost-first `[{type, message}]` of the mapped exception chain
  (exception type + message only, never the response body) — so the
  actual inner error is visible without an instrumented repro. The
  `reason` enum is unchanged; the field is additive (response schema,
  tool description, and `llm_instructions` updated).
- `anyio` promoted from transitive (via httpx) to a **declared direct
  dependency** for the `isinstance` checks — resolution-neutral (already
  pinned 4.13.0), mirroring the dnspython / cryptography precedent.
  `docs/codebase/connectors-net-diagnostics.md` + CHANGELOG updated.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (strict) — clean
- [x] `pytest backend/tests -k http_probe` — 29 passed (16 existing stay
  green: redirect gating, allowlist, timeout, anti-exfil — AC5)
- [x] `pytest backend/tests/test_connectors_net_probe.py` — 17 passed
  (sibling net-package regression check)
- [x] `code-quality.py --diff` — 0 blockers
- [x] `uv sync --locked` — lock matches pyproject

Acceptance criteria:

- [x] **AC1** dual-stack `ExceptionGroup` children →
  `refused` / `dns_failure` / `tls_error`, not `unreachable`
  (`test_group_children_are_classified_not_collapsed`,
  `test_priority_picks_most_actionable_when_children_disagree`)
- [x] **AC2** TLS-phase `BrokenResourceError` / `EndOfStream` `ConnectError`
  → `tls_error` (stage attribution proved feasible — not dropped)
  (`test_tls_phase_stream_failure_on_https_is_tls_error`,
  `test_broken_resource_on_plain_http_stays_unreachable`)
- [x] **AC3** failure results carry bounded `error_detail`; schema + tool
  description updated (`test_error_detail_*`,
  `test_response_schema_declares_error_detail`, refused-probe integration
  assertion)
- [x] **AC4** untrusted-CA scenario classifies `tls_error`
  (`test_untrusted_ca_classifies_tls_error`, both group-child and
  direct-cause `SSLCertVerificationError`). Live re-verification against
  the appliance is the reporter's tracking-thread channel per the issue.
- [x] **AC5** existing http_probe tests stay green

## Out of scope

- TLS-trust override for probes (verify-skip / CA-pin, or honouring a
  matching target's `verify_tls` / `tls_ca_pin`) — a separate
  security-surface enhancement per the issue; file separately.
- Other `net.*` ops; any httpx/anyio version bump.

## Adjacent findings (recorded, not fixed — out of scope for this bug)

- `http_probe.py` is 791 lines (>600 soft limit) — pre-existing (was
  already 660 before this change); splitting the module is a separate
  refactor. `_walk_redirects` (113 lines) pre-exists; `net_http_probe`
  (71 lines) is under the 100 hard limit.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2771
