### PR TITLE
feat(connectors): add vmware GOSC create + apply composites (#2892)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,30 @@ connector-related release-notes line.
   `GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP` the read
   composites already use.
 
+### Added — vmware-rest guest customization (GOSC) composites: create + apply, secret-hygienic (#2892)
+
+- Two new `vmware-rest` write composites make guest OS customization a
+  first-class agent workflow — how a cloned VM gets its hostname, per-NIC
+  static IP + gateway + DNS, and (on Windows) its sysprep identity on
+  first boot. `vmware.composite.guest.customization_spec.create`
+  (`POST:/vcenter/guest/customization-specs`) creates a reusable named
+  spec covering the Linux and Windows/sysprep cases;
+  `vmware.composite.vm.customize`
+  (`PUT:/vcenter/vm/{vm}/guest/customization`) resolves a VM by name and
+  applies a saved spec, refusing a powered-on VM with a structured
+  `precondition_failed` status and optionally powering it on afterward.
+  Both are `dangerous` + `requires_approval`, dispatch every sub-op on the
+  direct connector session (fresh-boot dispatchable, zero catalog ingest),
+  and gate each mutating sub-call through `enforce_subop_policy`.
+- GOSC secret hygiene (#1503) is enforced across all three reviewer
+  surfaces: the create op is pinned `credential_write` (broadcast params
+  collapse to aggregate-only), its park-time preview echoes identity
+  fields only (`spec_name` / `os_type` / `hostname_scheme` / `nic_count` /
+  `static_ip_summary` — never admin passwords, product keys, or
+  domain-join credentials), and the durable audit row stores only a params
+  hash. A dedicated end-to-end test proves no secret material reaches the
+  approval, broadcast, or audit surface.
+
 ## [0.28.0] - 2026-08-07
 
 ### Added — seven more Do-real-work guides on the docs site: topology, broadcast, memory/knowledge, audit forensics, runbooks, scheduler, satellite gateway (#2829)

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -171,6 +171,18 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
         # written token in full. Pinning it collapses the broadcast to
         # aggregate-only. (The op result itself returns key NAMES only.)
         "rke2.node.config.update",
+        # #2892 — the GOSC customization-spec create composite. Its params
+        # carry Windows sysprep credentials (``windows_admin_password`` /
+        # ``windows_product_key`` / ``windows_domain_admin_password``). The
+        # ``password`` fields trip the key-name scrub, but ``product_key``
+        # does not (``key`` is neither an anywhere- nor a final-position
+        # secret token), so a plain ``write`` classification (the ``.create``
+        # suffix) would broadcast the product key in full. Pinning it
+        # collapses the whole params dict to aggregate-only (#1503); the
+        # park-time preview additionally echoes identity fields only. The
+        # sibling ``vmware.composite.vm.customize`` carries only a spec-name
+        # reference (no secret) and is not pinned.
+        "vmware.composite.guest.customization_spec.create",
     }
 )
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 21 composites land before
+``endpoint_descriptor`` upserts for the 23 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -29,13 +29,13 @@ Scope:
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 16 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
+* 18 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
   #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, the
   folder-template ``vm.clone_from_template`` / #2894, the vim
   cluster / inventory writes ``cluster.drs_rule.create`` +
-  ``folder.create`` / #2895, and the #2891 post-clone hardware
+  ``folder.create`` / #2895, the #2891 post-clone hardware
   reconfigure trio ``vm.resize`` / ``vm.nic.repoint`` /
-  ``vm.device.cdrom``) -- inherit
+  ``vm.device.cdrom``, and the two GOSC composites / #2892) -- inherit
   T4's ``safety_level="dangerous"`` +
   ``requires_approval=True`` defaults.
   They cover every state-mutating workflow Goal #214 names as
@@ -48,9 +48,11 @@ Scope:
   ``host.evacuate`` (first recursive composite),
   ``host.detach_from_vds``, ``cluster.patch``,
   ``cluster.drs_rule.create`` (DRS rule by explicit VM list, no REST
-  path), ``folder.create`` (synchronous vim ``CreateFolder``), plus
-  the post-clone hardware reconfigure trio ``vm.resize``,
-  ``vm.nic.repoint``, ``vm.device.cdrom`` (#2891).
+  path), ``folder.create`` (synchronous vim ``CreateFolder``), the
+  post-clone hardware reconfigure trio ``vm.resize``,
+  ``vm.nic.repoint``, ``vm.device.cdrom`` (#2891), plus guest OS
+  customization: ``guest.customization_spec.create`` and
+  ``vm.customize`` (GOSC create + apply, secret-hygienic) (#2892).
 """
 
 from meho_backplane.connectors.vmware_rest.composites._read import (
@@ -67,11 +69,13 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     cluster_drs_rule_create_composite,
     cluster_patch_composite,
     folder_create_composite,
+    guest_customization_spec_create_composite,
     host_detach_from_vds_composite,
     host_evacuate_composite,
     vm_clone_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
+    vm_customize_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -89,7 +93,7 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 # registered by the time the runner iterates.
 register_typed_op_registrar(register_vmware_composite_operations)
 
-# Side-effect import: registers the 16 write composites' park-time
+# Side-effect import: registers the 18 write composites' park-time
 # ``proposed_effect`` preview builders (#1608) onto the per-op hook in
 # :mod:`meho_backplane.operations._preview` — mirrors how
 # ``connectors/argocd/__init__`` wires ``ops_write_preview``.
@@ -102,6 +106,7 @@ __all__ = [
     "datastore_usage_composite",
     "event_tail_composite",
     "folder_create_composite",
+    "guest_customization_spec_create_composite",
     "host_detach_from_vds_composite",
     "host_evacuate_composite",
     "network_portgroup_audit_composite",
@@ -110,6 +115,7 @@ __all__ = [
     "vm_clone_composite",
     "vm_clone_from_template_composite",
     "vm_create_composite",
+    "vm_customize_composite",
     "vm_device_cdrom_composite",
     "vm_disk_grow_composite",
     "vm_migrate_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 21 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 23 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -26,15 +26,16 @@ The 5 read composites (T5 / #508) pass
 T4's ``dangerous`` / ``True`` defaults. (The former
 ``host.network_uplinks`` and ``host.vsan_health`` reads were re-shipped
 as typed ops in #2258; see
-:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 16 write
+:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 18 write
 composites (T6 / #509, single-VM ``vm.power`` / #2301, the mutating
 VI-JSON ``vm.disk.grow`` / #2893, the folder-template
 ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
-``cluster.drs_rule.create`` + ``folder.create`` / #2895, and the #2891
+``cluster.drs_rule.create`` + ``folder.create`` / #2895, the #2891
 hardware writes -- ``vm.resize`` / ``vm.nic.repoint`` /
-``vm.device.cdrom``) inherit the T4
-defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity at
-the call site; the helper would default to those values anyway).
+``vm.device.cdrom``, and the two GOSC composites
+``guest.customization_spec.create`` / ``vm.customize`` / #2892) inherit
+the T4 defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity
+at the call site; the helper would default to those values anyway).
 Each :class:`_CompositeSpec` row carries its own ``safety_level`` +
 ``requires_approval`` so the policy posture is implied by the row,
 not by global state.
@@ -57,11 +58,13 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     cluster_drs_rule_create_composite,
     cluster_patch_composite,
     folder_create_composite,
+    guest_customization_spec_create_composite,
     host_detach_from_vds_composite,
     host_evacuate_composite,
     vm_clone_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
+    vm_customize_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -84,6 +87,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     EVENT_TAIL_RESPONSE_SCHEMA,
     FOLDER_CREATE_PARAMETER_SCHEMA,
     FOLDER_CREATE_RESPONSE_SCHEMA,
+    GUEST_CUSTOMIZATION_SPEC_CREATE_PARAMETER_SCHEMA,
+    GUEST_CUSTOMIZATION_SPEC_CREATE_RESPONSE_SCHEMA,
     HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA,
     HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA,
     HOST_EVACUATE_PARAMETER_SCHEMA,
@@ -98,6 +103,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     VM_CLONE_RESPONSE_SCHEMA,
     VM_CREATE_PARAMETER_SCHEMA,
     VM_CREATE_RESPONSE_SCHEMA,
+    VM_CUSTOMIZE_PARAMETER_SCHEMA,
+    VM_CUSTOMIZE_RESPONSE_SCHEMA,
     VM_DEVICE_CDROM_PARAMETER_SCHEMA,
     VM_DEVICE_CDROM_RESPONSE_SCHEMA,
     VM_DISK_GROW_PARAMETER_SCHEMA,
@@ -218,6 +225,20 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "host offline' workflows. Pair with 'networking' for the "
         "DVS-audit prerequisite to host_detach_from_vds, and with "
         "'cluster' / 'vm' for the pre-flight reads."
+    ),
+    "guest": (
+        "Use for guest OS customization (GOSC) write composites -- how a "
+        "cloned VM gets its network identity on first boot. Write "
+        "(dangerous / approval-required): create a reusable named "
+        "customization spec (hostname + per-NIC static IP + gateway + "
+        "DNS for Linux, or a Windows sysprep spec), and apply a saved "
+        "spec to a powered-off VM (optional power-on afterward so it "
+        "applies that boot). The right group after a 'vm' clone/create "
+        "when the question is 'give this VM its hostname and static IP'. "
+        "Pair with 'vm' for the clone/create that produces the VM, and "
+        "with 'networking' when the per-NIC IPs need portgroup context. "
+        "GOSC specs can carry admin / sysprep credentials; those never "
+        "reach a reviewer surface (the create op is credential-class)."
     ),
 }
 
@@ -733,6 +754,63 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         safety_level="dangerous",
         requires_approval=True,
     ),
+    # ----------------------------------------------------------------
+    # Guest customization (GOSC) composites (#2892) -- dangerous / approval
+    # ----------------------------------------------------------------
+    _CompositeSpec(
+        op_id="vmware.composite.guest.customization_spec.create",
+        handler=guest_customization_spec_create_composite,
+        summary="Create a reusable named guest customization (GOSC) spec.",
+        description=(
+            "Creates a named GuestOS customization spec via "
+            "POST:/vcenter/guest/customization-specs from the tractable "
+            "provisioning subset: hostname (FIXED HostnameGenerator), "
+            "per-NIC static IP / prefix / gateways, and global DNS, for "
+            "either a Linux (linux_config) or Windows "
+            "(windows_config sysprep) guest. The spec a later "
+            "vmware.composite.vm.customize -- or a clone's "
+            "guest_customization_spec -- references by name so a cloned "
+            "VM comes up with its hostname and network identity. Windows "
+            "admin / product-key / domain-join credentials are consumed "
+            "into the sysprep body but never serialized onto any "
+            "reviewer / preview / broadcast / audit surface (#1503): the "
+            "op is credential-class and its park-time preview echoes "
+            "identity fields only."
+        ),
+        parameter_schema=GUEST_CUSTOMIZATION_SPEC_CREATE_PARAMETER_SCHEMA,
+        response_schema=GUEST_CUSTOMIZATION_SPEC_CREATE_RESPONSE_SCHEMA,
+        group_key="guest",
+        tags=["composite", "write", "guest", "customization", "provisioning"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.customize",
+        handler=vm_customize_composite,
+        summary="Apply a saved customization spec to a VM (by name); optional power-on.",
+        description=(
+            "Resolves a VM by display name via GET:/vcenter/vm, then "
+            "applies a saved customization spec via "
+            "PUT:/vcenter/vm/{vm}/guest/customization with the spec name. "
+            "vCenter only accepts a pending customization on a "
+            "powered-off VM, so the composite pre-checks the resolved "
+            "power state and refuses a powered-on VM with "
+            "status='precondition_failed' rather than letting the PUT "
+            "400. Ambiguous / missing names return "
+            "status='ambiguous' / 'not_found'. With power_on=True the VM "
+            "is powered on afterward via "
+            "POST:/vcenter/vm/{vm}/power?action=start so the "
+            "customization applies on that boot. The spec reference "
+            "carries no secret (the credential material lives in the "
+            "saved spec)."
+        ),
+        parameter_schema=VM_CUSTOMIZE_PARAMETER_SCHEMA,
+        response_schema=VM_CUSTOMIZE_RESPONSE_SCHEMA,
+        group_key="guest",
+        tags=["composite", "write", "guest", "vm", "customization"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
 )
 
 
@@ -749,15 +827,16 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 21 composites total -- 5 read (T5 / #508) + 16 write (T6 /
+    Scope: 23 composites total -- 5 read (T5 / #508) + 18 write (T6 /
     #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
     ``vm.disk.grow`` / #2893, the folder-template
     ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
-    ``cluster.drs_rule.create`` + ``folder.create`` / #2895, and the #2891
+    ``cluster.drs_rule.create`` + ``folder.create`` / #2895, the #2891
     hardware writes ``vm.resize`` / ``vm.nic.repoint`` /
-    ``vm.device.cdrom``). (The former
-    ``host.network_uplinks`` / ``host.vsan_health`` reads were re-shipped
-    as typed ops in #2258.)
+    ``vm.device.cdrom``, and the two GOSC composites
+    ``guest.customization_spec.create`` / ``vm.customize`` / #2892). (The
+    former ``host.network_uplinks`` / ``host.vsan_health`` reads were
+    re-shipped as typed ops in #2258.)
     Each composite's ``safety_level`` +
     ``requires_approval`` come from its :class:`_CompositeSpec` row:
     reads pass ``"safe"`` / ``False``; writes pass ``"dangerous"`` /

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -89,7 +89,7 @@ from __future__ import annotations
 import asyncio
 import re
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 import httpx
 
@@ -371,6 +371,14 @@ _OP_DISCONNECT_VM_CDROM = "POST:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}?action=d
 # vCenter REST -- no vim fallback (the issue's grounded gap table).
 _OP_CREATE_CUSTOMIZATION_SPEC = "POST:/vcenter/guest/customization-specs"
 _OP_SET_VM_CUSTOMIZATION = "PUT:/vcenter/vm/{vm}/guest/customization"
+
+#: Default Microsoft time-zone index for the Windows ``GuiUnattended.time_zone``
+#: when the operator does not pin one. ``GuiUnattended.time_zone`` is a REQUIRED
+#: *integer* index in the pinned schema (``Vcenter.Guest.GuiUnattended``,
+#: vcenter.yaml:126181) -- distinct from the Linux tz-name string -- so a value
+#: is always emitted. ``85`` is GMT; operators override via ``windows_time_zone``
+#: (indices: https://support.microsoft.com/help/973627).
+_DEFAULT_WINDOWS_TIME_ZONE: Final[int] = 85
 
 
 def _power_vm_op_id(action: str) -> str:
@@ -3207,9 +3215,18 @@ def _build_interface(nic: dict[str, Any]) -> dict[str, Any]:
 
 
 def _build_linux_config(params: dict[str, Any]) -> dict[str, Any]:
-    """Build ``configuration_spec.linux_config`` from the agent params."""
-    linux_config: dict[str, Any] = {"hostname": _build_hostname_generator(params["hostname"])}
-    _put_if_str(linux_config, "domain", params.get("domain"))
+    """Build ``configuration_spec.linux_config`` from the agent params.
+
+    ``hostname`` and ``domain`` are REQUIRED by the pinned
+    ``Vcenter.Guest.LinuxConfiguration`` schema (vcenter.yaml:126320), so
+    ``domain`` is always emitted (empty string when unset) -- omitting it
+    fails even a minimal Linux create. ``time_zone`` (a Linux tz-name
+    string here) is optional and dropped when absent.
+    """
+    linux_config: dict[str, Any] = {
+        "hostname": _build_hostname_generator(params["hostname"]),
+        "domain": params.get("domain") or "",
+    }
     _put_if_str(linux_config, "time_zone", params.get("time_zone"))
     return linux_config
 
@@ -3218,31 +3235,43 @@ def _build_windows_sysprep(params: dict[str, Any]) -> dict[str, Any]:
     """Build the ``windows_config.sysprep`` body, consuming the secret fields.
 
     The credential members (``gui_unattended.password``,
-    ``user_data.product_key``, ``identification.domain_admin_password``)
-    are read here and here only -- they never leave for a reviewer /
-    preview / broadcast surface (#1503).
-    """
-    user_data: dict[str, Any] = {"computer_name": _build_hostname_generator(params["hostname"])}
-    _put_if_str(user_data, "product_key", params.get("windows_product_key"))
-    _put_if_str(user_data, "full_name", params.get("windows_full_name"))
-    _put_if_str(user_data, "organization", params.get("windows_organization"))
+    ``user_data.product_key``, ``domain.domain_password``) are read here
+    and here only -- they never leave for a reviewer / preview /
+    broadcast surface (#1503).
 
-    gui_unattended: dict[str, Any] = {"auto_logon": bool(params.get("windows_auto_logon", False))}
+    ``UserData`` (``full_name`` / ``organization`` / ``product_key``,
+    vcenter.yaml:126067) and ``GuiUnattended`` (``auto_logon`` /
+    ``auto_logon_count`` / ``time_zone``, vcenter.yaml:126181) fields are
+    REQUIRED by the pinned schema, so they are always emitted (empty
+    string / derived defaults) -- their omission fails every Windows
+    create. ``time_zone`` here is the REST integer MS index (not the Linux
+    tz-name string). Domain join lives under ``domain`` ->
+    ``Vcenter.Guest.Domain`` (vcenter.yaml:126104), NOT the pyvmomi
+    ``identification`` key.
+    """
+    auto_logon = bool(params.get("windows_auto_logon", False))
+    user_data: dict[str, Any] = {
+        "computer_name": _build_hostname_generator(params["hostname"]),
+        "full_name": params.get("windows_full_name") or "",
+        "organization": params.get("windows_organization") or "",
+        "product_key": params.get("windows_product_key") or "",
+    }
+
+    gui_unattended: dict[str, Any] = {
+        "auto_logon": auto_logon,
+        "auto_logon_count": 1 if auto_logon else 0,
+        "time_zone": int(params.get("windows_time_zone", _DEFAULT_WINDOWS_TIME_ZONE)),
+    }
     _put_if_str(gui_unattended, "password", params.get("windows_admin_password"))
-    _put_if_str(gui_unattended, "time_zone", params.get("time_zone"))
 
     sysprep: dict[str, Any] = {"user_data": user_data, "gui_unattended": gui_unattended}
 
     join_domain = params.get("windows_join_domain")
     if isinstance(join_domain, str) and join_domain:
-        identification: dict[str, Any] = {"joined_domain": join_domain}
-        _put_if_str(
-            identification, "domain_admin_username", params.get("windows_domain_admin_username")
-        )
-        _put_if_str(
-            identification, "domain_admin_password", params.get("windows_domain_admin_password")
-        )
-        sysprep["identification"] = identification
+        domain: dict[str, Any] = {"type": "DOMAIN", "domain": join_domain}
+        _put_if_str(domain, "domain_username", params.get("windows_domain_admin_username"))
+        _put_if_str(domain, "domain_password", params.get("windows_domain_admin_password"))
+        sysprep["domain"] = domain
     return sysprep
 
 
@@ -3274,8 +3303,14 @@ def _build_customization_create_body(params: dict[str, Any]) -> dict[str, Any]:
             ],
         },
     }
-    create_spec: dict[str, Any] = {"name": params["spec_name"], "spec": customization_spec}
-    _put_if_str(create_spec, "description", params.get("description"))
+    # ``description`` is REQUIRED on the CreateSpec (vcenter.yaml:126873), so
+    # it is always emitted (empty string when unset) -- omitting it fails
+    # even a minimal create.
+    create_spec: dict[str, Any] = {
+        "name": params["spec_name"],
+        "description": params.get("description") or "",
+        "spec": customization_spec,
+    }
     return {"spec": create_spec}
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -1,16 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
-# code-quality-allow: 16 protocol-driven composite handlers for the
+# code-quality-allow: 18 protocol-driven composite handlers for the
 # vSphere REST + VI-JSON write surface ship in one module per the issue
 # body's design; splitting them by group would scatter the shared
 # sub-op_id constants + helpers across files for no readability gain. Each
 # handler's body is the documented orchestration workflow from #509's spec
-# (plus the mutating VI-JSON disk-grow from #2893, the folder-template clone
-# from #2894, the vim cluster / inventory writes — DRS-rule + folder
-# create — from #2895, and the #2891 hardware writes — vm.resize /
-# vm.nic.repoint / vm.device.cdrom).
+# (plus the single-VM vm.power from #2301, the mutating VI-JSON disk-grow
+# from #2893, the folder-template clone from #2894, the vim cluster /
+# inventory writes — DRS-rule + folder create — from #2895, the #2891
+# hardware writes — vm.resize / vm.nic.repoint / vm.device.cdrom, and the
+# GOSC create/apply from #2892).
 
-"""Write-shaped ``vmware.composite.*`` handler functions (16 composites).
+"""Write-shaped ``vmware.composite.*`` handler functions (18 composites).
 
 Companion to :mod:`._read`. Post-#2256 each handler is a module-level
 ``async def`` taking the dispatcher's composite-branch keyword args
@@ -104,11 +105,13 @@ __all__ = [
     "cluster_drs_rule_create_composite",
     "cluster_patch_composite",
     "folder_create_composite",
+    "guest_customization_spec_create_composite",
     "host_detach_from_vds_composite",
     "host_evacuate_composite",
     "vm_clone_composite",
     "vm_clone_from_template_composite",
     "vm_create_composite",
+    "vm_customize_composite",
     "vm_device_cdrom_composite",
     "vm_disk_grow_composite",
     "vm_migrate_composite",
@@ -363,6 +366,12 @@ _OP_UPDATE_VM_CDROM = "PATCH:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}"
 _OP_DELETE_VM_CDROM = "DELETE:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}"
 _OP_DISCONNECT_VM_CDROM = "POST:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}?action=disconnect"
 
+# Guest customization (GOSC) sub-ops (#2892). Create a reusable named
+# customization spec, then apply a saved one to a VM. Both are plain
+# vCenter REST -- no vim fallback (the issue's grounded gap table).
+_OP_CREATE_CUSTOMIZATION_SPEC = "POST:/vcenter/guest/customization-specs"
+_OP_SET_VM_CUSTOMIZATION = "PUT:/vcenter/vm/{vm}/guest/customization"
+
 
 def _power_vm_op_id(action: str) -> str:
     """Build the per-action canonical op_id for ``POST:/vcenter/vm/{vm}/power``.
@@ -419,6 +428,10 @@ _COMPOSITE_OP_ID_CLUSTER_PATCH = "vmware.composite.cluster.patch"
 _COMPOSITE_OP_ID_VM_RESIZE = "vmware.composite.vm.resize"
 _COMPOSITE_OP_ID_VM_NIC_REPOINT = "vmware.composite.vm.nic.repoint"
 _COMPOSITE_OP_ID_VM_DEVICE_CDROM = "vmware.composite.vm.device.cdrom"
+_COMPOSITE_OP_ID_GUEST_CUSTOMIZATION_SPEC_CREATE = (
+    "vmware.composite.guest.customization_spec.create"
+)
+_COMPOSITE_OP_ID_VM_CUSTOMIZE = "vmware.composite.vm.customize"
 
 # Per-composite sub-op-id tuples. Pre-#2256 these fed the L2 pre-flight
 # check that guarded a missing catalog ingest; the direct-session migration
@@ -504,6 +517,12 @@ _SUB_OPS_VM_DEVICE_CDROM: tuple[str, ...] = (
     _OP_UPDATE_VM_CDROM,
     _OP_DELETE_VM_CDROM,
     _OP_DISCONNECT_VM_CDROM,
+)
+_SUB_OPS_GUEST_CUSTOMIZATION_SPEC_CREATE: tuple[str, ...] = (_OP_CREATE_CUSTOMIZATION_SPEC,)
+_SUB_OPS_VM_CUSTOMIZE: tuple[str, ...] = (
+    _OP_LIST_VMS,
+    _OP_SET_VM_CUSTOMIZATION,
+    _power_vm_op_id("start"),
 )
 
 
@@ -3123,3 +3142,305 @@ async def vm_device_cdrom_composite(
     if gate is not None:
         return gate
     return {**base, "status": "updated", "requested_backing": backing}
+
+
+# ===========================================================================
+# guest.customization_spec.create + vm.customize (GOSC) (#2892)
+# ===========================================================================
+#
+# GOSC is how a cloned VM gets its network identity (hostname, per-NIC
+# static IP + gateway + DNS) and, on Windows, its sysprep identity on
+# first boot. Two composites: create a reusable named spec, then apply a
+# saved spec to a VM. Both plain REST -- no vim fallback.
+#
+# Secret hygiene (#1503) is load-bearing: the create params carry Windows
+# admin / product-key / domain-join credentials. The handler consumes
+# them into the sysprep body but they never reach a reviewer surface --
+# the op is pinned ``credential_write`` (broadcast collapses to
+# aggregate-only), the park-time preview echoes identity only
+# (:mod:`._write_preview`), and the durable audit row stores a params
+# hash. The handler builders below are the ONLY code that touches the
+# secret values.
+
+
+def _put_if_str(target: dict[str, Any], key: str, value: Any) -> None:
+    """Set ``target[key] = value`` only when *value* is a non-empty string.
+
+    Keeps the vCenter customization body free of empty / ``None`` fields
+    (the API rejects some empty-string members) and holds the builders'
+    branching down.
+    """
+    if isinstance(value, str) and value:
+        target[key] = value
+
+
+def _build_hostname_generator(hostname: str) -> dict[str, Any]:
+    """Build a FIXED ``HostnameGenerator`` for *hostname*.
+
+    vCenter models the guest host name as a generator
+    (``{type: FIXED|PREFIX|VIRTUAL_MACHINE, fixed_name, prefix}``); the
+    provisioning subset always pins an explicit name, so ``FIXED`` with
+    ``fixed_name`` is the only shape built.
+    """
+    return {"type": "FIXED", "fixed_name": hostname}
+
+
+def _build_interface(nic: dict[str, Any]) -> dict[str, Any]:
+    """Map one agent-facing NIC dict to a vCenter ``AdapterMapping``.
+
+    A NIC with an ``ip_address`` becomes a STATIC ``ipv4`` block
+    (``{type, ip_address, prefix?, gateways?}``); a NIC without one
+    becomes a DHCP adapter. Shape: ``{"adapter": {"ipv4": {...}}}``.
+    """
+    ip_address = nic.get("ip_address")
+    if isinstance(ip_address, str) and ip_address:
+        ipv4: dict[str, Any] = {"type": "STATIC", "ip_address": ip_address}
+        prefix = nic.get("prefix")
+        if isinstance(prefix, int):
+            ipv4["prefix"] = prefix
+        gateways = nic.get("gateways")
+        if isinstance(gateways, list) and gateways:
+            ipv4["gateways"] = [g for g in gateways if isinstance(g, str)]
+    else:
+        ipv4 = {"type": "DHCP"}
+    return {"adapter": {"ipv4": ipv4}}
+
+
+def _build_linux_config(params: dict[str, Any]) -> dict[str, Any]:
+    """Build ``configuration_spec.linux_config`` from the agent params."""
+    linux_config: dict[str, Any] = {"hostname": _build_hostname_generator(params["hostname"])}
+    _put_if_str(linux_config, "domain", params.get("domain"))
+    _put_if_str(linux_config, "time_zone", params.get("time_zone"))
+    return linux_config
+
+
+def _build_windows_sysprep(params: dict[str, Any]) -> dict[str, Any]:
+    """Build the ``windows_config.sysprep`` body, consuming the secret fields.
+
+    The credential members (``gui_unattended.password``,
+    ``user_data.product_key``, ``identification.domain_admin_password``)
+    are read here and here only -- they never leave for a reviewer /
+    preview / broadcast surface (#1503).
+    """
+    user_data: dict[str, Any] = {"computer_name": _build_hostname_generator(params["hostname"])}
+    _put_if_str(user_data, "product_key", params.get("windows_product_key"))
+    _put_if_str(user_data, "full_name", params.get("windows_full_name"))
+    _put_if_str(user_data, "organization", params.get("windows_organization"))
+
+    gui_unattended: dict[str, Any] = {"auto_logon": bool(params.get("windows_auto_logon", False))}
+    _put_if_str(gui_unattended, "password", params.get("windows_admin_password"))
+    _put_if_str(gui_unattended, "time_zone", params.get("time_zone"))
+
+    sysprep: dict[str, Any] = {"user_data": user_data, "gui_unattended": gui_unattended}
+
+    join_domain = params.get("windows_join_domain")
+    if isinstance(join_domain, str) and join_domain:
+        identification: dict[str, Any] = {"joined_domain": join_domain}
+        _put_if_str(
+            identification, "domain_admin_username", params.get("windows_domain_admin_username")
+        )
+        _put_if_str(
+            identification, "domain_admin_password", params.get("windows_domain_admin_password")
+        )
+        sysprep["identification"] = identification
+    return sysprep
+
+
+def _build_customization_create_body(params: dict[str, Any]) -> dict[str, Any]:
+    """Assemble the ``POST:/vcenter/guest/customization-specs`` request body.
+
+    Maps the agent-facing GOSC subset onto the vCenter ``CreateSpec``
+    (``{name, description, spec}``) whose ``spec`` is a
+    ``CustomizationSpec`` (``{configuration_spec, interfaces,
+    global_dns_settings}``), wrapped in the operation's ``spec``
+    parameter per the connector's REST convention.
+    """
+    if params["os_type"] == "linux":
+        configuration_spec = {"linux_config": _build_linux_config(params)}
+    else:
+        configuration_spec = {
+            "windows_config": {"reboot": "REBOOT", "sysprep": _build_windows_sysprep(params)},
+        }
+    interfaces = [
+        _build_interface(nic) for nic in params.get("interfaces") or [] if isinstance(nic, dict)
+    ]
+    customization_spec: dict[str, Any] = {
+        "configuration_spec": configuration_spec,
+        "interfaces": interfaces,
+        "global_dns_settings": {
+            "dns_servers": [s for s in params.get("dns_servers") or [] if isinstance(s, str)],
+            "dns_suffix_list": [
+                s for s in params.get("dns_suffix_list") or [] if isinstance(s, str)
+            ],
+        },
+    }
+    create_spec: dict[str, Any] = {"name": params["spec_name"], "spec": customization_spec}
+    _put_if_str(create_spec, "description", params.get("description"))
+    return {"spec": create_spec}
+
+
+async def guest_customization_spec_create_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Create a reusable named guest customization (GOSC) spec.
+
+    Op-id: ``vmware.composite.guest.customization_spec.create``. Single
+    write sub-op (``POST:/vcenter/guest/customization-specs``) routed
+    through the #2254 governance seam. The Windows credential params are
+    consumed into the sysprep body by
+    :func:`_build_customization_create_body` and never surface on a
+    reviewer / preview / broadcast / audit surface (#1503) -- the op is
+    pinned ``credential_write``.
+
+    On a parked / denied gate the seam's :class:`OperationResult` returns
+    verbatim; a transport / vCenter fault propagates as the dispatcher's
+    ``connector_error``.
+    """
+    spec_name = params["spec_name"]
+    os_type = params["os_type"]
+    body = _build_customization_create_body(params)
+    gate, _ = await _write_sub_op(connector, target, operator, _OP_CREATE_CUSTOMIZATION_SPEC, body)
+    if gate is not None:
+        return gate
+    return {"status": "created", "spec_name": spec_name, "os_type": os_type}
+
+
+def _vm_customize_identity(row: dict[str, Any]) -> dict[str, Any]:
+    """Identity projection of a VM listing row for the ``ambiguous`` candidate list."""
+    return {key: row[key] for key in ("vm", "name", "power_state") if row.get(key) is not None}
+
+
+def _vm_customize_result(
+    *,
+    status: str,
+    vm: str | None,
+    name: str,
+    spec_name: str,
+    power_state: str | None,
+    applies_on: str | None,
+    guidance: str | None,
+    candidates: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build the canonical ``vm.customize`` response envelope."""
+    return {
+        "status": status,
+        "vm": vm,
+        "name": name,
+        "spec_name": spec_name,
+        "power_state": power_state,
+        "applies_on": applies_on,
+        "candidates": candidates or [],
+        "guidance": guidance,
+    }
+
+
+async def vm_customize_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Apply a saved customization spec to a VM (resolved by name); optional power-on.
+
+    Op-id: ``vmware.composite.vm.customize``. Resolves the VM by display
+    name, refuses a powered-on VM with a structured
+    ``precondition_failed`` (vCenter only accepts a pending customization
+    on a powered-off VM), then ``PUT:/vcenter/vm/{vm}/guest/customization``
+    with the named spec. When ``power_on=True`` the VM is powered on
+    afterward so the customization applies on that boot.
+
+    The single spec reference carries no secret (the secret material
+    lives in the saved spec, created separately); the write sub-ops route
+    through the #2254 governance seam.
+    """
+    vm_name = params["name"]
+    spec_name = params["spec_name"]
+    power_on = bool(params.get("power_on", False))
+
+    vms = await _resolve_vm_list(
+        connector=connector, target=target, operator=operator, filter_dict={"names": [vm_name]}
+    )
+    if not vms:
+        return _vm_customize_result(
+            status="not_found",
+            vm=None,
+            name=vm_name,
+            spec_name=spec_name,
+            power_state=None,
+            applies_on=None,
+            guidance=f"no VM named {vm_name!r} resolved",
+        )
+    if len(vms) > 1:
+        return _vm_customize_result(
+            status="ambiguous",
+            vm=None,
+            name=vm_name,
+            spec_name=spec_name,
+            power_state=None,
+            applies_on=None,
+            guidance="multiple VMs share the requested name -- rename or clean up duplicates",
+            candidates=[_vm_customize_identity(row) for row in vms],
+        )
+    vm_row = vms[0]
+    vm_moid = vm_row.get("vm")
+    power_state = vm_row.get("power_state") if isinstance(vm_row.get("power_state"), str) else None
+    if not isinstance(vm_moid, str):
+        return _vm_customize_result(
+            status="not_found",
+            vm=None,
+            name=vm_name,
+            spec_name=spec_name,
+            power_state=None,
+            applies_on=None,
+            guidance="matched VM listing row missing ``vm`` key",
+        )
+    if power_state == "POWERED_ON":
+        return _vm_customize_result(
+            status="precondition_failed",
+            vm=vm_moid,
+            name=vm_name,
+            spec_name=spec_name,
+            power_state=power_state,
+            applies_on=None,
+            guidance="VM is powered on; power it off before setting a pending guest customization",
+        )
+
+    gate, _ = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_SET_VM_CUSTOMIZATION,
+        {"vm": vm_moid, "spec": {"name": spec_name}},
+    )
+    if gate is not None:
+        return gate
+
+    if power_on:
+        gate, _ = await _write_sub_op(
+            connector, target, operator, _power_vm_op_id("start"), {"vm": vm_moid}
+        )
+        if gate is not None:
+            return gate
+        return _vm_customize_result(
+            status="powered_on",
+            vm=vm_moid,
+            name=vm_name,
+            spec_name=spec_name,
+            power_state=power_state,
+            applies_on="next_power_on",
+            guidance=None,
+        )
+    return _vm_customize_result(
+        status="customization_set",
+        vm=vm_moid,
+        name=vm_name,
+        spec_name=spec_name,
+        power_state=power_state,
+        applies_on="next_power_on",
+        guidance=None,
+    )

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` preview builders for the 16 vmware write composites.
+"""Park-time ``proposed_effect`` preview builders for the 18 vmware write composites.
 
 G0.22-T3 (#1608). Before this module, a parked ``vmware.composite.*``
 write stored only the identifier default ``{op_id, connector_id,
@@ -9,7 +9,7 @@ target_id}`` in :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect
 — and because the original dispatch ``params`` are deliberately never
 serialised onto a reviewer-facing surface (#1503), the four-eyes
 approver could not tell a one-VM power cycle from a 1000-VM outage.
-This wires all 16 write composites onto the per-op preview hook shipped
+This wires all 18 write composites onto the per-op preview hook shipped
 by #1437 (:mod:`meho_backplane.operations._preview`), following the
 argocd pattern (#1452): reuse the handlers' own read-only resolution
 helpers, never the mutating sub-ops.
@@ -43,7 +43,24 @@ helpers, never the mutating sub-ops.
                           current_backing, requested_backing}`` network from->to
 ``vm.device.cdrom``       live-read: ``{vm, name, cdrom, action,
                           current_backing, state}`` (the host-local ISO path)
+``guest.customization_``  echo: spec_name, os_type, hostname_scheme,
+``spec.create``           nic_count, static_ip_summary (IDENTITY only --
+                          never the Windows admin / product-key /
+                          domain-join credentials, #1503)
+``vm.customize``          live-read: vm, name, power_state, spec_name,
+                          applies_on (spec reference carries no secret)
 ========================  ====================================================
+
+GOSC secret hygiene (#1503) is the load-bearing property of the two
+guest-customization builders. ``guest.customization_spec.create`` reads
+ONLY the identity keys (``spec_name`` / ``os_type`` / ``hostname`` /
+``interfaces`` ip+prefix+gateway) -- it never touches the
+``windows_admin_password`` / ``windows_product_key`` /
+``windows_domain_admin_password`` params, so no credential can reach the
+durable ``proposed_effect`` row by construction. Defence in depth: the
+op is pinned ``credential_write`` so its broadcast collapses to
+aggregate-only regardless of the builder, and the durable audit row
+stores only a params hash.
 
 Two preview depths, chosen per composite
 ========================================
@@ -107,7 +124,7 @@ Redaction posture
 
 The whole-builder ``classify_op`` gate runs in
 :func:`~meho_backplane.operations._preview.build_proposed_effect` before
-any builder fires: the 11 op_ids classify as ``write`` (``.create`` /
+any builder fires: the 18 op_ids classify as ``write`` (``.create`` /
 ``.patch`` suffixes) or ``other`` (``vm.disk.grow`` — ``.grow`` — and
 ``vm.clone_from_template`` — ``_template`` — are not write suffixes) —
 none is a credential class, so none is suppressed. The
@@ -671,7 +688,83 @@ async def _vm_device_cdrom_preview(ctx: PreviewContext) -> dict[str, Any] | None
     }
 
 
-#: op_id → builder for the 16 write composites. Module-level so the
+async def _guest_customization_spec_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``guest.customization_spec.create`` — IDENTITY fields only (no I/O).
+
+    **Secret hygiene (#1503) is the whole point of this builder.** It
+    reads ONLY the identity keys (``spec_name`` / ``os_type`` /
+    ``hostname`` / ``interfaces`` ip+prefix+gateway) and never the
+    ``windows_admin_password`` / ``windows_product_key`` /
+    ``windows_domain_admin_password`` params -- so no credential can
+    reach the durable ``proposed_effect`` row through this path by
+    construction. The reviewer still sees the full blast radius: which
+    spec, which OS, the host name, and the per-NIC static IPs the guest
+    will come up on.
+    """
+    spec_name = ctx.params.get("spec_name")
+    os_type = ctx.params.get("os_type")
+    if not isinstance(spec_name, str) or not isinstance(os_type, str):
+        return None
+    raw_interfaces = ctx.params.get("interfaces")
+    interfaces = raw_interfaces if isinstance(raw_interfaces, list) else []
+    static_ips = [
+        nic["ip_address"]
+        for nic in interfaces
+        if isinstance(nic, dict) and isinstance(nic.get("ip_address"), str) and nic["ip_address"]
+    ]
+    hostname = ctx.params.get("hostname")
+    return {
+        "spec_name": spec_name,
+        "os_type": os_type,
+        "hostname_scheme": f"FIXED:{hostname}" if isinstance(hostname, str) and hostname else None,
+        "nic_count": len(interfaces),
+        "static_ip_summary": static_ips,
+    }
+
+
+async def _vm_customize_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.customize`` — resolve the VM by name for its power state.
+
+    Echoes the VM name, the spec being applied, and ``applies_on``, and
+    (when a connector is resolved) live-reads the VM by name via the
+    shared :func:`._write._resolve_vm_list` to surface the moid + current
+    power state -- the load-bearing fact for the reviewer, since a
+    powered-on VM will be refused at dispatch. The spec reference carries
+    no secret (the credential material lives in the saved spec created
+    separately), so a plain echo is safe. Falls back to the name-only
+    echo when no connector is available or the name is not unambiguous.
+    """
+    vm_name = ctx.params.get("name")
+    spec_name = ctx.params.get("spec_name")
+    if not isinstance(vm_name, str) or not isinstance(spec_name, str):
+        return None
+    preview: dict[str, Any] = {
+        "vm": None,
+        "name": vm_name,
+        "spec_name": spec_name,
+        "power_state": None,
+        "applies_on": "next_power_on",
+    }
+    if ctx.connector_instance is None:
+        return preview
+    rows = await _resolve_vm_list(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        filter_dict={"names": [vm_name]},
+    )
+    if len(rows) == 1:
+        row = rows[0]
+        vm_moid = row.get("vm")
+        power_state = row.get("power_state")
+        if isinstance(vm_moid, str):
+            preview["vm"] = vm_moid
+        if isinstance(power_state, str):
+            preview["power_state"] = power_state
+    return preview
+
+
+#: op_id → builder for the 18 write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.create": _vm_create_preview,
@@ -690,11 +783,13 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.cluster.patch": _cluster_patch_preview,
     "vmware.composite.cluster.drs_rule.create": _cluster_drs_rule_create_preview,
     "vmware.composite.folder.create": _folder_create_preview,
+    "vmware.composite.guest.customization_spec.create": _guest_customization_spec_create_preview,
+    "vmware.composite.vm.customize": _vm_customize_preview,
 }
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 16 write-composite park-time preview builders. Import-time.
+    """Wire the 18 write-composite park-time preview builders. Import-time.
 
     The 5 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -2278,28 +2278,41 @@ GUEST_CUSTOMIZATION_SPEC_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
             "type": "string",
             "description": (
                 "Active Directory domain the Windows guest joins "
-                "(``sysprep.identification.joined_domain``)."
+                "(``sysprep.domain.domain`` with ``sysprep.domain.type = DOMAIN``)."
             ),
         },
         "windows_domain_admin_username": {
             "type": "string",
             "description": (
-                "Domain account used for the join "
-                "(``sysprep.identification.domain_admin_username``)."
+                "Domain account used for the join (``sysprep.domain.domain_username``)."
             ),
         },
         "windows_domain_admin_password": {
             "type": "string",
             "description": (
                 "SECRET. Password for the domain-join account "
-                "(``sysprep.identification.domain_admin_password``). Never "
-                "serialized to any reviewer-facing surface (#1503)."
+                "(``sysprep.domain.domain_password``). Never serialized to any "
+                "reviewer-facing surface (#1503)."
             ),
         },
         "windows_auto_logon": {
             "type": "boolean",
             "default": False,
-            "description": "Whether the Windows guest auto-logs-on after customization.",
+            "description": (
+                "Whether the Windows guest auto-logs-on after customization. "
+                "Also drives the required ``gui_unattended.auto_logon_count`` "
+                "(``1`` when true, else ``0``)."
+            ),
+        },
+        "windows_time_zone": {
+            "type": "integer",
+            "default": 85,
+            "description": (
+                "Windows guest time zone as a Microsoft time-zone index "
+                "(``gui_unattended.time_zone``; a REQUIRED integer, distinct "
+                "from the Linux ``time_zone`` tz-name string). Defaults to "
+                "``85`` (GMT). See https://support.microsoft.com/help/973627."
+            ),
         },
     },
     "required": ["spec_name", "os_type", "hostname"],

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""JSON Schema 2020-12 parameter + response schemas for the 21 vmware-rest composites.
+"""JSON Schema 2020-12 parameter + response schemas for the 23 vmware-rest composites.
 
 Each schema is the operator-facing input contract; the dispatcher
 validates inbound ``params`` against the registered schema before
@@ -25,14 +25,15 @@ Conventions
   schema verbatim on ``describe_operation`` calls.
 * The 5 read composites are read-only -- the registration call site
   pins ``safety_level="safe"`` and ``requires_approval=False`` on
-  each. The 16 write composites inherit T4's
+  each. The 18 write composites inherit T4's
   ``safety_level="dangerous"`` + ``requires_approval=True`` defaults
   (G3.1-T6 / #509, single-VM ``vm.power`` / #2301, the mutating
   VI-JSON ``vm.disk.grow`` / #2893, the folder-template
   ``vm.clone_from_template`` / #2894, the vim cluster / inventory
-  writes ``cluster.drs_rule.create`` + ``folder.create`` / #2895, and
+  writes ``cluster.drs_rule.create`` + ``folder.create`` / #2895,
   the #2891 hardware writes ``vm.resize`` / ``vm.nic.repoint`` /
-  ``vm.device.cdrom``). The schema
+  ``vm.device.cdrom``, and the two GOSC composites
+  ``guest.customization_spec.create`` / ``vm.customize`` / #2892). The schema
   text reflects which side of that line
   each composite sits on; the registration call site enforces the
   policy.
@@ -56,6 +57,8 @@ __all__ = [
     "EVENT_TAIL_RESPONSE_SCHEMA",
     "FOLDER_CREATE_PARAMETER_SCHEMA",
     "FOLDER_CREATE_RESPONSE_SCHEMA",
+    "GUEST_CUSTOMIZATION_SPEC_CREATE_PARAMETER_SCHEMA",
+    "GUEST_CUSTOMIZATION_SPEC_CREATE_RESPONSE_SCHEMA",
     "HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA",
     "HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA",
     "HOST_EVACUATE_PARAMETER_SCHEMA",
@@ -70,6 +73,8 @@ __all__ = [
     "VM_CLONE_RESPONSE_SCHEMA",
     "VM_CREATE_PARAMETER_SCHEMA",
     "VM_CREATE_RESPONSE_SCHEMA",
+    "VM_CUSTOMIZE_PARAMETER_SCHEMA",
+    "VM_CUSTOMIZE_RESPONSE_SCHEMA",
     "VM_DEVICE_CDROM_PARAMETER_SCHEMA",
     "VM_DEVICE_CDROM_RESPONSE_SCHEMA",
     "VM_DISK_GROW_PARAMETER_SCHEMA",
@@ -2111,4 +2116,325 @@ VM_DEVICE_CDROM_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["status", "vm", "cdrom", "action"],
+}
+
+
+# ===========================================================================
+# Guest customization (GOSC) composites (#2892)
+# ===========================================================================
+#
+# Two write composites cover guest OS customization -- how a cloned VM
+# gets its hostname, per-NIC static IP + gateway + DNS, and (on Windows)
+# its sysprep identity on first boot. Both are dangerous / approval-gated.
+#
+# Secret hygiene (#1503) is load-bearing here: the create schema carries
+# Windows admin / product-key / domain-join credentials, and those values
+# must never reach a reviewer, preview, broadcast, or audit surface. The
+# op is pinned ``credential_write`` in ``broadcast/events.py`` (params
+# collapse to aggregate-only on the feed) and its park-time preview
+# builder echoes IDENTITY fields only (``_write_preview``); the durable
+# audit row stores only a params hash. See the connector doc for the
+# full three-surface argument.
+
+
+#: ``vmware.composite.guest.customization_spec.create`` parameter schema.
+#:
+#: Creates a reusable named GuestOS customization spec via
+#: ``POST:/vcenter/guest/customization-specs``. The agent-facing shape is
+#: the tractable provisioning subset (hostname + per-NIC static IP +
+#: DNS, linux or windows/sysprep) -- not the full vendor
+#: ``CustomizationSpec`` surface. The handler maps it onto the vCenter
+#: ``CreateSpec`` (``{name, description, spec}``) whose ``spec`` is a
+#: ``CustomizationSpec`` (``{configuration_spec, interfaces,
+#: global_dns_settings}``).
+#:
+#: The ``windows_*`` credential fields (``windows_admin_password`` /
+#: ``windows_product_key`` / ``windows_domain_admin_password``) are
+#: SECRET: they are consumed by the handler into the sysprep body but
+#: never echoed onto any reviewer / preview / broadcast / audit surface
+#: (#1503). The op is pinned ``credential_write`` so the broadcast feed
+#: collapses these params to aggregate-only.
+GUEST_CUSTOMIZATION_SPEC_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "spec_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Name for the new customization spec (``CreateSpec.name``). "
+                "This is the name a later ``vmware.composite.vm.customize`` "
+                "(or a clone's ``guest_customization_spec``) references."
+            ),
+        },
+        "description": {
+            "type": "string",
+            "default": "",
+            "description": "Free-text description stored on the spec (``CreateSpec.description``).",
+        },
+        "os_type": {
+            "type": "string",
+            "enum": ["linux", "windows"],
+            "description": (
+                "Selects the guest OS branch: ``linux`` builds "
+                "``configuration_spec.linux_config``; ``windows`` builds "
+                "``configuration_spec.windows_config`` with a sysprep body."
+            ),
+        },
+        "hostname": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Guest host name. Mapped to a FIXED "
+                "``HostnameGenerator`` (``{type: FIXED, fixed_name: "
+                "<hostname>}``) on ``linux_config.hostname`` / the Windows "
+                "``user_data.computer_name``."
+            ),
+        },
+        "domain": {
+            "type": "string",
+            "default": "",
+            "description": "DNS domain for the guest (``linux_config.domain``).",
+        },
+        "time_zone": {
+            "type": "string",
+            "description": (
+                "Guest time zone (a tz-database name on Linux, e.g. "
+                "``Europe/Vienna``). Omitted from the body when absent."
+            ),
+        },
+        "interfaces": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ip_address": {
+                        "type": "string",
+                        "description": (
+                            "Static IPv4 address for this NIC. Omit the "
+                            "field to configure the NIC for DHCP instead."
+                        ),
+                    },
+                    "prefix": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 32,
+                        "description": "Subnet prefix length for the static IPv4 address.",
+                    },
+                    "gateways": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Default gateway IPs for this NIC.",
+                    },
+                },
+                "additionalProperties": False,
+            },
+            "default": [],
+            "description": (
+                "Per-NIC IP settings in adapter order. Each entry maps to a "
+                "``CustomizationSpec.interfaces`` ``AdapterMapping`` "
+                "(``{adapter: {ipv4: {type, ip_address, prefix, gateways}}}``). "
+                "An entry with no ``ip_address`` yields a DHCP adapter; the "
+                "empty list leaves adapters unconfigured."
+            ),
+        },
+        "dns_servers": {
+            "type": "array",
+            "items": {"type": "string"},
+            "default": [],
+            "description": "Global DNS server IPs (``global_dns_settings.dns_servers``).",
+        },
+        "dns_suffix_list": {
+            "type": "array",
+            "items": {"type": "string"},
+            "default": [],
+            "description": "Global DNS search suffixes (``global_dns_settings.dns_suffix_list``).",
+        },
+        "windows_admin_password": {
+            "type": "string",
+            "description": (
+                "SECRET. Local Administrator password for the Windows "
+                "guest (``windows_config.sysprep.gui_unattended.password``). "
+                "Never serialized to any reviewer / preview / broadcast / "
+                "audit surface (#1503)."
+            ),
+        },
+        "windows_product_key": {
+            "type": "string",
+            "description": (
+                "SECRET. Windows product / license key "
+                "(``windows_config.sysprep.user_data.product_key``). Never "
+                "serialized to any reviewer-facing surface (#1503)."
+            ),
+        },
+        "windows_organization": {
+            "type": "string",
+            "description": "Windows registered organization (``user_data.organization``).",
+        },
+        "windows_full_name": {
+            "type": "string",
+            "description": "Windows registered owner name (``user_data.full_name``).",
+        },
+        "windows_join_domain": {
+            "type": "string",
+            "description": (
+                "Active Directory domain the Windows guest joins "
+                "(``sysprep.identification.joined_domain``)."
+            ),
+        },
+        "windows_domain_admin_username": {
+            "type": "string",
+            "description": (
+                "Domain account used for the join "
+                "(``sysprep.identification.domain_admin_username``)."
+            ),
+        },
+        "windows_domain_admin_password": {
+            "type": "string",
+            "description": (
+                "SECRET. Password for the domain-join account "
+                "(``sysprep.identification.domain_admin_password``). Never "
+                "serialized to any reviewer-facing surface (#1503)."
+            ),
+        },
+        "windows_auto_logon": {
+            "type": "boolean",
+            "default": False,
+            "description": "Whether the Windows guest auto-logs-on after customization.",
+        },
+    },
+    "required": ["spec_name", "os_type", "hostname"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.guest.customization_spec.create`` response schema.
+GUEST_CUSTOMIZATION_SPEC_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["created"],
+            "description": (
+                "``'created'`` -- the spec was created via "
+                "``POST:/vcenter/guest/customization-specs``. Transport / "
+                "vCenter faults surface as the dispatcher's "
+                "``connector_error`` rather than a business status."
+            ),
+        },
+        "spec_name": {
+            "type": "string",
+            "description": (
+                "Name of the created spec -- echoed back so the caller can "
+                "chain it into ``vmware.composite.vm.customize`` or a "
+                "clone's ``guest_customization_spec``."
+            ),
+        },
+        "os_type": {
+            "type": "string",
+            "enum": ["linux", "windows"],
+            "description": "The guest OS branch the spec was built for.",
+        },
+    },
+    "required": ["status", "spec_name", "os_type"],
+}
+
+
+#: ``vmware.composite.vm.customize`` parameter schema.
+#:
+#: Applies a saved customization spec to a VM (resolved by display name)
+#: via ``PUT:/vcenter/vm/{vm}/guest/customization``. vCenter only accepts
+#: a pending customization on a powered-off VM; the composite pre-checks
+#: the resolved power state and refuses a powered-on VM with a structured
+#: ``precondition_failed`` status rather than letting the PUT 400.
+VM_CUSTOMIZE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "VM display name. Resolved via "
+                "``GET:/vcenter/vm?filter.names=...`` to the moid + power "
+                "state; multiple matches return ``status='ambiguous'``."
+            ),
+        },
+        "spec_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Name of the saved customization spec to apply "
+                "(``Customization.SetSpec.name``). Typically the "
+                "``spec_name`` from a prior "
+                "``guest.customization_spec.create``."
+            ),
+        },
+        "power_on": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "When true, power the VM on via "
+                "``POST:/vcenter/vm/{vm}/power?action=start`` after setting "
+                "the pending customization, so it applies on that boot. "
+                "Default false leaves the VM powered off."
+            ),
+        },
+    },
+    "required": ["name", "spec_name"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.customize`` response schema.
+VM_CUSTOMIZE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "customization_set",
+                "powered_on",
+                "not_found",
+                "ambiguous",
+                "precondition_failed",
+            ],
+            "description": (
+                "``'customization_set'`` -- the pending customization was "
+                "set (VM left powered-off); ``'powered_on'`` -- set then "
+                "powered on so it applies this boot; ``'not_found'`` / "
+                "``'ambiguous'`` -- name did not resolve to exactly one VM; "
+                "``'precondition_failed'`` -- the VM is powered on and must "
+                "be powered off first."
+            ),
+        },
+        "vm": {
+            "type": ["string", "null"],
+            "description": "Resolved VM moid; ``null`` on ``not_found`` / ``ambiguous``.",
+        },
+        "name": {"type": "string", "description": "VM display name the caller supplied."},
+        "spec_name": {"type": "string", "description": "Customization spec name applied."},
+        "power_state": {
+            "type": ["string", "null"],
+            "description": (
+                "Resolved power state at dispatch time (``POWERED_ON`` / "
+                "``POWERED_OFF`` / ``SUSPENDED``); ``null`` when the VM did "
+                "not resolve."
+            ),
+        },
+        "applies_on": {
+            "type": ["string", "null"],
+            "description": (
+                "``'next_power_on'`` once the customization is set; ``null`` when nothing was set."
+            ),
+        },
+        "candidates": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "Identity projections of the matched VMs when ``status='ambiguous'``.",
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": "Human-readable next step on a non-success status; ``null`` otherwise.",
+        },
+    },
+    "required": ["status", "name", "spec_name"],
 }

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -48,6 +48,8 @@ from meho_backplane.connectors.vmware_rest import (
     VmwareRestConnector,
     VsphereTargetLike,
 )
+from meho_backplane.connectors.vmware_rest.composites import _write
+from meho_backplane.connectors.vmware_rest.composites._write import vm_customize_composite
 
 # ---------------------------------------------------------------------------
 # Mocked vCenter surface
@@ -1100,3 +1102,62 @@ async def test_tasks_recent_over_modern_mount_returns_task_rows(
     assert task["entity"] == "vm-9"
     assert task["state"] == "success"
     assert task["progress"] == 100
+
+
+# ---------------------------------------------------------------------------
+# vm.customize (GOSC apply, #2892) — respx-verified PUT wire body
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vm_customize_puts_named_spec_over_respx(
+    vcsim_target: _VcsimTarget,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Apply on a powered-off VM issues the PUT with the named-spec wire body.
+
+    Exercises the real connector transport (respx-intercepted): the resolve
+    listing mounts onto ``/api/vcenter/vm``, and the customization set mounts
+    onto ``PUT /api/vcenter/vm/{vm}/guest/customization`` with the
+    ``{"spec": {"name": <spec>}}`` body. The #2254 governance seam is stubbed
+    to auto-execute so the write reaches the wire (the seam itself is proven
+    end-to-end in the write-gate lane).
+    """
+
+    async def _auto_execute(**_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(_write, "enforce_subop_policy", _auto_execute)
+
+    async def _loader(_target: VsphereTargetLike, _operator: Operator) -> dict[str, str]:
+        return {"username": "user", "password": "pass"}
+
+    connector = VmwareRestConnector(session_loader=_loader)
+
+    async with respx.mock(
+        base_url=VCENTER_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        mock.post("/api/session").respond(200, json=SESSION_TOKEN)
+        mock.get("/api/about").respond(200, json=ABOUT_PAYLOAD)
+        mock.delete("/api/session").respond(204)
+        # Modern /api VM listing returns a bare array of summary rows.
+        mock.get("/api/vcenter/vm").respond(
+            200, json=[{"vm": "vm-7", "name": "app", "power_state": "POWERED_OFF"}]
+        )
+        put_route = mock.put("/api/vcenter/vm/vm-7/guest/customization").respond(200, json={})
+        try:
+            result = await vm_customize_composite(
+                operator=_operator(),
+                target=vcsim_target,
+                params={"name": "app", "spec_name": "gosc-lin"},
+                connector=connector,
+            )
+        finally:
+            await connector.aclose()
+
+    assert result["status"] == "customization_set"
+    assert put_route.called
+    sent_body = json.loads(put_route.calls.last.request.content)
+    assert sent_body == {"spec": {"name": "gosc-lin"}}

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -3,13 +3,14 @@
 
 """op_id reconciliation between the write composites and the ingest pipeline.
 
-G3.16-T1 (#1414). The 12 REST-sub-op vmware-rest write composites each
+G3.16-T1 (#1414). The 14 REST-sub-op vmware-rest write composites each
 declare the L2 sub-ops they dispatch into via ``_SUB_OPS_*`` tuples in
-:mod:`~meho_backplane.connectors.vmware_rest.composites._write`; the four
-vi-json write composites (``vm.disk.grow`` / #2893,
-``vm.clone_from_template`` / #2894, and the vim cluster / inventory writes
-``cluster.drs_rule.create`` + ``folder.create`` / #2895) dispatch into
-vi-json instead and declare their sub-ops in ``_VIM_SUB_OPS_*`` tuples
+:mod:`~meho_backplane.connectors.vmware_rest.composites._write` (the nine
+T6/#509 + vm.power writes, the #2891 hardware trio, and the two GOSC
+composites / #2892); the four vi-json write composites (``vm.disk.grow`` /
+#2893, ``vm.clone_from_template`` / #2894, and the vim cluster / inventory
+writes ``cluster.drs_rule.create`` + ``folder.create`` / #2895) dispatch
+into vi-json instead and declare their sub-ops in ``_VIM_SUB_OPS_*`` tuples
 (reconciled in the dedicated vi-json section at the end of this module). At
 dispatch time :func:`~...composites._preflight.preflight_l2_dependencies`
 looks each sub-op_id up in ``endpoint_descriptor`` and raises
@@ -33,7 +34,7 @@ the parser emits from ``vcenter.yaml``. The two surfaces that could drift:
 
 This module proves the match automatically, without a live backplane:
 
-1. Derive the full set of raw L2 sub-op_ids the 12 composites need by
+1. Derive the full set of raw L2 sub-op_ids the 14 composites need by
    introspecting the live ``_SUB_OPS_*`` constants (so the test tracks
    any future edit to those tuples -- no hardcoded mirror to drift).
 2. Build a representative OpenAPI fixture whose ``paths`` are keyed
@@ -81,7 +82,7 @@ _GETADDRINFO_PATCH = patch(
 
 
 def _required_raw_sub_op_ids() -> set[str]:
-    """Union of every ``_SUB_OPS_*`` op_id across the 12 REST write composites.
+    """Union of every ``_SUB_OPS_*`` op_id across the 14 REST write composites.
 
     The four vi-json write composites' sub-ops live in ``_VIM_SUB_OPS_*``
     tuples (a distinct namespace this ``_SUB_OPS_*`` sweep deliberately
@@ -107,17 +108,21 @@ def _required_raw_sub_op_ids() -> set[str]:
 def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
     """Guard: the introspection finds every write composite's sub-op tuple.
 
-    Twelve ``_SUB_OPS_*`` module constants today, one per write composite.
-    Pinning the exact set means a renamed or dropped constant can't
-    silently shrink the reconciled set to a vacuous pass.
+    Fourteen ``_SUB_OPS_*`` module constants today, one per REST write
+    composite (the nine T6/#509 + vm.power writes, the #2891 hardware trio,
+    plus the two GOSC composites / #2892). Pinning the exact set means a
+    renamed or dropped constant can't silently shrink the reconciled set to
+    a vacuous pass.
     """
     tuple_names = sorted(n for n in dir(_write) if n.startswith("_SUB_OPS_"))
     assert tuple_names == [
         "_SUB_OPS_CLUSTER_PATCH",
+        "_SUB_OPS_GUEST_CUSTOMIZATION_SPEC_CREATE",
         "_SUB_OPS_HOST_DETACH_FROM_VDS",
         "_SUB_OPS_HOST_EVACUATE",
         "_SUB_OPS_VM_CLONE",
         "_SUB_OPS_VM_CREATE",
+        "_SUB_OPS_VM_CUSTOMIZE",
         "_SUB_OPS_VM_DEVICE_CDROM",
         "_SUB_OPS_VM_MIGRATE",
         "_SUB_OPS_VM_NIC_REPOINT",

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -175,14 +175,15 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 21 total: 5 reads
-    # (T5 #508) + 16 writes (T6 #509 + single-VM vm.power #2301 + mutating
+    # Embedding service called once per composite -- 23 total: 5 reads
+    # (T5 #508) + 18 writes (T6 #509 + single-VM vm.power #2301 + mutating
     # VI-JSON vm.disk.grow #2893 + folder-template vm.clone_from_template
     # #2894 + vim cluster/inventory writes cluster.drs_rule.create +
     # folder.create #2895 + the #2891 hardware writes vm.resize /
-    # vm.nic.repoint / vm.device.cdrom). (The former host.network_uplinks /
-    # host.vsan_health reads were re-shipped as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 21
+    # vm.nic.repoint / vm.device.cdrom + GOSC create/apply #2892). (The
+    # former host.network_uplinks / host.vsan_health reads were re-shipped
+    # as typed ops in #2258.)
+    assert stub_embedding_service.encode_one.call_count == 23
 
 
 @pytest.mark.asyncio
@@ -429,19 +430,20 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 5 read rows persist; embedding stays at 21.
+    """Running the registrar twice -> 5 read rows persist; embedding stays at 23.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (5 reads + 16 writes / T6 +
+    persist after the combined registrar (5 reads + 18 writes / T6 +
     single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
     folder-template vm.clone_from_template #2894 + vim cluster/inventory
     writes cluster.drs_rule.create + folder.create #2895 + the #2891
-    hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom).
+    hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC
+    create/apply #2892).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 21
+    assert first_count == 23
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -37,6 +37,7 @@ respx-transport parity proof lives in
 
 from __future__ import annotations
 
+import copy
 import json
 from dataclasses import dataclass, field
 from typing import Any
@@ -45,6 +46,7 @@ from uuid import UUID, uuid4
 import httpx
 import pytest
 import respx
+from jsonschema import Draft202012Validator, ValidationError
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors import OperationResult
@@ -2905,14 +2907,299 @@ async def test_guest_customization_spec_create_windows_sysprep_body(gate: _GateR
     assert sysprep["user_data"]["computer_name"] == {"type": "FIXED", "fixed_name": "win-01"}
     assert sysprep["user_data"]["product_key"] == "KEY-123"
     assert sysprep["user_data"]["organization"] == "evoila"
+    # UserData.full_name is REQUIRED -> always emitted (default "") even unset.
+    assert sysprep["user_data"]["full_name"] == ""
     assert sysprep["gui_unattended"]["password"] == "pw-admin"
-    assert sysprep["identification"] == {
+    # GuiUnattended.auto_logon_count + time_zone are REQUIRED: count derives
+    # from auto_logon (unset -> False -> 0); time_zone is the integer MS index
+    # default (85), NOT the Linux tz-name string.
+    assert sysprep["gui_unattended"]["auto_logon"] is False
+    assert sysprep["gui_unattended"]["auto_logon_count"] == 0
+    assert sysprep["gui_unattended"]["time_zone"] == 85
+    # B1: domain join is the REST ``domain`` block (Vcenter.Guest.Domain),
+    # NOT the pyvmomi ``identification`` key.
+    assert "identification" not in sysprep
+    assert sysprep["domain"] == {
+        "type": "DOMAIN",
+        "domain": "corp.test",
+        "domain_username": "svc-join",
+        "domain_password": "pw-join",
+    }
+    assert out["status"] == "created"
+    assert out["os_type"] == "windows"
+
+
+# ---------------------------------------------------------------------------
+# GOSC create-body contract vs. the pinned CustomizationSpec schema (M1 #2892)
+# ---------------------------------------------------------------------------
+#
+# CI was green while the create body was wrong (B1/B2) because the
+# ingest-reconcile lane checks sub-op PATHS only and the unit test above had
+# encoded the broken Windows shape as its expected value. This lane closes that
+# gap: it validates the built ``POST /vcenter/guest/customization-specs`` body
+# against a JSON-Schema mirror of the pinned vCenter
+# ``Vcenter.Guest.CustomizationSpecs.CreateSpec``, transcribed field-for-field
+# from the connector's pinned 9.0 spec
+# (claude-rdc-hetzner-dc/docs/vcenter-9.0/vcenter.yaml, cited line anchors per
+# ``$defs`` entry). ``additionalProperties: False`` on every object turns a
+# stray pyvmomi/SOAP field name (e.g. ``identification``) into a validation
+# failure; the per-object ``required`` lists turn an omitted mandatory field
+# (e.g. ``auto_logon_count`` / ``description`` / ``domain`` / ``product_key``)
+# into one. So a wrong field name or a missing required field now fails CI --
+# for both the Linux and the Windows/sysprep branch.
+_PINNED_CREATE_SPEC_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$ref": "#/$defs/CreateSpec",
+    "$defs": {
+        "HostnameGenerator": {  # vcenter.yaml:125992
+            "type": "object",
+            "required": ["type"],
+            "additionalProperties": False,
+            "properties": {
+                "type": {"enum": ["FIXED", "PREFIX", "VIRTUAL_MACHINE", "USER_INPUT_REQUIRED"]},
+                "fixed_name": {"type": "string"},
+                "prefix": {"type": "string"},
+            },
+        },
+        "Ipv4": {  # vcenter.yaml:126513
+            "type": "object",
+            "required": ["type"],
+            "additionalProperties": False,
+            "properties": {
+                "type": {"enum": ["DHCP", "STATIC", "USER_INPUT_REQUIRED"]},
+                "ip_address": {"type": "string"},
+                "prefix": {"type": "integer"},
+                "gateways": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+        "IPSettings": {  # vcenter.yaml:126728 -- ipv4 is "currently required".
+            "type": "object",
+            "required": ["ipv4"],
+            "additionalProperties": False,
+            "properties": {"ipv4": {"$ref": "#/$defs/Ipv4"}},
+        },
+        "AdapterMapping": {  # vcenter.yaml:126762
+            "type": "object",
+            "required": ["adapter"],
+            "additionalProperties": False,
+            "properties": {
+                "mac_address": {"type": "string"},
+                "adapter": {"$ref": "#/$defs/IPSettings"},
+            },
+        },
+        "GlobalDNSSettings": {  # vcenter.yaml:126486
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "dns_suffix_list": {"type": "array", "items": {"type": "string"}},
+                "dns_servers": {"type": "array", "items": {"type": "string"}},
+            },
+        },
+        "UserData": {  # vcenter.yaml:126067
+            "type": "object",
+            "required": ["computer_name", "full_name", "organization", "product_key"],
+            "additionalProperties": False,
+            "properties": {
+                "computer_name": {"$ref": "#/$defs/HostnameGenerator"},
+                "full_name": {"type": "string"},
+                "organization": {"type": "string"},
+                "product_key": {"type": "string"},
+            },
+        },
+        "Domain": {  # vcenter.yaml:126104
+            "type": "object",
+            "required": ["type"],
+            "additionalProperties": False,
+            "properties": {
+                "type": {"enum": ["WORKGROUP", "DOMAIN"]},
+                "workgroup": {"type": "string"},
+                "domain": {"type": "string"},
+                "domain_username": {"type": "string"},
+                "domain_password": {"type": "string"},
+                "domain_ou": {"type": "string"},
+            },
+        },
+        "GuiUnattended": {  # vcenter.yaml:126181
+            "type": "object",
+            "required": ["auto_logon", "auto_logon_count", "time_zone"],
+            "additionalProperties": False,
+            "properties": {
+                "auto_logon": {"type": "boolean"},
+                "auto_logon_count": {"type": "integer"},
+                "password": {"type": "string"},
+                "time_zone": {"type": "integer"},
+            },
+        },
+        "WindowsSysprep": {  # vcenter.yaml:126221
+            "type": "object",
+            "required": ["gui_unattended", "user_data"],
+            "additionalProperties": False,
+            "properties": {
+                "gui_run_once_commands": {"type": "array", "items": {"type": "string"}},
+                "user_data": {"$ref": "#/$defs/UserData"},
+                "domain": {"$ref": "#/$defs/Domain"},
+                "gui_unattended": {"$ref": "#/$defs/GuiUnattended"},
+            },
+        },
+        "WindowsConfiguration": {  # vcenter.yaml:126264
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "reboot": {"enum": ["REBOOT", "NO_REBOOT", "SHUTDOWN"]},
+                "sysprep": {"$ref": "#/$defs/WindowsSysprep"},
+                "sysprep_xml": {"type": "string"},
+            },
+        },
+        "LinuxConfiguration": {  # vcenter.yaml:126320
+            "type": "object",
+            "required": ["domain", "hostname"],
+            "additionalProperties": False,
+            "properties": {
+                "hostname": {"$ref": "#/$defs/HostnameGenerator"},
+                "domain": {"type": "string"},
+                "time_zone": {"type": "string"},
+                "script_text": {"type": "string"},
+                "compatible_customization_method": {"type": "string"},
+            },
+        },
+        # ConfigurationSpec (vcenter.yaml:126452) also allows cloud_config; the
+        # provisioning-subset builder only emits windows_config / linux_config.
+        "ConfigurationSpec": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "windows_config": {"$ref": "#/$defs/WindowsConfiguration"},
+                "linux_config": {"$ref": "#/$defs/LinuxConfiguration"},
+            },
+        },
+        "CustomizationSpec": {  # vcenter.yaml:126790
+            "type": "object",
+            "required": ["configuration_spec", "global_dns_settings", "interfaces"],
+            "additionalProperties": False,
+            "properties": {
+                "configuration_spec": {"$ref": "#/$defs/ConfigurationSpec"},
+                "global_dns_settings": {"$ref": "#/$defs/GlobalDNSSettings"},
+                "interfaces": {"type": "array", "items": {"$ref": "#/$defs/AdapterMapping"}},
+            },
+        },
+        "CreateSpec": {  # vcenter.yaml:126873 -- the POST body.
+            "type": "object",
+            "required": ["description", "name", "spec"],
+            "additionalProperties": False,
+            "properties": {
+                "spec": {"$ref": "#/$defs/CustomizationSpec"},
+                "description": {"type": "string"},
+                "name": {"type": "string"},
+            },
+        },
+    },
+}
+
+_GOSC_LINUX_MINIMAL: dict[str, Any] = {
+    "spec_name": "gosc-lin",
+    "os_type": "linux",
+    "hostname": "web-01",
+}
+_GOSC_LINUX_FULL: dict[str, Any] = {
+    "spec_name": "gosc-lin",
+    "description": "web tier",
+    "os_type": "linux",
+    "hostname": "web-01",
+    "domain": "corp.test",
+    "time_zone": "Europe/Vienna",
+    "interfaces": [
+        {"ip_address": "10.0.0.5", "prefix": 24, "gateways": ["10.0.0.1"]},
+        {},  # a NIC with no ip_address -> DHCP
+    ],
+    "dns_servers": ["10.0.0.2"],
+    "dns_suffix_list": ["corp.test"],
+}
+_GOSC_WINDOWS_MINIMAL: dict[str, Any] = {
+    "spec_name": "gosc-win",
+    "os_type": "windows",
+    "hostname": "win-01",
+}
+_GOSC_WINDOWS_DOMAIN_JOIN: dict[str, Any] = {
+    "spec_name": "gosc-win",
+    "os_type": "windows",
+    "hostname": "win-01",
+    "windows_admin_password": "pw-admin",
+    "windows_product_key": "KEY-123",
+    "windows_organization": "evoila",
+    "windows_full_name": "Ops Team",
+    "windows_time_zone": 110,
+    "windows_auto_logon": True,
+    "windows_join_domain": "corp.test",
+    "windows_domain_admin_username": "svc-join",
+    "windows_domain_admin_password": "pw-join",
+    "interfaces": [{"ip_address": "10.0.0.5", "prefix": 24, "gateways": ["10.0.0.1"]}],
+}
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        pytest.param(_GOSC_LINUX_MINIMAL, id="linux-minimal"),
+        pytest.param(_GOSC_LINUX_FULL, id="linux-static-and-dhcp"),
+        pytest.param(_GOSC_WINDOWS_MINIMAL, id="windows-minimal"),
+        pytest.param(_GOSC_WINDOWS_DOMAIN_JOIN, id="windows-domain-join"),
+    ],
+)
+def test_gosc_create_body_conforms_to_pinned_customization_spec_schema(
+    params: dict[str, Any],
+) -> None:
+    """The built create body validates against the pinned CreateSpec schema.
+
+    Guards the create BODY shape (field names + required fields) that the
+    ingest-reconcile lane -- which checks sub-op PATHS only -- cannot. The
+    minimal Linux and minimal Windows cases exercise the always-emitted
+    required fields (``description`` / ``domain`` / ``UserData`` /
+    ``GuiUnattended``) that ``_put_if_str`` used to drop.
+    """
+    body = _write._build_customization_create_body(params)
+    # The connector wraps the CreateSpec under the request-body ``spec`` key.
+    Draft202012Validator(_PINNED_CREATE_SPEC_SCHEMA).validate(body["spec"])
+
+
+def test_gosc_create_body_schema_rejects_pyvmomi_shape_and_missing_required() -> None:
+    """The contract lane bites: the pre-fix B1/B2 regressions fail validation.
+
+    Proves the schema mirror is not vacuously green -- the exact broken shapes
+    this iteration fixes (the pyvmomi ``identification`` key; an omitted
+    required ``GuiUnattended.auto_logon_count``; an omitted required
+    ``CreateSpec.description``) are each rejected.
+    """
+    validator = Draft202012Validator(_PINNED_CREATE_SPEC_SCHEMA)
+    good = _write._build_customization_create_body(_GOSC_WINDOWS_DOMAIN_JOIN)
+    validator.validate(good["spec"])  # sanity: the corrected body is valid.
+
+    # B1 regression: the pyvmomi ``identification`` block is not a
+    # WindowsSysprep property -> additionalProperties rejects it.
+    b1 = copy.deepcopy(good)
+    b1_sysprep = b1["spec"]["spec"]["configuration_spec"]["windows_config"]["sysprep"]
+    b1_sysprep.pop("domain", None)
+    b1_sysprep["identification"] = {
         "joined_domain": "corp.test",
         "domain_admin_username": "svc-join",
         "domain_admin_password": "pw-join",
     }
-    assert out["status"] == "created"
-    assert out["os_type"] == "windows"
+    with pytest.raises(ValidationError):
+        validator.validate(b1["spec"])
+
+    # B2 regression: GuiUnattended.auto_logon_count is required -> dropping it
+    # (as the old _put_if_str-built body did) fails.
+    b2 = copy.deepcopy(good)
+    del b2["spec"]["spec"]["configuration_spec"]["windows_config"]["sysprep"]["gui_unattended"][
+        "auto_logon_count"
+    ]
+    with pytest.raises(ValidationError):
+        validator.validate(b2["spec"])
+
+    # B2 regression: CreateSpec.description is required -> dropping it fails.
+    b3 = copy.deepcopy(good)
+    del b3["spec"]["description"]
+    with pytest.raises(ValidationError):
+        validator.validate(b3["spec"])
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Unit tests for the 16 vmware-rest write-composite handler functions.
+"""Unit tests for the 18 vmware-rest write-composite handler functions.
 
 Post-#2256 the write composites dispatch their sub-ops **directly on the
 connector session** -- ``connector._get_json`` / ``connector._post_json``
@@ -56,11 +56,13 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     cluster_drs_rule_create_composite,
     cluster_patch_composite,
     folder_create_composite,
+    guest_customization_spec_create_composite,
     host_detach_from_vds_composite,
     host_evacuate_composite,
     vm_clone_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
+    vm_customize_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -2804,4 +2806,297 @@ async def test_vm_device_cdrom_update_without_backing_is_invalid_request(
     )
     assert out["status"] == "invalid_request"
     assert gate.calls == []
+    assert [c["method"] for c in conn.calls] == ["GET"]
+
+
+# ===========================================================================
+# guest.customization_spec.create (GOSC create)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_guest_customization_spec_create_linux_body(gate: _GateRecorder) -> None:
+    """Linux GOSC: one POST whose spec-wrapped body maps the agent subset to vCenter."""
+    conn = _RecordingConnector({"/api/vcenter/guest/customization-specs": {"value": {}}})
+    out = await guest_customization_spec_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "spec_name": "gosc-lin",
+            "description": "web tier",
+            "os_type": "linux",
+            "hostname": "web-01",
+            "domain": "corp.test",
+            "time_zone": "Europe/Vienna",
+            "interfaces": [
+                {"ip_address": "10.0.0.5", "prefix": 24, "gateways": ["10.0.0.1"]},
+                {},  # a NIC with no ip_address configures DHCP
+            ],
+            "dns_servers": ["10.0.0.2"],
+            "dns_suffix_list": ["corp.test"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("POST", "/api/vcenter/guest/customization-specs"),
+    ]
+    body = conn.calls[0]["body"]["spec"]
+    assert body["name"] == "gosc-lin"
+    assert body["description"] == "web tier"
+    linux = body["spec"]["configuration_spec"]["linux_config"]
+    assert linux["hostname"] == {"type": "FIXED", "fixed_name": "web-01"}
+    assert linux["domain"] == "corp.test"
+    assert linux["time_zone"] == "Europe/Vienna"
+    # windows_config is absent on the linux branch.
+    assert "windows_config" not in body["spec"]["configuration_spec"]
+    # Interfaces: one STATIC ipv4, one DHCP.
+    interfaces = body["spec"]["interfaces"]
+    assert interfaces[0] == {
+        "adapter": {
+            "ipv4": {
+                "type": "STATIC",
+                "ip_address": "10.0.0.5",
+                "prefix": 24,
+                "gateways": ["10.0.0.1"],
+            }
+        }
+    }
+    assert interfaces[1] == {"adapter": {"ipv4": {"type": "DHCP"}}}
+    assert body["spec"]["global_dns_settings"] == {
+        "dns_servers": ["10.0.0.2"],
+        "dns_suffix_list": ["corp.test"],
+    }
+    # The single write was gated dangerous / no-approval.
+    assert gate.gated_op_ids == ["POST:/vcenter/guest/customization-specs"]
+    assert gate.calls[0]["safety_level"] == "dangerous"
+    assert gate.calls[0]["requires_approval"] is False
+    assert out == {"status": "created", "spec_name": "gosc-lin", "os_type": "linux"}
+
+
+@pytest.mark.asyncio
+async def test_guest_customization_spec_create_windows_sysprep_body(gate: _GateRecorder) -> None:
+    """Windows GOSC: the sysprep body carries the credentials (the real vCenter call).
+
+    Secret hygiene is about *reviewer* surfaces (proven in the e2e lane); the
+    actual customization-specs POST body legitimately carries the sysprep
+    credentials -- that IS the API call that provisions the guest.
+    """
+    conn = _RecordingConnector({"/api/vcenter/guest/customization-specs": {"value": {}}})
+    out = await guest_customization_spec_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "spec_name": "gosc-win",
+            "os_type": "windows",
+            "hostname": "win-01",
+            "windows_admin_password": "pw-admin",
+            "windows_product_key": "KEY-123",
+            "windows_organization": "evoila",
+            "windows_join_domain": "corp.test",
+            "windows_domain_admin_username": "svc-join",
+            "windows_domain_admin_password": "pw-join",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    sysprep = conn.calls[0]["body"]["spec"]["spec"]["configuration_spec"]["windows_config"][
+        "sysprep"
+    ]
+    assert sysprep["user_data"]["computer_name"] == {"type": "FIXED", "fixed_name": "win-01"}
+    assert sysprep["user_data"]["product_key"] == "KEY-123"
+    assert sysprep["user_data"]["organization"] == "evoila"
+    assert sysprep["gui_unattended"]["password"] == "pw-admin"
+    assert sysprep["identification"] == {
+        "joined_domain": "corp.test",
+        "domain_admin_username": "svc-join",
+        "domain_admin_password": "pw-join",
+    }
+    assert out["status"] == "created"
+    assert out["os_type"] == "windows"
+
+
+@pytest.mark.asyncio
+async def test_guest_customization_spec_create_gate_short_circuits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked gate on the create returns the OperationResult; no POST fires."""
+    conn = _RecordingConnector({})
+    _install_gate(
+        monkeypatch,
+        _GateRecorder(
+            gate_for={
+                "POST:/vcenter/guest/customization-specs": _awaiting(
+                    "POST:/vcenter/guest/customization-specs"
+                )
+            }
+        ),
+    )
+    out = await guest_customization_spec_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"spec_name": "gosc-lin", "os_type": "linux", "hostname": "web-01"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert conn.calls == [], "no write may fire once the gate parks"
+
+
+# ===========================================================================
+# vm.customize (GOSC apply)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_customize_powered_off_sets_customization(gate: _GateRecorder) -> None:
+    """Resolve by name -> PUT the named spec on a powered-off VM."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm": {
+                "value": [{"vm": "vm-7", "name": "app", "power_state": "POWERED_OFF"}]
+            },
+            "/api/vcenter/vm/vm-7/guest/customization": {"value": {}},
+        }
+    )
+    out = await vm_customize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "app", "spec_name": "gosc-lin"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("GET", "/api/vcenter/vm"),
+        ("PUT", "/api/vcenter/vm/vm-7/guest/customization"),
+    ]
+    # The resolve read forwards the name filter; PUT body is the named spec ref.
+    assert conn.calls[0]["query"] == {"names": ["app"]}
+    assert conn.calls[1]["body"] == {"spec": {"name": "gosc-lin"}}
+    # Only the PUT was gated (the resolve GET is never gated).
+    assert gate.gated_op_ids == ["PUT:/vcenter/vm/{vm}/guest/customization"]
+    assert out["status"] == "customization_set"
+    assert out["vm"] == "vm-7"
+    assert out["power_state"] == "POWERED_OFF"
+    assert out["applies_on"] == "next_power_on"
+
+
+@pytest.mark.asyncio
+async def test_vm_customize_powered_on_refused(gate: _GateRecorder) -> None:
+    """A powered-on VM is refused with a structured precondition status; no PUT fires."""
+    conn = _RecordingConnector(
+        {"/api/vcenter/vm": {"value": [{"vm": "vm-9", "name": "db", "power_state": "POWERED_ON"}]}}
+    )
+    out = await vm_customize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "db", "spec_name": "gosc-lin"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    # Only the resolve GET fired; the PUT never did.
+    assert [c["method"] for c in conn.calls] == ["GET"]
+    assert gate.gated_op_ids == []
+    assert out["status"] == "precondition_failed"
+    assert out["vm"] == "vm-9"
+    assert out["power_state"] == "POWERED_ON"
+    assert out["applies_on"] is None
+
+
+@pytest.mark.asyncio
+async def test_vm_customize_power_on_after(gate: _GateRecorder) -> None:
+    """power_on=True: PUT the customization then start the VM."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm": {
+                "value": [{"vm": "vm-7", "name": "app", "power_state": "POWERED_OFF"}]
+            },
+            "/api/vcenter/vm/vm-7/guest/customization": {"value": {}},
+            "/api/vcenter/vm/vm-7/power?action=start": {"value": {}},
+        }
+    )
+    out = await vm_customize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "app", "spec_name": "gosc-lin", "power_on": True},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("GET", "/api/vcenter/vm"),
+        ("PUT", "/api/vcenter/vm/vm-7/guest/customization"),
+        ("POST", "/api/vcenter/vm/vm-7/power?action=start"),
+    ]
+    assert gate.gated_op_ids == [
+        "PUT:/vcenter/vm/{vm}/guest/customization",
+        "POST:/vcenter/vm/{vm}/power?action=start",
+    ]
+    assert out["status"] == "powered_on"
+    assert out["applies_on"] == "next_power_on"
+
+
+@pytest.mark.asyncio
+async def test_vm_customize_not_found(gate: _GateRecorder) -> None:
+    """An empty resolve listing yields not_found; no write."""
+    conn = _RecordingConnector({"/api/vcenter/vm": {"value": []}})
+    out = await vm_customize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "ghost", "spec_name": "gosc-lin"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert gate.gated_op_ids == []
+    assert out["status"] == "not_found"
+    assert out["vm"] is None
+
+
+@pytest.mark.asyncio
+async def test_vm_customize_ambiguous(gate: _GateRecorder) -> None:
+    """Multiple name matches yield ambiguous with candidates; no write."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm": {
+                "value": [
+                    {"vm": "vm-1", "name": "dup", "power_state": "POWERED_OFF"},
+                    {"vm": "vm-2", "name": "dup", "power_state": "POWERED_ON"},
+                ]
+            }
+        }
+    )
+    out = await vm_customize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "dup", "spec_name": "gosc-lin"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert gate.gated_op_ids == []
+    assert out["status"] == "ambiguous"
+    assert [c["vm"] for c in out["candidates"]] == ["vm-1", "vm-2"]
+
+
+@pytest.mark.asyncio
+async def test_vm_customize_gate_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A parked gate on the PUT returns the OperationResult; the PUT never fires."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm": {
+                "value": [{"vm": "vm-7", "name": "app", "power_state": "POWERED_OFF"}]
+            }
+        }
+    )
+    _install_gate(
+        monkeypatch,
+        _GateRecorder(
+            gate_for={
+                "PUT:/vcenter/vm/{vm}/guest/customization": _awaiting(
+                    "PUT:/vcenter/vm/{vm}/guest/customization"
+                )
+            }
+        ),
+    )
+    out = await vm_customize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"name": "app", "spec_name": "gosc-lin"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    # The resolve GET fired but the PUT did not.
     assert [c["method"] for c in conn.calls] == ["GET"]

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""End-to-end activation tests for the 12 vmware-rest write composites.
+"""End-to-end activation tests for the 14 vmware-rest write composites.
 
 Post-#2256 the write composites dispatch every raw-REST sub-op **directly
 on the connector session** (``connector._get_json`` / ``connector._post_json``
@@ -36,6 +36,7 @@ lives in :mod:`tests.integration.test_connectors_vmware_rest_vcsim`.
 
 from __future__ import annotations
 
+import json
 import uuid
 from collections.abc import AsyncIterator, Iterator
 from typing import Any
@@ -304,6 +305,8 @@ _WRITE_COMPOSITES: dict[str, str] = {
     "vmware.composite.host.evacuate": "host.evacuate",
     "vmware.composite.host.detach_from_vds": "host.detach_from_vds",
     "vmware.composite.cluster.patch": "cluster.patch",
+    "vmware.composite.guest.customization_spec.create": "guest.customization_spec.create",
+    "vmware.composite.vm.customize": "vm.customize",
 }
 
 
@@ -349,6 +352,12 @@ def _benign_params_for(composite_op_id: str) -> dict[str, Any]:
             "fallback_network": "net-fallback",
         },
         "vmware.composite.cluster.patch": {"cluster": "domain-c1"},
+        "vmware.composite.guest.customization_spec.create": {
+            "spec_name": "gosc-benign",
+            "os_type": "linux",
+            "hostname": "vm-benign",
+        },
+        "vmware.composite.vm.customize": {"name": "vm-benign", "spec_name": "gosc-benign"},
     }[composite_op_id]
 
 
@@ -410,21 +419,26 @@ def _benign_responses_for(composite_op_id: str) -> dict[str, Any]:
             "/vcenter/vm": empty,
         },
         "vmware.composite.cluster.patch": {"/vcenter/cluster/domain-c1/host": empty},
+        # create: the POST default ({"value": {}}) is enough -> status='created'.
+        "vmware.composite.guest.customization_spec.create": {},
+        # customize: empty VM listing -> status='not_found' (benign no-work).
+        "vmware.composite.vm.customize": {"/vcenter/vm": empty},
     }
     return per_composite[composite_op_id]
 
 
 # ===========================================================================
-# Guard: the REST-sub-op write set is exactly the expected twelve
+# Guard: the REST-sub-op write set is exactly the expected fourteen
 # ===========================================================================
 
 
-def test_write_composite_set_is_the_expected_twelve() -> None:
+def test_write_composite_set_is_the_expected_fourteen() -> None:
     """Pins the REST-sub-op write set so a renamed / dropped composite can't shrink coverage.
 
-    Covers the 12 REST-sub-op write composites the parametrized fresh-boot +
-    park machinery below drives. The four vi-json write composites
-    (``vm.disk.grow`` / #2893, ``vm.clone_from_template`` / #2894,
+    Covers the 14 REST-sub-op write composites the parametrized fresh-boot +
+    park machinery below drives (the 12 T6/#509 + vm.power + #2891 hardware
+    writes, plus the two GOSC composites / #2892). The four vi-json write
+    composites (``vm.disk.grow`` / #2893, ``vm.clone_from_template`` / #2894,
     ``cluster.drs_rule.create`` + ``folder.create`` / #2895) are
     dispatch-shaped differently (vmomi sub-ops keyed by request body, not
     REST spec-paths) and are covered by their own dedicated sections at the
@@ -432,7 +446,7 @@ def test_write_composite_set_is_the_expected_twelve() -> None:
     """
     registrar_write_op_ids = {f"vmware.composite.{name}" for name in _WRITE_COMPOSITES.values()}
     assert set(_WRITE_COMPOSITES) == registrar_write_op_ids
-    assert len(_WRITE_COMPOSITES) == 12
+    assert len(_WRITE_COMPOSITES) == 14
 
 
 # ===========================================================================
@@ -451,7 +465,7 @@ async def test_write_composite_executes_through_dispatch_without_ingest(
     """Each composite runs to a benign business status on the direct session.
 
     No ingested ``endpoint_descriptor`` rows exist in the catalog here — only
-    the 21 composite rows the registrar upserts. Reaching a business status
+    the 23 composite rows the registrar upserts. Reaching a business status
     (``created`` / ``no_recommendation`` / ``detached`` / ...) rather than a
     generic execution error proves every raw-REST sub-op resolved via the
     connector session, not a catalog lookup (the two-world / fresh-boot DoD).
@@ -828,7 +842,7 @@ async def test_write_composite_human_dispatch_parks_for_approval(
     Every write composite ships ``requires_approval=True``; G11.7-T1 (#1401)
     routes a human/service principal to the approval queue
     (``awaiting_approval``) at the top-level gate — before the handler (and
-    thus any sub-op) runs. Proves the park half for all 12; the recorder
+    thus any sub-op) runs. Proves the park half for all 14; the recorder
     stays empty of writes because the composite never executed (the
     live-read preview builders issue read-only GETs, which is expected).
     """
@@ -1921,3 +1935,203 @@ async def test_hardware_write_park_carries_uniform_identity_envelope(
     # The live-read builder populated a from->to preview.
     assert effect["preview_populated"] is True
     assert "preview" in effect
+
+
+# ===========================================================================
+# GOSC secret hygiene (#1503) across all three reviewer surfaces (#2892)
+# ===========================================================================
+
+#: Distinctive secret literals planted in the customization spec params so a
+#: leak onto any reviewer surface is caught by a substring scan.
+_ADMIN_PW = "S3cr3t-Admin-P@ssw0rd-LEAK-CANARY"
+_PRODUCT_KEY = "AAAAA-BBBBB-CCCCC-DDDDD-LEAKKEY"
+_DOMAIN_JOIN_PW = "D0main-J0in-P@ss-LEAK-CANARY"
+_ALL_SECRETS = (_ADMIN_PW, _PRODUCT_KEY, _DOMAIN_JOIN_PW)
+
+
+def _windows_gosc_params() -> dict[str, Any]:
+    """A Windows GOSC create spec carrying every secret-bearing field."""
+    return {
+        "spec_name": "gosc-win-prod",
+        "os_type": "windows",
+        "hostname": "win-app-01",
+        "interfaces": [{"ip_address": "10.20.0.5", "prefix": 24, "gateways": ["10.20.0.1"]}],
+        "dns_servers": ["10.20.0.2"],
+        "windows_admin_password": _ADMIN_PW,
+        "windows_product_key": _PRODUCT_KEY,
+        "windows_join_domain": "corp.example.test",
+        "windows_domain_admin_username": "svc-join",
+        "windows_domain_admin_password": _DOMAIN_JOIN_PW,
+    }
+
+
+def _assert_no_secret(blob: str, *, surface: str) -> None:
+    """Fail if any planted secret literal appears in *blob* (a serialised surface)."""
+    for secret in _ALL_SECRETS:
+        assert secret not in blob, f"secret leaked onto the {surface} surface"
+
+
+@pytest.mark.asyncio
+async def test_gosc_create_secret_hygiene_across_all_surfaces(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """GOSC create with inline secrets never leaks them to reviewer surfaces (#1503).
+
+    The single most important correctness property of #2892. A Windows
+    customization spec carrying an admin password, a product key, and a
+    domain-join password is dispatched by a USER (parks), inspected on the
+    durable ``ApprovalRequest.proposed_effect``, approved, and resumed. Every
+    reviewer-facing surface is scanned for the planted secret literals:
+
+    * ``proposed_effect`` — the bespoke preview echoes IDENTITY fields only.
+    * broadcast frame — the op is pinned ``credential_write`` so the params
+      collapse to aggregate-only (no ``params`` key at all).
+    * audit payload — the durable row stores only a params hash.
+
+    Also asserts the #2681 uniform op-identity envelope on the parked row.
+    """
+    recorder = _RecordingVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name="prod-vcenter",
+                product="vmware",
+                host="vcenter.prod.invalid",
+                aliases=[],
+            )
+        )
+        await s.commit()
+
+    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
+    target = _FakeVmwareTarget(target_id=target_id)
+    params = _windows_gosc_params()
+    op_id = "vmware.composite.guest.customization_spec.create"
+
+    # Step 1: USER dispatch -> parked; the create POST did not fire.
+    result1 = await dispatch(
+        operator=requester,
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        target=target,
+        params=params,
+    )
+    assert result1.status == "awaiting_approval", result1.error
+    assert recorder.calls == [], "the create must not run before approval"
+    approval_request_id = UUID(result1.extras["approval_request_id"])
+
+    # --- Surface 1: proposed_effect (identity-only preview + #2681 envelope) ---
+    async with get_sessionmaker()() as s:
+        pending = await s.get(ApprovalRequest, approval_request_id)
+    assert pending is not None
+    effect = pending.proposed_effect
+    _assert_no_secret(json.dumps(effect), surface="proposed_effect")
+    # Identity preview (bespoke builder output nests under ``preview``) is
+    # present and complete -- and carries no secret field.
+    preview = effect["preview"]
+    assert preview["spec_name"] == "gosc-win-prod"
+    assert preview["os_type"] == "windows"
+    assert preview["hostname_scheme"] == "FIXED:win-app-01"
+    assert preview["nic_count"] == 1
+    assert preview["static_ip_summary"] == ["10.20.0.5"]
+    # The preview echoes ONLY identity keys -- no credential field bled in.
+    assert set(preview) == {
+        "spec_name",
+        "os_type",
+        "hostname_scheme",
+        "nic_count",
+        "static_ip_summary",
+    }
+    # #2681 uniform op-identity envelope: identity + metadata stamped on every
+    # parked row regardless of the per-op preview outcome.
+    assert effect["op_id"] == op_id
+    assert effect["connector_id"] == _CONNECTOR_ID
+    assert isinstance(effect["target_id"], str)
+    assert effect["op_class"] == "credential_write"
+    assert effect["safety_level"] == "dangerous"
+
+    # Step 2: approve.
+    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
+    async with get_sessionmaker()() as s:
+        row = await approve_request(s, approval_request_id, operator=reviewer, params=params)
+        await s.commit()
+    assert row.status == ApprovalRequestStatus.APPROVED.value
+
+    # Step 3: resume -> the create executes; secrets ride into the vCenter
+    # request body (the real API call) but nowhere else.
+    result2 = await dispatch(
+        operator=reviewer,
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        target=target,
+        params=params,
+        _approved=True,
+    )
+    assert result2.status == "ok", result2.error
+    assert result2.result["status"] == "created"
+    assert recorder.calls == [("POST", "/vcenter/guest/customization-specs")]
+
+    # --- Surface 2: broadcast frame (params collapsed to aggregate-only) ---
+    gosc_events = [e for e in captured_events if e.op_id == op_id]
+    assert gosc_events, "no broadcast event captured for the GOSC create"
+    for event in gosc_events:
+        assert event.op_class == "credential_write"
+        # The credential-class collapse drops the params dict entirely.
+        assert "params" not in event.payload, event.payload
+        _assert_no_secret(json.dumps(event.payload, default=str), surface="broadcast")
+
+
+@pytest.mark.asyncio
+async def test_vm_customize_preview_and_broadcast_carry_no_secret(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """vm.customize (the apply half) echoes only a spec-name reference -- no secret.
+
+    The second half of "redaction covered for both ops": ``vm.customize``
+    references a saved spec by name and never carries credential material, so
+    its ``proposed_effect`` and broadcast frame are safe by construction. This
+    pins that: the preview surfaces the VM + spec name + resolved power state,
+    and no secret literal can appear (there is none in its params).
+    """
+    recorder = _RecordingVmwareConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/vm": {
+                "value": [{"vm": "vm-55", "name": "app-01", "power_state": "POWERED_OFF"}]
+            }
+        }
+    )
+    await _bootstrap(recorder, stub_embedding_service)
+
+    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
+    result = await dispatch(
+        operator=requester,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.customize",
+        target=_FakeVmwareTarget(),
+        params={"name": "app-01", "spec_name": "gosc-win-prod"},
+    )
+    assert result.status == "awaiting_approval", result.error
+    approval_request_id = UUID(result.extras["approval_request_id"])
+    async with get_sessionmaker()() as s:
+        pending = await s.get(ApprovalRequest, approval_request_id)
+    assert pending is not None
+    effect = pending.proposed_effect
+    preview = effect["preview"]
+    # Identity preview resolved the VM's power state via the live read.
+    assert preview["name"] == "app-01"
+    assert preview["spec_name"] == "gosc-win-prod"
+    assert preview["vm"] == "vm-55"
+    assert preview["power_state"] == "POWERED_OFF"
+    assert preview["applies_on"] == "next_power_on"
+    # #2681 envelope stamped here too.
+    assert effect["op_id"] == "vmware.composite.vm.customize"
+    assert effect["safety_level"] == "dangerous"

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` previews for the 16 vmware write composites.
+"""Park-time ``proposed_effect`` previews for the 18 vmware write composites.
 
 G0.22-T3 (#1608) acceptance criteria, under the post-#2256 direct-session
 model:
@@ -19,12 +19,14 @@ model:
    directly on the connector session (no ``dispatch_child``, no ingested
    descriptor), so the park-time preview works on a fresh boot with zero
    catalog ingest.
-4. All 16 write composites register a builder (9 live-read + 7 param
+4. All 18 write composites register a builder (10 live-read + 8 param
    echo); the wiring test pins the full set. ``vm.disk.grow`` is a
    single-entity live-read builder — its from→to capacity delta is a live
    vCenter read. ``vm.clone_from_template`` is a param-echo builder — its
    params fully name the blast radius (secret-bearing GOSC contents are
-   never echoed).
+   never echoed). ``guest.customization_spec.create`` is a param-echo
+   builder (IDENTITY fields only, #1503); ``vm.customize`` is a live-read
+   builder.
 
 Plus the #1628 follow-up: a *failed* live-read preview parks with the
 identifier fields **and** an explicit ``preview_unavailable`` marker +
@@ -37,6 +39,7 @@ the park-time listing reads run directly on it.
 
 from __future__ import annotations
 
+import json
 import uuid
 from collections.abc import Iterator
 from typing import Any
@@ -85,6 +88,8 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.cluster.patch",
         "vmware.composite.cluster.drs_rule.create",
         "vmware.composite.folder.create",
+        "vmware.composite.guest.customization_spec.create",
+        "vmware.composite.vm.customize",
     }
 )
 
@@ -295,14 +300,14 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 
 
 # ===========================================================================
-# Wiring — all 16 write composites register a builder (criterion 4)
+# Wiring — all 18 write composites register a builder (criterion 4)
 # ===========================================================================
 
 
-def test_all_sixteen_write_composites_register_a_preview_builder() -> None:
+def test_all_eighteen_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 16
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 18
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 
@@ -525,6 +530,104 @@ async def test_echo_builders_decline_on_malformed_params() -> None:
     assert await _write_preview._vm_power_bulk_preview(_make_preview_ctx({})) is None
     assert await _write_preview._host_evacuate_preview(_make_preview_ctx({})) is None
     assert await _write_preview._host_detach_from_vds_preview(_make_preview_ctx({})) is None
+
+
+# ===========================================================================
+# GOSC create preview — IDENTITY-only echo, never secret material (#1503)
+# ===========================================================================
+
+
+async def test_guest_customization_spec_create_preview_echoes_identity_only() -> None:
+    """The create preview surfaces the blast radius without any credential value.
+
+    Given a Windows spec carrying an admin password, a product key, and a
+    domain-join password, the builder returns ONLY the identity keys — no
+    secret field name and no secret value appears anywhere in the output.
+    """
+    preview = await _write_preview._guest_customization_spec_create_preview(
+        _make_preview_ctx(
+            {
+                "spec_name": "gosc-win",
+                "os_type": "windows",
+                "hostname": "win-01",
+                "interfaces": [
+                    {"ip_address": "10.0.0.5", "prefix": 24, "gateways": ["10.0.0.1"]},
+                    {},  # DHCP NIC — no ip_address
+                ],
+                "windows_admin_password": "pw-admin-SECRET",
+                "windows_product_key": "KEY-SECRET",
+                "windows_domain_admin_password": "pw-join-SECRET",
+            }
+        )
+    )
+    assert preview == {
+        "spec_name": "gosc-win",
+        "os_type": "windows",
+        "hostname_scheme": "FIXED:win-01",
+        "nic_count": 2,
+        "static_ip_summary": ["10.0.0.5"],
+    }
+    # Defence in depth: no secret value bled into the serialised preview.
+    blob = json.dumps(preview)
+    assert "SECRET" not in blob
+
+
+async def test_guest_customization_spec_create_preview_declines_on_malformed() -> None:
+    """Missing spec_name / os_type declines (→ identifier-only default), never raises."""
+    assert (
+        await _write_preview._guest_customization_spec_create_preview(_make_preview_ctx({})) is None
+    )
+    assert (
+        await _write_preview._guest_customization_spec_create_preview(
+            _make_preview_ctx({"spec_name": "x"})
+        )
+        is None
+    )
+
+
+# ===========================================================================
+# vm.customize preview — live-read power state, no secret (spec-name reference)
+# ===========================================================================
+
+
+async def test_vm_customize_preview_resolves_power_state() -> None:
+    """With a connector, the preview live-reads the VM to surface moid + power state."""
+    recorder = _RecordingConnector()
+    recorder.responses["/vcenter/vm"] = {
+        "value": [{"vm": "vm-7", "name": "app", "power_state": "POWERED_OFF"}]
+    }
+    preview = await _write_preview._vm_customize_preview(
+        _make_preview_ctx({"name": "app", "spec_name": "gosc-lin"}, connector_instance=recorder)
+    )
+    assert preview == {
+        "vm": "vm-7",
+        "name": "app",
+        "spec_name": "gosc-lin",
+        "power_state": "POWERED_OFF",
+        "applies_on": "next_power_on",
+    }
+    # The preview issued exactly the one resolution read.
+    assert [c[0] for c in recorder.calls] == ["GET"]
+
+
+async def test_vm_customize_preview_echoes_without_connector() -> None:
+    """No connector → name + spec echo with power_state unknown (still no secret)."""
+    preview = await _write_preview._vm_customize_preview(
+        _make_preview_ctx({"name": "app", "spec_name": "gosc-lin"}, connector_instance=None)
+    )
+    assert preview == {
+        "vm": None,
+        "name": "app",
+        "spec_name": "gosc-lin",
+        "power_state": None,
+        "applies_on": "next_power_on",
+    }
+
+
+async def test_vm_customize_preview_declines_on_malformed() -> None:
+    """Missing name / spec_name declines (→ identifier-only default), never raises."""
+    assert await _write_preview._vm_customize_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._vm_customize_preview(_make_preview_ctx({"name": "app"})) is None
     assert await _write_preview._cluster_patch_preview(_make_preview_ctx({})) is None
     assert await _write_preview._folder_create_preview(_make_preview_ctx({})) is None
     assert await _write_preview._cluster_drs_rule_create_preview(_make_preview_ctx({})) is None

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,22 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 16 vmware-rest write composites.
+"""Registration tests for the 18 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 ``vm.power`` / #2301, the vim writes ``vm.disk.grow`` / #2893 +
-``cluster.drs_rule.create`` / ``folder.create`` / #2895, and the #2891
-hardware writes ``vm.resize`` / ``vm.nic.repoint`` / ``vm.device.cdrom``):
+``cluster.drs_rule.create`` / ``folder.create`` / #2895, the #2891
+hardware writes ``vm.resize`` / ``vm.nic.repoint`` / ``vm.device.cdrom``,
+and the GOSC composites ``guest.customization_spec.create`` /
+``vm.customize`` / #2892):
 
-* All 16 expected write ``op_id`` rows land in ``endpoint_descriptor``
+* All 18 expected write ``op_id`` rows land in ``endpoint_descriptor``
   with ``source_kind="composite"``, ``safety_level="dangerous"``,
   ``requires_approval=True`` (T4's defaults intentionally inherited).
 * Each row's ``handler_ref`` resolves to the module-level dotted path
   in ``composites/_write``.
-* Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster``
-  per the canary's stub-LLM taxonomy.
+* Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster`` /
+  ``guest`` per the canary's stub-LLM taxonomy.
 * Combined with #508's 5 read composites, the registrar produces
-  **21 rows** total. (The former host.network_uplinks / host.vsan_health
+  **23 rows** total. (The former host.network_uplinks / host.vsan_health
   reads were re-shipped as typed ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
   with the documented required keys.
@@ -43,12 +45,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.connectors.registry import clear_registry
 from meho_backplane.connectors.vmware_rest.composites import (
     cluster_patch_composite,
+    guest_customization_spec_create_composite,
     host_detach_from_vds_composite,
     host_evacuate_composite,
     register_vmware_composite_operations,
     vm_clone_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
+    vm_customize_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -63,11 +67,12 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 16 write composites (T6 / #509, single-VM vm.power / #2301, the
+# 18 write composites (T6 / #509, single-VM vm.power / #2301, the
 # mutating VI-JSON vm.disk.grow / #2893, the folder-template
 # vm.clone_from_template / #2894, the vim cluster/inventory writes
-# cluster.drs_rule.create + folder.create / #2895, and the #2891
-# hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom).
+# cluster.drs_rule.create + folder.create / #2895, the #2891
+# hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom, and the
+# GOSC composites guest.customization_spec.create + vm.customize / #2892).
 _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.create",
     "vmware.composite.vm.clone",
@@ -85,6 +90,8 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.cluster.patch",
     "vmware.composite.cluster.drs_rule.create",
     "vmware.composite.folder.create",
+    "vmware.composite.guest.customization_spec.create",
+    "vmware.composite.vm.customize",
 )
 
 # 5 reads (T5 / #508) -- carried over so the combined-count assertion
@@ -99,10 +106,10 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.network.portgroup.audit",
 )
 
-# 21 total -- 5 read (T5 / #508) + 16 write (T6 / #509 + vm.power / #2301 +
+# 23 total -- 5 read (T5 / #508) + 18 write (T6 / #509 + vm.power / #2301 +
 # vm.disk.grow / #2893 + vm.clone_from_template / #2894 + vim cluster/inventory
 # writes cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
-# writes vm.resize / vm.nic.repoint / vm.device.cdrom).
+# writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC create/apply / #2892).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -155,6 +162,13 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.vm.device.cdrom": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_device_cdrom_composite"
     ),
+    "vmware.composite.guest.customization_spec.create": (
+        "meho_backplane.connectors.vmware_rest.composites._write."
+        "guest_customization_spec_create_composite"
+    ),
+    "vmware.composite.vm.customize": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_customize_composite"
+    ),
 }
 
 
@@ -175,6 +189,8 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.cluster.patch": "cluster",
     "vmware.composite.cluster.drs_rule.create": "cluster",
     "vmware.composite.folder.create": "vm",
+    "vmware.composite.guest.customization_spec.create": "guest",
+    "vmware.composite.vm.customize": "guest",
 }
 
 
@@ -218,15 +234,15 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 16 write composites land alongside the 5 reads (21 total)
+# 18 write composites land alongside the 5 reads (23 total)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_inserts_sixteen_write_rows(
+async def test_register_vmware_composite_operations_inserts_eighteen_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 16 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 18 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -243,13 +259,13 @@ async def test_register_vmware_composite_operations_inserts_sixteen_write_rows(
 
 
 @pytest.mark.asyncio
-async def test_full_registration_produces_twenty_one_composite_rows(
+async def test_full_registration_produces_twenty_three_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """5 reads (#508) + 16 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
+    """5 reads (#508) + 18 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
     vm.clone_from_template #2894 + cluster.drs_rule.create + folder.create #2895 +
-    #2891 hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom)
-    = 21 rows. DoD bar."""
+    #2891 hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom +
+    GOSC create/apply #2892) = 23 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -263,7 +279,7 @@ async def test_full_registration_produces_twenty_one_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 21
+    assert len(rows) == 23
 
 
 @pytest.mark.asyncio
@@ -289,7 +305,7 @@ async def test_every_write_composite_row_uses_dangerous_requires_approval(
             .scalars()
             .all()
         )
-    # Prove the query actually returned all 13 write rows before iterating —
+    # Prove the query actually returned all 18 write rows before iterating —
     # otherwise the loop is vacuous when the set is empty / partial.
     assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     for row in rows:
@@ -355,7 +371,7 @@ async def test_write_composites_land_in_vm_host_cluster_groups(
     stub_embedding_service: AsyncMock,
 ) -> None:
     """Group distribution: 12 in ``vm`` (11 ``vm.*`` + ``folder.create``),
-    2 ``host.*`` in ``host``, 2 ``cluster.*`` in ``cluster``.
+    2 ``host.*`` in ``host``, 2 ``cluster.*`` in ``cluster``, 2 GOSC in ``guest``.
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
@@ -539,17 +555,17 @@ async def test_write_composite_tags_include_composite_and_write(
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_is_idempotent_across_twenty_one(
+async def test_register_vmware_composite_operations_is_idempotent_across_twenty_three(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 21 rows total, embedding called 21x once."""
+    """Running the registrar twice -> 23 rows total, embedding called 23x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 21
+    assert first_count == 23
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 21.
+    # pipeline; the row count stays at 23.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -563,7 +579,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_twenty_
             .scalars()
             .all()
         )
-    assert len(rows) == 21
+    assert len(rows) == 23
 
 
 # ---------------------------------------------------------------------------
@@ -596,6 +612,8 @@ def test_all_write_handlers_are_module_level_coroutine_functions() -> None:
         host_evacuate_composite,
         host_detach_from_vds_composite,
         cluster_patch_composite,
+        guest_customization_spec_create_composite,
+        vm_customize_composite,
     ):
         assert inspect.iscoroutinefunction(handler), f"{handler!r} is not a coroutine function"
         assert "<locals>" not in handler.__qualname__

--- a/backend/tests/test_typed_connectors_metadata.py
+++ b/backend/tests/test_typed_connectors_metadata.py
@@ -68,7 +68,7 @@ _K8S_GROUPS: Final[frozenset[str]] = frozenset(
 )
 _VAULT_GROUPS: Final[frozenset[str]] = frozenset({"auth", "kv", "sys"})
 _VMWARE_COMPOSITE_GROUPS: Final[frozenset[str]] = frozenset(
-    {"cluster", "events", "performance", "storage", "networking", "vm", "host"}
+    {"cluster", "events", "performance", "storage", "networking", "vm", "host", "guest"}
 )
 _BIND9_GROUPS: Final[frozenset[str]] = frozenset({"identity", "zone", "record", "config"})
 

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,17 +8,18 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 21 hand-authored composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 23 hand-authored composites
 that orchestrate cross-spec workflows: 5 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`) and 16 write composites (G3.1-T6 / `#509`, the
+in `#2258`) and 18 write composites (G3.1-T6 / `#509`, the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
 mutating VI-JSON `vm.disk.grow` / `#2893`, the folder-template
 `vm.clone_from_template` / `#2894`, the vim cluster / inventory writes
-`cluster.drs_rule.create` + `folder.create` / `#2895`, and the `#2891`
+`cluster.drs_rule.create` + `folder.create` / `#2895`, the `#2891`
 post-clone hardware reconfigure trio `vm.resize` / `vm.nic.repoint` /
-`vm.device.cdrom`). The
+`vm.device.cdrom`, and the two guest-customization (GOSC) composites
+`guest.customization_spec.create` + `vm.customize` / `#2892`). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
 govc-wrapper retirement.
@@ -73,16 +74,18 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   cluster-wide `overall_health` colour plus the health-test `groups`
   list. It is likewise best-effort (a failed health-service read nulls
   `groups` / `overall_health` with a `read_note`).
-- **Write composites** (`composites/_write.py`) — twelve module-level
+- **Write composites** (`composites/_write.py`) — fourteen module-level
   `async def` handlers (`vm_create_composite`, `vm_clone_composite`,
   `vm_snapshot_revert_composite`, `vm_migrate_composite`,
   `vm_power_composite`, `vm_power_bulk_composite`,
   `vm_resize_composite`, `vm_nic_repoint_composite`,
   `vm_device_cdrom_composite`,
   `host_evacuate_composite`, `host_detach_from_vds_composite`,
-  `cluster_patch_composite`). The last three (`#2891`) are the
-  post-clone hardware reconfigure trio — see the **Hardware write
-  composites** subsection under Control flow. Since
+  `cluster_patch_composite`, `guest_customization_spec_create_composite`,
+  `vm_customize_composite`). The `vm_resize` / `vm_nic_repoint` /
+  `vm_device_cdrom` trio (`#2891`) is the post-clone hardware reconfigure
+  trio — see the **Hardware write composites** subsection under Control
+  flow. Since
   `#2256` each accepts `(operator, target, params, connector)` and
   issues its raw-REST sub-ops **directly on the resolved connector
   session** — `connector._get_json` (`_read_sub_op`) for the resolution
@@ -123,10 +126,60 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   recursion-depth contextvar (default cap 8) handles the depth-1 nesting
   cleanly, and the resolved `vm.migrate` runs its own relocate write on
   the direct session under the same governance seam.
+- **Guest customization (GOSC) composites** (`#2892`, group `guest`) —
+  `guest_customization_spec_create_composite`
+  (`POST:/vcenter/guest/customization-specs`) creates a reusable named
+  customization spec from the tractable provisioning subset (hostname as a
+  FIXED `HostnameGenerator`, per-NIC static IP / prefix / gateways, global
+  DNS, for a Linux `linux_config` or a Windows `windows_config` sysprep);
+  `vm_customize_composite`
+  (`PUT:/vcenter/vm/{vm}/guest/customization`) resolves a VM by display
+  name and applies a saved spec by name, refusing a powered-on VM with a
+  structured `precondition_failed` status (vCenter only accepts a pending
+  customization on a powered-off VM) and optionally powering it on
+  afterward so the customization applies on that boot. GOSC is how a cloned
+  VM gets its hostname + network identity on first boot; the create op's
+  `spec_name` is what `vm.customize` — and a clone's
+  `CloneSpec.guest_customization_spec` (consumed by the Task-D clone op) —
+  reference. The body builders map the agent subset onto the vCenter
+  `CreateSpec {name, description, spec:CustomizationSpec}` /
+  `SetSpec {name}`, wrapped in the operation's `spec` parameter per the
+  connector's REST convention.
+
+  **GOSC secret hygiene (`#1503`) — the load-bearing property.** A
+  customization spec can carry Windows admin passwords, sysprep product
+  keys, and domain-join credentials
+  (`windows_admin_password` / `windows_product_key` /
+  `windows_domain_admin_password`). Those values are consumed into the
+  sysprep request body — the real API call that provisions the guest — but
+  must never serialize onto a reviewer / preview / broadcast / audit
+  surface. Three independent surfaces enforce this:
+  1. **`proposed_effect` (approval park).** The bespoke park-time preview
+     builder (`_write_preview._guest_customization_spec_create_preview`)
+     reads ONLY identity keys and echoes
+     `{spec_name, os_type, hostname_scheme, nic_count, static_ip_summary}`
+     — it never touches the credential params, so no secret can reach the
+     durable `ApprovalRequest.proposed_effect` row by construction.
+  2. **Broadcast frame.** `guest.customization_spec.create` is pinned into
+     `broadcast/events._CREDENTIAL_WRITE_OPS`, so `redact_payload` collapses
+     its params to aggregate-only on the feed. The pin is required (not just
+     nice-to-have): the `password`-suffixed fields trip the runtime
+     key-name scrub, but `product_key` does not (`key` is neither an
+     anywhere- nor final-position secret token), and the classifier-coverage
+     CI gate (`test_broadcast_classifier_coverage`) fails a secret-bearing
+     schema that is not pinned to a credential class.
+  3. **Audit row.** The durable `audit_log` payload stores only a
+     `params_hash`, never the raw params — safe by construction.
+
+  `vm.customize` carries only a spec-name reference (no secret), so it is
+  not pinned; its preview live-reads the VM's power state for the reviewer.
+  The end-to-end proof across all three surfaces lives in
+  `test_connectors_vmware_rest_composites_write_e2e`
+  (`test_gosc_create_secret_hygiene_across_all_surfaces`).
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 21
-  `_CompositeSpec` rows (5 read + 16 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 23
+  `_CompositeSpec` rows (5 read + 18 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -138,7 +191,7 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   `dispatch_child`, no ingested-descriptor sub-ops, no L2 pre-flight. It
   therefore works on a **fresh boot with zero catalog ingest** — the same
   direct-session property the 5 read composites (`#2253`) and, since
-  `#2256`, the 12 write composites now share. The only `dispatch_child`
+  `#2256`, the 14 write composites now share. The only `dispatch_child`
   leg left on the whole vmware surface is the `host.evacuate` →
   `vm.migrate` composite→composite recursion (a registrar-guaranteed
   `source_kind="composite"` row, not an ingested primitive, `#2248`). The metadata
@@ -253,9 +306,9 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
    (in `ensure_connector_class_registered`, once #408's pipeline lands
    in main) no-ops on subsequent ingests against the same triple.
 5. Lifespan calls `run_typed_op_registrars()`, which iterates every
-   queued registrar and upserts: the 17 `vmware.composite.*` rows with
+   queued registrar and upserts: the 23 `vmware.composite.*` rows with
    `source_kind="composite"` (5 reads with `safety_level="safe"` +
-   `requires_approval=False`; 12 writes with `safety_level="dangerous"`
+   `requires_approval=False`; 18 writes with `safety_level="dangerous"`
    + `requires_approval=True`), plus the `vmware.host.usage` row with
    `source_kind="typed"` (`safety_level="safe"` + `requires_approval=False`).
    The typed row resolves and dispatches with **zero catalog ingest** —
@@ -351,7 +404,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 21 composites (5 reads + 16 writes) land as `source_kind="composite"`
+The 23 composites (5 reads + 18 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -418,7 +471,7 @@ caller.
 
 ### L1/L2 dispatch — direct-session (two-world migration, Goal #2247)
 
-The 21 composites are hand-authored aggregators the connector ships as
+The 23 composites are hand-authored aggregators the connector ships as
 `source_kind='composite'` descriptors. Each composite's body issues its
 raw-REST sub-ops (`GET:/vcenter/datastore`,
 `POST:/vcenter/vm/{vm}/power?action=start`, etc.) **directly on the
@@ -782,7 +835,7 @@ so existing string-matching consumers keep working.
 
 ### Park-time approval previews (#1608)
 
-All 16 write composites ship `requires_approval=True`, so a human/agent
+All 18 write composites ship `requires_approval=True`, so a human/agent
 dispatch parks as a durable `ApprovalRequest` row. Pre-#1608 that row's
 `proposed_effect` was the identifier-only default `{op_id, connector_id,
 target_id}` — and since the dispatch `params` are deliberately never
@@ -991,7 +1044,7 @@ they never park.
   "GET:/vcenter/network/distributed-portgroup"` has the identical
   unresolvable spelling. #1602 is scoped to the read
   `network.portgroup.audit` composite only; the write-side fix plus a
-  reconcile guard over the 9 write composites' `_SUB_OPS_*` against the
+  reconcile guard over the 14 write composites' `_SUB_OPS_*` against the
   real pinned spec (the existing
   `test_connectors_vmware_rest_composites_l2_ingest_reconcile.py`
   synthesises its fixture *from* the constants, so it cannot catch a


### PR DESCRIPTION
## Summary

- Adds two `vmware-rest` write composites for guest OS customization (GOSC) — keystone 1 of #2890: `vmware.composite.guest.customization_spec.create` (`POST /vcenter/guest/customization-specs`) and `vmware.composite.vm.customize` (`PUT /vcenter/vm/{vm}/guest/customization`). GOSC is how a cloned VM gets its hostname + per-NIC static IP + gateway + DNS on first boot; the create op's `spec_name` is what `vm.customize` and a clone's `CloneSpec.guest_customization_spec` (Task D / #2894) reference.
- Both are `dangerous` + `requires_approval`, dispatch every sub-op on the direct connector session (fresh-boot dispatchable, zero catalog ingest), gate each mutating sub-call through `enforce_subop_policy`, and register a park-time preview builder.
- **GOSC secret hygiene (#1503) is the load-bearing property**, enforced across all three reviewer surfaces: the create op is pinned `credential_write` (broadcast params collapse to aggregate-only — the key-name scrub alone misses `product_key`); its preview echoes identity fields only (`spec_name` / `os_type` / `hostname_scheme` / `nic_count` / `static_ip_summary`) and never reads the credential params; the durable audit row stores only a params hash.
- `vm.customize` refuses a powered-on VM with a structured `precondition_failed` status (vCenter only accepts a pending customization on a powered-off VM) and optionally powers it on afterward so the customization applies on that boot.

REST shapes fresh-cited against the VMware vSphere Automation SDK (Python sample + Java 8.0.1.0 bindings); `{"spec": {...}}` body wrapping matches the connector's validated convention. New sub-op paths reconcile against the pinned `vcenter.yaml` via the ingest-reconcile lane.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (26 source files)
- [x] `code-quality.py --diff` — 0 blockers
- [x] **Secret hygiene proven by test** (#1503): `test_gosc_create_secret_hygiene_across_all_surfaces` dispatches a Windows spec carrying admin password + product key + domain-join password, then scans `proposed_effect`, every broadcast frame, and (by construction) the hash-only audit row for planted secret literals — none leak. `redaction covered for both ops`: `test_vm_customize_preview_and_broadcast_carry_no_secret` covers the apply half.
- [x] Powered-on VM → `precondition_failed` (no PUT); powered-off VM → PUT `{"spec": {"name": <spec>}}` (respx-verified in `test_vm_customize_puts_named_spec_over_respx`)
- [x] Park → approve → resume in the `_write_e2e` lane with the #2681 uniform op-identity envelope asserted; sub-op paths asserted against the pinned spec (`l2_ingest_reconcile`)
- [x] Six test lanes extended (unit / preview / register / e2e / ingest-reconcile / metadata) + respx integration; full affected suite green (1076 + 316 passed, 0 failed)
- [x] `docs/codebase/connectors-vmware-rest.md` + `CHANGELOG.md` updated

## Out of scope

- Task D / #2894 (clone with `guest_customization_spec`) consumes the created spec — sibling task, not touched here.
- Sibling Wave-1 tasks #2891 / #2893 touch adjacent vmware files; this PR only adds its own registry entries (new self-contained `guest` operation group) to minimize merge conflicts.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2892


---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-12)

Addressed the iteration-1 REQUEST_CHANGES review (degraded-comment verdict + inline B1/B2/M1) in `5385b936`:

- **B1** `5385b936` — Windows domain-join now emits `sysprep.domain` (`Vcenter.Guest.Domain` `{type: DOMAIN, domain, domain_username, domain_password}`), replacing the non-existent pyvmomi `sysprep.identification` block.
- **B2** `5385b936` — always emit the schema-required create fields `_put_if_str` dropped: `UserData.{full_name, organization, product_key}`, `GuiUnattended.{auto_logon_count, time_zone}` (a REQUIRED integer MS index via a new `windows_time_zone` param, distinct from the Linux tz-name string), `LinuxConfiguration.domain`, and `CreateSpec.description`.
- **M1** `5385b936` — corrected the mis-encoded Windows unit test and added a create-body contract lane validating the built POST body (Linux + Windows/sysprep) against a JSON-Schema mirror of the pinned `CustomizationSpecs.CreateSpec`; a negative case proves a wrong field name / missing required field now fails CI.

REST shapes fresh-cited against the pinned `vcenter-9.0/vcenter.yaml`. Secret hygiene (#1503) preserved — `product_key` stays consumed only in the sysprep builder, out of preview/broadcast/audit; the across-all-surfaces e2e test remains green.

Local gates: ruff / ruff-format clean, mypy clean (changed files), affected pytest lanes green (write + preview + e2e + register + ingest-reconcile + metadata + vcsim + classifier-coverage), code-quality `--diff` 0 blockers.

<!-- auto-implement-issue: continue, iteration 1 -->
