### PR TITLE
feat(connectors): project live dpinger status onto pfsense.gateway.list (#2850)

### DIFF
--- a/backend/src/meho_backplane/connectors/pfsense/ops_read.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops_read.py
@@ -12,7 +12,8 @@ Adds the following typed ops to :class:`PfSenseConnector`:
 * ``pfsense.nat.rules`` -- ``pfctl -sn`` parsed into NAT rule rows.
 * ``pfsense.interface.list`` -- ``ifconfig -a`` parsed.
 * ``pfsense.gateway.list`` -- ``/cf/conf/config.xml`` ``<gateways>``
-  block parsed.
+  block parsed, merged with live ``dpinger`` health (up/RTT/loss) from
+  ``pfSsh.php playback gatewaystatus``.
 * ``pfsense.config.show`` -- full ``/cf/conf/config.xml`` content
   returned as a structured envelope.
 * ``pfsense.dhcp.leases`` (#2849) -- ``cat
@@ -78,6 +79,7 @@ if TYPE_CHECKING:
 __all__ = [
     "READ_OPS",
     "parse_dhcp_leases",
+    "parse_gateway_status",
     "parse_gateways_xml",
     "parse_ifconfig",
     "parse_pfctl_nat",
@@ -645,6 +647,113 @@ def parse_dhcp_leases(
     return list(leases.values())
 
 
+# ``pfSsh.php playback gatewaystatus`` renders pfSense's live ``dpinger``
+# view (``return_gateways_status_text`` in ``gwlb.inc``) as a
+# whitespace-padded table: one header row, then one row per *monitored*
+# gateway. Example (columns space-padded; abbreviated here):
+#
+#   Name      Monitor        Source          Delay     StdDev    Loss    Status  Substatus
+#   WAN_DHCP  172.21.16.1    172.21.16.226   0.651ms   0.112ms   0.0%    online  none
+#   LTE_GW    1.1.1.1        10.0.5.1        0ms       0ms       100%    down    highloss
+#
+# No field value contains internal whitespace (names are alnum/underscore,
+# IPs and metrics have none), so a plain ``str.split()`` yields exactly the
+# eight columns. ``Delay``/``StdDev`` carry an ``ms`` suffix, ``Loss`` a
+# ``%`` suffix. Only gateways ``dpinger`` is actively monitoring appear --
+# a configured-but-unmonitored gateway (e.g. on a down interface) is simply
+# absent from the output.
+_GATEWAY_STATUS_HEADER = ("Name", "Monitor", "Source")
+
+#: Live-health fields set to ``None`` for a configured gateway that is
+#: absent from the ``gatewaystatus`` view (never mutated -- merged via
+#: ``dict.update`` which copies the values).
+_GATEWAY_STATUS_NULL_FIELDS: dict[str, Any] = {
+    "status": None,
+    "delay_ms": None,
+    "stddev_ms": None,
+    "loss_pct": None,
+    "substatus": None,
+}
+
+
+def parse_gateway_status(text: str) -> dict[str, dict[str, Any]]:
+    """Parse ``pfSsh.php playback gatewaystatus`` output into a status map.
+
+    Returns a dict keyed by gateway ``name``; each value carries the live
+    ``dpinger`` health for that gateway:
+
+    .. code-block:: python
+
+        {
+            "WAN_DHCP": {
+                "status": "online",
+                "delay_ms": 0.651,
+                "stddev_ms": 0.112,
+                "loss_pct": 0.0,
+                "substatus": "none",
+            },
+        }
+
+    ``status`` / ``substatus`` are the raw dpinger strings (``online`` /
+    ``down`` for status; ``none`` / ``delay`` / ``loss`` / ``highdelay`` /
+    ``highloss`` / ``force_down`` for substatus). ``delay_ms`` and
+    ``stddev_ms`` are the ``Delay`` / ``StdDev`` columns with the ``ms``
+    suffix stripped and parsed to float; ``loss_pct`` is the ``Loss``
+    column with ``%`` stripped and parsed to float. A metric that fails to
+    parse (unexpected placeholder) becomes ``None`` for that field.
+
+    The header row and any line that does not split into exactly eight
+    columns are skipped; the parser never raises on malformed input and
+    returns ``{}`` for empty text.
+
+    >>> out = (
+    ...     "Name Monitor Source Delay StdDev Loss Status Substatus\\n"
+    ...     "WAN_DHCP 1.1.1.1 10.0.0.2 0.6ms 0.1ms 0.0% online none\\n"
+    ... )
+    >>> parse_gateway_status(out)["WAN_DHCP"]["status"]
+    'online'
+    >>> parse_gateway_status(out)["WAN_DHCP"]["delay_ms"]
+    0.6
+    """
+    status_map: dict[str, dict[str, Any]] = {}
+    for line in text.splitlines():
+        tokens = line.split()
+        if len(tokens) != 8:
+            continue
+        if tuple(tokens[:3]) == _GATEWAY_STATUS_HEADER:
+            continue  # header row
+        name, _monitorip, _srcip, delay, stddev, loss, status, substatus = tokens
+        status_map[name] = {
+            "status": status,
+            "delay_ms": _parse_metric(delay, "ms"),
+            "stddev_ms": _parse_metric(stddev, "ms"),
+            "loss_pct": _parse_metric(loss, "%"),
+            "substatus": substatus,
+        }
+    return status_map
+
+
+def _parse_metric(value: str, unit: str) -> float | None:
+    """Strip a trailing *unit* from *value* and parse the rest to float.
+
+    ``_parse_metric("0.651ms", "ms")`` -> ``0.651``;
+    ``_parse_metric("100%", "%")`` -> ``100.0``. Returns ``None`` when the
+    remainder is not a number (defends against placeholders such as ``~``).
+
+    >>> _parse_metric("0ms", "ms")
+    0.0
+    >>> _parse_metric("100%", "%")
+    100.0
+    >>> _parse_metric("n/a", "ms") is None
+    True
+    """
+    stripped = value[: -len(unit)] if value.endswith(unit) else value
+    try:
+        return float(stripped)
+    except ValueError:
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Handler functions (bound-method shims on PfSenseConnector)
 # ---------------------------------------------------------------------------
@@ -781,13 +890,26 @@ async def pfsense_gateway_list(
     params: dict[str, Any],
     operator: Operator | None = None,
 ) -> dict[str, Any]:
-    """Return the pfSense gateway list from ``/cf/conf/config.xml``.
+    """Return the pfSense gateway list merged with live ``dpinger`` status.
 
-    Op-id: ``pfsense.gateway.list``. Reads the live pfSense
-    configuration file and parses the ``<gateways>`` block into
-    structured gateway dicts. Each gateway dict carries ``name``,
-    ``interface``, ``gateway`` (IP), ``monitor`` (monitor IP),
-    ``descr``, and ``defaultgw`` (bool).
+    Op-id: ``pfsense.gateway.list``. Two SSH round-trips (the asyncssh
+    pool reuses one connection), mirroring
+    :func:`meho_backplane.connectors.bind9.ops_zone.bind9_zone_read`:
+
+    1. ``cat /cf/conf/config.xml`` -- the static ``<gateways>`` block
+       (``name``, ``interface``, ``gateway`` IP, ``monitor`` IP,
+       ``descr``, ``defaultgw``).
+    2. ``pfSsh.php playback gatewaystatus`` -- pfSense's shell view onto
+       ``dpinger``'s live per-gateway state.
+
+    The live status is keyed by gateway name and merged onto each config
+    row, adding ``status``, ``delay_ms``, ``stddev_ms``, ``loss_pct``,
+    and ``substatus``. A gateway configured in ``config.xml`` but not
+    currently monitored by ``dpinger`` (e.g. on a down interface) is
+    absent from the live view; its five health fields are ``None`` and
+    the row is never dropped. A failure of the status command degrades to
+    all-``None`` health fields rather than failing the whole op -- the
+    config listing is still returned.
     """
     del params  # declared empty; intentionally ignored
     proc = await self._run_command(target, "cat /cf/conf/config.xml", operator=operator)
@@ -800,6 +922,22 @@ async def pfsense_gateway_list(
             "error": f"cat /cf/conf/config.xml exit {proc.exit_status}",
         }
     rows = parse_gateways_xml(content)
+
+    # Second round-trip: overlay live dpinger health. A failed / empty
+    # status command yields an empty map, so every row falls back to the
+    # null health fields -- the config listing is never lost to a dpinger
+    # hiccup.
+    status_proc = await self._run_command(
+        target, "pfSsh.php playback gatewaystatus", operator=operator
+    )
+    status_stdout = (status_proc.stdout or "") if hasattr(status_proc, "stdout") else ""
+    status_text = status_stdout if isinstance(status_stdout, str) else ""
+    status_map = parse_gateway_status(status_text)
+    for row in rows:
+        name = row.get("name")
+        live = status_map.get(name) if isinstance(name, str) else None
+        row.update(live or _GATEWAY_STATUS_NULL_FIELDS)
+
     return {"rows": rows, "total": len(rows)}
 
 
@@ -899,7 +1037,9 @@ _WHEN_TO_USE_NETWORK = (
     "``pfsense.interface.list`` when the operator wants IP address, "
     "MAC, MTU, or link-status information. Call "
     "``pfsense.gateway.list`` when the operator wants routing-gateway "
-    "configuration from the pfSense config."
+    "configuration together with each gateway's live ``dpinger`` health "
+    "(up/down, round-trip latency, packet loss) -- e.g. to answer "
+    "whether the WAN is degraded right now."
 )
 
 #: Curated ``when_to_use`` for the ``config`` group.
@@ -1172,14 +1312,21 @@ READ_OPS: tuple[PfSenseOp, ...] = (
     PfSenseOp(
         op_id="pfsense.gateway.list",
         handler_attr="gateway_list",
-        summary="List pfSense routing gateways from config.xml.",
+        summary="List pfSense routing gateways with live dpinger up/RTT/loss status.",
         description=(
-            "Reads ``/cf/conf/config.xml`` over SSH and parses the "
-            "``<gateways>`` block into structured gateway dicts. Each "
-            "dict carries the gateway name, interface, gateway IP, "
-            "monitor IP, description, and whether it is the default "
-            "gateway. Returns a ``{rows, total}`` envelope. No params; "
-            "safe to call on any healthy pfSense target."
+            "Reads ``/cf/conf/config.xml`` over SSH for the static "
+            "``<gateways>`` block, then runs ``pfSsh.php playback "
+            "gatewaystatus`` for pfSense's live ``dpinger`` view and "
+            "merges the two by gateway name. Each row carries the static "
+            "config (name, interface, gateway IP, monitor IP, "
+            "description, default flag) plus the live health "
+            "(``status`` up/down, ``delay_ms`` round-trip latency, "
+            "``stddev_ms``, ``loss_pct`` packet loss, ``substatus``). "
+            "Use to answer whether a WAN gateway is degraded right now. "
+            "A gateway configured but not currently monitored by dpinger "
+            "reports ``null`` health fields. Returns a ``{rows, total}`` "
+            "envelope. No params; safe to call on any healthy pfSense "
+            "target."
         ),
         parameter_schema=_EMPTY_PARAMS,
         response_schema={
@@ -1196,6 +1343,11 @@ READ_OPS: tuple[PfSenseOp, ...] = (
                             "monitor": {"type": ["string", "null"]},
                             "descr": {"type": ["string", "null"]},
                             "defaultgw": {"type": "boolean"},
+                            "status": {"type": ["string", "null"]},
+                            "delay_ms": {"type": ["number", "null"]},
+                            "stddev_ms": {"type": ["number", "null"]},
+                            "loss_pct": {"type": ["number", "null"]},
+                            "substatus": {"type": ["string", "null"]},
                         },
                     },
                 },
@@ -1212,11 +1364,22 @@ READ_OPS: tuple[PfSenseOp, ...] = (
             "parameter_hints": {},
             "output_shape": (
                 "``{rows: [{name, interface, gateway, monitor, descr, "
-                "defaultgw}], total: N}``. ``defaultgw`` is ``true`` "
-                "when the ``<defaultgw/>`` element is present in the "
-                "pfSense config. ``gateway`` is the gateway IP address. "
-                "``interface`` is the pfSense interface logical name "
-                "(e.g. ``wan``, ``lan``)."
+                "defaultgw, status, delay_ms, stddev_ms, loss_pct, "
+                "substatus}], total: N}``. The first six fields are static "
+                "config from ``config.xml``; the last five are live "
+                "``dpinger`` health merged from ``pfSsh.php playback "
+                "gatewaystatus``. ``status`` is ``online`` or ``down``; "
+                "``delay_ms`` / ``stddev_ms`` are round-trip latency and "
+                "its standard deviation in milliseconds; ``loss_pct`` is "
+                "packet-loss percent; ``substatus`` refines the state "
+                "(``none`` / ``delay`` / ``loss`` / ``highdelay`` / "
+                "``highloss`` / ``force_down``). A gateway configured but "
+                "not currently monitored by dpinger (e.g. on a down "
+                "interface) has all five live fields ``null`` -- the row "
+                "is still returned. ``defaultgw`` is ``true`` when the "
+                "``<defaultgw/>`` element is present. ``gateway`` is the "
+                "gateway IP; ``interface`` is the pfSense logical "
+                "interface name (e.g. ``wan``, ``lan``)."
             ),
         },
     ),

--- a/backend/tests/test_connectors_pfsense_e2e.py
+++ b/backend/tests/test_connectors_pfsense_e2e.py
@@ -152,6 +152,13 @@ lease 192.168.1.150 {
 }
 """
 
+# Live ``dpinger`` view for the single WAN_DHCP gateway in the config
+# fixture above -- monitor IP matches so the merge lands on that row.
+_FIXTURE_GATEWAY_STATUS = """\
+Name      Monitor        Source        Delay     StdDev    Loss    Status  Substatus
+WAN_DHCP  192.168.1.254  192.168.1.1   0.651ms   0.112ms   0.0%    online  none
+"""
+
 # Map SSH command string → pre-recorded stdout.
 _FIXTURE_RESPONSES: dict[str, str] = {
     "cat /etc/version": _FIXTURE_VERSION,
@@ -161,6 +168,7 @@ _FIXTURE_RESPONSES: dict[str, str] = {
     "ifconfig -a": _FIXTURE_IFCONFIG,
     "cat /cf/conf/config.xml": _FIXTURE_CONFIG_XML,
     "cat /var/dhcpd/var/db/dhcpd.leases": _FIXTURE_DHCP_LEASES,
+    "pfSsh.php playback gatewaystatus": _FIXTURE_GATEWAY_STATUS,
 }
 
 # ---------------------------------------------------------------------------
@@ -618,6 +626,11 @@ async def test_pfsense_e2e_gateway_list_dispatches_ok(
     assert len(rows) == 1
     assert rows[0]["name"] == "WAN_DHCP"
     assert rows[0]["defaultgw"] is True
+    # Live dpinger health merged from the second command.
+    assert rows[0]["status"] == "online"
+    assert rows[0]["delay_ms"] == 0.651
+    assert rows[0]["loss_pct"] == 0.0
+    assert rows[0]["substatus"] == "none"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_pfsense_ops.py
+++ b/backend/tests/test_connectors_pfsense_ops.py
@@ -56,6 +56,7 @@ from meho_backplane.connectors.pfsense import PFSENSE_OPS, PfSenseConnector
 from meho_backplane.connectors.pfsense.ops_read import (
     _netmask_to_cidr,
     parse_dhcp_leases,
+    parse_gateway_status,
     parse_gateways_xml,
     parse_ifconfig,
     parse_pfctl_nat,
@@ -438,6 +439,85 @@ def test_parse_gateways_xml_no_gateways_block_returns_empty_list() -> None:
 
 
 # ---------------------------------------------------------------------------
+# parse_gateway_status
+# ---------------------------------------------------------------------------
+
+# Captured ``pfSsh.php playback gatewaystatus`` output (whitespace-padded
+# table from pfSense's ``return_gateways_status_text``). One healthy
+# gateway, one online-with-warning gateway, one down gateway.
+_GATEWAY_STATUS_SAMPLE = """\
+Name          Monitor         Source          Delay      StdDev     Loss     Status    Substatus
+WAN_DHCP      192.168.0.1     192.168.0.100   0.651ms    0.112ms    0.0%     online    none
+VPN_GW        10.8.0.1        10.8.0.2        54.926ms   11.309ms   0.0%     online    delay
+WANGW_LTE     1.1.1.1         10.0.5.1        0ms        0ms        100%     down      highloss
+"""
+
+
+def test_parse_gateway_status_keys_by_gateway_name() -> None:
+    status = parse_gateway_status(_GATEWAY_STATUS_SAMPLE)
+    assert set(status) == {"WAN_DHCP", "VPN_GW", "WANGW_LTE"}
+
+
+def test_parse_gateway_status_online_gateway_fields() -> None:
+    status = parse_gateway_status(_GATEWAY_STATUS_SAMPLE)
+    wan = status["WAN_DHCP"]
+    assert wan["status"] == "online"
+    assert wan["delay_ms"] == 0.651
+    assert wan["stddev_ms"] == 0.112
+    assert wan["loss_pct"] == 0.0
+    assert wan["substatus"] == "none"
+
+
+def test_parse_gateway_status_down_gateway_fields() -> None:
+    status = parse_gateway_status(_GATEWAY_STATUS_SAMPLE)
+    lte = status["WANGW_LTE"]
+    assert lte["status"] == "down"
+    assert lte["loss_pct"] == 100.0
+    assert lte["delay_ms"] == 0.0
+    assert lte["substatus"] == "highloss"
+
+
+def test_parse_gateway_status_metric_fields_are_float() -> None:
+    vpn = parse_gateway_status(_GATEWAY_STATUS_SAMPLE)["VPN_GW"]
+    assert isinstance(vpn["delay_ms"], float)
+    assert isinstance(vpn["stddev_ms"], float)
+    assert isinstance(vpn["loss_pct"], float)
+    assert vpn["delay_ms"] == 54.926
+
+
+def test_parse_gateway_status_skips_header_row() -> None:
+    status = parse_gateway_status(_GATEWAY_STATUS_SAMPLE)
+    assert "Name" not in status
+
+
+def test_parse_gateway_status_empty_input_returns_empty_dict() -> None:
+    assert parse_gateway_status("") == {}
+    assert parse_gateway_status("\n\n") == {}
+
+
+def test_parse_gateway_status_short_line_skipped_without_crash() -> None:
+    # A line that does not split into the expected 8 columns is ignored.
+    output = (
+        "Name Monitor Source Delay StdDev Loss Status Substatus\n"
+        "PARTIAL 10.0.0.1 online\n"
+        "WAN_DHCP 1.1.1.1 10.0.0.2 0.6ms 0.1ms 0.0% online none\n"
+    )
+    status = parse_gateway_status(output)
+    assert set(status) == {"WAN_DHCP"}
+
+
+def test_parse_gateway_status_unparseable_metric_becomes_none() -> None:
+    output = (
+        "Name Monitor Source Delay StdDev Loss Status Substatus\n"
+        "PENDING_GW 1.1.1.1 10.0.0.2 ~ms ~ms ~% pending none\n"
+    )
+    row = parse_gateway_status(output)["PENDING_GW"]
+    assert row["delay_ms"] is None
+    assert row["loss_pct"] is None
+    assert row["status"] == "pending"
+
+
+# ---------------------------------------------------------------------------
 # Bound-method shims -- pfsense_version
 # ---------------------------------------------------------------------------
 
@@ -579,25 +659,129 @@ async def test_pfsense_interface_list_empty_output_returns_empty_rows() -> None:
 
 
 @pytest.mark.asyncio
-async def test_pfsense_gateway_list_reads_config_xml() -> None:
+async def test_pfsense_gateway_list_runs_both_commands() -> None:
     connector = PfSenseConnector()
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
-        mock_cmd.return_value = _proc(_CONFIG_XML_WITH_GATEWAYS)
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_XML_WITH_GATEWAYS),
+            _proc(_GATEWAY_STATUS_SAMPLE),
+        ]
         result = await connector.gateway_list(_TARGET, {})
-    mock_cmd.assert_awaited_once_with(_TARGET, "cat /cf/conf/config.xml", operator=None)
+    commands = [call.args[1] for call in mock_cmd.await_args_list]
+    assert commands == ["cat /cf/conf/config.xml", "pfSsh.php playback gatewaystatus"]
     assert result["total"] == 2
     names = [r["name"] for r in result["rows"]]
     assert "WAN_DHCP" in names
 
 
 @pytest.mark.asyncio
+async def test_pfsense_gateway_list_merges_live_dpinger_status() -> None:
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_XML_WITH_GATEWAYS),
+            _proc(_GATEWAY_STATUS_SAMPLE),
+        ]
+        result = await connector.gateway_list(_TARGET, {})
+    wan = next(r for r in result["rows"] if r["name"] == "WAN_DHCP")
+    assert wan["status"] == "online"
+    assert wan["delay_ms"] == 0.651
+    assert wan["stddev_ms"] == 0.112
+    assert wan["loss_pct"] == 0.0
+    assert wan["substatus"] == "none"
+    # Static config fields are preserved alongside the live overlay.
+    assert wan["interface"] == "wan"
+    assert wan["defaultgw"] is True
+
+
+@pytest.mark.asyncio
+async def test_pfsense_gateway_list_unmonitored_gateway_has_null_health() -> None:
+    # LAN_GW is in config.xml but absent from the gatewaystatus sample.
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_XML_WITH_GATEWAYS),
+            _proc(_GATEWAY_STATUS_SAMPLE),
+        ]
+        result = await connector.gateway_list(_TARGET, {})
+    lan = next(r for r in result["rows"] if r["name"] == "LAN_GW")
+    assert lan["status"] is None
+    assert lan["delay_ms"] is None
+    assert lan["stddev_ms"] is None
+    assert lan["loss_pct"] is None
+    assert lan["substatus"] is None
+    # The unmonitored gateway is never dropped.
+    assert lan["gateway"] == "10.0.0.254"
+
+
+@pytest.mark.asyncio
+async def test_pfsense_gateway_list_status_command_failure_degrades_to_null() -> None:
+    # A failed gatewaystatus command must not lose the config listing.
+    connector = PfSenseConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = [
+            _proc(_CONFIG_XML_WITH_GATEWAYS),
+            _proc("", exit_status=127),
+        ]
+        result = await connector.gateway_list(_TARGET, {})
+    assert result["total"] == 2
+    assert all(row["status"] is None for row in result["rows"])
+    assert "error" not in result
+
+
+@pytest.mark.asyncio
 async def test_pfsense_gateway_list_malformed_xml_returns_empty_rows() -> None:
     connector = PfSenseConnector()
     with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
-        mock_cmd.return_value = _proc("<broken xml")
+        mock_cmd.side_effect = [_proc("<broken xml"), _proc(_GATEWAY_STATUS_SAMPLE)]
         result = await connector.gateway_list(_TARGET, {})
     assert result["rows"] == []
     assert result["total"] == 0
+
+
+def test_pfsense_gateway_list_response_schema_accepts_merged_rows() -> None:
+    """The updated response_schema declares the merged live-health fields."""
+    from jsonschema import Draft202012Validator
+
+    op = next(o for o in PFSENSE_OPS if o.op_id == "pfsense.gateway.list")
+    assert op.response_schema is not None
+    payload = {
+        "rows": [
+            {
+                "name": "WAN_DHCP",
+                "interface": "wan",
+                "gateway": "192.168.0.1",
+                "monitor": "192.168.0.1",
+                "descr": "WAN gateway",
+                "defaultgw": True,
+                "status": "online",
+                "delay_ms": 0.651,
+                "stddev_ms": 0.112,
+                "loss_pct": 0.0,
+                "substatus": "none",
+            },
+            {
+                "name": "LAN_GW",
+                "interface": "lan",
+                "gateway": "10.0.0.254",
+                "monitor": None,
+                "descr": None,
+                "defaultgw": False,
+                "status": None,
+                "delay_ms": None,
+                "stddev_ms": None,
+                "loss_pct": None,
+                "substatus": None,
+            },
+        ],
+        "total": 2,
+    }
+    # Raises jsonschema.ValidationError if the declared types reject the row.
+    Draft202012Validator(op.response_schema).validate(payload)
+    # The numeric health fields are genuinely constrained (not just waved
+    # through by additionalProperties) -- a string delay_ms is rejected.
+    bad = {"rows": [{"name": "X", "delay_ms": "not-a-number"}], "total": 1}
+    assert not Draft202012Validator(op.response_schema).is_valid(bad)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-pfsense.md
+++ b/docs/codebase/connectors-pfsense.md
@@ -51,6 +51,9 @@ Source: `backend/src/meho_backplane/connectors/pfsense/`.
   - `parse_dhcp_leases` (#2849) — parses `/var/dhcpd/var/db/dhcpd.leases`
     (log-structured ISC dhcpd lease DB) into de-duplicated lease rows; an
     `active` lease whose `ends` is past reads as `expired`.
+  - `parse_gateway_status` / `_parse_metric` — parser for the live
+    `pfSsh.php playback gatewaystatus` (dpinger) table, keyed by gateway
+    name.
   - Handler functions: `pfsense_version`, `pfsense_firewall_rules`,
     `pfsense_firewall_state`, `pfsense_nat_rules`, `pfsense_interface_list`,
     `pfsense_gateway_list`, `pfsense_config_show`, `pfsense_dhcp_leases`.
@@ -164,7 +167,7 @@ Two-phase registration, identical to the bind9 pattern:
 | `pfsense.firewall.state` | `pfctl -ss` | `firewall` |
 | `pfsense.nat.rules` | `pfctl -sn` | `nat` |
 | `pfsense.interface.list` | `ifconfig -a` | `network` |
-| `pfsense.gateway.list` | `cat /cf/conf/config.xml` (gateways block) | `network` |
+| `pfsense.gateway.list` | `cat /cf/conf/config.xml` (gateways block) + `pfSsh.php playback gatewaystatus` (live dpinger status) | `network` |
 | `pfsense.config.show` | `cat /cf/conf/config.xml` (full) | `config` |
 | `pfsense.dhcp.leases` | `cat /var/dhcpd/var/db/dhcpd.leases` (ISC dhcpd lease DB) | `dhcp` |
 
@@ -184,6 +187,18 @@ whose `ends` has passed is reported as `expired`. DHCPv6 (`dhcpd6.leases`) and
 pool-exhaustion percentage math (correlating against the `config.xml` `<range>`)
 are out of scope — follow-ups.
 
+`pfsense.gateway.list` runs **two** SSH commands and merges them (mirroring
+`bind9.zone.read`): `cat /cf/conf/config.xml` for the static `<gateways>`
+block, then `pfSsh.php playback gatewaystatus` for pfSense's live `dpinger`
+view. The live state is keyed by gateway name and overlaid onto each config
+row as `status` (`online`/`down`), `delay_ms`, `stddev_ms`, `loss_pct`, and
+`substatus`. `config.xml` alone only answers "what gateways are configured";
+the second command answers "is this gateway degraded right now". A gateway
+present in `config.xml` but absent from the live view (e.g. on a down
+interface `dpinger` is not monitoring) keeps its row with all five health
+fields `null`; a failure of the status command degrades the whole set to
+`null` health rather than failing the op.
+
 ## Known issues
 
 - `known_hosts=None` in the SSH adapter disables host-key verification for
@@ -198,6 +213,8 @@ are out of scope — follow-ups.
 - Task #2849: `pfsense.dhcp.leases` — ISC dhcpd lease-DB read op (connector
   read-op coverage wave 2, initiative #2833). Grammar per `dhcpd.leases(5)`;
   chroot path confirmed against pfSense's `status_dhcp_leases.php`.
+- Task #2850: project live `dpinger` status (up/RTT/loss) onto
+  `pfsense.gateway.list` via `pfSsh.php playback gatewaystatus`.
 - Parent initiative: #370 (G3.7 tier-3 standalone connectors).
 - Bind9 connector (canonical typed-SSH reference): `docs/codebase/connectors-bind9.md`.
 - `SshConnector` adapter: `backend/src/meho_backplane/connectors/adapters/ssh.py`.


### PR DESCRIPTION
## Summary

- `pfsense.gateway.list` was config-side only (`cat /cf/conf/config.xml`), so it answered *what gateways are configured* but never *is this gateway degraded right now* — the operator had to drop to a bare SSH session and run `pfSsh.php playback gatewaystatus` by hand, bypassing policy/audit/broadcast.
- The handler now runs that second command and merges pfSense's live `dpinger` view onto each config row by gateway name (mirroring the two-round-trips-in-one-handler shape of `bind9.zone.read`), using the existing `_run_command` SSH transport — no new transport code.
- Each row gains `status` (`online`/`down`), `delay_ms`, `stddev_ms`, `loss_pct`, `substatus`. A gateway configured but not currently monitored by dpinger (e.g. on a down interface) keeps its row with all five health fields `null`; a failure of the status command degrades the whole set to `null` health rather than failing the op.
- `response_schema` and `llm_instructions.output_shape` (plus the op `summary`/`description` and the `network` group hint) declare the merged shape and the "configured-but-unmonitored → null" case.

New pure parser `parse_gateway_status(text) -> dict[str, dict]` keyed by gateway name; the format was grounded against pfSense CE 2.7.x's `return_gateways_status_text` source and real captured output (including a down row: `… 0ms 0ms 100% down highloss`).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean for touched files (one pre-existing macOS-only `net/icmp.py` `MSG_ERRQUEUE` error, unrelated; passes on Linux CI)
- [x] `pytest tests/test_connectors_pfsense_ops.py` — 80 passed (7 new `parse_gateway_status` unit tests + merge/null/degradation handler tests)
- [x] `pytest tests/test_connectors_pfsense_e2e.py` — 16 passed (fake-shell now serves `gatewaystatus`; e2e asserts merged `status=online`/`delay_ms`)
- [x] **AC** parser unit-tested against a captured fixture with ≥1 `online` and ≥1 `down`/loss gateway
- [x] **AC** unmonitored gateway returns `status: null` + null health, row not dropped (`test_pfsense_gateway_list_unmonitored_gateway_has_null_health`)
- [x] **AC** `response_schema` declares the five new keys; a jsonschema test validates a merged fixture against it and rejects a wrong-typed `delay_ms` (`test_pfsense_gateway_list_response_schema_accepts_merged_rows`)
- [x] **AC** `docs/codebase/connectors-pfsense.md` op-table row updated (+ parser list + merge note)
- [x] **AC** OpenAPI snapshot regenerated (`make snapshot-openapi`) → **zero drift** (typed-op response schemas live in `endpoint_descriptor`, not the HTTP route spec)
- [x] code-quality `--diff` gate — 0 blockers (4 warnings are pre-existing: `ops_read.py` file size and `parse_ifconfig` complexity, both untouched by this change)

## Out of scope

- A standalone `pfsense.gateway.status` op — the issue rejects it (the operator question always wants config context alongside the number; widening the existing projection matches the #2831 precedent).
- CLI human-table render of the new fields — not in the acceptance criteria; the `meho pfsense network gateway --json` path already surfaces every row field. Recorded as an adjacent finding.
- Splitting the pre-existing 1.2k-line `ops_read.py` module (file-size warning predates this change).
- Gateway groups / failover-tier health, write paths, historical latency — all explicitly out of scope in the issue.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2850
