### PR TITLE
fix(connectors): bound datastore.usage vm_names for per-entity sensing

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -129,6 +129,8 @@ import httpx
 
 from meho_backplane.auth.operator import Operator
 
+from .schemas import DATASTORE_USAGE_MAX_VM_NAMES
+
 if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
 
@@ -532,6 +534,13 @@ async def datastore_usage_composite(
         are ``None`` and the row carries an ``enrichment_note`` string
         describing the skipped enrichment; on success the row has no
         ``enrichment_note`` key.
+
+        ``vm_count`` is the exact VM total; ``vm_names`` is bounded to a
+        sample of at most
+        :data:`~meho_backplane.connectors.vmware_rest.composites.schemas.DATASTORE_USAGE_MAX_VM_NAMES`
+        names, so a one-name ``filter_names`` result stays inline under the
+        JSONFlux byte threshold and a per-datastore Sensor can select
+        ``$.datastores[0].free_space`` (#2758).
     """
     filter_names: list[str] = list(params.get("filter_names") or [])
 
@@ -615,8 +624,13 @@ async def datastore_usage_composite(
                 for v in vm_entries
                 if isinstance(v, dict) and isinstance(v.get("name"), str)
             ]
+            # vm_count is the exact total, taken before the cap; vm_names is
+            # bounded to a sample so a one-name filter_names result stays
+            # inline under the dispatcher's 4096-byte JSONFlux threshold and
+            # a per-datastore Sensor can still select free_space (#2758).
+            # vm_count > len(vm_names) is the truncation signal.
             row["vm_count"] = len(vm_names)
-            row["vm_names"] = vm_names
+            row["vm_names"] = vm_names[:DATASTORE_USAGE_MAX_VM_NAMES]
         aggregated.append(row)
     return {"datastores": aggregated}
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -42,6 +42,7 @@ __all__ = [
     "CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA",
     "CLUSTER_PATCH_PARAMETER_SCHEMA",
     "CLUSTER_PATCH_RESPONSE_SCHEMA",
+    "DATASTORE_USAGE_MAX_VM_NAMES",
     "DATASTORE_USAGE_PARAMETER_SCHEMA",
     "DATASTORE_USAGE_RESPONSE_SCHEMA",
     "EVENT_TAIL_PARAMETER_SCHEMA",
@@ -194,6 +195,20 @@ PERFORMANCE_SUMMARY_PARAMETER_SCHEMA: dict[str, Any] = {
 }
 
 
+#: Upper bound on the ``vm_names`` sample carried by a single
+#: ``datastore.usage`` row (the response-schema ``maxItems``; the handler
+#: slices to it). ``vm_count`` stays exact -- ``vm_names`` is a bounded
+#: sample, not the full set. The bound keeps a one-name ``filter_names``
+#: result serialising under the dispatcher's 4096-byte JSONFlux threshold,
+#: so it passes through inline (unsampled) and a per-datastore Sensor can
+#: select ``$.datastores[0].free_space``; an unbounded list on a VM-dense
+#: datastore (a vSAN with hundreds of VMs) pushes the row past the
+#: threshold, the whole ``{"datastores": [row]}`` collapses to a sampled
+#: envelope, and the assertion loses its selector (#2758). 20 leaves a
+#: single row well under 4096 bytes even at maximum VM-name length.
+DATASTORE_USAGE_MAX_VM_NAMES = 20
+
+
 #: ``vmware.composite.datastore.usage`` parameter schema.
 #:
 #: Lists datastores with capacity + free + VM placement aggregation.
@@ -209,9 +224,14 @@ DATASTORE_USAGE_PARAMETER_SCHEMA: dict[str, Any] = {
             "items": {"type": "string", "minLength": 1},
             "description": (
                 "Optional list of datastore names. When supplied, only "
-                "datastores whose name appears in this list are surfaced. "
-                "Empty / absent returns every datastore the operator can "
-                "see."
+                "datastores whose name appears in this list are surfaced; "
+                "the ``GET:/vcenter/datastore`` listing forwards them as "
+                "``filter.names`` (exact match, no fuzzy matching). Empty / "
+                "absent returns every datastore the operator can see. "
+                "For a per-datastore Sensor, pass exactly one name: the "
+                "single-row result returns inline (unsampled), so the "
+                "assertion can select ``$.datastores[0].free_space`` (bytes) "
+                "and threshold it."
             ),
         },
     },
@@ -443,10 +463,15 @@ DATASTORE_USAGE_RESPONSE_SCHEMA: dict[str, Any] = {
                     "vm_names": {
                         "type": ["array", "null"],
                         "items": {"type": "string"},
+                        "maxItems": DATASTORE_USAGE_MAX_VM_NAMES,
                         "description": (
-                            "Names of VMs placed on this datastore; ``null`` when "
-                            "the best-effort VM-placement enrichment was skipped "
-                            "(see ``enrichment_note``)."
+                            "Names of VMs placed on this datastore, bounded to the "
+                            "sample size in ``maxItems`` (``vm_count`` is the exact "
+                            "total; ``vm_count`` greater than ``len(vm_names)`` means "
+                            "the sample was truncated to keep the row inline under "
+                            "the JSONFlux byte threshold). ``null`` when the "
+                            "best-effort VM-placement enrichment was skipped (see "
+                            "``enrichment_note``)."
                         ),
                     },
                     "enrichment_note": {

--- a/backend/tests/test_datastore_usage_per_entity_sensor.py
+++ b/backend/tests/test_datastore_usage_per_entity_sensor.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-entity capacity sensing on ``vmware.composite.datastore.usage`` (#2758).
+
+Initiative #2780 (checks reliability & evidence). The v0.26.0 ops report
+could not assert on a single datastore's free/capacity: the op returned a
+sampled envelope with no way to narrow to one entity. The exact-match
+``filter_names`` param already existed (#524) but two things were unproven:
+
+* that a **one-name** ``filter_names`` result returns **inline** (unsampled)
+  under the dispatcher's default JSONFlux thresholds, so a Sensor can select
+  ``$.datastores[0].free_space`` and threshold it; and
+* that a realistic **VM-dense** datastore does not blow the single row past
+  the 4096-byte byte threshold via the unbounded ``vm_names`` enrichment,
+  which would collapse ``{"datastores": [row]}`` to a sampled envelope and
+  strip the sensor's selector.
+
+These tests compose the three real components the sensor dispatch+evaluate
+path chains (``runner.py`` calls ``dispatch`` -> the dispatcher runs the
+JSONFlux reducer -> the runner feeds ``result.result`` to
+``evaluate_assertion``): the real composite handler, a real
+``JsonFluxReducer()`` (the same default 50-row / 4096-byte instance
+installed at ``main.py``), and the real ``evaluate_assertion``. They are
+deterministic (no vcsim, no DB) so the regression is pinned in CI's unit
+sweep, not gated on a live upstream.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+import msgspec
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.checks import AssertionSpec, evaluate_assertion
+from meho_backplane.connectors.vmware_rest.composites._read import (
+    datastore_usage_composite,
+)
+from meho_backplane.connectors.vmware_rest.composites.schemas import (
+    DATASTORE_USAGE_MAX_VM_NAMES,
+    DATASTORE_USAGE_PARAMETER_SCHEMA,
+    DATASTORE_USAGE_RESPONSE_SCHEMA,
+)
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
+
+#: Fixed, timezone-aware instant (evaluate_assertion requires an aware now).
+NOW = datetime(2026, 8, 4, 12, 0, 0, tzinfo=UTC)
+
+#: Bytes in a gibibyte -- free_space / capacity are bytes on the wire.
+_GIB = 1024**3
+
+#: The reducer's default byte threshold (``JsonFluxReducer()`` installed at
+#: ``main.py``). A single row serialising past this collapses to an envelope.
+_BYTE_THRESHOLD = 4096
+
+#: A per-datastore free-space threshold: degrade below 500 GiB, crit below 100.
+_FREE_SPACE_COMPARE: dict[str, Any] = {
+    "type": "threshold",
+    "op": "lt",
+    "degraded": float(500 * _GIB),
+    "critical": float(100 * _GIB),
+}
+
+
+def _reducer() -> JsonFluxReducer:
+    """A default-threshold reducer (50 rows / 4096 bytes, matching the singleton
+    installed at ``main.py``).
+
+    An explicit ``sample_byte_budget`` is passed only so the over-threshold
+    assemble path does not read app settings (``get_settings()``) in this
+    pure-module test; it sizes the envelope's inline sample and does not
+    change the byte threshold that decides whether a payload collapses.
+    """
+    return JsonFluxReducer(sample_byte_budget=_BYTE_THRESHOLD)
+
+
+def _make_operator() -> Operator:
+    """Synthetic operator for the composite-handler call."""
+    return Operator(
+        sub="op-2758",
+        name="Per-entity Sensor Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _SequenceConnector:
+    """Minimal ``VmwareRestConnector`` stand-in serving canned GETs in order.
+
+    ``datastore.usage`` issues only GET sub-ops (list datastores -> per-DS
+    detail -> per-DS VM list), each routed through ``_read_sub_op``'s
+    ``mount_op_path`` -> ``adapt_op_query`` -> ``_get_json`` seam. This double
+    serves the responses sequentially and records each call's ``(path, query)``
+    so a test can assert the ``filter.names`` narrowing flowed to the listing.
+    """
+
+    def __init__(self, responses: list[Any]) -> None:
+        self._responses = responses
+        self._index = 0
+        self.calls: list[dict[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        del target, operator
+        return f"/api{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return query
+
+    async def _get_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        del target, operator
+        self.calls.append({"path": path, "query": params})
+        payload = self._responses[self._index]
+        self._index += 1
+        return payload
+
+
+async def _usage_one_datastore(
+    *,
+    name: str,
+    capacity: int,
+    free_space: int,
+    vm_names: list[str],
+) -> tuple[dict[str, Any], _SequenceConnector]:
+    """Run the real handler for a single filtered datastore, return (payload, conn)."""
+    listing = [{"datastore": "datastore-42", "name": name, "type": "vSAN"}]
+    detail = {"capacity": capacity, "free_space": free_space, "type": "vSAN"}
+    vms = [{"name": vm_name} for vm_name in vm_names]
+    conn = _SequenceConnector([listing, detail, vms])
+    payload = await datastore_usage_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"filter_names": [name]},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    return payload, conn
+
+
+@pytest.mark.parametrize(
+    ("free_space", "expected_state"),
+    [
+        (50 * _GIB, "critical"),
+        (200 * _GIB, "degraded"),
+        (800 * _GIB, "ok"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_one_name_filter_returns_inline_and_sensor_bands(
+    free_space: int, expected_state: str
+) -> None:
+    """AC#1: one-name filter_names -> inline row; a free_space Sensor bands right.
+
+    The filtered result arrives inline (no ``{row_count, ..., source_key}``
+    envelope) under the default reducer thresholds, so
+    ``$.datastores[0].free_space`` under a ``ThresholdCompare`` evaluates
+    through the real ``evaluate_assertion`` to the expected band.
+    """
+    capacity = 20 * 1024 * _GIB
+    raw, conn = await _usage_one_datastore(
+        name="vsan-prod-01",
+        capacity=capacity,
+        free_space=free_space,
+        vm_names=["vm-a", "vm-b"],
+    )
+
+    # The one name narrowed the listing sub-op (forwarded as filter.names).
+    assert conn.calls[0]["query"] == {"filter.names": ["vsan-prod-01"]}
+    # Exactly one row, full aggregated shape.
+    assert raw == {
+        "datastores": [
+            {
+                "id": "datastore-42",
+                "name": "vsan-prod-01",
+                "type": "vSAN",
+                "capacity": capacity,
+                "free_space": free_space,
+                "vm_count": 2,
+                "vm_names": ["vm-a", "vm-b"],
+            }
+        ]
+    }
+
+    reduced, handle = await _reducer().reduce(raw, None, {})
+    # Inline: no result handle, payload unchanged, no sampled-envelope keys.
+    assert handle is None
+    assert reduced == raw
+    assert "row_count" not in reduced
+    assert "source_key" not in reduced
+
+    spec = AssertionSpec.model_validate(
+        {"select": {"path": "$.datastores[0].free_space"}, "compare": _FREE_SPACE_COMPARE}
+    )
+    outcome = evaluate_assertion(spec, reduced, now=NOW)
+    assert outcome.state == expected_state
+    assert outcome.value == free_space
+
+
+@pytest.mark.asyncio
+async def test_vm_dense_row_capped_stays_inline_and_assertable() -> None:
+    """AC#2 guard: a VM-dense datastore's one-name result stays inline + assertable.
+
+    ``vm_count`` stays exact; ``vm_names`` is bounded to the sample cap, so the
+    single-row payload serialises under the reducer byte threshold, the real
+    reducer passes it through inline, and ``$.datastores[0].free_space`` is
+    still selectable. The uncapped row (full VM list) exceeds the threshold and
+    the real reducer collapses it to a sampled envelope, stripping the selector
+    -- the exact failure the cap prevents (#2758).
+    """
+    dense_names = [f"prod-workload-vm-{i:04d}" for i in range(300)]
+    free_space = 40 * _GIB
+    raw, _ = await _usage_one_datastore(
+        name="vsan-dense-01",
+        capacity=50 * 1024 * _GIB,
+        free_space=free_space,
+        vm_names=dense_names,
+    )
+    row = raw["datastores"][0]
+
+    # vm_count is the exact total; vm_names is the bounded sample (truncated).
+    assert row["vm_count"] == 300
+    assert row["vm_names"] == dense_names[:DATASTORE_USAGE_MAX_VM_NAMES]
+    assert len(row["vm_names"]) == DATASTORE_USAGE_MAX_VM_NAMES
+
+    # Capped payload is under the reducer byte threshold ...
+    assert len(msgspec.json.encode(raw)) <= _BYTE_THRESHOLD
+    # ... so the real reducer passes it through inline (free_space selectable).
+    reduced, handle = await _reducer().reduce(raw, None, {})
+    assert handle is None
+    assert reduced == raw
+
+    spec = AssertionSpec.model_validate(
+        {
+            "select": {"path": "$.datastores[0].free_space"},
+            "compare": {"type": "threshold", "op": "lt", "critical": float(100 * _GIB)},
+        }
+    )
+    assert evaluate_assertion(spec, reduced, now=NOW).state == "critical"
+
+    # Contrast: the UNCAPPED row (full 300 names) exceeds the threshold, so the
+    # reducer collapses {"datastores": [row]} to a sampled envelope and the
+    # sensor's selector is gone (evaluates "unknown").
+    uncapped = {"datastores": [{**row, "vm_count": 300, "vm_names": dense_names}]}
+    assert len(msgspec.json.encode(uncapped)) > _BYTE_THRESHOLD
+    envelope, env_handle = await _reducer().reduce(uncapped, None, {})
+    assert env_handle is not None
+    assert "row_count" in envelope
+    assert evaluate_assertion(spec, envelope, now=NOW).state == "unknown"
+
+
+def test_response_schema_maxitems_matches_cap_constant() -> None:
+    """The declared response-schema bound is the single source the handler caps to."""
+    vm_names_schema = DATASTORE_USAGE_RESPONSE_SCHEMA["properties"]["datastores"]["items"][
+        "properties"
+    ]["vm_names"]
+    assert vm_names_schema["maxItems"] == DATASTORE_USAGE_MAX_VM_NAMES
+
+
+def test_param_surface_stays_filter_names_only() -> None:
+    """AC#4: no new params -- the op's parameter surface is filter_names-only."""
+    assert list(DATASTORE_USAGE_PARAMETER_SCHEMA["properties"]) == ["filter_names"]
+    assert DATASTORE_USAGE_PARAMETER_SCHEMA["additionalProperties"] is False

--- a/backend/tests/test_datastore_usage_per_entity_sensor.py
+++ b/backend/tests/test_datastore_usage_per_entity_sensor.py
@@ -67,15 +67,19 @@ _FREE_SPACE_COMPARE: dict[str, Any] = {
 
 
 def _reducer() -> JsonFluxReducer:
-    """A default-threshold reducer (50 rows / 4096 bytes, matching the singleton
-    installed at ``main.py``).
+    """A reducer pinned to the production default thresholds (50 rows /
+    ``_BYTE_THRESHOLD`` bytes, matching ``JsonFluxReducer()`` installed at
+    ``main.py``).
 
-    An explicit ``sample_byte_budget`` is passed only so the over-threshold
+    ``byte_threshold`` is passed explicitly rather than relying on the
+    constructor default, so the guard tests' byte assertions and the reducer's
+    own collapse decision share one source of truth if the library default
+    ever moves. ``sample_byte_budget`` is set only so the over-threshold
     assemble path does not read app settings (``get_settings()``) in this
-    pure-module test; it sizes the envelope's inline sample and does not
-    change the byte threshold that decides whether a payload collapses.
+    pure-module test; it sizes the envelope's inline sample, not the collapse
+    decision.
     """
-    return JsonFluxReducer(sample_byte_budget=_BYTE_THRESHOLD)
+    return JsonFluxReducer(byte_threshold=_BYTE_THRESHOLD, sample_byte_budget=_BYTE_THRESHOLD)
 
 
 def _make_operator() -> Operator:

--- a/backend/tests/test_datastore_usage_per_entity_sensor.py
+++ b/backend/tests/test_datastore_usage_per_entity_sensor.py
@@ -210,23 +210,28 @@ async def test_one_name_filter_returns_inline_and_sensor_bands(
     assert outcome.value == free_space
 
 
+#: A critical-below-100-GiB free-space compare used by the dense-row guards.
+_CRIT_ONLY_COMPARE: dict[str, Any] = {
+    "type": "threshold",
+    "op": "lt",
+    "critical": float(100 * _GIB),
+}
+
+
 @pytest.mark.asyncio
 async def test_vm_dense_row_capped_stays_inline_and_assertable() -> None:
     """AC#2 guard: a VM-dense datastore's one-name result stays inline + assertable.
 
-    ``vm_count`` stays exact; ``vm_names`` is bounded to the sample cap, so the
-    single-row payload serialises under the reducer byte threshold, the real
-    reducer passes it through inline, and ``$.datastores[0].free_space`` is
-    still selectable. The uncapped row (full VM list) exceeds the threshold and
-    the real reducer collapses it to a sampled envelope, stripping the selector
-    -- the exact failure the cap prevents (#2758).
+    ``vm_count`` stays the exact total; ``vm_names`` is bounded to the sample
+    cap, so the single-row payload serialises under the reducer byte threshold,
+    the real reducer passes it through inline, and ``$.datastores[0].free_space``
+    is still selectable and thresholdable (#2758).
     """
     dense_names = [f"prod-workload-vm-{i:04d}" for i in range(300)]
-    free_space = 40 * _GIB
     raw, _ = await _usage_one_datastore(
         name="vsan-dense-01",
         capacity=50 * 1024 * _GIB,
-        free_space=free_space,
+        free_space=40 * _GIB,
         vm_names=dense_names,
     )
     row = raw["datastores"][0]
@@ -234,31 +239,51 @@ async def test_vm_dense_row_capped_stays_inline_and_assertable() -> None:
     # vm_count is the exact total; vm_names is the bounded sample (truncated).
     assert row["vm_count"] == 300
     assert row["vm_names"] == dense_names[:DATASTORE_USAGE_MAX_VM_NAMES]
-    assert len(row["vm_names"]) == DATASTORE_USAGE_MAX_VM_NAMES
 
-    # Capped payload is under the reducer byte threshold ...
+    # Under the byte threshold, so the real reducer passes it through inline.
     assert len(msgspec.json.encode(raw)) <= _BYTE_THRESHOLD
-    # ... so the real reducer passes it through inline (free_space selectable).
     reduced, handle = await _reducer().reduce(raw, None, {})
     assert handle is None
     assert reduced == raw
 
     spec = AssertionSpec.model_validate(
-        {
-            "select": {"path": "$.datastores[0].free_space"},
-            "compare": {"type": "threshold", "op": "lt", "critical": float(100 * _GIB)},
-        }
+        {"select": {"path": "$.datastores[0].free_space"}, "compare": _CRIT_ONLY_COMPARE}
     )
     assert evaluate_assertion(spec, reduced, now=NOW).state == "critical"
 
-    # Contrast: the UNCAPPED row (full 300 names) exceeds the threshold, so the
-    # reducer collapses {"datastores": [row]} to a sampled envelope and the
-    # sensor's selector is gone (evaluates "unknown").
-    uncapped = {"datastores": [{**row, "vm_count": 300, "vm_names": dense_names}]}
+
+@pytest.mark.asyncio
+async def test_uncapped_dense_row_would_collapse_and_lose_selector() -> None:
+    """Why the cap is load-bearing: an unbounded single row blows the threshold.
+
+    A datastore row carrying its full (unbounded) ``vm_names`` list serialises
+    past the reducer byte threshold, so the reducer collapses
+    ``{"datastores": [row]}`` to a sampled envelope and
+    ``$.datastores[0].free_space`` is no longer selectable (evaluates
+    ``unknown``) -- the exact failure the cap prevents (#2758).
+    """
+    uncapped: dict[str, Any] = {
+        "datastores": [
+            {
+                "id": "datastore-42",
+                "name": "vsan-dense-01",
+                "type": "vSAN",
+                "capacity": 50 * 1024 * _GIB,
+                "free_space": 40 * _GIB,
+                "vm_count": 300,
+                "vm_names": [f"prod-workload-vm-{i:04d}" for i in range(300)],
+            }
+        ]
+    }
     assert len(msgspec.json.encode(uncapped)) > _BYTE_THRESHOLD
-    envelope, env_handle = await _reducer().reduce(uncapped, None, {})
-    assert env_handle is not None
+
+    envelope, handle = await _reducer().reduce(uncapped, None, {})
+    assert handle is not None
     assert "row_count" in envelope
+
+    spec = AssertionSpec.model_validate(
+        {"select": {"path": "$.datastores[0].free_space"}, "compare": _CRIT_ONLY_COMPARE}
+    )
     assert evaluate_assertion(spec, envelope, now=NOW).state == "unknown"
 
 

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -489,6 +489,33 @@ recording the failing sub-op, its status, and the underlying error.
 The response schema marks `vm_count`/`vm_names` as nullable and adds the
 optional `enrichment_note` key (present only on a skipped row).
 
+### Per-entity capacity sensing (`filter_names`, #2758)
+
+`datastore.usage` takes an exact-match `filter_names` param (array of
+datastore names, forwarded to the listing as `filter.names`). Passing
+**exactly one** name is the per-datastore Sensor pattern: the one-row
+result returns inline (unsampled), so a Sensor can select
+`$.datastores[0].free_space` (bytes) under a `ThresholdCompare` and
+threshold a single vSAN/VMFS store's free space — the capacity-tier
+monitoring the v0.26.0 ops report needed. No new param, no fuzzy
+matching, no top-N; the filter is exact-match only.
+
+Why this is not automatic: the dispatcher's JSONFlux reducer collapses
+any op result serialising past `byte_threshold` (4096 bytes, the default
+`JsonFluxReducer()` installed at `main.py`) into a sampled envelope
+(`{row_count, …, source_key}`). A single row is one row (well under the
+50-row bound), but the best-effort `vm_names` list is unbounded — a
+VM-dense datastore (a vSAN with a few hundred VMs) pushes one row past
+4096 bytes, the whole `{"datastores": [row]}` collapses to the envelope,
+and `$.datastores[0].free_space` is no longer selectable. So `vm_names`
+is **bounded to a sample** (`DATASTORE_USAGE_MAX_VM_NAMES`, 20; the row's
+`maxItems`), while `vm_count` stays the exact total — `vm_count >
+len(vm_names)` signals truncation. Bounding the enrichment payload (not
+raising the global JSONFlux threshold) is what keeps a one-name filtered
+row reliably inline and assertable. `free_space`/`capacity` are bytes;
+band them directly (`op: lt`, `degraded`/`critical` in bytes) — no
+server-side `free_gb`/percent derivation.
+
 `capacity`/`free_space` are read from the per-datastore detail payload
 with a **list-row fallback** (#2078): some vCenter builds (observed on an
 8.0.3 vCenter against the 9.0 spec) return a detail `Datastore.Info` that


### PR DESCRIPTION
## Summary

- **Rescoped task (premise was stale).** `vmware.composite.datastore.usage` is *not* param-less: the exact-match `filter_names` param has shipped since #524. The real gaps were (a) a one-name filtered result was never *proven* to arrive inline (unsampled) and assertable, (b) the unbounded `vm_names` enrichment could push a single VM-dense row past the reducer's byte threshold, collapsing `{"datastores": [row]}` to a sampled envelope and stripping the sensor's selector, and (c) the per-entity Sensor pattern was undiscoverable.
- **Desired-state 2 fired (verified, not assumed).** Using the real `msgspec` encoder the reducer uses, an *uncapped* single row crosses the 4096-byte JSONFlux threshold at ~150 VMs — a routine vSAN datastore. So the enrichment-bounding fix landed: `vm_names` is bounded to a sample (`DATASTORE_USAGE_MAX_VM_NAMES = 20`, the row's response-schema `maxItems`) while `vm_count` stays the **exact** total (`vm_count > len(vm_names)` signals truncation). We bound the payload — we do **not** touch the global JSONFlux threshold.
- **Discoverability.** The `filter_names` description and `docs/codebase/connectors-vmware-rest.md` now name the per-entity Sensor pattern verbatim ("pass exactly one name, select `$.datastores[0].free_space`").
- **Param surface unchanged.** Only `filter_names` (description-only change); no new params, no fuzzy matching, no top-N. The only schema-shape change is the `vm_names` response bound (the sanctioned Desired-state-2 change).

## Acceptance criteria

- [x] **E2E test through the dispatch+evaluate chain.** `tests/test_datastore_usage_per_entity_sensor.py::test_one_name_filter_returns_inline_and_sensor_bands` (×3 bands): one-name `filter_names` → inline `{"datastores": [row]}` with no `row_count`/`source_key` envelope keys (real `JsonFluxReducer()`), then `$.datastores[0].free_space` under a `lt` `ThresholdCompare` → `ok`/`degraded`/`critical` via the real `evaluate_assertion`. Composes the same handler → reducer → `evaluate_assertion` the runner wires (`checks/runner.py:390-418`).
- [x] **Guard on the single-row byte shape.** `test_vm_dense_row_capped_stays_inline_and_assertable`: a 300-VM datastore keeps `vm_count == 300` while `vm_names` is capped at 20; the capped payload serialises `<= 4096` and the real reducer passes it through inline (free_space still selectable); the **uncapped** row (full 300 names) serialises `> 4096` and the real reducer collapses it to an envelope (selector → `unknown`). Plus `test_response_schema_maxitems_matches_cap_constant` pins schema↔handler sync.
- [x] **Discoverability + issue comment.** `filter_names` description (`schemas.py`) + `docs/codebase/` name the per-entity Sensor use; a comment on #2758 maps the probe's rejected guesses (`datastore`/`name`/`filter`) to the real `filter_names` param.
- [x] **No new params.** `test_param_surface_stays_filter_names_only` pins that the op's parameter schema is `filter_names`-only with `additionalProperties: false`.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run mypy src/` — no new errors (my files clean; a pre-existing darwin-only `net/icmp.py` `MSG_ERRQUEUE` error is unrelated and passes on CI's Linux runner)
- [x] `uv run pytest tests/test_datastore_usage_per_entity_sensor.py` — 6 passed
- [x] `uv run pytest` on composites read/register/write-register + recursive-e2e + MCP output/input schema conformance + checks-assertions — 191 passed, 1 skipped (vcsim acceptance)
- [x] `code-quality.py --diff` — 0 blockers (3 pre-existing warnings on untouched functions/file)

## Out of scope (per the issue)

- Exact-match filters on the other four composites (`cluster.drs_recommendations`, `event.tail`, `performance.summary`, `network.portgroup.audit`) — file per-op when a consumer asks.
- Server-side derived fields (`free_gb`, percent-full) — `free_space`/`capacity` are bytes; band directly.
- Changing the global JSONFlux thresholds or the reducer's envelope shape.

## Adjacent findings (recorded, not fixed)

- Pre-existing code-quality warnings: `cluster_drs_recommendations_composite` (62 lines) and `performance_summary_composite` (81 lines) exceed the 60-line warn bound; `composites/schemas.py` is 1305 lines (> 600). All pre-date this change and are untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2758
