### PR TITLE
fix(ci): dependabot — ignore presidio-anonymizer bumps until upstream supports the cryptography>=50 floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,16 @@ updates:
       - "python"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # presidio-anonymizer >=2.2.363 caps cryptography below 49, which
+      # conflicts with the repo's cryptography>=50.0.0 floor
+      # (backend/pyproject.toml:123, raised by security bumps #1768 + #2798).
+      # Every weekly bump attempt fails dependency_file_not_resolvable (e.g.
+      # Actions runs 30800676016, 30253401120). Remove this ignore when
+      # upstream presidio supports the repo's cryptography floor — and note
+      # that ignore also suppresses future *security*-update PRs for this
+      # package (none open today), so drop it immediately if an alert lands.
+      - dependency-name: "presidio-anonymizer"
 
   # The backplane image's base is `FROM python:3.12-slim@sha256:…` in
   # backend/Dockerfile. Dependabot's docker ecosystem bumps that literal,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,18 @@ connector-related release-notes line.
   applied uniformly to every error arm. The params-only broadcast frame is
   unchanged; the never-raises and audit-fail-open contracts are preserved.
 
+- The weekly `uv in /backend` Dependabot version-update run no longer
+  concludes red (#2802): every `presidio-anonymizer` release above the
+  pinned 2.2.362 caps `cryptography` below 49, which is unsatisfiable
+  against the repo's `cryptography>=50.0.0` security floor, so the weekly
+  2.2.362 → 2.2.364 bump attempt failed `dependency_file_not_resolvable`
+  on every run since 2026-06-29 (the other backend bumps still flowed).
+  `.github/dependabot.yml` now carries an `ignore` rule for
+  `presidio-anonymizer` with the removal conditions documented in-file:
+  drop it when upstream supports the repo's cryptography floor, or
+  immediately if a security advisory lands (the ignore also suppresses
+  security-update PRs for the package — none open today).
+
 ### Security
 
 - Bump `aiohttp` 3.14.1 → 3.14.3 (CVE-2026-69244, out-of-bounds heap


### PR DESCRIPTION
## Summary

- The weekly `uv in /backend` Dependabot version-update run has concluded **failure on every run since 2026-06-29** (last green: 27942430662, 2026-06-22): every `presidio-anonymizer` release above the pinned 2.2.362 caps `cryptography` below 49 (2.2.363 → `<47.0.0`, 2.2.364 → `<49.0.0`), which is unsatisfiable against the repo's `cryptography>=50.0.0` security floor (`backend/pyproject.toml`, raised by #1768 and #2798). Dependabot retries the known-impossible 2.2.362 → 2.2.364 bump weekly and the run goes red after creating its other update PRs.
- Adds an `ignore` rule for `presidio-anonymizer` to the uv `/backend` block of `.github/dependabot.yml`, mirroring the `golangci/golangci-lint-action` ignore precedent already in the file. Name-only (no `update-types`/`versions`) is deliberate — an enumerated known-bad version list would re-red the run on the next incompatible upstream release.
- The in-file comment carries the cap, the failing-run evidence (Actions runs 30800676016, 30253401120), and **both removal conditions**: drop the ignore when upstream presidio supports the repo's cryptography floor, or immediately if a security advisory lands — per the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) (fetched 2026-08-04), `ignore` applies to **both** version updates and security updates, so it would suppress future security PRs for this package too (none open today).
- CHANGELOG: one `Fixed` bullet under `[Unreleased]`, following the #2704 precedent of changelogging CI-run-health fixes.

## Test plan

- [x] `uvx check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml` — `ok -- validation done` (official Dependabot config schema).
- [x] YAML structural assert — the uv `/backend` block carries exactly `ignore: [{dependency-name: "presidio-anonymizer"}]`; the other two ecosystem blocks are untouched.
- [x] Ignore-rule semantics fresh-cited against the Dependabot options reference: a name-only rule filters all matching updates; exact-name match (no `*`), so non-presidio backend bumps are structurally unaffected; `uv` is a supported ecosystem for `ignore`.
- [x] Acceptance criterion 1 (ignore + comment with cap, evidence, removal conditions) — verified in the diff.
- [ ] Acceptance criteria 2–3 (next weekly `uv in /backend` run concludes success; non-presidio bumps keep flowing) — **not verifiable from a PR branch**: Dependabot version-update runs cannot be re-triggered on demand against PR config. The real acceptance signal is the **next scheduled Monday 09:00 run after merge** (2026-08-10).

## Out of scope

- The `uv in /.` grouped security-update failures (phantom pre-pivot root `uv.lock`) — separate ticket, separate root cause.
- Upgrading presidio itself — blocked upstream until it supports `cryptography>=50`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2802

🤖 Generated with [Claude Code](https://claude.com/claude-code)
