### PR TITLE
feat(connectors): project_view surfaces per-item board field values

### DIFF
--- a/backend/src/meho_backplane/connectors/github/composites/_board.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_board.py
@@ -87,7 +87,16 @@ _OWNER_TYPE_ROOT: dict[str, str] = {"organization": "organization", "user": "use
 # ``__ROOT__`` is replaced with the closed-map literal above (org / user);
 # ``$login`` / ``$number`` / ``$first`` are GraphQL variables. Reads the
 # project node id + every field (single-select fields additionally carry
-# their ``options {id name}``) + the current items in one round-trip.
+# their ``options {id name}``) + the current items, each with its own
+# Status / Priority / Size / ... field values, in one round-trip.
+#
+# ``fieldValues(first: 20)`` is a per-item bound, not a page size: an item
+# carries one value per set field, and auto-populated values (assignees,
+# labels, linked PRs, repository) precede the custom single-selects in the
+# connection. The live MEHO board's busiest items hold 9 values, where
+# ``first: 8`` drops the trailing ``Track`` single-select on every assigned
+# item; 20 clears that observed max with headroom and needs no per-item
+# cursor (board-item field-value pagination is a separate follow-on).
 _PROJECT_VIEW_QUERY = """
 query ($login: String!, $number: Int!, $first: Int!) {
   __ROOT__(login: $login) {
@@ -105,6 +114,19 @@ query ($login: String!, $number: Int!, $first: Int!) {
         totalCount
         nodes {
           id
+          fieldValues(first: 20) {
+            nodes {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldTextValue {
+                text
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+            }
+          }
           content {
             __typename
             ... on Issue { number title url }
@@ -200,13 +222,49 @@ def _parse_fields(project: dict[str, Any]) -> list[dict[str, Any]]:
     return parsed
 
 
+def _parse_field_values(node: dict[str, Any]) -> dict[str, Any]:
+    """Collapse an item's ``fieldValues.nodes`` array into ``{field name: value}``.
+
+    Only single-select (its selected option ``name``) and plain-text (its
+    ``text``) value types are projected -- the Status / Priority / Size
+    fields the board-status read needs, plus the common free-text field.
+    Every other value type (iteration, number, date, repository, labels,
+    ...) is dropped, mirroring :func:`_parse_fields`' "skip unexpected
+    shapes" defensiveness; a node whose owning field name cannot be
+    resolved is likewise skipped rather than raised.
+    """
+    values_conn = node.get("fieldValues")
+    nodes = values_conn.get("nodes") if isinstance(values_conn, dict) else None
+    if not isinstance(nodes, list):
+        return {}
+    parsed: dict[str, Any] = {}
+    for value_node in nodes:
+        if not isinstance(value_node, dict):
+            continue
+        typename = value_node.get("__typename")
+        if typename == "ProjectV2ItemFieldSingleSelectValue":
+            value = value_node.get("name")
+        elif typename == "ProjectV2ItemFieldTextValue":
+            value = value_node.get("text")
+        else:
+            continue
+        field = value_node.get("field")
+        field_name = field.get("name") if isinstance(field, dict) else None
+        if not isinstance(field_name, str):
+            continue
+        parsed[field_name] = value
+    return parsed
+
+
 def _parse_items(project: dict[str, Any]) -> list[dict[str, Any]]:
     """Collapse the ``items.nodes`` array into ``{item_id, content_type, ...}`` rows.
 
     Each row carries the board ``item_id`` (the node id
     ``project_item_set_field`` needs) plus the underlying content's type,
-    number, title, and url. Draft issues have no number / url; those keys
-    surface as ``None``.
+    number, title, and url, and a ``field_values`` map of the item's set
+    Status / Priority / Size / text fields (see :func:`_parse_field_values`).
+    Draft issues have no number / url; those keys surface as ``None``. An
+    item with no projected field values carries an empty ``field_values``.
     """
     items_conn = project.get("items")
     nodes = items_conn.get("nodes") if isinstance(items_conn, dict) else None
@@ -225,6 +283,7 @@ def _parse_items(project: dict[str, Any]) -> list[dict[str, Any]]:
                 "number": content_dict.get("number"),
                 "title": content_dict.get("title"),
                 "url": content_dict.get("url"),
+                "field_values": _parse_field_values(node),
             }
         )
     return parsed

--- a/backend/src/meho_backplane/connectors/github/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/github/composites/schemas.py
@@ -247,10 +247,42 @@ PROJECT_VIEW_RESPONSE_SCHEMA: dict[str, Any] = {
         "items": {
             "type": "array",
             "description": (
-                "Board items. Each is ``{item_id, content_type, number, title, url}``; "
-                "``number`` / ``url`` are ``null`` for draft issues."
+                "Board items. Each is ``{item_id, content_type, number, title, url, "
+                "field_values}``; ``number`` / ``url`` are ``null`` for draft issues."
             ),
-            "items": {"type": "object"},
+            "items": {
+                "type": "object",
+                "properties": {
+                    "item_id": {
+                        "type": ["string", "null"],
+                        "description": "Board item's node id (input to project_item_set_field).",
+                    },
+                    "content_type": {
+                        "type": ["string", "null"],
+                        "description": "Content type (Issue / PullRequest / DraftIssue).",
+                    },
+                    "number": {
+                        "type": ["integer", "null"],
+                        "description": "The issue / PR number; ``null`` for draft issues.",
+                    },
+                    "title": {"type": ["string", "null"], "description": "The item's title."},
+                    "url": {
+                        "type": ["string", "null"],
+                        "description": "The issue / PR URL; ``null`` for draft issues.",
+                    },
+                    "field_values": {
+                        "type": "object",
+                        "description": (
+                            "The item's current single-select (Status / Priority / Size) and "
+                            'text field values, keyed by field name -- e.g. ``{"Status": "In '
+                            'Progress", "Priority": "high"}``. Only single-select and text '
+                            "field types are projected; other value types (iteration / number "
+                            "/ date / repository / labels / ...) are omitted. Empty when the "
+                            "item has no such field set."
+                        ),
+                    },
+                },
+            },
         },
         "item_count": {
             "type": ["integer", "null"],

--- a/backend/tests/test_connectors_github_composites_board.py
+++ b/backend/tests/test_connectors_github_composites_board.py
@@ -122,6 +122,33 @@ def _project_view_payload() -> dict[str, Any]:
                         "nodes": [
                             {
                                 "id": "PVTI_1",
+                                "fieldValues": {
+                                    "nodes": [
+                                        {
+                                            "__typename": "ProjectV2ItemFieldTextValue",
+                                            "text": "Fix X",
+                                            "field": {"name": "Title"},
+                                        },
+                                        {
+                                            "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                            "name": "In Progress",
+                                            "field": {"name": "Status"},
+                                        },
+                                        {
+                                            "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                            "name": "high",
+                                            "field": {"name": "Priority"},
+                                        },
+                                        # Unrecognised value type -> dropped (matches the wire:
+                                        # no inline fragment is taken, so only __typename returns).
+                                        {"__typename": "ProjectV2ItemFieldRepositoryValue"},
+                                        # Recognised type but no resolvable field -> skipped.
+                                        {
+                                            "__typename": "ProjectV2ItemFieldSingleSelectValue",
+                                            "name": "orphan",
+                                        },
+                                    ]
+                                },
                                 "content": {
                                     "__typename": "Issue",
                                     "number": 42,
@@ -203,6 +230,35 @@ async def test_project_view_parses_items_including_draft() -> None:
     draft_item = next(i for i in envelope["items"] if i["content_type"] == "DraftIssue")
     assert draft_item["number"] is None
     assert draft_item["url"] is None
+
+
+@pytest.mark.asyncio
+async def test_project_view_projects_item_field_values() -> None:
+    """Item rows carry ``field_values`` from single-select + text nodes; other types drop."""
+    connector = _RecordingConnector([_project_view_payload()])
+    envelope = await project_view_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "project_number": 19},
+        connector=connector,  # type: ignore[arg-type]
+    )
+    # ----- The query asks for each item's field values with the union fragments -----
+    query = connector.post_calls[0]["json"]["query"]
+    assert "fieldValues(first: 20)" in query
+    assert "... on ProjectV2ItemFieldSingleSelectValue" in query
+    assert "... on ProjectV2ItemFieldTextValue" in query
+    assert "... on ProjectV2FieldCommon { name }" in query
+    # ----- Status/Priority single-selects + the Title text value surface by field name;
+    # the ProjectV2ItemFieldRepositoryValue node and the field-less single-select drop -----
+    issue_item = next(i for i in envelope["items"] if i["content_type"] == "Issue")
+    assert issue_item["field_values"] == {
+        "Title": "Fix X",
+        "Status": "In Progress",
+        "Priority": "high",
+    }
+    # An item with no fieldValues selection collapses to an empty map, not an error.
+    draft_item = next(i for i in envelope["items"] if i["content_type"] == "DraftIssue")
+    assert draft_item["field_values"] == {}
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-github.md
+++ b/docs/codebase/connectors-github.md
@@ -127,7 +127,21 @@ gh catalog ingest.
     `options {id name}`), and its items. This is the ergonomic linchpin:
     it hands back the `project_id` / `field_id` / `option_id` node ids the
     two writes consume, so an agent never shells out to `gh project` to
-    discover them.
+    discover them. Each item row also carries a **`field_values`** map of
+    the item's currently-set fields keyed by field name (e.g.
+    `{"Status": "In Progress", "Priority": "high"}`) — the read half of the
+    board that answers `/board-status`-shaped "what Status/Priority is #N?"
+    questions without a `gh` GraphQL fallback (#2845). The query selects
+    each item's `fieldValues` and `_parse_field_values` projects only the
+    single-select (`ProjectV2ItemFieldSingleSelectValue.name`) and text
+    (`ProjectV2ItemFieldTextValue.text`) value types, dropping the other
+    union members (iteration / number / date / repository / labels / ...)
+    the same defensive way `_parse_fields` skips unexpected shapes. The
+    `fieldValues(first: 20)` bound is a deliberate per-item cap: on the
+    live MEHO board the busiest items hold 9 field values and the smaller
+    `first: 8` the Task originally sketched was measured to truncate the
+    trailing `Track` single-select on every assigned item; per-item
+    field-value pagination stays a separate follow-on.
   - `gh.composite.project_item_add` (write) — `addProjectV2ItemById`.
   - `gh.composite.project_item_set_field` (write) —
     `updateProjectV2ItemFieldValue` with a `singleSelectOptionId` value.


### PR DESCRIPTION
## Summary
- `gh.composite.project_view` now projects each board item's current **field values** (Status / Priority / Size single-selects + text fields) under a new additive `field_values` key — the read half of the board that `/board-status`-shaped "what Status/Priority is #N?" questions need, so they no longer fall back to the `gh` CLI's GraphQL passthrough (which bypasses MEHO's policy/audit/broadcast path).
- Thin projection on the **existing** composite: extended `_PROJECT_VIEW_QUERY`'s `items` selection with `fieldValues` + inline fragments on the `ProjectV2ItemFieldValue` union, and added `_parse_field_values` (mirrors `_parse_fields`' defensive node-walk). No new `op_id`, no new composite, no new registration. Existing row keys (`item_id` / `content_type` / `number` / `title` / `url`) are unchanged — backward-compatible.
- Only single-select (`name`) and text (`text`) value types are projected; every other union member (iteration / number / date / repository / labels / ...) is dropped, not raised — the same defensiveness `_parse_fields` uses.

### Deviation from the issue: `fieldValues(first: 20)`, not `first: 8`
The issue sketched `first: 8`. I confirmed the live GitHub GraphQL schema (`ProjectV2Item.fieldValues` → `ProjectV2ItemFieldValueConnection!`; `ProjectV2ItemFieldValue` is a **union**, so inline fragments are required) and smoke-tested the exact query against the real MEHO board (`evoila-bosnia` project 19 — the board `/board-status` targets). Measurement across all 584 items: the busiest hold **9** field values, and `first: 8` was observed to truncate the trailing **`Track`** single-select on **every assigned item** (18 of the first 100) — an assigned item prepends a `<User>` (Assignees) value that pushes `Track` to position 9. `first: 20` clears the observed max with comfortable headroom and needs no per-item cursor (field-value pagination stays a separate follow-on, per the initiative's own medium-tier list). The bound is documented in-code and locked by a test.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean (4 files already formatted)
- [x] `mypy src/meho_backplane/connectors/github/composites/` — Success, no issues in 7 files
- [x] `pytest` github-composites suite — **63 passed** (board + read + register + sub_issues + flow)
- [x] `.claude/hooks/code-quality.py --diff` — **0 blockers** (2 pre-existing file-size warnings on the extended files)
- [x] **AC1** query selects `fieldValues` with `ProjectV2ItemFieldSingleSelectValue` (`name` + `field.name`) and `ProjectV2ItemFieldTextValue` (`text` + `field.name`) fragments, dispatched via the existing `gh.composite.project_view` op (no new op_id) — asserted in `test_project_view_projects_item_field_values`; exact query smoke-tested against the live board.
- [x] **AC2** `_parse_items` returns `field_values` as `{field name: value}` built only from recognised `__typename`s; unrecognised dropped — asserted (RepositoryValue + a field-less single-select both dropped; Status/Priority/Title surface).
- [x] **AC3** `PROJECT_VIEW_RESPONSE_SCHEMA` declares `field_values` on each item row.
- [x] **AC4** test asserts a Status single-select **and** a text field surface in `field_values`, and an unrecognised value-type node is dropped without error.
- [x] **AC5** `docs/codebase/connectors-github.md` "Board (Projects-v2)" section updated.
- [x] **AC6** CLI OpenAPI snapshot — ran `make snapshot-openapi`, **zero diff** (composite schemas are `endpoint_descriptor` rows, not FastAPI routes; no regen needed).

## Out of scope
- No write counterpart (`gh.composite.project_item_set_field` already exists and is unaffected — this is the read-side mirror).
- No number / date / iteration value-type projection (additive follow-on if a workflow needs it).
- No per-item `fieldValues` pagination and no `project_view` item-cursor (both separate follow-ons in the initiative's medium tier).
- File-size warnings on `_board.py` (454) and `schemas.py` (480) are pre-existing (>400 warn, <600 block); splitting is a separate refactor, not this thin projection.

Parent initiative: #2833

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2845
