### PR TITLE
fix(ci): docs-site deploy — post-publish reachability gate on the published version URL

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -107,6 +107,10 @@ jobs:
     # to publish under.
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    # mike build/push runs a few minutes and the reachability gate below
+    # waits up to 10; 20 keeps a genuinely stuck job from burning the
+    # 6-hour default while leaving healthy runs ample head-room.
+    timeout-minutes: 20
     permissions:
       contents: write
     concurrency:

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -22,6 +22,11 @@
 #   Branch: gh-pages / root. The gh-pages branch exists after the
 #   first tag-triggered run. The site then serves at
 #   https://evoila.github.io/meho/.
+# The deploy job's final step enforces this: it polls the version URL
+# just published and fails the run if Pages never serves it, so a
+# missing one-time setup goes red instead of publishing an unservable
+# site silently (#2741 — the v0.26.0 deploy reported success while the
+# site returned 404).
 #
 # mike's CI requirements (https://github.com/jimporter/mike):
 #   * the gh-pages branch must be fetched locally before deploying —
@@ -135,6 +140,7 @@ jobs:
         working-directory: backend
 
       - name: Deploy versioned docs
+        id: deploy
         # One docs version per minor: v0.26.3 publishes as "0.26" and
         # re-points `latest`. `--update-aliases` lets `latest` move
         # off the previous minor; `set-default latest` (idempotent)
@@ -151,9 +157,49 @@ jobs:
               VERSION=$(printf '%s' "${GITHUB_REF_NAME#v}" | sed -E 's/^([0-9]+\.[0-9]+).*/\1/')
               uv run --project backend --no-sync mike deploy --push --update-aliases "${VERSION}" latest
               uv run --project backend --no-sync mike set-default --push latest
+              # Hand the just-published MAJOR.MINOR to the reachability
+              # gate below so it polls THIS run's version path, not the
+              # site root.
+              printf 'version=%s\n' "${VERSION}" >> "${GITHUB_OUTPUT}"
               ;;
             *)
               echo "Ref '${GITHUB_REF_NAME}' is not a vMAJOR.MINOR[.PATCH] tag — nothing to deploy." >&2
               exit 1
               ;;
           esac
+
+      - name: Verify published docs are reachable
+        # A green `mike deploy` only means the built site was committed
+        # to gh-pages — not that anything serves it. GitHub Pages must
+        # be enabled once by a maintainer (see this file's one-time-setup
+        # header); until then gh-pages is committed but unserved and the
+        # publish is silently unservable (#2741 — the v0.26.0 run
+        # reported success while the site returned 404). Poll the version
+        # path THIS run published — not the site root, whose redirect to
+        # `latest` returns 200 and would mask a failed version publish —
+        # until Pages serves it.
+        env:
+          VERSION: ${{ steps.deploy.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VERSION}" ]; then
+            echo "::error::No published version resolved from the deploy step; cannot verify reachability." >&2
+            exit 1
+          fi
+          url="https://evoila.github.io/meho/${VERSION}/"
+          deadline=$(( SECONDS + 600 ))  # 10 min budget — legacy Pages builds take ~1-3 min
+          interval=15
+          echo "Polling ${url} for HTTP 200 (up to 10 min)..."
+          while true; do
+            code=$(curl -sSL --max-time 30 -o /dev/null -w '%{http_code}' "${url}") || code="000"
+            if [ "${code}" = "200" ]; then
+              echo "Reachable: ${url} returned HTTP 200."
+              exit 0
+            fi
+            if [ "${SECONDS}" -ge "${deadline}" ]; then
+              echo "::error::Published docs never became reachable: ${url} last returned HTTP ${code} after 10 min. GitHub Pages is likely not enabled (or not serving gh-pages) — a maintainer must set Settings -> Pages -> Deploy from a branch -> gh-pages / root (one-time; see this workflow's header)." >&2
+              exit 1
+            fi
+            echo "  ${url} -> HTTP ${code}; retrying in ${interval}s..."
+            sleep "${interval}"
+          done

--- a/docs/codebase/docs-site.md
+++ b/docs/codebase/docs-site.md
@@ -57,6 +57,16 @@ One docs version **per minor**, with a `latest` alias:
 4. GitHub Pages serves the branch. A job-level concurrency group
    (`docs-site-gh-pages`, no cancel) serialises publishes so two tags
    can't race the branch update.
+5. A final **reachability gate** polls the freshly-published
+   `https://evoila.github.io/meho/<MAJOR.MINOR>/` (the version path
+   this run wrote, passed from the deploy step via a `version` output —
+   *not* the site root, whose redirect to `latest` would return 200 and
+   mask a failed version publish) until it returns HTTP 200, up to a
+   10-minute deadline at 15 s intervals. If the deadline passes the job
+   fails with an error naming the one-time Pages setup. This turns a
+   publish onto a repo where Pages was never enabled — which used to
+   report `success` while the site 404'd (#2741, the v0.26.0 incident)
+   — into a red run.
 
 PRs touching the site (or the toolchain lock) get a `mkdocs build
 --strict` check instead; nothing deploys from PRs or main pushes.
@@ -91,7 +101,9 @@ GitHub Pages must be enabled once by a maintainer (CI cannot safely
 mutate repo settings — same custody rule as image.yml's GHCR
 visibility flip): **Settings → Pages → Deploy from a branch →
 `gh-pages` / root**. The branch exists after the first tag-triggered
-deploy.
+deploy. The deploy job's reachability gate (control-flow step 5) makes
+skipping this setup fail loudly: the run goes red instead of publishing
+a site that returns 404 (#2741).
 
 ## Known issues / gotchas
 


### PR DESCRIPTION
## Summary
- The docs-site tag deploy reported `success` as soon as `mike` pushed the built site to `gh-pages`, even when GitHub Pages served nothing — every publish since the scaffold landed was silently unservable until Pages was enabled by hand on 2026-08-02 (v0.26.0 run `30747603545`: success vs. site 404).
- Adds a post-publish reachability gate: the deploy job now polls the exact `MAJOR.MINOR` version path this run published until it returns HTTP 200, and fails after a 10-minute deadline (15 s intervals) with an error that names the one-time Pages setup.
- The gate polls the **version path** (handed from the deploy step via a `version` output), never the site root — a stale root redirect to `latest` returns 200 and would otherwise green-light a failed version publish. An empty-version guard closes the `//` → root-200 hole.
- Documents the enforcement in the workflow header's one-time-setup block and in `docs/codebase/docs-site.md` (control flow + one-time setup).

## Test plan
- [x] `actionlint` v1.7.12 with `shellcheck` 0.11.0 on the `run:` blocks — 0 issues
- [x] `pre-commit run --files ...` — check-yaml, trailing-whitespace, end-of-file-fixer, mixed-line-ending, gitleaks all Passed
- [x] YAML parses via `yaml.safe_load`
- [x] code-quality gate (`--diff`) — exit 0 (no Python touched)
- [x] **AC1** — step "Verify published docs are reachable" runs after `mike deploy` and `exit 1`s past a 600 s deadline when the URL never returns HTTP 200
- [x] **AC2** — failure message names `Settings -> Pages -> Deploy from a branch -> gh-pages / root (one-time; see this workflow's header)`, mirroring the header comment
- [x] **AC3** — polls `https://evoila.github.io/meho/${{ steps.deploy.outputs.version }}/` (this run's version), not the root; verified live that `/meho/0.26/` → 200, `/meho/9.99/` → 404, and `/meho//` → 200 (which is exactly why the empty-version guard exists)
- [x] **AC5** — the header comment's one-time-setup block is updated to note the workflow now enforces reachability
- [ ] **AC4** — a normal tag deploy passes the gate: validated by construction (the current published `/meho/0.26/` serves HTTP 200 live, so a healthy deploy clears the poll). Empirical CI confirmation lands on the next `v*` tag or a `workflow_dispatch` on a tag ref — the deploy job is tag-ref-gated (`if: startsWith(github.ref, 'refs/tags/v')`), so the deploy+gate path cannot be exercised from a PR branch pre-merge.

## Out of scope
- Automating Pages enablement from CI (repo-settings mutation — the header comment's custody rationale stands).
- Content/link checks beyond reachability (that is `mkdocs build --strict` on the PR path).
- Custom-domain / CNAME handling (none configured).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2741

🤖 Generated with [Claude Code](https://claude.com/claude-code)
