### PR TITLE
feat(connectors): add gcloud service-account key inventory read (#2846)

### DIFF
--- a/backend/src/meho_backplane/connectors/gcloud/__init__.py
+++ b/backend/src/meho_backplane/connectors/gcloud/__init__.py
@@ -19,7 +19,8 @@ Two-phase registration (same shape as
   :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
   invokes :meth:`GcloudConnector.register_gcloud_typed_operations`, which
   delegates to :func:`~meho_backplane.operations.typed_register.register_typed_operation`
-  for each of the eight G3.7-T5 (#848) read-only ops.
+  for each read-only op in ``GCLOUD_OPS`` (eight from G3.7-T5 #848 plus
+  the #2846 service-account-key inventory op).
 
 The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
 point is deliberately **not** called. The connector advertises an explicit

--- a/backend/src/meho_backplane/connectors/gcloud/connector.py
+++ b/backend/src/meho_backplane/connectors/gcloud/connector.py
@@ -962,6 +962,64 @@ class GcloudConnector(HttpConnector):
 
         return {"rows": rows, "total": len(rows)}
 
+    async def gcloud_iam_service_account_keys_list(
+        self,
+        operator: Operator,
+        target: GcloudTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List the keys on a single service account.
+
+        Op-id: ``gcloud.iam.service_account_keys.list``. Calls IAM v1
+        ``projects.serviceAccounts.keys.list``
+        (``GET .../serviceAccounts/<email>/keys``). Required
+        ``params.service_account_email`` selects the SA — the endpoint is
+        per-SA, not project-wide. Optional ``params.key_types`` forwards to
+        the API's repeated ``keyTypes[]`` query filter; omit it to return both
+        managed types.
+
+        Unlike ``keys.get``, the list endpoint returns no ``privateKeyData``
+        or ``publicKeyData``; each row exposes only key metadata. ``keyType``
+        is what the org-policy compliance question keys on: ``USER_MANAGED``
+        is the violation, ``SYSTEM_MANAGED`` is Google-rotated and expected;
+        ``validBeforeTime`` is the expiry.
+
+        No ``nextPageToken`` pagination — ``keys.list`` returns the full key
+        set in one response (unlike the ``serviceAccounts.list`` sibling), so
+        this is a single GET rather than a pagination loop.
+        """
+        email = params.get("service_account_email")
+        if not isinstance(email, str) or not email.strip():
+            raise ValueError(
+                "gcloud.iam.service_account_keys.list requires a non-empty "
+                "'service_account_email' param (the service account to inspect)."
+            )
+
+        query_params: dict[str, Any] = {}
+        key_types = params.get("key_types")
+        if key_types:
+            query_params["keyTypes"] = key_types
+
+        base_url = (
+            f"https://iam.googleapis.com/v1/projects/{target.gcp_project}"
+            f"/serviceAccounts/{email}/keys"
+        )
+        payload = await self._get_json_abs(
+            target, base_url, operator=operator, params=query_params or None
+        )
+        rows: list[dict[str, Any]] = [
+            {
+                "name": key.get("name", ""),
+                "key_type": key.get("keyType"),
+                "key_origin": key.get("keyOrigin"),
+                "valid_after_time": key.get("validAfterTime"),
+                "valid_before_time": key.get("validBeforeTime"),
+                "disabled": bool(key.get("disabled", False)),
+            }
+            for key in payload.get("keys") or []
+        ]
+        return {"rows": rows, "total": len(rows)}
+
     # C901 pre-existing (11>10): the zone/aggregated branch + paginated
     # while-loops predate this Task. #985 only threads `operator` for the
     # SA-key gate; complexity is unchanged from main. Refactoring the

--- a/backend/src/meho_backplane/connectors/gcloud/ops.py
+++ b/backend/src/meho_backplane/connectors/gcloud/ops.py
@@ -3,10 +3,11 @@
 
 """Typed operations exposed by :class:`GcloudConnector`.
 
-G3.7-T5 (#848) adds eight read-only typed ops registered against the
-GCP REST surfaces (cloudresourcemanager, compute, iam, serviceusage).
-All ops are registered via ``register_typed_operation()`` at lifespan
-startup through :meth:`GcloudConnector.register_gcloud_typed_operations`.
+G3.7-T5 (#848) added eight read-only typed ops registered against the
+GCP REST surfaces (cloudresourcemanager, compute, iam, serviceusage);
+#2846 adds a ninth (per-SA key inventory). All ops are registered via
+``register_typed_operation()`` at lifespan startup through
+:meth:`GcloudConnector.register_gcloud_typed_operations`.
 
 Ops
 ---
@@ -21,6 +22,9 @@ Ops
 * ``gcloud.compute.networks.list`` — VPC networks.
 * ``gcloud.compute.subnetworks.list`` — subnet inventory.
 * ``gcloud.iam.policy.read`` — project IAM policy via CRM ``getIamPolicy``.
+* ``gcloud.iam.service_account_keys.list`` — per-SA key inventory
+  (``USER_MANAGED`` vs ``SYSTEM_MANAGED`` + expiry) via IAM
+  ``serviceAccounts.keys.list``; surfaces org-policy key violations.
 
 GCP REST URL references
 -----------------------
@@ -30,6 +34,8 @@ GCP REST URL references
   https://cloud.google.com/service-usage/docs/reference/rest/v1/services/list
 * IAM v1 (service accounts):
   https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts/list
+* IAM v1 (service-account keys):
+  https://cloud.google.com/iam/docs/reference/rest/v1/projects.serviceAccounts.keys/list
 * Compute Engine v1 (instances.aggregatedList, networks.list,
   subnetworks.aggregatedList):
   https://cloud.google.com/compute/docs/reference/rest/v1
@@ -623,12 +629,124 @@ _GCLOUD_IAM_POLICY_READ_OP = GcloudOp(
 
 
 # ---------------------------------------------------------------------------
+# gcloud.iam.service_account_keys.list
+# ---------------------------------------------------------------------------
+
+_GCLOUD_IAM_SERVICE_ACCOUNT_KEYS_LIST_OP = GcloudOp(
+    op_id="gcloud.iam.service_account_keys.list",
+    handler_attr="gcloud_iam_service_account_keys_list",
+    summary="List a service account's keys (USER_MANAGED vs SYSTEM_MANAGED + expiry).",
+    description=(
+        "Calls ``GET https://iam.googleapis.com/v1/projects/<id>/serviceAccounts/"
+        "<email>/keys`` (IAM v1 ``projects.serviceAccounts.keys.list``) for a "
+        "single service account. Each row carries the key name, key_type "
+        "(``USER_MANAGED`` / ``SYSTEM_MANAGED``), key_origin, valid_after_time, "
+        "valid_before_time (the expiry), and whether the key is disabled. The "
+        "list endpoint returns no private or public key material. Optional "
+        "``key_types`` maps to the API's ``keyTypes[]`` filter; omit it to "
+        "return both managed types. Use to audit whether an SA still carries an "
+        "operator-minted ``USER_MANAGED`` key — a violation of the org policy "
+        "``constraints/iam.disableServiceAccountKeyCreation`` — and when it "
+        "expires. This endpoint is per-SA: enumerate SAs with "
+        "``gcloud.iam.service_accounts.list`` first, then call this op per SA."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "service_account_email": {
+                "type": "string",
+                "minLength": 1,
+                "description": (
+                    "Email (or unique numeric ID) of the service account whose "
+                    "keys to list, e.g. 'svc@<project>.iam.gserviceaccount.com'. "
+                    "Obtain candidates from gcloud.iam.service_accounts.list."
+                ),
+            },
+            "key_types": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": ["USER_MANAGED", "SYSTEM_MANAGED", "KEY_TYPE_UNSPECIFIED"],
+                },
+                "description": (
+                    "Optional keyTypes[] filter. Omit to return both "
+                    "USER_MANAGED and SYSTEM_MANAGED keys. Pass ['USER_MANAGED'] "
+                    "to narrow to operator-minted keys only."
+                ),
+            },
+        },
+        "required": ["service_account_email"],
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "key_type": {"type": ["string", "null"]},
+                        "key_origin": {"type": ["string", "null"]},
+                        "valid_after_time": {"type": ["string", "null"]},
+                        "valid_before_time": {"type": ["string", "null"]},
+                        "disabled": {"type": "boolean"},
+                    },
+                    "required": ["name", "disabled"],
+                    "additionalProperties": False,
+                },
+            },
+            "total": {"type": "integer"},
+        },
+        "required": ["rows", "total"],
+        "additionalProperties": False,
+    },
+    group_key="iam",
+    tags=("read-only", "iam", "gcloud", "service-accounts", "keys"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to inventory the keys on ONE service account — the compliance "
+            "read for 'does this SA still carry a USER_MANAGED (operator-minted) "
+            "key, and when does it expire?'. On this org, USER_MANAGED keys "
+            "violate constraints/iam.disableServiceAccountKeyCreation; "
+            "SYSTEM_MANAGED keys are Google-rotated and expected. The endpoint "
+            "is per-SA: first call gcloud.iam.service_accounts.list to enumerate "
+            "SAs, then call this op per SA of interest — the same two-step "
+            "discovery pattern as keycloak.client.list -> keycloak.client.get. "
+            "Pair with gcloud.iam.policy.read for a full access-review report. "
+            "The response never contains private or public key material, only "
+            "key metadata."
+        ),
+        "parameter_hints": {
+            "service_account_email": (
+                "The SA to inspect, e.g. 'svc@<project>.iam.gserviceaccount.com'. "
+                "Get candidates from gcloud.iam.service_accounts.list."
+            ),
+            "key_types": (
+                "Omit to list both USER_MANAGED and SYSTEM_MANAGED keys. Pass "
+                "['USER_MANAGED'] to narrow to operator-minted keys only."
+            ),
+        },
+        "output_shape": (
+            "{'rows': [{name, key_type, key_origin, valid_after_time, "
+            "valid_before_time, disabled}], 'total': <int>}. ``key_type`` is "
+            "'USER_MANAGED' or 'SYSTEM_MANAGED'; ``valid_before_time`` is the "
+            "RFC3339 expiry. No key material is ever returned."
+        ),
+    },
+)
+
+
+# ---------------------------------------------------------------------------
 # Merged tuple
 # ---------------------------------------------------------------------------
 
 
 def _gcloud_ops() -> tuple[GcloudOp, ...]:
-    """Return the full registration tuple for all G3.7-T5 gcloud ops."""
+    """Return the full registration tuple for all gcloud typed ops."""
     return (
         _GCLOUD_ABOUT_OP,
         _GCLOUD_PROJECT_DESCRIBE_OP,
@@ -638,14 +756,16 @@ def _gcloud_ops() -> tuple[GcloudOp, ...]:
         _GCLOUD_COMPUTE_NETWORKS_LIST_OP,
         _GCLOUD_COMPUTE_SUBNETWORKS_LIST_OP,
         _GCLOUD_IAM_POLICY_READ_OP,
+        _GCLOUD_IAM_SERVICE_ACCOUNT_KEYS_LIST_OP,
     )
 
 
 #: The ops :class:`GcloudConnector` registers at lifespan startup.
 #:
-#: G3.7-T5 (#848) ships all eight read-only ops:
+#: G3.7-T5 (#848) shipped eight read-only ops; #2846 adds a ninth
+#: (``gcloud.iam.service_account_keys.list``):
 #: ``gcloud.about``, ``gcloud.project.describe``, ``gcloud.services.list``,
 #: ``gcloud.iam.service_accounts.list``, ``gcloud.compute.instances.list``,
 #: ``gcloud.compute.networks.list``, ``gcloud.compute.subnetworks.list``,
-#: ``gcloud.iam.policy.read``.
+#: ``gcloud.iam.policy.read``, ``gcloud.iam.service_account_keys.list``.
 GCLOUD_OPS: tuple[GcloudOp, ...] = _gcloud_ops()

--- a/backend/tests/test_connectors_gcloud_e2e.py
+++ b/backend/tests/test_connectors_gcloud_e2e.py
@@ -5,7 +5,7 @@
 
 Acceptance criteria addressed here:
 
-(a) All 8 gcloud read ops dispatch through the full connector handler path
+(a) All 9 gcloud read ops dispatch through the full connector handler path
     with respx-mocked GCP REST responses and return the expected shape.
 (b) Audit row: each dispatch records op_id + target_id + params_hash via
     the audit module — asserted via patched audit_and_broadcast_safe.
@@ -181,7 +181,7 @@ class _AuditCapture:
 
 
 # ---------------------------------------------------------------------------
-# (a) All 8 ops — happy-path E2E with respx-mocked GCP REST
+# (a) All 9 ops — happy-path E2E with respx-mocked GCP REST
 # ---------------------------------------------------------------------------
 
 
@@ -318,6 +318,113 @@ async def test_gcloud_e2e_iam_service_accounts_list_returns_sa_rows() -> None:
     # disabled flag preserved
     old_row = next(r for r in result["rows"] if r["email"] != _SA_EMAIL)
     assert old_row["disabled"] is True
+    await connector.aclose()
+
+
+_SA_KEYS_URL = (
+    f"https://iam.googleapis.com/v1/projects/{_GCP_PROJECT}/serviceAccounts/{_SA_EMAIL}/keys"
+)
+
+
+@pytest.mark.asyncio
+async def test_gcloud_e2e_iam_service_account_keys_list_returns_key_rows() -> None:
+    """gcloud.iam.service_account_keys.list: per-key rows with key_type + expiry.
+
+    Fixture carries one USER_MANAGED and one SYSTEM_MANAGED key. Asserts the
+    row shape surfaces key_type and valid_before_time and never leaks private
+    or public key material.
+    """
+    connector = _make_connector()
+    _, patch_fn, _ = _make_adc_loader()
+
+    with (
+        patch("google.auth.impersonated_credentials.Credentials", side_effect=patch_fn),
+        respx.mock() as mock,
+    ):
+        route = mock.get(_SA_KEYS_URL).respond(
+            200,
+            json={
+                "keys": [
+                    {
+                        "name": f"projects/{_GCP_PROJECT}/serviceAccounts/{_SA_EMAIL}/keys/aaa111",
+                        "keyType": "USER_MANAGED",
+                        "keyOrigin": "USER_PROVIDED",
+                        "validAfterTime": "2026-01-01T00:00:00Z",
+                        "validBeforeTime": "2027-01-01T00:00:00Z",
+                        "disabled": False,
+                    },
+                    {
+                        "name": f"projects/{_GCP_PROJECT}/serviceAccounts/{_SA_EMAIL}/keys/sys999",
+                        "keyType": "SYSTEM_MANAGED",
+                        "keyOrigin": "GOOGLE_PROVIDED",
+                        "validAfterTime": "2026-08-01T00:00:00Z",
+                        "validBeforeTime": "2026-08-22T00:00:00Z",
+                        "disabled": False,
+                    },
+                ]
+            },
+        )
+        result = await connector.gcloud_iam_service_account_keys_list(
+            _OPERATOR, _E2E_TARGET, params={"service_account_email": _SA_EMAIL}
+        )
+
+    assert route.called
+    assert result["total"] == 2
+    by_type = {r["key_type"]: r for r in result["rows"]}
+    assert set(by_type) == {"USER_MANAGED", "SYSTEM_MANAGED"}
+    # USER_MANAGED is the org-policy violation; its expiry must surface.
+    user_key = by_type["USER_MANAGED"]
+    assert user_key["valid_before_time"] == "2027-01-01T00:00:00Z"
+    assert user_key["valid_after_time"] == "2026-01-01T00:00:00Z"
+    assert user_key["key_origin"] == "USER_PROVIDED"
+    assert user_key["disabled"] is False
+    # No private/public key material ever surfaces in a row.
+    for row in result["rows"]:
+        assert set(row) == {
+            "name",
+            "key_type",
+            "key_origin",
+            "valid_after_time",
+            "valid_before_time",
+            "disabled",
+        }
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_gcloud_e2e_iam_service_account_keys_list_requires_email() -> None:
+    """A missing or blank service_account_email raises before any HTTP call."""
+    connector = _make_connector()
+    with pytest.raises(ValueError, match="service_account_email"):
+        await connector.gcloud_iam_service_account_keys_list(_OPERATOR, _E2E_TARGET, params={})
+    with pytest.raises(ValueError, match="service_account_email"):
+        await connector.gcloud_iam_service_account_keys_list(
+            _OPERATOR, _E2E_TARGET, params={"service_account_email": "  "}
+        )
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_gcloud_e2e_iam_service_account_keys_list_forwards_key_types_filter() -> None:
+    """The key_types param maps to the API's repeated keyTypes[] query filter."""
+    connector = _make_connector()
+    _, patch_fn, _ = _make_adc_loader()
+
+    with (
+        patch("google.auth.impersonated_credentials.Credentials", side_effect=patch_fn),
+        respx.mock() as mock,
+    ):
+        route = mock.get(_SA_KEYS_URL).respond(200, json={"keys": []})
+        result = await connector.gcloud_iam_service_account_keys_list(
+            _OPERATOR,
+            _E2E_TARGET,
+            params={"service_account_email": _SA_EMAIL, "key_types": ["USER_MANAGED"]},
+        )
+
+    assert result == {"rows": [], "total": 0}
+    # The keyTypes[] filter reached the wire.
+    sent_url = str(route.calls.last.request.url)
+    assert "keyTypes=USER_MANAGED" in sent_url
     await connector.aclose()
 
 
@@ -534,14 +641,14 @@ async def test_gcloud_e2e_iam_policy_read_returns_bindings() -> None:
 
 @pytest.mark.asyncio
 async def test_gcloud_e2e_audit_params_hash_field_present_in_all_ops() -> None:
-    """All 8 gcloud ops produce a result that carries sufficient fields for audit.
+    """All 9 gcloud ops produce a result that carries sufficient fields for audit.
 
     Verifies that each handler returns a non-None result dict — the
     dispatcher computes ``params_hash = compute_params_hash(params)`` before
     calling the handler; this test ensures the handler side does not swallow
     or transform params in a way that would break the audit path.
 
-    One combined respx.mock() scope covers all 8 ops in sequence to keep the
+    One combined respx.mock() scope covers all 9 ops in sequence to keep the
     test fast while verifying each handler independently.
     """
     connector = _make_connector()
@@ -551,7 +658,7 @@ async def test_gcloud_e2e_audit_params_hash_field_present_in_all_ops() -> None:
         patch("google.auth.impersonated_credentials.Credentials", side_effect=patch_fn),
         respx.mock(assert_all_called=False) as mock,
     ):
-        # Seed minimal mock responses for all 8 GCP endpoints
+        # Seed minimal mock responses for all 9 GCP endpoints
         mock.get(f"https://cloudresourcemanager.googleapis.com/v1/projects/{_GCP_PROJECT}").respond(
             200,
             json={
@@ -578,8 +685,9 @@ async def test_gcloud_e2e_audit_params_hash_field_present_in_all_ops() -> None:
         mock.post(
             f"https://cloudresourcemanager.googleapis.com/v1/projects/{_GCP_PROJECT}:getIamPolicy"
         ).respond(200, json={"version": 1, "etag": "e", "bindings": []})
+        mock.get(_SA_KEYS_URL).respond(200, json={"keys": []})
 
-        # Dispatch all 8 ops and verify each returns a non-None result
+        # Dispatch all 9 ops and verify each returns a non-None result
         handler_method_map: dict[str, tuple[str, dict[str, Any]]] = {
             "gcloud.about": ("gcloud_about", {}),
             "gcloud.project.describe": ("gcloud_project_describe", {}),
@@ -589,6 +697,10 @@ async def test_gcloud_e2e_audit_params_hash_field_present_in_all_ops() -> None:
             "gcloud.compute.networks.list": ("gcloud_compute_networks_list", {}),
             "gcloud.compute.subnetworks.list": ("gcloud_compute_subnetworks_list", {}),
             "gcloud.iam.policy.read": ("gcloud_iam_policy_read", {}),
+            "gcloud.iam.service_account_keys.list": (
+                "gcloud_iam_service_account_keys_list",
+                {"service_account_email": _SA_EMAIL},
+            ),
         }
         for op_id, (method_name, params) in handler_method_map.items():
             handler = getattr(connector, method_name)
@@ -603,7 +715,7 @@ async def test_gcloud_e2e_audit_params_hash_field_present_in_all_ops() -> None:
 
 @pytest.mark.asyncio
 async def test_gcloud_e2e_all_ops_have_op_id_registered() -> None:
-    """All 8 GCLOUD_OPS have op_id and handler_attr — audit op_id binding verified.
+    """All 9 GCLOUD_OPS have op_id and handler_attr — audit op_id binding verified.
 
     The dispatcher writes ``payload['op_id'] = op_id`` into the audit row.
     This test pins the full op_id registry to catch regressions where an op
@@ -619,6 +731,7 @@ async def test_gcloud_e2e_all_ops_have_op_id_registered() -> None:
         "gcloud.compute.networks.list",
         "gcloud.compute.subnetworks.list",
         "gcloud.iam.policy.read",
+        "gcloud.iam.service_account_keys.list",
     }
     registered_op_ids = {op.op_id for op in GCLOUD_OPS}
     assert registered_op_ids == expected_op_ids, (
@@ -768,8 +881,8 @@ async def test_gcloud_live_integration_about() -> None:
 
 @_SKIP_LIVE
 @pytest.mark.asyncio
-async def test_gcloud_live_integration_all_8_ops_return_ok_status() -> None:
-    """Live integration: all 8 gcloud ops return non-None results against real GCP.
+async def test_gcloud_live_integration_all_9_ops_return_ok_status() -> None:
+    """Live integration: all 9 gcloud ops return non-None results against real GCP.
 
     Requires the same environment variables as test_gcloud_live_integration_about.
     Dispatches each op against the real GCP REST APIs; asserts the result is
@@ -808,6 +921,14 @@ async def test_gcloud_live_integration_all_8_ops_return_ok_status() -> None:
             ("gcloud.compute.networks.list", "gcloud_compute_networks_list", {}),
             ("gcloud.compute.subnetworks.list", "gcloud_compute_subnetworks_list", {}),
             ("gcloud.iam.policy.read", "gcloud_iam_policy_read", {}),
+            # keys.list is per-SA: inspect the impersonated SA itself (always
+            # exists; iam.serviceAccountKeys.list is covered by the same
+            # roles/iam.serviceAccountViewer the service_accounts.list op needs).
+            (
+                "gcloud.iam.service_account_keys.list",
+                "gcloud_iam_service_account_keys_list",
+                {"service_account_email": impersonate_sa},
+            ),
         ]
         for op_id, method_name, params in handler_method_map:
             handler = getattr(connector, method_name)

--- a/backend/tests/test_connectors_gcloud_ops.py
+++ b/backend/tests/test_connectors_gcloud_ops.py
@@ -14,9 +14,11 @@ Covers:
 - ``gcloud.compute.subnetworks.list`` — aggregatedList path; per-region;
   nextPageToken.
 - ``gcloud.iam.policy.read`` — POST getIamPolicy; binding parse.
+- ``gcloud.iam.service_account_keys.list`` — per-SA key inventory;
+  required service_account_email; no key material in the row schema.
 - ``register_gcloud_typed_operations`` — idempotent; AttributeError on
   missing handler; raises on unknown group_key.
-- GCLOUD_OPS has 8 entries; all ops are safe + non-approving.
+- GCLOUD_OPS has 9 entries; all ops are safe + non-approving.
 
 Auth is fully mocked via the same ADC + impersonation mock pattern
 established in ``test_connectors_gcloud_auth.py``.
@@ -124,8 +126,8 @@ def _make_connector(token: str = "test-bearer-token") -> GcloudConnector:
 # ---------------------------------------------------------------------------
 
 
-def test_gcloud_ops_has_eight_entries() -> None:
-    assert len(GCLOUD_OPS) == 8
+def test_gcloud_ops_has_nine_entries() -> None:
+    assert len(GCLOUD_OPS) == 9
 
 
 def test_gcloud_ops_op_ids_are_unique() -> None:
@@ -156,6 +158,7 @@ def test_all_gcloud_ops_have_expected_op_ids() -> None:
         "gcloud.compute.networks.list",
         "gcloud.compute.subnetworks.list",
         "gcloud.iam.policy.read",
+        "gcloud.iam.service_account_keys.list",
     }
     actual = {op.op_id for op in GCLOUD_OPS}
     assert actual == expected
@@ -164,6 +167,32 @@ def test_all_gcloud_ops_have_expected_op_ids() -> None:
 def test_gcloud_ops_is_tuple_of_gcloud_op() -> None:
     for op in GCLOUD_OPS:
         assert isinstance(op, GcloudOp)
+
+
+def test_gcloud_sa_keys_list_op_metadata() -> None:
+    """The SA-key inventory op is an iam-group read whose row schema carries no
+    key material and whose only required param is service_account_email."""
+    op = next(o for o in GCLOUD_OPS if o.op_id == "gcloud.iam.service_account_keys.list")
+    assert op.handler_attr == "gcloud_iam_service_account_keys_list"
+    assert op.group_key == "iam"
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    # Required param is the SA email; key_types is optional.
+    assert op.parameter_schema["required"] == ["service_account_email"]
+    assert set(op.parameter_schema["properties"]) == {"service_account_email", "key_types"}
+    # The row schema must never expose private/public key material.
+    assert op.response_schema is not None
+    row_props = op.response_schema["properties"]["rows"]["items"]["properties"]
+    assert set(row_props) == {
+        "name",
+        "key_type",
+        "key_origin",
+        "valid_after_time",
+        "valid_before_time",
+        "disabled",
+    }
+    assert "privateKeyData" not in row_props
+    assert "publicKeyData" not in row_props
 
 
 # ---------------------------------------------------------------------------
@@ -1011,8 +1040,8 @@ async def test_register_gcloud_typed_operations_idempotent() -> None:
     ):
         await GcloudConnector.register_gcloud_typed_operations()
         await GcloudConnector.register_gcloud_typed_operations()
-    # 8 ops x 2 calls = 16 total register invocations
-    assert mock_register.call_count == 16
+    # 9 ops x 2 calls = 18 total register invocations
+    assert mock_register.call_count == 18
 
 
 @pytest.mark.asyncio
@@ -1038,7 +1067,7 @@ async def test_register_gcloud_typed_operations_accepts_embedding_service_kwarg(
     ):
         # Mirrors run_typed_op_registrars: the kwarg is always supplied.
         await GcloudConnector.register_gcloud_typed_operations(embedding_service=None)
-    assert mock_register.call_count == 8
+    assert mock_register.call_count == 9
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-gcloud.md
+++ b/docs/codebase/connectors-gcloud.md
@@ -26,10 +26,11 @@ refused before any token is built. This is not a soft warning — it raises
 
 ## Typed ops (G3.7-T5 #848)
 
-Eight read-only ops registered via `register_gcloud_typed_operations()`
-at lifespan startup. All ops have `safety_level="safe"` and
-`requires_approval=False`. They land in the `endpoint_descriptor` table
-under `connector_id="gcloud-rest-1.0"`.
+Nine read-only ops registered via `register_gcloud_typed_operations()`
+at lifespan startup (eight from G3.7-T5 #848; the ninth,
+`gcloud.iam.service_account_keys.list`, added by #2846). All ops have
+`safety_level="safe"` and `requires_approval=False`. They land in the
+`endpoint_descriptor` table under `connector_id="gcloud-rest-1.0"`.
 
 | Op ID | API surface | HTTP verb | Notes |
 |---|---|---|---|
@@ -41,6 +42,7 @@ under `connector_id="gcloud-rest-1.0"`.
 | `gcloud.compute.networks.list` | Compute v1 global networks | GET | Follows `nextPageToken` |
 | `gcloud.compute.subnetworks.list` | Compute v1 `aggregatedList` | GET | Follows `nextPageToken`; `region` param |
 | `gcloud.iam.policy.read` | CRM v1 `getIamPolicy` | POST | Returns `version`, `etag`, `bindings` |
+| `gcloud.iam.service_account_keys.list` | IAM v1 `serviceAccounts.keys.list` | GET | Per-SA key inventory; required `service_account_email`, optional `key_types` → `keyTypes[]` filter; row carries `key_type` (USER_MANAGED/SYSTEM_MANAGED) + `valid_before_time` expiry; never returns key material; single GET (no pagination) |
 
 Groups and `when_to_use` blurbs are defined in `_WHEN_TO_USE_BY_GROUP`
 in `connector.py`: `identity`, `project`, `services`, `iam`, `compute`.
@@ -65,7 +67,7 @@ and return a `ResultHandle` without any connector-side changes.
   `op_id`, `handler_attr`, `summary`, `description`, `parameter_schema`,
   `response_schema`, `group_key`, `tags`, `safety_level`,
   `requires_approval`, `llm_instructions`.
-- **`GCLOUD_OPS`** (`ops.py`) — tuple of all 8 `GcloudOp` entries.
+- **`GCLOUD_OPS`** (`ops.py`) — tuple of all 9 `GcloudOp` entries.
   `register_gcloud_typed_operations()` walks this tuple.
 - **`GcloudTargetLike`** (`session.py`) — runtime-checkable Protocol
   capturing the minimum target shape the connector reads: `name`,
@@ -210,7 +212,9 @@ is required and threaded to `_ensure_token` for the SA-JSON-key gate.
 
 ## CLI verbs (G3.7-T6 #851)
 
-All 8 ops are reachable via `meho gcloud …`. Source:
+The eight G3.7-T5 ops are reachable via `meho gcloud …` (the ninth,
+`gcloud.iam.service_account_keys.list`, is dispatchable via
+`call_operation` but has no CLI verb yet). Source:
 `cli/internal/cmd/gcloud/`.
 
 | File | Commands |
@@ -231,7 +235,7 @@ to a single zone/region.
 ## E2E tests (G3.7-T6 #851)
 
 `backend/tests/test_connectors_gcloud_e2e.py` — httpx_mock (respx) unit-
-level E2E tests covering all 8 ops. A `_StubTarget` dataclass satisfies
+level E2E tests covering all 9 ops. A `_StubTarget` dataclass satisfies
 `GcloudTargetLike`; `google.auth` calls are patched so no live GCP
 credentials are needed.
 
@@ -250,10 +254,13 @@ Key tests:
 | `test_gcloud_e2e_compute_networks_list` | VPC network inventory |
 | `test_gcloud_e2e_compute_subnetworks_list_region_filter` | `--region` sends per-region URL |
 | `test_gcloud_e2e_iam_policy_read` | IAM policy bindings |
-| `test_gcloud_e2e_audit_params_hash_field_present_in_all_ops` | All 8 handlers return non-None results |
-| `test_gcloud_e2e_all_ops_have_op_id_registered` | All 8 op IDs registered, handler methods exist |
+| `test_gcloud_e2e_iam_service_account_keys_list_returns_key_rows` | Per-SA key rows: `key_type` (USER_MANAGED/SYSTEM_MANAGED) + expiry, no key material |
+| `test_gcloud_e2e_iam_service_account_keys_list_requires_email` | Missing/blank `service_account_email` raises before any HTTP call |
+| `test_gcloud_e2e_iam_service_account_keys_list_forwards_key_types_filter` | `key_types` → repeated `keyTypes[]` query filter |
+| `test_gcloud_e2e_audit_params_hash_field_present_in_all_ops` | All 9 handlers return non-None results |
+| `test_gcloud_e2e_all_ops_have_op_id_registered` | All 9 op IDs registered, handler methods exist |
 | `test_gcloud_live_integration_about` _(gated)_ | Live GCP probe; skips unless `CI_GCLOUD_CREDENTIALS_PRESENT=1` |
-| `test_gcloud_live_integration_all_8_ops_return_ok_status` _(gated)_ | Live 8-ops sweep |
+| `test_gcloud_live_integration_all_9_ops_return_ok_status` _(gated)_ | Live 9-ops sweep |
 
 **Design note:** The always-on tests use handler method calls directly
 (not `call_operation`) because the `Target` ORM model does not yet have


### PR DESCRIPTION
## Summary

- Adds **`gcloud.iam.service_account_keys.list`** — the missing read path for the org-policy compliance question "does any service account still carry a `USER_MANAGED` key, and when does it expire?". The connector already *refuses* SA-JSON-key credential material (the `constraints/iam.disableServiceAccountKeyCreation` gate), but had no way to *audit* whether some other process already minted a standing user-managed key. Operators fell back to `gcloud iam service-accounts keys list`, bypassing MEHO's audit trail.
- Calls IAM v1 `projects.serviceAccounts.keys.list` (`GET .../serviceAccounts/<email>/keys`). Per-SA read (required `service_account_email`; the same two-step discovery as `keycloak.client.list` → `keycloak.client.get`), `safety_level="safe"`, `requires_approval=False`, group `iam`.
- Each row carries `{name, key_type, key_origin, valid_after_time, valid_before_time, disabled}` — `key_type` is `USER_MANAGED` (the violation) / `SYSTEM_MANAGED` (Google-rotated), `valid_before_time` is the expiry. **No private/public key material is ever returned** — the list endpoint returns neither `privateKeyData` (create-only) nor `publicKeyData` (get-only), verified against the IAM v1 discovery document.
- Optional `key_types` maps to the API's repeated `keyTypes[]` filter; omitted → both managed types (keeps the op a general inventory read, not a single-purpose compliance check).

### Design note
Unlike the `serviceAccounts.list` sibling, `keys.list` has **no** `pageToken`/`pageSize`/`nextPageToken` (confirmed via the IAM v1 discovery doc), so this is a single GET rather than a pagination loop — the issue's "mirror the pagination loop" guidance would have been dead code (kept the `{rows, total}` envelope). Extends the gcloud typed-op inventory 8 → 9.

## Test plan

- [x] `ruff check` — clean; `ruff format --check` — clean
- [x] `mypy` (gate scope `files=["src"]`) — no new errors from these changes (only a pre-existing darwin-only `net/icmp.py` `MSG_ERRQUEUE` false positive, unrelated; CI runs on Linux)
- [x] `pytest tests/test_connectors_gcloud_ops.py tests/test_connectors_gcloud_e2e.py tests/test_connectors_registry_v2.py` — **82 passed, 2 skipped** (skips = CI-gated live-credential tests)
- [x] `code-quality.py --diff` — 0 blockers (4 pre-existing file/function-size warnings on `connector.py`/`ops.py`, already >600 lines before this change)
- [x] **AC1** — `gcloud.iam.service_account_keys.list` registered (`safe`, no-approval, group `iam`); dispatch verified in the combined-audit e2e sweep
- [x] **AC2** — required `service_account_email` validated (`test_..._requires_email`); `key_types` → `keyTypes[]` (`test_..._forwards_key_types_filter`)
- [x] **AC3** — row shape asserted against a fixture with one `USER_MANAGED` + one `SYSTEM_MANAGED` key; row-key set pinned so no `privateKeyData`/`publicKeyData` can leak (`test_..._returns_key_rows` + schema test `test_gcloud_sa_keys_list_op_metadata`)
- [x] **AC5** — `docs/codebase/connectors-gcloud.md` "Typed ops" table 8 → 9 rows; `ops.py` module docstring updated
- [x] **AC6** — N/A: a typed op adds no CLI route/OpenAPI schema, so no snapshot regen needed

## Out of scope

- **No write op** (`keys.create`/`keys.delete`) — contradicts the connector's key-refusal posture (issue out-of-scope).
- **No project-wide sweep** — `keys.list` is per-SA on GCP's side; a composite is a later follow-on if the agent-side loop proves common.
- **No CLI verb** — explicitly not a hard gate (issue out-of-scope); the op is reachable via `call_operation`. Adjacent finding: `docs/cross-repo/gcloud-onboarding.md`'s CLI-oriented op table could gain a row if/when a `meho gcloud iam sa keys list` verb lands.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2846
