### PR TITLE
fix(scheduler): self-heal the Vault credential so background features survive unattended (#2668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,31 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — scheduler self-heals its Vault credential so background features survive unattended (#2668)
+
+- The scheduler authenticates to Vault with a **static periodic token**
+  (`VAULT_SCHEDULER_TOKEN`) that has died in the field, after which every
+  Vault-first credential read 403s and the scheduler **silently skips its
+  fires**. The broker previously *detected* a dead token but could not
+  recover without an operator re-minting one. It now **self-heals**: on a
+  `lookup-self`-confirmed dead token it mints a fresh Vault token by
+  `jwt_login` as the runner principal (runner JWT + `VAULT_CHECK_RUNNER_ROLE`,
+  falling back to `VAULT_OIDC_ROLE`) and retries the failed read/write once —
+  no operator, no sidecar in the loop. If the re-mint *itself* fails it falls
+  back to the existing loud failure, never a silent skip.
+- **Renewal moved onto a timer.** `auth/token/renew-self` previously fired
+  only on agent-secret read/write traffic, so an *idle* scheduler never
+  renewed and aged its periodic token out. A dedicated tick-loop cadence now
+  renews independent of traffic; the on-use renew stays as a cheap extra.
+- **Periodic guard.** Startup and the hourly `lookup-self` now log a loud
+  `ERROR` (`scheduler_vault_token_will_expire`) when the token is
+  non-renewable or carries an `explicit_max_ttl` — it will die despite
+  renewal, so it must be minted `-period=768h`.
+- The headless `client_credentials` → runner-JWT → Vault `jwt_login` mint
+  (no interactive session) is documented in
+  `docs/cross-repo/vault-provisioning.md` for adopters whose scheduled
+  dispatch has no durable identity.
+
 ### Added — check-runner can use a dedicated Vault JWT role (`VAULT_CHECK_RUNNER_ROLE`) (#2757)
 
 - The in-process check-runner's **background dispatch** can now log in to

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -196,6 +196,17 @@ _CLAIM_BATCH_LIMIT: int = 50
 #: alive) runs at tick frequency; this is only the visibility backstop.
 _TOKEN_CHECK_INTERVAL_SECONDS: float = 3600.0
 
+#: Dedicated cadence (seconds) for the scheduler Vault-token
+#: ``auth/token/renew-self`` (#2668). Renewal used to ride only on
+#: agent-secret read/write traffic (``_maybe_renew_scheduler_token``), so an
+#: *idle* scheduler -- no agent-secret reads for longer than the token's
+#: ``period`` -- never renewed and aged its periodic token out. This timer
+#: renews independent of traffic. Hourly is far more frequent than any sane
+#: token ``period`` (the documented mint is ``-period=768h``); the on-use
+#: renew still covers a busy scheduler at tick frequency, so this is the
+#: idle-scheduler backstop.
+_TOKEN_RENEW_INTERVAL_SECONDS: float = 3600.0
+
 
 #: Consecutive precondition-skips a trigger tolerates before the loop
 #: parks it (``status='paused'``) with its ``last_skip_reason`` (#2327).
@@ -953,6 +964,29 @@ async def _check_scheduler_vault_token(*, reason: str) -> None:
         _log.warning("scheduler_vault_token_check_errored", reason=reason, exc_info=True)
 
 
+async def _renew_scheduler_vault_token(*, reason: str) -> None:
+    """Renew the scheduler Vault token on a dedicated cadence (#2668).
+
+    Thin, never-raising wrapper around
+    :func:`~meho_backplane.scheduler.vault_credentials.renew_scheduler_token`
+    so a renewal (which reaches Vault) can never stall or crash the tick
+    loop. Approach item 2: this dedicated timer keeps an *idle* scheduler's
+    periodic token alive independent of agent-secret traffic; the on-use
+    renew inside the broker stays as a cheap extra for a busy scheduler.
+    ``renew_scheduler_token`` already swallows Vault errors loudly; this only
+    guards against an unexpected error escaping it. An unconfigured token is
+    a silent no-op there (the documented env-var-fallback opt-out).
+    """
+    from meho_backplane.scheduler.vault_credentials import renew_scheduler_token
+
+    try:
+        await renew_scheduler_token(reason=reason)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        _log.warning("scheduler_vault_token_renew_errored", reason=reason, exc_info=True)
+
+
 async def _scheduler_loop() -> None:
     """The forever loop: reconcile once, then sleep one cadence, tick, repeat.
 
@@ -965,7 +999,10 @@ async def _scheduler_loop() -> None:
     A Vault-token ``lookup-self`` runs once at startup and then on a
     slow cadence (:data:`_TOKEN_CHECK_INTERVAL_SECONDS`) so a dead
     scheduler token surfaces as a loud log within minutes rather than
-    weeks (#2328).
+    weeks (#2328). A dedicated ``renew-self`` timer
+    (:data:`_TOKEN_RENEW_INTERVAL_SECONDS`, #2668) renews the token
+    independent of agent-secret traffic, so an idle scheduler never ages
+    its periodic token out.
     """
     interval = get_settings().scheduler_tick_interval_seconds
     _log.info("scheduler_started", interval_seconds=interval)
@@ -979,7 +1016,9 @@ async def _scheduler_loop() -> None:
         _log.warning("scheduler_event_reconcile_failed", exc_info=True)
 
     await _check_scheduler_vault_token(reason="startup")
+    await _renew_scheduler_vault_token(reason="startup")
     last_token_check = time.monotonic()
+    last_token_renew = time.monotonic()
     while True:
         # Sleep first so the very first tick does not race the rest of
         # the lifespan startup; CancelledError here unwinds cleanly.
@@ -993,6 +1032,11 @@ async def _scheduler_loop() -> None:
         if time.monotonic() - last_token_check >= _TOKEN_CHECK_INTERVAL_SECONDS:
             last_token_check = time.monotonic()
             await _check_scheduler_vault_token(reason="periodic")
+        # Dedicated renewal timer (#2668): renew independent of agent-secret
+        # traffic so an idle scheduler still keeps its periodic token alive.
+        if time.monotonic() - last_token_renew >= _TOKEN_RENEW_INTERVAL_SECONDS:
+            last_token_renew = time.monotonic()
+            await _renew_scheduler_vault_token(reason="periodic")
 
 
 def start_scheduler() -> asyncio.Task[None]:

--- a/backend/src/meho_backplane/scheduler/vault_credentials.py
+++ b/backend/src/meho_backplane/scheduler/vault_credentials.py
@@ -46,35 +46,48 @@ The secret payload shape is ``{"client_secret": "<value>"}``. No secret
 value ever enters a log event or an error message — only the path and
 the field *name* do.
 
-Token lifetime — renew-on-use + self-lookup (#2328)
-===================================================
+Token lifetime — renew, self-lookup, and self-heal (#2328, #2668)
+================================================================
 
 The documented scheduler token is a Vault **periodic** token
 (``-period=768h`` in the onboarding guidance). A periodic token expires
 ``period`` after its *last renewal*, so a long-running scheduler that
 never renews carries a built-in ~32-day fuse: once it blows, every
-Vault-first read returns 403 and the scheduler silently skips. Two
-mechanisms defuse it here:
+Vault-first read returns 403 and the scheduler silently skips. Four
+mechanisms keep the credential alive — and the failure survivable when
+it dies anyway:
 
 * :func:`_maybe_renew_scheduler_token` fires a best-effort
   ``auth/token/renew-self`` after every successful read/write, at
-  scheduler-tick frequency, so a periodic token with any sane
-  ``period`` never expires while the process runs. A failed renewal is
-  logged and swallowed — the read/write it follows already succeeded.
+  scheduler-tick frequency, so a *busy* periodic token never expires. A
+  failed renewal is logged and swallowed — the read/write it follows
+  already succeeded.
+* :func:`renew_scheduler_token` is that same renew on a **dedicated
+  tick-loop cadence** (#2668), so an *idle* scheduler — no agent-secret
+  traffic for longer than ``period`` — still renews independent of
+  read/write traffic. The on-use renew stays as a cheap extra.
 * :func:`verify_scheduler_token` runs ``auth/token/lookup-self`` at
-  scheduler startup and on a slow cadence from the tick loop. It does
-  not fix the fuse — it shortens time-to-notice from weeks to minutes
-  by logging a dead/unreachable token as a loud ``ERROR``. Sibling
-  #2327 consumes the same signal for its ``/ready features.scheduler``
-  skip-state surface.
+  startup and on a slow cadence, logging a dead/unreachable token as a
+  loud ``ERROR`` and — the periodic guard (#2668) — a loud ``ERROR``
+  when the token is non-renewable or carries an ``explicit_max_ttl``
+  (it will die despite renewal). Sibling #2327 consumes the status for
+  its ``/ready features.scheduler`` skip-state surface.
+* :func:`_remint_scheduler_client` **self-heals** (#2668): when a read
+  or write draws a 403 that ``lookup-self`` confirms is a dead token,
+  the broker mints a fresh Vault token by ``jwt_login`` as the runner
+  principal (:func:`~meho_backplane.auth.runner_identity.check_runner_jwt`
+  + ``role = vault_check_runner_role or vault_oidc_role``, the #2757
+  fallback) and retries the failed operation **once** against it — no
+  operator, no sidecar in the loop. Only when the re-mint *itself* fails
+  does the broker fall back to the loud failure below.
 
-The same ``lookup-self`` primitive also disambiguates the *write*
-failure path (#2652): a dead token and a live token on an under-scoped
-policy both draw a **403**, but the fixes are opposites (re-mint vs.
-widen the policy). :func:`write_agent_secret` probes
-:func:`_scheduler_token_rejected` on that 403 — and only that 403 — and
+The ``lookup-self`` probe still disambiguates that 403 (#2652): a dead
+token and a live token on an under-scoped policy both draw a **403**,
+but the fixes are opposites (self-heal / re-mint vs. widen the policy).
+:func:`_execute_with_self_heal` probes :func:`_scheduler_token_rejected`
+on that 403 — and only that 403 — attempts the self-heal above, and
 stamps ``token_invalid`` on the raised
-:class:`SchedulerVaultBrokerError`. Diagnosis only: no retry.
+:class:`SchedulerVaultBrokerError` only when it could not heal.
 
 The token is resolved from its live source on **every** use
 (:func:`_current_scheduler_token`) rather than frozen at process start,
@@ -85,6 +98,7 @@ so a Vault-Agent sidecar (or an operator) that re-mints the token into
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -93,7 +107,8 @@ import hvac.exceptions
 import requests.exceptions
 import structlog
 
-from meho_backplane.auth.vault import _build_client
+from meho_backplane.auth.runner_identity import check_runner_jwt
+from meho_backplane.auth.vault import VaultClientError, _build_client, _to_thread_jwt_login
 from meho_backplane.settings import Settings, get_settings
 
 __all__ = [
@@ -104,6 +119,7 @@ __all__ = [
     "SchedulerVaultBrokerError",
     "SchedulerVaultNotConfiguredError",
     "read_agent_secret",
+    "renew_scheduler_token",
     "split_kv_v2_api_path",
     "vault_path_for_client_id",
     "verify_scheduler_token",
@@ -313,6 +329,172 @@ async def _maybe_renew_scheduler_token(client: hvac.Client) -> None:
     _log.debug("scheduler_vault_token_renewed")
 
 
+async def renew_scheduler_token(*, reason: str = "periodic") -> None:
+    """Renew the scheduler's periodic Vault token on a dedicated cadence (#2668).
+
+    Approach item 2: renewal is lifted off the read/write hot path onto a
+    dedicated tick-loop timer (:mod:`meho_backplane.scheduler.loop`) so an
+    **idle** scheduler — one with no agent-secret reads for longer than the
+    token's ``period`` — still renews and never ages out. The on-use renew in
+    :func:`read_agent_secret` / :func:`write_agent_secret` stays as a cheap
+    extra for a busy scheduler.
+
+    Never raises. An unconfigured token (the documented env-var-fallback
+    opt-out) or a Vault-unconfigured install returns quietly; a renewal that
+    reaches Vault and fails is logged loudly by
+    :func:`_maybe_renew_scheduler_token`. Issues **no** read or write — the
+    renewal is independent of agent-secret traffic by construction. No token
+    value ever enters a log event.
+    """
+    settings = get_settings()
+    token = _current_scheduler_token(settings)
+    if not token:
+        return
+    try:
+        client = _build_client(settings, token=token)
+    except VaultClientError as exc:
+        _log.error(
+            "scheduler_vault_token_renew_unconfigured",
+            reason=type(exc).__name__,
+            check=reason,
+        )
+        return
+    await _maybe_renew_scheduler_token(client)
+
+
+async def _remint_scheduler_client(settings: Settings) -> hvac.Client | None:
+    """Self-heal a dead scheduler token: mint a fresh Vault client (#2668).
+
+    Approach item 1. Reuses the runner-principal identity (#2642) and the
+    check-runner Vault role (#2757) — **no scheduler-specific role knob**:
+    mint the runner's OAuth token
+    (:func:`~meho_backplane.auth.runner_identity.check_runner_jwt`), then
+    ``jwt_login`` under ``role = vault_check_runner_role or vault_oidc_role``
+    (the same fallback #2757 shipped for the check-runner dispatch operator).
+
+    Fail-closed: returns ``None`` — never raises, never a half-built client —
+    when the runner principal is unconfigured (empty JWT), no role resolves,
+    Vault is unconfigured, or the login is refused. The caller then falls back
+    to the loud-fail path so a dead credential is never silently no-op'd. No
+    secret, JWT, or token value ever enters a log event — only the failure
+    reason class and which role source was used.
+    """
+    jwt = await check_runner_jwt()
+    if not jwt:
+        _log.error("scheduler_vault_remint_unavailable", reason="runner_identity_unconfigured")
+        return None
+    role = settings.vault_check_runner_role or settings.vault_oidc_role
+    if not role:
+        _log.error("scheduler_vault_remint_unavailable", reason="no_vault_role")
+        return None
+    try:
+        client = _build_client(settings)
+        await _to_thread_jwt_login(
+            client,
+            role=role,
+            jwt=jwt,
+            mount_path=settings.vault_oidc_mount_path,
+        )
+    except (
+        VaultClientError,
+        hvac.exceptions.VaultError,
+        requests.exceptions.RequestException,
+    ) as exc:
+        _log.error("scheduler_vault_remint_failed", reason=type(exc).__name__)
+        return None
+    _log.info(
+        "scheduler_vault_reminted",
+        role_source="check_runner_role" if settings.vault_check_runner_role else "oidc_role",
+    )
+    return client
+
+
+async def _execute_with_self_heal[T](
+    settings: Settings,
+    operation: Callable[[hvac.Client], T],
+    *,
+    check: str,
+    api_path: str,
+) -> tuple[T, hvac.Client]:
+    """Run *operation* under the scheduler token; self-heal a dead token once.
+
+    The single execution seam for both :func:`read_agent_secret` and
+    :func:`write_agent_secret` (#2668). *operation* is a callable taking an
+    hvac client and performing the KV read/write; it is offloaded to a worker
+    thread. Returns ``(payload, client)`` where *client* is the token that
+    actually succeeded — the original, or the re-minted one — so the caller
+    renews the right token.
+
+    Failure mapping (fail-loud, never silent):
+
+    * Vault unreachable → :class:`SchedulerVaultBrokerError` (``token_invalid``
+      stays ``False`` — an outage is not a dead token).
+    * 403 + ``lookup-self`` says the token is **live** (under-scoped policy) →
+      :class:`SchedulerVaultBrokerError` with ``token_invalid=False``.
+    * 403 + ``lookup-self`` confirms the token is **dead** → self-heal via
+      :func:`_remint_scheduler_client` and retry *operation* once; on success
+      return the healed result. If the re-mint or the retry fails, raise
+      :class:`SchedulerVaultBrokerError` with ``token_invalid=True`` (today's
+      loud-fail behaviour).
+    * Any other Vault status (sealed/500/502/429) → describes Vault, not the
+      token → :class:`SchedulerVaultBrokerError`, ``token_invalid=False``.
+    * :class:`hvac.exceptions.InvalidPath` (KV-v2 404) propagates unwrapped so
+      :func:`read_agent_secret` can map it to its "not in Vault" ``None``.
+    """
+    client = _scheduler_client(settings)
+    try:
+        return await asyncio.to_thread(operation, client), client
+    except hvac.exceptions.InvalidPath:
+        raise
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+        raise SchedulerVaultBrokerError(
+            f"vault unreachable for {check} at {api_path!r}: {type(exc).__name__}"
+        ) from exc
+    except hvac.exceptions.Forbidden as exc:
+        # 403 is the one ambiguous rejection: a dead token and a live-but-
+        # under-scoped policy look identical, yet the remediations are
+        # opposites. Split them with one ``lookup-self`` on the *same* client
+        # that just failed (#2652), then self-heal a confirmed-dead token
+        # rather than only diagnosing it (#2668).
+        token_invalid = await _scheduler_token_rejected(client, check=check)
+        if not token_invalid:
+            raise SchedulerVaultBrokerError(
+                f"vault rejected {check} at {api_path!r}: {type(exc).__name__}",
+                token_invalid=False,
+            ) from exc
+        _log.error("scheduler_vault_token_dead", reason=type(exc).__name__, check=check)
+        healed = await _remint_scheduler_client(settings)
+        if healed is None:
+            # Re-mint unavailable/refused — fall back to today's loud fail so
+            # the dead credential surfaces instead of silently skipping.
+            raise SchedulerVaultBrokerError(
+                f"vault rejected {check} at {api_path!r}: {type(exc).__name__}",
+                token_invalid=True,
+            ) from exc
+        try:
+            payload = await asyncio.to_thread(operation, healed)
+        except hvac.exceptions.InvalidPath:
+            # A missing path on the healed client is a legitimate result for a
+            # read, not a heal failure — let the caller map it to ``None``.
+            raise
+        except (requests.exceptions.RequestException, hvac.exceptions.VaultError) as retry_exc:
+            _log.error(
+                "scheduler_vault_self_heal_retry_failed",
+                reason=type(retry_exc).__name__,
+                check=check,
+            )
+            raise SchedulerVaultBrokerError(
+                f"vault rejected {check} at {api_path!r} after re-mint: {type(retry_exc).__name__}",
+                token_invalid=True,
+            ) from retry_exc
+        _log.info("scheduler_vault_self_healed", check=check)
+        return payload, healed
+    except hvac.exceptions.VaultError as exc:
+        raise SchedulerVaultBrokerError(
+            f"vault rejected {check} at {api_path!r}: {type(exc).__name__}"
+        ) from exc
+
+
 async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
     """Persist *client_secret* for *identity_ref* to Vault; return the path.
 
@@ -332,55 +514,34 @@ async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
         with a warning (env-var fallback remains); the read caller treats
         it as "fall back to the env var".
     SchedulerVaultBrokerError
-        Vault is unreachable or rejected the write. On a **403** the
-        error carries ``token_invalid=True`` when a follow-up
-        ``lookup-self`` also 403s (the token is dead — re-mint it) and
-        ``False`` when the token is live, leaving the policy scope at
-        fault (#2652). No other status is evidence about the token, so
-        each keeps ``False``.
+        Vault is unreachable or rejected the write. On a **403** the broker
+        runs ``lookup-self``: a **dead** token triggers the #2668 self-heal
+        (re-mint via runner JWT + retry the write once) and only surfaces
+        here — with ``token_invalid=True`` — when the re-mint *itself* fails;
+        a **live** token leaves the policy scope at fault
+        (``token_invalid=False``, #2652). No other status is evidence about
+        the token, so each keeps ``False``.
     """
     settings = get_settings()
     api_path = vault_path_for_client_id(identity_ref, settings=settings)
     mount, logical = split_kv_v2_api_path(api_path)
-    client = _scheduler_client(settings)
-    try:
-        await asyncio.to_thread(
-            client.secrets.kv.v2.create_or_update_secret,
+
+    def _write(client: hvac.Client) -> None:
+        client.secrets.kv.v2.create_or_update_secret(
             path=logical,
             secret={SECRET_FIELD: client_secret},
             mount_point=mount,
         )
-    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
-        raise SchedulerVaultBrokerError(
-            f"vault unreachable writing agent secret at {api_path!r}: {type(exc).__name__}"
-        ) from exc
-    except hvac.exceptions.Forbidden as exc:
-        # 403 is the one ambiguous rejection: a dead token and a live-but-
-        # under-scoped policy look identical, yet the remediations are
-        # opposites (re-mint vs. widen the policy). Split them with one
-        # ``lookup-self`` on the *same* client that just failed and carry
-        # the disposition so all four register surfaces inherit it
-        # (#2652). Diagnosis only — the write is never retried.
-        token_invalid = await _scheduler_token_rejected(client)
-        if token_invalid:
-            _log.error(
-                "scheduler_vault_token_dead",
-                reason=type(exc).__name__,
-                check="agent_secret_write",
-            )
-        raise SchedulerVaultBrokerError(
-            f"vault rejected agent-secret write at {api_path!r}: {type(exc).__name__}",
-            token_invalid=token_invalid,
-        ) from exc
-    except hvac.exceptions.VaultError as exc:
-        # Every other status hvac maps onto ``VaultError`` (429, 500, 502,
-        # 503 sealed/down …) describes Vault, not the token — nothing to
-        # disambiguate, so no probe; the policy-scope remediation stands.
-        raise SchedulerVaultBrokerError(
-            f"vault rejected agent-secret write at {api_path!r}: {type(exc).__name__}"
-        ) from exc
-    # The token just authenticated a write — renew it so the periodic
-    # token never ages out (#2328). Best-effort; never raises.
+
+    # #2652 (403 disambiguation) + #2668 (self-heal a confirmed-dead token,
+    # retry once) both live in the shared seam. A non-403 rejection describes
+    # Vault, not the token, so it is never probed or healed.
+    _, client = await _execute_with_self_heal(
+        settings, _write, check="agent_secret_write", api_path=api_path
+    )
+    # The token that succeeded (original or re-minted) just authenticated a
+    # write — renew it so a periodic token never ages out (#2328).
+    # Best-effort; never raises.
     await _maybe_renew_scheduler_token(client)
     _log.info(
         "scheduler_agent_secret_written",
@@ -405,35 +566,35 @@ async def read_agent_secret(identity_ref: str) -> str | None:
         ``VAULT_SCHEDULER_TOKEN`` is unset — the caller treats this as
         "Vault not available, try the env-var fallback".
     SchedulerVaultBrokerError
-        Vault is unreachable or rejected the read for a reason other than
-        a missing path.
+        Vault is unreachable, or rejected the read for a reason other than a
+        missing path. A **403** that ``lookup-self`` confirms is a dead token
+        triggers the #2668 self-heal (re-mint via runner JWT + retry the read
+        once) and only surfaces here when the re-mint *itself* fails.
     """
     settings = get_settings()
     api_path = vault_path_for_client_id(identity_ref, settings=settings)
     mount, logical = split_kv_v2_api_path(api_path)
-    client = _scheduler_client(settings)
-    try:
-        payload = await asyncio.to_thread(
-            client.secrets.kv.v2.read_secret_version,
+
+    def _read(client: hvac.Client) -> object:
+        return client.secrets.kv.v2.read_secret_version(
             path=logical,
             mount_point=mount,
             raise_on_deleted_version=False,
         )
+
+    try:
+        payload, client = await _execute_with_self_heal(
+            settings, _read, check="agent_secret_read", api_path=api_path
+        )
     except hvac.exceptions.InvalidPath:
-        # KV-v2 read of a non-existent path raises InvalidPath (404). This
-        # is the "agent secret not in Vault yet" case — return None so the
-        # resolver falls back to the env var rather than failing the fire.
+        # KV-v2 read of a non-existent path raises InvalidPath (404) — the
+        # "agent secret not in Vault yet" case, on the original token or a
+        # re-minted one. Return None so the resolver falls back to the env
+        # var rather than failing the fire.
         return None
-    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
-        raise SchedulerVaultBrokerError(
-            f"vault unreachable reading agent secret at {api_path!r}: {type(exc).__name__}"
-        ) from exc
-    except hvac.exceptions.VaultError as exc:
-        raise SchedulerVaultBrokerError(
-            f"vault rejected agent-secret read at {api_path!r}: {type(exc).__name__}"
-        ) from exc
-    # The token just authenticated a read — renew it so the periodic
-    # token never ages out (#2328). Best-effort; never raises.
+    # The token that succeeded (original or re-minted) just authenticated a
+    # read — renew it so a periodic token never ages out (#2328).
+    # Best-effort; never raises.
     await _maybe_renew_scheduler_token(client)
     secret = _unwrap_secret(payload)
     if not secret:
@@ -452,7 +613,10 @@ class SchedulerTokenStatus:
     when the token is dead (403 / expired) or Vault was unreachable.
     ``ttl_seconds`` and ``expire_time`` echo Vault's own view so an
     operator (or #2327's ``/ready`` surface) can watch ``expire_time``
-    advance across renewals. Never carries a token value.
+    advance across renewals. ``will_expire_reason`` is the periodic-guard
+    verdict (#2668): ``None`` when the token renews indefinitely, or a
+    comma-joined reason string (``non_renewable`` / ``explicit_max_ttl``)
+    when it will die despite the renewal timer. Never carries a token value.
     """
 
     configured: bool
@@ -460,6 +624,7 @@ class SchedulerTokenStatus:
     detail: str
     ttl_seconds: int | None = None
     expire_time: str | None = None
+    will_expire_reason: str | None = None
 
 
 def _lookup_self_blocking(client: hvac.Client) -> object:
@@ -467,13 +632,17 @@ def _lookup_self_blocking(client: hvac.Client) -> object:
     return client.auth.token.lookup_self()
 
 
-async def _scheduler_token_rejected(client: hvac.Client) -> bool:
+async def _scheduler_token_rejected(
+    client: hvac.Client, *, check: str = "agent_secret_write"
+) -> bool:
     """Is *client*'s token itself dead, rather than merely under-scoped?
 
-    Called from the write-failure path (#2652) after Vault answered a
-    write with 403. A revoked / expired / lost-lease token and a live
-    token on a policy without ``create``+``update`` both produce that
-    403, so the write response alone cannot name the remediation.
+    Called from the shared read/write 403 seam (:func:`_execute_with_self_heal`,
+    #2652) after Vault answered with 403; *check* labels the calling
+    operation in the inconclusive/unreachable log events. A revoked /
+    expired / lost-lease token and a live token on a policy without the
+    needed capabilities both produce that 403, so the response alone cannot
+    name the remediation.
     ``auth/token/lookup-self`` can: Vault answers it for a live token
     granted ``read`` there (``meho-scheduler`` grants it — load-bearing,
     see ``docs/cross-repo/vault-provisioning.md``) and 403s an invalid one.
@@ -497,11 +666,11 @@ async def _scheduler_token_rejected(client: hvac.Client) -> bool:
         _log.warning(
             "scheduler_vault_token_lookup_inconclusive",
             reason=type(exc).__name__,
-            check="agent_secret_write",
+            check=check,
         )
         return False
     except requests.exceptions.RequestException:
-        _log.warning("scheduler_vault_token_lookup_unreachable", check="agent_secret_write")
+        _log.warning("scheduler_vault_token_lookup_unreachable", check=check)
         return False
     return False
 
@@ -524,12 +693,47 @@ def _unwrap_token_lifetime(payload: object) -> tuple[int | None, str | None]:
     return ttl_int, expire_str
 
 
+def _token_expiry_warning(payload: object) -> str | None:
+    """Periodic guard (#2668): reason the token dies despite renewal, or None.
+
+    Two ``lookup-self`` signals mean the renewal timer cannot keep the token
+    alive forever, so no amount of ``renew-self`` will save it:
+
+    * ``renewable == False`` — the token cannot be renewed at all; it dies at
+      its current ``ttl``.
+    * ``explicit_max_ttl > 0`` — a hard lifetime cap renewal cannot cross; the
+      token dies at the cap even while being renewed.
+
+    Returns a comma-joined reason string (stable tokens for log / alert
+    matching) or ``None`` when neither holds. ``period`` is *inspected and
+    logged* by the caller for operator visibility but does not alone condemn
+    the token here: Vault only emits ``period`` for periodic tokens, its
+    presence in ``lookup-self`` is version-dependent, and the #2668 self-heal
+    makes a merely non-periodic token survivable regardless. Malformed
+    payloads return ``None`` — the caller has already logged liveness.
+    """
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, dict):
+        return None
+    reasons: list[str] = []
+    if data.get("renewable") is False:
+        reasons.append("non_renewable")
+    max_ttl = data.get("explicit_max_ttl")
+    if isinstance(max_ttl, (int, float)) and not isinstance(max_ttl, bool) and max_ttl > 0:
+        reasons.append("explicit_max_ttl")
+    return ",".join(reasons) if reasons else None
+
+
 async def verify_scheduler_token(*, reason: str = "check") -> SchedulerTokenStatus:
     """Self-lookup the scheduler Vault token; log loudly when it's dead.
 
     Called at scheduler startup and on a slow cadence from the tick loop
-    (:mod:`meho_backplane.scheduler.loop`). It does **not** fix the fuse
-    (that is :func:`_maybe_renew_scheduler_token`; see the module docstring).
+    (:mod:`meho_backplane.scheduler.loop`). It does **not** renew (that is the
+    dedicated :func:`renew_scheduler_token` timer, #2668) — it is the
+    *visibility* backstop. It raises two loud signals: a dead / unreachable
+    token (``ok=False``), and the periodic guard (#2668) — a token that is
+    live now but will die despite renewal (``will_expire_reason`` set, ``ok``
+    stays ``True``).
 
     Never raises. An unconfigured token returns ``configured=False``
     (the documented env-var-fallback opt-out) and any Vault failure is
@@ -565,18 +769,32 @@ async def verify_scheduler_token(*, reason: str = "check") -> SchedulerTokenStat
             configured=True, ok=False, detail=f"denied:{type(exc).__name__}"
         )
     ttl, expire_time = _unwrap_token_lifetime(payload)
-    _log.info(
-        "scheduler_vault_token_verified",
-        check=reason,
-        ttl_seconds=ttl,
-        expire_time=expire_time,
-    )
+    expiry_warning = _token_expiry_warning(payload)
+    if expiry_warning is not None:
+        # Periodic guard (#2668): the token is live now but will die despite
+        # the renewal timer. Loud ERROR — a background credential must never
+        # silently count down to a dead token.
+        _log.error(
+            "scheduler_vault_token_will_expire",
+            check=reason,
+            reasons=expiry_warning,
+            ttl_seconds=ttl,
+            expire_time=expire_time,
+        )
+    else:
+        _log.info(
+            "scheduler_vault_token_verified",
+            check=reason,
+            ttl_seconds=ttl,
+            expire_time=expire_time,
+        )
     return SchedulerTokenStatus(
         configured=True,
         ok=True,
         detail="ok",
         ttl_seconds=ttl,
         expire_time=expire_time,
+        will_expire_reason=expiry_warning,
     )
 
 

--- a/backend/src/meho_backplane/scheduler/vault_credentials.py
+++ b/backend/src/meho_backplane/scheduler/vault_credentials.py
@@ -339,12 +339,13 @@ async def renew_scheduler_token(*, reason: str = "periodic") -> None:
     :func:`read_agent_secret` / :func:`write_agent_secret` stays as a cheap
     extra for a busy scheduler.
 
-    Never raises. An unconfigured token (the documented env-var-fallback
-    opt-out) or a Vault-unconfigured install returns quietly; a renewal that
-    reaches Vault and fails is logged loudly by
-    :func:`_maybe_renew_scheduler_token`. Issues **no** read or write — the
-    renewal is independent of agent-secret traffic by construction. No token
-    value ever enters a log event.
+    Never raises. An unconfigured token (no ``VAULT_SCHEDULER_TOKEN`` — the
+    documented env-var-fallback opt-out) returns silently. A token configured
+    on a Vault-unconfigured install (no ``VAULT_ADDR``) is a misconfiguration
+    and logs a loud ``ERROR`` before returning. A renewal that reaches Vault
+    and fails is logged loudly by :func:`_maybe_renew_scheduler_token`. Issues
+    **no** read or write — the renewal is independent of agent-secret traffic
+    by construction. No token value ever enters a log event.
     """
     settings = get_settings()
     token = _current_scheduler_token(settings)
@@ -446,7 +447,14 @@ async def _execute_with_self_heal[T](
         return await asyncio.to_thread(operation, client), client
     except hvac.exceptions.InvalidPath:
         raise
-    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+    except requests.exceptions.RequestException as exc:
+        # Any transport-layer failure (connection refused, timeout, TLS,
+        # redirect loop, ...) is "Vault unreachable" — catch the
+        # RequestException base, mirroring the retry leg below and the rest
+        # of this module (``_scheduler_token_rejected``,
+        # ``_maybe_renew_scheduler_token``) rather than only its
+        # Connection/Timeout subclasses, so no exotic transport error escapes
+        # the broker-error mapping.
         raise SchedulerVaultBrokerError(
             f"vault unreachable for {check} at {api_path!r}: {type(exc).__name__}"
         ) from exc
@@ -516,11 +524,12 @@ async def write_agent_secret(identity_ref: str, client_secret: str) -> str:
     SchedulerVaultBrokerError
         Vault is unreachable or rejected the write. On a **403** the broker
         runs ``lookup-self``: a **dead** token triggers the #2668 self-heal
-        (re-mint via runner JWT + retry the write once) and only surfaces
-        here — with ``token_invalid=True`` — when the re-mint *itself* fails;
-        a **live** token leaves the policy scope at fault
-        (``token_invalid=False``, #2652). No other status is evidence about
-        the token, so each keeps ``False``.
+        (re-mint via runner JWT + retry the write once) and surfaces here —
+        with ``token_invalid=True`` — only when the self-heal cannot recover:
+        the re-mint fails, *or* the retry against the re-minted token also
+        fails (e.g. an under-scoped runner-role policy). A **live** token
+        leaves the policy scope at fault (``token_invalid=False``, #2652). No
+        other status is evidence about the token, so each keeps ``False``.
     """
     settings = get_settings()
     api_path = vault_path_for_client_id(identity_ref, settings=settings)
@@ -569,7 +578,8 @@ async def read_agent_secret(identity_ref: str) -> str | None:
         Vault is unreachable, or rejected the read for a reason other than a
         missing path. A **403** that ``lookup-self`` confirms is a dead token
         triggers the #2668 self-heal (re-mint via runner JWT + retry the read
-        once) and only surfaces here when the re-mint *itself* fails.
+        once) and surfaces here only when the self-heal cannot recover — the
+        re-mint fails, *or* the retry against the re-minted token also fails.
     """
     settings = get_settings()
     api_path = vault_path_for_client_id(identity_ref, settings=settings)

--- a/backend/tests/test_scheduler_vault_credentials.py
+++ b/backend/tests/test_scheduler_vault_credentials.py
@@ -229,6 +229,26 @@ async def test_write_unreachable_maps_to_broker_error(fake_kv: _FakeKvV2) -> Non
     assert fake_kv.token_api.lookup_calls == 0
 
 
+async def test_write_non_connection_transport_error_maps_to_broker_error(
+    fake_kv: _FakeKvV2,
+) -> None:
+    """Any requests transport error maps to the broker error, not just Connection/Timeout.
+
+    The self-heal seam catches the ``RequestException`` base (mirroring the
+    retry leg), so an exotic transport failure never escapes the broker-error
+    mapping into the generic tick-failure handler.
+    """
+
+    def _boom(**_: Any) -> None:
+        raise requests.exceptions.TooManyRedirects("redirect loop")
+
+    fake_kv.create_or_update_secret = _boom  # type: ignore[method-assign]
+    with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
+        await vc.write_agent_secret("agent:reporter", "s")
+    assert excinfo.value.token_invalid is False
+    assert fake_kv.token_api.lookup_calls == 0
+
+
 # --- write-failure disposition: dead token vs. under-scoped policy (#2652) ---
 
 

--- a/backend/tests/test_scheduler_vault_credentials.py
+++ b/backend/tests/test_scheduler_vault_credentials.py
@@ -23,14 +23,26 @@ Vault. The live round-trip is covered by the integration suite.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable
 from typing import Any
 
 import hvac.exceptions
 import pytest
 import requests.exceptions
+from structlog.testing import capture_logs
 
 import meho_backplane.scheduler.vault_credentials as vc
 from meho_backplane.settings import get_settings
+
+
+def _async_return(value: Any) -> Callable[..., Any]:
+    """Build an async stand-in that ignores its args and returns *value*."""
+
+    async def _f(*_args: Any, **_kwargs: Any) -> Any:
+        return value
+
+    return _f
 
 
 @pytest.fixture(autouse=True)
@@ -518,3 +530,308 @@ async def test_verify_unreachable(fake_kv_any_token: _FakeKvV2) -> None:
     assert status.configured is True
     assert status.ok is False
     assert status.detail.startswith("unreachable:")
+
+
+# --- self-heal re-mint (#2668) ---------------------------------------
+
+
+async def test_write_dead_token_self_heals_and_retries(
+    fake_kv_any_token: _FakeKvV2, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dead static token re-mints via runner JWT and the write is retried.
+
+    Pins AC #1 for the write path: a 403 write + a 403 ``lookup-self`` ⇒ mint a
+    runner JWT and ``jwt_login`` ⇒ retry the write once against the re-minted
+    client, no operator in the loop.
+    """
+    kv = fake_kv_any_token
+    kv.token_api.lookup_raises = hvac.exceptions.Forbidden("dead token")
+
+    state = {"healed": False}
+    real_write = kv.create_or_update_secret
+
+    def _write(**kwargs: Any) -> Any:
+        if not state["healed"]:
+            raise hvac.exceptions.Forbidden("permission denied")
+        return real_write(**kwargs)
+
+    kv.create_or_update_secret = _write  # type: ignore[method-assign]
+
+    jwt_calls: list[dict[str, Any]] = []
+
+    async def _fake_jwt_login(_client: Any, *, role: str, jwt: str, mount_path: str) -> None:
+        jwt_calls.append({"role": role, "jwt": jwt, "mount_path": mount_path})
+        state["healed"] = True
+
+    monkeypatch.setattr(vc, "check_runner_jwt", _async_return("runner-jwt"))
+    monkeypatch.setattr(vc, "_to_thread_jwt_login", _fake_jwt_login)
+
+    api_path = await vc.write_agent_secret("agent:reporter", "s3cr3t")
+
+    assert api_path == "secret/data/agents/AGENT_REPORTER/credentials"
+    assert len(jwt_calls) == 1  # a jwt_login occurred
+    assert jwt_calls[0]["role"] == "meho-mcp"  # vault_oidc_role fallback (#2757)
+    assert jwt_calls[0]["jwt"] == "runner-jwt"
+    assert jwt_calls[0]["mount_path"] == "jwt"
+    assert len(kv.writes) == 1  # the write was retried and committed
+    assert kv.token_api.lookup_calls == 1  # a single dead-token probe
+
+
+async def test_read_dead_token_self_heals_and_retries(
+    fake_kv_any_token: _FakeKvV2, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dead static token re-mints via runner JWT and the read is retried.
+
+    Pins AC #1 for the read path — the scheduler's hot path on every fire.
+    """
+    kv = fake_kv_any_token
+    kv.token_api.lookup_raises = hvac.exceptions.Forbidden("dead token")
+
+    state = {"healed": False}
+
+    def _read(**_kwargs: Any) -> Any:
+        if not state["healed"]:
+            raise hvac.exceptions.Forbidden("permission denied")
+        return {"data": {"data": {vc.SECRET_FIELD: "gen-secret"}, "metadata": {}}}
+
+    kv.read_secret_version = _read  # type: ignore[method-assign]
+
+    jwt_calls: list[str] = []
+
+    async def _fake_jwt_login(_client: Any, *, role: str, jwt: str, mount_path: str) -> None:
+        jwt_calls.append(role)
+        state["healed"] = True
+
+    monkeypatch.setattr(vc, "check_runner_jwt", _async_return("runner-jwt"))
+    monkeypatch.setattr(vc, "_to_thread_jwt_login", _fake_jwt_login)
+
+    secret = await vc.read_agent_secret("agent:reporter")
+
+    assert secret == "gen-secret"  # the retry against the re-minted client won
+    assert len(jwt_calls) == 1
+    assert kv.token_api.lookup_calls == 1
+
+
+async def test_dead_token_remint_unavailable_falls_back_loud(fake_kv: _FakeKvV2) -> None:
+    """No runner principal configured ⇒ loud fail, never a silent skip (#2668).
+
+    ``check_runner_jwt`` returns ``""`` when the check-runner client is unset
+    (the default test env), so the re-mint cannot proceed and the broker falls
+    back to today's loud ``token_invalid=True`` failure — the write is never
+    silently retried against a dead token.
+    """
+    _deny_write(fake_kv)
+    fake_kv.token_api.lookup_raises = hvac.exceptions.Forbidden("dead token")
+
+    with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
+        await vc.write_agent_secret("agent:reporter", "s")
+
+    assert excinfo.value.token_invalid is True
+    assert fake_kv.writes == []
+
+
+async def test_selfheal_retry_failure_fails_loud(
+    fake_kv_any_token: _FakeKvV2, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the re-minted client also fails the write, surface it loudly (#2668)."""
+    kv = fake_kv_any_token
+    kv.token_api.lookup_raises = hvac.exceptions.Forbidden("dead token")
+
+    def _always_forbidden(**_kwargs: Any) -> Any:
+        raise hvac.exceptions.Forbidden("still denied after re-mint")
+
+    kv.create_or_update_secret = _always_forbidden  # type: ignore[method-assign]
+
+    async def _fake_jwt_login(_client: Any, *, role: str, jwt: str, mount_path: str) -> None:
+        return None
+
+    monkeypatch.setattr(vc, "check_runner_jwt", _async_return("runner-jwt"))
+    monkeypatch.setattr(vc, "_to_thread_jwt_login", _fake_jwt_login)
+
+    with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
+        await vc.write_agent_secret("agent:reporter", "s")
+
+    assert excinfo.value.token_invalid is True
+    assert kv.writes == []
+
+
+async def test_remint_login_denied_falls_back_loud(
+    fake_kv_any_token: _FakeKvV2, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A refused ``jwt_login`` during re-mint ⇒ None ⇒ loud fail (#2668)."""
+    _deny_write(fake_kv_any_token)
+    fake_kv_any_token.token_api.lookup_raises = hvac.exceptions.Forbidden("dead token")
+
+    async def _login_denied(_client: Any, *, role: str, jwt: str, mount_path: str) -> None:
+        raise hvac.exceptions.Forbidden("role denied")
+
+    monkeypatch.setattr(vc, "check_runner_jwt", _async_return("runner-jwt"))
+    monkeypatch.setattr(vc, "_to_thread_jwt_login", _login_denied)
+
+    with pytest.raises(vc.SchedulerVaultBrokerError) as excinfo:
+        await vc.write_agent_secret("agent:reporter", "s")
+
+    assert excinfo.value.token_invalid is True
+    assert fake_kv_any_token.writes == []
+
+
+# --- dedicated renewal timer (#2668) ---------------------------------
+
+
+async def test_renew_scheduler_token_issues_renew_without_read_or_write(
+    fake_kv: _FakeKvV2,
+) -> None:
+    """The renewal primitive fires renew-self and touches no agent secret.
+
+    Pins AC #2's "independent of agent-secret traffic": the dedicated timer's
+    primitive issues ``renew-self`` with zero reads and zero writes.
+    """
+    await vc.renew_scheduler_token(reason="periodic")
+
+    assert fake_kv.token_api.renew_calls == 1
+    assert fake_kv.writes == []
+    assert fake_kv.last_read is None
+
+
+async def test_renew_scheduler_token_unconfigured_is_noop(
+    fake_kv: _FakeKvV2, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unset token is the documented opt-out — renew is a silent no-op."""
+    monkeypatch.delenv("VAULT_SCHEDULER_TOKEN", raising=False)
+    get_settings.cache_clear()
+
+    await vc.renew_scheduler_token()
+
+    assert fake_kv.token_api.renew_calls == 0
+
+
+async def test_renew_scheduler_token_swallows_failure(fake_kv: _FakeKvV2) -> None:
+    """A failed renew is swallowed — the dedicated timer path never raises."""
+    fake_kv.token_api.renew_raises = hvac.exceptions.Forbidden("not renewable")
+
+    await vc.renew_scheduler_token()  # must not raise
+
+    assert fake_kv.token_api.renew_calls == 1
+
+
+async def test_scheduler_loop_renews_vault_token_on_dedicated_timer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The tick loop renews on its own cadence, with zero agent-secret fires.
+
+    Pins AC #2's "fires from a dedicated tick-loop timer": drive
+    :func:`_scheduler_loop` through startup + one iteration with ``run_one_tick``
+    doing nothing (zero reads/writes), and observe the renewal wrapper called on
+    both the startup and the periodic cadence.
+    """
+    from meho_backplane.scheduler import loop
+
+    async def _anoop(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def _tick_noop(*_args: Any, **_kwargs: Any) -> int:
+        return 0
+
+    monkeypatch.setattr(loop, "reconcile_active_event_triggers", _anoop)
+    monkeypatch.setattr(loop, "run_one_tick", _tick_noop)
+    monkeypatch.setattr(loop, "_check_scheduler_vault_token", _anoop)
+    # Trip the renewal cadence on the first post-tick check.
+    monkeypatch.setattr(loop, "_TOKEN_RENEW_INTERVAL_SECONDS", 0.0)
+
+    renew_reasons: list[str] = []
+
+    async def _fake_renew(*, reason: str) -> None:
+        renew_reasons.append(reason)
+        if len(renew_reasons) >= 2:
+            # startup + one periodic fire is enough — stop the forever loop.
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(loop, "_renew_scheduler_vault_token", _fake_renew)
+    monkeypatch.setenv("SCHEDULER_TICK_INTERVAL_SECONDS", "1")
+    get_settings.cache_clear()
+
+    with pytest.raises(asyncio.CancelledError):
+        await loop._scheduler_loop()
+
+    assert "startup" in renew_reasons
+    assert "periodic" in renew_reasons
+
+
+# --- periodic guard (#2668) ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ({"renewable": True, "explicit_max_ttl": 0}, None),
+        ({"renewable": False, "explicit_max_ttl": 0}, "non_renewable"),
+        ({"renewable": True, "explicit_max_ttl": 7200}, "explicit_max_ttl"),
+        ({"renewable": False, "explicit_max_ttl": 7200}, "non_renewable,explicit_max_ttl"),
+        # A healthy periodic token: renewable, no cap, carries a period.
+        ({"renewable": True, "explicit_max_ttl": 0, "period": 2764800}, None),
+        ({}, None),
+    ],
+)
+def test_token_expiry_warning(data: dict[str, Any], expected: str | None) -> None:
+    assert vc._token_expiry_warning({"data": data}) == expected
+
+
+def test_token_expiry_warning_malformed_payload_is_none() -> None:
+    assert vc._token_expiry_warning("nonsense") is None
+    assert vc._token_expiry_warning({"data": "nope"}) is None
+
+
+async def test_verify_flags_explicit_max_ttl_with_loud_error(
+    fake_kv_any_token: _FakeKvV2,
+) -> None:
+    """A live token carrying an explicit_max_ttl logs a loud ERROR (AC #3)."""
+    fake_kv_any_token.token_api.lookup_result = {
+        "data": {
+            "ttl": 3600,
+            "expire_time": "2026-08-06T15:00:00Z",
+            "renewable": True,
+            "explicit_max_ttl": 7200,
+        }
+    }
+
+    with capture_logs() as logs:
+        status = await vc.verify_scheduler_token(reason="startup")
+
+    assert status.ok is True  # live right now …
+    assert status.will_expire_reason == "explicit_max_ttl"  # … but doomed despite renewal
+    warn = next(e for e in logs if e["event"] == "scheduler_vault_token_will_expire")
+    assert warn["log_level"] == "error"
+    assert warn["reasons"] == "explicit_max_ttl"
+
+
+async def test_verify_flags_non_renewable_token(fake_kv_any_token: _FakeKvV2) -> None:
+    fake_kv_any_token.token_api.lookup_result = {
+        "data": {"ttl": 3600, "expire_time": None, "renewable": False, "explicit_max_ttl": 0}
+    }
+
+    status = await vc.verify_scheduler_token()
+
+    assert status.ok is True
+    assert status.will_expire_reason == "non_renewable"
+
+
+async def test_verify_healthy_periodic_token_no_warning(fake_kv_any_token: _FakeKvV2) -> None:
+    """A proper periodic token draws no periodic-guard warning."""
+    fake_kv_any_token.token_api.lookup_result = {
+        "data": {
+            "ttl": 2764800,
+            "expire_time": "2026-09-07T00:00:00Z",
+            "renewable": True,
+            "explicit_max_ttl": 0,
+            "period": 2764800,
+        }
+    }
+
+    with capture_logs() as logs:
+        status = await vc.verify_scheduler_token()
+
+    assert status.ok is True
+    assert status.will_expire_reason is None
+    events = [e["event"] for e in logs]
+    assert "scheduler_vault_token_will_expire" not in events
+    assert "scheduler_vault_token_verified" in events

--- a/docs/cross-repo/vault-provisioning.md
+++ b/docs/cross-repo/vault-provisioning.md
@@ -346,8 +346,9 @@ RUNNER_JWT=$(curl -sS -X POST \
   | jq -r .access_token)
 
 # 2. Vault jwt_login under the runner role -> fresh Vault token
-#    (auth/jwt/ is the dedicated mount from surface 1).
-vault write -field=token auth/jwt/login \
+#    (auth/<mount>/ is the dedicated JWT mount from surface 1;
+#    VAULT_OIDC_MOUNT_PATH selects it, default `jwt`).
+vault write -field=token "auth/${VAULT_OIDC_MOUNT_PATH:-jwt}/login" \
   role="${VAULT_CHECK_RUNNER_ROLE:-$VAULT_OIDC_ROLE}" jwt="$RUNNER_JWT"
 ```
 

--- a/docs/cross-repo/vault-provisioning.md
+++ b/docs/cross-repo/vault-provisioning.md
@@ -291,14 +291,81 @@ is picked up without a restart. When both are set the file wins; an
 unreadable/empty file falls through to `VAULT_SCHEDULER_TOKEN`.
 
 **When the fuse has already blown.** Renewal and the startup/hourly
-self-lookup shorten time-to-notice, but they do not resurrect a token
-that is already dead — and until #2652 the *registration* path did not
-say so: a dead token and an under-scoped policy both produced the
-policy-widening message, sending operators to verify a policy that was
-already correct. Registration now runs the same `auth/token/lookup-self`
-probe whenever Vault answers the write with a 403 and emits
-`scheduler_vault_token_invalid` with the re-mint remediation instead.
-The two rows in *Failure modes* below are the decision table.
+self-lookup shorten time-to-notice; since #2668 the broker also
+**self-heals** a dead token rather than only diagnosing it. When a
+Vault-first read or the registration write draws a 403 that
+`auth/token/lookup-self` confirms is a dead token, the broker mints a
+fresh Vault token by `jwt_login` as the runner principal and retries the
+operation once (see *Self-heal* below), so a scheduled fire survives a
+dead static token with no operator in the loop. It falls back to the loud
+`scheduler_vault_token_invalid` failure — the re-mint remediation,
+distinct from the under-scoped-policy message since #2652 — only when the
+re-mint *itself* cannot proceed (no runner principal configured, or its
+role is refused). The two rows in *Failure modes* below are the decision
+table for that fallback.
+
+Also since #2668, renewal no longer rides only on agent-secret traffic:
+a dedicated tick-loop timer fires `auth/token/renew-self` on its own
+cadence, so an **idle** scheduler still renews. And the startup/hourly
+`lookup-self` now also emits a loud `scheduler_vault_token_will_expire`
+`ERROR` when the token is non-renewable or carries an `explicit_max_ttl`
+— it will die despite renewal, so mint it `-period=768h` as above.
+
+#### Self-heal — headless re-mint via the runner principal (#2668)
+
+The self-heal above needs a Vault identity the scheduler can obtain
+**without an operator or an interactive session** — background dispatch
+runs unattended. It reuses the check-runner principal (surface 7 below,
+#2642): a confidential Keycloak client whose OAuth `client_credentials`
+grant mints a runner JWT with no human in the loop, which Vault's JWT auth
+method exchanges for a fresh token. The whole chain is headless:
+
+1. **Keycloak `client_credentials`** — the backplane mints the runner
+   principal's access token from `CHECK_RUNNER_CLIENT_ID` /
+   `CHECK_RUNNER_CLIENT_SECRET`
+   ([`auth/runner_identity.py`](../../backend/src/meho_backplane/auth/runner_identity.py)),
+   the same grant the agent-principal path uses. No user session, no
+   `gcloud` / browser login, nothing that expires out from under a
+   long-running loop.
+2. **Vault `jwt_login`** — the broker logs that JWT into Vault's JWT auth
+   method under `role = VAULT_CHECK_RUNNER_ROLE or VAULT_OIDC_ROLE` (the
+   #2757 fallback), yielding a fresh Vault token.
+3. **Retry once** — the failed read/write re-runs against the re-minted
+   token; only if the re-mint itself fails does the loud
+   `scheduler_vault_token_invalid` path stand.
+
+Reproduce it by hand — no interactive session at any step:
+
+```bash
+# 1. Keycloak client_credentials -> runner JWT (confidential client).
+RUNNER_JWT=$(curl -sS -X POST \
+  "$KEYCLOAK_ISSUER_URL/protocol/openid-connect/token" \
+  -d grant_type=client_credentials \
+  -d client_id="$CHECK_RUNNER_CLIENT_ID" \
+  -d client_secret="$CHECK_RUNNER_CLIENT_SECRET" \
+  | jq -r .access_token)
+
+# 2. Vault jwt_login under the runner role -> fresh Vault token
+#    (auth/jwt/ is the dedicated mount from surface 1).
+vault write -field=token auth/jwt/login \
+  role="${VAULT_CHECK_RUNNER_ROLE:-$VAULT_OIDC_ROLE}" jwt="$RUNNER_JWT"
+```
+
+**Provision the runner role to reach the agent-credentials path.** The
+re-minted token authenticates as the runner principal, so the role it logs
+in with (`VAULT_CHECK_RUNNER_ROLE`, else `VAULT_OIDC_ROLE`) must itself
+grant the scheduler's capabilities — `create` / `read` / `update` on
+`secret/data/agents/*/credentials` — or the retry 403s just like the dead
+static token did. The scheduler adds **no** dedicated role knob (#2668
+reuses the landed identity); when you scope a dedicated
+`VAULT_CHECK_RUNNER_ROLE` (surface 7, Option A), attach the
+`meho-scheduler` policy's agent-credentials grants to its policy so the
+self-heal can complete the read/write it re-mints for.
+
+This is the supported answer for an adopter whose scheduled dispatch has
+no durable identity — e.g. a scheduled investigator that today ties its
+JWT to an interactive user session that expires (pm-tnt/MFC.ClaudeOps#277):
+point it at the `client_credentials` runner principal instead.
 
 ### 7. Bounding the check-runner principal (#2642)
 


### PR DESCRIPTION
## Summary

- Turns the scheduler's Vault-credential handling from **detect-and-log** into **detect-and-heal**: on a `lookup-self`-confirmed dead static token, the broker re-mints a fresh Vault token by `jwt_login` as the runner principal and retries the failed read/write **once** — so background features (scheduler, in-process check-runner, scheduled agents) survive a dead credential unattended, no operator in the loop.
- Moves token renewal onto a **dedicated tick-loop timer** so an *idle* scheduler still renews (renewal previously rode only on agent-secret read/write traffic); keeps the on-use renew as a cheap extra.
- Adds a **periodic guard**: startup + hourly `lookup-self` now logs a loud `ERROR` (`scheduler_vault_token_will_expire`) when the token is non-renewable or carries an `explicit_max_ttl` (it will die despite renewal).
- Documents the **headless** `client_credentials` → runner-JWT → Vault `jwt_login` mint (no interactive session) in `docs/cross-repo/vault-provisioning.md`.

Reuses the runner identity (#2642) and the check-runner Vault role (#2757, `VAULT_CHECK_RUNNER_ROLE` → `VAULT_OIDC_ROLE` fallback) — **no** scheduler-specific role knob. Read and write share one self-heal seam (`_execute_with_self_heal`). Fail-closed: if the re-mint itself fails the existing loud failure stands (never a silent skip); no secret value ever enters a log.

## Test plan
- [x] `ruff check` + `ruff format --check` — clean on all changed files
- [x] `mypy src/` — clean on the two changed src modules (the one repo-wide error is a pre-existing Darwin-only `MSG_ERRQUEUE` artifact in `connectors/net/icmp.py`, unrelated; CI runs on Linux)
- [x] `pytest backend/tests -k "scheduler and vault"` — 72 passed, 5 skipped (live-Vault e2e, run in CI)
- [x] `pytest backend/tests -k "scheduler or vault"` — 840 passed, 46 skipped, 1 **pre-existing** teardown error in `test_connectors_vault.py::test_preflight_fail_soft_when_probe_raises` that reproduces identically on untouched `origin/main` (connector-vault surface untouched here — not a regression)
- [x] code-quality gate (`--diff`) — 0 blockers (5 pre-existing size warnings)

### Acceptance criteria
- [x] **Re-mint retry** (read + write) — `test_write_dead_token_self_heals_and_retries` / `test_read_dead_token_self_heals_and_retries` mock a 403 `lookup-self`, assert a `jwt_login` occurs and the op is retried; fail-closed paths pinned too.
- [x] **Dedicated-timer renew** — `test_renew_scheduler_token_issues_renew_without_read_or_write` (zero reads/writes) + `test_scheduler_loop_renews_vault_token_on_dedicated_timer` (advances the loop).
- [x] **Periodic-guard ERROR** — `test_verify_flags_explicit_max_ttl_with_loud_error` (+ non-renewable, healthy-no-warning, `_token_expiry_warning` param table).
- [x] **Docs** — `grep -i "client_credentials" docs/cross-repo/vault-provisioning.md` non-empty (headless mint recipe added).
- [x] **CHANGELOG** — `[Unreleased]` entry under a unique `### Fixed …` header.
- [x] **Tests green + ruff/mypy clean** on changed files.

## Out of scope (deferred per the issue)
- Field root-cause of *why* `renew-self` doesn't hold, and the 7+ day unattended soak — both need live-Vault reproduction over days; the self-heal makes the failure survivable regardless. Track under the live-soak follow-up (#2665).
- Adjacent finding: `scheduler/vault_credentials.py` (was already 601 lines, now 819) and `scheduler/loop.py` (1070) exceed the 600-line soft limit — pre-existing, cohesive modules; splitting is out of this bug-fix's surgical scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2668
