### PR TITLE
feat(connectors): add vault.token.lookup_accessor detail read (#2844)

### DIFF
--- a/backend/src/meho_backplane/connectors/vault/__init__.py
+++ b/backend/src/meho_backplane/connectors/vault/__init__.py
@@ -103,10 +103,10 @@ register_typed_op_registrar(register_vault_typed_operations)
 # handler state, distinct endpoint_descriptor rows.
 register_typed_op_registrar(register_vault_sys_typed_operations)
 # The identity (entity/group/alias) + token (create/revoke_accessor/
-# list_accessors) op groups (G3.15-T4 #1412) ship their own registrar so
-# they register independently of the KV / sys / auth surfaces. Writes are
-# requires_approval=True; vault.token.create's response token is redacted
-# via the credential_mint op-class allowlist.
+# list_accessors/lookup_accessor) op groups (G3.15-T4 #1412, #2844) ship
+# their own registrar so they register independently of the KV / sys /
+# auth surfaces. Writes are requires_approval=True; vault.token.create's
+# response token is redacted via the credential_mint op-class allowlist.
 register_typed_op_registrar(register_vault_identity_token_operations)
 
 __all__ = [

--- a/backend/src/meho_backplane/connectors/vault/ops_identity_token.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_identity_token.py
@@ -5,7 +5,7 @@
 
 The identity surface (entity / entity-alias / group lifecycle) lives in
 :mod:`meho_backplane.connectors.vault.ops_identity`; the token surface
-(create / revoke_accessor / list_accessors) lives in
+(create / revoke_accessor / list_accessors / lookup_accessor) lives in
 :mod:`meho_backplane.connectors.vault.ops_token`. Each module owns its
 handlers, schemas import, ``when_to_use`` blurb, and per-op spec table.
 
@@ -40,6 +40,7 @@ from meho_backplane.connectors.vault.ops_token import (
     TOKEN_WHEN_TO_USE,
     vault_token_create,
     vault_token_list_accessors,
+    vault_token_lookup_accessor,
     vault_token_revoke_accessor,
 )
 from meho_backplane.operations.typed_register import register_typed_operation
@@ -56,6 +57,7 @@ __all__ = [
     "vault_identity_list",
     "vault_token_create",
     "vault_token_list_accessors",
+    "vault_token_lookup_accessor",
     "vault_token_revoke_accessor",
 ]
 

--- a/backend/src/meho_backplane/connectors/vault/ops_token.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_token.py
@@ -12,9 +12,13 @@ mounted):
   accessor (``requires_approval=True``).
 * ``vault.token.list_accessors`` lists accessor handles
   (``safety_level="safe"``).
+* ``vault.token.lookup_accessor`` reads one token's TTL / policies /
+  expiry by its accessor (``safety_level="safe"``).
 
 There is **no bulk-revoke op** by design -- never revoke broadly to
-recover from one leak (the vault skill's loudest Don't-rule).
+recover from one leak (the vault skill's loudest Don't-rule). There is
+likewise no bulk full-detail lookup: an agent that needs many tokens'
+detail lists accessors then looks up each of interest.
 
 **Secret redaction is at the classification layer, not the handler**
 (#1397 / #1401). ``vault.token.create``'s minted client token rides in
@@ -24,8 +28,10 @@ the *response* (under Vault's ``auth`` envelope);
 write-suffix), so the broadcast collapses to aggregate-only and the
 audit row holds only a ``params_hash``. The caller's ``OperationResult``
 still carries the token (the whole point of minting). A token
-**accessor** (``revoke_accessor`` param, ``list_accessors`` response) is
-a reference handle, not the token secret -- deliberately not redacted.
+**accessor** (``revoke_accessor`` / ``lookup_accessor`` param,
+``list_accessors`` response) is a reference handle, not the token secret
+-- deliberately not redacted; ``lookup_accessor``'s response also omits
+the token ``id`` (Vault blanks it), so it exposes no secret.
 
 Handler shape mirrors :mod:`meho_backplane.connectors.vault.ops_auth`:
 ``async def (operator, target, params) -> dict``, raises on failure,
@@ -42,7 +48,7 @@ from typing import Any
 
 import meho_backplane.auth.vault as _auth_vault
 from meho_backplane.auth.operator import Operator
-from meho_backplane.connectors.vault.ops_auth import _extract_keys
+from meho_backplane.connectors.vault.ops_auth import _extract_data, _extract_keys
 from meho_backplane.connectors.vault.ops_token_schemas import (
     VAULT_TOKEN_CREATE_LLM_INSTRUCTIONS,
     VAULT_TOKEN_CREATE_PARAMETER_SCHEMA,
@@ -50,6 +56,9 @@ from meho_backplane.connectors.vault.ops_token_schemas import (
     VAULT_TOKEN_LIST_ACCESSORS_LLM_INSTRUCTIONS,
     VAULT_TOKEN_LIST_ACCESSORS_PARAMETER_SCHEMA,
     VAULT_TOKEN_LIST_ACCESSORS_RESPONSE_SCHEMA,
+    VAULT_TOKEN_LOOKUP_ACCESSOR_LLM_INSTRUCTIONS,
+    VAULT_TOKEN_LOOKUP_ACCESSOR_PARAMETER_SCHEMA,
+    VAULT_TOKEN_LOOKUP_ACCESSOR_RESPONSE_SCHEMA,
     VAULT_TOKEN_REVOKE_ACCESSOR_LLM_INSTRUCTIONS,
     VAULT_TOKEN_REVOKE_ACCESSOR_PARAMETER_SCHEMA,
     VAULT_TOKEN_REVOKE_ACCESSOR_RESPONSE_SCHEMA,
@@ -60,6 +69,7 @@ __all__ = [
     "TOKEN_WHEN_TO_USE",
     "vault_token_create",
     "vault_token_list_accessors",
+    "vault_token_lookup_accessor",
     "vault_token_revoke_accessor",
 ]
 
@@ -169,14 +179,43 @@ async def vault_token_list_accessors(
     return {"keys": _extract_keys(payload)}
 
 
+async def vault_token_lookup_accessor(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Look up ONE token's TTL / policies / expiry by its accessor.
+
+    Op-id: ``vault.token.lookup_accessor``. Delegates to hvac's
+    ``client.auth.token.lookup_accessor(accessor=...)`` (POST
+    /v1/auth/token/lookup-accessor) and returns the unwrapped ``data``
+    metadata dict (policies, ttl, expire_time, period, display_name,
+    creation_time, renewable, ...). The accessor is a reference handle,
+    not the token secret, and Vault deliberately blanks the token ``id``
+    in a lookup-accessor response -- the endpoint exists precisely so this
+    is a safe read. Unlike ``list_accessors`` (which normalises an
+    empty-store ``404`` to ``{"keys": []}``), a single-accessor lookup has
+    no "legitimately empty" case: an unknown accessor is a genuine
+    not-found, so the underlying :class:`hvac.exceptions.InvalidPath`
+    propagates as a read-phase ``connector_error`` rather than being
+    swallowed.
+    """
+    accessor: str = str(params["accessor"]).strip()
+
+    async with _auth_vault.vault_client_for_operator(operator) as client:
+        payload = await asyncio.to_thread(client.auth.token.lookup_accessor, accessor=accessor)
+
+    return _extract_data(payload)
+
+
 # --- spec table ------------------------------------------------------------
 
 TOKEN_WHEN_TO_USE: str = (
     "Use to manage Vault TOKEN lifecycle: mint a client token "
     "(vault.token.create -- requires approval; the token is secret and "
     "redacted from audit/broadcast), surgically revoke ONE token by its "
-    "accessor (vault.token.revoke_accessor -- requires approval), and "
-    "list active token accessors (vault.token.list_accessors -- safe). "
+    "accessor (vault.token.revoke_accessor -- requires approval), "
+    "list active token accessors (vault.token.list_accessors -- safe), "
+    "and look up one token's TTL/policies/expiry by its accessor "
+    "(vault.token.lookup_accessor -- safe). "
     "There is intentionally NO bulk-revoke op: never revoke broadly to "
     "recover from one leak. Accessors are non-secret reference handles. "
     "Route entity/group/policy questions to the 'identity' group."
@@ -250,5 +289,30 @@ TOKEN_OP_SPECS: tuple[dict[str, Any], ...] = (
         "safety_level": "safe",
         "requires_approval": False,
         "llm_instructions": VAULT_TOKEN_LIST_ACCESSORS_LLM_INSTRUCTIONS,
+    },
+    {
+        "op_id": "vault.token.lookup_accessor",
+        "handler": vault_token_lookup_accessor,
+        "group_key": "token",
+        "summary": "Look up one token's TTL/policies/expiry by its accessor.",
+        "description": (
+            "Reads one token's metadata by its accessor (POST "
+            "/v1/auth/token/lookup-accessor) -- policies, ttl, expire_time, "
+            "period (periodic tokens), display_name, creation_time, "
+            "renewable. Answers 'what policies does this token carry and "
+            "when does it expire' for a token audit / access review. "
+            "Read-only; registered safety_level=safe, "
+            "requires_approval=False. The accessor is a non-secret "
+            "reference handle and Vault blanks the token id in the "
+            "response, so no secret is exposed. Unlike list_accessors, an "
+            "unknown accessor is a genuine not-found and surfaces as a "
+            "connector_error (InvalidPath)."
+        ),
+        "parameter_schema": VAULT_TOKEN_LOOKUP_ACCESSOR_PARAMETER_SCHEMA,
+        "response_schema": VAULT_TOKEN_LOOKUP_ACCESSOR_RESPONSE_SCHEMA,
+        "tags": ["read-only", "token", "identity"],
+        "safety_level": "safe",
+        "requires_approval": False,
+        "llm_instructions": VAULT_TOKEN_LOOKUP_ACCESSOR_LLM_INSTRUCTIONS,
     },
 )

--- a/backend/src/meho_backplane/connectors/vault/ops_token_schemas.py
+++ b/backend/src/meho_backplane/connectors/vault/ops_token_schemas.py
@@ -14,9 +14,11 @@ Secret-material discipline (#1412): the ``vault.token.create``
 classification layer -- :func:`meho_backplane.broadcast.events.classify_op`
 maps ``vault.token.create`` to ``credential_mint`` (aggregate-only
 broadcast, ``params_hash`` only in the audit row) -- not in these
-schemas. A token **accessor** (``revoke_accessor`` param,
-``list_accessors`` response) is a reference handle, not the token secret
--- deliberately not redacted.
+schemas. A token **accessor** (``revoke_accessor`` / ``lookup_accessor``
+param, ``list_accessors`` response) is a reference handle, not the token
+secret -- deliberately not redacted. Vault also blanks the token ``id``
+in a ``lookup-accessor`` response, so the metadata read (#2844) exposes
+no secret either.
 """
 
 from __future__ import annotations
@@ -30,6 +32,9 @@ __all__ = [
     "VAULT_TOKEN_LIST_ACCESSORS_LLM_INSTRUCTIONS",
     "VAULT_TOKEN_LIST_ACCESSORS_PARAMETER_SCHEMA",
     "VAULT_TOKEN_LIST_ACCESSORS_RESPONSE_SCHEMA",
+    "VAULT_TOKEN_LOOKUP_ACCESSOR_LLM_INSTRUCTIONS",
+    "VAULT_TOKEN_LOOKUP_ACCESSOR_PARAMETER_SCHEMA",
+    "VAULT_TOKEN_LOOKUP_ACCESSOR_RESPONSE_SCHEMA",
     "VAULT_TOKEN_REVOKE_ACCESSOR_LLM_INSTRUCTIONS",
     "VAULT_TOKEN_REVOKE_ACCESSOR_PARAMETER_SCHEMA",
     "VAULT_TOKEN_REVOKE_ACCESSOR_RESPONSE_SCHEMA",
@@ -239,10 +244,107 @@ VAULT_TOKEN_LIST_ACCESSORS_LLM_INSTRUCTIONS: dict[str, Any] = {
         "Enumerate every active token by its accessor handle. Read-only; "
         "registered safe (no approval). Accessors are non-secret "
         "references usable to look up or surgically revoke one token "
-        "(vault.token.revoke_accessor) -- this never returns token secrets."
+        "(vault.token.lookup_accessor / vault.token.revoke_accessor) -- "
+        "this never returns token secrets."
     ),
     "parameter_hints": {},
     "output_shape": (
         "On success: {'keys': [...]} -- accessor handles. An empty store yields {'keys': []}."
+    ),
+}
+
+
+# --- token.lookup_accessor -------------------------------------------------
+
+VAULT_TOKEN_LOOKUP_ACCESSOR_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "accessor": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "The accessor of the single token to look up (from a "
+                "token.create response or token.list_accessors). A reference "
+                "handle, not the token secret."
+            ),
+        },
+    },
+    "required": ["accessor"],
+    "additionalProperties": False,
+}
+
+VAULT_TOKEN_LOOKUP_ACCESSOR_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "The token's metadata, unwrapped from Vault's {'data': {...}} "
+        "envelope. Vault's lookup-accessor deliberately blanks the token id "
+        "(the raw secret), so the accessor cannot recover the token. "
+        "Carries at least policies / ttl / expire_time / period / "
+        "display_name / creation_time / renewable; additional Vault fields "
+        "(meta, path, orphan, entity_id, num_uses, ...) pass through."
+    ),
+    "properties": {
+        "policies": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Policies attached to the token (the privilege grant).",
+        },
+        "ttl": {
+            "type": "integer",
+            "description": "Remaining time-to-live in seconds (0 for a non-expiring token).",
+        },
+        "expire_time": {
+            "type": ["string", "null"],
+            "description": "RFC3339 expiry timestamp; null for a non-expiring token.",
+        },
+        "period": {
+            "type": ["integer", "null"],
+            "description": (
+                "Renewal period in seconds for a PERIODIC token (0/null "
+                "otherwise) -- the field that answers 'when does the "
+                "scheduler token's fuse blow' (evoila/meho#2328)."
+            ),
+        },
+        "display_name": {
+            "type": "string",
+            "description": "Human-readable display name stamped on the token.",
+        },
+        "creation_time": {
+            "type": "integer",
+            "description": "Unix epoch seconds when the token was minted.",
+        },
+        "renewable": {
+            "type": "boolean",
+            "description": "Whether the token can be renewed.",
+        },
+    },
+    "additionalProperties": True,
+}
+
+VAULT_TOKEN_LOOKUP_ACCESSOR_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Look up ONE token's metadata by its accessor -- its policies, "
+        "remaining TTL, expiry timestamp, periodic-renewal period, display "
+        "name, creation time, and renewable flag. Use to audit 'what "
+        "policies does this token carry and when does it expire' (e.g. "
+        "diagnosing a silently-dead periodic token) or an access review "
+        "('any long-lived broad-policy tokens still active'). Read-only; "
+        "registered safe (no approval) -- the accessor is a non-secret "
+        "reference handle and Vault's lookup-accessor never returns the "
+        "token secret. An unknown accessor surfaces as a connector_error "
+        "(InvalidPath)."
+    ),
+    "parameter_hints": {
+        "accessor": (
+            "Required. The accessor of the token to look up (from "
+            "list_accessors or a create response)."
+        ),
+    },
+    "output_shape": (
+        "On success: the token's metadata dict (policies, ttl, expire_time, "
+        "period, display_name, creation_time, renewable, and additional "
+        "Vault fields). On failure: a connector_error OperationResult "
+        "(InvalidPath when the accessor does not exist)."
     ),
 }

--- a/backend/tests/_vault_fakes.py
+++ b/backend/tests/_vault_fakes.py
@@ -100,6 +100,9 @@ class _FakeTokenAuth:
     accessors_payload: Any = None
     raise_on_list_accessors: Exception | None = None
     list_accessors_calls: int = 0
+    lookup_accessor_payload: Any = None
+    raise_on_lookup_accessor: Exception | None = None
+    lookup_accessor_calls: list[str] = field(default_factory=list)
 
     def revoke_self(self, mount_point: str = "token") -> None:
         _ = mount_point
@@ -132,6 +135,13 @@ class _FakeTokenAuth:
         if self.raise_on_list_accessors is not None:
             raise self.raise_on_list_accessors
         return self.accessors_payload
+
+    def lookup_accessor(self, accessor: str, mount_point: str = "token") -> Any:
+        _ = mount_point
+        self.lookup_accessor_calls.append(accessor)
+        if self.raise_on_lookup_accessor is not None:
+            raise self.raise_on_lookup_accessor
+        return self.lookup_accessor_payload
 
 
 @dataclass

--- a/backend/tests/integration/test_connectors_vault_dev_e2e.py
+++ b/backend/tests/integration/test_connectors_vault_dev_e2e.py
@@ -1669,7 +1669,8 @@ async def test_token_list_and_revoke_accessor_against_dev_vault(
     vault_e2e: tuple[_VaultTarget, str],
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """list_accessors enumerates accessors; revoke_accessor surgically revokes one."""
+    """list_accessors enumerates accessors; lookup_accessor reads one token's
+    metadata; revoke_accessor surgically revokes one."""
     target, addr = vault_e2e
     minted = await dispatch(
         operator=_make_operator(sub="op-token-for-revoke"),
@@ -1691,6 +1692,22 @@ async def test_token_list_and_revoke_accessor_against_dev_vault(
     )
     assert listing.status == "ok", listing.error
     assert accessor in listing.result["keys"]
+
+    looked_up = await dispatch(
+        operator=_make_operator(sub="op-token-lookup"),
+        connector_id="vault-1.x",
+        op_id="vault.token.lookup_accessor",
+        target=target,
+        params={"accessor": accessor},
+    )
+    assert looked_up.status == "ok", looked_up.error
+    # The audit fields the op exists to surface, against a real Vault.
+    assert "default" in looked_up.result["policies"]
+    assert looked_up.result["ttl"] > 0
+    for field_name in ("expire_time", "display_name", "creation_time", "renewable"):
+        assert field_name in looked_up.result, f"missing {field_name}"
+    # lookup-accessor never returns the raw token id (Vault blanks it).
+    assert not looked_up.result.get("id")
 
     revoke = await dispatch(
         operator=_make_operator(sub="op-token-revoke"),

--- a/backend/tests/test_connectors_vault_identity_token.py
+++ b/backend/tests/test_connectors_vault_identity_token.py
@@ -144,6 +144,7 @@ _EXPECTED: dict[str, tuple[str, bool, str]] = {
     "vault.token.create": ("dangerous", True, "token"),
     "vault.token.revoke_accessor": ("dangerous", True, "token"),
     "vault.token.list_accessors": ("safe", False, "token"),
+    "vault.token.lookup_accessor": ("safe", False, "token"),
 }
 
 
@@ -504,6 +505,83 @@ async def test_list_accessors_empty_store_normalises(
 
     assert result.status == "ok", result.error
     assert result.result == {"keys": []}
+
+
+# ---------------------------------------------------------------------------
+# token.lookup_accessor
+# ---------------------------------------------------------------------------
+
+
+async def test_lookup_accessor_unwraps_token_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """lookup_accessor unwraps Vault's data envelope into the token metadata."""
+    fake = install_fake_client(monkeypatch)
+    fake.auth.token.lookup_accessor_payload = {
+        "data": {
+            "accessor": "acc-1412",
+            "policies": ["default", "scheduler"],
+            "ttl": 2_592_000,
+            "expire_time": "2026-09-12T00:00:00Z",
+            "period": 2_764_800,
+            "display_name": "token-scheduler",
+            "creation_time": 1_754_000_000,
+            "renewable": True,
+            # Vault blanks the token id in a lookup-accessor response; it
+            # passes through harmlessly (never the raw secret).
+            "id": "",
+        }
+    }
+
+    result = await _dispatch_vault("vault.token.lookup_accessor", {"accessor": "  acc-1412 "})
+
+    assert result.status == "ok", result.error
+    # Every field the TTL/policy/expiry audit needs is present.
+    for field_name in (
+        "policies",
+        "ttl",
+        "expire_time",
+        "period",
+        "display_name",
+        "creation_time",
+        "renewable",
+    ):
+        assert field_name in result.result, f"missing {field_name}"
+    assert result.result["policies"] == ["default", "scheduler"]
+    assert result.result["period"] == 2_764_800
+    # The accessor is stripped before it reaches hvac (mirrors revoke_accessor).
+    assert fake.auth.token.lookup_accessor_calls == ["acc-1412"]
+
+
+def test_lookup_accessor_classifies_other() -> None:
+    """lookup_accessor falls through to `other` — `.lookup_accessor` is no read-suffix.
+
+    Matches revoke_accessor / list_accessors: no secret rides in the
+    response (Vault blanks the token id), so the full-detail `other`
+    broadcast is safe.
+    """
+    assert classify_op("vault.token.lookup_accessor") == "other"
+
+
+async def test_lookup_accessor_unknown_surfaces_connector_error(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_vault_typed_ops: None,
+) -> None:
+    """An unknown accessor RAISES (not swallowed) -> connector_error naming InvalidPath.
+
+    Distinct from list_accessors' empty-store normalisation: a
+    single-accessor lookup has no 'legitimately empty' case, so a 404 is a
+    genuine not-found the dispatcher surfaces.
+    """
+    fake = install_fake_client(monkeypatch)
+    fake.auth.token.raise_on_lookup_accessor = hvac.exceptions.InvalidPath("no such accessor")
+
+    result = await _dispatch_vault("vault.token.lookup_accessor", {"accessor": "ghost"})
+
+    assert result.status == "error"
+    assert result.extras["error_code"] == "connector_error"
+    assert result.extras["exception_class"] == "InvalidPath"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vault.md
+++ b/docs/codebase/connectors-vault.md
@@ -215,6 +215,7 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
   | `vault.token.create` | `auth.token.create` | dangerous | True | `credential_mint` |
   | `vault.token.revoke_accessor` | `auth.token.revoke_accessor` | dangerous | True | `other` |
   | `vault.token.list_accessors` | `auth.token.list_accessors` | safe | False | `other` |
+  | `vault.token.lookup_accessor` | `auth.token.lookup_accessor` | safe | False | `other` |
 
   `token.create` mints a client token in its **response** →
   `credential_mint` (aggregate-only broadcast; the token reaches only the
@@ -223,8 +224,25 @@ Source: `backend/src/meho_backplane/connectors/vault/`.
   **surgical** — it revokes exactly one token by accessor; there is
   intentionally **no bulk-revoke op** (the vault skill's loudest
   Don't-rule). Token accessors are non-secret reference handles, so they
-  are not redacted (`revoke_accessor` param / `list_accessors` response
-  classify `other`).
+  are not redacted (`revoke_accessor` / `lookup_accessor` param /
+  `list_accessors` response classify `other`).
+
+  `lookup_accessor` (#2844, Initiative #2833) reads one token's metadata
+  by its accessor (Vault's `POST /v1/auth/token/lookup-accessor`) —
+  `policies`, `ttl`, `expire_time`, `period` (non-null only for periodic
+  tokens), `display_name`, `creation_time`, `renewable`, unwrapped from
+  the `{'data': {...}}` envelope like `identity.entity.read`. It closes
+  the audit gap behind the scheduler periodic-token death
+  (#2328 / #2652): `list_accessors` answers *which* accessors exist,
+  `lookup_accessor` answers *what a token carries and when it expires* —
+  without falling back to a break-glass `vault token lookup` that bypasses
+  policy / audit / broadcast. Vault deliberately blanks the token `id` in
+  a lookup-accessor response, so the read exposes no secret — the same
+  non-secret-reference-handle framing that keeps it `safe` /
+  `requires_approval=False` / `other`-class. Unlike `list_accessors`
+  (empty-store `404` → `{"keys": []}`), a single-accessor lookup has no
+  legitimately-empty case, so an unknown accessor's `404` surfaces as the
+  underlying `hvac.exceptions.InvalidPath` rather than being swallowed.
 
   Both groups register from `ops_identity.py` / `ops_token.py` spec
   tables, composed by the thin
@@ -658,7 +676,8 @@ and a real Postgres audit store (reusing the integration conftest's
   #547 (G3.3-T3 auth read group), #551 (G3.3-T7 dev-mode CI
   integration harness), #1409 (G3.15-T1 KV writes), #1410 (G3.15-T2
   policy ops), #1411 (G3.15-T3 auth credential lifecycle), #1412
-  (G3.15-T4 identity + token ops).
+  (G3.15-T4 identity + token ops), #2844 (token lookup_accessor detail
+  read — TTL/policy/expiry audit; Initiative #2833).
 - Vault dev mode: https://developer.hashicorp.com/vault/docs/concepts/dev-server
 - Substrate: #388 (G0.6 operation registry), #390 (Refactor-Vault).
 - Vault API: https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2


### PR DESCRIPTION
## Summary

- Adds **`vault.token.lookup_accessor`** — a `safe`, approval-free read that answers "what policies does this token carry and when does it expire" through the governed `call_operation` surface, closing the gap that forced a break-glass `vault token lookup` (bypassing policy/audit/broadcast).
- Grounded in the scheduler periodic-token death (**#2328**) and the follow-up field report (**#2652**): `list_accessors` could say *which* accessors exist but nothing could say *what a token carries or when its fuse blows*.
- Mirrors the precedents the task names: `revoke_accessor`'s single-`accessor` param shape, `identity.entity.read`'s `{data}`-envelope unwrap, and `list_accessors`' non-secret-handle safety posture. Delegates to hvac `client.auth.token.lookup_accessor(accessor=...)` (`POST /v1/auth/token/lookup-accessor`) via `vault_client_for_operator` + `asyncio.to_thread`.
- Vault deliberately blanks the token `id` in a lookup-accessor response, so no secret rides in the payload → classifies `other` (verified), needs no redaction. Unlike `list_accessors` (empty-store 404 → `{"keys": []}`), an unknown accessor is a genuine not-found and surfaces the underlying `InvalidPath` as a `connector_error` rather than being swallowed.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean (1411 files formatted)
- [x] `uv run mypy src/` — clean for changed files (the one reported error is `net/icmp.py` `socket.MSG_ERRQUEUE`, a pre-existing darwin-only artifact on a file this PR does not touch; the attr exists on Linux where CI runs)
- [x] `python3 .claude/hooks/code-quality.py --diff` — pass (exit 0, no violations)
- [x] `uv run pytest tests/test_connectors_vault_identity_token.py` — **36 passed**
- [x] Vault-keyed unit sweep (`pytest -k vault`) — **674 passed, 2 skipped** (the 1 teardown ERROR in `test_preflight_fail_soft_when_probe_raises` reproduces identically on clean `main` — pre-existing, unrelated to this change)

Acceptance criteria:

- [x] `vault.token.lookup_accessor` registered in `TOKEN_OP_SPECS` — `safety_level="safe"`, `requires_approval=False`, group `token`, dispatchable via `call_operation` (proven by the parametrized `test_ops_register_with_expected_safety_approval_group` + a runtime spec smoke check)
- [x] Handler calls `client.auth.token.lookup_accessor(accessor=...)` via `vault_client_for_operator` + `asyncio.to_thread` and **raises** (not swallows) on an unknown accessor — `test_lookup_accessor_unknown_surfaces_connector_error`
- [x] Response includes at minimum `policies` / `ttl` / `expire_time` / `period` / `display_name` / `creation_time` / `renewable` — `test_lookup_accessor_unwraps_token_metadata`
- [x] Test extends `test_connectors_vault_identity_token.py`, asserts the response shape against the `tests/_vault_fakes.py` fake-hvac seam **and** asserts `op_class == "other"` (`test_lookup_accessor_classifies_other`)
- [x] `docs/codebase/connectors-vault.md` `token` op-group table extended with the 4th row + prose
- [x] CLI OpenAPI snapshot: **not regenerated — no schema/route changed.** Typed ops dispatch through the generic `call_operation` route, not per-op FastAPI routes; `cli/api/openapi.json` contains no vault op-ids and no files under `cli/` are touched, so the freshness gate stays green.

Real-Vault coverage: the dev-mode e2e (`test_connectors_vault_dev_e2e.py`, Docker-gated) mints → lists → **looks up** → revokes, asserting the audit fields against a live Vault.

## Out of scope

- No CLI verb (the vault CLI dir has no `token.go`; adding token-group CLI parity is a separate task) — per the issue.
- No bulk full-detail lookup — the connector's deliberately-narrow posture (mirrors "no bulk-revoke by design"); list accessors then look up each of interest.
- No change to the scheduler's own renewal/`lookup-self` machinery (#2369) — a different, already-shipped path.

**Adjacent finding (not addressed):** `test_connectors_vault.py::test_preflight_fail_soft_when_probe_raises` emits a teardown ERROR locally (the injected `VaultDown('sealed')` propagating during teardown of the sys/capabilities preflight fake). It reproduces on clean `main` and is unrelated to this change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2844
