### PR TITLE
feat(connectors): add vrops.resource.stats typed read for sizing (#2838)

### DIFF
--- a/backend/src/meho_backplane/connectors/vcf_operations/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/connector.py
@@ -162,6 +162,7 @@ _OPS_TOKEN_SCHEME = "OpsToken"
 _VERSIONS_CURRENT_PATH = "/suite-api/api/versions/current"
 _ALERTS_PATH = "/suite-api/api/alerts"
 _RESOURCES_QUERY_PATH = "/suite-api/api/resources/query"
+_RESOURCES_STATS_LATEST_PATH = "/suite-api/api/resources/stats/latest"
 
 
 def _vrops_acquire_payload_builder(
@@ -564,6 +565,43 @@ class VcfOperationsConnector(HttpConnector):
         if query:
             path = f"{path}?{urlencode(query, doseq=True)}"
         return await self._post_json(target, path, operator=operator, json=body)
+
+    async def resource_stats(
+        self,
+        operator: Operator,
+        target: VcfOperationsTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vrops.resource.stats`` — ``GET /suite-api/api/resources/stats/latest``.
+
+        Returns the latest metric *values* vROps computed for the named
+        resources — the sizing / resource-pressure answer. ``resourceId``
+        (required, one or more UUIDs) and the optional ``statKey`` list ride
+        as repeated query params (``resourceId=a&resourceId=b``); httpx
+        serialises a list value to repeated pairs, the same mechanism
+        :meth:`alert_list` relies on. The optional ``currentOnly`` boolean
+        rides as a scalar query param.
+
+        ``resourceId`` is read with subscript, not ``dict.get``: the op's
+        ``parameter_schema`` marks it ``required`` with ``minItems=1``, so
+        the dispatcher's pre-execution
+        :func:`~meho_backplane.operations._validate.validate_params` rejects
+        a missing / empty list before this handler runs — an unbounded
+        all-resource stats read never reaches the wire. The payload is
+        returned unparsed: the dispatch layer reduces a large stat set to a
+        JSONFlux handle, so the vendor's ``stats-of-resources`` field names
+        stay out of executable code.
+        """
+        query: dict[str, Any] = {"resourceId": params["resourceId"]}
+        stat_keys = params.get("statKey")
+        if stat_keys:
+            query["statKey"] = stat_keys
+        current_only = params.get("currentOnly")
+        if current_only is not None:
+            query["currentOnly"] = current_only
+        return await self._get_json(
+            target, _RESOURCES_STATS_LATEST_PATH, operator=operator, params=query
+        )
 
     async def invalidate_credentials(self, target: VcfOperationsTargetLike) -> None:
         """Public duck-typed credential-eviction hook for the dispatch path (#2396).

--- a/backend/src/meho_backplane/connectors/vcf_operations/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_operations/typed_ops.py
@@ -35,6 +35,18 @@ The audited set (three ops):
   ``GET /suite-api/api/resources`` list the ingested curation still
   browses).
 
+A fourth typed read joins the set in wave 2 (#2838), extending the
+surface from resource *identity* to resource *metric values*:
+
+* ``vrops.resource.stats`` — sizing / resource-pressure read. A
+  ``GET /suite-api/api/resources/stats/latest`` returning the latest
+  metric **values** vROps computed for named resources (current CPU
+  demand, memory workload, capacity-remaining). ``resourceId`` is a
+  required list (typically fed from ``vrops.resource.query``); the
+  schema refuses an unbounded all-resource stats read. Closes the gap
+  where the backplane could find resources and see alerts but never
+  read the values vROps exists to compute.
+
 Sibling precedent for the dataclass + registrar shape:
 :mod:`meho_backplane.connectors.argocd.ops` (metadata dataclasses here,
 thin bound-method handlers on the connector, a module-level registrar
@@ -64,6 +76,7 @@ __all__ = [
     "VROPS_LIVENESS_OP",
     "VROPS_RESOURCE_QUERY_BODY_FIELDS",
     "VROPS_RESOURCE_QUERY_OP",
+    "VROPS_RESOURCE_STATS_OP",
     "VROPS_TYPED_OPS",
     "VROPS_TYPED_WHEN_TO_USE_BY_GROUP",
     "VropsTypedOp",
@@ -80,6 +93,7 @@ _log = structlog.get_logger(__name__)
 _LIVENESS_GROUP_KEY = "vrops-liveness"
 _ALERT_TRIAGE_GROUP_KEY = "vrops-alert-triage"
 _RESOURCE_QUERY_GROUP_KEY = "vrops-resource-query"
+_RESOURCE_STATS_GROUP_KEY = "vrops-resource-stats"
 
 #: Top-level ``ResourceQuerySpec`` body fields ``vrops.resource.query``
 #: forwards (a curated subset of the full spec). ``page`` / ``pageSize``
@@ -156,6 +170,14 @@ VROPS_TYPED_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "with pagination. The right group when the question is 'find the "
         "resource(s) matching X' or 'which monitored objects are in state "
         "Y?'. Read-only."
+    ),
+    _RESOURCE_STATS_GROUP_KEY: (
+        "Use to read the latest metric/stat *values* vROps computed for "
+        "specific resources — current CPU demand, memory workload, "
+        "capacity-remaining — the sizing and resource-pressure answer. The "
+        "right group when the question is 'what is this VM/host actually "
+        "using?' or 'how much capacity is left?'. Feed resource UUIDs from "
+        "the vrops-resource-query group. Read-only."
     ),
 }
 
@@ -427,13 +449,106 @@ VROPS_RESOURCE_QUERY_OP = VropsTypedOp(
 )
 
 
+VROPS_RESOURCE_STATS_OP = VropsTypedOp(
+    op_id="vrops.resource.stats",
+    handler_attr="resource_stats",
+    summary="Read the latest vROps stat/metric values for named resources (sizing input).",
+    description=(
+        "Reads GET /suite-api/api/resources/stats/latest directly on the "
+        "connector's OpsToken session (no catalog ingest) to return the "
+        "latest metric *values* vROps computed for one or more resources — "
+        "the sizing / resource-pressure answer vROps exists to give (current "
+        "CPU demand, memory workload, capacity-remaining). resourceId is a "
+        "required list of resource UUIDs (typically from a prior "
+        "vrops.resource.query); an unbounded all-resource stats read is "
+        "refused at the schema layer. Optional statKey restricts to specific "
+        "stat keys (e.g. 'cpu|demandmhz', 'mem|workload'); omit to return "
+        "every stat the named resources report. Optional currentOnly reports "
+        "only current values. resourceId and statKey serialise to repeated "
+        "query params. Unlike vrops.resource.query (which filters resources "
+        "by whether they report a statKey but never returns the value), this "
+        "op returns the value. Large stat sets are reduced to a JSONFlux "
+        "handle, the same posture vrops.alert.list / vrops.resource.query "
+        "take. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "resourceId": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "minItems": 1,
+                "description": (
+                    "Resource UUIDs (typically from vrops.resource.query) to "
+                    "read latest stat values for. Required — at least one; an "
+                    "unbounded all-resource stats read is refused."
+                ),
+            },
+            "statKey": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "description": (
+                    "Restrict to these stat keys (e.g. 'cpu|demandmhz', "
+                    "'mem|workload', 'cpu|capacity_remaining'). Omit to return "
+                    "every stat the named resources report."
+                ),
+            },
+            "currentOnly": {
+                "type": "boolean",
+                "description": "When true, report only current stat values.",
+            },
+        },
+        "required": ["resourceId"],
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "values": {"type": "array"},
+        },
+        "additionalProperties": True,
+    },
+    group_key=_RESOURCE_STATS_GROUP_KEY,
+    tags=("read-only", "vrops", "vmware", "stats", "metrics"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator is sizing a cluster / VM or diagnosing "
+            "resource pressure and needs vROps's own computed metric values "
+            "— current CPU demand, memory workload, capacity-remaining — for "
+            "specific resources. Feed resourceId from a prior "
+            "vrops.resource.query; narrow with statKey when only certain "
+            "metrics matter."
+        ),
+        "parameter_hints": {
+            "resourceId": "Required list of resource UUIDs from vrops.resource.query.",
+            "statKey": "e.g. 'cpu|demandmhz' / 'mem|workload'; omit for all stats.",
+            "currentOnly": "true to report only current values.",
+        },
+        "output_shape": (
+            "{values: [{resourceId, stats: {stat: [{statKey: {key}, data: "
+            "[number], timestamps: [epoch_ms], ...}, ...]}}, ...]}. Each stat "
+            "entry carries the metric's latest data point(s) and timestamp(s) "
+            "for one statKey on one resource. Large sets return a JSONFlux "
+            "handle — drill in with result_query / result_aggregate. Field "
+            "names follow the VCF Operations 9.0 Suite API stats-of-resources "
+            "shape; confirm against a live target if exact-shape parsing is "
+            "ever needed (the handler passes the payload through unparsed)."
+        ),
+    },
+)
+
+
 #: The typed ops :class:`VcfOperationsConnector` registers at lifespan
-#: startup — the audited vROps read set (#2303). The tuple shape lets a
-#: future typed read join without touching the registrar.
+#: startup — the audited vROps read set (#2303) plus the sizing stat-value
+#: read (#2838). The tuple shape lets a future typed read join without
+#: touching the registrar.
 VROPS_TYPED_OPS: tuple[VropsTypedOp, ...] = (
     VROPS_LIVENESS_OP,
     VROPS_ALERT_LIST_OP,
     VROPS_RESOURCE_QUERY_OP,
+    VROPS_RESOURCE_STATS_OP,
 )
 
 

--- a/backend/tests/test_connectors_vcf_operations_typed_reads.py
+++ b/backend/tests/test_connectors_vcf_operations_typed_reads.py
@@ -13,6 +13,9 @@ Covers the audited read set converted from ingested-row curation to
 * ``vrops.alert.list`` — ``GET /suite-api/api/alerts`` (alert triage).
 * ``vrops.resource.query`` — ``POST /suite-api/api/resources/query`` (a
   body-shaped POST carrying a typed ``ResourceQuerySpec``).
+* ``vrops.resource.stats`` — ``GET /suite-api/api/resources/stats/latest``
+  (the wave-2 sizing read, #2838; latest metric *values* for named
+  resources, gated by a required ``resourceId`` list).
 
 Coverage matrix (per #2303 acceptance criteria):
 
@@ -32,7 +35,7 @@ Coverage matrix (per #2303 acceptance criteria):
   omitted otherwise.
 * **OpsToken on every read** — each read carries
   ``Authorization: OpsToken <token>``, never Basic or Bearer.
-* **Metadata shape** — all three are ``safety_level="safe"``,
+* **Metadata shape** — all four are ``safety_level="safe"``,
   ``requires_approval=False``, tagged ``read-only``, with
   ``additionalProperties=False`` parameter schemas and non-empty
   ``llm_instructions``; no write op is registered.
@@ -85,6 +88,7 @@ _VROPS_BASE_URL = f"https://{_VROPS_HOST}"
 _LIVENESS_PATH = "/suite-api/api/versions/current"
 _ALERTS_PATH = "/suite-api/api/alerts"
 _RESOURCES_QUERY_PATH = "/suite-api/api/resources/query"
+_STATS_LATEST_PATH = "/suite-api/api/resources/stats/latest"
 
 #: OpsToken session-establish path + canned acquire response (#2395).
 _ACQUIRE_PATH = "/suite-api/api/auth/token/acquire"
@@ -111,6 +115,22 @@ _RESOURCES_QUERY_RESPONSE: dict[str, Any] = {
         },
     ],
     "pageInfo": {"page": 0, "pageSize": 1000, "totalCount": 1},
+}
+_STATS_RESPONSE: dict[str, Any] = {
+    "values": [
+        {
+            "resourceId": "r-1",
+            "stats": {
+                "stat": [
+                    {
+                        "statKey": {"key": "cpu|demandmhz"},
+                        "data": [1234.5],
+                        "timestamps": [1470421325035],
+                    },
+                ],
+            },
+        },
+    ],
 }
 
 
@@ -220,6 +240,13 @@ async def _register_typed_ops(stub: AsyncMock) -> None:
             _RESOURCES_QUERY_PATH,
             _RESOURCES_QUERY_RESPONSE,
         ),
+        (
+            "vrops.resource.stats",
+            {"resourceId": ["r-1"]},
+            "GET",
+            _STATS_LATEST_PATH,
+            _STATS_RESPONSE,
+        ),
     ],
     ids=lambda v: v if isinstance(v, str) else "",
 )
@@ -273,7 +300,12 @@ async def test_typed_ops_registered_with_source_kind_typed(
     """
     await _register_typed_ops(_stub_embedding)
 
-    expected = {"vrops.liveness", "vrops.alert.list", "vrops.resource.query"}
+    expected = {
+        "vrops.liveness",
+        "vrops.alert.list",
+        "vrops.resource.query",
+        "vrops.resource.stats",
+    }
     rows = (
         (
             await session.execute(
@@ -339,6 +371,81 @@ async def test_resource_query_sends_body_and_paginates(
     # Pagination rides as query params.
     assert request.url.params["page"] == "0"
     assert request.url.params["pageSize"] == "100"
+
+
+@pytest.mark.asyncio
+async def test_resource_stats_sends_repeated_ids_and_keys_and_returns_values(
+    _stub_embedding: AsyncMock, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """vrops.resource.stats GETs stats/latest with repeated ids/keys and returns values."""
+    await _register_typed_ops(_stub_embedding)
+    install_fake_client(
+        monkeypatch, secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    )
+
+    params = {
+        "resourceId": ["r-1", "r-2"],
+        "statKey": ["cpu|demandmhz", "mem|workload"],
+        "currentOnly": True,
+    }
+    async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_ACQUIRE_RESPONSE)
+        route = mock.get(_STATS_LATEST_PATH).respond(200, json=_STATS_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="vrops.resource.stats",
+            target=_TypedReadTarget(),
+            params=params,
+        )
+
+    # The op returns the metric *values* (not just resource identity).
+    assert result.status == "ok", result.error
+    assert result.result == _STATS_RESPONSE
+
+    sent = route.calls[0].request.url.params
+    resource_ids = [value for key, value in sent.multi_items() if key == "resourceId"]
+    stat_keys = [value for key, value in sent.multi_items() if key == "statKey"]
+    assert resource_ids == ["r-1", "r-2"]
+    assert stat_keys == ["cpu|demandmhz", "mem|workload"]
+    assert sent["currentOnly"] == "true"
+    # Scheme-regression pin: the read carries OpsToken, never Basic/Bearer.
+    assert route.calls[0].request.headers.get("authorization") == f"OpsToken {_OPS_TOKEN}"
+
+
+@pytest.mark.asyncio
+async def test_resource_stats_refuses_unbounded_all_resource_read(
+    _stub_embedding: AsyncMock, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """resourceId is required (minItems=1): an unbounded all-resource read never hits the wire."""
+    await _register_typed_ops(_stub_embedding)
+    install_fake_client(
+        monkeypatch, secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD}
+    )
+
+    async with respx.mock(base_url=_VROPS_BASE_URL, assert_all_called=False) as mock:
+        mock.post(_ACQUIRE_PATH).respond(200, json=_ACQUIRE_RESPONSE)
+        stats_route = mock.get(_STATS_LATEST_PATH).respond(200, json=_STATS_RESPONSE)
+        empty = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="vrops.resource.stats",
+            target=_TypedReadTarget(),
+            params={"resourceId": []},
+        )
+        missing = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="vrops.resource.stats",
+            target=_TypedReadTarget(),
+            params={"statKey": ["cpu|demandmhz"]},
+        )
+
+    for result in (empty, missing):
+        assert result.status == "error"
+        assert result.extras.get("error_code") == "invalid_params"
+    # The schema gate refuses before any wire call — the stats endpoint is never hit.
+    assert not stats_route.called
 
 
 @pytest.mark.asyncio
@@ -442,6 +549,7 @@ def test_typed_ops_are_read_only_and_well_formed() -> None:
         "vrops.liveness",
         "vrops.alert.list",
         "vrops.resource.query",
+        "vrops.resource.stats",
     }
     for op in VROPS_TYPED_OPS:
         assert op.safety_level == "safe", f"{op.op_id} must be safe (read-only surface)"

--- a/docs/codebase/connectors-vcf-operations.md
+++ b/docs/codebase/connectors-vcf-operations.md
@@ -209,12 +209,32 @@ registrar is queued via `register_typed_op_registrar` in the package
   `resourceKind` / `name` / `regex` / `adapterKind` / state / status /
   health / parent / `statKey`), paginated via `page` / `pageSize` query
   params.
+- **`vrops.resource.stats`** — `GET /suite-api/api/resources/stats/latest`
+  (wave-2 sizing read, #2838). Returns the latest metric **values** vROps
+  computed for named resources — current CPU demand, memory workload,
+  capacity-remaining — the sizing / resource-pressure answer, closing the
+  gap where the backplane could find resources (`vrops.resource.query`) and
+  see alerts (`vrops.alert.list`) but never read the values vROps exists to
+  compute. `resourceId` is a **required** list (`minItems=1`, typically fed
+  from `vrops.resource.query`); the optional `statKey` list narrows to
+  specific stat keys and the optional `currentOnly` boolean reports only
+  current values. `resourceId` / `statKey` serialise to repeated query
+  params. The `required`/`minItems` schema means the dispatcher's
+  pre-execution param validation refuses an unbounded all-resource stats
+  read before the handler runs. Unlike `vrops.resource.query`'s `statKey`
+  (which filters resources by *whether* they report a stat), this op returns
+  the stat's **value**; the handler passes the payload through unparsed so
+  the vendor's `stats-of-resources` field names stay out of executable code.
 
-All three are `safety_level="safe"`, `requires_approval=False`,
+All four are `safety_level="safe"`, `requires_approval=False`,
 read-only. Each rides the connector's `OpsToken` session; `authSource`
 federation lives in the acquire body, not on the reads. `vrops.resource.query`
 encodes its `page`/`pageSize` pagination onto the request path (the base
-`_post_json` takes no `params` mapping).
+`_post_json` takes no `params` mapping); `vrops.resource.stats` threads its
+`resourceId` / `statKey` / `currentOnly` through the base `_get_json`
+`params` mapping (httpx serialises a list value to repeated pairs). Large
+stat / alert / resource sets reduce to a JSONFlux handle at the dispatch
+layer.
 
 The remaining 6 ingested-browse ops (resource list/get, alert definitions,
 symptoms, recommendations, super metrics) stay browsable until Initiative
@@ -270,6 +290,7 @@ NSX / vRLI take).
 
 - **Task (skeleton)**: <https://github.com/evoila/meho/issues/829>
 - **Task (OpsToken auth rebuild)**: <https://github.com/evoila/meho/issues/2395>
+- **Task (stat/metric read for sizing)**: <https://github.com/evoila/meho/issues/2838>
 - **Parent initiative**: <https://github.com/evoila/meho/issues/369>
 - **Parent goal**: <https://github.com/evoila/meho/issues/214>
 - **Sibling skeletons (same Initiative wave)**:


### PR DESCRIPTION
## Summary

- Adds a fourth vROps typed read, **`vrops.resource.stats`**, hitting
  `GET /suite-api/api/resources/stats/latest` on the connector's existing
  `OpsToken` session. It surfaces the latest metric **values** vROps
  computed for named resources (current CPU demand, memory workload,
  capacity-remaining) — the sizing / resource-pressure answer vROps exists
  to give. Until now the backplane could find resources
  (`vrops.resource.query`) and see alerts (`vrops.alert.list`) but never
  read the values, so operators fell back to the vROps UI or a raw
  `/suite-api` call, bypassing policy / audit / broadcast / JSONFlux.
- **`resourceId` is required (`minItems=1`, typically fed from a prior
  `vrops.resource.query`).** The schema gate makes the dispatcher's
  pre-execution param validation refuse an unbounded all-resource stats
  read before the handler runs — the vendor marks the param optional, but
  an all-resource latest-stats sweep is an appliance-straining footgun this
  op deliberately closes. Optional `statKey` narrows to specific stat keys;
  optional `currentOnly` reports only current values. Both `resourceId` and
  `statKey` serialise to repeated query params via httpx (the same
  mechanism `vrops.alert.list` uses).
- The handler is a **pass-through**: it returns the vendor payload unparsed,
  so the `stats-of-resources` response field names stay out of executable
  code (documented only in `llm_instructions.output_shape`), and the
  dispatch layer reduces a large stat set to a JSONFlux handle — the same
  posture the sibling reads take. Endpoint + params verified against the
  VCF Operations 9.0 Suite API reference (Broadcom developer docs).

## Test plan

- [x] `ruff check` — clean (changed source + test)
- [x] `ruff format --check` — clean
- [x] `mypy --strict` — no issues in the changed source
- [x] `pytest tests/test_connectors_vcf_operations_typed_reads.py` — 11 passed
- [x] `pytest` vcf_operations auth + credread + typed_reads + e2e — 55 passed (no regression)
- [x] Acceptance #1 (registered, `safe`, no-approval, `connector_id="vrops-rest-9.0"`) — `test_typed_ops_registered_with_source_kind_typed` + parametrized dispatch
- [x] Acceptance #2/#3 (`resourceId`/`statKey` arrays forwarded to the stats endpoint on the OpsToken session, returns **values**) — `test_resource_stats_sends_repeated_ids_and_keys_and_returns_values` (asserts repeated `resourceId`/`statKey` query params, `currentOnly`, `OpsToken` header, and the returned `values[]` payload)
- [x] Acceptance #4 (JSONFlux large-set reduction) — handler returns the raw dict, dispatch layer reduces (mirrors `vrops.alert.list` / `vrops.resource.query`); documented in the op + docs
- [x] Acceptance #5 (respx-mocked `/suite-api/api/resources/stats/latest` test) — added, plus `test_resource_stats_refuses_unbounded_all_resource_read` proving the required-`resourceId` gate returns `invalid_params` before any wire call
- [x] Acceptance #6 (`docs/codebase/connectors-vcf-operations.md`) — `vrops.resource.stats` added to the typed-read list, count updated three → four
- [x] Acceptance #7 (OpenAPI snapshot) — regenerated `cli/api/openapi.json` from source; byte-identical (a typed connector op is a runtime descriptor row, not a FastAPI route), so nothing to commit

## Out of scope

- Historical time-range stat queries (`POST /suite-api/api/resources/stats/query`) and super-metric / definition reads — per the issue's out-of-scope; a plausible fast-follow.
- `maxSamples` / `metrics` vendor params — "latest value for sizing" is served by the default (`maxSamples` defaults to 1); left out to keep the surface minimal.
- **Adjacent findings (code-quality `--diff`, 0 blockers / 4 warnings):** `connector.py` (633) and `typed_ops.py` (627) each cross the 600-line file-size warn threshold, and `_session_token` (64) / `register_vcf_operations_typed_operations` (72) cross the 60-line function warn. These are cohesive single-connector modules; splitting them for a line count is a separate refactor, not this task.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2838
