### PR TITLE
feat(connectors): add vmware VM hardware-write composites (#2891)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,26 @@ connector-related release-notes line.
   previews: a capped VM fan-out (cluster + cluster name + resolved VM set)
   for the rule op, a parent + new-folder-name echo for the folder op.
 
+### Added — vSphere hardware write composites: `vm.resize` / `vm.nic.repoint` / `vm.device.cdrom` (#2891)
+
+- Three new dangerous, approval-gated `vmware.composite.*` write
+  composites reconfigure a VM's virtual hardware post-clone over pure
+  vSphere Automation REST — no `pyvmomi`. `vm.resize` reads current
+  sizing + hot-add flags and PATCHes `hardware/cpu` / `hardware/memory`,
+  returning a typed `requires_power_off` status (never a raw 400) when a
+  powered-on VM cannot take the change live. `vm.nic.repoint` resolves a
+  distributed portgroup by display name and repoints an existing vNIC's
+  backing to it. `vm.device.cdrom` removes / updates / disconnects a
+  CD-ROM device — clearing a template's host-local-ISO backing that
+  would otherwise pin every clone to one host and block vMotion. Each
+  ships a live-read **from->to** approval preview so the four-eyes
+  reviewer sees the current state alongside the requested change. Also
+  fixes the #1602 defect: the write surface's distributed-portgroup
+  resolution moved off the unresolvable singular
+  `/vcenter/network/distributed-portgroup` path to the generic
+  `GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP` the read
+  composites already use.
+
 ## [0.28.0] - 2026-08-07
 
 ### Added — seven more Do-real-work guides on the docs site: topology, broadcast, memory/knowledge, audit forensics, runbooks, scheduler, satellite gateway (#2829)

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 18 composites land before
+``endpoint_descriptor`` upserts for the 21 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -29,11 +29,13 @@ Scope:
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 13 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
+* 16 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
   #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, the
-  folder-template ``vm.clone_from_template`` / #2894, and the vim
+  folder-template ``vm.clone_from_template`` / #2894, the vim
   cluster / inventory writes ``cluster.drs_rule.create`` +
-  ``folder.create`` / #2895) -- inherit
+  ``folder.create`` / #2895, and the #2891 post-clone hardware
+  reconfigure trio ``vm.resize`` / ``vm.nic.repoint`` /
+  ``vm.device.cdrom``) -- inherit
   T4's ``safety_level="dangerous"`` +
   ``requires_approval=True`` defaults.
   They cover every state-mutating workflow Goal #214 names as
@@ -46,7 +48,9 @@ Scope:
   ``host.evacuate`` (first recursive composite),
   ``host.detach_from_vds``, ``cluster.patch``,
   ``cluster.drs_rule.create`` (DRS rule by explicit VM list, no REST
-  path) and ``folder.create`` (synchronous vim ``CreateFolder``).
+  path), ``folder.create`` (synchronous vim ``CreateFolder``), plus
+  the post-clone hardware reconfigure trio ``vm.resize``,
+  ``vm.nic.repoint``, ``vm.device.cdrom`` (#2891).
 """
 
 from meho_backplane.connectors.vmware_rest.composites._read import (
@@ -68,10 +72,13 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_clone_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
+    vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
+    vm_nic_repoint_composite,
     vm_power_bulk_composite,
     vm_power_composite,
+    vm_resize_composite,
     vm_snapshot_revert_composite,
 )
 from meho_backplane.operations.typed_register import register_typed_op_registrar
@@ -82,7 +89,7 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 # registered by the time the runner iterates.
 register_typed_op_registrar(register_vmware_composite_operations)
 
-# Side-effect import: registers the 13 write composites' park-time
+# Side-effect import: registers the 16 write composites' park-time
 # ``proposed_effect`` preview builders (#1608) onto the per-op hook in
 # :mod:`meho_backplane.operations._preview` — mirrors how
 # ``connectors/argocd/__init__`` wires ``ops_write_preview``.
@@ -103,9 +110,12 @@ __all__ = [
     "vm_clone_composite",
     "vm_clone_from_template_composite",
     "vm_create_composite",
+    "vm_device_cdrom_composite",
     "vm_disk_grow_composite",
     "vm_migrate_composite",
+    "vm_nic_repoint_composite",
     "vm_power_bulk_composite",
     "vm_power_composite",
+    "vm_resize_composite",
     "vm_snapshot_revert_composite",
 ]

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 18 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 21 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -26,11 +26,13 @@ The 5 read composites (T5 / #508) pass
 T4's ``dangerous`` / ``True`` defaults. (The former
 ``host.network_uplinks`` and ``host.vsan_health`` reads were re-shipped
 as typed ops in #2258; see
-:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 13 write
+:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 16 write
 composites (T6 / #509, single-VM ``vm.power`` / #2301, the mutating
 VI-JSON ``vm.disk.grow`` / #2893, the folder-template
-``vm.clone_from_template`` / #2894, and the vim cluster / inventory writes
-``cluster.drs_rule.create`` + ``folder.create`` / #2895) inherit the T4
+``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
+``cluster.drs_rule.create`` + ``folder.create`` / #2895, and the #2891
+hardware writes -- ``vm.resize`` / ``vm.nic.repoint`` /
+``vm.device.cdrom``) inherit the T4
 defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity at
 the call site; the helper would default to those values anyway).
 Each :class:`_CompositeSpec` row carries its own ``safety_level`` +
@@ -60,10 +62,13 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_clone_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
+    vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
+    vm_nic_repoint_composite,
     vm_power_bulk_composite,
     vm_power_composite,
+    vm_resize_composite,
     vm_snapshot_revert_composite,
 )
 from meho_backplane.connectors.vmware_rest.composites.schemas import (
@@ -93,14 +98,20 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     VM_CLONE_RESPONSE_SCHEMA,
     VM_CREATE_PARAMETER_SCHEMA,
     VM_CREATE_RESPONSE_SCHEMA,
+    VM_DEVICE_CDROM_PARAMETER_SCHEMA,
+    VM_DEVICE_CDROM_RESPONSE_SCHEMA,
     VM_DISK_GROW_PARAMETER_SCHEMA,
     VM_DISK_GROW_RESPONSE_SCHEMA,
     VM_MIGRATE_PARAMETER_SCHEMA,
     VM_MIGRATE_RESPONSE_SCHEMA,
+    VM_NIC_REPOINT_PARAMETER_SCHEMA,
+    VM_NIC_REPOINT_RESPONSE_SCHEMA,
     VM_POWER_BULK_PARAMETER_SCHEMA,
     VM_POWER_BULK_RESPONSE_SCHEMA,
     VM_POWER_PARAMETER_SCHEMA,
     VM_POWER_RESPONSE_SCHEMA,
+    VM_RESIZE_PARAMETER_SCHEMA,
+    VM_RESIZE_RESPONSE_SCHEMA,
     VM_SNAPSHOT_REVERT_PARAMETER_SCHEMA,
     VM_SNAPSHOT_REVERT_RESPONSE_SCHEMA,
 )
@@ -214,7 +225,7 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
 class _CompositeSpec(NamedTuple):
     """Per-composite registration arguments.
 
-    Field-table form rather than fourteen repeated kwargs blocks:
+    Field-table form rather than seventeen repeated kwargs blocks:
     keeps the op_id / handler / schemas / group / tags / policy
     posture adjacent per composite and drops the outer registrar
     function below the 100-line block limit. Common fields
@@ -652,6 +663,76 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         safety_level="dangerous",
         requires_approval=True,
     ),
+    # ----------------------------------------------------------------
+    # Hardware write composites (#2891) -- dangerous / requires approval
+    # ----------------------------------------------------------------
+    _CompositeSpec(
+        op_id="vmware.composite.vm.resize",
+        handler=vm_resize_composite,
+        summary="Reconfigure a VM's CPU count / cores-per-socket and/or memory.",
+        description=(
+            "Reads current sizing + hot-add flags via GET:/vcenter/vm/{vm}, "
+            "then PATCHes PATCH:/vcenter/vm/{vm}/hardware/cpu and/or "
+            "PATCH:/vcenter/vm/{vm}/hardware/memory. A freshly-cloned VM is "
+            "stuck at the template's sizing; this rightsizes it. A change a "
+            "powered-on VM cannot take live (no hot-add, a decrease, or a "
+            "cores_per_socket change) returns status='requires_power_off' "
+            "rather than a raw vCenter 400; a request already matching "
+            "current returns 'no_change'. Equivalent of the sizing half of "
+            "'govc vm.change'."
+        ),
+        parameter_schema=VM_RESIZE_PARAMETER_SCHEMA,
+        response_schema=VM_RESIZE_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "hardware"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.nic.repoint",
+        handler=vm_nic_repoint_composite,
+        summary="Repoint a vNIC to a different distributed portgroup.",
+        description=(
+            "Reads the NIC's current backing + MAC via "
+            "GET:/vcenter/vm/{vm}/hardware/ethernet/{nic}, resolves the "
+            "target portgroup by display name via "
+            "GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP (there "
+            "is no dedicated portgroup list resource), then PATCHes the NIC "
+            "backing to {type: DISTRIBUTED_PORTGROUP, network}. A name that "
+            "resolves to zero / many portgroups refuses the repoint "
+            "(status='not_found' / 'ambiguous') with no PATCH issued. The "
+            "from->to network pair is what the four-eyes reviewer needs. "
+            "Equivalent of 'govc vm.network.change'."
+        ),
+        parameter_schema=VM_NIC_REPOINT_PARAMETER_SCHEMA,
+        response_schema=VM_NIC_REPOINT_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "networking"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.device.cdrom",
+        handler=vm_device_cdrom_composite,
+        summary="Remove / update / disconnect a VM CD-ROM device.",
+        description=(
+            "Reads the CD-ROM's current backing + state via "
+            "GET:/vcenter/vm/{vm}/hardware/cdrom/{cdrom} (the host-local ISO "
+            "path the approver needs to see), then dispatches the requested "
+            "action: 'remove' (DELETE the device), 'update' (PATCH its "
+            "backing, e.g. to CLIENT_DEVICE to un-pin a host-local ISO), or "
+            "'disconnect' (POST ?action=disconnect). A template shipping a "
+            "host-local-ISO-backed CD-ROM silently pins every clone to one "
+            "host and blocks vMotion; this clears it. Equivalent of "
+            "'govc device.cdrom.eject' / 'govc device.remove'."
+        ),
+        parameter_schema=VM_DEVICE_CDROM_PARAMETER_SCHEMA,
+        response_schema=VM_DEVICE_CDROM_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "hardware"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
 )
 
 
@@ -668,11 +749,13 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 18 composites total -- 5 read (T5 / #508) + 13 write (T6 /
+    Scope: 21 composites total -- 5 read (T5 / #508) + 16 write (T6 /
     #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
     ``vm.disk.grow`` / #2893, the folder-template
-    ``vm.clone_from_template`` / #2894, and the vim cluster / inventory writes
-    ``cluster.drs_rule.create`` + ``folder.create`` / #2895). (The former
+    ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
+    ``cluster.drs_rule.create`` + ``folder.create`` / #2895, and the #2891
+    hardware writes ``vm.resize`` / ``vm.nic.repoint`` /
+    ``vm.device.cdrom``). (The former
     ``host.network_uplinks`` / ``host.vsan_health`` reads were re-shipped
     as typed ops in #2258.)
     Each composite's ``safety_level`` +

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -1,15 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
-# code-quality-allow: 13 protocol-driven composite handlers for the
+# code-quality-allow: 16 protocol-driven composite handlers for the
 # vSphere REST + VI-JSON write surface ship in one module per the issue
 # body's design; splitting them by group would scatter the shared
 # sub-op_id constants + helpers across files for no readability gain. Each
 # handler's body is the documented orchestration workflow from #509's spec
 # (plus the mutating VI-JSON disk-grow from #2893, the folder-template clone
-# from #2894, and the vim cluster / inventory writes — DRS-rule + folder
-# create — from #2895).
+# from #2894, the vim cluster / inventory writes — DRS-rule + folder
+# create — from #2895, and the #2891 hardware writes — vm.resize /
+# vm.nic.repoint / vm.device.cdrom).
 
-"""Write-shaped ``vmware.composite.*`` handler functions (13 composites).
+"""Write-shaped ``vmware.composite.*`` handler functions (16 composites).
 
 Companion to :mod:`._read`. Post-#2256 each handler is a module-level
 ``async def`` taking the dispatcher's composite-branch keyword args
@@ -108,10 +109,13 @@ __all__ = [
     "vm_clone_composite",
     "vm_clone_from_template_composite",
     "vm_create_composite",
+    "vm_device_cdrom_composite",
     "vm_disk_grow_composite",
     "vm_migrate_composite",
+    "vm_nic_repoint_composite",
     "vm_power_bulk_composite",
     "vm_power_composite",
+    "vm_resize_composite",
     "vm_snapshot_revert_composite",
 ]
 
@@ -157,7 +161,14 @@ _OP_GET_DRS_RECOMMENDATIONS = "GET:/vcenter/cluster/{cluster}/drs/recommendation
 _OP_DEPLOY_LIBRARY_VM = "POST:/vcenter/vm-template/library-items?action=deploy"
 _OP_GET_TASK = "GET:/cis/tasks/{task}"
 _OP_HOST_PATCH = "POST:/vcenter/host/{host}?action=patch"
-_OP_LIST_PORTGROUPS = "GET:/vcenter/network/distributed-portgroup"
+# There is NO dedicated ``distributed-portgroup(s)`` list resource in the
+# REST Automation API: distributed portgroups are enumerated via the
+# generic network resource filtered to ``DISTRIBUTED_PORTGROUP`` (the
+# #1602 reconciliation lesson -- the singular ``distributed-portgroup``
+# op_id #509 declared here was absent from the pinned spec). Each summary
+# row is ``{network (id), name, type}``. Mirrors ``_read._OP_LIST_NETWORK``.
+_OP_LIST_NETWORK = "GET:/vcenter/network"
+_NETWORK_TYPE_DISTRIBUTED_PORTGROUP = "DISTRIBUTED_PORTGROUP"
 _OP_REMOVE_DVS_HOST = "POST:/vcenter/network/dvs/{dvs}?action=remove_host"
 # REST Disk.Info read — the disk-grow park-time preview reads label +
 # current capacity (bytes) off this; the disk id is the vim device key.
@@ -337,6 +348,21 @@ _VIM_SUB_OPS_CLUSTER_DRS_RULE_CREATE: tuple[str, ...] = (
 )
 _VIM_SUB_OPS_FOLDER_CREATE: tuple[str, ...] = (_OP_CREATE_FOLDER,)
 
+# Hardware write ops (#2891). Post-clone reconfigure of a VM's virtual
+# hardware, straight vSphere Automation REST. CPU/memory update and the
+# ethernet/cdrom device sub-resources take the update spec wrapped in the
+# ``{"spec": {...}}`` envelope this connector's write sub-ops author (see
+# ``_write_sub_op``); the CD-ROM ``disconnect`` rides an ``?action=``
+# suffix like the other action endpoints (power / relocate / maintenance).
+_OP_UPDATE_VM_CPU = "PATCH:/vcenter/vm/{vm}/hardware/cpu"
+_OP_UPDATE_VM_MEMORY = "PATCH:/vcenter/vm/{vm}/hardware/memory"
+_OP_GET_VM_NIC = "GET:/vcenter/vm/{vm}/hardware/ethernet/{nic}"
+_OP_UPDATE_VM_NIC = "PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}"
+_OP_GET_VM_CDROM = "GET:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}"
+_OP_UPDATE_VM_CDROM = "PATCH:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}"
+_OP_DELETE_VM_CDROM = "DELETE:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}"
+_OP_DISCONNECT_VM_CDROM = "POST:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}?action=disconnect"
+
 
 def _power_vm_op_id(action: str) -> str:
     """Build the per-action canonical op_id for ``POST:/vcenter/vm/{vm}/power``.
@@ -390,6 +416,9 @@ _COMPOSITE_OP_ID_VM_POWER = "vmware.composite.vm.power"
 _COMPOSITE_OP_ID_HOST_EVACUATE = "vmware.composite.host.evacuate"
 _COMPOSITE_OP_ID_HOST_DETACH_FROM_VDS = "vmware.composite.host.detach_from_vds"
 _COMPOSITE_OP_ID_CLUSTER_PATCH = "vmware.composite.cluster.patch"
+_COMPOSITE_OP_ID_VM_RESIZE = "vmware.composite.vm.resize"
+_COMPOSITE_OP_ID_VM_NIC_REPOINT = "vmware.composite.vm.nic.repoint"
+_COMPOSITE_OP_ID_VM_DEVICE_CDROM = "vmware.composite.vm.device.cdrom"
 
 # Per-composite sub-op-id tuples. Pre-#2256 these fed the L2 pre-flight
 # check that guarded a missing catalog ingest; the direct-session migration
@@ -449,7 +478,7 @@ _SUB_OPS_HOST_EVACUATE: tuple[str, ...] = (
     _host_maintenance_op_id("enter"),
 )
 _SUB_OPS_HOST_DETACH_FROM_VDS: tuple[str, ...] = (
-    _OP_LIST_PORTGROUPS,
+    _OP_LIST_NETWORK,
     _OP_LIST_VMS,
     _OP_ATTACH_VM_NIC,
     _OP_REMOVE_DVS_HOST,
@@ -459,6 +488,22 @@ _SUB_OPS_CLUSTER_PATCH: tuple[str, ...] = (
     _host_maintenance_op_id("enter"),
     _host_maintenance_op_id("exit"),
     _OP_HOST_PATCH,
+)
+_SUB_OPS_VM_RESIZE: tuple[str, ...] = (
+    _OP_GET_VM,
+    _OP_UPDATE_VM_CPU,
+    _OP_UPDATE_VM_MEMORY,
+)
+_SUB_OPS_VM_NIC_REPOINT: tuple[str, ...] = (
+    _OP_GET_VM_NIC,
+    _OP_LIST_NETWORK,
+    _OP_UPDATE_VM_NIC,
+)
+_SUB_OPS_VM_DEVICE_CDROM: tuple[str, ...] = (
+    _OP_GET_VM_CDROM,
+    _OP_UPDATE_VM_CDROM,
+    _OP_DELETE_VM_CDROM,
+    _OP_DISCONNECT_VM_CDROM,
 )
 
 
@@ -1430,7 +1475,11 @@ async def host_detach_from_vds_composite(
     fallback_network = params["fallback_network"]
 
     await _read_sub_op(
-        connector, target, operator, _OP_LIST_PORTGROUPS, {"filter.hosts": [host_moid]}
+        connector,
+        target,
+        operator,
+        _OP_LIST_NETWORK,
+        {"filter.types": [_NETWORK_TYPE_DISTRIBUTED_PORTGROUP], "filter.hosts": [host_moid]},
     )
     vms = await _resolve_vm_list(
         connector=connector, target=target, operator=operator, filter_dict={"hosts": [host_moid]}
@@ -2661,3 +2710,416 @@ async def folder_create_composite(
         "folder": new_folder_moid,
         "guidance": None,
     }
+
+
+# ===========================================================================
+# Hardware write composites (#2891): vm.resize / vm.nic.repoint /
+# vm.device.cdrom -- pure vSphere Automation REST post-clone reconfigure.
+# ===========================================================================
+
+
+async def _read_vm_info(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    vm_moid: str,
+) -> dict[str, Any] | None:
+    """Read a VM's config via ``GET:/vcenter/vm/{vm}`` (name, power_state, cpu, memory).
+
+    Shared seam (#1608): the ``vm.resize`` handler + preview read current
+    sizing here, and the ``vm.nic.repoint`` / ``vm.device.cdrom`` previews
+    read the VM's display ``name`` from it. One read-only GET on the
+    connector session; returns the unwrapped ``Vm.Info`` dict, or ``None``
+    when the payload is not a dict.
+    """
+    payload = await _read_sub_op(connector, target, operator, _OP_GET_VM, {"vm": vm_moid})
+    info = _unwrap_value(payload)
+    return info if isinstance(info, dict) else None
+
+
+async def _read_ethernet_nic(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    vm_moid: str,
+    nic_id: str,
+) -> dict[str, Any] | None:
+    """Read one vNIC via ``GET:/vcenter/vm/{vm}/hardware/ethernet/{nic}`` (mac + backing).
+
+    Shared between the ``vm.nic.repoint`` handler and its preview builder
+    (#1608). Returns the unwrapped ``Ethernet.Info`` dict or ``None``.
+    """
+    payload = await _read_sub_op(
+        connector, target, operator, _OP_GET_VM_NIC, {"vm": vm_moid, "nic": nic_id}
+    )
+    info = _unwrap_value(payload)
+    return info if isinstance(info, dict) else None
+
+
+async def _read_cdrom(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    vm_moid: str,
+    cdrom_id: str,
+) -> dict[str, Any] | None:
+    """Read one CD-ROM via ``GET:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}`` (backing + state).
+
+    Shared between the ``vm.device.cdrom`` handler and its preview builder
+    (#1608). Returns the unwrapped ``Cdrom.Info`` dict or ``None``.
+    """
+    payload = await _read_sub_op(
+        connector, target, operator, _OP_GET_VM_CDROM, {"vm": vm_moid, "cdrom": cdrom_id}
+    )
+    info = _unwrap_value(payload)
+    return info if isinstance(info, dict) else None
+
+
+async def _resolve_distributed_portgroup(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    portgroup_name: str,
+) -> tuple[str | None, str, list[dict[str, Any]]]:
+    """Resolve a distributed-portgroup display name to its network moid.
+
+    Reads ``GET:/vcenter/network`` filtered to ``DISTRIBUTED_PORTGROUP`` +
+    the name (the #1602 fix -- there is no dedicated portgroup list
+    resource). Returns ``(network_moid, "ok", [])`` on a unique match,
+    ``(None, "not_found", [])`` on no match, or ``(None, "ambiguous",
+    candidates)`` when the name is not unique. Shared between the
+    ``vm.nic.repoint`` handler (dispatch time) and its preview builder
+    (#1608), so the reviewer sees the same portgroup the approved dispatch
+    will bind.
+    """
+    listing = await _read_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_LIST_NETWORK,
+        {
+            "filter.types": [_NETWORK_TYPE_DISTRIBUTED_PORTGROUP],
+            "filter.names": [portgroup_name],
+        },
+    )
+    rows = _unwrap_value(listing)
+    matches = (
+        [row for row in rows if isinstance(row, dict) and row.get("name") == portgroup_name]
+        if isinstance(rows, list)
+        else []
+    )
+    if not matches:
+        return None, "not_found", []
+    if len(matches) > 1:
+        return None, "ambiguous", matches
+    network_moid = matches[0].get("network")
+    if not isinstance(network_moid, str):
+        return None, "not_found", matches
+    return network_moid, "ok", []
+
+
+def _resize_requires_power_off(
+    *,
+    current: dict[str, Any],
+    cpu_count: int | None,
+    cores_per_socket: int | None,
+    memory_mib: int | None,
+    cpu_hot_add: bool,
+    memory_hot_add: bool,
+) -> str | None:
+    """Return a reason when a *powered-on* VM cannot take the resize live, else ``None``.
+
+    vCenter refuses (HTTP 400) a live CPU/memory change that is not a
+    hot-add: a count/size *increase* needs the matching hot-add flag; a
+    *decrease* or any ``cores_per_socket`` change is never live. Surfacing
+    this as a typed ``requires_power_off`` status (rather than letting the
+    PATCH 400) is the composite's contract. Consulted only when the VM is
+    powered on.
+    """
+    cur_count = current.get("cpu_count")
+    cur_cores = current.get("cores_per_socket")
+    cur_mem = current.get("memory_MiB")
+    if (
+        cpu_count is not None
+        and cpu_count != cur_count
+        and (not cpu_hot_add or (isinstance(cur_count, int) and cpu_count < cur_count))
+    ):
+        return "CPU count change needs hot-add (increase only) on a powered-on VM; power off first"
+    if (
+        cores_per_socket is not None
+        and isinstance(cur_cores, int)
+        and cores_per_socket != cur_cores
+    ):
+        return "cores_per_socket cannot change on a powered-on VM; power off first"
+    if (
+        memory_mib is not None
+        and memory_mib != cur_mem
+        and (not memory_hot_add or (isinstance(cur_mem, int) and memory_mib < cur_mem))
+    ):
+        return "memory change needs hot-add (increase only) on a powered-on VM; power off first"
+    return None
+
+
+async def vm_resize_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Reconfigure a VM's CPU count / cores-per-socket and/or memory.
+
+    Op-id: ``vmware.composite.vm.resize``. Reads current sizing + hot-add
+    flags via ``GET:/vcenter/vm/{vm}``, then PATCHes ``hardware/cpu``
+    and/or ``hardware/memory``. A change a powered-on VM cannot take live
+    returns ``status='requires_power_off'`` (never a raw 400); a request
+    already matching current returns ``no_change``; a CPU PATCH that lands
+    followed by a memory PATCH that faults returns ``partial``.
+    """
+    vm_moid = params["vm"]
+    req_cpu_count = params.get("cpu_count")
+    req_cores = params.get("cores_per_socket")
+    req_mem = params.get("memory_mib")
+
+    info = await _read_vm_info(
+        connector=connector, target=target, operator=operator, vm_moid=vm_moid
+    )
+    if info is None:
+        raise RuntimeError(f"vm.resize: GET:/vcenter/vm/{vm_moid} returned no VM info dict")
+    cpu_raw = info.get("cpu")
+    mem_raw = info.get("memory")
+    cpu_info = cpu_raw if isinstance(cpu_raw, dict) else {}
+    mem_info = mem_raw if isinstance(mem_raw, dict) else {}
+    power_state = info.get("power_state")
+    from_sizing = {
+        "cpu_count": cpu_info.get("count"),
+        "cores_per_socket": cpu_info.get("cores_per_socket"),
+        "memory_MiB": mem_info.get("size_MiB"),
+    }
+    base = {
+        "vm": vm_moid,
+        "name": info.get("name"),
+        "power_state": power_state,
+        "from": from_sizing,
+        "to": {"cpu_count": req_cpu_count, "cores_per_socket": req_cores, "memory_MiB": req_mem},
+    }
+
+    cpu_changes = (req_cpu_count is not None and req_cpu_count != from_sizing["cpu_count"]) or (
+        req_cores is not None and req_cores != from_sizing["cores_per_socket"]
+    )
+    mem_changes = req_mem is not None and req_mem != from_sizing["memory_MiB"]
+    if not cpu_changes and not mem_changes:
+        return {
+            **base,
+            "status": "no_change",
+            "applied": {"cpu": False, "memory": False},
+            "guidance": None,
+        }
+
+    if power_state == "POWERED_ON":
+        reason = _resize_requires_power_off(
+            current=from_sizing,
+            cpu_count=req_cpu_count,
+            cores_per_socket=req_cores,
+            memory_mib=req_mem,
+            cpu_hot_add=bool(cpu_info.get("hot_add_enabled")),
+            memory_hot_add=bool(mem_info.get("hot_add_enabled")),
+        )
+        if reason is not None:
+            return {
+                **base,
+                "status": "requires_power_off",
+                "applied": {"cpu": False, "memory": False},
+                "guidance": reason,
+            }
+
+    applied_cpu = False
+    if cpu_changes:
+        cpu_spec: dict[str, Any] = {}
+        if req_cpu_count is not None:
+            cpu_spec["count"] = req_cpu_count
+        if req_cores is not None:
+            cpu_spec["cores_per_socket"] = req_cores
+        gate, _ = await _write_sub_op(
+            connector, target, operator, _OP_UPDATE_VM_CPU, {"vm": vm_moid, "spec": cpu_spec}
+        )
+        if gate is not None:
+            return gate
+        applied_cpu = True
+
+    if mem_changes:
+        try:
+            gate, _ = await _write_sub_op(
+                connector,
+                target,
+                operator,
+                _OP_UPDATE_VM_MEMORY,
+                {"vm": vm_moid, "spec": {"size_MiB": req_mem}},
+            )
+        except httpx.HTTPError as exc:
+            if applied_cpu:
+                return {
+                    **base,
+                    "status": "partial",
+                    "applied": {"cpu": True, "memory": False},
+                    "guidance": f"CPU applied; memory update failed: {exc}",
+                }
+            raise
+        if gate is not None:
+            return gate
+        return {
+            **base,
+            "status": "resized",
+            "applied": {"cpu": applied_cpu, "memory": True},
+            "guidance": None,
+        }
+
+    return {
+        **base,
+        "status": "resized",
+        "applied": {"cpu": applied_cpu, "memory": False},
+        "guidance": None,
+    }
+
+
+async def vm_nic_repoint_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Repoint an existing vNIC to a different distributed portgroup.
+
+    Op-id: ``vmware.composite.vm.nic.repoint``. Reads the NIC's current
+    backing + MAC via ``GET:/vcenter/vm/{vm}/hardware/ethernet/{nic}``,
+    resolves the target portgroup by name via ``GET:/vcenter/network``
+    filtered to ``DISTRIBUTED_PORTGROUP`` (the #1602 fix -- no dedicated
+    portgroup list resource), then PATCHes the NIC backing. A name that
+    resolves to zero / many portgroups refuses the repoint
+    (``not_found`` / ``ambiguous``) with no PATCH issued.
+    """
+    vm_moid = params["vm"]
+    nic_id = params["nic"]
+    portgroup_name = params["portgroup_name"]
+
+    nic_info = await _read_ethernet_nic(
+        connector=connector, target=target, operator=operator, vm_moid=vm_moid, nic_id=nic_id
+    )
+    mac_address = nic_info.get("mac_address") if nic_info else None
+    current_backing = nic_info.get("backing") if nic_info else None
+
+    network_moid, resolution, candidates = await _resolve_distributed_portgroup(
+        connector=connector, target=target, operator=operator, portgroup_name=portgroup_name
+    )
+    base = {
+        "vm": vm_moid,
+        "nic": nic_id,
+        "mac_address": mac_address,
+        "current_backing": current_backing,
+        "requested_backing": {"portgroup_id": network_moid, "portgroup_name": portgroup_name},
+    }
+    if resolution == "not_found":
+        return {
+            **base,
+            "status": "not_found",
+            "candidates": [],
+            "guidance": f"no distributed portgroup named {portgroup_name!r}",
+        }
+    if resolution == "ambiguous":
+        return {
+            **base,
+            "status": "ambiguous",
+            "candidates": candidates,
+            "guidance": "multiple distributed portgroups share the name; pass a unique name",
+        }
+
+    gate, _ = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_UPDATE_VM_NIC,
+        {
+            "vm": vm_moid,
+            "nic": nic_id,
+            "spec": {
+                "backing": {"type": _NETWORK_TYPE_DISTRIBUTED_PORTGROUP, "network": network_moid}
+            },
+        },
+    )
+    if gate is not None:
+        return gate
+    return {**base, "status": "repointed", "candidates": [], "guidance": None}
+
+
+async def vm_device_cdrom_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Remove / update / disconnect a VM CD-ROM device.
+
+    Op-id: ``vmware.composite.vm.device.cdrom``. Reads the device's
+    current backing + state via ``GET:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}``
+    (the host-local ISO path the approver needs to see), then dispatches
+    the requested ``action``: ``remove`` (DELETE the device), ``update``
+    (PATCH its backing -- requires ``backing``), or ``disconnect`` (POST
+    ``?action=disconnect``). ``update`` without a ``backing`` object
+    returns ``invalid_request`` with no write issued.
+    """
+    vm_moid = params["vm"]
+    cdrom_id = params["cdrom"]
+    action = params["action"]
+
+    cdrom_info = await _read_cdrom(
+        connector=connector, target=target, operator=operator, vm_moid=vm_moid, cdrom_id=cdrom_id
+    )
+    base = {
+        "vm": vm_moid,
+        "cdrom": cdrom_id,
+        "action": action,
+        "current_backing": cdrom_info.get("backing") if cdrom_info else None,
+        "state": cdrom_info.get("state") if cdrom_info else None,
+        "requested_backing": None,
+        "guidance": None,
+    }
+
+    if action == "remove":
+        gate, _ = await _write_sub_op(
+            connector, target, operator, _OP_DELETE_VM_CDROM, {"vm": vm_moid, "cdrom": cdrom_id}
+        )
+        if gate is not None:
+            return gate
+        return {**base, "status": "removed"}
+
+    if action == "disconnect":
+        gate, _ = await _write_sub_op(
+            connector, target, operator, _OP_DISCONNECT_VM_CDROM, {"vm": vm_moid, "cdrom": cdrom_id}
+        )
+        if gate is not None:
+            return gate
+        return {**base, "status": "disconnected"}
+
+    backing = params.get("backing")
+    if not isinstance(backing, dict):
+        return {
+            **base,
+            "status": "invalid_request",
+            "guidance": "action='update' needs a 'backing' object, e.g. {'type': 'CLIENT_DEVICE'}",
+        }
+    gate, _ = await _write_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_UPDATE_VM_CDROM,
+        {"vm": vm_moid, "cdrom": cdrom_id, "spec": {"backing": backing}},
+    )
+    if gate is not None:
+        return gate
+    return {**base, "status": "updated", "requested_backing": backing}

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` preview builders for the 13 vmware write composites.
+"""Park-time ``proposed_effect`` preview builders for the 16 vmware write composites.
 
 G0.22-T3 (#1608). Before this module, a parked ``vmware.composite.*``
 write stored only the identifier default ``{op_id, connector_id,
@@ -9,7 +9,7 @@ target_id}`` in :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect
 — and because the original dispatch ``params`` are deliberately never
 serialised onto a reviewer-facing surface (#1503), the four-eyes
 approver could not tell a one-VM power cycle from a 1000-VM outage.
-This wires all 13 write composites onto the per-op preview hook shipped
+This wires all 16 write composites onto the per-op preview hook shipped
 by #1437 (:mod:`meho_backplane.operations._preview`), following the
 argocd pattern (#1452): reuse the handlers' own read-only resolution
 helpers, never the mutating sub-ops.
@@ -37,6 +37,12 @@ helpers, never the mutating sub-ops.
 ``cluster.drs_rule.create`` live-read: cluster, cluster_name, rule_type,
                           rule_name, enabled, resolved, total_resolved
 ``folder.create``         echo: parent_folder, new_folder_name
+``vm.resize``             live-read: ``{vm, name, power_state, current,
+                          requested}`` sizing from->to
+``vm.nic.repoint``        live-read: ``{vm, name, nic, mac_address,
+                          current_backing, requested_backing}`` network from->to
+``vm.device.cdrom``       live-read: ``{vm, name, cdrom, action,
+                          current_backing, state}`` (the host-local ISO path)
 ========================  ====================================================
 
 Two preview depths, chosen per composite
@@ -55,6 +61,16 @@ Two preview depths, chosen per composite
   not a param — so the preview reads the disk's current size + label and
   echoes the requested capacity so the approver sees the disk grows (never
   shrinks) and by how much.
+* **Live-read from->to diff** for the three #2891 hardware composites
+  (``vm.resize`` / ``vm.nic.repoint`` / ``vm.device.cdrom``): the delta
+  *is* the decision, so the builder live-reads the VM's current sizing /
+  NIC backing / CD-ROM backing via the same shared helpers the handlers
+  use (:func:`._write._read_vm_info` / :func:`._write._read_ethernet_nic`
+  / :func:`._write._read_cdrom` /
+  :func:`._write._resolve_distributed_portgroup`) and pairs it with the
+  requested change. Declines (``None`` -> identifier-only default) when no
+  connector resolved or the VM read returns no dict, and fails-soft on a
+  resolution fault exactly like the fan-out builders.
 * **Param echo** (no I/O — the ``secret.move`` precedent, #1580) for the
   six single-entity composites whose params fully name the blast
   radius. ``vm.clone_from_template`` echoes only the customization spec
@@ -114,9 +130,13 @@ from typing import Any
 
 from meho_backplane.connectors.vmware_rest.composites._write import (
     _GUEST_POWER_VERBS,
+    _read_cdrom,
+    _read_ethernet_nic,
+    _read_vm_info,
     _resolve_cluster_hosts,
     _resolve_cluster_name,
     _resolve_disk_info,
+    _resolve_distributed_portgroup,
     _resolve_vm_list,
     _resolve_vm_name,
 )
@@ -518,7 +538,140 @@ async def _folder_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     return {"parent_folder": parent_folder, "new_folder_name": folder_name}
 
 
-#: op_id → builder for the 13 write composites. Module-level so the
+async def _vm_resize_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.resize`` — live-read the current sizing, echo the requested.
+
+    The from->to diff is the decision the approver signs off: which VM,
+    what it is now (cpu_count / cores_per_socket / memory_MiB + power
+    state), and what it would become. Reads current sizing via the shared
+    :func:`._write._read_vm_info` (one read-only GET); no CPU/memory PATCH
+    fires here.
+    """
+    vm = ctx.params.get("vm")
+    if not isinstance(vm, str) or ctx.connector_instance is None:
+        return None
+    info = await _read_vm_info(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        vm_moid=vm,
+    )
+    if info is None:
+        return None
+    cpu_raw = info.get("cpu")
+    mem_raw = info.get("memory")
+    cpu = cpu_raw if isinstance(cpu_raw, dict) else {}
+    mem = mem_raw if isinstance(mem_raw, dict) else {}
+    return {
+        "vm": vm,
+        "name": info.get("name"),
+        "power_state": info.get("power_state"),
+        "current": {
+            "cpu_count": cpu.get("count"),
+            "cores_per_socket": cpu.get("cores_per_socket"),
+            "memory_MiB": mem.get("size_MiB"),
+        },
+        "requested": {
+            "cpu_count": ctx.params.get("cpu_count"),
+            "cores_per_socket": ctx.params.get("cores_per_socket"),
+            "memory_MiB": ctx.params.get("memory_mib"),
+        },
+    }
+
+
+async def _vm_nic_repoint_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.nic.repoint`` — live-read the NIC + resolve the target portgroup.
+
+    The from->to network pair is what the four-eyes reviewer needs: the
+    NIC's current backing (which network it is on now) and the target
+    portgroup (name + resolved moid). Reads the NIC via
+    :func:`._write._read_ethernet_nic` and resolves the portgroup via
+    :func:`._write._resolve_distributed_portgroup` (the same helper the
+    approved dispatch binds); the VM ``name`` comes from
+    :func:`._write._read_vm_info`. No NIC PATCH fires here.
+    """
+    vm = ctx.params.get("vm")
+    nic = ctx.params.get("nic")
+    portgroup_name = ctx.params.get("portgroup_name")
+    if (
+        not isinstance(vm, str)
+        or not isinstance(nic, str)
+        or not isinstance(portgroup_name, str)
+        or ctx.connector_instance is None
+    ):
+        return None
+    info = await _read_vm_info(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        vm_moid=vm,
+    )
+    nic_info = await _read_ethernet_nic(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        vm_moid=vm,
+        nic_id=nic,
+    )
+    network_moid, _resolution, _candidates = await _resolve_distributed_portgroup(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        portgroup_name=portgroup_name,
+    )
+    return {
+        "vm": vm,
+        "name": info.get("name") if info else None,
+        "nic": nic,
+        "mac_address": nic_info.get("mac_address") if nic_info else None,
+        "current_backing": nic_info.get("backing") if nic_info else None,
+        "requested_backing": {"portgroup_id": network_moid, "portgroup_name": portgroup_name},
+    }
+
+
+async def _vm_device_cdrom_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.device.cdrom`` — live-read the current backing + state.
+
+    The host-local ISO path in the current backing is exactly what the
+    approver needs to see before removing / updating / disconnecting the
+    device. Reads the CD-ROM via :func:`._write._read_cdrom` and the VM
+    ``name`` via :func:`._write._read_vm_info`; no DELETE / PATCH /
+    disconnect fires here.
+    """
+    vm = ctx.params.get("vm")
+    cdrom = ctx.params.get("cdrom")
+    action = ctx.params.get("action")
+    if (
+        not isinstance(vm, str)
+        or not isinstance(cdrom, str)
+        or not isinstance(action, str)
+        or ctx.connector_instance is None
+    ):
+        return None
+    info = await _read_vm_info(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        vm_moid=vm,
+    )
+    cdrom_info = await _read_cdrom(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        vm_moid=vm,
+        cdrom_id=cdrom,
+    )
+    return {
+        "vm": vm,
+        "name": info.get("name") if info else None,
+        "cdrom": cdrom,
+        "action": action,
+        "current_backing": cdrom_info.get("backing") if cdrom_info else None,
+        "state": cdrom_info.get("state") if cdrom_info else None,
+    }
+
+
+#: op_id → builder for the 16 write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.create": _vm_create_preview,
@@ -529,6 +682,9 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.power": _vm_power_preview,
     "vmware.composite.vm.power.bulk": _vm_power_bulk_preview,
     "vmware.composite.vm.disk.grow": _vm_disk_grow_preview,
+    "vmware.composite.vm.resize": _vm_resize_preview,
+    "vmware.composite.vm.nic.repoint": _vm_nic_repoint_preview,
+    "vmware.composite.vm.device.cdrom": _vm_device_cdrom_preview,
     "vmware.composite.host.evacuate": _host_evacuate_preview,
     "vmware.composite.host.detach_from_vds": _host_detach_from_vds_preview,
     "vmware.composite.cluster.patch": _cluster_patch_preview,
@@ -538,7 +694,7 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 13 write-composite park-time preview builders. Import-time.
+    """Wire the 16 write-composite park-time preview builders. Import-time.
 
     The 5 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""JSON Schema 2020-12 parameter + response schemas for the 18 vmware-rest composites.
+"""JSON Schema 2020-12 parameter + response schemas for the 21 vmware-rest composites.
 
 Each schema is the operator-facing input contract; the dispatcher
 validates inbound ``params`` against the registered schema before
@@ -25,12 +25,14 @@ Conventions
   schema verbatim on ``describe_operation`` calls.
 * The 5 read composites are read-only -- the registration call site
   pins ``safety_level="safe"`` and ``requires_approval=False`` on
-  each. The 13 write composites inherit T4's
+  each. The 16 write composites inherit T4's
   ``safety_level="dangerous"`` + ``requires_approval=True`` defaults
   (G3.1-T6 / #509, single-VM ``vm.power`` / #2301, the mutating
   VI-JSON ``vm.disk.grow`` / #2893, the folder-template
-  ``vm.clone_from_template`` / #2894, and the vim cluster / inventory
-  writes ``cluster.drs_rule.create`` + ``folder.create`` / #2895). The schema
+  ``vm.clone_from_template`` / #2894, the vim cluster / inventory
+  writes ``cluster.drs_rule.create`` + ``folder.create`` / #2895, and
+  the #2891 hardware writes ``vm.resize`` / ``vm.nic.repoint`` /
+  ``vm.device.cdrom``). The schema
   text reflects which side of that line
   each composite sits on; the registration call site enforces the
   policy.
@@ -68,14 +70,20 @@ __all__ = [
     "VM_CLONE_RESPONSE_SCHEMA",
     "VM_CREATE_PARAMETER_SCHEMA",
     "VM_CREATE_RESPONSE_SCHEMA",
+    "VM_DEVICE_CDROM_PARAMETER_SCHEMA",
+    "VM_DEVICE_CDROM_RESPONSE_SCHEMA",
     "VM_DISK_GROW_PARAMETER_SCHEMA",
     "VM_DISK_GROW_RESPONSE_SCHEMA",
     "VM_MIGRATE_PARAMETER_SCHEMA",
     "VM_MIGRATE_RESPONSE_SCHEMA",
+    "VM_NIC_REPOINT_PARAMETER_SCHEMA",
+    "VM_NIC_REPOINT_RESPONSE_SCHEMA",
     "VM_POWER_BULK_PARAMETER_SCHEMA",
     "VM_POWER_BULK_RESPONSE_SCHEMA",
     "VM_POWER_PARAMETER_SCHEMA",
     "VM_POWER_RESPONSE_SCHEMA",
+    "VM_RESIZE_PARAMETER_SCHEMA",
+    "VM_RESIZE_RESPONSE_SCHEMA",
     "VM_SNAPSHOT_REVERT_PARAMETER_SCHEMA",
     "VM_SNAPSHOT_REVERT_RESPONSE_SCHEMA",
 ]
@@ -1790,4 +1798,317 @@ FOLDER_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["status", "parent_folder", "new_folder_name"],
+}
+
+
+# ---------------------------------------------------------------------------
+# Hardware write composites (#2891) -- parameter + response schemas
+# ---------------------------------------------------------------------------
+#
+# Three pure-REST hardware writes from the #2859 provisioning flow:
+# reconfigure CPU/memory (a freshly-cloned VM is stuck at the template's
+# sizing), repoint a vNIC to a different distributed portgroup, and
+# remove/edit/disconnect a CD-ROM (a template shipping a host-local-ISO
+# CD-ROM pins every clone to one host and blocks vMotion). Each is
+# ``dangerous`` / ``requires_approval=True`` like the other write
+# composites.
+
+
+#: ``vmware.composite.vm.resize`` parameter schema.
+#:
+#: Reads current sizing, then PATCHes CPU and/or memory. At least one of
+#: ``cpu_count`` / ``cores_per_socket`` / ``memory_mib`` must be present
+#: (``anyOf``). A change a powered-on VM cannot take live (no hot-add, a
+#: decrease, or any cores_per_socket change) returns
+#: ``status='requires_power_off'`` rather than a raw vCenter 400.
+VM_RESIZE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": "VM moid to resize.",
+        },
+        "cpu_count": {
+            "type": "integer",
+            "minimum": 1,
+            "description": (
+                "New total vCPU count. Omit to leave CPU count unchanged. "
+                "On a powered-on VM an increase requires CPU hot-add; a "
+                "decrease requires power off (surfaced as "
+                "``status='requires_power_off'``, never a raw 400)."
+            ),
+        },
+        "cores_per_socket": {
+            "type": "integer",
+            "minimum": 1,
+            "description": (
+                "New cores-per-socket. The total vCPU count must be a "
+                "multiple of this value. Not hot-changeable -- a change on "
+                "a powered-on VM returns ``status='requires_power_off'``."
+            ),
+        },
+        "memory_mib": {
+            "type": "integer",
+            "minimum": 1,
+            "description": (
+                "New memory size in MiB (maps to the vSphere ``size_MiB`` "
+                "field). Omit to leave memory unchanged. On a powered-on VM "
+                "an increase requires memory hot-add; a decrease requires "
+                "power off (``status='requires_power_off'``)."
+            ),
+        },
+    },
+    "required": ["vm"],
+    "anyOf": [
+        {"required": ["cpu_count"]},
+        {"required": ["cores_per_socket"]},
+        {"required": ["memory_mib"]},
+    ],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.nic.repoint`` parameter schema.
+#:
+#: Repoints an existing vNIC to a different distributed portgroup,
+#: resolved by display name via
+#: ``GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP`` (there is
+#: no dedicated portgroup list resource -- the #1602 reconciliation
+#: lesson). Ambiguous / missing names refuse the repoint.
+VM_NIC_REPOINT_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": "VM moid owning the vNIC.",
+        },
+        "nic": {
+            "type": "string",
+            "minLength": 1,
+            "description": "vNIC device id (e.g. ``4000``) to repoint.",
+        },
+        "portgroup_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Display name of the target distributed portgroup. "
+                "Resolved to its network moid via "
+                "``GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP``. "
+                "A name matching zero portgroups returns "
+                "``status='not_found'``; more than one returns "
+                "``status='ambiguous'`` with the candidates listed."
+            ),
+        },
+    },
+    "required": ["vm", "nic", "portgroup_name"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.device.cdrom`` parameter schema.
+#:
+#: Verb-driven CD-ROM edit: ``remove`` (DELETE the device), ``update``
+#: (PATCH its backing -- requires ``backing``), or ``disconnect`` (POST
+#: ``?action=disconnect``; the device stays but the guest sees it
+#: unplugged). The resolution read surfaces the current backing (the
+#: host-local ISO path the approver needs to see) into the preview.
+VM_DEVICE_CDROM_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "vm": {
+            "type": "string",
+            "minLength": 1,
+            "description": "VM moid owning the CD-ROM device.",
+        },
+        "cdrom": {
+            "type": "string",
+            "minLength": 1,
+            "description": "CD-ROM device id (e.g. ``16000``).",
+        },
+        "action": {
+            "type": "string",
+            "enum": ["remove", "update", "disconnect"],
+            "description": (
+                "``remove`` -> ``DELETE:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}``; "
+                "``update`` -> ``PATCH`` the backing (requires ``backing``); "
+                "``disconnect`` -> ``POST ?action=disconnect`` (the device "
+                "stays, the guest sees it unplugged)."
+            ),
+        },
+        "backing": {
+            "type": "object",
+            "additionalProperties": True,
+            "description": (
+                "New CD-ROM backing spec when ``action='update'`` (e.g. "
+                '``{"type": "CLIENT_DEVICE"}`` to un-pin a host-local '
+                "ISO backing). Ignored for ``remove`` / ``disconnect``."
+            ),
+        },
+    },
+    "required": ["vm", "cdrom", "action"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.resize`` response schema.
+VM_RESIZE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["resized", "requires_power_off", "no_change", "partial"],
+            "description": (
+                "``'resized'`` -- every requested dimension applied; "
+                "``'requires_power_off'`` -- the VM is powered on and the "
+                "change cannot be made live (no hot-add, a decrease, or a "
+                "cores_per_socket change); ``'no_change'`` -- the requested "
+                "values already match current; ``'partial'`` -- CPU applied "
+                "but the memory PATCH failed."
+            ),
+        },
+        "vm": {"type": "string", "description": "VM moid the resize targeted."},
+        "name": {
+            "type": ["string", "null"],
+            "description": "VM display name read from ``GET:/vcenter/vm/{vm}``.",
+        },
+        "power_state": {
+            "type": ["string", "null"],
+            "description": "VM power state at read time (e.g. ``POWERED_ON`` / ``POWERED_OFF``).",
+        },
+        "applied": {
+            "type": "object",
+            "properties": {
+                "cpu": {"type": "boolean"},
+                "memory": {"type": "boolean"},
+            },
+            "required": ["cpu", "memory"],
+            "description": "Which dimensions the composite actually PATCHed.",
+        },
+        "from": {
+            "type": "object",
+            "properties": {
+                "cpu_count": {"type": ["integer", "null"]},
+                "cores_per_socket": {"type": ["integer", "null"]},
+                "memory_MiB": {"type": ["integer", "null"]},
+            },
+            "description": "Current sizing read before the change.",
+        },
+        "to": {
+            "type": "object",
+            "properties": {
+                "cpu_count": {"type": ["integer", "null"]},
+                "cores_per_socket": {"type": ["integer", "null"]},
+                "memory_MiB": {"type": ["integer", "null"]},
+            },
+            "description": "Requested sizing (``null`` for dimensions left unchanged).",
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Next-step hint on ``requires_power_off`` / ``partial``; ``null`` otherwise."
+            ),
+        },
+    },
+    "required": ["status", "vm", "applied", "from", "to"],
+}
+
+
+#: ``vmware.composite.vm.nic.repoint`` response schema.
+VM_NIC_REPOINT_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["repointed", "not_found", "ambiguous"],
+            "description": (
+                "``'repointed'`` -- the NIC backing was PATCHed to the "
+                "target portgroup; ``'not_found'`` -- no distributed "
+                "portgroup matched ``portgroup_name``; ``'ambiguous'`` -- "
+                "more than one did (candidates listed, no PATCH issued)."
+            ),
+        },
+        "vm": {"type": "string", "description": "VM moid owning the NIC."},
+        "nic": {"type": "string", "description": "vNIC device id repointed."},
+        "mac_address": {
+            "type": ["string", "null"],
+            "description": (
+                "NIC MAC address read from ``GET:/vcenter/vm/{vm}/hardware/ethernet/{nic}``."
+            ),
+        },
+        "current_backing": {
+            "type": ["object", "null"],
+            "description": "The NIC's backing before the repoint (type, network, network_name).",
+        },
+        "requested_backing": {
+            "type": "object",
+            "properties": {
+                "portgroup_id": {"type": ["string", "null"]},
+                "portgroup_name": {"type": "string"},
+            },
+            "required": ["portgroup_id", "portgroup_name"],
+            "description": "The target distributed portgroup (moid resolved from the name).",
+        },
+        "candidates": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": "Matching portgroup rows when ``status='ambiguous'`` (empty otherwise).",
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Disambiguation hint on ``not_found`` / ``ambiguous``; ``null`` otherwise."
+            ),
+        },
+    },
+    "required": ["status", "vm", "nic", "requested_backing"],
+}
+
+
+#: ``vmware.composite.vm.device.cdrom`` response schema.
+VM_DEVICE_CDROM_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["removed", "updated", "disconnected", "invalid_request"],
+            "description": (
+                "``'removed'`` -- the device was deleted; ``'updated'`` -- "
+                "its backing was PATCHed; ``'disconnected'`` -- the device "
+                "was disconnected in-guest; ``'invalid_request'`` -- "
+                "``action='update'`` without a ``backing`` object (no write "
+                "issued)."
+            ),
+        },
+        "vm": {"type": "string", "description": "VM moid owning the CD-ROM."},
+        "cdrom": {"type": "string", "description": "CD-ROM device id acted on."},
+        "action": {
+            "type": "string",
+            "enum": ["remove", "update", "disconnect"],
+            "description": "The verb requested.",
+        },
+        "current_backing": {
+            "type": ["object", "null"],
+            "description": (
+                "The CD-ROM backing read before the change (the host-local "
+                "ISO path the approver needs to see)."
+            ),
+        },
+        "state": {
+            "type": ["string", "null"],
+            "description": (
+                "Connection state at read time (e.g. ``CONNECTED`` / ``NOT_CONNECTED``)."
+            ),
+        },
+        "requested_backing": {
+            "type": ["object", "null"],
+            "description": "Echoed target backing when ``action='update'``; ``null`` otherwise.",
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": "Hint on ``invalid_request``; ``null`` otherwise.",
+        },
+    },
+    "required": ["status", "vm", "cdrom", "action"],
 }

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -3,12 +3,14 @@
 
 """op_id reconciliation between the write composites and the ingest pipeline.
 
-G3.16-T1 (#1414). The 9 REST-sub-op vmware-rest write composites each
+G3.16-T1 (#1414). The 12 REST-sub-op vmware-rest write composites each
 declare the L2 sub-ops they dispatch into via ``_SUB_OPS_*`` tuples in
-:mod:`~meho_backplane.connectors.vmware_rest.composites._write`; the tenth
-write composite, ``vm.disk.grow`` (#2893), dispatches into vi-json instead
-and declares its sub-ops in ``_VIM_SUB_OPS_VM_DISK_GROW`` (reconciled in the
-dedicated vi-json section at the end of this module). At
+:mod:`~meho_backplane.connectors.vmware_rest.composites._write`; the four
+vi-json write composites (``vm.disk.grow`` / #2893,
+``vm.clone_from_template`` / #2894, and the vim cluster / inventory writes
+``cluster.drs_rule.create`` + ``folder.create`` / #2895) dispatch into
+vi-json instead and declare their sub-ops in ``_VIM_SUB_OPS_*`` tuples
+(reconciled in the dedicated vi-json section at the end of this module). At
 dispatch time :func:`~...composites._preflight.preflight_l2_dependencies`
 looks each sub-op_id up in ``endpoint_descriptor`` and raises
 :class:`~meho_backplane.operations.composite.CompositeL2DependencyMissing`
@@ -31,7 +33,7 @@ the parser emits from ``vcenter.yaml``. The two surfaces that could drift:
 
 This module proves the match automatically, without a live backplane:
 
-1. Derive the full set of raw L2 sub-op_ids the 8 composites need by
+1. Derive the full set of raw L2 sub-op_ids the 12 composites need by
    introspecting the live ``_SUB_OPS_*`` constants (so the test tracks
    any future edit to those tuples -- no hardcoded mirror to drift).
 2. Build a representative OpenAPI fixture whose ``paths`` are keyed
@@ -79,12 +81,13 @@ _GETADDRINFO_PATCH = patch(
 
 
 def _required_raw_sub_op_ids() -> set[str]:
-    """Union of every ``_SUB_OPS_*`` op_id across the 9 REST write composites.
+    """Union of every ``_SUB_OPS_*`` op_id across the 12 REST write composites.
 
-    ``vm.disk.grow``'s vi-json sub-ops live in ``_VIM_SUB_OPS_VM_DISK_GROW``
-    (a distinct namespace this ``_SUB_OPS_*`` sweep deliberately skips), so
-    a vcenter.yaml-shaped fixture never has to model a vi-json path; the
-    vi-json section at the end of this module reconciles them separately.
+    The four vi-json write composites' sub-ops live in ``_VIM_SUB_OPS_*``
+    tuples (a distinct namespace this ``_SUB_OPS_*`` sweep deliberately
+    skips), so a vcenter.yaml-shaped fixture never has to model a vi-json
+    path; the vi-json section at the end of this module reconciles them
+    separately.
 
     Excludes composite-to-composite references (``vmware.composite.*``):
     those are not ``endpoint_descriptor`` rows and the pre-flight walk
@@ -104,7 +107,7 @@ def _required_raw_sub_op_ids() -> set[str]:
 def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
     """Guard: the introspection finds every write composite's sub-op tuple.
 
-    Nine ``_SUB_OPS_*`` module constants today, one per write composite.
+    Twelve ``_SUB_OPS_*`` module constants today, one per write composite.
     Pinning the exact set means a renamed or dropped constant can't
     silently shrink the reconciled set to a vacuous pass.
     """
@@ -115,9 +118,12 @@ def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
         "_SUB_OPS_HOST_EVACUATE",
         "_SUB_OPS_VM_CLONE",
         "_SUB_OPS_VM_CREATE",
+        "_SUB_OPS_VM_DEVICE_CDROM",
         "_SUB_OPS_VM_MIGRATE",
+        "_SUB_OPS_VM_NIC_REPOINT",
         "_SUB_OPS_VM_POWER",
         "_SUB_OPS_VM_POWER_BULK",
+        "_SUB_OPS_VM_RESIZE",
         "_SUB_OPS_VM_SNAPSHOT_REVERT",
     ]
 

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -175,13 +175,14 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 18 total: 5 reads
-    # (T5 #508) + 13 writes (T6 #509 + single-VM vm.power #2301 + mutating
+    # Embedding service called once per composite -- 21 total: 5 reads
+    # (T5 #508) + 16 writes (T6 #509 + single-VM vm.power #2301 + mutating
     # VI-JSON vm.disk.grow #2893 + folder-template vm.clone_from_template
     # #2894 + vim cluster/inventory writes cluster.drs_rule.create +
-    # folder.create #2895). (The former host.network_uplinks /
+    # folder.create #2895 + the #2891 hardware writes vm.resize /
+    # vm.nic.repoint / vm.device.cdrom). (The former host.network_uplinks /
     # host.vsan_health reads were re-shipped as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 18
+    assert stub_embedding_service.encode_one.call_count == 21
 
 
 @pytest.mark.asyncio
@@ -428,18 +429,19 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 5 read rows persist; embedding stays at 18.
+    """Running the registrar twice -> 5 read rows persist; embedding stays at 21.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (5 reads + 13 writes / T6 +
+    persist after the combined registrar (5 reads + 16 writes / T6 +
     single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
     folder-template vm.clone_from_template #2894 + vim cluster/inventory
-    writes cluster.drs_rule.create + folder.create #2895).
+    writes cluster.drs_rule.create + folder.create #2895 + the #2891
+    hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 18
+    assert first_count == 21
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Unit tests for the 11 vmware-rest write-composite handler functions.
+"""Unit tests for the 16 vmware-rest write-composite handler functions.
 
 Post-#2256 the write composites dispatch their sub-ops **directly on the
 connector session** -- ``connector._get_json`` / ``connector._post_json``
@@ -61,10 +61,13 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_clone_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
+    vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
+    vm_nic_repoint_composite,
     vm_power_bulk_composite,
     vm_power_composite,
+    vm_resize_composite,
     vm_snapshot_revert_composite,
 )
 
@@ -962,7 +965,9 @@ async def test_host_detach_from_vds_happy_path(gate: _GateRecorder) -> None:
     """Portgroup GET + VM GET + per-VM NIC PATCH + DVS remove POST; status=detached."""
     conn = _RecordingConnector(
         {
-            "/api/vcenter/network/distributed-portgroup": [],
+            # #1602 fix: distributed portgroups are listed via the generic
+            # /vcenter/network resource (no dedicated portgroup path).
+            "/api/vcenter/network": [],
             "/api/vcenter/vm": [{"vm": "vm-1"}, {"vm": "vm-2"}],
             "/api/vcenter/vm/vm-1/network": {},
             "/api/vcenter/vm/vm-2/network": {},
@@ -2441,3 +2446,362 @@ async def test_folder_create_body_reaches_the_wire_respx(
         assert body == {"name": "cluster-nodes"}
     finally:
         await connector.aclose()
+
+
+# ===========================================================================
+# vm.resize (#2891)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_resize_powered_off_patches_cpu_and_memory(gate: _GateRecorder) -> None:
+    """Read sizing -> PATCH cpu -> PATCH memory (both gated, spec-wrapped bodies)."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1": {
+                "name": "web-1",
+                "power_state": "POWERED_OFF",
+                "cpu": {"count": 1, "cores_per_socket": 1, "hot_add_enabled": False},
+                "memory": {"size_MiB": 1024, "hot_add_enabled": False},
+            },
+            "/api/vcenter/vm/vm-1/hardware/cpu": {},
+            "/api/vcenter/vm/vm-1/hardware/memory": {},
+        }
+    )
+    out = await vm_resize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "cpu_count": 4, "cores_per_socket": 2, "memory_mib": 8192},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "resized"
+    assert out["name"] == "web-1"
+    assert out["applied"] == {"cpu": True, "memory": True}
+    assert out["from"] == {"cpu_count": 1, "cores_per_socket": 1, "memory_MiB": 1024}
+    assert out["to"] == {"cpu_count": 4, "cores_per_socket": 2, "memory_MiB": 8192}
+    # Read is not gated; both PATCHes are, with the spec-wrapped bodies.
+    assert gate.gated_op_ids == [
+        "PATCH:/vcenter/vm/{vm}/hardware/cpu",
+        "PATCH:/vcenter/vm/{vm}/hardware/memory",
+    ]
+    cpu_call = next(c for c in conn.calls if c["path"].endswith("/hardware/cpu"))
+    mem_call = next(c for c in conn.calls if c["path"].endswith("/hardware/memory"))
+    assert cpu_call["method"] == "PATCH"
+    assert cpu_call["body"] == {"spec": {"count": 4, "cores_per_socket": 2}}
+    assert mem_call["body"] == {"spec": {"size_MiB": 8192}}
+
+
+@pytest.mark.asyncio
+async def test_vm_resize_powered_on_without_hot_add_requires_power_off(
+    gate: _GateRecorder,
+) -> None:
+    """A powered-on VM with hot-add disabled surfaces requires_power_off, never a 400."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1": {
+                "name": "web-1",
+                "power_state": "POWERED_ON",
+                "cpu": {"count": 2, "cores_per_socket": 1, "hot_add_enabled": False},
+                "memory": {"size_MiB": 2048, "hot_add_enabled": False},
+            }
+        }
+    )
+    out = await vm_resize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "cpu_count": 4},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "requires_power_off"
+    assert out["applied"] == {"cpu": False, "memory": False}
+    assert "power off" in out["guidance"]
+    # Only the read fired; no PATCH was gated or issued.
+    assert gate.calls == []
+    assert [c["method"] for c in conn.calls] == ["GET"]
+
+
+@pytest.mark.asyncio
+async def test_vm_resize_no_requested_change_is_no_change(gate: _GateRecorder) -> None:
+    """Requested values matching current -> no_change; no PATCH dispatched."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1": {
+                "name": "web-1",
+                "power_state": "POWERED_OFF",
+                "cpu": {"count": 4, "cores_per_socket": 2},
+                "memory": {"size_MiB": 8192},
+            }
+        }
+    )
+    out = await vm_resize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "cpu_count": 4, "memory_mib": 8192},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "no_change"
+    assert gate.calls == []
+    assert len(conn.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_vm_resize_memory_failure_after_cpu_is_partial(gate: _GateRecorder) -> None:
+    """CPU PATCH lands, memory PATCH faults -> status=partial (CPU already applied)."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1": {
+                "name": "web-1",
+                "power_state": "POWERED_OFF",
+                "cpu": {"count": 1},
+                "memory": {"size_MiB": 1024},
+            },
+            "/api/vcenter/vm/vm-1/hardware/cpu": {},
+            "/api/vcenter/vm/vm-1/hardware/memory": _http_error(
+                400, "https://vc/api/vcenter/vm/vm-1/hardware/memory"
+            ),
+        }
+    )
+    out = await vm_resize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "cpu_count": 4, "memory_mib": 8192},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "partial"
+    assert out["applied"] == {"cpu": True, "memory": False}
+    assert "memory update failed" in out["guidance"]
+
+
+@pytest.mark.asyncio
+async def test_vm_resize_gate_short_circuits_before_any_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked CPU gate returns the awaiting result verbatim; no PATCH is issued."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1": {
+                "power_state": "POWERED_OFF",
+                "cpu": {"count": 1},
+                "memory": {"size_MiB": 1024},
+            }
+        }
+    )
+    gate = _install_gate(
+        monkeypatch,
+        _GateRecorder(gate_for={"PATCH:/vcenter/vm/{vm}/hardware/cpu": _awaiting("resize")}),
+    )
+    out = await vm_resize_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "cpu_count": 4},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    # Only the read + the gated (but not issued) CPU PATCH attempt; no memory.
+    assert [c["method"] for c in conn.calls] == ["GET"]
+    assert gate.gated_op_ids == ["PATCH:/vcenter/vm/{vm}/hardware/cpu"]
+
+
+# ===========================================================================
+# vm.nic.repoint (#2891)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_nic_repoint_happy_path(gate: _GateRecorder) -> None:
+    """Read NIC -> resolve portgroup by name -> PATCH backing (gated, spec-wrapped)."""
+    # The NIC GET and the NIC PATCH mount to the same path (the PATCH carries
+    # no ?action suffix); one canned value serves both -- the handler ignores
+    # the PATCH's return payload.
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/ethernet/4000": {
+                "mac_address": "00:50:56:aa:bb:cc",
+                "backing": {
+                    "type": "DISTRIBUTED_PORTGROUP",
+                    "network": "dvportgroup-1",
+                    "network_name": "old-net",
+                },
+            },
+            "/api/vcenter/network": [
+                {"network": "dvportgroup-9", "name": "prod-net", "type": "DISTRIBUTED_PORTGROUP"}
+            ],
+        }
+    )
+    out = await vm_nic_repoint_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "nic": "4000", "portgroup_name": "prod-net"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "repointed"
+    assert out["mac_address"] == "00:50:56:aa:bb:cc"
+    assert out["current_backing"]["network"] == "dvportgroup-1"
+    assert out["requested_backing"] == {
+        "portgroup_id": "dvportgroup-9",
+        "portgroup_name": "prod-net",
+    }
+    # The NIC read + the network resolve read are not gated; only the PATCH is.
+    assert gate.gated_op_ids == ["PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}"]
+    patch_call = next(c for c in conn.calls if c["method"] == "PATCH")
+    assert patch_call["body"] == {
+        "spec": {"backing": {"type": "DISTRIBUTED_PORTGROUP", "network": "dvportgroup-9"}}
+    }
+    # The portgroup resolve used the corrected /vcenter/network path (#1602 fix).
+    net_read = next(c for c in conn.calls if c["path"] == "/api/vcenter/network")
+    assert net_read["method"] == "GET"
+
+
+@pytest.mark.asyncio
+async def test_vm_nic_repoint_portgroup_not_found(gate: _GateRecorder) -> None:
+    """No portgroup matches the name -> status=not_found; no PATCH dispatched."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/ethernet/4000": {
+                "mac_address": "00:50:56:aa:bb:cc",
+                "backing": {"type": "STANDARD_PORTGROUP"},
+            },
+            "/api/vcenter/network": [],
+        }
+    )
+    out = await vm_nic_repoint_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "nic": "4000", "portgroup_name": "ghost"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "not_found"
+    assert out["requested_backing"] == {"portgroup_id": None, "portgroup_name": "ghost"}
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_vm_nic_repoint_ambiguous_portgroup(gate: _GateRecorder) -> None:
+    """Two portgroups share the name -> status=ambiguous with candidates; no PATCH."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/ethernet/4000": {"mac_address": "aa", "backing": {}},
+            "/api/vcenter/network": [
+                {"network": "dvportgroup-1", "name": "dup", "type": "DISTRIBUTED_PORTGROUP"},
+                {"network": "dvportgroup-2", "name": "dup", "type": "DISTRIBUTED_PORTGROUP"},
+            ],
+        }
+    )
+    out = await vm_nic_repoint_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "nic": "4000", "portgroup_name": "dup"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "ambiguous"
+    assert len(out["candidates"]) == 2
+    assert gate.calls == []
+
+
+# ===========================================================================
+# vm.device.cdrom (#2891)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_device_cdrom_remove(gate: _GateRecorder) -> None:
+    """Read backing -> DELETE the device (gated); status=removed, backing surfaced."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/cdrom/16000": {
+                "backing": {"type": "ISO_FILE", "iso_file": "[datastore1] installer.iso"},
+                "state": "CONNECTED",
+            },
+        }
+    )
+    out = await vm_device_cdrom_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "cdrom": "16000", "action": "remove"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "removed"
+    assert out["current_backing"]["iso_file"] == "[datastore1] installer.iso"
+    assert out["state"] == "CONNECTED"
+    assert gate.gated_op_ids == ["DELETE:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}"]
+    delete_call = next(c for c in conn.calls if c["method"] == "DELETE")
+    assert delete_call["body"] is None
+
+
+@pytest.mark.asyncio
+async def test_vm_device_cdrom_disconnect(gate: _GateRecorder) -> None:
+    """action=disconnect -> POST ?action=disconnect (gated); status=disconnected."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/cdrom/16000": {
+                "backing": {"type": "HOST_DEVICE", "host_device": "/dev/cdrom"},
+                "state": "CONNECTED",
+            },
+            "/api/vcenter/vm/vm-1/hardware/cdrom/16000?action=disconnect": {},
+        }
+    )
+    out = await vm_device_cdrom_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "cdrom": "16000", "action": "disconnect"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "disconnected"
+    assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}?action=disconnect"]
+    post_call = next(c for c in conn.calls if c["method"] == "POST")
+    assert post_call["path"] == "/api/vcenter/vm/vm-1/hardware/cdrom/16000?action=disconnect"
+    assert post_call["body"] is None
+
+
+@pytest.mark.asyncio
+async def test_vm_device_cdrom_update_patches_backing(gate: _GateRecorder) -> None:
+    """action=update with backing -> PATCH backing (gated, spec-wrapped); status=updated."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/cdrom/16000": {
+                "backing": {"type": "ISO_FILE", "iso_file": "[local] pinned.iso"},
+                "state": "CONNECTED",
+            },
+        }
+    )
+    out = await vm_device_cdrom_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "vm": "vm-1",
+            "cdrom": "16000",
+            "action": "update",
+            "backing": {"type": "CLIENT_DEVICE"},
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "updated"
+    assert out["requested_backing"] == {"type": "CLIENT_DEVICE"}
+    assert gate.gated_op_ids == ["PATCH:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}"]
+    patch_call = next(c for c in conn.calls if c["method"] == "PATCH")
+    assert patch_call["body"] == {"spec": {"backing": {"type": "CLIENT_DEVICE"}}}
+
+
+@pytest.mark.asyncio
+async def test_vm_device_cdrom_update_without_backing_is_invalid_request(
+    gate: _GateRecorder,
+) -> None:
+    """action=update with no backing -> invalid_request; no write issued."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/vm/vm-1/hardware/cdrom/16000": {
+                "backing": {"type": "ISO_FILE"},
+                "state": "NOT_CONNECTED",
+            },
+        }
+    )
+    out = await vm_device_cdrom_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"vm": "vm-1", "cdrom": "16000", "action": "update"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "invalid_request"
+    assert gate.calls == []
+    assert [c["method"] for c in conn.calls] == ["GET"]

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""End-to-end activation tests for the 8 vmware-rest write composites.
+"""End-to-end activation tests for the 12 vmware-rest write composites.
 
 Post-#2256 the write composites dispatch every raw-REST sub-op **directly
 on the connector session** (``connector._get_json`` / ``connector._post_json``
@@ -298,6 +298,9 @@ _WRITE_COMPOSITES: dict[str, str] = {
     "vmware.composite.vm.migrate": "vm.migrate",
     "vmware.composite.vm.power": "vm.power",
     "vmware.composite.vm.power.bulk": "vm.power.bulk",
+    "vmware.composite.vm.resize": "vm.resize",
+    "vmware.composite.vm.nic.repoint": "vm.nic.repoint",
+    "vmware.composite.vm.device.cdrom": "vm.device.cdrom",
     "vmware.composite.host.evacuate": "host.evacuate",
     "vmware.composite.host.detach_from_vds": "host.detach_from_vds",
     "vmware.composite.cluster.patch": "cluster.patch",
@@ -328,6 +331,17 @@ def _benign_params_for(composite_op_id: str) -> dict[str, Any]:
         },
         "vmware.composite.vm.power": {"vm": "vm-1", "verb": "on"},
         "vmware.composite.vm.power.bulk": {"action": "start"},
+        "vmware.composite.vm.resize": {"vm": "vm-1", "cpu_count": 2},
+        "vmware.composite.vm.nic.repoint": {
+            "vm": "vm-1",
+            "nic": "4000",
+            "portgroup_name": "prod-pg",
+        },
+        "vmware.composite.vm.device.cdrom": {
+            "vm": "vm-1",
+            "cdrom": "16000",
+            "action": "disconnect",
+        },
         "vmware.composite.host.evacuate": {"host": "host-1"},
         "vmware.composite.host.detach_from_vds": {
             "host": "host-1",
@@ -357,9 +371,42 @@ def _benign_responses_for(composite_op_id: str) -> dict[str, Any]:
         "vmware.composite.vm.migrate": {"/vcenter/cluster/domain-c1/drs/recommendations": empty},
         "vmware.composite.vm.power": {},
         "vmware.composite.vm.power.bulk": {"/vcenter/vm": empty},
+        "vmware.composite.vm.resize": {
+            "/vcenter/vm/vm-1": {
+                "value": {
+                    "name": "vm-1",
+                    "power_state": "POWERED_OFF",
+                    "cpu": {"count": 1, "cores_per_socket": 1},
+                    "memory": {"size_MiB": 1024},
+                }
+            }
+        },
+        "vmware.composite.vm.nic.repoint": {
+            "/vcenter/vm/vm-1": {"value": {"name": "vm-1"}},
+            "/vcenter/vm/vm-1/hardware/ethernet/4000": {
+                "value": {
+                    "mac_address": "00:50:56:aa:bb:cc",
+                    "backing": {"type": "STANDARD_PORTGROUP"},
+                }
+            },
+            "/vcenter/network": {
+                "value": [
+                    {"network": "dvportgroup-9", "name": "prod-pg", "type": "DISTRIBUTED_PORTGROUP"}
+                ]
+            },
+        },
+        "vmware.composite.vm.device.cdrom": {
+            "/vcenter/vm/vm-1": {"value": {"name": "vm-1"}},
+            "/vcenter/vm/vm-1/hardware/cdrom/16000": {
+                "value": {
+                    "backing": {"type": "ISO_FILE", "iso_file": "[local] pinned.iso"},
+                    "state": "CONNECTED",
+                }
+            },
+        },
         "vmware.composite.host.evacuate": {"/vcenter/vm": empty},
         "vmware.composite.host.detach_from_vds": {
-            "/vcenter/network/distributed-portgroup": empty,
+            "/vcenter/network": empty,
             "/vcenter/vm": empty,
         },
         "vmware.composite.cluster.patch": {"/vcenter/cluster/domain-c1/host": empty},
@@ -368,22 +415,24 @@ def _benign_responses_for(composite_op_id: str) -> dict[str, Any]:
 
 
 # ===========================================================================
-# Guard: the REST-sub-op write set is exactly the expected nine
+# Guard: the REST-sub-op write set is exactly the expected twelve
 # ===========================================================================
 
 
-def test_write_composite_set_is_the_expected_nine() -> None:
+def test_write_composite_set_is_the_expected_twelve() -> None:
     """Pins the REST-sub-op write set so a renamed / dropped composite can't shrink coverage.
 
-    Covers the 9 REST-sub-op write composites the parametrized fresh-boot +
-    park machinery below drives. The tenth write composite, the mutating
-    VI-JSON ``vm.disk.grow`` (#2893), is dispatch-shaped differently (vmomi
-    sub-ops keyed by request body, not REST spec-paths) and is covered by
-    its own dedicated section at the end of this module.
+    Covers the 12 REST-sub-op write composites the parametrized fresh-boot +
+    park machinery below drives. The four vi-json write composites
+    (``vm.disk.grow`` / #2893, ``vm.clone_from_template`` / #2894,
+    ``cluster.drs_rule.create`` + ``folder.create`` / #2895) are
+    dispatch-shaped differently (vmomi sub-ops keyed by request body, not
+    REST spec-paths) and are covered by their own dedicated sections at the
+    end of this module.
     """
     registrar_write_op_ids = {f"vmware.composite.{name}" for name in _WRITE_COMPOSITES.values()}
     assert set(_WRITE_COMPOSITES) == registrar_write_op_ids
-    assert len(_WRITE_COMPOSITES) == 9
+    assert len(_WRITE_COMPOSITES) == 12
 
 
 # ===========================================================================
@@ -402,7 +451,7 @@ async def test_write_composite_executes_through_dispatch_without_ingest(
     """Each composite runs to a benign business status on the direct session.
 
     No ingested ``endpoint_descriptor`` rows exist in the catalog here — only
-    the 15 composite rows the registrar upserts. Reaching a business status
+    the 21 composite rows the registrar upserts. Reaching a business status
     (``created`` / ``no_recommendation`` / ``detached`` / ...) rather than a
     generic execution error proves every raw-REST sub-op resolved via the
     connector session, not a catalog lookup (the two-world / fresh-boot DoD).
@@ -703,7 +752,8 @@ async def test_host_detach_from_vds_sub_op_sequence(
     recorder = _RecordingVmwareConnector()
     recorder.responses.update(
         {
-            "/vcenter/network/distributed-portgroup": {"value": []},
+            # #1602 fix: distributed portgroups list via /vcenter/network.
+            "/vcenter/network": {"value": []},
             "/vcenter/vm": {"value": [{"vm": "vm-a"}]},
         }
     )
@@ -722,7 +772,7 @@ async def test_host_detach_from_vds_sub_op_sequence(
     assert result.result["status"] == "detached"
     assert result.result["vms_migrated"] == ["vm-a"]
     assert recorder.calls == [
-        ("GET", "/vcenter/network/distributed-portgroup"),
+        ("GET", "/vcenter/network"),
         ("GET", "/vcenter/vm"),
         ("PATCH", "/vcenter/vm/vm-a/network"),
         ("POST", "/vcenter/network/dvs/dvs-1?action=remove_host"),
@@ -778,8 +828,9 @@ async def test_write_composite_human_dispatch_parks_for_approval(
     Every write composite ships ``requires_approval=True``; G11.7-T1 (#1401)
     routes a human/service principal to the approval queue
     (``awaiting_approval``) at the top-level gate — before the handler (and
-    thus any sub-op) runs. Proves the park half for all 8; the recorder stays
-    empty because the composite never executed.
+    thus any sub-op) runs. Proves the park half for all 12; the recorder
+    stays empty of writes because the composite never executed (the
+    live-read preview builders issue read-only GETs, which is expected).
     """
     recorder = _RecordingVmwareConnector()
     await _bootstrap(recorder, stub_embedding_service)
@@ -1683,3 +1734,190 @@ async def test_folder_create_fresh_boot_dispatchable_without_ingest(
     assert result.status == "ok", result.error
     assert result.result["status"] == "created"
     assert recorder.create_writes == ["/Folder/group-v1/CreateFolder"]
+
+
+# ===========================================================================
+# Hardware write composites (#2891) — sub-op sequence through dispatch
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_vm_resize_sub_op_sequence(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """vm.resize: read VM info -> PATCH cpu -> PATCH memory."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses["/vcenter/vm/vm-1"] = {
+        "value": {
+            "name": "web-1",
+            "power_state": "POWERED_OFF",
+            "cpu": {"count": 1, "cores_per_socket": 1},
+            "memory": {"size_MiB": 1024},
+        }
+    }
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.resize"}, recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.resize",
+        target=_FakeVmwareTarget(),
+        params={"vm": "vm-1", "cpu_count": 4, "memory_mib": 8192},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result["status"] == "resized"
+    assert result.result["applied"] == {"cpu": True, "memory": True}
+    assert recorder.calls == [
+        ("GET", "/vcenter/vm/vm-1"),
+        ("PATCH", "/vcenter/vm/vm-1/hardware/cpu"),
+        ("PATCH", "/vcenter/vm/vm-1/hardware/memory"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vm_nic_repoint_sub_op_sequence(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """vm.nic.repoint: read NIC -> resolve portgroup via /vcenter/network -> PATCH backing."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/vm/vm-1/hardware/ethernet/4000": {
+                "value": {
+                    "mac_address": "00:50:56:aa:bb:cc",
+                    "backing": {"type": "STANDARD_PORTGROUP"},
+                }
+            },
+            "/vcenter/network": {
+                "value": [
+                    {"network": "dvportgroup-9", "name": "prod-pg", "type": "DISTRIBUTED_PORTGROUP"}
+                ]
+            },
+        }
+    )
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.nic.repoint"}, recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.nic.repoint",
+        target=_FakeVmwareTarget(),
+        params={"vm": "vm-1", "nic": "4000", "portgroup_name": "prod-pg"},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result["status"] == "repointed"
+    assert result.result["requested_backing"] == {
+        "portgroup_id": "dvportgroup-9",
+        "portgroup_name": "prod-pg",
+    }
+    assert recorder.calls == [
+        ("GET", "/vcenter/vm/vm-1/hardware/ethernet/4000"),
+        ("GET", "/vcenter/network"),
+        ("PATCH", "/vcenter/vm/vm-1/hardware/ethernet/4000"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_vm_device_cdrom_remove_sub_op_sequence(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """vm.device.cdrom (remove): read backing -> DELETE the device."""
+    recorder = _RecordingVmwareConnector()
+    recorder.responses["/vcenter/vm/vm-1/hardware/cdrom/16000"] = {
+        "value": {
+            "backing": {"type": "ISO_FILE", "iso_file": "[local] pinned.iso"},
+            "state": "CONNECTED",
+        }
+    }
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.device.cdrom"}, recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.device.cdrom",
+        target=_FakeVmwareTarget(),
+        params={"vm": "vm-1", "cdrom": "16000", "action": "remove"},
+    )
+
+    assert result.status == "ok", result.error
+    assert result.result["status"] == "removed"
+    assert recorder.calls == [
+        ("GET", "/vcenter/vm/vm-1/hardware/cdrom/16000"),
+        ("DELETE", "/vcenter/vm/vm-1/hardware/cdrom/16000"),
+    ]
+
+
+# ===========================================================================
+# Park-envelope uniformity for the #2891 hardware writes (#2681)
+# ===========================================================================
+
+#: The op-identity + metadata fields every parked envelope carries
+#: uniformly (#2681). The bespoke ``preview`` content key is deliberately
+#: not in this set — it is asserted separately.
+_ENVELOPE_IDENTITY_META_KEYS = frozenset(
+    {"op_id", "connector_id", "target_id", "op_class", "preview_populated", "safety_level"}
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "composite_op_id",
+    [
+        "vmware.composite.vm.resize",
+        "vmware.composite.vm.nic.repoint",
+        "vmware.composite.vm.device.cdrom",
+    ],
+)
+async def test_hardware_write_park_carries_uniform_identity_envelope(
+    composite_op_id: str,
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A parked hardware-write composite carries the #2681 uniform op-identity envelope.
+
+    The G0.38 #2681 contract: every parked ``proposed_effect`` carries the
+    same op-identity + metadata field-set (op_id / connector_id /
+    target_id / op_class / preview_populated / safety_level) regardless of
+    the per-op preview outcome. Here the live-read builders additionally
+    populate a from->to ``preview``, so ``preview_populated`` is True.
+    """
+    recorder = _RecordingVmwareConnector()
+    recorder.responses.update(_benign_responses_for(composite_op_id))
+    await _bootstrap(recorder, stub_embedding_service)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id=composite_op_id,
+        target=_FakeVmwareTarget(),
+        params=_benign_params_for(composite_op_id),
+    )
+    assert result.status == "awaiting_approval", result.error
+    approval_request_id = UUID(result.extras["approval_request_id"])
+    async with get_sessionmaker()() as s:
+        row = await s.get(ApprovalRequest, approval_request_id)
+    assert row is not None
+    effect = dict(row.proposed_effect)
+
+    # The uniform op-identity + metadata envelope is present (#2681).
+    assert effect.keys() >= _ENVELOPE_IDENTITY_META_KEYS, sorted(effect)
+    assert effect["op_id"] == composite_op_id
+    assert effect["connector_id"] == _CONNECTOR_ID
+    assert isinstance(effect["target_id"], str)
+    assert effect["safety_level"] == "dangerous"
+    assert effect["op_class"] == "other"
+    # The live-read builder populated a from->to preview.
+    assert effect["preview_populated"] is True
+    assert "preview" in effect

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` previews for the 11 vmware write composites.
+"""Park-time ``proposed_effect`` previews for the 16 vmware write composites.
 
 G0.22-T3 (#1608) acceptance criteria, under the post-#2256 direct-session
 model:
@@ -19,11 +19,12 @@ model:
    directly on the connector session (no ``dispatch_child``, no ingested
    descriptor), so the park-time preview works on a fresh boot with zero
    catalog ingest.
-4. All 11 write composites register a builder (5 live-read + 6 param
-   echo); the wiring test pins the full set. ``vm.disk.grow`` is the fifth
-   live-read builder — its from→to capacity delta is a live vCenter read.
-   ``vm.clone_from_template`` is a param-echo builder — its params fully
-   name the blast radius (secret-bearing GOSC contents are never echoed).
+4. All 16 write composites register a builder (9 live-read + 7 param
+   echo); the wiring test pins the full set. ``vm.disk.grow`` is a
+   single-entity live-read builder — its from→to capacity delta is a live
+   vCenter read. ``vm.clone_from_template`` is a param-echo builder — its
+   params fully name the blast radius (secret-bearing GOSC contents are
+   never echoed).
 
 Plus the #1628 follow-up: a *failed* live-read preview parks with the
 identifier fields **and** an explicit ``preview_unavailable`` marker +
@@ -76,6 +77,9 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.vm.power",
         "vmware.composite.vm.power.bulk",
         "vmware.composite.vm.disk.grow",
+        "vmware.composite.vm.resize",
+        "vmware.composite.vm.nic.repoint",
+        "vmware.composite.vm.device.cdrom",
         "vmware.composite.host.evacuate",
         "vmware.composite.host.detach_from_vds",
         "vmware.composite.cluster.patch",
@@ -240,7 +244,7 @@ class _RecordingConnector:
 
 
 async def _bootstrap_registry(stub_embedding_service: AsyncMock) -> _RecordingConnector:
-    """Register the connector + 14 composites and seed the recording instance."""
+    """Register the connector + 17 composites and seed the recording instance."""
     register_connector_v2(
         product="vmware",
         version="9.0",
@@ -291,14 +295,14 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 
 
 # ===========================================================================
-# Wiring — all 13 write composites register a builder (criterion 4)
+# Wiring — all 16 write composites register a builder (criterion 4)
 # ===========================================================================
 
 
-def test_all_thirteen_write_composites_register_a_preview_builder() -> None:
+def test_all_sixteen_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 13
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 16
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 
@@ -320,11 +324,13 @@ def _make_preview_ctx(params: dict[str, Any], *, connector_instance: Any = None)
 
 
 async def test_live_read_builders_decline_without_a_connector_instance() -> None:
-    """The four fan-out builders decline (return None) when no connector resolved.
+    """The live-read builders decline (return None) when no connector resolved.
 
     Post-#2256 the live-read builders resolve their blast radius on the
     connector session; with ``connector_instance=None`` there is nothing to
     read, so they decline to the identifier-only default rather than raise.
+    Covers the four fan-out builders, the cluster.drs_rule.create builder,
+    and the three #2891 hardware builders.
     """
     for builder, params in (
         (_write_preview._vm_power_bulk_preview, {"action": "stop"}),
@@ -342,6 +348,15 @@ async def test_live_read_builders_decline_without_a_connector_instance() -> None
                 "rule_type": "anti_affinity",
                 "vms": ["web-01", "web-02"],
             },
+        ),
+        (_write_preview._vm_resize_preview, {"vm": "vm-1", "cpu_count": 4}),
+        (
+            _write_preview._vm_nic_repoint_preview,
+            {"vm": "vm-1", "nic": "4000", "portgroup_name": "pg"},
+        ),
+        (
+            _write_preview._vm_device_cdrom_preview,
+            {"vm": "vm-1", "cdrom": "16000", "action": "remove"},
         ),
     ):
         assert await builder(_make_preview_ctx(params, connector_instance=None)) is None
@@ -974,3 +989,293 @@ async def test_folder_create_preview_echoes_parent_and_new_name() -> None:
         _make_preview_ctx({"parent_folder": "prod", "folder_name": "cluster-nodes"})
     )
     assert preview == {"parent_folder": "prod", "new_folder_name": "cluster-nodes"}
+
+
+# ===========================================================================
+# #2891 hardware-write builders — live-read from->to diffs (builder-direct)
+# ===========================================================================
+
+
+async def test_vm_resize_preview_live_reads_current_sizing() -> None:
+    """The resize preview pairs the live-read current sizing with the request."""
+    recorder = _RecordingConnector()
+    recorder.responses["/vcenter/vm/vm-1"] = {
+        "value": {
+            "name": "web-1",
+            "power_state": "POWERED_OFF",
+            "cpu": {"count": 2, "cores_per_socket": 1},
+            "memory": {"size_MiB": 2048},
+        }
+    }
+    preview = await _write_preview._vm_resize_preview(
+        _make_preview_ctx(
+            {"vm": "vm-1", "cpu_count": 4, "memory_mib": 8192}, connector_instance=recorder
+        )
+    )
+    assert preview == {
+        "vm": "vm-1",
+        "name": "web-1",
+        "power_state": "POWERED_OFF",
+        "current": {"cpu_count": 2, "cores_per_socket": 1, "memory_MiB": 2048},
+        "requested": {"cpu_count": 4, "cores_per_socket": None, "memory_MiB": 8192},
+    }
+    assert recorder.specs == ["/vcenter/vm/vm-1"]
+
+
+async def test_vm_nic_repoint_preview_reads_backing_and_resolves_portgroup() -> None:
+    """The NIC preview surfaces the from->to network pair the reviewer needs."""
+    recorder = _RecordingConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/vm/vm-1": {"value": {"name": "web-1"}},
+            "/vcenter/vm/vm-1/hardware/ethernet/4000": {
+                "value": {
+                    "mac_address": "00:50:56:aa:bb:cc",
+                    "backing": {
+                        "type": "DISTRIBUTED_PORTGROUP",
+                        "network": "dvportgroup-1",
+                        "network_name": "old-net",
+                    },
+                }
+            },
+            "/vcenter/network": {
+                "value": [
+                    {
+                        "network": "dvportgroup-9",
+                        "name": "prod-net",
+                        "type": "DISTRIBUTED_PORTGROUP",
+                    }
+                ]
+            },
+        }
+    )
+    preview = await _write_preview._vm_nic_repoint_preview(
+        _make_preview_ctx(
+            {"vm": "vm-1", "nic": "4000", "portgroup_name": "prod-net"}, connector_instance=recorder
+        )
+    )
+    assert preview == {
+        "vm": "vm-1",
+        "name": "web-1",
+        "nic": "4000",
+        "mac_address": "00:50:56:aa:bb:cc",
+        "current_backing": {
+            "type": "DISTRIBUTED_PORTGROUP",
+            "network": "dvportgroup-1",
+            "network_name": "old-net",
+        },
+        "requested_backing": {"portgroup_id": "dvportgroup-9", "portgroup_name": "prod-net"},
+    }
+    assert recorder.specs == [
+        "/vcenter/vm/vm-1",
+        "/vcenter/vm/vm-1/hardware/ethernet/4000",
+        "/vcenter/network",
+    ]
+
+
+async def test_vm_device_cdrom_preview_live_reads_current_backing() -> None:
+    """The CD-ROM preview surfaces the host-local ISO backing + state to the approver."""
+    recorder = _RecordingConnector()
+    recorder.responses.update(
+        {
+            "/vcenter/vm/vm-1": {"value": {"name": "web-1"}},
+            "/vcenter/vm/vm-1/hardware/cdrom/16000": {
+                "value": {
+                    "backing": {"type": "ISO_FILE", "iso_file": "[esx-1-local] installer.iso"},
+                    "state": "CONNECTED",
+                }
+            },
+        }
+    )
+    preview = await _write_preview._vm_device_cdrom_preview(
+        _make_preview_ctx(
+            {"vm": "vm-1", "cdrom": "16000", "action": "remove"}, connector_instance=recorder
+        )
+    )
+    assert preview == {
+        "vm": "vm-1",
+        "name": "web-1",
+        "cdrom": "16000",
+        "action": "remove",
+        "current_backing": {"type": "ISO_FILE", "iso_file": "[esx-1-local] installer.iso"},
+        "state": "CONNECTED",
+    }
+    assert recorder.specs == ["/vcenter/vm/vm-1", "/vcenter/vm/vm-1/hardware/cdrom/16000"]
+
+
+async def test_hardware_builders_decline_on_malformed_params() -> None:
+    """Missing required params decline (→ identifier-only default), even with a connector."""
+    recorder = _RecordingConnector()
+    assert (
+        await _write_preview._vm_resize_preview(_make_preview_ctx({}, connector_instance=recorder))
+        is None
+    )
+    assert (
+        await _write_preview._vm_nic_repoint_preview(
+            _make_preview_ctx({"vm": "vm-1", "nic": "4000"}, connector_instance=recorder)
+        )
+        is None
+    )
+    assert (
+        await _write_preview._vm_device_cdrom_preview(
+            _make_preview_ctx({"vm": "vm-1", "cdrom": "16000"}, connector_instance=recorder)
+        )
+        is None
+    )
+    # Declined before issuing any read.
+    assert recorder.calls == []
+
+
+# ===========================================================================
+# #2891 hardware writes — park path carries the from->to diff (criterion 3)
+# ===========================================================================
+
+
+async def test_vm_resize_park_carries_sizing_from_to_diff(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The parked resize row names the current + requested sizing (from->to)."""
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses["/vcenter/vm/vm-1"] = {
+        "value": {
+            "name": "web-1",
+            "power_state": "POWERED_OFF",
+            "cpu": {"count": 1, "cores_per_socket": 1},
+            "memory": {"size_MiB": 1024},
+        }
+    }
+
+    _, row = await _park(
+        "vmware.composite.vm.resize", {"vm": "vm-1", "cpu_count": 4, "memory_mib": 8192}
+    )
+
+    assert _strip_uniform_identity(row.proposed_effect, op_id="vmware.composite.vm.resize") == {
+        "op_class": "other",
+        "preview": {
+            "vm": "vm-1",
+            "name": "web-1",
+            "power_state": "POWERED_OFF",
+            "current": {"cpu_count": 1, "cores_per_socket": 1, "memory_MiB": 1024},
+            "requested": {"cpu_count": 4, "cores_per_socket": None, "memory_MiB": 8192},
+        },
+        "preview_populated": True,
+        "safety_level": "dangerous",
+    }
+    # Only the read-only VM info GET fired — no CPU / memory PATCH.
+    assert recorder.specs == ["/vcenter/vm/vm-1"]
+
+
+async def test_vm_nic_repoint_park_carries_network_from_to_pair(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The parked NIC row names the current backing + resolved target portgroup."""
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses.update(
+        {
+            "/vcenter/vm/vm-1": {"value": {"name": "web-1"}},
+            "/vcenter/vm/vm-1/hardware/ethernet/4000": {
+                "value": {"mac_address": "aa:bb", "backing": {"type": "STANDARD_PORTGROUP"}}
+            },
+            "/vcenter/network": {
+                "value": [
+                    {
+                        "network": "dvportgroup-9",
+                        "name": "prod-net",
+                        "type": "DISTRIBUTED_PORTGROUP",
+                    }
+                ]
+            },
+        }
+    )
+
+    _, row = await _park(
+        "vmware.composite.vm.nic.repoint",
+        {"vm": "vm-1", "nic": "4000", "portgroup_name": "prod-net"},
+    )
+
+    assert _strip_uniform_identity(
+        row.proposed_effect, op_id="vmware.composite.vm.nic.repoint"
+    ) == {
+        "op_class": "other",
+        "preview": {
+            "vm": "vm-1",
+            "name": "web-1",
+            "nic": "4000",
+            "mac_address": "aa:bb",
+            "current_backing": {"type": "STANDARD_PORTGROUP"},
+            "requested_backing": {"portgroup_id": "dvportgroup-9", "portgroup_name": "prod-net"},
+        },
+        "preview_populated": True,
+        "safety_level": "dangerous",
+    }
+    # Only read-only resolution GETs fired — no NIC PATCH.
+    assert recorder.specs == [
+        "/vcenter/vm/vm-1",
+        "/vcenter/vm/vm-1/hardware/ethernet/4000",
+        "/vcenter/network",
+    ]
+
+
+async def test_vm_device_cdrom_park_carries_current_backing(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The parked CD-ROM row names the current backing (host-local ISO) + action."""
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses.update(
+        {
+            "/vcenter/vm/vm-1": {"value": {"name": "web-1"}},
+            "/vcenter/vm/vm-1/hardware/cdrom/16000": {
+                "value": {
+                    "backing": {"type": "ISO_FILE", "iso_file": "[esx-1-local] pinned.iso"},
+                    "state": "CONNECTED",
+                }
+            },
+        }
+    )
+
+    _, row = await _park(
+        "vmware.composite.vm.device.cdrom",
+        {"vm": "vm-1", "cdrom": "16000", "action": "remove"},
+    )
+
+    assert _strip_uniform_identity(
+        row.proposed_effect, op_id="vmware.composite.vm.device.cdrom"
+    ) == {
+        "op_class": "other",
+        "preview": {
+            "vm": "vm-1",
+            "name": "web-1",
+            "cdrom": "16000",
+            "action": "remove",
+            "current_backing": {"type": "ISO_FILE", "iso_file": "[esx-1-local] pinned.iso"},
+            "state": "CONNECTED",
+        },
+        "preview_populated": True,
+        "safety_level": "dangerous",
+    }
+    # Only the read-only backing GETs fired — no DELETE.
+    assert recorder.specs == ["/vcenter/vm/vm-1", "/vcenter/vm/vm-1/hardware/cdrom/16000"]
+
+
+async def test_vm_resize_preview_failure_parks_with_unavailable_marker(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A failing VM-info read parks with identifiers + the preview_unavailable marker (#1628)."""
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.failures["/vcenter/vm/vm-1"] = "vCenter VM read unavailable"
+
+    target = _FakeVmwareTarget()
+    _, row = await _park(
+        "vmware.composite.vm.resize",
+        {"vm": "vm-1", "cpu_count": 4},
+        target=target,
+    )
+
+    effect = row.proposed_effect
+    assert effect["op_id"] == "vmware.composite.vm.resize"
+    assert effect["connector_id"] == _CONNECTOR_ID
+    assert effect["target_id"] == str(target.id)
+    assert effect["safety_level"] == "dangerous"
+    assert effect["preview_unavailable"] is True
+    assert "GET:/vcenter/vm/vm-1" in effect["preview_error"]
+    assert "preview" not in effect

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 13 vmware-rest write composites.
+"""Registration tests for the 16 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
-``vm.power`` / #2301 and the vim writes ``vm.disk.grow`` / #2893 +
-``cluster.drs_rule.create`` / ``folder.create`` / #2895):
+``vm.power`` / #2301, the vim writes ``vm.disk.grow`` / #2893 +
+``cluster.drs_rule.create`` / ``folder.create`` / #2895, and the #2891
+hardware writes ``vm.resize`` / ``vm.nic.repoint`` / ``vm.device.cdrom``):
 
-* All 13 expected write ``op_id`` rows land in ``endpoint_descriptor``
+* All 16 expected write ``op_id`` rows land in ``endpoint_descriptor``
   with ``source_kind="composite"``, ``safety_level="dangerous"``,
   ``requires_approval=True`` (T4's defaults intentionally inherited).
 * Each row's ``handler_ref`` resolves to the module-level dotted path
@@ -15,7 +16,7 @@ Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster``
   per the canary's stub-LLM taxonomy.
 * Combined with #508's 5 read composites, the registrar produces
-  **18 rows** total. (The former host.network_uplinks / host.vsan_health
+  **21 rows** total. (The former host.network_uplinks / host.vsan_health
   reads were re-shipped as typed ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
   with the documented required keys.
@@ -48,10 +49,13 @@ from meho_backplane.connectors.vmware_rest.composites import (
     vm_clone_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
+    vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
+    vm_nic_repoint_composite,
     vm_power_bulk_composite,
     vm_power_composite,
+    vm_resize_composite,
     vm_snapshot_revert_composite,
 )
 from meho_backplane.db.engine import get_sessionmaker
@@ -59,10 +63,11 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 13 write composites (T6 / #509, single-VM vm.power / #2301, the
+# 16 write composites (T6 / #509, single-VM vm.power / #2301, the
 # mutating VI-JSON vm.disk.grow / #2893, the folder-template
-# vm.clone_from_template / #2894, and the vim cluster/inventory writes
-# cluster.drs_rule.create + folder.create / #2895).
+# vm.clone_from_template / #2894, the vim cluster/inventory writes
+# cluster.drs_rule.create + folder.create / #2895, and the #2891
+# hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom).
 _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.create",
     "vmware.composite.vm.clone",
@@ -72,6 +77,9 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.power",
     "vmware.composite.vm.power.bulk",
     "vmware.composite.vm.disk.grow",
+    "vmware.composite.vm.resize",
+    "vmware.composite.vm.nic.repoint",
+    "vmware.composite.vm.device.cdrom",
     "vmware.composite.host.evacuate",
     "vmware.composite.host.detach_from_vds",
     "vmware.composite.cluster.patch",
@@ -91,9 +99,10 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.network.portgroup.audit",
 )
 
-# 18 total -- 5 read (T5 / #508) + 13 write (T6 / #509 + vm.power / #2301 +
+# 21 total -- 5 read (T5 / #508) + 16 write (T6 / #509 + vm.power / #2301 +
 # vm.disk.grow / #2893 + vm.clone_from_template / #2894 + vim cluster/inventory
-# writes cluster.drs_rule.create + folder.create / #2895).
+# writes cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
+# writes vm.resize / vm.nic.repoint / vm.device.cdrom).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -137,6 +146,15 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.folder.create": (
         "meho_backplane.connectors.vmware_rest.composites._write.folder_create_composite"
     ),
+    "vmware.composite.vm.resize": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_resize_composite"
+    ),
+    "vmware.composite.vm.nic.repoint": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_nic_repoint_composite"
+    ),
+    "vmware.composite.vm.device.cdrom": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_device_cdrom_composite"
+    ),
 }
 
 
@@ -149,6 +167,9 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.power": "vm",
     "vmware.composite.vm.power.bulk": "vm",
     "vmware.composite.vm.disk.grow": "vm",
+    "vmware.composite.vm.resize": "vm",
+    "vmware.composite.vm.nic.repoint": "vm",
+    "vmware.composite.vm.device.cdrom": "vm",
     "vmware.composite.host.evacuate": "host",
     "vmware.composite.host.detach_from_vds": "host",
     "vmware.composite.cluster.patch": "cluster",
@@ -197,15 +218,15 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 13 write composites land alongside the 5 reads (18 total)
+# 16 write composites land alongside the 5 reads (21 total)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_inserts_thirteen_write_rows(
+async def test_register_vmware_composite_operations_inserts_sixteen_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 13 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 16 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -222,12 +243,13 @@ async def test_register_vmware_composite_operations_inserts_thirteen_write_rows(
 
 
 @pytest.mark.asyncio
-async def test_full_registration_produces_eighteen_composite_rows(
+async def test_full_registration_produces_twenty_one_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """5 reads (#508) + 13 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
-    vm.clone_from_template #2894 + cluster.drs_rule.create + folder.create #2895)
-    = 18 rows."""
+    """5 reads (#508) + 16 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
+    vm.clone_from_template #2894 + cluster.drs_rule.create + folder.create #2895 +
+    #2891 hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom)
+    = 21 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -241,7 +263,7 @@ async def test_full_registration_produces_eighteen_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 18
+    assert len(rows) == 21
 
 
 @pytest.mark.asyncio
@@ -332,7 +354,9 @@ async def test_write_handler_ref_round_trips_to_module_level_dotted_path(
 async def test_write_composites_land_in_vm_host_cluster_groups(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """7 vm.* in ``vm``, 2 host.* in ``host``, 1 cluster.* in ``cluster``."""
+    """Group distribution: 12 in ``vm`` (11 ``vm.*`` + ``folder.create``),
+    2 ``host.*`` in ``host``, 2 ``cluster.*`` in ``cluster``.
+    """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -408,6 +432,16 @@ async def test_write_composite_parameter_schemas_persist_with_required_fields(
     # cluster.patch requires cluster.
     patch_schema: dict[str, Any] = dict(by_op["vmware.composite.cluster.patch"].parameter_schema)
     assert patch_schema["required"] == ["cluster"]
+    # vm.resize requires vm (at least one sizing field via anyOf).
+    resize_schema: dict[str, Any] = dict(by_op["vmware.composite.vm.resize"].parameter_schema)
+    assert set(resize_schema["required"]) == {"vm"}
+    assert "anyOf" in resize_schema
+    # vm.nic.repoint requires vm + nic + portgroup_name.
+    repoint_schema: dict[str, Any] = dict(by_op["vmware.composite.vm.nic.repoint"].parameter_schema)
+    assert set(repoint_schema["required"]) == {"vm", "nic", "portgroup_name"}
+    # vm.device.cdrom requires vm + cdrom + action.
+    cdrom_schema: dict[str, Any] = dict(by_op["vmware.composite.vm.device.cdrom"].parameter_schema)
+    assert set(cdrom_schema["required"]) == {"vm", "cdrom", "action"}
 
     # All write schemas pin additionalProperties=False.
     for op_id in _WRITE_OP_IDS:
@@ -454,6 +488,14 @@ async def test_write_composite_response_schemas_persist_with_status_enums(
         "vmware.composite.host.evacuate": {"evacuated", "partial", "aborted"},
         "vmware.composite.host.detach_from_vds": {"detached", "incomplete"},
         "vmware.composite.cluster.patch": {"completed", "stopped"},
+        "vmware.composite.vm.resize": {"resized", "requires_power_off", "no_change", "partial"},
+        "vmware.composite.vm.nic.repoint": {"repointed", "not_found", "ambiguous"},
+        "vmware.composite.vm.device.cdrom": {
+            "removed",
+            "updated",
+            "disconnected",
+            "invalid_request",
+        },
     }
     for op_id, expected_values in expected_status_values.items():
         schema: dict[str, Any] = dict(by_op[op_id].response_schema)
@@ -497,17 +539,17 @@ async def test_write_composite_tags_include_composite_and_write(
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_is_idempotent_across_eighteen(
+async def test_register_vmware_composite_operations_is_idempotent_across_twenty_one(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 18 rows total, embedding called 18x once."""
+    """Running the registrar twice -> 21 rows total, embedding called 21x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 18
+    assert first_count == 21
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 18.
+    # pipeline; the row count stays at 21.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -521,7 +563,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_eightee
             .scalars()
             .all()
         )
-    assert len(rows) == 18
+    assert len(rows) == 21
 
 
 # ---------------------------------------------------------------------------
@@ -548,6 +590,9 @@ def test_all_write_handlers_are_module_level_coroutine_functions() -> None:
         vm_power_composite,
         vm_power_bulk_composite,
         vm_disk_grow_composite,
+        vm_resize_composite,
+        vm_nic_repoint_composite,
+        vm_device_cdrom_composite,
         host_evacuate_composite,
         host_detach_from_vds_composite,
         cluster_patch_composite,

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,14 +8,17 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 18 hand-authored composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 21 hand-authored composites
 that orchestrate cross-spec workflows: 5 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`) and 13 write composites (G3.1-T6 / `#509`, plus the
+in `#2258`) and 16 write composites (G3.1-T6 / `#509`, the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
-mutating VI-JSON `vm.disk.grow` / `#2893`, and the folder-template
-`vm.clone_from_template` / `#2894`). The
+mutating VI-JSON `vm.disk.grow` / `#2893`, the folder-template
+`vm.clone_from_template` / `#2894`, the vim cluster / inventory writes
+`cluster.drs_rule.create` + `folder.create` / `#2895`, and the `#2891`
+post-clone hardware reconfigure trio `vm.resize` / `vm.nic.repoint` /
+`vm.device.cdrom`). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
 govc-wrapper retirement.
@@ -70,12 +73,16 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   cluster-wide `overall_health` colour plus the health-test `groups`
   list. It is likewise best-effort (a failed health-service read nulls
   `groups` / `overall_health` with a `read_note`).
-- **Write composites** (`composites/_write.py`) — nine module-level
+- **Write composites** (`composites/_write.py`) — twelve module-level
   `async def` handlers (`vm_create_composite`, `vm_clone_composite`,
   `vm_snapshot_revert_composite`, `vm_migrate_composite`,
   `vm_power_composite`, `vm_power_bulk_composite`,
+  `vm_resize_composite`, `vm_nic_repoint_composite`,
+  `vm_device_cdrom_composite`,
   `host_evacuate_composite`, `host_detach_from_vds_composite`,
-  `cluster_patch_composite`). Since
+  `cluster_patch_composite`). The last three (`#2891`) are the
+  post-clone hardware reconfigure trio — see the **Hardware write
+  composites** subsection under Control flow. Since
   `#2256` each accepts `(operator, target, params, connector)` and
   issues its raw-REST sub-ops **directly on the resolved connector
   session** — `connector._get_json` (`_read_sub_op`) for the resolution
@@ -118,8 +125,8 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   the direct session under the same governance seam.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 18
-  `_CompositeSpec` rows (5 read + 13 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 21
+  `_CompositeSpec` rows (5 read + 16 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -131,7 +138,7 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   `dispatch_child`, no ingested-descriptor sub-ops, no L2 pre-flight. It
   therefore works on a **fresh boot with zero catalog ingest** — the same
   direct-session property the 5 read composites (`#2253`) and, since
-  `#2256`, the 9 write composites now share. The only `dispatch_child`
+  `#2256`, the 12 write composites now share. The only `dispatch_child`
   leg left on the whole vmware surface is the `host.evacuate` →
   `vm.migrate` composite→composite recursion (a registrar-guaranteed
   `source_kind="composite"` row, not an ingested primitive, `#2248`). The metadata
@@ -246,9 +253,9 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
    (in `ensure_connector_class_registered`, once #408's pipeline lands
    in main) no-ops on subsequent ingests against the same triple.
 5. Lifespan calls `run_typed_op_registrars()`, which iterates every
-   queued registrar and upserts: the 14 `vmware.composite.*` rows with
+   queued registrar and upserts: the 17 `vmware.composite.*` rows with
    `source_kind="composite"` (5 reads with `safety_level="safe"` +
-   `requires_approval=False`; 9 writes with `safety_level="dangerous"`
+   `requires_approval=False`; 12 writes with `safety_level="dangerous"`
    + `requires_approval=True`), plus the `vmware.host.usage` row with
    `source_kind="typed"` (`safety_level="safe"` + `requires_approval=False`).
    The typed row resolves and dispatches with **zero catalog ingest** —
@@ -344,7 +351,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 18 composites (5 reads + 13 writes) land as `source_kind="composite"`
+The 21 composites (5 reads + 16 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -411,7 +418,7 @@ caller.
 
 ### L1/L2 dispatch — direct-session (two-world migration, Goal #2247)
 
-The 18 composites are hand-authored aggregators the connector ships as
+The 21 composites are hand-authored aggregators the connector ships as
 `source_kind='composite'` descriptors. Each composite's body issues its
 raw-REST sub-ops (`GET:/vcenter/datastore`,
 `POST:/vcenter/vm/{vm}/power?action=start`, etc.) **directly on the
@@ -465,12 +472,71 @@ enum) are:
 | `cluster.patch` | `completed`, `stopped` |
 | `cluster.drs_rule.create` | `created`, `rule_exists`, `insufficient_vms`, `timeout` (idempotent on rule name — a duplicate `rule_exists` is refused before any write; `insufficient_vms` when fewer than two named VMs resolve to the cluster; `timeout` when the `ReconfigureComputeResource_Task` poll gives up) |
 | `folder.create` | `created`, `parent_not_found`, `ambiguous_parent` (synchronous `CreateFolder` — the resolution refusals are structured, not raw vim faults) |
+| `vm.resize` | `resized`, `requires_power_off`, `no_change`, `partial` |
+| `vm.nic.repoint` | `repointed`, `not_found`, `ambiguous` |
+| `vm.device.cdrom` | `removed`, `updated`, `disconnected`, `invalid_request` |
 
 `vm.create` is the only composite that issues a compensating
 mutation (`DELETE:/vcenter/vm/{vm}`) on partial failure. The other
 write composites prefer "stop and report" semantics over silent
 rollback -- the operator decides whether to manually finish or
-revert.
+revert. `vm.resize`'s `partial` follows the same rule: a CPU PATCH
+that lands followed by a failing memory PATCH is reported (CPU stays
+applied), not rolled back.
+
+### Hardware write composites (`vm.resize` / `vm.nic.repoint` / `vm.device.cdrom`, #2891)
+
+The post-clone reconfigure trio are pure vSphere Automation REST
+writes (no `pyvmomi`). A freshly-cloned VM is stuck at the template's
+sizing, on the template's portgroup, and with the template's CD-ROM
+backing — these three composites rightsize it, move its NIC, and clear
+a host-pinning ISO:
+
+- **`vm.resize`** reads current sizing + hot-add flags via
+  `GET:/vcenter/vm/{vm}` (one read serves `name`, `power_state`,
+  `cpu.{count,cores_per_socket,hot_add_enabled}`,
+  `memory.{size_MiB,hot_add_enabled}`), then PATCHes
+  `PATCH:/vcenter/vm/{vm}/hardware/cpu` and/or
+  `PATCH:/vcenter/vm/{vm}/hardware/memory`. When the VM is powered on
+  and the requested change cannot be made live — no hot-add for the
+  changed dimension, a decrease, or any `cores_per_socket` change — the
+  handler returns `requires_power_off` **before** issuing the PATCH, so
+  the operator gets a typed status instead of a raw vCenter 400.
+- **`vm.nic.repoint`** reads the NIC's current backing + MAC via
+  `GET:/vcenter/vm/{vm}/hardware/ethernet/{nic}`, resolves the target
+  distributed portgroup by display name via
+  `GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP`, then PATCHes
+  `PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}` with
+  `{backing: {type: DISTRIBUTED_PORTGROUP, network: <moid>}}`. A name
+  that matches zero / many portgroups refuses the repoint
+  (`not_found` / `ambiguous`) with no PATCH issued.
+- **`vm.device.cdrom`** reads the device's current backing + state via
+  `GET:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}` (surfacing a host-local
+  ISO path the approver needs to see), then dispatches the `action`:
+  `remove` (`DELETE:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}`), `update`
+  (`PATCH` the backing — requires a `backing` param, e.g.
+  `{type: CLIENT_DEVICE}` to un-pin a host-local ISO), or `disconnect`
+  (`POST:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}?action=disconnect`).
+
+All three register a live-read **from->to** preview builder in
+`_write_preview.py`, so the parked approval row names the current state
+alongside the requested change (the delta is the decision the four-eyes
+reviewer signs off). Update PATCH bodies are wrapped in the
+`{"spec": {...}}` envelope the connector's `_write_sub_op` authors,
+matching the other write composites.
+
+**Portgroup resolution — the #1602 lesson.** There is no dedicated
+`distributed-portgroup` list resource in the REST Automation API;
+distributed portgroups are enumerated via the generic
+`GET:/vcenter/network` resource filtered to `DISTRIBUTED_PORTGROUP`
+(each summary row is `{network (id), name, type}`). The
+`_OP_LIST_PORTGROUPS = "GET:/vcenter/network/distributed-portgroup"`
+constant `_write.py` carried (declared by `#509`, singular spelling,
+absent from the pinned spec) was corrected to `_OP_LIST_NETWORK =
+"GET:/vcenter/network"` as part of `#2891` — the same shape
+`_read.py`'s `network.portgroup.audit` composite already used. The
+`host.detach_from_vds` composite's pre-flight portgroup read moved to
+the corrected path too.
 
 ### Mutating VI-JSON write substrate (`vm.disk.grow`, #2893)
 
@@ -716,7 +782,7 @@ so existing string-matching consumers keep working.
 
 ### Park-time approval previews (#1608)
 
-All 13 write composites ship `requires_approval=True`, so a human/agent
+All 16 write composites ship `requires_approval=True`, so a human/agent
 dispatch parks as a durable `ApprovalRequest` row. Pre-#1608 that row's
 `proposed_effect` was the identifier-only default `{op_id, connector_id,
 target_id}` — and since the dispatch `params` are deliberately never
@@ -727,7 +793,7 @@ approver could not tell a one-VM power cycle from a 1000-VM outage.
 composite on the generic per-op hook (`register_preview_builder`,
 `operations/_preview.py`, #1437). The builder result lands under
 `proposed_effect["preview"]`, wrapped with the op's sensitivity
-`op_class` (see [`approvals.md`](approvals.md)). Two depths:
+`op_class` (see [`approvals.md`](approvals.md)). Three depths:
 
 | Composite | Preview | Depth |
 | --- | --- | --- |
@@ -735,6 +801,9 @@ composite on the generic per-op hook (`register_preview_builder`,
 | `host.evacuate` | `{host, tolerate_partial_failure, resolved, total_resolved}` | live read (`GET:/vcenter/vm`) |
 | `host.detach_from_vds` | `{host, dvs, fallback_network, resolved, total_resolved}` | live read (`GET:/vcenter/vm`) |
 | `cluster.patch` | `{cluster, patch_method, resolved, total_resolved}` | live read (`GET:/vcenter/cluster/{cluster}/host`) |
+| `vm.resize` | `{vm, name, power_state, current, requested}` sizing from->to | live read (`GET:/vcenter/vm/{vm}`) |
+| `vm.nic.repoint` | `{vm, name, nic, mac_address, current_backing, requested_backing}` network from->to | live read (`ethernet/{nic}` + `GET:/vcenter/network`) |
+| `vm.device.cdrom` | `{vm, name, cdrom, action, current_backing, state}` (the host-local ISO path) | live read (`cdrom/{cdrom}`) |
 | `vm.create` | creation-spec echo (name, guest_os, sizing, networks, power-on) | param echo, no I/O |
 | `vm.clone` | clone-coordinates echo | param echo, no I/O |
 | `vm.snapshot.revert` | `{vm, snapshot_name}` echo | param echo, no I/O |
@@ -743,7 +812,14 @@ composite on the generic per-op hook (`register_preview_builder`,
 | `cluster.drs_rule.create` | `{cluster, cluster_name, rule_type, rule_name, enabled, resolved, total_resolved}` | live read (`GET:/vcenter/vm` + `GET:/vcenter/cluster/{cluster}`) |
 | `folder.create` | `{parent_folder, new_folder_name}` echo | param echo, no I/O |
 
-The live-read previews resolve the same entity set the approved
+The `#2891` hardware previews are a live-read **from->to diff**: the
+delta between the VM's current sizing / NIC backing / CD-ROM backing
+and the requested change is exactly what the approver signs off, so
+the builder reads current state via the shared
+`_write._read_vm_info` / `_write._read_ethernet_nic` /
+`_write._read_cdrom` / `_write._resolve_distributed_portgroup` helpers
+(the same ones the handlers use) and pairs it with the request. The
+fan-out live-read previews resolve the same entity set the approved
 dispatch would act on, through the **same shared helpers** the handlers
 use at dispatch time (`_write._resolve_vm_list` /
 `_write._resolve_cluster_hosts`) — one resolution code path, two call
@@ -868,8 +944,10 @@ they never park.
   (#509) ships 8 write composites, #2301 adds a 9th (single-VM
   `vm.power`, incl. Tools soft shutdown), #2893 adds a 10th (the
   mutating VI-JSON `vm.disk.grow`), #2894 an 11th (the folder-template
-  `vm.clone_from_template`), and #2895 a 12th + 13th (the vim cluster /
-  inventory writes `cluster.drs_rule.create` + `folder.create`) — 18
+  `vm.clone_from_template`), #2895 a 12th + 13th (the vim cluster /
+  inventory writes `cluster.drs_rule.create` + `folder.create`), and
+  #2891 a 14th / 15th / 16th (the post-clone hardware reconfigure trio
+  `vm.resize` / `vm.nic.repoint` / `vm.device.cdrom`) — 21
   composites today. The
   "All hand-authored composites land as endpoint_descriptor rows with
   source_kind='composite'" Definition-of-done line in [#227](https://github.com/evoila/meho/issues/227)


### PR DESCRIPTION
## Summary

- Adds the three `#2859`-flow post-clone hardware writes as dangerous,
  approval-gated `vmware.composite.*` composites over pure vSphere
  Automation REST (no `pyvmomi`): **`vm.resize`** (CPU/memory via
  `PATCH hardware/cpu` + `/memory`), **`vm.nic.repoint`** (`PATCH
  hardware/ethernet/{nic}` backing to a distributed portgroup resolved by
  name), and **`vm.device.cdrom`** (`remove` / `update` / `disconnect`).
- `vm.resize` reads current sizing + hot-add flags first and returns a
  typed `requires_power_off` status when a powered-on VM cannot take the
  change live, instead of letting the PATCH surface a raw vCenter 400.
- Each composite registers a **live-read from→to preview builder** in
  `_PREVIEW_BUILDERS`, so the parked approval row shows the current sizing
  / NIC backing / CD-ROM backing alongside the requested change — the diff
  the four-eyes reviewer signs off. Every mutating sub-call routes through
  `enforce_subop_policy` (`#2254`).
- Folds in the **`#1602`** fix: the write surface's distributed-portgroup
  listing moves off the unresolvable singular
  `GET:/vcenter/network/distributed-portgroup` to the generic
  `GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP` the read
  composites already use (`_OP_LIST_PORTGROUPS` → `_OP_LIST_NETWORK`).

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (strict) — no issues
- [x] `pytest -k vmware_rest_composites` — 169 passed
- [x] `pytest -k vmware_rest` (broader) — 352 passed, 11 skipped (lab-smoke, real vCenter only)
- [x] `code-quality.py --diff` — 0 blockers
- [x] **AC1** — three `_CompositeSpec` rows registered (group_key `vm`),
  `dangerous` + `requires_approval`, dispatchable on a fresh boot
  (register + e2e fresh-boot lanes, no catalog ingest)
- [x] **AC2** — every mutating sub-call gated via `enforce_subop_policy`;
  park→approve→resume + the `#2681` uniform op-identity envelope asserted
  in `_write_e2e`
- [x] **AC3** — preview builders live-read the from→to diffs; fail-soft
  `preview_unavailable` covered
- [x] **AC4** — `_OP_LIST_PORTGROUPS` singular-spelling defect fixed; new
  REST sub-op paths reconcile in the ingest-reconcile lane
- [x] **AC5** — four test lanes (handler / register / preview / e2e)
  extended; full suite green
- [x] **AC6** — `docs/codebase/connectors-vmware-rest.md` write-surface
  section updated; CHANGELOG bullet added

## REST shapes (fresh-cited)

vSphere Automation REST paths/bodies verified against the vSphere
Automation SDK API reference (Ruby SDK docs for `ethernet.update` /
`cdrom.{delete,disconnect,update}` paths + models; WebSearch for the CPU
update spec). The CD-ROM `disconnect` uses the modern `/api`
`?action=disconnect` query form the connector already uses for every
action endpoint (power / relocate / maintenance). Update bodies wrap the
spec in the `{"spec": {...}}` envelope the connector's `_write_sub_op`
authors, matching the other write composites.

## Out of scope

- Sibling Wave-1 tasks `#2892` (GOSC) and `#2893` (VI-JSON substrate +
  disk-grow) cover the rest of the `#2890` write surface; shared registries
  were only appended to (no refactor) to minimize cross-PR conflicts.
- `vm_nic_repoint_composite` (68 lines) and `vm_device_cdrom_composite`
  (67 lines) sit just over the 60-line function-size *warning* (not
  blocker), consistent with the existing sibling composites
  (`host_evacuate_composite` is 81 lines).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2891
