### PR TITLE
feat(connectors): add k8s storage + custom-resource read ops (#2830)

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -188,6 +188,29 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "Interactive shells ('kubectl exec -it') are deliberately out "
         "of scope -- command-and-capture only."
     ),
+    "storage": (
+        "Use for storage sizing and capacity questions: "
+        "``k8s.storageclass.list`` (which class is default, what "
+        "provisioner backs it, can it expand), "
+        "``k8s.persistentvolume.list`` (provisioned volumes -- phase / "
+        "capacity / bound claim) and ``k8s.persistentvolumeclaim.list`` "
+        "(what workloads have requested -- per-namespace or "
+        "cluster-wide). The right group for pre-flight cluster sizing "
+        "before provisioning new workloads. Pair with the 'workload' "
+        "group to map a PVC back to the pod that mounts it."
+    ),
+    "custom_resources": (
+        "Use to read custom resources generically -- the state that "
+        "lives outside built-in kinds on GitOps clusters (MetalLB "
+        "IPAddressPools, cert-manager Certificates, ExternalSecrets, "
+        "Argo/Flux). ``k8s.crd.list`` discovers which CRDs exist plus "
+        "the group/version/plural triple; ``k8s.cr.list`` / "
+        "``k8s.cr.info`` read the objects (metadata + a bounded spec "
+        "excerpt). The right group when the operator's question names a "
+        "resource kind no built-in op covers ('which MetalLB pool "
+        "ranges are allocated?'). Start with ``k8s.crd.list`` to learn "
+        "the arguments the read ops need."
+    ),
 }
 
 
@@ -794,6 +817,200 @@ class KubernetesConnector(Connector):
         sorted_rows = sort_event_rows_recent_first(rows)
         truncated = sorted_rows[:limit]
         return {"rows": truncated, "total": len(truncated)}
+
+    async def k8s_storageclass_list(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List StorageClasses -- name / provisioner / default / expansion.
+
+        Op-id: ``k8s.storageclass.list``. Wraps
+        ``StorageV1Api.list_storage_class()`` and projects each
+        :class:`V1StorageClass` through
+        :func:`~meho_backplane.connectors.kubernetes.ops_storage.storageclass_row`.
+        Cluster-scoped (no parameters, mirrors ``k8s.node.list``).
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
+        """
+        from meho_backplane.connectors.kubernetes.ops_storage import storageclass_row
+
+        del params
+        api_client = await self._get_api_client(target, operator)
+        storage_v1 = client.StorageV1Api(api_client)
+        resp = await storage_v1.list_storage_class()
+        rows = [storageclass_row(sc) for sc in resp.items]
+        return {"rows": rows, "total": len(rows)}
+
+    async def k8s_persistentvolume_list(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List PersistentVolumes -- phase / capacity / storage class / claim.
+
+        Op-id: ``k8s.persistentvolume.list``. Wraps
+        ``CoreV1Api.list_persistent_volume()`` and projects each
+        :class:`V1PersistentVolume` through
+        :func:`~meho_backplane.connectors.kubernetes.ops_storage.persistentvolume_row`.
+        Cluster-scoped (no parameters, mirrors ``k8s.node.list``).
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
+        """
+        from meho_backplane.connectors.kubernetes.ops_storage import persistentvolume_row
+
+        del params
+        api_client = await self._get_api_client(target, operator)
+        core_v1 = client.CoreV1Api(api_client)
+        resp = await core_v1.list_persistent_volume()
+        rows = [persistentvolume_row(pv) for pv in resp.items]
+        return {"rows": rows, "total": len(rows)}
+
+    async def k8s_persistentvolumeclaim_list(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List PersistentVolumeClaims per-namespace or cluster-wide.
+
+        Op-id: ``k8s.persistentvolumeclaim.list``. Branches on
+        ``all_namespaces`` between
+        ``CoreV1Api.list_namespaced_persistent_volume_claim(namespace, ...)``
+        and
+        ``CoreV1Api.list_persistent_volume_claim_for_all_namespaces(...)``
+        (the shared XOR selector, G0.17-T1 #1330) and projects each
+        :class:`V1PersistentVolumeClaim` through
+        :func:`~meho_backplane.connectors.kubernetes.ops_storage.persistentvolumeclaim_row`.
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
+        """
+        from meho_backplane.connectors.kubernetes.ops_storage import persistentvolumeclaim_row
+
+        namespace: str | None = params.get("namespace")
+        all_namespaces = bool(params.get("all_namespaces", False))
+        api_client = await self._get_api_client(target, operator)
+        core_v1 = client.CoreV1Api(api_client)
+        if all_namespaces:
+            resp = await core_v1.list_persistent_volume_claim_for_all_namespaces()
+        else:
+            # Schema enforces XOR; ``or ""`` is defensive against a
+            # future schema relaxation.
+            resp = await core_v1.list_namespaced_persistent_volume_claim(namespace=namespace or "")
+        rows = [persistentvolumeclaim_row(pvc) for pvc in resp.items]
+        return {"rows": rows, "total": len(rows)}
+
+    async def k8s_crd_list(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List CustomResourceDefinitions -- group / kind / plural / scope / versions.
+
+        Op-id: ``k8s.crd.list``. Wraps
+        ``ApiextensionsV1Api.list_custom_resource_definition()`` and
+        projects each :class:`V1CustomResourceDefinition` through
+        :func:`~meho_backplane.connectors.kubernetes.ops_customresource.crd_row`.
+        The discovery op for the generic ``k8s.cr.*`` reads.
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
+        """
+        from meho_backplane.connectors.kubernetes.ops_customresource import crd_row
+
+        del params
+        api_client = await self._get_api_client(target, operator)
+        ext_v1 = client.ApiextensionsV1Api(api_client)
+        resp = await ext_v1.list_custom_resource_definition()
+        rows = [crd_row(crd) for crd in resp.items]
+        return {"rows": rows, "total": len(rows)}
+
+    async def k8s_cr_list(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List custom-resource objects by group/version/plural.
+
+        Op-id: ``k8s.cr.list``. Branches on whether a ``namespace`` is
+        supplied between
+        ``CustomObjectsApi.list_namespaced_custom_object(...)`` and
+        ``CustomObjectsApi.list_cluster_custom_object(...)`` -- the
+        cluster form lists a namespaced CRD across every namespace, or a
+        cluster-scoped CRD's objects. CustomObjectsApi returns a plain
+        dict (CRs have no typed model), so the ``items`` list is read
+        with ``.get`` and each object projects through
+        :func:`~meho_backplane.connectors.kubernetes.ops_customresource.custom_resource_row`
+        (metadata + bounded spec excerpt).
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
+        """
+        from meho_backplane.connectors.kubernetes.ops_customresource import custom_resource_row
+
+        group: str = params["group"]
+        version: str = params["version"]
+        plural: str = params["plural"]
+        namespace: str | None = params.get("namespace")
+        api_client = await self._get_api_client(target, operator)
+        custom = client.CustomObjectsApi(api_client)
+        if namespace:
+            resp = await custom.list_namespaced_custom_object(
+                group=group, version=version, namespace=namespace, plural=plural
+            )
+        else:
+            resp = await custom.list_cluster_custom_object(
+                group=group, version=version, plural=plural
+            )
+        items = resp.get("items") or []
+        rows = [custom_resource_row(obj) for obj in items]
+        return {"rows": rows, "total": len(rows)}
+
+    async def k8s_cr_info(
+        self,
+        operator: Operator,
+        target: KubernetesTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Read one named custom-resource object.
+
+        Op-id: ``k8s.cr.info``. Branches on whether a ``namespace`` is
+        supplied between
+        ``CustomObjectsApi.get_namespaced_custom_object(...)`` and
+        ``CustomObjectsApi.get_cluster_custom_object(...)`` and returns
+        the single-object projection from
+        :func:`~meho_backplane.connectors.kubernetes.ops_customresource.custom_resource_row`
+        (a flat dict, not a rows/total envelope -- the counterpart to
+        ``k8s.configmap.info``).
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
+        """
+        from meho_backplane.connectors.kubernetes.ops_customresource import custom_resource_row
+
+        group: str = params["group"]
+        version: str = params["version"]
+        plural: str = params["plural"]
+        name: str = params["name"]
+        namespace: str | None = params.get("namespace")
+        api_client = await self._get_api_client(target, operator)
+        custom = client.CustomObjectsApi(api_client)
+        if namespace:
+            obj = await custom.get_namespaced_custom_object(
+                group=group, version=version, namespace=namespace, plural=plural, name=name
+            )
+        else:
+            obj = await custom.get_cluster_custom_object(
+                group=group, version=version, plural=plural, name=name
+            )
+        return custom_resource_row(obj)
 
     async def k8s_ls(
         self,

--- a/backend/src/meho_backplane/connectors/kubernetes/ops.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops.py
@@ -180,7 +180,10 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
     ``k8s.service.list`` / ``k8s.ingress.list``) + ``CONFIG_OPS`` (T4
     config: ``k8s.configmap.list`` keys-only / ``k8s.configmap.info``
     full data) + ``EVENT_OPS`` (T4 observability: ``k8s.event.list``)
-    + ``k8s.logs`` (T5).
+    + ``STORAGE_OPS`` (#2830 storage: ``k8s.storageclass.list`` /
+    ``k8s.persistentvolume.list`` / ``k8s.persistentvolumeclaim.list``)
+    + ``CUSTOM_RESOURCE_OPS`` (#2830 generic CR reads: ``k8s.crd.list``
+    / ``k8s.cr.list`` / ``k8s.cr.info``) + ``k8s.logs`` (T5).
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
@@ -197,6 +200,7 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
     """
     from meho_backplane.connectors.kubernetes.ops_config import CONFIG_OPS
     from meho_backplane.connectors.kubernetes.ops_core import CORE_OPS
+    from meho_backplane.connectors.kubernetes.ops_customresource import CUSTOM_RESOURCE_OPS
     from meho_backplane.connectors.kubernetes.ops_events import EVENT_OPS
     from meho_backplane.connectors.kubernetes.ops_logs import (
         K8S_LOGS_LLM_INSTRUCTIONS,
@@ -204,6 +208,7 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
         K8S_LOGS_RESPONSE_SCHEMA,
     )
     from meho_backplane.connectors.kubernetes.ops_network import NETWORK_OPS
+    from meho_backplane.connectors.kubernetes.ops_storage import STORAGE_OPS
     from meho_backplane.connectors.kubernetes.ops_workload import WORKLOAD_OPS
     from meho_backplane.connectors.kubernetes.ops_write_meta import (
         WRITE_CAUTION_OPS,
@@ -248,6 +253,8 @@ def _kubernetes_ops() -> tuple[KubernetesOp, ...]:
         *NETWORK_OPS,
         *CONFIG_OPS,
         *EVENT_OPS,
+        *STORAGE_OPS,
+        *CUSTOM_RESOURCE_OPS,
         logs_op,
         _exec_op(),
         *WRITE_CAUTION_OPS,

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_customresource.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_customresource.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Custom-resource read ops -- ``k8s.crd.list`` / ``k8s.cr.list`` / ``k8s.cr.info``.
+
+Connector read-op coverage wave 2 (#2830 of Initiative #2833). On
+GitOps-heavy clusters the operationally interesting state lives in
+custom resources (MetalLB ``IPAddressPool``, cert-manager
+``Certificate``, ESO ``ExternalSecret``, Argo / Flux) -- and while
+``k8s.apply`` could already *write* a CR through the dynamic client, no
+op could *read* one back. These three ops close that gap generically,
+without a per-CRD typed op:
+
+* ``k8s.crd.list`` -- ``ApiextensionsV1Api.list_custom_resource_definition``.
+  One row per CRD with ``{group, kind, plural, scope, versions}`` so the
+  agent can discover the ``group`` / ``version`` / ``plural`` triple a
+  ``k8s.cr.*`` call needs.
+* ``k8s.cr.list`` -- generic list over ``CustomObjectsApi``:
+  ``list_namespaced_custom_object`` when a ``namespace`` is supplied,
+  ``list_cluster_custom_object`` otherwise (which lists a namespaced CRD
+  across every namespace, or the objects of a cluster-scoped CRD).
+* ``k8s.cr.info`` -- generic single-object read:
+  ``get_namespaced_custom_object`` / ``get_cluster_custom_object``.
+
+CustomObjectsApi returns **plain dicts** (custom resources have no
+generated typed model), so the CR projection walks dict keys rather than
+model attributes. Every CR object is projected through
+:func:`custom_resource_row`, which keeps the result **bounded**: the
+operator-relevant metadata identifiers plus a JSON-serialised, byte-
+capped excerpt of ``.spec`` (:data:`CR_SPEC_EXCERPT_MAX_BYTES`). A large
+Argo ``Application`` or cert-manager ``Certificate`` spec cannot blow
+the result envelope; when the excerpt is truncated, ``spec_truncated``
+is ``true`` and the excerpt is a preview (not parseable JSON). The
+truncation rule is documented in each op's ``llm_instructions``. The
+verbose ``metadata.managedFields`` / ``metadata.annotations`` blocks
+(server-side-apply carries huge ones) are dropped from the projection
+entirely.
+
+Helpers (:func:`crd_row`, :func:`crd_version_row`,
+:func:`custom_resource_row`) are pure functions so the unit tests pin
+the wire shape -- including the truncation bound -- without an event
+loop. The handlers live as bound methods on
+:class:`~meho_backplane.connectors.kubernetes.connector.KubernetesConnector`
+(``k8s_crd_list`` / ``k8s_cr_list`` / ``k8s_cr_info``).
+
+References
+----------
+* Parent task: #2830; parent Initiative: #2833 (read-op coverage wave 2).
+* Prior art: ``k8s.apply`` already drives the dynamic client for CR
+  writes (:mod:`ops_write_dangerous`); this is the read counterpart.
+* k8s CRD API: https://kubernetes.io/docs/reference/kubernetes-api/extend-resources/custom-resource-definition-v1/
+* ``kubernetes_asyncio.ApiextensionsV1Api``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/ApiextensionsV1Api.md
+* ``kubernetes_asyncio.CustomObjectsApi``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/CustomObjectsApi.md
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+
+if TYPE_CHECKING:
+    from kubernetes_asyncio.client.models import (
+        V1CustomResourceDefinition,
+        V1CustomResourceDefinitionVersion,
+    )
+
+__all__ = [
+    "CR_SPEC_EXCERPT_MAX_BYTES",
+    "CUSTOM_RESOURCE_OPS",
+    "K8S_CRD_LIST_LLM_INSTRUCTIONS",
+    "K8S_CRD_LIST_PARAMETER_SCHEMA",
+    "K8S_CRD_LIST_RESPONSE_SCHEMA",
+    "K8S_CR_INFO_LLM_INSTRUCTIONS",
+    "K8S_CR_INFO_PARAMETER_SCHEMA",
+    "K8S_CR_INFO_RESPONSE_SCHEMA",
+    "K8S_CR_LIST_LLM_INSTRUCTIONS",
+    "K8S_CR_LIST_PARAMETER_SCHEMA",
+    "K8S_CR_LIST_RESPONSE_SCHEMA",
+    "crd_row",
+    "crd_version_row",
+    "custom_resource_row",
+]
+
+
+#: Byte budget for the JSON-serialised ``.spec`` excerpt on a CR row.
+#: Bounds ``k8s.cr.list`` / ``k8s.cr.info`` result sizes so a large CR
+#: spec (Argo Application, cert-manager Certificate) cannot blow the
+#: envelope. A pre-flight ``IPAddressPool`` spec is well under this, so
+#: the target sizing use case never truncates.
+CR_SPEC_EXCERPT_MAX_BYTES = 2048
+
+
+# ---------------------------------------------------------------------------
+# Row-shape helpers -- pure mappings over kubernetes_asyncio models (CRD)
+# and over the plain dicts CustomObjectsApi returns (CR).
+# ---------------------------------------------------------------------------
+
+
+def crd_version_row(version: V1CustomResourceDefinitionVersion) -> dict[str, Any]:
+    """Project a :class:`V1CustomResourceDefinitionVersion` to {name, served, storage}.
+
+    ``served`` marks the version as reachable via the API; ``storage``
+    marks the one version persisted in etcd (exactly one per CRD). The
+    schema / subresources blocks are deliberately omitted -- the agent
+    needs the ``name`` to build a ``k8s.cr.*`` ``version`` argument, not
+    the full OpenAPI schema.
+    """
+    return {
+        "name": version.name,
+        "served": version.served,
+        "storage": version.storage,
+    }
+
+
+def crd_row(crd: V1CustomResourceDefinition) -> dict[str, Any]:
+    """Project a :class:`V1CustomResourceDefinition` into the wire dict shape.
+
+    ``group`` / ``plural`` are exactly the arguments a follow-up
+    ``k8s.cr.list`` / ``k8s.cr.info`` call needs; ``versions`` supplies
+    the ``version`` argument (pick a ``served`` one, usually the
+    ``storage`` version). ``scope`` is 'Namespaced' or 'Cluster' -- it
+    tells the agent whether to pass a ``namespace`` to the CR read.
+    """
+    spec = crd.spec
+    names = spec.names if spec is not None else None
+    versions = spec.versions if spec is not None else None
+    return {
+        "group": spec.group if spec is not None else None,
+        "kind": names.kind if names is not None else None,
+        "plural": names.plural if names is not None else None,
+        "scope": spec.scope if spec is not None else None,
+        "versions": [crd_version_row(v) for v in (versions or [])],
+    }
+
+
+def _bounded_spec_excerpt(spec: Any) -> tuple[str | None, bool]:
+    """Return ``(excerpt, truncated)`` for a CR's ``.spec`` block.
+
+    ``spec`` is the raw value CustomObjectsApi hands back (typically a
+    dict, but any JSON value is possible). It is serialised
+    deterministically (``sort_keys``) and capped at
+    :data:`CR_SPEC_EXCERPT_MAX_BYTES`. When the serialised form fits, the
+    full spec round-trips as JSON; when it does not, the excerpt is
+    truncated on a UTF-8 byte boundary and ``truncated`` is ``True`` (the
+    excerpt is then a preview, not parseable JSON). ``(None, False)``
+    when the object has no ``spec`` (e.g. a status-only CR).
+    """
+    if spec is None:
+        return None, False
+    serialised = json.dumps(spec, sort_keys=True, default=str)
+    encoded = serialised.encode("utf-8")
+    if len(encoded) <= CR_SPEC_EXCERPT_MAX_BYTES:
+        return serialised, False
+    # ``errors="ignore"`` drops a partial multi-byte sequence at the cut
+    # point so the preview is always valid UTF-8.
+    return encoded[:CR_SPEC_EXCERPT_MAX_BYTES].decode("utf-8", errors="ignore"), True
+
+
+def custom_resource_row(obj: dict[str, Any]) -> dict[str, Any]:
+    """Project a raw custom-resource dict into the bounded wire shape.
+
+    Custom resources have no generated typed model, so *obj* is the
+    plain dict CustomObjectsApi returns. The projection keeps the
+    operator-relevant identifiers (name / namespace / apiVersion / kind /
+    creationTimestamp / labels) and a bounded ``.spec`` excerpt (see
+    :func:`_bounded_spec_excerpt`); the verbose ``managedFields`` /
+    ``annotations`` metadata blocks are dropped to keep result sizes
+    sane. ``namespace`` is ``None`` for a cluster-scoped CR.
+    """
+    metadata = obj.get("metadata") or {}
+    excerpt, truncated = _bounded_spec_excerpt(obj.get("spec"))
+    return {
+        "name": metadata.get("name"),
+        "namespace": metadata.get("namespace"),
+        "api_version": obj.get("apiVersion"),
+        "kind": obj.get("kind"),
+        "creation_timestamp": metadata.get("creationTimestamp"),
+        "labels": metadata.get("labels") or {},
+        "spec_excerpt": excerpt,
+        "spec_truncated": truncated,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Op metadata -- shared param blocks, schemas, llm_instructions, rows.
+# ---------------------------------------------------------------------------
+
+
+_GROUP_PARAM: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "API group of the custom resource (e.g. "
+        "``metallb.io``, ``cert-manager.io``). From ``k8s.crd.list``'s "
+        "``group`` column."
+    ),
+}
+
+_VERSION_PARAM: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "Served API version (e.g. ``v1beta1``, ``v1``). From a "
+        "``k8s.crd.list`` row's ``versions[].name`` -- prefer the "
+        "``storage`` version."
+    ),
+}
+
+_PLURAL_PARAM: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "Plural resource name (e.g. ``ipaddresspools``, "
+        "``certificates``). From ``k8s.crd.list``'s ``plural`` column -- "
+        "NOT the kind."
+    ),
+}
+
+_CR_NAMESPACE_PARAM: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "Namespace to scope to. Omit for a cluster-scoped CRD, or to "
+        "list a namespaced CRD across every namespace."
+    ),
+}
+
+_CR_NAME_PARAM: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "Name of the specific custom-resource object to read.",
+}
+
+
+K8S_CRD_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+K8S_CRD_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "group": {"type": ["string", "null"]},
+                    "kind": {"type": ["string", "null"]},
+                    "plural": {"type": ["string", "null"]},
+                    "scope": {"type": ["string", "null"]},
+                    "versions": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": ["string", "null"]},
+                                "served": {"type": ["boolean", "null"]},
+                                "storage": {"type": ["boolean", "null"]},
+                            },
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "required": ["group", "kind", "plural", "scope", "versions"],
+                "additionalProperties": False,
+            },
+        },
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_CRD_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call to discover which custom resources a cluster defines "
+        "before reading any: 'what CRDs are installed?', 'what's the "
+        "group/version/plural for MetalLB IPAddressPools?'. Read-only; "
+        "cluster-scoped. The ``group`` / ``versions[].name`` / "
+        "``plural`` columns are exactly the arguments a follow-up "
+        "``k8s.cr.list`` / ``k8s.cr.info`` needs; ``scope`` tells you "
+        "whether to pass a namespace."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "{'rows': [{group, kind, plural, scope, versions: [{name, "
+        "served, storage}]}], 'total': <int>}. ``scope`` is "
+        "'Namespaced' or 'Cluster'. Pick a ``served`` version (usually "
+        "the ``storage`` one) for the ``k8s.cr.*`` ``version`` argument."
+    ),
+}
+
+
+K8S_CR_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "group": _GROUP_PARAM,
+        "version": _VERSION_PARAM,
+        "plural": _PLURAL_PARAM,
+        "namespace": _CR_NAMESPACE_PARAM,
+    },
+    "required": ["group", "version", "plural"],
+    "additionalProperties": False,
+}
+
+
+_CR_ROW_ITEM_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": ["string", "null"]},
+        "namespace": {"type": ["string", "null"]},
+        "api_version": {"type": ["string", "null"]},
+        "kind": {"type": ["string", "null"]},
+        "creation_timestamp": {"type": ["string", "null"]},
+        "labels": {"type": "object"},
+        "spec_excerpt": {"type": ["string", "null"]},
+        "spec_truncated": {"type": "boolean"},
+    },
+    "required": [
+        "name",
+        "namespace",
+        "api_version",
+        "kind",
+        "creation_timestamp",
+        "labels",
+        "spec_excerpt",
+        "spec_truncated",
+    ],
+    "additionalProperties": False,
+}
+
+
+K8S_CR_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {"type": "array", "items": _CR_ROW_ITEM_SCHEMA},
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_CR_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call to read custom-resource objects generically: 'which "
+        "MetalLB IPAddressPools are allocated?', 'what cert-manager "
+        "Certificates exist?'. Get ``group`` / ``version`` / ``plural`` "
+        "from ``k8s.crd.list`` first. Omit ``namespace`` to list a "
+        "namespaced CRD across every namespace (or for a cluster-scoped "
+        "CRD); pass ``namespace`` to scope. Read-only."
+    ),
+    "parameter_hints": {
+        "group": "API group, e.g. ``metallb.io``. From k8s.crd.list.",
+        "version": "Served version, e.g. ``v1beta1``. From k8s.crd.list.",
+        "plural": "Plural name, e.g. ``ipaddresspools``. NOT the kind.",
+        "namespace": "Optional; omit for cluster-scoped or all-namespaces listing.",
+    },
+    "output_shape": (
+        "{'rows': [{name, namespace, api_version, kind, "
+        "creation_timestamp, labels, spec_excerpt, spec_truncated}], "
+        "'total': <int>}. ``spec_excerpt`` is a JSON string of the CR's "
+        f".spec capped at {CR_SPEC_EXCERPT_MAX_BYTES} bytes; when "
+        "``spec_truncated`` is true the excerpt is a preview (not "
+        "parseable JSON) -- narrow to one object via ``k8s.cr.info`` for "
+        "that name."
+    ),
+}
+
+
+K8S_CR_INFO_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "group": _GROUP_PARAM,
+        "version": _VERSION_PARAM,
+        "plural": _PLURAL_PARAM,
+        "name": _CR_NAME_PARAM,
+        "namespace": _CR_NAMESPACE_PARAM,
+    },
+    "required": ["group", "version", "plural", "name"],
+    "additionalProperties": False,
+}
+
+
+K8S_CR_INFO_RESPONSE_SCHEMA: dict[str, Any] = _CR_ROW_ITEM_SCHEMA
+
+
+K8S_CR_INFO_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call to read one named custom-resource object: 'what is the "
+        "address range on the metallb-system default IPAddressPool?'. "
+        "Get ``group`` / ``version`` / ``plural`` from ``k8s.crd.list``; "
+        "pass ``namespace`` for a namespaced CRD, omit it for a "
+        "cluster-scoped one. Read-only."
+    ),
+    "parameter_hints": {
+        "group": "API group, e.g. ``metallb.io``. From k8s.crd.list.",
+        "version": "Served version, e.g. ``v1beta1``. From k8s.crd.list.",
+        "plural": "Plural name, e.g. ``ipaddresspools``. NOT the kind.",
+        "name": "The object's metadata.name.",
+        "namespace": "Required for a namespaced CRD; omit for cluster-scoped.",
+    },
+    "output_shape": (
+        "Single object (not a rows/total envelope): {name, namespace, "
+        "api_version, kind, creation_timestamp, labels, spec_excerpt, "
+        f"spec_truncated}}. ``spec_excerpt`` is the JSON .spec capped at "
+        f"{CR_SPEC_EXCERPT_MAX_BYTES} bytes; ``spec_truncated`` flags a "
+        "preview-only excerpt for a spec over the cap."
+    ),
+}
+
+
+CUSTOM_RESOURCE_OPS: tuple[KubernetesOp, ...] = (
+    KubernetesOp(
+        op_id="k8s.crd.list",
+        handler_attr="k8s_crd_list",
+        summary="List CustomResourceDefinitions -- group / kind / plural / scope / versions.",
+        description=(
+            "Calls "
+            "``ApiextensionsV1Api.list_custom_resource_definition()`` "
+            "and projects each CRD into {group, kind, plural, scope, "
+            "versions:[{name, served, storage}]}. The discovery op for "
+            "the generic ``k8s.cr.*`` reads -- its group / version / "
+            "plural columns are exactly the arguments those ops need. "
+            "``scope`` ('Namespaced' / 'Cluster') tells the agent "
+            "whether a namespace applies. Cluster-scoped; read-only."
+        ),
+        parameter_schema=K8S_CRD_LIST_PARAMETER_SCHEMA,
+        response_schema=K8S_CRD_LIST_RESPONSE_SCHEMA,
+        group_key="custom_resources",
+        tags=("read-only", "custom-resource", "crd"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_CRD_LIST_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.cr.list",
+        handler_attr="k8s_cr_list",
+        summary="List custom-resource objects by group/version/plural -- bounded spec excerpts.",
+        description=(
+            "Generic custom-resource list over ``CustomObjectsApi``: "
+            "``list_namespaced_custom_object(group, version, namespace, "
+            "plural)`` when a namespace is supplied, else "
+            "``list_cluster_custom_object(group, version, plural)`` "
+            "(which lists a namespaced CRD across all namespaces, or a "
+            "cluster-scoped CRD's objects). Each object projects to "
+            "{name, namespace, api_version, kind, creation_timestamp, "
+            "labels, spec_excerpt, spec_truncated}. ``spec_excerpt`` is "
+            "a JSON string of .spec capped at "
+            f"{CR_SPEC_EXCERPT_MAX_BYTES} bytes; ``spec_truncated`` "
+            "flags an over-cap preview. Read-only. Get group / version "
+            "/ plural from ``k8s.crd.list``."
+        ),
+        parameter_schema=K8S_CR_LIST_PARAMETER_SCHEMA,
+        response_schema=K8S_CR_LIST_RESPONSE_SCHEMA,
+        group_key="custom_resources",
+        tags=("read-only", "custom-resource", "cr"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_CR_LIST_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.cr.info",
+        handler_attr="k8s_cr_info",
+        summary="Read one named custom-resource object -- bounded spec excerpt.",
+        description=(
+            "Generic single custom-resource read over "
+            "``CustomObjectsApi``: "
+            "``get_namespaced_custom_object(group, version, namespace, "
+            "plural, name)`` when a namespace is supplied, else "
+            "``get_cluster_custom_object(group, version, plural, name)``. "
+            "Returns the single-object projection {name, namespace, "
+            "api_version, kind, creation_timestamp, labels, "
+            "spec_excerpt, spec_truncated} (not a rows/total envelope). "
+            "``spec_excerpt`` is the JSON .spec capped at "
+            f"{CR_SPEC_EXCERPT_MAX_BYTES} bytes. Read-only; the "
+            "counterpart drill-in for a ``k8s.cr.list`` row."
+        ),
+        parameter_schema=K8S_CR_INFO_PARAMETER_SCHEMA,
+        response_schema=K8S_CR_INFO_RESPONSE_SCHEMA,
+        group_key="custom_resources",
+        tags=("read-only", "custom-resource", "cr"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_CR_INFO_LLM_INSTRUCTIONS,
+    ),
+)

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_storage.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_storage.py
@@ -1,0 +1,496 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Storage read ops -- StorageClass / PersistentVolume / PersistentVolumeClaim lists.
+
+Connector read-op coverage wave 2 (#2830 of Initiative #2833). Closes
+the pre-flight storage-sizing gap: before this tier the connector could
+*count* PVCs (``k8s.ls``'s per-namespace walk) but returned no
+capacity / storageclass / provisioner columns, and ``k8s.ls /`` already
+advertised ``storageclasses`` / ``persistentvolumes`` in its
+``cluster_kinds`` root output with no op behind them (dead-end
+advertisements -- see
+:data:`~meho_backplane.connectors.kubernetes.ops_core.K8S_CLUSTER_KINDS`).
+The three ops here back those advertisements so an agent told the kinds
+exist can actually read them.
+
+* ``k8s.storageclass.list`` -- ``StorageV1Api.list_storage_class``.
+  Cluster-scoped (no ``namespace`` axis), one row per StorageClass with
+  ``{name, provisioner, is_default, reclaim_policy,
+  volume_binding_mode, allow_expansion}``. ``is_default`` reads the GA
+  ``storageclass.kubernetes.io/is-default-class`` annotation.
+* ``k8s.persistentvolume.list`` -- ``CoreV1Api.list_persistent_volume``.
+  Cluster-scoped (mirrors ``k8s.node.list``), one row per PV with
+  ``{name, phase, capacity, storage_class, claim_ref, access_modes,
+  reclaim_policy}``.
+* ``k8s.persistentvolumeclaim.list`` -- per-namespace
+  ``CoreV1Api.list_namespaced_persistent_volume_claim`` /
+  cluster-wide ``CoreV1Api.list_persistent_volume_claim_for_all_namespaces``
+  (the ``namespace`` XOR ``all_namespaces`` selector shared from
+  :mod:`ops_listparams`). One row per PVC with ``{name, namespace,
+  status, capacity, storage_class, volume_name, access_modes}``.
+
+Both cluster-scoped list ops (``storageclass`` / ``persistentvolume``)
+follow the ``k8s.node.list`` no-parameter shape rather than the
+namespaced XOR shape -- StorageClasses and PersistentVolumes are
+cluster-scoped resources with no namespace axis (authoring contract
+branch 3 in :mod:`ops_listparams`). The PVC op deliberately omits the
+``label_selector`` / ``limit`` / ``continue_token`` knobs the workload
+list ops carry; the G0.17-T1 (#1330) paging deferral applies to this
+new op unchanged (#2830 Out of scope).
+
+Row-shape helpers (:func:`storageclass_row`, :func:`persistentvolume_row`,
+:func:`persistentvolumeclaim_row`) are pure functions over
+:mod:`kubernetes_asyncio.client.models` instances so the unit tests can
+pin the wire shape against synthetic fixtures without booting an event
+loop -- the same discipline the ops_core / ops_network helpers
+established. The handlers live as bound methods on
+:class:`~meho_backplane.connectors.kubernetes.connector.KubernetesConnector`
+(``k8s_storageclass_list`` / ``k8s_persistentvolume_list`` /
+``k8s_persistentvolumeclaim_list``) and delegate the model -> row
+projection to the helpers here.
+
+References
+----------
+* Parent task: #2830; parent Initiative: #2833 (read-op coverage wave 2).
+* Request-shape parity: G0.17-T1 (#1330); conventions doc
+  ``docs/codebase/api-shape-conventions.md`` §10.
+* k8s StorageClass API: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/storage-class-v1/
+* k8s PersistentVolume API: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-v1/
+* ``kubernetes_asyncio.StorageV1Api``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/StorageV1Api.md
+* ``kubernetes_asyncio.CoreV1Api``:
+  https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/CoreV1Api.md
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+from meho_backplane.connectors.kubernetes.ops_listparams import (
+    ALL_NAMESPACES_PARAM,
+    NAMESPACE_PARAM,
+    NAMESPACE_XOR_ALL_NAMESPACES,
+)
+
+if TYPE_CHECKING:
+    from kubernetes_asyncio.client.models import (
+        V1ObjectReference,
+        V1PersistentVolume,
+        V1PersistentVolumeClaim,
+        V1StorageClass,
+    )
+
+__all__ = [
+    "IS_DEFAULT_STORAGE_CLASS_ANNOTATION",
+    "K8S_PERSISTENTVOLUMECLAIM_LIST_LLM_INSTRUCTIONS",
+    "K8S_PERSISTENTVOLUMECLAIM_LIST_PARAMETER_SCHEMA",
+    "K8S_PERSISTENTVOLUMECLAIM_LIST_RESPONSE_SCHEMA",
+    "K8S_PERSISTENTVOLUME_LIST_LLM_INSTRUCTIONS",
+    "K8S_PERSISTENTVOLUME_LIST_PARAMETER_SCHEMA",
+    "K8S_PERSISTENTVOLUME_LIST_RESPONSE_SCHEMA",
+    "K8S_STORAGECLASS_LIST_LLM_INSTRUCTIONS",
+    "K8S_STORAGECLASS_LIST_PARAMETER_SCHEMA",
+    "K8S_STORAGECLASS_LIST_RESPONSE_SCHEMA",
+    "STORAGE_OPS",
+    "persistentvolume_row",
+    "persistentvolumeclaim_row",
+    "storageclass_row",
+]
+
+
+#: GA annotation key marking a StorageClass as the cluster default. The
+#: value is the literal string ``"true"`` (not a bool); the beta form
+#: ``storageclass.beta.kubernetes.io/is-default-class`` predates k8s
+#: 1.11 and is not read here -- every supported target sets the GA key.
+IS_DEFAULT_STORAGE_CLASS_ANNOTATION = "storageclass.kubernetes.io/is-default-class"
+
+
+# ---------------------------------------------------------------------------
+# Row-shape helpers -- pure mappings over kubernetes_asyncio model objects.
+# ---------------------------------------------------------------------------
+
+
+def _storage_quantity(capacity: dict[str, str] | None) -> str | None:
+    """Pluck the ``storage`` resource quantity from a capacity map.
+
+    Both ``V1PersistentVolumeSpec.capacity`` and
+    ``V1PersistentVolumeClaimStatus.capacity`` are ``ResourceList``
+    dicts (``{"storage": "10Gi"}``). Operators sizing a cluster want the
+    single ``storage`` quantity string, not the whole map; ``None`` when
+    the capacity is unset (an unbound PVC has no ``status.capacity``).
+    """
+    if not capacity:
+        return None
+    return capacity.get("storage")
+
+
+def _claim_ref(claim_ref: V1ObjectReference | None) -> str | None:
+    """Render a PV's bound claim reference as ``namespace/name``.
+
+    ``spec.claim_ref`` is a :class:`V1ObjectReference`; kubectl shows the
+    bound PVC as ``<namespace>/<name>`` in the CLAIM column, which is the
+    operator's mental model. ``None`` when the PV is unbound (Available /
+    Released with the ref cleared); the name alone when the reference
+    carries no namespace (defensive -- PVCs are always namespaced).
+    """
+    if claim_ref is None:
+        return None
+    namespace = claim_ref.namespace
+    name = claim_ref.name
+    if namespace and name:
+        return f"{namespace}/{name}"
+    return name
+
+
+def storageclass_row(sc: V1StorageClass) -> dict[str, Any]:
+    """Project a :class:`V1StorageClass` into the wire dict shape.
+
+    ``is_default`` reads the GA
+    ``storageclass.kubernetes.io/is-default-class`` annotation; the
+    annotations block is ``None`` on a StorageClass with no annotations,
+    so it is coerced to ``{}`` before the lookup. ``allow_expansion``
+    forwards ``allow_volume_expansion`` verbatim (``None`` when the
+    field is unset -- the provisioner's default applies).
+    """
+    metadata = sc.metadata
+    annotations = (metadata.annotations or {}) if metadata is not None else {}
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "provisioner": sc.provisioner,
+        "is_default": annotations.get(IS_DEFAULT_STORAGE_CLASS_ANNOTATION) == "true",
+        "reclaim_policy": sc.reclaim_policy,
+        "volume_binding_mode": sc.volume_binding_mode,
+        "allow_expansion": sc.allow_volume_expansion,
+    }
+
+
+def persistentvolume_row(pv: V1PersistentVolume) -> dict[str, Any]:
+    """Project a :class:`V1PersistentVolume` into the wire dict shape.
+
+    ``phase`` is the lifecycle phase from ``status`` (Available / Bound /
+    Released / Failed). ``capacity`` is the ``storage`` quantity from
+    ``spec.capacity``. ``claim_ref`` is the bound PVC rendered as
+    ``namespace/name`` (``None`` when unbound). ``reclaim_policy`` is the
+    ``persistentVolumeReclaimPolicy`` (Retain / Delete / Recycle).
+    """
+    metadata = pv.metadata
+    spec = pv.spec
+    status = pv.status
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "phase": status.phase if status is not None else None,
+        "capacity": _storage_quantity(spec.capacity if spec is not None else None),
+        "storage_class": spec.storage_class_name if spec is not None else None,
+        "claim_ref": _claim_ref(spec.claim_ref if spec is not None else None),
+        "access_modes": (list(spec.access_modes or []) if spec is not None else []),
+        "reclaim_policy": (spec.persistent_volume_reclaim_policy if spec is not None else None),
+    }
+
+
+def persistentvolumeclaim_row(pvc: V1PersistentVolumeClaim) -> dict[str, Any]:
+    """Project a :class:`V1PersistentVolumeClaim` into the wire dict shape.
+
+    ``status`` is the PVC phase (Pending / Bound / Lost). ``capacity`` is
+    the ``storage`` quantity from ``status.capacity`` -- the *bound*
+    volume size (kubectl's CAPACITY column), ``None`` for an unbound
+    (Pending) claim whose status carries no capacity yet. ``storage_class``
+    /``volume_name`` come from ``spec``; ``volume_name`` is the bound PV
+    (``None`` until binding completes).
+    """
+    metadata = pvc.metadata
+    spec = pvc.spec
+    status = pvc.status
+    return {
+        "name": metadata.name if metadata is not None else None,
+        "namespace": metadata.namespace if metadata is not None else None,
+        "status": status.phase if status is not None else None,
+        "capacity": _storage_quantity(status.capacity if status is not None else None),
+        "storage_class": spec.storage_class_name if spec is not None else None,
+        "volume_name": spec.volume_name if spec is not None else None,
+        "access_modes": (list(spec.access_modes or []) if spec is not None else []),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Op metadata -- schemas + llm_instructions + KubernetesOp rows.
+# ---------------------------------------------------------------------------
+
+
+#: ``k8s.storageclass.list`` takes no parameters -- StorageClasses are
+#: cluster-scoped (no namespace axis), same shape as ``k8s.node.list``.
+K8S_STORAGECLASS_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+K8S_STORAGECLASS_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "provisioner": {"type": ["string", "null"]},
+                    "is_default": {"type": "boolean"},
+                    "reclaim_policy": {"type": ["string", "null"]},
+                    "volume_binding_mode": {"type": ["string", "null"]},
+                    "allow_expansion": {"type": ["boolean", "null"]},
+                },
+                "required": [
+                    "name",
+                    "provisioner",
+                    "is_default",
+                    "reclaim_policy",
+                    "volume_binding_mode",
+                    "allow_expansion",
+                ],
+                "additionalProperties": False,
+            },
+        },
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_STORAGECLASS_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call for pre-flight storage sizing: 'which StorageClass is the "
+        "default?', 'what provisioner backs the fast tier?', 'can this "
+        "class expand volumes?'. Read-only; cluster-scoped (no "
+        "namespace). Pair with ``k8s.persistentvolume.list`` for the "
+        "provisioned-volume side and ``k8s.persistentvolumeclaim.list`` "
+        "for what workloads have requested."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "{'rows': [{name, provisioner, is_default, reclaim_policy, "
+        "volume_binding_mode, allow_expansion}], 'total': <int>}. "
+        "``is_default`` is the boolean from the "
+        "``storageclass.kubernetes.io/is-default-class`` annotation; "
+        "``volume_binding_mode`` is 'Immediate' or "
+        "'WaitForFirstConsumer'; ``allow_expansion`` may be null when "
+        "the class leaves it unset."
+    ),
+}
+
+
+#: ``k8s.persistentvolume.list`` takes no parameters -- PersistentVolumes
+#: are cluster-scoped (no namespace axis), same shape as ``k8s.node.list``.
+K8S_PERSISTENTVOLUME_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+K8S_PERSISTENTVOLUME_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "phase": {"type": ["string", "null"]},
+                    "capacity": {"type": ["string", "null"]},
+                    "storage_class": {"type": ["string", "null"]},
+                    "claim_ref": {"type": ["string", "null"]},
+                    "access_modes": {"type": "array", "items": {"type": "string"}},
+                    "reclaim_policy": {"type": ["string", "null"]},
+                },
+                "required": [
+                    "name",
+                    "phase",
+                    "capacity",
+                    "storage_class",
+                    "claim_ref",
+                    "access_modes",
+                    "reclaim_policy",
+                ],
+                "additionalProperties": False,
+            },
+        },
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_PERSISTENTVOLUME_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call to inventory cluster-provisioned storage: 'which PVs "
+        "exist and what backs them?', 'is this PV bound or released?', "
+        "'how much capacity is provisioned?'. Read-only; cluster-scoped "
+        "(no namespace). Pair with ``k8s.persistentvolumeclaim.list`` "
+        "to map a PV back to the claim that bound it."
+    ),
+    "parameter_hints": {},
+    "output_shape": (
+        "{'rows': [{name, phase, capacity, storage_class, claim_ref, "
+        "access_modes, reclaim_policy}], 'total': <int>}. ``phase`` is "
+        "'Available' / 'Bound' / 'Released' / 'Failed'; ``capacity`` is "
+        "the storage quantity string (e.g. '10Gi'); ``claim_ref`` is "
+        "the bound PVC as 'namespace/name' (null when unbound)."
+    ),
+}
+
+
+#: ``k8s.persistentvolumeclaim.list`` adopts the shared ``namespace`` XOR
+#: ``all_namespaces`` selector (G0.17-T1 #1330). ``label_selector`` /
+#: server-side paging are deliberately omitted -- the #1330 deferral
+#: applies to this new op unchanged (#2830 Out of scope).
+K8S_PERSISTENTVOLUMECLAIM_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "namespace": NAMESPACE_PARAM,
+        "all_namespaces": ALL_NAMESPACES_PARAM,
+    },
+    "oneOf": NAMESPACE_XOR_ALL_NAMESPACES,
+    "additionalProperties": False,
+}
+
+
+K8S_PERSISTENTVOLUMECLAIM_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rows": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": ["string", "null"]},
+                    "namespace": {"type": ["string", "null"]},
+                    "status": {"type": ["string", "null"]},
+                    "capacity": {"type": ["string", "null"]},
+                    "storage_class": {"type": ["string", "null"]},
+                    "volume_name": {"type": ["string", "null"]},
+                    "access_modes": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": [
+                    "name",
+                    "namespace",
+                    "status",
+                    "capacity",
+                    "storage_class",
+                    "volume_name",
+                    "access_modes",
+                ],
+                "additionalProperties": False,
+            },
+        },
+        "total": {"type": "integer"},
+    },
+    "required": ["rows", "total"],
+    "additionalProperties": False,
+}
+
+
+K8S_PERSISTENTVOLUMECLAIM_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Call to see what storage workloads have requested: 'which PVCs "
+        "are Pending (unbound)?', 'how much has namespace X claimed?', "
+        "'which StorageClass does this claim use?'. Use "
+        "``all_namespaces=true`` for a cluster-wide sizing view. "
+        "Read-only. Pair with ``k8s.persistentvolume.list`` for the "
+        "provisioned-volume side and ``k8s.storageclass.list`` for the "
+        "class definitions."
+    ),
+    "parameter_hints": {
+        "namespace": "Required unless ``all_namespaces`` is true.",
+        "all_namespaces": (
+            "Pass true for a cluster-wide PVC listing; mutually exclusive with ``namespace``."
+        ),
+    },
+    "output_shape": (
+        "{'rows': [{name, namespace, status, capacity, storage_class, "
+        "volume_name, access_modes}], 'total': <int>}. ``status`` is "
+        "'Pending' / 'Bound' / 'Lost'; ``capacity`` is the bound "
+        "storage quantity (null while Pending); ``volume_name`` is the "
+        "bound PV (null until binding completes). Each row carries its "
+        "own ``namespace`` so cross-namespace rows stay distinguishable."
+    ),
+}
+
+
+STORAGE_OPS: tuple[KubernetesOp, ...] = (
+    KubernetesOp(
+        op_id="k8s.storageclass.list",
+        handler_attr="k8s_storageclass_list",
+        summary="List StorageClasses -- provisioner / default / expansion / binding mode.",
+        description=(
+            "Calls ``StorageV1Api.list_storage_class()`` and projects "
+            "each StorageClass into {name, provisioner, is_default, "
+            "reclaim_policy, volume_binding_mode, allow_expansion}. "
+            "``is_default`` is derived from the GA "
+            "``storageclass.kubernetes.io/is-default-class`` annotation "
+            "(the annotations block is guarded for None). Cluster-scoped "
+            "(no namespace parameter). Read-only; the pre-flight "
+            "'which class is default and what backs it?' question."
+        ),
+        parameter_schema=K8S_STORAGECLASS_LIST_PARAMETER_SCHEMA,
+        response_schema=K8S_STORAGECLASS_LIST_RESPONSE_SCHEMA,
+        group_key="storage",
+        tags=("read-only", "storage", "storageclass"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_STORAGECLASS_LIST_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.persistentvolume.list",
+        handler_attr="k8s_persistentvolume_list",
+        summary="List PersistentVolumes -- phase / capacity / storage class / claim.",
+        description=(
+            "Calls ``CoreV1Api.list_persistent_volume()`` and projects "
+            "each PV into {name, phase, capacity, storage_class, "
+            "claim_ref, access_modes, reclaim_policy}. ``phase`` is the "
+            "lifecycle state (Available / Bound / Released / Failed); "
+            "``capacity`` is the storage quantity string; ``claim_ref`` "
+            "is the bound PVC rendered as 'namespace/name' (None when "
+            "unbound). Cluster-scoped (no namespace parameter, mirrors "
+            "``k8s.node.list``). Read-only."
+        ),
+        parameter_schema=K8S_PERSISTENTVOLUME_LIST_PARAMETER_SCHEMA,
+        response_schema=K8S_PERSISTENTVOLUME_LIST_RESPONSE_SCHEMA,
+        group_key="storage",
+        tags=("read-only", "storage", "persistentvolume"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_PERSISTENTVOLUME_LIST_LLM_INSTRUCTIONS,
+    ),
+    KubernetesOp(
+        op_id="k8s.persistentvolumeclaim.list",
+        handler_attr="k8s_persistentvolumeclaim_list",
+        summary="List PersistentVolumeClaims -- status / capacity / storage class.",
+        description=(
+            "Calls "
+            "``CoreV1Api.list_namespaced_persistent_volume_claim(namespace, ...)`` "
+            "(per-namespace) or "
+            "``CoreV1Api.list_persistent_volume_claim_for_all_namespaces(...)`` "
+            "(``all_namespaces=true``) and projects each PVC into {name, "
+            "namespace, status, capacity, storage_class, volume_name, "
+            "access_modes}. ``status`` is the PVC phase (Pending / Bound "
+            "/ Lost); ``capacity`` is the bound storage quantity from "
+            "``status.capacity`` (None while Pending); ``volume_name`` "
+            "is the bound PV. Read-only. Op id is "
+            "``k8s.persistentvolumeclaim.list`` (not ``pvc``) so "
+            "``k8s.ls /<ns>/persistentvolumeclaims`` forwards to it."
+        ),
+        parameter_schema=K8S_PERSISTENTVOLUMECLAIM_LIST_PARAMETER_SCHEMA,
+        response_schema=K8S_PERSISTENTVOLUMECLAIM_LIST_RESPONSE_SCHEMA,
+        group_key="storage",
+        tags=("read-only", "storage", "persistentvolumeclaim"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=K8S_PERSISTENTVOLUMECLAIM_LIST_LLM_INSTRUCTIONS,
+    ),
+)

--- a/backend/tests/integration/test_connectors_k8s_e2e.py
+++ b/backend/tests/integration/test_connectors_k8s_e2e.py
@@ -149,6 +149,13 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "k8s.configmap.list",
     "k8s.configmap.info",
     "k8s.event.list",
+    # #2830 storage + custom-resource read tier.
+    "k8s.storageclass.list",
+    "k8s.persistentvolume.list",
+    "k8s.persistentvolumeclaim.list",
+    "k8s.crd.list",
+    "k8s.cr.list",
+    "k8s.cr.info",
     "k8s.logs",
     # G3.14-T1 single-call write ops (approval-gated mutations).
     "k8s.scale",
@@ -897,6 +904,6 @@ async def test_dispatch_unknown_op_returns_dispatcher_unknown_op_envelope(
     extras = result.extras
     assert extras.get("error_code") == "unknown_op"
     # ``known_op_count`` carries the descriptor count for the triple;
-    # post-G3.14-T2 this is len(EXPECTED_OP_IDS) (25: 14 read + 10 write
-    # + 1 exec).
+    # post-#2830 this is len(EXPECTED_OP_IDS) (31: 20 read [14 + the 6
+    # storage/CR reads] + 10 write + 1 exec).
     assert extras.get("known_op_count") == len(EXPECTED_OP_IDS)

--- a/backend/tests/test_connectors_k8s_storage_cr.py
+++ b/backend/tests/test_connectors_k8s_storage_cr.py
@@ -1,0 +1,746 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the K8s storage + custom-resource read tier (#2830).
+
+Covers the six ops added by Initiative #2833 wave 2:
+
+* ``k8s.storageclass.list`` / ``k8s.persistentvolume.list`` /
+  ``k8s.persistentvolumeclaim.list`` (:mod:`ops_storage`)
+* ``k8s.crd.list`` / ``k8s.cr.list`` / ``k8s.cr.info``
+  (:mod:`ops_customresource`)
+
+Two layers, matching the ops_core / ops_network discipline: pure
+row-helper tests that pin the wire shape against synthetic
+``kubernetes_asyncio`` models (or plain dicts, for CRs) without an event
+loop, and handler tests that mock the API clients. Plus regression
+guards for the ``cluster_kinds`` dead-end advertisements the tier
+closes.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from kubernetes_asyncio.client.models import (
+    V1CustomResourceDefinition,
+    V1CustomResourceDefinitionNames,
+    V1CustomResourceDefinitionSpec,
+    V1CustomResourceDefinitionVersion,
+    V1ObjectMeta,
+    V1ObjectReference,
+    V1PersistentVolume,
+    V1PersistentVolumeClaim,
+    V1PersistentVolumeClaimSpec,
+    V1PersistentVolumeClaimStatus,
+    V1PersistentVolumeSpec,
+    V1PersistentVolumeStatus,
+    V1StorageClass,
+)
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.kubernetes import KubernetesConnector, KubernetesTargetLike
+from meho_backplane.connectors.kubernetes.ops import KUBERNETES_OPS
+from meho_backplane.connectors.kubernetes.ops_core import K8S_CLUSTER_KINDS
+from meho_backplane.connectors.kubernetes.ops_customresource import (
+    CR_SPEC_EXCERPT_MAX_BYTES,
+    CUSTOM_RESOURCE_OPS,
+    crd_row,
+    crd_version_row,
+    custom_resource_row,
+)
+from meho_backplane.connectors.kubernetes.ops_storage import (
+    STORAGE_OPS,
+    persistentvolume_row,
+    persistentvolumeclaim_row,
+    storageclass_row,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Settings env the connector import chain reaches for.
+
+    CI runs in a clean env; the KEYCLOAK_* / VAULT_ADDR triple must be
+    set explicitly (see #743) or ``get_settings`` raises at import.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Target / connector fixtures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="rke2-meho",
+    host="rke2-meho.test.invalid",
+    port=6443,
+    secret_ref="k8s/rke2-meho",
+)
+
+
+def _stub_kubeconfig() -> dict[str, Any]:
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": "default",
+        "contexts": [{"name": "default", "context": {"cluster": "c1", "user": "u1"}}],
+        "clusters": [{"name": "c1", "cluster": {"server": "https://k8s.test:6443"}}],
+        "users": [{"name": "u1", "user": {"token": "stub-token"}}],
+    }
+
+
+def _make_connector() -> KubernetesConnector:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
+        return _stub_kubeconfig()
+
+    return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-storage-cr-test",
+        name="Storage/CR Test Operator",
+        email=None,
+        raw_jwt="op.storage.jwt",
+        tenant_id=__import__("uuid").UUID("00000000-0000-0000-0000-00000000b0b0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model builders
+# ---------------------------------------------------------------------------
+
+
+def _make_storageclass(
+    *,
+    name: str = "ebs-fast",
+    provisioner: str = "ebs.csi.aws.com",
+    is_default: bool = False,
+    reclaim_policy: str | None = "Delete",
+    binding_mode: str | None = "WaitForFirstConsumer",
+    allow_expansion: bool | None = True,
+) -> V1StorageClass:
+    annotations = {"storageclass.kubernetes.io/is-default-class": "true"} if is_default else None
+    return V1StorageClass(
+        metadata=V1ObjectMeta(name=name, annotations=annotations),
+        provisioner=provisioner,
+        reclaim_policy=reclaim_policy,
+        volume_binding_mode=binding_mode,
+        allow_volume_expansion=allow_expansion,
+    )
+
+
+def _make_pv(
+    *,
+    name: str = "pvc-abc",
+    phase: str = "Bound",
+    capacity: str | None = "10Gi",
+    storage_class: str | None = "ebs-fast",
+    claim_ns: str | None = "team-a",
+    claim_name: str | None = "data-0",
+) -> V1PersistentVolume:
+    claim_ref = None
+    if claim_name is not None:
+        claim_ref = V1ObjectReference(namespace=claim_ns, name=claim_name)
+    return V1PersistentVolume(
+        metadata=V1ObjectMeta(name=name),
+        spec=V1PersistentVolumeSpec(
+            capacity={"storage": capacity} if capacity is not None else None,
+            storage_class_name=storage_class,
+            claim_ref=claim_ref,
+            access_modes=["ReadWriteOnce"],
+            persistent_volume_reclaim_policy="Delete",
+        ),
+        status=V1PersistentVolumeStatus(phase=phase),
+    )
+
+
+def _make_pvc(
+    *,
+    name: str = "data-0",
+    namespace: str = "team-a",
+    phase: str | None = "Bound",
+    capacity: str | None = "10Gi",
+    storage_class: str | None = "ebs-fast",
+    volume_name: str | None = "pvc-abc",
+) -> V1PersistentVolumeClaim:
+    return V1PersistentVolumeClaim(
+        metadata=V1ObjectMeta(name=name, namespace=namespace),
+        spec=V1PersistentVolumeClaimSpec(
+            storage_class_name=storage_class,
+            volume_name=volume_name,
+            access_modes=["ReadWriteOnce"],
+        ),
+        status=V1PersistentVolumeClaimStatus(
+            phase=phase,
+            capacity={"storage": capacity} if capacity is not None else None,
+        ),
+    )
+
+
+def _make_crd() -> V1CustomResourceDefinition:
+    return V1CustomResourceDefinition(
+        spec=V1CustomResourceDefinitionSpec(
+            group="metallb.io",
+            names=V1CustomResourceDefinitionNames(kind="IPAddressPool", plural="ipaddresspools"),
+            scope="Namespaced",
+            versions=[
+                V1CustomResourceDefinitionVersion(name="v1beta1", served=True, storage=True),
+                V1CustomResourceDefinitionVersion(name="v1alpha1", served=False, storage=False),
+            ],
+        ),
+    )
+
+
+def _make_cr(*, namespace: str | None = "metallb-system", spec: Any = None) -> dict[str, Any]:
+    metadata: dict[str, Any] = {"name": "default", "creationTimestamp": "2026-08-01T00:00:00Z"}
+    if namespace is not None:
+        metadata["namespace"] = namespace
+    return {
+        "apiVersion": "metallb.io/v1beta1",
+        "kind": "IPAddressPool",
+        "metadata": metadata,
+        "spec": spec if spec is not None else {"addresses": ["192.168.1.0/24"]},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration surface
+# ---------------------------------------------------------------------------
+
+
+def test_storage_and_cr_ops_in_kubernetes_ops_tuple() -> None:
+    op_ids = {op.op_id for op in KUBERNETES_OPS}
+    assert {
+        "k8s.storageclass.list",
+        "k8s.persistentvolume.list",
+        "k8s.persistentvolumeclaim.list",
+        "k8s.crd.list",
+        "k8s.cr.list",
+        "k8s.cr.info",
+    } <= op_ids
+
+
+def test_storage_ops_are_safe_no_approval_reads() -> None:
+    by_id = {op.op_id: op for op in STORAGE_OPS}
+    for op_id in (
+        "k8s.storageclass.list",
+        "k8s.persistentvolume.list",
+        "k8s.persistentvolumeclaim.list",
+    ):
+        op = by_id[op_id]
+        assert op.safety_level == "safe"
+        assert op.requires_approval is False
+        assert "read-only" in op.tags
+        assert op.group_key == "storage"
+        assert op.llm_instructions is not None
+
+
+def test_custom_resource_ops_are_safe_no_approval_reads() -> None:
+    by_id = {op.op_id: op for op in CUSTOM_RESOURCE_OPS}
+    for op_id in ("k8s.crd.list", "k8s.cr.list", "k8s.cr.info"):
+        op = by_id[op_id]
+        assert op.safety_level == "safe"
+        assert op.requires_approval is False
+        assert "read-only" in op.tags
+        assert op.group_key == "custom_resources"
+        assert op.llm_instructions is not None
+
+
+def test_handler_attrs_resolve_to_async_methods() -> None:
+    import inspect
+
+    for op in (*STORAGE_OPS, *CUSTOM_RESOURCE_OPS):
+        method = getattr(KubernetesConnector, op.handler_attr, None)
+        assert method is not None, f"{op.op_id!r} declares missing handler {op.handler_attr!r}"
+        assert inspect.iscoroutinefunction(method), f"{op.handler_attr!r} must be ``async def``"
+
+
+def test_response_schemas_forbid_additional_properties() -> None:
+    for op in (*STORAGE_OPS, *CUSTOM_RESOURCE_OPS):
+        assert op.response_schema is not None
+        assert op.response_schema.get("additionalProperties") is False
+
+
+# ---------------------------------------------------------------------------
+# Dead-end advertisement regression guards (acceptance criterion 3)
+# ---------------------------------------------------------------------------
+
+
+def test_every_cluster_kind_has_a_backing_list_op() -> None:
+    """``k8s.ls /`` advertises these kinds; each must now have a real op."""
+    op_ids = {op.op_id for op in KUBERNETES_OPS}
+    kind_to_op = {
+        "nodes": "k8s.node.list",
+        "namespaces": "k8s.namespace.list",
+        "persistentvolumes": "k8s.persistentvolume.list",
+        "storageclasses": "k8s.storageclass.list",
+    }
+    for kind in K8S_CLUSTER_KINDS:
+        assert kind in kind_to_op, f"{kind!r} advertised but not mapped to an op"
+        assert kind_to_op[kind] in op_ids, f"{kind!r} is a dead-end advertisement"
+
+
+@pytest.mark.asyncio
+async def test_ls_forwards_persistentvolumeclaims_to_new_op() -> None:
+    """``k8s.ls /<ns>/persistentvolumeclaims`` resolves to the new op, not unknown_op."""
+    connector = _make_connector()
+    forwarded = MagicMock()
+    forwarded.model_dump.return_value = {"status": "ok"}
+    connector.execute = AsyncMock(return_value=forwarded)  # type: ignore[method-assign]
+
+    result = await connector._k8s_ls_namespace_kind(_TARGET, "team-a", "persistentvolumeclaims")
+
+    connector.execute.assert_awaited_once_with(
+        _TARGET, "k8s.persistentvolumeclaim.list", {"namespace": "team-a"}
+    )
+    assert result["forwarded_to"] == "k8s.persistentvolumeclaim.list"
+
+
+# ---------------------------------------------------------------------------
+# storageclass_row
+# ---------------------------------------------------------------------------
+
+
+def test_storageclass_row_flags_default_from_annotation() -> None:
+    row = storageclass_row(_make_storageclass(name="ebs-fast", is_default=True))
+    assert row["is_default"] is True
+    assert row["name"] == "ebs-fast"
+
+
+def test_storageclass_row_not_default_when_annotation_absent() -> None:
+    row = storageclass_row(_make_storageclass(is_default=False))
+    assert row["is_default"] is False
+
+
+def test_storageclass_row_projects_provisioner_and_policy_fields() -> None:
+    row = storageclass_row(
+        _make_storageclass(
+            provisioner="rancher.io/local-path",
+            reclaim_policy="Delete",
+            binding_mode="WaitForFirstConsumer",
+            allow_expansion=False,
+        )
+    )
+    assert row["provisioner"] == "rancher.io/local-path"
+    assert row["reclaim_policy"] == "Delete"
+    assert row["volume_binding_mode"] == "WaitForFirstConsumer"
+    assert row["allow_expansion"] is False
+
+
+# ---------------------------------------------------------------------------
+# persistentvolume_row
+# ---------------------------------------------------------------------------
+
+
+def test_persistentvolume_row_bound_renders_claim_ref_ns_slash_name() -> None:
+    row = persistentvolume_row(_make_pv(claim_ns="team-a", claim_name="data-0"))
+    assert row["claim_ref"] == "team-a/data-0"
+    assert row["phase"] == "Bound"
+    assert row["capacity"] == "10Gi"
+    assert row["storage_class"] == "ebs-fast"
+    assert row["access_modes"] == ["ReadWriteOnce"]
+    assert row["reclaim_policy"] == "Delete"
+
+
+def test_persistentvolume_row_unbound_has_null_claim_ref() -> None:
+    row = persistentvolume_row(_make_pv(phase="Available", claim_name=None))
+    assert row["claim_ref"] is None
+    assert row["phase"] == "Available"
+
+
+# ---------------------------------------------------------------------------
+# persistentvolumeclaim_row
+# ---------------------------------------------------------------------------
+
+
+def test_persistentvolumeclaim_row_bound_projects_capacity_and_volume() -> None:
+    row = persistentvolumeclaim_row(_make_pvc(namespace="team-a", capacity="10Gi"))
+    assert row["namespace"] == "team-a"
+    assert row["status"] == "Bound"
+    assert row["capacity"] == "10Gi"
+    assert row["volume_name"] == "pvc-abc"
+    assert row["storage_class"] == "ebs-fast"
+    assert row["access_modes"] == ["ReadWriteOnce"]
+
+
+def test_persistentvolumeclaim_row_pending_has_null_capacity() -> None:
+    row = persistentvolumeclaim_row(_make_pvc(phase="Pending", capacity=None, volume_name=None))
+    assert row["status"] == "Pending"
+    assert row["capacity"] is None
+    assert row["volume_name"] is None
+
+
+# ---------------------------------------------------------------------------
+# crd_row / crd_version_row
+# ---------------------------------------------------------------------------
+
+
+def test_crd_version_row_flat_shape() -> None:
+    version = V1CustomResourceDefinitionVersion(name="v1beta1", served=True, storage=True)
+    assert crd_version_row(version) == {"name": "v1beta1", "served": True, "storage": True}
+
+
+def test_crd_row_projects_group_plural_scope_and_versions() -> None:
+    row = crd_row(_make_crd())
+    assert row["group"] == "metallb.io"
+    assert row["kind"] == "IPAddressPool"
+    assert row["plural"] == "ipaddresspools"
+    assert row["scope"] == "Namespaced"
+    assert [v["name"] for v in row["versions"]] == ["v1beta1", "v1alpha1"]
+    assert row["versions"][0]["storage"] is True
+
+
+# ---------------------------------------------------------------------------
+# custom_resource_row + bounded spec excerpt (acceptance: "a test pins the bound")
+# ---------------------------------------------------------------------------
+
+
+def test_custom_resource_row_small_spec_is_full_json_not_truncated() -> None:
+    row = custom_resource_row(_make_cr(spec={"addresses": ["192.168.1.0/24"]}))
+    assert row["name"] == "default"
+    assert row["namespace"] == "metallb-system"
+    assert row["api_version"] == "metallb.io/v1beta1"
+    assert row["kind"] == "IPAddressPool"
+    assert row["spec_truncated"] is False
+    assert json.loads(row["spec_excerpt"]) == {"addresses": ["192.168.1.0/24"]}
+
+
+def test_custom_resource_row_large_spec_is_truncated_within_bound() -> None:
+    """A spec over the byte cap sets spec_truncated and stays within the bound."""
+    big_spec = {"addresses": ["10.0.0.0/24"] * 500}
+    assert len(json.dumps(big_spec).encode("utf-8")) > CR_SPEC_EXCERPT_MAX_BYTES
+
+    row = custom_resource_row(_make_cr(spec=big_spec))
+
+    assert row["spec_truncated"] is True
+    assert len(row["spec_excerpt"].encode("utf-8")) <= CR_SPEC_EXCERPT_MAX_BYTES
+
+
+def test_custom_resource_row_no_spec_yields_none_excerpt() -> None:
+    obj = {"apiVersion": "v1", "kind": "Foo", "metadata": {"name": "x"}}
+    row = custom_resource_row(obj)
+    assert row["spec_excerpt"] is None
+    assert row["spec_truncated"] is False
+
+
+def test_custom_resource_row_cluster_scoped_has_null_namespace() -> None:
+    row = custom_resource_row(_make_cr(namespace=None))
+    assert row["namespace"] is None
+
+
+def test_custom_resource_row_drops_managed_fields_metadata() -> None:
+    """Verbose managedFields must not leak into the bounded projection."""
+    cr = _make_cr()
+    cr["metadata"]["managedFields"] = [{"manager": "meho", "operation": "Apply"}] * 20
+    cr["metadata"]["labels"] = {"app": "metallb"}
+    row = custom_resource_row(cr)
+    assert "managedFields" not in row
+    assert "managed_fields" not in row
+    assert row["labels"] == {"app": "metallb"}
+
+
+# ---------------------------------------------------------------------------
+# Handlers -- storage (mocked API clients)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_storageclass_list_returns_rows_and_total() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.StorageV1Api") as sc_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = [
+            _make_storageclass(name="ebs-fast", is_default=True),
+            _make_storageclass(name="ebs-slow"),
+        ]
+        sc_cls.return_value.list_storage_class = AsyncMock(return_value=list_resp)
+        result = await connector.k8s_storageclass_list(_make_operator(), _TARGET, {})
+
+    assert result["total"] == 2
+    assert result["rows"][0]["name"] == "ebs-fast"
+    assert result["rows"][0]["is_default"] is True
+
+
+@pytest.mark.asyncio
+async def test_k8s_persistentvolume_list_returns_rows() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = [
+            _make_pv(name="pv-1"),
+            _make_pv(name="pv-2", phase="Available", claim_name=None),
+        ]
+        core_cls.return_value.list_persistent_volume = AsyncMock(return_value=list_resp)
+        result = await connector.k8s_persistentvolume_list(_make_operator(), _TARGET, {})
+
+    assert result["total"] == 2
+    assert result["rows"][1]["claim_ref"] is None
+
+
+@pytest.mark.asyncio
+async def test_k8s_pvc_list_namespaced_forwards_namespace() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = [_make_pvc(name="data-0", namespace="team-a")]
+        core_cls.return_value.list_namespaced_persistent_volume_claim = AsyncMock(
+            return_value=list_resp
+        )
+        result = await connector.k8s_persistentvolumeclaim_list(
+            _make_operator(), _TARGET, {"namespace": "team-a"}
+        )
+        core_cls.return_value.list_namespaced_persistent_volume_claim.assert_awaited_once_with(
+            namespace="team-a"
+        )
+
+    assert result["total"] == 1
+    assert result["rows"][0]["namespace"] == "team-a"
+
+
+@pytest.mark.asyncio
+async def test_k8s_pvc_list_all_namespaces_uses_cluster_api() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = [
+            _make_pvc(name="data-0", namespace="team-a"),
+            _make_pvc(name="data-0", namespace="team-b"),
+        ]
+        core_cls.return_value.list_persistent_volume_claim_for_all_namespaces = AsyncMock(
+            return_value=list_resp
+        )
+        result = await connector.k8s_persistentvolumeclaim_list(
+            _make_operator(), _TARGET, {"all_namespaces": True}
+        )
+        core_cls.return_value.list_persistent_volume_claim_for_all_namespaces.assert_awaited_once_with()
+
+    assert result["total"] == 2
+    assert {r["namespace"] for r in result["rows"]} == {"team-a", "team-b"}
+
+
+# ---------------------------------------------------------------------------
+# Handlers -- custom resources (mocked API clients)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_crd_list_returns_rows() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.client.ApiextensionsV1Api"
+        ) as ext_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = [_make_crd()]
+        ext_cls.return_value.list_custom_resource_definition = AsyncMock(return_value=list_resp)
+        result = await connector.k8s_crd_list(_make_operator(), _TARGET, {})
+
+    assert result["total"] == 1
+    assert result["rows"][0]["plural"] == "ipaddresspools"
+
+
+@pytest.mark.asyncio
+async def test_k8s_cr_list_namespaced_forwards_gvp_and_namespace() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CustomObjectsApi") as co_cls,
+    ):
+        co_cls.return_value.list_namespaced_custom_object = AsyncMock(
+            return_value={"items": [_make_cr()]}
+        )
+        result = await connector.k8s_cr_list(
+            _make_operator(),
+            _TARGET,
+            {
+                "group": "metallb.io",
+                "version": "v1beta1",
+                "plural": "ipaddresspools",
+                "namespace": "metallb-system",
+            },
+        )
+        co_cls.return_value.list_namespaced_custom_object.assert_awaited_once_with(
+            group="metallb.io",
+            version="v1beta1",
+            namespace="metallb-system",
+            plural="ipaddresspools",
+        )
+
+    assert result["total"] == 1
+    assert result["rows"][0]["name"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_k8s_cr_list_without_namespace_uses_cluster_api() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CustomObjectsApi") as co_cls,
+    ):
+        co_cls.return_value.list_cluster_custom_object = AsyncMock(
+            return_value={"items": [_make_cr(namespace=None)]}
+        )
+        result = await connector.k8s_cr_list(
+            _make_operator(),
+            _TARGET,
+            {"group": "metallb.io", "version": "v1beta1", "plural": "ipaddresspools"},
+        )
+        co_cls.return_value.list_cluster_custom_object.assert_awaited_once_with(
+            group="metallb.io", version="v1beta1", plural="ipaddresspools"
+        )
+
+    assert result["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_k8s_cr_list_missing_items_key_yields_empty_rows() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CustomObjectsApi") as co_cls,
+    ):
+        co_cls.return_value.list_cluster_custom_object = AsyncMock(return_value={})
+        result = await connector.k8s_cr_list(
+            _make_operator(),
+            _TARGET,
+            {"group": "metallb.io", "version": "v1beta1", "plural": "ipaddresspools"},
+        )
+
+    assert result == {"rows": [], "total": 0}
+
+
+@pytest.mark.asyncio
+async def test_k8s_cr_info_namespaced_returns_single_object() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CustomObjectsApi") as co_cls,
+    ):
+        co_cls.return_value.get_namespaced_custom_object = AsyncMock(return_value=_make_cr())
+        result = await connector.k8s_cr_info(
+            _make_operator(),
+            _TARGET,
+            {
+                "group": "metallb.io",
+                "version": "v1beta1",
+                "plural": "ipaddresspools",
+                "name": "default",
+                "namespace": "metallb-system",
+            },
+        )
+        co_cls.return_value.get_namespaced_custom_object.assert_awaited_once_with(
+            group="metallb.io",
+            version="v1beta1",
+            namespace="metallb-system",
+            plural="ipaddresspools",
+            name="default",
+        )
+
+    # Single-object projection, not a rows/total envelope.
+    assert "rows" not in result
+    assert result["name"] == "default"
+    assert json.loads(result["spec_excerpt"]) == {"addresses": ["192.168.1.0/24"]}
+
+
+@pytest.mark.asyncio
+async def test_k8s_cr_info_without_namespace_uses_cluster_api() -> None:
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CustomObjectsApi") as co_cls,
+    ):
+        co_cls.return_value.get_cluster_custom_object = AsyncMock(
+            return_value=_make_cr(namespace=None)
+        )
+        result = await connector.k8s_cr_info(
+            _make_operator(),
+            _TARGET,
+            {
+                "group": "example.io",
+                "version": "v1",
+                "plural": "widgets",
+                "name": "default",
+            },
+        )
+        co_cls.return_value.get_cluster_custom_object.assert_awaited_once_with(
+            group="example.io", version="v1", plural="widgets", name="default"
+        )
+
+    assert result["namespace"] is None

--- a/backend/tests/test_typed_connectors_metadata.py
+++ b/backend/tests/test_typed_connectors_metadata.py
@@ -64,7 +64,18 @@ from meho_backplane.settings import get_settings
 # regression test below reads these to assert one OperationGroup row
 # per declared group lands with a curated when_to_use.
 _K8S_GROUPS: Final[frozenset[str]] = frozenset(
-    {"cluster", "inventory", "workload", "network", "config", "events", "logs", "exec"}
+    {
+        "cluster",
+        "inventory",
+        "workload",
+        "network",
+        "config",
+        "events",
+        "logs",
+        "exec",
+        "storage",
+        "custom_resources",
+    }
 )
 _VAULT_GROUPS: Final[frozenset[str]] = frozenset({"auth", "kv", "sys"})
 _VMWARE_COMPOSITE_GROUPS: Final[frozenset[str]] = frozenset(

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -157,6 +157,12 @@ real operator through the same loader.
 | `k8s.configmap.list`   | safe   | `CoreV1Api.list_namespaced_config_map()` / `list_config_map_for_all_namespaces()` -- **keys only, NO values** + `label_selector`. |
 | `k8s.configmap.info`   | safe   | `CoreV1Api.read_namespaced_config_map()` -- full data + binary_data. |
 | `k8s.event.list`       | safe   | `CoreV1Api.list_namespaced_event()` / `list_event_for_all_namespaces()` -- pulls up to `MAX_EVENT_LIMIT` (500) rows, sorts client-side by `last_seen` desc, truncates to caller's `--limit`. Server has no `lastTimestamp` ordering guarantee. EventSeries `count` honoured. Forwards `label_selector` + `field_selector`. |
+| `k8s.storageclass.list` | safe  | `StorageV1Api.list_storage_class()` -- name / provisioner / `is_default` (GA `storageclass.kubernetes.io/is-default-class` annotation) / reclaim_policy / volume_binding_mode / allow_expansion. Cluster-scoped, no params. (`ops_storage.py`) |
+| `k8s.persistentvolume.list` | safe | `CoreV1Api.list_persistent_volume()` -- name / phase / capacity / storage_class / claim_ref (`namespace/name`) / access_modes / reclaim_policy. Cluster-scoped, no params. (`ops_storage.py`) |
+| `k8s.persistentvolumeclaim.list` | safe | `CoreV1Api.list_namespaced_persistent_volume_claim()` / `list_persistent_volume_claim_for_all_namespaces()` -- name / namespace / status / capacity (`status.capacity.storage`) / storage_class / volume_name / access_modes. `namespace` XOR `all_namespaces`. Backs `k8s.ls /<ns>/persistentvolumeclaims`. (`ops_storage.py`) |
+| `k8s.crd.list`         | safe   | `ApiextensionsV1Api.list_custom_resource_definition()` -- group / kind / plural / scope / versions (`{name, served, storage}`). Discovery op for the generic CR reads. (`ops_customresource.py`) |
+| `k8s.cr.list`          | safe   | Generic CR list over `CustomObjectsApi.list_namespaced_custom_object()` (with `namespace`) / `list_cluster_custom_object()` (without). Rows = metadata + bounded JSON `spec_excerpt` (cap `CR_SPEC_EXCERPT_MAX_BYTES` = 2048 B, `spec_truncated` flag). Requires `group`/`version`/`plural`. (`ops_customresource.py`) |
+| `k8s.cr.info`          | safe   | Generic single CR read over `CustomObjectsApi.get_namespaced_custom_object()` / `get_cluster_custom_object()`. Single-object projection (metadata + bounded `spec_excerpt`), not a rows envelope. Requires `group`/`version`/`plural`/`name`. (`ops_customresource.py`) |
 | `k8s.logs`             | safe   | `CoreV1Api.read_namespaced_pod_log()` non-streaming -- tail / container / since / previous + 1 MiB cap. |
 | `k8s.exec`             | **dangerous** (`requires_approval=True`) | `CoreV1Api.connect_get_namespaced_pod_exec()` over the `WsApiClient` websocket transport -- bounded argv command-and-capture: stdout / stderr demuxed from the `v4.channel.k8s.io` channels + exit code parsed from the channel-3 status frame, per-stream 1 MiB cap, bounded timeout. Interactive `-it` deferred. |
 
@@ -341,6 +347,40 @@ configmap when?". v0.2 classifies `info` as `op_class=read`; G6.3 may
 upgrade specific configmap-name patterns (managed-by
 `secret-translator`, names matching `*-secret-config`) to
 `sensitive-read`.
+
+### Storage + custom-resource read tier (#2830, `ops_storage.py` / `ops_customresource.py`)
+
+Six safe reads that close the pre-flight sizing gap (the RDC Hetzner
+consumer session that fell back to raw kubectl):
+
+- **Storage** (`ops_storage.py`): `k8s.storageclass.list`,
+  `k8s.persistentvolume.list`, `k8s.persistentvolumeclaim.list`. The two
+  cluster-scoped list ops (StorageClass, PV) take no parameters (the
+  `k8s.node.list` shape); PVC adopts the shared `namespace` XOR
+  `all_namespaces` selector. `is_default` reads the GA
+  `storageclass.kubernetes.io/is-default-class` annotation; PVC/PV
+  capacity is the `storage` quantity plucked from `status.capacity` /
+  `spec.capacity`; a PV's `claim_ref` renders as `namespace/name`.
+- **Custom resources** (`ops_customresource.py`): `k8s.crd.list` is the
+  discovery op (group / version / plural / scope / versions), and
+  `k8s.cr.list` / `k8s.cr.info` read objects generically over
+  `CustomObjectsApi` (namespaced call when a `namespace` is supplied,
+  cluster call otherwise). CustomObjectsApi returns plain dicts, so the
+  projection walks dict keys. Result size is bounded: the projection
+  keeps metadata identifiers + `labels` and a JSON `spec_excerpt` capped
+  at `CR_SPEC_EXCERPT_MAX_BYTES` (2048 B); over the cap, `spec_truncated`
+  is `true` and the excerpt is a preview (not parseable JSON). The
+  verbose `managedFields` / `annotations` metadata blocks are dropped.
+
+This tier also retires the `cluster_kinds` **dead-end advertisements**:
+`k8s.ls /` had long listed `storageclasses` / `persistentvolumes` in its
+root output (and the namespace walk counted `persistentvolumeclaims`)
+with no op behind them. The op ids are exactly
+`k8s.storageclass.list` / `k8s.persistentvolume.list` /
+`k8s.persistentvolumeclaim.list` so the `k8s.ls` singular-normalisation
+map (`_PLURAL_TO_SINGULAR_KIND`, pre-wired) forwards
+`k8s.ls /<ns>/persistentvolumeclaims` to the new op instead of the
+`unknown_op` envelope.
 
 ## Control flow
 


### PR DESCRIPTION
## Summary

- Adds a read-only tier of six safe, no-approval ops to the `k8s-1.x`
  typed connector, closing the pre-flight storage-sizing gap that
  dropped a live RDC Hetzner consumer session to raw kubectl.
- **Storage** (`ops_storage.py`): `k8s.storageclass.list`
  (`StorageV1Api`), `k8s.persistentvolume.list` and
  `k8s.persistentvolumeclaim.list` (`CoreV1Api`) — cluster-scoped SC/PV
  take no params (the `k8s.node.list` shape); PVC uses the shared
  `namespace` XOR `all_namespaces` selector.
- **Custom resources** (`ops_customresource.py`): `k8s.crd.list`
  (`ApiextensionsV1Api`) as the discovery op, plus generic
  `k8s.cr.list` / `k8s.cr.info` (`CustomObjectsApi`) that read any CR by
  `group`/`version`/`plural` (+ optional `namespace`, + `name`).
- Retires the `cluster_kinds` dead-end advertisements: op ids are
  exactly `k8s.persistentvolumeclaim.list` etc., so the pre-wired
  `_PLURAL_TO_SINGULAR_KIND` map forwards
  `k8s.ls /<ns>/persistentvolumeclaims` to the new op instead of
  `unknown_op`, and `storageclasses` / `persistentvolumes` now have real
  backing ops.

## Design notes

- CR reads return **bounded** rows: operator-relevant metadata + a
  JSON `spec_excerpt` capped at `CR_SPEC_EXCERPT_MAX_BYTES` (2048 B) with
  a `spec_truncated` flag; verbose `managedFields` / `annotations` are
  dropped. The truncation rule is documented in each op's
  `llm_instructions`. Keeps large Argo / cert-manager specs from blowing
  the envelope while the target `IPAddressPool` sizing case never
  truncates.
- All list ops emit the `rows` / `total` envelope, so the default
  `JsonFluxReducer` wraps set-shaped responses in a result handle
  (CLAUDE.md postulate 6). `k8s.cr.info` returns a single bounded object
  (the `k8s.configmap.info` shape), not a rows envelope.
- Two new op groups (`storage`, `custom_resources`) with curated
  `when_to_use` strings so `list_operation_groups` gives a real
  selection signal.
- All `kubernetes_asyncio` 36.1.0 API methods + model fields verified by
  introspecting the installed wheel (StorageV1Api / CoreV1Api /
  ApiextensionsV1Api / CustomObjectsApi).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (5 files)
- [x] `mypy src/meho_backplane/connectors/kubernetes/` — clean (18 files)
- [x] `pytest tests/test_connectors_k8s_storage_cr.py` — 31 passed
      (pure row-helper per-key tests without an event loop + handler
      tests against mocked API clients)
- [x] Broader `-k "k8s or kubernetes"` suite — 402 passed; updated the
      `EXPECTED_OP_IDS` and `_K8S_GROUPS` drift-detectors + the k3s-e2e
      `known_op_count` (25 → 31 ops) and re-verified the two integration
      tests + the metadata group test pass
- [x] Acceptance — six ops registered as safe reads with
      `requires_approval=False`; op ids exact; `k8s.ls /<ns>/…claims`
      forwards to the new op (test), cluster-kind dead-ends closed
      (test); CR spec bound pinned by a test; response schemas inline
      with `additionalProperties: false` (test)
- [x] `docs/codebase/connectors-kubernetes.md` "Shipped op surface"
      table + a new tier subsection updated
- [x] CLI OpenAPI snapshot regenerated — **no diff** (connector ops
      dispatch via the generic `POST /api/v1/operations/call`; no new
      FastAPI route/schema)

## Out of scope

- `k8s.service.list` LoadBalancer-VIP projection — #2831.
- Any write/delete surface for storage kinds (`DELETABLE_KINDS`
  deliberately excludes PVC/PV); watch/streaming CR support; new
  `field_selector`/`limit`/`continue` knobs beyond `ops_listparams.py`
  (the #1330 deferral).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2830
