### PR TITLE
feat(connectors): project lb_ingress on k8s.service.list — surface the LoadBalancer VIP

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -139,7 +139,7 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     "network": (
         "Use for service-routing and ingress questions: "
         "``k8s.service.list`` (ClusterIP / NodePort / LoadBalancer "
-        "with endpoint counts) and ``k8s.ingress.list`` (hostname + "
+        "with its assigned VIP) and ``k8s.ingress.list`` (hostname + "
         "path -> backend mappings). The right group for 'how is this "
         "workload exposed?' or 'which hostname routes to which "
         "service?'. Pair with the 'workload' group to map back to "

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_network.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_network.py
@@ -126,16 +126,29 @@ def service_row(svc: V1Service) -> dict[str, Any]:
     """Project a :class:`V1Service` into the wire dict shape.
 
     ``external_ips`` is the static list operators set on
-    ``spec.externalIPs``; LoadBalancer-assigned IPs live under
-    ``status.loadBalancer.ingress`` and are out of v0.2 scope (the
-    operator question "what IP routes to this service?" is answered by
-    the type + cluster_ip combination plus the namespace's Ingress
-    rows). ``selector`` is forwarded verbatim; an absent selector
-    (``None`` on a headless / ExternalName service) surfaces as ``{}``
-    so downstream consumers see a stable dict type.
+    ``spec.externalIPs``. ``lb_ingress`` surfaces the
+    LoadBalancer-assigned VIPs from ``status.loadBalancer.ingress`` --
+    one ``{ip, hostname}`` entry per :class:`V1LoadBalancerIngress` -- so
+    the "which VIP does this service hold?" question (MetalLB pool
+    occupancy, DNS-target verification, IPAM reconciliation) is
+    answerable without falling back to ``kubectl``. It is ``[]`` for
+    non-LoadBalancer services and for LoadBalancer services with no
+    assignment yet; each level of the status chain (``status`` /
+    ``status.load_balancer`` / ``.ingress``) is None-guarded. Widened
+    from the G3.2 v0.2 cut once RDC dogfooding showed the type +
+    cluster_ip + Ingress rows could not answer VIP occupancy.
+    ``selector`` is forwarded verbatim; an absent selector (``None`` on a
+    headless / ExternalName service) surfaces as ``{}`` so downstream
+    consumers see a stable dict type.
     """
     metadata = svc.metadata
     spec = svc.spec
+    status = svc.status
+    load_balancer = status.load_balancer if status is not None else None
+    ingress = load_balancer.ingress if load_balancer is not None else None
+    lb_ingress: list[dict[str, Any]] = [
+        {"ip": entry.ip, "hostname": entry.hostname} for entry in (ingress or [])
+    ]
     return {
         "name": metadata.name if metadata is not None else None,
         "namespace": metadata.namespace if metadata is not None else None,
@@ -144,6 +157,7 @@ def service_row(svc: V1Service) -> dict[str, Any]:
         "external_ips": (list(spec.external_ips or []) if spec is not None else []),
         "ports": ([service_port_row(p) for p in (spec.ports or [])] if spec is not None else []),
         "selector": (dict(spec.selector or {}) if spec is not None else {}),
+        "lb_ingress": lb_ingress,
     }
 
 
@@ -278,6 +292,17 @@ K8S_SERVICE_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
                         },
                     },
                     "selector": {"type": "object"},
+                    "lb_ingress": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "ip": {"type": ["string", "null"]},
+                                "hostname": {"type": ["string", "null"]},
+                            },
+                            "additionalProperties": False,
+                        },
+                    },
                 },
                 "required": [
                     "name",
@@ -287,6 +312,7 @@ K8S_SERVICE_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
                     "external_ips",
                     "ports",
                     "selector",
+                    "lb_ingress",
                 ],
                 "additionalProperties": False,
             },
@@ -319,10 +345,15 @@ K8S_SERVICE_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
     },
     "output_shape": (
         "{'rows': [{name, namespace, type, cluster_ip, external_ips, "
-        "ports: [{name, port, target_port, protocol}], selector}], "
-        "'total': <int>}. ``type`` is the Service type "
+        "ports: [{name, port, target_port, protocol}], selector, "
+        "lb_ingress: [{ip, hostname}]}], 'total': <int>}. ``type`` is "
+        "the Service type "
         "('ClusterIP' / 'NodePort' / 'LoadBalancer' / 'ExternalName'); "
-        "``cluster_ip`` is the stable in-cluster VIP. Each row "
+        "``cluster_ip`` is the stable in-cluster VIP; ``lb_ingress`` is "
+        "the LoadBalancer-assigned external VIP(s) from "
+        "``status.loadBalancer.ingress`` (``[]`` for non-LoadBalancer "
+        "services or before assignment) -- the field that answers "
+        "MetalLB pool occupancy. Each row "
         "carries its own ``namespace`` so cross-namespace rows under "
         "``all_namespaces=true`` stay distinguishable."
     ),
@@ -436,7 +467,8 @@ NETWORK_OPS: tuple[KubernetesOp, ...] = (
             "``CoreV1Api.list_service_for_all_namespaces(...)`` "
             "(``all_namespaces=true``) and projects each Service into "
             "{name, namespace, type, cluster_ip, external_ips, ports, "
-            "selector}. ``type`` is the Service type ('ClusterIP' / "
+            "selector, lb_ingress}. ``type`` is the Service type "
+            "('ClusterIP' / "
             "'NodePort' / 'LoadBalancer' / 'ExternalName'); "
             "``cluster_ip`` is the stable in-cluster VIP (may be 'None' "
             "for ExternalName services or headless services with "
@@ -444,6 +476,10 @@ NETWORK_OPS: tuple[KubernetesOp, ...] = (
             "{name, port, target_port, protocol}; ``target_port`` may "
             "be either an integer or a named-port string. ``selector`` "
             "is the label map the service uses to pick pods. "
+            "``lb_ingress`` is the LoadBalancer-assigned external VIP "
+            "list ({ip, hostname} from ``status.loadBalancer.ingress`` "
+            "-- e.g. a MetalLB-assigned address); ``[]`` for "
+            "non-LoadBalancer services or before assignment. "
             "``label_selector`` is forwarded server-side. Read-only."
         ),
         parameter_schema=K8S_SERVICE_LIST_PARAMETER_SCHEMA,

--- a/backend/tests/test_connectors_k8s_network_config.py
+++ b/backend/tests/test_connectors_k8s_network_config.py
@@ -57,12 +57,15 @@ from kubernetes_asyncio.client.models import (
     V1IngressSpec,
     V1IngressTLS,
     V1ListMeta,
+    V1LoadBalancerIngress,
+    V1LoadBalancerStatus,
     V1ObjectMeta,
     V1ObjectReference,
     V1Service,
     V1ServiceBackendPort,
     V1ServicePort,
     V1ServiceSpec,
+    V1ServiceStatus,
 )
 
 from meho_backplane.auth.operator import Operator, TenantRole
@@ -84,6 +87,7 @@ from meho_backplane.connectors.kubernetes.ops_events import (
     sort_event_rows_recent_first,
 )
 from meho_backplane.connectors.kubernetes.ops_network import (
+    K8S_SERVICE_LIST_RESPONSE_SCHEMA,
     NETWORK_OPS,
     ingress_path_row,
     ingress_row,
@@ -262,6 +266,7 @@ def _make_service(
     external_ips: list[str] | None = None,
     ports: list[V1ServicePort] | None = None,
     selector: dict[str, str] | None = None,
+    status: V1ServiceStatus | None = None,
 ) -> V1Service:
     return V1Service(
         metadata=V1ObjectMeta(name=name, namespace=namespace),
@@ -272,6 +277,7 @@ def _make_service(
             ports=ports or [],
             selector=selector or {},
         ),
+        status=status,
     )
 
 
@@ -332,6 +338,75 @@ def test_service_row_external_ips_forwarded() -> None:
         external_ips=["1.2.3.4", "5.6.7.8"],
     )
     assert service_row(svc)["external_ips"] == ["1.2.3.4", "5.6.7.8"]
+
+
+def _lb_status(*ingress: V1LoadBalancerIngress) -> V1ServiceStatus:
+    """Wrap LoadBalancer ingress entries into a ``V1ServiceStatus`` seam."""
+    return V1ServiceStatus(load_balancer=V1LoadBalancerStatus(ingress=list(ingress)))
+
+
+def test_service_row_lb_ingress_projects_ip_and_hostname_entries() -> None:
+    """A LoadBalancer with a populated ``status.loadBalancer.ingress`` surfaces
+    one ``{ip, hostname}`` entry per assignment -- the MetalLB VIP-occupancy
+    signal. Both an IP-only and a hostname-only entry are covered."""
+    svc = _make_service(
+        name="argocd-lb",
+        type_="LoadBalancer",
+        status=_lb_status(
+            V1LoadBalancerIngress(ip="10.0.0.5"),
+            V1LoadBalancerIngress(hostname="lb.evba.lab"),
+        ),
+    )
+    assert service_row(svc)["lb_ingress"] == [
+        {"ip": "10.0.0.5", "hostname": None},
+        {"ip": None, "hostname": "lb.evba.lab"},
+    ]
+
+
+def test_service_row_lb_ingress_empty_for_clusterip() -> None:
+    """A ClusterIP service (no ``status``) surfaces ``lb_ingress == []``."""
+    svc = _make_service(name="argocd-server")
+    assert service_row(svc)["lb_ingress"] == []
+
+
+def test_service_row_lb_ingress_empty_for_unassigned_loadbalancer() -> None:
+    """A LoadBalancer whose VIP is not yet assigned (``ingress=None``) surfaces
+    ``lb_ingress == []`` rather than raising on the None chain."""
+    svc = _make_service(
+        name="pending-lb",
+        type_="LoadBalancer",
+        status=V1ServiceStatus(load_balancer=V1LoadBalancerStatus(ingress=None)),
+    )
+    assert service_row(svc)["lb_ingress"] == []
+
+
+def test_service_row_validates_against_response_schema() -> None:
+    """``service_row`` output conforms to ``K8S_SERVICE_LIST_RESPONSE_SCHEMA``.
+
+    Nothing else pinned the helper against the schema, so a key added to
+    one and not the other -- the exact drift this projection widens --
+    would slip past review. Validate the ``{rows, total}`` envelope for a
+    spread of shapes (ClusterIP, ExternalName, LoadBalancer-with-VIP)
+    against the live schema; ``additionalProperties: false`` + the
+    ``required`` list (now carrying ``lb_ingress``) both bite here.
+    """
+    from jsonschema import Draft202012Validator
+
+    services = [
+        _make_service(name="clusterip", ports=[V1ServicePort(name="http", port=80)]),
+        V1Service(
+            metadata=V1ObjectMeta(name="external", namespace="default"),
+            spec=V1ServiceSpec(type="ExternalName", external_name="db.example.com"),
+        ),
+        _make_service(
+            name="argocd-lb",
+            type_="LoadBalancer",
+            status=_lb_status(V1LoadBalancerIngress(ip="10.0.0.5")),
+        ),
+    ]
+    rows = [service_row(s) for s in services]
+    payload = {"rows": rows, "total": len(rows)}
+    Draft202012Validator(K8S_SERVICE_LIST_RESPONSE_SCHEMA).validate(payload)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -152,7 +152,7 @@ real operator through the same loader.
 | `k8s.pod.info`         | safe   | Full pod detail; exact name or unique prefix.                     |
 | `k8s.deployment.list`  | safe   | Deployments with live replica counts + image + strategy.          |
 | `k8s.deployment.info`  | safe   | Full deployment detail; exact name or unique prefix.              |
-| `k8s.service.list`     | safe   | `CoreV1Api.list_namespaced_service()` / `list_service_for_all_namespaces()` -- type / cluster_ip / ports / selector + `label_selector`. |
+| `k8s.service.list`     | safe   | `CoreV1Api.list_namespaced_service()` / `list_service_for_all_namespaces()` -- type / cluster_ip / ports / selector / lb_ingress (LoadBalancer VIP from `status.loadBalancer.ingress`, `[]` otherwise) + `label_selector`. |
 | `k8s.ingress.list`     | safe   | `NetworkingV1Api.list_namespaced_ingress()` / `list_ingress_for_all_namespaces()` -- class / hosts / TLS / rules + `label_selector`. |
 | `k8s.configmap.list`   | safe   | `CoreV1Api.list_namespaced_config_map()` / `list_config_map_for_all_namespaces()` -- **keys only, NO values** + `label_selector`. |
 | `k8s.configmap.info`   | safe   | `CoreV1Api.read_namespaced_config_map()` -- full data + binary_data. |

--- a/docs/cross-repo/kubernetes-onboarding.md
+++ b/docs/cross-repo/kubernetes-onboarding.md
@@ -314,7 +314,7 @@ $ meho k8s ingress list --target rke2-meho --namespace argocd
 
 | Verb | op_id | Result |
 | --- | --- | --- |
-| `service list` | `k8s.service.list` | `{rows: [{name, namespace, type, cluster_ip, external_ips, ports, selector}], total}` |
+| `service list` | `k8s.service.list` | `{rows: [{name, namespace, type, cluster_ip, external_ips, ports, selector, lb_ingress}], total}` |
 | `ingress list` | `k8s.ingress.list` | `{rows: [{name, namespace, class, hosts, tls_hosts, rules: [{host, paths: [{path, path_type, service, port}]}]}], total}` |
 
 ### Config — `meho k8s configmap …`


### PR DESCRIPTION
## Summary
- `k8s.service.list` omitted `status.loadBalancer.ingress`, so `type=LoadBalancer` services surfaced no address at all — `external_ips` is `spec.externalIPs`, which MetalLB never writes. A live RDC session verifying MetalLB range carve-up across RKE2 clusters fell back to `kubectl get svc -A -o wide`.
- Adds an `lb_ingress` projection key: `[{ip, hostname}]` from `status.load_balancer.ingress` (`V1LoadBalancerIngress.ip`/`.hostname`, kubernetes_asyncio 36.1.0), `[]` for non-LoadBalancer services and for LoadBalancer services with no assignment yet. The full status chain (`status` / `status.load_balancer` / `.ingress`) is None-guarded.
- Backward-compatible (additive key). Schema (`required` + `additionalProperties: false`), `llm_instructions.output_shape`, the op description, the `network` group description, and both the codebase and cross-repo docs move in lockstep.
- A new test validates `service_row` output against `K8S_SERVICE_LIST_RESPONSE_SCHEMA` — closing the helper/schema drift gap the issue flagged (nothing pinned the two together before).

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (strict) — no issues in the two changed source files. Repo-wide mypy reports one pre-existing, darwin-only false positive (`socket.MSG_ERRQUEUE` in the untouched `connectors/net/icmp.py`); that constant is Linux-only, so CI on `meho-runners` passes.
- [x] `pytest tests/test_connectors_k8s_network_config.py` — 55 passed
- [x] `pytest -k "k8s or kubernetes"` — green
- [x] `code-quality.py --diff` — 0 blockers
- [x] AC: `lb_ingress == [{"ip": "10.0.0.5", "hostname": None}]` for a populated LoadBalancer; `[]` for ClusterIP and for an unassigned LoadBalancer — `test_service_row_lb_ingress_*`
- [x] AC: `_make_service` gains a `status` seam kwarg; per-key `lb_ingress` assertions added
- [x] AC: schema / `output_shape` / op description / `network` group description all list `lb_ingress`
- [x] AC: `docs/codebase/connectors-kubernetes.md` `service.list` row shape updated
- [x] CLI OpenAPI snapshot: **N/A** — the op response schema does not surface in `cli/api/openapi.json` (verified by grep = 0); no FastAPI route or handler docstring is touched, so `cli-api-snapshot-freshness` is unaffected.

## Out of scope
- #2830 (sibling — k8s storage/CR read ops): shares the connector but different files. This PR touches no op-count drift-detector (no op added), so no conflict expected; if one arises at merge it is trivial.
- `ip_mode` / `ports` sub-fields of `V1LoadBalancerIngress`, and a `k8s.service.info` op (both per the issue).

## Adjacent findings (recorded, not fixed)
- `cli/internal/cmd/k8s/network.go:59` — the Go CLI command help text enumerates the row shape and could mention `lb_ingress`. Left untouched: separate toolchain, help-text only, and the CLI already passes the new key through in its JSON output (no strict decoding).
- `backend/.../ops_network.py` is 527 lines (code-quality warns >400, blocks >600) — a future split candidate; not caused by this change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2831
