### PR TITLE
feat(checks): persist per-tick sensor evidence + retention-bounded trend query (#2756)

### DIFF
--- a/backend/alembic/versions/0071_create_sensor_results.py
+++ b/backend/alembic/versions/0071_create_sensor_results.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``sensor_results`` per-tick evidence-history table.
+
+Revision ID: 0071
+Revises: 0070
+Create Date: 2026-08-04
+
+Task #2756 under Initiative #2780 (parent goal #221). The check layer's
+:class:`~meho_backplane.db.models.Sensor` carries only a latest-state
+projection (``last_state`` / ``last_value`` / ``last_evidence`` /
+``last_evaluated_at``); every tick overwrites it, so the history the runner
+already computed was discarded. A post-incident review needed "when did this
+first flap / how fast is it filling" and had nothing to read. This migration
+adds the append-only history table that
+:func:`~meho_backplane.checks.repository.record_sensor_result` writes to, in
+the same transaction as the projection update, when
+``CHECKS_EVIDENCE_RETENTION_DAYS > 0``.
+
+What this migration adds
+------------------------
+
+* The ``sensor_results`` table -- one append-only row per completed (non-stale)
+  evaluation: ``(sensor_id, evaluated_at, state, value, evidence, reason)``.
+* Two indexes:
+  * ``sensor_results_sensor_evaluated_idx`` -- b-tree on
+    ``(sensor_id, evaluated_at)`` drives the trend query
+    (``WHERE sensor_id = ? ... ORDER BY evaluated_at ASC`` + the keyset
+    ``evaluated_at > :cursor``).
+  * ``sensor_results_evaluated_at_idx`` -- b-tree on ``evaluated_at`` lets the
+    retention sweep range-scan ``WHERE evaluated_at < cutoff`` instead of
+    seq-scanning (the composite above leads with ``sensor_id``).
+
+Cascade delete
+--------------
+
+``sensor_id`` is a real ``REFERENCES sensor(id)`` FK with
+``ON DELETE CASCADE`` -- deleting a Sensor drops its history, the same
+discipline the ``check_dashboard_sensors`` membership join (migration
+``0065``) uses off ``sensor.id``. The #2756 acceptance criterion pins this
+choice (cascade, not tombstone).
+
+Closed enum
+-----------
+
+``state`` is the five-state check vocabulary declared once in #2504's
+``meho_backplane.checks.assertions.CheckState``; the literal tuple below is a
+frozen independent snapshot, drift-guarded against ``CheckState`` in
+``tests.test_db_sensor_results`` -- the same discipline ``sensor.last_state``
+(migration ``0064``) follows.
+
+Dialect portability
+-------------------
+
+Mirrors migration ``0064``:
+
+* ``id`` server default -- PG gets ``gen_random_uuid()``; SQLite leaves the
+  column to the ORM ``default=uuid.uuid4``.
+* ``value`` / ``evidence`` -- portable ``JSON`` -> ``JSONB`` variant with
+  ``none_as_null=True`` so a Python ``None`` round-trips as SQL NULL.
+
+Reversibility contract
+----------------------
+
+Purely additive forward (a new table + its indexes), so a ``helm rollback``
+to a pre-0071 image (which never mentions the table) is safe -- the projection
+on ``sensor`` is untouched and remains the current-state source.
+``downgrade()`` drops the indexes then the table in inverse order, the same
+discipline migrations ``0065`` / ``0064`` follow; it discards accumulated
+history, the expected cost of removing a history table.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0071"
+down_revision: str | None = "0070"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Closed ``sensor_results.state`` vocabulary -- a frozen snapshot of #2504's
+#: five-state ``CheckState``. The drift guard in
+#: :mod:`tests.test_db_sensor_results` asserts this set equals ``CheckState``'s
+#: members, so a change to the shared vocabulary reddens this migration's test
+#: rather than drifting silently.
+_SENSOR_RESULT_STATES: tuple[str, ...] = (
+    "ok",
+    "degraded",
+    "critical",
+    "unknown",
+    "skip",
+)
+
+
+def _check_in(column: str, values: tuple[str, ...]) -> str:
+    """Render a portable ``column IN ('a', 'b', ...)`` CHECK body."""
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"{column} IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Create the ``sensor_results`` table + its two indexes."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    # Nullable JSON columns use ``none_as_null=True`` so a Python ``None``
+    # round-trips as SQL NULL rather than the JSON literal ``'null'`` -- the
+    # same load-bearing flag ``sensor.last_value`` / ``last_evidence`` use.
+    nullable_json = sa.JSON(none_as_null=True).with_variant(
+        postgresql.JSONB(none_as_null=True), "postgresql"
+    )
+
+    op.create_table(
+        "sensor_results",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        sa.Column(
+            "sensor_id",
+            sa.Uuid(),
+            sa.ForeignKey("sensor.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("evaluated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("state", sa.Text(), nullable=False),
+        sa.Column("value", nullable_json, nullable=True),
+        sa.Column("evidence", nullable_json, nullable=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        # ``state`` over exactly #2504's CheckState members -- widening it is a
+        # coordinated migration + model change (drift guard in
+        # tests.test_db_sensor_results).
+        sa.CheckConstraint(
+            _check_in("state", _SENSOR_RESULT_STATES),
+            name="ck_sensor_results_state",
+        ),
+    )
+
+    # The trend query: ``WHERE sensor_id = ? [AND evaluated_at >= ?]
+    # [AND evaluated_at <= ?] ORDER BY evaluated_at ASC`` + keyset.
+    op.create_index(
+        "sensor_results_sensor_evaluated_idx",
+        "sensor_results",
+        ["sensor_id", "evaluated_at"],
+        postgresql_using="btree",
+    )
+    # The retention sweep: ``DELETE WHERE evaluated_at < cutoff``.
+    op.create_index(
+        "sensor_results_evaluated_at_idx",
+        "sensor_results",
+        ["evaluated_at"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Drop the indexes then the ``sensor_results`` table."""
+    op.drop_index(
+        "sensor_results_evaluated_at_idx",
+        table_name="sensor_results",
+    )
+    op.drop_index(
+        "sensor_results_sensor_evaluated_idx",
+        table_name="sensor_results",
+    )
+    op.drop_table("sensor_results")

--- a/backend/src/meho_backplane/api/v1/sensors.py
+++ b/backend/src/meho_backplane/api/v1/sensors.py
@@ -65,6 +65,8 @@ from meho_backplane.checks.schemas import (
     SensorCreate,
     SensorListResponse,
     SensorRead,
+    SensorResultListResponse,
+    SensorResultsQuery,
     SensorStatusFilter,
 )
 from meho_backplane.checks.service import (
@@ -73,6 +75,7 @@ from meho_backplane.checks.service import (
     SensorNameConflictError,
     SensorOperationNotFoundError,
     SensorRequiresSafeOperationError,
+    SensorResultsCursorError,
 )
 
 __all__ = ["router"]
@@ -90,6 +93,7 @@ _SENSOR_OP_IDS: Final[dict[str, str]] = {
     "list": "sensor.list",
     "create": "sensor.create",
     "delete": "sensor.delete",
+    "results": "sensor.results",
 }
 
 
@@ -242,3 +246,51 @@ async def delete_sensor(
             detail="sensor_not_found",
         )
     return Response(status_code=http_status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/{sensor_id}/results", response_model=SensorResultListResponse)
+async def list_sensor_results(
+    sensor_id: Annotated[uuid.UUID, Path()],
+    operator: Annotated[Operator, _require_operator],
+    query: Annotated[SensorResultsQuery, Query()],
+) -> SensorResultListResponse:
+    """Return a page of a sensor's per-tick evidence history, ``evaluated_at ASC``.
+
+    The forensic trend query (#2756) -- "when did this start degrading / how
+    fast is it filling". ``operator`` role. Binary filters only: an inclusive
+    ``from`` / ``to`` window, an exact ``state``, a bounded ``limit``, and an
+    opaque keyset ``cursor`` (echo ``next_cursor`` back to page). An unknown
+    query param is a 422 (the :class:`SensorResultsQuery` model forbids extras)
+    so "no aggregation knobs" holds at the wire; a malformed ``cursor`` is a 422
+    ``sensor_results_invalid_cursor``. An absent sensor id (or one owned by
+    another tenant) returns 404 ``sensor_not_found`` -- never 403 -- so neither
+    a sensor's existence nor its history leaks across the tenant boundary.
+
+    Scoped to the caller's own tenant: unlike ``list`` / ``delete`` there is no
+    platform-admin ``tenant_filter`` here. Cross-tenant forensic history is not
+    a stated need, the MCP ``meho_sensor_results`` tool is likewise
+    own-tenant-only, and folding a standalone cross-tenant query param in beside
+    the :class:`SensorResultsQuery` model would collapse the flattened OpenAPI
+    query parameters into a single opaque object -- breaking the typed Go CLI
+    client the ``meho sensor results`` verb is generated from.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_SENSOR_OP_IDS["results"],
+        audit_op_class="read",
+        audit_sensor_id=str(sensor_id),
+    )
+    service = SensorAdminService()
+    try:
+        page = await service.list_results(operator.tenant_id, sensor_id, query)
+    except SensorResultsCursorError as exc:
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=exc.error_code,
+        ) from exc
+    if page is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail="sensor_not_found",
+        )
+    structlog.contextvars.bind_contextvars(audit_row_count=len(page.items))
+    return page

--- a/backend/src/meho_backplane/checks/evidence_retention.py
+++ b/backend/src/meho_backplane/checks/evidence_retention.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Scheduled background retention prune for per-tick sensor evidence (#2756).
+
+Initiative #2780, Task #2756. The
+:class:`~meho_backplane.db.models.SensorResult` table (migration ``0070``) is
+the append-only per-tick evidence history the check runner writes on every
+non-stale evaluation. Without a retention policy it grows unbounded -- a fleet
+of sub-minute sensors adds a row every tick, indefinitely -- which is exactly
+the "nobody's DB grows surprisingly" surprise the ops report asked the default
+to avoid.
+
+This module ships the physical cleanup: an ``asyncio`` task the FastAPI
+lifespan owns that ticks on a fixed cadence (default 7 days / weekly) and
+deletes rows where
+``evaluated_at < now() - checks_evidence_retention_days``. It is the **only**
+place the application issues a DELETE against ``sensor_results``.
+
+Deliberate copy of the announcement-retention mold, with one divergence
+--------------------------------------------------------------------------
+
+Structure, sentinels, and the audit-row shape mirror
+:mod:`meho_backplane.broadcast.announcement_retention` verbatim (which itself
+copied the topology-history mold). Carried over unchanged:
+
+* **``asyncio`` loop, not APScheduler.** The chassis's established shape for
+  lifespan-owned background loops. Zero new dependency.
+* **One audit row per non-no-op tick** (not per tenant): the prune is a
+  system-wide op, attributed to the system sentinel tenant so operators
+  querying their own timeline never see the prune row.
+* **Fail-closed audit, loop-survival on the tick.** The audit writer swallows
+  its own commit failure; the per-tick ``try`` / ``except`` in
+  :func:`_prune_loop` logs and continues so one bad tick cannot kill the loop.
+
+The **one deliberate divergence** is the ``retention_days == 0`` meaning. In
+the announcement / topology sweepers ``0`` is *keep-forever* (the loop still
+runs, no DELETE). Here ``0`` disables the whole feature:
+:func:`~meho_backplane.checks.repository.record_sensor_result` writes **no**
+history rows when ``checks_evidence_retention_days == 0`` (gated by the runner
+on the same setting), so there is nothing to prune -- the tick logs a heartbeat
+and returns. "Grows forever" is the surprise #2756 exists to prevent, so ``0``
+means "off", not "unbounded". ``checks_evidence_prune_enabled=false`` still
+skips starting the loop entirely (an operator running an external sweep).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from sqlalchemy import delete
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import SensorResult
+from meho_backplane.memory.audit import (
+    INTERNAL_METHOD,
+    write_internal_audit_row,
+)
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "EVIDENCE_RETENTION_PRUNE_PATH",
+    "EVIDENCE_RETENTION_SYSTEM_TENANT_ID",
+    "SYSTEM_OPERATOR_SUB",
+    "start_evidence_retention_sweeper",
+    "stop_evidence_retention_sweeper",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Synthetic ``operator_sub`` for retention-prune audit rows. The
+#: ``"system:<job>"`` shape lets audit-query filters partition prune rows from
+#: other background-job rows by ``operator_sub`` alone, mirroring
+#: :data:`meho_backplane.broadcast.announcement_retention.SYSTEM_OPERATOR_SUB`.
+SYSTEM_OPERATOR_SUB: str = "system:checks-evidence-retention"
+
+#: Canonical ``path`` for the prune audit row. Defined here so the audit doc,
+#: the prune task, and any audit-query consumer share one symbol.
+EVIDENCE_RETENTION_PRUNE_PATH: str = "checks.evidence.prune"
+
+#: Sentinel tenant id for the system-wide ``INTERNAL`` prune audit row. The
+#: cutoff predicate spans every tenant's rows in one statement, so attributing
+#: the audit row to a real tenant would mislead operators querying their own
+#: timeline. Encodes the task number (2756) in the final segment, the same
+#: convention the announcement / topology prune sentinels use.
+EVIDENCE_RETENTION_SYSTEM_TENANT_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-000000002756")
+
+
+async def _delete_sensor_results_older_than(cutoff: datetime) -> int:
+    """Run the bounded DELETE; return the dropped-row count.
+
+    The DELETE is bounded by the ``evaluated_at < cutoff`` predicate -- no
+    unbounded LIMIT-less statement that could lock the table. The filter rides
+    the ``sensor_results_evaluated_at_idx`` btree (migration ``0070``), so even
+    a large history prunes in one indexed range-scan.
+
+    ``rowcount`` is only typed on the concrete ``CursorResult`` the
+    ``session.execute(delete(...))`` call returns at runtime; ``or 0``
+    collapses the ``int | None`` the abstract ``Result`` superclass declares to
+    the ``int`` the audit payload requires (same ``type: ignore`` the sibling
+    sweepers document).
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            delete(SensorResult).where(SensorResult.evaluated_at < cutoff)
+        )
+        await session.commit()
+        dropped: int = result.rowcount or 0  # type: ignore[attr-defined]
+    return dropped
+
+
+async def _write_prune_audit_row(
+    *,
+    dropped_rows: int,
+    retention_days: int,
+    cutoff: datetime,
+    duration_ms: float,
+) -> None:
+    """Write the one summary audit row, swallowing audit-side failures.
+
+    The DELETE has already committed before this helper runs; an audit-write
+    failure must not stall the prune loop. Surface it loud-but-non-fatal (same
+    shape as the announcement / topology / memory sweepers).
+    """
+    try:
+        await write_internal_audit_row(
+            operator_sub=SYSTEM_OPERATOR_SUB,
+            tenant_id=EVIDENCE_RETENTION_SYSTEM_TENANT_ID,
+            method=INTERNAL_METHOD,
+            path=EVIDENCE_RETENTION_PRUNE_PATH,
+            status_code=200,
+            duration_ms=duration_ms,
+            payload={
+                "dropped_rows": dropped_rows,
+                "retention_days": retention_days,
+                "cutoff": cutoff.isoformat(),
+            },
+        )
+    except Exception:
+        _log.exception(
+            "checks_evidence_retention_audit_write_failed",
+            dropped_rows=dropped_rows,
+            retention_days=retention_days,
+        )
+
+
+async def _run_one_prune_tick() -> None:
+    """One prune sweep: delete rows older than the retention window, audit.
+
+    Reads ``checks_evidence_retention_days`` and computes a cutoff of
+    ``now(UTC) - retention_days``. When ``retention_days == 0`` the feature is
+    disabled (:func:`record_sensor_result` wrote no rows), so the tick logs the
+    heartbeat and returns without a DELETE or audit row -- the no-op case would
+    otherwise emit one ``dropped_rows=0`` row per weekly tick, indistinguishable
+    from a real "swept clean" outcome.
+
+    Returns no value; the per-tick ``try`` / ``except`` in :func:`_prune_loop`
+    catches any exception so one bad tick cannot kill the loop.
+    """
+    tick_started = time.perf_counter()
+    settings = get_settings()
+    retention_days = settings.checks_evidence_retention_days
+
+    if retention_days == 0:
+        _log.info(
+            "checks_evidence_retention_disabled",
+            retention_days=0,
+            interval_seconds=settings.checks_evidence_prune_interval_seconds,
+        )
+        return
+
+    cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+    dropped_rows = await _delete_sensor_results_older_than(cutoff)
+    duration_ms = (time.perf_counter() - tick_started) * 1000.0
+    _log.info(
+        "checks_evidence_retention_tick_done",
+        dropped_rows=dropped_rows,
+        retention_days=retention_days,
+        cutoff=cutoff.isoformat(),
+        duration_ms=duration_ms,
+    )
+    await _write_prune_audit_row(
+        dropped_rows=dropped_rows,
+        retention_days=retention_days,
+        cutoff=cutoff,
+        duration_ms=duration_ms,
+    )
+
+
+async def _prune_loop() -> None:
+    """The forever loop: sleep one cadence, prune, repeat.
+
+    Sleep-then-prune (not prune-then-sleep) so the first tick after start does
+    not race the rest of lifespan boot. Per-tick ``try`` / ``except`` means a
+    transient DB blip is logged and the loop continues;
+    ``asyncio.CancelledError`` propagates so lifespan shutdown stops the task
+    cleanly.
+    """
+    interval = get_settings().checks_evidence_prune_interval_seconds
+    _log.info(
+        "checks_evidence_retention_started",
+        interval_seconds=interval,
+        retention_days=get_settings().checks_evidence_retention_days,
+    )
+    while True:
+        await asyncio.sleep(get_settings().checks_evidence_prune_interval_seconds)
+        try:
+            await _run_one_prune_tick()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning(
+                "checks_evidence_retention_tick_failed",
+                exc_info=True,
+            )
+
+
+def start_evidence_retention_sweeper() -> asyncio.Task[None]:
+    """Start the background retention prune loop and return its task.
+
+    Registered in :func:`meho_backplane.main.lifespan` behind the
+    ``CHECKS_EVIDENCE_PRUNE_ENABLED`` setting. The returned task is cancelled on
+    lifespan shutdown; the caller awaits the cancellation so the loop unwinds
+    cleanly. Returning the task (rather than fire-and-forgetting) keeps a strong
+    reference alive -- an un-referenced task can be GC'd mid-flight, producing
+    the "Task was destroyed but it is pending!" warnings pytest-asyncio rejects.
+    Naming mirrors the sibling retention sweepers so the disposal pattern stays
+    uniform across the lifespan-owned loops.
+    """
+    return asyncio.create_task(
+        _prune_loop(),
+        name="checks-evidence-retention-sweeper",
+    )
+
+
+async def stop_evidence_retention_sweeper(task: asyncio.Task[None]) -> None:
+    """Cancel the retention prune task and await its unwind.
+
+    Swallows the expected :class:`asyncio.CancelledError`; any other exception
+    during unwind propagates so a broken shutdown is visible. Mirrors the
+    announcement retention sweeper's disposal shape verbatim.
+    """
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/backend/src/meho_backplane/checks/repository.py
+++ b/backend/src/meho_backplane/checks/repository.py
@@ -31,7 +31,7 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.checks.assertions import CheckState
-from meho_backplane.db.models import Sensor, SensorCadenceKind, SensorStatus
+from meho_backplane.db.models import Sensor, SensorCadenceKind, SensorResult, SensorStatus
 from meho_backplane.scheduler.cron import next_fire_after
 
 __all__ = [
@@ -39,6 +39,7 @@ __all__ = [
     "advance_sensor_next_fire",
     "claim_due_sensors",
     "create_sensor",
+    "list_sensor_results",
     "park_sensor",
     "record_sensor_result",
 ]
@@ -132,7 +133,7 @@ def _as_utc(dt: datetime) -> datetime:
     return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
 
 
-async def record_sensor_result(
+def _append_evidence_row(
     session: AsyncSession,
     *,
     sensor_id: uuid.UUID,
@@ -140,82 +141,80 @@ async def record_sensor_result(
     value: object,
     evidence: dict[str, object],
     evaluated_at: datetime,
+) -> None:
+    """Append one per-tick :class:`SensorResult` history row (#2756).
+
+    Called by :func:`record_sensor_result` for every non-stale evaluation when
+    retention is enabled, in the caller's transaction (flush-not-commit). The
+    row records the *observed* outcome -- committed, soft/pending (#2799), or
+    re-confirmed -- so a flapping reading that never commits still lands in
+    history. ``evidence['reason']`` (the evaluator's machine reason on an
+    ``unknown`` outcome, absent otherwise) is surfaced as a first-class
+    ``reason`` column so "why did it flap" reads without unpacking the blob.
+    """
+    raw_reason = evidence.get("reason") if isinstance(evidence, dict) else None
+    session.add(
+        SensorResult(
+            sensor_id=sensor_id,
+            evaluated_at=evaluated_at,
+            state=state,
+            value=value,
+            evidence=evidence,
+            reason=str(raw_reason) if raw_reason is not None else None,
+        )
+    )
+
+
+async def _commit_through_confirmation_gate(
+    session: AsyncSession,
+    row: Sensor,
+    state: CheckState,
+    evaluated_at: datetime,
 ) -> bool:
-    """Update the latest-state projection for *sensor_id*; return state-committed.
+    """Commit *state* onto *row* through the soft/hard confirmation gate (#2799).
 
-    Updates ``last_value`` / ``last_evidence`` / ``last_evaluated_at`` on
-    every accepted result, and flips ``last_state`` / bumps ``state_since``
-    **only** when the new state is *confirmed* -- so #2506's ``for:``
-    hold-time hysteresis measures confirmed time. Returns ``True`` iff the
-    committed state changed.
+    With ``retry_times == 0`` (the default) every differing reading commits
+    immediately -- the pre-#2799 behaviour, bit for bit. With ``retry_times >
+    0`` a reading that differs from the committed ``last_state`` is held as a
+    soft state instead:
 
-    **Confirmation gate (#2799, Nagios soft/hard states).** With
-    ``retry_times == 0`` (the default) every differing reading commits
-    immediately -- the pre-#2799 behaviour, bit for bit. With
-    ``retry_times > 0`` a reading that differs from the committed
-    ``last_state`` is held as a soft state instead:
-
-    * differs from ``pending_state`` too -> a new confirmation window
-      opens (``pending_state = outcome``, ``pending_count = 1``); an
-      escalation mid-window restarts the count on the new candidate.
+    * differs from ``pending_state`` too -> a new confirmation window opens
+      (``pending_state = state``, ``pending_count = 1``); an escalation
+      mid-window restarts the count on the new candidate.
     * equals ``pending_state`` -> ``pending_count += 1``; once
-      ``pending_count > retry_times`` the state commits (``last_state``
-      flips, ``state_since`` bumps to this result's ``evaluated_at``)
-      and the window clears.
+      ``pending_count > retry_times`` the state commits (``last_state`` flips,
+      ``state_since`` bumps to this result's ``evaluated_at``) and the window
+      clears.
     * equals the committed ``last_state`` (the candidate reverted) -> the
       window clears without committing anything.
 
-    The gate is symmetric in both directions -- recovery to ``ok`` is
-    confirmed exactly like a degradation (deliberately unlike Nagios'
-    immediate hard recovery: the observed flap's second nuisance mail
-    *was* a flapping all-clear, the failure mode Prometheus grew
-    ``keep_firing_for`` for) -- and ``unknown`` participates like any
-    state, so a transient dispatch timeout cannot flip the sensor. The
-    gate lives here, not in the runner task, so the satellite-gateway
-    batch-post path is confirmed identically.
-
-    **Monotonicity guard.** A result whose ``evaluated_at`` is not strictly
-    newer than the row's recorded ``last_evaluated_at`` is ignored (returns
-    ``False`` without mutating the projection). #2505's runner is the single
-    serialised evaluator, but a retried or reordered persist -- the gateway
-    batch-post (#2415-T3) can deliver remote results out of order -- must not
-    overwrite a newer projection with a stale one, nor move ``state_since``
-    backwards. An equal timestamp is treated as an already-recorded
-    idempotent retry.
-
-    A ``sensor_id`` that names no row (deleted between an evaluation and
-    the persist) returns ``False`` without raising -- the runner treats
-    the missing row as "nothing to record".
+    Symmetric in both directions -- recovery to ``ok`` is confirmed exactly
+    like a degradation (deliberately unlike Nagios' immediate hard recovery:
+    the observed flap's second nuisance mail *was* a flapping all-clear, the
+    failure mode Prometheus grew ``keep_firing_for`` for) -- and ``unknown``
+    participates like any state, so a transient dispatch timeout cannot flip
+    the sensor. The gate lives in this repository seam, not the runner task, so
+    the satellite-gateway batch-post path is confirmed identically. Flushes and
+    returns ``True`` iff the committed state changed.
     """
-    row = await session.get(Sensor, sensor_id)
-    if row is None:
-        return False
-    if row.last_evaluated_at is not None and _as_utc(evaluated_at) <= _as_utc(
-        row.last_evaluated_at
-    ):
-        # Stale or duplicate result -- keep the newer projection intact.
-        return False
-    row.last_value = value
-    row.last_evidence = evidence
-    row.last_evaluated_at = evaluated_at
     if state == row.last_state:
-        # The committed state re-confirmed itself; any half-open
-        # confirmation window was a transient -- close it.
+        # The committed state re-confirmed itself; any half-open confirmation
+        # window was a transient -- close it.
         row.pending_state = None
         row.pending_count = 0
         await session.flush()
         return False
     if row.retry_times > 0:
         if state != row.pending_state:
-            # First differing reading (or an escalation mid-window):
-            # open a fresh window on this candidate.
+            # First differing reading (or an escalation mid-window): open a
+            # fresh window on this candidate.
             row.pending_state = state
             row.pending_count = 1
         else:
             row.pending_count += 1
         if row.pending_count <= row.retry_times:
-            # Soft state -- observed but unconfirmed. No commit, no
-            # transition for downstream consumers.
+            # Soft state -- observed but unconfirmed. No commit, no transition
+            # for downstream consumers.
             await session.flush()
             return False
     row.last_state = state
@@ -224,6 +223,124 @@ async def record_sensor_result(
     row.pending_count = 0
     await session.flush()
     return True
+
+
+async def record_sensor_result(
+    session: AsyncSession,
+    *,
+    sensor_id: uuid.UUID,
+    state: CheckState,
+    value: object,
+    evidence: dict[str, object],
+    evaluated_at: datetime,
+    record_history: bool = False,
+) -> bool:
+    """Record one evaluation onto *sensor_id*'s projection; return state-committed.
+
+    Updates ``last_value`` / ``last_evidence`` / ``last_evaluated_at`` on every
+    accepted result, then commits ``last_state`` / ``state_since`` through
+    :func:`_commit_through_confirmation_gate` (#2799's soft/hard-state gate) --
+    returning ``True`` iff the *committed* state changed, so #2506's ``for:``
+    hold-time hysteresis measures confirmed time. When *record_history* is true
+    it also appends a per-tick :class:`~meho_backplane.db.models.SensorResult`
+    row via :func:`_append_evidence_row` (#2756) **in the same transaction** as
+    the projection update, so history and projection cannot diverge; the
+    runner's ``_persist_outcome`` sets it from
+    ``CHECKS_EVIDENCE_RETENTION_DAYS > 0`` (``0`` disables it -- the pre-#2756
+    latest-only behaviour). The full confirmation-gate + evidence-history
+    mechanics are in ``docs/codebase/sensor.md``.
+
+    **Monotonicity guard.** A result whose ``evaluated_at`` is not strictly
+    newer than the row's recorded ``last_evaluated_at`` is ignored (returns
+    ``False`` without mutating the projection **or appending history**).
+    #2505's runner is the single serialised evaluator, but a retried or
+    reordered persist -- the gateway batch-post (#2415-T3) can deliver remote
+    results out of order -- must not overwrite a newer projection with a stale
+    one, move ``state_since`` backwards, or duplicate a history row. An equal
+    timestamp is an already-recorded idempotent retry; gating the append on the
+    same guard keeps ``evaluated_at`` strictly monotonic per sensor, which the
+    trend query's keyset pagination relies on.
+
+    A ``sensor_id`` that names no row (deleted between an evaluation and the
+    persist) returns ``False`` without raising -- "nothing to record".
+    """
+    row = await session.get(Sensor, sensor_id)
+    if row is None:
+        return False
+    if row.last_evaluated_at is not None and _as_utc(evaluated_at) <= _as_utc(
+        row.last_evaluated_at
+    ):
+        # Stale or duplicate result -- keep the newer projection intact and
+        # append no history row.
+        return False
+    row.last_value = value
+    row.last_evidence = evidence
+    row.last_evaluated_at = evaluated_at
+    if record_history:
+        # Append after the monotonicity guard (no dup on a stale persist) and
+        # before the confirmation gate (a pending/unconfirmed reading still
+        # lands in history), so every non-stale evaluation records exactly one
+        # observed-outcome row.
+        _append_evidence_row(
+            session,
+            sensor_id=sensor_id,
+            state=state,
+            value=value,
+            evidence=evidence,
+            evaluated_at=evaluated_at,
+        )
+    return await _commit_through_confirmation_gate(session, row, state, evaluated_at)
+
+
+async def list_sensor_results(
+    session: AsyncSession,
+    *,
+    sensor_id: uuid.UUID,
+    from_ts: datetime | None,
+    to_ts: datetime | None,
+    state: CheckState | None,
+    limit: int,
+    after: datetime | None,
+) -> tuple[Sequence[SensorResult], datetime | None]:
+    """Return up to *limit* evidence rows for *sensor_id*, ``evaluated_at ASC``.
+
+    The forensic trend query (#2756). Binary filters only -- an inclusive
+    ``[from_ts, to_ts]`` window, an optional exact *state*, and a keyset
+    *after* cursor (``evaluated_at > after``); no smoothing, downsampling, or
+    scoring. Raw rows in deterministic ``evaluated_at ASC`` order; the caller
+    aggregates.
+
+    Over-fetches ``limit + 1`` so the next-page cursor is computed without a
+    second COUNT: when more than *limit* rows match, the surplus row is dropped
+    and the last kept row's ``evaluated_at`` is returned as the next cursor
+    (``None`` when this is the final page). ``evaluated_at`` is strictly
+    monotonic within one sensor's history (:func:`record_sensor_result`'s
+    guard), so it totally orders the rows and the keyset needs no tiebreaker.
+
+    Tenant scoping is the caller's job: this function trusts *sensor_id* has
+    already been resolved within the caller's tenant (the service verifies
+    ownership before calling), so it filters on ``sensor_id`` alone.
+    """
+    stmt = (
+        select(SensorResult)
+        .where(SensorResult.sensor_id == sensor_id)
+        .order_by(SensorResult.evaluated_at.asc())
+        .limit(limit + 1)
+    )
+    if from_ts is not None:
+        stmt = stmt.where(SensorResult.evaluated_at >= from_ts)
+    if to_ts is not None:
+        stmt = stmt.where(SensorResult.evaluated_at <= to_ts)
+    if state is not None:
+        stmt = stmt.where(SensorResult.state == state)
+    if after is not None:
+        stmt = stmt.where(SensorResult.evaluated_at > after)
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+    if len(rows) > limit:
+        kept = rows[:limit]
+        return kept, kept[-1].evaluated_at
+    return rows, None
 
 
 async def claim_due_sensors(

--- a/backend/src/meho_backplane/checks/runner.py
+++ b/backend/src/meho_backplane/checks/runner.py
@@ -449,6 +449,12 @@ async def _persist_outcome(snap: _SensorSnapshot, outcome: AssertionOutcome) -> 
     recomputes sees no edge from it.
     """
     evaluated_at = datetime.now(UTC)
+    # #2756: persist a per-tick evidence-history row alongside the projection
+    # when retention is enabled. ``CHECKS_EVIDENCE_RETENTION_DAYS == 0``
+    # disables the feature (no history rows -- the pre-#2756 latest-only
+    # behaviour); the append rides ``record_sensor_result``'s own transaction
+    # so it commits or rolls back atomically with the projection update.
+    record_history = get_settings().checks_evidence_retention_days > 0
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
         await record_sensor_result(
@@ -458,6 +464,7 @@ async def _persist_outcome(snap: _SensorSnapshot, outcome: AssertionOutcome) -> 
             value=outcome.value,
             evidence=outcome.evidence,
             evaluated_at=evaluated_at,
+            record_history=record_history,
         )
         # Identity-map read (record_sensor_result already loaded the row;
         # a missing row means it was deleted mid-evaluation -- nothing to

--- a/backend/src/meho_backplane/checks/schemas.py
+++ b/backend/src/meho_backplane/checks/schemas.py
@@ -28,7 +28,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from meho_backplane.checks.assertions import AssertionSpec
+from meho_backplane.checks.assertions import AssertionSpec, CheckState
 from meho_backplane.db.models import SensorCadenceKind, SensorSeverity, SensorStatus
 from meho_backplane.scheduler.cron import is_valid_cron_expr, resolve_timezone
 
@@ -36,6 +36,9 @@ __all__ = [
     "SensorCreate",
     "SensorListResponse",
     "SensorRead",
+    "SensorResultListResponse",
+    "SensorResultRead",
+    "SensorResultsQuery",
 ]
 
 #: Max length of an operator-supplied Sensor name. Sensors are referenced
@@ -243,3 +246,71 @@ SensorStatusFilter = Literal["active", "paused"]
 
 #: Re-exported sentinel cadence-kind literal for query-string filtering.
 SensorCadenceFilter = Literal["interval", "cron"]
+
+
+# ---------------------------------------------------------------------------
+# Per-tick evidence trend query (#2756)
+# ---------------------------------------------------------------------------
+
+#: Default / max page size for the evidence trend query. Mirrors the sensor
+#: list bounds (``SensorAdminService.DEFAULT_LIST_LIMIT`` / ``MAX_LIST_LIMIT``)
+#: for surface consistency; larger windows page via the keyset ``cursor``.
+_RESULTS_DEFAULT_LIMIT = 100
+_RESULTS_MAX_LIMIT = 500
+
+
+class SensorResultRead(BaseModel):
+    """Response shape for one ``sensor_results`` evidence row (#2756).
+
+    Mirrors :class:`~meho_backplane.db.models.SensorResult`, projected to the
+    wire types the JSON renderer serialises: the raw ``(evaluated_at, state,
+    value, evidence, reason)`` the runner computed, plus the owning
+    ``sensor_id``. ``frozen=True`` so a route handler cannot mutate a row after
+    returning it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sensor_id: uuid.UUID
+    evaluated_at: datetime
+    state: Literal["ok", "degraded", "critical", "unknown", "skip"]
+    value: Any
+    evidence: dict[str, object] | None
+    reason: str | None
+
+
+class SensorResultListResponse(BaseModel):
+    """Response envelope for ``GET /api/v1/sensors/{sensor_id}/results``.
+
+    The ``{items, next_cursor}`` keyset-pagination shape (#2742): ``items`` is
+    the page of evidence rows in ``evaluated_at ASC`` order; ``next_cursor`` is
+    the opaque continuation token to pass back as ``?cursor=`` for the next
+    page, or ``null`` when this is the final page. No aggregate / rollup fields
+    -- the client aggregates raw rows (#2756's determinism bound).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    items: list[SensorResultRead]
+    next_cursor: str | None = None
+
+
+class SensorResultsQuery(BaseModel):
+    """Query-parameter model for the evidence trend query (#2756).
+
+    ``extra="forbid"`` is load-bearing: FastAPI otherwise silently ignores
+    unknown query parameters, but the task pins "no aggregation knobs" -- an
+    unknown filter (``smoothing=``, ``downsample=``, ``aggregate=``) must be
+    *rejected* with a 422, not quietly dropped. Binary filters only: an exact
+    ``state``, an inclusive ``[from, to]`` window, a bounded ``limit``, and the
+    opaque keyset ``cursor``. ``from`` is aliased because it is a Python
+    keyword. All optional except the implicit path ``sensor_id``.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    from_: datetime | None = Field(default=None, alias="from")
+    to: datetime | None = None
+    state: CheckState | None = None
+    limit: int = Field(default=_RESULTS_DEFAULT_LIMIT, ge=1, le=_RESULTS_MAX_LIMIT)
+    cursor: str | None = None

--- a/backend/src/meho_backplane/checks/service.py
+++ b/backend/src/meho_backplane/checks/service.py
@@ -53,17 +53,26 @@ Error contract
 
 from __future__ import annotations
 
+import base64
+import binascii
 import uuid
 from collections.abc import Sequence
+from datetime import datetime
 
 import structlog
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
 
-from meho_backplane.checks.repository import create_sensor
-from meho_backplane.checks.schemas import SensorCreate, SensorRead
+from meho_backplane.checks.repository import create_sensor, list_sensor_results
+from meho_backplane.checks.schemas import (
+    SensorCreate,
+    SensorRead,
+    SensorResultListResponse,
+    SensorResultRead,
+    SensorResultsQuery,
+)
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import Sensor
+from meho_backplane.db.models import Sensor, SensorResult
 from meho_backplane.operations._lookup import lookup_descriptor, parse_connector_id
 
 __all__ = [
@@ -72,6 +81,7 @@ __all__ = [
     "SensorNameConflictError",
     "SensorOperationNotFoundError",
     "SensorRequiresSafeOperationError",
+    "SensorResultsCursorError",
 ]
 
 
@@ -194,6 +204,25 @@ class SensorIdentitySubForbiddenError(Exception):
         )
 
 
+class SensorResultsCursorError(Exception):
+    """Raised when the evidence trend query's ``cursor`` is malformed (#2756).
+
+    The trend query paginates by an opaque keyset ``cursor`` (base64url of the
+    last row's ``evaluated_at``). A token that is not valid base64, or whose
+    payload is not an ISO-8601 timestamp, is a client error -- surfaced here so
+    the boundary renders a 422 ``sensor_results_invalid_cursor`` rather than
+    silently ignoring the corrupt cursor and returning page one (which would
+    make a scripted pager loop forever on the first page).
+    """
+
+    #: Machine-readable error code surfaced on every transport.
+    error_code = "sensor_results_invalid_cursor"
+
+    def __init__(self, cursor: str) -> None:
+        self.cursor = cursor
+        super().__init__("cursor is not a valid pagination token")
+
+
 def _is_unique_violation(exc: IntegrityError) -> bool:
     """Return whether *exc* is a unique-constraint violation.
 
@@ -241,6 +270,48 @@ def _row_to_read(row: Sensor) -> SensorRead:
     timezone on the SQLite path.
     """
     return SensorRead.model_validate(row, from_attributes=True)
+
+
+def _result_to_read(row: SensorResult) -> SensorResultRead:
+    """Materialise a :class:`SensorResult` ORM row as the wire shape (#2756).
+
+    Same ``from_attributes`` posture as :func:`_row_to_read`: no force-attached
+    UTC (the SQLite unit-test path stores naive), and the stored ``state`` is
+    validated against the wire Literal on the way out (always valid -- the
+    ``ck_sensor_results_state`` CHECK guarantees it).
+    """
+    return SensorResultRead.model_validate(row, from_attributes=True)
+
+
+def _encode_results_cursor(evaluated_at: datetime) -> str:
+    """Encode a keyset pagination cursor from a row's ``evaluated_at`` (#2756).
+
+    The cursor is the last returned row's ``evaluated_at`` -- a total order
+    within one sensor's history (:func:`record_sensor_result`'s monotonicity
+    guard) -- base64url-encoded so it is opaque and URL-safe. Encoding the
+    ISO-8601 string (not exposing the raw timestamp) signals it is a token to
+    echo back verbatim, not a field to hand-edit into an aggregation knob.
+    """
+    return base64.urlsafe_b64encode(evaluated_at.isoformat().encode("utf-8")).decode("ascii")
+
+
+def _decode_results_cursor(cursor: str | None) -> datetime | None:
+    """Decode a keyset cursor to its ``evaluated_at`` boundary; ``None`` passes through.
+
+    Raises
+    ------
+    SensorResultsCursorError
+        The token is not valid base64url, or its payload is not an ISO-8601
+        timestamp. The boundary maps it to 422 so a corrupt cursor fails loud
+        rather than silently resetting the pager to page one.
+    """
+    if cursor is None:
+        return None
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode("ascii"))
+        return datetime.fromisoformat(raw.decode("utf-8"))
+    except (ValueError, binascii.Error, UnicodeDecodeError) as exc:
+        raise SensorResultsCursorError(cursor) from exc
 
 
 class SensorAdminService:
@@ -384,6 +455,60 @@ class SensorAdminService:
             result = await session.execute(stmt)
             rows = list(result.scalars().all())
             return [_row_to_read(r) for r in rows]
+
+    async def list_results(
+        self,
+        tenant_id: uuid.UUID,
+        sensor_id: uuid.UUID,
+        query: SensorResultsQuery,
+    ) -> SensorResultListResponse | None:
+        """Return a page of a sensor's per-tick evidence history (#2756).
+
+        The forensic trend query. Tenant scoping is enforced first: the sensor
+        is resolved ``WHERE tenant_id = :tenant_id AND id = :sensor_id`` before
+        any history is read, so a probe for another tenant's sensor id returns
+        ``None`` (the 404 the boundary renders) and never that tenant's
+        history -- the same 404-vs-existence-leak collapse
+        :meth:`get` / :meth:`delete` use. A sensor that exists but has no rows
+        (or none in the window) returns an empty ``{items: [], next_cursor:
+        None}`` page (200), distinct from the ``None`` absence signal.
+
+        Filters are binary only (``from`` / ``to`` inclusive window, exact
+        ``state``, bounded ``limit``) with deterministic ``evaluated_at ASC``
+        ordering and opaque keyset ``cursor`` pagination -- no smoothing,
+        downsampling, or scoring (#2756's determinism bound; the query model's
+        ``extra="forbid"`` rejects unknown params at the wire).
+
+        Raises
+        ------
+        SensorResultsCursorError
+            ``query.cursor`` is a malformed pagination token. The boundary maps
+            it to 422 ``sensor_results_invalid_cursor``.
+        """
+        after = _decode_results_cursor(query.cursor)
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            owner = await session.execute(
+                select(Sensor.id).where(
+                    Sensor.tenant_id == tenant_id,
+                    Sensor.id == sensor_id,
+                )
+            )
+            if owner.scalar_one_or_none() is None:
+                return None
+            rows, next_key = await list_sensor_results(
+                session,
+                sensor_id=sensor_id,
+                from_ts=query.from_,
+                to_ts=query.to,
+                state=query.state,
+                limit=query.limit,
+                after=after,
+            )
+        return SensorResultListResponse(
+            items=[_result_to_read(r) for r in rows],
+            next_cursor=(_encode_results_cursor(next_key) if next_key is not None else None),
+        )
 
     async def get(
         self,

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -6103,18 +6103,29 @@ class Sensor(Base):
     #2505's claim query (``status='active' AND next_fire_at <= now``) is
     uniform; the composite partial index ``sensor_due_idx`` drives it.
 
-    Latest-state projection (not a results table)
-    ---------------------------------------------
+    Latest-state projection + per-tick evidence history
+    ---------------------------------------------------
 
-    Sensor results live as a projection ON the row -- ``last_state`` /
+    Current state lives as a projection ON the row -- ``last_state`` /
     ``last_value`` / ``last_evidence`` / ``last_evaluated_at`` /
     ``state_since`` -- the in-repo precedent #2327's scheduler skip-state
     set. #2506's rollup and ``for:`` hold-time hysteresis need only the
-    current state and how long it has held (``state_since``), never
-    history; a results table would demand retention/pruning, speculative
-    until an operator asks for history. The named write path is one
-    repository function
-    (:func:`~meho_backplane.checks.repository.record_sensor_result`).
+    current state and how long it has held (``state_since``), so the
+    projection stays the fast current-state read path.
+
+    The projection alone was originally the *whole* story (Task #2503
+    Decision D: "not a results table", on the grounds a history table
+    would demand retention/pruning and was speculative until an operator
+    asked). Task #2756 (Initiative #2780) supersedes that: a post-incident
+    review needed "when did this first flap / how fast is it filling", and
+    every tick overwriting the projection had discarded exactly the history
+    the runner already computed. The bounded answer -- a deploy-level
+    retention window (``CHECKS_EVIDENCE_RETENTION_DAYS``) -- settles the
+    original cost objection, so per-tick evidence now persists to
+    :class:`SensorResult` **in the same transaction** as this projection
+    update. The single named write path is unchanged
+    (:func:`~meho_backplane.checks.repository.record_sensor_result`); it
+    now also appends the history row when retention is enabled.
 
     #2799 extends the projection with a *soft-state* window
     (``pending_state`` / ``pending_count``): because there is no history
@@ -6386,6 +6397,114 @@ class Sensor(Base):
         sa.CheckConstraint(
             _SENSOR_CADENCE_FIELDS_CHECK,
             name="ck_sensor_cadence_fields",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SensorResult -- append-only per-tick evidence history
+# (Initiative #2780, Task #2756)
+# ---------------------------------------------------------------------------
+
+
+class SensorResult(Base):
+    """One append-only row per completed Sensor evaluation (#2756).
+
+    The latest-state projection on :class:`Sensor` (``last_state`` /
+    ``last_value`` / ``last_evidence`` / ``last_evaluated_at``) answers "what
+    is this sensor doing right now" but overwrites the prior tick, so the
+    history the runner already computed was discarded. This table preserves
+    it: one row per non-stale evaluation, appended in the **same transaction**
+    as the projection update
+    (:func:`~meho_backplane.checks.repository.record_sensor_result`), so
+    history and projection can never diverge.
+
+    Bounded, not unbounded. Rows are pruned past
+    ``CHECKS_EVIDENCE_RETENTION_DAYS`` by the lifespan-owned sweeper
+    (:mod:`meho_backplane.checks.evidence_retention`); a retention of ``0``
+    disables the feature entirely (no rows written), so the latest-only
+    behaviour that predates #2756 is one env var away. The forensic read
+    surface is the trend query (REST ``GET /api/v1/sensors/{id}/results``, the
+    ``meho_sensor_results`` MCP tool, and ``meho sensor results``): binary
+    filters (``sensor_id`` exact, ``from`` / ``to``, optional ``state``,
+    bounded ``limit``), deterministic ``evaluated_at ASC``, raw rows -- no
+    server-side smoothing, downsampling, or scoring (the #1177 determinism
+    bound the report cites).
+
+    Per-sensor monotonicity. ``record_sensor_result`` appends only when the
+    result's ``evaluated_at`` is strictly newer than the projection's last
+    (the monotonicity guard), so ``evaluated_at`` is strictly increasing --
+    and therefore unique -- within one sensor's rows. The trend query's
+    keyset pagination relies on that: ``evaluated_at`` alone totally orders a
+    single sensor's rows, so the cursor needs no tiebreaker.
+    """
+
+    __tablename__ = "sensor_results"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid(), primary_key=True, default=uuid.uuid4)
+    # Real REFERENCES sensor(id) FK with ON DELETE CASCADE -- deleting a
+    # Sensor drops its history (the delete-cascades decision #2756 pins; the
+    # membership join #2506 cascades off ``sensor.id`` the same way).
+    sensor_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("sensor.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # The instant the runner evaluated this result (UTC). NOT NULL -- the
+    # temporal key the trend query filters and orders on.
+    evaluated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    # The five-state ``CheckState`` verdict, over exactly #2504's vocabulary
+    # (the ``ck_sensor_results_state`` CHECK below, drift-guarded via
+    # ``_SENSOR_LAST_STATES``).
+    state: Mapped[str] = mapped_column(Text, nullable=False)
+    # The observed scalar the comparator judged (``AssertionOutcome.value`` --
+    # a JSON scalar, not a dict), or NULL when unknown. Mirrors
+    # ``sensor.last_value``'s portable-JSON encoding.
+    value: Mapped[object | None] = mapped_column(
+        JSON(none_as_null=True).with_variant(JSONB(none_as_null=True), "postgresql"),
+        nullable=True,
+        default=None,
+    )
+    # The full evidence dict the evaluator emitted. Mirrors
+    # ``sensor.last_evidence``.
+    evidence: Mapped[dict[str, object] | None] = mapped_column(
+        JSON(none_as_null=True).with_variant(JSONB(none_as_null=True), "postgresql"),
+        nullable=True,
+        default=None,
+    )
+    # Denormalised machine reason (``evidence['reason']``) -- the evaluator
+    # sets it on an ``unknown`` outcome, NULL otherwise. A first-class column
+    # so "why did this flap" reads without unpacking the evidence blob.
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+
+    __table_args__ = (
+        # The trend query: ``WHERE sensor_id = ? [AND evaluated_at >= ?]
+        # [AND evaluated_at <= ?] ORDER BY evaluated_at ASC`` + the keyset
+        # ``evaluated_at > :cursor``. A composite btree on
+        # (sensor_id, evaluated_at) serves the equality + range + order in one.
+        Index(
+            "sensor_results_sensor_evaluated_idx",
+            "sensor_id",
+            "evaluated_at",
+            postgresql_using="btree",
+        ),
+        # The retention sweep: ``DELETE WHERE evaluated_at < cutoff``. A
+        # standalone btree on ``evaluated_at`` lets the periodic prune
+        # range-scan instead of seq-scanning (the composite above leads with
+        # ``sensor_id``, so it cannot drive the fleet-wide cutoff predicate).
+        Index(
+            "sensor_results_evaluated_at_idx",
+            "evaluated_at",
+            postgresql_using="btree",
+        ),
+        # ``state`` over exactly #2504's ``CheckState`` members -- the same
+        # closed vocabulary + drift guard ``sensor.last_state`` uses.
+        sa.CheckConstraint(
+            _ck_in("state", _SENSOR_LAST_STATES),
+            name="ck_sensor_results_state",
         ),
     )
 

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -123,6 +123,10 @@ from meho_backplane.broadcast.announcement_retention import (
     start_announcement_retention_sweeper,
     stop_announcement_retention_sweeper,
 )
+from meho_backplane.checks.evidence_retention import (
+    start_evidence_retention_sweeper,
+    stop_evidence_retention_sweeper,
+)
 from meho_backplane.checks.runner import start_sensor_runner, stop_sensor_runner
 from meho_backplane.checks.watchdog import start_checks_watchdog, stop_checks_watchdog
 from meho_backplane.connectors.registry import _eager_import_connectors, registered_product_tokens
@@ -450,6 +454,7 @@ class _BackgroundTasks:
     memory_expiry: asyncio.Task[None] | None
     topology_history: asyncio.Task[None] | None
     announcement_retention: asyncio.Task[None] | None
+    evidence_retention: asyncio.Task[None] | None
     grant_expiry: asyncio.Task[None] | None
     approval_expiry: asyncio.Task[None] | None
     scheduler: asyncio.Task[None] | None
@@ -460,6 +465,14 @@ class _BackgroundTasks:
     gateway_deadman: asyncio.Task[None] | None
 
 
+# Deliberately-flat lifespan task registry: the length is per-task
+# documentation (each loop's ticket, gate flag, 0-semantics), not logic —
+# N individually-rationalised background loops, one block each, mirrored 1:1 by
+# the _BackgroundTasks dataclass and _stop_background_tasks' reverse-order
+# teardown. Collapsing the blocks into a gated-start helper would delete that
+# documentation and break the structural mirror; a holistic split of main.py
+# rides its own (pre-existing) file-size warning.
+# code-quality-allow: flat N-loop lifespan registry; length is per-task docs.
 def _start_background_tasks() -> _BackgroundTasks:
     """Start every lifespan-owned background loop, return their handles.
 
@@ -492,6 +505,12 @@ def _start_background_tasks() -> _BackgroundTasks:
     announcement_retention: asyncio.Task[None] | None = None
     if settings.broadcast_announcement_prune_enabled:
         announcement_retention = start_announcement_retention_sweeper()
+    # #2756 (Initiative #2780) — per-tick sensor-evidence retention prune.
+    # Gated on CHECKS_EVIDENCE_PRUNE_ENABLED; ``RETENTION_DAYS=0`` disables the
+    # feature (no rows written) — the divergent 0-semantics the setting docs.
+    evidence_retention: asyncio.Task[None] | None = None
+    if settings.checks_evidence_prune_enabled:
+        evidence_retention = start_evidence_retention_sweeper()
     # G11.2-T6 #819 — gated on GRANT_EXPIRY_ENABLED so operators using
     # an external cleanup mechanism don't double-sweep.
     grant_expiry: asyncio.Task[None] | None = None
@@ -550,6 +569,7 @@ def _start_background_tasks() -> _BackgroundTasks:
         memory_expiry=memory_expiry,
         topology_history=topology_history,
         announcement_retention=announcement_retention,
+        evidence_retention=evidence_retention,
         grant_expiry=grant_expiry,
         approval_expiry=approval_expiry,
         scheduler=scheduler,
@@ -585,6 +605,8 @@ async def _stop_background_tasks(tasks: _BackgroundTasks) -> None:
         await stop_approval_expiry_sweeper(tasks.approval_expiry)
     if tasks.grant_expiry is not None:
         await stop_grant_expiry_sweeper(tasks.grant_expiry)
+    if tasks.evidence_retention is not None:
+        await stop_evidence_retention_sweeper(tasks.evidence_retention)
     if tasks.announcement_retention is not None:
         await stop_announcement_retention_sweeper(tasks.announcement_retention)
     if tasks.topology_history is not None:

--- a/backend/src/meho_backplane/mcp/tools/sensors.py
+++ b/backend/src/meho_backplane/mcp/tools/sensors.py
@@ -44,13 +44,14 @@ from pydantic import ValidationError
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import authorize_tenant_scope
-from meho_backplane.checks.schemas import SensorCreate, SensorRead
+from meho_backplane.checks.schemas import SensorCreate, SensorRead, SensorResultsQuery
 from meho_backplane.checks.service import (
     SensorAdminService,
     SensorIdentitySubForbiddenError,
     SensorNameConflictError,
     SensorOperationNotFoundError,
     SensorRequiresSafeOperationError,
+    SensorResultsCursorError,
 )
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
@@ -62,6 +63,7 @@ _SENSOR_OP_IDS: Final[dict[str, str]] = {
     "list": "sensor.list",
     "create": "sensor.create",
     "delete": "sensor.delete",
+    "results": "sensor.results",
 }
 
 
@@ -414,4 +416,105 @@ register_mcp_tool(
         op_class="write",
     ),
     handler=_delete_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# meho_sensor_results (#2756)
+# ---------------------------------------------------------------------------
+
+
+async def _results_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    sensor_id = _require_sensor_id(arguments)
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_SENSOR_OP_IDS["results"],
+        audit_op_class="read",
+        audit_sensor_id=str(sensor_id),
+    )
+    # Re-validate the filter args through the frozen query model: this is the
+    # MCP-side "schema refusal" for an unknown param (``extra="forbid"``
+    # rejects an aggregation knob), and it applies the same date-time / enum /
+    # bounds parsing the REST route gets. ``sensor_id`` is the path arg, not a
+    # filter field, so it is stripped before validation.
+    filter_args = {k: v for k, v in arguments.items() if k != "sensor_id"}
+    try:
+        query = SensorResultsQuery.model_validate(filter_args)
+    except ValidationError as exc:
+        raise McpInvalidParamsError(str(exc)) from exc
+    service = SensorAdminService()
+    try:
+        page = await service.list_results(operator.tenant_id, sensor_id, query)
+    except SensorResultsCursorError as exc:
+        raise McpInvalidParamsError(exc.error_code) from exc
+    if page is None:
+        raise McpInvalidParamsError("sensor_not_found")
+    structlog.contextvars.bind_contextvars(audit_row_count=len(page.items))
+    return page.model_dump(mode="json")
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        feature="sensors",
+        name="meho_sensor_results",
+        description=(
+            "Per-tick evidence trend query for one sensor (Initiative #2780, "
+            "#2756). Operator-level read -- the forensic 'when did this start "
+            "degrading / how fast is it filling' history the latest-result "
+            "projection discards. Returns {items: [{sensor_id, evaluated_at, "
+            "state, value, evidence, reason}, ...], next_cursor} in "
+            "evaluated_at ASC order. Binary filters only: from / to (inclusive "
+            "ISO-8601 window), state (exact), limit (bounded); page via the "
+            "opaque cursor (echo next_cursor back). Raw rows -- no smoothing, "
+            "downsampling, or aggregation (the client aggregates). "
+            "Tenant-scoped via the JWT; a cross-tenant / absent sensor id -> "
+            "'sensor_not_found'."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "sensor_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "UUID of the sensor whose evidence history to read.",
+                },
+                "from": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Inclusive lower bound on evaluated_at (ISO 8601). Optional.",
+                },
+                "to": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "Inclusive upper bound on evaluated_at (ISO 8601). Optional.",
+                },
+                "state": {
+                    "type": "string",
+                    "enum": ["ok", "degraded", "critical", "unknown", "skip"],
+                    "description": "Optional exact state filter.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 500,
+                    "default": 100,
+                    "description": "Max rows per page. Default 100; max 500.",
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": (
+                        "Opaque keyset pagination token; echo the response's "
+                        "next_cursor back here to fetch the next page. Optional."
+                    ),
+                },
+            },
+            "required": ["sensor_id"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class="read",
+    ),
+    handler=_results_handler,
 )

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -439,6 +439,44 @@ class Settings(BaseModel):
         running as a cheap heartbeat; ``enabled=False`` skips starting the
         loop entirely (no audit-row noise, no log line). Read once at
         lifespan startup; toggling post-start requires a pod restart.
+    checks_evidence_retention_days:
+        Maximum age (in days) of ``sensor_results`` per-tick evidence rows
+        the #2756 retention prune task preserves. Rows whose
+        ``evaluated_at`` is older than
+        ``now() - checks_evidence_retention_days`` are deleted in one
+        bounded batch per run. Default 7 -- the conservative single-digit
+        window the ops report asked for ("nobody's DB grows
+        surprisingly"). Range ``[0, 3650]`` (10-year ceiling).
+
+        **``0`` disables the feature entirely** -- no history rows are
+        written at all (``record_sensor_result`` skips the append), so the
+        latest-only projection behaviour that predates #2756 is restored
+        and the table stays empty. This DELIBERATELY DIVERGES from the
+        ``broadcast_announcement_retention_days=0`` /
+        ``topology_history_retention_days=0`` keep-forever sentinel: an
+        evidence history that grows forever is exactly the surprise the
+        report wanted the default to avoid, so ``0`` here means "off", not
+        "unbounded". Read once per prune-tick, and once per persist, through
+        :func:`get_settings`'s cache.
+    checks_evidence_prune_interval_seconds:
+        Cadence of the #2756 evidence retention prune background loop, in
+        seconds. The task (registered in the FastAPI lifespan) sleeps this
+        long between scans of ``sensor_results``. Default 604800 (7 d /
+        weekly), matching the announcement + topology-history prune
+        cadences. Range ``[60, 604800]``: below one minute the prune
+        competes with the runner's persist load; the ceiling is the weekly
+        cadence. Tests override to sub-second values via env-var monkeypatch
+        + :func:`get_settings` cache-clear.
+    checks_evidence_prune_enabled:
+        Whether to start the #2756 evidence retention prune background task
+        in the FastAPI lifespan. Default ``True``. Operators running an
+        external retention mechanism (k8s CronJob, archive-then-delete) flip
+        ``CHECKS_EVIDENCE_PRUNE_ENABLED=false`` so the chassis does not race
+        the external job. Distinct from
+        ``checks_evidence_retention_days=0``: ``0`` turns the *feature* off
+        (no writes, nothing to prune) while a running loop still heartbeats;
+        ``enabled=False`` skips starting the loop entirely. Read once at
+        lifespan startup; toggling post-start requires a pod restart.
     result_handle_max_spill_rows:
         Upper bound on how many rows the reducer spills into the
         :class:`~meho_backplane.connectors.result_handle_store.ResultHandleStore`
@@ -1091,6 +1129,15 @@ class Settings(BaseModel):
     broadcast_announcement_retention_days: int = Field(default=90, ge=0, le=3650)
     broadcast_announcement_prune_interval_seconds: int = Field(default=604800, ge=60, le=604800)
     broadcast_announcement_prune_enabled: bool = True
+    # Checks per-tick evidence retention (#2756, Initiative #2780) -- the
+    # sensor_results history table + its retention sweeper. Same mould as the
+    # broadcast-announcement knobs above, with ONE deliberate divergence: here
+    # ``days=0`` DISABLES the feature (no history rows written -- the
+    # latest-only behaviour predating #2756), where the other sweepers treat
+    # ``0`` as keep-forever. See the class docstring for the rationale.
+    checks_evidence_retention_days: int = Field(default=7, ge=0, le=3650)
+    checks_evidence_prune_interval_seconds: int = Field(default=604800, ge=60, le=604800)
+    checks_evidence_prune_enabled: bool = True
     result_handle_max_spill_rows: int = Field(default=10000, gt=0)
     jsonflux_sample_byte_budget: int = Field(default=4096, gt=0)
     composite_max_depth: int = Field(default=8, gt=0)
@@ -1782,6 +1829,15 @@ def get_settings() -> Settings:
         ),
         broadcast_announcement_prune_enabled=parse_bool_env(
             os.environ.get("BROADCAST_ANNOUNCEMENT_PRUNE_ENABLED", "true"),
+        ),
+        checks_evidence_retention_days=int(
+            os.environ.get("CHECKS_EVIDENCE_RETENTION_DAYS", "7"),
+        ),
+        checks_evidence_prune_interval_seconds=int(
+            os.environ.get("CHECKS_EVIDENCE_PRUNE_INTERVAL_SECONDS", "604800"),
+        ),
+        checks_evidence_prune_enabled=parse_bool_env(
+            os.environ.get("CHECKS_EVIDENCE_PRUNE_ENABLED", "true"),
         ),
         result_handle_max_spill_rows=int(
             os.environ.get("RESULT_HANDLE_MAX_SPILL_ROWS", "10000"),

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -266,6 +266,13 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # acceptance test errors at setup with ``cannot truncate a table
     # referenced in a foreign key constraint``.
     "sensor",
+    # ``sensor_results`` FKs ``sensor`` with ``ondelete=CASCADE`` (migration
+    # ``0071``, #2756 per-tick evidence). It has no ``tenant_id`` FK, so the
+    # tenant-FK drift guard (tests/test_truncate_list_drift) does not require
+    # it -- but PG still rejects truncating ``sensor`` unless every referencing
+    # table is in the same statement, exactly as ``check_dashboard_sensors``
+    # (also a sensor-FK, no tenant_id) is listed below.
+    "sensor_results",
     # ``check_dashboards.tenant_id`` is a real ``REFERENCES tenant(id)`` FK
     # from migration ``0065`` (Initiative #2416 T2506); and
     # ``check_dashboard_sensors`` FKs both ``check_dashboards`` and ``sensor``

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -428,12 +428,16 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         # * ``gateway_command`` — migration 0059 (Initiative #2415 T2, #2498)
         #   carries a real ``REFERENCES tenant(id)`` FK; same rule, must be
         #   listed here or PG rejects the per-test TRUNCATE.
+        # * ``sensor_results`` — migration 0071 (#2756 per-tick evidence) carries
+        #   a real ``REFERENCES sensor(id)`` FK, so truncating ``sensor`` in this
+        #   same statement requires ``sensor_results`` be listed too or PG raises
+        #   ``cannot truncate a table referenced in a foreign key constraint``.
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
                 "agent_principal, runner_principal, "
                 "runner_assignments, runner_check_results, "
-                "scheduled_trigger, sensor, "
+                "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, event_outbox, gateway_command, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
@@ -491,8 +495,9 @@ async def pg_engine_empty_tenant(
     async with eng.connect() as conn:
         # Same single non-cascading TRUNCATE as ``pg_engine`` (see that
         # fixture for why every real ``REFERENCES tenant(id)`` table —
-        # including ``agent_run`` from migration 0017 and
-        # ``agent_principal`` from migration 0018 — must be listed
+        # including ``agent_run`` from migration 0017,
+        # ``agent_principal`` from migration 0018, and ``sensor_results``
+        # (FK to ``sensor``) from migration 0071 — must be listed
         # here). Deliberately no follow-up INSERT —
         # ``tenant`` stays empty, reproducing the clean-room deploy.
         await conn.execute(
@@ -500,7 +505,7 @@ async def pg_engine_empty_tenant(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
                 "agent_principal, runner_principal, "
                 "runner_assignments, runner_check_results, "
-                "scheduled_trigger, sensor, "
+                "scheduled_trigger, sensor_results, sensor, "
                 "check_dashboard_sensors, check_dashboards, event_outbox, gateway_command, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "

--- a/backend/tests/migrations/test_migration_0071_create_sensor_results.py
+++ b/backend/tests/migrations/test_migration_0071_create_sensor_results.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Migration 0071 -- create the ``sensor_results`` evidence-history table.
+
+Task #2756 under Initiative #2780 (parent goal #221). Asserts the additive
+create-table migration lands the documented columns + indexes, the
+nullability contract holds, the downgrade round-trips, and sibling tables are
+untouched. Every upgrade target is the explicit revision ``"0071"`` (never
+``"head"``) so the test keeps exercising *this* migration regardless of how
+many later migrations land -- the pin-to-own-revision discipline the 0064
+migration test established.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0071.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _table_names(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type = 'table'")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def _table_columns(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _column_is_nullable(sync_url: str, table: str, column: str) -> bool:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            # notnull is index 3: 0 => nullable, 1 => NOT NULL.
+            return int(row[3]) == 0
+    raise AssertionError(f"column {column!r} not present on {table}")
+
+
+def _table_indexes(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA index_list({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+_EXPECTED_COLUMNS: frozenset[str] = frozenset(
+    {
+        "id",
+        "sensor_id",
+        "evaluated_at",
+        "state",
+        "value",
+        "evidence",
+        "reason",
+    }
+)
+
+_EXPECTED_INDEXES: frozenset[str] = frozenset(
+    {
+        "sensor_results_sensor_evaluated_idx",
+        "sensor_results_evaluated_at_idx",
+    }
+)
+
+
+def test_upgrade_creates_sensor_results_table_columns_indexes(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``upgrade 0071`` lands ``sensor_results`` with its columns + indexes."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0071")
+
+    assert "sensor_results" in _table_names(sync_url), (
+        "migration 0071 must create the sensor_results table"
+    )
+
+    columns = _table_columns(sync_url, "sensor_results")
+    assert columns == _EXPECTED_COLUMNS, (
+        f"sensor_results columns drifted from the documented set: "
+        f"missing={_EXPECTED_COLUMNS - columns}, extra={columns - _EXPECTED_COLUMNS}"
+    )
+
+    indexes = _table_indexes(sync_url, "sensor_results")
+    for expected in _EXPECTED_INDEXES:
+        assert expected in indexes, f"migration 0071 must create index {expected!r}"
+
+
+def test_column_nullability(alembic_cfg: tuple[Config, str]) -> None:
+    """NOT NULL columns reject NULL; nullable columns permit it."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0071")
+
+    for col in ("sensor_id", "evaluated_at", "state"):
+        assert not _column_is_nullable(sync_url, "sensor_results", col), f"{col} must be NOT NULL"
+
+    for col in ("value", "evidence", "reason"):
+        assert _column_is_nullable(sync_url, "sensor_results", col), f"{col} must be nullable"
+
+
+def test_downgrade_then_upgrade_round_trips(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``downgrade "0070"`` drops the table; ``upgrade 0071`` restores it."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0071")
+    assert "sensor_results" in _table_names(sync_url)
+
+    command.downgrade(cfg, "0070")
+    assert "sensor_results" not in _table_names(sync_url), (
+        "downgrade must drop the sensor_results table"
+    )
+
+    command.upgrade(cfg, "0071")
+    assert "sensor_results" in _table_names(sync_url)
+    assert _table_columns(sync_url, "sensor_results") == _EXPECTED_COLUMNS
+
+
+def test_sibling_tables_untouched(alembic_cfg: tuple[Config, str]) -> None:
+    """0071 adds a new table only; the pre-existing tables survive."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0071")
+
+    tables = _table_names(sync_url)
+    assert "sensor_results" in tables
+    # The parent sensor table (0064) and a representative earlier sibling.
+    assert "sensor" in tables
+    assert "tenant" in tables

--- a/backend/tests/test_checks_evidence_retention.py
+++ b/backend/tests/test_checks_evidence_retention.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the per-tick evidence retention sweeper (#2756).
+
+Initiative #2780 (parent goal #221), Task #2756. Coverage:
+
+* A tick with a positive retention window deletes rows older than the cutoff
+  and keeps in-window rows.
+* ``CHECKS_EVIDENCE_RETENTION_DAYS=0`` is a no-op tick (heartbeat) -- it prunes
+  nothing (the chosen 0-semantics: the feature is off, so nothing is written to
+  prune, and an already-present row is left untouched) and writes no audit row.
+* A non-no-op tick writes exactly one INTERNAL audit row attributed to the
+  system sentinel.
+
+Runs on the SQLite engine from :mod:`tests.conftest`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.checks.evidence_retention import (
+    EVIDENCE_RETENTION_PRUNE_PATH,
+    SYSTEM_OPERATOR_SUB,
+    _run_one_prune_tick,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AuditLog,
+    Sensor,
+    SensorCadenceKind,
+    SensorResult,
+    SensorSeverity,
+    SensorStatus,
+    Tenant,
+)
+from meho_backplane.settings import get_settings
+
+_ASSERTION = {
+    "select": {"path": "$.count"},
+    "compare": {"type": "threshold", "op": "lt", "critical": 10},
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _seed_sensor() -> uuid.UUID:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = uuid.uuid4()
+        session.add(Tenant(id=tenant_id, slug="ev-ret-tenant", name="Evidence Retention"))
+        sensor_id = uuid.uuid4()
+        session.add(
+            Sensor(
+                id=sensor_id,
+                tenant_id=tenant_id,
+                name="disk-space",
+                connector_id="vmware-rest-9.0",
+                op_id="vmware.vm.list",
+                params={},
+                assertion=_ASSERTION,
+                status=SensorStatus.ACTIVE.value,
+                cadence_kind=SensorCadenceKind.INTERVAL.value,
+                interval_seconds=60,
+                severity=SensorSeverity.CRITICAL.value,
+                for_seconds=0,
+                last_state="unknown",
+                created_by_sub="op-admin",
+            )
+        )
+        await session.commit()
+        return sensor_id
+
+
+async def _seed_result(sensor_id: uuid.UUID, *, evaluated_at: datetime) -> uuid.UUID:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row_id = uuid.uuid4()
+        session.add(
+            SensorResult(
+                id=row_id,
+                sensor_id=sensor_id,
+                evaluated_at=evaluated_at,
+                state="ok",
+                value=1,
+                evidence={"observed": 1},
+                reason=None,
+            )
+        )
+        await session.commit()
+        return row_id
+
+
+async def _list_result_ids(sensor_id: uuid.UUID) -> set[uuid.UUID]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = await session.execute(
+            select(SensorResult.id).where(SensorResult.sensor_id == sensor_id)
+        )
+        return {r for (r,) in rows.all()}
+
+
+async def _list_prune_audit_rows() -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = await session.execute(
+            select(AuditLog).where(AuditLog.path == EVIDENCE_RETENTION_PRUNE_PATH)
+        )
+        return list(rows.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_tick_deletes_past_cutoff_rows_and_keeps_newer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Past-cutoff evidence rows are deleted; in-window rows survive."""
+    monkeypatch.setenv("CHECKS_EVIDENCE_RETENTION_DAYS", "7")
+    get_settings.cache_clear()
+
+    sensor_id = await _seed_sensor()
+    old = await _seed_result(sensor_id, evaluated_at=datetime.now(UTC) - timedelta(days=8))
+    recent = await _seed_result(sensor_id, evaluated_at=datetime.now(UTC) - timedelta(days=1))
+
+    await _run_one_prune_tick()
+
+    ids = await _list_result_ids(sensor_id)
+    assert old not in ids, "past-cutoff evidence row was not deleted"
+    assert recent in ids, "in-window evidence row was wrongly deleted"
+
+
+@pytest.mark.asyncio
+async def test_tick_with_retention_zero_prunes_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``RETENTION_DAYS=0`` is a no-op tick: it prunes nothing, writes no audit row."""
+    monkeypatch.setenv("CHECKS_EVIDENCE_RETENTION_DAYS", "0")
+    get_settings.cache_clear()
+
+    sensor_id = await _seed_sensor()
+    very_old = await _seed_result(
+        sensor_id, evaluated_at=datetime.now(UTC) - timedelta(days=365 * 5)
+    )
+
+    await _run_one_prune_tick()
+
+    assert very_old in await _list_result_ids(sensor_id), (
+        "RETENTION_DAYS=0 must not prune (feature-off heartbeat)"
+    )
+    assert await _list_prune_audit_rows() == [], "no-op tick must not write an audit row"
+
+
+@pytest.mark.asyncio
+async def test_tick_writes_one_audit_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tick that runs a real sweep writes exactly one INTERNAL audit row."""
+    monkeypatch.setenv("CHECKS_EVIDENCE_RETENTION_DAYS", "7")
+    get_settings.cache_clear()
+
+    sensor_id = await _seed_sensor()
+    await _seed_result(sensor_id, evaluated_at=datetime.now(UTC) - timedelta(days=8))
+
+    await _run_one_prune_tick()
+
+    audit_rows = await _list_prune_audit_rows()
+    assert len(audit_rows) == 1
+    assert audit_rows[0].operator_sub == SYSTEM_OPERATOR_SUB

--- a/backend/tests/test_checks_sensor_results.py
+++ b/backend/tests/test_checks_sensor_results.py
@@ -1,0 +1,545 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-tick evidence retention + trend query -- repository / service / REST (#2756).
+
+Initiative #2780 (parent goal #221), Task #2756. Coverage matrix:
+
+* **Repository** -- ``record_sensor_result(record_history=...)`` appends one
+  ``sensor_results`` row per non-stale evaluation in the projection's
+  transaction (two ticks => two rows), writes nothing when disabled, appends no
+  duplicate on a stale timestamp, and rolls back with the projection;
+  ``list_sensor_results`` filters + orders + keyset-paginates.
+* **Service** -- ``list_results`` scopes to the tenant (cross-tenant => None),
+  round-trips the keyset cursor, and rejects a malformed cursor.
+* **REST** -- the ``{items, next_cursor}`` envelope in ``evaluated_at ASC``
+  order, an unknown query param rejected 422 (no aggregation knobs), a
+  cross-tenant read 404, a state filter, and a malformed cursor 422.
+* **Settings** -- the ``CHECKS_EVIDENCE_*`` env round-trips through
+  ``get_settings()`` (the #2737 discipline), incl. the ``0``-disables default.
+
+Runs on the SQLite engine from :mod:`tests.conftest`; REST via
+:class:`fastapi.testclient.TestClient`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.checks.repository import list_sensor_results, record_sensor_result
+from meho_backplane.checks.schemas import SensorCreate, SensorResultsQuery
+from meho_backplane.checks.service import SensorAdminService, SensorResultsCursorError
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, SensorResult, Tenant
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import (
+    make_rsa_keypair,
+    mint_token,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+from ._vault_fakes import install_fake_vault
+
+_TENANT_A = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_TENANT_B = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+_SAFE_CONNECTOR = "vmware-rest-9.0"
+_SAFE_OP = "vmware.vm.list"
+
+_ASSERTION: dict[str, Any] = {
+    "select": {"path": "$.count"},
+    "compare": {"type": "threshold", "op": "lt", "critical": 10},
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    monkeypatch.setenv("SCHEDULER_ENABLED", "false")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+def _token(
+    key: Any,
+    *,
+    sub: str = "op-admin",
+    role: TenantRole = TenantRole.TENANT_ADMIN,
+    tenant_id: UUID = _TENANT_A,
+) -> str:
+    return mint_token(
+        key,
+        sub=sub,
+        tenant_role=role.value,
+        tenant_id=str(tenant_id),
+    )
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    install_fake_vault(monkeypatch)
+    yield TestClient(app)
+
+
+async def _seed_tenant(tenant_id: UUID, slug: str) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        existing = await session.execute(select(Tenant).where(Tenant.id == tenant_id))
+        if existing.scalar_one_or_none() is None:
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+            await session.commit()
+
+
+async def _seed_descriptor(op_id: str = _SAFE_OP) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        existing = await session.execute(
+            select(EndpointDescriptor).where(
+                EndpointDescriptor.tenant_id.is_(None),
+                EndpointDescriptor.op_id == op_id,
+            )
+        )
+        if existing.scalar_one_or_none() is None:
+            session.add(
+                EndpointDescriptor(
+                    product="vmware",
+                    version="9.0",
+                    impl_id="vmware-rest",
+                    op_id=op_id,
+                    source_kind="ingested",
+                    method="GET",
+                    path=f"/{op_id}",
+                    parameter_schema={"type": "object", "properties": {}},
+                    safety_level="safe",
+                )
+            )
+            await session.commit()
+
+
+def _create_payload(name: str = "disk-space") -> SensorCreate:
+    return SensorCreate.model_validate(
+        {
+            "name": name,
+            "connector_id": _SAFE_CONNECTOR,
+            "op_id": _SAFE_OP,
+            "assertion": _ASSERTION,
+            "cadence_kind": "interval",
+            "interval_seconds": 60,
+        }
+    )
+
+
+async def _seed_sensor(tenant_id: UUID = _TENANT_A, *, name: str = "disk-space") -> UUID:
+    """Seed a tenant + safe descriptor + one sensor; return the sensor id."""
+    await _seed_tenant(tenant_id, slug=str(tenant_id)[:8])
+    await _seed_descriptor()
+    service = SensorAdminService()
+    created = await service.create(
+        tenant_id=tenant_id, created_by_sub="op-admin", payload=_create_payload(name)
+    )
+    return created.id
+
+
+async def _append_results(
+    sensor_id: UUID,
+    *,
+    count: int,
+    base: datetime,
+    step_seconds: int = 60,
+    state: str = "ok",
+) -> None:
+    """Append *count* evidence rows via the runner's persist seam."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        for i in range(count):
+            await record_sensor_result(
+                session,
+                sensor_id=sensor_id,
+                state=state,  # type: ignore[arg-type]
+                value=i,
+                evidence={"observed": i},
+                evaluated_at=base + timedelta(seconds=i * step_seconds),
+                record_history=True,
+            )
+        await session.commit()
+
+
+async def _count_results(sensor_id: UUID) -> int:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        total = await session.execute(
+            select(func.count())
+            .select_from(SensorResult)
+            .where(SensorResult.sensor_id == sensor_id)
+        )
+        return int(total.scalar_one())
+
+
+# ---------------------------------------------------------------------------
+# Repository: record_history
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_history_appends_one_row_per_tick() -> None:
+    """Two non-stale ticks => two rows; the projection reflects the latest."""
+    sensor_id = await _seed_sensor()
+    t0 = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+    await _append_results(sensor_id, count=2, base=t0)
+
+    assert await _count_results(sensor_id) == 2
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = list(
+            (
+                await session.execute(
+                    select(SensorResult)
+                    .where(SensorResult.sensor_id == sensor_id)
+                    .order_by(SensorResult.evaluated_at.asc())
+                )
+            ).scalars()
+        )
+    assert [r.value for r in rows] == [0, 1]
+
+
+@pytest.mark.asyncio
+async def test_record_history_disabled_writes_no_rows() -> None:
+    """``record_history=False`` (retention disabled) appends nothing."""
+    sensor_id = await _seed_sensor()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await record_sensor_result(
+            session,
+            sensor_id=sensor_id,
+            state="ok",
+            value=1,
+            evidence={"observed": 1},
+            evaluated_at=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+            record_history=False,
+        )
+        await session.commit()
+    assert await _count_results(sensor_id) == 0
+
+
+@pytest.mark.asyncio
+async def test_record_history_stale_result_appends_no_duplicate() -> None:
+    """A non-newer ``evaluated_at`` is ignored: no projection change, no extra row."""
+    sensor_id = await _seed_sensor()
+    t0 = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        assert (
+            await record_sensor_result(
+                session,
+                sensor_id=sensor_id,
+                state="ok",
+                value=1,
+                evidence={},
+                evaluated_at=t0,
+                record_history=True,
+            )
+            is True
+        )
+        # Same timestamp again -> stale/idempotent, must not append a 2nd row.
+        assert (
+            await record_sensor_result(
+                session,
+                sensor_id=sensor_id,
+                state="critical",
+                value=9,
+                evidence={},
+                evaluated_at=t0,
+                record_history=True,
+            )
+            is False
+        )
+        await session.commit()
+    assert await _count_results(sensor_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_record_history_rolls_back_with_projection() -> None:
+    """A rollback discards both the history row and the projection update."""
+    sensor_id = await _seed_sensor()
+    t0 = datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await record_sensor_result(
+            session,
+            sensor_id=sensor_id,
+            state="critical",
+            value=99,
+            evidence={"observed": 99},
+            evaluated_at=t0,
+            record_history=True,
+        )
+        # Simulate a downstream persist failure before the caller commits.
+        await session.rollback()
+
+    # Neither the row nor the projection change survived the aborted txn.
+    assert await _count_results(sensor_id) == 0
+    read = await SensorAdminService().get(_TENANT_A, sensor_id)
+    assert read is not None
+    assert read.last_state == "unknown"
+    assert read.last_evaluated_at is None
+
+
+# ---------------------------------------------------------------------------
+# Repository: list_sensor_results
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_sensor_results_filters_window_and_state() -> None:
+    """From/to window + state filter narrow the rows; order is evaluated_at ASC."""
+    sensor_id = await _seed_sensor()
+    base = datetime(2026, 8, 1, 0, 0, 0, tzinfo=UTC)
+    # 5 ok rows at 0..4 min, then 3 critical rows at 5..7 min.
+    await _append_results(sensor_id, count=5, base=base, state="ok")
+    await _append_results(sensor_id, count=3, base=base + timedelta(minutes=5), state="critical")
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows, nxt = await list_sensor_results(
+            session,
+            sensor_id=sensor_id,
+            from_ts=base + timedelta(minutes=5),
+            to_ts=None,
+            state="critical",
+            limit=100,
+            after=None,
+        )
+    assert nxt is None
+    assert [r.state for r in rows] == ["critical", "critical", "critical"]
+    # ascending order
+    assert rows == sorted(rows, key=lambda r: r.evaluated_at)
+
+
+@pytest.mark.asyncio
+async def test_list_sensor_results_keyset_pagination() -> None:
+    """A full page returns a next cursor; the next page continues after it."""
+    sensor_id = await _seed_sensor()
+    base = datetime(2026, 8, 1, 0, 0, 0, tzinfo=UTC)
+    await _append_results(sensor_id, count=5, base=base)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        page1, nxt = await list_sensor_results(
+            session,
+            sensor_id=sensor_id,
+            from_ts=None,
+            to_ts=None,
+            state=None,
+            limit=2,
+            after=None,
+        )
+        assert len(page1) == 2
+        assert nxt is not None
+        page2, nxt2 = await list_sensor_results(
+            session,
+            sensor_id=sensor_id,
+            from_ts=None,
+            to_ts=None,
+            state=None,
+            limit=2,
+            after=nxt,
+        )
+    assert [r.value for r in page1] == [0, 1]
+    assert [r.value for r in page2] == [2, 3]
+    assert nxt2 is not None  # still one more row (index 4)
+
+
+# ---------------------------------------------------------------------------
+# Service: list_results (tenant scope + cursor)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_list_results_cross_tenant_returns_none() -> None:
+    """A caller in tenant B cannot read tenant A's sensor history."""
+    sensor_id = await _seed_sensor(_TENANT_A)
+    await _append_results(sensor_id, count=1, base=datetime(2026, 8, 1, tzinfo=UTC))
+    await _seed_tenant(_TENANT_B, slug="tenant-b")
+    page = await SensorAdminService().list_results(_TENANT_B, sensor_id, SensorResultsQuery())
+    assert page is None
+
+
+@pytest.mark.asyncio
+async def test_service_list_results_cursor_round_trip() -> None:
+    """The opaque cursor pages through the full series without gaps/dupes."""
+    sensor_id = await _seed_sensor()
+    await _append_results(sensor_id, count=3, base=datetime(2026, 8, 1, tzinfo=UTC))
+    service = SensorAdminService()
+    page1 = await service.list_results(_TENANT_A, sensor_id, SensorResultsQuery(limit=2))
+    assert page1 is not None
+    assert len(page1.items) == 2
+    assert page1.next_cursor is not None
+    page2 = await service.list_results(
+        _TENANT_A, sensor_id, SensorResultsQuery(limit=2, cursor=page1.next_cursor)
+    )
+    assert page2 is not None
+    assert len(page2.items) == 1
+    assert page2.next_cursor is None
+
+
+@pytest.mark.asyncio
+async def test_service_list_results_invalid_cursor_raises() -> None:
+    """A malformed cursor raises the typed error the boundary maps to 422."""
+    sensor_id = await _seed_sensor()
+    with pytest.raises(SensorResultsCursorError):
+        await SensorAdminService().list_results(
+            _TENANT_A, sensor_id, SensorResultsQuery(cursor="!!not-base64!!")
+        )
+
+
+@pytest.mark.asyncio
+async def test_service_list_results_empty_when_no_rows() -> None:
+    """A sensor with no history returns an empty page (not None)."""
+    sensor_id = await _seed_sensor()
+    page = await SensorAdminService().list_results(_TENANT_A, sensor_id, SensorResultsQuery())
+    assert page is not None
+    assert page.items == []
+    assert page.next_cursor is None
+
+
+# ---------------------------------------------------------------------------
+# REST
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rest_results_envelope_and_order(client: TestClient) -> None:
+    """GET returns the {items, next_cursor} envelope, evaluated_at ASC."""
+    sensor_id = await _seed_sensor()
+    await _append_results(sensor_id, count=3, base=datetime(2026, 8, 1, tzinfo=UTC))
+    key = make_rsa_keypair("kid-results")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/sensors/{sensor_id}/results",
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body.keys()) == {"items", "next_cursor"}
+    values = [item["value"] for item in body["items"]]
+    assert values == [0, 1, 2]
+    assert all(item["sensor_id"] == str(sensor_id) for item in body["items"])
+
+
+@pytest.mark.asyncio
+async def test_rest_results_unknown_param_returns_422(client: TestClient) -> None:
+    """An unknown filter param is rejected 422 -- pins 'no aggregation knobs'."""
+    sensor_id = await _seed_sensor()
+    key = make_rsa_keypair("kid-results")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/sensors/{sensor_id}/results",
+            params={"smoothing": "ewma"},
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_rest_results_state_filter(client: TestClient) -> None:
+    """The state filter returns only matching rows."""
+    sensor_id = await _seed_sensor()
+    base = datetime(2026, 8, 1, tzinfo=UTC)
+    await _append_results(sensor_id, count=2, base=base, state="ok")
+    await _append_results(sensor_id, count=2, base=base + timedelta(minutes=5), state="critical")
+    key = make_rsa_keypair("kid-results")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/sensors/{sensor_id}/results",
+            params={"state": "critical"},
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    assert len(items) == 2
+    assert all(item["state"] == "critical" for item in items)
+
+
+@pytest.mark.asyncio
+async def test_rest_results_cross_tenant_returns_404(client: TestClient) -> None:
+    """A tenant-B caller reading a tenant-A sensor's history gets 404, not 403."""
+    sensor_id = await _seed_sensor(_TENANT_A)
+    await _append_results(sensor_id, count=1, base=datetime(2026, 8, 1, tzinfo=UTC))
+    key = make_rsa_keypair("kid-results")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/sensors/{sensor_id}/results",
+            headers={"Authorization": f"Bearer {_token(key, tenant_id=_TENANT_B)}"},
+        )
+    assert resp.status_code == 404, resp.text
+    assert resp.json()["detail"] == "sensor_not_found"
+
+
+@pytest.mark.asyncio
+async def test_rest_results_invalid_cursor_returns_422(client: TestClient) -> None:
+    """A malformed cursor is a 422 sensor_results_invalid_cursor."""
+    sensor_id = await _seed_sensor()
+    key = make_rsa_keypair("kid-results")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/sensors/{sensor_id}/results",
+            params={"cursor": "!!bad!!"},
+            headers={"Authorization": f"Bearer {_token(key)}"},
+        )
+    assert resp.status_code == 422, resp.text
+    assert resp.json()["detail"] == "sensor_results_invalid_cursor"
+
+
+# ---------------------------------------------------------------------------
+# Settings round-trip (#2737 discipline)
+# ---------------------------------------------------------------------------
+
+
+def test_settings_evidence_env_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CHECKS_EVIDENCE_* env round-trips through get_settings()."""
+    monkeypatch.setenv("CHECKS_EVIDENCE_RETENTION_DAYS", "14")
+    monkeypatch.setenv("CHECKS_EVIDENCE_PRUNE_INTERVAL_SECONDS", "3600")
+    monkeypatch.setenv("CHECKS_EVIDENCE_PRUNE_ENABLED", "false")
+    get_settings.cache_clear()
+    settings = get_settings()
+    assert settings.checks_evidence_retention_days == 14
+    assert settings.checks_evidence_prune_interval_seconds == 3600
+    assert settings.checks_evidence_prune_enabled is False
+
+
+def test_settings_evidence_defaults() -> None:
+    """Defaults: 7-day retention, weekly cadence, prune enabled."""
+    get_settings.cache_clear()
+    settings = get_settings()
+    assert settings.checks_evidence_retention_days == 7
+    assert settings.checks_evidence_prune_interval_seconds == 604800
+    assert settings.checks_evidence_prune_enabled is True

--- a/backend/tests/test_checks_sensor_results.py
+++ b/backend/tests/test_checks_sensor_results.py
@@ -40,7 +40,7 @@ from meho_backplane.checks.repository import list_sensor_results, record_sensor_
 from meho_backplane.checks.schemas import SensorCreate, SensorResultsQuery
 from meho_backplane.checks.service import SensorAdminService, SensorResultsCursorError
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import EndpointDescriptor, SensorResult, Tenant
+from meho_backplane.db.models import EndpointDescriptor, Sensor, SensorResult, Tenant
 from meho_backplane.main import app
 from meho_backplane.settings import get_settings
 
@@ -280,6 +280,47 @@ async def test_record_history_stale_result_appends_no_duplicate() -> None:
             is False
         )
         await session.commit()
+    assert await _count_results(sensor_id) == 1
+
+
+@pytest.mark.asyncio
+async def test_record_history_appends_row_for_unconfirmed_soft_reading() -> None:
+    """A #2799 soft/pending reading (unconfirmed) still lands in history.
+
+    The #2756 x #2799 collision invariant the initiative called out: the
+    evidence append rides *before* the confirmation gate, so a reading held as
+    a soft state (no commit, projection unchanged) still produces exactly one
+    evidence row -- history records the observed outcome, not just committed
+    transitions.
+    """
+    sensor_id = await _seed_sensor()
+    # Give the sensor a confirmation window (#2799); there is no update route,
+    # so set it directly on the row.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(Sensor, sensor_id)
+        assert row is not None
+        row.retry_times = 2
+        await session.commit()
+
+    async with sessionmaker() as session:
+        committed = await record_sensor_result(
+            session,
+            sensor_id=sensor_id,
+            state="critical",
+            value=9,
+            evidence={"reason": "breach"},
+            evaluated_at=datetime(2026, 8, 1, 12, 0, 0, tzinfo=UTC),
+            record_history=True,
+        )
+        await session.commit()
+
+    # retry_times=2 holds the first differing reading soft: nothing commits...
+    assert committed is False
+    read = await SensorAdminService().get(_TENANT_A, sensor_id)
+    assert read is not None
+    assert read.last_state == "unknown"
+    # ...but the unconfirmed reading is still in the evidence history.
     assert await _count_results(sensor_id) == 1
 
 

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -399,6 +399,12 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                 # KeyErrors on KEYCLOAK_ISSUER_URL in this env-free lifespan test.
                 start_announcement_retention_sweeper=MagicMock(),
                 stop_announcement_retention_sweeper=AsyncMock(),
+                # #2756 per-tick evidence retention sweeper (same #2547 mould,
+                # gated on checks_evidence_prune_enabled). Same defensive patch
+                # so the real sweeper never starts its get_settings() tick read
+                # and KeyErrors on KEYCLOAK_ISSUER_URL in this env-free test.
+                start_evidence_retention_sweeper=MagicMock(),
+                stop_evidence_retention_sweeper=AsyncMock(),
                 start_agent_run_reaper=MagicMock(),
                 stop_agent_run_reaper=AsyncMock(),
                 start_event_drain=MagicMock(),
@@ -522,6 +528,12 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                 # KeyErrors on KEYCLOAK_ISSUER_URL in this env-free lifespan test.
                 start_announcement_retention_sweeper=MagicMock(),
                 stop_announcement_retention_sweeper=AsyncMock(),
+                # #2756 per-tick evidence retention sweeper (same #2547 mould,
+                # gated on checks_evidence_prune_enabled). Same defensive patch
+                # so the real sweeper never starts its get_settings() tick read
+                # and KeyErrors on KEYCLOAK_ISSUER_URL in this env-free test.
+                start_evidence_retention_sweeper=MagicMock(),
+                stop_evidence_retention_sweeper=AsyncMock(),
                 start_agent_run_reaper=MagicMock(),
                 stop_agent_run_reaper=AsyncMock(),
                 start_event_drain=MagicMock(),

--- a/backend/tests/test_db_sensor_results.py
+++ b/backend/tests/test_db_sensor_results.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the :class:`SensorResult` ORM model (#2756).
+
+Initiative #2780 (parent goal #221), Task #2756. The ``sensor_results`` table
+is the append-only per-tick evidence history the check runner writes alongside
+the :class:`Sensor` latest-state projection.
+
+Coverage matrix
+---------------
+
+* **Round-trip persists every field** ``(sensor_id, evaluated_at, state, value,
+  evidence, reason)``.
+* **Closed-enum CHECK rejects an unknown ``state``.**
+* **Drift guards.** The ``ck_sensor_results_state`` value set equals #2504's
+  :data:`CheckState`; the migration's frozen literal snapshot agrees.
+* **``ON DELETE CASCADE``**: deleting a Sensor drops its history rows (the
+  cascade-not-tombstone decision #2756 pins), exercised with SQLite
+  foreign-key enforcement opted in.
+
+The tests run against ``sqlite+aiosqlite`` via the shared engine the autouse
+``_default_database_url`` fixture pre-migrates to head.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import get_args
+
+import pytest
+from sqlalchemy import CheckConstraint, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.checks.assertions import CheckState
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import (
+    _SENSOR_LAST_STATES,
+    Sensor,
+    SensorCadenceKind,
+    SensorResult,
+    SensorSeverity,
+    SensorStatus,
+    Tenant,
+)
+from meho_backplane.settings import get_settings
+
+_ASSERTION = {
+    "select": {"path": "$.count"},
+    "compare": {"type": "threshold", "op": "lt", "critical": 10},
+}
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def _enforce_sqlite_foreign_keys(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Opt this test in to SQLite foreign-key enforcement.
+
+    ``ON DELETE CASCADE`` only fires when SQLite has ``PRAGMA foreign_keys =
+    ON``; flipping ``MEHO_SQLITE_FOREIGN_KEYS=1`` and resetting the cached
+    engine rebuilds it with the per-connection PRAGMA listener attached, on top
+    of the per-test DB the conftest already migrated to head. Mirrors
+    :func:`tests.test_agents_delete_cascade._enforce_sqlite_foreign_keys`.
+    """
+    monkeypatch.setenv("MEHO_SQLITE_FOREIGN_KEYS", "1")
+    reset_engine_for_testing()
+    yield
+    reset_engine_for_testing()
+
+
+async def _seed_tenant(session: AsyncSession, *, slug: str = "sr-test-tenant") -> uuid.UUID:
+    """Insert a tenant row and return its UUID (slug must not be ``default``)."""
+    tenant_id = uuid.uuid4()
+    session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+    await session.commit()
+    return tenant_id
+
+
+async def _seed_sensor(
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    *,
+    name: str = "disk-space",
+) -> uuid.UUID:
+    """Insert a minimal interval Sensor and return its UUID."""
+    sensor_id = uuid.uuid4()
+    session.add(
+        Sensor(
+            id=sensor_id,
+            tenant_id=tenant_id,
+            name=name,
+            connector_id="vmware-rest-9.0",
+            op_id="vmware.vm.list",
+            params={},
+            assertion=_ASSERTION,
+            status=SensorStatus.ACTIVE.value,
+            cadence_kind=SensorCadenceKind.INTERVAL.value,
+            interval_seconds=60,
+            severity=SensorSeverity.CRITICAL.value,
+            for_seconds=0,
+            last_state="unknown",
+            created_by_sub="user-admin",
+        )
+    )
+    await session.commit()
+    return sensor_id
+
+
+@pytest.mark.asyncio
+async def test_round_trip_persists_every_field() -> None:
+    """Insert a fully-populated :class:`SensorResult`; every field round-trips."""
+    sessionmaker = get_sessionmaker()
+    evaluated_at = datetime.now(UTC)
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        sensor_id = await _seed_sensor(session, tenant_id)
+        row_id = uuid.uuid4()
+        session.add(
+            SensorResult(
+                id=row_id,
+                sensor_id=sensor_id,
+                evaluated_at=evaluated_at,
+                state="critical",
+                value=42,
+                evidence={"reason": "threshold_breach", "observed": 42},
+                reason="threshold_breach",
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(select(SensorResult).where(SensorResult.id == row_id))
+        ).scalar_one()
+
+    assert row.sensor_id == sensor_id
+    assert row.state == "critical"
+    assert row.value == 42
+    assert row.evidence == {"reason": "threshold_breach", "observed": 42}
+    assert row.reason == "threshold_breach"
+
+
+@pytest.mark.asyncio
+async def test_nullable_columns_accept_none() -> None:
+    """``value`` / ``evidence`` / ``reason`` accept NULL (an unknown outcome)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        sensor_id = await _seed_sensor(session, tenant_id)
+        row_id = uuid.uuid4()
+        session.add(
+            SensorResult(
+                id=row_id,
+                sensor_id=sensor_id,
+                evaluated_at=datetime.now(UTC),
+                state="unknown",
+                value=None,
+                evidence=None,
+                reason=None,
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(select(SensorResult).where(SensorResult.id == row_id))
+        ).scalar_one()
+    assert row.value is None
+    assert row.evidence is None
+    assert row.reason is None
+
+
+@pytest.mark.asyncio
+async def test_state_check_rejects_unknown_value() -> None:
+    """``ck_sensor_results_state`` rejects a value outside CheckState."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        sensor_id = await _seed_sensor(session, tenant_id)
+        session.add(
+            SensorResult(
+                id=uuid.uuid4(),
+                sensor_id=sensor_id,
+                evaluated_at=datetime.now(UTC),
+                state="bogus",
+                value=None,
+                evidence=None,
+                reason=None,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
+@pytest.mark.usefixtures("_enforce_sqlite_foreign_keys")
+@pytest.mark.asyncio
+async def test_delete_sensor_cascades_its_results() -> None:
+    """Deleting a Sensor drops its ``sensor_results`` rows (ON DELETE CASCADE)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        sensor_id = await _seed_sensor(session, tenant_id)
+        base = datetime.now(UTC)
+        for i in range(3):
+            session.add(
+                SensorResult(
+                    id=uuid.uuid4(),
+                    sensor_id=sensor_id,
+                    evaluated_at=base + timedelta(seconds=i),
+                    state="ok",
+                    value=i,
+                    evidence=None,
+                    reason=None,
+                )
+            )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        rows_before = (
+            (await session.execute(select(SensorResult).where(SensorResult.sensor_id == sensor_id)))
+            .scalars()
+            .all()
+        )
+        assert len(rows_before) == 3
+        sensor = await session.get(Sensor, sensor_id)
+        assert sensor is not None
+        await session.delete(sensor)
+        await session.commit()
+
+    async with sessionmaker() as session:
+        rows_after = (
+            (await session.execute(select(SensorResult).where(SensorResult.sensor_id == sensor_id)))
+            .scalars()
+            .all()
+        )
+    assert rows_after == [], "sensor delete must cascade-delete its evidence rows"
+
+
+def _orm_check_bodies() -> dict[str, str]:
+    """Map each named CHECK on the ``sensor_results`` ORM table to its SQL body."""
+    return {
+        c.name: str(c.sqltext)
+        for c in SensorResult.__table__.constraints
+        if isinstance(c, CheckConstraint) and c.name is not None
+    }
+
+
+def test_state_value_set_equals_checkstate() -> None:
+    """``ck_sensor_results_state`` covers exactly #2504's ``CheckState`` members."""
+    body = _orm_check_bodies()["ck_sensor_results_state"]
+    for member in get_args(CheckState):
+        assert f"'{member}'" in body
+    # And the ORM derives its CHECK from the shared _SENSOR_LAST_STATES tuple.
+    assert set(_SENSOR_LAST_STATES) == set(get_args(CheckState))
+
+
+def _load_migration_by_name(name: str) -> object:
+    """Load an Alembic migration module by its file basename."""
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parent.parent / "alembic" / "versions" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(f"_migration_{name}", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_migration_frozen_state_literal_equals_checkstate() -> None:
+    """Migration 0071's frozen ``state`` literal is a snapshot of ``CheckState``."""
+    migration = _load_migration_by_name("0071_create_sensor_results")
+    assert set(migration._SENSOR_RESULT_STATES) == set(get_args(CheckState))  # type: ignore[attr-defined]

--- a/backend/tests/test_mcp_tool_sensor_results.py
+++ b/backend/tests/test_mcp_tool_sensor_results.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``meho_sensor_results`` MCP tool (#2756).
+
+Initiative #2780 (parent goal #221), Task #2756. Covers:
+
+* the tool is registered and appears in a ``tools/list`` for an operator;
+* the handler returns the ``{items, next_cursor}`` envelope for the caller's
+  tenant, oldest-first;
+* a cross-tenant sensor id surfaces as ``sensor_not_found``;
+* an unknown filter param is rejected (schema refusal -- "no aggregation
+  knobs"), as is a malformed cursor.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.checks.repository import record_sensor_result
+from meho_backplane.checks.schemas import SensorCreate
+from meho_backplane.checks.service import SensorAdminService
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, Tenant
+from meho_backplane.mcp.registry import all_tools_for, get_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+
+# Importing the module runs its side-effect register_mcp_tool calls.
+from meho_backplane.mcp.tools import sensors as _sensor_tools
+from meho_backplane.settings import get_settings
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_TENANT_B = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+_SAFE_CONNECTOR = "vmware-rest-9.0"
+_SAFE_OP = "vmware.vm.list"
+_ASSERTION: dict[str, Any] = {
+    "select": {"path": "$.count"},
+    "compare": {"type": "threshold", "op": "lt", "critical": 10},
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _operator(tenant_id: uuid.UUID = _TENANT_A) -> Operator:
+    return Operator(
+        sub="mcp-op",
+        raw_jwt="dummy",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        await session.commit()
+
+
+async def _seed_descriptor() -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            EndpointDescriptor(
+                product="vmware",
+                version="9.0",
+                impl_id="vmware-rest",
+                op_id=_SAFE_OP,
+                source_kind="ingested",
+                method="GET",
+                path=f"/{_SAFE_OP}",
+                parameter_schema={"type": "object", "properties": {}},
+                safety_level="safe",
+            )
+        )
+        await session.commit()
+
+
+async def _seed_sensor_with_results(
+    tenant_id: uuid.UUID = _TENANT_A, *, count: int = 3
+) -> uuid.UUID:
+    await _seed_tenant(tenant_id, slug=str(tenant_id)[:8])
+    await _seed_descriptor()
+    created = await SensorAdminService().create(
+        tenant_id=tenant_id,
+        created_by_sub="op-admin",
+        payload=SensorCreate.model_validate(
+            {
+                "name": "disk-space",
+                "connector_id": _SAFE_CONNECTOR,
+                "op_id": _SAFE_OP,
+                "assertion": _ASSERTION,
+                "cadence_kind": "interval",
+                "interval_seconds": 60,
+            }
+        ),
+    )
+    base = datetime(2026, 8, 1, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        for i in range(count):
+            await record_sensor_result(
+                session,
+                sensor_id=created.id,
+                state="ok",
+                value=i,
+                evidence={"observed": i},
+                evaluated_at=base + timedelta(minutes=i),
+                record_history=True,
+            )
+        await session.commit()
+    return created.id
+
+
+def test_results_tool_registered() -> None:
+    """meho_sensor_results is registered and appears in tools/list."""
+    assert _sensor_tools is not None
+    assert get_tool("meho_sensor_results") is not None
+    listed = {t.name for t in all_tools_for(_operator())}
+    assert "meho_sensor_results" in listed
+
+
+@pytest.mark.asyncio
+async def test_results_handler_returns_items() -> None:
+    """The handler returns the {items, next_cursor} envelope, oldest-first."""
+    sensor_id = await _seed_sensor_with_results(count=3)
+    result = await _sensor_tools._results_handler(_operator(), {"sensor_id": str(sensor_id)})
+    assert set(result.keys()) == {"items", "next_cursor"}
+    assert [item["value"] for item in result["items"]] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_results_handler_cross_tenant_not_found() -> None:
+    """A caller in another tenant cannot read the sensor's history."""
+    sensor_id = await _seed_sensor_with_results(_TENANT_A, count=1)
+    await _seed_tenant(_TENANT_B, "tenant-b")
+    with pytest.raises(McpInvalidParamsError) as exc:
+        await _sensor_tools._results_handler(_operator(_TENANT_B), {"sensor_id": str(sensor_id)})
+    assert "sensor_not_found" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_results_handler_rejects_unknown_param() -> None:
+    """An unknown filter param is a schema refusal (no aggregation knobs)."""
+    sensor_id = await _seed_sensor_with_results(count=1)
+    with pytest.raises(McpInvalidParamsError):
+        await _sensor_tools._results_handler(
+            _operator(), {"sensor_id": str(sensor_id), "smoothing": "ewma"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_results_handler_rejects_invalid_cursor() -> None:
+    """A malformed cursor surfaces as an invalid-params error."""
+    sensor_id = await _seed_sensor_with_results(count=1)
+    with pytest.raises(McpInvalidParamsError):
+        await _sensor_tools._results_handler(
+            _operator(), {"sensor_id": str(sensor_id), "cursor": "!!bad!!"}
+        )

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -8138,6 +8138,121 @@
         }
       }
     },
+    "/api/v1/sensors/{sensor_id}/results": {
+      "get": {
+        "tags": [
+          "sensors"
+        ],
+        "summary": "List Sensor Results",
+        "description": "Return a page of a sensor's per-tick evidence history, ``evaluated_at ASC``.\n\nThe forensic trend query (#2756) -- \"when did this start degrading / how\nfast is it filling\". ``operator`` role. Binary filters only: an inclusive\n``from`` / ``to`` window, an exact ``state``, a bounded ``limit``, and an\nopaque keyset ``cursor`` (echo ``next_cursor`` back to page). An unknown\nquery param is a 422 (the :class:`SensorResultsQuery` model forbids extras)\nso \"no aggregation knobs\" holds at the wire; a malformed ``cursor`` is a 422\n``sensor_results_invalid_cursor``. An absent sensor id (or one owned by\nanother tenant) returns 404 ``sensor_not_found`` -- never 403 -- so neither\na sensor's existence nor its history leaks across the tenant boundary.\n\nScoped to the caller's own tenant: unlike ``list`` / ``delete`` there is no\nplatform-admin ``tenant_filter`` here. Cross-tenant forensic history is not\na stated need, the MCP ``meho_sensor_results`` tool is likewise\nown-tenant-only, and folding a standalone cross-tenant query param in beside\nthe :class:`SensorResultsQuery` model would collapse the flattened OpenAPI\nquery parameters into a single opaque object -- breaking the typed Go CLI\nclient the ``meho sensor results`` verb is generated from.",
+        "operationId": "list_sensor_results_api_v1_sensors__sensor_id__results_get",
+        "parameters": [
+          {
+            "name": "sensor_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Sensor Id"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true,
+              "title": "From"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true,
+              "title": "To"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "critical",
+                "unknown",
+                "skip"
+              ],
+              "type": "string",
+              "nullable": true,
+              "title": "State"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SensorResultListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/checks/dashboards": {
       "get": {
         "tags": [
@@ -28099,6 +28214,78 @@
         ],
         "title": "SensorRead",
         "description": "Response shape for one ``sensor`` row.\n\nMirrors :class:`~meho_backplane.db.models.Sensor`'s column set,\nprojected to the wire types the JSON renderer can serialise. Includes\nthe latest-result projection (``last_state`` / ``last_value`` /\n``last_evidence`` / ``last_evaluated_at`` / ``state_since``) so the\nlist response carries the current status view (there is no REST\nGET-by-id -- the mould exposes none). ``frozen=True`` so a route\nhandler cannot mutate the row after returning it."
+      },
+      "SensorResultListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SensorResultRead"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "next_cursor": {
+            "type": "string",
+            "nullable": true,
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "SensorResultListResponse",
+        "description": "Response envelope for ``GET /api/v1/sensors/{sensor_id}/results``.\n\nThe ``{items, next_cursor}`` keyset-pagination shape (#2742): ``items`` is\nthe page of evidence rows in ``evaluated_at ASC`` order; ``next_cursor`` is\nthe opaque continuation token to pass back as ``?cursor=`` for the next\npage, or ``null`` when this is the final page. No aggregate / rollup fields\n-- the client aggregates raw rows (#2756's determinism bound)."
+      },
+      "SensorResultRead": {
+        "properties": {
+          "sensor_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Sensor Id"
+          },
+          "evaluated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Evaluated At"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "degraded",
+              "critical",
+              "unknown",
+              "skip"
+            ],
+            "title": "State"
+          },
+          "value": {
+            "title": "Value"
+          },
+          "evidence": {
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true,
+            "title": "Evidence"
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true,
+            "title": "Reason"
+          }
+        },
+        "type": "object",
+        "required": [
+          "sensor_id",
+          "evaluated_at",
+          "state",
+          "value",
+          "evidence",
+          "reason"
+        ],
+        "title": "SensorResultRead",
+        "description": "Response shape for one ``sensor_results`` evidence row (#2756).\n\nMirrors :class:`~meho_backplane.db.models.SensorResult`, projected to the\nwire types the JSON renderer serialises: the raw ``(evaluated_at, state,\nvalue, evidence, reason)`` the runner computed, plus the owning\n``sensor_id``. ``frozen=True`` so a route handler cannot mutate a row after\nreturning it."
       },
       "SensorRunnerStatus": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -393,6 +393,15 @@ const (
 	SensorReadPendingStateUnknown  SensorReadPendingState = "unknown"
 )
 
+// Defines values for SensorResultReadState.
+const (
+	SensorResultReadStateCritical SensorResultReadState = "critical"
+	SensorResultReadStateDegraded SensorResultReadState = "degraded"
+	SensorResultReadStateOk       SensorResultReadState = "ok"
+	SensorResultReadStateSkip     SensorResultReadState = "skip"
+	SensorResultReadStateUnknown  SensorResultReadState = "unknown"
+)
+
 // Defines values for SensorSeverity.
 const (
 	SensorSeverityCritical SensorSeverity = "critical"
@@ -644,6 +653,15 @@ const (
 const (
 	ListSensorsApiV1SensorsGetParamsCadenceKindCron     ListSensorsApiV1SensorsGetParamsCadenceKind = "cron"
 	ListSensorsApiV1SensorsGetParamsCadenceKindInterval ListSensorsApiV1SensorsGetParamsCadenceKind = "interval"
+)
+
+// Defines values for ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState.
+const (
+	ListSensorResultsApiV1SensorsSensorIdResultsGetParamsStateCritical ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState = "critical"
+	ListSensorResultsApiV1SensorsSensorIdResultsGetParamsStateDegraded ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState = "degraded"
+	ListSensorResultsApiV1SensorsSensorIdResultsGetParamsStateOk       ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState = "ok"
+	ListSensorResultsApiV1SensorsSensorIdResultsGetParamsStateSkip     ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState = "skip"
+	ListSensorResultsApiV1SensorsSensorIdResultsGetParamsStateUnknown  ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState = "unknown"
 )
 
 // Defines values for RunbooksIndexUiRunbooksGetParamsStatus.
@@ -6477,6 +6495,37 @@ type SensorReadLastState string
 // SensorReadPendingState defines model for SensorRead.PendingState.
 type SensorReadPendingState string
 
+// SensorResultListResponse Response envelope for “GET /api/v1/sensors/{sensor_id}/results“.
+//
+// The “{items, next_cursor}“ keyset-pagination shape (#2742): “items“ is
+// the page of evidence rows in “evaluated_at ASC“ order; “next_cursor“ is
+// the opaque continuation token to pass back as “?cursor=“ for the next
+// page, or “null“ when this is the final page. No aggregate / rollup fields
+// -- the client aggregates raw rows (#2756's determinism bound).
+type SensorResultListResponse struct {
+	Items      []SensorResultRead `json:"items"`
+	NextCursor *string            `json:"next_cursor"`
+}
+
+// SensorResultRead Response shape for one “sensor_results“ evidence row (#2756).
+//
+// Mirrors :class:`~meho_backplane.db.models.SensorResult`, projected to the
+// wire types the JSON renderer serialises: the raw “(evaluated_at, state,
+// value, evidence, reason)“ the runner computed, plus the owning
+// “sensor_id“. “frozen=True“ so a route handler cannot mutate a row after
+// returning it.
+type SensorResultRead struct {
+	EvaluatedAt time.Time               `json:"evaluated_at"`
+	Evidence    *map[string]interface{} `json:"evidence"`
+	Reason      *string                 `json:"reason"`
+	SensorId    openapi_types.UUID      `json:"sensor_id"`
+	State       SensorResultReadState   `json:"state"`
+	Value       interface{}             `json:"value"`
+}
+
+// SensorResultReadState defines model for SensorResultRead.State.
+type SensorResultReadState string
+
 // SensorRunnerStatus Liveness of this process's sensor evaluation loop (#2763).
 //
 // The queryable half of the checks-runner watchdog: an external prober
@@ -8431,6 +8480,19 @@ type DeleteSensorApiV1SensorsSensorIdDeleteParams struct {
 	TenantFilter  *openapi_types.UUID `form:"tenant_filter,omitempty" json:"tenant_filter,omitempty"`
 	Authorization *string             `json:"authorization,omitempty"`
 }
+
+// ListSensorResultsApiV1SensorsSensorIdResultsGetParams defines parameters for ListSensorResultsApiV1SensorsSensorIdResultsGet.
+type ListSensorResultsApiV1SensorsSensorIdResultsGetParams struct {
+	From          *time.Time                                                  `form:"from,omitempty" json:"from,omitempty"`
+	To            *time.Time                                                  `form:"to,omitempty" json:"to,omitempty"`
+	State         *ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState `form:"state,omitempty" json:"state,omitempty"`
+	Limit         *int                                                        `form:"limit,omitempty" json:"limit,omitempty"`
+	Cursor        *string                                                     `form:"cursor,omitempty" json:"cursor,omitempty"`
+	Authorization *string                                                     `json:"authorization,omitempty"`
+}
+
+// ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState defines parameters for ListSensorResultsApiV1SensorsSensorIdResultsGet.
+type ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState string
 
 // ListTargetsApiV1TargetsGetParams defines parameters for ListTargetsApiV1TargetsGet.
 type ListTargetsApiV1TargetsGetParams struct {
@@ -11127,6 +11189,9 @@ type ClientInterface interface {
 
 	// DeleteSensorApiV1SensorsSensorIdDelete request
 	DeleteSensorApiV1SensorsSensorIdDelete(ctx context.Context, sensorId openapi_types.UUID, params *DeleteSensorApiV1SensorsSensorIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListSensorResultsApiV1SensorsSensorIdResultsGet request
+	ListSensorResultsApiV1SensorsSensorIdResultsGet(ctx context.Context, sensorId openapi_types.UUID, params *ListSensorResultsApiV1SensorsSensorIdResultsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListTargetsApiV1TargetsGet request
 	ListTargetsApiV1TargetsGet(ctx context.Context, params *ListTargetsApiV1TargetsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -13950,6 +14015,18 @@ func (c *Client) CreateSensorApiV1SensorsPost(ctx context.Context, params *Creat
 
 func (c *Client) DeleteSensorApiV1SensorsSensorIdDelete(ctx context.Context, sensorId openapi_types.UUID, params *DeleteSensorApiV1SensorsSensorIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeleteSensorApiV1SensorsSensorIdDeleteRequest(c.Server, sensorId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListSensorResultsApiV1SensorsSensorIdResultsGet(ctx context.Context, sensorId openapi_types.UUID, params *ListSensorResultsApiV1SensorsSensorIdResultsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListSensorResultsApiV1SensorsSensorIdResultsGetRequest(c.Server, sensorId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -25596,6 +25673,141 @@ func NewDeleteSensorApiV1SensorsSensorIdDeleteRequest(server string, sensorId op
 	}
 
 	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewListSensorResultsApiV1SensorsSensorIdResultsGetRequest generates requests for ListSensorResultsApiV1SensorsSensorIdResultsGet
+func NewListSensorResultsApiV1SensorsSensorIdResultsGetRequest(server string, sensorId openapi_types.UUID, params *ListSensorResultsApiV1SensorsSensorIdResultsGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "sensor_id", runtime.ParamLocationPath, sensorId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/sensors/%s/results", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.From != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, *params.From); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.To != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "to", runtime.ParamLocationQuery, *params.To); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.State != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "state", runtime.ParamLocationQuery, *params.State); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -37926,6 +38138,9 @@ type ClientWithResponsesInterface interface {
 	// DeleteSensorApiV1SensorsSensorIdDeleteWithResponse request
 	DeleteSensorApiV1SensorsSensorIdDeleteWithResponse(ctx context.Context, sensorId openapi_types.UUID, params *DeleteSensorApiV1SensorsSensorIdDeleteParams, reqEditors ...RequestEditorFn) (*DeleteSensorApiV1SensorsSensorIdDeleteResponse, error)
 
+	// ListSensorResultsApiV1SensorsSensorIdResultsGetWithResponse request
+	ListSensorResultsApiV1SensorsSensorIdResultsGetWithResponse(ctx context.Context, sensorId openapi_types.UUID, params *ListSensorResultsApiV1SensorsSensorIdResultsGetParams, reqEditors ...RequestEditorFn) (*ListSensorResultsApiV1SensorsSensorIdResultsGetResponse, error)
+
 	// ListTargetsApiV1TargetsGetWithResponse request
 	ListTargetsApiV1TargetsGetWithResponse(ctx context.Context, params *ListTargetsApiV1TargetsGetParams, reqEditors ...RequestEditorFn) (*ListTargetsApiV1TargetsGetResponse, error)
 
@@ -41467,6 +41682,29 @@ func (r DeleteSensorApiV1SensorsSensorIdDeleteResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r DeleteSensorApiV1SensorsSensorIdDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListSensorResultsApiV1SensorsSensorIdResultsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SensorResultListResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListSensorResultsApiV1SensorsSensorIdResultsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListSensorResultsApiV1SensorsSensorIdResultsGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -47850,6 +48088,15 @@ func (c *ClientWithResponses) DeleteSensorApiV1SensorsSensorIdDeleteWithResponse
 		return nil, err
 	}
 	return ParseDeleteSensorApiV1SensorsSensorIdDeleteResponse(rsp)
+}
+
+// ListSensorResultsApiV1SensorsSensorIdResultsGetWithResponse request returning *ListSensorResultsApiV1SensorsSensorIdResultsGetResponse
+func (c *ClientWithResponses) ListSensorResultsApiV1SensorsSensorIdResultsGetWithResponse(ctx context.Context, sensorId openapi_types.UUID, params *ListSensorResultsApiV1SensorsSensorIdResultsGetParams, reqEditors ...RequestEditorFn) (*ListSensorResultsApiV1SensorsSensorIdResultsGetResponse, error) {
+	rsp, err := c.ListSensorResultsApiV1SensorsSensorIdResultsGet(ctx, sensorId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListSensorResultsApiV1SensorsSensorIdResultsGetResponse(rsp)
 }
 
 // ListTargetsApiV1TargetsGetWithResponse request returning *ListTargetsApiV1TargetsGetResponse
@@ -54517,6 +54764,39 @@ func ParseDeleteSensorApiV1SensorsSensorIdDeleteResponse(rsp *http.Response) (*D
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListSensorResultsApiV1SensorsSensorIdResultsGetResponse parses an HTTP response from a ListSensorResultsApiV1SensorsSensorIdResultsGetWithResponse call
+func ParseListSensorResultsApiV1SensorsSensorIdResultsGetResponse(rsp *http.Response) (*ListSensorResultsApiV1SensorsSensorIdResultsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListSensorResultsApiV1SensorsSensorIdResultsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SensorResultListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/cli/internal/cmd/sensor/results.go
+++ b/cli/internal/cmd/sensor/results.go
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package sensor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// validResultStates mirrors the backend CheckState vocabulary the trend
+// query's --state filter accepts.
+var validResultStates = map[string]bool{
+	"ok": true, "degraded": true, "critical": true, "unknown": true, "skip": true,
+}
+
+// newResultsCmd returns the `meho sensor results` command.
+//
+//	meho sensor results <sensor_id> [--from T] [--to T] [--state S]
+//	                    [--limit N] [--cursor C] [--json] [--backplane <url>]
+//
+// Role: operator. The forensic per-tick evidence trend query (#2756):
+// binary filters only, deterministic evaluated_at ASC order, raw rows.
+func newResultsCmd() *cobra.Command {
+	var (
+		from              string
+		to                string
+		state             string
+		limit             int
+		cursor            string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "results <sensor_id>",
+		Short: "Show a sensor's per-tick evidence history (trend query)",
+		Long: "results calls GET /api/v1/sensors/{id}/results and renders one " +
+			"sensor's per-tick evidence history (#2756), oldest-first " +
+			"(evaluated_at ASC) — the forensic 'when did this start degrading / " +
+			"how fast is it filling' view the latest-result projection discards. " +
+			"Role: operator, scoped to your own tenant; a cross-tenant / absent " +
+			"id returns 404 sensor_not_found.\n\n" +
+			"Binary filters only: --from / --to bound an inclusive evaluated_at " +
+			"window (RFC 3339, e.g. 2026-08-01T00:00:00Z); --state narrows to an " +
+			"exact ok|degraded|critical|unknown|skip; --limit caps the page " +
+			"(1..500, server default 100). There are no smoothing / downsampling " +
+			"/ aggregation knobs — the client aggregates the raw rows.\n\n" +
+			"Pages via an opaque keyset --cursor: when a page is full the output " +
+			"prints the next cursor; paste it back with --cursor to continue. " +
+			"--json emits the raw {items, next_cursor} envelope.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runResults(cmd, resultsOptions{
+				SensorID:          args[0],
+				From:              from,
+				To:                to,
+				State:             state,
+				Limit:             limit,
+				Cursor:            cursor,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&from, "from", "",
+		"inclusive lower bound on evaluated_at (RFC 3339, e.g. 2026-08-01T00:00:00Z)")
+	cmd.Flags().StringVar(&to, "to", "",
+		"inclusive upper bound on evaluated_at (RFC 3339, e.g. 2026-08-02T00:00:00Z)")
+	cmd.Flags().StringVar(&state, "state", "",
+		"filter by state: ok | degraded | critical | unknown | skip")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max rows per page (1..500, server default 100 when omitted)")
+	cmd.Flags().StringVar(&cursor, "cursor", "",
+		"opaque keyset pagination token (echo the printed next cursor to continue)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the raw {items, next_cursor} JSON envelope instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type resultsOptions struct {
+	SensorID          string
+	From              string
+	To                string
+	State             string
+	Limit             int
+	Cursor            string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runResults(cmd *cobra.Command, opts resultsOptions) error {
+	if opts.SensorID == "" {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("results requires a non-empty <sensor_id> argument"), opts.JSONOut)
+	}
+	var sensorID openapi_types.UUID
+	if err := sensorID.UnmarshalText([]byte(opts.SensorID)); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("sensor-id is not a valid UUID: %v", err)),
+			opts.JSONOut)
+	}
+	if opts.State != "" && !validResultStates[opts.State] {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("--state must be one of: ok, degraded, critical, unknown, skip"),
+			opts.JSONOut)
+	}
+	if opts.Limit < 0 || opts.Limit > 500 {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 500; got %d", opts.Limit)),
+			opts.JSONOut)
+	}
+	from, err := parseRFC3339Flag(opts.From, "--from")
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	to, err := parseRFC3339Flag(opts.To, "--to")
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := getResults(cmd.Context(), backplaneURL, sensorID, opts, from, to)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	// Guard against 200 + missing-content-type leaving JSON200 nil (the
+	// generated parser only populates it when Content-Type is JSON). Without
+	// the guard a malformed 200 would print "no evidence rows" as if the
+	// window were genuinely empty — actively misleading.
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a results payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printResultsTable(cmd.OutOrStdout(), resp.JSON200)
+	return nil
+}
+
+// parseRFC3339Flag parses an optional RFC 3339 timestamp flag; an empty
+// value yields a nil pointer so the filter is omitted.
+func parseRFC3339Flag(raw, flagName string) (*time.Time, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return nil, fmt.Errorf("%s is not a valid RFC 3339 timestamp: %v", flagName, err)
+	}
+	return &parsed, nil
+}
+
+// resultsQueryParams maps the CLI flags onto the generated query-param shape.
+// --state is a typed enum pointer; --from / --to are time pointers; --limit /
+// --cursor only send when set so the backend defaults apply when omitted.
+func resultsQueryParams(
+	opts resultsOptions,
+	from, to *time.Time,
+) *api.ListSensorResultsApiV1SensorsSensorIdResultsGetParams {
+	params := &api.ListSensorResultsApiV1SensorsSensorIdResultsGetParams{}
+	if from != nil {
+		params.From = from
+	}
+	if to != nil {
+		params.To = to
+	}
+	if opts.State != "" {
+		s := api.ListSensorResultsApiV1SensorsSensorIdResultsGetParamsState(opts.State)
+		params.State = &s
+	}
+	if opts.Limit > 0 {
+		l := opts.Limit
+		params.Limit = &l
+	}
+	if opts.Cursor != "" {
+		c := opts.Cursor
+		params.Cursor = &c
+	}
+	return params
+}
+
+// getResults calls GET /api/v1/sensors/{id}/results via the generated typed
+// client.
+func getResults(
+	ctx context.Context,
+	backplaneURL string,
+	sensorID openapi_types.UUID,
+	opts resultsOptions,
+	from, to *time.Time,
+) (*api.ListSensorResultsApiV1SensorsSensorIdResultsGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	params := resultsQueryParams(opts, from, to)
+	return retryOn401(
+		ctx,
+		authed,
+		func(ctx context.Context) (*api.ListSensorResultsApiV1SensorsSensorIdResultsGetResponse, error) {
+			return authed.ListSensorResultsApiV1SensorsSensorIdResultsGetWithResponse(ctx, sensorID, params)
+		},
+		func(r *api.ListSensorResultsApiV1SensorsSensorIdResultsGetResponse) int { return r.StatusCode() },
+	)
+}
+
+// printResultsTable renders the evidence rows in the server's returned order
+// (evaluated_at ASC — do NOT re-sort): EVALUATED_AT, STATE, VALUE, REASON. A
+// full page surfaces the next keyset cursor as a paste-to-continue hint.
+func printResultsTable(w io.Writer, r *api.SensorResultListResponse) {
+	if r == nil || len(r.Items) == 0 {
+		fmt.Fprintln(w, "no evidence rows matched the filter")
+		return
+	}
+	fmt.Fprintf(w, "%-30s %-10s %-24s %s\n", "EVALUATED_AT", "STATE", "VALUE", "REASON")
+	for _, row := range r.Items {
+		evaluatedAt := row.EvaluatedAt
+		reason := "-"
+		if row.Reason != nil && *row.Reason != "" {
+			reason = sanitizeCell(*row.Reason)
+		}
+		fmt.Fprintf(w, "%-30s %-10s %-24s %s\n",
+			formatTime(&evaluatedAt), string(row.State),
+			sanitizeCell(formatResultValue(row.Value)), reason)
+	}
+	if r.NextCursor != nil && *r.NextCursor != "" {
+		fmt.Fprintf(w, "NEXT: --cursor=%s  (paste to continue)\n", *r.NextCursor)
+	}
+}
+
+// formatResultValue renders the observed JSON scalar for the table. A nil
+// value (an unknown outcome) shows as "-"; everything else is its default
+// Go rendering, which is compact for the scalar types the value carries
+// (bool / number / string).
+func formatResultValue(v any) string {
+	if v == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%v", v)
+}

--- a/cli/internal/cmd/sensor/results_test.go
+++ b/cli/internal/cmd/sensor/results_test.go
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package sensor
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+// fakeSensorResult builds a minimal api.SensorResultRead fixture keyed off
+// the stub sensor id.
+func fakeSensorResult(t *testing.T) api.SensorResultRead {
+	t.Helper()
+	reason := "dispatch_error"
+	evidence := map[string]interface{}{"reason": reason}
+	return api.SensorResultRead{
+		SensorId:    parseStubUUID(t, stubSensorID),
+		EvaluatedAt: time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC),
+		State:       api.SensorResultReadStateCritical,
+		Value:       42,
+		Evidence:    &evidence,
+		Reason:      &reason,
+	}
+}
+
+func TestRunResultsHappyPath(t *testing.T) {
+	cursor := "Y3Vyc29yLXRva2Vu"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/sensors/"+stubSensorID+"/results",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Errorf("expected GET; got %s", r.Method)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.SensorResultListResponse{
+				Items:      []api.SensorResultRead{fakeSensorResult(t)},
+				NextCursor: &cursor,
+			})
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runResults(cmd, resultsOptions{
+		SensorID:          stubSensorID,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runResults: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "critical") {
+		t.Errorf("expected state in stdout; got %q", out)
+	}
+	if !strings.Contains(out, "dispatch_error") {
+		t.Errorf("expected reason in stdout; got %q", out)
+	}
+	if !strings.Contains(out, "--cursor="+cursor) {
+		t.Errorf("expected next-cursor hint in stdout; got %q", out)
+	}
+}
+
+func TestRunResultsEmptyResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/sensors/"+stubSensorID+"/results",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.SensorResultListResponse{Items: nil})
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runResults(cmd, resultsOptions{
+		SensorID:          stubSensorID,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runResults: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no evidence rows") {
+		t.Errorf("expected empty-list message; got %q", stdout.String())
+	}
+}
+
+func TestRunResultsForwardsFilters(t *testing.T) {
+	var captured url.Values
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/sensors/"+stubSensorID+"/results",
+		func(w http.ResponseWriter, r *http.Request) {
+			captured = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.SensorResultListResponse{})
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	if err := runResults(cmd, resultsOptions{
+		SensorID:          stubSensorID,
+		From:              "2026-08-01T00:00:00Z",
+		To:                "2026-08-02T00:00:00Z",
+		State:             "degraded",
+		Limit:             25,
+		Cursor:            "abc123",
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runResults: %v; stderr=%s", err, stderr.String())
+	}
+	checks := map[string]string{
+		"from":   "2026-08-01T00:00:00Z",
+		"to":     "2026-08-02T00:00:00Z",
+		"state":  "degraded",
+		"limit":  "25",
+		"cursor": "abc123",
+	}
+	for key, want := range checks {
+		if got := captured.Get(key); got != want {
+			t.Errorf("query %q = %q; want %q", key, got, want)
+		}
+	}
+}
+
+func TestRunResultsInvalidStateFailsFast(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := runResults(cmd, resultsOptions{SensorID: stubSensorID, State: "bogus"}); err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !strings.Contains(stderr.String(), "--state must be one of") {
+		t.Errorf("expected validation message; got %q", stderr.String())
+	}
+}
+
+func TestRunResultsInvalidFromFailsFast(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := runResults(cmd, resultsOptions{SensorID: stubSensorID, From: "not-a-timestamp"}); err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !strings.Contains(stderr.String(), "--from is not a valid RFC 3339 timestamp") {
+		t.Errorf("expected validation message; got %q", stderr.String())
+	}
+}
+
+func TestRunResults404SurfacesNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/sensors/"+stubSensorID+"/results",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"detail":"sensor_not_found"}`))
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	if err := runResults(cmd, resultsOptions{
+		SensorID:          stubSensorID,
+		BackplaneOverride: srv.URL,
+	}); err == nil {
+		t.Fatalf("expected 404 to surface as error")
+	}
+	if !strings.Contains(stderr.String(), "sensor_not_found") {
+		t.Errorf("expected backend detail; got %q", stderr.String())
+	}
+}

--- a/cli/internal/cmd/sensor/sensor.go
+++ b/cli/internal/cmd/sensor/sensor.go
@@ -20,6 +20,11 @@
 //   - `meho sensor delete <sensor_id> [--tenant <id>] [--json]` —
 //     hard-delete one sensor via DELETE /api/v1/sensors/{id}.
 //     Role: tenant_admin.
+//   - `meho sensor results <sensor_id> [--from T] [--to T] [--state S]
+//     [--limit N] [--cursor C] [--json]` — the per-tick evidence trend
+//     query (#2756) via GET /api/v1/sensors/{id}/results: raw rows in
+//     evaluated_at ASC order, binary filters only, keyset-cursor paging.
+//     Role: operator, own-tenant only.
 //
 // Every verb drives the generated `api.ClientWithResponses` surface
 // directly (the G0.12-T13 typed-client discipline): consumer-side struct
@@ -151,6 +156,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newCreateCmd())
 	cmd.AddCommand(newDeleteCmd())
+	cmd.AddCommand(newResultsCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/sensor/sensor_test.go
+++ b/cli/internal/cmd/sensor/sensor_test.go
@@ -123,7 +123,9 @@ func TestNewRootCmd_Subcommands(t *testing.T) {
 	if cmd.Use != "sensor" {
 		t.Fatalf("expected Use=sensor, got %q", cmd.Use)
 	}
-	want := map[string]bool{"list": true, "create": true, "delete <sensor_id>": true}
+	want := map[string]bool{
+		"list": true, "create": true, "delete <sensor_id>": true, "results <sensor_id>": true,
+	}
 	for _, sub := range cmd.Commands() {
 		if !want[sub.Use] {
 			t.Errorf("unexpected subcommand %q", sub.Use)

--- a/docs/codebase/sensor.md
+++ b/docs/codebase/sensor.md
@@ -38,17 +38,25 @@ delete, the runner (#2505) owns claim/advance/park and the result write.
   (`ok`/`degraded`/`critical`/`unknown`/`skip`); `ck_sensor_last_state` is
   populated from `CheckState`'s members and drift-guarded against them in
   `tests/test_db_sensor.py`.
+- `meho_backplane.db.models.SensorResult` — the append-only per-tick evidence
+  row (`sensor_results`, #2756); see **Per-tick evidence history**.
 - `meho_backplane.checks.schemas` — `SensorCreate` (frozen, `extra="forbid"`;
   the `assertion` field is typed with `AssertionSpec`, so a bad select path
-  or comparator is a 422 at the wire), `SensorRead`, `SensorListResponse`.
+  or comparator is a 422 at the wire), `SensorRead`, `SensorListResponse`,
+  plus the trend-query trio `SensorResultRead` / `SensorResultListResponse`
+  (`{items, next_cursor}`) / `SensorResultsQuery` (frozen, `extra="forbid"`).
 - `meho_backplane.checks.repository` — `create_sensor` (materialises
-  `next_fire_at`) and `record_sensor_result` (the one named projection
-  write path).
+  `next_fire_at`), `record_sensor_result` (the one named projection write
+  path, which also appends the history row when `record_history=True`), and
+  `list_sensor_results` (the keyset trend read).
 - `meho_backplane.checks.service.SensorAdminService` — tenant-scoped CRUD +
-  the four guard exceptions (`SensorIdentitySubForbiddenError`,
-  `SensorOperationNotFoundError`, `SensorRequiresSafeOperationError`,
-  `SensorNameConflictError`), each carrying an `error_code` the transports
+  `list_results` (the trend query) + the guard exceptions
+  (`SensorIdentitySubForbiddenError`, `SensorOperationNotFoundError`,
+  `SensorRequiresSafeOperationError`, `SensorNameConflictError`,
+  `SensorResultsCursorError`), each carrying an `error_code` the transports
   surface verbatim.
+- `meho_backplane.checks.evidence_retention` — the lifespan-owned retention
+  prune sweeper for `sensor_results` (#2756).
 
 ## Control flow
 
@@ -113,25 +121,74 @@ accepted call, and commits `last_state`/`state_since` through the
 
 The gate lives in the repository function — not the runner task — so
 runner-local and satellite-gateway batch-posted results are confirmed
-identically. Returns `True` iff the *committed* state changed. There is
-still no results history table — the projection (now including the
-soft-state window) is the single source of current state (**Decision D,
-annotated by #2799**: the consecutive-confirmation counter is carried
-as projection columns, the #2327 `skip_count` precedent, not derived
-from history). Downstream, `state_since` marks the *confirmed*
-transition instant, so a `for_seconds` hold measures confirmed time on
-top of confirmation — count-based commit gate first, duration-based
-fold hold second, two independent layers.
+identically. Returns `True` iff the *committed* state changed. A
+monotonicity guard ignores a result whose `evaluated_at` is not strictly
+newer than the row's last (a stale / reordered / duplicate persist),
+leaving the projection untouched. Downstream, `state_since` marks the
+*confirmed* transition instant, so a `for_seconds` hold measures confirmed
+time on top of confirmation — count-based commit gate first, duration-based
+hold second, two independent layers.
+
+The projection (now including the soft-state window) is the current-state
+fast path — but it is **no longer the only** record. Task #2503 originally
+shipped it as "not a results table" (Decision D: a history table would
+demand retention/pruning, speculative until asked for; #2799 annotated that
+the consecutive-confirmation counter is carried as projection columns, the
+#2327 `skip_count` precedent, not derived from history). Task #2756
+(Initiative #2780) supersedes the "no history table" half: a post-incident
+review needed "when did this first flap / how fast is it filling", and every
+tick overwriting the projection had discarded exactly the history the runner
+already computed. So `record_sensor_result` now **also** appends a per-tick
+`sensor_results` row (see **Per-tick evidence history** below) **in the same
+transaction** as the projection update, gated on retention being enabled —
+history and projection can never diverge. The row records the *observed*
+outcome of each evaluation (committed, soft/pending, or re-confirmed), so a
+flapping reading that never commits still lands in history.
+
+### Per-tick evidence history (#2756)
+
+`meho_backplane.db.models.SensorResult` (`sensor_results` table, migration
+`0071`) is an append-only `(sensor_id, evaluated_at, state, value, evidence,
+reason)` row per non-stale evaluation. `sensor_id` is a real FK with
+**`ON DELETE CASCADE`** — deleting a Sensor drops its history. Because the
+monotonicity guard makes `evaluated_at` strictly increasing per sensor, it is
+a total order the trend query's keyset cursor rides with no tiebreaker.
+
+- **Retention is deploy-level**: `CHECKS_EVIDENCE_RETENTION_DAYS` (default 7,
+  conservative single-digit) bounds row age; a lifespan-owned sweeper
+  (`meho_backplane.checks.evidence_retention`, the #2547 announcement-sweeper
+  mould) deletes rows past the window on `CHECKS_EVIDENCE_PRUNE_INTERVAL_SECONDS`
+  cadence, gated by `CHECKS_EVIDENCE_PRUNE_ENABLED`. **`0` disables the feature
+  entirely** — no rows are written (`record_sensor_result` skips the append,
+  gated by the runner on the same setting), restoring the pre-#2756 latest-only
+  behaviour. This deliberately diverges from the announcement/topology sweepers'
+  `0`=keep-forever, because an evidence history that grows forever is the
+  surprise #2756 exists to prevent.
+- **The trend query** (`SensorAdminService.list_results` →
+  `repository.list_sensor_results`) answers the forensic question with binary
+  filters only — `sensor_id` (exact), `from`/`to` (inclusive window), optional
+  `state`, bounded `limit` — deterministic `evaluated_at ASC` ordering, and an
+  opaque keyset `cursor`. Raw rows in a `{items, next_cursor}` envelope (#2742);
+  the client aggregates. **No** server-side smoothing / downsampling / scoring
+  — the `SensorResultsQuery` wire model is `extra="forbid"`, so an unknown
+  filter param is a 422 (REST) / schema refusal (MCP), pinning that bound.
+- **Tenant scoping**: `list_results` resolves the sensor within the caller's
+  tenant first, so a cross-tenant sensor id returns `None` → 404
+  `sensor_not_found` (never a 403, and never another tenant's history). The
+  trend surface is own-tenant-only on all three transports (no platform-admin
+  `tenant_filter`).
 
 **Delete** is a hard `DELETE` (no tombstone) — a sensor carries no
 fire-history the audit trail needs post-delete.
 
 Surfaces: REST (`api/v1/sensors.py`, registered in `main.py`), MCP
 (`mcp/tools/sensors.py`, auto-loaded), Go CLI (`cli/internal/cmd/sensor/`).
-There is **no** update / pause / resume path — `status` is
-server-initialized to `active` at create (clients cannot supply it; a body
-carrying `status` is a 422) and transitions to `paused` only via #2505's
-runner parking.
+Each surface carries the four verbs — `list` / `create` / `delete` plus the
+`results` trend query (#2756): `GET /api/v1/sensors/{id}/results`, the
+`meho_sensor_results` MCP tool, and `meho sensor results <id>`. There is
+**no** update / pause / resume path — `status` is server-initialized to
+`active` at create (clients cannot supply it; a body carrying `status` is a
+422) and transitions to `paused` only via #2505's runner parking.
 
 ## Dependencies
 
@@ -141,8 +198,11 @@ runner parking.
 - `meho_backplane.scheduler.cron` — `is_valid_cron_expr`, `resolve_timezone`,
   `next_fire_after` (shared with the scheduler).
 - `meho_backplane.operations._lookup` — descriptor resolution for the guard.
-- Migrations `0064_create_sensor.py` (`down_revision="0063"`) and
-  `0070_add_sensor_confirmation_retries.py` (#2799 columns).
+- Migrations `0064_create_sensor.py` (`down_revision="0063"`),
+  `0070_add_sensor_confirmation_retries.py` (#2799 soft-state columns), and
+  `0071_create_sensor_results.py` (`down_revision="0070"`, #2756 history table).
+- **#2756** (Initiative #2780) — per-tick evidence retention + trend query;
+  the retention sweeper reuses the #2547 announcement-sweeper mould.
 
 ## Known issues / boundaries
 


### PR DESCRIPTION
## Summary

Sensors kept only a latest-state projection — every tick overwrote
`last_*`, discarding the history the runner already computed, so a
post-incident review could not answer "when did this first flap / how fast
is it filling" (#2756, Initiative #2780).

- **Append-only `sensor_results` history** (migration `0070`).
  `record_sensor_result` gains `record_history` and appends one
  `(sensor_id, evaluated_at, state, value, evidence, reason)` row per
  **non-stale** evaluation **in the same transaction** as the projection
  update, so history and projection can never diverge. FK is
  `ON DELETE CASCADE` (deleting a sensor drops its history).
- **Deploy-level retention.** `CHECKS_EVIDENCE_RETENTION_DAYS` (default 7)
  bounds row age via a lifespan-owned sweeper built on the #2547
  announcement-sweeper mould. **`0` disables the feature entirely** (no rows
  written) — a deliberate divergence from the announcement/topology
  `0`=keep-forever, documented on the setting, so "zero surprise DB growth"
  is the default-safe opt-out the ops report asked for.
- **Trend query on REST + MCP + CLI.** Binary filters only (`sensor_id`
  exact, `from`/`to` inclusive window, optional `state`, bounded `limit`),
  deterministic `evaluated_at ASC`, opaque keyset `cursor`, `{items,
  next_cursor}` envelope (#2742). Raw rows — no smoothing/downsampling/
  scoring: the `SensorResultsQuery` model is `extra="forbid"`, so an unknown
  filter param is a 422 (REST) / schema refusal (MCP). Own-tenant-scoped.
- **Supersedes** the Sensor model's "not a results table" (Decision D)
  docstring and updates `docs/codebase/sensor.md`.

**Design note (deviation from the issue's literal path):** the REST route
nests under the existing sensor resource `GET /api/v1/sensors/{id}/results`
rather than `/api/v1/checks/sensors/{id}/results`. It reuses the sensors
router's operator-auth + tenant-scope + 404-no-leak seam, is idiomatic
sub-resource nesting, and — critically — keeps the OpenAPI query parameters
**flattened** for the generated typed Go CLI client (a standalone
platform-admin `tenant_filter` param alongside the query model collapses the
params into one opaque object, breaking codegen). Consequently the trend
surface is own-tenant-only on all three transports (cross-tenant history
read was not a stated need; the MCP tool is likewise own-tenant-only). The
acceptance criteria pin behaviour, not the URL.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean for changed code (one pre-existing macOS-only
  `MSG_ERRQUEUE` false-positive in `connectors/net/icmp.py`, untouched;
  Linux CI passes)
- [x] `pytest` — 122 passed across new + affected suites
  (`test_db_sensor_results`, `test_checks_sensor_results`,
  `test_checks_evidence_retention`, `test_mcp_tool_sensor_results`,
  `tests/migrations/test_migration_0070_*`, plus `test_db_sensor`,
  `test_checks_admin`, `test_sensor_runner`, `test_mcp_tool_sensors`,
  `test_settings`)
- [x] `scripts/ci/check_migration_compat.py` — 0070 is purely additive
- [x] code-quality gate (`--diff`) — 0 blockers
- [x] Go: `go build ./...`, `go test ./internal/cmd/sensor/...`, `gofmt`,
  `go vet` — clean; OpenAPI snapshot re-generated + verified fresh

**Acceptance criteria**

- [x] Every completed evaluation appends exactly one row in the projection's
  transaction — `test_record_history_appends_one_row_per_tick` (two ticks ⇒
  two rows), `test_record_history_rolls_back_with_projection` (rollback
  discards both), `test_record_history_stale_result_appends_no_duplicate`
- [x] Retention sweeper prunes past the window; `0`-semantics pinned
  (`test_tick_with_retention_zero_prunes_nothing`,
  `test_record_history_disabled_writes_no_rows`); env round-trip
  (`test_settings_evidence_env_round_trip`)
- [x] Trend query over REST + MCP + CLI: filters, `evaluated_at ASC`,
  bounded limit, `{items, next_cursor}`; unknown param rejected 422 / schema
  refusal (`test_rest_results_unknown_param_returns_422`,
  `test_results_handler_rejects_unknown_param`)
- [x] Tenant scoping — cross-tenant read → 404
  (`test_rest_results_cross_tenant_returns_404`,
  `test_service_list_results_cross_tenant_returns_none`,
  `test_results_handler_cross_tenant_not_found`); delete cascades
  (`test_delete_sensor_cascades_its_results`)
- [x] One alembic migration post-0069; Decision D docstring rewritten;
  `docs/codebase/sensor.md` updated

## Out of scope / adjacent findings

- Honours the issue's non-goals: no PromQL engine, no per-VM cardinality, no
  downsampling/aggregation, no dashboard rendering, no history backfill, no
  change to the rollup/staleness/notify/investigate seams.
- **Collision seam with #2799 / PR #2805** (sensor state-confirmation
  retries) touches the same `record_sensor_result` / `_persist_outcome`
  path. This lands on `main`; whichever merges second rebases. The evidence
  row is appended on every non-stale evaluation (not gated on state change),
  so a future soft/pending result still produces history.
- Pre-existing code-quality **warnings** (non-blocking, recorded not fixed):
  `db/models.py` / `main.py` / `settings.py` file-size (pre-existing),
  `checks/service.py` (556 lines; `create` 95 lines), `mcp/tools/sensors.py`
  (495 lines), `checks/repository.py` (402 lines) crossed the 400-line
  warn threshold with this change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2756


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sensor evaluation history with evidence, status, values, reasons, filtering, time ranges, and cursor-based pagination.
  * Added REST, MCP, and CLI access through `sensor results`, including table and JSON output.
  * Added configurable evidence retention with scheduled cleanup and audit tracking.
* **Documentation**
  * Documented sensor evidence history, querying, retention behavior, and configuration.
* **Bug Fixes**
  * Improved tenant isolation and validation for missing sensors and invalid pagination cursors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->