### PR TITLE
feat(connectors): add vcfa tenant deployment list typed read (#2839)

### DIFF
--- a/backend/src/meho_backplane/connectors/vcf_automation/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/__init__.py
@@ -110,7 +110,7 @@ register_connector_v2(
 
 # Queue the typed-op upsert onto the lifespan-driven registrar list. The
 # runner (``run_typed_op_registrars``) iterates after
-# ``_eager_import_connectors`` so the five typed read descriptors land
+# ``_eager_import_connectors`` so the six typed read descriptors land
 # before the first dispatch — no ingested catalog state required (VCFA
 # ships no vendor spec; typed conversion is the only working read path).
 register_typed_op_registrar(register_vcfa_typed_operations)

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -130,6 +130,7 @@ from meho_backplane.connectors.vcf_automation.typed_ops import (
     PROVIDER_REGIONS_PATH,
     PROVIDER_SITE_PATH,
     TENANT_ABOUT_PATH,
+    TENANT_DEPLOYMENTS_PATH,
     TENANT_PROJECTS_PATH,
 )
 
@@ -725,6 +726,21 @@ class VcfAutomationConnector(HttpConnector):
             target,
             "GET",
             TENANT_PROJECTS_PATH,
+            operator=operator,
+            params=_tenant_odata_query(params),
+        )
+
+    async def tenant_deployment_list(
+        self,
+        operator: Operator,
+        target: VcfAutomationTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vcfa.tenant.deployment.list`` — ``GET /iaas/api/deployments`` (tenant plane)."""
+        return await self._request_json(
+            target,
+            "GET",
+            TENANT_DEPLOYMENTS_PATH,
             operator=operator,
             params=_tenant_odata_query(params),
         )

--- a/backend/src/meho_backplane/connectors/vcf_automation/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/typed_ops.py
@@ -16,7 +16,8 @@ This module converts the **audited read set** (evoila/meho#2294 row 22:
 "org/region list + provider health"; the VCFA follow-up: "org/region
 list, /iaas/api/projects + about") to ``source_kind="typed"`` operations
 that dispatch through the connector's own dual-plane session — no
-``endpoint_descriptor`` catalog state required. Five ops:
+``endpoint_descriptor`` catalog state required. Six ops — the five
+#2294 audited reads plus the #2839 tenant deployment list:
 
 Provider plane (``/cloudapi/1.0.0/*`` — Basic-auth →
 ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` JWT session):
@@ -32,6 +33,7 @@ Tenant plane (``/iaas/api/*`` — JSON-body login → ``{"token": …}``
 session):
 
 * ``vcfa.tenant.project.list`` — ``GET /iaas/api/projects``
+* ``vcfa.tenant.deployment.list`` — ``GET /iaas/api/deployments``
 * ``vcfa.tenant.about`` — ``GET /iaas/api/about``
 
 Every op declares the **plane it rides** (``provider`` / ``tenant``).
@@ -74,6 +76,7 @@ __all__ = [
     "PROVIDER_REGIONS_PATH",
     "PROVIDER_SITE_PATH",
     "TENANT_ABOUT_PATH",
+    "TENANT_DEPLOYMENTS_PATH",
     "TENANT_PROJECTS_PATH",
     "VCFA_TYPED_OPS",
     "VCFA_TYPED_WHEN_TO_USE_BY_GROUP",
@@ -88,6 +91,7 @@ PROVIDER_ORGS_PATH: Final[str] = "/cloudapi/1.0.0/orgs"
 PROVIDER_REGIONS_PATH: Final[str] = "/cloudapi/1.0.0/regions"
 PROVIDER_SITE_PATH: Final[str] = "/cloudapi/1.0.0/site"
 TENANT_PROJECTS_PATH: Final[str] = "/iaas/api/projects"
+TENANT_DEPLOYMENTS_PATH: Final[str] = "/iaas/api/deployments"
 TENANT_ABOUT_PATH: Final[str] = "/iaas/api/about"
 
 
@@ -153,7 +157,10 @@ VCFA_TYPED_WHEN_TO_USE_BY_GROUP: Final[dict[str, str]] = {
     "vcfa-tenant-reads": (
         "Use on the VCFA **tenant plane** to read within one tenant "
         "organization: list projects, the deployment-scoping construct "
-        "every deployment belongs to (vcfa.tenant.project.list), or read "
+        "every deployment belongs to (vcfa.tenant.project.list), list "
+        "deployments — which exist, which failed, which are stuck "
+        "in-progress, narrowable with a status $filter "
+        "(vcfa.tenant.deployment.list), or read "
         "the IaaS API self-describe surface — supported API versions + "
         "latest version — as a tenant-plane reachability/version probe "
         "(vcfa.tenant.about). Tenant-plane ops authenticate with the "
@@ -414,6 +421,86 @@ _TENANT_PROJECT_LIST = VcfaTypedOp(
     },
 )
 
+_TENANT_DEPLOYMENT_LIST = VcfaTypedOp(
+    op_id="vcfa.tenant.deployment.list",
+    handler_attr="tenant_deployment_list",
+    plane="tenant",
+    path=TENANT_DEPLOYMENTS_PATH,
+    summary="List deployments within the tenant organization (tenant plane).",
+    description=(
+        "Lists deployments within the tenant organization via "
+        "GET /iaas/api/deployments on the tenant plane — the tenant-plane "
+        "inventory answer to 'which deployments exist, which failed, which "
+        "are stuck in-progress'; typically the first read when a tenant "
+        "reports 'my deployment didn't come up'. Supports OData-style "
+        "$filter / $orderby / $top / $skip query params; narrow to failures "
+        "with a status filter (e.g. \"status eq 'CREATE_FAILED'\"). Returns a "
+        "'content' array; each entry carries id, name, description, status, "
+        "projectId, blueprintId, ownedBy, createdAt, lastUpdatedAt, and "
+        "resources[], plus totalElements / totalPages page metadata. "
+        "safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "$filter": {
+                "type": "string",
+                "minLength": 1,
+                "description": (
+                    "Optional OData filter expression (e.g. \"status eq 'CREATE_FAILED'\")."
+                ),
+            },
+            "$orderby": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Optional OData order-by expression.",
+            },
+            "$top": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Optional page size (OData $top).",
+            },
+            "$skip": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Optional offset (OData $skip).",
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "content": {"type": ["array", "null"]},
+            "totalElements": {"type": ["integer", "null"]},
+            "totalPages": {"type": ["integer", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key="vcfa-tenant-reads",
+    tags=("read-only", "vcfa", "tenant"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_call": (
+            "Call on the tenant plane to list deployments in the tenant org — "
+            "the first read when a tenant asks 'which deployments exist' or "
+            "reports 'my deployment didn't come up'. Narrow with a status "
+            "$filter (e.g. \"status eq 'CREATE_FAILED'\") to isolate failed or "
+            "in-progress deployments."
+        ),
+        "output_shape": (
+            "{content: [Deployment, ...], totalElements, totalPages}. Each "
+            "Deployment carries id, name, status, projectId, blueprintId, "
+            "ownedBy, createdAt, lastUpdatedAt, resources[]."
+        ),
+        "next_step": (
+            "Cross-reference projectId against vcfa.tenant.project.list, or "
+            "inspect a failed deployment's status to triage the failure."
+        ),
+    },
+)
+
 _TENANT_ABOUT = VcfaTypedOp(
     op_id="vcfa.tenant.about",
     handler_attr="tenant_about",
@@ -460,15 +547,17 @@ _TENANT_ABOUT = VcfaTypedOp(
 )
 
 
-#: The five typed VCFA read ops the connector registers at lifespan
-#: startup — the audited read set (#2294). Ordered provider → tenant,
-#: probe last within each plane, to match the operator's typical drill
-#: path (inventory first, health as needed).
+#: The six typed VCFA read ops the connector registers at lifespan
+#: startup — the #2294 audited read set plus the #2839 tenant deployment
+#: list. Ordered provider → tenant, probe last within each plane, to
+#: match the operator's typical drill path (inventory first, health as
+#: needed).
 VCFA_TYPED_OPS: Final[tuple[VcfaTypedOp, ...]] = (
     _PROVIDER_ORG_LIST,
     _PROVIDER_REGION_LIST,
     _PROVIDER_HEALTH,
     _TENANT_PROJECT_LIST,
+    _TENANT_DEPLOYMENT_LIST,
     _TENANT_ABOUT,
 )
 

--- a/backend/tests/test_connectors_vcf_automation_typed_reads.py
+++ b/backend/tests/test_connectors_vcf_automation_typed_reads.py
@@ -12,8 +12,9 @@ state**. Acceptance contract (#2305):
 
 * **Typed dispatch on a fresh boot with zero catalog state** — after
   ``register_typed_operations()`` and with **no** ingested
-  ``endpoint_descriptor`` rows seeded, all five audited ops (org list,
-  region list, provider health, tenant project list, tenant about)
+  ``endpoint_descriptor`` rows seeded, all six typed read ops (org list,
+  region list, provider health, tenant project list, tenant deployment
+  list, tenant about)
   dispatch through ``call_operation`` against a respx-mocked VCFA
   appliance and return ``status="ok"``, with ``source_kind="typed"`` on
   every registered row.
@@ -68,7 +69,11 @@ from meho_backplane.connectors.vcf_automation._routing import (
 )
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import EndpointDescriptor, Target
-from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations import (
+    PassThroughReducer,
+    reset_dispatcher_caches,
+    set_default_reducer,
+)
 from meho_backplane.operations._handler_resolve import (
     get_or_create_connector_instance,
     reset_handler_cache,
@@ -135,6 +140,39 @@ _TENANT_PROJECTS: dict[str, Any] = {
     "totalElements": 1,
     "totalPages": 1,
 }
+#: Two deployments — one succeeded, one failed — so the shape assertion
+#: covers the "which failed" half of the operator's question. Fields
+#: mirror the recorded-fixture shape in tests.test_connectors_vcf_automation_e2e.
+_TENANT_DEPLOYMENTS: dict[str, Any] = {
+    "content": [
+        {
+            "id": "deployment-1",
+            "name": "deploy-ok",
+            "description": "synthetic deployment",
+            "status": "CREATE_SUCCESSFUL",
+            "projectId": "project-1",
+            "blueprintId": "blueprint-1",
+            "ownedBy": "user-1",
+            "createdAt": "2026-05-01T00:00:00Z",
+            "lastUpdatedAt": "2026-05-15T00:00:00Z",
+            "resources": [],
+        },
+        {
+            "id": "deployment-2",
+            "name": "deploy-failed",
+            "description": "synthetic deployment",
+            "status": "CREATE_FAILED",
+            "projectId": "project-1",
+            "blueprintId": "blueprint-1",
+            "ownedBy": "user-1",
+            "createdAt": "2026-05-02T00:00:00Z",
+            "lastUpdatedAt": "2026-05-16T00:00:00Z",
+            "resources": [],
+        },
+    ],
+    "totalElements": 2,
+    "totalPages": 1,
+}
 _TENANT_ABOUT: dict[str, Any] = {
     "latestApiVersion": "9.0",
     "supportedApis": [{"apiVersion": "9.0"}],
@@ -146,6 +184,7 @@ _PAYLOAD_BY_OP: dict[str, dict[str, Any]] = {
     "vcfa.provider.region.list": _PROVIDER_REGIONS,
     "vcfa.provider.health": _PROVIDER_SITE,
     "vcfa.tenant.project.list": _TENANT_PROJECTS,
+    "vcfa.tenant.deployment.list": _TENANT_DEPLOYMENTS,
     "vcfa.tenant.about": _TENANT_ABOUT,
 }
 
@@ -254,7 +293,7 @@ def _resolve_connector() -> VcfAutomationConnector:
 
 
 def _register_routes(mock: respx.MockRouter, *, capture: dict[str, str] | None = None) -> None:
-    """Register the dual-plane login + five typed-op GET routes on *mock*.
+    """Register the dual-plane login + six typed-op GET routes on *mock*.
 
     When *capture* is passed, every GET records its ``Accept`` header under
     the request path so the plane-selection tests can assert the media type.
@@ -285,7 +324,7 @@ class _Bundle:
 
 @pytest.fixture
 async def typed_bundle(captured_events: list[Any]) -> AsyncIterator[_Bundle]:
-    """Register the five typed ops (zero ingested state) + respx-mock the appliance."""
+    """Register the six typed ops (zero ingested state) + respx-mock the appliance."""
     await VcfAutomationConnector.register_typed_operations()
     seeded = await _seed_target(host="10.20.30.5", fqdn=_FQDN)
     instance = _resolve_connector()
@@ -354,7 +393,7 @@ def test_every_typed_op_declares_the_plane_its_path_rides() -> None:
     misrouted HTTP 401 — both planes carry a Bearer header but reject the
     other plane's token).
     """
-    assert len(VCFA_TYPED_OPS) == 5
+    assert len(VCFA_TYPED_OPS) == 6
     for op in VCFA_TYPED_OPS:
         assert plane_for_path(op.path) == op.plane, (
             f"op {op.op_id!r} declares plane={op.plane!r} but "
@@ -371,7 +410,7 @@ _TYPED_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in VCFA_TYPED_OPS)
 
 @pytest.mark.parametrize("op_id", _TYPED_OP_IDS, ids=lambda op: op)
 async def test_typed_ops_dispatch_ok(op_id: str, typed_bundle: _Bundle) -> None:
-    """All five typed ops dispatch through ``call_operation`` and return ``status='ok'``."""
+    """All six typed ops dispatch through ``call_operation`` and return ``status='ok'``."""
     result = await call_operation(
         _OPERATOR,
         {
@@ -504,3 +543,56 @@ async def test_provider_op_query_params_forward_pagination(captured_events: list
 
     assert result["status"] == "ok", result
     assert "page=2" in captured["query"] and "pageSize=50" in captured["query"], captured
+
+
+async def test_tenant_deployment_list_forwards_odata_and_returns_content(
+    captured_events: list[Any],
+) -> None:
+    """``vcfa.tenant.deployment.list`` forwards OData params, returns the content envelope.
+
+    Pins the PassThrough reducer so the assertion targets the inline
+    payload deterministically. The recorded list is two rows — under any
+    handle threshold — so pinning only guards against reducer state a
+    sibling test module might leave set (the E2E force-handle test).
+    """
+    await VcfAutomationConnector.register_typed_operations()
+    await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    instance = _resolve_connector()
+    captured: dict[str, str] = {}
+
+    def _deployments_responder(request: httpx.Request) -> httpx.Response:
+        captured["query"] = str(request.url.query.decode())
+        return httpx.Response(200, json=_TENANT_DEPLOYMENTS)
+
+    set_default_reducer(PassThroughReducer())
+    try:
+        async with respx.mock(
+            base_url=_BASE_URL, assert_all_called=False, assert_all_mocked=False
+        ) as m:
+            m.post("/iaas/api/login").respond(200, json={"token": _TENANT_TOKEN})
+            m.get("/iaas/api/deployments").mock(side_effect=_deployments_responder)
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VCFA_CONNECTOR_ID,
+                    "op_id": "vcfa.tenant.deployment.list",
+                    "target": {"name": _TARGET_NAME},
+                    "params": {"$filter": "status eq 'CREATE_FAILED'", "$top": 50},
+                },
+            )
+    finally:
+        await instance.aclose()
+        set_default_reducer(PassThroughReducer())
+        reset_dispatcher_caches()
+
+    assert result["status"] == "ok", result
+    # OData params forward onto the tenant-plane request. httpx may encode
+    # the leading ``$`` as ``%24`` or leave it raw (a query sub-delimiter).
+    query = captured["query"]
+    assert "%24filter=" in query or "$filter=" in query, query
+    assert "%24top=50" in query or "$top=50" in query, query
+    # The vendor's content[] envelope round-trips inline with the failed
+    # deployment's fields intact — the "which failed" half of the question.
+    content = result["result"]["content"]
+    assert {d["status"] for d in content} == {"CREATE_SUCCESSFUL", "CREATE_FAILED"}, content
+    assert {"id", "name", "status", "projectId", "resources"} <= content[0].keys(), content[0]

--- a/docs/codebase/connectors-vcf-automation.md
+++ b/docs/codebase/connectors-vcf-automation.md
@@ -13,15 +13,17 @@ G3.6-T11 (#836) added the dual-plane spec ingestion + operator-review
 curation. G3.6-T12 (#840) shipped the recorded-fixture E2E. The operator
 runbook lives at `docs/cross-repo/g36-vcfa-canary.md`.
 
-**Typed reads (T5 #2305).** VCFA ships **no vendor OpenAPI spec** (the
-provider plane publishes none; the tenant plane ships only Swagger 2.0
-fragments the ingest parser rejects by decision #2090), so the curated
-`core_ops` ingested-curation path is dispatch-inert on a real deploy —
-there is nothing to ingest. The **audited read set** (evoila/meho#2294:
-org/region list, provider health, `/iaas/api/projects` + tenant `about`)
-is therefore served by `source_kind="typed"` ops (`typed_ops.py`) that
-dispatch through the connector's own dual-plane session with **zero
-catalog state**. Five ops:
+**Typed reads (T5 #2305; deployment list #2839).** VCFA ships **no
+vendor OpenAPI spec** (the provider plane publishes none; the tenant
+plane ships only Swagger 2.0 fragments the ingest parser rejects by
+decision #2090), so there is nothing to ingest — the hand-curated
+`core_ops` ingested-enable apparatus that once wrapped this gap was
+dispatch-inert on a real deploy and was **retired in #2362**. The
+**audited read set** (evoila/meho#2294: org/region list, provider
+health, `/iaas/api/projects` + tenant `about`), plus the tenant
+**deployment list** (#2839), is served by `source_kind="typed"` ops
+(`typed_ops.py`) that dispatch through the connector's own dual-plane
+session with **zero catalog state**. Six ops:
 
 | op_id | plane | path |
 |---|---|---|
@@ -29,6 +31,7 @@ catalog state**. Five ops:
 | `vcfa.provider.region.list` | provider | `GET /cloudapi/1.0.0/regions` |
 | `vcfa.provider.health` | provider | `GET /cloudapi/1.0.0/site` |
 | `vcfa.tenant.project.list` | tenant | `GET /iaas/api/projects` |
+| `vcfa.tenant.deployment.list` | tenant | `GET /iaas/api/deployments` |
 | `vcfa.tenant.about` | tenant | `GET /iaas/api/about` |
 
 Each op **declares the plane it rides**; `typed_ops._validate_typed_op_planes`
@@ -37,15 +40,19 @@ asserts at import time that the declared `plane` matches
 surfacing as a misrouted HTTP 401. The `org create` write
 (`POST /cloudapi/1.0.0/orgs`) is deliberately out of scope — a first
 write on a read-only connector belongs in a G3.x-mold approval-gated
-write-surface initiative. The remaining `core_ops` /`_core_data`
-ingested-curation surface is now the 5-group / 6-op browse remainder
-(the two get-by-id ops, provider users list, tenant deployment/blueprint
-browse) — declined from typed conversion because they are not in the
-operator-run audited set.
+write-surface initiative. Per-id deployment detail
+(`vcfa.tenant.deployment.get`), blueprint listing, and the provider
+users list remain unconverted — a natural fast-follow, not part of the
+"which deployments exist / which failed" answer this surface delivers.
+The hand-curated ingested-enable apparatus (`core_ops.py` / `_core_data`)
+those once lived under was retired in #2362; the wider ingested catalog
+would stay browsable through the generic `ReviewService.enable_reads`
+flow only where a convertible OpenAPI 3.x spec exists — which, for VCFA,
+it does not.
 
 `register_typed_operations` (a classmethod on the connector, queued onto
 the lifespan registrar list via `register_vcfa_typed_operations` in
-`__init__.py`) upserts the five descriptors on startup — the same
+`__init__.py`) upserts the six descriptors on startup — the same
 argocd / bind9 / Kubernetes typed-registrar shape.
 
 Source: `backend/src/meho_backplane/connectors/vcf_automation/`.
@@ -93,42 +100,20 @@ domains.
   lands. Mirrors `load_credentials_from_vault` in `connectors/sddc_manager/`
   and `load_session_credentials_from_vault` in `connectors/nsx/` /
   `connectors/vmware_rest/`.
-- **`VcfaCoreGroup` / `VcfaCoreOp`** (`core_ops.py`) — frozen dataclasses
-  carrying the operator-review metadata for one curated group / op. Each
-  entry includes a `plane` field (`"provider"` or `"tenant"`) that is
-  asserted at module import time to match
-  `_routing.plane_for_path(path)` — a path-vs-plane drift fails import
-  rather than surfacing as a misrouted 401 in production.
 - **`VCFA_TYPED_OPS` / `VcfaTypedOp` / `VCFA_TYPED_WHEN_TO_USE_BY_GROUP`**
-  (`typed_ops.py`) — the five typed read ops (T5 #2305) and their two
-  per-plane groups (`vcfa-provider-reads`, `vcfa-tenant-reads`). Each
-  `VcfaTypedOp` carries a `plane` + `path`; the module's
-  `_validate_typed_op_planes()` cross-checks them at import.
-- **`VCFA_CORE_GROUPS` / `VCFA_CORE_OPS`** (`core_ops.py`) — the
-  ingested-curation browse remainder: 5 curated groups (3 provider + 2
-  tenant) and 6 curated ops (3 provider + 3 tenant) left after the
-  audited read set moved to `typed_ops.py`. Every group's `when_to_use`
-  names its plane explicitly so the agent's `list_operation_groups`
-  step routes correctly across the dual-plane surface.
+  (`typed_ops.py`) — the six typed read ops (T5 #2305; tenant deployment
+  list #2839) and their two per-plane groups (`vcfa-provider-reads`,
+  `vcfa-tenant-reads`). Each `VcfaTypedOp` carries a `plane` + `path`;
+  the module's `_validate_typed_op_planes()` cross-checks them at import
+  so a declared-plane / path drift fails the import rather than
+  surfacing as a misrouted 401.
 - **`VCFA_PRODUCT` / `VCFA_VERSION` / `VCFA_IMPL_ID` /
-  `VCFA_CONNECTOR_ID`** (`core_ops.py`) — DB-side keys. Since #1814 the
+  `VCFA_CONNECTOR_ID`** (`__init__.py`) — DB-side keys. Since #1814 the
   registry key `VcfAutomationConnector.product` was unified to `"vcfa"`,
   matching `VCFA_PRODUCT` (what `parse_connector_id("vcfa-rest-9.0")`
   extracts). All `endpoint_descriptor` and `operation_group` rows carry
-  `product="vcfa"`.
-- **`apply_vcfa_core_curation`** (`core_ops.py`) — async helper
-  driving `ReviewService.edit_group` + `enable_group` +
-  `edit_op(is_enabled=False)` (for non-core ops in curated groups)
-  + `edit_op(llm_instructions=…)` (for the 6 core ops) so exactly
-  the curated set is dispatchable after the call returns. Mirrors
-  `apply_nsx_core_curation` / `apply_harbor_core_curation`
-  verbatim; the audit-log-driven operator-override exclusion is the
-  mechanism that threads "enable only ops X, Y, Z under group G"
-  through `ReviewService.enable_group`'s cascade.
-- **`classify_vcfa_op` / `VCFA_PATH_RULES`** (`core_ops.py`) —
-  path-prefix classifier. Tenant rules (`/iaas/api/*`) are listed
-  first defensively; the two planes never share a path family so
-  ordering is not load-bearing today.
+  `product="vcfa"`. Relocated here from the retired `core_ops` /
+  `_core_data` curation modules (#2358).
 
 ## Control flow
 
@@ -287,38 +272,20 @@ VCFA's session has an idle timeout, and a per-target network call during
 lifespan shutdown is more risk than benefit) and delegates to
 `HttpConnector.aclose()` which closes every per-target httpx client.
 
-### Operator-review curation (G3.6-T11 #836)
+### Operator-review curation (retired #2362)
 
-`apply_vcfa_core_curation(review_service, *, tenant_id)` is the
-post-ingest helper that drives the substrate so exactly the 6 curated
-ops in `VCFA_CORE_OPS` end `is_enabled=True` and the 5 curated groups
-in `VCFA_CORE_GROUPS` end `review_status='enabled'`. (This path applies
-only to the ingested-curation browse remainder; the audited read set is
-served typed and needs no curation.) The control flow mirrors
-`apply_nsx_core_curation`:
-
-1. `ReviewService.get_review_payload("vcfa-rest-9.0", tenant_id)` loads
-   the post-ingest state.
-2. For each non-core op in a curated group, `ReviewService.edit_op(...,
-   is_enabled=False)` writes an operator-override audit row so the
-   follow-on `enable_group` cascade skips it.
-3. `ReviewService.edit_group` lands the curated `name` +
-   plane-named `when_to_use`; `ReviewService.enable_group` flips
-   `review_status='enabled'` and cascades `is_enabled=True` only to
-   the 6 core ops.
-4. `ReviewService.edit_op(..., llm_instructions=…)` lands the per-op
-   guidance blob on each of the 6 curated ops.
-
-The helper is safe to re-run (end-state idempotent) but emits redundant
-audit rows on re-runs — the intended posture is one-shot per ingest.
-The ingestion + operator-review wiring expects both VCFA specs
-(`vcf-automation-9.0/cloudapi.yaml` + `vcf-automation-9.0/iaas.yaml`)
-to be ingested under the same `(product, version, impl_id) = ("vcfa",
-"9.0", "vcfa-rest")` triple **before** the helper runs — the same
-multi-spec-merge contract `register_ingested_operations` implements
-for vSphere's `vcenter.yaml` + `vi-json.yaml`. Each row carries a
-`spec:cloudapi` or `spec:iaas` tag so operators can filter the review
-payload per plane.
+The hand-curated ingested-enable apparatus G3.6-T11 (#836) once
+added — `apply_vcfa_core_curation`, `VCFA_CORE_OPS` /
+`VCFA_CORE_GROUPS`, `classify_vcfa_op` / `VCFA_PATH_RULES` — was
+**retired in #2362** (T7 of #2358), along with the equivalent modules
+in five sibling connectors. It had zero production call sites
+(`apply_vcfa_core_curation` was invoked only by tests; real deploys
+enable ingested ops through the generic review flow), and for VCFA it
+was dispatch-inert regardless: the product ships no ingestible OpenAPI
+3.x spec (see the **Typed reads** note above), so there was never a
+catalog row to curate. The working read surface is the typed ops in
+`typed_ops.py`; `ReviewService.enable_reads` remains the generic path
+for ingested breadth on connectors that *do* publish a convertible spec.
 
 ## Dependencies
 
@@ -351,9 +318,9 @@ payload per plane.
   `nsx` / `sddc_manager` precedents.
 - The classic vCD `/api/versions` response is XML; the connector reads
   status only and does not parse "latest non-deprecated version" out of it.
-  Operators who need that string call the wrapper directly; the curated
-  ingest in #836 will route through the structured `/cloudapi/*` and
-  `/iaas/api/*` paths instead.
+  Operators who need that string call the wrapper directly; the typed
+  `vcfa.provider.health` / `vcfa.tenant.about` probes read the structured
+  `/cloudapi/*` and `/iaas/api/*` version surfaces instead.
 - The VCFA tenant/consumption plane's only *vendor-published*
   machine-readable surface is the 8 **Swagger 2.0** fragments vendored
   under [`vmware/vra-sdk-go`
@@ -367,11 +334,10 @@ payload per plane.
   ["Product ships only Swagger
   2.0"](../cross-repo/connector-ingestion.md#product-ships-only-swagger-20)
   runbook section, which uses VCFA as the worked example). This is
-  **orthogonal to the curated 11-op read core**: `VCFA_CORE_OPS` is
-  sourced from the OpenAPI-3.x `vcf-automation-9.0/cloudapi.yaml` +
-  `iaas.yaml` documents, so lighting up the core never touches the
-  vra-sdk-go 2.0 fragments — converting them only *widens* the surface
-  beyond the curated core.
+  **orthogonal to the typed read surface**: the working reads in
+  `typed_ops.py` dispatch with zero catalog state, so they never touch
+  the vra-sdk-go 2.0 fragments — converting those would only *widen* the
+  ingested browse breadth, not change the typed reads.
 - `--resolve`-style DNS override (consumer-wrapper-only) has no direct
   httpx equivalent in the connector — operators are expected to make the
   appliance's FQDN resolvable on the meho-backplane host (typical: split-DNS
@@ -404,8 +370,8 @@ payload per plane.
 - Precedent: `connectors/nsx/connector.py` (session-cookie + XSRF +
   401-retry-once); `connectors/sddc_manager/connector.py` (per-target
   credential cache, dispatch-shim shape); `connectors/vmware_rest/`
-  (dual-spec ingestion shape — same `spec_source` tagging that #836 will
-  apply to the provider + tenant plane specs);
+  (dual-spec ingestion shape — the `spec_source` tagging precedent for a
+  connector that ingests two specs under one triple);
   `connectors/adapters/http.py` (`HttpConnector`);
   `connectors/registry.py:108` (`register_connector_v2`).
 - VCFA API references:


### PR DESCRIPTION
## Summary

- Adds `vcfa.tenant.deployment.list` (`GET /iaas/api/deployments`) as a typed read on the VCFA tenant plane, mirroring `vcfa.tenant.project.list` exactly — same plane, same OData `$filter`/`$orderby`/`$top`/`$skip` params, same `{content, totalElements, totalPages}` envelope. This is the tenant-plane inventory answer to "which deployments exist / which failed / which are stuck", the first read when a tenant reports "my deployment didn't come up".
- VCFA ships no ingestible spec, so the ingested `GET:/iaas/api/deployments` op is dispatch-inert on a real deploy — typed conversion is the only working read path (same rationale as the existing 5 typed ops). The handler is a pure pass-through GET, so vendor field shapes (`id`, `name`, `status`, `projectId`, `blueprintId`, `resources[]`, …) round-trip unchanged and set-shaped responses ride the dispatcher's existing JSONFlux result-handle seam, identical to `project.list`.
- A status `$filter` (e.g. `"status eq 'CREATE_FAILED'"`) narrows to failed deployments directly, the same way `project.list`'s `$filter` narrows to a named project.
- Refreshes `docs/codebase/connectors-vcf-automation.md`: adds the op to the typed table (now six) and retires the stale `core_ops.py` / `VcfaCoreGroup` / `VcfaCoreOp` / "Operator-review curation (G3.6-T11 #836)" sections to reflect the #2362 ingested-curation retirement.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean (4 files already formatted)
- [x] `mypy src/meho_backplane/` — no new errors (only the pre-existing, unrelated `net/icmp.py` macOS `MSG_ERRQUEUE`; test-file check identical to `main`)
- [x] `pytest tests/test_connectors_vcf_automation_typed_reads.py tests/test_connectors_vcf_automation_e2e.py` — 25 passed
- [x] `pytest tests/test_connectors_registry.py` — 16 passed (no aggregate typed-op count regressed)
- [x] `.claude/hooks/code-quality.py --diff` — pass (exit 0)
- [x] AC: op registered as typed with `plane="tenant"`, `safety_level="safe"`, `requires_approval=False`, dispatching via `call_operation` on `connector_id="vcfa-rest-9.0"` — `test_typed_ops_dispatch_ok[vcfa.tenant.deployment.list]` PASSED
- [x] AC: `_validate_typed_op_planes()` passes — `/iaas/api/deployments` → `plane="tenant"` via `plane_for_path`; `test_every_typed_op_declares_the_plane_its_path_rides` PASSED (len == 6)
- [x] AC: `parameter_schema` accepts `$filter`/`$orderby`/`$top`/`$skip` and the handler forwards them — `test_tenant_deployment_list_forwards_odata_and_returns_content` asserts `$filter` + `$top` on the wire
- [x] AC: handler returns the `content[]` envelope with `id`/`name`/`status`/`projectId`/`resources` intact — same test asserts the shape (incl. a `CREATE_FAILED` row)
- [x] AC: new test against a respx-mocked `/iaas/api/deployments` fixture — added
- [x] AC: `docs/codebase/connectors-vcf-automation.md` updated (6-op table + `core_ops` retirement)
- [x] AC: CLI OpenAPI snapshot — no schema/route changed (diff is connector code + test + docs only), so no regen needed

## Out of scope

- `vcfa.tenant.deployment.get` (per-id detail), deployment writes/day-2 actions, blueprint listing, provider-plane surface — per the issue.
- **Adjacent finding (recommend follow-up):** the Go CLI verb `meho vcf-automation deployment list` (`cli/internal/cmd/vcf-automation/deployment.go`) still dispatches the inert ingested op-id `GET:/iaas/api/deployments`, not the new typed `vcfa.tenant.deployment.list` — so that operator CLI verb remains non-functional on a real deploy until repointed (the sibling `project`/`org`/`region` list verbs were repointed to their typed op-ids in #2266; `TestRepointedListVerbsDispatchTypedOpIDs` deliberately omits `deployment`). Repoint + a matching test case is a trivial follow-up; left out here because it is a different-language surface not named in this task's acceptance criteria, and the `deployment get` counterpart (which shares the command) is itself out of scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2839
