### PR TITLE
feat(connectors): add rke2.node.service.status read op (#2852)

### DIFF
--- a/backend/src/meho_backplane/connectors/rke2/connector.py
+++ b/backend/src/meho_backplane/connectors/rke2/connector.py
@@ -25,6 +25,9 @@ This module ships:
   :meth:`fingerprint`, registered as the ``rke2.about`` typed op.
 * :meth:`Rke2SshConnector.posture_show` -- the read-only posture tier
   (``rke2.posture.show``): config-file modes + redacted token presence.
+* :meth:`Rke2SshConnector.service_status` -- the read-only service-state
+  probe (``rke2.node.service.status``, #2833 / #2852): live systemd state
+  of the ``rke2-server`` / ``rke2-agent`` units via ``systemctl show``.
 * :meth:`Rke2SshConnector.etcd_snapshot_save` -- the safe, non-gated
   ``rke2.etcd-snapshot.save`` op (T4 #2431): an on-demand managed-etcd
   snapshot on a server node, returning a snapshot name + path.
@@ -326,6 +329,28 @@ class Rke2SshConnector(SshConnector):
 
         return await _rke2_posture_show(self, target, params, operator)
 
+    async def service_status(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``rke2.node.service.status`` (#2833 / #2852).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.rke2.ops_read.rke2_service_status`,
+        which runs one read-only ``systemctl show`` probe over the shared SSH
+        adapter across the fixed ``rke2-server`` / ``rke2-agent`` pair and
+        returns their live systemd state (load/active/sub state, start time,
+        restart count) without mutating anything. Safe / non-gated like the
+        sibling ``posture_show``.
+        """
+        from meho_backplane.connectors.rke2.ops_read import (
+            rke2_service_status as _rke2_service_status,
+        )
+
+        return await _rke2_service_status(self, target, params, operator)
+
     async def token_rotate(
         self,
         target: Target,
@@ -574,6 +599,18 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "exists (presence + mode only -- the token VALUE is never read). "
         "Pair with a rotation runbook to confirm the token is present "
         "before rotating. Transport: plain SSH (``stat``, read-only)."
+    ),
+    "rke2-service-read": (
+        "Use to check whether an RKE2 node's systemd service is up WITHOUT "
+        "changing it: ``rke2.node.service.status`` runs a read-only "
+        "``systemctl show`` over the fixed ``rke2-server`` / ``rke2-agent`` "
+        "pair and reports each unit's load / active / sub state, start time, "
+        "and restart count. The unit reporting ``not-found`` is not installed "
+        "on the node, so the result also reveals the node's role. Reach for "
+        "it when the Kubernetes API is unreachable and ``kubernetes.*`` ops "
+        "cannot answer 'is rke2-server actually up, and is it crash-looping?'. "
+        "Read-only -- the restart itself is the approval-gated "
+        "``rke2.node.service.restart``. Transport: plain SSH."
     ),
     "rke2-etcd-snapshot": (
         "Use to capture an on-demand managed-etcd snapshot on an RKE2 "

--- a/backend/src/meho_backplane/connectors/rke2/ops_read.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_read.py
@@ -1,7 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Read-only posture tier for :class:`Rke2SshConnector` (G-Node/RKE2-T1 #2221).
+"""Read-only tier for :class:`Rke2SshConnector` (G-Node/RKE2-T1 #2221).
+
+Hosts the connector's safe, non-mutating read ops:
+
+* ``rke2.posture.show`` -- the config-surface security posture (below).
+* ``rke2.node.service.status`` -- the systemd service-state probe added by
+  Initiative #2833 (#2852): one read-only ``systemctl show`` round-trip
+  over the fixed ``(rke2-server, rke2-agent)`` unit pair, reporting each
+  unit's load/active/sub state, start time, and restart count so an
+  operator can answer "is ``rke2-server`` up, since when, and is it
+  crash-looping?" when the Kubernetes API itself is down. See
+  :func:`rke2_service_status`.
 
 ``rke2.posture.show`` reports the security posture of an RKE2 node's
 config surface without ever reading secret material:
@@ -71,14 +82,20 @@ __all__ = [
     "POSTURE_CONFIG_PATHS",
     "READ_OPS",
     "RKE2_TOKEN_PATH",
+    "SERVICE_STATUS_PROPERTIES",
+    "SERVICE_UNITS",
     "STATUS_ABSENT",
     "STATUS_PRESENT",
     "STATUS_UNKNOWN",
     "Rke2PostureProbeError",
+    "Rke2ServiceStatusProbeError",
     "build_posture_probe_command",
+    "build_service_status_command",
     "parse_posture",
     "parse_posture_probe_output",
+    "parse_service_status",
     "rke2_posture_show",
+    "rke2_service_status",
 ]
 
 
@@ -433,7 +450,289 @@ _RKE2_POSTURE_OP = Rke2Op(
 )
 
 
-#: The read-only posture tier ops. ``rke2.about`` (the identity canary)
-#: is composed alongside these in
-#: :func:`meho_backplane.connectors.rke2.ops._rke2_ops`.
-READ_OPS: tuple[Rke2Op, ...] = (_RKE2_POSTURE_OP,)
+# ---------------------------------------------------------------------------
+# Service-state read (``rke2.node.service.status``, Initiative #2833 / #2852)
+# ---------------------------------------------------------------------------
+
+#: The RKE2 systemd units a node may run. A control-plane node runs
+#: ``rke2-server``; a worker runs ``rke2-agent``. A node runs exactly one,
+#: so probing both is how the op reports which role the node has -- the same
+#: closed pair the approval-gated restart op allow-lists, here read-only.
+#: Fixed constants: no operator-supplied unit, so no arbitrary-unit or
+#: shell-injection surface.
+SERVICE_UNITS: tuple[str, ...] = ("rke2-server", "rke2-agent")
+
+#: The systemd unit properties the status probe reads per unit. All are
+#: read-only introspection (``systemctl show`` never mutates). ``LoadState``
+#: separates an installed unit from ``not-found``; ``ActiveState`` /
+#: ``SubState`` are the running signal; ``ExecMainStartTimestamp`` answers
+#: "active since when"; ``NRestarts`` is the crash-loop counter.
+SERVICE_STATUS_PROPERTIES: tuple[str, ...] = (
+    "LoadState",
+    "ActiveState",
+    "SubState",
+    "ExecMainStartTimestamp",
+    "NRestarts",
+)
+
+#: systemd's "this unit is not installed on this node" ``LoadState`` value.
+#: ``systemctl show`` prints it on stdout and still exits 0
+#: (systemd/systemd#1105), so it -- not the exit code -- is how the op tells
+#: a node's role apart and reports both units honestly.
+_LOAD_STATE_NOT_FOUND: str = "not-found"
+
+#: Marker line the probe prints before each unit's ``systemctl show`` block
+#: so the parser can attribute the ``KEY=VALUE`` lines that follow to a unit.
+#: ``systemctl show`` never emits a ``UNIT`` property, so the marker cannot
+#: collide with real output.
+_UNIT_MARKER: str = "UNIT"
+
+#: Exit code the probe uses when the node has no ``systemctl``. Any non-zero
+#: exit is an infrastructure failure, not a service-state verdict.
+_PROBE_NO_SYSTEMCTL_EXIT: int = 127
+
+
+class Rke2ServiceStatusProbeError(RuntimeError):
+    """The service-status probe itself failed to run (no ``systemctl``, broken shell).
+
+    Distinct from any service-state verdict: the dispatcher maps it to a
+    ``connector_error`` result (the #986 discipline) so an infrastructure
+    failure is never served as a service-state answer.
+    """
+
+
+def build_service_status_command(units: tuple[str, ...]) -> str:
+    """Build the single-round-trip ``systemctl show`` service-status probe.
+
+    Emits a ``UNIT=<name>`` marker then that unit's ``KEY=VALUE`` property
+    block for each unit, in one SSH round-trip. Every unit name is a fixed
+    module constant (no operator input) and is ``shlex.quote``d defensively.
+    ``--all`` un-suppresses the zero/empty properties within the ``-p``
+    selection (``systemctl show`` drops ``NRestarts=0`` and an empty
+    ``ExecMainStartTimestamp`` otherwise), so a healthy unit reports
+    ``restart_count: 0`` rather than a missing field. ``systemctl show`` is
+    read-only and exits 0 even for a ``not-found`` unit, so the ``|| true``
+    per unit means the only non-zero exit is the ``systemctl``-absent guard
+    -- which lets the handler tell an infrastructure failure apart from a
+    real verdict.
+    """
+    props = ",".join(SERVICE_STATUS_PROPERTIES)
+    quoted = " ".join(shlex.quote(unit) for unit in units)
+    return (
+        f"command -v systemctl >/dev/null 2>&1 || exit {_PROBE_NO_SYSTEMCTL_EXIT}; "
+        f"for u in {quoted}; do "
+        f"printf '{_UNIT_MARKER}=%s\\n' \"$u\"; "
+        f'systemctl show --all -p {props} "$u" 2>/dev/null || true; '
+        "done"
+    )
+
+
+def _parse_restart_count(raw: str | None) -> int | None:
+    """Parse a ``systemctl`` ``NRestarts`` value into an int, else ``None``.
+
+    A missing or non-integer value resolves to ``None`` rather than raising --
+    a suppressed or unparseable counter must not fail the whole probe.
+    """
+    if raw is None:
+        return None
+    try:
+        return int(raw.strip())
+    except ValueError:
+        return None
+
+
+def _service_unit_entry(unit: str, fields: dict[str, str]) -> dict[str, Any]:
+    """Compose one unit's status entry from its parsed ``KEY=VALUE`` fields.
+
+    A ``LoadState=not-found`` unit is not installed on this node, so every
+    live-state field is ``null``: systemd still prints ``inactive`` /
+    ``dead`` defaults for an absent unit, and surfacing those would misreport
+    "not present here" as "present but stopped". A missing ``LoadState``
+    (unusual) resolves to ``null`` rather than ``not-found`` -- undetermined,
+    not a confident absence.
+    """
+    load_state = fields.get("LoadState") or None
+    if load_state == _LOAD_STATE_NOT_FOUND:
+        return {
+            "unit": unit,
+            "load_state": _LOAD_STATE_NOT_FOUND,
+            "active_state": None,
+            "sub_state": None,
+            "since": None,
+            "restart_count": None,
+        }
+    return {
+        "unit": unit,
+        "load_state": load_state,
+        "active_state": fields.get("ActiveState") or None,
+        "sub_state": fields.get("SubState") or None,
+        "since": fields.get("ExecMainStartTimestamp", "").strip() or None,
+        "restart_count": _parse_restart_count(fields.get("NRestarts")),
+    }
+
+
+def parse_service_status(stdout: str) -> list[dict[str, Any]]:
+    """Parse the probe's ``UNIT=`` / ``KEY=VALUE`` stream into per-unit entries.
+
+    Each ``UNIT=<name>`` marker opens a block; the ``systemctl show``
+    ``KEY=VALUE`` lines that follow belong to it until the next marker. The
+    ``partition("=")`` split reuses the ``ops_write._parse_preflight`` idiom,
+    generalised from one flat map to one map per unit. Entries preserve the
+    order the units were probed in. Lines before the first marker, and lines
+    with no ``=``, are ignored -- defensive against a login-shell banner.
+    """
+    entries: list[dict[str, Any]] = []
+    current_unit: str | None = None
+    current_fields: dict[str, str] = {}
+    for line in stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        key = key.strip()
+        if key == _UNIT_MARKER:
+            if current_unit is not None:
+                entries.append(_service_unit_entry(current_unit, current_fields))
+            current_unit = value.strip()
+            current_fields = {}
+        elif current_unit is not None:
+            current_fields[key] = value.strip()
+    if current_unit is not None:
+        entries.append(_service_unit_entry(current_unit, current_fields))
+    return entries
+
+
+async def rke2_service_status(
+    connector: Rke2SshConnector,
+    target: Target,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``rke2.node.service.status``.
+
+    Runs one read-only ``systemctl show`` probe over SSH across the fixed
+    ``(rke2-server, rke2-agent)`` unit pair and returns their live systemd
+    state -- ``load_state`` / ``active_state`` / ``sub_state``, the start
+    timestamp, and the restart count -- without mutating anything. No param
+    is consumed; the probed units are code constants, never operator input.
+
+    Answers "is ``rke2-server`` up when the Kubernetes API is down?": a node
+    runs exactly one of the two units and the other reports
+    ``load_state: not-found``. ``restart_count`` (systemd ``NRestarts``)
+    paired with a non-``active`` ``active_state`` is the crash-loop signal.
+
+    Raises :class:`Rke2ServiceStatusProbeError` when the probe exits non-zero
+    (no ``systemctl`` on the node, broken shell). ``systemctl show`` exits 0
+    for every real verdict including a ``not-found`` unit
+    (systemd/systemd#1105), so a non-zero exit is an infrastructure failure,
+    not service state -- the same discipline ``rke2.posture.show`` applies.
+    ``exit_status`` is ``None`` when the peer sent no exit status at all
+    (asyncssh's documented third case); that is tolerated when at least one
+    unit block came back, because the probe emits a marker per unit and a
+    parsed entry is independent evidence it ran. Transport / auth failures
+    propagate to the dispatcher's ``connector_error`` branch (#986).
+    """
+    del params  # declared empty in schema; the probed units are fixed
+    cmd = build_service_status_command(SERVICE_UNITS)
+    proc = await connector._run_command(target, cmd, operator=operator)
+    exit_status = getattr(proc, "exit_status", None)
+    stdout_raw = proc.stdout if hasattr(proc, "stdout") else ""
+    stdout = stdout_raw if isinstance(stdout_raw, str) else ""
+    units = parse_service_status(stdout)
+    if exit_status not in (0, None) or not units:
+        stderr_raw = getattr(proc, "stderr", "")
+        stderr_txt = stderr_raw.strip()[:400] if isinstance(stderr_raw, str) else ""
+        hint = " (no `systemctl` on the node)" if exit_status == _PROBE_NO_SYSTEMCTL_EXIT else ""
+        raise Rke2ServiceStatusProbeError(
+            f"the RKE2 service-status probe failed to run over SSH "
+            f"(exit {exit_status}){hint}: {stderr_txt or 'no stderr'}"
+        )
+    return {"units": units}
+
+
+_RKE2_SERVICE_STATUS_OP = Rke2Op(
+    op_id="rke2.node.service.status",
+    handler_attr="service_status",
+    summary="Report RKE2 systemd unit state (rke2-server/rke2-agent) without mutating.",
+    description=(
+        "Runs a single read-only ``systemctl show`` probe over SSH across "
+        "the fixed ``rke2-server`` / ``rke2-agent`` unit pair and returns "
+        "each unit's live systemd state: ``load_state`` (``loaded`` vs "
+        "``not-found``), ``active_state`` / ``sub_state`` (the running "
+        "signal), ``since`` (the systemd ``ExecMainStartTimestamp`` -- active "
+        "since when), and ``restart_count`` (systemd ``NRestarts`` -- the "
+        "crash-loop counter). A node runs exactly one of the two units; the "
+        "other reports ``load_state: not-found`` (every other field null), so "
+        "the result also tells the caller the node's role. Answers 'is "
+        "rke2-server actually up?' when the Kubernetes API server itself is "
+        "down and ``kubernetes.*`` ops cannot help. ``systemctl show`` never "
+        "mutates -- there is NO restart/start/stop here (that is the "
+        "approval-gated ``rke2.node.service.restart``). No params; safe and "
+        "read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "units": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "unit": {"type": "string"},
+                        "load_state": {"type": ["string", "null"]},
+                        "active_state": {"type": ["string", "null"]},
+                        "sub_state": {"type": ["string", "null"]},
+                        "since": {"type": ["string", "null"]},
+                        "restart_count": {"type": ["integer", "null"]},
+                    },
+                    "required": ["unit", "load_state"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        "required": ["units"],
+        "additionalProperties": False,
+    },
+    group_key="rke2-service-read",
+    tags=("read-only", "service", "systemd", "rke2"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to check whether an RKE2 node's systemd service is up "
+            "WITHOUT changing anything -- especially 'is rke2-server active, "
+            "since when, and is it crash-looping?' when the Kubernetes API is "
+            "unreachable and node-level ops like ``kubernetes.node.list`` "
+            "cannot answer (the API server is what is down). Probes the fixed "
+            "``rke2-server`` / ``rke2-agent`` pair; the unit reporting "
+            "``load_state: not-found`` is simply not installed on this node, "
+            "which is how the op reveals the node's role. This is READ-ONLY: "
+            "to actually restart a unit use the approval-gated "
+            "``rke2.node.service.restart``. " + SSH_TRANSPORT_NOTE
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "``{units: [{unit, load_state, active_state, sub_state, since, "
+            "restart_count}]}`` -- one entry per probed unit. ``load_state`` "
+            "is ``loaded`` for an installed unit or ``not-found`` when the "
+            "unit is not present on this node (then every other field is "
+            "null). ``active_state`` (e.g. ``active`` / ``inactive`` / "
+            "``failed`` / ``activating``) with ``sub_state`` (e.g. "
+            "``running`` / ``dead`` / ``auto-restart``) is the running "
+            "signal; ``since`` is the systemd ``ExecMainStartTimestamp`` "
+            "string (e.g. ``Fri 2026-08-01 09:12:03 UTC``), null when the "
+            "unit has no recorded start; ``restart_count`` is systemd "
+            "``NRestarts`` (0 or more) -- a non-zero value paired with a "
+            "non-``active`` state signals a crash loop."
+        ),
+    },
+)
+
+
+#: The read-only tier ops. ``rke2.about`` (the identity canary) is composed
+#: alongside these in :func:`meho_backplane.connectors.rke2.ops._rke2_ops`.
+READ_OPS: tuple[Rke2Op, ...] = (_RKE2_POSTURE_OP, _RKE2_SERVICE_STATUS_OP)

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -22,17 +22,25 @@ Coverage matrix (per Task #2221 acceptance criteria):
   probe (never a ``cat`` of the token path); the token entry carries
   ``redacted: true`` and no secret material bleeds into the result
   envelope or logs.
-* ``RKE2_OPS`` registration shape -- 6 ops: two read (``rke2.about`` /
-  ``rke2.posture.show``, T1 #2221), three approval-gated write
-  (``rke2.token.rotate`` T2 #2429, ``rke2.node.service.restart`` /
-  ``rke2.node.config.update`` T3 #2430), and one safe non-gated snapshot
-  (``rke2.etcd-snapshot.save`` T4 #2431). Read ops are safe / read-only /
-  no-approval and take no params; write ops are dangerous / approval-gated;
-  the snapshot op is safe / no-approval but neither read-only nor write and
-  takes an optional charset-bounded ``name``. Every op has
-  ``additionalProperties=False`` on its parameter schema, a non-empty
-  SSH-transport ``when_to_use``, and a ``rke2.`` op_id with a handler method
-  on the class.
+* :func:`build_service_status_command` / :func:`parse_service_status` -- the
+  service-state read (``rke2.node.service.status``, #2833 / #2852): the
+  read-only ``systemctl show`` probe over the fixed ``rke2-server`` /
+  ``rke2-agent`` pair, and the ``UNIT=`` / ``KEY=VALUE`` parser that reports
+  each unit's load / active / sub state, start time, and restart count.
+  ``LoadState=not-found`` nulls the live-state fields; a non-zero
+  ``NRestarts`` surfaces as the crash-loop signal; the probe raises
+  :class:`Rke2ServiceStatusProbeError` when ``systemctl`` is absent.
+* ``RKE2_OPS`` registration shape -- 7 ops: three read (``rke2.about`` /
+  ``rke2.posture.show``, T1 #2221; ``rke2.node.service.status``, #2852),
+  three approval-gated write (``rke2.token.rotate`` T2 #2429,
+  ``rke2.node.service.restart`` / ``rke2.node.config.update`` T3 #2430), and
+  one safe non-gated snapshot (``rke2.etcd-snapshot.save`` T4 #2431). Read
+  ops are safe / read-only / no-approval and take no params; write ops are
+  dangerous / approval-gated; the snapshot op is safe / no-approval but
+  neither read-only nor write and takes an optional charset-bounded
+  ``name``. Every op has ``additionalProperties=False`` on its parameter
+  schema, a non-empty SSH-transport ``when_to_use``, and a ``rke2.`` op_id
+  with a handler method on the class.
 * ``rke2.etcd-snapshot.save`` handler -- name charset re-check
   (fail-closed), the embedded-etcd-server precondition guard, and a
   bounded-name save parsed from the RKE2 ``Snapshot <name> saved.`` log.
@@ -57,13 +65,18 @@ from meho_backplane.connectors.rke2.connector import (
 from meho_backplane.connectors.rke2.ops_read import (
     POSTURE_CONFIG_PATHS,
     RKE2_TOKEN_PATH,
+    SERVICE_STATUS_PROPERTIES,
+    SERVICE_UNITS,
     STATUS_ABSENT,
     STATUS_PRESENT,
     STATUS_UNKNOWN,
     Rke2PostureProbeError,
+    Rke2ServiceStatusProbeError,
     build_posture_probe_command,
+    build_service_status_command,
     parse_posture,
     parse_posture_probe_output,
+    parse_service_status,
 )
 from meho_backplane.connectors.rke2.ops_snapshot import (
     SNAPSHOT_DEFAULT_DIR,
@@ -533,13 +546,184 @@ async def test_posture_show_never_leaks_secret_material(
 
 
 # ---------------------------------------------------------------------------
+# build_service_status_command / parse_service_status (#2833 / #2852)
+# ---------------------------------------------------------------------------
+
+
+# A server node: rke2-server active, rke2-agent not installed. systemd still
+# prints inactive/dead + NRestarts=0 for the not-found unit under `--all`; the
+# parser must null those live-state fields off the LoadState=not-found verdict.
+_SERVICE_STATUS_SERVER_ACTIVE = (
+    "UNIT=rke2-server\n"
+    "LoadState=loaded\n"
+    "ActiveState=active\n"
+    "SubState=running\n"
+    "ExecMainStartTimestamp=Fri 2026-08-01 09:12:03 UTC\n"
+    "NRestarts=0\n"
+    "UNIT=rke2-agent\n"
+    "LoadState=not-found\n"
+    "ActiveState=inactive\n"
+    "SubState=dead\n"
+    "ExecMainStartTimestamp=\n"
+    "NRestarts=0\n"
+)
+
+# A crash-looping server: systemd auto-restarting, NRestarts non-zero.
+_SERVICE_STATUS_SERVER_CRASHLOOP = (
+    "UNIT=rke2-server\n"
+    "LoadState=loaded\n"
+    "ActiveState=activating\n"
+    "SubState=auto-restart\n"
+    "ExecMainStartTimestamp=Sat 2026-08-02 14:03:11 UTC\n"
+    "NRestarts=7\n"
+    "UNIT=rke2-agent\n"
+    "LoadState=not-found\n"
+)
+
+
+def test_build_service_status_command_probes_both_units_read_only() -> None:
+    cmd = build_service_status_command(SERVICE_UNITS)
+    # Both fixed units are probed; the caller supplies no unit name.
+    for unit in ("rke2-server", "rke2-agent"):
+        assert unit in cmd
+    # Every requested property is in the -p selection.
+    for prop in SERVICE_STATUS_PROPERTIES:
+        assert prop in cmd
+    # Read-only: `systemctl show`, never a mutating systemctl verb.
+    assert "systemctl show" in cmd
+    for verb in ("restart", "start", "stop", "reload", "kill", "enable", "disable"):
+        assert f"systemctl {verb}" not in cmd
+    assert "is-active" not in cmd
+    # --all so NRestarts=0 / an empty start-time are not suppressed.
+    assert "--all" in cmd
+    # Fails closed when the node has no systemctl (infra failure != verdict).
+    assert "command -v systemctl" in cmd
+    assert "exit 127" in cmd
+
+
+def test_parse_service_status_active_server_and_not_found_agent() -> None:
+    units = parse_service_status(_SERVICE_STATUS_SERVER_ACTIVE)
+    by_unit = {u["unit"]: u for u in units}
+    server = by_unit["rke2-server"]
+    assert server["load_state"] == "loaded"
+    assert server["active_state"] == "active"
+    assert server["sub_state"] == "running"
+    assert server["since"] == "Fri 2026-08-01 09:12:03 UTC"
+    assert server["restart_count"] == 0
+    # The agent unit is not installed on a server node: not-found nulls the
+    # live-state fields even though systemd prints inactive/dead defaults.
+    agent = by_unit["rke2-agent"]
+    assert agent["load_state"] == "not-found"
+    assert agent["active_state"] is None
+    assert agent["sub_state"] is None
+    assert agent["since"] is None
+    assert agent["restart_count"] is None
+
+
+def test_parse_service_status_preserves_probe_order() -> None:
+    units = parse_service_status(_SERVICE_STATUS_SERVER_ACTIVE)
+    assert [u["unit"] for u in units] == ["rke2-server", "rke2-agent"]
+
+
+def test_parse_service_status_surfaces_nonzero_restart_count() -> None:
+    """AC: a non-zero NRestarts surfaces as the crash-loop signal."""
+    units = parse_service_status(_SERVICE_STATUS_SERVER_CRASHLOOP)
+    server = next(u for u in units if u["unit"] == "rke2-server")
+    assert server["restart_count"] == 7
+    assert server["active_state"] == "activating"
+    assert server["sub_state"] == "auto-restart"
+
+
+def test_parse_service_status_ignores_banner_and_blank_lines() -> None:
+    noisy = "login banner line\n\n" + _SERVICE_STATUS_SERVER_ACTIVE
+    units = parse_service_status(noisy)
+    assert {u["unit"] for u in units} == {"rke2-server", "rke2-agent"}
+
+
+def test_parse_service_status_loaded_but_never_started_has_null_since() -> None:
+    """A loaded-but-stopped unit reports restart_count 0 and a null since."""
+    stdout = (
+        "UNIT=rke2-server\n"
+        "LoadState=loaded\n"
+        "ActiveState=inactive\n"
+        "SubState=dead\n"
+        "ExecMainStartTimestamp=\n"
+        "NRestarts=0\n"
+    )
+    entry = parse_service_status(stdout)[0]
+    assert entry["load_state"] == "loaded"
+    assert entry["active_state"] == "inactive"
+    assert entry["since"] is None
+    assert entry["restart_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# service_status shim (service-state read tier)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_status_runs_systemctl_show_and_returns_units() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_SERVICE_STATUS_SERVER_ACTIVE)
+        result = await connector.service_status(_TARGET, {})
+    by_unit = {u["unit"]: u for u in result["units"]}
+    assert by_unit["rke2-server"]["active_state"] == "active"
+    assert by_unit["rke2-agent"]["load_state"] == "not-found"
+    # Exactly one read-only systemctl-show round-trip; never a mutation.
+    issued = [call.args[1] for call in mock_cmd.await_args_list]
+    assert len(issued) == 1
+    assert "systemctl show" in issued[0]
+    assert "systemctl restart" not in issued[0]
+
+
+@pytest.mark.asyncio
+async def test_service_status_missing_systemctl_raises_probe_error() -> None:
+    """A node with no systemctl (guard exit 127) is an infra failure, not a verdict."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="", stderr="", exit_status=127)
+        with pytest.raises(Rke2ServiceStatusProbeError, match="no `systemctl` on the node"):
+            await connector.service_status(_TARGET, {})
+
+
+@pytest.mark.asyncio
+async def test_service_status_accepts_output_with_no_exit_status() -> None:
+    """``exit_status=None`` + parsed unit blocks is a complete run, not a failure.
+
+    ``asyncssh`` reports ``None`` when the peer closed the channel without
+    sending an exit status; the per-unit markers give independent evidence the
+    probe finished, so this must not fail a status read that worked.
+    """
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_SERVICE_STATUS_SERVER_ACTIVE, exit_status=None)
+        result = await connector.service_status(_TARGET, {})
+    assert {u["unit"] for u in result["units"]} == {"rke2-server", "rke2-agent"}
+
+
+@pytest.mark.asyncio
+async def test_service_status_propagates_ssh_failure() -> None:
+    """A transport failure escapes so the dispatcher reports connector_error."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = OSError("connection refused")
+        with pytest.raises(OSError, match="connection refused"):
+            await connector.service_status(_TARGET, {})
+
+
+# ---------------------------------------------------------------------------
 # RKE2_OPS registration shape
 # ---------------------------------------------------------------------------
 
 
-#: The read-only tier (T1 #2221). Every entry is safe-tier / no-approval and
-#: takes no operator parameters.
-_READ_OP_IDS: frozenset[str] = frozenset({"rke2.about", "rke2.posture.show"})
+#: The read-only tier: ``rke2.about`` + ``rke2.posture.show`` (T1 #2221) and
+#: ``rke2.node.service.status`` (Initiative #2833 / #2852). Every entry is
+#: safe-tier / no-approval and takes no operator parameters.
+_READ_OP_IDS: frozenset[str] = frozenset(
+    {"rke2.about", "rke2.posture.show", "rke2.node.service.status"}
+)
 
 #: The approval-gated write tier: ``rke2.token.rotate`` (T2 #2429) plus the
 #: node-write ops ``rke2.node.service.restart`` / ``rke2.node.config.update``
@@ -558,8 +742,9 @@ _EXPECTED_OP_IDS: frozenset[str] = _READ_OP_IDS | _WRITE_OP_IDS | _SNAPSHOT_OP_I
 
 
 def test_rke2_ops_count_matches_expected() -> None:
-    # Two read ops (#2221) + three approval-gated write ops (#2429 / #2430)
-    # + one safe non-gated snapshot op (#2431) = six.
+    # Three read ops (#2221 posture/about + #2852 service.status) + three
+    # approval-gated write ops (#2429 / #2430) + one safe non-gated snapshot
+    # op (#2431) = seven.
     assert len(RKE2_OPS) == len(_EXPECTED_OP_IDS)
 
 

--- a/backend/tests/test_connectors_rke2_e2e.py
+++ b/backend/tests/test_connectors_rke2_e2e.py
@@ -3,7 +3,8 @@
 
 """RKE2 connector recorded-fixture / asyncssh fake-shell E2E test (#2221).
 
-Drives ``rke2.about``, ``rke2.posture.show`` and the safe, non-gated
+Drives ``rke2.about``, ``rke2.posture.show``, the service-state read
+``rke2.node.service.status`` (#2852) and the safe, non-gated
 ``rke2.etcd-snapshot.save`` (T4 #2431) through the full ``call_operation``
 dispatch stack against an in-process asyncssh fake-shell server that
 replays plain-SSH command stubs -- no Docker dependency, no live RKE2
@@ -76,6 +77,21 @@ _PROBE_FIXTURE = (
     "S|/etc/rancher/rke2/rke2.yaml|600|root|root\n"
     "S|/var/lib/rancher/rke2/server/token|600|root|root\n"
 )
+# rke2.node.service.status -- `systemctl show --all` over the fixed unit
+# pair: rke2-server active, rke2-agent not installed on this control-plane
+# node. One `UNIT=` marker per unit, then that unit's KEY=VALUE block.
+_SERVICE_STATUS_FIXTURE = (
+    "UNIT=rke2-server\n"
+    "LoadState=loaded\n"
+    "ActiveState=active\n"
+    "SubState=running\n"
+    "ExecMainStartTimestamp=Fri 2026-08-01 09:12:03 UTC\n"
+    "NRestarts=0\n"
+    "UNIT=rke2-agent\n"
+    "LoadState=not-found\n"
+    "ActiveState=inactive\n"
+    "SubState=dead\n"
+)
 # Precondition-guard sentinel for an embedded-etcd server node.
 _SNAPSHOT_GUARD_FIXTURE = "ok\n"
 # `rke2 etcd-snapshot save` logs the saved snapshot name to stderr.
@@ -111,6 +127,9 @@ async def _fake_shell_process_factory(process: Any) -> None:
     elif cmd.startswith("command -v stat"):
         # rke2.posture.show -- the per-path stat probe (#2698).
         response = _PROBE_FIXTURE
+    elif cmd.startswith("command -v systemctl"):
+        # rke2.node.service.status -- the systemctl-show service probe (#2852).
+        response = _SERVICE_STATUS_FIXTURE
     elif cmd.startswith("printf 'ACTIVE="):
         # rke2.token.rotate fingerprint preflight: server node, active,
         # patched version (1.29 is above the CVE-fix range).
@@ -397,6 +416,39 @@ async def test_rke2_e2e_posture_show_unknown_token_survives_dispatch(
     assert token["detail"]
     assert token["redacted"] is True
     assert _TOKEN_VALUE_CANARY not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_rke2_e2e_service_status_dispatches_ok(
+    rke2_e2e: _Rke2E2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """rke2.node.service.status dispatches safe/non-gated and reports unit state.
+
+    A TENANT_ADMIN dispatch of the safe, non-approval service-status op runs
+    to completion through the full ``call_operation`` stack (no approval park)
+    and returns the live systemd state of both probed units: rke2-server
+    active, rke2-agent not installed on this node.
+    """
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": _CONNECTOR_ID,
+            "op_id": "rke2.node.service.status",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"rke2.node.service.status failed: {result.get('error')}"
+    by_unit = {u["unit"]: u for u in result["result"]["units"]}
+    assert by_unit["rke2-server"]["active_state"] == "active"
+    assert by_unit["rke2-server"]["sub_state"] == "running"
+    assert by_unit["rke2-server"]["since"] == "Fri 2026-08-01 09:12:03 UTC"
+    assert by_unit["rke2-server"]["restart_count"] == 0
+    # The other unit is not installed here -- not-found nulls its live state.
+    assert by_unit["rke2-agent"]["load_state"] == "not-found"
+    assert by_unit["rke2-agent"]["active_state"] is None
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -78,11 +78,37 @@ T4 (#2431) adds the lone **safe, non-gated snapshot op** (in the
   `sudo` argv) — the connector already authenticates as root, so no sudo
   construction is needed and the repo-wide sudo-guard stays satisfied.
 
-Six ops total: two safe read-only (T1), three `dangerous` /
-`requires_approval=true` write ops (T2 + T3), and one safe non-gated snapshot
-op (T4). The snapshot op is safe / no-approval like the read ops but is
-neither read-only-tagged nor in the dangerous write tier — it belongs to
-neither sweep set.
+Initiative #2833 (read-op coverage wave 2, #2852) adds a **second safe
+read-only op** alongside the posture tier, in a new `rke2-service-read` group:
+
+- `rke2.node.service.status` — reports the **live systemd state** of the
+  `rke2-server` / `rke2-agent` units without mutating anything. Runs one
+  read-only `systemctl show --all -p LoadState,ActiveState,SubState,ExecMainStartTimestamp,NRestarts <unit>`
+  round-trip over the fixed unit pair and returns, per unit, `load_state`
+  (`loaded` vs `not-found`), `active_state` / `sub_state` (the running
+  signal), `since` (the systemd `ExecMainStartTimestamp` string), and
+  `restart_count` (systemd `NRestarts`, the crash-loop counter). A node runs
+  exactly one of the two units; the other reports `load_state: not-found`
+  (every other field null), so the result also reveals the node's role. It
+  answers "is `rke2-server` actually up, since when, and is it crash-looping?"
+  when the Kubernetes API server itself is down and `kubernetes.*` ops cannot
+  help. `safety_level="safe"` / `requires_approval=false`, no params, and the
+  probed unit set is the fixed `("rke2-server", "rke2-agent")` pair — there is
+  **no** operator-supplied unit, so no arbitrary-unit or shell-injection
+  surface. This is the read-only sibling of the approval-gated
+  `rke2.node.service.restart`: `systemctl show` never restarts/starts/stops a
+  unit. `--all` un-suppresses the `NRestarts=0` / empty-`ExecMainStartTimestamp`
+  properties `systemctl show` drops by default, so a healthy unit reports
+  `restart_count: 0` rather than a missing field. A node with no `systemctl`
+  makes the probe exit non-zero (guarded), which raises
+  `Rke2ServiceStatusProbeError` rather than being served as a service-state
+  answer — the same infrastructure-failure discipline `rke2.posture.show` uses.
+
+Seven ops total: three safe read-only (T1 `about` / `posture.show` + the
+#2852 `node.service.status`), three `dangerous` / `requires_approval=true`
+write ops (T2 + T3), and one safe non-gated snapshot op (T4). The snapshot op
+is safe / no-approval like the read ops but is neither read-only-tagged nor in
+the dangerous write tier — it belongs to neither sweep set.
 
 Source: `backend/src/meho_backplane/connectors/rke2/`.
 
@@ -93,7 +119,7 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
   Inherits the per-target asyncssh connection pool, `_auth_config`,
   `_run_command`, `_assert_reachable`, and `aclose()` from the adapter.
   Ships `fingerprint`, `probe`, `execute`, `about`, `posture_show`,
-  `register_operations`. Two module-level pure parsers live here:
+  `service_status`, `register_operations`. Two module-level pure parsers live here:
   `parse_rke2_version` (release string from `rke2 --version`) and
   `parse_os_pretty_name` (`PRETTY_NAME` from `/etc/os-release`).
 
@@ -106,6 +132,17 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
   and `RKE2_TOKEN_PATH` are fixed code constants — there is **no** operator
   path parameter, so no path-traversal / shell-injection surface.
   `Rke2PostureProbeError` fires when the probe itself could not run.
+
+- **Service-state handler + parsers** (`ops_read.py`, #2833 / #2852) —
+  `rke2_service_status` (the async handler, bound via the `service_status`
+  shim), `build_service_status_command` (assembles the single-round-trip
+  `systemctl show --all` probe over the fixed `SERVICE_UNITS` pair), and
+  `parse_service_status` (`UNIT=` / `KEY=VALUE` marker stream → one entry per
+  unit; a `LoadState=not-found` unit nulls its live-state fields, and
+  `NRestarts` becomes `restart_count`). `SERVICE_UNITS` and
+  `SERVICE_STATUS_PROPERTIES` are fixed code constants — no operator-supplied
+  unit, so no arbitrary-unit surface. `Rke2ServiceStatusProbeError` fires when
+  the probe cannot run (no `systemctl` on the node).
 
 - **Op metadata** (`ops.py`) — `Rke2Op` frozen dataclass (mirrors
   `Bind9Op` / `HolodeckOp`), `SSH_TRANSPORT_NOTE` (the plain-SSH reminder
@@ -173,9 +210,11 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
    `connector_id="rke2-ssh-1.x"` + the target, runs the policy gate, and
    invokes the bound handler. `about` reuses `fingerprint` and asserts
    reachability (#986); `posture_show` runs one probe round-trip and returns
-   the redacted envelope. Transport/auth failures propagate to the
-   dispatcher's `connector_error` branch; a merely-absent file surfaces as
-   `present: false`, and an undeterminable one as `present: null`.
+   the redacted envelope; `service_status` runs one `systemctl show` probe and
+   returns the per-unit systemd state (`{units: [...]}`). Transport/auth
+   failures propagate to the dispatcher's `connector_error` branch; a
+   merely-absent file surfaces as `present: false`, and an undeterminable one
+   as `present: null`.
 
 ## Posture tri-state (#2698)
 


### PR DESCRIPTION
## Summary

- Adds `rke2.node.service.status` — a **safe, non-gated read op** that reports the live systemd state of the `rke2-server` / `rke2-agent` units over the connector's existing SSH pathway, so an operator or agent can answer "is `rke2-server` up, since when, and is it crash-looping?" **when the Kubernetes API server itself is down** and `kubernetes.*` ops cannot help (field case `claude-rdc-hetzner-dc#615`, Initiative #2833 / #2172).
- One read-only `systemctl show --all -p LoadState,ActiveState,SubState,ExecMainStartTimestamp,NRestarts <unit>` round-trip over the fixed unit pair returns, per unit: `load_state` (`loaded` vs `not-found`), `active_state` / `sub_state`, `since` (the systemd `ExecMainStartTimestamp`), and `restart_count` (systemd `NRestarts`). The unit reporting `load_state: not-found` is simply not installed on the node, which also reveals the node's role. `--all` un-suppresses `NRestarts=0` / an empty start-time so a healthy unit reports `restart_count: 0` rather than a missing field ([systemd docs](https://www.freedesktop.org/software/systemd/man/latest/systemctl.html)).
- **Pure read, no new transport.** The probed unit set is the fixed `("rke2-server", "rke2-agent")` pair — no operator-supplied unit, so no arbitrary-unit / shell-injection surface — mirroring the restart op's allow-list, here read-only. `systemctl show` never mutates; the restart itself stays the approval-gated `rke2.node.service.restart`. A `systemctl`-absent node makes the probe exit non-zero (guarded) and raises `Rke2ServiceStatusProbeError` rather than serving an infrastructure failure as a verdict — the same discipline `rke2.posture.show` uses ([systemctl show exits 0 for a not-found unit](https://github.com/systemd/systemd/issues/1105)).
- Lands in a new `rke2-service-read` op group (curated `_WHEN_TO_USE_BY_GROUP` entry, fail-closed registration check); `ops_read.py` `READ_OPS` grows to two and `RKE2_OPS` to seven.

## Test plan

- [x] `ruff check` — clean (4 touched files)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/rke2/` — Success, no issues
- [x] `pytest tests/test_connectors_rke2.py` — passed (adds command-builder, parse active-server-+-not-found-agent, probe-order, non-zero-`NRestarts` crash-loop, banner-noise, loaded-never-started, and the handler-shim / missing-`systemctl` / no-exit-status / transport-failure cases)
- [x] `pytest tests/test_connectors_rke2_e2e.py` — passed (new `test_rke2_e2e_service_status_dispatches_ok` drives the op through the full `call_operation` dispatch stack against the asyncssh fake shell; safe/non-gated, no approval park)
- [x] Blast-radius suites: `test_broadcast_classifier_coverage.py`, `test_typed_connectors_metadata.py`, `test_connectors_rke2_write.py` — all pass (the new op classifies `other` like the shipped `rke2.posture.show`; empty params, so the secret-bearing sweep does not flag it)
- [x] `code-quality.py --diff` — 0 blockers (file-size warnings on the pre-existing `ops_read.py` / `connector.py` recorded below)
- [x] AC checkboxes: registered `safe` / `requires_approval=False` and dispatchable; `_READ_OP_IDS` + count/covers tests; `test_rke2_read_ops_all_safe_read_only_no_approval` / `..._parameter_schemas_closed` pass with only the fixture changed; the two fixture-transcript parse tests (active-server + not-found-agent, and non-zero `NRestarts`); `rke2-service-read` in `_WHEN_TO_USE_BY_GROUP` and `register_operations()` does not raise; `docs/codebase/connectors-rke2.md` bumped six → seven with a per-op bullet.

## Out of scope

- No write/mutation counterpart — service lifecycle changes remain the approval-gated `rke2.node.service.restart`.
- No arbitrary-unit `systemctl show`, no `journalctl` / log-tailing surface (per the issue's Out of scope).
- No CLI OpenAPI snapshot regen: the diff touches only connector code, tests, and docs — no FastAPI route or schema changed, so the snapshot stays fresh (AC7 is conditional and not triggered).

## Adjacent findings (recorded, not addressed)

- `ops_read.py` is now 739 lines and `connector.py` 627 lines (both > the 600-line code-quality warn threshold). The issue explicitly directs landing this op in `ops_read.py` (appended to `READ_OPS`), so a module split is out of scope here; both files are future split candidates.
- Pre-existing `connector.py` warnings not touched by this change: `fingerprint` (67 lines), `execute` (77 lines), `PLR0911` at `connector.py:235`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2852
