### PR TITLE
feat(connectors): Keycloak realm-role inventory + role-members read

### DIFF
--- a/backend/src/meho_backplane/connectors/keycloak/connector.py
+++ b/backend/src/meho_backplane/connectors/keycloak/connector.py
@@ -836,6 +836,22 @@ class KeycloakConnector(HttpConnector):
 
         return await keycloak_role_mapping_get(self, operator, target, params)
 
+    async def role_list(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``keycloak.role.list`` op (#2843)."""
+        from meho_backplane.connectors.keycloak.ops_read import keycloak_role_list
+
+        return await keycloak_role_list(self, operator, target, params)
+
+    async def role_users(
+        self, operator: Operator, target: KeycloakTargetLike, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Bound-method shim for the ``keycloak.role.users`` op (#2843)."""
+        from meho_backplane.connectors.keycloak.ops_read import keycloak_role_users
+
+        return await keycloak_role_users(self, operator, target, params)
+
     # -- typed-op write handler shims (G3.13-T4 #1406) ------------------
 
     async def realm_create(

--- a/backend/src/meho_backplane/connectors/keycloak/ops_read.py
+++ b/backend/src/meho_backplane/connectors/keycloak/ops_read.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+# code-quality-allow: file-size — pre-existing module size (>600 lines before
+# this change); #2843 appends two role read ops to the established READ_OPS
+# pattern this file owns, so splitting the read-op module is out of scope here.
 
 """Curated read ops for :class:`KeycloakConnector` (G3.13-T2 #1394).
 
-Six ``safety_level="safe"`` / ``requires_approval=False`` read ops that
-surface the realm / client / client-scope / user / role-mapping config an
-operator would otherwise read with ``kcadm.sh get`` or the admin console:
+Eight ``safety_level="safe"`` / ``requires_approval=False`` read ops that
+surface the realm / client / client-scope / user / role-mapping / role
+config an operator would otherwise read with ``kcadm.sh get`` or the admin
+console:
 
 ================================  =================================================
 op_id                             Admin REST API
@@ -16,6 +20,8 @@ op_id                             Admin REST API
 ``keycloak.client_scope.list``    ``GET /admin/realms/{realm}/client-scopes``
 ``keycloak.user.list``            ``GET /admin/realms/{realm}/users`` (``?username=``/``?max=``)
 ``keycloak.role_mapping.get``     ``GET /admin/realms/{realm}/users/{id}/role-mappings``
+``keycloak.role.list``            ``GET /admin/realms/{realm}/roles``
+``keycloak.role.users``           ``GET /admin/realms/{realm}/roles/{role-name}/users``
 ================================  =================================================
 
 All ops dispatch via the **admin-auth** path the T1 substrate built
@@ -88,7 +94,9 @@ __all__ = [
     "keycloak_client_list",
     "keycloak_client_scope_list",
     "keycloak_realm_get",
+    "keycloak_role_list",
     "keycloak_role_mapping_get",
+    "keycloak_role_users",
     "keycloak_user_list",
 ]
 
@@ -285,6 +293,64 @@ async def keycloak_role_mapping_get(
     return {"role_mappings": redact_secret_fields(mappings)}
 
 
+async def keycloak_role_list(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """List the managed realm's roles (``GET /admin/realms/{realm}/roles``).
+
+    Op-id: ``keycloak.role.list``. No params. Returns ``{rows, total}``;
+    each row is a :class:`RoleRepresentation` (``id``, ``name``,
+    ``description``, ``composite``, ``clientRole``, ``containerId``) — the
+    realm's role catalogue an operator would list with
+    ``kcadm.sh get roles``. This is the entry point for an access review:
+    discover a role's ``name`` here, then read its members with
+    ``keycloak.role.users``. No credential material is present, but the
+    response is run through the scrubber for defence-in-depth consistency
+    with the sibling ops.
+    """
+    del params  # declared empty; intentionally ignored
+    realms = resolve_realm_config(target)
+    rows = await self._get_admin_list(
+        target,
+        f"/admin/realms/{realms.managed_realm}/roles",
+        operator=operator,
+    )
+    scrubbed = [redact_secret_fields(row) for row in rows]
+    return {"rows": scrubbed, "total": len(scrubbed)}
+
+
+async def keycloak_role_users(
+    self: KeycloakConnector,
+    operator: Operator,
+    target: KeycloakTargetLike,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """List the users holding a realm role (``GET .../roles/{role-name}/users``).
+
+    Op-id: ``keycloak.role.users``. ``name`` is the realm role's **name**
+    (from ``keycloak.role.list``), not a UUID — Keycloak keys this endpoint
+    on the role name, so the segment is only ``quote_segment``-encoded (no
+    UUID-pattern gate). Returns ``{rows, total}``; each row is a
+    :class:`UserRepresentation` with its ``credentials`` scrubbed — the
+    same discipline ``keycloak.user.list`` applies, non-optional for any op
+    returning ``UserRepresentation`` rows. Keycloak sorts the members by
+    username and returns its default first page (100 users); a very large
+    role is capped at that page.
+    """
+    realms = resolve_realm_config(target)
+    role_name = quote_segment(params["name"])
+    rows = await self._get_admin_list(
+        target,
+        f"/admin/realms/{realms.managed_realm}/roles/{role_name}/users",
+        operator=operator,
+    )
+    scrubbed = [redact_secret_fields(row) for row in rows]
+    return {"rows": scrubbed, "total": len(scrubbed)}
+
+
 # ---------------------------------------------------------------------------
 # Curated when_to_use blurbs (one per op group)
 # ---------------------------------------------------------------------------
@@ -324,6 +390,19 @@ _WHEN_TO_USE_USER = (
     "``keycloak.role_mapping.get`` for that user's role assignments."
 )
 
+_WHEN_TO_USE_ROLE = (
+    "Use for realm-role access review: list the realm's role catalogue "
+    "(``keycloak.role.list`` — the roles ``kcadm.sh get roles`` shows) or "
+    "read which users currently hold a given realm role "
+    "(``keycloak.role.users`` by role **name**, not UUID). Call "
+    "``keycloak.role.list`` to discover role names, then "
+    "``keycloak.role.users`` with a role ``name`` to audit its members. "
+    'This answers "which realm roles exist?" and "who holds '
+    'operator/admin?" directly — the reverse of '
+    "``keycloak.role_mapping.get``, which needs a user UUID and only "
+    "reports that one user's roles."
+)
+
 #: Curated ``when_to_use`` blurb per op group, consumed by
 #: :meth:`KeycloakConnector.register_operations` (a group_key without an
 #: entry is a hard registration error). Co-located with the ops so the
@@ -333,6 +412,7 @@ WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     "client": _WHEN_TO_USE_CLIENT,
     "client_scope": _WHEN_TO_USE_CLIENT_SCOPE,
     "user": _WHEN_TO_USE_USER,
+    "role": _WHEN_TO_USE_ROLE,
 }
 
 #: UUID pattern used as a defence-in-depth constraint on every ``id``/``uuid``
@@ -599,6 +679,75 @@ READ_OPS: tuple[KeycloakOp, ...] = (
             "when_to_use": _WHEN_TO_USE_USER,
             "parameter_hints": {"id": "The user's internal UUID, from keycloak.user.list."},
             "output_shape": ("``{role_mappings: {realmMappings: [...], clientMappings: {...}}}``."),
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.role.list",
+        handler_attr="role_list",
+        summary="List the managed Keycloak realm's roles (the realm role catalogue).",
+        description=(
+            "GETs ``/admin/realms/{realm}/roles`` and returns the realm's "
+            "role catalogue as ``{rows, total}``. Each row is a "
+            "RoleRepresentation (``id``, ``name``, ``description``, "
+            "``composite``, ``clientRole``, ``containerId``) — the realm "
+            "roles ``kcadm.sh get roles`` lists. No params. Use "
+            "``keycloak.role.users`` to read a role's members by name. "
+            "Dispatches via the admin-auth path."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema=_ROWS_SCHEMA,
+        group_key="role",
+        tags=("read-only", "role", "keycloak"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_ROLE,
+            "parameter_hints": {},
+            "output_shape": (
+                "``{rows: [{<RoleRepresentation>}], total: N}``. Each row's "
+                "``name`` is the role name for ``keycloak.role.users``."
+            ),
+        },
+    ),
+    KeycloakOp(
+        op_id="keycloak.role.users",
+        handler_attr="role_users",
+        summary="List the Keycloak users holding a realm role by role name (no credentials).",
+        description=(
+            "GETs ``/admin/realms/{realm}/roles/{role-name}/users`` where "
+            "``name`` is the realm role's **name** (from "
+            "``keycloak.role.list`` — NOT a UUID) and returns the users "
+            "holding that role as ``{rows, total}``. Each row is a "
+            "UserRepresentation with its ``credentials`` redacted — the op "
+            "never surfaces credential material. Keycloak sorts by username "
+            "and returns its default first page (100 users); a very large "
+            "role is capped at that page. Dispatches via the admin-auth path."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The realm role's name (NOT a UUID; from keycloak.role.list).",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        response_schema=_ROWS_SCHEMA,
+        group_key="role",
+        tags=("read-only", "role", "keycloak"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_ROLE,
+            "parameter_hints": {
+                "name": "The realm role's name (not a UUID), from keycloak.role.list."
+            },
+            "output_shape": (
+                "``{rows: [{<UserRepresentation, credentials redacted>}], "
+                "total: N}`` — the realm-role members."
+            ),
         },
     ),
 )

--- a/backend/tests/test_connectors_keycloak_auth.py
+++ b/backend/tests/test_connectors_keycloak_auth.py
@@ -884,7 +884,7 @@ def test_read_ops_handler_attrs_resolve_to_bound_methods() -> None:
     """
     from meho_backplane.connectors.keycloak.ops_read import READ_OPS, WHEN_TO_USE_BY_GROUP
 
-    assert len(READ_OPS) == 6
+    assert len(READ_OPS) == 8
     for op in READ_OPS:
         handler = getattr(KeycloakConnector, op.handler_attr, None)
         assert callable(handler), (

--- a/backend/tests/test_connectors_keycloak_e2e.py
+++ b/backend/tests/test_connectors_keycloak_e2e.py
@@ -14,8 +14,8 @@ live Vault read.
 Acceptance criteria verified (Issue #1394)
 ==========================================
 
-(a) All 6 read ops dispatch through ``call_operation`` via the admin-auth
-    path and return ``status="ok"``; all 6 are visible to
+(a) All 8 read ops dispatch through ``call_operation`` via the admin-auth
+    path and return ``status="ok"``; all 8 are visible to
     ``search_operations``.
 (b) ``keycloak.client.get`` returns the client's flows
     (``authenticationFlowBindingOverrides``), redirect URIs
@@ -65,6 +65,8 @@ _CLIENT_UUID = "11111111-1111-1111-1111-111111111111"
 _USER_UUID = "22222222-2222-2222-2222-222222222222"
 _CLIENT_SECRET_SENTINEL = "super-secret-client-secret-DO-NOT-LEAK"
 _USER_CRED_SENTINEL = "hashed-password-DO-NOT-LEAK"
+_ROLE_NAME = "operator"
+_ROLE_USER_CRED_SENTINEL = "role-member-hash-DO-NOT-LEAK"
 
 _OPERATOR_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000000ad")
 _OPERATOR = Operator(
@@ -83,6 +85,8 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "keycloak.client_scope.list",
     "keycloak.user.list",
     "keycloak.role_mapping.get",
+    "keycloak.role.list",
+    "keycloak.role.users",
 )
 
 
@@ -146,6 +150,36 @@ _FIXTURE_ROLE_MAPPINGS: dict[str, Any] = {
     },
 }
 
+_FIXTURE_ROLES: list[dict[str, Any]] = [
+    {
+        "id": "role-uuid-operator",
+        "name": "operator",
+        "description": "Operator role",
+        "composite": False,
+        "clientRole": False,
+        "containerId": "evba",
+    },
+    {
+        "id": "role-uuid-admin",
+        "name": "admin",
+        "description": "Realm administrator",
+        "composite": True,
+        "clientRole": False,
+        "containerId": "evba",
+    },
+]
+
+_FIXTURE_ROLE_USERS: list[dict[str, Any]] = [
+    {
+        "id": _USER_UUID,
+        "username": "operator-a",
+        "enabled": True,
+        # Planted credential material — role.users must scrub it exactly as
+        # keycloak.user.list does for any UserRepresentation row.
+        "credentials": [{"type": "password", "secretData": _ROLE_USER_CRED_SENTINEL}],
+    }
+]
+
 
 def _mount_admin_routes(mock: respx.MockRouter) -> None:
     """Register the token endpoint + 6 admin REST fixture routes on *mock*."""
@@ -160,6 +194,8 @@ def _mount_admin_routes(mock: respx.MockRouter) -> None:
     mock.get(f"/admin/realms/evba/users/{_USER_UUID}/role-mappings").respond(
         200, json=_FIXTURE_ROLE_MAPPINGS
     )
+    mock.get("/admin/realms/evba/roles").respond(200, json=_FIXTURE_ROLES)
+    mock.get(f"/admin/realms/evba/roles/{_ROLE_NAME}/users").respond(200, json=_FIXTURE_ROLE_USERS)
 
 
 # ---------------------------------------------------------------------------
@@ -251,10 +287,10 @@ async def keycloak_e2e() -> AsyncIterator[KeycloakConnector]:
 
 
 def test_keycloak_read_ops_registration_set() -> None:
-    """READ_OPS carries exactly the 6 curated read ops and no write op."""
+    """READ_OPS carries exactly the 8 curated read ops and no write op."""
     op_ids = {op.op_id for op in READ_OPS}
     assert op_ids == set(EXPECTED_OP_IDS)
-    assert len(READ_OPS) == 6
+    assert len(READ_OPS) == 8
 
 
 def test_keycloak_read_ops_all_safe_no_approval_read_only_tag() -> None:
@@ -411,6 +447,55 @@ async def test_keycloak_e2e_role_mapping_get(keycloak_e2e: KeycloakConnector) ->
     mappings = result["result"]["role_mappings"]
     assert mappings["realmMappings"][0]["name"] == "tenant_admin"
     assert "meho-backplane" in mappings["clientMappings"]
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_role_list(keycloak_e2e: KeycloakConnector) -> None:
+    """keycloak.role.list returns the realm role catalogue as {rows, total}."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_admin_routes(mock)
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "keycloak.role.list",
+                "target": {"name": _TARGET_NAME},
+                "params": {},
+            },
+        )
+    assert result["status"] == "ok", f"role.list failed: {result.get('error')}"
+    assert result["result"]["total"] == 2
+    rows = result["result"]["rows"]
+    assert {row["name"] for row in rows} == {"operator", "admin"}
+    # RoleRepresentation fields the access-review caller reads.
+    assert rows[0]["containerId"] == "evba"
+    assert rows[0]["clientRole"] is False
+
+
+@pytest.mark.asyncio
+async def test_keycloak_e2e_role_users_redacts_credentials(
+    keycloak_e2e: KeycloakConnector,
+) -> None:
+    """keycloak.role.users returns {rows, total} with member credentials redacted."""
+    with respx.mock(base_url=_KC_BASE_URL, assert_all_called=False) as mock:
+        _mount_admin_routes(mock)
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "keycloak.role.users",
+                "target": {"name": _TARGET_NAME},
+                "params": {"name": _ROLE_NAME},
+            },
+        )
+    assert result["status"] == "ok", f"role.users failed: {result.get('error')}"
+    assert result["result"]["total"] == 1
+    rows = result["result"]["rows"]
+    assert rows[0]["username"] == "operator-a"
+    # Acceptance: a planted credentials field is redacted identically to
+    # keycloak.user.list's UserRepresentation scrub.
+    assert rows[0]["credentials"] == REDACTED
+    assert _ROLE_USER_CRED_SENTINEL not in str(result)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_keycloak_path_encoding.py
+++ b/backend/tests/test_connectors_keycloak_path_encoding.py
@@ -440,7 +440,8 @@ def test_quote_segment_imported_and_called_in_both_handler_modules() -> None:
     Uses exact call-site counts (not >=) so that any future addition or removal
     of a call site triggers an explicit review.  Current counts:
 
-    * ops_read: 2 sites — ``keycloak_client_get`` + ``keycloak_role_mapping_get``.
+    * ops_read: 3 sites — ``keycloak_client_get`` + ``keycloak_role_mapping_get``
+      + ``keycloak_role_users`` (role name → path segment, #2843).
     * ops_write: 4 sites — ``keycloak_client_update``, ``keycloak_protocol_mapper_create``,
       ``keycloak_user_password_reset``, ``keycloak_role_mapping_add``.
     """
@@ -450,7 +451,7 @@ def test_quote_segment_imported_and_called_in_both_handler_modules() -> None:
     import meho_backplane.connectors.keycloak.ops_write as ops_write_mod
 
     expected_counts = {
-        ops_read_mod: 2,
+        ops_read_mod: 3,
         ops_write_mod: 4,
     }
     for mod, expected in expected_counts.items():

--- a/docs/codebase/connectors-keycloak.md
+++ b/docs/codebase/connectors-keycloak.md
@@ -14,7 +14,8 @@ verbs + onboarding docs. G3.13-T4 (#1406) adds the **nine approval-gated
 write ops** (realm/client/client-scope/protocol-mapper/user/role-mapping
 creates + updates + reset-password) that retire the consumer's five
 Keycloak bootstrap scripts; `idp.create` is deferred (not exercised by
-those scripts).
+those scripts). #2843 extends the read surface to **eight** by adding the
+`role` group (`role.list` + `role.users`) for realm-role access review.
 
 Registry v2 triple: `(product="keycloak", version="26.x",
 impl_id="keycloak-admin")`, plus the `(keycloak, "", "")` wildcard so a
@@ -26,7 +27,8 @@ fresh target with no asserted version still resolves.
   `HttpConnector` subclass. Holds a per-target admin-token cache with
   TTL-driven refresh and an injectable admin-credential loader. Exposes a
   thin bound-method shim per read op (`realm_get`, `client_list`,
-  `client_get`, `client_scope_list`, `user_list`, `role_mapping_get`) and
+  `client_get`, `client_scope_list`, `user_list`, `role_mapping_get`,
+  `role_list`, `role_users`) and
   per write op (`realm_create`/`realm_update`, `client_create`/
   `client_update`, `client_scope_create`, `protocol_mapper_create`,
   `user_create`/`user_reset_password`, `role_mapping_assign`), the
@@ -35,7 +37,7 @@ fresh target with no asserted version still resolves.
   `_find_client_uuid` / `_find_user_uuid` / `_find_realm_role` name→UUID
   resolvers.
 - `KeycloakOp` + `READ_OPS` (`connectors/keycloak/ops_read.py`) — the
-  op-metadata dataclass and the six-op read registration table (the bind9 /
+  op-metadata dataclass and the eight-op read registration table (the bind9 /
   pfSense `ops`-table precedent). `WHEN_TO_USE_BY_GROUP` maps each op
   group to its curated selection blurb.
 - `WRITE_OPS` + the write handlers (`connectors/keycloak/ops_write.py`) —
@@ -155,9 +157,9 @@ rejects a whitespace-only secret rather than setting an empty password.
   name→UUID (and role-name→representation) resolvers the write handlers
   call before keying a mutation on the object's UUID.
 
-## Read ops (G3.13-T2)
+## Read ops (G3.13-T2, extended by #2843)
 
-Six `safety_level="safe"` / `requires_approval=False` read ops, all
+Eight `safety_level="safe"` / `requires_approval=False` read ops, all
 tagged `read-only`, all dispatching via the admin-auth path. The realm is
 the target's `managed_realm` (no per-op realm param):
 
@@ -169,10 +171,17 @@ the target's `managed_realm` (no per-op realm param):
 | `keycloak.client_scope.list` | `GET .../client-scopes` | `{rows, total}` |
 | `keycloak.user.list` | `GET .../users` (`?username=`/`?max=`) | `{rows, total}`, no credentials |
 | `keycloak.role_mapping.get` | `GET .../users/{id}/role-mappings` | realm + client role mappings |
+| `keycloak.role.list` | `GET .../roles` | `{rows, total}` — realm role catalogue |
+| `keycloak.role.users` | `GET .../roles/{role-name}/users` | `{rows, total}`, no credentials — role members |
 
 `client.get` / `role_mapping.get` take the **internal UUID** (`id`), not
 the human `clientId` / `username` — discover it via the matching `.list`
-op first.
+op first. `role.users` is the exception: it keys on the role **name**
+(from `role.list`), not a UUID. `role.list` + `role.users` are the
+access-review pair — "which realm roles exist?" and "who holds role X?" —
+the reverse direction of the per-user `role_mapping.get`. Keycloak returns
+`role.users` sorted by username, its default first page (100 members); a
+larger role is capped at that page.
 
 ### Secret redaction
 


### PR DESCRIPTION
## Summary
- Adds two `safety_level="safe"` reads in a new `role` group to the Keycloak connector: `keycloak.role.list` (`GET /admin/realms/{realm}/roles`) and `keycloak.role.users` (`GET /admin/realms/{realm}/roles/{role-name}/users`), closing the access-review gap where the only role-shaped read (`role_mapping.get`) was per-user/by-UUID. This is the reverse direction: "which realm roles exist?" and "who holds `operator`/`admin`?" — auditable through MEHO's policy/audit/broadcast instead of `kcadm.sh` / the admin console.
- `role.users` keys on the role **name** (not a UUID — `quote_segment` only, no UUID pattern) and scrubs `UserRepresentation.credentials` via the same `redact_secret_fields` discipline `keycloak.user.list` uses. Both reuse the existing admin-auth `_get_admin_list` path.
- Registration is automatic via the `READ_OPS` walk; `WHEN_TO_USE_BY_GROUP` gains a `role` entry (a missing group is a hard registration error).

## Test plan
- [x] `ruff check` + `ruff format --check` — clean (changed files)
- [x] `mypy src/meho_backplane/connectors/keycloak/` — Success, no issues
- [x] `pytest -k keycloak` — 168 passed, 2 skipped (integration, skipped-in-sandbox)
- [x] AC — `role.list` returns `{rows: [<RoleRepresentation>], total: N}`; `role.users` returns `{rows: [<UserRepresentation, credentials redacted>], total: N}` — new E2E tests assert both shapes + a planted-`credentials` redaction (`test_keycloak_e2e_role_list`, `test_keycloak_e2e_role_users_redacts_credentials`)
- [x] AC — `WHEN_TO_USE_BY_GROUP` carries `role`; `READ_OPS` count guards bumped 6→8; `ops_read` `quote_segment` call-site guard bumped 2→3
- [x] AC — `docs/codebase/connectors-keycloak.md` Read-ops table extended six→eight
- [x] `code-quality.py --diff` — 0 blockers (file-size on the already->600-line `ops_read.py` carries a `code-quality-allow` marker, mirroring `connector.py`'s pre-existing one)

## Endpoint grounding
Keycloak Admin REST API (26.x) — confirmed against the official OpenAPI spec (`docs-api/latest/rest-api/openapi.json`): `roles/{role-name}/users` takes a string `role-name` path param + `first`/`max`/`briefRepresentation` query params and returns a `UserRepresentation` array sorted by username, **default first 100** (documented on the op + in docs). In-repo `_find_realm_role` already dispatches the `/admin/realms/{realm}/roles` base.

## Out of scope
- **No CLI verb** — typed ops register into `endpoint_descriptor` at runtime, not the OpenAPI surface, so no snapshot change is required; `meho keycloak role ...` (mirroring `role_mapping.go`) is the issue-sanctioned fast-follow.
- No write counterpart, no client-role catalog/members, no pagination params (the issue specified the minimal single-param shape).
- Pre-existing WARNs (untouched by this change): `_mint_admin_token` / `fingerprint` / `register_operations` in `connector.py` exceed the 60-line function-size warn.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2843
