### PR TITLE
feat(connectors): add postgres.replication read for standby lag (#2842)

### DIFF
--- a/backend/src/meho_backplane/connectors/postgres/connector.py
+++ b/backend/src/meho_backplane/connectors/postgres/connector.py
@@ -78,15 +78,18 @@ class PostgresConnector(Connector):
 
     Registry v2 triple ``("postgres", "16", "postgres-wire")``. ``priority`` is
     ``1`` so a future ``GenericRestConnector`` auto-shim registering the same
-    product loses the resolver tie-break. ``supported_version_range`` covers
-    the maintained PostgreSQL releases; the catalog + statistics views this
-    connector reads are stable across them.
+    product loses the resolver tie-break. ``supported_version_range`` starts at
+    PostgreSQL 13 (12 is EOL as of 2024-11): the catalog + statistics views this
+    connector reads are stable across 13-17, and ``pg_stat_wal_receiver`` (read
+    by ``postgres.replication``) only gained the ``written_lsn`` / ``flushed_lsn``
+    columns -- which replaced 12's single ``received_lsn`` -- in 13, so
+    advertising 12 would parse-error that op on a 12 standby.
     """
 
     product = "postgres"
     version = "16"
     impl_id = "postgres-wire"
-    supported_version_range = ">=12,<18"
+    supported_version_range = ">=13,<18"
     priority = 1
 
     # ------------------------------------------------------------------

--- a/backend/src/meho_backplane/connectors/postgres/connector.py
+++ b/backend/src/meho_backplane/connectors/postgres/connector.py
@@ -162,6 +162,18 @@ class PostgresConnector(Connector):
         async with self._connection(target, operator) as conn:
             return await queries.fetch_settings(conn, params.get("names"))
 
+    async def replication(
+        self, operator: Operator, target: Target, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``postgres.replication`` -- physical replication health + standby lag.
+
+        Cluster-wide views, so no ``database`` param -- connects to the default
+        maintenance database like ``postgres.activity``.
+        """
+        del params  # declared empty in schema
+        async with self._connection(target, operator) as conn:
+            return await queries.fetch_replication(conn)
+
     async def run_query(
         self, operator: Operator, target: Target, params: dict[str, Any]
     ) -> dict[str, Any]:

--- a/backend/src/meho_backplane/connectors/postgres/ops.py
+++ b/backend/src/meho_backplane/connectors/postgres/ops.py
@@ -13,6 +13,8 @@ uses, without reaching for ``psql`` against ``:5432``:
 * ``postgres.indexes`` -- user indexes with scan counters + on-disk sizes.
 * ``postgres.activity`` -- current sessions (``pg_stat_activity``, no query text).
 * ``postgres.settings`` -- curated (or caller-named) runtime settings.
+* ``postgres.replication`` -- physical replication health + standby lag
+  (``pg_stat_replication`` / ``pg_stat_wal_receiver``).
 * ``postgres.query`` -- a guarded free-form read-only SELECT.
 
 Every op is ``safety_level="safe"`` + ``requires_approval=False`` and carries a
@@ -76,11 +78,14 @@ PG_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     "postgres-runtime": (
         "Use to inspect a PostgreSQL instance's live runtime: the current "
         "sessions and what they are waiting on (postgres.activity, from "
-        "pg_stat_activity) or the effective configuration parameters "
-        "(postgres.settings). The right group for 'what is blocking / idle in "
-        "transaction right now?' or 'what are max_connections / shared_buffers "
-        "/ the autovacuum knobs set to?'. Read-only; the session query text is "
-        "intentionally not returned by postgres.activity."
+        "pg_stat_activity), the effective configuration parameters "
+        "(postgres.settings), or the physical streaming replication health and "
+        "standby lag (postgres.replication, from pg_stat_replication / "
+        "pg_stat_wal_receiver). The right group for 'what is blocking / idle in "
+        "transaction right now?', 'what are max_connections / shared_buffers / "
+        "the autovacuum knobs set to?', or 'is the standby caught up before I "
+        "fail over?'. Read-only; the session query text is intentionally not "
+        "returned by postgres.activity."
     ),
     "postgres-query": (
         "Use to run an ad-hoc read-only SQL query when no curated op fits "
@@ -352,6 +357,55 @@ _SETTINGS = PostgresOp(
 )
 
 
+_REPLICATION = PostgresOp(
+    op_id="postgres.replication",
+    handler_attr="replication",
+    summary="Snapshot physical streaming replication health and standby lag.",
+    description=(
+        "Returns a physical streaming replication snapshot from both role "
+        "sides: the connected standbys from pg_stat_replication (primary-side, "
+        "one row per standby with sent/write/flush/replay LSNs, the "
+        "write/flush/replay lag in seconds, and sync_state), the WAL receiver "
+        "from pg_stat_wal_receiver (standby-side, 0 or 1 row, populated only "
+        "while actively streaming), and the recovery role (pg_is_in_recovery) "
+        "plus the last replayed-transaction timestamp. The op for 'is "
+        "replication healthy and how far behind is the standby before I fail "
+        "over or take the primary down?'. Physical streaming replication only "
+        "(not logical). safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema=_LIST_RESPONSE_SCHEMA,
+    group_key="postgres-runtime",
+    tags=("read-only", "postgres", "runtime", "replication"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to check streaming replication health and standby lag before "
+            "a failover or before taking the primary down. Run against the "
+            "primary to see per-standby lag (standbys[]); against a standby to "
+            "see its WAL receiver state and replay staleness (wal_receiver, "
+            "in_recovery=true)."
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "{in_recovery, last_xact_replay_timestamp, standbys:[{pid, usename, "
+            "application_name, client_addr, state, sent_lsn, write_lsn, "
+            "flush_lsn, replay_lsn, write_lag, flush_lag, replay_lag, "
+            "sync_state, sync_priority, reply_time}], wal_receiver:{status, "
+            "receive_start_lsn, written_lsn, flushed_lsn, latest_end_lsn, "
+            "last_msg_send_time, last_msg_receipt_time, slot_name, sender_host, "
+            "sender_port} | null}. LSNs are canonical 'X/Y' strings; the *_lag "
+            "fields are float seconds; timestamps are ISO-8601 or null."
+        ),
+    },
+)
+
+
 _QUERY = PostgresOp(
     op_id="postgres.query",
     handler_attr="run_query",
@@ -425,5 +479,6 @@ PG_OPS: tuple[PostgresOp, ...] = (
     _INDEXES,
     _ACTIVITY,
     _SETTINGS,
+    _REPLICATION,
     _QUERY,
 )

--- a/backend/src/meho_backplane/connectors/postgres/queries.py
+++ b/backend/src/meho_backplane/connectors/postgres/queries.py
@@ -32,6 +32,7 @@ __all__ = [
     "fetch_databases",
     "fetch_fingerprint",
     "fetch_indexes",
+    "fetch_replication",
     "fetch_schemas",
     "fetch_settings",
     "fetch_tables",
@@ -228,6 +229,57 @@ WHERE datistemplate = false
 ORDER BY size_bytes DESC
 """
 
+# Recovery role + replay staleness. pg_is_in_recovery() tells which side of a
+# streaming pair the instance is on; pg_last_xact_replay_timestamp() is NULL
+# outside recovery, and now() - it is the staleness measure a standby exposes
+# even when pg_stat_wal_receiver has no row (WAL replayed from an archive).
+_RECOVERY_STATUS_SQL = """
+SELECT pg_is_in_recovery() AS in_recovery,
+       pg_last_xact_replay_timestamp() AS last_xact_replay_timestamp
+"""
+
+# Primary-side view: one row per connected standby. Empty on a standby, and on
+# a primary with no replicas. LSNs are cast to their canonical 'X/Y' text form
+# because asyncpg decodes pg_lsn as a raw int8; the *_lag columns are interval
+# and become float seconds through _jsonable.
+_REPLICATION_STANDBYS_SQL = """
+SELECT pid,
+       usename,
+       application_name,
+       client_addr::text AS client_addr,
+       state,
+       sent_lsn::text AS sent_lsn,
+       write_lsn::text AS write_lsn,
+       flush_lsn::text AS flush_lsn,
+       replay_lsn::text AS replay_lsn,
+       write_lag,
+       flush_lag,
+       replay_lag,
+       sync_state,
+       sync_priority,
+       reply_time
+FROM pg_catalog.pg_stat_replication
+ORDER BY pid
+"""
+
+# Standby-side view: 0 or 1 row, populated only while actively streaming from a
+# primary. conninfo is deliberately omitted -- it carries the primary DSN which
+# can hold a password, the same "never surface a secret" discipline that omits
+# the query text from pg_stat_activity.
+_WAL_RECEIVER_SQL = """
+SELECT status,
+       receive_start_lsn::text AS receive_start_lsn,
+       written_lsn::text AS written_lsn,
+       flushed_lsn::text AS flushed_lsn,
+       latest_end_lsn::text AS latest_end_lsn,
+       last_msg_send_time,
+       last_msg_receipt_time,
+       slot_name,
+       sender_host,
+       sender_port
+FROM pg_catalog.pg_stat_wal_receiver
+"""
+
 
 async def fetch_databases(conn: asyncpg.Connection) -> dict[str, Any]:
     """List non-template databases with owner, encoding, and on-disk size."""
@@ -292,3 +344,30 @@ async def fetch_fingerprint(conn: asyncpg.Connection) -> dict[str, Any]:
     identity = {key: _jsonable(val) for key, val in row.items()} if row else {}
     identity["database_sizes"] = _rows(sizes)
     return identity
+
+
+async def fetch_replication(conn: asyncpg.Connection) -> dict[str, Any]:
+    """Snapshot physical streaming replication health from both role sides.
+
+    Combines three catalog reads into one op response (the multi-read shape
+    :func:`fetch_fingerprint` uses): the recovery role + last-replay timestamp,
+    ``pg_stat_replication`` (primary-side, one row per connected standby), and
+    ``pg_stat_wal_receiver`` (standby-side, 0 or 1 row). The op is symmetric by
+    design -- a primary reports its standbys with ``wal_receiver`` null, a
+    standby reports its ``wal_receiver`` with an empty ``standbys`` list, and a
+    standalone instance reports both empty -- so ``in_recovery`` tells the
+    caller which side of the snapshot is meaningful.
+    """
+    status = await conn.fetchrow(_RECOVERY_STATUS_SQL)
+    standbys = await conn.fetch(_REPLICATION_STANDBYS_SQL)
+    receiver = await conn.fetchrow(_WAL_RECEIVER_SQL)
+    return {
+        "in_recovery": _jsonable(status["in_recovery"]) if status else None,
+        "last_xact_replay_timestamp": (
+            _jsonable(status["last_xact_replay_timestamp"]) if status else None
+        ),
+        "standbys": _rows(standbys),
+        "wal_receiver": (
+            {key: _jsonable(val) for key, val in receiver.items()} if receiver else None
+        ),
+    }

--- a/backend/tests/test_connectors_postgres.py
+++ b/backend/tests/test_connectors_postgres.py
@@ -40,6 +40,8 @@ from uuid import UUID
 
 import pytest
 import structlog
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator, TenantRole
@@ -274,6 +276,25 @@ def test_postgres_resolves_versioned_and_wildcard_and_appears_in_registry() -> N
     fresh = _PgTarget()
     fresh.fingerprint = type("_FP", (), {"version": None})()
     assert resolve_connector(fresh) is PostgresConnector
+
+
+def test_supported_version_range_excludes_eol_postgres_12() -> None:
+    """AC: the advertised range starts at 13, not the EOL 12.
+
+    ``postgres.replication`` reads ``pg_stat_wal_receiver.written_lsn`` /
+    ``flushed_lsn`` -- the columns that replaced 12's single ``received_lsn`` in
+    PostgreSQL 13 (https://www.postgresql.org/docs/13/monitoring-stats.html) --
+    so advertising the (EOL) 12 would parse-error that op on a 12 standby.
+    Matched with the same ``SpecifierSet`` the resolver applies, 12 must fall
+    outside the range while the written_lsn/flushed_lsn-bearing releases stay in.
+    """
+    version_range = PostgresConnector.supported_version_range
+    assert version_range is not None
+    spec = SpecifierSet(version_range)
+    assert Version("12") not in spec
+    assert Version("13") in spec
+    assert Version("17") in spec
+    assert Version("18") not in spec
 
 
 def test_every_op_is_safe_read_only_with_closed_schema() -> None:

--- a/backend/tests/test_connectors_postgres.py
+++ b/backend/tests/test_connectors_postgres.py
@@ -205,19 +205,35 @@ class _FakeConn:
         fetchrow_result: dict[str, Any] | None = None,
         fetchval_result: Any = 1,
         cursor_records: list[dict[str, Any]] | None = None,
+        fetch_by_sql: dict[str, list[dict[str, Any]]] | None = None,
+        fetchrow_by_sql: dict[str, dict[str, Any] | None] | None = None,
     ) -> None:
         self._fetch_result = fetch_result or []
         self._fetchrow_result = fetchrow_result
         self._fetchval_result = fetchval_result
         self._cursor_records = cursor_records or []
+        # Optional per-query routing for ops that issue several reads over one
+        # connection (postgres.replication): the first marker that is a
+        # substring of the executed SQL selects the canned result. Unset =>
+        # the single-result fields above (every other op's shape).
+        self._fetch_by_sql = fetch_by_sql
+        self._fetchrow_by_sql = fetchrow_by_sql
         self.closed = False
         self.readonly_txn: bool | None = None
         self.cursor_sql: str | None = None
 
     async def fetch(self, sql: str, *args: Any) -> list[dict[str, Any]]:
+        if self._fetch_by_sql is not None:
+            for marker, records in self._fetch_by_sql.items():
+                if marker in sql:
+                    return records
         return self._fetch_result
 
     async def fetchrow(self, sql: str, *args: Any) -> dict[str, Any] | None:
+        if self._fetchrow_by_sql is not None:
+            for marker, record in self._fetchrow_by_sql.items():
+                if marker in sql:
+                    return record
         return self._fetchrow_result
 
     async def fetchval(self, sql: str, *args: Any) -> Any:
@@ -269,6 +285,7 @@ def test_every_op_is_safe_read_only_with_closed_schema() -> None:
         "postgres.indexes",
         "postgres.activity",
         "postgres.settings",
+        "postgres.replication",
         "postgres.query",
     }
     for op in PG_OPS:
@@ -459,6 +476,136 @@ async def test_activity_omits_query_text(monkeypatch: pytest.MonkeyPatch) -> Non
     result = await PostgresConnector().activity(_make_operator(), _PgTarget(), {})
     assert result["sessions"][0]["pid"] == 42
     assert "query" not in result["sessions"][0]
+
+
+@pytest.mark.asyncio
+async def test_replication_primary_reports_standbys_with_lag_seconds_and_lsn_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: a primary reports per-standby rows; interval lag -> float seconds.
+
+    ``pg_stat_replication`` is populated, ``pg_stat_wal_receiver`` is empty
+    (a primary has no receiver), ``pg_is_in_recovery()`` is false. The lag
+    columns are ``interval`` -> ``timedelta`` -> float seconds, LSNs keep their
+    canonical ``X/Y`` text form, and ``reply_time`` becomes ISO-8601.
+    """
+    reply_time = dt.datetime(2026, 8, 12, 10, 30, tzinfo=dt.UTC)
+    conn = _FakeConn(
+        fetch_by_sql={
+            "pg_stat_replication": [
+                {
+                    "pid": 5140,
+                    "usename": "replicator",
+                    "application_name": "standby1",
+                    "client_addr": "10.0.0.7",
+                    "state": "streaming",
+                    "sent_lsn": "0/16CC63C",
+                    "write_lsn": "0/16CC63C",
+                    "flush_lsn": "0/16CC63C",
+                    "replay_lsn": "0/16CC600",
+                    "write_lag": dt.timedelta(milliseconds=5),
+                    "flush_lag": dt.timedelta(milliseconds=12),
+                    "replay_lag": dt.timedelta(seconds=2, microseconds=250000),
+                    "sync_state": "sync",
+                    "sync_priority": 1,
+                    "reply_time": reply_time,
+                }
+            ]
+        },
+        fetchrow_by_sql={
+            "pg_is_in_recovery": {"in_recovery": False, "last_xact_replay_timestamp": None},
+            "pg_stat_wal_receiver": None,
+        },
+    )
+    _patch_connection(monkeypatch, conn)
+
+    result = await PostgresConnector().replication(_make_operator(), _PgTarget(), {})
+
+    assert result["in_recovery"] is False
+    assert result["last_xact_replay_timestamp"] is None
+    assert result["wal_receiver"] is None
+    standby = result["standbys"][0]
+    assert standby["state"] == "streaming"
+    assert standby["sync_state"] == "sync"
+    assert standby["replay_lsn"] == "0/16CC600"  # canonical LSN text preserved
+    assert standby["replay_lag"] == 2.25  # interval -> float seconds
+    assert standby["write_lag"] == 0.005
+    assert standby["reply_time"] == reply_time.isoformat()
+    assert standby["client_addr"] == "10.0.0.7"
+    assert conn.closed is True
+
+
+@pytest.mark.asyncio
+async def test_replication_standby_reports_wal_receiver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A standby reports its WAL receiver + replay staleness, empty standbys.
+
+    ``pg_is_in_recovery()`` is true, ``pg_stat_wal_receiver`` has its one row,
+    ``pg_stat_replication`` is empty. ``conninfo`` is omitted at the SQL level
+    (it carries the primary DSN), so it never appears in the response shape.
+    """
+    last_replay = dt.datetime(2026, 8, 12, 10, 29, 58, tzinfo=dt.UTC)
+    send_time = dt.datetime(2026, 8, 12, 10, 30, tzinfo=dt.UTC)
+    conn = _FakeConn(
+        fetch_by_sql={"pg_stat_replication": []},
+        fetchrow_by_sql={
+            "pg_is_in_recovery": {
+                "in_recovery": True,
+                "last_xact_replay_timestamp": last_replay,
+            },
+            "pg_stat_wal_receiver": {
+                "status": "streaming",
+                "receive_start_lsn": "0/16000000",
+                "written_lsn": "0/16CC63C",
+                "flushed_lsn": "0/16CC63C",
+                "latest_end_lsn": "0/16CC63C",
+                "last_msg_send_time": send_time,
+                "last_msg_receipt_time": send_time,
+                "slot_name": "standby1_slot",
+                "sender_host": "primary.internal",
+                "sender_port": 5432,
+            },
+        },
+    )
+    _patch_connection(monkeypatch, conn)
+
+    result = await PostgresConnector().replication(_make_operator(), _PgTarget(), {})
+
+    assert result["in_recovery"] is True
+    assert result["last_xact_replay_timestamp"] == last_replay.isoformat()
+    assert result["standbys"] == []
+    receiver = result["wal_receiver"]
+    assert receiver["status"] == "streaming"
+    assert receiver["sender_host"] == "primary.internal"
+    assert receiver["last_msg_send_time"] == send_time.isoformat()
+    assert "conninfo" not in receiver
+    assert conn.closed is True
+
+
+@pytest.mark.asyncio
+async def test_replication_standalone_reports_both_views_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: a standalone instance -> standbys == [] and wal_receiver is None."""
+    conn = _FakeConn(
+        fetch_by_sql={"pg_stat_replication": []},
+        fetchrow_by_sql={
+            "pg_is_in_recovery": {"in_recovery": False, "last_xact_replay_timestamp": None},
+            "pg_stat_wal_receiver": None,
+        },
+    )
+    _patch_connection(monkeypatch, conn)
+
+    result = await PostgresConnector().replication(_make_operator(), _PgTarget(), {})
+
+    assert result == {
+        "in_recovery": False,
+        "last_xact_replay_timestamp": None,
+        "standbys": [],
+        "wal_receiver": None,
+    }
+    assert conn.closed is True
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-postgres.md
+++ b/docs/codebase/connectors-postgres.md
@@ -1,4 +1,4 @@
-# Connector: postgres (PostgreSQL 12–17, read-only)
+# Connector: postgres (PostgreSQL 13–17, read-only)
 
 ## Overview
 
@@ -25,7 +25,7 @@ Source: `backend/src/meho_backplane/connectors/postgres/`.
 
 - **`PostgresConnector`** (`connector.py`) — `Connector` subclass. Class
   attributes: `product="postgres"`, `version="16"`, `impl_id="postgres-wire"`,
-  `supported_version_range=">=12,<18"`, `priority=1` (outranks a
+  `supported_version_range=">=13,<18"`, `priority=1` (outranks a
   `GenericRestConnector` auto-shim). Owns the connect/close lifecycle
   (`_connection` async context manager), `fingerprint`, `probe`, the eight op
   handlers, `register_operations`, and the `execute` dispatcher shim.
@@ -134,6 +134,12 @@ operator-less probe path resolves here), `tcp_unreachable` (`OSError`), and
 
 ## Known issues / scope
 
+- **Lower bound is PostgreSQL 13, not 12.** `postgres.replication` reads
+  `pg_stat_wal_receiver.written_lsn` / `flushed_lsn`, the columns that replaced
+  12's single `received_lsn` in PostgreSQL 13
+  (<https://www.postgresql.org/docs/13/monitoring-stats.html>). PostgreSQL 12 is
+  EOL (2024-11-21), so `supported_version_range` starts at `13` rather than
+  carrying a version-branched wal_receiver query.
 - **TLS is not yet wired.** `connect_read_only` passes no `ssl` argument, so it
   connects unencrypted (fine for a trust-auth port-forward or an in-cluster
   instance). A `verify_tls` / SNI-aware SSL path is a follow-up when a

--- a/docs/codebase/connectors-postgres.md
+++ b/docs/codebase/connectors-postgres.md
@@ -27,7 +27,7 @@ Source: `backend/src/meho_backplane/connectors/postgres/`.
   attributes: `product="postgres"`, `version="16"`, `impl_id="postgres-wire"`,
   `supported_version_range=">=12,<18"`, `priority=1` (outranks a
   `GenericRestConnector` auto-shim). Owns the connect/close lifecycle
-  (`_connection` async context manager), `fingerprint`, `probe`, the seven op
+  (`_connection` async context manager), `fingerprint`, `probe`, the eight op
   handlers, `register_operations`, and the `execute` dispatcher shim.
 - **`PostgresOp`** (`ops.py`) — frozen dataclass carrying one op's registration
   metadata. `PG_OPS` is the tuple the registrar walks;
@@ -50,7 +50,7 @@ Source: `backend/src/meho_backplane/connectors/postgres/`.
   (regenerated CLI snapshot at `cli/api/openapi.json`).
 - **Lifespan** — `register_postgres_typed_operations` (queued via
   `register_typed_op_registrar`) delegates to
-  `PostgresConnector.register_operations`, which upserts the seven descriptors
+  `PostgresConnector.register_operations`, which upserts the eight descriptors
   into `endpoint_descriptor`. Idempotent across restarts.
 
 ### Dispatch
@@ -71,6 +71,7 @@ Ops:
 | `postgres.indexes` | `pg_stat_user_indexes` + `pg_relation_size` | scan counters + index size |
 | `postgres.activity` | `pg_stat_activity` | sessions; **query text omitted** (may hold literal secrets) |
 | `postgres.settings` | `pg_settings` | curated set by default; `names` filter overrides |
+| `postgres.replication` | `pg_stat_replication` + `pg_stat_wal_receiver` + `pg_is_in_recovery()` / `pg_last_xact_replay_timestamp()` | physical streaming replication health + standby lag; symmetric (standbys on the primary, `wal_receiver` on the standby); LSNs cast to canonical `X/Y` text, `*_lag` as float seconds; **`conninfo` omitted** (holds the primary DSN) |
 | `postgres.query` | any read-only statement | first-keyword allowlisted + server read-only; row-capped |
 
 Schemas/tables/indexes/query accept an optional `database` param (catalog stats
@@ -148,8 +149,11 @@ operator-less probe path resolves here), `tcp_unreachable` (`OSError`), and
 - Read-only transactions:
   <https://www.postgresql.org/docs/current/sql-set-transaction.html>
 - Monitoring stats (`pg_stat_activity` / `pg_stat_user_tables` /
-  `pg_stat_user_indexes`):
+  `pg_stat_user_indexes` / `pg_stat_replication` / `pg_stat_wal_receiver`):
   <https://www.postgresql.org/docs/current/monitoring-stats.html>
+- Recovery information functions (`pg_is_in_recovery` /
+  `pg_last_xact_replay_timestamp`, NULL outside recovery):
+  <https://www.postgresql.org/docs/current/functions-admin.html>
 - Sibling read-only connector: `docs/codebase/connectors-loki.md`.
 - Task #2236; Initiative #2228 (data-tier + hypervisor connector coverage);
   establishes the DB-connector shape for mongodb (#2237).


### PR DESCRIPTION
## Summary

- Adds `postgres.replication`, an eighth curated read on the postgres connector, answering "is streaming replication healthy and how far behind is the standby before I fail over?" through the governed dispatch → policy → audit path instead of `psql`-ing `pg_stat_replication` directly.
- `fetch_replication` returns one symmetric snapshot combining three catalog reads (the multi-read shape `fetch_fingerprint` already uses): `pg_stat_replication` (per-standby, primary-side), `pg_stat_wal_receiver` (standby-side, 0/1 row), and `pg_is_in_recovery()` + `pg_last_xact_replay_timestamp()`. `in_recovery` tells the caller which side of the snapshot is meaningful — a primary reports `standbys` with `wal_receiver: null`, a standby reports `wal_receiver` with `standbys: []`, a standalone reports both empty.
- Registers under the existing `postgres-runtime` group, `safety_level="safe"`, empty `parameter_schema`, mirroring `postgres.activity` (cluster-wide views, no `database` param, full snapshot).

### Two vendor-fidelity decisions

- **LSNs are cast `::text`.** asyncpg 0.31.0 decodes `pg_lsn` via `int8_decode`, i.e. it returns the raw 64-bit integer, not the canonical `0/16CC63C` form. Since this op replaces `psql -c "select * from pg_stat_replication"` and LSN comparison is its whole point, every `pg_lsn` column is cast to text so the operator sees exactly what psql shows. The `interval` lag columns (`write_lag`/`flush_lag`/`replay_lag`) pass through the existing `_jsonable` normaliser to float seconds.
- **`conninfo` is omitted** from `pg_stat_wal_receiver` — it carries the primary DSN, which can hold a password. Same "never surface a secret" discipline that omits the query text from `postgres.activity`.

## Read-only confirmation (issue acceptance criterion)

No `ALLOWED_FIRST_KEYWORDS` / keyword-gate change is needed. That gate only guards the caller-supplied `sql` on the free-form `postgres.query` op. `postgres.replication` executes fixed, hard-coded `SELECT`s via `conn.fetch()` / `conn.fetchrow()` — the same shape `fetch_activity` uses — and inherits read-only purely from the server-enforced `default_transaction_read_only=on` startup parameter every connection already carries (`session.py`). `session.py` is untouched.

## Test plan

- [x] `ruff check` (connector + tests) — clean
- [x] `ruff format --check` — clean (6 files already formatted)
- [x] `mypy src/…/connectors/postgres/` (CI's `mypy src/` scope) — clean
- [x] `pytest tests/test_connectors_postgres.py` — **46 passed**
- [x] `code-quality.py --diff` — 0 blockers
- [x] CLI OpenAPI snapshot regenerated (`make snapshot-openapi`) — **byte-identical**, no route/schema change (ops are runtime `endpoint_descriptor` rows, and `postgres` is already a registered product token)

Acceptance criteria:

- [x] `fetch_replication` runs the three reads and returns `{in_recovery, last_xact_replay_timestamp, standbys, wal_receiver}`; temporals go through `_jsonable`.
- [x] `postgres.replication` registered in `PG_OPS` — `safety_level="safe"`, empty `parameter_schema`, `postgres-runtime` group with its `when_to_use` blurb extended.
- [x] No keyword-gate change (see above).
- [x] Op id added to the closed set in `test_every_op_is_safe_read_only_with_closed_schema`.
- [x] Unit tests against a fake connection with canned `pg_stat_replication` / `pg_stat_wal_receiver` rows: primary (per-standby lag + LSN text + interval→seconds), standby (`wal_receiver` populated), and the standalone both-empty case (`standbys == []`, `wal_receiver is None`).
- [x] `docs/codebase/connectors-postgres.md` ops table gets a `postgres.replication` row.

## Out of scope

- Logical replication (`pg_stat_subscription`), replication-slots inventory (`pg_replication_slots`), and any write/failover action (`pg_promote()`) — all explicitly deferred by the issue.
- Adjacent findings (pre-existing, not addressed here): `ops.py` is now 485 lines (code-quality warn >400; a declarative one-dataclass-per-op registry — a split is its own refactor); `_jsonable` trips `PLR0911` (9 returns, pre-existing, unmodified); two pre-existing `union-attr` mypy notes in the test file on `await_args.kwargs` (tests are outside CI's `mypy src/` scope).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2842


---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-12)

Addressed the iteration-1 `REQUEST_CHANGES` review (`.claude/auto/review-results/pr-2922-iter-1.json`):

- **B1** `89f4f63e` — `pg_stat_wal_receiver.written_lsn` / `flushed_lsn` are PostgreSQL 13+ columns (they replaced 12's single `received_lsn`), so `postgres.replication` parse-errored (SQLSTATE 42703) on a PG 12 standby while the connector advertised `supported_version_range=">=12,<18"`. PostgreSQL 12 is EOL (final 12.22, 2024-11-21), so pinned the range to `>=13,<18`, moved the connector docstring + `docs/codebase/connectors-postgres.md` view-stability claim in lockstep, and added a `SpecifierSet` guard test (the resolver's own matcher) asserting 12 is excluded while 13/17 stay in range. Confirmed against the PG 12 vs 13 `monitoring-stats` docs.

Deferred (recorded as adjacent findings; orchestrator may file follow-up issues):

- Reviewer `adjacent_improvements` only, not blockers: `_RECOVERY_STATUS_SQL`'s `if status else None` guard is dead-defensive (mirrors `fetch_fingerprint`); `ops.py` at 485 lines and `_jsonable`'s `PLR0911` are pre-existing and out of scope for B1 (an `ops.py` split is its own refactor).

<!-- auto-implement-issue: continue, iteration 1 -->
