### PR TITLE
feat(connectors): add rke2.etcd-snapshot.list read op (#2853)

### DIFF
--- a/backend/src/meho_backplane/connectors/rke2/connector.py
+++ b/backend/src/meho_backplane/connectors/rke2/connector.py
@@ -31,6 +31,10 @@ This module ships:
 * :meth:`Rke2SshConnector.etcd_snapshot_save` -- the safe, non-gated
   ``rke2.etcd-snapshot.save`` op (T4 #2431): an on-demand managed-etcd
   snapshot on a server node, returning a snapshot name + path.
+* :meth:`Rke2SshConnector.etcd_snapshot_list` -- the safe, read-only
+  ``rke2.etcd-snapshot.list`` op (#2853): enumerates the managed-etcd
+  snapshots that already exist on a server node (the ``.save`` read
+  counterpart), returning name / location / size / timestamp rows.
 * :meth:`Rke2SshConnector.execute` -- the G0.6 dispatcher shim (same
   shape as :meth:`Bind9Connector.execute` / :meth:`HolodeckConnector.execute`).
 
@@ -44,8 +48,9 @@ the bind9 anti-shape.
 The approval-gated write ops (``rke2.token.rotate`` /
 ``rke2.node.service.restart`` / ``rke2.node.config.update``) land in
 :mod:`~meho_backplane.connectors.rke2.ops_write` (sibling Tasks
-#2429/#2430) and the safe, non-gated ``rke2.etcd-snapshot.save`` (T4
-#2431) in :mod:`~meho_backplane.connectors.rke2.ops_snapshot`; all are
+#2429/#2430) and the safe, non-gated snapshot ops
+``rke2.etcd-snapshot.save`` (T4 #2431) + ``rke2.etcd-snapshot.list``
+(#2853) in :mod:`~meho_backplane.connectors.rke2.ops_snapshot`; all are
 composed onto :data:`~meho_backplane.connectors.rke2.ops.RKE2_OPS` and
 their bound-method shims live here. The dispatcher shim does not change.
 """
@@ -432,6 +437,29 @@ class Rke2SshConnector(SshConnector):
 
         return await _rke2_etcd_snapshot_save(self, target, params, operator)
 
+    async def etcd_snapshot_list(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``rke2.etcd-snapshot.list`` (#2853).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.rke2.ops_snapshot.rke2_etcd_snapshot_list`,
+        which runs the shared embedded-etcd-server precondition guard and
+        enumerates the existing managed-etcd snapshots over the shared SSH
+        adapter. Safe tier, non-gated, and genuinely read-only -- the result
+        carries snapshot names / locations / sizes / timestamps only, never
+        etcd contents. Set-shaped, so the JSONFlux reducer materialises a
+        result handle above threshold.
+        """
+        from meho_backplane.connectors.rke2.ops_snapshot import (
+            rke2_etcd_snapshot_list as _rke2_etcd_snapshot_list,
+        )
+
+        return await _rke2_etcd_snapshot_list(self, target, params, operator)
+
     @classmethod
     async def register_operations(cls) -> None:
         """Upsert every op in :data:`RKE2_OPS` into ``endpoint_descriptor``.
@@ -613,14 +641,18 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "``rke2.node.service.restart``. Transport: plain SSH."
     ),
     "rke2-etcd-snapshot": (
-        "Use to capture an on-demand managed-etcd snapshot on an RKE2 "
-        "server node before a risky change: ``rke2.etcd-snapshot.save`` "
-        "runs ``rke2 etcd-snapshot save`` as root over SSH and returns the "
-        "snapshot name + on-disk path (never etcd contents). Refuses "
-        "non-server or external-datastore nodes with a structured error. "
-        "Safe and non-mutating to running cluster state -- it copies etcd "
-        "to disk. Pair it ahead of the approval-gated node-write ops "
-        "(token rotate / config update / service restart) as the recovery "
-        "point. Transport: plain SSH."
+        "Use for managed-etcd snapshots on an RKE2 server node. "
+        "``rke2.etcd-snapshot.save`` runs ``rke2 etcd-snapshot save`` as "
+        "root over SSH and returns the snapshot name + on-disk path (never "
+        "etcd contents) -- capture one before a risky change as the "
+        "recovery point, ahead of the approval-gated node-write ops (token "
+        "rotate / config update / service restart). "
+        "``rke2.etcd-snapshot.list`` runs ``rke2 etcd-snapshot list`` and "
+        "returns the existing snapshots as ``{name, location, size_bytes, "
+        "created_at}`` rows -- read-only, and the way to CONFIRM a fresh "
+        "snapshot landed after a rotation (a snapshot taken before the "
+        "rotation was made with the retired token). Both refuse non-server "
+        "or external-datastore nodes with a structured error and are safe / "
+        "non-mutating to running cluster state. Transport: plain SSH."
     ),
 }

--- a/backend/src/meho_backplane/connectors/rke2/ops.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops.py
@@ -18,10 +18,11 @@ The approval-gated write ops land in
 :mod:`meho_backplane.connectors.rke2.ops_write` and are composed onto
 :data:`RKE2_OPS` here via :data:`WRITE_OPS`: ``rke2.token.rotate`` (T2 #2429)
 plus ``rke2.node.service.restart`` / ``rke2.node.config.update`` (T3 #2430).
-The safe, non-gated ``rke2.etcd-snapshot.save`` op (T4 #2431) is composed
-in from :mod:`~meho_backplane.connectors.rke2.ops_snapshot` via
-:data:`SNAPSHOT_OPS` -- it is the lone non-gated op in the Initiative #2172
-surface.
+The safe, non-gated snapshot ops ``rke2.etcd-snapshot.save`` (T4 #2431)
+and ``rke2.etcd-snapshot.list`` (#2853) are composed in from
+:mod:`~meho_backplane.connectors.rke2.ops_snapshot` via
+:data:`SNAPSHOT_OPS` -- the two safe / no-approval ops in the surface
+(``.save`` is active, ``.list`` is read-only).
 
 The dataclass + tuple shape mirrors
 :mod:`~meho_backplane.connectors.bind9.ops` and
@@ -136,8 +137,9 @@ def _rke2_ops() -> tuple[Rke2Op, ...]:
     read-only posture tier: ``rke2.posture.show``) + ``WRITE_OPS`` (the
     approval-gated write tier: ``rke2.token.rotate`` (T2 #2429) plus
     ``rke2.node.service.restart`` / ``rke2.node.config.update`` (T3 #2430))
-    + ``SNAPSHOT_OPS`` (the safe, non-gated ``rke2.etcd-snapshot.save`` --
-    T4 #2431). This layers the write + snapshot tiers onto the read surface
+    + ``SNAPSHOT_OPS`` (the safe, non-gated ``rke2.etcd-snapshot.save``
+    (T4 #2431) + ``rke2.etcd-snapshot.list`` (#2853)). This layers the
+    write + snapshot tiers onto the read surface
     exactly as
     :func:`meho_backplane.connectors.holodeck.ops._holodeck_ops` layers its
     ``WRITE_OPS`` on.

--- a/backend/src/meho_backplane/connectors/rke2/ops_snapshot.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_snapshot.py
@@ -1,26 +1,39 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Safe (non-gated) managed-etcd snapshot op for :class:`Rke2SshConnector`.
+"""Safe (non-gated) managed-etcd snapshot ops for :class:`Rke2SshConnector`.
 
-G-Node/RKE2-T4 (#2431) -- ``rke2.etcd-snapshot.save`` triggers an
-on-demand RKE2 managed-etcd snapshot over SSH. It is the lone
-**non-gated** op in the Initiative #2172 surface: ``safety_level="safe"``,
-``requires_approval=False`` -- deliberately, because it is read-only with
-respect to *running* cluster state (it copies the embedded etcd store to
-a file on disk) and its result carries only a snapshot name + path, never
-secret material.
+Two safe, ``requires_approval=False`` snapshot ops share this module and
+the same embedded-etcd-server precondition guard:
+
+* ``rke2.etcd-snapshot.save`` (G-Node/RKE2-T4 #2431) -- triggers an
+  on-demand RKE2 managed-etcd snapshot over SSH. Safe / non-gated because
+  it is read-only with respect to *running* cluster state (it copies the
+  embedded etcd store to a file on disk); its result carries only a
+  snapshot name + path, never secret material. It is *active* (it writes
+  a file), so it is deliberately NOT ``read-only``-tagged.
+* ``rke2.etcd-snapshot.list`` (#2853) -- enumerates the managed-etcd
+  snapshots that already exist on a server node (``rke2 etcd-snapshot
+  list``). It is a genuine read (it enumerates, mutates nothing), so it
+  carries the ``read-only`` tag. It verifies a fresh post-rotation
+  snapshot landed -- the ``claude-rdc-hetzner-dc#615`` rotation-runbook
+  step that ``.save`` alone could not confirm.
+
+A snapshot listing carries names / locations / sizes / timestamps only,
+never etcd contents, so -- like ``.save`` -- no result-envelope secret can
+leak.
 
 Design notes
 ------------
 
-* **Precondition guard (fail-closed).** A managed-etcd snapshot is only
-  meaningful on a *server* node running *embedded* etcd. The guard runs
-  first and refuses -- with a structured
-  :class:`Rke2SnapshotPreconditionError` -- when the node configures an
-  external ``datastore-endpoint`` (snapshots are unavailable there) or
-  when the embedded-etcd data directory is absent (an agent node, or a
-  server not yet initialised). No snapshot command runs on a refusal.
+* **Precondition guard (fail-closed), shared by both ops.** A managed-etcd
+  snapshot (save or list) is only meaningful on a *server* node running
+  *embedded* etcd. :func:`_run_precondition_guard` runs first and refuses
+  -- with a structured :class:`Rke2SnapshotPreconditionError` -- when the
+  node configures an external ``datastore-endpoint`` (snapshots are
+  unavailable there) or when the embedded-etcd data directory is absent
+  (an agent node, or a server not yet initialised). No snapshot command
+  runs on a refusal.
 
 * **Name bounding (fail-closed, defence-in-depth).** The single optional
   ``name`` parameter is charset-bounded to ``^[A-Za-z0-9._-]+$`` at the
@@ -46,9 +59,27 @@ Design notes
 
 * **No secret in the result.** ``rke2 etcd-snapshot save`` logs
   ``Snapshot <name> saved.``; the handler parses that name and returns
-  ``{snapshot_name, path, exit_status}``. The snapshot *file* holds etcd
-  bootstrap data, but the result envelope (and thus the audit
-  ``raw_payload``) does not, so no redaction pin is required.
+  ``{snapshot_name, path, exit_status}``. ``rke2 etcd-snapshot list``
+  prints a ``Name / Location / Size / Created`` table; the handler parses
+  it into ``{snapshots: [{name, location, size_bytes, created_at}, ...]}``.
+  The snapshot *files* hold etcd bootstrap data, but neither result
+  envelope (and thus neither audit ``raw_payload``) does, so no redaction
+  pin is required.
+
+* **List output parsing (version-drift-resilient).** RKE2's own docs
+  (``docs.rke2.io/datastore/backup_restore``) document only the fixed
+  ``Name / Location / Size / Created`` table for ``etcd-snapshot list``;
+  a ``-o json`` flag was requested upstream (``k3s-io/k3s#5130``) but its
+  schema and per-version availability are NOT documented, so this handler
+  parses the documented table rather than an unconfirmed JSON shape. The
+  ``Location`` column varies across versions (``local`` / a ``file://``
+  URL / a bare path / an ``s3://`` URL) and the ``Size`` column may be a
+  raw byte count or a human string, so each row is matched by a regex that
+  anchors the ``Created`` column as an ISO-8601 timestamp (which skips the
+  header line regardless of casing) and passes ``location`` through
+  verbatim; ``size_bytes`` is the integer byte count when the ``Size``
+  column is a bare integer and ``null`` otherwise (fail-closed, never a
+  guessed conversion).
 """
 
 from __future__ import annotations
@@ -70,6 +101,8 @@ __all__ = [
     "Rke2SnapshotNameError",
     "Rke2SnapshotPreconditionError",
     "parse_saved_snapshot_name",
+    "parse_snapshot_list",
+    "rke2_etcd_snapshot_list",
     "rke2_etcd_snapshot_save",
 ]
 
@@ -100,6 +133,20 @@ _SNAPSHOT_NAME_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9._-]+$")
 #: only, not a path) via logrus. The regex recovers ``<name>`` from
 #: stdout or stderr; the returned ``path`` is composed from it.
 _SNAPSHOT_SAVED_RE: re.Pattern[str] = re.compile(r"Snapshot\s+(\S+)\s+saved")
+
+#: One row of ``rke2 etcd-snapshot list``'s ``Name / Location / Size /
+#: Created`` table. ``name`` and ``location`` are single whitespace-free
+#: tokens (a charset-bounded snapshot name; a ``local`` / ``file://`` /
+#: bare-path / ``s3://`` location -- none contain spaces). ``size`` is
+#: lazy so a human-readable ``Size`` column (``50 MiB``) is captured whole
+#: even though the documented format is a bare byte count. ``created`` is
+#: anchored to an ISO-8601 timestamp, which is what lets this same regex
+#: skip the header row (its ``Created`` label is not a timestamp) without
+#: depending on the header's casing.
+_SNAPSHOT_LIST_ROW_RE: re.Pattern[str] = re.compile(
+    r"^(?P<name>\S+)\s+(?P<location>\S+)\s+(?P<size>.+?)\s+"
+    r"(?P<created>\d{4}-\d{2}-\d{2}T[0-9:.+Z-]+)\s*$"
+)
 
 #: Precondition guard: emit a single sentinel token describing the node's
 #: snapshot eligibility. ``external-datastore`` when a ``datastore-endpoint``
@@ -151,6 +198,55 @@ def parse_saved_snapshot_name(output: str) -> str | None:
     return match.group(1) if match else None
 
 
+def parse_snapshot_list(output: str) -> list[dict[str, Any]]:
+    """Parse ``rke2 etcd-snapshot list`` table output into snapshot rows.
+
+    RKE2 prints a ``Name / Location / Size / Created`` table. Each data row
+    is turned into ``{"name", "location", "size_bytes", "created_at"}``:
+
+    * ``name`` / ``location`` -- passed through verbatim (``location`` is
+      whatever the vendor emits: ``local``, a ``file://`` URL, a bare path,
+      or an ``s3://`` URL).
+    * ``size_bytes`` -- the integer byte count when the ``Size`` column is
+      a bare integer (the documented format), else ``None`` -- never a
+      guessed unit conversion.
+    * ``created_at`` -- the ISO-8601 timestamp string.
+
+    The header row and any non-matching line (a banner, a blank line, a
+    "no snapshots" notice) are skipped: only lines whose final column is an
+    ISO-8601 timestamp are treated as rows, so the header's ``Created``
+    label -- whatever its casing -- never parses as a snapshot.
+
+    Examples
+    --------
+
+    >>> rows = parse_snapshot_list(
+    ...     "Name  Location  Size  Created\\n"
+    ...     "on-demand-srv-0-1  local  52428800  2026-08-06T09:12:03Z\\n"
+    ... )
+    >>> rows == [{
+    ...     "name": "on-demand-srv-0-1", "location": "local",
+    ...     "size_bytes": 52428800, "created_at": "2026-08-06T09:12:03Z",
+    ... }]
+    True
+    """
+    rows: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        match = _SNAPSHOT_LIST_ROW_RE.match(line.strip())
+        if match is None:
+            continue
+        size_raw = match.group("size").strip()
+        rows.append(
+            {
+                "name": match.group("name"),
+                "location": match.group("location"),
+                "size_bytes": int(size_raw) if size_raw.isdigit() else None,
+                "created_at": match.group("created"),
+            }
+        )
+    return rows
+
+
 def _validate_name(name: Any) -> str | None:
     """Fail-closed re-check of the optional ``name`` param.
 
@@ -167,6 +263,54 @@ def _validate_name(name: Any) -> str | None:
             "dot, underscore, hyphen); no path separators or whitespace"
         )
     return name
+
+
+async def _run_precondition_guard(
+    connector: Rke2SshConnector,
+    target: Target,
+    operator: Operator | None = None,
+) -> None:
+    """Run the shared embedded-etcd-server precondition guard.
+
+    Both snapshot ops (``.save`` and ``.list``) enforce the identical
+    precondition through this one function -- a genuine reuse of
+    :data:`_GUARD_CMD`, not a per-op reimplementation. Returns ``None`` on
+    the ``ok`` verdict; otherwise raises:
+
+    * :class:`Rke2SnapshotError` when the guard itself could not run over
+      SSH. ``_run_command`` wraps ``conn.run(check=False)``, so a
+      transport / SSH / shell failure returns a non-zero exit with
+      (typically) empty stdout; the guard prints a sentinel token and
+      exits 0 on every *real* verdict (external-datastore / no-embedded-etcd
+      / ok), so a non-zero exit is unambiguously an infrastructure failure.
+      Interpreting that empty verdict as "not an embedded-etcd server"
+      would mislabel it. Fail closed either way, but with the accurate
+      cause.
+    * :class:`Rke2SnapshotPreconditionError` on ``external-datastore``
+      (snapshots do not apply to an external datastore-endpoint) or any
+      non-``ok`` verdict (agent node / uninitialised server).
+    """
+    guard = await connector._run_command(target, _GUARD_CMD, operator=operator)
+    guard_exit = getattr(guard, "exit_status", None)
+    if guard_exit not in (0, None):
+        guard_err = getattr(guard, "stderr", "") if hasattr(guard, "stderr") else ""
+        guard_err_txt = guard_err.strip()[:400] if isinstance(guard_err, str) else ""
+        raise Rke2SnapshotError(
+            "the snapshot precondition guard failed to run over SSH "
+            f"(exit {guard_exit}): {guard_err_txt or 'no stderr'}"
+        )
+    guard_raw = guard.stdout if hasattr(guard, "stdout") else ""
+    verdict = guard_raw.strip() if isinstance(guard_raw, str) else ""
+    if verdict == "external-datastore":
+        raise Rke2SnapshotPreconditionError(
+            "this RKE2 node configures an external datastore-endpoint; "
+            "managed-etcd snapshots apply to embedded etcd only"
+        )
+    if verdict != "ok":
+        raise Rke2SnapshotPreconditionError(
+            "this RKE2 node is not an embedded-etcd server "
+            "(no server/db/etcd data directory); cannot take a snapshot"
+        )
 
 
 async def rke2_etcd_snapshot_save(
@@ -192,35 +336,7 @@ async def rke2_etcd_snapshot_save(
     """
     name = _validate_name(params.get("name"))
 
-    guard = await connector._run_command(target, _GUARD_CMD, operator=operator)
-    # M1: check the guard's own exit status first. ``_run_command`` wraps
-    # ``conn.run(check=False)``, so a transport / SSH / shell failure returns
-    # a non-zero exit with (typically) empty stdout -- interpreting that
-    # empty verdict as "not an embedded-etcd server" would mislabel an
-    # infrastructure failure as a node-role verdict. The guard prints a
-    # sentinel token and exits 0 on every real verdict (external-datastore /
-    # no-embedded-etcd / ok), so a non-zero exit is unambiguously a transport
-    # failure. Fail closed either way, but with the accurate cause.
-    guard_exit = getattr(guard, "exit_status", None)
-    if guard_exit not in (0, None):
-        guard_err = getattr(guard, "stderr", "") if hasattr(guard, "stderr") else ""
-        guard_err_txt = guard_err.strip()[:400] if isinstance(guard_err, str) else ""
-        raise Rke2SnapshotError(
-            "the snapshot precondition guard failed to run over SSH "
-            f"(exit {guard_exit}): {guard_err_txt or 'no stderr'}"
-        )
-    guard_raw = guard.stdout if hasattr(guard, "stdout") else ""
-    verdict = guard_raw.strip() if isinstance(guard_raw, str) else ""
-    if verdict == "external-datastore":
-        raise Rke2SnapshotPreconditionError(
-            "this RKE2 node configures an external datastore-endpoint; "
-            "managed-etcd snapshots apply to embedded etcd only"
-        )
-    if verdict != "ok":
-        raise Rke2SnapshotPreconditionError(
-            "this RKE2 node is not an embedded-etcd server "
-            "(no server/db/etcd data directory); cannot take a snapshot"
-        )
+    await _run_precondition_guard(connector, target, operator)
 
     argv = [_RKE2_BIN, "etcd-snapshot", "save"]
     if name is not None:
@@ -250,6 +366,55 @@ async def rke2_etcd_snapshot_save(
         "path": path,
         "exit_status": exit_status,
     }
+
+
+async def rke2_etcd_snapshot_list(
+    connector: Rke2SshConnector,
+    target: Target,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``rke2.etcd-snapshot.list``.
+
+    Runs the shared embedded-etcd-server precondition guard, then
+    enumerates existing managed-etcd snapshots via
+    ``/var/lib/rancher/rke2/bin/rke2 etcd-snapshot list``, run as root over
+    plain SSH -- no ``sudo`` argv, the same privilege model as ``.save``.
+    Takes no operator parameters (the local snapshot store only; S3 listing
+    is out of scope). Returns
+    ``{"snapshots": [{name, location, size_bytes, created_at}, ...]}`` --
+    a set-shaped payload the central JSONFlux reducer materialises into a
+    result handle above its row / byte threshold. The listing carries no
+    etcd contents, so nothing in the result envelope is secret.
+
+    Raises :class:`Rke2SnapshotPreconditionError` (non-server /
+    external-datastore node -- the same guard ``.save`` runs) or
+    :class:`Rke2SnapshotError` (non-zero ``rke2`` exit); the dispatcher
+    maps each to a non-ok ``connector_error`` result. Transport / auth
+    failures propagate the same way (#986).
+    """
+    del params  # no operator params; the local snapshot store is fixed
+
+    await _run_precondition_guard(connector, target, operator)
+
+    # Plain (root) invocation via ``_run_command`` -- no ``sudo`` argv, same
+    # as ``.save``. ``shlex.quote`` bounds the fixed argv defensively (a
+    # no-op here, since no operator input is interpolated).
+    list_cmd = " ".join(shlex.quote(arg) for arg in [_RKE2_BIN, "etcd-snapshot", "list"])
+    proc = await connector._run_command(target, list_cmd, operator=operator, timeout=60.0)
+    exit_status = getattr(proc, "exit_status", None)
+
+    stdout_raw = proc.stdout if hasattr(proc, "stdout") else ""
+    stderr_raw = proc.stderr if hasattr(proc, "stderr") else ""
+    stdout = stdout_raw if isinstance(stdout_raw, str) else ""
+    stderr = stderr_raw if isinstance(stderr_raw, str) else ""
+
+    if exit_status not in (0, None) and exit_status != 0:
+        raise Rke2SnapshotError(
+            f"rke2 etcd-snapshot list exited {exit_status}: {(stderr or stdout).strip()[:400]}"
+        )
+
+    return {"snapshots": parse_snapshot_list(stdout)}
 
 
 _RKE2_ETCD_SNAPSHOT_SAVE_OP = Rke2Op(
@@ -326,7 +491,89 @@ _RKE2_ETCD_SNAPSHOT_SAVE_OP = Rke2Op(
 )
 
 
-#: The safe (non-gated) snapshot tier. Composed alongside the read ops +
-#: the approval-gated write ops in
+_RKE2_ETCD_SNAPSHOT_LIST_OP = Rke2Op(
+    op_id="rke2.etcd-snapshot.list",
+    handler_attr="etcd_snapshot_list",
+    summary="List the managed-etcd snapshots on an RKE2 server node.",
+    description=(
+        "Runs ``rke2 etcd-snapshot list`` on an RKE2 server node over SSH "
+        "to enumerate the managed-etcd snapshots that already exist under "
+        "``/var/lib/rancher/rke2/server/db/snapshots`` (plus any remote "
+        "store the node reports). Returns one row per snapshot with its "
+        "name, location, size in bytes, and creation timestamp -- never "
+        "etcd contents. The same fail-closed precondition guard as "
+        "``rke2.etcd-snapshot.save`` refuses a node that is not an "
+        "embedded-etcd server (agent node, or one configuring an external "
+        "``datastore-endpoint``). Safe tier, non-gated, and genuinely "
+        "read-only (it enumerates, mutating nothing). Use it to confirm a "
+        "fresh snapshot landed after a token rotation / config change, or "
+        "to inventory recovery points before a risky op."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "snapshots": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "location": {"type": "string"},
+                        "size_bytes": {"type": ["integer", "null"]},
+                        "created_at": {"type": "string"},
+                    },
+                    "required": ["name", "location", "size_bytes", "created_at"],
+                    "additionalProperties": False,
+                },
+            },
+        },
+        "required": ["snapshots"],
+        "additionalProperties": False,
+    },
+    group_key="rke2-etcd-snapshot",
+    tags=("read-only", "etcd", "snapshot", "rke2"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to inventory the managed-etcd snapshots on an RKE2 server "
+            "node: which snapshots exist, how old and how large they are. "
+            "The mandatory post-check of a safe token rotation -- confirm a "
+            "FRESH snapshot landed after the rotation, since a snapshot "
+            "taken before it was made with the retired token. Returns rows "
+            "of ``{name, location, size_bytes, created_at}``; never etcd "
+            "contents. Refuses non-server / external-datastore nodes with a "
+            "structured error. Safe and read-only. " + SSH_TRANSPORT_NOTE
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "``{snapshots: [{name, location, size_bytes, created_at}, "
+            "...]}``. A set-shaped payload: above the reducer threshold it "
+            "is returned as a JSONFlux result handle -- drill in with "
+            "``result_query`` / ``result_aggregate`` (e.g. newest "
+            "``created_at``) rather than expecting every row inline. "
+            "``location`` is whatever RKE2 reports (``local`` / a "
+            "``file://`` URL / a bare path / an ``s3://`` URL). "
+            "``size_bytes`` is the integer byte count, or null when RKE2 "
+            "printed a non-integer size. ``created_at`` is an ISO-8601 "
+            "timestamp. An empty ``snapshots`` list means the node has no "
+            "snapshots (NOT an error)."
+        ),
+    },
+)
+
+
+#: The safe (non-gated) snapshot tier: the *active* ``.save`` op (copies
+#: etcd to disk -- not ``read-only``-tagged) and the genuinely read-only
+#: ``.list`` op (enumerates existing snapshots). Composed alongside the
+#: read ops + the approval-gated write ops in
 #: :func:`meho_backplane.connectors.rke2.ops._rke2_ops`.
-SNAPSHOT_OPS: tuple[Rke2Op, ...] = (_RKE2_ETCD_SNAPSHOT_SAVE_OP,)
+SNAPSHOT_OPS: tuple[Rke2Op, ...] = (
+    _RKE2_ETCD_SNAPSHOT_SAVE_OP,
+    _RKE2_ETCD_SNAPSHOT_LIST_OP,
+)

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -30,20 +30,25 @@ Coverage matrix (per Task #2221 acceptance criteria):
   ``LoadState=not-found`` nulls the live-state fields; a non-zero
   ``NRestarts`` surfaces as the crash-loop signal; the probe raises
   :class:`Rke2ServiceStatusProbeError` when ``systemctl`` is absent.
-* ``RKE2_OPS`` registration shape -- 7 ops: three read (``rke2.about`` /
+* ``RKE2_OPS`` registration shape -- 8 ops: three read (``rke2.about`` /
   ``rke2.posture.show``, T1 #2221; ``rke2.node.service.status``, #2852),
   three approval-gated write (``rke2.token.rotate`` T2 #2429,
   ``rke2.node.service.restart`` / ``rke2.node.config.update`` T3 #2430), and
-  one safe non-gated snapshot (``rke2.etcd-snapshot.save`` T4 #2431). Read
-  ops are safe / read-only / no-approval and take no params; write ops are
-  dangerous / approval-gated; the snapshot op is safe / no-approval but
-  neither read-only nor write and takes an optional charset-bounded
-  ``name``. Every op has ``additionalProperties=False`` on its parameter
-  schema, a non-empty SSH-transport ``when_to_use``, and a ``rke2.`` op_id
-  with a handler method on the class.
+  two safe non-gated snapshot (``rke2.etcd-snapshot.save`` T4 #2431,
+  ``rke2.etcd-snapshot.list`` #2853). Read ops are safe / read-only /
+  no-approval and take no params; write ops are dangerous / approval-gated;
+  ``.save`` is safe / no-approval but active (neither read-only nor write)
+  and takes an optional charset-bounded ``name``; ``.list`` is safe /
+  no-approval / read-only and takes no params. Every op has
+  ``additionalProperties=False`` on its parameter schema, a non-empty
+  SSH-transport ``when_to_use``, and a ``rke2.`` op_id with a handler method
+  on the class.
 * ``rke2.etcd-snapshot.save`` handler -- name charset re-check
-  (fail-closed), the embedded-etcd-server precondition guard, and a
+  (fail-closed), the shared embedded-etcd-server precondition guard, and a
   bounded-name save parsed from the RKE2 ``Snapshot <name> saved.`` log.
+* ``rke2.etcd-snapshot.list`` handler -- the *same* shared precondition
+  guard, and a version-drift-resilient parse of the RKE2 ``Name / Location
+  / Size / Created`` table into ``{snapshots: [...]}`` rows.
 """
 
 from __future__ import annotations
@@ -83,6 +88,7 @@ from meho_backplane.connectors.rke2.ops_snapshot import (
     Rke2SnapshotNameError,
     Rke2SnapshotPreconditionError,
     parse_saved_snapshot_name,
+    parse_snapshot_list,
 )
 from meho_backplane.settings import get_settings
 from tests._ssh_vault_stub import stub_ssh_vault_secrets
@@ -732,19 +738,27 @@ _WRITE_OP_IDS: frozenset[str] = frozenset(
     {"rke2.token.rotate", "rke2.node.service.restart", "rke2.node.config.update"}
 )
 
-#: The safe, non-gated snapshot tier (T4 #2431): ``rke2.etcd-snapshot.save``.
-#: Safe-tier / no-approval like the read ops, but it is active (it copies etcd
-#: to disk), so it carries NEITHER the read-only tag NOR the dangerous/write
-#: tier -- it belongs to neither sweep set.
-_SNAPSHOT_OP_IDS: frozenset[str] = frozenset({"rke2.etcd-snapshot.save"})
+#: The safe, non-gated snapshot tier: ``.save`` (T4 #2431) + ``.list``
+#: (#2853). Both are safe-tier / no-approval like the read ops.
+_SNAPSHOT_OP_IDS: frozenset[str] = frozenset({"rke2.etcd-snapshot.save", "rke2.etcd-snapshot.list"})
+
+#: The *active* snapshot op: ``.save`` copies etcd to disk, so it carries
+#: NEITHER the read-only tag NOR the dangerous/write tier -- it belongs to
+#: neither sweep set. (``.list``, by contrast, is a genuine read.)
+_SNAPSHOT_ACTIVE_OP_IDS: frozenset[str] = frozenset({"rke2.etcd-snapshot.save"})
+
+#: Every op that must carry the ``read-only`` tag: the identity/posture read
+#: tier plus the read-only ``.list`` snapshot op (#2853). ``.save`` is
+#: deliberately excluded (it is active).
+_READ_ONLY_TAGGED_OP_IDS: frozenset[str] = _READ_OP_IDS | frozenset({"rke2.etcd-snapshot.list"})
 
 _EXPECTED_OP_IDS: frozenset[str] = _READ_OP_IDS | _WRITE_OP_IDS | _SNAPSHOT_OP_IDS
 
 
 def test_rke2_ops_count_matches_expected() -> None:
     # Three read ops (#2221 posture/about + #2852 service.status) + three
-    # approval-gated write ops (#2429 / #2430) + one safe non-gated snapshot
-    # op (#2431) = seven.
+    # approval-gated write ops (#2429 / #2430) + two safe non-gated snapshot
+    # ops (.save #2431, .list #2853) = eight.
     assert len(RKE2_OPS) == len(_EXPECTED_OP_IDS)
 
 
@@ -772,30 +786,52 @@ def test_rke2_read_ops_all_safe_read_only_no_approval() -> None:
 
 
 def test_rke2_read_ops_tagged_read_only() -> None:
-    """The read-tier ops carry the read-only tag; the snapshot op does not."""
+    """Read-tier ops + ``.list`` carry the read-only tag; ``.save`` does not."""
     by_id = {op.op_id: op for op in RKE2_OPS}
-    for op_id in _READ_OP_IDS:
+    for op_id in _READ_ONLY_TAGGED_OP_IDS:
         assert "read-only" in by_id[op_id].tags, f"{op_id!r} missing read-only tag"
-    # The snapshot op is active (copies etcd to disk), so it is NOT read-only.
-    assert "read-only" not in by_id["rke2.etcd-snapshot.save"].tags
+    # ``.save`` is active (copies etcd to disk), so it is NOT read-only.
+    for op_id in _SNAPSHOT_ACTIVE_OP_IDS:
+        assert "read-only" not in by_id[op_id].tags, f"{op_id!r} must not be read-only"
 
 
 def test_rke2_snapshot_op_safe_active_not_gated() -> None:
-    """AC: the snapshot op is safe-tier / no-approval, but neither read nor write.
+    """AC: the active snapshot op is safe-tier / no-approval, neither read nor write.
 
     ``rke2.etcd-snapshot.save`` copies etcd to disk -- it is active on the node
     filesystem yet does not mutate running cluster state, so it is deliberately
     safe-tier and non-gated. It must sit in NEITHER sweep set: not read-only
-    (no ``read-only`` tag) and not the dangerous/approval write tier.
+    (no ``read-only`` tag) and not the dangerous/approval write tier. (``.list``
+    is a genuine read and IS read-only -- covered separately.)
     """
     by_id = {op.op_id: op for op in RKE2_OPS}
-    for op_id in _SNAPSHOT_OP_IDS:
+    for op_id in _SNAPSHOT_ACTIVE_OP_IDS:
         op = by_id[op_id]
         assert op.safety_level == "safe", f"{op_id!r} is not safe-tier"
         assert op.requires_approval is False, f"{op_id!r} requires approval"
         assert "read-only" not in op.tags, f"{op_id!r} must not be read-only-tagged"
         assert op_id not in _READ_OP_IDS
         assert op_id not in _WRITE_OP_IDS
+
+
+def test_rke2_snapshot_list_is_read_only_safe_no_approval() -> None:
+    """AC: ``.list`` is safe-tier / no-approval / read-only (unlike ``.save``).
+
+    Unlike ``.save`` (active), ``rke2.etcd-snapshot.list`` only enumerates
+    existing snapshots -- a genuine read -- so it carries the ``read-only`` tag
+    and is counted in the snapshot tier, but it is NOT in the dangerous/approval
+    write set.
+    """
+    by_id = {op.op_id: op for op in RKE2_OPS}
+    op = by_id["rke2.etcd-snapshot.list"]
+    assert op.safety_level == "safe"
+    assert op.requires_approval is False
+    assert "read-only" in op.tags, "'.list' must be read-only-tagged"
+    assert "rke2.etcd-snapshot.list" in _SNAPSHOT_OP_IDS
+    assert "rke2.etcd-snapshot.list" not in _WRITE_OP_IDS
+    # No operator params: the local snapshot store is fixed.
+    assert op.parameter_schema.get("properties") == {}
+    assert op.parameter_schema.get("additionalProperties") is False
 
 
 def test_rke2_write_ops_all_dangerous_approval_gated() -> None:
@@ -992,6 +1028,169 @@ async def test_etcd_snapshot_save_never_leaks_credentials(
         mock_cmd.side_effect = sequence
         with caplog.at_level("DEBUG"):
             result = await connector.etcd_snapshot_save(_TARGET, {})
+    rendered = repr(result)
+    for canary in (_CANARY_PASSWORD, _CANARY_SSH_KEY, _CANARY_TOKEN_VALUE):
+        assert canary not in rendered
+        assert canary not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# etcd-snapshot.list handler (#2853)
+# ---------------------------------------------------------------------------
+
+
+# A realistic ``rke2 etcd-snapshot list`` transcript: a header row and three
+# snapshot rows (two local ``file://``, one ``s3://``). The first row's size is
+# non-trivial (50 MiB) per the acceptance criterion; sizes are the documented
+# raw-byte integers. Each row is split across adjacent string literals (the
+# real vendor lines exceed the 100-col lint limit); they concatenate at compile
+# time, and the parser is whitespace-count-insensitive.
+_LIST_TABLE_OK = (
+    "Name  Location  Size  Created\n"
+    "on-demand-srv-0-1754471523  "
+    "file:///var/lib/rancher/rke2/server/db/snapshots/on-demand-srv-0-1754471523  "
+    "52428800  2026-08-06T09:12:03Z\n"
+    "on-demand-srv-0-1754385123  "
+    "file:///var/lib/rancher/rke2/server/db/snapshots/on-demand-srv-0-1754385123  "
+    "51380224  2026-08-05T09:12:03Z\n"
+    "etcd-snapshot-srv-0-1754298723  "
+    "s3://rke2-backups/etcd-snapshot-srv-0-1754298723  "
+    "50331648  2026-08-04T09:12:03Z\n"
+)
+
+
+def test_parse_snapshot_list_parses_rows() -> None:
+    rows = parse_snapshot_list(_LIST_TABLE_OK)
+    assert rows == [
+        {
+            "name": "on-demand-srv-0-1754471523",
+            "location": (
+                "file:///var/lib/rancher/rke2/server/db/snapshots/on-demand-srv-0-1754471523"
+            ),
+            "size_bytes": 52428800,
+            "created_at": "2026-08-06T09:12:03Z",
+        },
+        {
+            "name": "on-demand-srv-0-1754385123",
+            "location": (
+                "file:///var/lib/rancher/rke2/server/db/snapshots/on-demand-srv-0-1754385123"
+            ),
+            "size_bytes": 51380224,
+            "created_at": "2026-08-05T09:12:03Z",
+        },
+        {
+            "name": "etcd-snapshot-srv-0-1754298723",
+            "location": "s3://rke2-backups/etcd-snapshot-srv-0-1754298723",
+            "size_bytes": 50331648,
+            "created_at": "2026-08-04T09:12:03Z",
+        },
+    ]
+
+
+def test_parse_snapshot_list_skips_header_regardless_of_casing() -> None:
+    # An UPPERCASE header (some versions) and a "no snapshots" notice are both
+    # skipped: neither ends in an ISO-8601 timestamp.
+    out = "NAME  LOCATION  SIZE  CREATED\nNo snapshots found\n"
+    assert parse_snapshot_list(out) == []
+
+
+def test_parse_snapshot_list_empty_output() -> None:
+    assert parse_snapshot_list("") == []
+    assert parse_snapshot_list("\n  \n") == []
+
+
+def test_parse_snapshot_list_non_integer_size_is_null() -> None:
+    # Version drift: a human-readable ``Size`` column parses to size_bytes=None
+    # (fail-closed) rather than a guessed byte conversion; the row survives.
+    out = "legacy-snap-1  local  50 MiB  2026-08-01T00:00:00Z\n"
+    rows = parse_snapshot_list(out)
+    assert rows == [
+        {
+            "name": "legacy-snap-1",
+            "location": "local",
+            "size_bytes": None,
+            "created_at": "2026-08-01T00:00:00Z",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_list_success_parses_and_no_sudo() -> None:
+    connector = Rke2SshConnector()
+    # side_effect order: precondition guard, then the list command.
+    sequence = [
+        _proc(stdout="ok\n"),
+        _proc(stdout=_LIST_TABLE_OK, exit_status=0),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        result = await connector.etcd_snapshot_list(_TARGET, {})
+    assert [s["name"] for s in result["snapshots"]] == [
+        "on-demand-srv-0-1754471523",
+        "on-demand-srv-0-1754385123",
+        "etcd-snapshot-srv-0-1754298723",
+    ]
+    assert result["snapshots"][0]["size_bytes"] == 52428800
+    issued = [call.args[1] for call in mock_cmd.await_args_list]
+    # Guard runs first (plain, as root -- no sudo argv); then the list by
+    # absolute binary path. No command constructs a sudo argv.
+    assert issued[0].startswith("sh -c ")
+    assert "datastore-endpoint" in issued[0]
+    assert issued[1] == "/var/lib/rancher/rke2/bin/rke2 etcd-snapshot list"
+    assert not any("sudo" in cmd for cmd in issued)
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_list_reuses_guard_refuses_external_datastore() -> None:
+    """AC: ``.list`` raises the SAME precondition error as ``.save`` (shared guard)."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="external-datastore\n")
+        with pytest.raises(Rke2SnapshotPreconditionError, match="external datastore"):
+            await connector.etcd_snapshot_list(_TARGET, {})
+    # Guard ran; the list command never did (single await).
+    mock_cmd.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_list_reuses_guard_refuses_non_server_node() -> None:
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="no-embedded-etcd\n")
+        with pytest.raises(Rke2SnapshotPreconditionError, match="embedded-etcd server"):
+            await connector.etcd_snapshot_list(_TARGET, {})
+    mock_cmd.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_list_nonzero_exit_raises() -> None:
+    from meho_backplane.connectors.rke2.ops_snapshot import Rke2SnapshotError
+
+    connector = Rke2SshConnector()
+    sequence = [
+        _proc(stdout="ok\n"),
+        _proc(stderr="FATA[0000] failed to list snapshots\n", exit_status=1),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        with pytest.raises(Rke2SnapshotError, match="list exited 1"):
+            await connector.etcd_snapshot_list(_TARGET, {})
+
+
+@pytest.mark.asyncio
+async def test_etcd_snapshot_list_never_leaks_credentials(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No SSH/sudo credential material appears in the result or logs."""
+    connector = Rke2SshConnector()
+    sequence = [
+        _proc(stdout="ok\n"),
+        _proc(stdout=_LIST_TABLE_OK, exit_status=0),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        with caplog.at_level("DEBUG"):
+            result = await connector.etcd_snapshot_list(_TARGET, {})
     rendered = repr(result)
     for canary in (_CANARY_PASSWORD, _CANARY_SSH_KEY, _CANARY_TOKEN_VALUE):
         assert canary not in rendered

--- a/backend/tests/test_connectors_rke2_e2e.py
+++ b/backend/tests/test_connectors_rke2_e2e.py
@@ -4,8 +4,9 @@
 """RKE2 connector recorded-fixture / asyncssh fake-shell E2E test (#2221).
 
 Drives ``rke2.about``, ``rke2.posture.show``, the service-state read
-``rke2.node.service.status`` (#2852) and the safe, non-gated
-``rke2.etcd-snapshot.save`` (T4 #2431) through the full ``call_operation``
+``rke2.node.service.status`` (#2852) and the safe, non-gated snapshot ops
+``rke2.etcd-snapshot.save`` (T4 #2431) + the read-only
+``rke2.etcd-snapshot.list`` (#2853) through the full ``call_operation``
 dispatch stack against an in-process asyncssh fake-shell server that
 replays plain-SSH command stubs -- no Docker dependency, no live RKE2
 node. The shape mirrors the G3.8 Holodeck recorded-fixture E2E precedent
@@ -96,6 +97,19 @@ _SERVICE_STATUS_FIXTURE = (
 _SNAPSHOT_GUARD_FIXTURE = "ok\n"
 # `rke2 etcd-snapshot save` logs the saved snapshot name to stderr.
 _SNAPSHOT_SAVE_FIXTURE = "INFO[0000] Snapshot pre-upgrade-rke2-node-e2e-1754907117 saved.\n"
+# `rke2 etcd-snapshot list` prints the Name/Location/Size/Created table to
+# stdout (two local snapshots; sizes are the documented raw-byte integers).
+# Rows are split across adjacent string literals (real vendor lines exceed the
+# 100-col lint limit) that concatenate at compile time.
+_SNAPSHOT_LIST_FIXTURE = (
+    "Name  Location  Size  Created\n"
+    "on-demand-rke2-node-e2e-1754907117  "
+    "file:///var/lib/rancher/rke2/server/db/snapshots/on-demand-rke2-node-e2e-1754907117  "
+    "52428800  2026-08-06T09:12:03Z\n"
+    "on-demand-rke2-node-e2e-1754820717  "
+    "file:///var/lib/rancher/rke2/server/db/snapshots/on-demand-rke2-node-e2e-1754820717  "
+    "51380224  2026-08-05T09:12:03Z\n"
+)
 
 # A canary token value the fixture never emits (posture never reads the
 # token content). Asserted absent from every dispatch result.
@@ -143,6 +157,10 @@ async def _fake_shell_process_factory(process: Any) -> None:
         process.stderr.write(_SNAPSHOT_SAVE_FIXTURE)
         process.exit(0)
         return
+    elif cmd.startswith("/var/lib/rancher/rke2/bin/rke2 etcd-snapshot list"):
+        # rke2.etcd-snapshot.list -- run as root over plain SSH (no sudo argv).
+        # rke2 prints the snapshot table to stdout.
+        response = _SNAPSHOT_LIST_FIXTURE
     elif cmd.startswith("sh -c "):
         # etcd-snapshot precondition guard (plain, as root) -- report an
         # embedded-etcd server node.
@@ -481,6 +499,41 @@ async def test_rke2_e2e_etcd_snapshot_save_dispatches_ok_non_gated(
         "/var/lib/rancher/rke2/server/db/snapshots/pre-upgrade-rke2-node-e2e-1754907117"
     )
     assert payload["exit_status"] == 0
+
+
+@pytest.mark.asyncio
+async def test_rke2_e2e_etcd_snapshot_list_dispatches_ok_read_only(
+    rke2_e2e: _Rke2E2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """rke2.etcd-snapshot.list (safe, read-only) enumerates snapshots via dispatch.
+
+    A TENANT_ADMIN dispatch of the safe, no-approval list op runs through the
+    full ``call_operation`` stack (guard -> list over plain SSH) and returns the
+    parsed ``{snapshots: [...]}`` rows. The module reducer is the
+    ``PassThroughReducer`` here, so the set-shaped payload is asserted inline
+    rather than as a handle (the JSONFlux threshold is the reducer's concern,
+    covered elsewhere).
+    """
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": _CONNECTOR_ID,
+            "op_id": "rke2.etcd-snapshot.list",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"rke2.etcd-snapshot.list failed: {result.get('error')}"
+    snapshots = result["result"]["snapshots"]
+    assert [s["name"] for s in snapshots] == [
+        "on-demand-rke2-node-e2e-1754907117",
+        "on-demand-rke2-node-e2e-1754820717",
+    ]
+    assert snapshots[0]["size_bytes"] == 52428800
+    assert snapshots[0]["location"].startswith("file:///var/lib/rancher/rke2/server/db/snapshots/")
+    assert snapshots[0]["created_at"] == "2026-08-06T09:12:03Z"
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -63,20 +63,28 @@ T3 (#2430) adds two more **approval-gated node-write ops**
   restart — it returns `restart_required: true` and changed key **names**
   only (never a value; the config body carries `token:` join credentials).
 
-T4 (#2431) adds the lone **safe, non-gated snapshot op** (in the
-`rke2-etcd-snapshot` group):
+T4 (#2431) + #2853 add the **safe, non-gated snapshot tier** (both in the
+`rke2-etcd-snapshot` group), sharing one embedded-etcd-server precondition
+guard:
 
-- `rke2.etcd-snapshot.save` — triggers an on-demand managed-etcd snapshot on
-  a server node (`rke2 etcd-snapshot save`, embedded-etcd only). It is
-  `safety_level="safe"` / `requires_approval=false` because it is read-only
-  with respect to *running* cluster state (it copies etcd to a file on disk)
-  and returns only a snapshot name + path, never etcd contents. An optional
-  `name` param is charset-bounded to `^[A-Za-z0-9._-]+$` at the schema
-  boundary AND re-checked in the handler; a fail-closed precondition guard
-  refuses a non-server / external-`datastore-endpoint` node. Like the sibling
-  T3 node-write ops it runs **as root over plain SSH** (`_run_command`, no
-  `sudo` argv) — the connector already authenticates as root, so no sudo
-  construction is needed and the repo-wide sudo-guard stays satisfied.
+- `rke2.etcd-snapshot.save` (T4 #2431) — triggers an on-demand managed-etcd
+  snapshot on a server node (`rke2 etcd-snapshot save`, embedded-etcd only).
+  It is `safety_level="safe"` / `requires_approval=false` because it is
+  read-only with respect to *running* cluster state (it copies etcd to a file
+  on disk) and returns only a snapshot name + path, never etcd contents. An
+  optional `name` param is charset-bounded to `^[A-Za-z0-9._-]+$` at the
+  schema boundary AND re-checked in the handler. It is **active** (it writes a
+  file), so it is deliberately NOT `read-only`-tagged.
+- `rke2.etcd-snapshot.list` (#2853) — enumerates the managed-etcd snapshots
+  that already exist on a server node (`rke2 etcd-snapshot list`). Takes no
+  operator params and returns `{snapshots: [{name, location, size_bytes,
+  created_at}, …]}` — a genuine read (it enumerates, mutating nothing), so it
+  DOES carry the `read-only` tag. It is the read counterpart `.save` lacked:
+  the way to **confirm a fresh snapshot landed after a token rotation** (a
+  snapshot taken before the rotation was made with the retired token — the
+  `claude-rdc-hetzner-dc#615` runbook step). The set-shaped result is
+  materialised into a JSONFlux result handle by the central reducer above its
+  row/byte threshold. See [List output parsing](#list-output-parsing-2853).
 
 Initiative #2833 (read-op coverage wave 2, #2852) adds a **second safe
 read-only op** alongside the posture tier, in a new `rke2-service-read` group:
@@ -104,11 +112,18 @@ read-only op** alongside the posture tier, in a new `rke2-service-read` group:
   `Rke2ServiceStatusProbeError` rather than being served as a service-state
   answer — the same infrastructure-failure discipline `rke2.posture.show` uses.
 
-Seven ops total: three safe read-only (T1 `about` / `posture.show` + the
+Both snapshot ops run **as root over plain SSH** (`_run_command`, no `sudo`
+argv) — like the sibling T3 node-write ops, the connector already
+authenticates as root, so no sudo construction is needed and the repo-wide
+sudo-guard stays satisfied.
+
+Eight ops total: three safe read-only (T1 `about` / `posture.show` + the
 #2852 `node.service.status`), three `dangerous` / `requires_approval=true`
-write ops (T2 + T3), and one safe non-gated snapshot op (T4). The snapshot op
-is safe / no-approval like the read ops but is neither read-only-tagged nor in
-the dangerous write tier — it belongs to neither sweep set.
+write ops (T2 + T3), and two safe non-gated snapshot ops (`.save` T4 #2431,
+`.list` #2853). `.save` is safe / no-approval but active, so it is neither
+`read-only`-tagged nor in the dangerous write tier — it belongs to neither
+sweep set; `.list` is safe / no-approval and genuinely read-only, so it
+carries the `read-only` tag alongside the T1 read tier.
 
 Source: `backend/src/meho_backplane/connectors/rke2/`.
 
@@ -148,7 +163,7 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
   `Bind9Op` / `HolodeckOp`), `SSH_TRANSPORT_NOTE` (the plain-SSH reminder
   copied into every op's `when_to_use`), `_RKE2_ABOUT_OP`, and `RKE2_OPS`
   (`about` + the `READ_OPS` posture tuple + the `WRITE_OPS` write tuple +
-  the `SNAPSHOT_OPS` tuple).
+  the `SNAPSHOT_OPS` tuple — the latter now `.save` + `.list`).
 
 - **Write ops** (`ops_write.py`, #2429 + #2430) — the three approval-gated
   write ops share one module:
@@ -178,18 +193,26 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
     `RKE2_WHEN_TO_USE_WRITE_BY_GROUP` (`rke2-token-write` + `rke2-node-write`,
     merged into the connector's `_WHEN_TO_USE_BY_GROUP`).
 
-- **Snapshot handler + parser** (`ops_snapshot.py`, #2431) —
-  `rke2_etcd_snapshot_save` (the async handler: guard → save → parse, both run
-  as root over plain `_run_command` with **no** `sudo` argv),
-  `parse_saved_snapshot_name` (recovers the name from the RKE2
-  `Snapshot <name> saved.` log), `_validate_name` (fail-closed charset
-  re-check), and the `Rke2SnapshotNameError` / `Rke2SnapshotPreconditionError`
-  / `Rke2SnapshotError` structured errors. The `rke2` binary is invoked by
-  absolute path; the single optional `name` is the only operator input and
-  is `shlex.quote`'d into the argv after the charset re-check. The precondition
-  guard's own exit status is checked before its stdout verdict is read, so an
-  SSH/transport failure surfaces as a distinct transport error rather than a
-  mislabeled "not an embedded-etcd server" verdict (fail-closed either way).
+- **Snapshot handlers + parsers** (`ops_snapshot.py`, #2431 + #2853) — two
+  handlers sharing one guard:
+  - `rke2_etcd_snapshot_save` (#2431): guard → save → parse, run as root over
+    plain `_run_command` with **no** `sudo` argv; `parse_saved_snapshot_name`
+    recovers the name from the RKE2 `Snapshot <name> saved.` log;
+    `_validate_name` is the fail-closed charset re-check of the single optional
+    `name` (the only operator input), `shlex.quote`'d into the argv.
+  - `rke2_etcd_snapshot_list` (#2853): guard → `rke2 etcd-snapshot list` →
+    `parse_snapshot_list`, also root-over-plain-SSH, no operator params.
+    Returns `{snapshots: [{name, location, size_bytes, created_at}, …]}`.
+  - `_run_precondition_guard` — the **shared** embedded-etcd-server guard both
+    handlers run first (a genuine reuse of `_GUARD_CMD`, not a per-op
+    reimplementation). Its own exit status is checked before its stdout verdict
+    is read, so an SSH/transport failure surfaces as a distinct transport error
+    (`Rke2SnapshotError`) rather than a mislabeled "not an embedded-etcd server"
+    verdict (fail-closed either way); an external-`datastore-endpoint` or
+    non-server node raises `Rke2SnapshotPreconditionError`.
+  - Structured errors: `Rke2SnapshotNameError` / `Rke2SnapshotPreconditionError`
+    / `Rke2SnapshotError`. The `rke2` binary is invoked by absolute path in
+    both handlers.
 
 - **Registration** (`__init__.py`) — two-phase, mirroring bind9/holodeck.
   Synchronous `register_connector_v2` at import time (versioned triple +
@@ -336,6 +359,38 @@ stdout verdict is interpreted, so a transport/SSH failure surfaces as a
 distinct error rather than a mislabeled node-role verdict (fail-closed either
 way).
 
+## List output parsing (#2853)
+
+`rke2 etcd-snapshot list` prints a `Name / Location / Size / Created` table.
+RKE2's own docs (`docs.rke2.io/datastore/backup_restore`, fetched 2026-08-12)
+document **only** this table for the `list` subcommand — a `-o json` /
+`--output json` flag was requested upstream (`k3s-io/k3s#5130`) but neither its
+schema nor its per-version availability is documented. Rather than parse an
+unconfirmed JSON shape from memory (the no-guessing-on-APIs rule), the handler
+parses the documented table, which is version-universal.
+
+The parse is deliberately drift-resilient, because two columns vary across
+RKE2 versions:
+
+- **`Location`** — `local`, a `file://` URL, a bare filesystem path, or an
+  `s3://` URL depending on version and store. It is a single whitespace-free
+  token in every form, and is **passed through verbatim** (never rewritten
+  against `SNAPSHOT_DEFAULT_DIR` — the vendor is the source of truth for where
+  a snapshot actually lives, including S3).
+- **`Size`** — the documented format is a raw byte count (e.g. `52428800`), but
+  some transcripts show a human string (`50 MiB`). `size_bytes` is the integer
+  when the column is a bare integer, else `null` (fail-closed — never a guessed
+  unit conversion).
+
+Each row is matched by a single regex (`_SNAPSHOT_LIST_ROW_RE`) that anchors the
+final column as an ISO-8601 timestamp. That anchor is what lets the same regex
+**skip the header row** — its `Created` label is not a timestamp — without
+depending on the header's casing (`Name` vs `NAME`), and also skips blank lines
+and any "no snapshots" notice. An empty `snapshots` list therefore means the
+node genuinely has no snapshots, not a parse failure. This mirrors the
+regex-based text parsing `parse_saved_snapshot_name` already does for `.save`'s
+log line.
+
 ## Broadcast / approval wiring (T3 #2430)
 
 - `rke2.node.service.restart` classifies plain `write` via the `.restart`
@@ -354,13 +409,19 @@ way).
 - `rke2.token.rotate` (T2 #2429), `rke2.node.service.restart` /
   `rke2.node.config.update` (T3 #2430), and `rke2.etcd-snapshot.save`
   (T4 #2431) are all landed — the Initiative #2172 SSH write/maintenance
-  surface is complete.
-- The node-write ops (service.restart / config.update) and the snapshot op
+  surface is complete. `rke2.etcd-snapshot.list` (#2853) adds the snapshot
+  read counterpart on top of that surface.
+- The node-write ops (service.restart / config.update) and the snapshot ops
   assume `root` SSH access (consistent with the read posture tier); a future
   non-root + sudo-password path would route the mutating node ops through
   `_sudo.run_remote_bash_with_sudo` (as `token.rotate` already does) if a
-  target ever connects as a non-root user. `rke2.etcd-snapshot.save` would
-  surface a `connector_error` on such a target rather than executing.
+  target ever connects as a non-root user. `rke2.etcd-snapshot.save` /
+  `rke2.etcd-snapshot.list` would surface a `connector_error` on such a
+  target rather than executing.
+- `rke2.etcd-snapshot.list` parses the documented `Name/Location/Size/Created`
+  table (not `-o json`) because the JSON flag's schema and per-version
+  availability are undocumented; if a future RKE2 pins a stable JSON contract,
+  the handler could prefer it. See [List output parsing](#list-output-parsing-2853).
 - The rotate is a **single-node atomic op**: multi-node token-propagation /
   restart choreography is an operator-composed runbook of T2+T3 ops, not part
   of this op (per the Initiative DoD).
@@ -374,6 +435,10 @@ way).
 
 - Parent Initiative #2172 (SSH cluster-node OS-lifecycle write ops); Task
   #2221 (this scaffold). Adapter fix prerequisite #2155.
+- Snapshot read tier: Task #2853 (`rke2.etcd-snapshot.list`, parent Initiative
+  #2833 connector read-op coverage). Vendor: `rke2 etcd-snapshot list` —
+  `docs.rke2.io/datastore/backup_restore` (Name/Location/Size/Created table);
+  JSON flag requested at `k3s-io/k3s#5130` (schema/availability undocumented).
 - Mold: holodeck-ssh (G3.18 #2145 / `docs/codebase/connectors-holodeck.md`),
   bind9-ssh (`docs/codebase/connectors-bind9.md`).
 - Cross-repo coordination: `docs/cross-repo/rke2-infra-coordination.md`.


### PR DESCRIPTION
## Summary

- Adds `rke2.etcd-snapshot.list` (safe / no-approval / **read-only**) — the read counterpart `.save` never had. It answers "which etcd snapshots exist on this server node, how old/large, did the fresh one land?" through the governed plane instead of an untracked `ssh <node> rke2 etcd-snapshot list`, so the mandatory post-rotation snapshot check of the `claude-rdc-hetzner-dc#615` runbook stays inside policy/audit/broadcast.
- Runs `rke2 etcd-snapshot list` as root over plain SSH (no `sudo` argv — same privilege model as `.save`) and returns `{snapshots: [{name, location, size_bytes, created_at}, ...]}`, a set-shaped payload the central JSONFlux reducer materialises into a result handle above threshold (postulate 6).
- **Shared precondition guard.** Extracted `.save`'s embedded-etcd-server guard into `_run_precondition_guard`; both snapshot ops now enforce the identical precondition (a genuine reuse, not a reimplementation) and raise the same `Rke2SnapshotPreconditionError` on a non-server / external-`datastore-endpoint` node. `.save` behaviour and response shape are unchanged.
- **Table parsing, not `-o json` (grounded in fresh docs).** RKE2's docs (`docs.rke2.io/datastore/backup_restore`, fetched 2026-08-12) document only the `Name/Location/Size/Created` table; the `-o json` flag (`k3s-io/k3s#5130`) has no documented schema or per-version availability, so an unconfirmed JSON shape is not parsed from memory. Each row is matched by a regex that anchors `Created` as an ISO-8601 timestamp — which skips the header regardless of casing — and passes `location` through verbatim (version drift: `local` / `file://` / bare path / `s3://`); `size_bytes` is the integer byte count or `null` (never a guessed unit conversion).

## Test plan

- [x] `ruff check` — clean (rke2 src + both test files)
- [x] `ruff format --check` — clean
- [x] `mypy src/` (CI shape) — `Success: no issues found`
- [x] `pytest tests/test_connectors_rke2.py tests/test_connectors_rke2_e2e.py` — **88 passed**
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (5 pre-existing size warnings)
- [x] CLI OpenAPI snapshot freshness — `make snapshot-openapi` produces **no diff** (connector op metadata is not on the REST surface; nothing to regenerate)
- [x] AC1 — `.list` registered safe / no-approval, dispatches end-to-end via `call_operation` (`test_rke2_e2e_etcd_snapshot_list_dispatches_ok_read_only`)
- [x] AC2 — `_SNAPSHOT_OP_IDS` gains `.list`; count (6→7) + covers tests pass
- [x] AC3 — `.list` carries the `read-only` tag and is in the read-only assertions (`test_rke2_snapshot_list_is_read_only_safe_no_approval`); the "neither sweep set" carve-out now targets only the active `.save`
- [x] AC4 — shared guard reused; `.list` raises the same `Rke2SnapshotPreconditionError` as `.save` on external-datastore / non-server fixtures
- [x] AC5 — table-transcript fixture (3 rows, one 50 MiB) parses to `{snapshots: [{name, location, size_bytes, created_at}, ...]}`
- [x] AC6 — `docs/codebase/connectors-rke2.md` updated (op count six→seven, `.list` documented, new "List output parsing" section)
- [x] Broadcast: `classify_op("rke2.etcd-snapshot.list") == "read"` (via `_READ_SUFFIXES` — no wiring change needed)

## Out of scope

- No `etcd-snapshot delete` / `prune`; no S3-credential wiring (local/default store only) — per the issue's Out of scope.
- Sibling rke2 tasks #2852 (PR #2931, not merged) and #2854 also touch the op-count / `SNAPSHOT_OPS`-adjacent enumeration points and the docs op-count. This branches off `main` and expects trivial merge conflicts there (READ/SNAPSHOT op counts, docs "seven ops"); no dependency on either.
- Adjacent findings (recorded, not fixed): `connector.py` is now 622 lines and `ops_snapshot.py` 580 lines (code-quality **warnings**, not blockers) — the connector-method-shim pattern and the two-op snapshot module are the established structure; splitting is a larger, separate refactor.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2853
