### PR TITLE
feat(connectors): project per-member lag on mongodb.replica_status

### DIFF
--- a/backend/src/meho_backplane/connectors/mongodb/ops.py
+++ b/backend/src/meho_backplane/connectors/mongodb/ops.py
@@ -338,10 +338,12 @@ _REPLICA_STATUS = MongoOp(
     description=(
         "Returns replica-set health from the hello handshake plus "
         "replSetGetStatus: set name, current primary, each member's role, and "
-        "(when available) each member's live state / health / uptime. On a "
-        "standalone it reports is_replica_set=false rather than erroring. The op "
-        "for 'is the replica set healthy and who is primary?'. safety_level=safe, "
-        "read-only."
+        "(when available) each member's live state / health / uptime, plus each "
+        "member's optime_date and a computed lag_seconds (seconds behind the "
+        "primary's oplog; null on the primary). On a standalone it reports "
+        "is_replica_set=false rather than erroring. The op for 'is the replica "
+        "set healthy, who is primary, and how far behind is each secondary?'. "
+        "safety_level=safe, read-only."
     ),
     parameter_schema=_EMPTY_PARAMS,
     response_schema=_OBJECT_RESPONSE_SCHEMA,
@@ -354,7 +356,8 @@ _REPLICA_STATUS = MongoOp(
         "parameter_hints": {},
         "output_shape": (
             "{is_replica_set, set_name, primary, me, members:[{host, role}], "
-            "repl_set_status:{set, members:[{name, state, health, uptime}]}}."
+            "repl_set_status:{set, members:[{name, state, health, uptime, "
+            "optime_date, sync_source_host, last_heartbeat, lag_seconds}]}}."
         ),
     },
 )

--- a/backend/src/meho_backplane/connectors/mongodb/queries.py
+++ b/backend/src/meho_backplane/connectors/mongodb/queries.py
@@ -246,6 +246,40 @@ def _members_from_hello(hello: dict[str, Any]) -> list[dict[str, str]]:
     return members
 
 
+def _primary_optime_date(members: list[Mapping[str, Any]]) -> _dt.datetime | None:
+    """Return the elected primary's ``optimeDate`` from a ``replSetGetStatus`` list.
+
+    Scans for the member whose ``stateStr`` is ``PRIMARY``; returns ``None`` when
+    no primary is currently elected or that member carries no ``optimeDate``, in
+    which case per-member replication lag is undefined.
+    """
+    for member in members:
+        if member.get("stateStr") == "PRIMARY":
+            optime = member.get("optimeDate")
+            return optime if isinstance(optime, _dt.datetime) else None
+    return None
+
+
+def _member_lag_seconds(
+    member: Mapping[str, Any], primary_optime: _dt.datetime | None
+) -> float | None:
+    """Seconds *member* trails the primary's oplog, or ``None`` when undefined.
+
+    ``None`` on the primary's own row (zero lag by definition), when no member is
+    currently ``PRIMARY``, or when *member* has no ``optimeDate`` (e.g. an
+    arbiter, which bears no data); otherwise the wall-clock delta between the
+    primary's and the member's last-applied oplog entry (``optimeDate``).
+    """
+    if member.get("stateStr") == "PRIMARY":
+        return None
+    if primary_optime is None:
+        return None
+    member_optime = member.get("optimeDate")
+    if not isinstance(member_optime, _dt.datetime):
+        return None
+    return (primary_optime - member_optime).total_seconds()
+
+
 async def fetch_replica_status(client: AsyncMongoClient[dict[str, Any]]) -> dict[str, Any]:
     """Return replica-set health from ``hello`` + ``replSetGetStatus``.
 
@@ -256,6 +290,11 @@ async def fetch_replica_status(client: AsyncMongoClient[dict[str, Any]]) -> dict
     ``clusterMonitor`` privilege; on a standalone it raises
     :data:`NO_REPLICATION_ENABLED_CODE` and the connector reports
     ``is_replica_set=False`` rather than surfacing an error.
+
+    Each ``repl_set_status.members`` entry also carries ``optime_date``,
+    ``sync_source_host``, ``last_heartbeat``, and a computed ``lag_seconds`` —
+    the seconds a member trails the primary's oplog (``None`` on the primary and
+    when no primary is elected or the member holds no ``optimeDate``).
     """
     hello = await _hello(client)
     set_name = hello.get("setName")
@@ -278,6 +317,8 @@ async def fetch_replica_status(client: AsyncMongoClient[dict[str, Any]]) -> dict
             payload["is_replica_set"] = False
             return payload
         raise
+    raw_members = status.get("members", [])
+    primary_optime = _primary_optime_date(raw_members)
     payload["repl_set_status"] = {
         "set": status.get("set"),
         "members": [
@@ -286,8 +327,12 @@ async def fetch_replica_status(client: AsyncMongoClient[dict[str, Any]]) -> dict
                 "state": member.get("stateStr"),
                 "health": member.get("health"),
                 "uptime": member.get("uptime"),
+                "optime_date": _jsonable(member.get("optimeDate")),
+                "sync_source_host": member.get("syncSourceHost"),
+                "last_heartbeat": _jsonable(member.get("lastHeartbeat")),
+                "lag_seconds": _member_lag_seconds(member, primary_optime),
             }
-            for member in status.get("members", [])
+            for member in raw_members
         ],
     }
     return payload

--- a/backend/tests/test_connectors_mongodb.py
+++ b/backend/tests/test_connectors_mongodb.py
@@ -29,6 +29,7 @@ exercises the real credential loader. Mirrors
 
 from __future__ import annotations
 
+import datetime as dt
 import uuid
 from collections.abc import AsyncIterator, Iterator
 from typing import Any
@@ -473,7 +474,9 @@ async def test_replica_status_standalone_reports_not_replica_set(
 async def test_replica_status_replica_set_returns_member_roles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A replica set surfaces member roles from hello + replSetGetStatus."""
+    """A replica set surfaces member roles + per-member lag from replSetGetStatus."""
+    primary_optime = dt.datetime(2026, 8, 12, 12, 0, 0, tzinfo=dt.UTC)
+    secondary_optime = primary_optime - dt.timedelta(seconds=12)
     admin = _FakeDb(
         command_responses={
             "hello": {
@@ -486,8 +489,23 @@ async def test_replica_status_replica_set_returns_member_roles(
             "replSetGetStatus": {
                 "set": "rs0",
                 "members": [
-                    {"name": "m1:27017", "stateStr": "PRIMARY", "health": 1, "uptime": 500},
-                    {"name": "m2:27017", "stateStr": "SECONDARY", "health": 1, "uptime": 490},
+                    {
+                        "name": "m1:27017",
+                        "stateStr": "PRIMARY",
+                        "health": 1,
+                        "uptime": 500,
+                        "optimeDate": primary_optime,
+                        "syncSourceHost": "",
+                    },
+                    {
+                        "name": "m2:27017",
+                        "stateStr": "SECONDARY",
+                        "health": 1,
+                        "uptime": 490,
+                        "optimeDate": secondary_optime,
+                        "syncSourceHost": "m1:27017",
+                        "lastHeartbeat": primary_optime,
+                    },
                 ],
             },
         }
@@ -501,7 +519,58 @@ async def test_replica_status_replica_set_returns_member_roles(
     assert result["primary"] == "m1:27017"
     roles = {m["host"]: m["role"] for m in result["members"]}
     assert roles == {"m1:27017": "primary", "m2:27017": "secondary"}
-    assert result["repl_set_status"]["members"][0]["state"] == "PRIMARY"
+
+    members = {m["name"]: m for m in result["repl_set_status"]["members"]}
+    assert members["m1:27017"]["state"] == "PRIMARY"
+    # Primary carries no lag by definition; the secondary trails by the fixture delta.
+    assert members["m1:27017"]["lag_seconds"] is None
+    assert members["m2:27017"]["lag_seconds"] == 12.0
+    # optimeDate / lastHeartbeat round-trip through _jsonable as ISO-8601; sync source projected.
+    assert members["m2:27017"]["optime_date"] == secondary_optime.isoformat()
+    assert members["m2:27017"]["last_heartbeat"] == primary_optime.isoformat()
+    assert members["m2:27017"]["sync_source_host"] == "m1:27017"
+
+
+@pytest.mark.asyncio
+async def test_replica_status_lag_is_null_without_primary_or_optime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """lag_seconds is null when no member is PRIMARY and for a member with no optimeDate."""
+    admin = _FakeDb(
+        command_responses={
+            "hello": {
+                "isWritablePrimary": False,
+                "setName": "rs0",
+                "primary": None,
+                "me": "m1:27017",
+                "hosts": ["m1:27017"],
+                "arbiters": ["arb:27017"],
+            },
+            "replSetGetStatus": {
+                "set": "rs0",
+                "members": [
+                    {
+                        "name": "m1:27017",
+                        "stateStr": "SECONDARY",
+                        "health": 1,
+                        "uptime": 500,
+                        "optimeDate": dt.datetime(2026, 8, 12, 12, 0, 0, tzinfo=dt.UTC),
+                    },
+                    {"name": "arb:27017", "stateStr": "ARBITER", "health": 1, "uptime": 480},
+                ],
+            },
+        }
+    )
+    client = _FakeClient(default=admin)
+    _patch_client(monkeypatch, client)
+
+    result = await MongoDbConnector().replica_status(_make_operator(), _MongoTarget(), {})
+    members = {m["name"]: m for m in result["repl_set_status"]["members"]}
+    # No elected primary -> lag undefined for every member; the arbiter also has no optimeDate.
+    assert members["m1:27017"]["lag_seconds"] is None
+    assert members["arb:27017"]["lag_seconds"] is None
+    assert members["arb:27017"]["optime_date"] is None
+    assert members["arb:27017"]["last_heartbeat"] is None
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-mongodb.md
+++ b/docs/codebase/connectors-mongodb.md
@@ -84,7 +84,7 @@ Ops:
 | `mongodb.indexes` | `listIndexes` | indexes incl. TTL `expireAfterSeconds` (`database`, `collection`) |
 | `mongodb.count` | `estimatedDocumentCount` | fast metadata count, O(1) (`database`, `collection`) |
 | `mongodb.server_status` | `serverStatus` | slim projection (heavy sections suppressed) |
-| `mongodb.replica_status` | `hello` + `replSetGetStatus` | replica-set health + member roles |
+| `mongodb.replica_status` | `hello` + `replSetGetStatus` | replica-set health + member roles + per-member `lag_seconds` (secs behind primary) |
 
 ### Read-only enforcement (fixed command set)
 
@@ -128,8 +128,9 @@ a credentialled target on the operator-less probe path resolves here),
 Member roles are derived from `hello` (`hosts`/`passives`/`arbiters` + `primary`)
 so the fingerprint does not need the elevated `clusterMonitor` privilege
 `replSetGetStatus` requires; `mongodb.replica_status` additionally calls
-`replSetGetStatus` for each member's live `stateStr`/health, and treats the
-standalone code-76 (`NoReplicationEnabled`) as `is_replica_set=False`.
+`replSetGetStatus` for each member's live `stateStr`/health and per-member
+replication lag, and treats the standalone code-76 (`NoReplicationEnabled`) as
+`is_replica_set=False`.
 
 ## Dependencies
 
@@ -155,6 +156,13 @@ standalone code-76 (`NoReplicationEnabled`) as `is_replica_set=False`.
   the wire, not just dropped in code.
 - Member roles in `fingerprint` come from `hello`; a live replica set's detailed
   per-member state is on `mongodb.replica_status`.
+- `mongodb.replica_status` computes each member's `lag_seconds` from the primary's
+  and the member's `optimeDate` in the same `replSetGetStatus` response — no extra
+  round trip. It is `null` on the primary's own row, when no member is currently
+  `PRIMARY`, and for a member with no `optimeDate` (e.g. an arbiter). Like
+  `rs.printSecondaryReplicationInfo()`, it is an `optimeDate` delta, so on a quiet
+  replica set with no recent writes it can read high because the secondary has had
+  nothing new to apply — not because it is unhealthy.
 
 ## References
 


### PR DESCRIPTION
## Summary

- `mongodb.replica_status` already fetched the full `replSetGetStatus`
  response but projected only `name`/`state`/`health`/`uptime`, discarding the
  `optimeDate` its own docstring promised as lag. This projects each member's
  `optime_date`, `sync_source_host`, `last_heartbeat`, and a **computed**
  `lag_seconds` from the response already in memory.
- `lag_seconds` = `(primary optimeDate − member optimeDate).total_seconds()`;
  `null` on the primary's own row, when no member is currently `PRIMARY`, or for
  a member with no `optimeDate` (e.g. an arbiter). Two small module-level helpers
  (`_primary_optime_date`, `_member_lag_seconds`) mirror the existing
  `_members_from_hello` "derive more from what's already fetched" pattern.
- No new op, no new command, **no `MONGO_READ_COMMANDS` allowlist change** —
  `replSetGetStatus` was already issued. The response schema is the open
  `_OBJECT_RESPONSE_SCHEMA`, so the added fields need no schema/route change.
- Lets an operator answer "how far behind is each secondary — safe to fail
  over?" through the governed dispatch/policy/audit surface instead of falling
  back to `rs.printSecondaryReplicationInfo()` against the replica set directly.

## Test plan

- [x] `ruff check` (queries.py, ops.py, test file) — clean
- [x] `ruff format --check` — clean (3 files already formatted)
- [x] `mypy src/meho_backplane/connectors/mongodb/` — clean (5 source files)
- [x] `pytest tests/test_connectors_mongodb.py` — 32 passed
- [x] **AC1** projection of the four new fields via `call_operation` on the
      existing `mongodb.replica_status` op — asserted in
      `test_replica_status_replica_set_returns_member_roles`
- [x] **AC2** lag math + `null` cases — secondary `lag_seconds == 12.0`, `null`
      on primary (extended test) and `null` with no primary / for an arbiter
      (new `test_replica_status_lag_is_null_without_primary_or_optime`)
- [x] **AC3** `_REPLICA_STATUS.description` + `output_shape` now name
      `optime_date` / `lag_seconds`
- [x] **AC4** unit test extends the named fixture with `optimeDate` values
- [x] **AC5** `docs/codebase/connectors-mongodb.md` ops table + "Known issues /
      scope" mention the lag field (incl. the quiet-replica-set caveat)
- [x] **AC6** `make snapshot-openapi` regenerated `cli/api/openapi.json` with
      **no drift** — no schema/route changed, so nothing to commit

## Out of scope

- **#2841** (mongodb `currentOp`) is a sibling in this wave that touches the same
  files in different regions (a new op + allowlist entry); merges are serialized
  by the orchestrator.
- Write/administrative failover actions, a caller-supplied lag threshold param,
  sharded-cluster-wide rollups, and historical/trend lag — all deferred per the
  issue's Out-of-scope section.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2840
