### PR TITLE
feat(connectors): gh Projects-v2 board ops + sub-issue linkage composites

### DIFF
--- a/backend/src/meho_backplane/connectors/github/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/github/composites/__init__.py
@@ -18,19 +18,33 @@ dispatch can fire.
 
 Layout mirrors the vmware-rest composites package: ``__init__`` wires
 the registrar; ``_register.py`` carries per-composite registration
-metadata; ``_read.py`` carries handler implementations; ``schemas.py``
-carries the JSON Schema 2020-12 parameter + response contracts.
+metadata; ``_read.py`` / ``_board.py`` / ``_sub_issues.py`` carry handler
+implementations; ``_graphql.py`` carries the shared GraphQL transport
+helper; ``schemas.py`` carries the JSON Schema 2020-12 parameter +
+response contracts.
 
-Scope at T4 (#1224): 1 read composite --
-``gh.composite.pr_status_summary``. Future T7+ Tasks add write
-composites under this package.
+Scope (5 composites): ``gh.composite.pr_status_summary`` (T4 #1224,
+read); and the #2081 board + sub-issue set -- ``gh.composite.project_view``
+(read), ``gh.composite.project_item_add`` /
+``gh.composite.project_item_set_field`` (Projects-v2 GraphQL writes), and
+``gh.composite.sub_issue_add`` (sub-issue linkage REST write). Together
+the #2081 set makes a board-complete ticket filable through MEHO without
+a ``gh`` CLI fallback.
 """
 
+from meho_backplane.connectors.github.composites._board import (
+    project_item_add_composite,
+    project_item_set_field_composite,
+    project_view_composite,
+)
 from meho_backplane.connectors.github.composites._read import (
     pr_status_summary_composite,
 )
 from meho_backplane.connectors.github.composites._register import (
     register_github_composite_operations,
+)
+from meho_backplane.connectors.github.composites._sub_issues import (
+    sub_issue_add_composite,
 )
 from meho_backplane.operations.typed_register import register_typed_op_registrar
 
@@ -42,5 +56,9 @@ register_typed_op_registrar(register_github_composite_operations)
 
 __all__ = [
     "pr_status_summary_composite",
+    "project_item_add_composite",
+    "project_item_set_field_composite",
+    "project_view_composite",
     "register_github_composite_operations",
+    "sub_issue_add_composite",
 ]

--- a/backend/src/meho_backplane/connectors/github/composites/_board.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_board.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Projects-v2 board ``gh.composite.*`` handlers (3 composites, #2081).
+
+The gh-rest connector can create an issue (the one live REST op) but a
+board-driven team's ticket is only complete once it lands on the
+Projects-v2 board with its Status / Priority / Size fields set. That
+surface is **GraphQL-only** -- ``addProjectV2ItemById`` /
+``updateProjectV2ItemFieldValue`` have no REST equivalent -- so before
+this Task a board-complete filing dropped back to the ``gh`` CLI. These
+three composites close that gap through the connector's own dispatch
+path (auth + policy + audit + JSONFlux + broadcast):
+
+* :func:`project_view_composite` (``gh.composite.project_view``) --
+  read the board in one call: its node id, its fields (with the option
+  ids of every single-select field), and its current items. This is the
+  ergonomic linchpin -- it hands back the ``project_id`` / ``field_id``
+  / ``option_id`` node ids the two write composites below consume, so an
+  agent never has to shell out to ``gh project`` to discover them.
+* :func:`project_item_add_composite` (``gh.composite.project_item_add``)
+  -- add an issue / PR (by content node id) to a board.
+* :func:`project_item_set_field_composite`
+  (``gh.composite.project_item_set_field``) -- set a single-select field
+  (Status / Priority / Size) on a board item.
+
+Direct-session dispatch (#2255)
+-------------------------------
+
+Each handler declares a ``connector`` parameter and issues its GraphQL
+call through the resolved
+:class:`~meho_backplane.connectors.github.connector.GitHubRestConnector`'s
+own session via :func:`._graphql.github_graphql`, with no
+``endpoint_descriptor`` lookup -- the same substrate the read composite
+uses, so the board ops work on a fresh deploy with zero gh catalog
+ingest.
+
+Governance posture
+------------------
+
+``project_view`` is a read (``safety_level="safe"`` /
+``requires_approval=False``). The two write composites are
+``safety_level="caution"`` / ``requires_approval=False`` (set in
+:mod:`._register`): adding a card to a board and setting a status field
+are low-blast-radius, reversible board-hygiene mutations -- honestly a
+write, but not ``dangerous`` like the vmware VM-delete / host-maintenance
+composites. Each is a *single* logical GraphQL mutation, so the
+composite itself is the reviewed unit: the dispatcher runs
+``policy_gate`` against the composite's own descriptor before invoking
+the handler, which fully governs the one write it performs. There is no
+heterogeneous internal write sub-op to protect, so -- unlike the
+multi-write vmware composites -- these do not need the
+``enforce_subop_policy`` seam (which exists to re-gate *additional*
+writes a direct-session composite fans out to). Under this posture a
+human / service operator auto-executes a board write (board-complete
+filing without a ``gh`` CLI fallback), while an agent principal routes
+to the approval queue via the ``caution`` safety default -- exactly the
+governance a raw CLI fallback would have bypassed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.github.composites._graphql import (
+    GitHubGraphQlError,
+    github_graphql,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.github.connector import GitHubRestConnector
+
+__all__ = [
+    "project_item_add_composite",
+    "project_item_set_field_composite",
+    "project_view_composite",
+]
+
+# Root selector for a Projects-v2 lookup keyed by ``owner_type``. Both
+# values are hardcoded GraphQL field names, never caller input -- the
+# parameter schema pins ``owner_type`` to this closed enum, and the
+# handler maps it here before composing the query text. Every *dynamic*
+# value (login, number, node ids) rides the GraphQL ``variables`` map.
+_OWNER_TYPE_ROOT: dict[str, str] = {"organization": "organization", "user": "user"}
+
+# ``__ROOT__`` is replaced with the closed-map literal above (org / user);
+# ``$login`` / ``$number`` / ``$first`` are GraphQL variables. Reads the
+# project node id + every field (single-select fields additionally carry
+# their ``options {id name}``) + the current items in one round-trip.
+_PROJECT_VIEW_QUERY = """
+query ($login: String!, $number: Int!, $first: Int!) {
+  __ROOT__(login: $login) {
+    projectV2(number: $number) {
+      id
+      title
+      fields(first: 50) {
+        nodes {
+          __typename
+          ... on ProjectV2FieldCommon { id name dataType }
+          ... on ProjectV2SingleSelectField { options { id name } }
+        }
+      }
+      items(first: $first) {
+        totalCount
+        nodes {
+          id
+          content {
+            __typename
+            ... on Issue { number title url }
+            ... on PullRequest { number title url }
+            ... on DraftIssue { title }
+          }
+        }
+      }
+    }
+  }
+}
+""".strip()
+
+_ADD_ITEM_MUTATION = """
+mutation ($projectId: ID!, $contentId: ID!) {
+  addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+    item { id }
+  }
+}
+""".strip()
+
+_SET_FIELD_MUTATION = """
+mutation ($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+  updateProjectV2ItemFieldValue(
+    input: {
+      projectId: $projectId
+      itemId: $itemId
+      fieldId: $fieldId
+      value: { singleSelectOptionId: $optionId }
+    }
+  ) {
+    projectV2Item { id }
+  }
+}
+""".strip()
+
+
+def _extract_project(data: dict[str, Any], owner_type: str) -> dict[str, Any]:
+    """Return the ``projectV2`` object from a project-view response, or raise.
+
+    A ``null`` owner (login typo / no access) or ``null`` project
+    (number does not exist / not visible to the token) both surface as a
+    :class:`GitHubGraphQlError` rather than a chained-lookup crash, so
+    the operator learns which of the two failed.
+    """
+    root = _OWNER_TYPE_ROOT[owner_type]
+    owner = data.get(root)
+    if not isinstance(owner, dict):
+        raise GitHubGraphQlError(
+            f"GitHub GraphQL returned no {root!r} for the requested login "
+            f"(unknown login, or the token cannot see it)"
+        )
+    project = owner.get("projectV2")
+    if not isinstance(project, dict):
+        raise GitHubGraphQlError(
+            "GitHub GraphQL returned no projectV2 for the requested number "
+            "(no board with that number, or the token lacks project scope)"
+        )
+    return project
+
+
+def _parse_fields(project: dict[str, Any]) -> list[dict[str, Any]]:
+    """Collapse the ``fields.nodes`` array into ``{id, name, data_type, options}``.
+
+    ``options`` is a list of ``{id, name}`` for single-select fields
+    (the ids an operator threads into ``project_item_set_field``) and
+    ``None`` for every other field type. Rows missing an id / name (an
+    unexpected upstream shape) are dropped defensively.
+    """
+    fields_conn = project.get("fields")
+    nodes = fields_conn.get("nodes") if isinstance(fields_conn, dict) else None
+    if not isinstance(nodes, list):
+        return []
+    parsed: list[dict[str, Any]] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        field_id = node.get("id")
+        name = node.get("name")
+        if not isinstance(field_id, str) or not isinstance(name, str):
+            continue
+        raw_options = node.get("options")
+        options: list[dict[str, Any]] | None = None
+        if isinstance(raw_options, list):
+            options = [
+                {"id": opt.get("id"), "name": opt.get("name")}
+                for opt in raw_options
+                if isinstance(opt, dict)
+            ]
+        parsed.append(
+            {"id": field_id, "name": name, "data_type": node.get("dataType"), "options": options}
+        )
+    return parsed
+
+
+def _parse_items(project: dict[str, Any]) -> list[dict[str, Any]]:
+    """Collapse the ``items.nodes`` array into ``{item_id, content_type, ...}`` rows.
+
+    Each row carries the board ``item_id`` (the node id
+    ``project_item_set_field`` needs) plus the underlying content's type,
+    number, title, and url. Draft issues have no number / url; those keys
+    surface as ``None``.
+    """
+    items_conn = project.get("items")
+    nodes = items_conn.get("nodes") if isinstance(items_conn, dict) else None
+    if not isinstance(nodes, list):
+        return []
+    parsed: list[dict[str, Any]] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        content = node.get("content")
+        content_dict = content if isinstance(content, dict) else {}
+        parsed.append(
+            {
+                "item_id": node.get("id"),
+                "content_type": content_dict.get("__typename"),
+                "number": content_dict.get("number"),
+                "title": content_dict.get("title"),
+                "url": content_dict.get("url"),
+            }
+        )
+    return parsed
+
+
+def _item_count(project: dict[str, Any]) -> int | None:
+    """Return the board's ``items.totalCount`` (all items, not just the page)."""
+    items_conn = project.get("items")
+    if not isinstance(items_conn, dict):
+        return None
+    total = items_conn.get("totalCount")
+    return total if isinstance(total, int) else None
+
+
+async def project_view_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: GitHubRestConnector,
+) -> dict[str, Any]:
+    """Read a Projects-v2 board: node id + fields (with options) + items.
+
+    Op-id: ``gh.composite.project_view``. One GraphQL round-trip returns
+    the ``project_id`` (needed to add items / set fields), every field
+    with the option ids of single-select fields, and the current items.
+
+    Raises
+    ------
+    GitHubGraphQlError
+        The login / project number did not resolve, or the GraphQL call
+        itself returned an ``errors`` array.
+    """
+    owner = params["owner"]
+    project_number = params["project_number"]
+    owner_type = params.get("owner_type", "organization")
+    if owner_type not in _OWNER_TYPE_ROOT:
+        raise GitHubGraphQlError(
+            f"owner_type must be one of {sorted(_OWNER_TYPE_ROOT)}; got {owner_type!r}"
+        )
+    first = int(params.get("first", 20))
+
+    query = _PROJECT_VIEW_QUERY.replace("__ROOT__", _OWNER_TYPE_ROOT[owner_type])
+    data = await github_graphql(
+        connector,
+        target,
+        operator,
+        query=query,
+        variables={"login": owner, "number": project_number, "first": first},
+    )
+    project = _extract_project(data, owner_type)
+    return {
+        "project_id": project.get("id"),
+        "title": project.get("title"),
+        "fields": _parse_fields(project),
+        "items": _parse_items(project),
+        "item_count": _item_count(project),
+    }
+
+
+async def project_item_add_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: GitHubRestConnector,
+) -> dict[str, Any]:
+    """Add an issue / PR to a Projects-v2 board by content node id.
+
+    Op-id: ``gh.composite.project_item_add``. Wraps the
+    ``addProjectV2ItemById`` GraphQL mutation. ``project_id`` and
+    ``content_id`` are GraphQL node ids (the ``project_id`` from
+    :func:`project_view_composite`; the ``content_id`` is the issue / PR
+    ``node_id`` the REST create-issue response carries). Idempotent on
+    GitHub's side -- re-adding an already-present item returns the
+    existing item's id.
+
+    Raises
+    ------
+    GitHubGraphQlError
+        The mutation returned an ``errors`` array (unknown node id,
+        insufficient project scope) or a payload without an item id.
+    """
+    project_id = params["project_id"]
+    content_id = params["content_id"]
+    data = await github_graphql(
+        connector,
+        target,
+        operator,
+        query=_ADD_ITEM_MUTATION,
+        variables={"projectId": project_id, "contentId": content_id},
+    )
+    item_id = _extract_node_id(data, mutation="addProjectV2ItemById", node_key="item")
+    return {
+        "item_id": item_id,
+        "project_id": project_id,
+        "content_id": content_id,
+        "status": "added",
+    }
+
+
+async def project_item_set_field_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: GitHubRestConnector,
+) -> dict[str, Any]:
+    """Set a single-select field (Status / Priority / Size) on a board item.
+
+    Op-id: ``gh.composite.project_item_set_field``. Wraps the
+    ``updateProjectV2ItemFieldValue`` GraphQL mutation with a
+    ``singleSelectOptionId`` value. Every argument is a GraphQL node id
+    resolvable from :func:`project_view_composite` (``project_id`` +
+    ``item_id`` + each field's ``id`` + the chosen option's ``id``).
+
+    Raises
+    ------
+    GitHubGraphQlError
+        The mutation returned an ``errors`` array (unknown id, or the
+        option does not belong to the field) or a payload without an
+        item id.
+    """
+    project_id = params["project_id"]
+    item_id = params["item_id"]
+    field_id = params["field_id"]
+    option_id = params["option_id"]
+    data = await github_graphql(
+        connector,
+        target,
+        operator,
+        query=_SET_FIELD_MUTATION,
+        variables={
+            "projectId": project_id,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "optionId": option_id,
+        },
+    )
+    updated_item_id = _extract_node_id(
+        data, mutation="updateProjectV2ItemFieldValue", node_key="projectV2Item"
+    )
+    return {
+        "item_id": updated_item_id,
+        "field_id": field_id,
+        "option_id": option_id,
+        "status": "updated",
+    }
+
+
+def _extract_node_id(data: dict[str, Any], *, mutation: str, node_key: str) -> str:
+    """Pull ``data[mutation][node_key]["id"]`` out of a mutation response, or raise.
+
+    Both board mutations return a single nested object carrying the
+    affected item's node id (``addProjectV2ItemById -> item -> id``,
+    ``updateProjectV2ItemFieldValue -> projectV2Item -> id``). A missing
+    id means the mutation reported success shape but no node -- surfaced
+    as :class:`GitHubGraphQlError` rather than returning ``None``.
+    """
+    outer = data.get(mutation)
+    node = outer.get(node_key) if isinstance(outer, dict) else None
+    node_id = node.get("id") if isinstance(node, dict) else None
+    if not isinstance(node_id, str) or not node_id:
+        raise GitHubGraphQlError(
+            f"GitHub GraphQL {mutation} returned no {node_key}.id (payload shape: {data!r})"
+        )
+    return node_id

--- a/backend/src/meho_backplane/connectors/github/composites/_graphql.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_graphql.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared GraphQL transport for the gh-rest board composites (#2081).
+
+GitHub's Projects-v2 surface is **GraphQL-only** -- a REST connector
+structurally cannot add a project item or set a single-select field
+(the issue-body framing). The board composites in :mod:`._board`
+therefore POST GraphQL documents to ``/graphql`` through the resolved
+:class:`~meho_backplane.connectors.github.connector.GitHubRestConnector`'s
+own authenticated session (the #2255 direct-session substrate the read
+composite already uses), so they work on a fresh deploy with **zero gh
+catalog ingest**.
+
+Why a dedicated helper
+----------------------
+
+GitHub's GraphQL endpoint returns **HTTP 200 even when the query
+fails** -- a bad node id, a permissions error, or a malformed mutation
+comes back as a ``200`` whose JSON body carries a non-empty ``errors``
+array and (usually) ``data: null``. :meth:`HttpConnector._post_json`
+only raises on the HTTP status (via ``raise_for_status``), so it would
+hand a caller an ``errors``-bearing envelope as if it were success.
+:func:`github_graphql` closes that gap: it inspects the parsed body,
+raises :class:`GitHubGraphQlError` when ``errors`` is present, and
+returns the unwrapped ``data`` object otherwise. Every board composite
+routes through it so the failure mode is uniform (a write never
+silently no-ops on a GraphQL error).
+
+Variables, not string interpolation
+------------------------------------
+
+Every dynamic value (login, project number, node ids, option id) is
+passed through the GraphQL ``variables`` map, never spliced into the
+query text. This is the GraphQL analogue of a parameterised SQL
+statement -- it is injection-safe and lets GitHub type-check the
+document against its schema. The only value composed into query text is
+the root selector (``organization`` vs ``user``), which the board
+handler picks from a closed literal map keyed off a schema-validated
+enum, never from raw caller input.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.github.connector import GitHubRestConnector
+
+__all__ = ["GITHUB_GRAPHQL_PATH", "GitHubGraphQlError", "github_graphql"]
+
+#: Wire path for GitHub's GraphQL endpoint. The connector mounts it
+#: under ``https://api.github.com`` (``_base_url``), so the full URL is
+#: ``https://api.github.com/graphql``. GHES would remap this (``/api/
+#: graphql``), but T1 ships github.com only -- consistent with the rest
+#: of the connector's github.com-only scope.
+GITHUB_GRAPHQL_PATH = "/graphql"
+
+
+class GitHubGraphQlError(RuntimeError):
+    """A GitHub GraphQL call returned a non-empty ``errors`` array (or no data).
+
+    GitHub answers a failed GraphQL operation with ``HTTP 200`` and an
+    ``errors`` array in the body rather than a 4xx/5xx status, so this
+    is raised by :func:`github_graphql` after inspecting the parsed
+    payload -- not by the transport layer's ``raise_for_status``.
+
+    Subclasses :class:`RuntimeError` so the dispatcher's outer exception
+    branch wraps it as a structured ``connector_error``
+    :class:`~meho_backplane.connectors.schemas.OperationResult`, the
+    same way the read composite's malformed-payload ``RuntimeError`` is
+    surfaced. The GraphQL error messages are folded into the exception
+    string so the operator sees *why* the board op failed (unknown node
+    id, insufficient project scope, etc.).
+    """
+
+    def __init__(self, message: str, *, errors: list[Any] | None = None) -> None:
+        self.errors = errors or []
+        super().__init__(message)
+
+
+def _summarise_graphql_errors(errors: list[Any]) -> str:
+    """Join the ``message`` field of each GraphQL error into one string.
+
+    GitHub GraphQL errors are objects carrying a ``message`` (and often
+    a ``type`` / ``path``); the message is the operator-actionable part.
+    Non-dict / message-less entries are stringified verbatim so a
+    surprising error shape still surfaces rather than disappearing.
+    """
+    messages: list[str] = []
+    for err in errors:
+        if isinstance(err, dict) and isinstance(err.get("message"), str):
+            messages.append(err["message"])
+        else:
+            messages.append(repr(err))
+    return "; ".join(messages) if messages else "<no error messages>"
+
+
+async def github_graphql(
+    connector: GitHubRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    query: str,
+    variables: dict[str, Any],
+) -> dict[str, Any]:
+    """POST a GraphQL document to ``/graphql`` and return its ``data`` object.
+
+    Issues the call through *connector*'s own session
+    (:meth:`~meho_backplane.connectors.adapters.http.HttpConnector._post_json`,
+    which carries the connector's ``Authorization: Bearer`` header) with
+    the standard ``{"query": ..., "variables": ...}`` request body.
+
+    Returns
+    -------
+    dict[str, Any]
+        The unwrapped ``data`` object (the top-level ``data`` key of the
+        GraphQL response), guaranteed non-``None`` on return.
+
+    Raises
+    ------
+    GitHubGraphQlError
+        The response body was not a JSON object, carried a non-empty
+        ``errors`` array, or had a ``null`` / missing ``data`` object.
+        GitHub returns these as ``HTTP 200``, so they cannot surface via
+        the transport's ``raise_for_status``.
+    httpx.HTTPError
+        A transport-level or non-2xx failure (auth 401, rate-limit 403,
+        5xx). Propagates from ``_post_json`` for the dispatcher's outer
+        branch to map to the matching structured result.
+    """
+    payload = await connector._post_json(
+        target,
+        GITHUB_GRAPHQL_PATH,
+        operator=operator,
+        json={"query": query, "variables": variables},
+    )
+    if not isinstance(payload, dict):
+        raise GitHubGraphQlError(
+            f"GitHub GraphQL response was not a JSON object (got {type(payload).__name__})"
+        )
+    errors = payload.get("errors")
+    if errors:
+        error_list = errors if isinstance(errors, list) else [errors]
+        raise GitHubGraphQlError(
+            f"GitHub GraphQL call failed: {_summarise_graphql_errors(error_list)}",
+            errors=error_list,
+        )
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise GitHubGraphQlError(
+            "GitHub GraphQL response carried no ``data`` object "
+            f"(got {type(data).__name__}); the query returned neither data nor errors"
+        )
+    return data

--- a/backend/src/meho_backplane/connectors/github/composites/_graphql.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_graphql.py
@@ -50,11 +50,12 @@ if TYPE_CHECKING:
 
 __all__ = ["GITHUB_GRAPHQL_PATH", "GitHubGraphQlError", "github_graphql"]
 
-#: Wire path for GitHub's GraphQL endpoint. The connector mounts it
-#: under ``https://api.github.com`` (``_base_url``), so the full URL is
-#: ``https://api.github.com/graphql``. GHES would remap this (``/api/
-#: graphql``), but T1 ships github.com only -- consistent with the rest
-#: of the connector's github.com-only scope.
+#: Descriptor-relative path for GitHub's GraphQL endpoint. It is routed
+#: through ``connector.mount_op_path`` before the wire call (identity for
+#: github.com, so the full URL is ``https://api.github.com/graphql``),
+#: matching how the REST composites mount their paths. A future GHES
+#: override would remap it there (GHES GraphQL lives at ``/api/graphql``)
+#: in one place; T1 ships github.com only.
 GITHUB_GRAPHQL_PATH = "/graphql"
 
 
@@ -110,7 +111,10 @@ async def github_graphql(
     Issues the call through *connector*'s own session
     (:meth:`~meho_backplane.connectors.adapters.http.HttpConnector._post_json`,
     which carries the connector's ``Authorization: Bearer`` header) with
-    the standard ``{"query": ..., "variables": ...}`` request body.
+    the standard ``{"query": ..., "variables": ...}`` request body. The
+    path is routed through the connector's ``mount_op_path`` first
+    (identity for github.com), matching the REST composites and
+    localising a future GHES mount remap.
 
     Returns
     -------
@@ -130,9 +134,10 @@ async def github_graphql(
         5xx). Propagates from ``_post_json`` for the dispatcher's outer
         branch to map to the matching structured result.
     """
+    path = await connector.mount_op_path(target, GITHUB_GRAPHQL_PATH, operator)
     payload = await connector._post_json(
         target,
-        GITHUB_GRAPHQL_PATH,
+        path,
         operator=operator,
         json={"query": query, "variables": variables},
     )

--- a/backend/src/meho_backplane/connectors/github/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_register.py
@@ -51,12 +51,28 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any, Literal, NamedTuple
 
+from meho_backplane.connectors.github.composites._board import (
+    project_item_add_composite,
+    project_item_set_field_composite,
+    project_view_composite,
+)
 from meho_backplane.connectors.github.composites._read import (
     pr_status_summary_composite,
+)
+from meho_backplane.connectors.github.composites._sub_issues import (
+    sub_issue_add_composite,
 )
 from meho_backplane.connectors.github.composites.schemas import (
     PR_STATUS_SUMMARY_PARAMETER_SCHEMA,
     PR_STATUS_SUMMARY_RESPONSE_SCHEMA,
+    PROJECT_ITEM_ADD_PARAMETER_SCHEMA,
+    PROJECT_ITEM_ADD_RESPONSE_SCHEMA,
+    PROJECT_ITEM_SET_FIELD_PARAMETER_SCHEMA,
+    PROJECT_ITEM_SET_FIELD_RESPONSE_SCHEMA,
+    PROJECT_VIEW_PARAMETER_SCHEMA,
+    PROJECT_VIEW_RESPONSE_SCHEMA,
+    SUB_ISSUE_ADD_PARAMETER_SCHEMA,
+    SUB_ISSUE_ADD_RESPONSE_SCHEMA,
 )
 from meho_backplane.operations.typed_register import register_composite_operation
 from meho_backplane.retrieval.embedding import EmbeddingService
@@ -79,8 +95,8 @@ _IMPL_ID = "gh-rest"
 #: Curated agent-actionable group selectors for the gh-rest composite
 #: surface, surfaced verbatim by ``list_operation_groups`` so the LLM
 #: client picks the right composite group before drilling into
-#: ``search_operations``. T4 ships exactly one composite (the ``pulls``
-#: group); future T7+ composites populate ``release``, ``board``, etc.
+#: ``search_operations``. T4 shipped the ``pulls`` group; #2081 adds
+#: the ``board`` (Projects-v2) and ``issues`` (sub-issue linkage) groups.
 _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     "pulls": (
         "Use for one-call PR-status questions: 'is PR #N ready to "
@@ -91,6 +107,23 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "orchestrate three separate L2 calls. Read-only. Pair with the "
         "ingested L2 ops (gh.pr.get_files, gh.pr.get_commits, etc.) "
         "when drill-in beyond the summary is needed."
+    ),
+    "board": (
+        "Use to put a ticket on a GitHub Projects-v2 board and set its "
+        "Status / Priority / Size fields -- the GraphQL-only surface a "
+        "REST connector cannot reach. Start with project_view to read "
+        "the board's node id, its single-select field ids, and each "
+        "field's option ids; then project_item_add to place an issue / "
+        "PR on the board (by content node id); then "
+        "project_item_set_field to set a single-select field. This is "
+        "the 'file a board-complete ticket' path -- no gh CLI fallback."
+    ),
+    "issues": (
+        "Use to link a task to its parent as a GitHub sub-issue "
+        "(sub_issue_add). Complements the board group: after creating a "
+        "child issue you attach it under a parent by the child's "
+        "database id. The sub-issue must share the parent's repository "
+        "owner."
     ),
 }
 
@@ -143,6 +176,86 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         group_key="pulls",
         tags=["composite", "read-only", "pulls", "status"],
         safety_level="safe",
+        requires_approval=False,
+    ),
+    _CompositeSpec(
+        op_id="gh.composite.project_view",
+        handler=project_view_composite,
+        summary="Read a Projects-v2 board: node id + fields (with option ids) + items.",
+        description=(
+            "Reads a GitHub Projects-v2 board in one GraphQL call -- its node "
+            "id, its fields (single-select fields carry their option ids), and "
+            "its current items -- via the organization/user projectV2(number) "
+            "query. The GraphQL-only Projects-v2 surface has no REST "
+            "equivalent, so this is how an agent discovers the project_id / "
+            "field_id / option_id node ids the two write composites need. "
+            "Read-only. Pair with project_item_add + project_item_set_field to "
+            "file a board-complete ticket without a gh CLI fallback."
+        ),
+        parameter_schema=PROJECT_VIEW_PARAMETER_SCHEMA,
+        response_schema=PROJECT_VIEW_RESPONSE_SCHEMA,
+        group_key="board",
+        tags=["composite", "read-only", "board", "projectv2", "graphql"],
+        safety_level="safe",
+        requires_approval=False,
+    ),
+    _CompositeSpec(
+        op_id="gh.composite.project_item_add",
+        handler=project_item_add_composite,
+        summary="Add an issue / PR to a Projects-v2 board (addProjectV2ItemById).",
+        description=(
+            "Adds an issue or pull request to a GitHub Projects-v2 board by "
+            "content node id, wrapping the addProjectV2ItemById GraphQL "
+            "mutation. project_id comes from gh.composite.project_view; "
+            "content_id is the issue/PR node_id the REST payload carries. A "
+            "low-blast-radius board-hygiene write -- adding a card to a board "
+            "is reversible. Returns the new board item's node id, which "
+            "project_item_set_field then targets."
+        ),
+        parameter_schema=PROJECT_ITEM_ADD_PARAMETER_SCHEMA,
+        response_schema=PROJECT_ITEM_ADD_RESPONSE_SCHEMA,
+        group_key="board",
+        tags=["composite", "write", "board", "projectv2", "graphql"],
+        safety_level="caution",
+        requires_approval=False,
+    ),
+    _CompositeSpec(
+        op_id="gh.composite.project_item_set_field",
+        handler=project_item_set_field_composite,
+        summary="Set a single-select field (Status/Priority/Size) on a board item.",
+        description=(
+            "Sets a single-select field on a GitHub Projects-v2 board item -- "
+            "Status, Priority, Size, or any other single-select field -- "
+            "wrapping the updateProjectV2ItemFieldValue GraphQL mutation with a "
+            "singleSelectOptionId value. Every argument (project_id, item_id, "
+            "field_id, option_id) is a node id resolvable from "
+            "gh.composite.project_view. A reversible board-hygiene write."
+        ),
+        parameter_schema=PROJECT_ITEM_SET_FIELD_PARAMETER_SCHEMA,
+        response_schema=PROJECT_ITEM_SET_FIELD_RESPONSE_SCHEMA,
+        group_key="board",
+        tags=["composite", "write", "board", "projectv2", "graphql"],
+        safety_level="caution",
+        requires_approval=False,
+    ),
+    _CompositeSpec(
+        op_id="gh.composite.sub_issue_add",
+        handler=sub_issue_add_composite,
+        summary="Link a sub-issue to a parent issue (POST .../sub_issues).",
+        description=(
+            "Links a task to its parent as a GitHub sub-issue, wrapping "
+            "POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues. "
+            "sub_issue_id is the child issue's DATABASE id (the ``id`` field on "
+            "the issue payload), NOT its issue number -- the REST create-issue "
+            "response carries that id. The sub-issue must share the parent's "
+            "repository owner. Set replace_parent=true to move an already-"
+            "parented sub-issue. A reversible board-hygiene write."
+        ),
+        parameter_schema=SUB_ISSUE_ADD_PARAMETER_SCHEMA,
+        response_schema=SUB_ISSUE_ADD_RESPONSE_SCHEMA,
+        group_key="issues",
+        tags=["composite", "write", "issues", "sub_issue"],
+        safety_level="caution",
         requires_approval=False,
     ),
 )

--- a/backend/src/meho_backplane/connectors/github/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_register.py
@@ -19,19 +19,26 @@ in this module so a future shape change touches one file. The helper
 handles upsert, body-hash dedupe, embedding pipeline, and
 ``source_kind="composite"`` persistence.
 
-Scope at T4 (#1224)
--------------------
+Scope
+-----
 
-One composite ships: ``gh.composite.pr_status_summary``. It is read-
-only (``safety_level="read"`` / ``requires_approval=False``) -- the
-issue body's mandatory posture for the trigger use case (the operator
-asks "is PR #N ready to merge?" and gets a structured answer without
-mutating anything).
+Five composites ship. ``gh.composite.pr_status_summary`` (T4 #1224) is
+read-only. #2081 adds four more: ``gh.composite.project_view`` (read),
+``gh.composite.project_item_add`` /
+``gh.composite.project_item_set_field`` (Projects-v2 GraphQL writes),
+and ``gh.composite.sub_issue_add`` (sub-issue linkage REST write) --
+together the "file a board-complete ticket without a gh CLI fallback"
+surface.
 
 The composite-helper's defaults are ``safety_level="dangerous"`` +
-``requires_approval=True`` (suited to write composites); the read
-composite explicitly overrides both. Future T7+ write composites will
-omit the override and inherit the helper's safe-by-default policy.
+``requires_approval=True`` (suited to high-blast-radius write
+composites). The reads override to ``safe``; the board + sub-issue
+writes override to ``caution`` -- low-blast-radius, reversible
+board-hygiene mutations -- all with ``requires_approval=False`` so a
+human / service operator can file a board-complete ticket without an
+approval round-trip while an agent still routes through the ``caution``
+safety default. See :mod:`._board` / :mod:`._sub_issues` for the
+per-composite governance rationale.
 
 ``safety_level`` value note
 ---------------------------

--- a/backend/src/meho_backplane/connectors/github/composites/_sub_issues.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_sub_issues.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Sub-issue linkage ``gh.composite.*`` handler (1 composite, #2081).
+
+Filing a task under a parent on a board-driven team needs a parent /
+sub-issue link. GitHub exposes this over REST --
+``POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues`` -- but
+that op is not part of the gh-rest connector's live surface (the
+connector's ``execute`` is a stub; there is no ingested catalog), so
+before this Task a sub-issue link dropped back to the ``gh`` CLI. This
+composite makes the link callable through the connector's own dispatch
+path.
+
+:func:`sub_issue_add_composite` (``gh.composite.sub_issue_add``) issues
+the write directly on the resolved connector's session
+(:meth:`~meho_backplane.connectors.adapters.http.HttpConnector._post_json`
+mounted through ``mount_op_path``), the #2255 direct-session substrate,
+so it works on a fresh deploy with zero gh catalog ingest.
+
+The ``sub_issue_id`` gotcha
+---------------------------
+
+GitHub's endpoint takes the sub-issue's **database id** (the ``id``
+field on the issue payload), **not** its issue number (the ``#N`` in the
+URL). The REST create-issue response an agent already holds carries that
+``id``, so the board-complete flow (create child issue -> link it) has
+the value in hand; the parameter schema and this docstring both call the
+distinction out because passing the number is the obvious mistake.
+
+Governance posture
+------------------
+
+A single REST write, registered ``safety_level="caution"`` /
+``requires_approval=False`` (see :mod:`._register`) -- linking a
+sub-issue is a low-blast-radius, reversible board-hygiene mutation. As
+with the board write composites, the composite is the reviewed unit: the
+dispatcher gates it via ``policy_gate`` before invoking the handler, so
+the one write it performs is fully governed and no ``enforce_subop_policy``
+seam is needed (there is no additional internal write to re-gate).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.github.connector import GitHubRestConnector
+
+__all__ = ["sub_issue_add_composite"]
+
+# REST wire path for the add-sub-issue endpoint, keyed with ``str.format``
+# placeholders. Mounted under ``https://api.github.com`` by the
+# connector's ``_base_url``; ``mount_op_path`` is identity for github.com.
+_SUB_ISSUES_PATH = "/repos/{owner}/{repo}/issues/{issue_number}/sub_issues"
+
+
+async def sub_issue_add_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: GitHubRestConnector,
+) -> dict[str, Any]:
+    """Link a sub-issue to a parent issue via ``POST .../sub_issues``.
+
+    Op-id: ``gh.composite.sub_issue_add``. ``sub_issue_id`` is the
+    sub-issue's **database id** (not its issue number -- see the module
+    docstring). ``replace_parent=True`` moves a sub-issue that already
+    has a different parent under this one; omitted, GitHub uses its
+    default (reject when the sub-issue already has a parent).
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"parent": <parent issue payload>, "parent_number": <int>,
+        "sub_issue_id": <int>, "status": "linked"}``. GitHub returns the
+        full parent issue object (``201 Created``) on success; it is
+        surfaced verbatim under ``parent`` so the caller can read the
+        updated ``sub_issues_summary`` count.
+
+    Raises
+    ------
+    httpx.HTTPStatusError
+        A non-2xx status -- 404 (unknown parent / sub-issue), 422 (the
+        sub-issue is in a different repo owner, or already parented and
+        ``replace_parent`` was not set). Propagates for the dispatcher's
+        outer branch to map to the matching structured result.
+    """
+    owner = params["owner"]
+    repo = params["repo"]
+    issue_number = params["issue_number"]
+    sub_issue_id = params["sub_issue_id"]
+    replace_parent = params.get("replace_parent")
+
+    path = await connector.mount_op_path(
+        target,
+        _SUB_ISSUES_PATH.format(owner=owner, repo=repo, issue_number=issue_number),
+        operator,
+    )
+    body: dict[str, Any] = {"sub_issue_id": sub_issue_id}
+    if replace_parent is not None:
+        body["replace_parent"] = bool(replace_parent)
+
+    parent = await connector._post_json(target, path, operator=operator, verb="POST", json=body)
+    return {
+        "parent": parent,
+        "parent_number": issue_number,
+        "sub_issue_id": sub_issue_id,
+        "status": "linked",
+    }

--- a/backend/src/meho_backplane/connectors/github/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/github/composites/schemas.py
@@ -14,8 +14,10 @@ Same conventions as the vmware-rest composite schemas module
   surfaces the schema verbatim to LLM clients.
 * T4 ships exactly one composite -- ``gh.composite.pr_status_summary``
   -- which is read-only (``safety_level="read"`` /
-  ``requires_approval=False`` per the issue body). Future T7+ Tasks
-  add write composites and reuse this module's pattern.
+  ``requires_approval=False`` per the issue body). #2081 adds the four
+  board + sub-issue composites (``project_view`` read;
+  ``project_item_add`` / ``project_item_set_field`` / ``sub_issue_add``
+  writes) and reuses this module's pattern.
 """
 
 from __future__ import annotations
@@ -23,8 +25,16 @@ from __future__ import annotations
 from typing import Any
 
 __all__ = [
+    "PROJECT_ITEM_ADD_PARAMETER_SCHEMA",
+    "PROJECT_ITEM_ADD_RESPONSE_SCHEMA",
+    "PROJECT_ITEM_SET_FIELD_PARAMETER_SCHEMA",
+    "PROJECT_ITEM_SET_FIELD_RESPONSE_SCHEMA",
+    "PROJECT_VIEW_PARAMETER_SCHEMA",
+    "PROJECT_VIEW_RESPONSE_SCHEMA",
     "PR_STATUS_SUMMARY_PARAMETER_SCHEMA",
     "PR_STATUS_SUMMARY_RESPONSE_SCHEMA",
+    "SUB_ISSUE_ADD_PARAMETER_SCHEMA",
+    "SUB_ISSUE_ADD_RESPONSE_SCHEMA",
 ]
 
 
@@ -164,4 +174,273 @@ PR_STATUS_SUMMARY_RESPONSE_SCHEMA: dict[str, Any] = {
         "reviews, mergeable) plus two pre-computed summaries that "
         "collapse the per-record arrays into agent-actionable states."
     ),
+}
+
+
+# ===========================================================================
+# gh.composite.project_view (Projects-v2 board read, #2081)
+# ===========================================================================
+
+
+PROJECT_VIEW_PARAMETER_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["owner", "project_number"],
+    "properties": {
+        "owner": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The org or user login that owns the Projects-v2 board.",
+        },
+        "project_number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The board's number (the integer in its /projects/<N> URL).",
+        },
+        "owner_type": {
+            "type": "string",
+            "enum": ["organization", "user"],
+            "default": "organization",
+            "description": (
+                "Whether ``owner`` is an organization or a user login -- picks the "
+                "GraphQL root selector. Defaults to ``organization``."
+            ),
+        },
+        "first": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20,
+            "description": "How many board items to return (GraphQL page size, max 100).",
+        },
+    },
+    "description": (
+        "Parameters for gh.composite.project_view. Reads a Projects-v2 board's "
+        "node id, its fields (single-select fields include their option ids), "
+        "and its current items in one GraphQL call -- the node ids the "
+        "project_item_add / project_item_set_field write composites consume."
+    ),
+}
+
+
+PROJECT_VIEW_RESPONSE_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["project_id", "title", "fields", "items", "item_count"],
+    "properties": {
+        "project_id": {
+            "type": ["string", "null"],
+            "description": "The board's GraphQL node id -- input to the write composites.",
+        },
+        "title": {"type": ["string", "null"], "description": "The board's title."},
+        "fields": {
+            "type": "array",
+            "description": (
+                "Board fields. Each is ``{id, name, data_type, options}``; "
+                "``options`` is a list of ``{id, name}`` for single-select fields "
+                "(the option ids project_item_set_field needs) and ``null`` otherwise."
+            ),
+            "items": {"type": "object"},
+        },
+        "items": {
+            "type": "array",
+            "description": (
+                "Board items. Each is ``{item_id, content_type, number, title, url}``; "
+                "``number`` / ``url`` are ``null`` for draft issues."
+            ),
+            "items": {"type": "object"},
+        },
+        "item_count": {
+            "type": ["integer", "null"],
+            "description": "Total board item count (items.totalCount), not just this page.",
+        },
+    },
+    "description": "A Projects-v2 board snapshot: node id, fields (with option ids), and items.",
+}
+
+
+# ===========================================================================
+# gh.composite.project_item_add (Projects-v2 board write, #2081)
+# ===========================================================================
+
+
+PROJECT_ITEM_ADD_PARAMETER_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["project_id", "content_id"],
+    "properties": {
+        "project_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The board's GraphQL node id (from gh.composite.project_view).",
+        },
+        "content_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "The issue or PR GraphQL node id (the ``node_id`` field on the "
+                "REST issue/PR payload) to add to the board."
+            ),
+        },
+    },
+    "description": (
+        "Parameters for gh.composite.project_item_add. Wraps the "
+        "addProjectV2ItemById GraphQL mutation."
+    ),
+}
+
+
+PROJECT_ITEM_ADD_RESPONSE_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["item_id", "project_id", "content_id", "status"],
+    "properties": {
+        "item_id": {"type": "string", "description": "The new board item's GraphQL node id."},
+        "project_id": {"type": "string", "description": "Echo of the board node id."},
+        "content_id": {"type": "string", "description": "Echo of the added content node id."},
+        "status": {
+            "type": "string",
+            "enum": ["added"],
+            "description": "Always ``added`` on success.",
+        },
+    },
+    "description": "The board item created by addProjectV2ItemById.",
+}
+
+
+# ===========================================================================
+# gh.composite.project_item_set_field (Projects-v2 board write, #2081)
+# ===========================================================================
+
+
+PROJECT_ITEM_SET_FIELD_PARAMETER_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["project_id", "item_id", "field_id", "option_id"],
+    "properties": {
+        "project_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The board's GraphQL node id (from gh.composite.project_view).",
+        },
+        "item_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The board item's node id (from project_view or project_item_add).",
+        },
+        "field_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The single-select field's node id (from project_view fields).",
+        },
+        "option_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "The single-select option's id (from the field's ``options`` in "
+                "gh.composite.project_view) to set the field to."
+            ),
+        },
+    },
+    "description": (
+        "Parameters for gh.composite.project_item_set_field. Wraps the "
+        "updateProjectV2ItemFieldValue GraphQL mutation with a single-select value."
+    ),
+}
+
+
+PROJECT_ITEM_SET_FIELD_RESPONSE_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["item_id", "field_id", "option_id", "status"],
+    "properties": {
+        "item_id": {"type": "string", "description": "The updated board item's node id."},
+        "field_id": {"type": "string", "description": "Echo of the field node id set."},
+        "option_id": {"type": "string", "description": "Echo of the option id applied."},
+        "status": {
+            "type": "string",
+            "enum": ["updated"],
+            "description": "Always ``updated`` on success.",
+        },
+    },
+    "description": "The board item updated by updateProjectV2ItemFieldValue.",
+}
+
+
+# ===========================================================================
+# gh.composite.sub_issue_add (sub-issue linkage REST write, #2081)
+# ===========================================================================
+
+
+SUB_ISSUE_ADD_PARAMETER_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["owner", "repo", "issue_number", "sub_issue_id"],
+    "properties": {
+        "owner": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The parent issue's repository owner (user or org login).",
+        },
+        "repo": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The parent issue's repository name (without the owner prefix).",
+        },
+        "issue_number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The parent issue's number (the ``#N`` the sub-issue is linked under).",
+        },
+        "sub_issue_id": {
+            "type": "integer",
+            "minimum": 1,
+            "description": (
+                "The sub-issue's DATABASE id (the ``id`` field on the issue payload), "
+                "NOT its issue number. The REST create-issue response carries this id. "
+                "The sub-issue must belong to the same repository owner as the parent."
+            ),
+        },
+        "replace_parent": {
+            "type": "boolean",
+            "description": (
+                "When ``true``, move a sub-issue that already has a different parent "
+                "under this one. Omit to use GitHub's default (reject if already parented)."
+            ),
+        },
+    },
+    "description": (
+        "Parameters for gh.composite.sub_issue_add. Wraps "
+        "POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues."
+    ),
+}
+
+
+SUB_ISSUE_ADD_RESPONSE_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["parent", "parent_number", "sub_issue_id", "status"],
+    "properties": {
+        "parent": {
+            "description": (
+                "The parent issue payload GitHub returns (201). Surfaced verbatim so "
+                "the caller can read the updated ``sub_issues_summary`` count."
+            ),
+        },
+        "parent_number": {"type": "integer", "description": "Echo of the parent issue number."},
+        "sub_issue_id": {
+            "type": "integer",
+            "description": "Echo of the linked sub-issue database id.",
+        },
+        "status": {
+            "type": "string",
+            "enum": ["linked"],
+            "description": "Always ``linked`` on success.",
+        },
+    },
+    "description": "The parent issue after the sub-issue was linked.",
 }

--- a/backend/src/meho_backplane/connectors/github/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/github/composites/schemas.py
@@ -13,11 +13,12 @@ Same conventions as the vmware-rest composite schemas module
   documentation lives on ``description`` keys; ``describe_operation``
   surfaces the schema verbatim to LLM clients.
 * T4 ships exactly one composite -- ``gh.composite.pr_status_summary``
-  -- which is read-only (``safety_level="read"`` /
-  ``requires_approval=False`` per the issue body). #2081 adds the four
-  board + sub-issue composites (``project_view`` read;
-  ``project_item_add`` / ``project_item_set_field`` / ``sub_issue_add``
-  writes) and reuses this module's pattern.
+  -- which is read-only (registered ``safety_level="safe"`` --
+  the register-time enum value for the issue body's "read" label --
+  / ``requires_approval=False``). #2081 adds the four board + sub-issue
+  composites (``project_view`` read; ``project_item_add`` /
+  ``project_item_set_field`` / ``sub_issue_add`` writes) and reuses this
+  module's pattern.
 """
 
 from __future__ import annotations

--- a/backend/tests/test_connectors_github_composites_board.py
+++ b/backend/tests/test_connectors_github_composites_board.py
@@ -368,3 +368,17 @@ async def test_graphql_missing_data_raises() -> None:
             query="query { x }",
             variables={},
         )
+
+
+@pytest.mark.asyncio
+async def test_graphql_non_dict_payload_raises() -> None:
+    """A non-object GraphQL body (e.g. a bare list) raises GitHubGraphQlError."""
+    connector = _RecordingConnector([["unexpected", "list", "body"]])
+    with pytest.raises(GitHubGraphQlError, match="not a JSON object"):
+        await github_graphql(
+            connector,  # type: ignore[arg-type]
+            object(),
+            _make_operator(),
+            query="query { x }",
+            variables={},
+        )

--- a/backend/tests/test_connectors_github_composites_board.py
+++ b/backend/tests/test_connectors_github_composites_board.py
@@ -1,0 +1,370 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the Projects-v2 board composites (direct-session, #2081).
+
+The three board composites (``project_view`` read, ``project_item_add``
+/ ``project_item_set_field`` writes) issue GraphQL calls through the
+resolved ``GitHubRestConnector`` session via
+:func:`._graphql.github_graphql`. These tests drive each handler with a
+recording session stub whose ``_post_json`` returns canned GraphQL
+envelopes -- no live GitHub, no ``endpoint_descriptor`` table.
+
+Coverage:
+
+* ``project_view`` -- org + user roots select the right GraphQL selector
+  and forward login / number / first as variables; the envelope carries
+  project_id + parsed fields (single-select option ids) + parsed items +
+  item_count; unknown login / project number raise GitHubGraphQlError.
+* ``project_item_add`` / ``project_item_set_field`` -- the mutation is
+  posted with the right variables; the returned node id is surfaced;
+  a missing node id raises.
+* GraphQL error handling -- a ``200``-with-``errors`` envelope raises
+  GitHubGraphQlError (GitHub does not use a 4xx status for query errors).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.github.composites._board import (
+    project_item_add_composite,
+    project_item_set_field_composite,
+    project_view_composite,
+)
+from meho_backplane.connectors.github.composites._graphql import (
+    GitHubGraphQlError,
+    github_graphql,
+)
+
+
+def _make_operator() -> Operator:
+    """Synthetic operator for composite-handler unit tests."""
+    return Operator(
+        sub="op-gh-board",
+        name="GH Board Composite Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000b0b0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _RecordingConnector:
+    """Session stub matching the subset of ``GitHubRestConnector`` the board handlers use.
+
+    ``_post_json`` pops the next canned response off a queue (an
+    ``Exception`` instance is raised instead) and records the ``(path,
+    verb, json)`` of every call so tests can assert the GraphQL document
+    + variables that went on the wire. ``mount_op_path`` is identity,
+    mirroring the github connector's inherited default.
+    """
+
+    def __init__(self, post_responses: list[Any]) -> None:
+        self._post_responses = list(post_responses)
+        self.post_calls: list[dict[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return path
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> Any:
+        self.post_calls.append({"path": path, "verb": verb, "json": json})
+        response = self._post_responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _project_view_payload() -> dict[str, Any]:
+    """A canned ``projectV2`` GraphQL envelope with one single-select field + two items."""
+    return {
+        "data": {
+            "organization": {
+                "projectV2": {
+                    "id": "PVT_board1",
+                    "title": "MEHO Board",
+                    "fields": {
+                        "nodes": [
+                            {
+                                "__typename": "ProjectV2Field",
+                                "id": "F_title",
+                                "name": "Title",
+                                "dataType": "TITLE",
+                            },
+                            {
+                                "__typename": "ProjectV2SingleSelectField",
+                                "id": "F_status",
+                                "name": "Status",
+                                "dataType": "SINGLE_SELECT",
+                                "options": [
+                                    {"id": "opt_todo", "name": "Todo"},
+                                    {"id": "opt_done", "name": "Done"},
+                                ],
+                            },
+                        ]
+                    },
+                    "items": {
+                        "totalCount": 2,
+                        "nodes": [
+                            {
+                                "id": "PVTI_1",
+                                "content": {
+                                    "__typename": "Issue",
+                                    "number": 42,
+                                    "title": "Fix X",
+                                    "url": "https://github.com/o/r/issues/42",
+                                },
+                            },
+                            {
+                                "id": "PVTI_2",
+                                "content": {"__typename": "DraftIssue", "title": "Draft note"},
+                            },
+                        ],
+                    },
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_project_view_org_root_and_variables() -> None:
+    """``project_view`` uses the ``organization`` root and forwards login/number/first."""
+    connector = _RecordingConnector([_project_view_payload()])
+    envelope = await project_view_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "project_number": 19, "first": 20},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    # ----- GraphQL document + variables on the wire -----
+    assert len(connector.post_calls) == 1
+    call = connector.post_calls[0]
+    assert call["path"] == "/graphql"
+    assert "organization(login: $login)" in call["json"]["query"]
+    assert "user(login: $login)" not in call["json"]["query"]
+    assert call["json"]["variables"] == {"login": "evoila", "number": 19, "first": 20}
+    # ----- Parsed envelope -----
+    assert envelope["project_id"] == "PVT_board1"
+    assert envelope["title"] == "MEHO Board"
+    assert envelope["item_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_project_view_parses_single_select_options() -> None:
+    """The Status single-select field's option ids surface for project_item_set_field."""
+    connector = _RecordingConnector([_project_view_payload()])
+    envelope = await project_view_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "project_number": 19},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    status_field = next(f for f in envelope["fields"] if f["name"] == "Status")
+    assert status_field["id"] == "F_status"
+    assert status_field["data_type"] == "SINGLE_SELECT"
+    assert status_field["options"] == [
+        {"id": "opt_todo", "name": "Todo"},
+        {"id": "opt_done", "name": "Done"},
+    ]
+    # A non-single-select field carries options=None.
+    title_field = next(f for f in envelope["fields"] if f["name"] == "Title")
+    assert title_field["options"] is None
+
+
+@pytest.mark.asyncio
+async def test_project_view_parses_items_including_draft() -> None:
+    """Items surface item_id + content type/number/title/url; drafts have null number/url."""
+    connector = _RecordingConnector([_project_view_payload()])
+    envelope = await project_view_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "project_number": 19},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    issue_item = next(i for i in envelope["items"] if i["content_type"] == "Issue")
+    assert issue_item["item_id"] == "PVTI_1"
+    assert issue_item["number"] == 42
+    assert issue_item["url"] == "https://github.com/o/r/issues/42"
+    draft_item = next(i for i in envelope["items"] if i["content_type"] == "DraftIssue")
+    assert draft_item["number"] is None
+    assert draft_item["url"] is None
+
+
+@pytest.mark.asyncio
+async def test_project_view_user_root() -> None:
+    """``owner_type='user'`` switches the GraphQL root selector to ``user``."""
+    payload = {
+        "data": {"user": {"projectV2": {"id": "PVT_u", "title": "T", "fields": {}, "items": {}}}}
+    }
+    connector = _RecordingConnector([payload])
+    envelope = await project_view_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "octocat", "project_number": 3, "owner_type": "user"},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert "user(login: $login)" in connector.post_calls[0]["json"]["query"]
+    assert envelope["project_id"] == "PVT_u"
+    assert envelope["fields"] == []
+    assert envelope["items"] == []
+    assert envelope["item_count"] is None
+
+
+@pytest.mark.asyncio
+async def test_project_view_invalid_owner_type_raises() -> None:
+    """An owner_type outside the closed enum raises before any wire call."""
+    connector = _RecordingConnector([])
+    with pytest.raises(GitHubGraphQlError, match="owner_type"):
+        await project_view_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"owner": "x", "project_number": 1, "owner_type": "team"},
+            connector=connector,  # type: ignore[arg-type]
+        )
+    assert connector.post_calls == []
+
+
+@pytest.mark.asyncio
+async def test_project_view_unknown_project_raises() -> None:
+    """A ``null`` projectV2 (bad number / no project scope) raises GitHubGraphQlError."""
+    connector = _RecordingConnector([{"data": {"organization": {"projectV2": None}}}])
+    with pytest.raises(GitHubGraphQlError, match="no projectV2"):
+        await project_view_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"owner": "evoila", "project_number": 999},
+            connector=connector,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_project_view_unknown_owner_raises() -> None:
+    """A ``null`` owner (login typo / no access) raises GitHubGraphQlError."""
+    connector = _RecordingConnector([{"data": {"organization": None}}])
+    with pytest.raises(GitHubGraphQlError, match="no 'organization'"):
+        await project_view_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"owner": "nope", "project_number": 1},
+            connector=connector,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_project_item_add_posts_mutation_and_returns_item_id() -> None:
+    """``project_item_add`` posts addProjectV2ItemById with the right variables."""
+    connector = _RecordingConnector(
+        [{"data": {"addProjectV2ItemById": {"item": {"id": "PVTI_new"}}}}]
+    )
+    result = await project_item_add_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"project_id": "PVT_board1", "content_id": "I_kwissue"},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    call = connector.post_calls[0]
+    assert "addProjectV2ItemById" in call["json"]["query"]
+    assert call["json"]["variables"] == {"projectId": "PVT_board1", "contentId": "I_kwissue"}
+    assert result == {
+        "item_id": "PVTI_new",
+        "project_id": "PVT_board1",
+        "content_id": "I_kwissue",
+        "status": "added",
+    }
+
+
+@pytest.mark.asyncio
+async def test_project_item_add_missing_item_id_raises() -> None:
+    """A mutation payload without an item id raises rather than returning None."""
+    connector = _RecordingConnector([{"data": {"addProjectV2ItemById": {"item": {}}}}])
+    with pytest.raises(GitHubGraphQlError, match="returned no item"):
+        await project_item_add_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"project_id": "P", "content_id": "C"},
+            connector=connector,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.asyncio
+async def test_project_item_set_field_posts_single_select_value() -> None:
+    """``project_item_set_field`` posts updateProjectV2ItemFieldValue with the option id."""
+    connector = _RecordingConnector(
+        [{"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "PVTI_1"}}}}]
+    )
+    result = await project_item_set_field_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "project_id": "PVT_board1",
+            "item_id": "PVTI_1",
+            "field_id": "F_status",
+            "option_id": "opt_done",
+        },
+        connector=connector,  # type: ignore[arg-type]
+    )
+    call = connector.post_calls[0]
+    assert "updateProjectV2ItemFieldValue" in call["json"]["query"]
+    assert "singleSelectOptionId" in call["json"]["query"]
+    assert call["json"]["variables"] == {
+        "projectId": "PVT_board1",
+        "itemId": "PVTI_1",
+        "fieldId": "F_status",
+        "optionId": "opt_done",
+    }
+    assert result == {
+        "item_id": "PVTI_1",
+        "field_id": "F_status",
+        "option_id": "opt_done",
+        "status": "updated",
+    }
+
+
+@pytest.mark.asyncio
+async def test_graphql_errors_array_raises() -> None:
+    """A 200-with-errors GraphQL envelope raises GitHubGraphQlError with the message."""
+    connector = _RecordingConnector(
+        [
+            {
+                "data": None,
+                "errors": [{"message": "Could not resolve to a node with the global id of 'X'."}],
+            }
+        ]
+    )
+    with pytest.raises(GitHubGraphQlError, match="Could not resolve to a node"):
+        await github_graphql(
+            connector,  # type: ignore[arg-type]
+            object(),
+            _make_operator(),
+            query="query { x }",
+            variables={},
+        )
+
+
+@pytest.mark.asyncio
+async def test_graphql_missing_data_raises() -> None:
+    """A response with neither data nor errors raises GitHubGraphQlError."""
+    connector = _RecordingConnector([{"foo": "bar"}])
+    with pytest.raises(GitHubGraphQlError, match="no ``data`` object"):
+        await github_graphql(
+            connector,  # type: ignore[arg-type]
+            object(),
+            _make_operator(),
+            query="query { x }",
+            variables={},
+        )

--- a/backend/tests/test_connectors_github_composites_register.py
+++ b/backend/tests/test_connectors_github_composites_register.py
@@ -1,17 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the gh-rest composites (G3.11-T4 #1224).
+"""Registration tests for the gh-rest composites (G3.11-T4 #1224, #2081).
 
 Mirrors :mod:`tests.test_connectors_vmware_rest_composites_register`.
-T4 ships exactly one composite -- ``gh.composite.pr_status_summary`` --
-so the coverage scope is narrower than the vmware-rest precedent but
-the per-composite assertions are identical: ``source_kind="composite"``
-row, ``safety_level="safe"`` + ``requires_approval=False`` overrides,
-canonical module-level ``handler_ref``, group resolution into
-``pulls``, parameter schema round-trips with ``required`` keys and
-``additionalProperties:false``, response schema persists, tags include
-``composite`` + ``read-only``, idempotent re-registration, and the
+T4 shipped ``gh.composite.pr_status_summary``; #2081 adds the four
+board + sub-issue composites. The per-composite assertions are the
+same shape: ``source_kind="composite"`` row, the right ``safety_level``
++ ``requires_approval`` posture, canonical module-level ``handler_ref``,
+group resolution (``pulls`` / ``board`` / ``issues``), parameter schema
+round-trips with ``required`` keys and ``additionalProperties:false``,
+response schema persists, tags, idempotent re-registration, and the
 side-effect import wires the registrar onto the lifespan list.
 """
 
@@ -28,7 +27,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.connectors.github.composites import (
     pr_status_summary_composite,
+    project_item_add_composite,
+    project_item_set_field_composite,
+    project_view_composite,
     register_github_composite_operations,
+    sub_issue_add_composite,
 )
 from meho_backplane.connectors.registry import clear_registry
 from meho_backplane.db.engine import get_sessionmaker
@@ -40,16 +43,49 @@ from meho_backplane.operations.typed_register import (
 )
 from meho_backplane.settings import get_settings
 
-_EXPECTED_OP_IDS: tuple[str, ...] = ("gh.composite.pr_status_summary",)
+_EXPECTED_OP_IDS: tuple[str, ...] = (
+    "gh.composite.pr_status_summary",
+    "gh.composite.project_view",
+    "gh.composite.project_item_add",
+    "gh.composite.project_item_set_field",
+    "gh.composite.sub_issue_add",
+)
 
 _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "gh.composite.pr_status_summary": (
         "meho_backplane.connectors.github.composites._read.pr_status_summary_composite"
     ),
+    "gh.composite.project_view": (
+        "meho_backplane.connectors.github.composites._board.project_view_composite"
+    ),
+    "gh.composite.project_item_add": (
+        "meho_backplane.connectors.github.composites._board.project_item_add_composite"
+    ),
+    "gh.composite.project_item_set_field": (
+        "meho_backplane.connectors.github.composites._board.project_item_set_field_composite"
+    ),
+    "gh.composite.sub_issue_add": (
+        "meho_backplane.connectors.github.composites._sub_issues.sub_issue_add_composite"
+    ),
 }
 
 _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "gh.composite.pr_status_summary": "pulls",
+    "gh.composite.project_view": "board",
+    "gh.composite.project_item_add": "board",
+    "gh.composite.project_item_set_field": "board",
+    "gh.composite.sub_issue_add": "issues",
+}
+
+# Governance posture per op: reads are safe, the three writes are caution;
+# none floors to requires_approval (board-hygiene writes -- see _board /
+# _sub_issues module docstrings).
+_EXPECTED_SAFETY_BY_OP: dict[str, str] = {
+    "gh.composite.pr_status_summary": "safe",
+    "gh.composite.project_view": "safe",
+    "gh.composite.project_item_add": "caution",
+    "gh.composite.project_item_set_field": "caution",
+    "gh.composite.sub_issue_add": "caution",
 }
 
 
@@ -104,10 +140,10 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 @pytest.mark.asyncio
-async def test_register_github_composite_operations_inserts_pr_status_summary(
+async def test_register_github_composite_operations_inserts_all_composites(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """The registrar lands ``gh.composite.pr_status_summary`` in ``endpoint_descriptor``."""
+    """The registrar lands every gh-rest composite (pr-status + board + sub-issue)."""
     await register_github_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -121,7 +157,7 @@ async def test_register_github_composite_operations_inserts_pr_status_summary(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    assert stub_embedding_service.encode_one.call_count == 1
+    assert stub_embedding_service.encode_one.call_count == len(_EXPECTED_OP_IDS)
 
 
 @pytest.mark.asyncio
@@ -289,10 +325,10 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_github_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 1 row persists; embedding stays at 1 (skip-re-embed)."""
+    """Running the registrar twice -> N rows persist; embeddings stay at N (skip-re-embed)."""
     await register_github_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 1
+    assert first_count == len(_EXPECTED_OP_IDS)
 
     await register_github_composite_operations(embedding_service=stub_embedding_service)
     assert stub_embedding_service.encode_one.call_count == first_count, (
@@ -310,7 +346,7 @@ async def test_register_github_composite_operations_is_idempotent(
             .scalars()
             .all()
         )
-    assert len(rows) == 1
+    assert len(rows) == len(_EXPECTED_OP_IDS)
 
 
 # ---------------------------------------------------------------------------
@@ -379,3 +415,146 @@ def test_handler_is_module_level_coroutine_function() -> None:
     assert inspect.iscoroutinefunction(pr_status_summary_composite)
     assert "<locals>" not in pr_status_summary_composite.__qualname__
     assert pr_status_summary_composite.__qualname__ != "<lambda>"
+
+
+# ---------------------------------------------------------------------------
+# #2081 board (Projects-v2) + sub-issue composites
+# ---------------------------------------------------------------------------
+
+_NEW_OP_IDS: tuple[str, ...] = (
+    "gh.composite.project_view",
+    "gh.composite.project_item_add",
+    "gh.composite.project_item_set_field",
+    "gh.composite.sub_issue_add",
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("op_id", _NEW_OP_IDS)
+async def test_new_composite_registers_with_expected_posture(
+    op_id: str,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Each #2081 composite lands as a ``composite`` row with the right posture (AC #1/#2/#3).
+
+    Asserts the descriptor is present (so ``list_operations`` / meta-tools
+    surface it), routed to the expected group, carries the canonical
+    module-level ``handler_ref``, the documented ``safety_level``, and
+    ``requires_approval=False`` -- the board-hygiene write posture.
+    """
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        descriptor = (
+            await fresh.execute(select(EndpointDescriptor).where(EndpointDescriptor.op_id == op_id))
+        ).scalar_one()
+        group = (
+            await fresh.execute(
+                select(OperationGroup).where(OperationGroup.id == descriptor.group_id)
+            )
+        ).scalar_one()
+    assert descriptor.source_kind == "composite"
+    assert descriptor.tenant_id is None
+    assert descriptor.is_enabled is True
+    assert descriptor.product == "gh"
+    assert descriptor.version == "3"
+    assert descriptor.impl_id == "gh-rest"
+    assert descriptor.handler_ref == _EXPECTED_HANDLER_REF_BY_OP[op_id]
+    assert descriptor.safety_level == _EXPECTED_SAFETY_BY_OP[op_id]
+    assert descriptor.requires_approval is False
+    assert group.group_key == _EXPECTED_GROUP_KEY_BY_OP[op_id]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("group_key", "op_id"),
+    [("board", "gh.composite.project_view"), ("issues", "gh.composite.sub_issue_add")],
+)
+async def test_new_groups_created_with_when_to_use(
+    group_key: str,
+    op_id: str,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The ``board`` and ``issues`` groups are created with a curated ``when_to_use`` (AC #3).
+
+    ``list_operation_groups`` surfaces ``when_to_use`` verbatim so an LLM
+    client can pick the right group before ``search_operations`` -- a
+    missing / placeholder blurb would defeat the group selector.
+    """
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        group = (
+            await fresh.execute(
+                select(OperationGroup).where(
+                    OperationGroup.group_key == group_key,
+                    OperationGroup.product == "gh",
+                    OperationGroup.impl_id == "gh-rest",
+                )
+            )
+        ).scalar_one()
+    assert group.review_status == "enabled"
+    assert isinstance(group.when_to_use, str) and group.when_to_use.strip()
+
+
+@pytest.mark.asyncio
+async def test_projectv2_and_sub_issue_ops_carry_discovery_tags(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Board ops tag ``projectv2``; the sub-issue op tags ``sub_issue`` (searchable surface)."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = {
+            row.op_id: row
+            for row in (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_NEW_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        }
+    assert "projectv2" in rows["gh.composite.project_item_add"].tags
+    assert "projectv2" in rows["gh.composite.project_item_set_field"].tags
+    assert "projectv2" in rows["gh.composite.project_view"].tags
+    assert "sub_issue" in rows["gh.composite.sub_issue_add"].tags
+
+
+@pytest.mark.asyncio
+async def test_new_write_ops_persist_additional_properties_false_params(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Write composites' parameter schemas round-trip with ``additionalProperties:false``."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = {
+            row.op_id: row
+            for row in (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_NEW_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        }
+    for op_id in _NEW_OP_IDS:
+        schema = dict(rows[op_id].parameter_schema)
+        assert schema["additionalProperties"] is False, op_id
+        assert schema["required"], op_id
+
+
+def test_new_handlers_are_module_level_coroutines() -> None:
+    """The #2081 handlers are module-level ``async def`` -- no closures / lambdas / partials."""
+    import inspect
+
+    for handler in (
+        project_view_composite,
+        project_item_add_composite,
+        project_item_set_field_composite,
+        sub_issue_add_composite,
+    ):
+        assert inspect.iscoroutinefunction(handler), handler
+        assert "<locals>" not in handler.__qualname__, handler
+        assert handler.__qualname__ != "<lambda>", handler

--- a/backend/tests/test_connectors_github_composites_register.py
+++ b/backend/tests/test_connectors_github_composites_register.py
@@ -522,10 +522,10 @@ async def test_projectv2_and_sub_issue_ops_carry_discovery_tags(
 
 
 @pytest.mark.asyncio
-async def test_new_write_ops_persist_additional_properties_false_params(
+async def test_new_ops_persist_additional_properties_false_params(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Write composites' parameter schemas round-trip with ``additionalProperties:false``."""
+    """Each #2081 composite's parameter schema round-trips with ``additionalProperties:false``."""
     await register_github_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:

--- a/backend/tests/test_connectors_github_composites_sub_issues.py
+++ b/backend/tests/test_connectors_github_composites_sub_issues.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for ``gh.composite.sub_issue_add`` (direct-session REST, #2081).
+
+The composite issues ``POST /repos/{owner}/{repo}/issues/{issue_number}/
+sub_issues`` through the resolved ``GitHubRestConnector`` session
+(``connector._post_json`` mounted through ``mount_op_path``). These tests
+drive the handler with a recording session stub -- no live GitHub.
+
+Coverage:
+
+* Happy path -- the write posts the mounted path with a
+  ``{"sub_issue_id": ...}`` body and returns the parent payload +
+  ``status="linked"``.
+* ``replace_parent`` is included in the body only when supplied.
+* A transport failure (``httpx.HTTPStatusError``) propagates for the
+  dispatcher's outer branch to classify.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import httpx
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.github.composites._sub_issues import sub_issue_add_composite
+
+
+def _make_operator() -> Operator:
+    """Synthetic operator for composite-handler unit tests."""
+    return Operator(
+        sub="op-gh-sub-issue",
+        name="GH Sub-Issue Composite Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000c0c0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _http_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build an ``httpx.HTTPStatusError`` the way ``raise_for_status`` would."""
+    request = httpx.Request("POST", "https://api.github.com/x")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(f"http_{status_code}", request=request, response=response)
+
+
+class _RecordingConnector:
+    """Session stub matching the subset of ``GitHubRestConnector`` the handler uses."""
+
+    def __init__(self, response: Any) -> None:
+        self._response = response
+        self.post_calls: list[dict[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return path
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> Any:
+        self.post_calls.append({"path": path, "verb": verb, "json": json})
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_sub_issue_add_posts_database_id_body() -> None:
+    """The write posts the mounted path with a ``{"sub_issue_id": ...}`` body."""
+    parent_payload = {"number": 100, "sub_issues_summary": {"total": 1}}
+    connector = _RecordingConnector(parent_payload)
+    result = await sub_issue_add_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "repo": "meho", "issue_number": 100, "sub_issue_id": 987654},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    call = connector.post_calls[0]
+    assert call["path"] == "/repos/evoila/meho/issues/100/sub_issues"
+    assert call["verb"] == "POST"
+    assert call["json"] == {"sub_issue_id": 987654}
+    assert result == {
+        "parent": parent_payload,
+        "parent_number": 100,
+        "sub_issue_id": 987654,
+        "status": "linked",
+    }
+
+
+@pytest.mark.asyncio
+async def test_sub_issue_add_includes_replace_parent_when_set() -> None:
+    """``replace_parent`` is added to the body only when the caller passes it."""
+    connector = _RecordingConnector({"number": 100})
+    await sub_issue_add_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "owner": "evoila",
+            "repo": "meho",
+            "issue_number": 100,
+            "sub_issue_id": 5,
+            "replace_parent": True,
+        },
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert connector.post_calls[0]["json"] == {"sub_issue_id": 5, "replace_parent": True}
+
+
+@pytest.mark.asyncio
+async def test_sub_issue_add_omits_replace_parent_by_default() -> None:
+    """Without ``replace_parent`` the body carries only ``sub_issue_id``."""
+    connector = _RecordingConnector({"number": 100})
+    await sub_issue_add_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "repo": "meho", "issue_number": 100, "sub_issue_id": 5},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert "replace_parent" not in connector.post_calls[0]["json"]
+
+
+@pytest.mark.asyncio
+async def test_sub_issue_add_propagates_http_error() -> None:
+    """A 422 (already-parented / cross-owner) propagates for the dispatcher to map."""
+    connector = _RecordingConnector(_http_error(422))
+    with pytest.raises(httpx.HTTPStatusError):
+        await sub_issue_add_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"owner": "evoila", "repo": "meho", "issue_number": 100, "sub_issue_id": 5},
+            connector=connector,  # type: ignore[arg-type]
+        )

--- a/backend/tests/test_github_board_composite_flow.py
+++ b/backend/tests/test_github_board_composite_flow.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end 'file a board-complete ticket' flow (#2081, AC #4).
+
+Proves an agent can file a board-complete ticket through MEHO's own
+dispatch surface -- **without a ``gh`` CLI fallback** -- by composing the
+four #2081 composites in the documented order:
+
+    create issue -> add to Projects-v2 board -> set Status field
+                 -> link a sub-issue
+
+Every step runs against **one shared connector session stub** (the
+#2255 direct-session substrate): the create is the connector's live REST
+POST, the board reads/writes are the GraphQL composites, and the
+sub-issue link is the REST composite. Nothing shells out to ``gh`` -- the
+whole flow is connector-session calls, which is the point of the Task.
+
+Deterministic (mocked upstream) so it runs in the default unit lane
+(``tests/integration`` is ignored there); the live-GitHub smoke variant
+of the pr-status composite lives under ``tests/integration``.
+
+The load-bearing assertions are the *threading* ones: the board node id
+from ``project_view`` flows into the add + set-field mutations, and the
+sub-issue link uses the child's **database id** (from the create
+response) rather than its issue number -- the sub_issue_id gotcha.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.github.composites._board import (
+    project_item_add_composite,
+    project_item_set_field_composite,
+    project_view_composite,
+)
+from meho_backplane.connectors.github.composites._sub_issues import sub_issue_add_composite
+
+_OWNER = "evoila"
+_REPO = "meho"
+_PROJECT_NUMBER = 19
+
+
+def _make_operator() -> Operator:
+    """Human operator -- auto-executes ``caution`` board writes (board-complete filing)."""
+    return Operator(
+        sub="op-gh-board-flow",
+        name="GH Board Flow Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000d0d0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+_PROJECT_VIEW_RESPONSE: dict[str, Any] = {
+    "data": {
+        "organization": {
+            "projectV2": {
+                "id": "PVT_board",
+                "title": "MEHO Board",
+                "fields": {
+                    "nodes": [
+                        {
+                            "__typename": "ProjectV2SingleSelectField",
+                            "id": "F_status",
+                            "name": "Status",
+                            "dataType": "SINGLE_SELECT",
+                            "options": [
+                                {"id": "opt_todo", "name": "Todo"},
+                                {"id": "opt_in_progress", "name": "In Progress"},
+                            ],
+                        }
+                    ]
+                },
+                "items": {"totalCount": 0, "nodes": []},
+            }
+        }
+    }
+}
+
+
+class _BoardFlowConnector:
+    """One connector session stub routing every step of the board-complete flow.
+
+    Routes ``_post_json`` by wire path (and, for ``/graphql``, by the
+    mutation named in the document). Records every call in order so the
+    test can assert the four steps fired against the connector session --
+    never a ``gh`` subprocess.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        # Sequential create-issue responses: the main ticket, then the child.
+        self._create_queue: list[dict[str, Any]] = [
+            {"id": 500, "node_id": "I_kwMAIN", "number": 100},
+            {"id": 555, "node_id": "I_kwCHILD", "number": 200},
+        ]
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return path
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> Any:
+        self.calls.append({"path": path, "verb": verb, "json": json})
+        return self._route(path, json or {})
+
+    def _route(self, path: str, body: dict[str, Any]) -> Any:
+        if path == "/graphql":
+            return self._route_graphql(body.get("query", ""))
+        if path.endswith("/sub_issues"):
+            return {"number": 100, "sub_issues_summary": {"total": 1, "completed": 0}}
+        if path.endswith("/issues"):
+            return self._create_queue.pop(0)
+        raise AssertionError(f"unexpected REST path in board flow: {path!r}")
+
+    @staticmethod
+    def _route_graphql(query: str) -> Any:
+        if "projectV2(number:" in query:
+            return _PROJECT_VIEW_RESPONSE
+        if "addProjectV2ItemById" in query:
+            return {"data": {"addProjectV2ItemById": {"item": {"id": "PVTI_main"}}}}
+        if "updateProjectV2ItemFieldValue" in query:
+            return {
+                "data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "PVTI_main"}}}
+            }
+        raise AssertionError(f"unexpected graphql document in board flow: {query!r}")
+
+
+@pytest.mark.asyncio
+async def test_file_board_complete_ticket_without_gh_cli() -> None:
+    """create -> add-to-board -> set-Status -> link-sub-issue, all via the connector session."""
+    operator = _make_operator()
+    target = object()
+    connector = _BoardFlowConnector()
+
+    # ----- Step 1: create the main ticket + a child issue (live REST op) -----
+    main = await connector._post_json(
+        target, f"/repos/{_OWNER}/{_REPO}/issues", operator=operator, json={"title": "Main ticket"}
+    )
+    child = await connector._post_json(
+        target, f"/repos/{_OWNER}/{_REPO}/issues", operator=operator, json={"title": "Child task"}
+    )
+    assert main["node_id"] == "I_kwMAIN"
+    assert child["id"] == 555  # the DATABASE id -- distinct from its number (200)
+
+    # ----- Step 2: read the board (project id + Status field + its options) -----
+    board = await project_view_composite(
+        operator=operator,
+        target=target,
+        params={"owner": _OWNER, "project_number": _PROJECT_NUMBER},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    project_id = board["project_id"]
+    status_field = next(f for f in board["fields"] if f["name"] == "Status")
+    todo_option = next(o for o in status_field["options"] if o["name"] == "Todo")
+    assert project_id == "PVT_board"
+
+    # ----- Step 3: add the main ticket to the board (by content node id) -----
+    added = await project_item_add_composite(
+        operator=operator,
+        target=target,
+        params={"project_id": project_id, "content_id": main["node_id"]},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert added["status"] == "added"
+    item_id = added["item_id"]
+
+    # ----- Step 4: set the Status field on the new board item -----
+    field_set = await project_item_set_field_composite(
+        operator=operator,
+        target=target,
+        params={
+            "project_id": project_id,
+            "item_id": item_id,
+            "field_id": status_field["id"],
+            "option_id": todo_option["id"],
+        },
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert field_set["status"] == "updated"
+
+    # ----- Step 5: link the child as a sub-issue of the main ticket -----
+    linked = await sub_issue_add_composite(
+        operator=operator,
+        target=target,
+        params={
+            "owner": _OWNER,
+            "repo": _REPO,
+            "issue_number": main["number"],
+            "sub_issue_id": child["id"],
+        },
+        connector=connector,  # type: ignore[arg-type]
+    )
+    assert linked["status"] == "linked"
+
+    # ----- The flow used only the connector session, in the documented order -----
+    wire = [(c["path"], c["verb"]) for c in connector.calls]
+    assert wire == [
+        (f"/repos/{_OWNER}/{_REPO}/issues", "POST"),
+        (f"/repos/{_OWNER}/{_REPO}/issues", "POST"),
+        ("/graphql", "POST"),
+        ("/graphql", "POST"),
+        ("/graphql", "POST"),
+        (f"/repos/{_OWNER}/{_REPO}/issues/100/sub_issues", "POST"),
+    ]
+
+    # ----- Node-id / database-id threading is correct across the steps -----
+    add_call = connector.calls[3]
+    assert add_call["json"]["variables"] == {"projectId": "PVT_board", "contentId": "I_kwMAIN"}
+    set_field_call = connector.calls[4]
+    assert set_field_call["json"]["variables"]["fieldId"] == "F_status"
+    assert set_field_call["json"]["variables"]["optionId"] == "opt_todo"
+    sub_issue_call = connector.calls[5]
+    # The link uses the child's DATABASE id (555), never its issue number (200).
+    assert sub_issue_call["json"] == {"sub_issue_id": 555}

--- a/docs/codebase/connectors-github.md
+++ b/docs/codebase/connectors-github.md
@@ -27,9 +27,9 @@ multiple L2 sub-ops into one governed call. T4 ships the first one,
 `backend/src/meho_backplane/connectors/vmware_rest/composites/`:
 
 - **`composites/_register.py`** — `_COMPOSITES` tuple and the
-  `register_github_composite_operations` async registrar. T4 ships
-  exactly one row; future T7+ Tasks add `release_health`,
-  `board_snapshot`, etc., on the same pattern.
+  `register_github_composite_operations` async registrar. T4 shipped one
+  row (`pr_status_summary`); #2081 adds four more (the board + sub-issue
+  composites — see below), all on the same pattern.
 - **`composites/_read.py`** — module-level `async def` handlers. The
   handler `pr_status_summary_composite` declares a `connector` parameter
   and issues its three reads through the resolved `GitHubRestConnector`'s
@@ -99,6 +99,73 @@ than xfail-strict. (The separate T3 catalog-ingest parser dependency —
 the G0.7 OpenAPI parser not inlining `#/components/responses/*` refs —
 still applies to the ~700 ingested L2 ops, but is orthogonal to this
 composite now that it reads through the session directly.)
+
+### Board (Projects-v2) + sub-issue composites (#2081)
+
+`#2081` adds four composites so an agent can file a **board-complete
+ticket** through MEHO — create issue → add to a Projects-v2 board → set
+its Status/Priority field → link a sub-issue — without dropping to the
+`gh` CLI. All four use the same #2255 direct-session substrate (declare a
+`connector` parameter, call the connector's own session, no
+`endpoint_descriptor` lookup), so they work on a fresh deploy with zero
+gh catalog ingest.
+
+- **`composites/_graphql.py`** — shared GraphQL transport. GitHub's
+  Projects-v2 surface is GraphQL-only, so the board composites POST
+  documents to `/graphql` via `connector._post_json`. GitHub returns
+  **HTTP 200 even on query errors** (a bad node id / missing scope comes
+  back as `200` with a non-empty `errors` array), which
+  `raise_for_status` cannot catch; `github_graphql()` inspects the parsed
+  body, raises `GitHubGraphQlError` on `errors` (or missing `data`), and
+  returns the unwrapped `data`. Every dynamic value rides the GraphQL
+  `variables` map (injection-safe); only the `organization`/`user` root
+  selector is composed from a closed literal map keyed off the validated
+  `owner_type` enum.
+- **`composites/_board.py`** — the three `board`-group composites:
+  - `gh.composite.project_view` (read) — one GraphQL round-trip returns
+    the board's node id, its fields (single-select fields carry their
+    `options {id name}`), and its items. This is the ergonomic linchpin:
+    it hands back the `project_id` / `field_id` / `option_id` node ids the
+    two writes consume, so an agent never shells out to `gh project` to
+    discover them.
+  - `gh.composite.project_item_add` (write) — `addProjectV2ItemById`.
+  - `gh.composite.project_item_set_field` (write) —
+    `updateProjectV2ItemFieldValue` with a `singleSelectOptionId` value.
+- **`composites/_sub_issues.py`** — the one `issues`-group composite,
+  `gh.composite.sub_issue_add` (write), wrapping
+  `POST /repos/{owner}/{repo}/issues/{issue_number}/sub_issues`.
+  **`sub_issue_id` is the child's database `id`, not its issue number** —
+  the REST create-issue response carries that id; passing the number is
+  the obvious mistake, so the schema and docstring both call it out. The
+  sub-issue must share the parent's repository owner.
+
+**Governance posture.** `project_view` is `safety_level="safe"`; the
+three writes are `safety_level="caution"`, all four
+`requires_approval=False`. Adding a card to a board / setting a status
+field / linking a sub-issue are low-blast-radius, reversible
+board-hygiene mutations — honestly a write, but not `dangerous` like the
+vmware VM-delete composites. Each is a **single** logical mutation, so
+the composite is the reviewed unit: the dispatcher runs `policy_gate`
+against the composite's own descriptor before invoking the handler, which
+fully governs the one write it performs. Unlike the multi-write vmware
+composites there is no heterogeneous internal write sub-op to protect, so
+these do **not** call `enforce_subop_policy` (that seam re-gates
+*additional* writes a direct-session composite fans out to). Under this
+posture a human/service operator auto-executes a board write
+(board-complete filing without a `gh` CLI fallback), while an agent
+principal routes to the approval queue via the `caution` safety default —
+exactly the governance a raw CLI fallback would bypass.
+
+**End-to-end acceptance.**
+`backend/tests/test_github_board_composite_flow.py` drives the full
+create → add-to-board → set-Status → link-sub-issue sequence against one
+shared connector-session stub (deterministic, runs in the default unit
+lane), asserting the board node id threads from `project_view` into the
+add + set-field mutations and that the sub-issue link uses the child's
+database id rather than its number. Per-handler unit tests live in
+`test_connectors_github_composites_board.py` /
+`test_connectors_github_composites_sub_issues.py`; registration/posture
+assertions are in `test_connectors_github_composites_register.py`.
 
 ## Key types
 


### PR DESCRIPTION
## Summary

- Adds four direct-session composites to the `gh-rest` connector so an agent can file a **board-complete ticket** through MEHO's dispatch path (auth + policy + audit + JSONFlux + broadcast) instead of dropping to the `gh` CLI: `gh.composite.project_view` (read), `gh.composite.project_item_add`, `gh.composite.project_item_set_field` (Projects-v2 GraphQL writes), and `gh.composite.sub_issue_add` (sub-issue linkage REST write).
- Projects-v2 is GraphQL-only, so a shared `_graphql.py` helper POSTs to `/graphql` and raises `GitHubGraphQlError` on the `errors` array GitHub returns with **HTTP 200** (which `raise_for_status` cannot see). All dynamic values ride the GraphQL `variables` map (injection-safe); only the `organization`/`user` root selector is composed from a closed literal map.
- `project_view` is the ergonomic linchpin — one GraphQL round-trip returns the board node id, its fields (single-select fields carry their `options {id name}`), and its items, i.e. the `project_id` / `field_id` / `option_id` node ids the two writes consume, so an agent never shells out to `gh project` to discover them.
- Governance: `project_view` is `safety_level="safe"`; the three writes are `safety_level="caution"` / `requires_approval=False`. Each is a **single** logical mutation, so the composite is the reviewed unit (the dispatcher gates it before the handler runs) — no `enforce_subop_policy` seam, which exists to re-gate the heterogeneous multi-write vmware composites. A human/service operator auto-executes a board write; an agent routes to approval via the `caution` default — exactly the governance a raw CLI fallback bypasses.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on all changed files
- [x] `mypy src/meho_backplane/connectors/github/` — no issues (10 files)
- [x] `pytest` — new suites (`..._composites_board`, `..._composites_sub_issues`, `test_github_board_composite_flow`) + extended `..._composites_register` = 61 passed; regression sweep over composite / typed_register / two-world-invariant / dispatcher = 333 passed, 1 skipped
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] **AC1** — three board ops present under `connectors/github/`; `grep -riE "graphql|projectv2"` now matches (`_graphql.py`, `_board.py`, `schemas.py`, `_register.py`)
- [x] **AC2** — `gh.composite.sub_issue_add` registered under `gh-rest-3`; `grep -ri sub_issue` now matches (`_sub_issues.py`, `_register.py`, `schemas.py`)
- [x] **AC3** — all four ops register via `register_composite_operation` with `group_key` (`board` / `issues`) + curated `when_to_use`, so `list_operation_groups` / `search_operations` surface them (asserted in the register test)
- [x] **AC4** — `backend/tests/test_github_board_composite_flow.py` drives create → add-to-board → set-Status → link-sub-issue end-to-end against one connector session (deterministic, runs in the default unit lane), asserting node-id threading and the sub-issue database-id-not-number contract
- [x] **AC5** — `cd cli && make snapshot-openapi && make generate` produces **no diff**: connector composites dispatch through the stable `call_operation` meta-tool, not per-op FastAPI routes, so the OpenAPI/CLI surface is unchanged (freshness lane verified green)

## Out of scope

- Iteration / text / number / date field setters (only single-select is in the AC; the GraphQL value shape generalises later on the same pattern).
- GHES (`/api/graphql` mount) — the connector is github.com-only by existing scope.
- Adjacent finding (not touched, pre-existing): `docs/codebase/connectors-github.md` references `composites/_preflight.py`, which no longer exists in the package (retired earlier).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2081


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub Projects support for viewing boards, adding issues or pull requests, and updating single-select fields.
  * Added support for linking issues as sub-issues, with optional parent replacement.
  * Added validation and clear error handling for GitHub GraphQL and REST operations.

* **Documentation**
  * Updated GitHub connector documentation with the new board and sub-issue capabilities.

* **Tests**
  * Added comprehensive coverage for board workflows, sub-issue linking, registration, and end-to-end operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->