### PR TITLE
feat(connectors): add pfsense.dhcp.leases read op — live IP allocation and pool exhaustion (#2849)

### DIFF
--- a/backend/src/meho_backplane/connectors/pfsense/connector.py
+++ b/backend/src/meho_backplane/connectors/pfsense/connector.py
@@ -184,6 +184,14 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "``pfsense.config.show`` when the operator needs to inspect or "
         "export the complete pfSense config.xml."
     ),
+    "dhcp": (
+        "Use for pfSense DHCP lease-state operations: reading the live "
+        "DHCPv4 lease table (``pfsense.dhcp.leases``). Call when the "
+        "operator wants to know which IPs are currently leased, to whom, "
+        "or how close a DHCP pool is to exhaustion before provisioning "
+        "more hosts on a segment. Rows carry the client IP, MAC, hostname, "
+        "lease start/end, and effective binding state."
+    ),
 }
 
 
@@ -580,6 +588,27 @@ class PfSenseConnector(SshConnector):
         )
 
         return await _pfsense_config_show(self, target, params, operator)
+
+    async def dhcp_leases(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``pfsense.dhcp.leases`` (#2849).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.pfsense.ops_read.pfsense_dhcp_leases`.
+        A busy pool's lease table can be large; the dispatcher's default
+        :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+        wraps the result in a ``ResultHandle`` when ``total`` exceeds its
+        configured threshold.
+        """
+        from meho_backplane.connectors.pfsense.ops_read import (
+            pfsense_dhcp_leases as _pfsense_dhcp_leases,
+        )
+
+        return await _pfsense_dhcp_leases(self, target, params, operator)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/pfsense/ops.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops.py
@@ -117,12 +117,12 @@ _PFSENSE_ABOUT_OP = PfSenseOp(
 def _pfsense_ops() -> tuple[PfSenseOp, ...]:
     """Return the merged registration tuple.
 
-    Composition: ``pfsense.about`` (T1 canary) + ``READ_OPS`` (T2 read
+    Composition: ``pfsense.about`` (T1 canary) + ``READ_OPS`` (the read
     ops: ``pfsense.version``, ``pfsense.firewall.rules``,
     ``pfsense.firewall.state``, ``pfsense.nat.rules``,
     ``pfsense.interface.list``, ``pfsense.gateway.list``,
-    ``pfsense.config.show``). Eight ops total -- the full G3.7-T2
-    read surface.
+    ``pfsense.config.show``, and ``pfsense.dhcp.leases`` (#2849)).
+    Nine ops total -- the T2 read surface plus the DHCP-lease read op.
 
     Implemented as a function call rather than a literal-and-splat at
     module level so the import order stays linear: ``ops.py`` defines
@@ -142,7 +142,8 @@ def _pfsense_ops() -> tuple[PfSenseOp, ...]:
 #: (``pfsense.version``, ``pfsense.firewall.rules``,
 #: ``pfsense.firewall.state``, ``pfsense.nat.rules``,
 #: ``pfsense.interface.list``, ``pfsense.gateway.list``,
-#: ``pfsense.config.show``) -- 8 ops total. The shape of each
+#: ``pfsense.config.show``); #2849 adds ``pfsense.dhcp.leases`` --
+#: 9 ops total. The shape of each
 #: follow-on PR is "import a new module-level tuple and splat it
 #: into :data:`PFSENSE_OPS` via :func:`_pfsense_ops`" -- the
 #: registration walk in

--- a/backend/src/meho_backplane/connectors/pfsense/ops_read.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops_read.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""pfSense read ops -- 7 read ops for G3.7-T2 (#847).
+"""pfSense read ops -- the pfSense read-op surface (G3.7-T2 #847, #2849).
 
 Adds the following typed ops to :class:`PfSenseConnector`:
 
@@ -15,6 +15,10 @@ Adds the following typed ops to :class:`PfSenseConnector`:
   block parsed.
 * ``pfsense.config.show`` -- full ``/cf/conf/config.xml`` content
   returned as a structured envelope.
+* ``pfsense.dhcp.leases`` (#2849) -- ``cat
+  /var/dhcpd/var/db/dhcpd.leases`` (the ISC dhcpd lease database under
+  pfSense's dhcpd chroot) parsed into de-duplicated lease rows;
+  returns rows inline as ``{rows, total}``.
 
 Pure parsers vs handler thin layer
 -----------------------------------
@@ -60,6 +64,7 @@ References
 from __future__ import annotations
 
 import re
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from defusedxml.ElementTree import ParseError, fromstring
@@ -72,12 +77,14 @@ if TYPE_CHECKING:
 
 __all__ = [
     "READ_OPS",
+    "parse_dhcp_leases",
     "parse_gateways_xml",
     "parse_ifconfig",
     "parse_pfctl_nat",
     "parse_pfctl_rules",
     "parse_pfctl_states",
     "pfsense_config_show",
+    "pfsense_dhcp_leases",
     "pfsense_firewall_rules",
     "pfsense_firewall_state",
     "pfsense_gateway_list",
@@ -470,6 +477,174 @@ def _xml_text(element: Any, tag: str) -> str | None:
     return child.text if child is not None else None
 
 
+# ISC dhcpd lease database (``/var/dhcpd/var/db/dhcpd.leases`` under
+# pfSense's dhcpd chroot). Grammar per ``dhcpd.leases(5)``: the file is
+# log-structured -- every lease change appends a fresh
+# ``lease <ip> { ... }`` block, so the block appearing LAST for a given
+# IP is authoritative. Date statements are ``<weekday> YYYY/MM/DD
+# HH:MM:SS`` in UTC (the weekday index 0-6 is a human-readability aid),
+# with the literal ``never`` for non-expiring leases. Binding states are
+# ``active`` / ``free`` / ``backup`` plus failover transitional states.
+_LEASE_HEADER_RE = re.compile(r"^lease\s+(?P<ip>\d{1,3}(?:\.\d{1,3}){3})\s+\{")
+_LEASE_STARTS_RE = re.compile(r"^starts\s+(?P<val>.+?)\s*;\s*$")
+_LEASE_ENDS_RE = re.compile(r"^ends\s+(?P<val>.+?)\s*;\s*$")
+_LEASE_BINDING_RE = re.compile(r"^binding\s+state\s+(?P<state>\S+?)\s*;")
+_LEASE_HW_RE = re.compile(r"^hardware\s+ethernet\s+(?P<mac>[0-9A-Fa-f:]+)\s*;")
+_LEASE_HOSTNAME_RE = re.compile(r'^client-hostname\s+"(?P<hostname>[^"]*)"\s*;')
+_LEASE_TS_RE = re.compile(r"\d{4}/\d{2}/\d{2}\s+\d{2}:\d{2}:\d{2}")
+
+
+def _lease_timestamp(value: str | None) -> str | None:
+    """Normalise a lease ``starts``/``ends`` value to its UTC timestamp.
+
+    Returns the ``YYYY/MM/DD HH:MM:SS`` substring (dropping the leading
+    weekday index), the literal ``"never"``, or ``None`` when the value
+    holds neither a recognisable timestamp nor ``never``.
+    """
+    if value is None:
+        return None
+    value = value.strip()
+    if value == "never":
+        return "never"
+    match = _LEASE_TS_RE.search(value)
+    return match.group(0) if match else None
+
+
+def _lease_datetime(timestamp: str) -> datetime | None:
+    """Parse a ``YYYY/MM/DD HH:MM:SS`` lease timestamp as a UTC datetime."""
+    try:
+        return datetime.strptime(timestamp, "%Y/%m/%d %H:%M:%S").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+
+
+def _effective_binding_state(
+    raw_state: str | None,
+    ends: str | None,
+    now: datetime,
+) -> str | None:
+    """Return the effective binding state, downgrading a stale ``active`` lease.
+
+    An ``active`` lease whose ``ends`` timestamp has already elapsed
+    relative to *now* is reported as ``expired`` -- the classification
+    pfSense's own ``Status > DHCP Leases`` view applies to a past-``ends``
+    lease. Every other state (and ``ends == "never"``) passes through
+    unchanged.
+    """
+    if raw_state != "active" or ends is None or ends == "never":
+        return raw_state
+    ends_dt = _lease_datetime(ends)
+    if ends_dt is not None and ends_dt < now:
+        return "expired"
+    return raw_state
+
+
+def _apply_lease_body_line(current: dict[str, Any], line: str) -> None:
+    """Apply one in-block statement line to the lease dict under construction.
+
+    Recognises the ``starts`` / ``ends`` / ``binding state`` /
+    ``hardware ethernet`` / ``client-hostname`` statements; any other line
+    (``cltt``, ``tstp``, ``next binding state``, options) is ignored.
+    """
+    if starts := _LEASE_STARTS_RE.match(line):
+        current["starts"] = _lease_timestamp(starts.group("val"))
+    elif ends := _LEASE_ENDS_RE.match(line):
+        current["ends"] = _lease_timestamp(ends.group("val"))
+    elif binding := _LEASE_BINDING_RE.match(line):
+        current["binding_state"] = binding.group("state")
+    elif hardware := _LEASE_HW_RE.match(line):
+        current["mac"] = hardware.group("mac")
+    elif hostname := _LEASE_HOSTNAME_RE.match(line):
+        current["hostname"] = hostname.group("hostname")
+
+
+def parse_dhcp_leases(
+    output: str,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Parse an ISC dhcpd lease database into de-duplicated lease rows.
+
+    Accepts the raw text of ``/var/dhcpd/var/db/dhcpd.leases`` and returns
+    one dict per currently-effective lease:
+
+    .. code-block:: python
+
+        {
+            "ip": "192.168.1.100",
+            "mac": "08:00:27:aa:bb:cc",
+            "hostname": "laptop",
+            "starts": "2026/08/12 10:00:00",
+            "ends": "2026/08/12 22:00:00",
+            "binding_state": "active",
+        }
+
+    The lease file is log-structured (``dhcpd.leases(5)``): every lease
+    change appends a fresh ``lease <ip> { ... }`` block, so the block
+    appearing LAST for a given IP is authoritative. Rows are de-duplicated
+    to that last block per IP, preserving first-seen order.
+
+    ``mac`` comes from ``hardware ethernet`` and ``hostname`` from
+    ``client-hostname`` (``None`` when the client sent none). ``starts``
+    and ``ends`` are the lease-file UTC timestamps in ``YYYY/MM/DD
+    HH:MM:SS`` form (the leading weekday index is dropped); ``ends`` is
+    the literal ``"never"`` for a non-expiring lease, or ``None`` when
+    absent.
+
+    ``binding_state`` is the lease's effective state: the raw ``binding
+    state`` token (``active`` / ``free`` / ``backup`` / failover
+    transitional states), except an ``active`` lease whose ``ends`` has
+    already elapsed relative to *now* is reported as ``expired``. Only
+    ``binding_state == "active"`` rows are currently-live leases. *now*
+    defaults to the current UTC time; inject it for deterministic parsing.
+
+    Non-``lease`` blocks (``server-duid``, ``failover peer`` state) and
+    comment lines are ignored. An unterminated trailing block (a lease
+    dhcpd was mid-write on) is dropped. Empty or malformed input yields an
+    empty list.
+
+    >>> text = (
+    ...     "lease 10.0.0.5 {\\n"
+    ...     "  starts 3 2026/08/12 10:00:00;\\n"
+    ...     "  ends 3 2026/08/12 22:00:00;\\n"
+    ...     "  binding state active;\\n"
+    ...     "  hardware ethernet 08:00:27:aa:bb:cc;\\n"
+    ...     '  client-hostname "laptop";\\n'
+    ...     "}\\n"
+    ... )
+    >>> rows = parse_dhcp_leases(text, now=datetime(2026, 8, 12, 12, tzinfo=UTC))
+    >>> rows[0]["ip"], rows[0]["binding_state"], rows[0]["hostname"]
+    ('10.0.0.5', 'active', 'laptop')
+    """
+    if now is None:
+        now = datetime.now(UTC)
+
+    leases: dict[str, dict[str, Any]] = {}
+    current: dict[str, Any] | None = None
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if current is None:
+            header = _LEASE_HEADER_RE.match(line)
+            if header:
+                current = {
+                    "ip": header.group("ip"),
+                    "mac": None,
+                    "hostname": None,
+                    "starts": None,
+                    "ends": None,
+                    "binding_state": None,
+                }
+            continue
+        if line.startswith("}"):
+            current["binding_state"] = _effective_binding_state(
+                current["binding_state"], current["ends"], now
+            )
+            leases[current["ip"]] = current  # last block per IP wins
+            current = None
+            continue
+        _apply_lease_body_line(current, line)
+    return list(leases.values())
+
+
 # ---------------------------------------------------------------------------
 # Handler functions (bound-method shims on PfSenseConnector)
 # ---------------------------------------------------------------------------
@@ -656,6 +831,39 @@ async def pfsense_config_show(
     return {"config_xml": content, "length": len(content)}
 
 
+async def pfsense_dhcp_leases(
+    self: PfSenseConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Return the pfSense DHCPv4 lease table from the ISC dhcpd lease DB.
+
+    Op-id: ``pfsense.dhcp.leases``. Reads
+    ``/var/dhcpd/var/db/dhcpd.leases`` (the ISC dhcpd lease database under
+    pfSense's dhcpd chroot) over SSH and parses it into de-duplicated
+    lease rows via :func:`parse_dhcp_leases`. Returns rows inline as
+    ``{rows, total}``; a busy pool's lease table can be large, so the
+    dispatcher's default
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    wraps the payload in a ``ResultHandle`` when ``total`` exceeds its
+    threshold. Non-zero exit with empty stdout (file missing, DHCP server
+    disabled) returns the sibling error envelope.
+    """
+    del params  # declared empty; intentionally ignored
+    proc = await self._run_command(target, "cat /var/dhcpd/var/db/dhcpd.leases", operator=operator)
+    stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
+    content = stdout if isinstance(stdout, str) else ""
+    if proc.exit_status != 0 and not content.strip():
+        return {
+            "rows": [],
+            "total": 0,
+            "error": f"cat /var/dhcpd/var/db/dhcpd.leases exit {proc.exit_status}",
+        }
+    rows = parse_dhcp_leases(content)
+    return {"rows": rows, "total": len(rows)}
+
+
 # ---------------------------------------------------------------------------
 # Op metadata
 # ---------------------------------------------------------------------------
@@ -703,6 +911,18 @@ _WHEN_TO_USE_CONFIG = (
     "export the complete pfSense config.xml. Call "
     "``pfsense.version`` when a structured version output is needed "
     "without the full FingerprintResult envelope."
+)
+
+#: Curated ``when_to_use`` for the ``dhcp`` group.
+_WHEN_TO_USE_DHCP = (
+    "Use for pfSense DHCP lease-state operations: reading the live DHCPv4 "
+    "lease table (``pfsense.dhcp.leases``). Call when the operator wants to "
+    "know which IPs are currently leased (and to whom) or how close a DHCP "
+    "pool is to exhaustion before provisioning more hosts on a segment. Rows "
+    "carry the client IP, MAC, hostname, lease start/end (UTC), and the "
+    "effective binding state; only ``binding_state == 'active'`` rows are "
+    "currently-live leases. A busy pool's lease list is reduced to a JSONFlux "
+    "handle carrying a bounded inline sample plus a ``fetch_more`` envelope."
 )
 
 _EMPTY_PARAMS: dict[str, Any] = {
@@ -1034,6 +1254,65 @@ READ_OPS: tuple[PfSenseOp, ...] = (
                 "is the raw pfSense ``config.xml`` content as a string. "
                 "``length`` is the character count. ``error`` is set when "
                 "the command failed."
+            ),
+        },
+    ),
+    PfSenseOp(
+        op_id="pfsense.dhcp.leases",
+        handler_attr="dhcp_leases",
+        summary="List live pfSense DHCPv4 leases from the ISC dhcpd lease database.",
+        description=(
+            "Reads ``/var/dhcpd/var/db/dhcpd.leases`` (the ISC dhcpd lease "
+            "database under pfSense's dhcpd chroot) over SSH and parses it "
+            "into structured lease rows. Each row carries the client IP, MAC "
+            "(``hardware ethernet``), hostname (``client-hostname``, nullable), "
+            "the lease ``starts``/``ends`` UTC timestamps, and the effective "
+            "``binding_state`` (``active`` / ``free`` / ``backup`` / "
+            "``expired``). Rows are de-duplicated to the most-recent lease per "
+            "IP (the lease DB is log-structured). Returns a ``{rows, total}`` "
+            "envelope. Use to answer 'which IPs are leased right now' and DHCP "
+            "pool-exhaustion questions before provisioning hosts on a segment. "
+            "No params; safe to call on any healthy pfSense target."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "ip": {"type": "string"},
+                            "mac": {"type": ["string", "null"]},
+                            "hostname": {"type": ["string", "null"]},
+                            "starts": {"type": ["string", "null"]},
+                            "ends": {"type": ["string", "null"]},
+                            "binding_state": {"type": ["string", "null"]},
+                        },
+                    },
+                },
+                "total": {"type": "integer"},
+            },
+            "additionalProperties": True,
+        },
+        group_key="dhcp",
+        tags=("read-only", "dhcp", "leases", "pfsense"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_DHCP,
+            "parameter_hints": {},
+            "output_shape": (
+                "``{rows: [{ip, mac, hostname, starts, ends, binding_state}], "
+                "total: N}``. ``ip`` is the leased address; ``mac`` is the "
+                "client hardware address; ``hostname`` is the client-sent name "
+                "or ``null``. ``starts``/``ends`` are UTC ``YYYY/MM/DD "
+                "HH:MM:SS`` strings (``ends`` may be ``'never'``). "
+                "``binding_state`` is ``active`` / ``free`` / ``backup`` / "
+                "``expired``; only ``active`` rows are currently-live leases. "
+                "A large lease list is reduced to a JSONFlux handle with a "
+                "bounded inline sample plus a ``fetch_more`` envelope."
             ),
         },
     ),

--- a/backend/tests/test_connectors_pfsense_e2e.py
+++ b/backend/tests/test_connectors_pfsense_e2e.py
@@ -10,7 +10,7 @@ pre-recorded fixture responses — no Docker dependency, no live pfSense.
 Acceptance criteria verified (Issue #850)
 ==========================================
 
-(a) All 8 pfSense ops dispatch through ``call_operation`` and return
+(a) All 9 pfSense ops dispatch through ``call_operation`` and return
     ``status="ok"`` results against the fake-shell server.
 (b) This file passes in the ``meho-runners`` CI lane with no Docker
     dependency (asyncssh in-process server; SQLite via the autouse
@@ -43,6 +43,8 @@ Fixture responses reproduce realistic but minimal pfSense 2.7 output:
 - ``ifconfig -a``      → 2-interface output
 - ``cat /cf/conf/config.xml`` → minimal config.xml snippet (gateways +
   version) used by both ``gateway.list`` and ``config.show``
+- ``cat /var/dhcpd/var/db/dhcpd.leases`` → 2-lease ISC dhcpd DB
+  (one active, one past-``ends`` → expired) used by ``dhcp.leases``
 """
 
 from __future__ import annotations
@@ -133,6 +135,23 @@ _FIXTURE_CONFIG_XML = """\
 </pfsense>
 """
 
+_FIXTURE_DHCP_LEASES = """\
+# The format of this file is documented in the dhcpd.leases(5) manual page.
+lease 192.168.1.100 {
+  starts 3 2026/08/12 10:00:00;
+  ends 5 2099/01/01 00:00:00;
+  binding state active;
+  hardware ethernet 08:00:27:aa:bb:cc;
+  client-hostname "lab-vm-01";
+}
+lease 192.168.1.150 {
+  starts 3 2000/01/01 08:00:00;
+  ends 3 2000/01/01 09:00:00;
+  binding state active;
+  hardware ethernet 08:00:27:44:55:66;
+}
+"""
+
 # Map SSH command string → pre-recorded stdout.
 _FIXTURE_RESPONSES: dict[str, str] = {
     "cat /etc/version": _FIXTURE_VERSION,
@@ -141,6 +160,7 @@ _FIXTURE_RESPONSES: dict[str, str] = {
     "pfctl -sn": _FIXTURE_PFCTL_SN,
     "ifconfig -a": _FIXTURE_IFCONFIG,
     "cat /cf/conf/config.xml": _FIXTURE_CONFIG_XML,
+    "cat /var/dhcpd/var/db/dhcpd.leases": _FIXTURE_DHCP_LEASES,
 }
 
 # ---------------------------------------------------------------------------
@@ -265,6 +285,7 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "pfsense.interface.list",
     "pfsense.gateway.list",
     "pfsense.config.show",
+    "pfsense.dhcp.leases",
 )
 
 # ---------------------------------------------------------------------------
@@ -377,11 +398,11 @@ async def pfsense_e2e(
 
 
 def test_pfsense_ops_registration_count() -> None:
-    """All 8 pfSense ops are registered in PFSENSE_OPS."""
+    """All 9 pfSense ops are registered in PFSENSE_OPS."""
     op_ids = {op.op_id for op in PFSENSE_OPS}
     missing = set(EXPECTED_OP_IDS) - op_ids
     assert not missing, f"Missing ops: {missing}"
-    assert len(PFSENSE_OPS) == 8, f"Expected 8 ops, got {len(PFSENSE_OPS)}"
+    assert len(PFSENSE_OPS) == 9, f"Expected 9 ops, got {len(PFSENSE_OPS)}"
 
 
 def test_pfsense_ops_all_safe_and_no_approval_required() -> None:
@@ -404,7 +425,7 @@ def test_pfsense_ops_parameter_schemas_are_empty() -> None:
 
 
 def test_pfsense_ops_all_have_llm_instructions() -> None:
-    """All 8 ops carry non-empty llm_instructions for agent discoverability."""
+    """All 9 ops carry non-empty llm_instructions for agent discoverability."""
     for op in PFSENSE_OPS:
         assert op.llm_instructions, f"{op.op_id}: llm_instructions must not be empty"
         instr = op.llm_instructions
@@ -424,6 +445,7 @@ def test_pfsense_ops_correct_group_keys() -> None:
         "pfsense.interface.list": "network",
         "pfsense.gateway.list": "network",
         "pfsense.config.show": "config",
+        "pfsense.dhcp.leases": "dhcp",
     }
     op_by_id = {op.op_id: op for op in PFSENSE_OPS}
     for op_id, expected_group in expected_groups.items():
@@ -758,7 +780,7 @@ async def test_pfsense_e2e_all_ops_write_audit_rows(
     pfsense_e2e: _PfsenseE2EBundle,
     captured_events: list[Any],
 ) -> None:
-    """All 8 pfSense ops each produce an audit row after dispatch.
+    """All 9 pfSense ops each produce an audit row after dispatch.
 
     Dispatches every op in EXPECTED_OP_IDS and asserts that each one
     inserted at least one ``DISPATCH`` AuditLog row.

--- a/backend/tests/test_connectors_pfsense_ops.py
+++ b/backend/tests/test_connectors_pfsense_ops.py
@@ -23,24 +23,29 @@ Coverage matrix (per Task #847 acceptance criteria):
   config.xml or snippet; ``defaultgw`` bool; empty/malformed XML returns [].
 * Bound-method shims on :class:`PfSenseConnector` -- ``version``,
   ``firewall_rules``, ``firewall_state``, ``nat_rules``,
-  ``interface_list``, ``gateway_list``, ``config_show`` -- each runs
-  the correct SSH command, passes stdout through the parser, and returns
-  the expected envelope shape.
+  ``interface_list``, ``gateway_list``, ``config_show``,
+  ``dhcp_leases`` -- each runs the correct SSH command, passes stdout
+  through the parser, and returns the expected envelope shape.
+* ``parse_dhcp_leases`` -- parses an ISC ``dhcpd.leases`` DB; active /
+  expired-by-time / free / ``ends never`` states; ``client-hostname``
+  nullable; log-structured de-dup to the last block per IP.
 * Malformed command output → structured result (no crash); error field
   set on non-zero exit with empty stdout.
-* ``PFSENSE_OPS`` registration shape -- all 8 ops carry
+* ``PFSENSE_OPS`` registration shape -- all 9 ops carry
   ``safety_level='safe'``, ``additionalProperties=False`` on the
   parameter schema, non-empty ``llm_instructions``, and pfsense-
-  namespace op_ids; ``firewall``, ``nat``, ``network``, ``config``
-  groups are present.
-* Idempotency contract -- the ``PFSENSE_OPS`` tuple length matches 8
-  after T2 lands; the ``pfsense.about`` canary remains at index 0.
+  namespace op_ids; ``firewall``, ``nat``, ``network``, ``config``,
+  ``dhcp`` groups are present.
+* Idempotency contract -- the ``PFSENSE_OPS`` tuple length matches 9
+  (T2 read ops + ``pfsense.dhcp.leases``, #2849); the ``pfsense.about``
+  canary remains at index 0.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -50,6 +55,7 @@ import meho_backplane.connectors.pfsense  # noqa: F401 -- import for registry si
 from meho_backplane.connectors.pfsense import PFSENSE_OPS, PfSenseConnector
 from meho_backplane.connectors.pfsense.ops_read import (
     _netmask_to_cidr,
+    parse_dhcp_leases,
     parse_gateways_xml,
     parse_ifconfig,
     parse_pfctl_nat,
@@ -622,13 +628,228 @@ async def test_pfsense_config_show_returns_error_on_failure() -> None:
 
 
 # ---------------------------------------------------------------------------
+# parse_dhcp_leases
+# ---------------------------------------------------------------------------
+
+# A captured-shape ISC dhcpd.leases fixture: an active lease (ends in the
+# far future), an active lease whose ends is in the past (→ expired), a
+# free lease, an active lease with no client-hostname, an ``ends never``
+# lease, and a duplicate IP whose second (last) block must win. Bracketed
+# by a comment and a non-lease block that must both be ignored.
+_DHCP_LEASES_SAMPLE = """\
+# The format of this file is documented in the dhcpd.leases(5) manual page.
+server-duid "\\000\\001\\000\\001-abc";
+
+lease 192.168.1.100 {
+  starts 3 2026/08/12 10:00:00;
+  ends 5 2099/01/01 00:00:00;
+  cltt 3 2026/08/12 10:00:00;
+  binding state active;
+  next binding state free;
+  hardware ethernet 08:00:27:aa:bb:cc;
+  client-hostname "laptop";
+}
+lease 192.168.1.101 {
+  starts 3 2000/01/01 08:00:00;
+  ends 3 2000/01/01 09:00:00;
+  binding state active;
+  hardware ethernet 08:00:27:11:22:33;
+  client-hostname "old-host";
+}
+lease 192.168.1.102 {
+  starts 3 2026/08/12 07:00:00;
+  ends 3 2026/08/12 08:00:00;
+  binding state free;
+  hardware ethernet 08:00:27:44:55:66;
+}
+lease 192.168.1.103 {
+  starts 3 2026/08/12 07:00:00;
+  ends never;
+  binding state active;
+  hardware ethernet 08:00:27:77:88:99;
+  client-hostname "gateway";
+}
+lease 192.168.1.100 {
+  starts 4 2026/08/13 10:00:00;
+  ends 6 2099/06/01 22:00:00;
+  binding state active;
+  hardware ethernet 08:00:27:aa:bb:cc;
+  client-hostname "laptop-renewed";
+}
+"""
+
+# A now between the 2000 (expired) and 2099 (active) fixture timestamps,
+# so the active/expired split is deterministic regardless of wall-clock.
+_DHCP_NOW = datetime(2026, 8, 12, 12, 0, 0, tzinfo=UTC)
+
+
+def _lease_by_ip(rows: list[dict[str, Any]], ip: str) -> dict[str, Any]:
+    return next(r for r in rows if r["ip"] == ip)
+
+
+def test_parse_dhcp_leases_extracts_all_fields() -> None:
+    rows = parse_dhcp_leases(_DHCP_LEASES_SAMPLE, now=_DHCP_NOW)
+    lease = _lease_by_ip(rows, "192.168.1.101")
+    assert lease["mac"] == "08:00:27:11:22:33"
+    assert lease["hostname"] == "old-host"
+    assert lease["starts"] == "2000/01/01 08:00:00"
+    assert lease["ends"] == "2000/01/01 09:00:00"
+
+
+def test_parse_dhcp_leases_active_lease_stays_active() -> None:
+    rows = parse_dhcp_leases(_DHCP_LEASES_SAMPLE, now=_DHCP_NOW)
+    assert _lease_by_ip(rows, "192.168.1.100")["binding_state"] == "active"
+
+
+def test_parse_dhcp_leases_past_ends_active_is_expired() -> None:
+    """An ``active`` lease whose ``ends`` is in the past reads as expired."""
+    rows = parse_dhcp_leases(_DHCP_LEASES_SAMPLE, now=_DHCP_NOW)
+    assert _lease_by_ip(rows, "192.168.1.101")["binding_state"] == "expired"
+
+
+def test_parse_dhcp_leases_free_state_passes_through() -> None:
+    rows = parse_dhcp_leases(_DHCP_LEASES_SAMPLE, now=_DHCP_NOW)
+    assert _lease_by_ip(rows, "192.168.1.102")["binding_state"] == "free"
+
+
+def test_parse_dhcp_leases_missing_client_hostname_is_none() -> None:
+    rows = parse_dhcp_leases(_DHCP_LEASES_SAMPLE, now=_DHCP_NOW)
+    assert _lease_by_ip(rows, "192.168.1.102")["hostname"] is None
+
+
+def test_parse_dhcp_leases_ends_never_stays_active() -> None:
+    rows = parse_dhcp_leases(_DHCP_LEASES_SAMPLE, now=_DHCP_NOW)
+    lease = _lease_by_ip(rows, "192.168.1.103")
+    assert lease["ends"] == "never"
+    assert lease["binding_state"] == "active"
+
+
+def test_parse_dhcp_leases_dedupes_to_last_block_per_ip() -> None:
+    """The lease DB is log-structured; the last block for an IP wins."""
+    rows = parse_dhcp_leases(_DHCP_LEASES_SAMPLE, now=_DHCP_NOW)
+    matches = [r for r in rows if r["ip"] == "192.168.1.100"]
+    assert len(matches) == 1
+    assert matches[0]["hostname"] == "laptop-renewed"
+    assert matches[0]["starts"] == "2026/08/13 10:00:00"
+
+
+def test_parse_dhcp_leases_strips_weekday_index_from_timestamps() -> None:
+    rows = parse_dhcp_leases(_DHCP_LEASES_SAMPLE, now=_DHCP_NOW)
+    # .103's winning line is ``starts 3 2026/08/12 07:00:00;`` — the leading
+    # weekday ``3`` is dropped, leaving the bare UTC timestamp.
+    assert _lease_by_ip(rows, "192.168.1.103")["starts"] == "2026/08/12 07:00:00"
+
+
+def test_parse_dhcp_leases_ignores_non_lease_blocks() -> None:
+    rows = parse_dhcp_leases(_DHCP_LEASES_SAMPLE, now=_DHCP_NOW)
+    # server-duid + the comment line contribute no rows; 4 distinct IPs.
+    assert {r["ip"] for r in rows} == {
+        "192.168.1.100",
+        "192.168.1.101",
+        "192.168.1.102",
+        "192.168.1.103",
+    }
+
+
+def test_parse_dhcp_leases_empty_input_returns_empty_list() -> None:
+    assert parse_dhcp_leases("") == []
+    assert parse_dhcp_leases("\n\n# just a comment\n") == []
+
+
+def test_parse_dhcp_leases_drops_unterminated_trailing_block() -> None:
+    """A block dhcpd was mid-write on (no closing brace) is not emitted."""
+    text = "lease 10.0.0.1 {\n  binding state active;\n  hardware ethernet 00:11:22:33:44:55;\n"
+    assert parse_dhcp_leases(text, now=_DHCP_NOW) == []
+
+
+def test_parse_dhcp_leases_now_defaults_to_current_utc() -> None:
+    """Without an injected ``now`` a far-past active lease reads expired."""
+    text = (
+        "lease 10.0.0.9 {\n"
+        "  starts 3 2000/01/01 00:00:00;\n"
+        "  ends 3 2000/01/01 01:00:00;\n"
+        "  binding state active;\n"
+        "  hardware ethernet 00:11:22:33:44:55;\n"
+        "}\n"
+    )
+    rows = parse_dhcp_leases(text)
+    assert rows[0]["binding_state"] == "expired"
+
+
+# ---------------------------------------------------------------------------
+# Bound-method shim -- pfsense_dhcp_leases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pfsense_dhcp_leases_reads_lease_db() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(_DHCP_LEASES_SAMPLE)
+        result = await connector.dhcp_leases(_TARGET, {})
+    mock_cmd.assert_awaited_once_with(_TARGET, "cat /var/dhcpd/var/db/dhcpd.leases", operator=None)
+    assert result["total"] == 4
+    ips = {row["ip"] for row in result["rows"]}
+    assert "192.168.1.103" in ips
+
+
+@pytest.mark.asyncio
+async def test_pfsense_dhcp_leases_returns_error_on_failure() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc("", exit_status=1)
+        result = await connector.dhcp_leases(_TARGET, {})
+    assert result["rows"] == []
+    assert result["total"] == 0
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_pfsense_dhcp_leases_empty_file_returns_empty_rows() -> None:
+    """An empty (exit 0) lease DB — DHCP enabled, no leases yet — is not an error."""
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc("")
+        result = await connector.dhcp_leases(_TARGET, {})
+    assert result["rows"] == []
+    assert result["total"] == 0
+    assert "error" not in result
+
+
+@pytest.mark.asyncio
+async def test_pfsense_dhcp_leases_response_schema_matches_handler_rows() -> None:
+    """The registered op's response_schema row keys match the handler output."""
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(_DHCP_LEASES_SAMPLE)
+        result = await connector.dhcp_leases(_TARGET, {})
+    handler_row_keys = set(result["rows"][0].keys())
+
+    op = next(o for o in PFSENSE_OPS if o.op_id == "pfsense.dhcp.leases")
+    assert op.response_schema is not None
+    schema_row_keys = set(op.response_schema["properties"]["rows"]["items"]["properties"].keys())
+    assert (
+        schema_row_keys
+        == handler_row_keys
+        == {
+            "ip",
+            "mac",
+            "hostname",
+            "starts",
+            "ends",
+            "binding_state",
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # PFSENSE_OPS registration shape
 # ---------------------------------------------------------------------------
 
 
-def test_pfsense_ops_has_eight_entries() -> None:
-    """T1 canary + 7 T2 read ops = 8 total."""
-    assert len(PFSENSE_OPS) == 8
+def test_pfsense_ops_has_nine_entries() -> None:
+    """T1 canary + 7 T2 read ops + pfsense.dhcp.leases (#2849) = 9 total."""
+    assert len(PFSENSE_OPS) == 9
 
 
 def test_pfsense_ops_about_is_first() -> None:
@@ -671,6 +892,7 @@ def test_pfsense_ops_covers_expected_op_ids() -> None:
         "pfsense.interface.list",
         "pfsense.gateway.list",
         "pfsense.config.show",
+        "pfsense.dhcp.leases",
     }
     assert op_ids == expected
 
@@ -682,6 +904,7 @@ def test_pfsense_ops_group_keys_include_new_groups() -> None:
     assert "nat" in group_keys
     assert "network" in group_keys
     assert "config" in group_keys
+    assert "dhcp" in group_keys
 
 
 def test_pfsense_ops_handler_attrs_exist_on_connector() -> None:

--- a/cli/internal/cmd/pfsense/dhcp.go
+++ b/cli/internal/cmd/pfsense/dhcp.go
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package pfsense
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newDhcpCmd returns the `meho pfsense dhcp` parent with one sub-verb:
+// `leases` (pfsense.dhcp.leases).
+func newDhcpCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "dhcp",
+		Short:        "pfSense DHCP sub-verbs (leases)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newDhcpLeasesCmd())
+	return cmd
+}
+
+// newDhcpLeasesCmd returns the `meho pfsense dhcp leases` command.
+//
+// Maps to op_id `pfsense.dhcp.leases`. Reads the ISC dhcpd lease
+// database (`/var/dhcpd/var/db/dhcpd.leases`) over SSH and returns the
+// live DHCPv4 lease table as structured rows.
+func newDhcpLeasesCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "leases",
+		Short: "List live pfSense DHCPv4 leases (ISC dhcpd lease DB)",
+		Long: "leases dispatches pfsense.dhcp.leases and renders the live\n" +
+			"DHCPv4 lease table (IP / MAC / hostname / binding state / ends).\n" +
+			"Use to see which IPs are leased and gauge DHCP pool exhaustion\n" +
+			"before provisioning more hosts on a segment. Only leases in the\n" +
+			"'active' binding state are currently live.\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho pfsense dhcp leases --target pfsense-hetzner-dc\n" +
+			"  meho pfsense dhcp leases --target pfsense-hetzner-dc --json | jq '.result.rows[]'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDhcpLeases(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runDhcpLeases(
+	cmd *cobra.Command,
+	targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "pfsense.dhcp.leases", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "pfsense.dhcp.leases", r, jsonOut, printDhcpLeases)
+}
+
+func printDhcpLeases(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s pfsense.dhcp.leases — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	rows, err := decodeRowsResult(r.Result)
+	if err != nil || rows == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  %-16s %-18s %-18s %-9s %s\n",
+		"IP", "MAC", "HOSTNAME", "STATE", "ENDS (UTC)")
+	for _, row := range rows {
+		ip := stringField(row, "ip")
+		mac := stringField(row, "mac")
+		hostname := truncate(stringField(row, "hostname"), 18)
+		state := stringField(row, "binding_state")
+		ends := stringField(row, "ends")
+		fmt.Fprintf(w, "  %-16s %-18s %-18s %-9s %s\n",
+			ip, mac, hostname, state, ends)
+	}
+	fmt.Fprintf(w, "  (%d leases)\n", len(rows))
+}

--- a/cli/internal/cmd/pfsense/pfsense.go
+++ b/cli/internal/cmd/pfsense/pfsense.go
@@ -16,6 +16,7 @@
 //   - `meho pfsense network interface [--target T]` — pfsense.interface.list
 //   - `meho pfsense network gateway [--target T]`   — pfsense.gateway.list
 //   - `meho pfsense config show [--target T]`    — pfsense.config.show
+//   - `meho pfsense dhcp leases [--target T]`    — pfsense.dhcp.leases
 //
 // Every verb is a thin Cobra command that POSTs to
 // `/api/v1/operations/call` with a pre-baked connector_id. No new
@@ -75,6 +76,7 @@ const ConnectorID = "pfsense-ssh-2.7"
 //   - `pfsense nat rules`         — sub-tree
 //   - `pfsense network <interface|gateway>` — sub-tree
 //   - `pfsense config show`       — sub-tree
+//   - `pfsense dhcp leases`       — sub-tree
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pfsense",
@@ -103,6 +105,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newNatCmd())
 	cmd.AddCommand(newNetworkCmd())
 	cmd.AddCommand(newConfigCmd())
+	cmd.AddCommand(newDhcpCmd())
 	return cmd
 }
 

--- a/cli/internal/cmd/pfsense/pfsense_test.go
+++ b/cli/internal/cmd/pfsense/pfsense_test.go
@@ -317,6 +317,7 @@ func TestAllOpsUseCanonicalOpIDs(t *testing.T) {
 		"pfsense.interface.list",
 		"pfsense.gateway.list",
 		"pfsense.config.show",
+		"pfsense.dhcp.leases",
 	}
 
 	// Build a mock server that records which op_ids were dispatched.
@@ -360,6 +361,7 @@ func TestNewRootCmdHasExpectedSubcommands(t *testing.T) {
 		"nat":      false,
 		"network":  false,
 		"config":   false,
+		"dhcp":     false,
 	}
 	for _, sub := range root.Commands() {
 		want[sub.Name()] = true
@@ -422,6 +424,18 @@ func TestConfigHasShow(t *testing.T) {
 	}
 	if !subs["show"] {
 		t.Errorf("config is missing sub-verb 'show'")
+	}
+}
+
+// TestDhcpHasLeases — the `dhcp` sub-command must have a `leases` sub-verb.
+func TestDhcpHasLeases(t *testing.T) {
+	dhcp := newDhcpCmd()
+	subs := make(map[string]bool)
+	for _, s := range dhcp.Commands() {
+		subs[s.Name()] = true
+	}
+	if !subs["leases"] {
+		t.Errorf("dhcp is missing sub-verb 'leases'")
 	}
 }
 
@@ -497,6 +511,24 @@ func TestPrintNetworkGatewayDefaultFlag(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "YES") {
 		t.Errorf("expected 'YES' for default gateway; got:\n%s", out)
+	}
+}
+
+// TestPrintDhcpLeasesRendersTable — printDhcpLeases writes the header
+// row and the IP / hostname / binding state for each lease.
+func TestPrintDhcpLeasesRendersTable(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "pfsense.dhcp.leases",
+		Result: json.RawMessage(`{"rows":[{"ip":"192.168.1.100","mac":"08:00:27:aa:bb:cc","hostname":"lab-vm-01","starts":"2026/08/12 10:00:00","ends":"2099/01/01 00:00:00","binding_state":"active"}],"total":1}`),
+	}
+	var buf bytes.Buffer
+	printDhcpLeases(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"IP", "192.168.1.100", "lab-vm-01", "active"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printDhcpLeases output missing %q; got:\n%s", want, out)
+		}
 	}
 }
 

--- a/docs/codebase/connectors-pfsense.md
+++ b/docs/codebase/connectors-pfsense.md
@@ -24,7 +24,8 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
   attributes: `product="pfsense"`, `version="2.7"`, `impl_id="pfsense-ssh"`.
   Inherits the per-target asyncssh connection pool and `aclose()` from the
   adapter; overrides `_auth_config` to reject password auth, plus `fingerprint`,
-  `probe`, `execute`, `about`, and the 7 T2 read-op bound-method shims.
+  `probe`, `execute`, `about`, and the read-op bound-method shims (the 7 T2 ops
+  plus `dhcp_leases`, #2849).
 
 - **`_auth_config()` override** — the load-bearing auth constraint. Requires
   `ssh_private_key` in the target's **Vault secret** (`target.secret_ref` is a
@@ -37,18 +38,22 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
   REPL) instead of a POSIX shell, causing any subsequent command to hang.
 
 - **Op metadata** (`ops.py`) — the `PfSenseOp` dataclass, the `_pfsense_ops()`
-  composition function, and the `PFSENSE_OPS` tuple (8 ops total after T2).
-  T1 shipped `pfsense.about`; T2 adds 7 read ops via the `ops_read` module.
+  composition function, and the `PFSENSE_OPS` tuple (9 ops total). T1 shipped
+  `pfsense.about`; T2 (#847) adds 7 read ops via the `ops_read` module; #2849
+  appends `pfsense.dhcp.leases`.
 
-- **Read op parsers** (`ops_read.py`) — pure parsers for pfctl and config.xml
-  output, plus the 7 T2 handler functions and the `READ_OPS` tuple:
+- **Read op parsers** (`ops_read.py`) — pure parsers for pfctl, config.xml, and
+  the ISC dhcpd lease DB, plus the handler functions and the `READ_OPS` tuple:
   - `parse_pfctl_rules` / `parse_pfctl_states` / `parse_pfctl_nat` — pfctl
     output parsers.
   - `parse_ifconfig` / `_netmask_to_cidr` — ifconfig output parser.
   - `parse_gateways_xml` — XML parser for the `<gateways>` block.
+  - `parse_dhcp_leases` (#2849) — parses `/var/dhcpd/var/db/dhcpd.leases`
+    (log-structured ISC dhcpd lease DB) into de-duplicated lease rows; an
+    `active` lease whose `ends` is past reads as `expired`.
   - Handler functions: `pfsense_version`, `pfsense_firewall_rules`,
     `pfsense_firewall_state`, `pfsense_nat_rules`, `pfsense_interface_list`,
-    `pfsense_gateway_list`, `pfsense_config_show`.
+    `pfsense_gateway_list`, `pfsense_config_show`, `pfsense_dhcp_leases`.
 
 ## Control flow
 
@@ -149,7 +154,7 @@ Two-phase registration, identical to the bind9 pattern:
   (`connectors/registry.py`, `operations/typed_register.py`) — registration
   infrastructure.
 
-## Op surface (T1 + T2, 8 ops)
+## Op surface (9 ops)
 
 | Op ID | Command | Group |
 |---|---|---|
@@ -161,13 +166,23 @@ Two-phase registration, identical to the bind9 pattern:
 | `pfsense.interface.list` | `ifconfig -a` | `network` |
 | `pfsense.gateway.list` | `cat /cf/conf/config.xml` (gateways block) | `network` |
 | `pfsense.config.show` | `cat /cf/conf/config.xml` (full) | `config` |
+| `pfsense.dhcp.leases` | `cat /var/dhcpd/var/db/dhcpd.leases` (ISC dhcpd lease DB) | `dhcp` |
 
-All 8 ops are `safety_level="safe"`, `requires_approval=False`.
+All 9 ops are `safety_level="safe"`, `requires_approval=False`.
 
-`pfsense.firewall.state` returns `{rows, total}` and is the primary JSONFlux
-reduction candidate on busy firewalls (large state tables). The future reducer
-(key `pfsense_firewall_state`) spills to the HandleStore when `total` exceeds
-its threshold; today's `PassThroughReducer` returns the inline payload.
+`pfsense.firewall.state` and `pfsense.dhcp.leases` both return `{rows, total}`
+and are the JSONFlux reduction candidates: connection-state tables and busy
+DHCP pools can each carry many rows. The reducer (key `pfsense_firewall_state`
+/ `pfsense_dhcp_leases`) wraps the payload in a `ResultHandle` when `total`
+exceeds its threshold; smaller payloads pass through inline. Handle-vs-inline
+is the reducer's job, not the connector's — every handler returns rows inline.
+
+`pfsense.dhcp.leases` reads the live ISC dhcpd lease database (pfSense chroots
+`dhcpd` under `/var/dhcpd`). The file is log-structured, so the parser
+de-duplicates to the last block per IP; timestamps are UTC; an `active` lease
+whose `ends` has passed is reported as `expired`. DHCPv6 (`dhcpd6.leases`) and
+pool-exhaustion percentage math (correlating against the `config.xml` `<range>`)
+are out of scope — follow-ups.
 
 ## Known issues
 
@@ -180,6 +195,9 @@ its threshold; today's `PassThroughReducer` returns the inline payload.
 - Task #844 (this skeleton): G3.7-T1 PfSenseConnector skeleton.
 - Task #847 (this): G3.7-T2 pfSense 7 read ops (landed).
 - Task #850 (final): G3.7-T3 pfSense CLI verbs + E2E + onboarding doc.
+- Task #2849: `pfsense.dhcp.leases` — ISC dhcpd lease-DB read op (connector
+  read-op coverage wave 2, initiative #2833). Grammar per `dhcpd.leases(5)`;
+  chroot path confirmed against pfSense's `status_dhcp_leases.php`.
 - Parent initiative: #370 (G3.7 tier-3 standalone connectors).
 - Bind9 connector (canonical typed-SSH reference): `docs/codebase/connectors-bind9.md`.
 - `SshConnector` adapter: `backend/src/meho_backplane/connectors/adapters/ssh.py`.


### PR DESCRIPTION
## Summary

- Adds `pfsense.dhcp.leases` (op #9, new `dhcp` group) — reads the live ISC dhcpd lease database at `/var/dhcpd/var/db/dhcpd.leases` over the connector's existing SSH transport and parses it into de-duplicated lease rows, so operators/agents can answer "which IPs are leased right now" and DHCP pool-exhaustion questions through the governed `call_operation` path instead of the pfSense WebGUI or an ad hoc SSH one-liner.
- New pure parser `parse_dhcp_leases` grounded in `dhcpd.leases(5)`: the lease file is **log-structured**, so rows de-duplicate to the last block per IP (the one in effect); date statements are UTC `YYYY/MM/DD HH:MM:SS` (weekday index dropped, `ends never` preserved); `binding_state` is the raw token (`active`/`free`/`backup`), except an `active` lease whose `ends` has already elapsed reads as `expired` — the classification pfSense's own `Status > DHCP Leases` view applies.
- Handler returns the standard `{rows, total}` envelope so the default `JsonFluxReducer` wraps a busy pool's lease list in a `ResultHandle` — the connector never decides handle-vs-inline (postulate 6).
- Ships the `meho pfsense dhcp leases` CLI verb and updates `docs/codebase/connectors-pfsense.md` (op table + counts 8 → 9).

## Format grounding (fresh lookups)

- `dhcpd.leases(5)` — lease-block grammar, UTC timestamps, `ends never`, `binding state active/free/backup`, and the log-structured "last block wins" semantics.
- pfSense `status_dhcp_leases.php` — confirmed the chroot lease path `{dhcpd_chroot_path}/var/db/dhcpd.leases` (`/var/dhcpd/...`) and the past-`ends` → expired classification.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (no issues in the pfsense package)
- [x] `pytest tests/test_connectors_pfsense_ops.py tests/test_connectors_pfsense_e2e.py` — 100 passed (13 parser cases: active / expired-by-time / free / no-hostname / `ends never` / dedup / non-lease-block ignore / empty / unterminated-block / default-now; handler happy/error/empty; **response_schema ↔ handler row-key match**; registration count 9 + `dhcp` group + all-ops-dispatch audit)
- [x] `pytest tests/test_connectors_registry_v2.py tests/test_connectors_registry.py` — 54 passed (registration regression)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (pre-existing file-size/complexity warnings only)
- [x] `go build ./...` / `go vet` / `gofmt -l` / `go test ./internal/cmd/pfsense/` — clean (adds `TestDhcpHasLeases`, `TestPrintDhcpLeasesRendersTable`, op-id + subcommand coverage)
- [x] No FastAPI route/schema change → `cli-api-snapshot-freshness` unaffected (typed op is a DB descriptor dispatched via the existing `/api/v1/operations/call` route)

## Out of scope (per issue)

- Pool-exhaustion percentage math (correlating lease count against `config.xml`'s `<dhcpd>` `<range>`) — follow-up.
- DHCPv6 leases (`dhcpd6.leases`) — same shape, separate file.
- Any write path (static-mapping create, lease release/renew) and `<staticmap>` config-side enumeration.
- Sibling #2850 (pfSense gateway status) also touches this connector; changes here are additive (op appended to `READ_OPS`, new `dhcp` group, new CLI file) — expect only a trivial merge conflict at the shared enumeration points.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2849
