### PR TITLE
feat(connectors): curate Hetzner Robot firewall read op + CLI verb (#2848)

### DIFF
--- a/backend/src/meho_backplane/connectors/hetzner_robot/core_ops.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/core_ops.py
@@ -3,9 +3,9 @@
 
 """Hetzner Robot read-only v0.2 core — curated operator-enabled subset.
 
-This module names the **10 read-only Hetzner Robot operations** the G3.7
-Robot v0.2 ship enables out of the much larger Robot Webservice REST corpus
-the G0.7 spec-ingestion pipeline lands under
+This module names the **11 read-only Hetzner Robot operations** the
+curated Robot read core enables out of the much larger Robot Webservice
+REST corpus the G0.7 spec-ingestion pipeline lands under
 ``connector_id="hetzner-rest-2026.04"``. The curation is two-layered:
 
 * :data:`ROBOT_CORE_GROUPS` — the operator-reviewed ``when_to_use``
@@ -14,7 +14,7 @@ the G0.7 spec-ingestion pipeline lands under
   ops; the ``when_to_use`` is what the agent reads verbatim through
   :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
   to pick a group to search within.
-* :data:`ROBOT_CORE_OPS` — the 10 ``EndpointDescriptor.op_id`` strings
+* :data:`ROBOT_CORE_OPS` — the 11 ``EndpointDescriptor.op_id`` strings
   that flip to ``is_enabled=True`` at operator-review time, paired
   with the per-op ``llm_instructions`` blob the agent inlines into
   the reasoning context when it sees the op in
@@ -49,7 +49,7 @@ registry lookup (``(product, version, impl_id)`` triple) under the same
 token — the row-level product key and the registry key now agree. Same
 short token the SDDC Manager precedent uses (``"sddc"``).
 
-The 10 ops (paths cross-checked against the Hetzner Robot Webservice API
+The 11 ops (paths cross-checked against the Hetzner Robot Webservice API
 at https://robot.hetzner.com/doc/webservice/en.html):
 
 1.  ``GET:/query`` — ``hetzner-robot.about`` — API version + account info.
@@ -69,7 +69,11 @@ at https://robot.hetzner.com/doc/webservice/en.html):
     and their active routing target.
 9.  ``GET:/rdns`` — ``hetzner-robot.rdns.list`` — all reverse DNS entries
     (PTR records) set on the account's IPs.
-10. ``GET:/key`` — ``hetzner-robot.ssh_key.list`` — all SSH public keys
+10. ``GET:/firewall/{server-ip}`` — ``hetzner-robot.firewall.get`` — the
+    per-server packet-filter firewall (active status, whitelist-Hetzner-
+    services flag, and ordered input/output rule set) for one dedicated
+    server addressed by its primary IP.
+11. ``GET:/key`` — ``hetzner-robot.ssh_key.list`` — all SSH public keys
     registered in the Robot portal for the account.
 
 Path families and group_keys
@@ -85,7 +89,7 @@ Curation application
 --------------------
 
 :func:`apply_robot_core_curation` is the operator-review-time substrate
-call that makes exactly the 10 curated ops dispatchable. Mirrors
+call that makes exactly the 11 curated ops dispatchable. Mirrors
 :func:`~meho_backplane.connectors.harbor.core_ops.apply_harbor_core_curation`
 verbatim, threading the "enable group but pin non-core ops disabled" needle
 via the audit-log-driven operator-override exclusion.
@@ -206,19 +210,20 @@ class RobotCoreOp:
 #: matches ``/ip_address``.  More-specific prefixes must precede
 #: less-specific ones where overlap exists (e.g. ``/vswitch/{id}``
 #: before ``/vswitch``). The rules encode every root-level path the
-#: 10 curated ops use; paths outside these prefixes are un-curated
+#: 11 curated ops use; paths outside these prefixes are un-curated
 #: and stay ``is_enabled=False`` after :func:`apply_robot_core_curation`
 #: runs.
 ROBOT_PATH_RULES: Final[tuple[tuple[str, str], ...]] = (
     ("/query", "robot-about"),
     # Server family
     ("/server", "robot-servers"),
-    # Networking — IP, subnet, vSwitch, failover, rDNS
+    # Networking — IP, subnet, vSwitch, failover, rDNS, firewall
     ("/ip", "robot-networking"),
     ("/subnet", "robot-networking"),
     ("/vswitch", "robot-networking"),
     ("/failover", "robot-networking"),
     ("/rdns", "robot-networking"),
+    ("/firewall", "robot-networking"),
     # SSH keys
     ("/key", "robot-ssh-keys"),
 )
@@ -231,7 +236,7 @@ def classify_robot_op(op_id: str) -> str:
     helper strips the verb and matches the path against
     :data:`ROBOT_PATH_RULES` in order.
 
-    Only ``GET`` verbs are considered curated (all 10 core ops are
+    Only ``GET`` verbs are considered curated (all 11 core ops are
     read-only). A non-GET op or a path outside the curated families
     returns ``"none"`` — those rows stay ``is_enabled=False``.
 
@@ -308,10 +313,12 @@ ROBOT_CORE_GROUPS: Final[tuple[RobotCoreGroup, ...]] = (
             "Use this group to inspect the networking resources assigned to the "
             "Hetzner Robot account: IP addresses (with lock and traffic status), "
             "subnets (with gateway and IP version), vSwitches (with VLAN and server "
-            "memberships), failover IPs (with active routing targets), and reverse "
-            "DNS entries (PTR records). Use when answering questions about IP "
-            "assignments, routing, network topology, or DNS resolution for any "
-            "resource in the account."
+            "memberships), failover IPs (with active routing targets), reverse "
+            "DNS entries (PTR records), and per-server packet-filter firewall "
+            "configuration (active status, Hetzner-services allowlist flag, and "
+            "ordered input/output rules). Use when answering questions about IP "
+            "assignments, routing, network topology, DNS resolution, or edge "
+            "firewall rules for any resource in the account."
         ),
     ),
     RobotCoreGroup(
@@ -328,7 +335,7 @@ ROBOT_CORE_GROUPS: Final[tuple[RobotCoreGroup, ...]] = (
 )
 
 
-#: The 10 curated read-only Hetzner Robot core ops. Each entry carries
+#: The 11 curated read-only Hetzner Robot core ops. Each entry carries
 #: the op_id (``GET:/path`` form), the curated group assignment, and the
 #: operator-reviewed ``llm_instructions`` blob.
 #:
@@ -574,6 +581,42 @@ ROBOT_CORE_OPS: Final[tuple[RobotCoreOp, ...]] = (
             ),
         ),
     ),
+    RobotCoreOp(
+        op_id="GET:/firewall/{server-ip}",
+        group_key="robot-networking",
+        llm_instructions=_instructions(
+            when_to_call=(
+                "Call to read the packet-filter (edge) firewall configuration of "
+                "one dedicated server, addressed by its primary IP. Requires "
+                "server_ip obtained from hetzner-robot.server.list. Use to verify "
+                "a server's firewall after an onboarding template is applied: "
+                "confirm the firewall is active, that the intended operator/lab "
+                "source addresses are allowed on the expected ports (e.g. 22 and "
+                "443), and that the final rule is a default-discard. Answers the "
+                "operator question 'does server X's edge firewall match the "
+                "template'. This is a read only — it never mutates the firewall."
+            ),
+            output_shape=(
+                "Object under a firewall key: {firewall: {status ('active', "
+                "'disabled', or 'in process'), whitelist_hos (bool — whether "
+                "Hetzner's own service IPs are allowlisted), filter_ipv6 (bool), "
+                "port ('main' or 'kvm'), server_ip (string), server_number (int), "
+                "rules: {input: [rule, ...], output: [rule, ...]}}}. Each rule "
+                "carries name (string), ip_version ('ipv4' or 'ipv6', omitted for "
+                "both), src_ip and dst_ip (CIDR strings), src_port and dst_port "
+                "(single port or range strings), protocol ('tcp', 'udp', 'icmp', "
+                "...), tcp_flags (string), and action ('accept' or 'discard'). "
+                "Rules are ordered; the first match wins."
+            ),
+            next_step=(
+                "Inspect rules.input[] in order — the last rule is typically the "
+                "default-discard that the template ends on. Cross-reference "
+                "server_ip with hetzner-robot.server.info to confirm the server, "
+                "or with hetzner-robot.ip.list to see every IP the rule set "
+                "should cover."
+            ),
+        ),
+    ),
     # ---- SSH Keys ----
     RobotCoreOp(
         op_id="GET:/key",
@@ -603,15 +646,18 @@ ROBOT_CORE_OPS: Final[tuple[RobotCoreOp, ...]] = (
 )
 
 
+# code-quality-allow: verbatim mirror of apply_harbor_core_curation (both 107
+# lines); the five-phase substrate-override cascade must stay parallel across
+# the robot/harbor curation helpers, so it is not refactored in isolation.
 async def apply_robot_core_curation(
     review_service: ReviewService,
     *,
     tenant_id: UUID | None,
 ) -> None:
-    """Apply the curated 10-op read core against an ingested Robot connector.
+    """Apply the curated 11-op read core against an ingested Robot connector.
 
     Drives the substrate so that, after this call returns, exactly
-    the 10 ops in :data:`ROBOT_CORE_OPS` are dispatchable
+    the 11 ops in :data:`ROBOT_CORE_OPS` are dispatchable
     (``is_enabled=True``) and every other ingested op stays
     ``is_enabled=False``. The 4 curated groups land
     ``review_status='enabled'`` so the agent's

--- a/backend/tests/acceptance/_robot_canary_fixtures.py
+++ b/backend/tests/acceptance/_robot_canary_fixtures.py
@@ -7,10 +7,10 @@ Two Robot acceptance modules (dispatch smoke + JSONFlux force-handle)
 share the same plumbing: a registered
 :class:`~meho_backplane.connectors.hetzner_robot.HetznerRobotConnector` instance
 with a stub credentials loader (so no Vault read is required), a probed
-:class:`~meho_backplane.db.models.Target` row, the 10 curated
+:class:`~meho_backplane.db.models.Target` row, the 11 curated
 :class:`~meho_backplane.db.models.EndpointDescriptor` rows from
 :data:`~meho_backplane.connectors.hetzner_robot.core_ops.ROBOT_CORE_OPS`, and a
-:mod:`respx`-mocked Hetzner Robot REST surface answering each of the 10 curated
+:mod:`respx`-mocked Hetzner Robot REST surface answering each of the 11 curated
 read ops.
 
 Hetzner Robot uses HTTP Basic auth on every request — no session establish
@@ -24,7 +24,7 @@ The full Hetzner Robot spec ingest via :class:`IngestionPipelineService`
 needs the Robot OpenAPI spec reachable on the CI runner plus a live LLM
 for the grouping pass. Until the spec-shelf is wired to the meho-runners
 pool, the dispatch leg is exercised against a minimal direct-insert path
-that seeds the 10 curated endpoint_descriptor rows by hand. Same pattern
+that seeds the 11 curated endpoint_descriptor rows by hand. Same pattern
 :mod:`tests.acceptance._harbor_canary_fixtures` and
 :mod:`tests.acceptance._sddc_canary_fixtures` established.
 
@@ -245,6 +245,58 @@ ROBOT_CANARY_RDNS: list[dict[str, object]] = [
     {"rdns": {"ip": "1.2.3.2", "ptr": "canary-server-2.example.com"}},
 ]
 
+#: Synthetic single-server firewall config (server-ip=1.2.3.1). Models the
+#: onboarding template shape: operator /32 allowed on https, lab-internal
+#: 10.0.0.0/8 allowed, final default-discard.
+ROBOT_CANARY_FIREWALL: dict[str, object] = {
+    "firewall": {
+        "server_ip": "1.2.3.1",
+        "server_number": 100001,
+        "status": "active",
+        "filter_ipv6": False,
+        "whitelist_hos": True,
+        "port": "main",
+        "rules": {
+            "input": [
+                {
+                    "name": "operator-https",
+                    "ip_version": "ipv4",
+                    "dst_ip": None,
+                    "dst_port": "443",
+                    "src_ip": "198.51.100.7/32",
+                    "src_port": None,
+                    "protocol": "tcp",
+                    "tcp_flags": None,
+                    "action": "accept",
+                },
+                {
+                    "name": "lab-internal",
+                    "ip_version": "ipv4",
+                    "dst_ip": None,
+                    "dst_port": None,
+                    "src_ip": "10.0.0.0/8",
+                    "src_port": None,
+                    "protocol": None,
+                    "tcp_flags": None,
+                    "action": "accept",
+                },
+                {
+                    "name": "default-discard",
+                    "ip_version": None,
+                    "dst_ip": None,
+                    "dst_port": None,
+                    "src_ip": None,
+                    "src_port": None,
+                    "protocol": None,
+                    "tcp_flags": None,
+                    "action": "discard",
+                },
+            ],
+            "output": [],
+        },
+    }
+}
+
 #: Synthetic SSH key list — 2 keys registered in the Robot portal.
 ROBOT_CANARY_KEYS: list[dict[str, object]] = [
     {
@@ -277,7 +329,7 @@ class IngestedRobotCanary:
 
 
 async def _insert_robot_descriptors() -> None:
-    """Seed the 10 curated Robot core ops + their groups as enabled rows.
+    """Seed the 11 curated Robot core ops + their groups as enabled rows.
 
     One :class:`OperationGroup` per entry in :data:`ROBOT_CORE_GROUPS`
     (``review_status='enabled'``), one :class:`EndpointDescriptor` per
@@ -359,7 +411,7 @@ async def _robot_credentials_loader(
 
 
 def _register_robot_routes(mock: respx.MockRouter) -> None:
-    """Register the 10 Robot read-op routes on *mock*.
+    """Register the 11 Robot read-op routes on *mock*.
 
     Robot uses HTTP Basic on every request — no session establish call
     is needed. Each route returns a pre-seeded JSON body. Templated
@@ -375,11 +427,12 @@ def _register_robot_routes(mock: respx.MockRouter) -> None:
     mock.get("/vswitch/4321").respond(200, json=ROBOT_CANARY_VSWITCH_DETAIL)
     mock.get("/failover").respond(200, json=ROBOT_CANARY_FAILOVERS)
     mock.get("/rdns").respond(200, json=ROBOT_CANARY_RDNS)
+    mock.get("/firewall/1.2.3.1").respond(200, json=ROBOT_CANARY_FIREWALL)
     mock.get("/key").respond(200, json=ROBOT_CANARY_KEYS)
 
 
 def _register_robot_sandbox_routes(mock: respx.MockRouter) -> None:
-    """Register the 10 Robot sandbox routes — every path returns 200 + empty array.
+    """Register the 11 Robot sandbox routes — every path returns 200 + empty array.
 
     Mirrors the Hetzner Robot consumer sandbox behaviour:
     ``https://robot-sandbox.hetzner.com`` returns HTTP 200 with empty JSON
@@ -401,6 +454,7 @@ def _register_robot_sandbox_routes(mock: respx.MockRouter) -> None:
     mock.get("/vswitch/4321").respond(200, json={})
     mock.get("/failover").respond(200, json=[])
     mock.get("/rdns").respond(200, json=[])
+    mock.get("/firewall/1.2.3.1").respond(200, json={})
     mock.get("/key").respond(200, json=[])
 
 
@@ -427,7 +481,7 @@ async def ingested_robot_canary(
     Setup mirrors :func:`tests.acceptance._harbor_canary_fixtures.ingested_harbor_canary`:
 
     1. Insert built-in :class:`OperationGroup` + :class:`EndpointDescriptor`
-       rows for the 10 curated Robot core ops.
+       rows for the 11 curated Robot core ops.
     2. Seed a :class:`Target` with ``product="hetzner"`` and the
        :data:`ROBOT_CANARY_FINGERPRINT` so the resolver binds
        :class:`HetznerRobotConnector`.
@@ -503,7 +557,7 @@ async def ingested_robot_canary_sandbox(
     """Yield a dispatcher-ready Robot setup where every op returns 200 + empty arrays.
 
     Models the Hetzner Robot consumer sandbox
-    (``https://robot-sandbox.hetzner.com``): all 10 read endpoints respond
+    (``https://robot-sandbox.hetzner.com``): all 11 read endpoints respond
     with HTTP 200 + empty JSON arrays (``[]``) or empty objects (``{}``) for
     the query endpoint. Operators who run against the sandbox before they
     have a production Robot account should receive ``status='ok'`` with an

--- a/backend/tests/acceptance/test_g37_robot_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_g37_robot_dispatch_smoke.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""G3.7-T9 dispatch smoke — the 10 curated Hetzner Robot read ops over respx.
+"""G3.7-T9 dispatch smoke — the 11 curated Hetzner Robot read ops over respx.
 
 Proves the acceptance criteria for issue #852:
 
@@ -27,7 +27,7 @@ Proves the acceptance criteria for issue #852:
 Why respx and not a real Hetzner Robot Webservice:
 The Hetzner Robot Webservice has no public CI simulator (#536 per the
 Initiative DoD). respx mocks the exact wire contract the connector calls
-(HTTP Basic GET against each of the 10 path endpoints), so the
+(HTTP Basic GET against each of the 11 path endpoints), so the
 session-establishment (Basic auth header computation) and per-op HTTP
 requests all fire through the connector's real httpx client.
 
@@ -36,7 +36,7 @@ The Hetzner Robot consumer sandbox (``https://robot-sandbox.hetzner.com``)
 returns HTTP 200 with empty JSON arrays for every read endpoint. This
 test exercises the same code path: the respx router maps every path to
 ``200 + []`` (or ``200 + {}``) when the ``ROBOT_SANDBOX_OP_IDS`` fixture
-activates the sandbox router. The acceptance confirms all 10 ops tolerate
+activates the sandbox router. The acceptance confirms all 11 ops tolerate
 empty-array responses gracefully (no parsing crash, ``status='ok'``).
 
 Skip conditions:
@@ -118,7 +118,7 @@ def test_mcp_llm_instructions_contain_401_block_warning(op_id: str) -> None:
 # Smoke-test parameters — op ids and per-op path-parameter substitutions.
 # ---------------------------------------------------------------------------
 
-#: All 10 curated Hetzner Robot op ids, sourced from the canonical constant.
+#: All 11 curated Hetzner Robot op ids, sourced from the canonical constant.
 SMOKE_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in ROBOT_CORE_OPS)
 
 #: Path-parameter substitutions for ops with ``{var}`` templates.
@@ -126,6 +126,7 @@ SMOKE_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in ROBOT_CORE_OPS)
 SMOKE_PARAMS: dict[str, dict[str, object]] = {
     "GET:/server/{server-ip}": {"server-ip": "1.2.3.1"},
     "GET:/vswitch/{id}": {"id": "4321"},
+    "GET:/firewall/{server-ip}": {"server-ip": "1.2.3.1"},
 }
 
 
@@ -354,7 +355,7 @@ async def test_dispatch_writes_audit_row_with_op_id_target_id_params_hash(
 # ---------------------------------------------------------------------------
 # AC5 — sandbox 200/empty-array path.
 # The consumer sandbox returns HTTP 200 with empty arrays for every read op.
-# All 10 ops must tolerate empty-array/object responses without raising.
+# All 11 ops must tolerate empty-array/object responses without raising.
 # ---------------------------------------------------------------------------
 
 

--- a/backend/tests/test_connectors_hetzner_robot_core_ops.py
+++ b/backend/tests/test_connectors_hetzner_robot_core_ops.py
@@ -10,9 +10,9 @@ Covers :mod:`meho_backplane.connectors.hetzner_robot.core_ops`:
   only GET verbs are classified as curated.
 * :func:`apply_robot_core_curation` — the operator-review-time substrate
   call that flips ``review_status='enabled'`` on the 4 curated groups,
-  lands ``llm_instructions`` on the 10 curated ops, and explicitly
+  lands ``llm_instructions`` on the 11 curated ops, and explicitly
   disables non-core ops via the audit-log-driven operator-override
-  exclusion. The load-bearing assertion is "10 ops dispatchable, every
+  exclusion. The load-bearing assertion is "11 ops dispatchable, every
   other op in curated groups stays ``is_enabled=False``".
 * ``llm_instructions`` completeness — every op has the three canonical
   keys with non-empty string values.
@@ -97,6 +97,7 @@ def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
         ("GET:/vswitch/{id}", "robot-networking"),
         ("GET:/failover", "robot-networking"),
         ("GET:/rdns", "robot-networking"),
+        ("GET:/firewall/{server-ip}", "robot-networking"),
         # SSH keys
         ("GET:/key", "robot-ssh-keys"),
         # Non-curated paths → "none"
@@ -114,7 +115,7 @@ def _make_operator(*, tenant_id: uuid.UUID) -> Operator:
     ids=str,
 )
 def test_classify_robot_op_returns_correct_group(op_id: str, expected_group: str) -> None:
-    """classify_robot_op returns the curated group_key for all 10 core ops."""
+    """classify_robot_op returns the curated group_key for all 11 core ops."""
     assert classify_robot_op(op_id) == expected_group
 
 
@@ -122,6 +123,20 @@ def test_classify_robot_op_vswitch_info_classifies_as_networking() -> None:
     """GET:/vswitch/{id} classifies as robot-networking, not an artifact of /vswitch prefix."""
     assert classify_robot_op("GET:/vswitch/{id}") == "robot-networking"
     assert classify_robot_op("GET:/vswitch") == "robot-networking"
+
+
+def test_classify_robot_op_firewall_classifies_as_networking() -> None:
+    """GET:/firewall/{server-ip} classifies as robot-networking (#2848 firewall read).
+
+    The ``/firewall`` prefix is anchored (``path == prefix`` or
+    ``path.startswith(prefix + "/")``), so the templated single-server path
+    curates into robot-networking without colliding with the sibling
+    ``/failover`` prefix, and a path that merely shares leading characters
+    (``/firewalls``) is not curated.
+    """
+    assert classify_robot_op("GET:/firewall/{server-ip}") == "robot-networking"
+    assert classify_robot_op("GET:/firewall") == "robot-networking"
+    assert classify_robot_op("GET:/firewalls") == "none"
 
 
 def test_classify_robot_op_all_core_ops_are_classified() -> None:
@@ -175,10 +190,10 @@ def test_robot_core_groups_when_to_use_all_populated() -> None:
         assert group.name and group.name.strip(), f"group {group.group_key!r} has empty name"
 
 
-def test_robot_core_ops_count_is_10() -> None:
-    """ROBOT_CORE_OPS contains exactly 10 ops per the G3.7 DoD."""
-    assert len(ROBOT_CORE_OPS) == 10, (
-        f"expected 10 ops in ROBOT_CORE_OPS; got {len(ROBOT_CORE_OPS)}"
+def test_robot_core_ops_count_is_11() -> None:
+    """ROBOT_CORE_OPS contains exactly 11 ops (the 10 G3.7 core + the #2848 firewall read)."""
+    assert len(ROBOT_CORE_OPS) == 11, (
+        f"expected 11 ops in ROBOT_CORE_OPS; got {len(ROBOT_CORE_OPS)}"
     )
 
 
@@ -312,8 +327,8 @@ async def _seed_curated_groups_and_ops(
     return group_ids
 
 
-async def test_apply_robot_core_curation_enables_exactly_10_ops() -> None:
-    """apply_robot_core_curation enables exactly the 10 core ops."""
+async def test_apply_robot_core_curation_enables_exactly_11_ops() -> None:
+    """apply_robot_core_curation enables exactly the 11 core ops."""
     tenant_id = uuid.uuid4()
     operator = _make_operator(tenant_id=tenant_id)
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)
@@ -374,7 +389,7 @@ async def test_apply_robot_core_curation_disables_non_core_ops_in_curated_groups
 
 
 async def test_apply_robot_core_curation_sets_llm_instructions_on_all_core_ops() -> None:
-    """llm_instructions is populated on all 10 core ops after curation."""
+    """llm_instructions is populated on all 11 core ops after curation."""
     tenant_id = uuid.uuid4()
     operator = _make_operator(tenant_id=tenant_id)
     await _seed_curated_groups_and_ops(tenant_id=tenant_id)

--- a/cli/internal/cmd/hetzner-robot/firewall.go
+++ b/cli/internal/cmd/hetzner-robot/firewall.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package hetznerrobot
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newFirewallCmd returns `meho hetzner-robot firewall` with the get subcommand.
+func newFirewallCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "firewall",
+		Short:        "Read the packet-filter firewall of a dedicated server",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newFirewallGetCmd())
+	return cmd
+}
+
+func newFirewallGetCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "get <server-ip>",
+		Short: "Show the packet-filter firewall for one dedicated server by its primary IP",
+		Long: "get dispatches GET:/firewall/{server-ip} against\n" +
+			"connector_id=\"hetzner-rest-2026.04\" and renders the firewall status,\n" +
+			"the Hetzner-services allowlist flag, and the ordered input/output rules.\n" +
+			"<server-ip> is the primary IP from 'meho hetzner-robot server list'.\n" +
+			"Use it to verify a server's edge firewall after the onboarding template\n" +
+			"is applied (operator source allowed on the expected ports, final\n" +
+			"default-discard). --json emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho hetzner-robot firewall get 1.2.3.4 --target rdc-robot\n" +
+			"  meho hetzner-robot firewall get 1.2.3.4 --target rdc-robot --json | jq '.result.firewall.rules.input[]'",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFirewallGet(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "Hetzner Robot target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runFirewallGet(cmd *cobra.Command, serverIP, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	opID := "GET:/firewall/{server-ip}"
+	params := map[string]any{"server-ip": serverIP}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printFirewallGet)
+}
+
+func printFirewallGet(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s GET:/firewall/{server-ip} — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	fw := decodeFirewall(r.Result)
+	if fw == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	printFirewallFields(w, fw)
+}
+
+// decodeFirewall extracts the firewall object from either a {"firewall": {...}}
+// wrapper or a bare object carrying recognizable firewall fields. Returns nil
+// when the payload is neither (e.g. the sandbox's empty {}).
+func decodeFirewall(raw json.RawMessage) map[string]any {
+	var wrapper struct {
+		Firewall map[string]any `json:"firewall"`
+	}
+	if err := jsonUnmarshalStrict(raw, &wrapper); err == nil && wrapper.Firewall != nil {
+		return wrapper.Firewall
+	}
+	var bare map[string]any
+	if err := jsonUnmarshalStrict(raw, &bare); err == nil {
+		if _, ok := bare["rules"]; ok {
+			return bare
+		}
+		if _, ok := bare["status"]; ok {
+			return bare
+		}
+	}
+	return nil
+}
+
+func printFirewallFields(w io.Writer, fw map[string]any) {
+	printStringField(w, "status", "status", fw)
+	if v, ok := fw["whitelist_hos"].(bool); ok {
+		fmt.Fprintf(w, "  %-14s %v\n", "whitelist_hos:", v)
+	}
+	if v, ok := fw["filter_ipv6"].(bool); ok {
+		fmt.Fprintf(w, "  %-14s %v\n", "filter_ipv6:", v)
+	}
+	printStringField(w, "port", "port", fw)
+	rules, _ := fw["rules"].(map[string]any)
+	if rules == nil {
+		return
+	}
+	printFirewallRuleSet(w, "input", rules)
+	printFirewallRuleSet(w, "output", rules)
+}
+
+func printFirewallRuleSet(w io.Writer, direction string, rules map[string]any) {
+	arr, _ := rules[direction].([]any)
+	fmt.Fprintf(w, "  %s rules (%d):\n", direction, len(arr))
+	for _, item := range arr {
+		rule, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(w, "    - %-20s action=%-8s proto=%-5s src_ip=%-20s dst_port=%s\n",
+			truncate(firewallRuleField(rule, "name", "(unnamed)"), 20),
+			firewallRuleField(rule, "action", "?"),
+			firewallRuleField(rule, "protocol", "any"),
+			truncate(firewallRuleField(rule, "src_ip", "any"), 20),
+			firewallRuleField(rule, "dst_port", "any"),
+		)
+	}
+}
+
+// firewallRuleField returns rule[key] as a string, or fallback when the field
+// is absent, non-string, or empty. Hetzner emits JSON null for unset rule
+// fields (src_ip, dst_port, protocol on an allow-all rule), which decode to a
+// nil interface — the fallback keeps the rendered row aligned.
+func firewallRuleField(rule map[string]any, key, fallback string) string {
+	if v, ok := rule[key].(string); ok && v != "" {
+		return v
+	}
+	return fallback
+}

--- a/cli/internal/cmd/hetzner-robot/hetzner_robot.go
+++ b/cli/internal/cmd/hetzner-robot/hetzner_robot.go
@@ -3,7 +3,7 @@
 
 // Package hetznerrobot hosts the cobra commands under `meho hetzner-robot
 // ...` for G3.7-T9 (#852) of Initiative #370. v0.2 ships the
-// operator-facing alias verbs over the 10 Hetzner Robot read-only core
+// operator-facing alias verbs over the 11 Hetzner Robot read-only core
 // ops, each pre-baking connector_id="hetzner-rest-2026.04" so operators
 // don't type the connector ID on every dispatch:
 //
@@ -16,6 +16,7 @@
 //   - `meho hetzner-robot vswitch info <id>`                — GET:/vswitch/{id}
 //   - `meho hetzner-robot failover list [--target T]`       — GET:/failover
 //   - `meho hetzner-robot rdns list [--target T]`           — GET:/rdns
+//   - `meho hetzner-robot firewall get <server-ip>`         — GET:/firewall/{server-ip}
 //   - `meho hetzner-robot ssh-key list [--target T]`        — GET:/key
 //   - `meho hetzner-robot operation search "<query>"`       — search pre-scoped
 //   - `meho hetzner-robot operation call <op_id> ...`       — call pre-scoped
@@ -88,6 +89,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newVswitchCmd())
 	cmd.AddCommand(newFailoverCmd())
 	cmd.AddCommand(newRdnsCmd())
+	cmd.AddCommand(newFirewallCmd())
 	cmd.AddCommand(newSSHKeyCmd())
 	cmd.AddCommand(newOperationCmd())
 	return cmd

--- a/cli/internal/cmd/hetzner-robot/hetzner_robot_test.go
+++ b/cli/internal/cmd/hetzner-robot/hetzner_robot_test.go
@@ -281,6 +281,35 @@ func TestPrintFailoverList(t *testing.T) {
 	}
 }
 
+func TestPrintFirewallGet(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		Result: json.RawMessage(`{"firewall":{"server_ip":"1.2.3.1","status":"active","whitelist_hos":true,"filter_ipv6":false,"port":"main","rules":{"input":[{"name":"operator-https","ip_version":"ipv4","src_ip":"198.51.100.7/32","dst_port":"443","protocol":"tcp","action":"accept"},{"name":"default-discard","action":"discard"}],"output":[]}}}`),
+	}
+	var buf bytes.Buffer
+	printFirewallGet(&buf, r)
+	out := buf.String()
+	for _, want := range []string{
+		"status=ok", "active", "whitelist_hos", "input rules (2)",
+		"operator-https", "198.51.100.7/32", "443", "default-discard",
+		"discard", "output rules (0)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printFirewallGet missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintFirewallGetEmptySandbox(t *testing.T) {
+	// The sandbox returns 200 + {} for a single-object GET; render must not crash.
+	r := &CallResult{Status: "ok", Result: json.RawMessage(`{}`)}
+	var buf bytes.Buffer
+	printFirewallGet(&buf, r)
+	if !strings.Contains(buf.String(), "status=ok") {
+		t.Errorf("empty firewall should still print the status header; got:\n%s", buf.String())
+	}
+}
+
 func TestPrintSearchTable(t *testing.T) {
 	summary := "List dedicated servers"
 	r := &searchResponse{
@@ -478,6 +507,35 @@ func TestDispatchVswitchInfoSendsID(t *testing.T) {
 	}
 }
 
+// TestDispatchFirewallGetSendsParams — firewall get passes server-ip in params.
+func TestDispatchFirewallGetSendsParams(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			serverIP, _ := body.Params["server-ip"].(string)
+			if serverIP != "1.2.3.1" {
+				t.Errorf("server-ip: got %q want %q", serverIP, "1.2.3.1")
+			}
+			if body.OpID != "GET:/firewall/{server-ip}" {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	params := map[string]any{"server-ip": "1.2.3.1"}
+	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/firewall/{server-ip}", "rdc-robot", params); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
 // TestErrOpErrorIsSentinel — pins the exported sentinel.
 func TestErrOpErrorIsSentinel(t *testing.T) {
 	if errOpError == nil {
@@ -492,7 +550,7 @@ func TestNewRootCmdHasExpectedSubcommands(t *testing.T) {
 	for _, c := range root.Commands() {
 		names[c.Name()] = true
 	}
-	for _, expected := range []string{"about", "server", "ip", "subnet", "vswitch", "failover", "rdns", "ssh-key", "operation"} {
+	for _, expected := range []string{"about", "server", "ip", "subnet", "vswitch", "failover", "rdns", "firewall", "ssh-key", "operation"} {
 		if !names[expected] {
 			t.Errorf("expected subcommand %q under hetzner-robot; commands: %v", expected, names)
 		}

--- a/docs/codebase/connectors-hetzner-robot.md
+++ b/docs/codebase/connectors-hetzner-robot.md
@@ -7,14 +7,19 @@ for the [Hetzner Robot Webservice API](https://robot.hetzner.com/doc/webservice/
 G3.7-T7 (#846) ships the skeleton — HTTP Basic auth, fingerprint, probe,
 `_post_form` helper, and the G0.6 dispatch shim. G3.7-T8 (#849) ships the
 read-only v0.2 core: the Robot Webservice OpenAPI spec is ingested via G0.7
-into the `endpoint_descriptor` table, and the curated 10-op core is staged
+into the `endpoint_descriptor` table, and the curated read core is staged
 for operator review in `core_ops.py`. G3.7-T9 (#852) ships the read-only CLI
 verbs (`hetzner-robot about`, `server list`/`server info`, `ip list`,
 `subnet list`, `vswitch list`/`vswitch info`, `failover list`, `rdns list`,
 `ssh-key list`, and the generic `operation search`/`operation call`), the
-dispatch smoke test suite (AC1–AC5 covering all 10 read ops, JSONFlux handle
-path, audit-row assertions, and sandbox empty-array tolerance), and the
-operator onboarding doc.
+dispatch smoke test suite (AC1–AC5 covering all curated read ops, JSONFlux
+handle path, audit-row assertions, and sandbox empty-array tolerance), and the
+operator onboarding doc. Task #2848 (Initiative #2833) curates the per-server
+firewall read (`GET:/firewall/{server-ip}`) into the `robot-networking`
+group — the **11th** core op — and adds the `hetzner-robot firewall get
+<server-ip>` CLI verb, so the consumer onboarding runbook's firewall-verify
+step no longer shells `scripts/hetzner-robot.sh GET /firewall/<server-number>`
+outside MEHO's policy / audit / broadcast / JSONFlux path.
 
 Source: `backend/src/meho_backplane/connectors/hetzner_robot/`.
 
@@ -41,12 +46,15 @@ Source: `backend/src/meho_backplane/connectors/hetzner_robot/`.
 - **`ROBOT_CORE_GROUPS`** (`core_ops.py`) — 4 curated `RobotCoreGroup`
   entries with operator-reviewed `when_to_use` hints spanning the read-only
   core: `robot-about`, `robot-servers`, `robot-networking`, `robot-ssh-keys`.
-- **`ROBOT_CORE_OPS`** (`core_ops.py`) — 10 curated `RobotCoreOp` entries
+- **`ROBOT_CORE_OPS`** (`core_ops.py`) — 11 curated `RobotCoreOp` entries
   (the read-only v0.2 core), each with `op_id` (`GET:/path` form), `group_key`,
   and `llm_instructions` blob (`when_to_call` / `output_shape` / `next_step`).
+  The 11th, `GET:/firewall/{server-ip}` (#2848), reads one dedicated server's
+  packet-filter firewall (status, allowlist flag, ordered input/output rules)
+  for the onboarding firewall-verify step and classifies into `robot-networking`.
 - **`apply_robot_core_curation`** (`core_ops.py`) — async function that
   drives `ReviewService.edit_group` + `enable_group` + `edit_op` to flip the
-  10 curated ops to `is_enabled=True` and land `llm_instructions`.
+  11 curated ops to `is_enabled=True` and land `llm_instructions`.
 - **`classify_robot_op`** (`core_ops.py`) — path-prefix classifier mapping
   a `GET:/path` op_id to its curated `group_key` via `ROBOT_PATH_RULES`.
 
@@ -137,11 +145,16 @@ no OpenAPI document, MEHO ships a hand-authored minimal spec as package data:
 
 - **`operations/ingest/specs/hetzner_robot_minimal.yaml`** — OpenAPI 3.0
   covering list/get servers, vSwitch get + membership, per-server firewall
-  get/set, reverse DNS, and the `server_addon` order. The GET op_ids
-  (`GET:/server`, `GET:/server/{server-ip}`, `GET:/vswitch`,
-  `GET:/vswitch/{id}`, `GET:/firewall/{server-ip}`, `GET:/rdns`) match the
-  `ROBOT_CORE_OPS` strings so the ingested rows and the curated read core
-  agree.
+  get/set, reverse DNS, and the `server_addon` order. Each of these spec GET
+  op_ids (`GET:/server`, `GET:/server/{server-ip}`, `GET:/vswitch`,
+  `GET:/vswitch/{id}`, `GET:/firewall/{server-ip}`, `GET:/rdns`) is curated in
+  `ROBOT_CORE_OPS`, so the ingested rows and the curated read core agree on the
+  same strings. `GET:/firewall/{server-ip}` was ingested from this spec from the
+  start but only joined the curated core in #2848; before that it was
+  ingested-but-uncurated (`is_enabled=False`, no `llm_instructions`) and
+  unreachable through `search_operations` / `call_operation`. (`GET:/rdns/{ip}`
+  is the one spec GET the core deliberately leaves uncurated — the account-wide
+  `GET:/rdns` list covers the read need.)
 - Ingest via `meho connector ingest --product hetzner --version 2026.04
   --impl hetzner-rest --spec <this-file>`. The ingest guard defers to the
   registered `HetznerRobotConnector` for the triple rather than scaffolding a


### PR DESCRIPTION
## Summary

- Curate the already-ingested-but-uncurated `GET:/firewall/{server-ip}` Hetzner Robot read op into the read-only core, following the `GET:/server/{server-ip}` sibling. Adds `/firewall` to `ROBOT_PATH_RULES` (→ `robot-networking`) and a `RobotCoreOp` whose `llm_instructions` (`when_to_call` / `output_shape` / `next_step`) are grounded in a fresh Hetzner Robot Webservice doc lookup. `safety_level` stays `safe` (GET, stamped at ingest — no approval).
- Removes the consumer onboarding runbook's dependency on shelling `scripts/hetzner-robot.sh GET /firewall/<server-number>` outside MEHO's policy / audit / broadcast / JSONFlux path — the firewall-verify step is now a governed `call_operation`.
- Adds the operator CLI verb `meho hetzner-robot firewall get <server-ip>`, rendering `status`, `whitelist_hos`, and the ordered `rules.input[]` / `rules.output[]` sets.
- Wires the data-driven acceptance smoke (canary firewall response + respx routes for both the live and sandbox routers + `SMOKE_PARAMS`), bumps the core-op count 10 → 11 across the module/tests/docs, and corrects the connector doc's stale "already matches `ROBOT_CORE_OPS`" claim.

## Acceptance criteria

- [x] **`GET:/firewall/{server-ip}` in `ROBOT_PATH_RULES` → `robot-networking`** — `test_classify_robot_op_returns_correct_group[GET:/firewall/{server-ip}]` + new `test_classify_robot_op_firewall_classifies_as_networking` (anchored-prefix, no `/failover` collision) pass.
- [x] **Added to `ROBOT_CORE_OPS` with populated `llm_instructions`; count test asserts 11** — `test_robot_core_ops_count_is_10` renamed to `test_robot_core_ops_count_is_11` (asserts 11); `test_robot_core_ops_llm_instructions_all_populated` covers the new op.
- [x] **`is_enabled=True` + callable via `call_operation` after curation** — `test_apply_robot_core_curation_enables_exactly_11_ops` + acceptance `test_dispatch_smoke_robot_core_op_returns_ok[GET:/firewall/{server-ip}]` **PASSED** (real Postgres testcontainer, respx-mocked Webservice, `status='ok'`).
- [x] **Test asserts the new op classifies + curates correctly** — added the dedicated classify test + firewall param; the data-driven `test_classify_robot_op_all_core_ops_are_classified` / `enables_exactly_11_ops` families now include it.
- [x] **CLI verb `firewall get <server-ip>` rendering status / whitelist_hos / rules.input[] / rules.output[]** — `firewall.go`; `TestPrintFirewallGet`, `TestPrintFirewallGetEmptySandbox`, `TestDispatchFirewallGetSendsParams`, and `TestNewRootCmdHasExpectedSubcommands` (now lists `firewall`) pass.
- [x] **`docs/codebase/connectors-hetzner-robot.md` updated: 10 → 11, firewall bullet, L138-144 claim corrected.**
- [x] **CLI OpenAPI snapshot** — N/A: no backend route or schema changed (a curated op + a client-side cobra verb). `git status` shows no generated/snapshot drift; `make snapshot-openapi` not required.

## Test plan

- [x] `ruff check` (changed backend files) — clean
- [x] `ruff format --check` — clean (4 files already formatted)
- [x] `mypy src/.../hetzner_robot/core_ops.py` — clean
- [x] `pytest tests/test_connectors_hetzner_robot_core_ops.py` — 36 passed
- [x] `pytest tests/acceptance/test_g37_robot_dispatch_smoke.py tests/test_connectors_hetzner_robot_ingest.py` — 30 passed (incl. both `GET:/firewall/{server-ip}` cases)
- [x] `code-quality.py --diff` — 0 blockers (1 pre-existing file-size WARN)
- [x] CLI `gofmt` / `go vet` / `go build ./...` / `go test ./internal/cmd/hetzner-robot/...` — all clean/ok

## Out of scope

- `POST /firewall/{server-ip}` (`setFirewall`) write counterpart and any drift-detect-and-reapply flow — a separate write-path task.
- Bulk/fleet-wide firewall drift audit across every server — single-server read only here.
- Splitting the 759-line `core_ops.py` (pre-existing file-size warning) and refactoring the 107-line `apply_robot_core_curation` (a verbatim mirror of `apply_harbor_core_curation`, marked `# code-quality-allow:`) — out of scope; touching either in isolation would break the deliberate robot/harbor parallel.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2848
