### PR TITLE
chore(ci): purge phantom root uv.lock — dismiss 89 ghost Dependabot alerts, record incident in-file (#2801)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,14 @@ updates:
   # fail with `dependency_file_not_found: { "file-path": "/" }` (Dependabot
   # job 1360360077). The `uv` ecosystem covers the uv.lock format the
   # project uses (Dependabot supports it natively since 2025).
+  #
+  # A second, similar-looking failure had no config fix: after the
+  # 2026-05-09 history re-init the dependency graph kept the pre-pivot
+  # root uv.lock snapshot, so grouped security-update jobs kept spawning
+  # at `/.` (the manifest directory recorded on the 89 phantom alerts)
+  # and dying with `No files found in /` — a security-update job runs at
+  # its alerts' recorded path, which no dependabot.yml entry can change.
+  # Resolved 2026-08-04 by dismissing the phantom alerts (#2801).
   - package-ecosystem: "uv"
     directory: "/backend"
     schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,19 @@ connector-related release-notes line.
 
 ### Fixed
 
+- **Phantom root `uv.lock` purged from the Dependabot alert surface**
+  (#2801): the dependency graph still carried the repo's pre-pivot root
+  `uv.lock` (history re-initialized 2026-05-09), so new advisories kept
+  minting alerts for packages that exist nowhere in today's tree — 89
+  open ghost alerts — and every grouped `uv in /.` security-update job
+  died with `No files found in /` (17/17 retained runs red). All 89
+  phantom alerts are dismissed as `not_used` after verifying each
+  package is absent from `backend/uv.lock` or present there only at a
+  non-vulnerable version; the real `backend/uv.lock` alert surface is
+  untouched. `.github/dependabot.yml` now records the incident in-file.
+  The stale graph snapshot itself still lists the phantom packages —
+  the re-index maneuver is documented on #2801 as an operator
+  follow-up.
 - **`net.http_probe` classifies transport failures instead of
   collapsing them to `unreachable`** (#2771). The reason classifier now
   walks the whole `httpx.TransportError` tree — both the `__cause__`


### PR DESCRIPTION
## Summary

- Records the phantom root `uv.lock` incident (#2801) where the next reader will hit it: the `.github/dependabot.yml` comment block that already documents the first `dependency_file_not_found` sighting, plus a CHANGELOG `Fixed` bullet. The load-bearing lesson is in-file: a Dependabot *security-update* job spawns at the manifest directory recorded on its alerts, so no `dependabot.yml` entry could ever fix the chronic `uv in /.` failures.
- The fix itself was operational, executed 2026-08-04 alongside this PR: all **89** open alerts with `manifest_path == "uv.lock"` (root — a manifest that exists nowhere in the current tree; the graph kept the pre-pivot snapshot across the 2026-05-09 history re-init) were dismissed via `PATCH /repos/evoila/meho/dependabot/alerts/{n}` with `dismissed_reason=not_used` and a comment referencing #2801.
- Safety verification before any dismissal: 33 of the 89 packages exist in no in-tree manifest at all; the other 56 exist in `backend/uv.lock` but at versions **outside** every alert's vulnerable range (checked per-alert with `packaging` specifiers — 0 unsafe). The one real alert (#122, `setuptools` on `backend/uv.lock`) is untouched and remains open. Dismissals are reversible (`PATCH state=open`).

## Test plan

- [x] YAML validity: `yaml.safe_load('.github/dependabot.yml')` — valid
- [x] pre-commit hygiene equivalents (trailing whitespace / EOF newline) — clean
- [x] `.claude/hooks/code-quality.py --diff` — exit 0
- [x] Acceptance: `gh api "repos/evoila/meho/dependabot/alerts?per_page=100&state=open" --jq '[.[] | select(.dependency.manifest_path=="uv.lock")] | length'` → **0**
- [x] Acceptance: only remaining open alert is #122 (`backend/uv.lock`, setuptools); no alert outside `manifest_path == "uv.lock"` dismissed
- [ ] Deferred (observable only on future cycles): no new `uv in /.` run on the next advisory/push cycle; `/backend` Dependabot runs stay green — tracked on #2801

## Out of scope

- The stale dependency-graph snapshot itself: the SBOM still lists crawl4ai / litellm / nltk / zeep / jwcrypto. The re-index maneuver (two *separately merged* PRs: add a minimal empty root `uv.lock`, then delete it) requires sequenced human merges and is documented as an operator follow-up on #2801. Until it runs, a new uv-ecosystem advisory can mint a fresh phantom alert against the stale snapshot — dismiss it the same way if that happens before the re-index.
- The weekly `uv in /backend` version-update failures (presidio-anonymizer vs the cryptography floor) — #2802 / PR #2813.

Collision note: open PR #2813 also touches `.github/dependabot.yml` (adds an `ignore` block inside the `/backend` `uv` entry) and CHANGELOG `[Unreleased]`. Hunks don't overlap (this PR extends the comment block above the entry and inserts its bullet at the head of `### Fixed`); both merge orders are clean.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2801

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the resolution of phantom security alerts related to an outdated root lockfile snapshot.
  * Added a changelog entry noting the dismissal of unused alerts, unchanged active dependency alerts, and remaining graph re-index follow-up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->