### PR TITLE
feat(connectors): attribute bind9.zone.list rows with their view

### DIFF
--- a/backend/src/meho_backplane/connectors/bind9/ops_zone.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_zone.py
@@ -16,10 +16,13 @@ layers the first two read ops onto that surface:
 
 * ``bind9.zone.list`` -- run ``named-checkconf -p`` and parse the
   canonicalised config dump into one row per ``zone "<name>"`` block.
-  Each row is ``{name, file, type}`` where ``type`` is the zone's
-  declared role (``master`` / ``slave`` / ``forward`` / ...). No
-  per-handler handle truncation -- zone counts in real deployments
-  are O(10..100) and well under any reducer threshold.
+  Each row is ``{name, file, type, view}`` where ``type`` is the
+  zone's declared role (``master`` / ``slave`` / ``forward`` / ...)
+  and ``view`` is the enclosing ``view "<name>"`` block (``None`` when
+  the zone is declared outside any view). ``view`` disambiguates
+  split-horizon deployments, where the same zone name is declared once
+  per view. No per-handler handle truncation -- zone counts in real
+  deployments are O(10..100) and well under any reducer threshold.
 * ``bind9.zone.read <zone>`` -- locate the zonefile path via
   ``named-checkconf -p`` (so the operator doesn't have to know whether
   the file is under ``/etc/bind/`` or a chrooted ``/var/cache/bind/``
@@ -159,6 +162,21 @@ _ZONE_HEADER_RE = re.compile(
     """,
     re.VERBOSE,
 )
+# ``view "<name>" <class>? { ... };`` wraps the zone blocks of any
+# split-horizon deployment. named-checkconf emits the view name quoted;
+# the bare-name alternative mirrors ``_ZONE_HEADER_RE`` as a defensive
+# fallback. bind9's grammar forbids nesting a ``view`` inside a ``view``
+# (ARM "view Statement Grammar"), so the parser tracks a single active
+# view rather than a stack.
+_VIEW_HEADER_RE = re.compile(
+    r"""
+    ^\s*view\s+
+    (?:"(?P<name_quoted>[^"]+)"|(?P<name_bare>\S+))
+    (?:\s+(?P<class>IN|HS|CH))?
+    \s*\{\s*$
+    """,
+    re.VERBOSE,
+)
 _ZONE_FILE_RE = re.compile(r'^\s*file\s+"([^"]+)"\s*;\s*$')
 _ZONE_TYPE_RE = re.compile(r"^\s*type\s+(\w+)\s*;\s*$")
 
@@ -166,19 +184,27 @@ _ZONE_TYPE_RE = re.compile(r"^\s*type\s+(\w+)\s*;\s*$")
 def parse_named_checkconf_zones(output: str) -> list[dict[str, Any]]:
     """Parse ``named-checkconf -p`` output into zone rows.
 
-    Returns one ``{"name": str, "file": str | None, "type": str | None}``
-    dict per top-level ``zone "<name>"`` block found in *output*. Pure
-    function -- given the same string, returns identical output. The
-    unit suite pins it against captured fixtures without invoking
-    ``named-checkconf`` itself.
+    Returns one ``{"name": str, "file": str | None, "type": str | None,
+    "view": str | None}`` dict per ``zone "<name>"`` block found in
+    *output*. ``view`` is the name of the enclosing ``view "<name>"``
+    block, or ``None`` when the zone is declared outside any view (a
+    deployment with no views declared -- ``named-checkconf -p`` prints
+    those zones bare at the top level and does not synthesise the
+    internal ``_default`` view). Attributing the view disambiguates
+    split-horizon deployments, where the same zone name is declared once
+    per view and the bare ``{name, file, type}`` rows are otherwise
+    indistinguishable. Pure function -- given the same string, returns
+    identical output. The unit suite pins it against captured fixtures
+    without invoking ``named-checkconf`` itself.
 
     Brace tracking is line-oriented and uses a simple depth counter:
     every ``{`` increments, every ``}`` decrements. A zone block's body
     ends when the depth returns to the level it had **before** the
-    opening ``zone "..." {`` line. This correctly handles a ``view``
-    wrapping multiple zone blocks (each zone enters at view-depth+1 and
-    closes back at view-depth), which is what bind9 emits for any
-    deployment that declares views.
+    opening ``zone "..." {`` line. The outer scan tracks the same depth
+    to recognise when the active ``view`` block closes: the view opens at
+    some depth D and stays active until a ``}`` returns the running depth
+    to D. bind9 forbids nesting a ``view`` inside a ``view``, so a single
+    active view (not a stack) is sufficient.
 
     *output* is the stdout of ``named-checkconf -p`` -- the
     canonicalised form, not the raw ``/etc/bind/named.conf`` source.
@@ -189,31 +215,53 @@ def parse_named_checkconf_zones(output: str) -> list[dict[str, Any]]:
     """
     rows: list[dict[str, Any]] = []
     lines = output.splitlines()
+    brace_depth = 0
+    current_view: str | None = None
+    view_depth: int | None = None
     i = 0
     while i < len(lines):
         line = lines[i]
+
+        view_match = _VIEW_HEADER_RE.match(line)
+        if view_match:
+            # Enter the view: record its name and the depth we return to
+            # when its closing ``};`` lands. Views never nest, so a single
+            # active view (not a stack) is sufficient.
+            current_view = view_match.group("name_quoted") or view_match.group("name_bare")
+            view_depth = brace_depth
+            brace_depth += line.count("{") - line.count("}")
+            i += 1
+            continue
+
         match = _ZONE_HEADER_RE.match(line)
         if not match:
-            # Track depth so we can skip non-zone braces (e.g. ``options``
-            # blocks) cheaply; we only need to be at depth 0 (or a
-            # ``view`` body) when we hit a ``zone "..."`` line, but the
-            # regex anchors on the literal ``zone`` keyword so depth
-            # tracking is only required to scan *past* a zone body.
+            # Not a header line: track braces so we can tell when the
+            # active view block closes. Sibling ``options`` / ``logging``
+            # / ``key`` blocks pass through here too; their braces balance
+            # out and never drop the running depth below ``view_depth``
+            # while a view is open.
+            brace_depth += line.count("{") - line.count("}")
+            if view_depth is not None and brace_depth <= view_depth:
+                current_view = None
+                view_depth = None
             i += 1
             continue
 
         name = match.group("name_quoted") or match.group("name_bare")
-        depth = 1
+        # Skip the zone body with a local depth counter. The block is
+        # brace-balanced, so the running ``brace_depth`` is unchanged by
+        # the span we jump over and the enclosing view stays correct.
+        zone_depth = 1
         zone_file: str | None = None
         zone_type: str | None = None
         j = i + 1
-        while j < len(lines) and depth > 0:
+        while j < len(lines) and zone_depth > 0:
             inner = lines[j]
             # Track brace depth -- zone bodies can contain nested
             # ``masters`` / ``also-notify`` blocks under bind9 9.x; we
             # close the zone block only when the matching ``};`` lands.
-            depth += inner.count("{")
-            depth -= inner.count("}")
+            zone_depth += inner.count("{")
+            zone_depth -= inner.count("}")
             if zone_file is None:
                 file_match = _ZONE_FILE_RE.match(inner)
                 if file_match:
@@ -223,7 +271,7 @@ def parse_named_checkconf_zones(output: str) -> list[dict[str, Any]]:
                 if type_match:
                     zone_type = type_match.group(1)
             j += 1
-        rows.append({"name": name, "file": zone_file, "type": zone_type})
+        rows.append({"name": name, "file": zone_file, "type": zone_type, "view": current_view})
         i = j
     return rows
 
@@ -446,8 +494,18 @@ _BIND9_ZONE_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
                     "name": {"type": "string"},
                     "file": {"type": ["string", "null"]},
                     "type": {"type": ["string", "null"]},
+                    "view": {
+                        "type": ["string", "null"],
+                        "description": (
+                            "Name of the enclosing ``view`` block, or "
+                            "null when the zone is declared outside any "
+                            "view. Disambiguates split-horizon "
+                            "deployments where the same zone name is "
+                            "declared once per view."
+                        ),
+                    },
                 },
-                "required": ["name", "file", "type"],
+                "required": ["name", "file", "type", "view"],
                 "additionalProperties": False,
             },
             "description": (
@@ -483,10 +541,14 @@ BIND9_ZONE_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
     ),
     "parameter_hints": {},
     "output_shape": (
-        "{'rows': [{name, file, type}], 'total': <int>}. ``type`` is "
-        "the zone's declared role (``master`` / ``slave`` / "
+        "{'rows': [{name, file, type, view}], 'total': <int>}. ``type`` "
+        "is the zone's declared role (``master`` / ``slave`` / "
         "``forward`` / ...); ``file`` is the zonefile path as bind9 "
-        "sees it (absolute, post-chroot resolution)."
+        "sees it (absolute, post-chroot resolution); ``view`` is the "
+        "enclosing ``view`` name or null when the zone sits outside any "
+        "view. On a split-horizon nameserver the same zone name appears "
+        "once per view -- the rows differ only by ``view`` (and possibly "
+        "``file``), so use ``view`` to tell them apart."
     ),
 }
 
@@ -583,16 +645,19 @@ ZONE_OPS: tuple[Bind9Op, ...] = (
         summary="List zones declared on the bind9 nameserver with zonefile path + role.",
         description=(
             "Runs ``named-checkconf -p`` over SSH and parses the "
-            "canonicalised config dump into one row per top-level "
+            "canonicalised config dump into one row per "
             '``zone "<name>" { ... };`` block. Each row carries the '
             "zone name, its zonefile path (the post-canonicalisation "
-            "value bind9 resolves at zone-load time), and the declared "
+            "value bind9 resolves at zone-load time), the declared "
             "role (``master`` / ``slave`` / ``forward`` / ``stub`` / "
-            "``hint`` / ...). The handler scopes itself to the active "
-            "config, not the on-disk file tree -- a fragment staged "
-            "under ``/etc/bind/`` but not yet referenced from "
-            "``named.conf`` does not appear. Read-only; safe to call on "
-            "any healthy bind9 target."
+            "``hint`` / ...), and the enclosing ``view`` name (null when "
+            "the zone is declared outside any view). ``view`` "
+            "disambiguates split-horizon deployments, where the same "
+            "zone name is declared once per view. The handler scopes "
+            "itself to the active config, not the on-disk file tree -- a "
+            "fragment staged under ``/etc/bind/`` but not yet referenced "
+            "from ``named.conf`` does not appear. Read-only; safe to "
+            "call on any healthy bind9 target."
         ),
         parameter_schema=BIND9_ZONE_LIST_PARAMETER_SCHEMA,
         response_schema=_BIND9_ZONE_LIST_RESPONSE_SCHEMA,

--- a/backend/tests/test_connectors_bind9_reads.py
+++ b/backend/tests/test_connectors_bind9_reads.py
@@ -5,9 +5,10 @@
 
 Coverage matrix (per Task #588 acceptance criteria):
 
-* ``parse_named_checkconf_zones`` -- one row per top-level zone,
-  including zones nested inside ``view`` blocks; ``file`` / ``type``
-  extracted from inner directives.
+* ``parse_named_checkconf_zones`` -- one row per zone, including zones
+  nested inside ``view`` blocks; ``file`` / ``type`` extracted from
+  inner directives; ``view`` attributed from the enclosing ``view``
+  block (null outside any view, disambiguating split-horizon).
 * ``parse_zonefile`` -- one row per rrset member; absolute names,
   integer TTLs, canonical class / type / rdata strings; SOA, NS, MX,
   TXT, A, AAAA, CNAME all round-trip.
@@ -120,7 +121,12 @@ def _completed_process(stdout: str = "", exit_status: int = 0) -> Any:
 def test_parse_zones_master_zone_extracts_name_file_type() -> None:
     output = 'zone "evba.lab" {\n\ttype master;\n\tfile "/etc/bind/db.evba.lab";\n};\n'
     assert parse_named_checkconf_zones(output) == [
-        {"name": "evba.lab", "file": "/etc/bind/db.evba.lab", "type": "master"}
+        {
+            "name": "evba.lab",
+            "file": "/etc/bind/db.evba.lab",
+            "type": "master",
+            "view": None,
+        }
     ]
 
 
@@ -165,18 +171,94 @@ def test_parse_zones_walks_through_options_and_view_blocks() -> None:
     ext_row = next(r for r in rows if r["name"] == "ext.example.com")
     assert ext_row["type"] == "slave"
     assert ext_row["file"] == "/etc/bind/views/ext.example.com"
+    # The bare top-level zone carries no view; the view-wrapped zone is
+    # attributed to its enclosing ``view`` block. The nested
+    # ``masters { ... };`` inside the view must not close it early.
+    assert next(r for r in rows if r["name"] == "evba.lab")["view"] is None
+    assert ext_row["view"] == "external"
 
 
 def test_parse_zones_handles_hint_zone_without_file_gracefully() -> None:
     """``type hint`` zones lacking a ``file`` directive surface ``file=None``."""
     output = 'zone "." {\n\ttype hint;\n};\n'
     rows = parse_named_checkconf_zones(output)
-    assert rows == [{"name": ".", "file": None, "type": "hint"}]
+    assert rows == [{"name": ".", "file": None, "type": "hint", "view": None}]
 
 
 def test_parse_zones_empty_input_returns_empty_list() -> None:
     assert parse_named_checkconf_zones("") == []
     assert parse_named_checkconf_zones("options { };\n") == []
+
+
+def test_parse_zones_split_horizon_attributes_view_per_block() -> None:
+    """Same zone name under two views yields two rows differing by ``view``.
+
+    Mirrors the consumer's per-user split-horizon topology: a ``default``
+    view plus one per-operator view, each serving the same lab zone name.
+    The rows must be distinguishable by ``view`` even though ``name`` and
+    ``type`` are identical. The ``match-clients { ... };`` block inside
+    the second view is a single-line balanced brace pair -- the view must
+    stay open across it so its zone is still attributed correctly.
+    """
+    output = (
+        'view "default" {\n'
+        '\tzone "site-a.vcf.lab" {\n'
+        "\t\ttype master;\n"
+        '\t\tfile "/etc/bind/db.site-a";\n'
+        "\t};\n"
+        "};\n"
+        'view "operator-alice" {\n'
+        "\tmatch-clients { 10.9.0.7; };\n"
+        '\tzone "site-a.vcf.lab" {\n'
+        "\t\ttype master;\n"
+        '\t\tfile "/etc/bind/views/alice/db.site-a";\n'
+        "\t};\n"
+        "};\n"
+    )
+    rows = parse_named_checkconf_zones(output)
+    assert rows == [
+        {
+            "name": "site-a.vcf.lab",
+            "file": "/etc/bind/db.site-a",
+            "type": "master",
+            "view": "default",
+        },
+        {
+            "name": "site-a.vcf.lab",
+            "file": "/etc/bind/views/alice/db.site-a",
+            "type": "master",
+            "view": "operator-alice",
+        },
+    ]
+    # Same name + type across both rows; only ``view`` (and file) differ.
+    assert rows[0]["name"] == rows[1]["name"]
+    assert rows[0]["type"] == rows[1]["type"]
+    assert rows[0]["view"] != rows[1]["view"]
+
+
+def test_parse_zones_no_views_attributes_null_view() -> None:
+    """No ``view`` blocks: bare top-level zones carry ``view=None``.
+
+    ``named-checkconf -p`` prints zones bare at the top level when the
+    config declares no views (it does not synthesise the internal
+    ``_default`` view), so ``view`` must be null -- not ``"_default"``.
+    """
+    output = (
+        "options {\n"
+        '\tdirectory "/var/cache/bind";\n'
+        "};\n"
+        'zone "evba.lab" {\n'
+        "\ttype master;\n"
+        '\tfile "/etc/bind/db.evba.lab";\n'
+        "};\n"
+        'zone "10.5.50.in-addr.arpa" {\n'
+        "\ttype master;\n"
+        '\tfile "/etc/bind/db.10.5.50";\n'
+        "};\n"
+    )
+    rows = parse_named_checkconf_zones(output)
+    assert {row["name"] for row in rows} == {"evba.lab", "10.5.50.in-addr.arpa"}
+    assert all(row["view"] is None for row in rows)
 
 
 # ---------------------------------------------------------------------------

--- a/cli/internal/cmd/bind9/bind9_test.go
+++ b/cli/internal/cmd/bind9/bind9_test.go
@@ -297,18 +297,23 @@ func TestPrintAboutErrorRendersErrorString(t *testing.T) {
 	}
 }
 
-// TestPrintZoneListTable — happy-path render with 2 zones.
+// TestPrintZoneListTable — happy-path render including the `view`
+// column: two split-horizon rows sharing a zone name under different
+// views, plus a bare zone whose `view` is null (rendered blank).
 func TestPrintZoneListTable(t *testing.T) {
 	r := &CallResult{
 		Status:     "ok",
 		OpID:       "bind9.zone.list",
-		Result:     json.RawMessage(`{"rows":[{"name":"evba.lab","type":"master","file":"/etc/bind/db.evba.lab"},{"name":"50.5.10.in-addr.arpa","type":"master","file":"/etc/bind/db.10.5.50"}],"total":2}`),
+		Result:     json.RawMessage(`{"rows":[{"name":"site-a.vcf.lab","type":"master","file":"/etc/bind/db.site-a","view":"default"},{"name":"site-a.vcf.lab","type":"master","file":"/etc/bind/views/alice/db.site-a","view":"operator-alice"},{"name":"evba.lab","type":"master","file":"/etc/bind/db.evba.lab","view":null}],"total":3}`),
 		DurationMs: 12.0,
 	}
 	var buf bytes.Buffer
 	printZoneList(&buf, r)
 	out := buf.String()
-	for _, want := range []string{"evba.lab", "master", "/etc/bind/db.evba.lab", "50.5.10.in-addr.arpa"} {
+	// The `view` header renders; the two split-horizon rows are
+	// distinguishable by their view names; the null-view zone still
+	// renders (its blank view column is not asserted directly).
+	for _, want := range []string{"view", "site-a.vcf.lab", "master", "default", "operator-alice", "evba.lab", "/etc/bind/views/alice/db.site-a"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("printZoneList missing %q in output:\n%s", want, out)
 		}

--- a/cli/internal/cmd/bind9/zone.go
+++ b/cli/internal/cmd/bind9/zone.go
@@ -42,7 +42,7 @@ func newZoneListCmd() *cobra.Command {
 		Long: "list dispatches bind9.zone.list against the connector_id=\n" +
 			"\"bind9-ssh-9.x\" connector. Returns one row per zone declared\n" +
 			"in the active configuration (parsed from `named-checkconf -p`).\n" +
-			"The human render shows name / type / file columns; --json emits\n" +
+			"The human render shows name / type / view / file columns; --json emits\n" +
 			"the full OperationResult envelope.\n\n" +
 			"Exit codes mirror meho operation call.",
 		Example: "  meho bind9 zone list --target vcf-router-bind9\n" +
@@ -74,7 +74,9 @@ func runZoneList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneO
 }
 
 // printZoneList renders the zone list. Each row carries `{name,
-// file, type}` per `_BIND9_ZONE_LIST_RESPONSE_SCHEMA`.
+// file, type, view}` per `_BIND9_ZONE_LIST_RESPONSE_SCHEMA`. The
+// `view` column is blank for zones declared outside any view; on a
+// split-horizon nameserver it disambiguates rows that share a name.
 func printZoneList(w io.Writer, r *CallResult) {
 	fmt.Fprintf(w, "%s bind9.zone.list — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
 	if r.Status != "ok" {
@@ -90,14 +92,16 @@ func printZoneList(w io.Writer, r *CallResult) {
 		fmt.Fprintln(w, "  (0 zones)")
 		return
 	}
-	fmt.Fprintf(w, "%-40s %-10s %s\n", "name", "type", "file")
+	fmt.Fprintf(w, "%-40s %-10s %-24s %s\n", "name", "type", "view", "file")
 	for _, row := range rows {
 		name := stringField(row, "name")
 		zoneType := stringField(row, "type")
+		view := stringField(row, "view")
 		file := stringField(row, "file")
-		fmt.Fprintf(w, "%-40s %-10s %s\n",
+		fmt.Fprintf(w, "%-40s %-10s %-24s %s\n",
 			truncate(name, 40),
 			truncate(zoneType, 10),
+			truncate(view, 24),
 			file,
 		)
 	}

--- a/docs/codebase/connectors-bind9.md
+++ b/docs/codebase/connectors-bind9.md
@@ -191,7 +191,7 @@ reason.
 | Op id | Handler | Safety | Description |
 | ----- | ------- | ------ | ----------- |
 | `bind9.about` | `Bind9Connector.about` | `safe` | Operator-facing wrapper around fingerprint; returns vendor / product / version / build / os / named_conf_path |
-| `bind9.zone.list` | `Bind9Connector.bind9_zone_list` | `safe` | Parse `named-checkconf -p` into zone rows: `{name, file, type}` per declared zone |
+| `bind9.zone.list` | `Bind9Connector.bind9_zone_list` | `safe` | Parse `named-checkconf -p` into zone rows: `{name, file, type, view}` per declared zone (`view` is the enclosing `view "<name>"` block, or `null` outside any view — disambiguates split-horizon) |
 | `bind9.zone.read` | `Bind9Connector.bind9_zone_read` | `safe` | Resolve zonefile via `named-checkconf -p`, read + parse via dnspython; row per rrset member `{name, ttl, class, type, rdata}` |
 | `bind9.record.get` | `Bind9Connector.bind9_record_get` | `safe` | `dig @localhost <fqdn> <type>` parsed into structured rows; defaults to A; supports A / AAAA / CNAME / MX / TXT |
 | `bind9.record.add` | `Bind9Connector.bind9_record_add` | `caution` | Atomic A/AAAA record write with snapshot rollback; resolves owning zone via longest-suffix match when `zone` omitted; verify predicate = `dig` returns the new IP |
@@ -294,7 +294,7 @@ pins the parsers directly without booting an event loop:
 
 | Parser | Source module | Input | Output |
 | ------ | ------------- | ----- | ------ |
-| `parse_named_checkconf_zones` | `ops_zone.py` | `named-checkconf -p` stdout | list of `{name, file, type}` rows |
+| `parse_named_checkconf_zones` | `ops_zone.py` | `named-checkconf -p` stdout | list of `{name, file, type, view}` rows (`view` = enclosing `view "<name>"`, `null` outside any view) |
 | `parse_zonefile` | `ops_zone.py` | zonefile text + origin | list of `{name, ttl, class, type, rdata}` rows via `dns.zone.from_text` |
 | `parse_dig_answer` | `ops_record.py` | `dig` stdout (`+noall +answer` or default) | list of `{name, ttl, class, type, rdata}` rows |
 | `ensure_path_under_root` | `ops_config.py` | requested path + allowed root | canonical absolute path under root, or `ConfigPathRejectedError` |


### PR DESCRIPTION
## Summary
- `bind9.zone.list`'s parser (`parse_named_checkconf_zones`) already brace-tracked through `view { … }` blocks but threw the enclosing view name away, so on a split-horizon nameserver the same zone declared once per view produced indistinguishable `{name, file, type}` rows (and `bind9.zone.read`'s first-match path resolver silently returned whichever came first). This projects the enclosing view onto each row as a new `view` field — `null` for a zone declared outside any view.
- Threads the field through the response schema (`view` added to `properties` + `required`), the LLM `output_shape` hint, the `bind9.zone.list` op `description`, the `docs/codebase/connectors-bind9.md` op/parser tables, and the CLI `meho bind9 zone list` render (new `view` column, blank for null).
- Grounded in `named-checkconf -p` canonical output: views print quoted (`view "<name>" {`) and never nest (ARM "view Statement Grammar"), so a single active view (not a stack) suffices; a no-views config prints bare top-level zones and `-p` does **not** synthesise the internal `_default` view (built-in defaults require the separate `named -C` switch), so those rows are `view: null`, never `"_default"`.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` (strict, `files=["src"]`) — clean on this change. The single reported error is `net/icmp.py:205 MSG_ERRQUEUE`, a Linux-only socket constant absent on the macOS dev host — unrelated and pre-existing; resolves on the Linux CI runner.
- [x] `pytest tests/test_connectors_bind9_reads.py` — 62 passed (2 new + 1 enhanced parser test)
- [x] `pytest` other bind9 unit files (`_atomic`, `_config`, base) — 151 passed (regression)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers
- [x] Go — `gofmt` clean, `go build ./...` OK, `go test ./internal/cmd/bind9/...` OK (updated `TestPrintZoneListTable` covers the view column + split-horizon + null-view row)
- [x] `make snapshot-openapi` — no delta (connector op metadata isn't in the FastAPI OpenAPI), so `cli-api-snapshot-freshness` stays green
- [x] **AC2** — two views (`default` + per-user) declaring the same zone name → rows differ by `view` while `name`/`type` match (`test_parse_zones_split_horizon_attributes_view_per_block`)
- [x] **AC3** — no-views deployment, bare top-level zones → `view: null`, no regression (`test_parse_zones_no_views_attributes_null_view`)

## Out of scope
- Adding a `view` disambiguation parameter to `bind9.zone.read` / fixing `_resolve_zonefile_path`'s first-match ambiguity — real (see Summary), but it changes `zone.read`'s `parameter_schema`; a documented follow-on Task now that `zone.list` can tell the caller which view to ask for.
- Any change to `bind9.config.apply_views` or the write path — this is read-only projection work.
- Multi-level / nested view support — not a real bind9 construct (ARM grammar forbids nested `view` blocks).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2851
