### PR TITLE
feat(connectors): net.http_probe host_header for vhost-routed health probes by IP (#2896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,24 @@ connector-related release-notes line.
   `tasks.recent` `Task.info` read. See
   `docs/codebase/connectors-vmware-rest.md` for the full substrate.
 
+### Added — `net.http_probe` gains a `host_header` param for vhost-routed health probes by IP (#2896)
+
+- A strict-vhost appliance (VCFA and friends) probed by its NAT-alias IP
+  **before DNS exists** returns 404 whether it is healthy or wedged,
+  because the probe derives `Host:` and TLS SNI from the URL host (the
+  IP). The new optional `host_header` (`hostname[:port]`) decouples the
+  vhost identity from the dialed address: it is sent verbatim as the
+  initial request's `Host:` header and — for an `https` URL — also as the
+  TLS SNI + certificate-verification name (`sni_hostname`), so `verify`
+  stays on against a cert pinned to the vhost rather than the IP.
+- The probe allowlist still gates the **dialed** `url` host only —
+  `host_header` is never dialed and cannot widen the allowlist (the #2405
+  / #2784 SSRF floor is unchanged). The override rides the first redirect
+  hop only; each hop is re-gated as before. A closed single-purpose param
+  was chosen over a free-form `headers` map deliberately (no
+  header-injection / exfil surface on a body-less probe). Existing
+  `net.http_probe` calls without the param behave byte-identically.
+
 ## [0.28.0] - 2026-08-07
 
 ### Added — seven more Do-real-work guides on the docs site: topology, broadcast, memory/knowledge, audit forensics, runbooks, scheduler, satellite gateway (#2829)

--- a/backend/src/meho_backplane/connectors/net/http_probe.py
+++ b/backend/src/meho_backplane/connectors/net/http_probe.py
@@ -131,6 +131,23 @@ NET_HTTP_PROBE_PARAMETER_SCHEMA: dict[str, Any] = {
                 "reason='timeout'."
             ),
         },
+        "host_header": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional vhost override (hostname[:port]) for "
+                "health-probing a vhost-routed service by IP before DNS "
+                "exists: put the raw IP in `url` — that host is what is "
+                "dialed AND allowlist-gated — and the virtual host name "
+                "here. It is sent verbatim as the initial request's "
+                "`Host:` header and, for an https `url`, also as the TLS "
+                "SNI + certificate-verification name (so `verify` stays on "
+                "against a cert pinned to the vhost, not the IP). It is "
+                "NEVER dialed and NEVER widens the allowlist — the gate "
+                "stays on the `url` host — and is dropped after the first "
+                "redirect hop (each hop has its own canonical host)."
+            ),
+        },
     },
     "required": ["url"],
     "additionalProperties": False,
@@ -167,7 +184,10 @@ _NET_HTTP_PROBE_RESPONSE_SCHEMA: dict[str, Any] = {
             "type": ["object", "null"],
             "description": (
                 "Final response headers (lowercased names). Null if no "
-                "response was received. The body is never included."
+                "response was received. The body is never included. When "
+                "host_header is set these reflect the vhost-routed virtual "
+                "host (the origin the Host: header selected), not a default "
+                "vhost."
             ),
         },
         "redirect_chain": {
@@ -188,7 +208,10 @@ _NET_HTTP_PROBE_RESPONSE_SCHEMA: dict[str, Any] = {
             "description": (
                 "TLS summary of the final connection (version, cipher, "
                 "alpn, cert subject/issuer/not_after); null for plain "
-                "HTTP or when no response was received."
+                "HTTP or when no response was received. When host_header is "
+                "set on an https probe the cert reflects the vhost-routed "
+                "virtual host — SNI and certificate verification use the "
+                "vhost name, not the dialed IP."
             ),
         },
         "timing_ms": {
@@ -272,7 +295,10 @@ _NET_HTTP_PROBE_WHEN_TO_USE = (
     "normal result, not an error. The URL host must be inside "
     "MEHO_NETDIAG_PROBE_ALLOWLIST; one that is not fails with "
     "connector_probe_refused rather than reporting a (false) unreachable "
-    "URL."
+    "URL. To health-probe a vhost-routed service by IP before DNS exists "
+    "(a strict-vhost appliance behind a NAT-alias IP), put the IP in the "
+    "URL and the virtual host in the optional host_header param — the "
+    "allowlist still gates only the dialed IP."
 )
 
 _NET_HTTP_PROBE_LLM_INSTRUCTIONS: dict[str, Any] = {
@@ -287,6 +313,13 @@ _NET_HTTP_PROBE_LLM_INSTRUCTIONS: dict[str, Any] = {
         "url": "Required. Absolute http:// or https:// URL. Host must be allowlisted for probing.",
         "method": "Optional. HEAD (default) or GET only.",
         "timeout_seconds": "Optional. Total timeout across the redirect walk (default 5, max 30).",
+        "host_header": (
+            "Optional vhost override (hostname[:port]) to probe a "
+            "vhost-routed service by IP: put the IP in url (dialed + "
+            "allowlist-gated), the vhost here (sent as Host: and, for "
+            "https, as TLS SNI + cert-verify name). Never dialed, never "
+            "widens the allowlist, dropped after the first redirect hop."
+        ),
     },
     "output_shape": (
         "On a clean terminal response: {'reachable': true, 'reason': "
@@ -562,86 +595,158 @@ def _error_detail(exc: BaseException) -> list[dict[str, str]]:
     return detail
 
 
+def _sni_from_host_header(host_header: str) -> str:
+    """Strip an optional trailing ``:port`` off *host_header* for the SNI name.
+
+    The ``Host:`` header carries ``hostname[:port]`` verbatim, but the TLS
+    SNI extension (RFC 6066) — and the certificate-verification name
+    httpcore derives from it — is the bare hostname. ``rpartition`` peels
+    only a numeric trailing port, so a bare hostname passes through
+    untouched.
+    """
+    host, sep, port = host_header.rpartition(":")
+    if sep and port.isdigit():
+        return host
+    return host_header
+
+
+def _host_header_build_kwargs(host_header: str | None, *, is_https: bool) -> dict[str, Any]:
+    """``httpx.build_request`` kwargs that force the vhost ``Host:`` + TLS SNI.
+
+    Empty when no ``host_header`` is given, so the request is built
+    byte-identically to today (SNI / Host derive from the URL). When set,
+    ``Host:`` carries the vhost verbatim (``hostname[:port]``) and — for an
+    https initial URL — the ``sni_hostname`` extension makes the handshake
+    offer the bare vhost hostname as SNI and verify the presented cert
+    against it (httpcore derives ``server_hostname`` from that extension,
+    the #2002/#2863 seam). The ``Host:`` header alone does **not** suffice
+    for https: without the SNI override an IP-dialed probe with ``verify``
+    on offers the IP as SNI and fails cert verification (``tls_error``).
+    Applied to the **first hop only** by :func:`_walk_redirects`.
+    """
+    if not host_header:
+        return {}
+    kwargs: dict[str, Any] = {"headers": {"Host": host_header}}
+    if is_https:
+        kwargs["extensions"] = {"sni_hostname": _sni_from_host_header(host_header)}
+    return kwargs
+
+
+def _advance_or_halt(
+    *,
+    response: httpx.Response,
+    request: httpx.Request,
+    redirect_chain: list[dict[str, Any]],
+    url: str,
+    method: str,
+    started: float,
+) -> dict[str, Any] | tuple[str, str]:
+    """Decide the next step for a ``3xx`` *response* in the redirect walk.
+
+    Returns a terminal ``_result`` dict when the walk must **halt** — the
+    redirect budget is exhausted (``too_many_redirects``), the ``Location``
+    resolves to no follow-up request (treated as terminal), or the next
+    host is refused by the allowlist (``blocked_redirect`` SSRF re-gate,
+    never dialed) — or the ``(next_url, next_method)`` to dial when the
+    redirect target is allowlisted. Appends the current hop to
+    *redirect_chain*.
+    """
+    status = response.status_code
+    redirect_chain.append({"url": str(request.url), "status": status})
+    if len(redirect_chain) > _MAX_REDIRECTS:
+        return _result(
+            url=url,
+            method=method,
+            reachable=True,
+            reason="too_many_redirects",
+            status=status,
+            redirect_chain=redirect_chain,
+            timing_ms=_elapsed_ms(started),
+            final_url=str(request.url),
+        )
+    # httpx's own correctly-built follow-up request (method downgrade on
+    # 301/302/303, relative-Location resolution).
+    next_request = response.next_request
+    if next_request is None:
+        # has_redirect_location but no resolvable next request (e.g.
+        # malformed Location) — treat as terminal.
+        return _result(
+            url=url,
+            method=method,
+            reachable=True,
+            reason=None,
+            status=status,
+            headers=_headers_dict(response.headers),
+            redirect_chain=redirect_chain,
+            tls=_tls_summary(response),
+            timing_ms=_elapsed_ms(started),
+            final_url=str(request.url),
+        )
+    next_host = next_request.url.host
+    try:
+        assert_probe_allowed(next_host)
+    except ProbeNotAllowedError:
+        # SSRF re-gate: the redirect target is refused and never dialed.
+        # reachable=true (the prior host did answer), but the walk halts.
+        _log.info(
+            "net.http_probe.blocked_redirect",
+            blocked_redirect=next_host,
+            from_url=str(request.url),
+        )
+        return _result(
+            url=url,
+            method=method,
+            reachable=True,
+            reason="blocked_redirect",
+            status=status,
+            redirect_chain=redirect_chain,
+            timing_ms=_elapsed_ms(started),
+            final_url=str(request.url),
+            blocked_redirect=next_host,
+        )
+    return str(next_request.url), next_request.method
+
+
 async def _walk_redirects(
     *,
     client: httpx.AsyncClient,
     url: str,
     method: str,
     started: float,
+    first_hop_build_kwargs: dict[str, Any],
 ) -> dict[str, Any]:
     """Issue the request and walk redirects manually, re-gating each hop.
 
     The initial host has already been allowlist-checked by the caller.
-    For every ``3xx`` with a ``Location``, this re-gates the **next**
-    host through :func:`assert_probe_allowed` *before* dialing it; a
-    non-allowlisted target halts the walk with a ``blocked_redirect``
-    result and is never dialed. Bounded by :data:`_MAX_REDIRECTS`.
+    Each ``3xx`` is handed to :func:`_advance_or_halt`, which re-gates the
+    **next** host through :func:`assert_probe_allowed` *before* it is
+    dialed. Bounded by :data:`_MAX_REDIRECTS`. ``first_hop_build_kwargs``
+    (the ``host_header`` vhost override, from :func:`_host_header_build_kwargs`)
+    rides the **first hop only** — a redirect target has its own canonical
+    host, so carrying a forced ``Host:``/SNI across hops would probe the
+    wrong virtual host.
     """
     redirect_chain: list[dict[str, Any]] = []
     current_url = url
     current_method = method
 
-    for _hop in range(_MAX_REDIRECTS + 1):
-        request = client.build_request(current_method, current_url)
+    for hop_index in range(_MAX_REDIRECTS + 1):
+        build_kwargs = first_hop_build_kwargs if hop_index == 0 else {}
+        request = client.build_request(current_method, current_url, **build_kwargs)
         response = await client.send(request, stream=True)
         try:
-            status = response.status_code
             if response.has_redirect_location:
-                redirect_chain.append({"url": str(request.url), "status": status})
-                if len(redirect_chain) > _MAX_REDIRECTS:
-                    return _result(
-                        url=url,
-                        method=method,
-                        reachable=True,
-                        reason="too_many_redirects",
-                        status=status,
-                        redirect_chain=redirect_chain,
-                        timing_ms=_elapsed_ms(started),
-                        final_url=str(request.url),
-                    )
-                # httpx's own correctly-built follow-up request (method
-                # downgrade on 301/302/303, relative-Location resolution).
-                next_request = response.next_request
-                if next_request is None:
-                    # has_redirect_location but no resolvable next request
-                    # (e.g. malformed Location) — treat as terminal.
-                    return _result(
-                        url=url,
-                        method=method,
-                        reachable=True,
-                        reason=None,
-                        status=status,
-                        headers=_headers_dict(response.headers),
-                        redirect_chain=redirect_chain,
-                        tls=_tls_summary(response),
-                        timing_ms=_elapsed_ms(started),
-                        final_url=str(request.url),
-                    )
-                next_host = next_request.url.host
-                try:
-                    assert_probe_allowed(next_host)
-                except ProbeNotAllowedError:
-                    # SSRF re-gate: the redirect target is refused and
-                    # never dialed. reachable=true (the prior host did
-                    # answer), but the walk halts here.
-                    _log.info(
-                        "net.http_probe.blocked_redirect",
-                        blocked_redirect=next_host,
-                        from_url=str(request.url),
-                    )
-                    return _result(
-                        url=url,
-                        method=method,
-                        reachable=True,
-                        reason="blocked_redirect",
-                        status=status,
-                        redirect_chain=redirect_chain,
-                        timing_ms=_elapsed_ms(started),
-                        final_url=str(request.url),
-                        blocked_redirect=next_host,
-                    )
-                current_url = str(next_request.url)
-                current_method = next_request.method
+                outcome = _advance_or_halt(
+                    response=response,
+                    request=request,
+                    redirect_chain=redirect_chain,
+                    url=url,
+                    method=method,
+                    started=started,
+                )
+                if isinstance(outcome, dict):
+                    return outcome
+                current_url, current_method = outcome
                 continue
 
             # Terminal (non-redirect) response: capture TLS before the
@@ -653,7 +758,7 @@ async def _walk_redirects(
                 method=method,
                 reachable=True,
                 reason=None,
-                status=status,
+                status=response.status_code,
                 headers=_headers_dict(response.headers),
                 redirect_chain=redirect_chain,
                 tls=tls,
@@ -699,6 +804,8 @@ async def net_http_probe(operator: Operator, target: Any, params: dict[str, Any]
     url = str(params["url"])
     method = str(params.get("method", "HEAD")).upper()
     timeout = _clamp_timeout(params.get("timeout_seconds", _DEFAULT_TIMEOUT_SECONDS))
+    host_header_raw = params.get("host_header")
+    host_header = str(host_header_raw) if host_header_raw else None
 
     # Parse + validate the URL locally before any network work.
     try:
@@ -708,10 +815,16 @@ async def net_http_probe(operator: Operator, target: Any, params: dict[str, Any]
     if parsed.scheme not in ("http", "https") or not parsed.host:
         return _result(url=url, method=method, reachable=False, reason="invalid_url")
 
-    # Gate the initial host BEFORE any socket opens. A refusal propagates
-    # (#2784): no request was issued, so there is no observation to report
-    # — the dispatcher renders it as ``connector_probe_refused``.
+    # Gate the initial host BEFORE any socket opens. This gates the
+    # **dialed** ``url`` host only — never ``host_header``, which is an
+    # HTTP/TLS routing hint, is never dialed, and so can never widen the
+    # allowlist. A refusal propagates (#2784): no request was issued, so
+    # there is no observation to report — the dispatcher renders it as
+    # ``connector_probe_refused``.
     assert_probe_allowed(parsed.host)
+    first_hop_build_kwargs = _host_header_build_kwargs(
+        host_header, is_https=parsed.scheme == "https"
+    )
 
     started = time.perf_counter()
     # Fresh client per call (NOT HttpConnector's per-target pool);
@@ -725,7 +838,13 @@ async def net_http_probe(operator: Operator, target: Any, params: dict[str, Any]
             timeout=httpx.Timeout(timeout),
         ) as client:
             return await asyncio.wait_for(
-                _walk_redirects(client=client, url=url, method=method, started=started),
+                _walk_redirects(
+                    client=client,
+                    url=url,
+                    method=method,
+                    started=started,
+                    first_hop_build_kwargs=first_hop_build_kwargs,
+                ),
                 timeout=timeout,
             )
     except (TimeoutError, httpx.TimeoutException) as exc:
@@ -787,7 +906,15 @@ async def register_net_http_probe_operations(
             "product, never a connector error. A connection-level "
             "failure also carries error_detail: the actual mapped "
             "exception chain (innermost-first {type, message}, bounded) "
-            "behind the reason code."
+            "behind the reason code. An optional host_header "
+            "(hostname[:port]) health-probes a vhost-routed service by IP "
+            "before DNS exists: the IP goes in url and the virtual host in "
+            "host_header, sent verbatim as the initial Host: header and — "
+            "for an https url — as the TLS SNI + certificate-verification "
+            "name (so verify stays on against a cert pinned to the vhost). "
+            "The allowlist always gates the DIALED url host, never "
+            "host_header (which is never dialed and cannot widen it); the "
+            "override is dropped after the first redirect hop."
         ),
         parameter_schema=NET_HTTP_PROBE_PARAMETER_SCHEMA,
         response_schema=_NET_HTTP_PROBE_RESPONSE_SCHEMA,

--- a/backend/tests/test_connectors_net_http_probe.py
+++ b/backend/tests/test_connectors_net_http_probe.py
@@ -40,6 +40,7 @@ from uuid import UUID
 import anyio
 import httpx
 import pytest
+import respx
 from sqlalchemy import select
 
 from meho_backplane.auth.operator import Operator, TenantRole
@@ -144,6 +145,9 @@ class _TestServer:
     host: str
     port: int
     hits: list[str] = field(default_factory=list)
+    #: The verbatim ``Host:`` header seen on each hit, in order — lets a
+    #: test pin which host was sent on which redirect hop.
+    request_hosts: list[str] = field(default_factory=list)
 
     @property
     def origin(self) -> str:
@@ -171,12 +175,17 @@ async def _start_http_server(
             parts = request_line.decode("latin-1").split()
             method = parts[0] if parts else "GET"
             path = parts[1] if len(parts) > 1 else "/"
-            # Drain request headers.
+            # Drain request headers, capturing Host for override assertions.
+            request_host = ""
             while True:
                 line = await reader.readline()
                 if line in (b"\r\n", b"\n", b""):
                     break
+                name, sep, value = line.decode("latin-1").partition(":")
+                if sep and name.strip().lower() == "host":
+                    request_host = value.strip()
             state.hits.append(path)
+            state.request_hosts.append(request_host)
             route = routes.get(path, _Route(status=404, body=b"not found"))
             headers = dict(route.headers)
             headers.setdefault("Content-Length", str(len(route.body)))
@@ -694,3 +703,150 @@ def test_response_schema_declares_error_detail() -> None:
     schema = net_http_probe_mod._NET_HTTP_PROBE_RESPONSE_SCHEMA
     assert "error_detail" in schema["properties"]
     assert "error_detail" in schema["required"]
+
+
+# ---------------------------------------------------------------------------
+# host_header — vhost-routed health probes by IP (#2896)
+# ---------------------------------------------------------------------------
+
+
+def test_host_header_is_an_optional_string_in_the_schema() -> None:
+    """AC1: host_header is schema-accepted, optional, additive.
+
+    Present as a string property, absent from ``required`` (so existing
+    callers are unaffected), and the object stays closed
+    (``additionalProperties: false``).
+    """
+    schema = net_http_probe_mod.NET_HTTP_PROBE_PARAMETER_SCHEMA
+    assert schema["properties"]["host_header"]["type"] == "string"
+    assert schema["required"] == ["url"]
+    assert schema["additionalProperties"] is False
+
+
+@pytest.mark.parametrize(
+    ("host_header", "expected_sni"),
+    [
+        ("vcfa.corp.example", "vcfa.corp.example"),
+        ("vcfa.corp.example:8443", "vcfa.corp.example"),
+        # No numeric trailing port ⇒ passed through untouched.
+        ("vcfa.corp.example:", "vcfa.corp.example:"),
+    ],
+)
+def test_sni_from_host_header_strips_only_a_numeric_port(
+    host_header: str, expected_sni: str
+) -> None:
+    """The TLS SNI name is the bare hostname; the Host: header keeps its port."""
+    assert net_http_probe_mod._sni_from_host_header(host_header) == expected_sni
+
+
+async def test_host_header_sends_host_and_sni_on_https(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC1: an https probe by IP with host_header dials the IP but sends the
+    vhost as both the ``Host:`` header and the TLS SNI / cert-verify name.
+
+    ``sni_hostname`` is what httpcore reads as ``server_hostname`` — the
+    single value that drives BOTH the wire SNI extension and the
+    certificate hostname check — so setting it is what keeps ``verify`` on
+    against a cert pinned to the vhost rather than the dialed IP (the
+    #2002/#2863 seam). Transport-verified via respx.
+    """
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "203.0.113.9")
+    async with respx.mock(base_url="https://203.0.113.9") as mock:
+        route = mock.head("/health").respond(200, headers={"X-App": "vcfa"})
+        result = await net_http_probe(
+            _make_operator(),
+            None,
+            {"url": "https://203.0.113.9/health", "host_header": "vcfa.corp.example:8443"},
+        )
+
+    assert route.called
+    req = route.calls[0].request
+    # Host header = the vhost verbatim (port preserved).
+    assert req.headers["host"] == "vcfa.corp.example:8443"
+    # But the dialed address stays the IP the allowlist gated.
+    assert req.url.host == "203.0.113.9"
+    # SNI / cert-verification name = the bare vhost hostname (port stripped).
+    assert req.extensions["sni_hostname"] == "vcfa.corp.example"
+    assert result["reachable"] is True
+    assert result["status"] == 200
+
+
+async def test_host_header_omitted_dispatches_byte_identically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC5: without host_header, Host / SNI derive from the URL exactly as
+    before — no forced Host header, no sni_hostname extension."""
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "203.0.113.9")
+    async with respx.mock(base_url="https://203.0.113.9") as mock:
+        route = mock.head("/x").respond(200)
+        await net_http_probe(_make_operator(), None, {"url": "https://203.0.113.9/x"})
+
+    req = route.calls[0].request
+    assert req.headers["host"] == "203.0.113.9"
+    assert "sni_hostname" not in req.extensions
+
+
+async def test_host_header_does_not_widen_the_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_http_probe_op: None,
+) -> None:
+    """AC2: the allowlist gates the DIALED url host, never host_header.
+
+    A non-allowlisted IP carrying an allowlisted-looking host_header is
+    still refused as a dispatch error (#2784) and no socket opens — the
+    header cannot smuggle a probe past the floor.
+    """
+
+    async def _boom(*_a: object, **_kw: object) -> object:
+        raise AssertionError("no request may run when the dialed host is refused")
+
+    monkeypatch.setattr(net_http_probe_mod.httpx.AsyncClient, "send", _boom)
+    # 'localhost' is the only allowlisted token; the dialed 192.168.1.5 is not.
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "localhost")
+
+    result = await _dispatch_probe({"url": "http://192.168.1.5/health", "host_header": "localhost"})
+
+    assert result.status == "error"
+    assert result.extras["error_code"] == "connector_probe_refused"
+    # The refusal names the DIALED IP, not the host_header value.
+    assert result.extras["host"] == "192.168.1.5"
+
+
+async def test_host_header_override_is_dropped_after_the_first_redirect_hop(
+    monkeypatch: pytest.MonkeyPatch,
+    _registered_http_probe_op: None,
+) -> None:
+    """AC3: the override rides hop 1 only; the redirect target keeps its own
+    canonical host, and each hop is re-gated (127.0.0.1 stays allowlisted).
+
+    Carrying a forced ``Host:`` across hops would probe the wrong virtual
+    host, so hop 2 must fall back to the redirect target's own host.
+    """
+    monkeypatch.setenv(PROBE_ALLOWLIST_ENV, "127.0.0.1")
+    srv = await _start_http_server(
+        {
+            "/start": _Route(status=302, headers={"Location": "/final"}),
+            "/final": _Route(status=200, body=b"arrived"),
+        }
+    )
+    try:
+        result = await _dispatch_probe(
+            {
+                "url": f"{srv.origin}/start",
+                "method": "GET",
+                "host_header": "vhost.example:1234",
+            }
+        )
+    finally:
+        srv.server.close()
+        await srv.server.wait_closed()
+
+    assert result.status == "ok", result.error
+    body = result.result
+    assert body["status"] == 200
+    assert [hop["status"] for hop in body["redirect_chain"]] == [302]
+    # Hop 1 carried the forced vhost Host: header.
+    assert srv.request_hosts[0] == "vhost.example:1234"
+    # Hop 2 (the redirect target) carried its own canonical host — override dropped.
+    assert srv.request_hosts[1] == f"127.0.0.1:{srv.port}"

--- a/docs/codebase/connectors-net-diagnostics.md
+++ b/docs/codebase/connectors-net-diagnostics.md
@@ -278,6 +278,51 @@ transitively via httpx and is now declared a direct dependency in
 `backend/pyproject.toml` so the requirement is explicit (same pattern as
 `dnspython` / `cryptography`).
 
+### Vhost-routed probes by IP — `host_header` (#2896)
+
+A **strict-vhost appliance** (VCFA and friends) vhost-routes: it answers
+only when the request's `Host:` matches a virtual host it serves, and
+returns 404 for anything else. Probed by its NAT-alias IP **before DNS
+exists** — `https://<IP>/health` — the probe derives `Host:` and TLS SNI
+from the URL host (the IP), so a healthy service and a wedged one both
+read 404 (or `tls_error` with `verify` on): the reading is useless. Two
+labs sat API-dead ~14h behind green TCP/UI probes for exactly this.
+
+The optional **`host_header`** param (`hostname[:port]`) decouples the
+vhost identity from the dialed address, the same seam
+`HttpConnector.tls_server_name` uses for target-coupled dispatch (#2002 /
+#2863):
+
+- The raw IP stays in `url` — that host is what is **dialed** and what
+  `assert_probe_allowed` gates. `host_header` is **never dialed** and can
+  **never widen the allowlist**; the SSRF floor is unchanged.
+- `host_header` is sent **verbatim** as the initial request's `Host:`
+  header, and — for an `https` URL — also as
+  `extensions={"sni_hostname": <host minus port>}`. httpcore reads that
+  extension as `server_hostname`, the single value driving **both** the
+  wire TLS SNI extension **and** the certificate hostname check — so the
+  cert is verified against the vhost name and `verify` stays on against a
+  cert pinned to the FQDN rather than the IP. The `Host:` header alone
+  does not suffice for https: without the SNI override the handshake
+  offers the IP and fails verification (`tls_error`).
+- The override rides the **first hop only**. A redirect target has its own
+  canonical host, so `_walk_redirects` drops it after hop 1 (and re-gates
+  every hop's host as before). `headers` / `tls` in the result therefore
+  reflect the vhost-routed virtual host.
+
+Rejected (audit / anti-exfil posture, #2896): a free-form `headers` map
+(open header-injection + exfil surface on a deliberately body-less probe)
+and a full `--resolve`-style name→IP override (equivalent power, more
+surface — a caller can already put the IP in `url` and the vhost in
+`host_header`). The single closed-purpose param is the minimal shape.
+
+**Strict-vhost health sensor.** This makes a deterministic health check
+for a by-IP strict-vhost appliance expressible with the existing Sensor
+machinery: pin a `net.http_probe` Sensor whose args carry the IP `url` +
+the vhost `host_header`, and assert on `$.status` (e.g. `threshold`
+`== 200`, or membership). Without `host_header` the same Sensor reads a
+misleading 404 regardless of health.
+
 ## `net.ntp_check` — clock offset/skew + stratum (T5, #2410)
 
 `net.ntp_check(host, port=123, timeout_seconds?)` sends **one** mode-3

--- a/docs/codebase/sensor.md
+++ b/docs/codebase/sensor.md
@@ -17,6 +17,16 @@ The layer is deliberately minimal: a Sensor stores a **bounded** assertion
 model carries no transition logic; the admin service owns create/list/get/
 delete, the runner (#2505) owns claim/advance/park and the result write.
 
+Op-specific probe recipes live with their ops. One worth naming here:
+health-checking a **strict-vhost appliance** (a service that vhost-routes
+and 404s unless the request's `Host:` matches — e.g. VCFA behind a
+NAT-alias IP before DNS exists). Pin a `net.http_probe` Sensor with the
+`host_header` param so the probe dials the IP (what the allowlist gates)
+yet sends the virtual host as the `Host:` header and TLS SNI; otherwise a
+by-IP probe reads a misleading 404 / `tls_error` whether the service is
+healthy or wedged. See `docs/codebase/connectors-net-diagnostics.md`
+§ *Vhost-routed probes by IP*.
+
 ## Key types
 
 - `meho_backplane.db.models.Sensor` — the ORM row. 30 columns: identity


### PR DESCRIPTION
## Summary

- Adds one optional, closed-purpose `host_header` (`hostname[:port]`) param to `net.http_probe` so a strict-vhost appliance (VCFA and friends) reachable only by its NAT-alias IP **before DNS exists** can be health-probed. Today, probing `https://<IP>/health` derives `Host:` and TLS SNI from the URL host (the IP), so a healthy service and a wedged one both read 404 / `tls_error` — two labs sat API-dead ~14h behind green TCP/UI probes for exactly this.
- The raw IP stays in `url` — that host is what is **dialed** and what the probe allowlist gates. `host_header` is sent verbatim as the initial request's `Host:` header and, for an `https` URL, also as `extensions={"sni_hostname": <host minus port>}`. httpcore reads that extension as `server_hostname`, the single value driving **both** the wire TLS SNI extension **and** the certificate hostname check — so `verify` stays on against a cert pinned to the vhost, not the IP (the #2002 / #2863 seam). The `Host:` header alone does **not** suffice for https: without the SNI override the handshake offers the IP and fails verification.
- `host_header` is **never dialed** and can **never widen the allowlist** (the gate stays on the `url` host, #2405 / #2784 SSRF floor unchanged), and the override rides the **first redirect hop only** (a redirect target has its own canonical host). A closed single-purpose param was chosen over a free-form `headers` map deliberately — no header-injection / exfil surface on a deliberately body-less probe.
- Behaviour-preserving refactor: the redirect-decision branch is extracted into `_advance_or_halt` so the touched `_walk_redirects` stays within the code-quality function-size gate; the existing suite pins behaviour unchanged.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — the changed `http_probe.py` is clean; the sole remaining `src/` error (`icmp.py:205 socket.MSG_ERRQUEUE`) is a pre-existing Darwin-only platform quirk in an untouched file — `MSG_ERRQUEUE` is Linux-only and exists on the CI runners (proven pre-existing by reproducing it on stashed-pristine source).
- [x] `uv run pytest tests/test_connectors_net_http_probe.py` — **37 passed** (30 pre-existing + 7 new).
- [x] **AC1** — schema accepts `host_header` (`test_host_header_is_an_optional_string_in_the_schema`); an `https://<IP>` probe with `host_header` sends `Host: <vhost>` and `sni_hostname: <vhost bare>` while `req.url.host` stays the IP, respx/transport-verified (`test_host_header_sends_host_and_sni_on_https`). SNI = the value httpcore uses as `server_hostname` for cert verification (introspection-confirmed against httpx 0.28.1 / httpcore 1.0.9).
- [x] **AC2** — allowlist gates the dialed URL host: a non-allowlisted IP with an allowlisted-looking `host_header` is refused as `connector_probe_refused` and no socket opens (`test_host_header_does_not_widen_the_allowlist`).
- [x] **AC3** — override on hop 1 only, each hop re-gated: hop 1 carries the vhost `Host:`, hop 2 (the redirect target) carries its own canonical host (`test_host_header_override_is_dropped_after_the_first_redirect_hop`).
- [x] **AC4** — op description (registrar `description` + `when_to_use` + schema) documents the gate-on-dialed-host contract + vhost use case; `docs/codebase/connectors-net-diagnostics.md` § *Vhost-routed probes by IP* + `docs/codebase/sensor.md` document the strict-vhost sensor pattern.
- [x] **AC5** — omitted param is byte-identical (`test_host_header_omitted_dispatches_byte_identically`: no forced `Host:`, no `sni_hostname`); all pre-existing tests green; CHANGELOG `[Unreleased]` bullet added.

## Out of scope

- No refactor of the `net` connector beyond the surgical `_advance_or_halt` extraction the code-quality gate required on the touched function.
- Rejected per #2896: a free-form `headers` map (audit / anti-exfil posture) and a full `--resolve`-style name→IP override (equivalent power, more surface).
- Two unrelated pre-existing environmental test failures in untouched files (`test_connectors_net_dns_lookup.py::test_chosen_resolver_queries_that_nameserver` needs real-network resolution; `test_connectors_net_icmp.py::test_trace_reaches_loopback` — the ICMP cohort is documented Linux-only) reproduce identically on stashed-pristine source.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2896
