### PR TITLE
test(scheduler): compressed dev-Vault renewal + periodic-guard soak (#2827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,22 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — compressed dev-Vault soak for the scheduler credential's renewal timer + periodic guard (#2827)
+
+- New integration-lane coverage boots a real dev-mode Vault
+  (testcontainers) and drives #2668's scheduler-credential lifecycle over
+  a **seconds-long compressed timeline** — de-risking the multi-day
+  deployed soak (#2826) before it is attempted. A real **periodic token**
+  with a short period is kept alive across repeated
+  `renew_scheduler_token` cycles spanning more than one period
+  (`verify_scheduler_token` stays `ok`, `scheduler_vault_token_renewed`
+  observed, `scheduler_vault_token_dead` never), and a real
+  `explicit_max_ttl` token trips the periodic guard
+  (`scheduler_vault_token_will_expire`, ERROR) against the live
+  `lookup-self` payload — behaviour the unit layer could only mock.
+  Test-only; Docker-socket-absent sandboxes skip cleanly; no production
+  code change.
+
 ### Fixed — scheduler self-heals its Vault credential so background features survive unattended (#2668)
 
 - The scheduler authenticates to Vault with a **static periodic token**

--- a/backend/tests/integration/test_scheduler_vault_credentials_dev_e2e.py
+++ b/backend/tests/integration/test_scheduler_vault_credentials_dev_e2e.py
@@ -41,12 +41,14 @@ is a throwaway value on an in-memory Vault that never persists.
 
 from __future__ import annotations
 
+import asyncio
 import os
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import hvac
 import pytest
+from structlog.testing import capture_logs
 
 from meho_backplane.scheduler.credentials import (
     AgentCredentialsUnresolvedError,
@@ -55,6 +57,8 @@ from meho_backplane.scheduler.credentials import (
 from meho_backplane.scheduler.vault_credentials import (
     SECRET_FIELD,
     read_agent_secret,
+    renew_scheduler_token,
+    verify_scheduler_token,
     write_agent_secret,
 )
 from meho_backplane.settings import get_settings
@@ -181,8 +185,6 @@ async def test_seeded_payload_field_shape(vault_dev_addr: str, _scheduler_vault_
     A direct root-client read confirms the write shape independently of the
     broker's own read path (defends against a write/read key drift).
     """
-    import asyncio
-
     await write_agent_secret(_IDENTITY_REF, _AGENT_SECRET)
     root = hvac.Client(url=vault_dev_addr, token=_DEV_ROOT_TOKEN)
     payload = await asyncio.to_thread(
@@ -192,3 +194,163 @@ async def test_seeded_payload_field_shape(vault_dev_addr: str, _scheduler_vault_
         raise_on_deleted_version=False,
     )
     assert payload["data"]["data"] == {SECRET_FIELD: _AGENT_SECRET}
+
+
+# --- compressed renewal + periodic-guard soak (#2827) -----------------
+#
+# The unit layer (``tests/test_scheduler_vault_credentials.py``) mocks
+# ``renew-self`` / ``lookup-self``, so it proves the *logic* but never a
+# real token surviving repeated renewals, or actually crossing an
+# ``explicit_max_ttl`` cap. These two soaks drive #2668's renewal timer
+# and periodic guard against the **live** dev Vault over a seconds-long
+# compressed timeline — the same behaviour the multi-day deployed soak
+# (#2826) will exercise for real, de-risked here first. Runtime is bounded
+# to seconds; the module-scoped container boot is shared with the tests
+# above.
+
+#: Narrow policy granting exactly what the broker's renew/lookup path
+#: needs: ``renew-self`` (update) and ``lookup-self`` (read). Minted
+#: tokens carry **only** this policy (``no_default_policy``), so the soak
+#: also proves the policy is sufficient for the renewal timer and the
+#: guard's self-lookup — not merely riding on Vault's ``default`` policy.
+_SOAK_POLICY_NAME: str = "meho-scheduler-soak"
+_SOAK_POLICY_HCL: str = """\
+path "auth/token/renew-self" {
+  capabilities = ["update"]
+}
+path "auth/token/lookup-self" {
+  capabilities = ["read"]
+}
+"""
+
+#: Short renewal period for the periodic token. Small enough that the
+#: renew loop spans more than one period in a handful of seconds (proving
+#: renewal keeps a short-period token alive exactly as it must keep a
+#: 768h one alive over weeks); large enough to clear localhost
+#: renew/lookup round-trip jitter between renewals. Were renewal a no-op,
+#: this fuse would blow mid-loop and a later verify would flip to
+#: ``ok is False``.
+_SOAK_PERIOD_SECONDS: int = 4
+#: Renew cycles driven across the soak (≥3, per the acceptance criteria).
+_SOAK_RENEW_CYCLES: int = 4
+#: Gap between renewals — comfortably under ``_SOAK_PERIOD_SECONDS`` so a
+#: live token is never allowed to age out between renew calls, while the
+#: total elapsed time (cycles * gap) still exceeds one period.
+_SOAK_RENEW_GAP_SECONDS: float = 2.0
+
+
+def _ensure_soak_policy(root: hvac.Client) -> None:
+    """Create/update the narrow renew+lookup policy on the dev Vault."""
+    root.sys.create_or_update_policy(name=_SOAK_POLICY_NAME, policy=_SOAK_POLICY_HCL)
+
+
+def _mint_scheduler_token(
+    root: hvac.Client,
+    *,
+    period: str | None = None,
+    explicit_max_ttl: str | None = None,
+) -> str:
+    """Mint a scheduler token on the narrow policy; return its value.
+
+    ``period`` mints a **periodic** token (the renewal-soak subject);
+    ``explicit_max_ttl`` mints a token with a hard lifetime cap (the
+    periodic-guard subject). ``no_default_policy`` scopes the token to
+    exactly the renew/lookup grants under test.
+    """
+    resp = root.auth.token.create(
+        policies=[_SOAK_POLICY_NAME],
+        no_default_policy=True,
+        renewable=True,
+        period=period,
+        explicit_max_ttl=explicit_max_ttl,
+    )
+    return str(resp["auth"]["client_token"])
+
+
+@pytest.fixture
+def _scheduler_soak_env(
+    vault_dev_addr: str, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[Callable[[str], None]]:
+    """Pin Settings to the live Vault; the caller supplies the token.
+
+    Mirrors :func:`_scheduler_vault_env`'s env-pin + ``cache_clear``
+    discipline, but the scheduler token is a freshly-minted periodic /
+    max-TTL token (not the dev-root), so it is pinned by the returned
+    callable once the test has minted it against the live Vault.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", vault_dev_addr)
+
+    def _pin(token: str) -> None:
+        monkeypatch.setenv("VAULT_SCHEDULER_TOKEN", token)
+        get_settings.cache_clear()
+
+    yield _pin
+    get_settings.cache_clear()
+
+
+async def test_periodic_token_survives_renewal_soak(
+    vault_dev_addr: str, _scheduler_soak_env: Callable[[str], None]
+) -> None:
+    """A real periodic token stays live across renew cycles spanning >1 period.
+
+    AC #1. Mint a real periodic token with a short period, drive
+    :func:`renew_scheduler_token` across ``_SOAK_RENEW_CYCLES`` cycles
+    whose total elapsed time exceeds the period, and assert the token
+    never dies: :func:`verify_scheduler_token` reports ``ok`` on every
+    cycle, ``scheduler_vault_token_renewed`` is observed, and
+    ``scheduler_vault_token_dead`` is never logged. Renewal is what keeps
+    it alive — were it a no-op, the ``_SOAK_PERIOD_SECONDS`` fuse would
+    blow mid-loop and a later verify would flip to ``ok is False``.
+    """
+    root = hvac.Client(url=vault_dev_addr, token=_DEV_ROOT_TOKEN)
+    await asyncio.to_thread(_ensure_soak_policy, root)
+    token = await asyncio.to_thread(_mint_scheduler_token, root, period=f"{_SOAK_PERIOD_SECONDS}s")
+    _scheduler_soak_env(token)
+
+    # Live at the outset, and a healthy periodic token draws no guard.
+    baseline = await verify_scheduler_token(reason="soak-baseline")
+    assert baseline.ok is True
+    assert baseline.will_expire_reason is None
+
+    with capture_logs() as logs:
+        for _ in range(_SOAK_RENEW_CYCLES):
+            await renew_scheduler_token(reason="periodic")
+            await asyncio.sleep(_SOAK_RENEW_GAP_SECONDS)
+            status = await verify_scheduler_token(reason="soak")
+            assert status.ok is True
+
+    events = [entry["event"] for entry in logs]
+    assert events.count("scheduler_vault_token_renewed") >= 3
+    assert "scheduler_vault_token_dead" not in events
+
+
+async def test_explicit_max_ttl_token_trips_periodic_guard(
+    vault_dev_addr: str, _scheduler_soak_env: Callable[[str], None]
+) -> None:
+    """A real ``explicit_max_ttl`` token trips the #2668 periodic guard.
+
+    AC #2. Mint a token carrying an ``explicit_max_ttl`` (a hard lifetime
+    cap renewal cannot cross), point the broker at it, and assert
+    :func:`verify_scheduler_token` — reading the **live** ``lookup-self``
+    payload, not a mock — sets ``will_expire_reason`` while the token is
+    still ``ok``, and emits the loud ``scheduler_vault_token_will_expire``
+    ERROR. The cap sits well above the test runtime, so the token is
+    unambiguously alive at lookup and the verdict comes from the cap, not
+    from an already-expired token.
+    """
+    root = hvac.Client(url=vault_dev_addr, token=_DEV_ROOT_TOKEN)
+    await asyncio.to_thread(_ensure_soak_policy, root)
+    token = await asyncio.to_thread(_mint_scheduler_token, root, explicit_max_ttl="60s")
+    _scheduler_soak_env(token)
+
+    with capture_logs() as logs:
+        status = await verify_scheduler_token(reason="soak-guard")
+
+    assert status.ok is True  # live right now …
+    assert status.will_expire_reason is not None
+    assert "explicit_max_ttl" in status.will_expire_reason  # … but doomed despite renewal
+    warn = next(e for e in logs if e["event"] == "scheduler_vault_token_will_expire")
+    assert warn["log_level"] == "error"
+    assert "explicit_max_ttl" in warn["reasons"]


### PR DESCRIPTION
## Summary

- Extends the existing dev-Vault testcontainers harness
  (`backend/tests/integration/test_scheduler_vault_credentials_dev_e2e.py`)
  with two **compressed, seconds-not-days** soaks that drive #2668's
  scheduler-credential **renewal timer** and **periodic guard** against a
  **real dev-mode Vault** — the token-lifecycle behaviour the unit tests
  (`tests/test_scheduler_vault_credentials.py`) can only mock.
- **Renewal soak:** the dev-root client mints a real **periodic token**
  with a short (4s) period on a narrow `renew-self` + `lookup-self` policy
  (`no_default_policy`); the broker is pointed at it via
  `VAULT_SCHEDULER_TOKEN` and `renew_scheduler_token` is driven across 4
  cycles whose total elapsed time exceeds one period. `verify_scheduler_token().ok`
  stays `True` throughout, `scheduler_vault_token_renewed` is observed, and
  `scheduler_vault_token_dead` is never logged — were renewal a no-op the
  short-period fuse would blow mid-loop, so the assertion is load-bearing.
- **Periodic-guard trip:** a real `explicit_max_ttl` token makes
  `verify_scheduler_token` set `will_expire_reason` and emit
  `scheduler_vault_token_will_expire` (ERROR) against the **live**
  `lookup-self` payload, not a mock.
- **Test-only — no production source touched.** `git diff --name-only`
  lists exactly the test file + `CHANGELOG.md`. De-risks the multi-day
  deployed soak (#2826) before it is attempted.

## Test plan

- [x] `ruff check` (changed file) — clean
- [x] `ruff format --check` (changed file) — clean
- [x] `mypy` (changed file) — clean (0 errors in the file; the single
  `tests/_strategies.py:60` diagnostic is pre-existing on `main` and CI
  type-checks `src/` only)
- [x] `.claude/hooks/code-quality.py --diff` — exit 0
- [x] `pytest tests/integration/test_scheduler_vault_credentials_dev_e2e.py`
  — **7 skipped** cleanly (no Docker socket in the sandbox; the module
  fixture skips via the existing heuristic)
- [ ] **AC1 (renewal soak) / AC2 (periodic-guard trip)** — written;
  execute in CI's **Python (integration testcontainers)** lane, which
  provisions Docker + the `hashicorp/vault:1.18` container. **Skipped
  locally (no Docker socket)** — the integration lane is the authority for
  these two.
- [x] AC3 — Docker-absent sandbox skips cleanly; added runtime bounded to
  seconds (renewal soak ≈ 4 × 2s sleeps)
- [x] AC4 — ruff + format + mypy clean on the changed file; no production
  source touched
- [x] AC5 — `CHANGELOG.md` `[Unreleased]` entry under a unique `###`
  header

## Out of scope

- The full **re-mint** path against real Vault (JWT auth backend + runner
  JWT + `VAULT_CHECK_RUNNER_ROLE`) — unit-tested in #2668; real-Vault
  re-mint belongs to the deployed soak (#2826).
- Any multi-day / real-backend soak (#2826).
- Any production code change.

## Adjacent finding (not addressed)

- `tests/_strategies.py:60` — `WaitStrategy.with_startup_timeout` gets a
  `float` where the testcontainers stub expects `int | timedelta`. Present
  on `main`, unrelated to this change, and not a CI gate (CI runs
  `mypy src/`). Recorded, not touched (out of scope).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2827
