### PR TITLE
feat(connectors): add sddc network-pool typed read ops (#2837)

### DIFF
--- a/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/__init__.py
@@ -25,11 +25,12 @@ check there will no-op on the
 because this module has already registered the hand-rolled class. Until then,
 this module is the only registration path.
 
-Operations span two surfaces. The audited 12-read lab-audit set (#2306)
-ships as first-class **typed** ops in :mod:`.typed_ops` / :mod:`.typed_reads`
+Operations span two surfaces. The audited 12-read lab-audit set (#2306),
+extended with the network-pool pre-flight reads (#2837), ships as
+first-class **typed** ops in :mod:`.typed_ops` / :mod:`.typed_reads`
 (``source_kind="typed"``), dispatchable on a fresh boot with zero catalog
-ingest. The four non-audited reads (release, domain detail, network-pools,
-bundles) and the wider VCF API catalog arrive via G0.7 spec ingestion
+ingest. The three non-audited reads (release, domain detail, bundles) and
+the wider VCF API catalog arrive via G0.7 spec ingestion
 against the ``endpoint_descriptor`` table and stay browsable as
 profiled-dispatch breadth, enable-able through the generic review flow
 (``ReviewService.enable_reads``) — the hand-curated ingested-enable

--- a/backend/src/meho_backplane/connectors/sddc_manager/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/connector.py
@@ -71,14 +71,15 @@ unauthenticated version endpoint), so it goes through
 Operations
 ----------
 
-The audited 12-read lab-audit set (#2306) ships as **typed** ops
-(``source_kind="typed"``) via the bound-method shims below, registered
-through :mod:`meho_backplane.connectors.sddc_manager.typed_ops`; they
-dispatch on a fresh boot with zero catalog ingest. ``sddc.credential.list``
+The audited 12-read lab-audit set (#2306), extended with the network-pool
+pre-flight reads (#2837), ships as **typed** ops (``source_kind="typed"``)
+via the bound-method shims below, registered through
+:mod:`meho_backplane.connectors.sddc_manager.typed_ops`; they dispatch on
+a fresh boot with zero catalog ingest. ``sddc.credential.list``
 (``GET /v1/credentials``) is credential-read gated
 (``requires_approval=True`` + ``credential_read`` classification +
-boundary redaction). The four non-audited reads (release, domain detail,
-network-pools, bundles) and the wider ingested 375-op VCF catalog stay
+boundary redaction). The three non-audited reads (release, domain detail,
+bundles) and the wider ingested 375-op VCF catalog stay
 browsable as profiled-dispatch breadth (#2271) under their own
 ``METHOD:path`` op_ids, enable-able through the generic review flow
 (``ReviewService.enable_reads``) — two surfaces, no resolver shadowing
@@ -604,6 +605,22 @@ class SddcManagerConnector(HttpConnector):
         from meho_backplane.connectors.sddc_manager.typed_reads import sddc_nsxt_cluster_list_impl
 
         return await sddc_nsxt_cluster_list_impl(self, operator, target, params)
+
+    async def network_pool_list(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.network_pool.list`` shim (#2837)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_network_pool_list_impl
+
+        return await sddc_network_pool_list_impl(self, operator, target, params)
+
+    async def network_pool_get(
+        self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """``sddc.network_pool.get`` shim (#2837)."""
+        from meho_backplane.connectors.sddc_manager.typed_reads import sddc_network_pool_get_impl
+
+        return await sddc_network_pool_get_impl(self, operator, target, params)
 
     async def credential_list(
         self, operator: Operator, target: SddcTargetLike, params: dict[str, Any]

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
@@ -1,16 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 # code-quality-allow: declarative typed-op metadata table. This module is a
-# data file — 12 audited-read SddcTypedOp records, each a data-only value with
-# grounded operator-facing prose (summary / description / llm_instructions) the
+# data file — 14 SddcTypedOp records (the #2306 audited 12-read set plus the
+# #2837 network-pool pre-flight reads), each a data-only value with grounded
+# operator-facing prose (summary / description / llm_instructions) the
 # BM25 + embedding search surfaces read verbatim. Cyclomatic complexity is
-# trivial; the length is the 12-op catalog, not logic. Splitting the tuple
+# trivial; the length is the 14-op catalog, not logic. Splitting the tuple
 # across files fragments the single source of truth the registrar iterates.
 
 """Typed-op metadata + registrar for :class:`SddcManagerConnector` (#2306).
 
-The audited SDDC Manager read set (the #2294 12-read lab-audit surface) is
-registered as typed ops (``source_kind="typed"``) so it dispatches on a
+The audited SDDC Manager read set (the #2294 12-read lab-audit surface),
+extended with the network-pool pre-flight reads (#2837), is registered as
+typed ops (``source_kind="typed"``) so it dispatches on a
 fresh boot with **zero catalog ingest** -- the #2247 failure class the
 older ingested-row enablement was subject to
 (per-deploy catalog state). The op bodies live in
@@ -35,8 +37,8 @@ typed op carries a dotted op-id (``sddc.domain.list``) and a code
 ``handler_ref``, so it resolves through
 :func:`~meho_backplane.operations._branches.dispatch_typed`
 and never through an ``endpoint_descriptor`` ingested row (#2262). The
-four non-audited reads (releases/system, domain detail, network-pools,
-bundles) remain ingested browse breadth.
+three non-audited reads (releases/system, domain detail, bundles) remain
+ingested browse breadth.
 
 Credential-read gating (``sddc.credential.list``)
 -------------------------------------------------
@@ -126,10 +128,14 @@ SDDC_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "Use to read the VCF infrastructure inventory SDDC Manager governs: "
         "domains and their lifecycle status (sddc.domain.list / "
         "sddc.domain.status), vSphere clusters (sddc.cluster.list), ESXi "
-        "hosts (sddc.host.list), vCenters (sddc.vcenter.list), and NSX-T "
-        "clusters (sddc.nsxt_cluster.list). The right group for 'what does "
-        "this VCF stack contain' and for mapping a workload domain to its "
-        "vCenter and NSX-T cluster. Read-only."
+        "hosts (sddc.host.list), vCenters (sddc.vcenter.list), NSX-T "
+        "clusters (sddc.nsxt_cluster.list), and the network pools that back "
+        "host commissioning (sddc.network_pool.list / sddc.network_pool.get). "
+        "The right group for 'what does this VCF stack contain', for mapping "
+        "a workload domain to its vCenter and NSX-T cluster, and for the "
+        "host-commissioning IP-capacity pre-flight (does the pool's "
+        "VMOTION/vSAN network still have enough free IPs for N new hosts). "
+        "Read-only."
     ),
     _GROUP_PLATFORM: (
         "Use to read the SDDC Manager platform itself: the appliance "
@@ -441,6 +447,91 @@ _NSXT_CLUSTER_LIST = SddcTypedOp(
 
 
 # ---------------------------------------------------------------------------
+# sddc.network_pool.list
+# ---------------------------------------------------------------------------
+
+_NETWORK_POOL_LIST = SddcTypedOp(
+    op_id="sddc.network_pool.list",
+    handler_attr="network_pool_list",
+    summary="VCF network pools (IP ranges + VLANs) for host commissioning.",
+    description=(
+        "Lists the VCF network pools SDDC Manager defines for host "
+        "commissioning via GET /v1/network-pools. The entry point for the "
+        "host-commissioning IP-capacity pre-flight: pick the pool a domain "
+        "or cluster draws from, then read its per-network free-vs-used IP "
+        "counts with sddc.network_pool.get. Works with zero catalog ingest. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema=_NO_PARAMS,
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "network-pool", "inventory"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call to list network pools before commissioning hosts; pick the "
+            "pool a domain / cluster uses, then drill into its capacity with "
+            "sddc.network_pool.get."
+        ),
+        output_shape=(
+            "{elements: [{id, name, networks: [{type, vlanId}, ...]}, ...], pageMetadata}."
+        ),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# sddc.network_pool.get
+# ---------------------------------------------------------------------------
+
+_NETWORK_POOL_GET = SddcTypedOp(
+    op_id="sddc.network_pool.get",
+    handler_attr="network_pool_get",
+    summary="One network pool's networks[] with free-vs-used IP capacity.",
+    description=(
+        "Reads one network pool's detail via GET /v1/network-pools/{id}, "
+        "including its networks[] -- each network's type (VSAN / VMOTION / "
+        "...), vlanId, subnet / mask / gateway, ipPools[] ranges, and the "
+        "freeIps / usedIps lists whose lengths are the capacity an operator "
+        "confirms before commissioning N hosts. Requires a pool id from "
+        "sddc.network_pool.list. Works with zero catalog ingest. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The network-pool id (from sddc.network_pool.list).",
+            },
+        },
+        "required": ["id"],
+        "additionalProperties": False,
+    },
+    response_schema={"type": "object", "additionalProperties": True},
+    group_key=_GROUP_INVENTORY,
+    tags=("read-only", "sddc", "vcf", "network-pool", "capacity"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions=_instructions(
+        when_to_use=(
+            "Call with a pool id to check whether its VMOTION / vSAN networks "
+            "still have enough free IPs before commissioning N hosts. "
+            "free-vs-used = len(freeIps) vs len(usedIps) per network."
+        ),
+        output_shape=(
+            "{id, name, networks: [{type, vlanId, subnet, mask, gateway, "
+            "ipPools: [{start, end}], freeIps: [...], usedIps: [...]}, ...]}. "
+            "Report free/used counts per network type."
+        ),
+        parameter_hints={"id": "The network-pool id from sddc.network_pool.list."},
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
 # sddc.credential.list  (credential-read gated + redacted)
 # ---------------------------------------------------------------------------
 
@@ -659,8 +750,9 @@ _LICENSE_LIST = SddcTypedOp(
 
 
 #: The typed ops :class:`SddcManagerConnector` registers at lifespan
-#: startup -- the audited 12-read set (#2306). Ordered inventory ->
-#: credentials -> tasks -> platform to match the operator's typical path.
+#: startup -- the audited 12-read set (#2306) plus the network-pool
+#: pre-flight reads (#2837). Ordered inventory -> credentials -> tasks ->
+#: platform to match the operator's typical path.
 SDDC_TYPED_OPS: tuple[SddcTypedOp, ...] = (
     _DOMAIN_LIST,
     _DOMAIN_STATUS,
@@ -668,6 +760,8 @@ SDDC_TYPED_OPS: tuple[SddcTypedOp, ...] = (
     _HOST_LIST,
     _VCENTER_LIST,
     _NSXT_CLUSTER_LIST,
+    _NETWORK_POOL_LIST,
+    _NETWORK_POOL_GET,
     _CREDENTIAL_LIST,
     _TASK_LIST,
     _SYSTEM_INFO,

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_reads.py
@@ -24,9 +24,10 @@ calls in the connector's internal ``_get_json_with_session_retry``
 helper (that helper serves the fingerprint/probe path, which the
 dispatcher does not drive).
 
-The audited 12-read set (paths from the #2294 lab audit, cross-checked
+The typed read set -- the audited #2294 12-read lab-audit surface (#2306),
+extended with the network-pool pre-flight reads (#2837) -- cross-checked
 against the VCF / SDDC Manager 9.0 API at
-https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/):
+https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/:
 
 * ``sddc.domain.list`` -- ``GET /v1/domains`` (management + workload
   domain inventory).
@@ -40,6 +41,11 @@ https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/):
   inventory; optional ``domainId`` filter).
 * ``sddc.nsxt_cluster.list`` -- ``GET /v1/nsxt-clusters`` (NSX-T manager
   cluster inventory).
+* ``sddc.network_pool.list`` -- ``GET /v1/network-pools`` (network-pool
+  inventory for host commissioning).
+* ``sddc.network_pool.get`` -- ``GET /v1/network-pools/{id}`` (one pool's
+  ``networks[]`` with per-network free/used IP capacity, the
+  host-commissioning IP-capacity pre-flight).
 * ``sddc.credential.list`` -- ``GET /v1/credentials`` (nested-infra
   credential inventory). **Credential-read gated** (#2306): dispatch
   routes through the approval queue (``requires_approval=True``) and the
@@ -80,6 +86,8 @@ __all__ = [
     "sddc_host_list_impl",
     "sddc_license_list_impl",
     "sddc_manager_list_impl",
+    "sddc_network_pool_get_impl",
+    "sddc_network_pool_list_impl",
     "sddc_nsxt_cluster_list_impl",
     "sddc_system_info_impl",
     "sddc_task_list_impl",
@@ -105,6 +113,8 @@ _SYSTEM_PATH = "/v1/system"
 _VCF_SERVICES_PATH = "/v1/vcf-services"
 _SDDC_MANAGERS_PATH = "/v1/sddc-managers"
 _LICENSE_KEYS_PATH = "/v1/license-keys"
+_NETWORK_POOLS_PATH = "/v1/network-pools"
+_NETWORK_POOL_GET_PATH = "/v1/network-pools/{id}"
 
 #: Sentinel written in place of a scrubbed secret value. A non-empty
 #: marker (rather than dropping the key) keeps the shape stable so the
@@ -282,6 +292,45 @@ async def sddc_nsxt_cluster_list_impl(
     """
     del params  # schema declares the param object empty
     return await connector._get_json(target, _NSXT_CLUSTERS_PATH, operator=operator)
+
+
+async def sddc_network_pool_list_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.network_pool.list`` -- ``GET /v1/network-pools``.
+
+    Lists the VCF network pools SDDC Manager defines for host
+    commissioning as a paginated ``{elements: [...]}`` envelope. The entry
+    point for the host-commissioning IP-capacity pre-flight: pick the pool
+    a domain / cluster draws from, then read its per-network free-vs-used
+    IP counts with ``sddc.network_pool.get``.
+    """
+    del params  # schema declares the param object empty
+    return await connector._get_json(target, _NETWORK_POOLS_PATH, operator=operator)
+
+
+async def sddc_network_pool_get_impl(
+    connector: SddcManagerConnector,
+    operator: Operator,
+    target: SddcTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """``sddc.network_pool.get`` -- ``GET /v1/network-pools/{id}``.
+
+    Reads one network pool's detail, including its ``networks[]`` -- each
+    network's ``type`` (VSAN / VMOTION / ...), ``vlanId``, ``subnet`` /
+    ``mask`` / ``gateway``, the ``ipPools[]`` ranges, and the ``freeIps``
+    / ``usedIps`` lists whose lengths are the free-vs-used capacity an
+    operator confirms before commissioning N hosts. Requires a pool ``id``
+    from ``sddc.network_pool.list``. The vendor payload is returned intact
+    -- no capacity field is dropped or reshaped.
+    """
+    pool_id = params["id"]
+    path = _NETWORK_POOL_GET_PATH.format(id=pool_id)
+    return await connector._get_json(target, path, operator=operator)
 
 
 async def sddc_credential_list_impl(

--- a/backend/tests/acceptance/_sddc_canary_fixtures.py
+++ b/backend/tests/acceptance/_sddc_canary_fixtures.py
@@ -7,10 +7,10 @@ Two SDDC Manager acceptance modules (dispatch smoke + JSONFlux force-handle)
 share the same plumbing: a registered
 :class:`~meho_backplane.connectors.sddc_manager.SddcManagerConnector` instance
 with a stub credentials loader (so no Vault read is required), a probed
-:class:`~meho_backplane.db.models.Target` row, the 4 ingested browse-breadth
+:class:`~meho_backplane.db.models.Target` row, the 3 ingested browse-breadth
 :class:`~meho_backplane.db.models.EndpointDescriptor` rows from
 :data:`_SDDC_SEED_OPS`, and a :mod:`respx`-mocked SDDC Manager REST surface
-answering each of the 4 read ops.
+answering each of the 3 read ops.
 
 SDDC Manager is token-only: the connector establishes a session at
 ``POST /v1/tokens`` (the ``session_login_token`` scheme, #2290) and sends the
@@ -25,7 +25,7 @@ Why a minimal direct-insert path (not full G0.7 canary ingest)
 The full VCF API spec ingest needs the SDDC Manager 9.0 OpenAPI spec file
 reachable on the CI runner. Until the spec-shelf is wired to the
 meho-runners pool, the dispatch leg is exercised against a minimal
-direct-insert path that seeds the 4 curated endpoint_descriptor rows (plus
+direct-insert path that seeds the 3 curated endpoint_descriptor rows (plus
 the hosts breadth row the JSONFlux test dispatches) by
 hand. Same pattern :mod:`tests.acceptance._nsx_canary_fixtures` established
 for NSX (which also has no public CI simulator).
@@ -288,15 +288,18 @@ class IngestedSddcCanary:
 
 
 #: Ingested browse-breadth seed data for the SDDC Manager dispatch canary —
-#: the four ``source_kind="ingested"`` read ops (and their four groups)
-#: declined from typed conversion on #2306 but kept browsable. Relocated here
-#: from the retired ``sddc_manager.core_ops`` curation apparatus (#2358): this
-#: is test-only fixture material describing the ``EndpointDescriptor`` rows the
-#: dispatch tests seed and mock. ``(group_key, name, when_to_use)``.
+#: the three ``source_kind="ingested"`` read ops (and their three groups) that
+#: have no typed equivalent (release, domain detail, bundles), kept browsable.
+#: Network pools left this ingested-only set when #2837 promoted them to typed
+#: ops (hosts + domain list did the same on #2306); the ingested
+#: ``GET:/v1/network-pools`` row still exists as browse breadth but is no longer
+#: seeded here. Relocated here from the retired ``sddc_manager.core_ops``
+#: curation apparatus (#2358): this is test-only fixture material describing the
+#: ``EndpointDescriptor`` rows the dispatch tests seed and mock.
+#: ``(group_key, name, when_to_use)``.
 _SDDC_SEED_GROUPS: tuple[tuple[str, str, str], ...] = (
     ("sddc-releases", "SDDC Manager (release)", "Appliance release / BOM version info."),
     ("sddc-domains", "VCF Domains", "Management + workload domain inventory."),
-    ("sddc-network-pools", "VCF Network Pools", "Network pool inventory."),
     ("sddc-bundles", "VCF LCM Bundles", "Lifecycle-manager upgrade bundles."),
 )
 
@@ -304,7 +307,6 @@ _SDDC_SEED_GROUPS: tuple[tuple[str, str, str], ...] = (
 _SDDC_SEED_OPS: tuple[tuple[str, str], ...] = (
     ("GET:/v1/releases/system", "sddc-releases"),
     ("GET:/v1/domains/{id}", "sddc-domains"),
-    ("GET:/v1/network-pools", "sddc-network-pools"),
     ("GET:/v1/bundles", "sddc-bundles"),
 )
 
@@ -314,7 +316,7 @@ SDDC_CANARY_CORE_OP_IDS: tuple[str, ...] = tuple(op_id for op_id, _ in _SDDC_SEE
 
 
 async def _insert_sddc_descriptors(*, enabled: bool = True) -> None:
-    """Seed the 4 ingested SDDC Manager browse-breadth ops + their groups.
+    """Seed the 3 ingested SDDC Manager browse-breadth ops + their groups.
 
     One :class:`OperationGroup` per entry in :data:`_SDDC_SEED_GROUPS`,
     one :class:`EndpointDescriptor` per entry in :data:`_SDDC_SEED_OPS`
@@ -496,7 +498,7 @@ async def ingested_sddc_canary(
     Setup mirrors :func:`tests.acceptance._nsx_canary_fixtures.ingested_nsx_canary`:
 
     1. Insert built-in :class:`OperationGroup` + :class:`EndpointDescriptor`
-       rows for the 4 curated SDDC Manager core ops (plus the hosts breadth row).
+       rows for the 3 curated SDDC Manager core ops (plus the hosts breadth row).
     2. Seed a :class:`Target` with ``product="sddc"`` and the
        :data:`SDDC_CANARY_FINGERPRINT` so the resolver binds
        :class:`SddcManagerConnector`.

--- a/backend/tests/test_connectors_sddc_manager_e2e.py
+++ b/backend/tests/test_connectors_sddc_manager_e2e.py
@@ -222,8 +222,8 @@ async def sddc_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_SddcE2EB
 # ---------------------------------------------------------------------------
 
 _OP_IDS: tuple[str, ...] = SDDC_CANARY_CORE_OP_IDS
-assert len(_OP_IDS) == 4, (
-    f"Expected 4 ingested SDDC Manager browse ops, got {len(_OP_IDS)}: {_OP_IDS}"
+assert len(_OP_IDS) == 3, (
+    f"Expected 3 ingested SDDC Manager browse ops, got {len(_OP_IDS)}: {_OP_IDS}"
 )
 
 
@@ -232,10 +232,11 @@ async def test_sddc_e2e_all_ops_dispatch_ok(
     op_id: str,
     sddc_e2e_canary: _SddcE2EBundle,
 ) -> None:
-    """All 4 curated SDDC Manager ingested ops dispatch through the full dispatcher (status='ok').
+    """All 3 curated SDDC Manager ingested ops dispatch through the full dispatcher (status='ok').
 
-    The audited 12-read operational set is now typed ops (#2306); these 4
-    are the browse-breadth curation left in ``core_ops.py``.
+    The audited 12-read operational set is now typed ops (#2306), and network
+    pools joined the typed surface in #2837; these 3 are the browse-breadth
+    reads with no typed equivalent (release, domain detail, bundles).
 
     The connector mints a session token at ``POST /v1/tokens`` from the stub
     credentials loader on first dispatch (then caches both the credentials and
@@ -300,7 +301,7 @@ async def test_sddc_e2e_credentials_cached_after_first_dispatch(
         _OPERATOR,
         {
             "connector_id": SDDC_CONNECTOR_ID,
-            "op_id": "GET:/v1/network-pools",
+            "op_id": "GET:/v1/bundles",
             "target": {"name": target_name},
             "params": {},
         },
@@ -326,7 +327,7 @@ async def test_sddc_e2e_dispatch_writes_audit_row(
     * ``row.payload["op_id"]`` equals the dispatched ``op_id``.
     * ``row.payload["params_hash"]`` is present (non-None string).
     """
-    op_id = "GET:/v1/network-pools"
+    op_id = "GET:/v1/bundles"
     sessionmaker = get_sessionmaker()
 
     async def _count_dispatch_rows() -> int:
@@ -465,7 +466,7 @@ async def test_sddc_ingest_enable_reads_dispatch_round_trip(
     await _seed_target()
     instance = _resolve_connector()
 
-    op_id = "GET:/v1/network-pools"
+    op_id = "GET:/v1/bundles"
     async with respx.mock(
         base_url=SDDC_CANARY_BASE_URL,
         assert_all_called=False,

--- a/backend/tests/test_connectors_sddc_manager_typed_reads.py
+++ b/backend/tests/test_connectors_sddc_manager_typed_reads.py
@@ -21,9 +21,14 @@ Coverage matrix (per Task #2306 acceptance criteria):
   downstream GET is recovered by the dispatcher's auth-class arm calling
   the connector's public ``invalidate_session`` hook (#2290) and
   re-dispatching once; the op returns ``status="ok"``.
-* **Registration-shape invariants.** The 11 non-gated reads carry
+* **Registration-shape invariants.** The 13 non-gated reads carry
   ``safety_level="safe"``, ``requires_approval=False``, a ``read-only``
   tag, and non-empty llm_instructions; no write op is registered.
+
+The network-pool pre-flight reads (``sddc.network_pool.list`` /
+``sddc.network_pool.get``, #2837) ride the same AC #1 zero-catalog typed
+dispatch shape; ``.get`` additionally asserts id-substitution and that the
+``networks[]`` free/used IP-capacity fields pass through intact.
 
 Mirrors :mod:`tests.test_connectors_nsx_typed_reads` for the dispatch
 lifecycle + embedding stub and
@@ -193,6 +198,7 @@ _SYSTEM_PAYLOAD: dict[str, Any] = {"proxyConfiguration": {"isEnabled": False}}
         ("sddc.host.list", "/v1/hosts"),
         ("sddc.vcenter.list", "/v1/vcenters"),
         ("sddc.nsxt_cluster.list", "/v1/nsxt-clusters"),
+        ("sddc.network_pool.list", "/v1/network-pools"),
         ("sddc.task.list", "/v1/tasks"),
         ("sddc.system.info", "/v1/system"),
         ("sddc.vcf_service.list", "/v1/vcf-services"),
@@ -252,6 +258,77 @@ async def test_domain_status_builds_path_from_id(
 
     assert result.status == "ok", result.error
     assert result.result == {"status": "ACTIVE"}
+    assert route.called and route.call_count == 1
+
+
+#: A network-pool detail payload with the VCF ``networks[]`` capacity shape
+#: (Broadcom VCF API: type / vlanId / subnet / mask / gateway / ipPools /
+#: freeIps / usedIps). Free-vs-used capacity is ``len(freeIps)`` vs
+#: ``len(usedIps)`` per network -- the pre-flight the operator runs.
+_NETWORK_POOL_DETAIL: dict[str, Any] = {
+    "id": "np-01",
+    "name": "sfo-m01-np01",
+    "networks": [
+        {
+            "id": "net-vmotion",
+            "type": "VMOTION",
+            "vlanId": 1612,
+            "mtu": 9000,
+            "subnet": "172.16.12.0",
+            "mask": "255.255.255.0",
+            "gateway": "172.16.12.1",
+            "ipPools": [{"start": "172.16.12.101", "end": "172.16.12.108"}],
+            "freeIps": ["172.16.12.105", "172.16.12.106", "172.16.12.107", "172.16.12.108"],
+            "usedIps": ["172.16.12.101", "172.16.12.102", "172.16.12.103", "172.16.12.104"],
+        },
+        {
+            "id": "net-vsan",
+            "type": "VSAN",
+            "vlanId": 1613,
+            "mtu": 9000,
+            "subnet": "172.16.13.0",
+            "mask": "255.255.255.0",
+            "gateway": "172.16.13.1",
+            "ipPools": [{"start": "172.16.13.101", "end": "172.16.13.108"}],
+            "freeIps": ["172.16.13.105", "172.16.13.106", "172.16.13.107", "172.16.13.108"],
+            "usedIps": ["172.16.13.101", "172.16.13.102", "172.16.13.103", "172.16.13.104"],
+        },
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_network_pool_get_builds_path_from_id_and_passes_capacity_through(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+) -> None:
+    """#2837: sddc.network_pool.get interpolates the pool id and returns the
+    networks[] free/used IP-capacity fields intact (pass-through handler)."""
+    await _register_and_resolve(_stub_embedding)
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
+        route = mock.get("/v1/network-pools/np-01").respond(200, json=_NETWORK_POOL_DETAIL)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=SDDC_CONNECTOR_ID,
+            op_id="sddc.network_pool.get",
+            target=_SddcReadTarget(),
+            params={"id": "np-01"},
+        )
+
+    assert result.status == "ok", result.error
+    # The whole vendor payload passes through untouched -- no capacity field
+    # is dropped or reshaped at the connector boundary.
+    assert result.result == _NETWORK_POOL_DETAIL
+    vmotion = result.result["networks"][0]
+    assert vmotion["type"] == "VMOTION"
+    assert vmotion["gateway"] == "172.16.12.1"
+    assert vmotion["ipPools"] == [{"start": "172.16.12.101", "end": "172.16.12.108"}]
+    # free-vs-used capacity survives so the pre-flight can count it.
+    assert len(vmotion["freeIps"]) == 4
+    assert len(vmotion["usedIps"]) == 4
+    # The id was path-substituted, not sent as a query param.
     assert route.called and route.call_count == 1
 
 
@@ -481,6 +558,8 @@ _EXPECTED_OP_IDS = {
     "sddc.host.list",
     "sddc.vcenter.list",
     "sddc.nsxt_cluster.list",
+    "sddc.network_pool.list",
+    "sddc.network_pool.get",
     "sddc.credential.list",
     "sddc.task.list",
     "sddc.system.info",

--- a/cli/internal/cmd/sddc-manager/network_pool.go
+++ b/cli/internal/cmd/sddc-manager/network_pool.go
@@ -17,10 +17,11 @@ import (
 func newNetworkPoolCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "network-pool",
-		Short:        "VCF network pool operations",
+		Short:        "VCF network pool operations (list / get)",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newNetworkPoolListCmd())
+	cmd.AddCommand(newNetworkPoolGetCmd())
 	return cmd
 }
 
@@ -33,7 +34,7 @@ func newNetworkPoolListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List VCF network pools (IP ranges and VLANs for host commission)",
-		Long: "list dispatches GET:/v1/network-pools against connector_id=\"sddc-rest-9.0\".\n\n" +
+		Long: "list dispatches sddc.network_pool.list against connector_id=\"sddc-rest-9.0\".\n\n" +
 			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
 		Example:       "  meho sddc-manager network-pool list --target rdc-sddc-manager",
 		Args:          cobra.NoArgs,
@@ -55,17 +56,17 @@ func runNetworkPoolList(cmd *cobra.Command, targetName string, jsonOut bool, bac
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/network-pools", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "sddc.network_pool.list", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return conn.Render(cmd, "GET:/v1/network-pools", r, jsonOut, printNetworkPoolList)
+	return conn.Render(cmd, "sddc.network_pool.list", r, jsonOut, printNetworkPoolList)
 }
 
 func printNetworkPoolList(w io.Writer, r *CallResult) {
 	entries, err := decodeElementsResult(r.Result)
 	if err != nil || r.Status != "ok" {
-		conn.PrintGeneric(w, "GET:/v1/network-pools", r)
+		conn.PrintGeneric(w, "sddc.network_pool.list", r)
 		return
 	}
 	fmt.Fprintf(w, "VCF network pools (%d)\n", len(entries))
@@ -79,5 +80,83 @@ func printNetworkPoolList(w io.Writer, r *CallResult) {
 			truncate(sddcStringField(e, "id"), 36),
 			sddcStringField(e, "name"),
 		)
+	}
+}
+
+func newNetworkPoolGetCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "get <network-pool-id>",
+		Short: "Show one network pool's networks with free/used IP capacity",
+		Long: "get dispatches sddc.network_pool.get against connector_id=\"sddc-rest-9.0\".\n" +
+			"Requires a pool id from `sddc-manager network-pool list`. This is the\n" +
+			"host-commissioning IP-capacity pre-flight: free/used = free vs used IP\n" +
+			"counts per VMOTION/vSAN network.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example:       "  meho sddc-manager network-pool get np-01 --target rdc-sddc-manager",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runNetworkPoolGet(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "SDDC Manager target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runNetworkPoolGet(cmd *cobra.Command, poolID, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
+	}
+	params := map[string]any{"id": poolID}
+	r, err := conn.Call(cmd.Context(), backplaneURL, "sddc.network_pool.get", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return conn.Render(cmd, "sddc.network_pool.get", r, jsonOut, printNetworkPoolGet)
+}
+
+func printNetworkPoolGet(w io.Writer, r *CallResult) {
+	if r.Status != "ok" {
+		conn.PrintGeneric(w, "sddc.network_pool.get", r)
+		return
+	}
+	var p struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		Networks []struct {
+			Type    string `json:"type"`
+			VlanID  int    `json:"vlanId"`
+			Subnet  string `json:"subnet"`
+			Mask    string `json:"mask"`
+			Gateway string `json:"gateway"`
+			IPPools []struct {
+				Start string `json:"start"`
+				End   string `json:"end"`
+			} `json:"ipPools"`
+			FreeIps []string `json:"freeIps"`
+			UsedIps []string `json:"usedIps"`
+		} `json:"networks"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &p); err != nil || p.ID == "" {
+		conn.PrintGeneric(w, "sddc.network_pool.get", r)
+		return
+	}
+	fmt.Fprintf(w, "network pool: %s (%s) — %d network(s)\n", p.Name, p.ID, len(p.Networks))
+	for _, n := range p.Networks {
+		fmt.Fprintf(w, "  %-9s vlan=%-5d subnet=%s/%s gw=%s  free=%d used=%d\n",
+			n.Type, n.VlanID, n.Subnet, n.Mask, n.Gateway, len(n.FreeIps), len(n.UsedIps))
+		for _, pool := range n.IPPools {
+			fmt.Fprintf(w, "      ip-pool: %s - %s\n", pool.Start, pool.End)
+		}
 	}
 }

--- a/cli/internal/cmd/sddc-manager/sddc_manager.go
+++ b/cli/internal/cmd/sddc-manager/sddc_manager.go
@@ -13,7 +13,8 @@
 //   - `meho sddc-manager domain info <id> [--target T]`     — GET:/v1/domains/{id}
 //   - `meho sddc-manager cluster list [--domain D] [--target T]`   — GET:/v1/clusters
 //   - `meho sddc-manager host list [--domain D] [--cluster C] [--target T]` — GET:/v1/hosts
-//   - `meho sddc-manager network-pool list [--target T]`    — GET:/v1/network-pools
+//   - `meho sddc-manager network-pool list [--target T]`    — sddc.network_pool.list
+//   - `meho sddc-manager network-pool get <id> [--target T]` — sddc.network_pool.get
 //   - `meho sddc-manager bundle list [--target T]`          — GET:/v1/bundles
 //   - `meho sddc-manager workflow list [--status S] [--target T]`  — GET:/v1/tasks
 //   - `meho sddc-manager operation search/call`             — meta-tool wrappers

--- a/cli/internal/cmd/sddc-manager/sddc_manager_test.go
+++ b/cli/internal/cmd/sddc-manager/sddc_manager_test.go
@@ -293,6 +293,32 @@ func TestPrintNetworkPoolList(t *testing.T) {
 	}
 }
 
+func TestPrintNetworkPoolGet(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"id":"np-01","name":"sfo-m01-np01","networks":[{"type":"VMOTION","vlanId":1612,"subnet":"172.16.12.0","mask":"255.255.255.0","gateway":"172.16.12.1","ipPools":[{"start":"172.16.12.101","end":"172.16.12.108"}],"freeIps":["172.16.12.105","172.16.12.106","172.16.12.107","172.16.12.108"],"usedIps":["172.16.12.101","172.16.12.102","172.16.12.103","172.16.12.104"]}]}`),
+		DurationMs: 5.0,
+	}
+	var buf bytes.Buffer
+	printNetworkPoolGet(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"np-01", "sfo-m01-np01", "VMOTION", "1612", "172.16.12.1", "free=4", "used=4", "172.16.12.101 - 172.16.12.108"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printNetworkPoolGet missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintNetworkPoolGetErrorFallsBackToGeneric(t *testing.T) {
+	errMsg := "network pool not found"
+	r := &CallResult{Status: "error", OpID: "sddc.network_pool.get", Error: &errMsg}
+	var buf bytes.Buffer
+	printNetworkPoolGet(&buf, r)
+	if !strings.Contains(buf.String(), "network pool not found") {
+		t.Errorf("error path should surface the error; got:\n%s", buf.String())
+	}
+}
+
 func TestPrintBundleList(t *testing.T) {
 	r := &CallResult{
 		Status:     "ok",
@@ -517,6 +543,41 @@ func TestDispatchDomainInfoSendsIDParam(t *testing.T) {
 	}
 }
 
+// TestDispatchNetworkPoolGetSendsIDParam — network-pool get verb passes id in
+// params so the backend substitutes it into GET /v1/network-pools/{id}, and
+// dispatches the typed op_id.
+func TestDispatchNetworkPoolGetSendsIDParam(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			poolID, _ := body.Params["id"].(string)
+			if poolID != "np-01" {
+				t.Errorf("id param: got %q want %q", poolID, "np-01")
+			}
+			if body.OpID != "sddc.network_pool.get" {
+				t.Errorf("op_id: got %q want sddc.network_pool.get", body.OpID)
+			}
+			if body.ConnectorID != "sddc-rest-9.0" {
+				t.Errorf("connector_id: got %q want sddc-rest-9.0", body.ConnectorID)
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID,
+				Result: json.RawMessage(`{"id":"np-01","name":"np","networks":[]}`)})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	params := map[string]any{"id": "np-01"}
+	if _, err := conn.Call(context.Background(), srv.URL, "sddc.network_pool.get", "rdc-sddc", params); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
 // TestDispatchWorkflowListSendsStatusFilter — workflow list passes status in params.
 func TestDispatchWorkflowListSendsStatusFilter(t *testing.T) {
 	srv := mockBackplane(t, map[string]mockHandler{
@@ -614,6 +675,26 @@ func TestDomainSubtreeAssemblesAllVerbs(t *testing.T) {
 	t.Fatalf("domain sub-tree not found")
 }
 
+// TestNetworkPoolSubtreeAssemblesAllVerbs pins the `sddc-manager network-pool` sub-tree.
+func TestNetworkPoolSubtreeAssemblesAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	for _, c := range root.Commands() {
+		if c.Name() == "network-pool" {
+			subnames := map[string]bool{}
+			for _, sub := range c.Commands() {
+				subnames[sub.Name()] = true
+			}
+			for _, want := range []string{"list", "get"} {
+				if !subnames[want] {
+					t.Errorf("network-pool sub-tree missing %q; got %v", want, subnames)
+				}
+			}
+			return
+		}
+	}
+	t.Fatalf("network-pool sub-tree not found")
+}
+
 // TestOperationSubtreeAssemblesAllVerbs pins the `sddc-manager operation` sub-tree.
 func TestOperationSubtreeAssemblesAllVerbs(t *testing.T) {
 	root := NewRootCmd()
@@ -637,7 +718,7 @@ func TestOperationSubtreeAssemblesAllVerbs(t *testing.T) {
 // TestFlatListVerbsHaveListSubcommand pins single-verb sub-trees.
 func TestFlatListVerbsHaveListSubcommand(t *testing.T) {
 	root := NewRootCmd()
-	for _, parent := range []string{"manager", "cluster", "host", "network-pool", "bundle", "workflow"} {
+	for _, parent := range []string{"manager", "cluster", "host", "bundle", "workflow"} {
 		found := false
 		for _, c := range root.Commands() {
 			if c.Name() != parent {

--- a/cli/internal/cmd/sddc-manager/typed_opid_dispatch_test.go
+++ b/cli/internal/cmd/sddc-manager/typed_opid_dispatch_test.go
@@ -24,6 +24,17 @@ func TestRepointedVerbsDispatchTypedOpIDs(t *testing.T) {
 	}{
 		{name: "domain list", args: []string{"domain", "list"}, wantOp: "sddc.domain.list"},
 		{name: "manager list", args: []string{"manager", "list"}, wantOp: "sddc.manager.list"},
+		{name: "network-pool list", args: []string{"network-pool", "list"}, wantOp: "sddc.network_pool.list"},
+		{
+			name:   "network-pool get",
+			args:   []string{"network-pool", "get", "np-01"},
+			wantOp: "sddc.network_pool.get",
+			checkParam: func(t *testing.T, p map[string]any) {
+				if p["id"] != "np-01" {
+					t.Errorf("network-pool get: id param not forwarded; got %v", p)
+				}
+			},
+		},
 		{
 			name:   "cluster list",
 			args:   []string{"cluster", "list", "--domain", "domain-mgmt"},

--- a/docs/codebase/connectors-sddc-manager.md
+++ b/docs/codebase/connectors-sddc-manager.md
@@ -17,10 +17,12 @@ fresh boot with zero catalog ingest. This is now the documented operational
 surface; the wider ingested VCF catalog stays as profiled-dispatch breadth
 (#2271) under its own `METHOD:path` op_ids (two surfaces, no resolver
 shadowing — typed ops never resolve through `endpoint_descriptor` rows, #2262).
-The four non-audited reads (release, domain detail, network-pools, bundles) and
-the wider VCF catalog stay as ordinary `source_kind="ingested"` breadth, enabled
-generically through `ReviewService.enable_reads`. The hand-curated
-ingested-enable apparatus (`core_ops.py`) was retired in #2358 (T7 of #2266).
+The network-pool reads were promoted to typed ops in #2837 (host-commissioning
+IP-capacity pre-flight); the three remaining non-audited reads (release, domain
+detail, bundles) and the wider VCF catalog stay as ordinary
+`source_kind="ingested"` breadth, enabled generically through
+`ReviewService.enable_reads`. The hand-curated ingested-enable apparatus
+(`core_ops.py`) was retired in #2358 (T7 of #2266).
 
 Source: `backend/src/meho_backplane/connectors/sddc_manager/`.
 
@@ -146,7 +148,8 @@ client.
 
 ## `typed_ops.py` / `typed_reads.py` — typed read surface (#2306)
 
-The audited 12-read lab-audit set ships as typed ops. `typed_reads.py` holds
+The audited 12-read lab-audit set, plus the network-pool pre-flight reads added
+in #2837, ships as typed ops. `typed_reads.py` holds
 the async handler bodies (each issues one `connector._get_json(...)` on the
 token session); `connector.py` exposes them as thin bound-method shims
 (`domain_list`, `credential_list`, …) so the dispatcher's `import_handler`
@@ -165,6 +168,8 @@ dispatcher's #2067 recovery arm, which calls the connector's public
 | `sddc.host.list` | `sddc-inventory` | `GET /v1/hosts` |
 | `sddc.vcenter.list` | `sddc-inventory` | `GET /v1/vcenters` |
 | `sddc.nsxt_cluster.list` | `sddc-inventory` | `GET /v1/nsxt-clusters` |
+| `sddc.network_pool.list` | `sddc-inventory` | `GET /v1/network-pools` |
+| `sddc.network_pool.get` | `sddc-inventory` | `GET /v1/network-pools/{id}` |
 | `sddc.credential.list` | `sddc-credentials` | `GET /v1/credentials` |
 | `sddc.task.list` | `sddc-tasks-typed` | `GET /v1/tasks` |
 | `sddc.system.info` | `sddc-platform` | `GET /v1/system` |
@@ -181,17 +186,17 @@ not dispatchable without operator approval), the op-id is on
 `credential_read` and audit/broadcast rows collapse to aggregate-only), and the
 handler scrubs every secret-keyed value at the connector boundary
 (`_redact_secrets`). Three layers; no secret ever rides the result. `safety_level`
-is `caution`; the other 11 reads are `safe` / no-approval.
+is `caution`; the other 13 reads are `safe` / no-approval.
 
 ## Ingested breadth + read enablement
 
 The audited operational reads (domains list + status, clusters, hosts, vcenters,
-nsxt-clusters, credentials, tasks, system, vcf-services, sddc-managers,
-license-keys) are typed ops (see the typed read surface above) and dispatch on a
-fresh boot with zero catalog state.
+nsxt-clusters, network pools list + detail, credentials, tasks, system,
+vcf-services, sddc-managers, license-keys) are typed ops (see the typed read
+surface above) and dispatch on a fresh boot with zero catalog state.
 
-The four non-audited reads (`GET:/v1/releases/system`, `GET:/v1/domains/{id}`,
-`GET:/v1/network-pools`, `GET:/v1/bundles`) and the wider VCF API catalog land as
+The three non-audited reads (`GET:/v1/releases/system`, `GET:/v1/domains/{id}`,
+`GET:/v1/bundles`) and the wider VCF API catalog land as
 ordinary `source_kind="ingested"` `endpoint_descriptor` rows via G0.7 spec
 ingestion and stay browsable as profiled-dispatch breadth. They are enabled
 through the **generic review flow** — `ReviewService.enable_reads(connector_id,
@@ -235,7 +240,8 @@ so all list-verb printers share the same decode path.
 | `domain.go` | `meho sddc-manager domain info <id>` | `GET:/v1/domains/{id}` |
 | `cluster.go` | `meho sddc-manager cluster list [--domain <id>]` | `GET:/v1/clusters` |
 | `host.go` | `meho sddc-manager host list [--domain <id>] [--cluster <id>]` | `GET:/v1/hosts` |
-| `network_pool.go` | `meho sddc-manager network-pool list` | `GET:/v1/network-pools` |
+| `network_pool.go` | `meho sddc-manager network-pool list` | `sddc.network_pool.list` |
+| `network_pool.go` | `meho sddc-manager network-pool get <id>` | `sddc.network_pool.get` |
 | `bundle.go` | `meho sddc-manager bundle list` | `GET:/v1/bundles` |
 | `workflow.go` | `meho sddc-manager workflow list [--status <state>]` | `GET:/v1/tasks` |
 | `operation.go` | `meho sddc-manager operation search <query>` | `GET /api/v1/operations/search` |
@@ -244,11 +250,14 @@ so all list-verb printers share the same decode path.
 All verbs share `--target`, `--json`, and `--backplane` flags. The
 `--backplane` flag defaults to the URL written by the most recent `meho login`.
 
-### `domain info` path parameter
+### `domain info` / `network-pool get` path parameter
 
-`GET:/v1/domains/{id}` requires `{"id": "<domain-id>"}` in the params map for
-the dispatcher's path substitution. The CLI verb passes this as
-`params = map[string]any{"id": domainID}` before calling `dispatchOp`.
+`GET:/v1/domains/{id}` and the typed `sddc.network_pool.get` both require
+`{"id": "<id>"}` in the params map for the dispatcher's path substitution. Each
+CLI verb passes this as `params = map[string]any{"id": <id>}` before calling
+`conn.Call`. `network-pool get` renders the pool's `networks[]` with per-network
+`free=`/`used=` counts (from the `freeIps` / `usedIps` arrays) — the
+host-commissioning IP-capacity pre-flight; `--json` emits the full envelope.
 
 ### Tests
 
@@ -257,9 +266,11 @@ the dispatcher's path substitution. The CLI verb passes this as
 - All 9 top-level verbs assembled by `NewRootCmd`.
 - `decodeElementsResult` with `elements[]`-wrapped and bare-array payloads.
 - Wire-level dispatch: `connector_id` baked, empty target → null, domain info
-  sends id param, workflow list sends status filter, operation search sends
-  connector_id.
-- All verb printer renderers (table output, JSON path).
+  and network-pool get send the id param, workflow list sends status filter,
+  operation search sends connector_id.
+- The `network-pool` sub-tree assembles both `list` and `get`.
+- All verb printer renderers (table output, JSON path), including
+  `network-pool get`'s per-network free/used capacity table.
 
 ## Known issues
 


### PR DESCRIPTION
## Summary

- Adds two typed reads to the **sddc-manager** connector so an operator can run the host-commissioning **IP-capacity pre-flight** through the backplane (policy/audit/broadcast/JSONFlux) instead of the SDDC Manager UI or `sddc-manager.sh`:
  - `sddc.network_pool.list` — `GET /v1/network-pools` (the pools that back host commissioning).
  - `sddc.network_pool.get` — `GET /v1/network-pools/{id}` (one pool's `networks[]` with per-network `freeIps`/`usedIps` capacity — the data the pre-flight question needs).
- Both mirror the existing `sddc.domain.list` / `sddc.domain.status` pair: `source_kind="typed"`, group `sddc-inventory`, `safety_level="safe"`, `requires_approval=False` — so they **dispatch on a fresh boot with zero catalog ingest**, closing the #2247 per-deploy-catalog gap the ingested `GET:/v1/network-pools` op was subject to. Handlers are pure pass-through, so vendor `networks[]` field names aren't load-bearing; the set-shaped list response is JSONFlux/handle-wrapped by the generic dispatch path (postulate 6).
- CLI: `network-pool list` repointed to the typed op_id; new `network-pool get <id>` verb renders a per-network `free=`/`used=` capacity table (`--json` emits the full envelope).
- Since network pools are now typed, they leave the **ingested browse-breadth canary seed set** — following the exact precedent #2306 set for hosts/domain-list — so the e2e/acceptance fixtures drop from four ingested browse ops to three (release, domain detail, bundles).

Vendor shape confirmed against the Broadcom VCF SDDC Manager API reference (`GET /v1/network-pools/{id}` → `NetworkPool.networks[]` with `type` / `vlanId` / `subnet` / `mask` / `gateway` / `ipPools[start,end]` / `freeIps` / `usedIps`).

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/sddc_manager/` — Success, no issues
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (3 pre-existing/below-block warnings)
- [x] `pytest` sddc typed-reads + e2e + acceptance (smoke + jsonflux) + resolver-shadowing — **88 passed**
  - New: `sddc.network_pool.list` added to the zero-catalog dispatch parametrize; `test_network_pool_get_builds_path_from_id_and_passes_capacity_through` asserts id-substitution + `networks[]` free/used pass-through intact.
- [x] CLI: `go build`, `go vet`, `gofmt -l` clean, `go test ./internal/cmd/sddc-manager/` pass, `make lint` (golangci-lint) — **0 issues**
  - New: `network-pool get` wire test (id param), printer test (capacity table), subtree test (list + get), and both verbs added to `TestRepointedVerbsDispatchTypedOpIDs`.
- [x] `docs/codebase/connectors-sddc-manager.md` updated: both ops added to the typed-ops table; "four non-audited reads" → "three"; CLI verb-table op_id column updated + `get` row.
- [x] CLI OpenAPI snapshot unaffected — no backend route/schema changed (typed ops dispatch through the existing `POST /api/v1/operations/call` route).

## Out of scope / adjacent findings

- Network-pool create/update/delete (writes stay `staged` per Initiative #368 v0.2 scope); host commissioning itself; the remaining ingested breadth.
- **Pre-existing doc drift (not fixed here):** the CLI verb-table op_id column and the `sddc_manager.go` package-comment still show bare `GET:/v1/...` op_ids for `domain list` / `manager list` / `cluster list` / `host list`, but those verbs were already repointed to typed op_ids in #2266 (confirmed in `typed_opid_dispatch_test.go`). Only the network-pool rows were in scope here.
- **Pre-existing code-quality warnings** on `connector.py` (689 lines > 600 block limit — already over before this change) and the unchanged `register_sddc_typed_operations` (71 lines); `typed_reads.py` is now 459 lines (> 400 warn, < 600 block). All advisory, none agent-introduced blockers.
- **VCF field-shape confirmation:** the `networks[]` capacity field names are confirmed against the Broadcom VCF API reference but not against a live VCF 9.0 appliance this session; the pass-through handler makes them non-load-bearing regardless.

Closes #2837
