### PR TITLE
feat(connectors): add nsx transport-node list + per-node state reads (#2836)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,24 @@ connector-related release-notes line.
   domain-join credentials), and the durable audit row stores only a params
   hash. A dedicated end-to-end test proves no secret material reaches the
   approval, broadcast, or audit surface.
+### Added — `nsx.transport_node.list` + `nsx.transport_node.state` typed reads for edge health before maintenance/failover (#2836)
+
+- Two new `source_kind="typed"` ops dispatch on a fresh boot with zero
+  catalog ingest, in the `nsx-inventory` group. `nsx.transport_node.list`
+  (`GET /api/v1/transport-nodes`) lists the edge/host transport-node
+  fabric, but the list row carries no live health — NSX keeps per-node
+  state on a separate sub-resource — so `nsx.transport_node.state`
+  (`GET /api/v1/transport-nodes/{id}/state`, required `id`) reads one
+  node's realization result, `maintenance_mode_state`,
+  `node_deployment_state`, `deployment_progress_state`, and per-host-switch
+  tunnel/connectivity state. Together they answer "are both edges up, in
+  sync, and tunnel-healthy" before an operator drains an edge into
+  maintenance mode or relies on a tier-1 HA failover — instead of falling
+  back to the NSX Manager UI or `nsx.sh`, which bypass
+  policy/audit/broadcast/JSONFlux. The vendor payloads pass through
+  unmodified; `safety_level="safe"`, no approval. Transport-node
+  create/delete/maintenance-mode toggle (writes) stay out of scope
+  (a future approval-gated write-surface initiative).
 
 ## [0.28.0] - 2026-08-07
 

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -560,6 +560,22 @@ class NsxConnector(HttpConnector):
 
         return await nsx_segment_list_impl(self, operator, target, params)
 
+    async def transport_node_list(
+        self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``nsx.transport_node.list`` shim (#2836)."""
+        from meho_backplane.connectors.nsx.typed_reads import nsx_transport_node_list_impl
+
+        return await nsx_transport_node_list_impl(self, operator, target, params)
+
+    async def transport_node_state(
+        self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``nsx.transport_node.state`` shim (#2836)."""
+        from meho_backplane.connectors.nsx.typed_reads import nsx_transport_node_state_impl
+
+        return await nsx_transport_node_state_impl(self, operator, target, params)
+
     async def alarm_list(
         self, operator: Operator, target: NsxTargetLike, params: dict[str, Any]
     ) -> dict[str, Any]:

--- a/backend/src/meho_backplane/connectors/nsx/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/nsx/typed_ops.py
@@ -18,7 +18,7 @@ The dataclass + tuple + module-level registrar shape mirrors
 :mod:`meho_backplane.connectors.argocd.ops` and
 :mod:`meho_backplane.connectors.vmware_rest.typed_ops`.
 
-Ops NOT in the audited set (transport-node listing, tier-0 gateways,
+Ops NOT in the audited set (tier-0 gateways,
 distributed-firewall policies + rules) stay as ingested browse breadth
 -- enable-able through the generic review flow
 (``ReviewService.enable_reads``); only the audited operational reads are
@@ -108,9 +108,12 @@ NSX_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "Use to list the NSX routing/overlay inventory the operator asks "
         "about most: transport zones under the default enforcement point "
         "(nsx.transport_zone.list), per-tenant tier-1 gateways "
-        "(nsx.tier1.list), and overlay/VLAN segments with their "
+        "(nsx.tier1.list), overlay/VLAN segments with their "
         "subnet/CIDR occupancy (nsx.segment.list) -- the pre-flight read "
-        "before carving a new segment. Read-only."
+        "before carving a new segment -- and edge/host transport nodes "
+        "(nsx.transport_node.list), with per-node fabric health via "
+        "nsx.transport_node.state, the edge-health pre-flight before a "
+        "maintenance-mode or failover action. Read-only."
     ),
     _GROUP_ALARMS: (
         "Use to read NSX system alarms (nsx.alarm.list) -- open faults and "
@@ -407,6 +410,103 @@ _SEGMENT_LIST = NsxTypedOp(
 
 
 # ---------------------------------------------------------------------------
+# nsx.transport_node.list
+# ---------------------------------------------------------------------------
+
+_TRANSPORT_NODE_LIST = NsxTypedOp(
+    op_id="nsx.transport_node.list",
+    handler_attr="transport_node_list",
+    summary="NSX edge/host transport-node fabric inventory (state via nsx.transport_node.state).",
+    description=(
+        "Lists NSX transport nodes via GET /api/v1/transport-nodes -- the "
+        "edge and host nodes that carry the overlay. Returns "
+        "{results: [...], result_count} where each node carries id, "
+        "display_name, and node_deployment_info.resource_type "
+        "(EdgeNode / EsxiNode -- what tells an edge node from a host node). "
+        "The list row does NOT carry live health: NSX exposes per-node "
+        "fabric/tunnel/realization state on the separate .../state "
+        "sub-resource, so pair this with nsx.transport_node.state to answer "
+        "'are the edges healthy' before a maintenance-mode or failover "
+        "action. The vendor envelope passes through unmodified. Works with "
+        "zero catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "nsx", "manager", "transport-node"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to list edge/host transport nodes and get their ids -- the "
+            "entry point for the per-node health read nsx.transport_node.state. "
+            "Tell edge from host nodes on node_deployment_info.resource_type."
+        ),
+        "output_shape": (
+            "{results: [{id, display_name, node_deployment_info: "
+            "{resource_type}}, ...], result_count}. The list carries no live "
+            "state -- feed each id to nsx.transport_node.state for health."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# nsx.transport_node.state
+# ---------------------------------------------------------------------------
+
+_TRANSPORT_NODE_STATE = NsxTypedOp(
+    op_id="nsx.transport_node.state",
+    handler_attr="transport_node_state",
+    summary="Realization + maintenance-mode + tunnel state of one NSX transport node.",
+    description=(
+        "Reads one transport node's realization + fabric health via "
+        "GET /api/v1/transport-nodes/{id}/state -- requires a node id from "
+        "nsx.transport_node.list. NSX's TransportNodeState carries state "
+        "(overall realization result), maintenance_mode_state (whether the "
+        "node is already draining -- the datum that says whether the "
+        "surviving edge can still take over), node_deployment_state, "
+        "deployment_progress_state, and host_switch_states (per-host-switch "
+        "tunnel/connectivity realization). The read an operator runs before "
+        "putting an edge into maintenance mode or relying on a tier-1 HA "
+        "failover, so a degraded surviving node does not cost the tier-1 its "
+        "HA. The vendor payload passes through unmodified. Works with zero "
+        "catalog ingest. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The transport-node id (from nsx.transport_node.list).",
+            },
+        },
+        "required": ["id"],
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "nsx", "manager", "transport-node", "health"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call with a transport-node id before a maintenance-mode or "
+            "failover action, to confirm the node (and its HA peer) is "
+            "realized, not already in maintenance, and tunnel-healthy."
+        ),
+        "parameter_hints": {"id": "The transport-node id from nsx.transport_node.list."},
+        "output_shape": (
+            "{state, maintenance_mode_state, node_deployment_state, "
+            "deployment_progress_state, host_switch_states: [...]}. Read "
+            "maintenance_mode_state + state before draining the peer edge."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
 # nsx.alarm.list
 # ---------------------------------------------------------------------------
 
@@ -482,6 +582,8 @@ NSX_TYPED_OPS: tuple[NsxTypedOp, ...] = (
     _TRANSPORT_ZONE_LIST,
     _TIER1_LIST,
     _SEGMENT_LIST,
+    _TRANSPORT_NODE_LIST,
+    _TRANSPORT_NODE_STATE,
     _ALARM_LIST,
 )
 

--- a/backend/src/meho_backplane/connectors/nsx/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/nsx/typed_reads.py
@@ -43,6 +43,12 @@ The audited set:
 * ``nsx.segment.list`` -- ``GET /policy/api/v1/infra/segments`` (the
   overlay/VLAN segments and their subnet/CIDR occupancy -- the
   pre-flight read before carving a new segment).
+* ``nsx.transport_node.list`` -- ``GET /api/v1/transport-nodes`` (the
+  edge/host transport-node fabric inventory; live per-node state lives on
+  the ``.../state`` sub-resource below, not on the list row).
+* ``nsx.transport_node.state`` -- ``GET /api/v1/transport-nodes/{id}/state``
+  (one node's realization + maintenance-mode + tunnel/host-switch state --
+  the edge-health read before a maintenance-mode or failover action).
 * ``nsx.alarm.list`` -- ``GET /api/v1/alarms`` with optional
   ``status`` / ``feature_name`` / ``severity`` filters.
 
@@ -74,6 +80,8 @@ __all__ = [
     "nsx_node_status_impl",
     "nsx_segment_list_impl",
     "nsx_tier1_list_impl",
+    "nsx_transport_node_list_impl",
+    "nsx_transport_node_state_impl",
     "nsx_transport_zone_list_impl",
 ]
 
@@ -92,6 +100,8 @@ _TRANSPORT_ZONES_PATH = (
 )
 _TIER1S_PATH = "/policy/api/v1/infra/tier-1s"
 _SEGMENTS_PATH = "/policy/api/v1/infra/segments"
+_TRANSPORT_NODES_PATH = "/api/v1/transport-nodes"
+_TRANSPORT_NODE_STATE_PATH = "/api/v1/transport-nodes/{id}/state"
 _ALARMS_PATH = "/api/v1/alarms"
 
 #: Sentinel written in place of a scrubbed secret value. A non-empty
@@ -287,6 +297,56 @@ async def nsx_segment_list_impl(
     """
     del params  # schema declares the param object empty
     return await connector._get_json(target, _SEGMENTS_PATH, operator=operator)
+
+
+async def nsx_transport_node_list_impl(
+    connector: NsxConnector,
+    operator: Operator,
+    target: NsxTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``nsx.transport_node.list`` -- ``GET /api/v1/transport-nodes``.
+
+    Returns the transport-node fabric inventory -- the edge and host nodes
+    that carry the NSX overlay. ``{"results": [...], "result_count": N}``
+    where each node carries ``id``, ``display_name``, and
+    ``node_deployment_info.resource_type`` (``EdgeNode`` / ``EsxiNode`` --
+    the field that distinguishes an edge node from a host node). This list
+    row does **not** carry live health: NSX exposes per-node
+    fabric/tunnel/realization state on the separate ``.../state``
+    sub-resource, so pair this with ``nsx.transport_node.state`` to answer
+    "are the edges healthy" before a maintenance-mode or failover action.
+    The vendor ``{results, result_count}`` envelope is passed through
+    unmodified (same shape as :func:`nsx_tier1_list_impl`).
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _TRANSPORT_NODES_PATH, operator=operator)
+
+
+async def nsx_transport_node_state_impl(
+    connector: NsxConnector,
+    operator: Operator,
+    target: NsxTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``nsx.transport_node.state`` -- ``GET /api/v1/transport-nodes/{id}/state``.
+
+    Reads one transport node's realization + fabric health, given a node
+    ``id`` from ``nsx.transport_node.list``. The read an operator runs
+    before putting an edge node into maintenance mode or relying on a
+    tier-1 HA failover: NSX's ``TransportNodeState`` carries ``state`` (the
+    overall realization result), ``maintenance_mode_state`` (whether the
+    node is already draining -- the datum that says whether the surviving
+    edge can still take over), ``node_deployment_state``,
+    ``deployment_progress_state``, and ``host_switch_states`` (the
+    per-host-switch tunnel/connectivity realization). The vendor payload is
+    passed through unmodified so no health field is dropped at the connector
+    boundary. Mirrors the id-scoped ``sddc.domain.status`` status read
+    paired with its ``.list`` op.
+    """
+    node_id = params["id"]
+    path = _TRANSPORT_NODE_STATE_PATH.format(id=node_id)
+    return await connector._get_json(target, path, operator=operator)
 
 
 async def nsx_alarm_list_impl(

--- a/backend/tests/acceptance/_nsx_canary_fixtures.py
+++ b/backend/tests/acceptance/_nsx_canary_fixtures.py
@@ -88,6 +88,7 @@ __all__ = [
     "NSX_CANARY_TIER0S",
     "NSX_CANARY_TIER1S",
     "NSX_CANARY_TRANSPORT_NODES",
+    "NSX_CANARY_TRANSPORT_NODE_STATE",
     "NSX_FORCE_HANDLE_LIST_OP_ID",
     "NSX_TARGET_NAME",
     "IngestedNsxCanary",
@@ -150,6 +151,21 @@ NSX_CANARY_TRANSPORT_NODES: dict[str, object] = {
         for i in range(3)
     ],
     "result_count": 3,
+}
+
+#: Synthetic per-node state for ``transport-node-0`` — the shape NSX's
+#: ``GET /api/v1/transport-nodes/{id}/state`` returns: overall realization
+#: ``state``, ``maintenance_mode_state`` (the maintenance-safety datum an
+#: operator reads before draining an edge's HA peer), node-deployment +
+#: progress state, and per-host-switch realization.
+NSX_CANARY_TRANSPORT_NODE_STATE: dict[str, object] = {
+    "state": "success",
+    "maintenance_mode_state": "DISABLED",
+    "node_deployment_state": {"state": "NODE_READY", "details": []},
+    "deployment_progress_state": {"progress": 100, "current_step_title": "COMPLETE"},
+    "host_switch_states": [
+        {"host_switch_name": "canary-host-switch", "transport_zone_ids": ["tz-overlay"]}
+    ],
 }
 
 #: Synthetic segment listing — 12 rows so the force-handle reducer
@@ -414,8 +430,12 @@ def _register_nsx_routes(mock: respx.MockRouter) -> None:
             "external_id": "canary-external-id",
         },
     )
-    # nsx.node.list — transport-node inventory.
+    # nsx.transport_node.list — transport-node inventory.
     mock.get("/api/v1/transport-nodes").respond(200, json=NSX_CANARY_TRANSPORT_NODES)
+    # nsx.transport_node.state — per-node realization/health for node 0.
+    mock.get("/api/v1/transport-nodes/transport-node-0/state").respond(
+        200, json=NSX_CANARY_TRANSPORT_NODE_STATE
+    )
     # nsx.cluster.status — manager cluster health.
     mock.get("/api/v1/cluster/status").respond(
         200,

--- a/backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py
@@ -125,8 +125,23 @@ async def test_dispatch_smoke_nsx_core_op_returns_ok(
 #: acceptance surface. Unlike the ingested :data:`SMOKE_OP_IDS` above (seeded
 #: by the fixture), these need the typed registrar run in-test to persist
 #: their descriptor rows. ``nsx.segment.list`` (#2835) hits the same
-#: ``/policy/api/v1/infra/segments`` wire route the fixture already mocks.
-TYPED_SMOKE_OP_IDS: tuple[str, ...] = ("nsx.segment.list",)
+#: ``/policy/api/v1/infra/segments`` wire route the fixture already mocks;
+#: ``nsx.transport_node.list`` (#2836) hits the same
+#: ``/api/v1/transport-nodes`` wire route the fixture already mocks;
+#: ``nsx.transport_node.state`` (#2836) hits the per-node ``/state``
+#: sub-resource the fixture mocks for ``transport-node-0``.
+TYPED_SMOKE_OP_IDS: tuple[str, ...] = (
+    "nsx.segment.list",
+    "nsx.transport_node.list",
+    "nsx.transport_node.state",
+)
+
+#: Per-typed-op params. ``nsx.transport_node.state`` needs a transport-node
+#: ``id`` -- ``transport-node-0`` is the node the fixture's ``/state`` route
+#: is registered for; list ops take no params.
+TYPED_SMOKE_PARAMS: dict[str, dict[str, object]] = {
+    "nsx.transport_node.state": {"id": "transport-node-0"},
+}
 
 
 @pytest.mark.parametrize("op_id", TYPED_SMOKE_OP_IDS, ids=lambda op: op)
@@ -137,7 +152,8 @@ async def test_dispatch_smoke_nsx_typed_op_returns_ok(
 ) -> None:
     """Each NSX typed read dispatches over respx and returns ``status='ok'``.
 
-    ``nsx.segment.list`` (#2835) is a ``source_kind="typed"`` op: it is not
+    The segment (#2835) and transport-node (#2836) ops are
+    ``source_kind="typed"``: they are not
     in the ingested :data:`SMOKE_OP_IDS` set the fixture seeds, so this test
     runs :func:`register_nsx_typed_operations` to persist the typed
     descriptor rows before dispatching. ``encode_endpoint_text`` is stubbed
@@ -146,7 +162,8 @@ async def test_dispatch_smoke_nsx_typed_op_returns_ok(
     the multi-request model download (the same hazard
     :func:`~tests.acceptance._canary_fixtures.prewarmed_embeddings`
     documents). Dispatch itself takes a known ``op_id`` and needs no
-    embedding.
+    embedding; ``nsx.transport_node.state`` also carries the ``id`` of the
+    transport node the fixture's ``/state`` route is registered for.
     """
     monkeypatch.setattr(
         "meho_backplane.operations.typed_register.encode_endpoint_text",
@@ -160,7 +177,7 @@ async def test_dispatch_smoke_nsx_typed_op_returns_ok(
             "connector_id": ingested_nsx_canary.connector_id,
             "op_id": op_id,
             "target": {"name": ingested_nsx_canary.target_name},
-            "params": {},
+            "params": TYPED_SMOKE_PARAMS.get(op_id, {}),
         },
     )
 

--- a/backend/tests/test_connectors_nsx_typed_reads.py
+++ b/backend/tests/test_connectors_nsx_typed_reads.py
@@ -8,8 +8,8 @@ Coverage matrix (per Task #2302 acceptance criteria):
 * **Zero-catalog typed dispatch (AC #1).** Each audited read
   (nsx.node.status / nsx.cluster.status / nsx.backup.config /
   nsx.backup.status / nsx.transport_zone.list / nsx.tier1.list /
-  nsx.segment.list / nsx.alarm.list) dispatches through
-  :func:`~meho_backplane.operations.dispatch`
+  nsx.segment.list / nsx.transport_node.list / nsx.transport_node.state /
+  nsx.alarm.list) dispatches through :func:`~meho_backplane.operations.dispatch`
   against a respx-mocked NSX manager with **only** the typed registrar
   run -- no ingested descriptor rows -- and returns ``status="ok"``. The
   persisted descriptor carries ``source_kind="typed"``.
@@ -26,7 +26,7 @@ Coverage matrix (per Task #2302 acceptance criteria):
   nsx.segment.list forwards the vendor ``{results, result_count}``
   envelope so each segment's ``subnets[].gateway_address`` (the
   pre-flight CIDR-occupancy datum) reaches the operator unmodified.
-* **Registration-shape invariants.** All eight carry
+* **Registration-shape invariants.** All ten carry
   ``safety_level="safe"``, ``requires_approval=False``, a ``read-only``
   tag, ``additionalProperties=False`` on the parameter schema, and
   non-empty llm_instructions. No write op is registered.
@@ -226,6 +226,22 @@ _SEGMENTS_PAYLOAD: dict[str, Any] = {
     ],
     "result_count": 2,
 }
+_TRANSPORT_NODE_LIST_PAYLOAD: dict[str, Any] = {
+    "results": [
+        {
+            "id": "tn-edge-1",
+            "display_name": "edge-node-01",
+            "node_deployment_info": {"resource_type": "EdgeNode"},
+        }
+    ],
+    "result_count": 1,
+}
+_TRANSPORT_NODE_STATE_PAYLOAD: dict[str, Any] = {
+    "state": "success",
+    "maintenance_mode_state": "DISABLED",
+    "node_deployment_state": {"state": "NODE_READY", "details": []},
+    "host_switch_states": [{"host_switch_name": "nvds1", "transport_zone_ids": ["tz-overlay"]}],
+}
 _ALARM_PAYLOAD: dict[str, Any] = {
     "results": [
         {
@@ -265,6 +281,20 @@ _ALARM_PAYLOAD: dict[str, Any] = {
             "GET",
             "/policy/api/v1/infra/segments",
             _SEGMENTS_PAYLOAD,
+        ),
+        (
+            "nsx.transport_node.list",
+            {},
+            "GET",
+            "/api/v1/transport-nodes",
+            _TRANSPORT_NODE_LIST_PAYLOAD,
+        ),
+        (
+            "nsx.transport_node.state",
+            {"id": "tn-edge-1"},
+            "GET",
+            "/api/v1/transport-nodes/tn-edge-1/state",
+            _TRANSPORT_NODE_STATE_PAYLOAD,
         ),
         ("nsx.alarm.list", {}, "GET", "/api/v1/alarms", _ALARM_PAYLOAD),
     ],
@@ -390,6 +420,40 @@ async def test_segment_list_returns_cidr_occupancy_shape(
     assert segments[1]["subnets"][0]["gateway_address"] == "10.20.1.1/24"
     assert segments[0]["transport_zone_path"].endswith("/tz-overlay")
     assert segments[0]["resource_type"] == "Segment"
+
+
+@pytest.mark.asyncio
+async def test_transport_node_state_substitutes_id_into_path(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """nsx.transport_node.state substitutes ``id`` into the path and passes state through.
+
+    Exercises the id-scoped read shape (mirrors ``sddc.domain.status``):
+    the ``id`` param lands in the request path, and the vendor state
+    payload -- maintenance_mode_state + host_switch_states + the rest --
+    is returned unmodified so no health field is dropped at the boundary.
+    """
+    await _register_and_resolve(_stub_embedding)
+
+    node_id = "tn-edge-7"
+    async with respx.mock(base_url=_NSX_BASE_URL, assert_all_called=False) as mock:
+        mock.post("/api/session/create").respond(200, headers=_XSRF_HEADERS)
+        route = mock.get(f"/api/v1/transport-nodes/{node_id}/state").respond(
+            200, json=_TRANSPORT_NODE_STATE_PAYLOAD
+        )
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=NSX_CONNECTOR_ID,
+            op_id="nsx.transport_node.state",
+            target=_NsxReadTarget(),
+            params={"id": node_id},
+        )
+
+    assert result.status == "ok", result.error
+    assert route.called and route.call_count == 1
+    assert route.calls[0].request.url.path == f"/api/v1/transport-nodes/{node_id}/state"
+    assert result.result == _TRANSPORT_NODE_STATE_PAYLOAD
 
 
 # ---------------------------------------------------------------------------
@@ -537,6 +601,8 @@ _EXPECTED_OP_IDS = {
     "nsx.transport_zone.list",
     "nsx.tier1.list",
     "nsx.segment.list",
+    "nsx.transport_node.list",
+    "nsx.transport_node.state",
     "nsx.alarm.list",
 }
 

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -15,7 +15,9 @@ verbs + MCP review + recorded-fixture E2E arrive in G3.5-T3 (#615).
 **Audited reads are typed ops (#2302).** The audited operational read
 set -- node/cluster status+version, backup config+status,
 transport-zones list, tier-1 list, segment list (`nsx.segment.list`,
-#2835), and alarms -- is registered as
+#2835), transport-node list + per-node state
+(`nsx.transport_node.list` + `nsx.transport_node.state`, #2836), and
+alarms -- is registered as
 **typed** ops (`source_kind="typed"`, `typed_ops.py` metadata +
 `typed_reads.py` bodies + bound-method shims on `NsxConnector`), so it
 dispatches on a fresh boot with **zero catalog ingest** (avoiding the
@@ -23,8 +25,13 @@ dispatches on a fresh boot with **zero catalog ingest** (avoiding the
 (`GET /policy/api/v1/infra/segments`) passes the vendor
 `{results, result_count}` envelope through unmodified so the operator can
 read each segment's `subnets[].gateway_address` (subnet/CIDR occupancy)
-before carving a new segment. The remaining reads
-(transport-node listing, tier-0 gateways, distributed-firewall
+before carving a new segment. `nsx.transport_node.list`
+(`GET /api/v1/transport-nodes`) carries no live health -- state lives on
+the separate `.../state` sub-resource -- so `nsx.transport_node.state`
+(`GET /api/v1/transport-nodes/{id}/state`) reads one node's realization +
+`maintenance_mode_state` + tunnel/host-switch state, the edge-health
+pre-flight before a maintenance-mode or failover action. The remaining reads
+(tier-0 gateways, distributed-firewall
 policies + rules) stay as ordinary `source_kind="ingested"` breadth, enabled
 generically via `ReviewService.enable_reads`, so the wider ingested breadth
 remains browsable. `nsx.backup.config` is
@@ -92,7 +99,7 @@ Source: `backend/src/meho_backplane/connectors/nsx/`.
   typed-read / VCF-9-ingest tests one importable source of truth. Relocated
   here from the retired `core_ops` module in #2358.
 - **Ingested browse breadth** -- the reads outside the typed set
-  (transport-node listing, tier-0 gateways, distributed-firewall
+  (tier-0 gateways, distributed-firewall
   policies + rules, and the wider NSX catalog) land as ordinary
   `source_kind="ingested"` `endpoint_descriptor` rows via G0.7 spec ingestion
   and are enabled through the generic review flow
@@ -233,8 +240,8 @@ concern, same posture vSphere takes for proactive refresh.
 ## Ingested breadth + read enablement
 
 The audited operational reads are typed ops (see the Overview) and dispatch on
-a fresh boot with zero catalog state. The remaining reads (transport-node
-listing, tier-0 gateways, distributed-firewall policies + rules) and
+a fresh boot with zero catalog state. The remaining reads (tier-0
+gateways, distributed-firewall policies + rules) and
 the wider NSX catalog land as ordinary `source_kind="ingested"`
 `endpoint_descriptor` rows after a G0.7 ingest of the NSX `policy.yaml` +
 `manager.yaml` corpus (every row `is_enabled=False` until enabled).
@@ -299,9 +306,11 @@ The hand-curated ingested-enable apparatus (the `core_ops.py` module with its
 - Acceptance tests:
   - `backend/tests/acceptance/test_g35_nsx_dispatch_smoke.py` —
     dispatch the ingested NSX core ops against a respx-mocked NSX REST
-    surface (one parametrised case per op), plus a typed-op case that
-    registers `nsx.segment.list` (#2835) and dispatches it over the same
-    mocked `/policy/api/v1/infra/segments` route.
+    surface (one parametrised case per op), plus typed-op cases that
+    register `nsx.segment.list` (#2835) over the mocked
+    `/policy/api/v1/infra/segments` route and `nsx.transport_node.list` +
+    `nsx.transport_node.state` (#2836) over the mocked
+    `/api/v1/transport-nodes(/state)` routes.
   - `backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py`
     — install a test-only `ForceHandleReducer`, dispatch the
     segment-list op, assert `OperationResult.handle` is populated


### PR DESCRIPTION
## Summary
- Adds two `source_kind="typed"` NSX reads in the `nsx-inventory` group so an operator can answer "are both edges up, in sync, and tunnel-healthy" before draining an NSX edge into maintenance mode or relying on a tier-1 HA failover — through policy/audit/broadcast/JSONFlux instead of the NSX Manager UI or `nsx.sh`.
- `nsx.transport_node.list` (`GET /api/v1/transport-nodes`) lists the edge/host transport-node fabric. The list row carries **no live health** (confirmed by the repo's own NSX canary fixture), so it exists to surface node ids for the state read.
- `nsx.transport_node.state` (`GET /api/v1/transport-nodes/{id}/state`, required `id`) path-substitutes the id and returns the vendor `TransportNodeState` unmodified — `state`, `maintenance_mode_state` (the maintenance-safety datum), `node_deployment_state`, `deployment_progress_state`, `host_switch_states`. Mirrors the in-repo `sddc.domain.list` + `sddc.domain.status` list + id-scoped-status pairing.
- Both `safety_level="safe"`, `requires_approval=False`, dispatch through `call_operation` on connector `nsx-rest-9.0`.

## Test plan
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/` (strict, 702 files) — clean for changed files (the only error is a pre-existing macOS-only `socket.MSG_ERRQUEUE` artifact in untouched `net/icmp.py`, which is defined on the Linux CI runners)
- [x] `pytest tests/test_connectors_nsx_typed_reads.py` — 44 passed (both ops dispatch zero-catalog; a dedicated `.state` test asserts the `id` lands in `/{id}/state` and the full state payload returns unmodified)
- [x] `pytest tests/acceptance/test_g35_nsx_dispatch_smoke.py` — 7 passed (2 new typed-op cases dispatch via `call_operation` over respx, including the `/state` sub-resource with id-substitution)
- [x] Fixture-consumer regression check (`test_g35_nsx_jsonflux_force_handle.py` + `test_connectors_nsx_e2e.py`) — 10 passed
- [x] code-quality gate (`--diff`) — exit 0
- [x] `docs/codebase/connectors-nsx.md` — both ops added to the audited-typed-ops Overview; excluded-list note trimmed
- [x] OpenAPI snapshot — no route/schema change (typed ops are DB descriptors, not FastAPI routes), so regen not required (AC #7)

**Vendor grounding:** `/api/v1/transport-nodes` is repo-grounded (NSX canary fixture + onboarding docs). The `/api/v1/transport-nodes/{id}/state` sub-resource — flagged *unverified* at filing — was confirmed against the Broadcom NSX Manager API guide (`GetTransportNodeState`), corroborated across Broadcom TechDocs + KB 374279. The handler passes the payload through unmodified, so field fidelity holds regardless of version drift.

## Out of scope
- Edge-cluster listing/membership, transport-node writes (create/delete/maintenance-mode toggle), and the aggregate bulk `GET /api/v1/transport-nodes/state` endpoint (per the issue).
- **Sibling collision note:** #2835 (nsx segment list) touches the same NSX connector files (`typed_ops.py`, `typed_reads.py`, `connector.py`, docs, CHANGELOG) and adds a parallel `TYPED_SMOKE_OP_IDS` block to `test_g35_nsx_dispatch_smoke.py`; whichever of #2835/#2836 merges second needs a trivial union-merge on those hunks.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2836
