### PR TITLE
docs(guides): add the seven remaining Do-real-work guides (#2829)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — seven more Do-real-work guides on the docs site: topology, broadcast, memory/knowledge, audit forensics, runbooks, scheduler, satellite gateway (#2829)
+
+- Seven new task-first guides under `docs-site/guides/` complete the
+  "Do real work" section shaped by the #2663 initiative: **topology**
+  (the dependency graph — blast-radius, reachability, and how a resource
+  gets an anchor), **broadcast** (the cross-operator activity feed plus
+  the read-before-start discipline), **memory & knowledge** (the two
+  durable stores, memory scopes and TTL, and which belongs where),
+  **audit forensics** (`query_audit` filters, the broadcast/audit
+  correlation — pivot via the event's `audit_id` — and end-to-end
+  agent-session replay), **runbooks** (authoring and running versioned
+  multi-step procedures), **scheduler** (cron / one-off agent triggers,
+  including the #2668 durable-credential self-heal that keeps unattended
+  runs firing), and **satellite gateway** (remote check execution for
+  networks the central instance cannot dial). Each shows the CLI and MCP
+  surfaces against the same dispatch path and wires into the MkDocs nav;
+  the strict-build PR gate keeps the pages link-clean.
+
 ### Breaking changes — `net.*` allowlist refusals move from a `status="ok"` body to a dispatch error (#2784)
 
 - A `net.*` probe whose destination is outside

--- a/docs-site/guides/audit-forensics.md
+++ b/docs-site/guides/audit-forensics.md
@@ -1,0 +1,176 @@
+# Audit forensics
+
+Every authenticated operation against the backplane — a CLI verb, an
+MCP tool call, a REST request — writes exactly one **audit row**, and
+that row does not commit until the operation is allowed to report
+success. The ledger is append-only and synchronous: if the audit write
+fails, the operation fails. That property is what makes the audit log
+answer *"who did X to Y, and when?"* with authority rather than
+best-effort.
+
+This guide covers the `query_audit` filter surface, how to correlate an
+audit row with the live broadcast feed, and how to reconstruct an entire
+agent session end to end.
+
+!!! note "Prerequisites, roles, and maturity"
+
+    - A running backplane and a connected client
+      ([Connect clients](../clients/index.md)).
+    - Querying needs the **operator** role — and returns your whole
+      tenant's rows, not just your own. Replaying **another** operator's
+      or agent's session end to end needs **tenant_admin**.
+    - Audit is **GA** — the 1.0 stability promise applies (see the
+      [feature-maturity index](../reference/maturity.md#ga-features)).
+
+## What a row records
+
+Each `AuditEntry` carries the forensic fields you filter and pivot on:
+
+| Field | What it is |
+|---|---|
+| `id` | the audit row's UUID (the `audit_id` filter targets this) |
+| `ts` | when the operation occurred |
+| `principal_sub` / `principal_name` | the subject that acted (the JWT `sub`) |
+| `target_name` | the target it acted on |
+| `op_id` / `op_class` | the operation and its sensitivity class |
+| `result_status` | `ok` / `error` / `denied` |
+| `policy_decision` | the gate verdict: `auto-execute`, `needs-approval`, or `deny` |
+| `agent_session_id` | the originating agent's MCP session id — the key for session tracing |
+| `work_ref` | an external change-ticket reference, when one was stamped |
+| `method` / `path` / `status_code` / `duration_ms` / `payload` | the request particulars |
+
+## The filter surface
+
+The agent sees **one** tool, `query_audit` — every forensic shape is a
+filter combination, not a separate tool. The CLI adds pre-canned
+shortcuts over the same substrate.
+
+| Filter | `query_audit` arg | CLI |
+|---|---|---|
+| One row by id | `audit_id` | `meho audit show <id>` |
+| Everything on a target | `target` | `meho audit who-touched <target>` |
+| Your own recent activity | `principal=<your sub>` | `meho audit my-recent` |
+| Arbitrary combination | any of the below | `meho audit query …` |
+
+`query_audit` (and `meho audit query`) accept: `target`, `principal`
+(operator-sub substring), `op_id` (glob, e.g. `vault.*`), `op_class`
+(`read` / `write` / `credential_read` / `audit_query`), `result_status`,
+`since` / `until` (ISO-8601 **or** shorthand: `30m`, `24h`, `7d`, `2w`),
+`audit_id`, `agent_session_id`, `work_ref`, `limit` (default 100, max
+1000), and `cursor`. Calling it with **no** filters returns the most
+recent 100 rows of your tenant — bounded, never the whole ledger.
+
+```bash
+# "Did anyone read a Vault secret before the outage?"
+meho audit query --op-class credential_read --since 24h --result-status ok
+
+# "Show me every denied write this week."
+meho audit query --op-class write --result-status denied --since 7d
+```
+
+The agent surface returns the same rows, sorted newest-first, in a paged
+envelope:
+
+```json
+// query_audit {"target": "rdc-vcenter", "op_class": "write", "since": "7d"}
+{
+  "rows": [
+    {"id": "…", "ts": "2026-07-29T14:03:11Z", "principal_sub": "…",
+     "target_name": "rdc-vcenter", "op_id": "vsphere.host.maintenance",
+     "op_class": "write", "result_status": "ok",
+     "policy_decision": "needs-approval", "agent_session_id": "…",
+     "work_ref": "gh:evoila/meho#221"}
+  ],
+  "next_cursor": null
+}
+```
+
+`next_cursor` round-trips as the next call's `cursor`; `null` means the
+page is the end of the matching set. Tenant scoping is automatic — the
+JWT sets the boundary, and there is no `tenant_id` argument, so a
+cross-tenant probe is structurally impossible.
+
+## Correlating with the broadcast feed
+
+The audit ledger and the [broadcast feed](broadcast.md) are two views of
+the same operations — the audit row is the durable forensic record; the
+broadcast event is the live, redacted announcement. They are linked, but
+mind the direction:
+
+!!! warning "The link lives on the broadcast event, not the audit row"
+
+    The `AuditEntry` carries a `broadcast_event_id` field, but in this
+    version it is a **placeholder that is always `null`** — the
+    foreign key runs the *other* way. Each **broadcast event** carries
+    an `audit_id` pointing back at its audit row.
+
+So the correct pivot is broadcast → audit:
+
+1. You spot an event on the feed (`meho status --watch --json`) and read
+   its `audit_id`.
+2. You pull the full forensic row with that id:
+
+    ```bash
+    meho audit show <audit_id>
+    ```
+
+Do **not** try to filter audit rows by `broadcast_event_id` — it is
+unpopulated. Going the other way (audit → feed) is not an id lookup
+either: match on the operation's attributes instead (`principal`,
+`target`, `op_id`, and the timestamp window), remembering that
+`credential_read` and `audit_query` events are aggregate-only on the
+feed by redaction policy while the audit row keeps the full detail.
+
+## Tracing an agent session end to end
+
+When an autonomous agent fans out dozens of operations, `agent_session_id`
+ties them together. Filter flat:
+
+```bash
+meho audit query --session-id <agent_session_id> --since 24h
+```
+
+…or reconstruct the whole session as a parent/child tree. Over MCP an
+operator replays **their own** session:
+
+```json
+// query_audit {"shape": "tree", "agent_session_id": "<your own session id>"}
+{"root": [ /* ReplayNode forest, each node = an audit row + depth + children */ ],
+ "session_id": "…", "tenant_id": "…", "row_count": 37,
+ "excluded_null_session_count": 0}
+```
+
+Replaying **someone else's** session is a tenant_admin action —
+`meho audit replay <session-id>` (CLI) or the `meho_audit_replay` tool.
+Two guard rails worth knowing:
+
+- A session larger than 10,000 rows is refused with `session_too_large`
+  rather than returning a context-blowing tree — narrow with `since` /
+  `until` and page the flat shape instead.
+- `excluded_null_session_count` counts tenant MCP rows that carry **no**
+  session id (a client that reached `/mcp` without negotiating a
+  session). A non-zero value on an otherwise empty forest means "this
+  identity's MCP traffic is un-negotiated and invisible to lineage,"
+  not "this session did nothing."
+
+## What you never leak
+
+A `query_audit` call is itself an audited operation (`op_class:
+audit_query`), and the **contents** of your query — which target,
+which principal — are never published to the broadcast feed. Only the
+`{op_id, result_status, row_count}` aggregate appears, so an
+investigator searching for a compromised credential does not themselves
+broadcast the credential's path.
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| `broadcast_event_id` is `null` on every row | Working as designed — it is a v0.2 placeholder; the FK lives on the broadcast event's `audit_id`. | Pivot broadcast → audit: read the event's `audit_id`, then `meho audit show <id>`. |
+| `query_audit` with `parent_audit_id` returns `-32602` | The composite-subtree filter is not wired in this version. | Use `agent_session_id` + `shape="tree"` (or `meho audit replay`) for lineage instead. |
+| `shape="tree"` rejected with `-32602` naming your session | The tree path is **self-session only** for operators — the `agent_session_id` must equal your own MCP session id. | To replay another session, use the tenant_admin `meho audit replay <session-id>`. |
+| A replay is refused with `session_too_large` | The session exceeds the 10,000-row replay cap. | Narrow with `--since` / `--until` and page the flat `meho audit query --session-id …` shape. |
+| `meho audit query --since Tuesday` errors | `since` / `until` want ISO-8601 or the duration shorthand, not prose. | Use `--since 3d` or `--since 2026-07-28T00:00:00Z`. |
+| An empty result when you expected rows | The tenant boundary is on your JWT — a target/session in another tenant returns zero rows, not another tenant's data. | Confirm you are authenticated to the right tenant. |
+
+**Next:** [Runbooks](runbooks.md).

--- a/docs-site/guides/broadcast.md
+++ b/docs-site/guides/broadcast.md
@@ -1,0 +1,191 @@
+# Broadcast: cross-operator awareness
+
+When two operators — or two agents, or an operator and an agent — work
+the same estate at once, the failure mode is silent collision: you
+snapshot a VM while a colleague is mid-migration on it. MEHO's
+**broadcast** substrate is the shared activity feed that prevents it.
+Every governed operation emits a before/after event onto a per-tenant
+stream automatically, and agents can publish their *intent* on the same
+stream. Anyone — human or agent — can read it, filter it, and watch it
+live.
+
+This guide covers reading the feed, announcing intent, watching in real
+time, and the read-before-start discipline that turns the substrate into
+actual coordination.
+
+!!! note "Prerequisites, roles, and maturity"
+
+    - A running backplane and a connected client
+      ([Connect clients](../clients/index.md)).
+    - Reading and announcing need the **operator** role. A
+      `read_only` session can read but not announce.
+    - Broadcast is **Beta** — see the
+      [feature-maturity index](../reference/maturity.md#broadcast).
+
+## Two kinds of events on one stream
+
+The feed (`meho:feed:{tenant_id}`) carries two event kinds:
+
+| `kind` | Who writes it | When |
+|---|---|---|
+| `operation` | The dispatcher, **automatically** | before + after every `call_operation` — you never emit these by hand |
+| `agent_announcement` | An agent, via `broadcast_announce` | to declare intent, progress, or completion — the semantic layer per-op events lack |
+
+The automatic half means the feed is never empty of ground truth: every
+governed action is already on it, tied to its audit row (each event
+carries an `audit_id`). The announcement half is where an agent adds the
+*why* — "investigating cluster X latency for the next 20 minutes" — that
+a raw operation event can't express.
+
+## The surface at a glance
+
+| Action | MCP tool | CLI |
+|---|---|---|
+| Read recent events | `meho_broadcast_recent` | `meho status --watch` (live) |
+| Watch for new events (long-poll) | `meho_broadcast_watch` | `meho status --watch` |
+| Announce intent / progress / completion | `meho_broadcast_announce` | — (agent-authored; no CLI verb) |
+| Manage redaction detail (tenant_admin) | — | `meho broadcast overrides` |
+
+The read/watch surface is dual: agents drill the feed programmatically
+with `meho_broadcast_recent` / `meho_broadcast_watch`; an operator tails
+it live with `meho status --watch`. Announcing is deliberately
+agent-only — it is how an autonomous run narrates itself.
+
+## Read the feed
+
+```bash
+meho status --watch
+```
+
+That subscribes to the live SSE feed and prints one line per event until
+Ctrl-C. Narrow it with the same three filters the agent tool exposes:
+
+```bash
+meho status --watch --target prod-vc-1        # only events touching this target
+meho status --watch --op-class write          # only mutating operations
+meho status --watch --principal <jwt-sub>     # only this operator's actions
+```
+
+`--op-class` accepts `read`, `write`, `credential_read`, or
+`audit_query`. Pass `--json` to get one JSON object per line — the shape
+an agent consumes:
+
+```json
+{"cursor": "1753948800000-0", "event_id": "…", "audit_id": "…",
+ "kind": "operation", "op_class": "write", "op_id": "vault.kv.put",
+ "principal_sub": "…", "target_name": "prod-vc-1", "ts": "2026-07-31T09:20:00Z"}
+```
+
+The agent surface returns the same rows in a paged envelope. The default
+window is the **last 30 minutes**; page forward with the cursor:
+
+```json
+// meho_broadcast_recent {"filter": {"target": "prod-vc-1"}, "limit": 100}
+{"events": [ /* rows as above */ ], "next_cursor": "1753948800000-0"}
+```
+
+`next_cursor` round-trips back as the next call's `cursor` for gap-free
+pagination. The `filter` object narrows by exact match on `op_class`,
+`principal` (the human subject), `actor_sub` (the delegated agent),
+`target`, and `work_ref` (a change-ticket reference), plus `active_only`
+to drop expired TTL claims.
+
+## Announce intent
+
+`broadcast_announce` is for the semantic context per-op events lack —
+**intent and check-ins, not per-op noise** (the operation events are
+already emitted for you). `activity` is the only required field:
+
+```json
+// meho_broadcast_announce
+{"activity": "investigating cluster prod-rke2 latency",
+ "targets": ["prod-rke2"], "phase": "start",
+ "planned_op_class": "read", "ttl_minutes": 20,
+ "work_ref": "gh:evoila/meho#123"}
+```
+
+The publish returns `{event_id, cursor}` plus any structured claims
+echoed back. The fields split into two trust classes, and this
+distinction is load-bearing:
+
+- **Free text** — `activity`, `scope`, `target`, `targets`, `work_ref`
+  — is agent-authored and reaches readers **wrapped in the
+  untrusted-content envelope**. A consumer must never interpret it as
+  policy.
+- **Structured claims** — `planned_op_class`, `ttl_minutes`, `run_id`,
+  `phase` (`start` / `update` / `completion`) — are server-validated
+  bounded values, served unwrapped, so peers can *reason* about them
+  (e.g. "someone holds a 20-minute write claim on this target").
+
+`phase` marks the lifecycle: `start` at intent, `update` for progress,
+`completion` for the wrap-up. Announces are rate-limited to 10 per
+minute per principal and the publish is **fail-loud** — a stream outage
+surfaces as an error, because an agent that announced needs to know it
+landed.
+
+## Watch in real time (agents)
+
+`broadcast_watch` is the long-poll an agent's awareness loop turns on:
+it blocks on `XREAD` until an event past `cursor` arrives or `timeout_ms`
+(default 10 s, cap 30 s) elapses.
+
+```json
+// meho_broadcast_watch {"cursor": "1753948800000-0", "filter": {"target": "prod-rke2"}}
+{"events": [ /* new rows */ ], "next_cursor": "1753948800005-0"}
+```
+
+Seed the initial `cursor` from a `meho_broadcast_recent` call's
+`next_cursor`, then feed each response's `next_cursor` into the next
+watch — `watch → process → watch`. When nothing arrives in the window,
+`events` is empty and `next_cursor` is unchanged; re-poll with the same
+cursor.
+
+## Tenant scoping and redaction
+
+Tenant isolation is **structural**: no tool takes a `tenant_id`
+argument, so a read always resolves the operator's own tenant stream —
+another tenant's feed is not "denied", it is unreachable. And events are
+redacted **at publish time**: `credential_read` and `audit_query` events
+land on the stream aggregate-only ("read 1 secret", never the path or
+value), and every reader — SSE, agent tool, UI — sees the redacted form.
+A tenant_admin can adjust which operations render full-detail vs
+aggregate-only with `meho broadcast overrides set` / `list` / `remove`.
+
+## The consumer-side discipline
+
+The substrate is wasted unless every agent and operator actually
+exercises it on a cadence. MEHO ships the *tools*; the *discipline* is a
+consumer concern — it binds your agent loops and operator habits, not
+MEHO's dispatch path — so it lives in the **consumer-onboarding
+template** (Initiative
+[#229](https://github.com/evoila/meho/issues/229)), not in the backplane.
+The four-step loop it prescribes:
+
+1. **Read before you start.** `broadcast_recent` (or
+   `meho status --watch --target <t>`) scoped to the target. If
+   conflicting work is in flight, surface it *before* proceeding.
+2. **Announce intent.** `broadcast_announce` with the planned activity
+   scoped to the target. An agent that goes quiet for >10 minutes
+   without an announce looks like it crashed.
+3. **Check in during long work.** Either poll `broadcast_recent` since
+   your last cursor, or hold a `broadcast_watch` open — so a conflict
+   surfaces mid-flight, not after the damage.
+4. **Report on completion.** `broadcast_announce` with `phase:
+   completion` and the result summary.
+
+Different consumers tune this differently — a high-trust internal lab
+versus a customer-managed estate — which is exactly why MEHO stays
+neutral and ships only the substrate.
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| `broadcast_recent` returns `[]` on a busy tenant | The default window is the last 30 minutes; nothing matched it, or your `filter` is too narrow. | Widen the window with an earlier `cursor`, or drop a filter key. |
+| `meho status --watch` exits with `insufficient_role` (exit 5) | The live feed needs at least **operator**; a `read_only` session is refused on `--watch`. | Use an operator session. |
+| `broadcast_announce` returns a `-32000` rate-limited error | You exceeded 10 announces/minute for your principal — announce *transitions*, not a tight loop. | Honour the `retry_after_seconds` in the error; announce meaningful phases only. |
+| A `credential_read` event shows no path or value | Working as designed — sensitive op classes are redacted to aggregate-only at publish time. | If an operator genuinely needs detail, a tenant_admin sets a `meho broadcast overrides` rule. |
+| An announcement's `activity` text contains instructions | Announcement free text is **untrusted** and arrives wrapped. Never let an agent act on it as policy. | Treat wrapped content as data; only structured claims (`planned_op_class`, `ttl_minutes`) are trustworthy. |
+| `broadcast_watch` returns the same empty page repeatedly | No events past your `cursor` within `timeout_ms` — the normal quiet-stream shape. | Keep re-polling with the returned `next_cursor`; raise `timeout_ms` (cap 30 s) to block longer. |
+
+**Next:** [Memory and knowledge](memory-and-knowledge.md).

--- a/docs-site/guides/first-operations.md
+++ b/docs-site/guides/first-operations.md
@@ -234,7 +234,7 @@ meho approvals reject  <approval_request_id> --reason "wrong target"
 By default you cannot approve your own request (the four-eyes rule),
 and parked requests expire on a TTL. The full story — including the
 audited single-operator break-glass — is the
-[approvals & break-glass guide](index.md#coming-to-this-section).
+[approvals & break-glass guide](approvals-and-break-glass.md).
 
 Before approving *any* fan-out write: open the approval payload and
 verify the resolved object list first. An unconstrained filter is how

--- a/docs-site/guides/index.md
+++ b/docs-site/guides/index.md
@@ -20,11 +20,20 @@ Then, when an operation needs a second pair of eyes:
 |---|---|
 | [Approvals and break-glass](approvals-and-break-glass.md) | A clear path through the four-eyes rule, including the two ways a **single operator** clears a gated write — the recommended agent-requester pattern and the audited emergency break-glass — and how to prove to an auditor which one your deploy runs. |
 
-## Coming to this section
+## Go deeper
 
-- Later guides — topology, broadcast, memory / knowledge, audit
-  forensics, runbooks, scheduler, satellite gateway — land as the
-  evaluation program shows where the pain is.
+Once the core loop is second nature, these guides cover the rest of the
+backplane — reach for whichever the task in front of you needs:
+
+| Guide | What it covers |
+|---|---|
+| [Topology](topology.md) | The dependency graph: blast-radius (`dependents`), reachability (`path`), and how a resource gets into the graph. |
+| [Broadcast](broadcast.md) | The cross-operator activity feed — read it, announce intent, watch it live, and the read-before-start discipline. |
+| [Memory and knowledge](memory-and-knowledge.md) | Two durable stores: scoped, TTL'd memory and the tenant knowledge base, and which belongs where. |
+| [Audit forensics](audit-forensics.md) | Reconstructing "who did X to Y and when" from the append-only ledger, and tracing an agent session end to end. |
+| [Runbooks](runbooks.md) | Authoring versioned, multi-step procedures and running them one gated step at a time. |
+| [Scheduler](scheduler.md) | Firing agent runs on cron / one-off triggers, and the durable-credential behavior that keeps them running unattended. |
+| [Satellite gateway](satellite-gateway.md) | Remote check execution for networks the central instance cannot dial. |
 
 !!! tip "When a guide and your deploy disagree"
 

--- a/docs-site/guides/memory-and-knowledge.md
+++ b/docs-site/guides/memory-and-knowledge.md
@@ -1,0 +1,172 @@
+# Memory and knowledge
+
+MEHO gives an operator (and their agents) two places to write things
+down so they survive the session: **memory** for shorter-lived, scoped
+state — an operator preference, a tenant convention, a target-specific
+gotcha — and the **knowledge base** (kb) for durable, generalizable team
+knowledge: vendor API patterns, known-good runbooks, post-incident
+learnings. Both are searched the same way (hybrid lexical + semantic
+retrieval), and both exist as MCP tools for agents and CLI verbs for
+operators over one backplane.
+
+This guide covers what goes where, the memory scope and TTL model, and
+the search-before-you-write discipline that keeps both corpora from
+fragmenting.
+
+!!! note "Prerequisites, roles, and maturity"
+
+    - A running backplane and a connected client
+      ([Connect clients](../clients/index.md)).
+    - Reading and personal writes need the **operator** role. Writing
+      to a **tenant-shared** scope (memory `tenant`, or any kb entry)
+      needs **tenant_admin**.
+    - Memory and knowledge are **GA** — the 1.0 stability promise
+      applies (see the
+      [feature-maturity index](../reference/maturity.md#ga-features)).
+
+## Which store?
+
+| | **Memory** (G5) | **Knowledge / kb** (G4) |
+|---|---|---|
+| For | operator/tenant/target-scoped state | durable, generalizable team knowledge |
+| Lifetime | can carry a TTL (expires) | durable until deleted |
+| Scoped | five scopes, from personal to tenant-wide | tenant-wide |
+| Write | `add_to_memory` / `meho remember` | `add_to_knowledge` / `meho kb add` |
+| Search | `search_memory` / `meho recall --query` | `search_knowledge` / `meho kb search` |
+
+The rule of thumb the tools themselves enforce: *"is this a shorter-lived
+preference/convention/gotcha, or durable team knowledge?"* A session
+note about *your* tenant preference is memory; a distilled "here's how
+vCenter's session auth actually works" is knowledge.
+
+!!! note "The kb has two names"
+
+    Every non-MCP surface calls the knowledge base **`kb`** — the CLI
+    verb is `meho kb`, the REST route is `/api/v1/kb`, the console is
+    `/ui/kb`. Only the two agent tools are named `search_knowledge` /
+    `add_to_knowledge`. There is no `/api/v1/knowledge` route.
+
+## Memory: scopes
+
+Every memory entry has a **scope** that decides who can see it. Pick the
+narrowest scope that captures intent:
+
+| Scope | Visible to | Needs |
+|---|---|---|
+| `user` | you, across every tenant | — |
+| `user-tenant` | you, within this tenant (the CLI default) | — |
+| `user-target` | you, for one target | `target_name` |
+| `tenant` | everyone in the tenant | **tenant_admin** to write |
+| `target` | everyone touching that target | `target_name` |
+
+Write one with the CLI:
+
+```bash
+meho remember "prod-vc-1's DRS is manual — do not enable automation" \
+  --scope target --target prod-vc-1 --tag ops
+```
+
+Or from an agent:
+
+```json
+// add_to_memory
+{"body": "prod-vc-1's DRS is manual — do not enable automation",
+ "scope": "target", "target_name": "prod-vc-1", "tags": ["ops"]}
+```
+
+The write returns the full entry so you can confirm it landed:
+
+```json
+{"id": "…", "slug": "prod-vc-1-drs-manual", "scope": "target",
+ "body": "prod-vc-1's DRS is manual — do not enable automation",
+ "metadata": {"tags": ["ops"]}, "expires_at": null, "created_at": "…"}
+```
+
+## Memory: TTL
+
+Memory can **expire** — the difference from the durable kb. TTL is an
+ISO-8601 duration (`P7D` = 7 days, `PT1H` = 1 hour):
+
+- A `user`-scope write with **no** `ttl` picks up the backend default
+  (7 days, `MEMORY_USER_DEFAULT_TTL_DAYS`) — a personal note self-cleans.
+- Pass `--persist` (CLI) / `ttl: null` (MCP) to keep it forever.
+- `tenant`- and `target`-scope writes default to **no expiry** — shared
+  conventions are meant to last.
+
+```bash
+meho remember "debugging the flaky RKE2 upgrade" --scope user --ttl PT2H
+meho remember "team convention: always --dry-run first" --scope tenant --persist
+```
+
+## Search either store
+
+Retrieval fuses BM25 (lexical) and cosine (semantic) ranks. Search
+memory scoped or unscoped:
+
+```bash
+meho recall --query "DRS automation" --scope target --target prod-vc-1
+```
+
+```json
+// search_memory {"query": "DRS automation", "scope": "target"}
+{"hits": [
+  {"scope": "target", "slug": "prod-vc-1-drs-manual",
+   "snippet": "prod-vc-1's DRS is manual — do not enable…", "score": 0.87}
+]}
+```
+
+Search knowledge the same way:
+
+```bash
+meho kb search "vcenter session authentication"
+```
+
+Both search tools return a **snippet** and the natural key, not the full
+body — fetch the full body with a resource read (`meho://memory/{scope}/{slug}`
+or `meho://kb/{slug}`), or `meho recall <scope>/<slug>` / `meho kb show <slug>`.
+Omitting `scope` on `search_memory` searches every scope you can read;
+`search_knowledge` takes an optional `filters` object (e.g.
+`{"kind": "kb-entry"}`) that narrows by metadata containment.
+
+## Write knowledge
+
+```bash
+meho kb add vcenter-session-auth --body-file ./vcenter-session-auth.md
+```
+
+```json
+// add_to_knowledge {"slug": "vcenter-session-auth", "body": "# vCenter session auth\n…"}
+{"id": "…", "slug": "vcenter-session-auth", "body": "# vCenter session auth\n…",
+ "metadata": {}, "created_at": "…", "updated_at": "…"}
+```
+
+Re-adding the same slug **updates in place** — a body-hash short-circuit
+means an unchanged body costs only an `updated_at` bump (no re-embed), so
+an agent can call it freely as "remember this."
+
+## The discipline: search before you write
+
+Both `add_*` tools say the same thing, and it is the single most
+important habit: **`search_*` first.** Re-adding a note under a new slug
+fragments the corpus and dilutes future retrieval. If a matching entry
+exists, extend it (read it, merge, re-add with the same slug) instead of
+creating a near-duplicate. The mirror habit on the read side: `search_*`
+**before asking the operator** a question the corpus may already answer.
+
+This is also how the checks **investigator** closes its loop — when it
+diagnoses a red dashboard it writes its structured finding into tenant
+memory under `checks-noise-<group-key>`, retrievable later via
+`search_memory` (see [Watch your estate with sensors](sensors-quickstart.md#the-investigator-optional-deep-tier)).
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| `add_to_memory` denied with `INVALID_PARAMS` on a `tenant` write | Writing tenant-shared memory needs **tenant_admin**; your role is operator. | Write it `user-tenant` first, then `meho promote <scope>/<slug> --to tenant` as a tenant_admin. |
+| `add_to_memory` errors on a `target` / `user-target` write | Those scopes **require `target_name`** — the entry has nowhere to hang otherwise. | Add `--target <name>` (CLI) / `target_name` (MCP). |
+| A `user`-scope note vanished after a week | Working as designed — `user` scope carries the 7-day default TTL. | Re-add with `--persist` (CLI) / `ttl: null` (MCP) for a durable note, or a longer `--ttl`. |
+| `search_memory` misses an entry you know exists | It is scoped out of your view (another operator's `user` entry), or your `scope` filter excludes it. | Drop the `scope` filter to search everything you can read; check you wrote it to a shared scope if a teammate needs it. |
+| No `delete` shows up in the agent tools for kb | Deletion is deliberately **REST/CLI-only** — there is no `add_to_knowledge` inverse on the agent surface. | `meho kb delete <slug>` (tenant_admin) or `DELETE /api/v1/kb/{slug}`. |
+| A kb write "succeeds" but retrieval still returns the old text | You wrote a *new* slug instead of extending the existing one — now there are two entries. | `meho kb search` for the topic first; re-add under the existing slug to update in place. |
+
+**Next:** [Audit forensics](audit-forensics.md).

--- a/docs-site/guides/runbooks.md
+++ b/docs-site/guides/runbooks.md
@@ -1,0 +1,154 @@
+# Author and run runbooks
+
+A single operation does one thing. A **runbook** is the third kind of
+operation MEHO ships (alongside generic and typed connectors): a
+**versioned, parameterised, multi-step procedure** that composes
+operation calls and manual steps into one reviewable, repeatable whole —
+"rotate the ingress certificate", "drain and patch a host", "bring up a
+new tenant". A tenant_admin *authors* the template once; operators *run*
+it, advancing one gated step at a time.
+
+This guide covers both halves: authoring a template through its
+draft → publish lifecycle, and executing a run start-to-finish.
+
+!!! note "Prerequisites, roles, and maturity"
+
+    - A running backplane, a connected client, and at least one
+      registered target
+      ([Register targets and secrets](targets-and-secrets.md)).
+    - **Authoring** templates (draft / edit / publish / deprecate)
+      needs **tenant_admin**. **Running** a runbook needs **operator**.
+    - Runbooks are part of MEHO's write surfaces, which are **Beta** —
+      see the
+      [feature-maturity index](../reference/maturity.md#write_surfaces).
+
+## What a runbook is (and is not)
+
+A runbook template has a `title`, an optional `target_kind`, and an
+**ordered list of steps**. Each step is one of two kinds, and each
+carries a **`verify`** gate that must pass before the run advances:
+
+- **`operation_call`** — dispatches an `op_id` with `params`, exactly
+  like `call_operation`. This is the automated half.
+- **`manual`** — instructions for a human to carry out something MEHO
+  can't (rack a disk, get a sign-off). The operator does it, then
+  reports the step done.
+
+The runbook itself carries **no `safety_level`**. Its safety is the
+safety of the operations it dispatches: when an `operation_call` step
+runs a `requires_approval` op, that step **parks in the approval queue**
+exactly as a direct call would — the gate lives in the dispatch layer,
+not the runbook. A runbook is therefore not a way to bypass approvals;
+it is a governed sequence of the same governed calls.
+
+## The surface at a glance
+
+| Action | MCP tool | CLI |
+|---|---|---|
+| **Author** (tenant_admin) | | |
+| Create the first draft | `meho_runbook_draft_template` | `meho runbook draft-template <slug> --from <file>` |
+| Edit a draft | `meho_runbook_edit_template` | `meho runbook edit-template <slug> --from <file>` |
+| Publish a draft | `meho_runbook_publish_template` | `meho runbook publish-template <slug>` |
+| Deprecate a version | `meho_runbook_deprecate_template` | `meho runbook deprecate-template <slug>` |
+| **Discover** (operator) | | |
+| List templates | `meho_runbook_list_templates` | `meho runbook list-templates` |
+| Show one template | `meho_runbook_show_template` | `meho runbook show-template <slug>` |
+| **Run** (operator) | | |
+| Start a run | `meho_runbook_start` | `meho runbook start <slug> --target <name>` |
+| Advance one step | `meho_runbook_next` | `meho runbook next <run_id>` |
+| Abort a run | `meho_runbook_abort` | `meho runbook abort <run_id> --reason "…"` |
+| List runs | `meho_runbook_list_runs` | `meho runbook runs` |
+
+## Authoring a template
+
+Write the body as a YAML (or JSON) file and draft it. A minimal,
+two-step template:
+
+```yaml
+title: Rotate the ingress certificate
+target_kind: k8s
+steps:
+  - type: operation_call
+    title: Snapshot the current secret
+    body: Capture the live cert so the run has a rollback point.
+    op_id: k8s.secret.get
+    params: {namespace: ingress, name: tls-cert}
+    verify:
+      type: confirm
+      prompt: Confirm the snapshot was captured before proceeding.
+  - type: manual
+    title: Stage the renewed certificate
+    body: Place the renewed PEM at the target's secret path.
+    verify:
+      type: operation_call
+      op_id: vault.kv.versions
+      params: {path: tenants/acme/ingress-cert}
+      expect: {status: ok}
+```
+
+A `verify` is `type: confirm` (MEHO shows the `prompt` and the operator
+confirms) or `type: operation_call` (MEHO dispatches an op and matches
+the result against `expect`). Draft, then publish:
+
+```bash
+meho runbook draft-template ingress-cert-rotate --from ./ingress-cert-rotate.yaml
+meho runbook publish-template ingress-cert-rotate
+```
+
+Templates are **versioned and immutable once published**: editing a
+published template forks a new draft version; a run pins the exact
+version it started against, so republishing never changes a run already
+in flight. Retire an old version with
+`meho runbook deprecate-template <slug>` — existing runs finish, new
+runs pick the current published version.
+
+## Running a template
+
+Start a run against a concrete target; pass any parameters the steps
+reference:
+
+```bash
+meho runbook start ingress-cert-rotate --target lab-rke2 \
+  --param namespace=ingress --work-ref gh:evoila/meho#412
+# → run_id: 7c2a…   step 1/2: Snapshot the current secret
+```
+
+The run reveals **only the current step** — never the full template,
+never the steps ahead. This opacity is structural: `start`, `next`, and
+`runs` all refuse to leak future step bodies. Work the step, then
+advance:
+
+```bash
+meho runbook next 7c2a…
+# → step 1 verified; step 2/2: Stage the renewed certificate
+```
+
+`next` runs the step's `verify` — the **substrate is the oracle**. A
+`confirm` verify asks you to confirm; an `operation_call` verify
+dispatches its op and checks the result against `expect`. The run only
+advances when verify passes; a failing verify holds the run on the
+current step. Over MCP the same call is
+`meho_runbook_next {"run_id": "…", "last_verified": true}` — but
+`last_verified` is informational only; the server re-verifies regardless.
+
+When every step verifies, the run completes. To stop early:
+
+```bash
+meho runbook abort 7c2a… --reason "upstream CA delayed the renewal"
+```
+
+The `reason` is persisted to the audit ledger. List your runs and their
+state (run-level only — never step contents) with `meho runbook runs`.
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| `next` won't advance — the run stays on the current step | The step's `verify` did not pass (a `confirm` you declined, or an `operation_call` whose result didn't match `expect`). | Fix the underlying condition and call `next` again; the substrate re-verifies. |
+| A step returns `awaiting_approval` instead of running | That `operation_call` step dispatched a `requires_approval` op — the runbook does not bypass the gate. | Clear it on the approvals surface ([Approvals and break-glass](approvals-and-break-glass.md)), then continue. |
+| `show-template` / `list-runs` returns `-32603` / 500 with `template_body_validation_failed` | A stored template predates a schema tightening (e.g. an empty step body from before the non-empty-body rule) and fails read-time re-validation. | A tenant_admin re-edits the offending step; on-prem deploys apply the backfill migration named in the error. |
+| `draft-template` rejected — "disallowed substitution in op_id" | A step or verify tried to parameterise the `op_id` itself. Params may be substituted; the operation identity may not. | Hard-code `op_id`; use `params` for the variable parts. |
+| `403 insufficient_role` on `publish-template` / `draft-template` | Authoring needs **tenant_admin**; your session is operator. | Author under a tenant_admin session; operators run, they don't author. |
+| A republished template didn't change a run already in progress | By design — a run pins its template version at `start`. | Abort and re-`start` to pick up the new version, or let the in-flight run finish. |
+
+**Next:** [Scheduler](scheduler.md).

--- a/docs-site/guides/satellite-gateway.md
+++ b/docs-site/guides/satellite-gateway.md
@@ -1,0 +1,140 @@
+# Reach isolated networks with a satellite gateway
+
+Some of the systems you need to watch sit where the central backplane
+cannot dial them: behind NAT, on a private control plane, on a
+ClusterIP-only service, in a customer network with no inbound path. A
+**satellite gateway** solves this without poking holes in the firewall.
+It is a second deploy mode of the *same* MEHO container image, run inside
+the isolated network, that dials **outbound** to central, pulls the
+checks it has been assigned, runs them locally, and reports the results
+back.
+
+This guide covers the model, how to enroll and deploy a satellite, and
+what stays central (which is almost everything).
+
+!!! note "Prerequisites, roles, and maturity"
+
+    - A central backplane the satellite can reach **outbound** (the
+      satellite dials it; the reverse path is never opened).
+    - Registering and revoking runner principals needs **tenant_admin**.
+    - The satellite gateway is **Beta** — see the
+      [feature-maturity index](../reference/maturity.md#satellite_gateway).
+
+## The model: push-only, centrally authorized
+
+The satellite is a **dumb executor of centrally-authorized work.** Run it
+with `python -m meho_backplane.runner` — the third mode of the shared
+image, alongside Serve (the central API) and Migrate. It has **no** local
+database, no Valkey, no UI, no MCP surface, and **no inbound listener**.
+Every connection is initiated by the satellite; the center is passive.
+
+Each tick, the satellite:
+
+1. **Polls** central for its current assignment (a set of authorized
+   work items).
+2. **Executes** each item locally against the same connector surface the
+   central instance uses.
+3. **Reports** the results back.
+
+Two properties make this safe to run in an untrusted segment:
+
+- **Safe operations only.** A satellite **refuses** any work item whose
+  `safety_level` is not `safe` — it evaluates read-class checks and
+  nothing else. It also refuses any handler not under the connector
+  package. There is no path by which a satellite performs a write.
+- **Authorization, approval, and audit stay central.** The satellite
+  never self-authorizes: central mints the assignment, central holds the
+  audit ledger, central runs the approval queue. A compromised satellite
+  can, at worst, decline to run its assigned reads — it cannot escalate.
+
+Resilience is built in for the flaky-uplink reality of a remote segment:
+results that fail to post are written to an on-disk **spool** and
+re-posted oldest-first; a failed assignment fetch keeps the **cached**
+assignment running, so the satellite keeps evaluating its last-known
+checks while the uplink is down.
+
+## Enroll and deploy a satellite
+
+**1. Register a runner principal** on central. This mints the
+satellite's identity (a Keycloak client tagged `kind=runner`) and its
+credentials:
+
+```bash
+meho runner-principal register edge-dc-a
+# → runner_id + token (deploy these to the satellite as MEHO_RUNNER_ID / MEHO_RUNNER_TOKEN)
+```
+
+**2. Deploy the runner** inside the isolated network — the same image,
+started in runner mode, configured entirely through `MEHO_RUNNER_*` env:
+
+```bash
+MEHO_RUNNER_CENTRAL_URL=https://meho.example.com \
+MEHO_RUNNER_ID=edge-dc-a \
+MEHO_RUNNER_TOKEN=<token-from-step-1> \
+python -m meho_backplane.runner
+```
+
+Optional knobs: `MEHO_RUNNER_TICK_INTERVAL_SECONDS` (poll cadence),
+`MEHO_RUNNER_SPOOL_DIR` and `MEHO_RUNNER_SPOOL_MAX_FILES` (the retry
+spool bounds).
+
+**3. Confirm central sees it:**
+
+```bash
+meho runner-principal list
+meho runner-principal show edge-dc-a
+```
+
+Once the satellite is polling, central assigns it the checks whose
+targets live in its network, and their results flow into the same
+dashboards and sensor state as every locally-run check — the satellite
+is invisible to the consumer of the data.
+
+## Liveness and the kill switch
+
+A satellite that dies or loses its uplink must not leave its checks
+silently reporting last-known-good forever. Liveness is enforced on the
+**central clock**, never the satellite's own:
+
+- **Heartbeat is piggybacked**, not a separate call — every
+  authenticated poll stamps the runner principal's `last_seen_at`
+  server-side (the client cannot forge it). The poll cycle *is* the
+  heartbeat, so a healthy idle satellite still proves liveness, and a
+  wedged work loop cannot masquerade as alive.
+- **Dead-man staleness.** When a runner's `last_seen_at` falls behind
+  the cutoff, central flips its assignment rows to stale and writes an
+  internal audit row (`gateway.runner.stale`) — the affected checks
+  surface as `unknown`, not a stale green.
+
+To decommission or contain a satellite, revoke its principal — the kill
+switch:
+
+```bash
+meho runner-principal revoke edge-dc-a
+```
+
+## Satellite vs. the in-process check runner
+
+Do not confuse the satellite with the **in-process check runner** that
+evaluates [sensors](sensors-quickstart.md) inside the central pod. They
+run the same safe check evaluations; the difference is *where*. The
+in-process runner handles targets central can reach directly (and its
+background-credential story is in
+[Sensors and your credential backend](sensors-quickstart.md#sensors-and-your-credential-backend));
+the satellite handles the targets it cannot. A sensor's author does not
+choose — central routes each check to whichever runner can reach its
+target.
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| The runner exits 1 at startup naming a variable | A required `MEHO_RUNNER_*` var (`CENTRAL_URL` / `ID` / `TOKEN`) is missing or malformed. | Set all three; the error names the offender. |
+| Checks on a satellite's targets go `unknown` after the satellite stops | The dead-man sweep flipped its assignments stale because `last_seen_at` fell behind — working as designed, not a false green. | Bring the satellite back; restart it or check its outbound path to `MEHO_RUNNER_CENTRAL_URL`. |
+| A work item comes back `refused` | The satellite declined it — most often because its `safety_level` was not `safe`. Satellites never run writes. | Only read-class checks belong on a satellite; a write must run centrally through the approval path. |
+| Results lag but eventually appear | The uplink was down; results spooled to disk and re-posted when it recovered. | Nothing — this is the spool working. If the spool fills (`SPOOL_MAX_FILES`), fix the uplink. |
+| `403` registering a runner principal | `meho runner-principal register` / `revoke` need **tenant_admin**. | Enroll under a tenant_admin session; `show` / `list` are operator-level. |
+
+**Where next:** back to the [Do real work](index.md) index, or the
+[feature-maturity index](../reference/maturity.md) for what is GA versus
+Beta across the surfaces these guides cover.

--- a/docs-site/guides/scheduler.md
+++ b/docs-site/guides/scheduler.md
@@ -61,12 +61,15 @@ event (`--event-filter`) rather than a clock. The knobs worth knowing:
 
 - `--inputs` — a JSON object rendered into the agent's prompt at fire
   time.
-- `--identity-sub` — the subject the run acts under (this is what makes
-  a scheduled run park its writes under an *agent* principal, distinct
-  from your own, so four-eyes stays intact — see the
-  [approvals guide](approvals-and-break-glass.md)).
-- `--in-flight-policy` — what to do when a fire is due while the
-  previous run of the same trigger is still going.
+- `--identity-sub` — the identity the scheduler impersonates at fire
+  time (default `__scheduler__`); an override you rarely set. What keeps
+  four-eyes intact for a scheduled write is the **bound agent
+  definition's own subject** on an autonomous run, not this flag — see
+  the [approvals guide](approvals-and-break-glass.md).
+- `--in-flight-policy` — `fail_into_audit` (default) or `resume`: what
+  happens to a run the scheduler was killed in the middle of.
+  `fail_into_audit` records the interrupted run as failed on the audit
+  ledger; `resume` picks it back up on restart.
 - `--work-ref` — a change-ticket reference stamped onto the run's audit
   and broadcast lineage.
 
@@ -150,6 +153,6 @@ this page is its agent-run twin.
 | `403 insufficient_role` on `scheduler create` / `cancel` | Creating and cancelling triggers need **tenant_admin**; listing is operator. | Use a tenant_admin session to author triggers. |
 | A cron trigger never fires | The `--cron-expr` didn't parse, or `--timezone` is wrong, so `next_fire_at` was never set to a reachable instant. | Check `meho scheduler list` for `next_fire_at`; fix the 5-field expression / IANA timezone and recreate. |
 | A scheduled write is stuck `awaiting_approval` | Working as designed — an autonomous run's `requires_approval` write parks under the agent's subject. | Approve it as yourself; because the requester is the agent, four-eyes is satisfied ([approvals](approvals-and-break-glass.md)). |
-| Overlapping runs of the same trigger | A fire came due while the previous run was still going. | Set `--in-flight-policy` to the behavior you want (skip / queue) at create time. |
+| A run interrupted mid-flight (scheduler restart) shows as failed | The default `--in-flight-policy=fail_into_audit` records a killed-mid-run trigger as a failure rather than silently resuming it. | Set `--in-flight-policy=resume` at create time if you want interrupted runs picked back up on restart. |
 
 **Next:** [Satellite gateway](satellite-gateway.md).

--- a/docs-site/guides/scheduler.md
+++ b/docs-site/guides/scheduler.md
@@ -1,0 +1,155 @@
+# Schedule unattended work
+
+The scheduler is the floor of MEHO's 24/7 operation: it fires **agent
+runs** on durable triggers — a cron expression, a one-off instant, or an
+event — with no operator at the keyboard. An operator (or agent author)
+creates a trigger row; a background loop scans for what is due and
+launches the bound agent definition when its time comes. This is what
+runs your nightly reconciliation, your scheduled remediation, and the
+autonomous writes behind the [agent-requester approval
+pattern](approvals-and-break-glass.md#option-1-the-agent-requester-pattern-recommended).
+
+The hard part of unattended execution is not the timer — it is *credentials*:
+a scheduled run days later still needs a live identity to reach Vault.
+This guide covers creating triggers and the durable-credential behavior
+that keeps them firing.
+
+!!! note "Prerequisites, roles, and maturity"
+
+    - A running backplane and an **agent definition** to fire
+      (`meho agent create …`).
+    - Creating and cancelling triggers needs **tenant_admin**; listing
+      needs **operator**.
+    - The scheduler is **Beta** — see the
+      [feature-maturity index](../reference/maturity.md#scheduler). Its
+      road to GA is tracked in
+      [#2668](https://github.com/evoila/meho/issues/2668), the same
+      issue that hardened the durable-credential behavior below.
+
+## The surface at a glance
+
+| Action | MCP tool | CLI |
+|---|---|---|
+| List triggers | `meho_scheduler_list` | `meho scheduler list` |
+| Create a trigger (tenant_admin) | `meho_scheduler_create` | `meho scheduler create …` |
+| Cancel a trigger (tenant_admin) | `meho_scheduler_cancel` | `meho scheduler cancel <trigger_id>` |
+
+## Create a trigger
+
+Every trigger binds one `--agent-definition` and one `--kind`. A
+**cron** trigger fires repeatedly on a 5-field expression evaluated in
+its persisted `--timezone`:
+
+```bash
+meho scheduler create --kind cron \
+  --agent-definition nightly-reconcile \
+  --cron-expr "0 2 * * *" --timezone Europe/Vienna \
+  --inputs '{"scope": "prod"}' \
+  --work-ref gh:evoila/meho#520
+```
+
+A **one-off** trigger fires once at a stored instant, then transitions
+to a terminal state:
+
+```bash
+meho scheduler create --kind one_off \
+  --agent-definition drain-and-patch --fire-at 2026-08-10T22:00:00Z
+```
+
+A third kind, **event**, fires an agent run in response to a backplane
+event (`--event-filter`) rather than a clock. The knobs worth knowing:
+
+- `--inputs` — a JSON object rendered into the agent's prompt at fire
+  time.
+- `--identity-sub` — the subject the run acts under (this is what makes
+  a scheduled run park its writes under an *agent* principal, distinct
+  from your own, so four-eyes stays intact — see the
+  [approvals guide](approvals-and-break-glass.md)).
+- `--in-flight-policy` — what to do when a fire is due while the
+  previous run of the same trigger is still going.
+- `--work-ref` — a change-ticket reference stamped onto the run's audit
+  and broadcast lineage.
+
+List what's scheduled and its state:
+
+```bash
+meho scheduler list
+```
+
+Each `ScheduledTrigger` row carries `kind`, `cron_expr` / `fire_at`,
+`timezone`, the hot `next_fire_at` column the loop scans, `last_fired_at`,
+`status`, and — when a fire was skipped — a `last_skip_reason` and a
+`skip_count`.
+
+## Durable credentials: surviving unattended
+
+A scheduled run has **no operator logged in**, so there is no Keycloak
+JWT to forward to Vault's OIDC auth method. The scheduler instead sources
+the agent's `client_credentials` secret **Vault-first**, under its own
+static service token (`VAULT_SCHEDULER_TOKEN`), from
+`SCHEDULER_AGENT_VAULT_PATH_PATTERN` (default
+`secret/data/agents/{client_id}/credentials`), falling back to a pod env
+var only when Vault yields nothing.
+
+That static token is the failure point unattended operation used to hit:
+a periodic Vault token **dies in the field** — it ages out, or an
+operator forgets to re-mint it — and every credential read then `403`s,
+so the scheduler **silently skips its fires**. A job that ran for weeks
+just stops, quietly. The hardening shipped with the
+[#2668](https://github.com/evoila/meho/issues/2668) line closes that
+hole three ways:
+
+- **Self-heal instead of skip.** On a `lookup-self`-confirmed dead
+  token, the scheduler mints a **fresh** Vault token by `jwt_login` as
+  the runner principal (runner JWT + `VAULT_CHECK_RUNNER_ROLE`, falling
+  back to `VAULT_OIDC_ROLE`) and retries the failed read once — no
+  operator, no sidecar in the loop. If the re-mint itself fails it falls
+  back to the existing **loud** failure, never a silent skip.
+- **Renewal on a timer, not on traffic.** Token renewal now fires on a
+  dedicated tick cadence rather than only when agent-secret traffic
+  flows — so an *idle* scheduler no longer ages its token out between
+  jobs.
+- **A loud pre-death guard.** Startup and an hourly `lookup-self` log a
+  loud `ERROR` (`scheduler_vault_token_will_expire`) when the token is
+  non-renewable or carries an explicit max TTL — it will die despite
+  renewal, so it must be minted `-period=768h`.
+
+When credentials genuinely cannot be resolved (no self-heal path
+provisioned), the loop does the honest thing: it logs
+`scheduler_credentials_unresolved`, **skips** the fire, and records
+`last_skip_reason='credentials_unresolved'` with an incremented
+`skip_count` on the trigger row — so `meho scheduler list` shows you
+exactly why a job isn't running, instead of leaving you to guess.
+
+!!! note "Provisioning the headless mint"
+
+    The headless `client_credentials` → runner-JWT → Vault `jwt_login`
+    mint (the identity the self-heal logs in as) is provisioned once,
+    deploy-side. The recipe lives in
+    [`docs/cross-repo/vault-provisioning.md`](https://github.com/evoila/meho/blob/main/docs/cross-repo/vault-provisioning.md);
+    the dedicated `VAULT_CHECK_RUNNER_ROLE` lets you bound exactly what
+    that background identity can read.
+
+## Scheduler and the checks runner
+
+The scheduler fires **agent runs**. It is not the same background worker
+as the **checks/sensors runner**, which evaluates deterministic
+[sensors](sensors-quickstart.md) on their own cadence — but both are
+"background work with no operator present", and both depend on the same
+durable-credential story. The sensor side of it (the `checkRunner.*`
+chart block and `VAULT_CHECK_RUNNER_ROLE`) is covered in
+[Sensors and your credential backend](sensors-quickstart.md#sensors-and-your-credential-backend);
+this page is its agent-run twin.
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| A trigger shows `last_skip_reason=credentials_unresolved` and a rising `skip_count` | The scheduler could not resolve the agent's credentials and skipped the fire (loudly, not silently). | Stage the agent's `client_credentials` secret at `secret/data/agents/{client_id}/credentials`, or provision the self-heal mint (`vault-provisioning.md`). |
+| Startup logs `scheduler_vault_token_will_expire` (ERROR) | `VAULT_SCHEDULER_TOKEN` is non-renewable or has an `explicit_max_ttl` — it will die despite renewal. | Re-mint it as a periodic token: `vault token create -period=768h …`. |
+| `403 insufficient_role` on `scheduler create` / `cancel` | Creating and cancelling triggers need **tenant_admin**; listing is operator. | Use a tenant_admin session to author triggers. |
+| A cron trigger never fires | The `--cron-expr` didn't parse, or `--timezone` is wrong, so `next_fire_at` was never set to a reachable instant. | Check `meho scheduler list` for `next_fire_at`; fix the 5-field expression / IANA timezone and recreate. |
+| A scheduled write is stuck `awaiting_approval` | Working as designed — an autonomous run's `requires_approval` write parks under the agent's subject. | Approve it as yourself; because the requester is the agent, four-eyes is satisfied ([approvals](approvals-and-break-glass.md)). |
+| Overlapping runs of the same trigger | A fire came due while the previous run was still going. | Set `--in-flight-policy` to the behavior you want (skip / queue) at create time. |
+
+**Next:** [Satellite gateway](satellite-gateway.md).

--- a/docs-site/guides/sensors-quickstart.md
+++ b/docs-site/guides/sensors-quickstart.md
@@ -254,5 +254,5 @@ is also the sensors feature's road-to-GA tracker.
 
 **Where next:** compose sensors with the approvals workflow (a red
 dashboard, an investigator finding, a gated remediation) — the
-[approvals & break-glass guide](index.md#coming-to-this-section)
+[approvals & break-glass guide](approvals-and-break-glass.md)
 covers the gated half.

--- a/docs-site/guides/topology.md
+++ b/docs-site/guides/topology.md
@@ -1,0 +1,228 @@
+# Query your topology graph
+
+Before you delete a namespace, detach a datastore, or shut down a host,
+one question matters more than any other: **what else breaks?** MEHO
+answers it from a tenant-scoped **topology graph** — nodes (the
+resources it knows about) joined by directed edges (the dependencies
+between them). One meta-tool, `query_topology`, walks that graph in
+every direction an operator or agent needs: what depends on a resource
+(the blast-radius check), what a resource depends on, the route between
+two resources, and the graph's change history.
+
+This guide covers the model, how tenant scoping keeps it isolated, the
+traversals you will actually run, and how a resource gets *into* the
+graph in the first place.
+
+!!! note "Prerequisites, roles, and maturity"
+
+    - A running backplane and an authenticated session
+      ([Connect clients](../clients/index.md)).
+    - Reads (`dependents`, `dependencies`, `path`, `list-edges`,
+      `timeline`, `diff`, `history`) need the **operator** role.
+      Curated writes (`annotate`, `unannotate`, `bulk-import`,
+      `create-node`) need **tenant_admin**.
+    - Topology is **Beta** — see the
+      [feature-maturity index](../reference/maturity.md#topology) for
+      the road to GA. The load-bearing gap today: **automatic
+      discovery is Kubernetes-only**, so a freshly registered vCenter
+      or Vault target starts *untracked* until you annotate it (see
+      [Getting resources into the graph](#getting-resources-into-the-graph)).
+
+## The model
+
+A node is a resource — a `target`, a `vm`, a `host`, a `namespace`, a
+`datastore`. An edge is a directed dependency:
+
+> An edge `from --kind--> to` reads **"`from` depends on `to`"**. A
+> `vm` `runs-on` a `host` means the vm depends on the host.
+
+That one rule fixes the direction of every traversal:
+
+| You want | Traversal | Reads as |
+|---|---|---|
+| What breaks if I remove X | **dependents** (reverse) | everything that depends on X |
+| What X needs to function | **dependencies** (forward) | everything X depends on |
+| Is X connected to Y at all | **path** (undirected) | shortest hop chain, either direction |
+
+Every node carries a `source`: **`auto`** (discovered by a probe) or
+**`curated`** (asserted by an operator, or promoted from auto). A
+refresh never overwrites a curated node — operator intent outranks the
+probe's view. Well-known edge kinds include `runs-on`, `mounts`,
+`routes-through`, and `belongs-to`; the vocabulary is open (any
+lowercase slug), so connectors and operators can name relationships the
+core set doesn't.
+
+## Tenant scoping is structural, not a filter
+
+`query_topology` takes **no tenant argument**. The traversal filters
+`graph_node.tenant_id` and `graph_edge.tenant_id` against your JWT's
+tenant in both the anchor lookup and every recursive step, so a
+cross-tenant read is not "denied" — it is *unrepresentable*. A name
+that exists only in another tenant reads exactly like a name that
+exists nowhere: the untracked answer, never another tenant's graph.
+
+## The surface at a glance
+
+`query_topology` is **parametric**: one `kind` argument selects the
+read shape. There is deliberately no `topology.dependents` tool and no
+`list_edges` tool — that would be the per-op-tool anti-pattern. The CLI
+splits the same shapes into named verbs.
+
+| Read shape | MCP (`query_topology`) | CLI |
+|---|---|---|
+| Reverse closure (blast radius) | `{kind: "dependents", target}` | `meho topology dependents <name>` |
+| Forward closure | `{kind: "dependencies", target}` | `meho topology dependencies <name>` |
+| Shortest path | `{kind: "path", from_name, to_name}` | `meho topology path <from> <to>` |
+| Flat edge listing | `{kind: "edges", ...}` | `meho topology list-edges` |
+| Change feed (tenant-wide) | `{kind: "timeline", since}` | `meho topology timeline` |
+| Net delta (two timestamps) | `{kind: "diff", ts1, ts2}` | `meho topology diff <ts1> <ts2>` |
+| Per-resource history | `{kind: "history", target}` | `meho topology history <name>` |
+
+## Blast radius: `dependents`
+
+The one you run before anything destructive. "Is it safe to delete
+`customer-a-prod`?"
+
+```bash
+meho topology dependents customer-a-prod
+```
+
+The anchor itself is **row 0** of the result, depth-ordered outward.
+So a one-row answer means *"tracked, and nothing depends on it"* — a
+genuine green light — while an empty/untracked answer means the graph
+has no signal at all (a very different thing; see the failure table).
+
+The agent surface returns the same walk as a flat list of
+`TopologyNode` rows:
+
+```json
+{
+  "kind": "dependents",
+  "nodes": [
+    {"id": "…", "kind": "namespace", "name": "customer-a-prod",
+     "source": "auto", "depth": 0, "via_edge_kind": null,
+     "parent_node_id": null, "via_edge_id": null},
+    {"id": "…", "kind": "service", "name": "checkout",
+     "source": "auto", "depth": 1, "via_edge_kind": "belongs-to",
+     "parent_node_id": "…", "via_edge_id": "…"}
+  ]
+}
+```
+
+Each non-root node carries `parent_node_id` and `via_edge_id` — the
+node it hangs off and the exact edge walked — so the whole dependency
+**chain** reconstructs from the flat list without a second call. Scope
+the walk with `--depth N` (default 16, ceiling 64) and
+`--kind <edge_kind>` to follow one relationship kind only.
+
+`dependencies` is the mirror image — same shape, same flags, forward
+direction:
+
+```bash
+meho topology dependencies checkout --kind runs-on
+```
+
+## Reachability: `path`
+
+"Is there any route from this ingress to that datastore?" Path search
+is **undirected** (it walks edges both ways) and unweighted, so it
+follows connectivity rather than edge orientation:
+
+```bash
+meho topology path ingress-web datastore-ssd-01
+# ingress/ingress-web -> service/checkout -> vm/app-1 -> host/esx-3 (3 hops)
+```
+
+Unreachable within the hop budget (`--max-hops`, default 8, ceiling 32)
+is a **valid answer, not an error**:
+
+```bash
+meho topology path ingress-web datastore-cold-99
+# no path from "ingress-web" to "datastore-cold-99" within the hop budget
+```
+
+Over MCP the same result is `{kind: "path", path: <TopologyPath>|null}`
+— `null` is the unreachable answer. A `TopologyPath` carries `nodes`
+(ordered `from` → `to`) and `total_hops`.
+
+## Surveying and change history
+
+`list-edges` is the flat inventory of relationships — filterable by
+`--kind`, `--source curated|auto`, endpoints (`--from` / `--to`), and
+`--conflicts` (edges where a curated annotation contradicts a
+probe-derived one and needs review):
+
+```bash
+meho topology list-edges --source curated
+meho topology list-edges --conflicts        # what needs an operator's eye
+```
+
+The G9.3 history trio answers "what changed, and when":
+
+```bash
+meho topology timeline --since 24h          # tenant-wide change feed
+meho topology diff 2026-07-31T09:00:00Z 2026-07-31T11:00:00Z
+meho topology history checkout --include-edges
+```
+
+`timeline` is cursor-paginated (a non-null `next_cursor` means more
+rows); `diff` is the net per-resource delta between two timestamps
+(hard-capped at 1000 entries with a "narrow the window" hint); `history`
+carries the full `snapshot.before` / `snapshot.after` per row for
+forensic "what was the exact state before this change?" questions.
+
+## Getting resources into the graph
+
+A resource has to be *in* the graph before a traversal can find it.
+Two ways it gets there:
+
+1. **Automatic discovery (Kubernetes only, today).** Probing a
+   Kubernetes target populates its nodes and edges, and a background
+   sweep keeps them fresh. Force a refresh on demand:
+
+    ```bash
+    meho topology refresh lab-rke2
+    # nodes: +42 -0 ~3    edges: +51 -0 ~0    (1240 ms)
+    ```
+
+    A refresh against a **non-Kubernetes** target is a no-op *by
+    coverage gap* — no populator ships for it yet — and the result
+    says so, listing which products do have populators.
+
+2. **Curated annotation (any resource).** For the relationships probes
+   cannot infer — a vCenter that `belongs-to` a site, a Vault role a
+   service `depends-on` — a tenant_admin asserts the edge by hand:
+
+    ```bash
+    meho topology annotate app-1 depends-on vault-role-app
+    ```
+
+    On an empty tenant, seed the endpoints first with
+    `meho topology create-node` (annotate requires both endpoints to
+    exist). Curated edges are idempotent and survive every refresh.
+
+This is why a sensor's investigator correlation, or a blast-radius
+check, "degrades to per-sensor findings without topology anchors" on
+non-k8s estates: until you annotate them, the graph has no edges to
+walk.
+
+!!! warning "An `awaiting_approval` on a topology write is by design"
+
+    Curated writes carry `caution` classification. A **human**
+    tenant_admin executes them immediately, but an **agent** principal's
+    annotate parks in the approval queue like any other governed write —
+    the gate lives in the dispatcher, not the front. See
+    [Approvals and break-glass](approvals-and-break-glass.md).
+
+## What can go wrong here
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| CLI: *"`X` is not tracked in the topology graph — run `meho topology refresh` or annotate"* (HTTP 404 `node_untracked`; MCP `{status: "node_untracked", nodes: []}`) | The anchor resolves to no node in your tenant. **Do not read this as "safe to delete"** — the call produced no blast-radius signal at all. Auto-discovery is k8s-only, so every non-k8s target starts here. | `meho topology refresh <target>` (k8s) or `meho topology annotate` the relationships (non-k8s). |
+| *"node `X` is ambiguous across kinds: host, vm — re-run with `--node-kind`"* (HTTP 409) | The bare name maps to more than one node kind in the tenant. | Pin the anchor with `--node-kind <kind>` (CLI) / `node_kind` (MCP). Note `--kind` is the *edge* filter, not the anchor pin — it will not clear this. |
+| `dependents` returns exactly one row | Not an error — that row is the anchor itself (depth 0). It means "tracked, nothing depends on it." | This is your green light for a destructive op. |
+| `path` returns `null` / "no path" | Unreachable within `--max-hops`, a missing endpoint, or a cross-tenant endpoint — all the same answer by design. | Raise `--max-hops`, or check the endpoint names exist (`meho topology list-edges`). |
+| `refresh` reports all-zero counts with a "no populator" note | The target's product has no topology populator on this version — the refresh could never change anything. | Curate the edges by hand (`annotate`), or track the populator's issue from the note. |
+| `403 insufficient_role` on `annotate` / `unannotate` | Curated writes need **tenant_admin**; your JWT is operator. | Use a tenant_admin session. |
+
+**Next:** [Broadcast — cross-operator awareness](broadcast.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,13 @@ nav:
       - guides/first-operations.md
       - guides/sensors-quickstart.md
       - Approvals and break-glass: guides/approvals-and-break-glass.md
+      - Topology: guides/topology.md
+      - Broadcast: guides/broadcast.md
+      - Memory and knowledge: guides/memory-and-knowledge.md
+      - Audit forensics: guides/audit-forensics.md
+      - Runbooks: guides/runbooks.md
+      - Scheduler: guides/scheduler.md
+      - Satellite gateway: guides/satellite-gateway.md
   - Reference:
       - reference/index.md
       # Generated from the feature-maturity registry by


### PR DESCRIPTION
## Summary

- Add the seven remaining **Do-real-work** guides under `docs-site/guides/` — topology, broadcast, memory & knowledge, audit forensics, runbooks, scheduler, and satellite gateway — completing the section shaped by initiative #2663 (the four earlier guides shipped via #2673 / #2819).
- Each follows the shipped guide pattern: task-first, **CLI and MCP shown against the same dispatch path**, result-handle drill-ins where responses are set-shaped, and a "what can go wrong" table.
- Every command, tool name, flag, and response shape is **grounded in the actual code surface** — `query_topology`, `broadcast_recent`/`announce`/`watch`, `search_memory`/`add_to_memory`, `search_knowledge`/`add_to_knowledge`, `query_audit`, and the `meho runbook` / `meho scheduler` / `meho runner-principal` CLI verbs — not invented.

## Test plan

- [x] `mkdocs build --strict` — **green** (this is the `docs-site.yml` PR gate)
- [x] All seven pages present in the MkDocs nav under **Do real work**
- [x] No broken links/anchors — also repointed two now-obsolete `index.md#coming-to-this-section` "coming soon" links (in `first-operations` and `sensors-quickstart`) at the shipped approvals guide, since removing that placeholder section would otherwise dangle them
- [x] CHANGELOG `[Unreleased]` entry under a distinct `### Added` category header per repo convention

## On the "no invented output" criterion (load-bearing)

No live MEHO target was available, so — exactly as the four shipped guides do — command output is shown minimally and grounded in the real response schemas / CLI flags found in the code, never as fabricated API dumps. Two grounding calls worth flagging for the reviewer:

- **Audit forensics** documents the *real* broadcast↔audit link: the audit row's `broadcast_event_id` is a **v0.2 null placeholder** (verified in `AuditEntry`), and the FK lives on `BroadcastEvent.audit_id` — so the guide teaches the pivot as broadcast → audit, not a `broadcast_event_id` filter.
- **Runbooks** carry no `safety_level` of their own; approval is applied per step at the `call_operation` dispatch layer — the guide says exactly that.

## Out of scope

Per the issue: backup/restore, DR, sizing, and observability pages (v0.28 initiative); the generated reference section (v0.29, #2662 snapshots).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2829
