### PR TITLE
feat(connectors): add nsx.segment.list typed read for subnet/CIDR occupancy (#2835)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,20 @@ connector-related release-notes line.
   `/vcenter/network/distributed-portgroup` path to the generic
   `GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP` the read
   composites already use.
+### Added — `nsx.segment.list` typed read for overlay-segment + subnet/CIDR occupancy pre-flight (#2835)
+
+- A new `source_kind="typed"` op `nsx.segment.list` dispatches
+  `GET /policy/api/v1/infra/segments` on a fresh boot with zero catalog
+  ingest, mirroring `nsx.tier1.list` / `nsx.transport_zone.list` in the
+  `nsx-inventory` group. It passes the vendor `{results, result_count}`
+  envelope through unmodified — each segment carries `id`,
+  `display_name`, `resource_type`, `transport_zone_path`, and
+  `subnets[].gateway_address`, the CIDR-occupancy datum an operator reads
+  before carving a new segment (or attaching a workload) to avoid a
+  collision, instead of falling back to the NSX Policy Manager UI or a
+  raw `curl` that bypasses policy/audit/broadcast/JSONFlux.
+  `safety_level="safe"`, no approval; segment create/update/delete stays
+  out of scope (a future approval-gated write-surface initiative).
 
 ## [0.28.0] - 2026-08-07
 

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -552,6 +552,14 @@ class NsxConnector(HttpConnector):
 
         return await nsx_tier1_list_impl(self, operator, target, params)
 
+    async def segment_list(
+        self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``nsx.segment.list`` shim (#2835)."""
+        from meho_backplane.connectors.nsx.typed_reads import nsx_segment_list_impl
+
+        return await nsx_segment_list_impl(self, operator, target, params)
+
     async def alarm_list(
         self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
     ) -> dict[str, Any]:

--- a/backend/src/meho_backplane/connectors/nsx/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/nsx/typed_ops.py
@@ -18,13 +18,13 @@ The dataclass + tuple + module-level registrar shape mirrors
 :mod:`meho_backplane.connectors.argocd.ops` and
 :mod:`meho_backplane.connectors.vmware_rest.typed_ops`.
 
-Ops NOT in the audited set (transport-node listing, segment listing,
-tier-0 gateways, distributed-firewall policies + rules) stay as ingested
-browse breadth -- enable-able through the generic review flow
+Ops NOT in the audited set (transport-node listing, tier-0 gateways,
+distributed-firewall policies + rules) stay as ingested browse breadth
+-- enable-able through the generic review flow
 (``ReviewService.enable_reads``); only the audited operational reads are
-promoted to first-class typed ops. ``tier-1 gateway create`` (a write) is
-out of scope: the first write on a read-only connector is its own
-approval-gated G3.x write-surface initiative.
+promoted to first-class typed ops. Segment / tier-1 gateway *create*
+(a write) is out of scope: the first write on a read-only connector is
+its own approval-gated G3.x write-surface initiative.
 """
 
 from __future__ import annotations
@@ -107,8 +107,10 @@ NSX_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     _GROUP_INVENTORY: (
         "Use to list the NSX routing/overlay inventory the operator asks "
         "about most: transport zones under the default enforcement point "
-        "(nsx.transport_zone.list) and per-tenant tier-1 gateways "
-        "(nsx.tier1.list). Read-only."
+        "(nsx.transport_zone.list), per-tenant tier-1 gateways "
+        "(nsx.tier1.list), and overlay/VLAN segments with their "
+        "subnet/CIDR occupancy (nsx.segment.list) -- the pre-flight read "
+        "before carving a new segment. Read-only."
     ),
     _GROUP_ALARMS: (
         "Use to read NSX system alarms (nsx.alarm.list) -- open faults and "
@@ -363,6 +365,48 @@ _TIER1_LIST = NsxTypedOp(
 
 
 # ---------------------------------------------------------------------------
+# nsx.segment.list
+# ---------------------------------------------------------------------------
+
+_SEGMENT_LIST = NsxTypedOp(
+    op_id="nsx.segment.list",
+    handler_attr="segment_list",
+    summary="NSX overlay/VLAN segment inventory with subnet/CIDR occupancy.",
+    description=(
+        "Lists NSX segments via GET /policy/api/v1/infra/segments -- the "
+        "overlay/VLAN segments workloads attach to. Returns {results: [...]} "
+        "where each segment carries id, display_name, resource_type, "
+        "transport_zone_path (the transport zone it backs onto), and subnets "
+        "-- each subnet's gateway_address is the subnet/CIDR occupancy datum. "
+        "The pre-flight read before carving a new segment or attaching a "
+        "workload, to spot which CIDRs are already in use and avoid a "
+        "collision. The vendor {results, result_count} envelope passes "
+        "through unmodified. Read-only inventory: segment create/update/"
+        "delete is a separate approval-gated write and is not registered "
+        "here. Works with zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "nsx", "policy", "segment"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call before carving a new NSX overlay segment or attaching a "
+            "workload, to list existing segments and read which subnet/gateway "
+            "CIDRs are already in use (avoid a CIDR collision)."
+        ),
+        "output_shape": (
+            "{results: [{id, display_name, resource_type, transport_zone_path, "
+            "subnets: [{gateway_address}]}, ...]}. Read subnets[].gateway_address "
+            "across segments for the CIDR occupancy the pre-flight needs."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
 # nsx.alarm.list
 # ---------------------------------------------------------------------------
 
@@ -437,6 +481,7 @@ NSX_TYPED_OPS: tuple[NsxTypedOp, ...] = (
     _BACKUP_STATUS,
     _TRANSPORT_ZONE_LIST,
     _TIER1_LIST,
+    _SEGMENT_LIST,
     _ALARM_LIST,
 )
 

--- a/backend/src/meho_backplane/connectors/nsx/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/nsx/typed_reads.py
@@ -40,6 +40,9 @@ The audited set:
   default enforcement point.
 * ``nsx.tier1.list`` -- ``GET /policy/api/v1/infra/tier-1s`` (the
   per-tenant east-west routing surface).
+* ``nsx.segment.list`` -- ``GET /policy/api/v1/infra/segments`` (the
+  overlay/VLAN segments and their subnet/CIDR occupancy -- the
+  pre-flight read before carving a new segment).
 * ``nsx.alarm.list`` -- ``GET /api/v1/alarms`` with optional
   ``status`` / ``feature_name`` / ``severity`` filters.
 
@@ -69,6 +72,7 @@ __all__ = [
     "nsx_backup_status_impl",
     "nsx_cluster_status_impl",
     "nsx_node_status_impl",
+    "nsx_segment_list_impl",
     "nsx_tier1_list_impl",
     "nsx_transport_zone_list_impl",
 ]
@@ -87,6 +91,7 @@ _TRANSPORT_ZONES_PATH = (
     "/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones"
 )
 _TIER1S_PATH = "/policy/api/v1/infra/tier-1s"
+_SEGMENTS_PATH = "/policy/api/v1/infra/segments"
 _ALARMS_PATH = "/api/v1/alarms"
 
 #: Sentinel written in place of a scrubbed secret value. A non-empty
@@ -260,6 +265,28 @@ async def nsx_tier1_list_impl(
     """
     del params  # schema declares the param object empty
     return await connector._get_json(target, _TIER1S_PATH, operator=operator)
+
+
+async def nsx_segment_list_impl(
+    connector: NsxConnector,
+    operator: Operator,
+    target: NsxTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``nsx.segment.list`` -- ``GET /policy/api/v1/infra/segments``.
+
+    Returns the overlay/VLAN segment inventory -- the read an operator
+    runs before carving a new segment or attaching a workload, to see
+    which subnet/gateway CIDRs are already in use and avoid a collision.
+    The vendor's ``{"results": [...], "result_count": N}`` envelope is
+    passed through unmodified (same shape as :func:`nsx_tier1_list_impl`);
+    each segment carries ``id``, ``display_name``, ``resource_type``,
+    ``transport_zone_path`` (the transport zone it backs onto), and
+    ``subnets`` -- each subnet's ``gateway_address`` is the subnet/CIDR
+    occupancy datum the pre-flight question needs.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _SEGMENTS_PATH, operator=operator)
 
 
 async def nsx_alarm_list_impl(

--- a/backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py
@@ -38,8 +38,11 @@ Skip conditions:
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 
+from meho_backplane.connectors.nsx import register_nsx_typed_operations
 from meho_backplane.operations.meta_tools import call_operation
 from tests.acceptance._nsx_canary_fixtures import (
     NSX_CANARY_CORE_OP_IDS,
@@ -113,6 +116,56 @@ async def test_dispatch_smoke_nsx_core_op_returns_ok(
 
     assert result["status"] == "ok", (
         f"NSX op {op_id!r} failed against the respx-mocked NSX manager at "
+        f"{ingested_nsx_canary.base_url}: {result.get('error')!r}; "
+        f"full result={result!r}"
+    )
+
+
+#: Typed (``source_kind="typed"``) NSX read op ids dispatched through the
+#: acceptance surface. Unlike the ingested :data:`SMOKE_OP_IDS` above (seeded
+#: by the fixture), these need the typed registrar run in-test to persist
+#: their descriptor rows. ``nsx.segment.list`` (#2835) hits the same
+#: ``/policy/api/v1/infra/segments`` wire route the fixture already mocks.
+TYPED_SMOKE_OP_IDS: tuple[str, ...] = ("nsx.segment.list",)
+
+
+@pytest.mark.parametrize("op_id", TYPED_SMOKE_OP_IDS, ids=lambda op: op)
+async def test_dispatch_smoke_nsx_typed_op_returns_ok(
+    op_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+    ingested_nsx_canary: IngestedNsxCanary,
+) -> None:
+    """Each NSX typed read dispatches over respx and returns ``status='ok'``.
+
+    ``nsx.segment.list`` (#2835) is a ``source_kind="typed"`` op: it is not
+    in the ingested :data:`SMOKE_OP_IDS` set the fixture seeds, so this test
+    runs :func:`register_nsx_typed_operations` to persist the typed
+    descriptor rows before dispatching. ``encode_endpoint_text`` is stubbed
+    so the registrar computes no real embedding -- the fastembed ONNX fetch
+    would otherwise fire under the fixture's active respx router and corrupt
+    the multi-request model download (the same hazard
+    :func:`~tests.acceptance._canary_fixtures.prewarmed_embeddings`
+    documents). Dispatch itself takes a known ``op_id`` and needs no
+    embedding.
+    """
+    monkeypatch.setattr(
+        "meho_backplane.operations.typed_register.encode_endpoint_text",
+        AsyncMock(return_value=[0.1] * 384),
+    )
+    await register_nsx_typed_operations()
+
+    result = await call_operation(
+        ingested_nsx_canary.operator,
+        {
+            "connector_id": ingested_nsx_canary.connector_id,
+            "op_id": op_id,
+            "target": {"name": ingested_nsx_canary.target_name},
+            "params": {},
+        },
+    )
+
+    assert result["status"] == "ok", (
+        f"NSX typed op {op_id!r} failed against the respx-mocked NSX manager at "
         f"{ingested_nsx_canary.base_url}: {result.get('error')!r}; "
         f"full result={result!r}"
     )

--- a/backend/tests/test_connectors_nsx_typed_reads.py
+++ b/backend/tests/test_connectors_nsx_typed_reads.py
@@ -8,7 +8,8 @@ Coverage matrix (per Task #2302 acceptance criteria):
 * **Zero-catalog typed dispatch (AC #1).** Each audited read
   (nsx.node.status / nsx.cluster.status / nsx.backup.config /
   nsx.backup.status / nsx.transport_zone.list / nsx.tier1.list /
-  nsx.alarm.list) dispatches through :func:`~meho_backplane.operations.dispatch`
+  nsx.segment.list / nsx.alarm.list) dispatches through
+  :func:`~meho_backplane.operations.dispatch`
   against a respx-mocked NSX manager with **only** the typed registrar
   run -- no ingested descriptor rows -- and returns ``status="ok"``. The
   persisted descriptor carries ``source_kind="typed"``.
@@ -21,7 +22,11 @@ Coverage matrix (per Task #2302 acceptance criteria):
   downstream GET is recovered by the dispatcher's auth-class arm calling
   the connector's public ``invalidate_session`` hook and re-dispatching
   once; the op returns ``status="ok"``.
-* **Registration-shape invariants.** All seven carry
+* **Segment CIDR occupancy is passed through unmodified (#2835).**
+  nsx.segment.list forwards the vendor ``{results, result_count}``
+  envelope so each segment's ``subnets[].gateway_address`` (the
+  pre-flight CIDR-occupancy datum) reaches the operator unmodified.
+* **Registration-shape invariants.** All eight carry
   ``safety_level="safe"``, ``requires_approval=False``, a ``read-only``
   tag, ``additionalProperties=False`` on the parameter schema, and
   non-empty llm_instructions. No write op is registered.
@@ -198,6 +203,29 @@ _TZ_PAYLOAD: dict[str, Any] = {
 _TIER1_PAYLOAD: dict[str, Any] = {
     "results": [{"id": "t1-a", "display_name": "tenant-a", "tier0_path": "/infra/tier-0s/t0"}]
 }
+_SEGMENTS_PAYLOAD: dict[str, Any] = {
+    "results": [
+        {
+            "id": "seg-app",
+            "display_name": "app-tier",
+            "resource_type": "Segment",
+            "transport_zone_path": (
+                "/infra/sites/default/enforcement-points/default/transport-zones/tz-overlay"
+            ),
+            "subnets": [{"gateway_address": "10.20.0.1/24"}],
+        },
+        {
+            "id": "seg-db",
+            "display_name": "db-tier",
+            "resource_type": "Segment",
+            "transport_zone_path": (
+                "/infra/sites/default/enforcement-points/default/transport-zones/tz-overlay"
+            ),
+            "subnets": [{"gateway_address": "10.20.1.1/24"}],
+        },
+    ],
+    "result_count": 2,
+}
 _ALARM_PAYLOAD: dict[str, Any] = {
     "results": [
         {
@@ -231,6 +259,13 @@ _ALARM_PAYLOAD: dict[str, Any] = {
             _TZ_PAYLOAD,
         ),
         ("nsx.tier1.list", {}, "GET", "/policy/api/v1/infra/tier-1s", _TIER1_PAYLOAD),
+        (
+            "nsx.segment.list",
+            {},
+            "GET",
+            "/policy/api/v1/infra/segments",
+            _SEGMENTS_PAYLOAD,
+        ),
         ("nsx.alarm.list", {}, "GET", "/api/v1/alarms", _ALARM_PAYLOAD),
     ],
 )
@@ -314,6 +349,47 @@ async def test_alarm_list_forwards_filters(
     assert sent.params.get("status") == "OPEN"
     assert sent.params.get("feature_name") == "manager_health"
     assert sent.params.get("severity") == "CRITICAL"
+
+
+@pytest.mark.asyncio
+async def test_segment_list_returns_cidr_occupancy_shape(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """#2835: nsx.segment.list passes the vendor segment envelope through unmodified.
+
+    The operator's pre-flight question -- "which subnet/gateway CIDRs are
+    already in use before I carve a new segment?" -- is answered by
+    ``subnets[].gateway_address`` on each returned segment, so the handler
+    must forward the vendor payload without projecting it away.
+    """
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_NSX_BASE_URL, assert_all_called=False) as mock:
+        mock.post("/api/session/create").respond(200, headers=_XSRF_HEADERS)
+        route = mock.get("/policy/api/v1/infra/segments").respond(200, json=_SEGMENTS_PAYLOAD)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=NSX_CONNECTOR_ID,
+            op_id="nsx.segment.list",
+            target=_NsxReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert route.called and route.call_count == 1
+    body = result.result
+    assert isinstance(body, dict)
+    # Vendor {results, result_count} envelope passed through unmodified.
+    assert body["result_count"] == 2
+    segments = body["results"]
+    assert [seg["id"] for seg in segments] == ["seg-app", "seg-db"]
+    # The subnet/CIDR-occupancy datum the pre-flight needs, plus the
+    # transport-zone cross-reference and resource_type -- all unmodified.
+    assert segments[0]["subnets"][0]["gateway_address"] == "10.20.0.1/24"
+    assert segments[1]["subnets"][0]["gateway_address"] == "10.20.1.1/24"
+    assert segments[0]["transport_zone_path"].endswith("/tz-overlay")
+    assert segments[0]["resource_type"] == "Segment"
 
 
 # ---------------------------------------------------------------------------
@@ -460,6 +536,7 @@ _EXPECTED_OP_IDS = {
     "nsx.backup.status",
     "nsx.transport_zone.list",
     "nsx.tier1.list",
+    "nsx.segment.list",
     "nsx.alarm.list",
 }
 

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -14,12 +14,17 @@ verbs + MCP review + recorded-fixture E2E arrive in G3.5-T3 (#615).
 
 **Audited reads are typed ops (#2302).** The audited operational read
 set -- node/cluster status+version, backup config+status,
-transport-zones list, tier-1 list, and alarms -- is registered as
+transport-zones list, tier-1 list, segment list (`nsx.segment.list`,
+#2835), and alarms -- is registered as
 **typed** ops (`source_kind="typed"`, `typed_ops.py` metadata +
 `typed_reads.py` bodies + bound-method shims on `NsxConnector`), so it
 dispatches on a fresh boot with **zero catalog ingest** (avoiding the
-#2247 per-deploy catalog-state failure class). The remaining reads
-(transport-node listing, segments, tier-0 gateways, distributed-firewall
+#2247 per-deploy catalog-state failure class). `nsx.segment.list`
+(`GET /policy/api/v1/infra/segments`) passes the vendor
+`{results, result_count}` envelope through unmodified so the operator can
+read each segment's `subnets[].gateway_address` (subnet/CIDR occupancy)
+before carving a new segment. The remaining reads
+(transport-node listing, tier-0 gateways, distributed-firewall
 policies + rules) stay as ordinary `source_kind="ingested"` breadth, enabled
 generically via `ReviewService.enable_reads`, so the wider ingested breadth
 remains browsable. `nsx.backup.config` is
@@ -87,7 +92,7 @@ Source: `backend/src/meho_backplane/connectors/nsx/`.
   typed-read / VCF-9-ingest tests one importable source of truth. Relocated
   here from the retired `core_ops` module in #2358.
 - **Ingested browse breadth** -- the reads outside the typed set
-  (transport-node listing, segments, tier-0 gateways, distributed-firewall
+  (transport-node listing, tier-0 gateways, distributed-firewall
   policies + rules, and the wider NSX catalog) land as ordinary
   `source_kind="ingested"` `endpoint_descriptor` rows via G0.7 spec ingestion
   and are enabled through the generic review flow
@@ -229,7 +234,7 @@ concern, same posture vSphere takes for proactive refresh.
 
 The audited operational reads are typed ops (see the Overview) and dispatch on
 a fresh boot with zero catalog state. The remaining reads (transport-node
-listing, segments, tier-0 gateways, distributed-firewall policies + rules) and
+listing, tier-0 gateways, distributed-firewall policies + rules) and
 the wider NSX catalog land as ordinary `source_kind="ingested"`
 `endpoint_descriptor` rows after a G0.7 ingest of the NSX `policy.yaml` +
 `manager.yaml` corpus (every row `is_enabled=False` until enabled).
@@ -293,8 +298,10 @@ The hand-curated ingested-enable apparatus (the `core_ops.py` module with its
   lane with no Docker dependency.
 - Acceptance tests:
   - `backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py` —
-    dispatch the 9 NSX core ops against a respx-mocked NSX REST
-    surface; one parametrised case per op.
+    dispatch the ingested NSX core ops against a respx-mocked NSX REST
+    surface (one parametrised case per op), plus a typed-op case that
+    registers `nsx.segment.list` (#2835) and dispatches it over the same
+    mocked `/policy/api/v1/infra/segments` route.
   - `backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py`
     — install a test-only `ForceHandleReducer`, dispatch the
     segment-list op, assert `OperationResult.handle` is populated


### PR DESCRIPTION
## Summary
- New `source_kind="typed"` op **`nsx.segment.list`** dispatches `GET /policy/api/v1/infra/segments` on a fresh boot with **zero catalog ingest**, mirroring `nsx.tier1.list` / `nsx.transport_zone.list` in the `nsx-inventory` group (`safety_level="safe"`, `requires_approval=False`).
- Answers the operator's pre-flight *"which subnet/gateway CIDRs are already in use before I carve a new segment?"* through the governed backplane (policy/audit/broadcast/JSONFlux) instead of the NSX Policy Manager UI or a raw `curl` against `/policy/api/v1/infra/segments`.
- The handler (`nsx_segment_list_impl` + bound `segment_list` shim on `NsxConnector`) passes the vendor `{results, result_count}` envelope through **unmodified** — each segment's `id` / `display_name` / `resource_type` / `transport_zone_path` / `subnets[].gateway_address` reach the operator as-is (`subnets[].gateway_address` is the CIDR-occupancy datum).
- Set-shaped responses ride the existing dispatch-layer JSONFlux/result-handle path — the segment force-handle acceptance test still passes, so no handler-side wrapping is needed (postulate 6).

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean for this change (the only reported error is a pre-existing, Linux-CI-only `net/icmp.py` `socket.MSG_ERRQUEUE` attr on macOS; untouched here)
- [x] `pytest tests/test_connectors_nsx_typed_reads.py` — **40 passed** (AC #1/#2/#3: parametrized `nsx.segment.list` zero-catalog dispatch + dedicated `test_segment_list_returns_cidr_occupancy_shape` asserting the envelope/fields pass through unmodified; `_EXPECTED_OP_IDS` + safety / approval / read-only / schema / llm-instructions invariants now cover the 8th op)
- [x] `pytest tests/acceptance/test_g35_nsx_dispatch_smoke.py tests/acceptance/test_g35_nsx_jsonflux_force_handle.py` — **7 passed** against a real PostgreSQL testcontainer (AC #4: new parametrized `test_dispatch_smoke_nsx_typed_op_returns_ok[nsx.segment.list]` dispatches the typed op via `call_operation`; force-handle stays green)
- [x] `code-quality.py --diff` — 0 blockers (4 pre-existing size warnings, none agent-introduced)
- [x] AC #5: `docs/codebase/connectors-nsx.md` — `nsx.segment.list` added to the audited-typed-ops Overview list; the "remaining reads" excluded-list note trimmed (segments removed from the ingested-breadth mentions)
- [x] AC #6: no schema/route change (a typed op is a runtime `endpoint_descriptor` row, not a FastAPI route), so the CLI OpenAPI snapshot needs no regen — verified no route / `main.py` / `api/` / `cli/` / OpenAPI file is in the diff

## Vendor confirmation
`GET /policy/api/v1/infra/segments` (ListAllInfraSegments) returns a `SegmentListResult` envelope (`results`, `result_count`, `cursor`, …); each Segment carries `id`, `display_name`, `resource_type`, `subnets[].gateway_address`, and `transport_zone_path` — confirmed against the Broadcom NSX-T REST API doc and the repo's own pinned `NSX_CANARY_SEGMENTS` fixture. The handler is a pure pass-through, so it embeds no field-shape assumption in executable logic.

## Out of scope
- Segment create/update/delete (a write — the first write on this read-only connector is its own approval-gated write-surface initiative).
- Edge/transport-node state, tier-0 gateways, distributed-firewall policies + rules (separate gaps in the parent initiative #2833).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2835
