### PR TITLE
feat(connectors): vmware vm.disk.grow via governed mutating VI-JSON + vim Task-poll helper (#2893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,27 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — vmware `vm.disk.grow` + the governed mutating VI-JSON write substrate (#2893)
+
+- `vmware.composite.vm.disk.grow` grows a virtual disk's capacity — the
+  first vmware write with **no REST path** (the pinned 9.0 spec's
+  `Disk.UpdateSpec` carries only `backing`, no capacity field), so the
+  capacity change goes through vim `VirtualMachine.ReconfigVM_Task`, the
+  connector's first *mutating* VI-JSON call. Grow-only by contract: a
+  request at or below the current capacity is refused
+  (`status='invalid_shrink'`) before any write. `dangerous` +
+  approval-required, with a park-time preview that live-reads the
+  current→requested capacity delta so the approver sees the disk grows
+  (never shrinks) and by how much.
+- The write rides two reusable seams Tasks D/E build on:
+  `_write_vmomi_sub_op` routes a mutating vmomi POST through the same
+  `enforce_subop_policy` gate the REST writes use (a policy-denied vmomi
+  write never reaches the wire), and `poll_vim_task` (in `vim_task.py`)
+  drives the returned `*_Task` MoRef to a terminal state (`success` /
+  `error` / timeout) before success is reported — generalized from the
+  `tasks.recent` `Task.info` read. See
+  `docs/codebase/connectors-vmware-rest.md` for the full substrate.
+
 ## [0.28.0] - 2026-08-07
 
 ### Added — seven more Do-real-work guides on the docs site: topology, broadcast, memory/knowledge, audit forensics, runbooks, scheduler, satellite gateway (#2829)

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 14 composites land before
+``endpoint_descriptor`` upserts for the 15 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -29,13 +29,15 @@ Scope:
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 9 write composites (G3.1-T6 / #509, plus single-VM ``vm.power`` /
-  #2301) -- inherit T4's ``safety_level="dangerous"`` +
+* 10 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
+  #2301, and the mutating VI-JSON ``vm.disk.grow`` / #2893) -- inherit
+  T4's ``safety_level="dangerous"`` +
   ``requires_approval=True`` defaults.
   They cover every state-mutating workflow Goal #214 names as
   required for govc-wrapper retirement: ``vm.create``, ``vm.clone``,
   ``vm.snapshot.revert``, ``vm.migrate``, ``vm.power`` (single VM,
-  incl. Tools soft shutdown), ``vm.power.bulk``,
+  incl. Tools soft shutdown), ``vm.power.bulk``, ``vm.disk.grow`` (the
+  first mutating VI-JSON composite — disk capacity has no REST path),
   ``host.evacuate`` (first recursive composite),
   ``host.detach_from_vds``, ``cluster.patch``.
 """
@@ -56,6 +58,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     host_evacuate_composite,
     vm_clone_composite,
     vm_create_composite,
+    vm_disk_grow_composite,
     vm_migrate_composite,
     vm_power_bulk_composite,
     vm_power_composite,
@@ -69,7 +72,7 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 # registered by the time the runner iterates.
 register_typed_op_registrar(register_vmware_composite_operations)
 
-# Side-effect import: registers the 9 write composites' park-time
+# Side-effect import: registers the 10 write composites' park-time
 # ``proposed_effect`` preview builders (#1608) onto the per-op hook in
 # :mod:`meho_backplane.operations._preview` — mirrors how
 # ``connectors/argocd/__init__`` wires ``ops_write_preview``.
@@ -87,6 +90,7 @@ __all__ = [
     "register_vmware_composite_operations",
     "vm_clone_composite",
     "vm_create_composite",
+    "vm_disk_grow_composite",
     "vm_migrate_composite",
     "vm_power_bulk_composite",
     "vm_power_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 14 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 15 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -26,8 +26,9 @@ The 5 read composites (T5 / #508) pass
 T4's ``dangerous`` / ``True`` defaults. (The former
 ``host.network_uplinks`` and ``host.vsan_health`` reads were re-shipped
 as typed ops in #2258; see
-:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 9 write
-composites (T6 / #509, plus single-VM ``vm.power`` / #2301) inherit the T4
+:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 10 write
+composites (T6 / #509, single-VM ``vm.power`` / #2301, and the mutating
+VI-JSON ``vm.disk.grow`` / #2893) inherit the T4
 defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity at
 the call site; the helper would default to those values anyway).
 Each :class:`_CompositeSpec` row carries its own ``safety_level`` +
@@ -54,6 +55,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     host_evacuate_composite,
     vm_clone_composite,
     vm_create_composite,
+    vm_disk_grow_composite,
     vm_migrate_composite,
     vm_power_bulk_composite,
     vm_power_composite,
@@ -80,6 +82,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     VM_CLONE_RESPONSE_SCHEMA,
     VM_CREATE_PARAMETER_SCHEMA,
     VM_CREATE_RESPONSE_SCHEMA,
+    VM_DISK_GROW_PARAMETER_SCHEMA,
+    VM_DISK_GROW_RESPONSE_SCHEMA,
     VM_MIGRATE_PARAMETER_SCHEMA,
     VM_MIGRATE_RESPONSE_SCHEMA,
     VM_POWER_BULK_PARAMETER_SCHEMA,
@@ -465,6 +469,30 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         requires_approval=True,
     ),
     _CompositeSpec(
+        op_id="vmware.composite.vm.disk.grow",
+        handler=vm_disk_grow_composite,
+        summary="Grow a VM's virtual disk to a larger capacity via ReconfigVM_Task.",
+        description=(
+            "Grows one virtual disk's capacity. The pinned 9.0 REST spec's "
+            "Disk.UpdateSpec carries only backing (no capacity field), so the "
+            "capacity change goes through vim VirtualMachine.ReconfigVM_Task — "
+            "a single-device edit raising the VirtualDisk's capacityInBytes — "
+            "the connector's first mutating VI-JSON call. Reads the VM's "
+            "config.hardware.device to obtain the full VirtualDisk device + its "
+            "current capacity, refuses a shrink (status='invalid_shrink') "
+            "before any write, issues the ReconfigVM_Task edit through the same "
+            "governance seam as the REST write composites, and polls the "
+            "returned Task to a terminal state before reporting status='grown'. "
+            "Grow-only by contract. Equivalent of 'govc vm.disk.change -size'."
+        ),
+        parameter_schema=VM_DISK_GROW_PARAMETER_SCHEMA,
+        response_schema=VM_DISK_GROW_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "disk", "vi-json"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
         op_id="vmware.composite.host.evacuate",
         handler=host_evacuate_composite,
         summary="Migrate every VM off a host (via recursive vm.migrate) then enter maintenance.",
@@ -551,8 +579,9 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 14 composites total -- 5 read (T5 / #508) + 9 write (T6 /
-    #509, plus single-VM ``vm.power`` / #2301). (The former
+    Scope: 15 composites total -- 5 read (T5 / #508) + 10 write (T6 /
+    #509, single-VM ``vm.power`` / #2301, and the mutating VI-JSON
+    ``vm.disk.grow`` / #2893). (The former
     ``host.network_uplinks`` / ``host.vsan_health`` reads were re-shipped
     as typed ops in #2258.)
     Each composite's ``safety_level`` +

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
-# code-quality-allow: 8 protocol-driven composite handlers for the
-# vSphere REST write surface ship in one module per the issue body's
-# design; splitting them by group would scatter the shared sub-op_id
-# constants + helpers across files for no readability gain. Each
-# handler's body is the documented orchestration workflow from
-# #509's spec.
+# code-quality-allow: 9 protocol-driven composite handlers for the
+# vSphere REST + VI-JSON write surface ship in one module per the issue
+# body's design; splitting them by group would scatter the shared
+# sub-op_id constants + helpers across files for no readability gain. Each
+# handler's body is the documented orchestration workflow from #509's spec
+# (plus the mutating VI-JSON disk-grow from #2893).
 
-"""Write-shaped ``vmware.composite.*`` handler functions (8 composites).
+"""Write-shaped ``vmware.composite.*`` handler functions (9 composites).
 
 Companion to :mod:`._read`. Post-#2256 each handler is a module-level
 ``async def`` taking the dispatcher's composite-branch keyword args
@@ -91,6 +91,7 @@ import httpx
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.vmware_rest.vim_task import poll_vim_task
 from meho_backplane.operations.composite import DispatchChild, enforce_subop_policy
 
 if TYPE_CHECKING:
@@ -102,6 +103,7 @@ __all__ = [
     "host_evacuate_composite",
     "vm_clone_composite",
     "vm_create_composite",
+    "vm_disk_grow_composite",
     "vm_migrate_composite",
     "vm_power_bulk_composite",
     "vm_power_composite",
@@ -152,6 +154,61 @@ _OP_GET_TASK = "GET:/cis/tasks/{task}"
 _OP_HOST_PATCH = "POST:/vcenter/host/{host}?action=patch"
 _OP_LIST_PORTGROUPS = "GET:/vcenter/network/distributed-portgroup"
 _OP_REMOVE_DVS_HOST = "POST:/vcenter/network/dvs/{dvs}?action=remove_host"
+# REST Disk.Info read — the disk-grow park-time preview reads label +
+# current capacity (bytes) off this; the disk id is the vim device key.
+_OP_GET_VM_DISK = "GET:/vcenter/vm/{vm}/hardware/disk/{disk}"
+
+# vim (VI-JSON) op_ids for the disk-grow write path. These are the
+# canonical ``METHOD:/path`` keys the ingest parser emits from
+# ``vi-json.yaml`` (the moId rides the path as ``{moId}``, mirroring the
+# read composites' ``POST:/EventManager/{moId}/QueryEvents``). They are
+# the *governance* op_ids fed to :func:`enforce_subop_policy`; the
+# concrete path (moId substituted) is what
+# :meth:`VmwareRestConnector._post_vmomi_json` POSTs to. Kept out of the
+# ``_SUB_OPS_*`` namespace so the vCenter-REST ingest-reconcile sweep does
+# not treat a vi-json path as a ``vcenter.yaml`` row; the pinned
+# ``vi-json.yaml`` reconcile asserts them instead.
+#
+# ``ReconfigVM_Task`` is the only route to change a virtual disk's
+# capacity: the pinned 9.0 REST spec's ``Disk.UpdateSpec`` carries only
+# ``backing`` (no capacity field), so vim is the sole write path
+# (spec-verified). ``RetrievePropertiesEx`` reads the VM's
+# ``config.hardware.device`` to obtain the full ``VirtualDisk`` device
+# (its ``key`` + current ``capacityInBytes``) the reconfigure edits, and
+# is re-read by the shared Task-poll helper to drive the returned
+# ``*_Task`` MoRef to a terminal state.
+# Canonical vi-json.yaml path keys (moId as the ``{moId}`` template — the
+# form the ingest parser emits and the pinned-spec reconcile asserts).
+_OP_RECONFIG_VM_TASK = "POST:/VirtualMachine/{moId}/ReconfigVM_Task"
+_OP_RETRIEVE_PROPERTIES = "POST:/PropertyCollector/{moId}/RetrievePropertiesEx"
+# Concrete runtime path for the config read: the PropertyCollector is a
+# singleton whose moId is the literal ``propertyCollector`` (the same
+# concrete path the typed reads + read composites POST). ``ReconfigVM_Task``
+# substitutes the VM moid inline at call time.
+_VMOMI_RETRIEVE_PROPERTIES_PATH = "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+
+#: vi-json sub-op manifest for ``vm.disk.grow`` (parallel to the REST
+#: ``_SUB_OPS_*`` tuples, but named out of that namespace so the
+#: vcenter.yaml ingest-reconcile sweep skips it). The pinned
+#: ``vi-json.yaml`` reconcile lane introspects this to assert every
+#: declared vim path exists in the spec.
+_VIM_SUB_OPS_VM_DISK_GROW: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_RECONFIG_VM_TASK,
+)
+
+# VI-JSON polymorphic-type discriminator (``Any._typeName`` in
+# vi-json.yaml) + the VirtualDisk data-object type name. A device read
+# from ``config.hardware.device`` carries ``_typeName`` so the handler can
+# pick the VirtualDisk out of the mixed device list.
+_VMOMI_TYPE_NAME_KEY = "_typeName"
+_VIRTUAL_DISK_TYPE = "VirtualDisk"
+_VIRTUAL_MACHINE_MO_TYPE = "VirtualMachine"
+_PROP_CONFIG_HARDWARE_DEVICE = "config.hardware.device"
+
+# Default wall-clock bound for the ReconfigVM_Task poll — mirrors the 600s
+# ``vm.clone`` convention.
+_DISK_GROW_TASK_TIMEOUT_SECONDS = 600.0
 
 
 def _power_vm_op_id(action: str) -> str:
@@ -376,6 +433,64 @@ async def _write_sub_op(
     payload = await connector._post_json(
         target, mounted, operator=operator, verb=method, json=body or None
     )
+    return None, payload
+
+
+async def _write_vmomi_sub_op(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    op_id: str,
+    vmomi_path: str,
+    body: dict[str, Any],
+    params: dict[str, Any],
+) -> tuple[OperationResult | None, Any]:
+    """Gate then issue one *mutating* vim (VI-JSON) sub-call on the connector session.
+
+    The VI-JSON counterpart of :func:`_write_sub_op`: a vmomi POST that
+    *mutates* (``ReconfigVM_Task``, ``CloneVM_Task``,
+    ``ReconfigureComputeResource_Task`` …) is a write sub-op, not a
+    transport detail, so it flows through the **same** #2254 governance
+    seam the REST write sub-ops do. Runs
+    :func:`~meho_backplane.operations.composite.enforce_subop_policy` with
+    the vim method's canonical governance *op_id* (the ``METHOD:/path`` key
+    the ingest parser emits from ``vi-json.yaml``, e.g.
+    ``POST:/VirtualMachine/{moId}/ReconfigVM_Task``) and the sub-op's full
+    logical *params* (so the durable
+    :class:`~meho_backplane.db.models.ApprovalRequest` names the entity the
+    write touches) under the shared ``dangerous`` /
+    ``requires_approval=False`` posture.
+
+    When the seam returns a result (``awaiting_approval`` / ``denied``) the
+    vmomi write is **not** issued -- the ``(gate, None)`` tuple signals the
+    caller to return that :class:`OperationResult` verbatim, so a
+    policy-denied vmomi write never reaches the wire. When the seam clears
+    the gate (``None``), the method is POSTed through
+    :meth:`~meho_backplane.connectors.vmware_rest.connector.VmwareRestConnector._post_vmomi_json`
+    (which mounts it on the documented VI-JSON base ``/sdk/vim25/{release}``,
+    single ``/api`` fallback) and the parsed payload -- for a ``*_Task``
+    method, the returned Task :class:`ManagedObjectReference` -- rides back
+    as ``(None, payload)``. Transport failures raise :exc:`httpx.HTTPError`
+    for the caller.
+
+    ``vmomi_path`` is the concrete spec-relative method path (moId
+    substituted, e.g. ``/VirtualMachine/vm-1/ReconfigVM_Task``); ``op_id``
+    is the placeholder governance key so a per-``(principal, op, target)``
+    grant matches regardless of which VM the write targets.
+    """
+    gate = await enforce_subop_policy(
+        operator=operator,
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        safety_level=_WRITE_SAFETY_LEVEL,
+        requires_approval=_WRITE_REQUIRES_APPROVAL,
+        target=target,
+        params=params,
+    )
+    if gate is not None:
+        return gate, None
+    payload = await connector._post_vmomi_json(target, vmomi_path, operator=operator, json=body)
     return None, payload
 
 
@@ -1354,4 +1469,283 @@ async def cluster_patch_composite(
         "failed_host": None,
         "remaining_hosts": [],
         "failure_reason": None,
+    }
+
+
+# ===========================================================================
+# vm.disk.grow (VI-JSON write substrate — keystone 2, #2893)
+# ===========================================================================
+#
+# The first *mutating* VI-JSON composite. Growing a virtual disk has no
+# REST path — the pinned 9.0 spec's ``Disk.UpdateSpec`` carries only
+# ``backing`` (no capacity field, spec-verified), so ``ReconfigVM_Task``
+# is the sole route. The write rides the same governed direct-session seam
+# the REST writes do (:func:`_write_vmomi_sub_op` → the #2254 gate), and
+# the returned ``*_Task`` MoRef is driven to a terminal state via the
+# shared :func:`~meho_backplane.connectors.vmware_rest.vim_task.poll_vim_task`
+# helper before success is reported. Tasks D (#2894 clone) and E (#2895
+# DRS-rule) ride the same two seams.
+
+
+def _coerce_int(value: Any) -> int | None:
+    """Coerce a JSON number / numeric-string to int; reject bools + junk.
+
+    ``VirtualDisk.capacityInBytes`` is ``xsd:long``; some intermediaries
+    render a 64-bit value as a JSON string. ``True`` is an ``int`` subclass
+    and must not read as ``1``.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _build_vm_devices_retrieve_params(vm_moid: str) -> dict[str, Any]:
+    """Build the ``RetrievePropertiesEx`` body reading a VM's device list.
+
+    A single ``PropertyFilterSpec`` scoped directly to the VirtualMachine
+    object requesting ``config.hardware.device`` -- the list of
+    ``VirtualDevice`` objects (disks, controllers, NICs, …), each carrying
+    its VI-JSON ``_typeName`` discriminator so the disk-grow handler can
+    pick the ``VirtualDisk`` out. The singleton ``propertyCollector`` moId
+    rides the path, so the body is only the method args (the shape the
+    typed reads send).
+    """
+    return {
+        "specSet": [
+            {
+                "propSet": [
+                    {"type": _VIRTUAL_MACHINE_MO_TYPE, "pathSet": [_PROP_CONFIG_HARDWARE_DEVICE]}
+                ],
+                "objectSet": [{"obj": {"type": _VIRTUAL_MACHINE_MO_TYPE, "value": vm_moid}}],
+            }
+        ],
+        "options": {},
+    }
+
+
+def _extract_vm_devices(retrieve_result: Any) -> list[Any]:
+    """Pull the ``config.hardware.device`` list off a RetrievePropertiesEx result."""
+    payload = _unwrap_value(retrieve_result)
+    objects = payload.get("objects", []) if isinstance(payload, dict) else payload
+    if not isinstance(objects, list):
+        return []
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        for prop in obj.get("propSet", []) or []:
+            if isinstance(prop, dict) and prop.get("name") == _PROP_CONFIG_HARDWARE_DEVICE:
+                val = prop.get("val")
+                return val if isinstance(val, list) else []
+    return []
+
+
+def _find_virtual_disk(devices: list[Any], disk_id: str) -> dict[str, Any] | None:
+    """Return the ``VirtualDisk`` device whose key matches *disk_id*, else ``None``.
+
+    The REST disk id (resource type ``com.vmware.vcenter.vm.hardware.Disk``)
+    is the string form of the vim ``VirtualDevice.key``, so the disk-grow
+    ``disk`` param selects the device by ``str(key)`` match. The
+    ``_typeName == "VirtualDisk"`` guard skips the controllers / NICs /
+    CD-ROMs sharing the same ``config.hardware.device`` list.
+    """
+    for dev in devices:
+        if not isinstance(dev, dict):
+            continue
+        if dev.get(_VMOMI_TYPE_NAME_KEY) != _VIRTUAL_DISK_TYPE:
+            continue
+        if str(dev.get("key")) == disk_id:
+            return dev
+    return None
+
+
+async def _resolve_disk_info(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    vm: str,
+    disk: str,
+) -> dict[str, Any]:
+    """Resolve the REST ``Disk.Info`` (label + current capacity bytes) for a disk.
+
+    Read-only single ``GET:/vcenter/vm/{vm}/hardware/disk/{disk}`` on the
+    connector session, shared by the disk-grow park-time preview
+    (:mod:`._write_preview`). ``Vcenter.Vm.Hardware.Disk.Info`` carries
+    ``label`` + ``capacity`` (bytes) -- the current-capacity half of the
+    from→to delta the approver decides on. Raises :exc:`httpx.HTTPError` on
+    a transport fault; the preview builder lets it propagate into the #1628
+    ``preview_unavailable`` marker (the delta is unknowable, so the park is
+    honest about it).
+    """
+    info = await _read_sub_op(
+        connector, target, operator, _OP_GET_VM_DISK, {"vm": vm, "disk": disk}
+    )
+    payload = _unwrap_value(info)
+    return payload if isinstance(payload, dict) else {}
+
+
+async def _resolve_vm_name(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    vm: str,
+) -> str | None:
+    """Best-effort VM display name via ``GET:/vcenter/vm/{vm}``.
+
+    Cosmetic for the disk-grow preview -- a transport fault nulls the name
+    rather than sinking the preview, since the current→requested delta (not
+    the name) is the decision. The disk read is the load-bearing one.
+    """
+    try:
+        info = await _read_sub_op(connector, target, operator, _OP_GET_VM, {"vm": vm})
+    except httpx.HTTPError:
+        return None
+    payload = _unwrap_value(info)
+    name = payload.get("name") if isinstance(payload, dict) else None
+    return name if isinstance(name, str) else None
+
+
+async def vm_disk_grow_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Grow a VM's virtual disk to ``capacity_bytes`` via ``ReconfigVM_Task``.
+
+    Op-id: ``vmware.composite.vm.disk.grow``. The proving op for the
+    mutating VI-JSON substrate (#2893): grow has no REST path
+    (``Disk.UpdateSpec`` has only ``backing``), so the capacity change goes
+    through vim ``VirtualMachine.ReconfigVM_Task`` — a single-device
+    ``VirtualDeviceConfigSpec`` with ``operation="edit"`` and the target
+    ``VirtualDisk``'s ``capacityInBytes`` raised (spec-verified against
+    ``vi-json.yaml``).
+
+    Flow:
+
+    1. Read the VM's ``config.hardware.device`` (vmomi ``RetrievePropertiesEx``,
+       a *read* — no governance gate) to obtain the full ``VirtualDisk``
+       device (the spec requires the edited device "fully specified") + its
+       current ``capacityInBytes``.
+    2. **Grow-only by contract**: a request ``<=`` the current capacity is
+       refused with ``status="invalid_shrink"`` *before* any write —
+       vSphere rejects a shrink anyway; fail early and legibly.
+    3. Issue the single ``ReconfigVM_Task`` edit through the governed vmomi
+       write seam (:func:`_write_vmomi_sub_op` → the #2254 gate); a
+       parked/denied gate returns the :class:`OperationResult` verbatim and
+       no reconfigure fires.
+    4. Poll the returned ``*_Task`` MoRef to a terminal state via the shared
+       :func:`~meho_backplane.connectors.vmware_rest.vim_task.poll_vim_task`
+       helper before reporting success. A task fault raises (the dispatcher
+       wraps it ``connector_error``, mirroring ``vm.clone``); a poll timeout
+       returns ``status="timeout"`` with the task id for the operator.
+    """
+    vm_moid = params["vm"]
+    disk_id = params["disk"]
+    requested = int(params["capacity_bytes"])
+
+    devices_result = await connector._post_vmomi_json(
+        target,
+        _VMOMI_RETRIEVE_PROPERTIES_PATH,
+        operator=operator,
+        json=_build_vm_devices_retrieve_params(vm_moid),
+    )
+    device = _find_virtual_disk(_extract_vm_devices(devices_result), disk_id)
+    current = _coerce_int(device.get("capacityInBytes")) if device is not None else None
+    if device is None or current is None:
+        return {
+            "status": "disk_not_found",
+            "vm": vm_moid,
+            "disk": disk_id,
+            "task": None,
+            "from_capacity_bytes": current,
+            "to_capacity_bytes": requested,
+            "delta_bytes": None,
+            "guidance": (
+                f"no VirtualDisk with key {disk_id!r} (or no readable capacity) on "
+                f"vm {vm_moid!r}; list the VM's disks to confirm the disk id"
+            ),
+        }
+
+    delta = requested - current
+    if requested <= current:
+        return {
+            "status": "invalid_shrink",
+            "vm": vm_moid,
+            "disk": disk_id,
+            "task": None,
+            "from_capacity_bytes": current,
+            "to_capacity_bytes": requested,
+            "delta_bytes": delta,
+            "guidance": (
+                "vm.disk.grow is grow-only: requested capacity "
+                f"{requested} <= current {current} (delta {delta}). vSphere rejects "
+                "a disk shrink; re-issue with a capacity greater than the current size"
+            ),
+        }
+
+    reconfig_spec = {
+        "spec": {
+            "deviceChange": [
+                {"operation": "edit", "device": {**device, "capacityInBytes": requested}}
+            ]
+        }
+    }
+    gate, task_payload = await _write_vmomi_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_RECONFIG_VM_TASK,
+        vmomi_path=f"/VirtualMachine/{vm_moid}/ReconfigVM_Task",
+        body=reconfig_spec,
+        params={"vm": vm_moid, "disk": disk_id, "capacity_bytes": requested},
+    )
+    if gate is not None:
+        return gate
+
+    outcome = await poll_vim_task(
+        connector,
+        target,
+        operator,
+        task=_unwrap_value(task_payload),
+        timeout_seconds=_DISK_GROW_TASK_TIMEOUT_SECONDS,
+    )
+    if outcome.state == "error":
+        raise RuntimeError(
+            f"vm.disk.grow: ReconfigVM_Task on vm {vm_moid!r} disk {disk_id!r} faulted: "
+            f"{outcome.error_message or '<no fault reported>'}"
+        )
+    if outcome.timed_out:
+        return {
+            "status": "timeout",
+            "vm": vm_moid,
+            "disk": disk_id,
+            "task": outcome.task,
+            "from_capacity_bytes": current,
+            "to_capacity_bytes": requested,
+            "delta_bytes": delta,
+            "guidance": (
+                f"ReconfigVM_Task {outcome.task} did not reach a terminal state within "
+                f"{int(_DISK_GROW_TASK_TIMEOUT_SECONDS)}s; poll the task or re-read the disk "
+                "capacity — the grow may still complete in the background"
+            ),
+        }
+    return {
+        "status": "grown",
+        "vm": vm_moid,
+        "disk": disk_id,
+        "task": outcome.task,
+        "from_capacity_bytes": current,
+        "to_capacity_bytes": requested,
+        "delta_bytes": delta,
+        "guidance": None,
     }

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` preview builders for the 9 vmware write composites.
+"""Park-time ``proposed_effect`` preview builders for the 10 vmware write composites.
 
 G0.22-T3 (#1608). Before this module, a parked ``vmware.composite.*``
 write stored only the identifier default ``{op_id, connector_id,
@@ -9,7 +9,7 @@ target_id}`` in :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect
 — and because the original dispatch ``params`` are deliberately never
 serialised onto a reviewer-facing surface (#1503), the four-eyes
 approver could not tell a one-VM power cycle from a 1000-VM outage.
-This wires all 9 write composites onto the per-op preview hook shipped
+This wires all 10 write composites onto the per-op preview hook shipped
 by #1437 (:mod:`meho_backplane.operations._preview`), following the
 argocd pattern (#1452): reuse the handlers' own read-only resolution
 helpers, never the mutating sub-ops.
@@ -28,6 +28,9 @@ helpers, never the mutating sub-ops.
 ``vm.snapshot.revert``    echo: vm, snapshot_name
 ``vm.migrate``            echo: vm, cluster, target_host + resolution source
 ``vm.power``              echo: vm, verb, power_kind (hard vs Tools-soft)
+``vm.disk.grow``          live-read: vm, name, disk, disk_label,
+                          current_capacity_bytes, requested_capacity_bytes,
+                          delta_bytes
 ========================  ====================================================
 
 Two preview depths, chosen per composite
@@ -40,7 +43,12 @@ Two preview depths, chosen per composite
   (:func:`._write._resolve_vm_list` / :func:`._write._resolve_cluster_hosts`),
   so the reviewer sees the resolved entity list (capped at
   :data:`_PREVIEW_RESOLVED_CAP`, with ``total_resolved`` carrying the
-  uncapped count).
+  uncapped count). ``vm.disk.grow`` is also a live-read builder, but
+  single-entity: the decision is the *from→to capacity delta*, and the
+  current capacity is a live vCenter read (:func:`._write._resolve_disk_info`),
+  not a param — so the preview reads the disk's current size + label and
+  echoes the requested capacity so the approver sees the disk grows (never
+  shrinks) and by how much.
 * **Param echo** (no I/O — the ``secret.move`` precedent, #1580) for the
   five single-entity composites whose params fully name the blast
   radius. ``vm.power`` additionally echoes ``power_kind`` so the approver
@@ -74,11 +82,12 @@ Redaction posture
 
 The whole-builder ``classify_op`` gate runs in
 :func:`~meho_backplane.operations._preview.build_proposed_effect` before
-any builder fires: the 9 op_ids classify as ``write`` (``.create`` /
-``.patch`` suffixes) or ``other`` — none is a credential class, so none
-is suppressed. The previews themselves carry only vSphere inventory
-identity (moids, display names, power states) and the operator's own
-dispatch params — infrastructure topology, never credential material.
+any builder fires: the 10 op_ids classify as ``write`` (``.create`` /
+``.patch`` suffixes) or ``other`` (``vm.disk.grow`` — ``.grow`` is not a
+write suffix) — none is a credential class, so none is suppressed. The
+previews themselves carry only vSphere inventory identity (moids, display
+names, power states, disk capacities) and the operator's own dispatch
+params — infrastructure topology, never credential material.
 
 Fail-soft: every builder either declines (``None`` → identifier-only
 default) on malformed params or lets resolution faults propagate into
@@ -96,7 +105,9 @@ from typing import Any
 from meho_backplane.connectors.vmware_rest.composites._write import (
     _GUEST_POWER_VERBS,
     _resolve_cluster_hosts,
+    _resolve_disk_info,
     _resolve_vm_list,
+    _resolve_vm_name,
 )
 from meho_backplane.operations._preview import (
     PreviewBuilder,
@@ -339,7 +350,63 @@ async def _vm_power_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     }
 
 
-#: op_id → builder for the 9 write composites. Module-level so the
+async def _vm_disk_grow_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.disk.grow`` — live-read the current→requested capacity delta.
+
+    The delta *is* the decision: the reviewer must see that the disk grows
+    (never shrinks) and by how much. Reads the REST ``Disk.Info`` for the
+    disk's ``label`` + current ``capacity`` (bytes) — the load-bearing read,
+    shared with the handler-family via :func:`._write._resolve_disk_info` —
+    and best-effort the VM display name, then echoes the requested capacity
+    and the computed ``delta_bytes``. A failing disk read propagates into
+    the #1628 ``preview_unavailable`` marker (the delta is unknowable, so
+    the park is honest about it rather than showing a bare identifier). The
+    per-VM ``ReconfigVM_Task`` write never fires here. Declines (``None``)
+    without a resolved connector or on malformed params.
+    """
+    vm = ctx.params.get("vm")
+    disk = ctx.params.get("disk")
+    capacity_bytes = ctx.params.get("capacity_bytes")
+    if (
+        not isinstance(vm, str)
+        or not isinstance(disk, str)
+        or not isinstance(capacity_bytes, int)
+        or isinstance(capacity_bytes, bool)
+        or ctx.connector_instance is None
+    ):
+        return None
+    disk_info = await _resolve_disk_info(
+        ctx.connector_instance,  # type: ignore[arg-type]
+        ctx.target,
+        ctx.operator,
+        vm=vm,
+        disk=disk,
+    )
+    raw_capacity = disk_info.get("capacity")
+    current_bytes = (
+        raw_capacity
+        if isinstance(raw_capacity, int) and not isinstance(raw_capacity, bool)
+        else None
+    )
+    name = await _resolve_vm_name(
+        ctx.connector_instance,  # type: ignore[arg-type]
+        ctx.target,
+        ctx.operator,
+        vm=vm,
+    )
+    label = disk_info.get("label")
+    return {
+        "vm": vm,
+        "name": name,
+        "disk": disk,
+        "disk_label": label if isinstance(label, str) else None,
+        "current_capacity_bytes": current_bytes,
+        "requested_capacity_bytes": capacity_bytes,
+        "delta_bytes": (capacity_bytes - current_bytes if current_bytes is not None else None),
+    }
+
+
+#: op_id → builder for the 10 write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.create": _vm_create_preview,
@@ -348,6 +415,7 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.migrate": _vm_migrate_preview,
     "vmware.composite.vm.power": _vm_power_preview,
     "vmware.composite.vm.power.bulk": _vm_power_bulk_preview,
+    "vmware.composite.vm.disk.grow": _vm_disk_grow_preview,
     "vmware.composite.host.evacuate": _host_evacuate_preview,
     "vmware.composite.host.detach_from_vds": _host_detach_from_vds_preview,
     "vmware.composite.cluster.patch": _cluster_patch_preview,
@@ -355,7 +423,7 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 9 write-composite park-time preview builders. Import-time.
+    """Wire the 10 write-composite park-time preview builders. Import-time.
 
     The 5 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -25,9 +25,10 @@ Conventions
   schema verbatim on ``describe_operation`` calls.
 * The 5 read composites are read-only -- the registration call site
   pins ``safety_level="safe"`` and ``requires_approval=False`` on
-  each. The 9 write composites inherit T4's
+  each. The 10 write composites inherit T4's
   ``safety_level="dangerous"`` + ``requires_approval=True`` defaults
-  (G3.1-T6 / #509, plus single-VM ``vm.power`` / #2301). The schema
+  (G3.1-T6 / #509, single-VM ``vm.power`` / #2301, and the mutating
+  VI-JSON ``vm.disk.grow`` / #2893). The schema
   text reflects which side of that line
   each composite sits on; the registration call site enforces the
   policy.
@@ -59,6 +60,8 @@ __all__ = [
     "VM_CLONE_RESPONSE_SCHEMA",
     "VM_CREATE_PARAMETER_SCHEMA",
     "VM_CREATE_RESPONSE_SCHEMA",
+    "VM_DISK_GROW_PARAMETER_SCHEMA",
+    "VM_DISK_GROW_RESPONSE_SCHEMA",
     "VM_MIGRATE_PARAMETER_SCHEMA",
     "VM_MIGRATE_RESPONSE_SCHEMA",
     "VM_POWER_BULK_PARAMETER_SCHEMA",
@@ -550,7 +553,7 @@ NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA: dict[str, Any] = {
 # Write composites (G3.1-T6 / #509)
 # ===========================================================================
 #
-# The 9 write composites inherit T4's ``safety_level="dangerous"`` +
+# The 10 write composites inherit T4's ``safety_level="dangerous"`` +
 # ``requires_approval=True`` defaults. The registrar passes those
 # explicitly anyway to keep the policy posture obvious at the call site
 # alongside the read overrides.
@@ -908,6 +911,48 @@ CLUSTER_PATCH_PARAMETER_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["cluster"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.disk.grow`` parameter schema.
+#:
+#: Grow-only virtual-disk capacity change via vim ``ReconfigVM_Task`` (the
+#: pinned 9.0 REST spec's ``Disk.UpdateSpec`` carries only ``backing`` — no
+#: capacity field, so vim is the sole write path). A request ``<=`` the
+#: current capacity is refused (``status="invalid_shrink"``) before any
+#: write. ``disk`` is the REST disk id (== the vim ``VirtualDevice.key``).
+VM_DISK_GROW_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Managed-object ID of the VM owning the disk (e.g. 'vm-42').",
+        },
+        "disk": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Virtual disk identifier — the REST "
+                "``com.vmware.vcenter.vm.hardware.Disk`` id, which is the "
+                "string form of the vim ``VirtualDevice.key`` (e.g. '2000'). "
+                "The handler matches it against the VM's "
+                "``config.hardware.device`` list to select the VirtualDisk to edit."
+            ),
+        },
+        "capacity_bytes": {
+            "type": "integer",
+            "minimum": 1,
+            "description": (
+                "Requested new disk capacity in bytes. Grow-only: a value "
+                "less than or equal to the disk's current capacity is refused "
+                "with ``status='invalid_shrink'`` before any reconfigure is "
+                "issued (vSphere rejects a shrink)."
+            ),
+        },
+    },
+    "required": ["vm", "disk", "capacity_bytes"],
     "additionalProperties": False,
 }
 
@@ -1301,4 +1346,58 @@ CLUSTER_PATCH_RESPONSE_SCHEMA: dict[str, Any] = {
         "patched_hosts",
         "remaining_hosts",
     ],
+}
+
+
+#: ``vmware.composite.vm.disk.grow`` response schema.
+VM_DISK_GROW_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["grown", "invalid_shrink", "disk_not_found", "timeout"],
+            "description": (
+                "``'grown'`` — the ReconfigVM_Task edit reached terminal "
+                "success; ``'invalid_shrink'`` — the requested capacity was "
+                "``<=`` the current size (refused before any write); "
+                "``'disk_not_found'`` — no VirtualDisk with the given key (or "
+                "no readable capacity) on the VM; ``'timeout'`` — the "
+                "reconfigure task did not reach a terminal state within the "
+                "poll bound (it may still complete in the background)."
+            ),
+        },
+        "vm": {"type": "string", "description": "VM moid the disk belongs to."},
+        "disk": {"type": "string", "description": "Disk id (== vim device key) the grow targeted."},
+        "task": {
+            "type": ["string", "null"],
+            "description": (
+                "ReconfigVM_Task moid — present once the write was issued "
+                "(``grown`` / ``timeout``); ``null`` on the pre-write refusals."
+            ),
+        },
+        "from_capacity_bytes": {
+            "type": ["integer", "null"],
+            "description": (
+                "The disk's capacity in bytes before the grow; ``null`` on ``disk_not_found``."
+            ),
+        },
+        "to_capacity_bytes": {
+            "type": "integer",
+            "description": "The requested capacity in bytes.",
+        },
+        "delta_bytes": {
+            "type": ["integer", "null"],
+            "description": (
+                "``to_capacity_bytes - from_capacity_bytes`` (positive on a "
+                "grow, ``<= 0`` on ``invalid_shrink``); ``null`` on ``disk_not_found``."
+            ),
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Operator-facing next-step hint on a non-``grown`` status; ``null`` on a grow."
+            ),
+        },
+    },
+    "required": ["status", "vm", "disk", "to_capacity_bytes"],
 }

--- a/backend/src/meho_backplane/connectors/vmware_rest/vim_task.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/vim_task.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Reusable vim ``*_Task`` poll-to-terminal-state helper (#2893).
+
+Every vim (VI-JSON / SOAP-semantics) mutating method that vCenter models
+as long-running returns a ``Task`` :class:`ManagedObjectReference` rather
+than the finished result -- ``VirtualMachine.ReconfigVM_Task``,
+``VirtualMachine.CloneVM_Task`` (Task D / #2894),
+``ClusterComputeResource.ReconfigureComputeResource_Task`` (Task E /
+#2895). The caller must then poll the returned Task's ``info`` property
+until it reaches a terminal state (``success`` / ``error``) before
+declaring the write done. This module is the single, reusable poll seam
+those write composites share.
+
+It generalises the one-shot ``Task.info`` read already present in
+:mod:`~meho_backplane.connectors.vmware_rest.typed_ops_tasks_recent`
+(``vmware.tasks.recent`` reads ``TaskManager.recentTask`` then
+``Task.info`` once) into a *poll loop*: it reuses that module's public
+:func:`~meho_backplane.connectors.vmware_rest.typed_ops_tasks_recent.build_task_info_retrieve_params`
+request builder, re-reads ``Task.info`` through
+:meth:`VmwareRestConnector._post_vmomi_json` on a fixed cadence, and
+returns once the task is terminal or the wall-clock deadline elapses.
+
+Poll semantics
+--------------
+
+* **success** -- ``TaskInfo.state == "success"``; the
+  :class:`VimTaskResult` carries ``TaskInfo.result`` (e.g. the new VM
+  MoRef a ``CloneVM_Task`` produced) so the caller can thread it forward.
+* **error** -- ``TaskInfo.state == "error"``; the result carries the
+  localized fault message (``TaskInfo.error.localizedMessage``). The poll
+  helper does **not** raise on a task fault -- it returns the outcome so
+  each caller maps it to its own status envelope (a disk-grow fault and a
+  clone fault surface differently).
+* **timeout** -- the deadline elapsed before a terminal state; the result
+  carries the last-observed progress. The task itself may still complete
+  in the background -- the wall-clock bound mirrors the 600 s convention
+  ``vm.clone``'s ``GET:/cis/tasks/{task}`` poll established.
+
+The bound is wall-clock, not iteration-count: a poll that observes
+``queued`` / ``running`` sleeps ``poll_interval`` and re-reads until the
+deadline. The helper is transport-fault-transparent -- an
+:exc:`httpx.HTTPError` from the ``Task.info`` read propagates to the
+caller (a load-bearing failure the dispatcher wraps as
+``connector_error``), it is not swallowed as "still running".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from meho_backplane.connectors.vmware_rest.typed_ops import _unwrap_value
+from meho_backplane.connectors.vmware_rest.typed_ops_tasks_recent import (
+    build_task_info_retrieve_params,
+)
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
+    from meho_backplane.connectors.vmware_rest.session import VsphereTargetLike
+
+__all__ = [
+    "TASK_STATE_ERROR",
+    "TASK_STATE_SUCCESS",
+    "VimTaskResult",
+    "poll_vim_task",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The vim ``RetrievePropertiesEx`` method path (the PropertyCollector
+#: singleton moId rides the path, so the body is just the method args) --
+#: the same path the typed reads and vi-json read composites POST through
+#: :meth:`VmwareRestConnector._post_vmomi_json`.
+_RETRIEVE_PROPERTIES_PATH = "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+
+_PROP_INFO = "info"
+
+#: Terminal ``TaskInfoState`` enum values (vim25 wire contract). ``queued``
+#: / ``running`` are the non-terminal states the poll loop waits through.
+TASK_STATE_SUCCESS = "success"
+TASK_STATE_ERROR = "error"
+_TERMINAL_STATES: frozenset[str] = frozenset({TASK_STATE_SUCCESS, TASK_STATE_ERROR})
+
+#: Poll-outcome sentinel the helper stamps when the deadline elapsed before
+#: the task reached a terminal state. Not a vim ``TaskInfoState`` value --
+#: the task is still ``queued`` / ``running`` server-side.
+_OUTCOME_TIMEOUT = "timeout"
+
+#: Default wall-clock bound + cadence. 600 s mirrors the ``vm.clone``
+#: ``GET:/cis/tasks/{task}`` poll convention; a 2 s cadence keeps a fast
+#: reconfigure responsive without hammering ``Task.info``.
+_DEFAULT_TIMEOUT_SECONDS = 600.0
+_DEFAULT_POLL_INTERVAL = 2.0
+
+
+@dataclass(frozen=True)
+class VimTaskResult:
+    """Terminal (or timed-out) outcome of polling a vim ``*_Task`` MoRef.
+
+    Attributes:
+        task: The polled Task moid.
+        state: ``"success"`` / ``"error"`` (terminal vim ``TaskInfoState``)
+            or ``"timeout"`` (the poll deadline elapsed first).
+        result: ``TaskInfo.result`` on success -- e.g. the new VM MoRef a
+            ``CloneVM_Task`` produced. ``None`` on error / timeout, and on a
+            success whose task produces no result (``ReconfigVM_Task``).
+        error_message: The localized fault message
+            (``TaskInfo.error.localizedMessage``) on error; ``None``
+            otherwise.
+        progress: Last-observed ``TaskInfo.progress`` (0-100) -- present on
+            a timeout so the caller can report how far the background task
+            got.
+    """
+
+    task: str
+    state: str
+    result: Any = None
+    error_message: str | None = None
+    progress: int | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        """``True`` iff the task reached the terminal ``success`` state."""
+        return self.state == TASK_STATE_SUCCESS
+
+    @property
+    def timed_out(self) -> bool:
+        """``True`` iff the poll deadline elapsed before a terminal state."""
+        return self.state == _OUTCOME_TIMEOUT
+
+
+def task_moref_value(task: Any) -> str | None:
+    """Return the Task moid from a vim MoRef, a bare moid, or ``None``.
+
+    A vim ``ManagedObjectReference`` -- what a ``*_Task`` method returns --
+    serialises as ``{"type": "Task", "value": "task-42"}`` (optionally with
+    a ``_typeName`` discriminator). A bare moid string is tolerated so a
+    caller that already unwrapped the MoRef can pass it straight through.
+    """
+    if isinstance(task, dict):
+        value = task.get("value")
+        return value if isinstance(value, str) else None
+    return task if isinstance(task, str) else None
+
+
+def _extract_task_info(retrieve_result: Any, task_moid: str) -> dict[str, Any] | None:
+    """Pull the raw ``TaskInfo`` for *task_moid* out of a RetrievePropertiesEx result.
+
+    ``RetrievePropertiesEx`` returns a ``RetrieveResult`` whose ``objects``
+    list carries one ``ObjectContent`` per queried object, each with a
+    ``propSet`` list of ``{name, val}`` pairs. The poll queries exactly one
+    Task, so the matching object's ``info`` propSet holds the ``TaskInfo``.
+    Matches the object by moid when the ``obj`` MoRef is present, else falls
+    back to the first object's ``info`` (single-object query). Returns
+    ``None`` when the property is absent -- the caller treats that as "not
+    terminal yet", never an exception.
+    """
+    payload = _unwrap_value(retrieve_result)
+    objects = payload.get("objects", []) if isinstance(payload, dict) else payload
+    if not isinstance(objects, list):
+        return None
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        obj_moid = task_moref_value(obj.get("obj"))
+        if obj_moid is not None and obj_moid != task_moid:
+            continue
+        for prop in obj.get("propSet", []) or []:
+            if isinstance(prop, dict) and prop.get("name") == _PROP_INFO:
+                val = prop.get("val")
+                return val if isinstance(val, dict) else None
+    return None
+
+
+def _fault_message(info: dict[str, Any]) -> str | None:
+    """Return the localized fault message from a faulted ``TaskInfo``."""
+    error = info.get("error")
+    if not isinstance(error, dict):
+        return None
+    localized = error.get("localizedMessage")
+    return localized if isinstance(localized, str) else None
+
+
+def _progress(info: dict[str, Any]) -> int | None:
+    """Return ``TaskInfo.progress`` as an int, else ``None``."""
+    value = info.get("progress")
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+async def poll_vim_task(
+    connector: VmwareRestConnector,
+    target: VsphereTargetLike,
+    operator: Operator,
+    *,
+    task: Any,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+    poll_interval: float = _DEFAULT_POLL_INTERVAL,
+) -> VimTaskResult:
+    """Poll a vim ``*_Task`` MoRef's ``Task.info`` to a terminal state.
+
+    Reads ``Task.info`` through :meth:`VmwareRestConnector._post_vmomi_json`
+    (mounted on the documented VI-JSON base ``/sdk/vim25/{release}``) on a
+    ``poll_interval`` cadence until ``TaskInfo.state`` is ``success`` /
+    ``error`` or the ``timeout_seconds`` wall-clock deadline elapses.
+    Returns the :class:`VimTaskResult` outcome -- it never raises on a task
+    *fault* (that is a legible outcome each caller maps to its own status),
+    only propagates a transport :exc:`httpx.HTTPError` from the read.
+
+    ``task`` may be the vim MoRef the ``*_Task`` method returned
+    (``{"type": "Task", "value": "task-42"}``) or a bare moid string. A
+    MoRef the helper cannot resolve to a moid raises :exc:`ValueError` --
+    the caller passed a shape that is not a Task reference.
+
+    Parameters
+    ----------
+    task:
+        The Task MoRef (or moid) to poll.
+    timeout_seconds:
+        Wall-clock bound. On elapse the result's ``state`` is ``"timeout"``
+        and the task may still complete in the background. Defaults to the
+        600 s ``vm.clone`` convention.
+    poll_interval:
+        Seconds between ``Task.info`` reads while the task is non-terminal.
+        Tests pass ``0.0`` for an instant loop.
+    """
+    task_moid = task_moref_value(task)
+    if task_moid is None:
+        raise ValueError(
+            f"poll_vim_task: expected a Task MoRef or moid, got {type(task).__name__}: {task!r}"
+        )
+    retrieve_body = build_task_info_retrieve_params([task_moid])
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        retrieve_result = await connector._post_vmomi_json(
+            target,
+            _RETRIEVE_PROPERTIES_PATH,
+            operator=operator,
+            json=retrieve_body,
+        )
+        info = _extract_task_info(retrieve_result, task_moid)
+        state = info.get("state") if isinstance(info, dict) else None
+        if info is not None and state in _TERMINAL_STATES:
+            succeeded = state == TASK_STATE_SUCCESS
+            _log.info(
+                "vim_task_terminal",
+                target=getattr(target, "name", None),
+                task=task_moid,
+                state=state,
+            )
+            return VimTaskResult(
+                task=task_moid,
+                state=state,
+                result=info.get("result") if succeeded else None,
+                error_message=None if succeeded else _fault_message(info),
+                progress=_progress(info),
+            )
+        if time.monotonic() >= deadline:
+            _log.warning(
+                "vim_task_poll_timeout",
+                target=getattr(target, "name", None),
+                task=task_moid,
+                timeout_seconds=timeout_seconds,
+            )
+            return VimTaskResult(
+                task=task_moid,
+                state=_OUTCOME_TIMEOUT,
+                progress=_progress(info) if isinstance(info, dict) else None,
+            )
+        await asyncio.sleep(poll_interval)

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""op_id reconciliation between the 9 write composites and the ingest pipeline.
+"""op_id reconciliation between the write composites and the ingest pipeline.
 
-G3.16-T1 (#1414). The 8 vmware-rest write composites each declare the L2
-sub-ops they dispatch into via ``_SUB_OPS_*`` tuples in
-:mod:`~meho_backplane.connectors.vmware_rest.composites._write`. At
+G3.16-T1 (#1414). The 9 REST-sub-op vmware-rest write composites each
+declare the L2 sub-ops they dispatch into via ``_SUB_OPS_*`` tuples in
+:mod:`~meho_backplane.connectors.vmware_rest.composites._write`; the tenth
+write composite, ``vm.disk.grow`` (#2893), dispatches into vi-json instead
+and declares its sub-ops in ``_VIM_SUB_OPS_VM_DISK_GROW`` (reconciled in the
+dedicated vi-json section at the end of this module). At
 dispatch time :func:`~...composites._preflight.preflight_l2_dependencies`
 looks each sub-op_id up in ``endpoint_descriptor`` and raises
 :class:`~meho_backplane.operations.composite.CompositeL2DependencyMissing`
@@ -52,10 +55,12 @@ from typing import Any
 from unittest.mock import patch
 
 import httpx
+import pytest
 import respx
 
 from meho_backplane.connectors.vmware_rest.composites import _write
 from meho_backplane.operations.ingest import parse_openapi
+from tests.acceptance._vcenter_spec import VCENTER_SPEC_REASON, resolve_vi_json_yaml
 
 # Public IP returned by the mock getaddrinfo for specs.example.test.
 _PUBLIC_TEST_IP = "93.184.216.34"
@@ -74,7 +79,12 @@ _GETADDRINFO_PATCH = patch(
 
 
 def _required_raw_sub_op_ids() -> set[str]:
-    """Union of every ``_SUB_OPS_*`` op_id across the 9 write composites.
+    """Union of every ``_SUB_OPS_*`` op_id across the 9 REST write composites.
+
+    ``vm.disk.grow``'s vi-json sub-ops live in ``_VIM_SUB_OPS_VM_DISK_GROW``
+    (a distinct namespace this ``_SUB_OPS_*`` sweep deliberately skips), so
+    a vcenter.yaml-shaped fixture never has to model a vi-json path; the
+    vi-json section at the end of this module reconciles them separately.
 
     Excludes composite-to-composite references (``vmware.composite.*``):
     those are not ``endpoint_descriptor`` rows and the pre-flight walk
@@ -227,3 +237,93 @@ def test_action_discriminated_sub_ops_keep_query_suffix_through_ingest() -> None
     assert action_op_ids <= ingested_op_ids
     # And no op_id lost its query suffix (proves no stripping).
     assert all("?action=" in op_id for op_id in ingested_op_ids)
+
+
+# ---------------------------------------------------------------------------
+# vm.disk.grow VI-JSON sub-op reconciliation (#2893)
+# ---------------------------------------------------------------------------
+#
+# vm.disk.grow's mutating path is vi-json, not vcenter REST:
+# ``POST:/VirtualMachine/{moId}/ReconfigVM_Task`` (the capacity edit) plus
+# its config read ``POST:/PropertyCollector/propertyCollector/RetrievePropertiesEx``.
+# These are declared in ``_write._VIM_SUB_OPS_VM_DISK_GROW`` (deliberately
+# NOT in the ``_SUB_OPS_*`` namespace, so the vcenter.yaml sweep above skips
+# them). vi-json keys its path items the same ``METHOD:/path`` way vcenter
+# does — the moId rides the path as ``{moId}`` — so the same reconciliation
+# proof applies, and it is additionally checked against the pinned
+# ``vi-json.yaml`` when the spec-shelf is configured.
+
+
+def test_vm_disk_grow_vi_json_sub_op_manifest_is_the_expected_pair() -> None:
+    """Pin the disk-grow vi-json manifest so a drift can't shrink the reconcile."""
+    assert set(_write._VIM_SUB_OPS_VM_DISK_GROW) == {
+        "POST:/VirtualMachine/{moId}/ReconfigVM_Task",
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+    }
+
+
+def test_vm_disk_grow_vi_json_sub_ops_round_trip_through_ingest() -> None:
+    """The disk-grow vi-json op_ids are byte-for-byte what the parser emits.
+
+    Proves the ``METHOD:/path`` op_id strings the composite gates on match
+    what ``parse_openapi`` produces from a vi-json-shaped spec (the ``{moId}``
+    path template survives), so ``enforce_subop_policy``'s op_id / a grant's
+    op_pattern resolve against the ingested rows once the operator ingests
+    ``vi-json.yaml`` — the vi-json analogue of the vcenter reconcile above.
+    """
+    required = set(_write._VIM_SUB_OPS_VM_DISK_GROW)
+    spec = _build_vcenter_fixture(required)
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vi-json.yaml"
+
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200, content=spec_bytes, headers={"content-type": "application/json"}
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+    ingested_op_ids = {row.op_id for row in rows}
+    assert required <= ingested_op_ids
+
+
+def _vi_json_path_item_has_post(spec_text: str, path: str) -> bool:
+    """Whether *path* is a top-level ``paths`` item with a POST operation.
+
+    Line-scans rather than parsing the ~10 MB YAML: a path item is keyed at
+    2-space indent (``  /VirtualMachine/{moId}/ReconfigVM_Task:``); its
+    operations sit under it at 4-space indent (``    post:``); the item ends
+    at the next 2-space key. Precise (path keys are unique) and cheap.
+    """
+    lines = spec_text.splitlines()
+    key = f"  {path}:"
+    try:
+        start = lines.index(key)
+    except ValueError:
+        return False
+    for line in lines[start + 1 :]:
+        if line.startswith("  ") and not line.startswith("   "):
+            break  # next 2-indent key — end of this path item
+        if line.strip() == "post:":
+            return True
+    return False
+
+
+def test_vm_disk_grow_vi_json_paths_exist_in_the_pinned_spec() -> None:
+    """Each disk-grow vi-json sub-op path is a real POST path in the pinned vi-json.yaml.
+
+    The definitive #2893 grounding: the connector's first mutating VI-JSON
+    call must target paths that actually exist in the pinned spec. Skips
+    when the spec-shelf is not configured (the canary's convention), so CI —
+    where the env vars are wired — is the operator-visible signal.
+    """
+    spec_path = resolve_vi_json_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    spec_text = spec_path.read_text(encoding="utf-8")
+    for op_id in _write._VIM_SUB_OPS_VM_DISK_GROW:
+        _, _, path = op_id.partition(":")
+        assert _vi_json_path_item_has_post(spec_text, path), (
+            f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
+            "disk-grow vi-json sub-op targets a path the spec does not serve"
+        )

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -175,11 +175,11 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 14 total: 5 reads
-    # (T5 #508) + 9 writes (T6 #509 + single-VM vm.power #2301). (The
-    # former host.network_uplinks / host.vsan_health reads were re-shipped
-    # as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 14
+    # Embedding service called once per composite -- 15 total: 5 reads
+    # (T5 #508) + 10 writes (T6 #509 + single-VM vm.power #2301 + mutating
+    # VI-JSON vm.disk.grow #2893). (The former host.network_uplinks /
+    # host.vsan_health reads were re-shipped as typed ops in #2258.)
+    assert stub_embedding_service.encode_one.call_count == 15
 
 
 @pytest.mark.asyncio
@@ -426,16 +426,16 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 5 read rows persist; embedding stays at 14.
+    """Running the registrar twice -> 5 read rows persist; embedding stays at 15.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (5 reads + 9 writes / T6 +
-    single-VM vm.power #2301).
+    persist after the combined registrar (5 reads + 10 writes / T6 +
+    single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 14
+    assert first_count == 15
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Unit tests for the 9 vmware-rest write-composite handler functions.
+"""Unit tests for the 10 vmware-rest write-composite handler functions.
 
 Post-#2256 the write composites dispatch their sub-ops **directly on the
 connector session** -- ``connector._get_json`` / ``connector._post_json``
@@ -37,14 +37,19 @@ respx-transport parity proof lives in
 
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass, field
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
+import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.connectors.vmware_rest import VmwareRestConnector
 from meho_backplane.connectors.vmware_rest._mount import adapt_filter_params
 from meho_backplane.connectors.vmware_rest.composites import _write
 from meho_backplane.connectors.vmware_rest.composites._write import (
@@ -53,6 +58,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     host_evacuate_composite,
     vm_clone_composite,
     vm_create_composite,
+    vm_disk_grow_composite,
     vm_migrate_composite,
     vm_power_bulk_composite,
     vm_power_composite,
@@ -1102,3 +1108,351 @@ async def test_reads_are_never_gated_only_writes(gate: _GateRecorder) -> None:
     read_paths = [c["path"] for c in conn.calls if c["method"] == "GET"]
     assert read_paths == ["/api/vcenter/cluster/c-9/drs/recommendations"]
     assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}?action=relocate"]
+
+
+# ===========================================================================
+# vm.disk.grow (mutating VI-JSON — keystone 2, #2893)
+# ===========================================================================
+
+
+_TEN_GIB = 10 * 1024**3
+_TWENTY_GIB = 20 * 1024**3
+
+
+def _virtual_disk(key: int = 2000, capacity_bytes: int | None = _TEN_GIB) -> dict[str, Any]:
+    """A ``VirtualDisk`` device as ``config.hardware.device`` returns it."""
+    device: dict[str, Any] = {
+        "_typeName": "VirtualDisk",
+        "key": key,
+        "controllerKey": 1000,
+        "unitNumber": 0,
+        "backing": {
+            "_typeName": "VirtualDiskFlatVer2BackingInfo",
+            "fileName": "[datastore1] web-01/web-01.vmdk",
+            "diskMode": "persistent",
+        },
+    }
+    if capacity_bytes is not None:
+        device["capacityInBytes"] = capacity_bytes
+    return device
+
+
+class _DiskGrowConnector:
+    """Recording connector double serving the disk-grow VI-JSON sub-ops.
+
+    ``vm.disk.grow`` reads ``config.hardware.device`` (vmomi
+    ``RetrievePropertiesEx``), writes ``ReconfigVM_Task``, then polls
+    ``Task.info`` (again ``RetrievePropertiesEx``). The config read and the
+    Task poll share the ``RetrievePropertiesEx`` path, so this double
+    distinguishes them by the request body's ``specSet`` object type
+    (``VirtualMachine`` vs ``Task``) -- exactly the seam a real vCenter
+    keys them by.
+    """
+
+    def __init__(
+        self,
+        *,
+        devices: list[Any],
+        task_state: str = "success",
+        task_error: str | None = None,
+        reconfig_task: str = "task-grow-1",
+    ) -> None:
+        self.devices = devices
+        self.task_state = task_state
+        self.task_error = task_error
+        self.reconfig_task = reconfig_task
+        self.vmomi_calls: list[tuple[str, Any]] = []
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append((path, json))
+        if path.endswith("/ReconfigVM_Task"):
+            return {"type": "Task", "value": self.reconfig_task}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "VirtualMachine":
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "VirtualMachine", "value": "vm-1"},
+                        "propSet": [{"name": "config.hardware.device", "val": self.devices}],
+                    }
+                ]
+            }
+        if spec_type == "Task":
+            info: dict[str, Any] = {"state": self.task_state}
+            if self.task_error is not None:
+                info["error"] = {"localizedMessage": self.task_error}
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "Task", "value": self.reconfig_task},
+                        "propSet": [{"name": "info", "val": info}],
+                    }
+                ]
+            }
+        raise AssertionError(f"unexpected RetrievePropertiesEx type {spec_type!r}")
+
+    @property
+    def reconfig_bodies(self) -> list[Any]:
+        return [body for path, body in self.vmomi_calls if path.endswith("/ReconfigVM_Task")]
+
+
+async def test_vm_disk_grow_happy_path_edits_capacity_and_polls(gate: _GateRecorder) -> None:
+    """Grow: read device -> gated ReconfigVM_Task edit -> poll to success -> status=grown."""
+    conn = _DiskGrowConnector(devices=[_virtual_disk(key=2000, capacity_bytes=_TEN_GIB)])
+    out = await vm_disk_grow_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "grown"
+    assert out["from_capacity_bytes"] == _TEN_GIB
+    assert out["to_capacity_bytes"] == _TWENTY_GIB
+    assert out["delta_bytes"] == _TWENTY_GIB - _TEN_GIB
+    assert out["task"] == "task-grow-1"
+
+    # The single mutating sub-op was gated with its vi-json governance op_id
+    # + the logical params that name the entity the write touches.
+    assert gate.gated_op_ids == ["POST:/VirtualMachine/{moId}/ReconfigVM_Task"]
+    gated = gate.calls[0]
+    assert gated["safety_level"] == "dangerous"
+    assert gated["requires_approval"] is False
+    assert gated["params"] == {"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB}
+
+    # The ReconfigVM_Task body is a single-device edit raising capacityInBytes
+    # on the matched device key, with the full VirtualDisk preserved.
+    assert len(conn.reconfig_bodies) == 1
+    change = conn.reconfig_bodies[0]["spec"]["deviceChange"][0]
+    assert change["operation"] == "edit"
+    assert change["device"]["key"] == 2000
+    assert change["device"]["capacityInBytes"] == _TWENTY_GIB
+    assert change["device"]["_typeName"] == "VirtualDisk"
+    # The backing (fully-specified device) is carried through unchanged.
+    assert change["device"]["backing"]["fileName"] == "[datastore1] web-01/web-01.vmdk"
+
+
+async def test_vm_disk_grow_refuses_shrink_before_any_write(gate: _GateRecorder) -> None:
+    """A request <= the current capacity is refused; no ReconfigVM_Task, no gate."""
+    conn = _DiskGrowConnector(devices=[_virtual_disk(key=2000, capacity_bytes=_TWENTY_GIB)])
+    out = await vm_disk_grow_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "disk": "2000", "capacity_bytes": _TEN_GIB},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "invalid_shrink"
+    assert out["from_capacity_bytes"] == _TWENTY_GIB
+    assert out["to_capacity_bytes"] == _TEN_GIB
+    assert out["delta_bytes"] == _TEN_GIB - _TWENTY_GIB
+    assert out["task"] is None
+    # Only the config read fired; the write was never attempted, never gated.
+    assert conn.reconfig_bodies == []
+    assert gate.calls == []
+
+
+async def test_vm_disk_grow_refuses_a_no_op_equal_capacity(gate: _GateRecorder) -> None:
+    """Growing to the exact current size is a no-op -> refused (grow-only contract)."""
+    conn = _DiskGrowConnector(devices=[_virtual_disk(key=2000, capacity_bytes=_TEN_GIB)])
+    out = await vm_disk_grow_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "disk": "2000", "capacity_bytes": _TEN_GIB},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "invalid_shrink"
+    assert conn.reconfig_bodies == []
+
+
+async def test_vm_disk_grow_disk_not_found(gate: _GateRecorder) -> None:
+    """No VirtualDisk with the requested key -> disk_not_found; no write."""
+    conn = _DiskGrowConnector(devices=[_virtual_disk(key=2001, capacity_bytes=_TEN_GIB)])
+    out = await vm_disk_grow_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "disk_not_found"
+    assert out["from_capacity_bytes"] is None
+    assert out["delta_bytes"] is None
+    assert conn.reconfig_bodies == []
+    assert gate.calls == []
+
+
+async def test_vm_disk_grow_gate_short_circuits_before_the_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked gate on the ReconfigVM_Task write returns verbatim; no write fires."""
+    gate = _install_gate(
+        monkeypatch,
+        _GateRecorder(
+            gate_for={
+                "POST:/VirtualMachine/{moId}/ReconfigVM_Task": _awaiting(
+                    "POST:/VirtualMachine/{moId}/ReconfigVM_Task"
+                )
+            }
+        ),
+    )
+    conn = _DiskGrowConnector(devices=[_virtual_disk(key=2000, capacity_bytes=_TEN_GIB)])
+    out = await vm_disk_grow_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == "POST:/VirtualMachine/{moId}/ReconfigVM_Task"
+    # The config read fired; the ReconfigVM_Task write was gated off the wire.
+    assert conn.reconfig_bodies == []
+    assert gate.gated_op_ids == ["POST:/VirtualMachine/{moId}/ReconfigVM_Task"]
+
+
+async def test_vm_disk_grow_task_fault_raises(gate: _GateRecorder) -> None:
+    """A terminal task error raises (the dispatcher wraps it connector_error)."""
+    conn = _DiskGrowConnector(
+        devices=[_virtual_disk(key=2000, capacity_bytes=_TEN_GIB)],
+        task_state="error",
+        task_error="Insufficient disk space on datastore.",
+    )
+    with pytest.raises(RuntimeError, match="Insufficient disk space"):
+        await vm_disk_grow_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+            connector=conn,  # type: ignore[arg-type]
+        )
+
+
+async def test_vm_disk_grow_poll_timeout_returns_timeout_status(
+    monkeypatch: pytest.MonkeyPatch, gate: _GateRecorder
+) -> None:
+    """A poll that never sees a terminal state returns status=timeout with the task id."""
+    # Zero the poll bound so a still-``running`` task times out on the first read.
+    monkeypatch.setattr(_write, "_DISK_GROW_TASK_TIMEOUT_SECONDS", 0.0)
+    conn = _DiskGrowConnector(
+        devices=[_virtual_disk(key=2000, capacity_bytes=_TEN_GIB)],
+        task_state="running",
+    )
+    out = await vm_disk_grow_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "timeout"
+    assert out["task"] == "task-grow-1"
+    assert out["to_capacity_bytes"] == _TWENTY_GIB
+
+
+# ---------------------------------------------------------------------------
+# respx-verified ReconfigVM_Task wire body (through a real connector)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    """Minimal target the real connector's transport path reads from."""
+
+    name: str = "vc-grow"
+    host: str = "vc-grow.test.invalid"
+    port: int | None = 443
+    secret_ref: str = "vsphere/vc-grow"
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+async def _stub_loader(_target: Any, _operator: Operator) -> dict[str, str]:
+    return {"username": "svc-meho", "password": "stub-password"}
+
+
+def _patch_no_revoke_aclose(connector: VmwareRestConnector) -> None:
+    """Skip the session-revoke DELETE at teardown (mirrors the vmomi-mount tests)."""
+
+    async def _aclose() -> None:
+        connector._session_tokens.clear()
+        for client in connector._clients.values():
+            await client.aclose()
+        connector._clients.clear()
+
+    connector.aclose = _aclose  # type: ignore[method-assign]
+
+
+async def test_vm_disk_grow_reconfig_body_reaches_the_wire_respx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """respx-verified: the ReconfigVM_Task POST body carries operation:edit + raised
+    capacityInBytes on the right device key, mounted on the /sdk/vim25 base.
+
+    Drives the real handler through a real ``VmwareRestConnector`` over an
+    httpx (respx) transport, so the assertion is on the actual wire bytes,
+    not a recording double. The #2254 gate is auto-executed here (its own
+    governance is proven end-to-end in the gate + e2e lanes) so the write
+    reaches the wire.
+    """
+
+    async def _auto_execute(**_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(_write, "enforce_subop_policy", _auto_execute)
+
+    base = "https://vc-grow.test.invalid"
+    vijson = "/sdk/vim25/8.0.3.0"
+    device = _virtual_disk(key=2000, capacity_bytes=_TEN_GIB)
+    config_result = {
+        "objects": [
+            {
+                "obj": {"type": "VirtualMachine", "value": "vm-1"},
+                "propSet": [{"name": "config.hardware.device", "val": [device]}],
+            }
+        ]
+    }
+    task_result = {
+        "objects": [
+            {
+                "obj": {"type": "Task", "value": "task-1"},
+                "propSet": [{"name": "info", "val": {"state": "success"}}],
+            }
+        ]
+    }
+    connector = VmwareRestConnector(session_loader=_stub_loader)
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=base) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            mock.get("/api/about").respond(200, json={"version": "8.0.3"})
+            # config read then Task poll share the RetrievePropertiesEx URL.
+            mock.post(f"{vijson}/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
+                side_effect=[
+                    httpx.Response(200, json=config_result),
+                    httpx.Response(200, json=task_result),
+                ]
+            )
+            reconfig = mock.post(f"{vijson}/VirtualMachine/vm-1/ReconfigVM_Task").respond(
+                200, json={"type": "Task", "value": "task-1"}
+            )
+            out = await vm_disk_grow_composite(
+                operator=_make_operator(),
+                target=_StubTarget(),
+                params={"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+                connector=connector,
+            )
+        assert isinstance(out, dict)
+        assert out["status"] == "grown"
+        assert reconfig.called
+        body = json.loads(reconfig.calls[0].request.content)
+        change = body["spec"]["deviceChange"][0]
+        assert change["operation"] == "edit"
+        assert change["device"]["_typeName"] == "VirtualDisk"
+        assert change["device"]["key"] == 2000
+        assert change["device"]["capacityInBytes"] == _TWENTY_GIB
+    finally:
+        await connector.aclose()

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -259,7 +259,7 @@ def _seed_connector(recorder: _RecordingVmwareConnector) -> None:
 async def _bootstrap(
     recorder: _RecordingVmwareConnector, stub_embedding_service: AsyncMock
 ) -> None:
-    """Register the connector + all 14 composites and seed the recorder."""
+    """Register the connector + all 15 composites and seed the recorder."""
     _seed_connector(recorder)
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
 
@@ -368,12 +368,19 @@ def _benign_responses_for(composite_op_id: str) -> dict[str, Any]:
 
 
 # ===========================================================================
-# Guard: the write set is exactly the expected nine
+# Guard: the REST-sub-op write set is exactly the expected nine
 # ===========================================================================
 
 
 def test_write_composite_set_is_the_expected_nine() -> None:
-    """Pins the op_id set so a renamed / dropped composite can't shrink coverage."""
+    """Pins the REST-sub-op write set so a renamed / dropped composite can't shrink coverage.
+
+    Covers the 9 REST-sub-op write composites the parametrized fresh-boot +
+    park machinery below drives. The tenth write composite, the mutating
+    VI-JSON ``vm.disk.grow`` (#2893), is dispatch-shaped differently (vmomi
+    sub-ops keyed by request body, not REST spec-paths) and is covered by
+    its own dedicated section at the end of this module.
+    """
     registrar_write_op_ids = {f"vmware.composite.{name}" for name in _WRITE_COMPOSITES.values()}
     assert set(_WRITE_COMPOSITES) == registrar_write_op_ids
     assert len(_WRITE_COMPOSITES) == 9
@@ -395,7 +402,7 @@ async def test_write_composite_executes_through_dispatch_without_ingest(
     """Each composite runs to a benign business status on the direct session.
 
     No ingested ``endpoint_descriptor`` rows exist in the catalog here — only
-    the 14 composite rows the registrar upserts. Reaching a business status
+    the 15 composite rows the registrar upserts. Reaching a business status
     (``created`` / ``no_recommendation`` / ``detached`` / ...) rather than a
     generic execution error proves every raw-REST sub-op resolved via the
     connector session, not a catalog lookup (the two-world / fresh-boot DoD).
@@ -881,3 +888,216 @@ async def test_vm_create_full_queue_approve_resume_execute(
     assert result2.result["status"] == "created"
     assert result2.result["vm_id"] == "vm-789"
     assert recorder.calls == [("GET", "/vcenter/folder"), ("POST", "/vcenter/vm")]
+
+
+# ===========================================================================
+# vm.disk.grow — mutating VI-JSON: park → approve → resume, #2681 envelope
+# ===========================================================================
+
+
+_TEN_GIB = 10 * 1024**3
+_TWENTY_GIB = 20 * 1024**3
+
+
+class _DiskGrowVmwareConnector:
+    """Recording double for the disk-grow park→approve→resume E2E.
+
+    Serves the park-time preview REST reads (``_get_json``: disk detail +
+    VM name) and the dispatch-time VI-JSON sub-ops (``_post_vmomi_json``:
+    the ``config.hardware.device`` read, the ``ReconfigVM_Task`` write, and
+    the ``Task.info`` poll — the two ``RetrievePropertiesEx`` reads keyed
+    apart by the request body's ``specSet`` object type). Records both
+    surfaces so the test can prove the mutating vmomi write fires only on
+    the approved-resume path.
+    """
+
+    _MOUNT = "/api"
+
+    def __init__(self, *, capacity_bytes: int = _TEN_GIB) -> None:
+        self._capacity_bytes = capacity_bytes
+        self.rest_calls: list[tuple[str, str]] = []
+        self.vmomi_calls: list[str] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    def _spec(self, path: str) -> str:
+        return path[len(self._MOUNT) :] if path.startswith(self._MOUNT) else path
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        spec = self._spec(path)
+        self.rest_calls.append(("GET", spec))
+        if spec.endswith("/hardware/disk/2000"):
+            return {"label": "Hard disk 1", "type": "SCSI", "capacity": self._capacity_bytes}
+        if spec == "/vcenter/vm/vm-1":
+            return {"name": "web-01"}
+        return {"value": {}}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append(path)
+        if path.endswith("/ReconfigVM_Task"):
+            return {"type": "Task", "value": "task-grow-e2e"}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "VirtualMachine":
+            device = {
+                "_typeName": "VirtualDisk",
+                "key": 2000,
+                "capacityInBytes": self._capacity_bytes,
+                "backing": {
+                    "_typeName": "VirtualDiskFlatVer2BackingInfo",
+                    "fileName": "[ds] a.vmdk",
+                },
+            }
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "VirtualMachine", "value": "vm-1"},
+                        "propSet": [{"name": "config.hardware.device", "val": [device]}],
+                    }
+                ]
+            }
+        return {
+            "objects": [
+                {
+                    "obj": {"type": "Task", "value": "task-grow-e2e"},
+                    "propSet": [{"name": "info", "val": {"state": "success"}}],
+                }
+            ]
+        }
+
+    @property
+    def reconfig_writes(self) -> list[str]:
+        return [p for p in self.vmomi_calls if p.endswith("/ReconfigVM_Task")]
+
+
+@pytest.mark.asyncio
+async def test_disk_grow_queue_approve_resume_with_2681_envelope(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """vm.disk.grow: park (with the #2681 op-identity envelope) → approve → resume → grow.
+
+    1. A USER dispatch parks at ``awaiting_approval``; the durable row's
+       ``proposed_effect`` carries the uniform #2681 op-identity envelope
+       (``op_id`` / ``connector_id`` / ``target_id`` / ``op_class`` /
+       ``safety_level``) plus the live-read from→to capacity preview. No
+       ReconfigVM_Task fires — only the read-only preview GETs.
+    2. A distinct human reviewer approves.
+    3. The ``_approved=True`` resume executes the composite: the config read
+       + the (now auto-executed) governed ReconfigVM_Task edit + the Task
+       poll run, and the result is ``status='grown'``.
+    """
+    recorder = _DiskGrowVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name="prod-vcenter",
+                product="vmware",
+                host="vcenter.prod.invalid",
+                aliases=[],
+            )
+        )
+        await s.commit()
+
+    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
+    target = _FakeVmwareTarget(target_id=target_id)
+    params = {"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB}
+
+    # Step 1: human dispatch -> awaiting_approval; the write never ran.
+    result1 = await dispatch(
+        operator=requester,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.disk.grow",
+        target=target,
+        params=params,
+    )
+    assert result1.status == "awaiting_approval", result1.error
+    assert recorder.reconfig_writes == [], "no reconfigure before approval"
+    approval_request_id = UUID(result1.extras["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        pending = await s.get(ApprovalRequest, approval_request_id)
+    assert pending is not None
+    assert pending.target_id == target_id
+    # #2681 uniform op-identity + metadata envelope on the parked row.
+    effect = pending.proposed_effect
+    assert effect["op_id"] == "vmware.composite.vm.disk.grow"
+    assert effect["connector_id"] == _CONNECTOR_ID
+    assert effect["target_id"] == str(target_id)
+    assert effect["op_class"] == "other"
+    assert effect["safety_level"] == "dangerous"
+    assert effect["preview_populated"] is True
+    # The live-read from→to capacity delta — the decision the approver makes.
+    assert effect["preview"] == {
+        "vm": "vm-1",
+        "name": "web-01",
+        "disk": "2000",
+        "disk_label": "Hard disk 1",
+        "current_capacity_bytes": _TEN_GIB,
+        "requested_capacity_bytes": _TWENTY_GIB,
+        "delta_bytes": _TWENTY_GIB - _TEN_GIB,
+    }
+
+    # Step 2: a distinct human reviewer approves.
+    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
+    async with get_sessionmaker()() as s:
+        row = await approve_request(s, approval_request_id, operator=reviewer, params=params)
+        await s.commit()
+    assert row.status == ApprovalRequestStatus.APPROVED.value
+
+    # Step 3: resume re-dispatch with the gate bypass -> the grow executes.
+    result2 = await dispatch(
+        operator=reviewer,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.disk.grow",
+        target=target,
+        params=params,
+        _approved=True,
+    )
+    assert result2.status == "ok", result2.error
+    assert result2.result["status"] == "grown"
+    assert result2.result["from_capacity_bytes"] == _TEN_GIB
+    assert result2.result["to_capacity_bytes"] == _TWENTY_GIB
+    assert result2.result["delta_bytes"] == _TWENTY_GIB - _TEN_GIB
+    # The mutating ReconfigVM_Task fired exactly once, on the approved resume.
+    assert recorder.reconfig_writes == ["/VirtualMachine/vm-1/ReconfigVM_Task"]
+
+
+@pytest.mark.asyncio
+async def test_disk_grow_fresh_boot_dispatchable_without_ingest(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """vm.disk.grow runs to ``grown`` on the direct session with ZERO ingested rows."""
+    recorder = _DiskGrowVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.disk.grow"}, recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.disk.grow",
+        target=_FakeVmwareTarget(),
+        params={"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+    )
+    assert "composite_l2_missing" not in (result.error or ""), result.error
+    assert result.status == "ok", result.error
+    assert result.result["status"] == "grown"
+    assert recorder.reconfig_writes == ["/VirtualMachine/vm-1/ReconfigVM_Task"]

--- a/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
@@ -42,6 +42,7 @@ from meho_backplane.connectors import OperationResult
 from meho_backplane.connectors.vmware_rest._mount import adapt_filter_params
 from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_create_composite,
+    vm_disk_grow_composite,
     vm_migrate_composite,
 )
 from meho_backplane.db.engine import get_sessionmaker
@@ -233,5 +234,143 @@ async def test_human_operator_subop_auto_executes(session: AsyncSession) -> None
     # The relocate write executed on the session.
     assert [w["path"] for w in conn.writes] == ["/api/vcenter/vm/vm-1?action=relocate"]
     # No approval row -- the sub-op auto-executed.
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+
+
+# ===========================================================================
+# vm.disk.grow — the mutating VI-JSON write flows through the same gate (#2893)
+# ===========================================================================
+
+
+_RECONFIG_OP_ID = "POST:/VirtualMachine/{moId}/ReconfigVM_Task"
+
+
+class _DiskGrowRecordingConnector:
+    """Recording double for the disk-grow governance tests.
+
+    Serves the ``config.hardware.device`` read + the ``Task.info`` poll
+    (both vmomi ``RetrievePropertiesEx``, distinguished by the request
+    body's ``specSet`` object type) and records every ``ReconfigVM_Task``
+    write so the tests can assert the mutating vmomi POST never fired when
+    the gate parks / denies.
+    """
+
+    def __init__(self, *, capacity_bytes: int = 10 * 1024**3) -> None:
+        self._capacity_bytes = capacity_bytes
+        self.reconfig_writes: list[Any] = []
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        if path.endswith("/ReconfigVM_Task"):
+            self.reconfig_writes.append(json)
+            return {"type": "Task", "value": "task-grow-1"}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "VirtualMachine":
+            device = {
+                "_typeName": "VirtualDisk",
+                "key": 2000,
+                "capacityInBytes": self._capacity_bytes,
+                "backing": {
+                    "_typeName": "VirtualDiskFlatVer2BackingInfo",
+                    "fileName": "[ds] a.vmdk",
+                },
+            }
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "VirtualMachine", "value": "vm-1"},
+                        "propSet": [{"name": "config.hardware.device", "val": [device]}],
+                    }
+                ]
+            }
+        return {
+            "objects": [
+                {
+                    "obj": {"type": "Task", "value": "task-grow-1"},
+                    "propSet": [{"name": "info", "val": {"state": "success"}}],
+                }
+            ]
+        }
+
+
+@pytest.mark.asyncio
+async def test_disk_grow_gated_vmomi_write_queues_and_never_reaches_wire(
+    session: AsyncSession,
+) -> None:
+    """An agent-gated ReconfigVM_Task queues for approval; the vmomi write never fires.
+
+    The hard #2893 gate: a *mutating VI-JSON* sub-op is a write, not
+    transport detail — it flows through the same real
+    :func:`enforce_subop_policy` seam the REST writes do. With a
+    ``needs_approval`` grant on the vim method, ``vm.disk.grow`` returns
+    ``awaiting_approval``, writes a durable pending row, and issues no
+    ReconfigVM_Task on the connector session.
+    """
+    await _grant(
+        principal_sub="agent-write-composite",
+        op_pattern=_RECONFIG_OP_ID,
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _DiskGrowRecordingConnector()
+
+    out = await vm_disk_grow_composite(
+        operator=_operator(),
+        target=None,
+        params={"vm": "vm-1", "disk": "2000", "capacity_bytes": 20 * 1024**3},
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _RECONFIG_OP_ID
+    request_id = uuid.UUID(out.extras["approval_request_id"])
+    row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.op_id == _RECONFIG_OP_ID
+    assert row.connector_id == "vmware-rest-9.0"
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    # The mutating ReconfigVM_Task never reached the wire.
+    assert conn.reconfig_writes == []
+
+
+@pytest.mark.asyncio
+async def test_disk_grow_dangerous_vmomi_write_denied_without_grant(
+    session: AsyncSession,
+) -> None:
+    """An agent with no grant is denied the dangerous ReconfigVM_Task; it never runs."""
+    conn = _DiskGrowRecordingConnector()
+    out = await vm_disk_grow_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params={"vm": "vm-1", "disk": "2000", "capacity_bytes": 20 * 1024**3},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == _RECONFIG_OP_ID
+    # No pending row: a deny is not a park.
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+    assert conn.reconfig_writes == []
+
+
+@pytest.mark.asyncio
+async def test_disk_grow_human_operator_vmomi_write_auto_executes(
+    session: AsyncSession,
+) -> None:
+    """A human operator's already-approved composite auto-executes the ReconfigVM_Task."""
+    conn = _DiskGrowRecordingConnector()
+    out = await vm_disk_grow_composite(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        target=None,
+        params={"vm": "vm-1", "disk": "2000", "capacity_bytes": 20 * 1024**3},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "grown"
+    # The reconfigure write executed on the session; the sub-op auto-executed.
+    assert len(conn.reconfig_writes) == 1
     count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
     assert count == 0

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` previews for the 9 vmware write composites.
+"""Park-time ``proposed_effect`` previews for the 10 vmware write composites.
 
 G0.22-T3 (#1608) acceptance criteria, under the post-#2256 direct-session
 model:
@@ -19,8 +19,9 @@ model:
    directly on the connector session (no ``dispatch_child``, no ingested
    descriptor), so the park-time preview works on a fresh boot with zero
    catalog ingest.
-4. All 9 write composites register a builder (4 live-read + 5 param
-   echo); the wiring test pins the full set.
+4. All 10 write composites register a builder (5 live-read + 5 param
+   echo); the wiring test pins the full set. ``vm.disk.grow`` is the fifth
+   live-read builder — its from→to capacity delta is a live vCenter read.
 
 Plus the #1628 follow-up: a *failed* live-read preview parks with the
 identifier fields **and** an explicit ``preview_unavailable`` marker +
@@ -39,6 +40,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 from uuid import UUID
 
+import httpx
 import pytest
 
 import meho_backplane.operations._audit as audit_module
@@ -70,6 +72,7 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.vm.migrate",
         "vmware.composite.vm.power",
         "vmware.composite.vm.power.bulk",
+        "vmware.composite.vm.disk.grow",
         "vmware.composite.host.evacuate",
         "vmware.composite.host.detach_from_vds",
         "vmware.composite.cluster.patch",
@@ -287,9 +290,10 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 # ===========================================================================
 
 
-def test_all_nine_write_composites_register_a_preview_builder() -> None:
+def test_all_ten_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 10
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 
@@ -680,3 +684,139 @@ async def test_vm_create_park_carries_echo_preview_without_any_read(
         "safety_level": "dangerous",
     }
     assert recorder.calls == []
+
+
+# ===========================================================================
+# vm.disk.grow — the from→to capacity delta preview (live-read, #2893)
+# ===========================================================================
+
+
+_TEN_GIB = 10 * 1024**3
+_TWENTY_GIB = 20 * 1024**3
+
+
+async def test_disk_grow_park_carries_from_to_capacity_delta(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The parked row's preview names the current→requested delta (the decision)."""
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses["/vcenter/vm/vm-1/hardware/disk/2000"] = {
+        "label": "Hard disk 1",
+        "type": "SCSI",
+        "capacity": _TEN_GIB,
+    }
+    recorder.responses["/vcenter/vm/vm-1"] = {"name": "web-01"}
+
+    _, row = await _park(
+        "vmware.composite.vm.disk.grow",
+        {"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+    )
+
+    assert _strip_uniform_identity(row.proposed_effect, op_id="vmware.composite.vm.disk.grow") == {
+        "op_class": "other",
+        "preview": {
+            "vm": "vm-1",
+            "name": "web-01",
+            "disk": "2000",
+            "disk_label": "Hard disk 1",
+            "current_capacity_bytes": _TEN_GIB,
+            "requested_capacity_bytes": _TWENTY_GIB,
+            "delta_bytes": _TWENTY_GIB - _TEN_GIB,
+        },
+        "preview_populated": True,
+        "safety_level": "dangerous",
+    }
+    # Two read-only GETs: the disk detail (load-bearing) + the VM name
+    # (cosmetic). No ReconfigVM_Task mutation fires on the park path.
+    assert recorder.read_calls == [
+        ("/vcenter/vm/vm-1/hardware/disk/2000", None),
+        ("/vcenter/vm/vm-1", None),
+    ]
+    assert all(verb == "GET" for verb, _, _ in recorder.calls)
+
+
+async def test_disk_grow_preview_failure_parks_with_unavailable_marker(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A failing disk read parks with identifiers + an explicit marker (#1628).
+
+    The current capacity is the load-bearing half of the delta, so a disk
+    read that faults makes the blast radius unknowable — the park is honest
+    about it rather than showing a bare identifier default.
+    """
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.failures["/vcenter/vm/vm-1/hardware/disk/2000"] = "disk detail unavailable"
+
+    target = _FakeVmwareTarget()
+    _, row = await _park(
+        "vmware.composite.vm.disk.grow",
+        {"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+        target=target,
+    )
+
+    effect = row.proposed_effect
+    assert effect["op_id"] == "vmware.composite.vm.disk.grow"
+    assert effect["target_id"] == str(target.id)
+    assert effect["preview_unavailable"] is True
+    assert "disk detail unavailable" in effect["preview_error"]
+    assert "preview" not in effect
+
+
+async def test_disk_grow_preview_declines_without_a_connector_instance() -> None:
+    """A live-read builder with no resolved connector declines to the identifier default."""
+    assert (
+        await _write_preview._vm_disk_grow_preview(
+            _make_preview_ctx(
+                {"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+                connector_instance=None,
+            )
+        )
+        is None
+    )
+
+
+async def test_disk_grow_preview_declines_on_malformed_params() -> None:
+    """Missing / wrong-typed params decline (→ identifier-only default), never raise."""
+    recorder = _RecordingConnector()
+    for params in (
+        {},
+        {"vm": "vm-1", "disk": "2000"},  # no capacity
+        {"vm": "vm-1", "disk": "2000", "capacity_bytes": "20g"},  # non-int
+        {"vm": "vm-1", "disk": "2000", "capacity_bytes": True},  # bool is not a capacity
+    ):
+        assert (
+            await _write_preview._vm_disk_grow_preview(
+                _make_preview_ctx(params, connector_instance=recorder)
+            )
+            is None
+        )
+
+
+async def test_disk_grow_preview_vm_name_is_best_effort() -> None:
+    """A VM-name read fault nulls the name but still builds the delta preview."""
+
+    class _DiskOkVmFailConnector(_RecordingConnector):
+        async def _get_json(
+            self, target: Any, path: str, *, operator: Any, params: Any = None
+        ) -> Any:
+            spec = self._spec(path)
+            self.calls.append(("GET", spec, params))
+            if spec.endswith("/hardware/disk/2000"):
+                return {"label": "Hard disk 1", "capacity": _TEN_GIB}
+            # The VM summary read faults — best-effort nulls the name.
+            request = httpx.Request("GET", f"https://vc{path}")
+            raise httpx.HTTPStatusError(
+                "boom", request=request, response=httpx.Response(500, request=request)
+            )
+
+    preview = await _write_preview._vm_disk_grow_preview(
+        _make_preview_ctx(
+            {"vm": "vm-1", "disk": "2000", "capacity_bytes": _TWENTY_GIB},
+            connector_instance=_DiskOkVmFailConnector(),
+        )
+    )
+    assert preview is not None
+    assert preview["name"] is None
+    assert preview["disk_label"] == "Hard disk 1"
+    assert preview["current_capacity_bytes"] == _TEN_GIB
+    assert preview["delta_bytes"] == _TWENTY_GIB - _TEN_GIB

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 9 vmware-rest write composites.
+"""Registration tests for the 10 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 ``vm.power`` / #2301):
 
-* All 9 expected write ``op_id`` rows land in ``endpoint_descriptor``
+* All 10 expected write ``op_id`` rows land in ``endpoint_descriptor``
   with ``source_kind="composite"``, ``safety_level="dangerous"``,
   ``requires_approval=True`` (T4's defaults intentionally inherited).
 * Each row's ``handler_ref`` resolves to the module-level dotted path
@@ -14,7 +14,7 @@ Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster``
   per the canary's stub-LLM taxonomy.
 * Combined with #508's 5 read composites, the registrar produces
-  **14 rows** total. (The former host.network_uplinks / host.vsan_health
+  **15 rows** total. (The former host.network_uplinks / host.vsan_health
   reads were re-shipped as typed ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
   with the documented required keys.
@@ -46,6 +46,7 @@ from meho_backplane.connectors.vmware_rest.composites import (
     register_vmware_composite_operations,
     vm_clone_composite,
     vm_create_composite,
+    vm_disk_grow_composite,
     vm_migrate_composite,
     vm_power_bulk_composite,
     vm_power_composite,
@@ -56,7 +57,8 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 9 write composites (T6 / #509, plus single-VM vm.power / #2301).
+# 10 write composites (T6 / #509, single-VM vm.power / #2301, and the
+# mutating VI-JSON vm.disk.grow / #2893).
 _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.create",
     "vmware.composite.vm.clone",
@@ -64,6 +66,7 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.migrate",
     "vmware.composite.vm.power",
     "vmware.composite.vm.power.bulk",
+    "vmware.composite.vm.disk.grow",
     "vmware.composite.host.evacuate",
     "vmware.composite.host.detach_from_vds",
     "vmware.composite.cluster.patch",
@@ -81,7 +84,8 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.network.portgroup.audit",
 )
 
-# 14 total -- 5 read (T5 / #508) + 9 write (T6 / #509 + vm.power / #2301).
+# 15 total -- 5 read (T5 / #508) + 10 write (T6 / #509 + vm.power / #2301 +
+# vm.disk.grow / #2893).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -104,6 +108,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.vm.power.bulk": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_power_bulk_composite"
     ),
+    "vmware.composite.vm.disk.grow": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_disk_grow_composite"
+    ),
     "vmware.composite.host.evacuate": (
         "meho_backplane.connectors.vmware_rest.composites._write.host_evacuate_composite"
     ),
@@ -123,6 +130,7 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.migrate": "vm",
     "vmware.composite.vm.power": "vm",
     "vmware.composite.vm.power.bulk": "vm",
+    "vmware.composite.vm.disk.grow": "vm",
     "vmware.composite.host.evacuate": "host",
     "vmware.composite.host.detach_from_vds": "host",
     "vmware.composite.cluster.patch": "cluster",
@@ -169,15 +177,15 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 9 write composites land alongside the 5 reads (14 total)
+# 10 write composites land alongside the 5 reads (15 total)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_inserts_nine_write_rows(
+async def test_register_vmware_composite_operations_inserts_ten_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 9 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 10 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -194,10 +202,10 @@ async def test_register_vmware_composite_operations_inserts_nine_write_rows(
 
 
 @pytest.mark.asyncio
-async def test_full_registration_produces_fourteen_composite_rows(
+async def test_full_registration_produces_fifteen_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """5 reads (#508) + 9 writes (#509 + vm.power #2301) = 14 rows. Definition-of-done bar."""
+    """5 reads (#508) + 10 writes (#509 + vm.power #2301 + vm.disk.grow #2893) = 15 rows."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -211,7 +219,7 @@ async def test_full_registration_produces_fourteen_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 14
+    assert len(rows) == 15
 
 
 @pytest.mark.asyncio
@@ -237,7 +245,7 @@ async def test_every_write_composite_row_uses_dangerous_requires_approval(
             .scalars()
             .all()
         )
-    # Prove the query actually returned all 9 write rows before iterating —
+    # Prove the query actually returned all 10 write rows before iterating —
     # otherwise the loop is vacuous when the set is empty / partial.
     assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     for row in rows:
@@ -302,7 +310,7 @@ async def test_write_handler_ref_round_trips_to_module_level_dotted_path(
 async def test_write_composites_land_in_vm_host_cluster_groups(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """5 vm.* in ``vm``, 2 host.* in ``host``, 1 cluster.* in ``cluster``."""
+    """7 vm.* in ``vm``, 2 host.* in ``host``, 1 cluster.* in ``cluster``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -420,6 +428,7 @@ async def test_write_composite_response_schemas_persist_with_status_enums(
         "vmware.composite.vm.snapshot.revert": {"reverted", "ambiguous", "not_found"},
         "vmware.composite.vm.migrate": {"migrated", "no_recommendation"},
         "vmware.composite.vm.power": {"ok", "error", "tools_unavailable"},
+        "vmware.composite.vm.disk.grow": {"grown", "invalid_shrink", "disk_not_found", "timeout"},
         "vmware.composite.host.evacuate": {"evacuated", "partial", "aborted"},
         "vmware.composite.host.detach_from_vds": {"detached", "incomplete"},
         "vmware.composite.cluster.patch": {"completed", "stopped"},
@@ -466,17 +475,17 @@ async def test_write_composite_tags_include_composite_and_write(
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_is_idempotent_across_fourteen(
+async def test_register_vmware_composite_operations_is_idempotent_across_fifteen(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 14 rows total, embedding called 14x once."""
+    """Running the registrar twice -> 15 rows total, embedding called 15x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 14
+    assert first_count == 15
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 14.
+    # pipeline; the row count stays at 15.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -490,7 +499,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_fourtee
             .scalars()
             .all()
         )
-    assert len(rows) == 14
+    assert len(rows) == 15
 
 
 # ---------------------------------------------------------------------------
@@ -515,6 +524,7 @@ def test_all_write_handlers_are_module_level_coroutine_functions() -> None:
         vm_migrate_composite,
         vm_power_composite,
         vm_power_bulk_composite,
+        vm_disk_grow_composite,
         host_evacuate_composite,
         host_detach_from_vds_composite,
         cluster_patch_composite,

--- a/backend/tests/test_connectors_vmware_rest_vim_task.py
+++ b/backend/tests/test_connectors_vmware_rest_vim_task.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the reusable vim ``*_Task`` poll-to-terminal helper (#2893).
+
+:func:`~meho_backplane.connectors.vmware_rest.vim_task.poll_vim_task` is
+the seam every mutating VI-JSON write composite shares to drive a returned
+``*_Task`` MoRef (``ReconfigVM_Task``, ``CloneVM_Task``,
+``ReconfigureComputeResource_Task``) to a terminal state. These tests pin
+its contract against canned ``Task.info`` sequences:
+
+* **success** -- the terminal ``success`` state surfaces ``TaskInfo.result``
+  (the new-object MoRef a clone produces);
+* **error** -- the terminal ``error`` state surfaces the localized fault;
+* **timeout** -- the wall-clock deadline elapses before a terminal state;
+* the poll loops across ``queued`` / ``running`` reads until terminal;
+* MoRef / bare-moid input handling + the ``ValueError`` on a non-Task shape;
+* a transport fault on the ``Task.info`` read propagates (not swallowed).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from meho_backplane.connectors.vmware_rest.vim_task import (
+    TASK_STATE_ERROR,
+    TASK_STATE_SUCCESS,
+    poll_vim_task,
+    task_moref_value,
+)
+
+_RETRIEVE_PROPERTIES_PATH = "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+
+
+def _task_info_result(
+    task_moid: str,
+    *,
+    state: str,
+    result: Any = None,
+    error_message: str | None = None,
+    progress: int | None = None,
+) -> dict[str, Any]:
+    """Build a single-Task ``RetrievePropertiesEx`` result carrying one ``TaskInfo``."""
+    info: dict[str, Any] = {"state": state}
+    if result is not None:
+        info["result"] = result
+    if error_message is not None:
+        info["error"] = {"localizedMessage": error_message}
+    if progress is not None:
+        info["progress"] = progress
+    return {
+        "objects": [
+            {
+                "obj": {"type": "Task", "value": task_moid},
+                "propSet": [{"name": "info", "val": info}],
+            }
+        ]
+    }
+
+
+class _SeqTaskConnector:
+    """Stub connector serving a fixed sequence of ``Task.info`` reads.
+
+    Records every ``_post_vmomi_json`` call; returns the queued responses in
+    order and repeats the last one once the queue is exhausted (so an
+    always-``running`` sequence drives the timeout branch). A response that
+    is an :class:`Exception` is raised -- exercising the transport-fault
+    propagation path.
+    """
+
+    def __init__(self, responses: list[Any]) -> None:
+        self._responses = list(responses)
+        self._last: Any = None
+        self.calls: list[tuple[str, Any]] = []
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Any, json: Any = None
+    ) -> Any:
+        self.calls.append((path, json))
+        response = self._responses.pop(0) if self._responses else self._last
+        self._last = response
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+# ---------------------------------------------------------------------------
+# MoRef extraction
+# ---------------------------------------------------------------------------
+
+
+def test_task_moref_value_handles_moref_dict_bare_moid_and_junk() -> None:
+    assert task_moref_value({"type": "Task", "value": "task-42"}) == "task-42"
+    assert task_moref_value({"_typeName": "ManagedObjectReference", "value": "task-7"}) == "task-7"
+    assert task_moref_value("task-1") == "task-1"
+    assert task_moref_value({"type": "Task"}) is None
+    assert task_moref_value(123) is None
+    assert task_moref_value(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Terminal outcomes
+# ---------------------------------------------------------------------------
+
+
+async def test_poll_returns_success_with_task_result() -> None:
+    """A terminal ``success`` surfaces ``TaskInfo.result`` (e.g. a clone's new VM)."""
+    conn = _SeqTaskConnector(
+        [
+            _task_info_result(
+                "task-1", state="success", result={"type": "VirtualMachine", "value": "vm-9"}
+            )
+        ]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task={"type": "Task", "value": "task-1"},
+        poll_interval=0.0,
+    )
+    assert outcome.state == TASK_STATE_SUCCESS
+    assert outcome.succeeded is True
+    assert outcome.timed_out is False
+    assert outcome.result == {"type": "VirtualMachine", "value": "vm-9"}
+    assert outcome.error_message is None
+    # One read on the RetrievePropertiesEx path: the task was already terminal.
+    assert len(conn.calls) == 1
+    assert conn.calls[0][0] == _RETRIEVE_PROPERTIES_PATH
+
+
+async def test_poll_loops_through_running_until_success() -> None:
+    """Non-terminal ``queued`` / ``running`` reads are polled through to terminal."""
+    conn = _SeqTaskConnector(
+        [
+            _task_info_result("task-1", state="queued"),
+            _task_info_result("task-1", state="running", progress=40),
+            _task_info_result("task-1", state="success"),
+        ]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        poll_interval=0.0,
+    )
+    assert outcome.succeeded is True
+    assert len(conn.calls) == 3
+
+
+async def test_poll_returns_error_with_localized_message() -> None:
+    """A terminal ``error`` surfaces the localized fault message, does not raise."""
+    conn = _SeqTaskConnector(
+        [_task_info_result("task-1", state="error", error_message="The disk cannot be shrunk.")]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        poll_interval=0.0,
+    )
+    assert outcome.state == TASK_STATE_ERROR
+    assert outcome.succeeded is False
+    assert outcome.error_message == "The disk cannot be shrunk."
+    assert outcome.result is None
+
+
+async def test_poll_times_out_when_never_terminal() -> None:
+    """A zero deadline that observes a non-terminal state returns a ``timeout`` outcome."""
+    conn = _SeqTaskConnector([_task_info_result("task-1", state="running", progress=25)])
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        timeout_seconds=0.0,
+        poll_interval=0.0,
+    )
+    assert outcome.timed_out is True
+    assert outcome.state == "timeout"
+    assert outcome.progress == 25
+    # Exactly one read, then the deadline check fired — no sleep/loop.
+    assert len(conn.calls) == 1
+
+
+async def test_poll_treats_missing_info_as_not_terminal_then_times_out() -> None:
+    """An absent/empty ``TaskInfo`` (not populated yet) is 'not terminal', not a crash."""
+    conn = _SeqTaskConnector([{"objects": []}])
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        timeout_seconds=0.0,
+        poll_interval=0.0,
+    )
+    assert outcome.timed_out is True
+    assert outcome.progress is None
+
+
+# ---------------------------------------------------------------------------
+# Input + fault handling
+# ---------------------------------------------------------------------------
+
+
+async def test_poll_rejects_a_non_task_shape() -> None:
+    """A value that is neither a MoRef nor a moid string raises ValueError."""
+    conn = _SeqTaskConnector([])
+    with pytest.raises(ValueError, match="Task MoRef or moid"):
+        await poll_vim_task(
+            conn,  # type: ignore[arg-type]
+            object(),
+            object(),  # type: ignore[arg-type]
+            task=12345,
+        )
+    # The read was never issued — the shape was rejected up front.
+    assert conn.calls == []
+
+
+async def test_poll_propagates_a_transport_fault_on_the_info_read() -> None:
+    """An httpx error on the Task.info read propagates — it is not 'still running'."""
+    request = httpx.Request("POST", "https://vc.test" + _RETRIEVE_PROPERTIES_PATH)
+    conn = _SeqTaskConnector(
+        [
+            httpx.HTTPStatusError(
+                "boom", request=request, response=httpx.Response(500, request=request)
+            )
+        ]
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        await poll_vim_task(
+            conn,  # type: ignore[arg-type]
+            object(),
+            object(),  # type: ignore[arg-type]
+            task="task-1",
+            poll_interval=0.0,
+        )
+
+
+async def test_poll_matches_the_requested_task_among_multiple_objects() -> None:
+    """The extractor keys on the Task moid when the result carries several objects."""
+    conn = _SeqTaskConnector(
+        [
+            {
+                "objects": [
+                    {
+                        "obj": {"type": "Task", "value": "task-other"},
+                        "propSet": [{"name": "info", "val": {"state": "running"}}],
+                    },
+                    {
+                        "obj": {"type": "Task", "value": "task-1"},
+                        "propSet": [{"name": "info", "val": {"state": "success"}}],
+                    },
+                ]
+            }
+        ]
+    )
+    outcome = await poll_vim_task(
+        conn,  # type: ignore[arg-type]
+        object(),
+        object(),  # type: ignore[arg-type]
+        task="task-1",
+        poll_interval=0.0,
+    )
+    assert outcome.succeeded is True

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -342,7 +342,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 14 composites (5 reads + 9 writes) land as `source_kind="composite"`
+The 15 composites (5 reads + 10 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -456,6 +456,7 @@ enum) are:
 | `vm.migrate` | `migrated`, `no_recommendation` |
 | `vm.power` | `ok`, `error`, `tools_unavailable` (single VM; `tools_unavailable` when a soft `guest_shutdown`/`guest_reboot` finds Tools down) |
 | `vm.power.bulk` | (per-VM `results` + aggregate `summary` + `aborted_on_failure`) |
+| `vm.disk.grow` | `grown`, `invalid_shrink`, `disk_not_found`, `timeout` (grow-only; `invalid_shrink` refuses a request ≤ current capacity before any write; `timeout` when the `ReconfigVM_Task` poll gives up) |
 | `host.evacuate` | `evacuated`, `partial`, `aborted` |
 | `host.detach_from_vds` | `detached`, `incomplete` |
 | `cluster.patch` | `completed`, `stopped` |
@@ -465,6 +466,69 @@ mutation (`DELETE:/vcenter/vm/{vm}`) on partial failure. The other
 write composites prefer "stop and report" semantics over silent
 rollback -- the operator decides whether to manually finish or
 revert.
+
+### Mutating VI-JSON write substrate (`vm.disk.grow`, #2893)
+
+Some vim operations have **no REST path** — growing a virtual disk is the
+first: the pinned 9.0 spec's `Disk.UpdateSpec` carries only `backing` (no
+capacity field, spec-verified), so the capacity change is only reachable
+through vim `VirtualMachine.ReconfigVM_Task`. This is the connector's first
+*mutating* VI-JSON call, and it establishes two reusable seams that Tasks D
+(`vm.clone_from_template`, `CloneVM_Task`, #2894) and E (`cluster.drs_rule.create`,
+`ReconfigureComputeResource_Task`, #2895) ride.
+
+**1. Governed mutating vmomi sub-op — `_write_vmomi_sub_op` (in `_write.py`).**
+A mutating vmomi POST is a *write* sub-op, not a transport detail, so it
+flows through the **same** `enforce_subop_policy` gate the REST write
+sub-ops do — the VI-JSON counterpart of `_write_sub_op`. It runs the gate
+with the vim method's canonical governance op_id (the `METHOD:/path` key
+the ingest parser emits from `vi-json.yaml`, e.g.
+`POST:/VirtualMachine/{moId}/ReconfigVM_Task`) + the sub-op's full logical
+params (so the durable `ApprovalRequest` names the entity the write
+touches) under the shared `dangerous` / `requires_approval=False` posture.
+On an `awaiting_approval` / `denied` verdict the `_post_vmomi_json` write
+is **never issued** — a policy-denied vmomi write never reaches the wire.
+On `AUTO_EXECUTE` it POSTs the method through `_post_vmomi_json` (the same
+`/sdk/vim25/{release}` mount the reads use) and returns the parsed payload
+— for a `*_Task` method, the returned `Task` `ManagedObjectReference`.
+`_post_vmomi_json` itself stays a pure transport method (reads use it
+un-gated); the governance lives in the composite-layer seam, symmetric
+with the REST `_write_sub_op`.
+
+**2. Reusable vim Task-poll helper — `poll_vim_task` (in `vim_task.py`).**
+Every `*_Task` method returns a `Task` MoRef rather than the finished
+result; the caller must poll `Task.info` to a terminal state before
+declaring the write done. `poll_vim_task(connector, target, operator, *,
+task, timeout_seconds=600, poll_interval=2)` re-reads `Task.info` (via
+`_post_vmomi_json` + the shared `build_task_info_retrieve_params` request
+builder generalized from `tasks.recent`) on a fixed cadence until the vim
+state is `success` / `error` or the wall-clock deadline elapses, returning
+a `VimTaskResult{task, state, result, error_message, progress}`. It does
+**not** raise on a task *fault* — the outcome is a legible value each
+caller maps to its own status envelope (a clone surfaces `result` as the
+new VM MoRef; disk-grow raises on a fault so the dispatcher wraps it
+`connector_error`, mirroring `vm.clone`'s task-poll; a timeout returns
+`status='timeout'`). A transport `httpx.HTTPError` on the `Task.info` read
+*does* propagate — it is a load-bearing failure, not "still running". The
+600 s bound mirrors the `vm.clone` `GET:/cis/tasks/{task}` convention.
+
+**`vm.disk.grow` flow** (the proving op): read the VM's
+`config.hardware.device` (a *read* `RetrievePropertiesEx`, un-gated) to
+find the full `VirtualDisk` device (the `VirtualDeviceConfigSpec` requires
+the edited device "fully specified") + its current `capacityInBytes`;
+**refuse a shrink** (`status='invalid_shrink'`) for any request ≤ current,
+before any write (vSphere rejects a shrink — fail early and legibly);
+issue a single-device `ReconfigVM_Task` edit (`deviceChange=[{operation:
+"edit", device: {…VirtualDisk…, capacityInBytes: <raised>}}]`) through
+`_write_vmomi_sub_op`; poll the returned Task to terminal via
+`poll_vim_task`. The `disk` param is the REST disk id, which is the string
+form of the vim `VirtualDevice.key` — so the handler matches the device by
+`str(key)` and the REST `GET hardware/disk/{disk}` supplies label +
+capacity for the park-time preview. The preview is a live-read from→to
+capacity diff (`{vm, name, disk, disk_label, current_capacity_bytes,
+requested_capacity_bytes, delta_bytes}`) — the delta is the decision the
+approver makes; a failing disk read parks with the #1628
+`preview_unavailable` marker (the delta is unknowable).
 
 ### Read-composite best-effort enrichment (`datastore.usage`, #1908)
 
@@ -660,10 +724,12 @@ they never park.
   header per `docs/vcenter-9.0/MANIFEST.md`. Two of the read
   composites (`event.tail`, `performance.summary`) call vi-json
   sub-ops; the other three call vCenter REST sub-ops only.
-- **VI-JSON mount for vmomi reads — `/sdk/vim25/{release}` (#2466)** —
+- **VI-JSON mount for vmomi reads *and writes* — `/sdk/vim25/{release}`
+  (#2466, mutating writes #2893)** —
   vmomi (VI-JSON) methods (`RetrievePropertiesEx`,
   `VsanQueryVcClusterHealthSummary`, `QueryEvents`,
-  `QueryAvailablePerfMetric`, `QueryPerf`) are served under the
+  `QueryAvailablePerfMetric`, `QueryPerf`, and now the mutating
+  `ReconfigVM_Task`) are served under the
   documented release-versioned base
   `/sdk/vim25/{release}/{MoType}/{moId}/{method}` (Broadcom Web Services
   SDK guide, "Building JSON Request URLs"; available since vCenter 8.0U1,
@@ -683,14 +749,16 @@ they never park.
   best-effort caller's `read_note` is self-explanatory. Legacy/vcsim
   targets (session on `/rest`) skip VI-JSON entirely and mount the vmomi
   method on `/rest` (the pre-#2466 behaviour, so the vcsim integration
-  lane is unchanged). Every typed vmomi read and the composite vmomi
-  POST sub-ops route through `_post_vmomi_json`; only the vSphere
-  Automation `GET /vcenter/*` legs still use `mount_op_path`.
+  lane is unchanged). Every typed vmomi read, the read-composite vmomi
+  POST sub-ops, and the mutating `vm.disk.grow` write route through
+  `_post_vmomi_json`; only the vSphere Automation `GET /vcenter/*` legs
+  still use `mount_op_path`.
 - **All hand-authored composites shipped** — T5 (#508) ships 5 read;
   #2080 + #2135 add two more reads (`host.network_uplinks` /
   `host.vsan_health`, later re-shipped as typed ops in #2258); T6
-  (#509) ships 8 write composites, and #2301 adds a 9th (single-VM
-  `vm.power`, incl. Tools soft shutdown) — 14 composites today. The
+  (#509) ships 8 write composites, #2301 adds a 9th (single-VM
+  `vm.power`, incl. Tools soft shutdown), and #2893 adds a 10th (the
+  mutating VI-JSON `vm.disk.grow`) — 15 composites today. The
   "All hand-authored composites land as endpoint_descriptor rows with
   source_kind='composite'" Definition-of-done line in [#227](https://github.com/evoila/meho/issues/227)
   is fully ticked.


### PR DESCRIPTION
## Summary

- Lands the vmware connector's first **mutating VI-JSON** call — `vmware.composite.vm.disk.grow` — plus the two reusable seams Tasks D (#2894) and E (#2895) ride. Growing a virtual disk has **no REST path** (the pinned 9.0 spec's `Disk.UpdateSpec` carries only `backing`, no capacity field — spec-verified), so the capacity change goes through vim `VirtualMachine.ReconfigVM_Task`.
- **`_write_vmomi_sub_op`** (`composites/_write.py`): routes a mutating vmomi POST through the **same `enforce_subop_policy` (#2254) gate** the REST write sub-ops use — a policy-denied vmomi write never reaches the wire. `_post_vmomi_json` stays a pure transport method (reads use it un-gated); governance lives in the composite-layer seam, symmetric with the REST `_write_sub_op`.
- **`poll_vim_task`** (new `vmware_rest/vim_task.py`): drives a returned `*_Task` MoRef to a terminal state (`success` / `error` / `timeout`), generalized from the `tasks.recent` `Task.info` read and reusing its `RetrievePropertiesEx` request builder. Returns a `VimTaskResult` so each caller maps the outcome to its own status envelope. **Made clean + well-documented because D/E depend on its public shape.**
- `vm.disk.grow` is a `_CompositeSpec` row (`dangerous` + `requires_approval`, `group_key="vm"`) with a park-time preview builder registered in `_PREVIEW_BUILDERS` — a live-read current→requested capacity diff (the delta is the decision). **Grow-only by contract**: a request ≤ the current capacity is refused (`status='invalid_shrink'`) before any `ReconfigVM_Task` fires.

## Test plan

- [x] `ruff check` — clean (25 files)
- [x] `ruff format --check` — clean
- [x] `mypy src/…/vmware_rest/` — clean (17 files)
- [x] `code-quality.py --diff` — 0 blockers
- [x] **Poll helper** (`test_…_vim_task.py`, new lane) — success / error / timeout / running-then-success / MoRef+bare-moid input / non-Task `ValueError` / transport-fault propagation (9 tests)
- [x] **Governance gate** (`…_write_gate.py`) — a policy-denied vmomi write **never reaches the wire** (agent needs-approval → queues; no grant → denied; approved human → auto-executes)
- [x] **respx-verified `ReconfigVM_Task` body** (`…_write.py`) — through a real connector, the POST body carries `operation:"edit"` + raised `capacityInBytes` on the right device key, on the `/sdk/vim25` mount; plus grow / shrink-refusal / disk-not-found / gate-short-circuit / task-fault / poll-timeout unit paths
- [x] **`_write_e2e` park→approve→resume** (`…_write_e2e.py`) — parks with the **#2681 uniform op-identity envelope** (`op_id`/`connector_id`/`target_id`/`op_class`/`safety_level`/`preview_populated` + the from→to preview), approves, resumes → `grown`; the mutating write fires only on the approved resume; plus fresh-boot dispatchable with zero ingest
- [x] **Preview** (`…_write_preview.py`) — from→to capacity delta, `preview_unavailable` fail-soft (#1628), decline-without-connector / malformed-params, best-effort VM name
- [x] **Register lane** — 15 composites / 10 write rows, `dangerous`+approval, group `vm`, status enum, handler ref
- [x] **Ingest-reconcile** — the vi-json sub-op paths round-trip through `parse_openapi` **and are asserted against the pinned `vi-json.yaml`** (skip-guarded when the spec-shelf is unconfigured)
- [x] Full `-k vmware` suite green (373 passed / 12 skipped); no regressions in the composite-register / typed-register / metadata enumerations

## Out of scope

- `vm.clone_from_template` (`CloneVM_Task`, #2894) and `cluster.drs_rule.create` / `folder.create` (#2895) — they **depend on** this task's `_write_vmomi_sub_op` + `poll_vim_task` seams and land in their own PRs.
- Sibling Wave-1 REST-write tasks #2891 / #2892.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2893
