### PR TITLE
feat(connectors): add holodeck.backups.list read op — pre-prune review + backup-landing (#2847)

### DIFF
--- a/backend/src/meho_backplane/connectors/holodeck/connector.py
+++ b/backend/src/meho_backplane/connectors/holodeck/connector.py
@@ -197,6 +197,19 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "warning on the 74 GB root fs (VCF-9.x backup fill). "
         "Transport: plain SSH (``df`` / ``du``)."
     ),
+    "backups": (
+        "Use to inventory backup artefacts under ``/var/backups`` on the "
+        "HoloRouter: ``holodeck.backups.list [path=<sub-dir>]`` returns one "
+        "row per file ({path, mtime, size_bytes}) newest-first. Call it "
+        "before approving a ``holodeck.backups.prune`` -- the rows past "
+        "index ``keep_newest`` are exactly what that prune would delete, so "
+        "a destructive prune is never approved blind -- and as a routine "
+        "backup-landing health check (is the hourly backup still landing? "
+        "how old is the newest file?). This is the safe read half of the "
+        "``backups`` surface; ``holodeck.backups.prune`` (group "
+        "``backups-write``) is the approval-gated delete. Transport: plain "
+        "SSH (``find``)."
+    ),
     # G3.18-T2 (#2154) approval-gated remediation write groups. The keys
     # carry a ``-write`` suffix so they never collide with the read-op
     # group keys above; the blurbs are the single source of truth in
@@ -651,6 +664,25 @@ class HolodeckConnector(SshConnector):
         )
 
         return await _holodeck_disk_usage(self, target, params, operator)
+
+    async def backups_list(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.backups.list`` (#2847).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_read.holodeck_backups_list`.
+        Safe read; lists ``/var/backups`` newest-first reusing
+        ``holodeck.backups.prune``'s own ``find`` listing + path bound.
+        """
+        from meho_backplane.connectors.holodeck.ops_read import (
+            holodeck_backups_list as _holodeck_backups_list,
+        )
+
+        return await _holodeck_backups_list(self, target, params, operator)
 
     async def k8s_pods_gc(
         self,

--- a/backend/src/meho_backplane/connectors/holodeck/ops.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops.py
@@ -151,10 +151,12 @@ def _holodeck_ops() -> tuple[HolodeckOp, ...]:
     Mirrors :func:`meho_backplane.connectors.pfsense.ops._pfsense_ops`
     and :func:`meho_backplane.connectors.bind9.ops._bind9_ops`.
 
-    G3.18-T2 (#2154) appends the 3 approval-gated remediation write ops
-    (:data:`~meho_backplane.connectors.holodeck.ops_write.WRITE_OPS`:
+    G3.18-T1 (#2153) appends ``holodeck.disk.usage`` and #2847 appends
+    ``holodeck.backups.list`` (the safe read half of the ``backups``
+    surface). G3.18-T2 (#2154) appends the 3 approval-gated remediation
+    write ops (:data:`~meho_backplane.connectors.holodeck.ops_write.WRITE_OPS`:
     ``holodeck.k8s.pods.gc`` / ``holodeck.backups.prune`` /
-    ``holodeck.images.import``) onto the tuple -- 12 ops total.
+    ``holodeck.images.import``) onto the tuple -- 13 ops total.
     """
     from meho_backplane.connectors.holodeck.ops_read import READ_OPS
     from meho_backplane.connectors.holodeck.ops_write import WRITE_OPS
@@ -169,8 +171,9 @@ def _holodeck_ops() -> tuple[HolodeckOp, ...]:
 #: ``holodeck.pod.info``, ``holodeck.service.list``,
 #: ``holodeck.k8s.exec``, ``holodeck.logs.tail``,
 #: ``holodeck.networking.show``); G3.18-T1 (#2153) appends
-#: ``holodeck.disk.usage`` -- 9 ops total. The registration
-#: walk in :meth:`HolodeckConnector.register_operations` does not
-#: need to change as ops are added; only :func:`_holodeck_ops`
+#: ``holodeck.disk.usage`` and #2847 appends ``holodeck.backups.list``
+#: -- 10 read ops (13 total with the 3 G3.18-T2 write ops). The
+#: registration walk in :meth:`HolodeckConnector.register_operations`
+#: does not need to change as ops are added; only :func:`_holodeck_ops`
 #: composes the merged tuple.
 HOLODECK_OPS: tuple[HolodeckOp, ...] = _holodeck_ops()

--- a/backend/src/meho_backplane/connectors/holodeck/ops_read.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_read.py
@@ -138,6 +138,7 @@ __all__ = [
     "GROWTH_DIRS",
     "READ_OPS",
     "KubectlSafetyError",
+    "holodeck_backups_list",
     "holodeck_config_show",
     "holodeck_disk_usage",
     "holodeck_k8s_exec",
@@ -146,6 +147,7 @@ __all__ = [
     "holodeck_pod_info",
     "holodeck_pod_list",
     "holodeck_service_list",
+    "parse_backup_listing_output",
     "parse_disk_usage_output",
     "parse_kubectl_command",
     "parse_logs_tail_output",
@@ -676,6 +678,58 @@ def parse_disk_usage_output(
     }
 
 
+def parse_backup_listing_output(stdout: str) -> list[dict[str, Any]]:
+    """Parse ``find ... -printf '%T@ %s %p\\n' | sort -rn`` output into rows.
+
+    Each non-empty line carries three fields in the order the ``-printf``
+    format emits them, separated by a single space:
+
+    * ``%T@`` -- the file's modification time as seconds since the epoch,
+      *with a fractional part* (GNU findutils ``find(1)``); parsed to a
+      float.
+    * ``%s`` -- the file's size in bytes; parsed to an int.
+    * ``%p`` -- the file path. It is the trailing field and may itself
+      contain spaces, so only the first two fields are split off; the rest
+      of the line is the path verbatim.
+
+    The remote pipeline already orders newest-first (``sort -rn`` on the
+    numeric ``%T@`` field -- the same ordering ``holodeck.backups.prune``
+    uses internally to pick its keep window), so this parser **preserves**
+    input order rather than re-sorting. A row whose mtime or size field is
+    non-numeric is skipped, mirroring the :func:`_parse_du_bytes`
+    non-numeric guard so a stray line never crashes the envelope.
+
+    Returns ``[{path, mtime, size_bytes}, ...]`` newest-first.
+
+    >>> rows = parse_backup_listing_output(
+    ...     "1699999999.5 4096 /var/backups/db-2.sql.gz\\n"
+    ...     "1699990000.1 8192 /var/backups/db-1.sql.gz\\n"
+    ... )
+    >>> [r["path"] for r in rows]
+    ['/var/backups/db-2.sql.gz', '/var/backups/db-1.sql.gz']
+    >>> rows[0]["size_bytes"]
+    4096
+    """
+    rows: list[dict[str, Any]] = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        # Split on the two literal separator spaces the ``-printf`` format
+        # emits; maxsplit=2 keeps a path containing spaces intact as the
+        # trailing field.
+        parts = line.split(" ", 2)
+        if len(parts) < 3:
+            continue
+        mtime_field, size_field, path = parts
+        try:
+            mtime = float(mtime_field)
+            size_bytes = int(size_field)
+        except ValueError:
+            continue
+        rows.append({"path": path, "mtime": mtime, "size_bytes": size_bytes})
+    return rows
+
+
 # ---------------------------------------------------------------------------
 # Handler functions (bound-method shims on HolodeckConnector)
 # ---------------------------------------------------------------------------
@@ -1041,6 +1095,63 @@ async def holodeck_disk_usage(
         dir_usages.append((path, du_text))
 
     return parse_disk_usage_output(df_root_text=df_root_text, dir_usages=dir_usages)
+
+
+async def holodeck_backups_list(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """List backup artefacts under ``/var/backups`` newest-first.
+
+    Op-id: ``holodeck.backups.list``. *params*:
+
+    * ``path`` -- optional sub-path under ``/var/backups`` (absolute or
+      relative to it). Resolved via
+      :func:`~meho_backplane.connectors.holodeck.ops_write.resolve_backup_dir`,
+      the **same** bound ``holodeck.backups.prune`` applies -- a traversal
+      or absolute-path escape is rejected before any SSH traffic. Omit to
+      list the root.
+
+    Runs ``find <dir> -maxdepth 1 -type f -printf '%T@ %s %p\\n' | sort
+    -rn`` over plain SSH -- the read-only half of the prune handler's own
+    listing pipeline, with a ``%s`` (size) field added and the destructive
+    ``tail | cut | xargs rm`` tail dropped. Returns a ``{rows, total}``
+    envelope (:func:`parse_backup_listing_output`) whose rows are ordered
+    newest-first, exactly the ordering ``backups.prune`` uses internally to
+    decide its keep window -- so a caller can pass the same ``keep_newest``
+    a prune request proposes and locally read off which rows (index >=
+    ``keep_newest``) that prune would delete, without executing anything.
+
+    An SSH/transport failure surfaces as
+    ``{rows: [], total: 0, error: "<reason>"}`` so an empty result caused
+    by a broken connection is distinguishable from a genuinely empty
+    directory (the backup-landing health-check signal).
+    """
+    # Reuse the prune handler's own path bound -- imported lazily to keep
+    # the ops / ops_read / ops_write module triangle free of an import
+    # cycle (the same convention connector.py and ops._holodeck_ops use).
+    from meho_backplane.connectors.holodeck.ops_write import (
+        HolodeckWriteSafetyError,
+        resolve_backup_dir,
+    )
+
+    try:
+        resolved_dir = resolve_backup_dir(params.get("path"))
+    except HolodeckWriteSafetyError as exc:
+        return {"rows": [], "total": 0, "error": f"backups.list safety check: {exc}"}
+
+    quoted_dir = shlex.quote(resolved_dir)
+    cmd = f"find {quoted_dir} -maxdepth 1 -type f -printf '%T@ %s %p\\n' | sort -rn"
+    try:
+        proc = await self._run_command(target, cmd, operator=operator)
+    except Exception as exc:
+        return {"rows": [], "total": 0, "error": str(exc)}
+    stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
+    content = stdout if isinstance(stdout, str) else ""
+    rows = parse_backup_listing_output(content)
+    return {"rows": rows, "total": len(rows)}
 
 
 # ---------------------------------------------------------------------------
@@ -1699,6 +1810,96 @@ READ_OPS: tuple[HolodeckOp, ...] = (
                 "``percent_used`` is computed from the byte counts. "
                 "Each sub-section's ``ok`` flips false when its "
                 "sub-command failed or produced empty output."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.backups.list",
+        handler_attr="backups_list",
+        summary="List /var/backups artefacts newest-first (pre-prune review + landing).",
+        description=(
+            "Runs ``find <dir> -maxdepth 1 -type f -printf '%T@ %s %p' | "
+            "sort -rn`` over plain SSH -- the read-only half of "
+            "``holodeck.backups.prune``'s own listing pipeline, with a size "
+            "field added and the destructive ``rm`` tail removed. An "
+            "optional ``path`` sub-directory is resolved and confined to "
+            "/var/backups/** via the same bound the prune write op applies "
+            "(a traversal or absolute-path escape is rejected before any "
+            "SSH traffic); the listing runs at -maxdepth 1 so it never "
+            "recurses into a subtree. Returns a ``{rows, total}`` envelope "
+            "with one row per file ({path, mtime, size_bytes}) ordered "
+            "newest-first -- the exact ordering the prune uses to pick its "
+            "keep window, so a caller can pass the same ``keep_newest`` a "
+            "prune request proposes and locally read off which rows that "
+            "prune would delete, without executing anything. Also answers "
+            "the routine backup-landing health check (how old / how large "
+            "is the newest artefact). safety_level=safe, "
+            "requires_approval=False -- pure ``find``, no mutation."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Optional sub-path under /var/backups (absolute or "
+                        "relative to it). Must resolve strictly within "
+                        "/var/backups/**. Omit to list the root."
+                    ),
+                },
+            },
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "mtime": {"type": "number"},
+                            "size_bytes": {"type": "integer"},
+                        },
+                    },
+                },
+                "total": {"type": "integer"},
+                "error": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="backups",
+        tags=("read-only", "backups", "list", "holodeck"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call before approving a ``holodeck.backups.prune`` (so the "
+                "reviewer sees exactly which files past the keep window "
+                "would be deleted, not just a ``keep_newest`` count), or as "
+                "a routine backup-landing health check on ``/var/backups`` "
+                "(is the hourly backup still landing? how old / how large "
+                "is the newest artefact?). Complements "
+                "``holodeck.disk.usage``'s aggregate byte count with the "
+                "per-file drill-down. " + _SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "path": (
+                    "Optional; must stay within /var/backups/**. Omit to "
+                    "list the root. Same bound as ``holodeck.backups.prune``."
+                ),
+            },
+            "output_shape": (
+                "``{rows: [{path, mtime, size_bytes}], total: N}``, rows "
+                "newest-first (by mtime). ``mtime`` is epoch seconds with a "
+                "fractional part (``find -printf '%T@'``); ``size_bytes`` is "
+                "an integer (``%s``). The ordering matches "
+                "``holodeck.backups.prune``'s keep window, so rows at index "
+                ">= keep_newest are the ones that prune would remove. "
+                "``error`` is set (rows empty) when the SSH command failed "
+                "-- distinct from a genuinely empty directory."
             ),
         },
     ),

--- a/backend/src/meho_backplane/connectors/holodeck/ops_write.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_write.py
@@ -207,6 +207,25 @@ def bound_backup_path(raw_path: Any) -> str:
     return normalised
 
 
+def resolve_backup_dir(raw_path: Any) -> str:
+    """Resolve the optional ``path`` param to a bounded backups directory.
+
+    Shared by ``holodeck.backups.prune`` (write) and
+    ``holodeck.backups.list`` (read, #2847) so both confine an
+    operator-supplied sub-path through the **single**
+    :func:`bound_backup_path` safety bound -- there is no second
+    path-validation implementation that could drift from it. ``None`` (the
+    ``path`` param omitted) or :data:`_BACKUPS_ROOT` itself resolves to the
+    root; any sub-path is routed through :func:`bound_backup_path`, which
+    rejects a traversal or absolute-path escape by raising
+    :exc:`HolodeckWriteSafetyError`. The returned path is not yet
+    shell-quoted -- the caller quotes it.
+    """
+    if raw_path is None or raw_path == _BACKUPS_ROOT:
+        return _BACKUPS_ROOT
+    return bound_backup_path(raw_path)
+
+
 def bound_image_tar(raw_path: Any) -> str:
     """Return the canonical seed-image tar path, or raise if out of bounds.
 
@@ -328,14 +347,10 @@ async def holodeck_backups_prune(
     if not isinstance(keep_newest, int) or isinstance(keep_newest, bool) or keep_newest < 1:
         return {"pruned": False, "error": "keep_newest must be an integer >= 1"}
 
-    target_dir = params.get("path", _BACKUPS_ROOT)
-    if target_dir == _BACKUPS_ROOT:
-        resolved_dir = _BACKUPS_ROOT
-    else:
-        try:
-            resolved_dir = bound_backup_path(target_dir)
-        except HolodeckWriteSafetyError as exc:
-            return {"pruned": False, "error": f"backups.prune safety check: {exc}"}
+    try:
+        resolved_dir = resolve_backup_dir(params.get("path"))
+    except HolodeckWriteSafetyError as exc:
+        return {"pruned": False, "error": f"backups.prune safety check: {exc}"}
 
     quoted_dir = shlex.quote(resolved_dir)
     # List regular files newest-first (mtime), drop the newest keep_newest,

--- a/backend/tests/test_connectors_holodeck_e2e.py
+++ b/backend/tests/test_connectors_holodeck_e2e.py
@@ -386,6 +386,7 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "holodeck.logs.tail",
     "holodeck.networking.show",
     "holodeck.disk.usage",
+    "holodeck.backups.list",
 )
 
 # ---------------------------------------------------------------------------
@@ -499,16 +500,17 @@ async def holodeck_e2e(
 
 
 def test_holodeck_ops_registration_count() -> None:
-    """All 9 read ops + 3 G3.18-T2 write ops = 12 ops registered in HOLODECK_OPS.
+    """All 10 read ops + 3 G3.18-T2 write ops = 13 ops registered in HOLODECK_OPS.
 
-    ``EXPECTED_OP_IDS`` enumerates the 9 read ops (about + 7 T2 reads +
-    ``holodeck.disk.usage``); the 3 approval-gated write ids are asserted in
+    ``EXPECTED_OP_IDS`` enumerates the 10 read ops (about + 7 T2 reads +
+    ``holodeck.disk.usage`` + #2847 ``holodeck.backups.list``); the 3
+    approval-gated write ids are asserted in
     ``test_connectors_holodeck_write.py``.
     """
     op_ids = {op.op_id for op in HOLODECK_OPS}
     missing = set(EXPECTED_OP_IDS) - op_ids
     assert not missing, f"Missing ops: {missing}"
-    assert len(HOLODECK_OPS) == 12, f"Expected 12 ops, got {len(HOLODECK_OPS)}"
+    assert len(HOLODECK_OPS) == 13, f"Expected 13 ops, got {len(HOLODECK_OPS)}"
 
 
 def test_holodeck_read_ops_all_safe_and_no_approval_required() -> None:
@@ -526,7 +528,7 @@ def test_holodeck_read_ops_all_safe_and_no_approval_required() -> None:
 
 
 def test_holodeck_ops_all_have_llm_instructions() -> None:
-    """All 12 ops carry non-empty llm_instructions for agent discoverability."""
+    """All 13 ops carry non-empty llm_instructions for agent discoverability."""
     for op in HOLODECK_OPS:
         assert op.llm_instructions, f"{op.op_id}: llm_instructions must not be empty"
         instr = op.llm_instructions
@@ -543,7 +545,7 @@ def test_holodeck_ops_all_carry_ssh_only_transport_note() -> None:
 
     The exact phrase to look for is "Holodeck has no REST API"; the
     shared :data:`SSH_TRANSPORT_NOTE` constant guarantees consistency
-    across all 12 ops.
+    across all 13 ops.
     """
     canonical_phrase = "Holodeck has no REST API"
     pwsh_phrase = "PowerShell-over-SSH"

--- a/backend/tests/test_connectors_holodeck_ops.py
+++ b/backend/tests/test_connectors_holodeck_ops.py
@@ -62,6 +62,7 @@ from meho_backplane.connectors.holodeck.ops_read import (
     GROWTH_DIRS,
     READ_OPS,
     KubectlSafetyError,
+    parse_backup_listing_output,
     parse_disk_usage_output,
     parse_kubectl_command,
     parse_logs_tail_output,
@@ -1252,13 +1253,179 @@ def test_disk_usage_growth_dirs_are_the_expected_constant() -> None:
 
 
 # ---------------------------------------------------------------------------
+# parse_backup_listing_output (#2847)
+# ---------------------------------------------------------------------------
+
+
+# Fixture: ``find ... -printf '%T@ %s %p\n' | sort -rn`` output -- three
+# regular files under /var/backups, already ordered newest-first by the
+# remote ``sort -rn`` (mtime epoch descending), the same ordering
+# ``holodeck.backups.prune`` uses internally to pick its keep window.
+_FIND_BACKUPS_OK = (
+    "1723471200.5 10485760 /var/backups/nsx-2026-08-12T14.tar.gz\n"
+    "1723467600.0 10480000 /var/backups/nsx-2026-08-12T13.tar.gz\n"
+    "1723464000.9 10471234 /var/backups/nsx-2026-08-12T12.tar.gz\n"
+)
+
+
+def test_parse_backup_listing_output_row_shape_and_newest_first_order() -> None:
+    """AC: rows carry {path, mtime, size_bytes}, newest-first (input order preserved)."""
+    rows = parse_backup_listing_output(_FIND_BACKUPS_OK)
+    assert rows == [
+        {
+            "path": "/var/backups/nsx-2026-08-12T14.tar.gz",
+            "mtime": 1723471200.5,
+            "size_bytes": 10485760,
+        },
+        {
+            "path": "/var/backups/nsx-2026-08-12T13.tar.gz",
+            "mtime": 1723467600.0,
+            "size_bytes": 10480000,
+        },
+        {
+            "path": "/var/backups/nsx-2026-08-12T12.tar.gz",
+            "mtime": 1723464000.9,
+            "size_bytes": 10471234,
+        },
+    ]
+    # Newest-first: mtimes strictly descending, exactly as sort -rn emits.
+    mtimes = [r["mtime"] for r in rows]
+    assert mtimes == sorted(mtimes, reverse=True)
+
+
+def test_parse_backup_listing_output_mtime_is_float_size_is_int() -> None:
+    row = parse_backup_listing_output("1723471200.5 4096 /var/backups/db.sql.gz\n")[0]
+    assert isinstance(row["mtime"], float)
+    assert isinstance(row["size_bytes"], int)
+
+
+def test_parse_backup_listing_output_preserves_path_with_spaces() -> None:
+    """``%p`` is the trailing field; a filename with spaces stays intact."""
+    rows = parse_backup_listing_output("1723471200.5 4096 /var/backups/my backup 01.tar\n")
+    assert rows[0]["path"] == "/var/backups/my backup 01.tar"
+
+
+def test_parse_backup_listing_output_skips_malformed_and_blank_lines() -> None:
+    rows = parse_backup_listing_output(
+        "1723471200.5 4096 /var/backups/ok.tar\n"
+        "\n"
+        "   \n"
+        "not-a-find-row\n"
+        "1723467600.0 notanint /var/backups/bad-size.tar\n"
+        "notafloat 4096 /var/backups/bad-mtime.tar\n"
+    )
+    assert rows == [{"path": "/var/backups/ok.tar", "mtime": 1723471200.5, "size_bytes": 4096}]
+
+
+def test_parse_backup_listing_output_empty_input_returns_empty_list() -> None:
+    assert parse_backup_listing_output("") == []
+    assert parse_backup_listing_output("   \n\n") == []
+
+
+def test_parse_backup_listing_reproduces_prune_keep_window() -> None:
+    """AC: newest-first ordering lets a caller locally read off what a given
+    ``keep_newest`` would delete -- rows at index >= keep_newest are exactly
+    the files ``holodeck.backups.prune keep_newest=N`` removes."""
+    rows = parse_backup_listing_output(_FIND_BACKUPS_OK)
+    keep_newest = 1
+    would_delete = [r["path"] for r in rows[keep_newest:]]
+    assert would_delete == [
+        "/var/backups/nsx-2026-08-12T13.tar.gz",
+        "/var/backups/nsx-2026-08-12T12.tar.gz",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Bound-method shim -- backups_list (#2847)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backups_list_composes_find_pipeline_over_plain_ssh() -> None:
+    """AC: runs ``find <dir> -maxdepth 1 -type f -printf '%T@ %s %p\\n' | sort -rn``."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_FIND_BACKUPS_OK)
+        result = await connector.backups_list(_TARGET, {})
+    cmd = mock_cmd.await_args.args[1]
+    assert cmd == "find /var/backups -maxdepth 1 -type f -printf '%T@ %s %p\\n' | sort -rn"
+    # Read-only: no destructive tail from the prune pipeline leaks in.
+    assert "rm" not in cmd
+    assert "xargs" not in cmd
+    # JSONFlux-shaped {rows, total} envelope, newest-first.
+    assert result["total"] == 3
+    assert result["rows"][0]["path"] == "/var/backups/nsx-2026-08-12T14.tar.gz"
+    assert [r["mtime"] for r in result["rows"]] == sorted(
+        (r["mtime"] for r in result["rows"]), reverse=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_backups_list_honours_bounded_sub_path() -> None:
+    """A sub-path is confined under /var/backups and reaches the find target."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="")
+        result = await connector.backups_list(_TARGET, {"path": "daily"})
+    cmd = mock_cmd.await_args.args[1]
+    assert cmd.startswith("find /var/backups/daily -maxdepth 1 -type f")
+    assert result == {"rows": [], "total": 0}
+
+
+@pytest.mark.asyncio
+async def test_backups_list_rejects_out_of_tree_path_without_ssh() -> None:
+    """AC: a path escaping /var/backups/** is rejected before any SSH traffic."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.backups_list(_TARGET, {"path": "../etc"})
+        mock_cmd.assert_not_awaited()
+    assert result["rows"] == []
+    assert result["total"] == 0
+    assert "error" in result and "safety check" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_backups_list_ssh_failure_returns_error_envelope() -> None:
+    """A transport failure surfaces as an error envelope, distinct from an
+    empty directory -- the backup-landing health-check signal."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = OSError("connection refused")
+        result = await connector.backups_list(_TARGET, {})
+    assert result["rows"] == []
+    assert result["total"] == 0
+    assert "error" in result
+
+
+def test_backups_list_op_is_safe_read_only_optional_path() -> None:
+    """AC: safe / no-approval / read-only tag / group backups / optional path param."""
+    op = next(o for o in HOLODECK_OPS if o.op_id == "holodeck.backups.list")
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert "read-only" in op.tags
+    assert op.group_key == "backups"
+    assert op.parameter_schema.get("additionalProperties") is False
+    assert "path" in op.parameter_schema.get("properties", {})
+    # path is optional -- no required list, or an empty one.
+    assert not op.parameter_schema.get("required")
+
+
+def test_backups_list_response_schema_is_jsonflux_rows_total() -> None:
+    op = next(o for o in HOLODECK_OPS if o.op_id == "holodeck.backups.list")
+    assert op.response_schema is not None
+    props = op.response_schema.get("properties", {})
+    assert "rows" in props
+    assert "total" in props
+
+
+# ---------------------------------------------------------------------------
 # HOLODECK_OPS registration shape
 # ---------------------------------------------------------------------------
 
 
-#: The 9 read-op ids (T1 canary + 7 T2 reads + G3.18-T1 disk.usage).
-#: The G3.18-T2 (#2154) approval-gated write ops are asserted
-#: separately in ``test_connectors_holodeck_write.py``.
+#: The 10 read-op ids (T1 canary + 7 T2 reads + G3.18-T1 disk.usage +
+#: #2847 backups.list). The G3.18-T2 (#2154) approval-gated write ops are
+#: asserted separately in ``test_connectors_holodeck_write.py``.
 _READ_OP_IDS: frozenset[str] = frozenset(
     {
         "holodeck.about",
@@ -1270,13 +1437,14 @@ _READ_OP_IDS: frozenset[str] = frozenset(
         "holodeck.logs.tail",
         "holodeck.networking.show",
         "holodeck.disk.usage",
+        "holodeck.backups.list",
     }
 )
 
 
-def test_holodeck_ops_has_twelve_entries() -> None:
-    """T1 canary (about) + 7 T2 read ops + G3.18-T1 disk.usage + 3 G3.18-T2 write ops = 12 total."""
-    assert len(HOLODECK_OPS) == 12
+def test_holodeck_ops_has_thirteen_entries() -> None:
+    """about + 7 T2 reads + disk.usage + #2847 backups.list + 3 write ops = 13 total."""
+    assert len(HOLODECK_OPS) == 13
 
 
 def test_holodeck_ops_about_remains_at_index_zero() -> None:
@@ -1359,6 +1527,9 @@ def test_holodeck_ops_group_keys_include_new_groups() -> None:
         "networking",
         # G3.18-T1 (#2153) read-op diagnostics group (holodeck.disk.usage).
         "diagnostics",
+        # #2847 read-op backups group (holodeck.backups.list) -- distinct
+        # from the ``backups-write`` group the prune write op lives in.
+        "backups",
         # G3.18-T2 (#2154) write groups (``-write`` suffix avoids collision).
         "k8s-write",
         "backups-write",

--- a/backend/tests/test_connectors_holodeck_write.py
+++ b/backend/tests/test_connectors_holodeck_write.py
@@ -50,6 +50,7 @@ from meho_backplane.connectors.holodeck.ops_write import (
     HolodeckWriteSafetyError,
     bound_backup_path,
     bound_image_tar,
+    resolve_backup_dir,
 )
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog
@@ -173,6 +174,37 @@ def test_bound_backup_path_rejects_escape(path: str) -> None:
 def test_bound_backup_path_rejects_non_string() -> None:
     with pytest.raises(HolodeckWriteSafetyError):
         bound_backup_path(None)
+
+
+# ---------------------------------------------------------------------------
+# resolve_backup_dir -- the shared root-default + bound resolver reused by
+# backups.prune (write) and backups.list (read, #2847)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_backup_dir_none_defaults_to_root() -> None:
+    """Param omitted -> the backups root (the prune/list default)."""
+    assert resolve_backup_dir(None) == "/var/backups"
+
+
+def test_resolve_backup_dir_root_itself_stays_root() -> None:
+    """The root is the default, not an escape -- returned as-is, not rejected."""
+    assert resolve_backup_dir("/var/backups") == "/var/backups"
+
+
+def test_resolve_backup_dir_sub_path_is_bounded() -> None:
+    assert resolve_backup_dir("daily") == "/var/backups/daily"
+    assert resolve_backup_dir("/var/backups/a/b") == "/var/backups/a/b"
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["/etc/shadow", "../etc/passwd", "/var/backups/../etc", "daily/../../etc"],
+)
+def test_resolve_backup_dir_delegates_escape_rejection_to_bound_backup_path(path: str) -> None:
+    """The single safety bound stays ``bound_backup_path`` -- an escape raises."""
+    with pytest.raises(HolodeckWriteSafetyError):
+        resolve_backup_dir(path)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -24,7 +24,11 @@ the 7 read ops (`config.show`, `pod.list`, `pod.info`, `service.list`,
 registered under `connector_id="holodeck-ssh-9.0"`. G3.8-T3 (#855) ships
 the CLI verbs + E2E acceptance suite + onboarding doc. G3.18-T1 (#2153)
 appends `holodeck.disk.usage` — root-fs `df` + `du` on a fixed growth-dir
-set for pre-eviction disk diagnosis — bringing the total to 9 ops.
+set for pre-eviction disk diagnosis — bringing the total to 9 ops. #2847
+appends `holodeck.backups.list` — a safe per-file inventory of
+`/var/backups` reusing `holodeck.backups.prune`'s own `find` listing —
+taking the read surface to **10 ops** (13 total, including the 3
+approval-gated write ops).
 
 Source: `backend/src/meho_backplane/connectors/holodeck/`.
 
@@ -41,11 +45,14 @@ Source: `backend/src/meho_backplane/connectors/holodeck/`.
 - **Read-op handlers + parsers** (`ops_read.py`) — `holodeck_config_show`,
   `holodeck_pod_list`, `holodeck_pod_info`, `holodeck_service_list`,
   `holodeck_k8s_exec`, `holodeck_logs_tail`, `holodeck_networking_show`,
-  `holodeck_disk_usage`. Pure parsers: `parse_kubectl_command`
-  (verb-safelist enforcement), `parse_logs_tail_output` (GNU `tail`
-  `==> path <==` header split), `parse_networking_payload` (four-section
-  composer), `parse_disk_usage_output` (root-fs `df -B1` + per-dir
-  `du -sb` composer with per-section `ok`). `GROWTH_DIRS` is the fixed
+  `holodeck_disk_usage`, `holodeck_backups_list`. Pure parsers:
+  `parse_kubectl_command` (verb-safelist enforcement),
+  `parse_logs_tail_output` (GNU `tail` `==> path <==` header split),
+  `parse_networking_payload` (four-section composer),
+  `parse_disk_usage_output` (root-fs `df -B1` + per-dir `du -sb` composer
+  with per-section `ok`), `parse_backup_listing_output` (`find -printf
+  '%T@ %s %p'` → `{path, mtime, size_bytes}` rows, newest-first order
+  preserved). `GROWTH_DIRS` is the fixed
   code constant (`/var/backups`, `/holodeck-runtime`) the disk-usage op
   measures — no operator path parameter. `KubectlSafetyError` is the
   `ValueError` subclass the dispatcher's error envelope picks up when a
@@ -158,7 +165,7 @@ Four-stage health check; each stage maps to a distinct
 
 The probe does not mutate state. `Get-Service` is read-only on Photon.
 
-### Read ops (T2 surface + G3.18-T1 disk.usage)
+### Read ops (T2 surface + G3.18-T1 disk.usage + #2847 backups.list)
 
 The read ops route through the dispatcher's standard
 `call_operation` path. Each registers via `register_typed_operation()` with
@@ -273,6 +280,27 @@ disclosure (CLAUDE.md postulate 5 + Initiative #371).
   it can never become an arbitrary `du`. This is the complete
   pre-eviction disk signal for the 74 GB root fs (VCF-9.x backup fill).
 
+- **`holodeck.backups.list`** (group `backups`, JSONFlux-shaped, #2847).
+  Runs `find <dir> -maxdepth 1 -type f -printf '%T@ %s %p' | sort -rn`
+  over **plain SSH** — the read-only half of `holodeck.backups.prune`'s
+  own listing pipeline (same `find -maxdepth 1`, plus a `%s` size field,
+  minus the destructive `tail | cut | xargs rm` tail). An optional `path`
+  sub-directory is confined to `/var/backups/**` via `resolve_backup_dir`
+  (the shared resolver both this op and `backups.prune` call, so the
+  single `bound_backup_path` safety bound is never duplicated). Returns a
+  `{rows, total}` envelope with one `{path, mtime, size_bytes}` row per
+  file, **newest-first** — the exact ordering `backups.prune` uses to pick
+  its keep window, so a caller can pass the same `keep_newest` a prune
+  request proposes and locally read off which rows (index ≥ `keep_newest`)
+  that prune would delete, without executing anything. A transport failure
+  surfaces as `{rows: [], total: 0, error}` so an empty result from a
+  broken connection is distinguishable from a genuinely empty directory
+  (the backup-landing health-check signal). Closes the inspection half of
+  the same root-SSH fallback the `backups.prune` write op retired: a
+  reviewer approving that destructive prune is no longer asked to do so
+  blind. `parse_backup_listing_output` is the pure parser. `safety_level=
+  safe`, `requires_approval=False` — pure `find`, no mutation.
+
 ### Write ops (G3.18-T2 surface, approval-gated)
 
 `ops_write.py` (module `WRITE_OPS`, appended to `HOLODECK_OPS` via
@@ -289,7 +317,9 @@ Each handler validates its inputs against a fixed allowlist and **rejects
 before composing** the command, then `shlex.quote`s every interpolated
 token — the same reject-then-compose posture as `_COMPONENT_SAFE_RE` /
 `parse_kubectl_command`. `bound_backup_path` / `bound_image_tar` are the pure
-path-bounding helpers (unit-tested directly).
+path-bounding helpers (unit-tested directly); `resolve_backup_dir` wraps
+`bound_backup_path` with the root-default behaviour and is the single
+resolver `backups.prune` and `backups.list` (#2847) both call.
 
 - **`holodeck.k8s.pods.gc`** (group `k8s-write`). Runs one
   `kubectl delete pods --field-selector status.phase=<phase>` per requested
@@ -305,7 +335,9 @@ path-bounding helpers (unit-tested directly).
 - **`holodeck.backups.prune`** (group `backups-write`). Removes backup
   artefacts under `/var/backups`, keeping the newest `keep_newest` (explicit
   int, required). An optional `path` sub-directory is resolved via
-  `bound_backup_path`, which rejects any value that escapes `/var/backups/**`
+  `resolve_backup_dir` (shared with the `holodeck.backups.list` read op,
+  #2847), which defaults to the root and routes any sub-path through
+  `bound_backup_path` — rejecting any value that escapes `/var/backups/**`
   (relative/absolute traversal, or the root itself). The listing runs at
   `find -maxdepth 1` so the prune never recurses into a subtree.
 - **`holodeck.images.import`** (group `images-write`). Runs


### PR DESCRIPTION
## Summary

- Adds **`holodeck.backups.list`** (group `backups`, `safety_level=safe`, `requires_approval=False`) — a read-only per-file inventory of `/var/backups` so a destructive `holodeck.backups.prune` is never approved blind, and so "is the hourly backup still landing?" has a governed signal (today only `disk.usage`'s aggregate `du` byte count exists).
- Runs `find <dir> -maxdepth 1 -type f -printf '%T@ %s %p' | sort -rn` over plain SSH — the **read half of the prune handler's own listing pipeline** (adds a `%s` size field, drops the destructive `tail | cut | xargs rm` tail). Returns a JSONFlux-shaped `{rows: [{path, mtime, size_bytes}], total}` envelope **newest-first** — the exact ordering `backups.prune` uses for its keep window, so a caller can pass the same `keep_newest` a prune proposes and locally read off which rows (index ≥ `keep_newest`) it would delete, without executing anything.
- **Path bound reused, not reimplemented:** new `resolve_backup_dir` helper in `ops_write.py` wraps the existing `bound_backup_path` (root default + `/var/backups/**` confinement); both `backups.prune` and `backups.list` call it, so the single safety bound can never drift. `backups.prune` is refactored onto it (behaviour-preserving).
- A transport failure surfaces as `{rows: [], total: 0, error}` so an empty result from a broken connection is distinguishable from a genuinely empty directory (the backup-landing health-check signal).

## Acceptance criteria

- [x] **`holodeck.backups.list` registered** (safe / no-approval / group `backups`), dispatchable, runs the `find … -printf '%T@ %s %p' | sort -rn` pipeline over plain SSH — `test_backups_list_composes_find_pipeline_over_plain_ssh` asserts the exact command; `test_backups_list_op_is_safe_read_only_optional_path` asserts the descriptor.
- [x] **Optional `path` bounded via the existing `bound_backup_path`** (reused, not reimplemented) — `test_backups_list_rejects_out_of_tree_path_without_ssh` (rejects before any SSH) + `test_resolve_backup_dir_*` (the shared resolver delegates escape rejection to `bound_backup_path`).
- [x] **Returns `{rows: [{path, mtime, size_bytes}], total}`, newest-first** — `test_parse_backup_listing_output_row_shape_and_newest_first_order` + `test_parse_backup_listing_reproduces_prune_keep_window`.
- [x] **Test extends `test_connectors_holodeck_ops.py`** asserting row shape + newest-first ordering against fixture `find` output (cross-refs the write-test `backups.prune` fixtures).
- [x] **`docs/codebase/connectors-holodeck.md` "Read ops" extended** with `holodeck.backups.list` (9 → **10** read ops), noting the shared listing logic with `backups.prune`.
- [x] **CLI OpenAPI snapshot** — no FastAPI route/schema changed (typed ops are DB-registered `endpoint_descriptor` rows, not HTTP routes), so the snapshot is unaffected; no regeneration required.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (holodeck connector + 3 test files)
- [x] `mypy` — clean (6 source files)
- [x] `pytest tests/test_connectors_holodeck_ops.py tests/test_connectors_holodeck_write.py` — 241 passed
- [x] `pytest tests/test_connectors_holodeck_e2e.py` — 18 passed
- [x] `pytest --collect-only` (whole backend suite) — 11976 tests collected, **0 import errors**

## Out of scope (per the issue)

- Approval-preview builder wiring for `backups.prune` (the `proposed_effect` hook, keycloak-style) — this Task ships the read op a preview would call; wiring it is a separate connector-crossing follow-on.
- No change to `holodeck.disk.usage` / `GROWTH_DIRS` (the aggregate `du` signal stays); no `/holodeck-runtime` listing; no CLI verb (the holodeck CLI has no `disk.go` either — parity is not a gate).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2847
