### PR TITLE
feat(connectors): add mongodb.current_ops read for live in-flight operations (#2841)

### DIFF
--- a/backend/src/meho_backplane/connectors/mongodb/__init__.py
+++ b/backend/src/meho_backplane/connectors/mongodb/__init__.py
@@ -25,7 +25,7 @@ Two-phase registration, the same shape as
 * **Asynchronous (lifespan startup)** --
   :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
   invokes :func:`register_mongodb_typed_operations`, which delegates to
-  :meth:`MongoDbConnector.register_operations` to upsert the eight read-only
+  :meth:`MongoDbConnector.register_operations` to upsert the nine read-only
   descriptors. Idempotent on re-call with unchanged op text.
 
 The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry point

--- a/backend/src/meho_backplane/connectors/mongodb/connector.py
+++ b/backend/src/meho_backplane/connectors/mongodb/connector.py
@@ -177,6 +177,14 @@ class MongoDbConnector(Connector):
         async with self._client(target, operator) as client:
             return await queries.fetch_replica_status(client)
 
+    async def current_ops(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``mongodb.current_ops`` -- live in-flight operations, query text stripped."""
+        del params  # declared empty in schema
+        async with self._client(target, operator) as client:
+            return await queries.fetch_current_ops(client)
+
     # ------------------------------------------------------------------
     # Fingerprint / probe
     # ------------------------------------------------------------------

--- a/backend/src/meho_backplane/connectors/mongodb/ops.py
+++ b/backend/src/meho_backplane/connectors/mongodb/ops.py
@@ -16,6 +16,8 @@ uses, without reaching for ``mongosh`` against ``:27017``:
 * ``mongodb.count`` -- fast metadata document count (``estimatedDocumentCount``).
 * ``mongodb.server_status`` -- slim ``serverStatus`` projection.
 * ``mongodb.replica_status`` -- replica-set health (``hello`` + ``replSetGetStatus``).
+* ``mongodb.current_ops`` -- live in-flight operations (``currentOp``), query
+  text stripped.
 
 Every op is ``safety_level="safe"`` + ``requires_approval=False`` and carries a
 ``read-only`` tag. Read-only is guaranteed by the **fixed command set**: each op
@@ -82,10 +84,13 @@ MONGO_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     "mongodb-runtime": (
         "Use to inspect a MongoDB instance's live runtime: a slim serverStatus "
         "projection covering connections, network, opcounters, memory, and the "
-        "storage engine (mongodb.server_status), or replica-set health with each "
-        "member's role and state (mongodb.replica_status). The right group for "
-        "'is this instance under connection pressure?', 'what is the opcounter "
-        "mix?', or 'is the replica set healthy and who is primary?'. Read-only."
+        "storage engine (mongodb.server_status), replica-set health with each "
+        "member's role and state (mongodb.replica_status), or the operations "
+        "running right now with how long each has been going (mongodb.current_ops). "
+        "The right group for 'is this instance under connection pressure?', 'what "
+        "is the opcounter mix?', 'is the replica set healthy and who is primary?', "
+        "or 'which operations have been running longer than N seconds right now?'. "
+        "Read-only."
     ),
 }
 
@@ -363,6 +368,43 @@ _REPLICA_STATUS = MongoOp(
 )
 
 
+_CURRENT_OPS = MongoOp(
+    op_id="mongodb.current_ops",
+    handler_attr="current_ops",
+    summary="Snapshot the operations running right now (currentOp).",
+    description=(
+        "Returns the in-flight operations from currentOp: opid, op type, "
+        "namespace, whether active, how long each has been running "
+        "(secs_running / microsecs_running), client, description, connection id, "
+        "plan summary, yields, and lock-wait state. Idle connections and internal "
+        "system operations are excluded. The op for 'which operations have been "
+        "running longer than N seconds right now, and on which collection?'. The "
+        "query text (the command / originatingCommand documents) is intentionally "
+        "omitted because it can carry literal filter values or secrets. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema=_EMPTY_PARAMS,
+    response_schema=_OBJECT_RESPONSE_SCHEMA,
+    group_key="mongodb-runtime",
+    tags=("read-only", "mongodb", "runtime", "activity"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to triage live activity: the long-running or lock-waiting "
+            "operations in flight right now. Sort the result by secs_running to "
+            "find the long-runners; there are no filter parameters."
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "{operations:[{opid, op, ns, active, secs_running, microsecs_running, "
+            "client, desc, connectionId, planSummary, numYields, waitingForLock, "
+            "currentOpTime}]}. No command / query text is returned."
+        ),
+    },
+)
+
+
 #: The ops :class:`MongoDbConnector` registers at lifespan startup.
 MONGO_OPS: tuple[MongoOp, ...] = (
     _DATABASES,
@@ -373,4 +415,5 @@ MONGO_OPS: tuple[MongoOp, ...] = (
     _COUNT,
     _SERVER_STATUS,
     _REPLICA_STATUS,
+    _CURRENT_OPS,
 )

--- a/backend/src/meho_backplane/connectors/mongodb/queries.py
+++ b/backend/src/meho_backplane/connectors/mongodb/queries.py
@@ -13,7 +13,8 @@ command reference and to unit-test with a fake client).
 Command facts are pinned to the MongoDB manual:
 ``listDatabases`` / ``listCollections`` / ``dbStats`` / ``collStats`` /
 ``listIndexes`` / ``serverStatus`` / ``buildInfo`` / ``hello`` /
-``replSetGetStatus`` (https://www.mongodb.com/docs/manual/reference/command/).
+``replSetGetStatus`` / ``currentOp``
+(https://www.mongodb.com/docs/manual/reference/command/).
 """
 
 from __future__ import annotations
@@ -31,11 +32,13 @@ from pymongo.errors import OperationFailure
 from meho_backplane.connectors.mongodb.session import DEFAULT_AUTH_SOURCE, assert_read_command
 
 __all__ = [
+    "CURRENT_OP_SLIM_FIELDS",
     "NO_REPLICATION_ENABLED_CODE",
     "SERVER_STATUS_SLIM_FIELDS",
     "SERVER_STATUS_SUPPRESSED_SECTIONS",
     "fetch_collection_stats",
     "fetch_collections",
+    "fetch_current_ops",
     "fetch_databases",
     "fetch_db_stats",
     "fetch_estimated_count",
@@ -83,6 +86,34 @@ SERVER_STATUS_SLIM_FIELDS: tuple[str, ...] = (
     "storageEngine",
     "repl",
     "ok",
+)
+
+#: The triage-safe per-operation fields kept from a ``currentOp`` document. This
+#: is a positive projection (the same "fetch, then keep only the triage-safe
+#: subset" shape as :data:`SERVER_STATUS_SLIM_FIELDS`), not a drop-list: an op
+#: document is rebuilt from only these fields, so the query-bearing fields a
+#: ``currentOp`` entry can carry — ``command`` / ``originatingCommand`` /
+#: ``query`` / ``comment`` (all of which embed literal filter values and can
+#: preserve a ``comment`` even when the command is truncated) — never reach an
+#: :class:`OperationResult`, and a future server version adding a new
+#: value-bearing field cannot leak through a stale drop-list. ``planSummary`` is
+#: kept: it reports the chosen index's key pattern (field names, already public
+#: via ``mongodb.indexes``), not the literal query values. Mirrors the
+#: query-text omission ``postgres.activity`` applies to ``pg_stat_activity``.
+CURRENT_OP_SLIM_FIELDS: tuple[str, ...] = (
+    "opid",
+    "op",
+    "ns",
+    "active",
+    "secs_running",
+    "microsecs_running",
+    "client",
+    "desc",
+    "connectionId",
+    "planSummary",
+    "numYields",
+    "waitingForLock",
+    "currentOpTime",
 )
 
 
@@ -336,6 +367,38 @@ async def fetch_replica_status(client: AsyncMongoClient[dict[str, Any]]) -> dict
         ],
     }
     return payload
+
+
+async def fetch_current_ops(client: AsyncMongoClient[dict[str, Any]]) -> dict[str, Any]:
+    """Snapshot the in-flight operations via ``currentOp``, without query text.
+
+    Issues ``{"currentOp": 1, "$all": False}`` against the ``admin`` database.
+    ``$all: False`` (the command's own default) excludes idle connections and
+    internal system operations, so the payload stays a triage-sized snapshot of
+    the operations actually running. Each returned operation is projected down to
+    :data:`CURRENT_OP_SLIM_FIELDS`, dropping the query-bearing ``command`` /
+    ``originatingCommand`` fields that can carry literal filter values or secrets
+    — the same discipline ``postgres.activity`` applies to the in-flight query
+    text. An operator finds the long-runners by sorting the result on
+    ``secs_running`` (client-side, or via ``result_query`` on a handle).
+
+    Requires the ``inprog`` privilege (the built-in ``clusterMonitor`` role) —
+    the same role ``mongodb.replica_status``'s ``replSetGetStatus`` already
+    assumes, so no new elevated grant.
+
+    ``currentOp`` is deprecated as a command since MongoDB 6.2 in favour of the
+    ``$currentOp`` aggregation stage, but is still served through MongoDB 8.x,
+    inside this connector's supported range; the single fixed command keeps the
+    closed read-command allowlist a one-entry addition rather than admitting the
+    generic ``aggregate`` command.
+    """
+    assert_read_command("currentOp")
+    result = await _admin(client).command({"currentOp": 1, "$all": False})
+    operations = [
+        {field: _jsonable(op[field]) for field in CURRENT_OP_SLIM_FIELDS if field in op}
+        for op in result.get("inprog", [])
+    ]
+    return {"operations": operations}
 
 
 async def fetch_fingerprint(

--- a/backend/src/meho_backplane/connectors/mongodb/session.py
+++ b/backend/src/meho_backplane/connectors/mongodb/session.py
@@ -13,7 +13,7 @@ op surface:
   database there is no free-form query surface here at all: every op maps to
   exactly one fixed read command (``listDatabases`` / ``listCollections`` /
   ``dbStats`` / ``collStats`` / ``listIndexes`` / ``count`` / ``serverStatus`` /
-  ``buildInfo`` / ``hello`` / ``replSetGetStatus``). There is **no**
+  ``buildInfo`` / ``hello`` / ``replSetGetStatus`` / ``currentOp``). There is **no**
   arbitrary-command / ``eval`` / ``$where`` / aggregation passthrough, so
   read-only is guaranteed by the fixed command set rather than by a runtime gate.
   :func:`assert_read_command` is the belt-and-suspenders check the query layer
@@ -87,6 +87,7 @@ MONGO_READ_COMMANDS: frozenset[str] = frozenset(
         "buildInfo",
         "hello",
         "replSetGetStatus",
+        "currentOp",
     }
 )
 

--- a/backend/tests/test_connectors_mongodb.py
+++ b/backend/tests/test_connectors_mongodb.py
@@ -286,6 +286,7 @@ def test_every_op_is_safe_read_only_with_closed_schema() -> None:
         "mongodb.count",
         "mongodb.server_status",
         "mongodb.replica_status",
+        "mongodb.current_ops",
     }
     for op in MONGO_OPS:
         assert op.safety_level == "safe", op.op_id
@@ -314,6 +315,7 @@ def test_read_command_allowlist_is_the_closed_fixed_set() -> None:
                 "buildInfo",
                 "hello",
                 "replSetGetStatus",
+                "currentOp",
             }
         )
         == MONGO_READ_COMMANDS
@@ -571,6 +573,59 @@ async def test_replica_status_lag_is_null_without_primary_or_optime(
     assert members["arb:27017"]["lag_seconds"] is None
     assert members["arb:27017"]["optime_date"] is None
     assert members["arb:27017"]["last_heartbeat"] is None
+
+
+@pytest.mark.asyncio
+async def test_current_ops_omits_command_and_query_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: mongodb.current_ops returns ops but never the query-bearing fields.
+
+    The currentOp ``command`` / ``originatingCommand`` documents carry literal
+    filter values (and preserve a ``comment`` even when truncated), so the slim
+    projection strips them — mirroring ``postgres.activity``'s query-text
+    omission (:func:`test_activity_omits_query_text`).
+    """
+    admin = _FakeDb(
+        command_responses={
+            "currentOp": {
+                "inprog": [
+                    {
+                        "opid": 12345,
+                        "op": "query",
+                        "ns": "app.events",
+                        "active": True,
+                        "secs_running": 87,
+                        "microsecs_running": 87_000_000,
+                        "client": "10.0.0.5:51000",
+                        "desc": "conn42",
+                        "connectionId": 42,
+                        "planSummary": "COLLSCAN",
+                        "numYields": 3,
+                        "waitingForLock": False,
+                        "currentOpTime": "2026-08-12T10:00:00.000+00:00",
+                        # The query-bearing documents that must be stripped:
+                        "command": {"find": "events", "filter": {"token": "s3cr3t"}},
+                        "originatingCommand": {"aggregate": "events", "pipeline": []},
+                    }
+                ],
+                "ok": 1.0,
+            }
+        }
+    )
+    client = _FakeClient(default=admin)
+    _patch_client(monkeypatch, client)
+
+    result = await MongoDbConnector().current_ops(_make_operator(), _MongoTarget(), {})
+    op = result["operations"][0]
+    # The triage-safe fields survive the projection...
+    assert op["opid"] == 12345
+    assert op["secs_running"] == 87
+    assert op["ns"] == "app.events"
+    # ...but neither query-bearing document reaches the result.
+    assert "command" not in op
+    assert "originatingCommand" not in op
+    assert client.closed is True
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-mongodb.md
+++ b/docs/codebase/connectors-mongodb.md
@@ -38,7 +38,7 @@ supported client directly and pulls **no separate `motor` dependency**.
   attributes: `product="mongodb"`, `version="7"`, `impl_id="mongodb-wire"`,
   `supported_version_range=">=5,<9"`, `priority=1` (outranks a
   `GenericRestConnector` auto-shim). Owns the connect/close lifecycle
-  (`_client` async context manager), `fingerprint`, `probe`, the eight op
+  (`_client` async context manager), `fingerprint`, `probe`, the nine op
   handlers, `register_operations`, and the `execute` dispatcher shim.
 - **`MongoOp`** (`ops.py`) — frozen dataclass carrying one op's registration
   metadata. `MONGO_OPS` is the tuple the registrar walks;
@@ -62,7 +62,7 @@ supported client directly and pulls **no separate `motor` dependency**.
   (regenerated CLI snapshot at `cli/api/openapi.json`).
 - **Lifespan** — `register_mongodb_typed_operations` (queued via
   `register_typed_op_registrar`) delegates to
-  `MongoDbConnector.register_operations`, which upserts the eight descriptors
+  `MongoDbConnector.register_operations`, which upserts the nine descriptors
   into `endpoint_descriptor`. Idempotent across restarts.
 
 ### Dispatch
@@ -85,14 +85,16 @@ Ops:
 | `mongodb.count` | `estimatedDocumentCount` | fast metadata count, O(1) (`database`, `collection`) |
 | `mongodb.server_status` | `serverStatus` | slim projection (heavy sections suppressed) |
 | `mongodb.replica_status` | `hello` + `replSetGetStatus` | replica-set health + member roles + per-member `lag_seconds` (secs behind primary) |
+| `mongodb.current_ops` | `currentOp` | live in-flight ops; slim projection, `command`/`originatingCommand` query text stripped |
 
 ### Read-only enforcement (fixed command set)
 
 Unlike a SQL database there is no free-form query surface at all. Every op maps
 to exactly one command in `MONGO_READ_COMMANDS` (`listDatabases`,
 `listCollections`, `dbStats`, `collStats`, `listIndexes`, `count`,
-`serverStatus`, `buildInfo`, `hello`, `replSetGetStatus`), and no op's parameter
-schema accepts a caller-supplied command name, aggregation pipeline, filter, or
+`serverStatus`, `buildInfo`, `hello`, `replSetGetStatus`, `currentOp`), and no
+op's parameter schema accepts a caller-supplied command name, aggregation
+pipeline, filter, or
 `eval` body — the only params are `database` / `collection` selectors. Read-only
 is therefore a property of the closed command set. `assert_read_command` is a
 belt-and-suspenders check the query layer runs before every command, so a future
@@ -151,6 +153,18 @@ replication lag, and treats the standalone code-76 (`NoReplicationEnabled`) as
 - **`collStats` is deprecated** as a diagnostic command since MongoDB 6.2 but is
   still served through 8.x; if a future server removes it, `mongodb.collection_stats`
   moves to the `$collStats` aggregation stage.
+- **`mongodb.current_ops` strips the query text.** A `currentOp` operation
+  document's `command` and `originatingCommand` fields carry literal filter
+  values (and preserve a `comment` even when the command is truncated), so the op
+  returns only a curated triage-safe subset (`CURRENT_OP_SLIM_FIELDS`) — a
+  positive projection, the same discipline `postgres.activity` applies to the
+  in-flight query text, and future-proof against a new value-bearing field. It
+  issues `currentOp` with `$all: false` (excluding idle connections and internal
+  system operations; `currentOp` is deprecated as a command since 6.2 but still
+  served through 8.x), and needs the `inprog` privilege — the `clusterMonitor`
+  role `mongodb.replica_status` already assumes, so no new grant. The `$currentOp`
+  aggregation-stage variant is deliberately deferred: admitting it means adding
+  the generic `aggregate` command to the closed allowlist.
 - `serverStatus` is projected to a curated slim subset; the full internal
   metrics (`wiredTiger`, `metrics`, `locks`, `transactions`) are suppressed over
   the wire, not just dropped in code.


### PR DESCRIPTION
## Summary

- Adds **`mongodb.current_ops`**, the runtime read answering "which operations have been running longer than N seconds right now, and on which collection?" — the MongoDB counterpart to `postgres.activity`, closing a parity gap so operators stop reaching for `mongosh --eval "db.currentOp(...)"` outside MEHO's policy gate, synchronous audit, broadcast, and JSONFlux path.
- Issues the fixed `currentOp` command (`{"currentOp": 1, "$all": False}`) against the `admin` DB; `"currentOp"` is the single new entry in the closed `MONGO_READ_COMMANDS` allowlist. Needs only the `inprog` / `clusterMonitor` privilege `mongodb.replica_status` already assumes — no new grant.
- Registered under the existing `mongodb-runtime` group (blurb extended), `safety_level="safe"`, empty parameter schema — parameter-free, matching `postgres.activity`.

## Security note (goes beyond the literal AC — please review)

The task's AC said "strip the `command` field". Fresh MongoDB-docs research showed `command` is **not the only** query-bearing field a `currentOp` op document carries: `originatingCommand` embeds the *full originating query* of a `getMore` cursor op, and `query` / `comment` (preserved even when `command` is truncated) also carry literal values. A single-field drop-list would still leak the originating filter of any in-flight cursor op — defeating the exact privacy discipline the task invokes.

Following the issue's own References section (which directs this op to reuse `mongodb.server_status`'s "fetch, then keep only the triage-safe subset" shape), the op uses a **positive projection** `CURRENT_OP_SLIM_FIELDS` — keeping only the issue's enumerated safe fields. This strips `command` (AC satisfied), also strips `originatingCommand` / `query` / `comment`, and is future-proof against a new value-bearing field. `planSummary` is kept: it reports the chosen index's key pattern (field names, already public via `mongodb.indexes`), not literal query values.

## Test plan

- [x] `ruff check src/meho_backplane/connectors/mongodb/ tests/test_connectors_mongodb.py` — clean
- [x] `ruff format --check` — clean (6 files already formatted)
- [x] `mypy src/meho_backplane/connectors/mongodb/` — Success, no issues in 5 files
- [x] `pytest tests/test_connectors_mongodb.py` — **32 passed**
- [x] `code-quality.py --diff` — 0 blockers (2 pre-existing/adjacent warnings, see below)
- [x] **AC1** `"currentOp"` added to `MONGO_READ_COMMANDS` + to the closed-set assertion in `test_read_command_allowlist_is_the_closed_fixed_set`
- [x] **AC2** `fetch_current_ops` calls `assert_read_command("currentOp")` then `_admin(client).command({"currentOp": 1, "$all": False})` and returns only the projected fields (no `command`)
- [x] **AC3** `mongodb.current_ops` registered in `MONGO_OPS`: `safety_level="safe"`, empty `parameter_schema`, `mongodb-runtime` group with its `when_to_use` blurb extended
- [x] **AC4** op_id added to the closed set in `test_every_op_is_safe_read_only_with_closed_schema`
- [x] **AC5** new `test_current_ops_omits_command_and_query_text` asserts the returned op never contains `command` (or `originatingCommand`), using a fixture that includes both — mirrors `test_activity_omits_query_text`
- [x] **AC6** `docs/codebase/connectors-mongodb.md` ops table row + "Known issues / scope" note on the query-text omission
- [x] **AC7** no schema/route change (ops are `endpoint_descriptor` data rows; `mongodb` product token already registered) → CLI OpenAPI snapshot unaffected; regeneration not required (conditional AC does not fire)

## Framework research

- MongoDB `currentOp` command reference (output `inprog` array, `$all:false` default excludes idle/system ops, `command`/`originatingCommand` carry literal values, `inprog`/`clusterMonitor` privilege, deprecated 6.2 but served through 8.x): https://www.mongodb.com/docs/manual/reference/command/currentOp/
- pymongo 4.17.0 (installed) — `AsyncDatabase.command` accepts the dict-form command; introspected in-worktree.

## Out of scope (per issue)

- `killOp` (a mutating action — this connector registers no write op).
- Caller-supplied filter/pipeline params (kept parameter-free to match `postgres.activity`).
- The `$currentOp` aggregation-stage variant (would need the generic `aggregate` command admitted to the closed allowlist — deferred).
- Sharded-cluster `mongos`-level fan-out (this connector talks to one node via `directConnection=True`).

## Adjacent findings (not addressed — out of scope)

- `code-quality.py --diff` warns `ops.py` is now 417 lines (warn >400, block >600). It is a cohesive op-metadata data module, same shape as the postgres sibling; well under the block threshold.
- `PLR0911` on `queries.py:_jsonable` (10 returns) is **pre-existing** — a BSON type-dispatch normaliser I did not modify; my constant insertion only shifted its line number into the diff hunk. Project ruff (E,F) does not flag it.

> Heads-up for the merger: sibling PR #2918 (`feat/2840-mongodb-replica-lag`) touches `queries.py` / `session.py` in different regions; expect a trivial merge-serialization conflict at merge time.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2841
