### PR TITLE
fix(mcp): MCP-surface conformance gaps from the #2666 smoke test

### DIFF
--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -79,6 +79,7 @@ per-operator Vault tenant-scope exemption in
 from __future__ import annotations
 
 from typing import Any
+from uuid import UUID
 
 import structlog
 from fastapi import APIRouter, Depends
@@ -132,11 +133,22 @@ _FEDERATION_PROOF_TARGET_NAME: str = "health-federation-proof"
 
 
 class OperatorIdentity(BaseModel):
-    """Operator identity surface exposed to the CLI.
+    """Operator identity surface exposed to the CLI and MCP ``meho_status``.
 
     Excludes ``raw_jwt`` deliberately — the bearer token must never
     appear in a response body, and the :class:`Operator` model carries
     it for downstream Vault forward-auth only.
+
+    ``tenant_id`` + ``tenant_role`` (#2746) let a connected MCP session
+    confirm *which tenant and role it runs as* from inside the session —
+    the check the clean-room program's "logged in as operator, not
+    tenant_admin" discipline needs, and the identity the ``meho_status``
+    tool's own doc (``docs/cross-repo/mcp-client-setup.md`` Step 4)
+    already promises. Both are always present on the validated
+    :class:`Operator` (JWT claims), so the surface can never omit them;
+    they serialise as a UUID string / role value under
+    ``model_dump(mode="json")`` — the same wire shape the
+    ``meho://tenant/<id>/info`` resource returns.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -144,6 +156,8 @@ class OperatorIdentity(BaseModel):
     sub: str
     name: str | None
     email: str | None
+    tenant_id: UUID
+    tenant_role: TenantRole
 
 
 class VaultStatus(BaseModel):
@@ -556,6 +570,8 @@ async def build_health_response(operator: Operator) -> HealthResponse:
             sub=operator.sub,
             name=operator.name,
             email=operator.email,
+            tenant_id=operator.tenant_id,
+            tenant_role=operator.tenant_role,
         ),
         vault=vault_status,
         db=DbStatus(migrated=db_probe_result.ok),
@@ -587,6 +603,8 @@ async def liveness(
             sub=operator.sub,
             name=operator.name,
             email=operator.email,
+            tenant_id=operator.tenant_id,
+            tenant_role=operator.tenant_role,
         ),
         db=DbStatus(migrated=db_probe_result.ok),
         sensor_runner=_sensor_runner_status(),

--- a/backend/src/meho_backplane/mcp/handlers.py
+++ b/backend/src/meho_backplane/mcp/handlers.py
@@ -98,6 +98,7 @@ from meho_backplane.mcp.audit import compute_params_hash, write_mcp_audit_row
 from meho_backplane.mcp.registry import (
     ResourceTemplateDefinition,
     ToolDefinition,
+    all_listed_resources_for,
     all_resource_templates_for,
     all_tools_for,
     capability_satisfied,
@@ -564,18 +565,24 @@ def _operator_meets_required_role(
 
 
 async def handle_resources_list(
-    _operator: Operator,
+    operator: Operator,
     _params: dict[str, Any] | None,
 ) -> dict[str, Any]:
-    """Return concrete (non-templated) resources.
+    """Return concrete (non-templated) resources for the operator.
 
-    v0.2 registers only templated resources (every URI carries at least
-    one ``{var}``), so this always returns an empty list. The method is
-    present for MCP spec conformance: clients that call ``resources/list``
-    expect an empty array, not ``METHOD_NOT_FOUND``. Templated resources
-    surface via :func:`handle_resources_templates_list`.
+    Concrete resources are the operator-specific URIs registered templates
+    opt into publishing via their ``list_uris`` provider (#2746) — RBAC +
+    capability filtered on the owning template by
+    :func:`~meho_backplane.mcp.registry.all_listed_resources_for`. In v0.2
+    the sole contributor is the tenant-info resource, which lists the
+    caller's own ``meho://tenant/<tenant_id>/info`` so a discovery-driven
+    client (Claude Desktop's attachment picker) can offer the documented
+    verify-step resource without the operator knowing their tenant UUID.
+    Templated resources still surface via
+    :func:`handle_resources_templates_list`; the two lists are disjoint per
+    the MCP 2025-06-18 concrete-vs-templated split.
     """
-    return {"resources": []}
+    return {"resources": all_listed_resources_for(operator)}
 
 
 async def handle_resources_templates_list(

--- a/backend/src/meho_backplane/mcp/registry.py
+++ b/backend/src/meho_backplane/mcp/registry.py
@@ -77,10 +77,12 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.features import FEATURE_MATURITY
 
 __all__ = [
+    "ConcreteUriProvider",
     "ResourceHandler",
     "ResourceTemplateDefinition",
     "ToolDefinition",
     "ToolHandler",
+    "all_listed_resources_for",
     "all_resource_templates_for",
     "all_tools_for",
     "capability_satisfied",
@@ -112,6 +114,15 @@ ToolHandler = Callable[[Operator, dict[str, Any]], Awaitable[dict[str, Any]]]
 #: A resource handler receives the operator and the URI-template variables
 #: bound from the concrete URI, and returns the resource contents.
 ResourceHandler = Callable[[Operator, dict[str, str]], Awaitable[dict[str, Any]]]
+
+#: A concrete-URI provider materialises the operator-specific concrete
+#: resource URIs a template contributes to ``resources/list`` (#2746). Most
+#: templates contribute none — they are discoverable only via
+#: ``resources/templates/list``. The tenant-info resource returns the
+#: caller's own ``meho://tenant/<tenant_id>/info`` so a discovery-driven MCP
+#: client (Claude Desktop's attachment picker lists via ``resources/list``)
+#: can offer it without the operator knowing their tenant UUID.
+ConcreteUriProvider = Callable[[Operator], list[str]]
 
 
 # ---------------------------------------------------------------------------
@@ -363,6 +374,25 @@ class ResourceTemplateDefinition(BaseModel):
             out["title"] = self.title
         return out
 
+    def to_listed_wire(self, uri: str) -> dict[str, Any]:
+        """Serialise as a concrete ``Resource`` (``resources/list`` wire shape).
+
+        Same descriptive fields as :meth:`to_wire` but keyed by a concrete
+        ``uri`` instead of ``uriTemplate`` — the MCP 2025-06-18 ``Resource``
+        object a discovery-driven client renders as a selectable item. The
+        name / description / mimeType stay single-sourced on the template so
+        the listed and templated views can never drift.
+        """
+        out: dict[str, Any] = {
+            "uri": uri,
+            "name": self.name,
+            "description": self.description,
+            "mimeType": self.mimeType,
+        }
+        if self.title is not None:
+            out["title"] = self.title
+        return out
+
 
 # ---------------------------------------------------------------------------
 # Module-level state
@@ -371,6 +401,10 @@ class ResourceTemplateDefinition(BaseModel):
 
 _TOOLS: dict[str, tuple[ToolDefinition, ToolHandler]] = {}
 _RESOURCES: dict[str, tuple[ResourceTemplateDefinition, ResourceHandler]] = {}
+#: Concrete-URI providers keyed by the owning template's ``uriTemplate``
+#: (#2746). Populated by :func:`register_mcp_resource` when a resource opts
+#: into ``resources/list`` visibility; read by :func:`all_listed_resources_for`.
+_LISTED_URI_PROVIDERS: dict[str, ConcreteUriProvider] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -425,6 +459,8 @@ def register_mcp_tool(definition: ToolDefinition, handler: ToolHandler) -> None:
 def register_mcp_resource(
     definition: ResourceTemplateDefinition,
     handler: ResourceHandler,
+    *,
+    list_uris: ConcreteUriProvider | None = None,
 ) -> None:
     """Register a resource template keyed by :attr:`ResourceTemplateDefinition.uriTemplate`.
 
@@ -432,6 +468,10 @@ def register_mcp_resource(
     raise immediately because the registry is populated at module-import
     time and a collision indicates two modules trying to own the same
     URI namespace.
+
+    ``list_uris`` (#2746, optional) opts the resource into ``resources/list``
+    visibility — a provider ``(operator) -> [uri, ...]`` yielding the concrete
+    URIs the template exposes (default: template-only, off ``resources/list``).
 
     Three flavours of bad input are rejected:
 
@@ -472,6 +512,8 @@ def register_mcp_resource(
                 "match shape is identical)",
             )
     _RESOURCES[definition.uriTemplate] = (definition, handler)
+    if list_uris is not None:
+        _LISTED_URI_PROVIDERS[definition.uriTemplate] = list_uris
     _log.info("mcp_resource_registered", uri_template=definition.uriTemplate)
 
 
@@ -530,6 +572,33 @@ def all_resource_templates_for(
         if role_at_least(operator.tenant_role, defn.required_role)
         and capability_satisfied(operator, defn.required_capability)
     ]
+
+
+def all_listed_resources_for(operator: Operator) -> list[dict[str, Any]]:
+    """Return concrete ``resources/list`` entries the operator may see.
+
+    Each registered template may contribute zero or more concrete URIs via
+    the ``list_uris`` provider passed to :func:`register_mcp_resource`
+    (default: none). For every contributed URI the concrete
+    :class:`Resource` wire object is built from the owning template
+    (:meth:`ResourceTemplateDefinition.to_listed_wire`). The same two-gate
+    (role AND capability) filter as :func:`all_resource_templates_for` is
+    applied on the *owning template*, so a concrete resource never leaks
+    past the gate its template enforces. Registration order is preserved
+    (the Python dict guarantee) for a deterministic wire shape (#2746).
+    """
+    listed: list[dict[str, Any]] = []
+    for template, (defn, _handler) in _RESOURCES.items():
+        provider = _LISTED_URI_PROVIDERS.get(template)
+        if provider is None:
+            continue
+        if not (
+            role_at_least(operator.tenant_role, defn.required_role)
+            and capability_satisfied(operator, defn.required_capability)
+        ):
+            continue
+        listed.extend(defn.to_listed_wire(uri) for uri in provider(operator))
+    return listed
 
 
 # ---------------------------------------------------------------------------
@@ -673,3 +742,4 @@ def clear_registries() -> None:
     """
     _TOOLS.clear()
     _RESOURCES.clear()
+    _LISTED_URI_PROVIDERS.clear()

--- a/backend/src/meho_backplane/mcp/resources/tenant_info.py
+++ b/backend/src/meho_backplane/mcp/resources/tenant_info.py
@@ -108,6 +108,21 @@ async def _tenant_info_handler(
     }
 
 
+def _tenant_info_listed_uris(operator: Operator) -> list[str]:
+    """Publish the caller's own tenant-info resource to ``resources/list``.
+
+    The server knows the operator's tenant from the validated JWT, so it
+    can list the concrete ``meho://tenant/<tenant_id>/info`` URI a
+    discovery-driven MCP client (Claude Desktop's attachment picker calls
+    ``resources/list`` at handshake) offers — the operator never has to
+    know their tenant UUID to reach the documented Step-4 verify resource
+    (#2746). Only the caller's own tenant is listed; the per-read
+    tenant-boundary check in :func:`_tenant_info_handler` still guards the
+    fetch, so listing a single self-scoped URI leaks nothing cross-tenant.
+    """
+    return [f"meho://tenant/{operator.tenant_id}/info"]
+
+
 register_mcp_resource(
     definition=ResourceTemplateDefinition(
         uriTemplate="meho://tenant/{tenant_id}/info",
@@ -122,4 +137,5 @@ register_mcp_resource(
         required_role=TenantRole.READ_ONLY,
     ),
     handler=_tenant_info_handler,
+    list_uris=_tenant_info_listed_uris,
 )

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -85,7 +85,6 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, ValidationError
 
-from meho_backplane import __version__
 from meho_backplane.auth.operator import Operator
 from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
 from meho_backplane.mcp.maturity import FEATURE_MATURITY_BAND
@@ -106,6 +105,7 @@ from meho_backplane.mcp.schemas import (
     ServerCapabilities,
 )
 from meho_backplane.settings import Settings, get_settings
+from meho_backplane.version import deployed_version_label
 
 __all__ = [
     "RESOURCES_SUBSCRIBE_ENABLED",
@@ -447,7 +447,12 @@ async def _initialize(
                 "subscribe": RESOURCES_SUBSCRIBE_ENABLED,
             },
         ),
-        serverInfo={"name": _SERVER_NAME, "version": __version__},
+        # ``version`` reports the *deployed* build (CHART_VERSION / GIT_SHA
+        # via deployed_version_label, #1698 precedent), not the static
+        # package ``__version__`` — which is pinned to ``0.1.0-dev`` and never
+        # tracks a release, so the Step-4 upgrade-verify guidance in
+        # docs/cross-repo/mcp-client-setup.md could not work off it (#2746).
+        serverInfo={"name": _SERVER_NAME, "version": deployed_version_label()},
         instructions=await _session_instructions(operator),
     )
 

--- a/backend/src/meho_backplane/mcp/tools/meho_status.py
+++ b/backend/src/meho_backplane/mcp/tools/meho_status.py
@@ -65,7 +65,8 @@ register_mcp_tool(
         feature=None,
         name="meho_status",
         description=(
-            "Returns the operator's identity (sub, name, email) plus the "
+            "Returns the operator's identity (sub, name, email, tenant_id, "
+            "tenant_role) plus the "
             "MEHO backplane's dependency status: Vault federation chain "
             "(reachable + KV read OK?) and DB migration state. Call at "
             "MCP session start to verify the operator can reach all "

--- a/backend/tests/integration/test_mcp_inspector.py
+++ b/backend/tests/integration/test_mcp_inspector.py
@@ -287,20 +287,22 @@ async def test_full_mcp_lifecycle_succeeds(
             assert payload["db"]["migrated"] is True
 
             # 5. resources/list — concrete (non-templated) resources.
-            # v0.2 registers only templated resources, so the list MUST
-            # be empty. AC #2 lists ``resources/list`` explicitly; a
-            # spec-conformant client may call either method and both
-            # have to return well-formed envelopes. Asserting the empty
-            # contract here keeps the surface honest if a future change
-            # accidentally routes templated resources through the
-            # concrete endpoint.
+            # #2746: the tenant-info resource now publishes the caller's own
+            # concrete ``meho://tenant/<id>/info`` here so a discovery-driven
+            # client (Claude Desktop's attachment picker) can offer the
+            # documented verify-step resource. The listed URI is exactly the
+            # caller's own tenant (op-mcp-e2e → TENANT_A) — no cross-tenant
+            # leak, and templated resources still surface only via
+            # ``resources/templates/list``.
             list_resources = await client.post(
                 "/mcp",
                 json={"jsonrpc": "2.0", "id": 4, "method": "resources/list"},
                 headers=auth_headers,
             )
             assert list_resources.status_code == 200
-            assert list_resources.json()["result"]["resources"] == []
+            listed = list_resources.json()["result"]["resources"]
+            assert [r["uri"] for r in listed] == [f"meho://tenant/{TENANT_A_ID}/info"]
+            assert listed[0]["mimeType"] == "application/json"
 
             # 6. resources/templates/list — every MEHO resource is
             # templated, so the tenant-info template MUST appear here.

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -64,6 +64,7 @@ from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
 from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import DEFAULT_TENANT_ID as _DEFAULT_TENANT_ID
 from ._oidc_jwt_helpers import ISSUER as _ISSUER
 from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
 from ._oidc_jwt_helpers import mint_token as _mint_token
@@ -361,7 +362,15 @@ def test_happy_path_returns_full_federation_response(
     from meho_backplane.mcp.schemas import PROTOCOL_VERSION
 
     assert body == {
-        "operator": {"sub": "op-100", "name": "Alice", "email": "alice@example.com"},
+        # #2746: OperatorIdentity now carries tenant_id + tenant_role, so the
+        # federation health response echoes the caller's tenant identity too.
+        "operator": {
+            "sub": "op-100",
+            "name": "Alice",
+            "email": "alice@example.com",
+            "tenant_id": _DEFAULT_TENANT_ID,
+            "tenant_role": "operator",
+        },
         "vault": {"reachable": True, "read_ok": True, "detail": "version=11"},
         "db": {"migrated": True},
         "mcp_session_id_capture": "when_negotiated",

--- a/backend/tests/test_api_v1_health_split.py
+++ b/backend/tests/test_api_v1_health_split.py
@@ -49,6 +49,7 @@ from meho_backplane.main import app
 from meho_backplane.settings import get_settings
 
 from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import DEFAULT_TENANT_ID as _DEFAULT_TENANT_ID
 from ._oidc_jwt_helpers import ISSUER as _ISSUER
 from ._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
 from ._oidc_jwt_helpers import mint_token as _mint_token
@@ -175,6 +176,8 @@ def test_operator_rank_health_reaches_federation_probe(
         "sub": f"op-{role}",
         "name": "Alice",
         "email": "alice@example.com",
+        "tenant_id": _DEFAULT_TENANT_ID,
+        "tenant_role": role,
     }
     assert body["vault"] == {"reachable": True, "read_ok": True, "detail": "version=7"}
     assert body["db"] == {"migrated": True}
@@ -214,6 +217,8 @@ def test_read_only_liveness_returns_200_without_vault_touch(
             "sub": "op-monitor",
             "name": "Monitor",
             "email": "monitor@example.com",
+            "tenant_id": _DEFAULT_TENANT_ID,
+            "tenant_role": "read_only",
         },
         "db": {"migrated": True},
         # #2763: the runner-liveness facet rides the low-privilege

--- a/backend/tests/test_mcp_registry.py
+++ b/backend/tests/test_mcp_registry.py
@@ -636,18 +636,83 @@ def test_resources_templates_list_endpoint_returns_registered_templates(
     [TenantRole.OPERATOR],
     indirect=True,
 )
-def test_resources_list_endpoint_returns_empty_in_v02(
+def test_resources_list_endpoint_returns_empty_when_no_listable_resources(
     client_with_operator: tuple[TestClient, Operator],
 ) -> None:
-    """``resources/list`` is spec-conformant but empty in v0.2 (only templates exist)."""
+    """``resources/list`` returns a well-formed empty envelope, not an error.
+
+    A spec-conformant client may call ``resources/list`` even when the
+    server exposes no concrete resources (only templates); it must get an
+    empty array back, never ``METHOD_NOT_FOUND``. No resource in this
+    isolated registry opts into concrete listing, so the list is empty.
+    """
     client, _op = client_with_operator
     response = _post_mcp(
         client,
         {"jsonrpc": "2.0", "id": 11, "method": "resources/list"},
     )
     assert response.status_code == 200
-    body = response.json()
-    assert body["result"]["resources"] == []
+    assert response.json()["result"]["resources"] == []
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_resources_list_publishes_only_list_uris_providers(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """``resources/list`` publishes only resources that opt in via ``list_uris`` (#2746).
+
+    The concrete-vs-templated split: a resource registered without a
+    ``list_uris`` provider is discoverable only through
+    ``resources/templates/list`` and MUST NOT appear on ``resources/list``;
+    a resource that supplies a provider contributes the operator-specific
+    concrete URIs the provider returns (here the caller's own tenant).
+    """
+    client, op = client_with_operator
+
+    async def _stub(_op: Operator, _params: dict[str, str]) -> dict[str, Any]:
+        return {}
+
+    def _listed_provider(operator: Operator) -> list[str]:
+        return [f"meho://listed/{operator.tenant_id}/info"]
+
+    # Opts in: publishes the caller's own concrete URI to resources/list.
+    register_mcp_resource(
+        ResourceTemplateDefinition(
+            uriTemplate="meho://listed/{tenant_id}/info",
+            name="listed info",
+            description="A listed resource",
+            mimeType="application/json",
+        ),
+        _stub,
+        list_uris=_listed_provider,
+    )
+    # Does not opt in: template-only, must stay off resources/list.
+    register_mcp_resource(
+        ResourceTemplateDefinition(
+            uriTemplate="meho://templated/{slug}",
+            name="templated only",
+            description="A template-only resource",
+            mimeType="application/json",
+        ),
+        _stub,
+    )
+
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 11, "method": "resources/list"},
+    )
+
+    assert response.status_code == 200
+    resources = response.json()["result"]["resources"]
+    assert [r["uri"] for r in resources] == [f"meho://listed/{op.tenant_id}/info"]
+    assert resources[0]["name"] == "listed info"
+    assert resources[0]["mimeType"] == "application/json"
+    # MEHO-internal RBAC field never rides the wire shape.
+    assert "required_role" not in resources[0]
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_mcp_resource_tenant_info.py
+++ b/backend/tests/test_mcp_resource_tenant_info.py
@@ -7,8 +7,11 @@ Covers acceptance criteria 5-8 on issue #249:
 
 * ``resources/templates/list`` returns the tenant-info template entry.
   (The AC text says ``resources/list``, but per T3's spec-correctness
-  decision templated resources surface via ``resources/templates/list``;
-  concrete ``resources/list`` is empty in v0.2.)
+  decision templated resources surface via ``resources/templates/list``.)
+* ``resources/list`` publishes the caller's own concrete
+  ``meho://tenant/<tenant_id>/info`` resource (#2746) — the server derives
+  it from the JWT so a discovery-driven client can offer the verify-step
+  resource without the operator knowing their tenant UUID.
 * ``resources/read`` with the operator's own tenant_id returns
   ``{id, slug, name, operator_role}``.
 * ``resources/read`` with a *different* tenant's id returns
@@ -56,6 +59,70 @@ def test_resources_templates_list_exposes_tenant_info(
     assert tenant_info[0]["mimeType"] == "application/json"
     # MEHO-internal RBAC field stripped from the wire shape.
     assert "required_role" not in tenant_info[0]
+
+
+def test_resources_list_publishes_callers_own_tenant_info(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """#2746: ``resources/list`` publishes the caller's own tenant-info resource.
+
+    A discovery-driven MCP client (Claude Desktop's attachment picker calls
+    ``resources/list`` at handshake) must be able to reach the documented
+    Step-4 verify resource. The server materialises the caller's own
+    ``meho://tenant/<tenant_id>/info`` from the JWT, so the operator never
+    needs to know their tenant UUID.
+    """
+    client, op = client_with_operator
+    expected_uri = f"meho://tenant/{op.tenant_id}/info"
+
+    response = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 5, "method": "resources/list"},
+    )
+
+    assert response.status_code == 200
+    resources = response.json()["result"]["resources"]
+    listed = [r for r in resources if r["uri"] == expected_uri]
+    assert len(listed) == 1
+    assert listed[0]["mimeType"] == "application/json"
+    assert listed[0]["name"] == "Tenant identity"
+    # MEHO-internal RBAC field stripped from the concrete wire shape.
+    assert "required_role" not in listed[0]
+
+
+@pytest.mark.asyncio
+async def test_resources_list_uri_is_readable_round_trip(
+    client_with_operator: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,
+) -> None:
+    """#2746: the URI ``resources/list`` publishes is directly readable.
+
+    Proves the discovery path is executable end-to-end: list the concrete
+    resource, then ``resources/read`` the exact URI the listing returned
+    and get the tenant identity bundle back — the Step-4 verify step a
+    discovery-driven client performs.
+    """
+    client, op = client_with_operator
+
+    listing = post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 6, "method": "resources/list"},
+    )
+    uri = listing.json()["result"]["resources"][0]["uri"]
+    assert uri == f"meho://tenant/{op.tenant_id}/info"
+
+    read = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "resources/read",
+            "params": {"uri": uri},
+        },
+    )
+    bundle = json.loads(read.json()["result"]["contents"][0]["text"])
+    assert bundle["id"] == str(op.tenant_id)
+    assert bundle["operator_role"] == TenantRole.READ_ONLY.value
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -41,7 +41,6 @@ from uuid import UUID
 import pytest
 from fastapi.testclient import TestClient
 
-from meho_backplane import __version__
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.main import app
 from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
@@ -55,6 +54,7 @@ from meho_backplane.mcp.schemas import (
 )
 from meho_backplane.mcp.server import _MAX_REQUEST_BODY_BYTES
 from meho_backplane.settings import get_settings
+from meho_backplane.version import deployed_version_label
 
 _DISPATCH_TEST_OPERATOR: Operator = Operator(
     sub="dispatcher-test-operator",
@@ -152,7 +152,10 @@ def test_initialize_returns_protocol_version_capabilities_and_serverinfo(
 
     result = body["result"]
     assert result["protocolVersion"] == PROTOCOL_VERSION
-    assert result["serverInfo"] == {"name": "meho-backplane", "version": __version__}
+    assert result["serverInfo"] == {
+        "name": "meho-backplane",
+        "version": deployed_version_label(),
+    }
     # T3 (#248) registers tools/* and resources/* handlers, so the
     # capabilities envelope advertises both surfaces. ``listChanged:
     # false`` because v0.2 doesn't emit `notifications/tools/list_changed`
@@ -163,6 +166,42 @@ def test_initialize_returns_protocol_version_capabilities_and_serverinfo(
         "listChanged": False,
         "subscribe": False,
     }
+
+
+def test_initialize_serverinfo_version_reports_deployed_build(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``serverInfo.version`` reflects the deployed release, not ``__version__``.
+
+    #2746: the field used to render the static package ``__version__``
+    (pinned to ``0.1.0-dev``), so the upgrade-verify guidance in
+    ``docs/cross-repo/mcp-client-setup.md`` could not read the live build
+    off it. It is now wired to
+    :func:`~meho_backplane.version.deployed_version_label`, which renders
+    ``CHART_VERSION`` (``v``-prefixed) exactly as the UI footer does
+    (#1698). Setting ``CHART_VERSION`` and observing it on the wire proves
+    the handshake reports the deployed build rather than the dev stub.
+    """
+    monkeypatch.setenv("CHART_VERSION", "0.27.0")
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "0.0.1"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    server_info = response.json()["result"]["serverInfo"]
+    assert server_info["version"] == "v0.27.0"
+    assert server_info["version"] != "0.1.0-dev"
 
 
 def test_initialize_without_protocol_version_returns_invalid_params(

--- a/backend/tests/test_mcp_tool_meho_status.py
+++ b/backend/tests/test_mcp_tool_meho_status.py
@@ -108,6 +108,10 @@ def test_tools_call_meho_status_returns_health_response_shape(
     assert payload["operator"]["sub"] == op.sub
     assert payload["operator"]["name"] == op.name
     assert payload["operator"]["email"] is None
+    # #2746: tenant identity now rides the operator bundle so a connected
+    # session can confirm which tenant/role it runs as.
+    assert payload["operator"]["tenant_id"] == str(op.tenant_id)
+    assert payload["operator"]["tenant_role"] == op.tenant_role.value
 
     # Vault federation status is structurally present. The test environment
     # has no real Vault — the probe is designed to fail closed, returning

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -25960,16 +25960,26 @@
             "type": "string",
             "nullable": true,
             "title": "Email"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "tenant_role": {
+            "$ref": "#/components/schemas/TenantRole"
           }
         },
         "type": "object",
         "required": [
           "sub",
           "name",
-          "email"
+          "email",
+          "tenant_id",
+          "tenant_role"
         ],
         "title": "OperatorIdentity",
-        "description": "Operator identity surface exposed to the CLI.\n\nExcludes ``raw_jwt`` deliberately \u2014 the bearer token must never\nappear in a response body, and the :class:`Operator` model carries\nit for downstream Vault forward-auth only."
+        "description": "Operator identity surface exposed to the CLI and MCP ``meho_status``.\n\nExcludes ``raw_jwt`` deliberately \u2014 the bearer token must never\nappear in a response body, and the :class:`Operator` model carries\nit for downstream Vault forward-auth only.\n\n``tenant_id`` + ``tenant_role`` (#2746) let a connected MCP session\nconfirm *which tenant and role it runs as* from inside the session \u2014\nthe check the clean-room program's \"logged in as operator, not\ntenant_admin\" discipline needs, and the identity the ``meho_status``\ntool's own doc (``docs/cross-repo/mcp-client-setup.md`` Step 4)\nalready promises. Both are always present on the validated\n:class:`Operator` (JWT claims), so the surface can never omit them;\nthey serialise as a UUID string / role value under\n``model_dump(mode=\"json\")`` \u2014 the same wire shape the\n``meho://tenant/<id>/info`` resource returns."
       },
       "PermissionVerdict": {
         "type": "string",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4272,11 +4272,22 @@ type HealthResponse struct {
 	McpProtocolVersion  *string  `json:"mcp_protocol_version,omitempty"`
 	McpSessionIdCapture string   `json:"mcp_session_id_capture"`
 
-	// Operator Operator identity surface exposed to the CLI.
+	// Operator Operator identity surface exposed to the CLI and MCP ``meho_status``.
 	//
 	// Excludes ``raw_jwt`` deliberately — the bearer token must never
 	// appear in a response body, and the :class:`Operator` model carries
 	// it for downstream Vault forward-auth only.
+	//
+	// ``tenant_id`` + ``tenant_role`` (#2746) let a connected MCP session
+	// confirm *which tenant and role it runs as* from inside the session —
+	// the check the clean-room program's "logged in as operator, not
+	// tenant_admin" discipline needs, and the identity the ``meho_status``
+	// tool's own doc (``docs/cross-repo/mcp-client-setup.md`` Step 4)
+	// already promises. Both are always present on the validated
+	// :class:`Operator` (JWT claims), so the surface can never omit them;
+	// they serialise as a UUID string / role value under
+	// ``model_dump(mode="json")`` — the same wire shape the
+	// ``meho://tenant/<id>/info`` resource returns.
 	Operator OperatorIdentity `json:"operator"`
 
 	// SensorRunner Liveness of this process's sensor evaluation loop (#2763).
@@ -4735,11 +4746,22 @@ type LivenessResponse struct {
 	// handler now always populates it from the probe.
 	Db DbStatus `json:"db"`
 
-	// Operator Operator identity surface exposed to the CLI.
+	// Operator Operator identity surface exposed to the CLI and MCP ``meho_status``.
 	//
 	// Excludes ``raw_jwt`` deliberately — the bearer token must never
 	// appear in a response body, and the :class:`Operator` model carries
 	// it for downstream Vault forward-auth only.
+	//
+	// ``tenant_id`` + ``tenant_role`` (#2746) let a connected MCP session
+	// confirm *which tenant and role it runs as* from inside the session —
+	// the check the clean-room program's "logged in as operator, not
+	// tenant_admin" discipline needs, and the identity the ``meho_status``
+	// tool's own doc (``docs/cross-repo/mcp-client-setup.md`` Step 4)
+	// already promises. Both are always present on the validated
+	// :class:`Operator` (JWT claims), so the surface can never omit them;
+	// they serialise as a UUID string / role value under
+	// ``model_dump(mode="json")`` — the same wire shape the
+	// ``meho://tenant/<id>/info`` resource returns.
 	Operator OperatorIdentity `json:"operator"`
 
 	// SensorRunner Liveness of this process's sensor evaluation loop (#2763).
@@ -5001,15 +5023,45 @@ type OperationDescriptor struct {
 	Version           string                  `json:"version"`
 }
 
-// OperatorIdentity Operator identity surface exposed to the CLI.
+// OperatorIdentity Operator identity surface exposed to the CLI and MCP “meho_status“.
 //
 // Excludes “raw_jwt“ deliberately — the bearer token must never
 // appear in a response body, and the :class:`Operator` model carries
 // it for downstream Vault forward-auth only.
+//
+// “tenant_id“ + “tenant_role“ (#2746) let a connected MCP session
+// confirm *which tenant and role it runs as* from inside the session —
+// the check the clean-room program's "logged in as operator, not
+// tenant_admin" discipline needs, and the identity the “meho_status“
+// tool's own doc (“docs/cross-repo/mcp-client-setup.md“ Step 4)
+// already promises. Both are always present on the validated
+// :class:`Operator` (JWT claims), so the surface can never omit them;
+// they serialise as a UUID string / role value under
+// “model_dump(mode="json")“ — the same wire shape the
+// “meho://tenant/<id>/info“ resource returns.
 type OperatorIdentity struct {
-	Email *string `json:"email"`
-	Name  *string `json:"name"`
-	Sub   string  `json:"sub"`
+	Email    *string            `json:"email"`
+	Name     *string            `json:"name"`
+	Sub      string             `json:"sub"`
+	TenantId openapi_types.UUID `json:"tenant_id"`
+
+	// TenantRole Per-tenant role granted to the operator by the JWT issuer.
+	//
+	// The set is intentionally small in v0.2: a closed three-value enum
+	// lets the RBAC primitive (Task #234, ``require_role``) make
+	// exhaustive comparisons without leaking arbitrary string handling
+	// into route code. A richer policy engine — topology-aware
+	// permissions, ABAC, approval workflows — is a separate v0.2.next
+	// Goal; widening this enum is the only ratcheting mechanism in the
+	// interim.
+	//
+	// Values are the literal strings the Keycloak protocol-mapper recipe
+	// (Task #235) emits, so a JWT carrying ``"tenant_admin"`` materialises
+	// cleanly as :attr:`TENANT_ADMIN`. ``StrEnum`` (PEP 663, stdlib in
+	// 3.11+) gives the members ``str`` semantics for free, so
+	// ``f"role={role}"`` renders as ``"role=tenant_admin"`` rather than
+	// ``"role=TenantRole.TENANT_ADMIN"``.
+	TenantRole TenantRole `json:"tenant_role"`
 }
 
 // PermissionVerdict Three-state verdict returned by the permission resolver.

--- a/docs/codebase/backend.md
+++ b/docs/codebase/backend.md
@@ -675,9 +675,13 @@ this stage it exposes:
   `resources/list`, `resources/templates/list`, `resources/read`.
   Spec correctness note: the MCP 2025-06-18 spec separates concrete
   resources (`resources/list`) from templated ones
-  (`resources/templates/list`); v0.2 ships only templates so
-  `resources/list` returns an empty list while
-  `resources/templates/list` carries the registry. `tools/call`
+  (`resources/templates/list`). Templated resources surface via
+  `resources/templates/list`; `resources/list` publishes the concrete,
+  operator-specific resources a template opts into via its `list_uris`
+  provider (registry `all_listed_resources_for`, #2746) — in practice the
+  caller's own `meho://tenant/<tenant_id>/info`, so a discovery-driven
+  client can offer the documented verify-step resource without knowing the
+  tenant UUID. `tools/call`
   validates `arguments` against the tool's JSON Schema 2020-12
   `inputSchema` via `jsonschema` (4.26+); a violation surfaces as
   `INVALID_PARAMS` through `McpInvalidParamsError`.

--- a/docs/cross-repo/mcp-client-setup.md
+++ b/docs/cross-repo/mcp-client-setup.md
@@ -173,8 +173,8 @@ Opening RFC 7591 DCR on the realm side is **not** the right fix: a public DCR en
 
 After the client is wired:
 
-- Run `meho_status` from the connected client. The response should carry the operator's identity (sub, tenant_id, role) plus the Vault federation status and DB migration state.
-- Read the operator's tenant info: ask the client to read the resource at `meho://tenant/<your-tenant-id>/info`. The response should be the operator's tenant identity bundle (id, slug, name, role).
+- Run `meho_status` from the connected client. The response should carry the operator's identity (sub, name, email, tenant_id, tenant_role) plus the Vault federation status and DB migration state.
+- Read the operator's tenant info: the backplane lists the caller's own `meho://tenant/<your-tenant-id>/info` under `resources/list`, so a discovery-driven client (e.g. Claude Desktop's attachment picker) surfaces it directly — pick it there, or read the URI by hand (`tenant_id` from `meho_status` above fills `<your-tenant-id>`). The response should be the operator's tenant identity bundle (id, slug, name, role).
 - On the backplane, `SELECT method, path, operator_sub, status_code, occurred_at FROM audit_log ORDER BY occurred_at DESC LIMIT 10` should show the two operations with `method='MCP'` and `path='/mcp/tools/call/meho_status'` / `path='/mcp/resources/read/meho://tenant/<id>/info'`.
 
 If any of these don't appear, walk the troubleshooting section.


### PR DESCRIPTION
## Summary

Fixes the three secondary MCP-surface conformance gaps the #2666 Claude Desktop smoke test surfaced (all posture-independent; each broke a documented behavior or verify step in `docs/cross-repo/mcp-client-setup.md`):

- **`resources/list` published 0 concrete resources** — a discovery-driven client (Claude Desktop's attachment picker lists via `resources/list` at handshake) saw nothing to offer for the documented Step-4 verify resource. It now publishes the caller's **own** concrete `meho://tenant/<tenant_id>/info`, derived server-side from the JWT, so the operator never needs to know their tenant UUID. Added via an opt-in `list_uris` provider on the resource registry (`all_listed_resources_for`, RBAC + capability filtered on the owning template) — **no new resource kinds**; templated resources still surface only via `resources/templates/list`.
- **`meho_status` omitted tenant identity** — `OperatorIdentity` (shared by `meho_status` and `GET /api/v1/health[/live]`, wire-identical by design) now carries `tenant_id` + `tenant_role`, so a connected session can confirm which tenant/role it runs as (the clean-room "operator, not tenant_admin" check).
- **`serverInfo.version` was the `0.1.0-dev` stub** — wired to `deployed_version_label()` (CHART_VERSION / GIT_SHA, #1698 precedent), so the upgrade-verify guidance can read the live build.

Docs updated to match (`mcp-client-setup.md` Step 4, `docs/codebase/backend.md`).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` (strict) — clean
- [x] `pytest` (full unit suite) — **5307 passed, 1 skipped**. The sole failure (`test_connectors_net_icmp.py::test_trace_reaches_loopback`) is a pre-existing sandbox ICMP raw-socket/loopback-reachability failure that reproduces identically on `main` and is unrelated to this change (untouched file, imports nothing changed here).
- [x] code-quality `--diff` — **0 blockers** (pre-existing warnings only)
- [x] **AC1** (`resources/list` discoverable): `test_mcp_resource_tenant_info.py` — list publishes the caller's own URI + a list→read round-trip; `test_mcp_registry.py` — only `list_uris` opt-ins appear, template-only excluded, plus empty-envelope conformance
- [x] **AC2** (`meho_status` returns `tenant_id` + `tenant_role`): `test_mcp_tool_meho_status.py` + exact-shape updates in `test_api_v1_health_split.py` for `/health` and `/health/live`
- [x] **AC3** (`serverInfo.version` reports the deployed release): `test_mcp_server.py` — sets `CHART_VERSION` and asserts `serverInfo.version == v0.27.0` (not `0.1.0-dev`)

## Out of scope

- No new resource kinds beyond making the documented one discoverable (per the issue).
- Pre-existing `health.py` file-size (>600 lines) and other pre-existing function-size warnings are left untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2746


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP resource discovery now returns operator-specific, access-controlled concrete resources.
  * Health responses and status reporting now include tenant ID and tenant role.
  * MCP initialization reports the deployed build version.
* **Documentation**
  * Updated API schemas and guides to describe tenant context and concrete resource discovery.
* **Tests**
  * Added coverage for tenant identity, resource listing and reading, access filtering, and deployed version reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->