### PR TITLE
feat(checks): notify_email accepts a list of recipients

### DIFF
--- a/backend/src/meho_backplane/checks/dashboard_schemas.py
+++ b/backend/src/meho_backplane/checks/dashboard_schemas.py
@@ -22,7 +22,15 @@ import uuid
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+)
 
 from meho_backplane.checks.assertions import CheckState
 from meho_backplane.db.models import SensorSeverity, SensorStatus
@@ -64,6 +72,24 @@ _MAX_MEMBERS = 200
 #: which is also what the briefing's token budget tracks.
 _INVESTIGATOR_PROMPT_MAX_LENGTH = 4096
 
+#: Max recipients a Dashboard's ``notify_email`` may fan out to (#2764). The
+#: same closed-list posture as ``sensor_ids`` (``_MAX_MEMBERS``), scaled to the
+#: notification surface: a channel address plus a handful of individuals is the
+#: shape the ops report described, and a Dashboard mailing more than this many
+#: distinct mailboxes wants a distribution-list alias, not N recipients pinned
+#: on the row. Bounds both the comma-joined ``text`` column and the per-send
+#: fan-out, restoring the implicit single-address bound the field carried
+#: before it accepted a list.
+_MAX_NOTIFY_RECIPIENTS = 16
+
+#: Per-entry validator reused for the comma-separated ``notify_email`` list
+#: (#2764). Built once at import. ``EmailStr`` (``email-validator``) lower-cases
+#: the domain, strips surrounding whitespace, and returns the validated address
+#: as a plain ``str``; an unparseable entry raises
+#: :class:`~pydantic.ValidationError`, which the field validator re-raises as a
+#: boundary 422 naming the offending entry.
+_EMAIL_ADAPTER: TypeAdapter[str] = TypeAdapter(EmailStr)
+
 
 class DashboardCreate(BaseModel):
     """Request body for ``POST /api/v1/checks/dashboards``.
@@ -79,10 +105,13 @@ class DashboardCreate(BaseModel):
 
     ``notify_email`` / ``notify_min_state`` are the #2719 notification config,
     set at create only like membership. Omitting ``notify_email`` leaves
-    notifications off for this Dashboard. The address is validated with
-    pydantic's ``EmailStr`` (``email-validator``), so a malformed one is a
-    boundary 422 rather than a delivery failure discovered hours later on the
-    first transition.
+    notifications off for this Dashboard. Since #2764 it carries **one or more**
+    comma-separated recipients: each entry is validated individually with
+    pydantic's ``EmailStr`` (``email-validator``), so a single malformed entry
+    is a boundary 422 naming it rather than a delivery failure discovered hours
+    later on the first transition. The normalised, comma-joined form is what
+    persists (the existing ``text`` column from migration ``0068``, no new
+    migration), and a lone address is stored and read back unchanged.
 
     ``investigator_prompt`` is the #2721 operator context appended to the
     diagnose-only investigator's briefing. Bounded at
@@ -97,8 +126,11 @@ class DashboardCreate(BaseModel):
     description: str | None = Field(default=None, max_length=_DESCRIPTION_MAX_LENGTH)
     sensor_ids: list[uuid.UUID] = Field(default_factory=list, max_length=_MAX_MEMBERS)
     tenant_id: uuid.UUID | None = None
-    #: Single recipient for transition mail; ``None`` disables notification.
-    notify_email: EmailStr | None = None
+    #: One or more comma-separated recipients for transition + finding mail;
+    #: ``None`` disables notification. Each entry is ``EmailStr``-validated by
+    #: :meth:`_validate_notify_email` and the normalised set persists
+    #: comma-joined (#2764).
+    notify_email: str | None = None
     #: Floor an edge must reach before mail is sent, under
     #: ``ok < degraded < critical`` applied to ``max(previous, current)``.
     notify_min_state: NotifyMinState = "critical"
@@ -107,6 +139,42 @@ class DashboardCreate(BaseModel):
     investigator_prompt: str | None = Field(
         default=None, max_length=_INVESTIGATOR_PROMPT_MAX_LENGTH
     )
+
+    @field_validator("notify_email", mode="after")
+    @classmethod
+    def _validate_notify_email(cls, value: str | None) -> str | None:
+        """Validate ``notify_email`` as a comma-separated recipient list (#2764).
+
+        ``None`` stays ``None`` (notifications off). Otherwise the value is
+        split on commas, each entry is individually validated as an
+        ``EmailStr`` -- so one malformed address is a 422 naming it, not a
+        delivery failure found on the first transition -- and the normalised
+        entries are re-joined for storage in the existing ``text`` column. A
+        single address is stored and read back unchanged; a present-but-empty
+        value (empty or all-blank / comma-only string) is refused, since the
+        way to disable notifications is to omit the field, not to send a blank
+        recipient. Bounded at :data:`_MAX_NOTIFY_RECIPIENTS`.
+        """
+        if value is None:
+            return None
+        entries = [part.strip() for part in value.split(",") if part.strip()]
+        if not entries:
+            raise ValueError(
+                "notify_email must carry at least one address; omit the field "
+                "to disable notifications"
+            )
+        if len(entries) > _MAX_NOTIFY_RECIPIENTS:
+            raise ValueError(
+                f"notify_email accepts at most {_MAX_NOTIFY_RECIPIENTS} "
+                f"recipients; got {len(entries)}"
+            )
+        validated: list[str] = []
+        for entry in entries:
+            try:
+                validated.append(_EMAIL_ADAPTER.validate_python(entry))
+            except ValidationError as exc:
+                raise ValueError(f"{entry!r} is not a valid email address") from exc
+        return ",".join(validated)
 
 
 class DashboardMemberView(BaseModel):

--- a/backend/src/meho_backplane/checks/notify.py
+++ b/backend/src/meho_backplane/checks/notify.py
@@ -8,7 +8,11 @@ detector (:mod:`meho_backplane.checks.investigate`) already compare-and-swaps
 ``check_dashboards.last_rollup_state`` exactly once per rollup edge, replica-
 safe; until now that claim only ever reached the diagnose-only investigator.
 This module is the second, independent consumer of the same claim: it mails
-the Dashboard's configured recipient.
+the Dashboard's configured recipient(s). Since #2764 ``notify_email`` may
+carry more than one comma-separated address; the identical mail fans out to
+every recipient in one send, each screened individually against the
+deployment allowlist (:func:`_allowed_recipients`) so one refused entry
+drops only itself.
 
 Two notice kinds, one delivery seam
 ===================================
@@ -139,6 +143,10 @@ from typing import Final, cast
 import structlog
 
 from meho_backplane.broadcast.client import get_broadcast_client
+from meho_backplane.connectors.mail.allowlist import (
+    RecipientNotAllowedError,
+    assert_recipient_allowed,
+)
 from meho_backplane.connectors.mail.transport import send_email
 from meho_backplane.settings import get_settings
 
@@ -270,10 +278,12 @@ class FindingNotice:
     :class:`NotifyMember` is one: this module must not import
     :mod:`meho_backplane.checks.investigate`, which imports *it*.
 
-    :attr:`recipient` is resolved from the Dashboard's ``notify_email`` by
-    the investigator, so an unconfigured Dashboard arrives here as ``None``
-    and short-circuits in :func:`notify_finding` rather than being filtered
-    at the call site -- the skip is then logged in one place.
+    :attr:`recipient` is the Dashboard's ``notify_email`` (one or more
+    comma-separated addresses since #2764) resolved by the investigator, so an
+    unconfigured Dashboard arrives here as ``None`` and short-circuits in
+    :func:`notify_finding` rather than being filtered at the call site -- the
+    skip is then logged in one place. :func:`notify_finding` fans the identical
+    mail out to every allowlisted entry, the same seam the transition mail uses.
     """
 
     dashboard_id: uuid.UUID
@@ -303,9 +313,11 @@ def _suppression_key(tenant_id: uuid.UUID, dashboard_id: uuid.UUID, state: str) 
     """Valkey key bounding one ``(tenant, dashboard, state)`` per window (#2732).
 
     Unlike the #2718 advisory's key there is no caller segment: the
-    notification's audience is the Dashboard's single configured recipient,
-    not whoever happens to dispatch. Every segment is a UUID or a
-    CHECK-constrained vocabulary word, so the ``:`` delimiter cannot alias
+    notification's audience is the Dashboard's configured recipient(s), not
+    whoever happens to dispatch. Nor is there a recipient segment: the claim
+    is per edge, so one claim covers every recipient of a multi-recipient
+    Dashboard (#2764) -- it cannot burn N windows. Every segment is a UUID or
+    a CHECK-constrained vocabulary word, so the ``:`` delimiter cannot alias
     two keys.
     """
     return f"meho:checks:notify:{tenant_id}:{dashboard_id}:{state}"
@@ -432,16 +444,51 @@ def _body(notice: DashboardNotice) -> str:
     return "\n".join(lines) + "\n"
 
 
-async def _deliver(notice: DashboardNotice, recipient: str) -> None:
-    """Send one mail and record its outcome; swallow every failure.
+def _allowed_recipients(raw: str, **log_fields: object) -> list[str]:
+    """Split a comma-joined ``notify_email`` and keep the allowlisted entries.
+
+    The wire schema stores one or more recipients comma-joined (#2764). Each
+    entry is screened **individually** against the deployment recipient
+    allowlist -- the same
+    :func:`~meho_backplane.connectors.mail.allowlist.assert_recipient_allowed`
+    floor the transport enforces, reused here so one refused entry drops only
+    itself. A refused entry warn-logs ``checks_notify_recipient_refused`` and
+    is skipped; the survivors are returned for a single
+    :func:`~meho_backplane.connectors.mail.transport.send_email` fan-out. A
+    refused recipient must never silence delivery to the allowlisted rest --
+    the missed-alert-is-worse posture the module holds elsewhere.
+
+    ``send_email``'s own all-or-nothing screen is deliberately left untouched
+    (its audit-honesty rationale stands for the dispatched ``mail.send`` path);
+    it re-screens this already-clean survivor set and passes it as a whole.
+    """
+    survivors: list[str] = []
+    for entry in (part.strip() for part in raw.split(",")):
+        if not entry:
+            continue
+        try:
+            assert_recipient_allowed(entry)
+        except RecipientNotAllowedError:
+            _log().warning("checks_notify_recipient_refused", recipient=entry, **log_fields)
+            continue
+        survivors.append(entry)
+    return survivors
+
+
+async def _deliver(notice: DashboardNotice, recipients: list[str]) -> None:
+    """Fan the identical mail out to *recipients*; swallow every failure.
 
     Split out of :func:`notify_dashboard_transition` so that function reads
-    as the two gates it is, and so the never-raise guard wraps exactly the
-    I/O rather than the gates too.
+    as the gates it is, and so the never-raise guard wraps exactly the I/O
+    rather than the gates too. One
+    :func:`~meho_backplane.connectors.mail.transport.send_email` call delivers
+    the same message to every recipient (#2764); *recipients* is the
+    already-allowlisted survivor set from :func:`_allowed_recipients`, so the
+    transport's own all-or-nothing floor passes them as a whole.
     """
     try:
         result = await send_email(
-            to=[recipient],
+            to=recipients,
             subject=_subject(notice),
             body=_body(notice),
         )
@@ -468,11 +515,12 @@ async def _deliver(notice: DashboardNotice, recipient: str) -> None:
         previous_state=notice.previous_state,
         current_state=notice.current_state,
         member_count=len(notice.members),
+        recipient_count=len(recipients),
     )
 
 
 async def notify_dashboard_transition(notice: DashboardNotice) -> None:
-    """Mail the Dashboard's recipient about one claimed transition.
+    """Mail the Dashboard's recipient(s) about one claimed transition.
 
     Never raises. Short-circuits, in order:
 
@@ -482,16 +530,18 @@ async def notify_dashboard_transition(notice: DashboardNotice) -> None:
       :func:`_crosses_threshold`);
     * a same-state notification already claimed this edge's flap window
       (#2732, see :func:`_claim_suppression`; skipped entirely when the
-      window is ``0`` or the crossing is into a rank-0 state).
+      window is ``0`` or the crossing is into a rank-0 state);
+    * every configured recipient is refused by the allowlist, so there is
+      nothing to send (``checks_notify_no_allowed_recipients``).
 
     A rank-0 crossing (recovery) additionally clears the Dashboard's
     suppression keys before the floor gate -- the incident is over whether
     or not the recovery edge itself mails.
 
-    Otherwise :func:`_deliver` runs one
-    :func:`~meho_backplane.connectors.mail.transport.send_email` call,
-    screened by the deployment-level recipient allowlist floor that function
-    owns.
+    Otherwise the configured recipients are screened individually
+    (:func:`_allowed_recipients`) and :func:`_deliver` fans one
+    :func:`~meho_backplane.connectors.mail.transport.send_email` call out to
+    the allowlisted survivors (#2764).
     """
     if not notice.notify_email:
         _log().info(
@@ -525,7 +575,14 @@ async def notify_dashboard_transition(notice: DashboardNotice) -> None:
             window_minutes=window_minutes,
         )
         return
-    await _deliver(notice, notice.notify_email)
+    recipients = _allowed_recipients(notice.notify_email, dashboard_id=str(notice.dashboard_id))
+    if not recipients:
+        _log().warning(
+            "checks_notify_no_allowed_recipients",
+            dashboard_id=str(notice.dashboard_id),
+        )
+        return
+    await _deliver(notice, recipients)
 
 
 def schedule_dashboard_notification(notice: DashboardNotice) -> None:
@@ -599,10 +656,15 @@ def _finding_body(notice: FindingNotice) -> str:
 
 
 async def notify_finding(notice: FindingNotice) -> None:
-    """Mail one persisted investigator finding to the Dashboard's recipient.
+    """Mail one persisted investigator finding to the Dashboard's recipient(s).
 
     Never raises. Short-circuits when the Dashboard has no ``notify_email``
-    (the state every pre-#2719 row backfills to).
+    (the state every pre-#2719 row backfills to) or when every configured
+    recipient is refused by the allowlist
+    (``checks_finding_email_no_allowed_recipients``). Since #2764 the identical
+    finding mail fans out to every allowlisted recipient in one send, each
+    screened individually via :func:`_allowed_recipients` -- the same seam the
+    transition mail uses.
 
     There is deliberately **no** ``notify_min_state`` gate here.
     ``notify_min_state`` is a floor on a transition *edge* --
@@ -626,9 +688,21 @@ async def notify_finding(notice: FindingNotice) -> None:
             run_id=str(notice.run_id),
         )
         return
+    recipients = _allowed_recipients(
+        notice.recipient,
+        dashboard_id=str(notice.dashboard_id),
+        run_id=str(notice.run_id),
+    )
+    if not recipients:
+        _log().warning(
+            "checks_finding_email_no_allowed_recipients",
+            dashboard_id=str(notice.dashboard_id),
+            run_id=str(notice.run_id),
+        )
+        return
     try:
         result = await send_email(
-            to=[notice.recipient],
+            to=recipients,
             subject=_finding_subject(notice),
             body=_finding_body(notice),
         )
@@ -656,6 +730,7 @@ async def notify_finding(notice: FindingNotice) -> None:
         dashboard_id=str(notice.dashboard_id),
         run_id=str(notice.run_id),
         verdict=notice.verdict,
+        recipient_count=len(recipients),
     )
 
 

--- a/backend/tests/test_checks_broadcast.py
+++ b/backend/tests/test_checks_broadcast.py
@@ -74,6 +74,9 @@ def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
     monkeypatch.setenv("SCHEDULER_ENABLED", "false")
     monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    # The notifier pre-screens recipients against this floor (#2764); allowlist
+    # the ``example.com`` domain the seeded Dashboard mails to.
+    monkeypatch.setenv("MAIL_RECIPIENT_ALLOWLIST", "example.com")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/backend/tests/test_checks_dashboards.py
+++ b/backend/tests/test_checks_dashboards.py
@@ -546,6 +546,38 @@ async def test_rest_create_round_trips_notify_config(client: TestClient) -> None
 
 
 @pytest.mark.asyncio
+async def test_rest_create_accepts_multiple_notify_recipients(client: TestClient) -> None:
+    """A comma-separated ``notify_email`` lands normalised + comma-joined (#2764)."""
+    await _seed_tenant(_TENANT_A, "tenant-a")
+    sid = await _seed_sensor(name="multi-notify-sensor", last_state="ok")
+    key = make_rsa_keypair("kid-multi-notify")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key)}"}
+        created = client.post(
+            "/api/v1/checks/dashboards",
+            json={
+                "name": "multi-notified",
+                "sensor_ids": [str(sid)],
+                # Surrounding whitespace is normalised away on the way in.
+                "notify_email": "oncall@example.com, team@example.com",
+            },
+            headers=headers,
+        )
+        assert created.status_code == 201, created.text
+        assert created.json()["notify_email"] == "oncall@example.com,team@example.com"
+
+        dashboard_id = created.json()["id"]
+        detail = client.get(f"/api/v1/checks/dashboards/{dashboard_id}", headers=headers)
+        assert detail.json()["notify_email"] == "oncall@example.com,team@example.com"
+
+    async with get_sessionmaker()() as session:
+        persisted = await session.get(CheckDashboard, UUID(dashboard_id))
+        assert persisted is not None
+        assert persisted.notify_email == "oncall@example.com,team@example.com"
+
+
+@pytest.mark.asyncio
 async def test_rest_create_defaults_notify_off_at_critical(client: TestClient) -> None:
     """Omitting both fields leaves notifications off at the ``critical`` floor."""
     await _seed_tenant(_TENANT_A, "tenant-a")
@@ -569,6 +601,10 @@ async def test_rest_create_defaults_notify_off_at_critical(client: TestClient) -
     [
         pytest.param("notify_email", "not-an-address", id="malformed-email"),
         pytest.param("notify_email", "oncall@", id="empty-domain"),
+        # #2764: one malformed entry in an otherwise-valid list is a 422.
+        pytest.param("notify_email", "ok@example.com,not-an-address", id="malformed-in-list"),
+        # #2764: a present-but-blank recipient is refused (omit to disable).
+        pytest.param("notify_email", "   ", id="blank-recipient"),
         pytest.param("notify_min_state", "ok", id="floor-outside-vocabulary"),
         pytest.param("notify_min_state", "warn", id="floor-not-a-state"),
     ],

--- a/backend/tests/test_checks_investigate.py
+++ b/backend/tests/test_checks_investigate.py
@@ -98,6 +98,9 @@ def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
     monkeypatch.setenv("SCHEDULER_ENABLED", "false")
     monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    # The finding-mail notifier pre-screens recipients against this floor
+    # (#2764); allowlist the ``example.test`` domain these tests mail to.
+    monkeypatch.setenv("MAIL_RECIPIENT_ALLOWLIST", "example.test")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/backend/tests/test_checks_notify.py
+++ b/backend/tests/test_checks_notify.py
@@ -93,6 +93,10 @@ def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
     monkeypatch.setenv("SCHEDULER_ENABLED", "false")
     monkeypatch.setenv("SENSOR_RUNNER_ENABLED", "false")
+    # The notifier pre-screens every recipient against this floor (#2764), so
+    # the ``@example.com`` addresses these tests mail to must be allowlisted;
+    # a non-``example.com`` address exercises the per-entry refusal.
+    monkeypatch.setenv("MAIL_RECIPIENT_ALLOWLIST", "example.com")
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
@@ -502,6 +506,78 @@ async def test_body_bounds_members_and_fields(monkeypatch: pytest.MonkeyPatch) -
 
 
 # ---------------------------------------------------------------------------
+# Multi-recipient fan-out (#2764)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transition_mail_fans_out_to_every_recipient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A comma-joined ``notify_email`` delivers the identical mail to all (#2764)."""
+    fake = _install_transport(monkeypatch)
+    await notify_dashboard_transition(_notice(email="oncall@example.com,team@example.com"))
+    assert len(fake.calls) == 1, "one send fans out to every recipient"
+    assert fake.calls[0]["to"] == ["oncall@example.com", "team@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_transition_mail_drops_only_the_refused_recipient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refused recipient never silences delivery to the allowlisted rest (#2764).
+
+    The allowlist floor is ``example.com`` (the settings fixture); the
+    ``@blocked.test`` entry is refused per-entry and warn-logged, while the
+    allowlisted address still receives the mail in one ``send_email`` call --
+    the transport's own all-or-nothing screen is deliberately left untouched.
+    """
+    fake = _install_transport(monkeypatch)
+    with capture_logs() as logs:
+        await notify_dashboard_transition(_notice(email="oncall@example.com,stranger@blocked.test"))
+    assert len(fake.calls) == 1, "the allowlisted recipient still receives the mail"
+    assert fake.calls[0]["to"] == ["oncall@example.com"]
+    refused = [e for e in logs if e["event"] == "checks_notify_recipient_refused"]
+    assert len(refused) == 1
+    assert refused[0]["recipient"] == "stranger@blocked.test"
+
+
+@pytest.mark.asyncio
+async def test_transition_mail_all_recipients_refused_sends_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When every configured recipient is refused there is nothing to send (#2764)."""
+    fake = _install_transport(monkeypatch)
+    with capture_logs() as logs:
+        await notify_dashboard_transition(_notice(email="a@blocked.test,b@blocked.test"))
+    assert fake.calls == []
+    assert any(e["event"] == "checks_notify_no_allowed_recipients" for e in logs)
+    assert [e["recipient"] for e in logs if e["event"] == "checks_notify_recipient_refused"] == [
+        "a@blocked.test",
+        "b@blocked.test",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_one_suppression_claim_per_edge_regardless_of_recipients(
+    monkeypatch: pytest.MonkeyPatch,
+    suppression_store: _FakeSuppressionStore,
+) -> None:
+    """A multi-recipient Dashboard claims exactly one flap window per edge (#2764).
+
+    The suppression key carries no recipient segment, so N recipients cannot
+    burn N windows -- one claim covers the whole fan-out.
+    """
+    fake = _install_transport(monkeypatch)
+    await notify_dashboard_transition(
+        _notice(email="oncall@example.com,team@example.com", dashboard_id=uuid4())
+    )
+    assert len(fake.calls) == 1
+    assert len(fake.calls[0]["to"]) == 2, "both recipients received the one mail"
+    assert len(suppression_store.set_calls) == 1, "exactly one claim covers every recipient"
+
+
+# ---------------------------------------------------------------------------
 # Integration through the persist seam
 # ---------------------------------------------------------------------------
 
@@ -895,6 +971,43 @@ async def test_finding_mail_carries_verdict_summary_and_run(
     assert "Reclaim thin-provisioned space." in body
     # The advisory-only disclaimer rides with the action, not without it.
     assert "diagnose-only" in body
+
+
+@pytest.mark.asyncio
+async def test_finding_mail_fans_out_to_every_recipient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The finding mail fans out to the same recipient list as the transition (#2764)."""
+    fake = _install_transport(monkeypatch)
+    await notify_finding(_finding(email="oncall@example.com,team@example.com"))
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["to"] == ["oncall@example.com", "team@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_finding_mail_drops_only_the_refused_recipient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refused finding recipient drops only itself; the rest still get mailed (#2764)."""
+    fake = _install_transport(monkeypatch)
+    with capture_logs() as logs:
+        await notify_finding(_finding(email="oncall@example.com,stranger@blocked.test"))
+    assert fake.calls[0]["to"] == ["oncall@example.com"]
+    refused = [e for e in logs if e["event"] == "checks_notify_recipient_refused"]
+    assert len(refused) == 1
+    assert refused[0]["recipient"] == "stranger@blocked.test"
+
+
+@pytest.mark.asyncio
+async def test_finding_mail_all_recipients_refused_sends_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finding whose every recipient is refused sends nothing, warn-logged (#2764)."""
+    fake = _install_transport(monkeypatch)
+    with capture_logs() as logs:
+        await notify_finding(_finding(email="a@blocked.test,b@blocked.test"))
+    assert fake.calls == []
+    assert any(e["event"] == "checks_finding_email_no_allowed_recipients" for e in logs)
 
 
 @pytest.mark.asyncio

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -23510,7 +23510,6 @@
           },
           "notify_email": {
             "type": "string",
-            "format": "email",
             "nullable": true,
             "title": "Notify Email"
           },
@@ -23536,7 +23535,7 @@
           "name"
         ],
         "title": "DashboardCreate",
-        "description": "Request body for ``POST /api/v1/checks/dashboards``.\n\nMembership is set at create only (no PUT; \"edit\" is delete + recreate,\nthe trigger-immutability posture). An empty ``sensor_ids`` is permitted --\na member-less Dashboard rolls up to ``unknown`` (the zero-member rule) --\nbut duplicates are de-duplicated by the service before insert. A foreign\nor absent sensor id is refused 422 ``sensor_not_found`` at the boundary.\n\n*tenant_id* (optional) lets a platform-admin caller target another\ntenant; the boundary enforces the RBAC via ``authorize_tenant_scope``.\n\n``notify_email`` / ``notify_min_state`` are the #2719 notification config,\nset at create only like membership. Omitting ``notify_email`` leaves\nnotifications off for this Dashboard. The address is validated with\npydantic's ``EmailStr`` (``email-validator``), so a malformed one is a\nboundary 422 rather than a delivery failure discovered hours later on the\nfirst transition.\n\n``investigator_prompt`` is the #2721 operator context appended to the\ndiagnose-only investigator's briefing. Bounded at\n``_INVESTIGATOR_PROMPT_MAX_LENGTH``; oversize is a structured 422\n(``string_too_long`` with the limit in ``ctx``) rather than a truncation\nthe operator never learns about."
+        "description": "Request body for ``POST /api/v1/checks/dashboards``.\n\nMembership is set at create only (no PUT; \"edit\" is delete + recreate,\nthe trigger-immutability posture). An empty ``sensor_ids`` is permitted --\na member-less Dashboard rolls up to ``unknown`` (the zero-member rule) --\nbut duplicates are de-duplicated by the service before insert. A foreign\nor absent sensor id is refused 422 ``sensor_not_found`` at the boundary.\n\n*tenant_id* (optional) lets a platform-admin caller target another\ntenant; the boundary enforces the RBAC via ``authorize_tenant_scope``.\n\n``notify_email`` / ``notify_min_state`` are the #2719 notification config,\nset at create only like membership. Omitting ``notify_email`` leaves\nnotifications off for this Dashboard. Since #2764 it carries **one or more**\ncomma-separated recipients: each entry is validated individually with\npydantic's ``EmailStr`` (``email-validator``), so a single malformed entry\nis a boundary 422 naming it rather than a delivery failure discovered hours\nlater on the first transition. The normalised, comma-joined form is what\npersists (the existing ``text`` column from migration ``0068``, no new\nmigration), and a lone address is stored and read back unchanged.\n\n``investigator_prompt`` is the #2721 operator context appended to the\ndiagnose-only investigator's briefing. Bounded at\n``_INVESTIGATOR_PROMPT_MAX_LENGTH``; oversize is a structured 422\n(``string_too_long`` with the limit in ``ctx``) rather than a truncation\nthe operator never learns about."
       },
       "DashboardDetail": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3453,10 +3453,13 @@ type DailyUsageBucketSurface string
 //
 // “notify_email“ / “notify_min_state“ are the #2719 notification config,
 // set at create only like membership. Omitting “notify_email“ leaves
-// notifications off for this Dashboard. The address is validated with
-// pydantic's “EmailStr“ (“email-validator“), so a malformed one is a
-// boundary 422 rather than a delivery failure discovered hours later on the
-// first transition.
+// notifications off for this Dashboard. Since #2764 it carries **one or more**
+// comma-separated recipients: each entry is validated individually with
+// pydantic's “EmailStr“ (“email-validator“), so a single malformed entry
+// is a boundary 422 naming it rather than a delivery failure discovered hours
+// later on the first transition. The normalised, comma-joined form is what
+// persists (the existing “text“ column from migration “0068“, no new
+// migration), and a lone address is stored and read back unchanged.
 //
 // “investigator_prompt“ is the #2721 operator context appended to the
 // diagnose-only investigator's briefing. Bounded at
@@ -3467,7 +3470,7 @@ type DashboardCreate struct {
 	Description        *string                        `json:"description"`
 	InvestigatorPrompt *string                        `json:"investigator_prompt"`
 	Name               string                         `json:"name"`
-	NotifyEmail        *openapi_types.Email           `json:"notify_email"`
+	NotifyEmail        *string                        `json:"notify_email"`
 	NotifyMinState     *DashboardCreateNotifyMinState `json:"notify_min_state,omitempty"`
 	SensorIds          *[]openapi_types.UUID          `json:"sensor_ids,omitempty"`
 	TenantId           *openapi_types.UUID            `json:"tenant_id"`

--- a/cli/internal/cmd/dashboard/create.go
+++ b/cli/internal/cmd/dashboard/create.go
@@ -48,9 +48,9 @@ func newCreateCmd() *cobra.Command {
 			"empty member set is legal and rolls up 'unknown' (the zero-member " +
 			"rule); duplicate ids are de-duplicated server-side. --tenant " +
 			"targets another tenant (platform_admin cross-tenant create).\n\n" +
-			"--notify-email is the single address that receives one mail per " +
-			"rollup transition crossing --notify-min-state; leaving it unset " +
-			"keeps notifications off. --notify-min-state is degraded or " +
+			"--notify-email is one or more comma-separated addresses that each " +
+			"receive one mail per rollup transition crossing --notify-min-state; " +
+			"leaving it unset keeps notifications off. --notify-min-state is degraded or " +
 			"critical (default critical): an edge notifies when the worse of " +
 			"its two states reaches the floor, so at 'critical' a recovery " +
 			"from critical back to ok sends the all-clear while ok -> " +
@@ -87,7 +87,7 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().StringArrayVar(&sensorIDs, "sensor-id", nil,
 		"member sensor UUID (repeatable; empty set rolls up 'unknown')")
 	cmd.Flags().StringVar(&notifyEmail, "notify-email", "",
-		"address that receives transition mail (unset = notifications off)")
+		"comma-separated recipient(s) for transition mail (unset = notifications off)")
 	cmd.Flags().StringVar(&notifyMinState, "notify-min-state", "",
 		"notification floor: degraded or critical (server default: critical)")
 	cmd.Flags().StringVar(&investigatorPrompt, "investigator-prompt", "",
@@ -218,8 +218,10 @@ func validateNotifyMinState(value string) error {
 // both are `str | None` server-side, where null and absent read alike, so the
 // row keeps notifications off and keeps the pre-#2721 briefing respectively.
 // An unset --notify-email leaves the field nil rather than sending an empty
-// openapi_types.Email, whose MarshalJSON would reject the empty string before
-// the request goes out.
+// string; a set value is forwarded verbatim as a plain string, and the server
+// splits it on commas and validates each recipient individually (#2764), so no
+// client-side email-format guess is needed (and the multi-recipient form no
+// longer trips a single-address client-side marshal check).
 //
 // investigator_prompt's 4096-character cap is deliberately NOT re-checked
 // here: unlike --notify-min-state's closed vocabulary (a typo the CLI can
@@ -244,7 +246,7 @@ func buildCreateBody(
 		body.TenantId = tenantID
 	}
 	if opts.NotifyEmail != "" {
-		email := openapi_types.Email(opts.NotifyEmail)
+		email := opts.NotifyEmail
 		body.NotifyEmail = &email
 	}
 	if opts.NotifyMinState != "" {

--- a/cli/internal/cmd/dashboard/dashboard_test.go
+++ b/cli/internal/cmd/dashboard/dashboard_test.go
@@ -240,7 +240,7 @@ func TestBuildCreateBodyFull(t *testing.T) {
 	if body.TenantId == nil || body.TenantId.String() != stubOtherTenant {
 		t.Errorf("tenant_id not forwarded; got %+v", body.TenantId)
 	}
-	if body.NotifyEmail == nil || string(*body.NotifyEmail) != "oncall@example.com" {
+	if body.NotifyEmail == nil || *body.NotifyEmail != "oncall@example.com" {
 		t.Errorf("notify_email not forwarded; got %+v", body.NotifyEmail)
 	}
 	if body.NotifyMinState == nil || string(*body.NotifyMinState) != "degraded" {
@@ -248,6 +248,24 @@ func TestBuildCreateBodyFull(t *testing.T) {
 	}
 	if body.InvestigatorPrompt == nil || *body.InvestigatorPrompt != "check the SAN controller first" {
 		t.Errorf("investigator_prompt not forwarded; got %+v", body.InvestigatorPrompt)
+	}
+}
+
+func TestBuildCreateBodyMultipleRecipients(t *testing.T) {
+	// #2764: --notify-email now forwards one or more comma-separated recipients
+	// verbatim as a plain string; the server splits and validates each entry.
+	// Previously the generated openapi_types.Email type rejected the
+	// comma-separated form in its client-side MarshalJSON, so the multi-recipient
+	// call could never leave the CLI.
+	body := buildCreateBody(
+		createOptions{
+			Name:        "prod-health",
+			NotifyEmail: "oncall@example.com,team@example.com",
+		},
+		nil, nil,
+	)
+	if body.NotifyEmail == nil || *body.NotifyEmail != "oncall@example.com,team@example.com" {
+		t.Errorf("multi-recipient notify_email not forwarded verbatim; got %+v", body.NotifyEmail)
 	}
 }
 

--- a/docs/codebase/checks-notifications.md
+++ b/docs/codebase/checks-notifications.md
@@ -4,10 +4,17 @@
 
 When a check Dashboard's five-state rollup crosses an edge,
 `meho_backplane.checks.notify` mails the Dashboard's configured
-recipient — **in both directions**. An operator paged for `critical`
+recipient(s) — **in both directions**. An operator paged for `critical`
 gets the all-clear when the Dashboard recovers, which is what Prometheus
 Alertmanager's `send_resolved` provides and what #2716 made a binding
 decision for this layer.
+
+Since #2764 `notify_email` may carry **more than one** comma-separated
+address. The identical mail fans out to every recipient in one
+`send_email` call; each entry is screened individually against the
+`MAIL_RECIPIENT_ALLOWLIST` floor (`_allowed_recipients`), so one refused
+recipient drops only itself and never silences delivery to the
+allowlisted rest.
 
 The notifier is the second, independent consumer of #2507's transition
 claim. The first is the diagnose-only investigator
@@ -66,8 +73,14 @@ delivery — see `docs/codebase/checks-investigator.md`):
 
 | Column | Type | Meaning |
 |---|---|---|
-| `notify_email` | `text` NULL | The single recipient. **NULL = notifications off**, the state every pre-#2719 row backfills to. |
+| `notify_email` | `text` NULL | One or more comma-separated recipients (#2764), each `EmailStr`-validated on the way in and stored comma-joined. **NULL = notifications off**, the state every pre-#2719 row backfills to. |
 | `notify_min_state` | `text` NOT NULL, default `'critical'`, CHECK `IN ('degraded','critical')` | The floor an edge must reach. |
+
+The `notify_email` column type is unchanged by #2764 — a lone address is
+stored and read back verbatim, and pre-#2764 single-address rows keep
+working — so no migration was needed. The wire schema
+(`DashboardCreate.notify_email`) caps the list at `_MAX_NOTIFY_RECIPIENTS`
+(16); a Dashboard needing more mailboxes wants a distribution-list alias.
 
 `notify_min_state`'s vocabulary is deliberately narrower than
 `CheckState`: `ok` as a floor would mail on every edge, and
@@ -78,9 +91,12 @@ tuple are pinned against each other by drift guards in
 
 Both are set at Dashboard-create only — the same immutability posture as
 membership. There is no PATCH route; "edit" is delete + recreate.
-Surfaces: `POST /api/v1/checks/dashboards` (body fields, `EmailStr`-
-validated → 422 on a malformed address) and
-`meho dashboard create --notify-email --notify-min-state`.
+Surfaces: `POST /api/v1/checks/dashboards` (body fields; each
+comma-separated `notify_email` entry is `EmailStr`-validated → 422 naming
+a malformed one) and
+`meho dashboard create --notify-email --notify-min-state` (the CLI
+forwards the raw comma-separated string; the server splits and validates
+each entry).
 
 ## The notify rule
 
@@ -115,17 +131,24 @@ including `ok -> unknown`, since `unknown` shares rank 1 with
    that used to live inside the claim now sits at this single site,
    unchanged in meaning: `worsening and non_green` → investigator. Every
    claimed edge → `schedule_dashboard_notification`.
-3. **Threshold + flap window + build + send**
+3. **Threshold + flap window + screen + send**
    (`notify_dashboard_transition`). Unset recipient short-circuits; a
    recovery crossing clears the Dashboard's flap windows; then the rank
-   rule; then the #2732 suppression claim (see below); then one
-   `send_email`.
-4. **Outcome logging.** `checks_notify_sent` (info) on delivery;
-   `checks_notify_failed` (warning, with the transport's stable reason
-   code) on a `sent=False` result or an unexpected exception;
+   rule; then the #2732 suppression claim (see below); then per-entry
+   allowlist screening (`_allowed_recipients`, #2764); then one
+   `send_email` fan-out to the survivors. Screening sits **after** the
+   suppression claim, so the claim stays per-edge (one window covers all
+   recipients) and the attempt-based contract is unchanged.
+4. **Outcome logging.** `checks_notify_sent` (info, with
+   `recipient_count`) on delivery; `checks_notify_failed` (warning, with
+   the transport's stable reason code) on a `sent=False` result or an
+   unexpected exception; `checks_notify_recipient_refused` (warning, #2764)
+   for each configured recipient the allowlist drops;
+   `checks_notify_no_allowed_recipients` (warning, #2764) when every
+   configured recipient is refused and there is nothing to send;
    `checks_notify_skipped_unconfigured` /
    `checks_notify_skipped_below_threshold` /
-   `checks_notify_suppressed` (info) on the three short-circuits;
+   `checks_notify_suppressed` (info) on the short-circuits;
    `checks_notify_suppression_failed` (warning, `phase` = `claim` or
    `clear`) when Valkey misbehaves and the fail-open path runs. All are
    at info or above because a claimed edge is a rare event and "no mail
@@ -143,11 +166,12 @@ state)` window:
 - **Mechanism.** The first crossing into a non-green state claims a
   Valkey key — `meho:checks:notify:<tenant>:<dashboard>:<state>`, one
   atomic `SET NX EX`, the #2718 advisory's idiom (`checks/advisory.py`)
-  minus the caller segment (the audience is the Dashboard's one
-  configured recipient, not whoever dispatches). Repeat crossings into
-  the **same** state inside the window lose the claim and log
-  `checks_notify_suppressed`. The Valkey TTL key *is* the state —
-  nothing durable; a Valkey flush re-arms every window.
+  minus the caller segment. The key also carries **no recipient
+  segment**: the claim is per edge, so one window covers every recipient
+  of a multi-recipient Dashboard (#2764) — N recipients cannot burn N
+  windows. Repeat crossings into the **same** state inside the window
+  lose the claim and log `checks_notify_suppressed`. The Valkey TTL key
+  *is* the state — nothing durable; a Valkey flush re-arms every window.
 - **Knob.** `CHECKS_NOTIFY_SUPPRESSION_WINDOW_MINUTES`, default 30.
   `0` disables suppression entirely (one mail per claimed edge, the
   pre-#2732 behaviour) and short-circuits before any Valkey call.
@@ -270,8 +294,9 @@ from the memo would mean re-mailing every unchanged evaluation.
 - `meho_backplane.checks.investigate` — imports this module (never the
   reverse) and owns the claim.
 - `check_dashboards.notify_email` / `notify_min_state` — migration
-  `0068`. The finding mail reuses `notify_email` as its recipient (no
-  separate column).
+  `0068`. The finding mail reuses `notify_email` as its recipient(s) (no
+  separate column) and fans out to the same allowlist-screened list the
+  transition mail does (#2764).
 
 ## Known issues / boundaries
 
@@ -284,12 +309,19 @@ from the memo would mean re-mailing every unchanged evaluation.
   inside a window is not retried by the next same-state crossing, and a
   Valkey flush (or failover to an empty replica) re-arms every window —
   worst case one extra mail per state, never a dropped one.
-- **One recipient per Dashboard.** No lists, no routing rules, no
-  per-Sensor recipients. More when a consumer asks.
+- **Multiple recipients, but no routing.** Since #2764 `notify_email`
+  carries one or more comma-separated recipients and the identical mail
+  fans out to all of them (capped at `_MAX_NOTIFY_RECIPIENTS`). What is
+  still out of scope: routing rules, per-recipient `notify_min_state`,
+  per-Sensor recipients, templating, and digests/batching — the flat
+  closed list is deliberate (#2716 boundary). More when a consumer asks.
 - **Deployment-level SMTP.** One MTA and one allowlist for the whole
   backplane; there is no per-tenant mail config. A tenant admin can
-  therefore name a recipient the allowlist refuses, and learns about it
-  only from `checks_notify_failed` in the pod log.
+  therefore name a recipient the allowlist refuses. Since #2764 that
+  refusal is per-entry: the offending recipient is dropped and
+  warn-logged (`checks_notify_recipient_refused`) while the allowlisted
+  recipients still receive the mail, and a Dashboard whose every
+  recipient is refused logs `checks_notify_no_allowed_recipients`.
 - **No delivery record.** Nothing durable says a mail was sent; the
   structlog event is the whole trace (`checks_notify_sent` /
   `checks_finding_email_sent`). The `checks.transition` broadcast event


### PR DESCRIPTION
## Summary

- **`notify_email` now accepts one or more recipients** (`#2764`, child of Initiative `#2780`). A Dashboard can page a channel address *and* a specific on-call individual — the combination the ops report could not express.
- **Wire schema** (`DashboardCreate.notify_email`) keeps its string shape but validates each comma-separated entry as `EmailStr` (a malformed entry is a 422 naming it), normalises, and stores the set comma-joined in the existing `text` column from migration `0068` — **no migration**, and a single-address create is byte-for-byte unchanged. Bounded at `_MAX_NOTIFY_RECIPIENTS` (16).
- **Delivery seam** (`checks/notify.py`): the transition mail and the finding mail both fan the identical message out to every recipient in one `send_email` call. Each entry is pre-screened individually against `MAIL_RECIPIENT_ALLOWLIST` (`_allowed_recipients`); a refused recipient is dropped with a `checks_notify_recipient_refused` warning and **never silences delivery to the allowlisted rest**. `send_email`'s own all-or-nothing screen is deliberately left untouched (its audit-honesty rationale stands for the dispatched `mail.send` path).
- **Flap suppression (`#2732`) composes unchanged**: the claim key is per `(tenant, dashboard, state)` with no recipient segment, so a multi-recipient Dashboard makes exactly one claim per edge and cannot burn N windows.
- **CLI** `meho dashboard create --notify-email` forwards the raw comma-separated string; the regenerated OpenAPI snapshot + Go client drop the single-address `openapi_types.Email` client-side marshal check that previously rejected the multi-recipient form.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (backend `src/` + touched tests)
- [x] `mypy src/` — clean on changed files (`notify.py`, `dashboard_schemas.py`); the one repo-wide error is a pre-existing darwin-only `socket.MSG_ERRQUEUE` false positive in `net/icmp.py`, unrelated to this change and green on Linux CI
- [x] `pytest` — 157 passed across `test_checks_notify.py` / `test_checks_dashboards.py` / `test_checks_investigate.py` / `test_checks_broadcast.py` / `test_db_dashboard.py` / migration 0068/0069 / `test_ui_checks.py`
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers
- [x] Go: `go build ./...`, `go test ./...`, `go vet`, `gofmt -l` — all clean
- [x] `make snapshot-openapi` + `make generate` produce exactly the committed artifacts (the CI drift gate compares like-for-like)
- **Acceptance criteria:**
  - [x] POST + `meho dashboard create --notify-email` accept multiple recipients; a malformed entry is a 422 (`EmailStr` per entry); single-address create unchanged — `test_rest_create_accepts_multiple_notify_recipients`, `malformed-in-list` / `blank-recipient` params, `TestBuildCreateBodyMultipleRecipients`
  - [x] A two-recipient transition delivers the identical mail to both, and the finding mail fans out to the same list — `test_transition_mail_fans_out_to_every_recipient`, `test_finding_mail_fans_out_to_every_recipient`
  - [x] One allowlisted + one non-allowlisted: the allowlisted one still receives the mail and the refusal is warn-logged; `send_email`'s all-or-nothing contract stays pinned — `test_transition_mail_drops_only_the_refused_recipient`, `test_finding_mail_drops_only_the_refused_recipient`
  - [x] Exactly one suppression claim per claimed edge regardless of recipient count — `test_one_suppression_claim_per_edge_regardless_of_recipients`
  - [x] `docs/codebase/checks-notifications.md` — config-table row + "One recipient per Dashboard" known-issue bullet updated (plus overview, control-flow, logging, and suppression-key notes)

## Out of scope

- Routing rules, per-recipient `notify_min_state`, templating, digests/batching (the `#2716` boundary, restated by the report).
- Per-tenant SMTP config / per-tenant allowlists (deployment-level boundary).
- The dispatched `mail.send` op's recipient semantics — already a list under the all-or-nothing screen; unchanged.
- **Adjacent findings (not addressed):** `checks/notify.py` is a pre-existing 767-line module (>600 soft cap); `notify_dashboard_transition` (64) and `notify_finding` (77) exceed the 60-line soft warn — both dominated by docstrings and well under the 100-line block limit. Left as-is to honour the module's "function reads as its gates" design and keep the change surgical.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2764
