### PR TITLE
feat(connectors): add argocd.cluster.list destination-cluster read op

### DIFF
--- a/backend/src/meho_backplane/connectors/argocd/__init__.py
+++ b/backend/src/meho_backplane/connectors/argocd/__init__.py
@@ -23,11 +23,11 @@ The asynchronous (lifespan startup) typed-op registrar — queued via
 the way Harbor (#621) and bind9 (#367) do — lands in this module as of
 G3.12-T2 (#1391). :func:`register_argocd_typed_operations` delegates to
 :meth:`ArgoCdConnector.register_operations`, which walks
-:data:`~meho_backplane.connectors.argocd.ops.ARGOCD_OPS` and upserts the six
+:data:`~meho_backplane.connectors.argocd.ops.ARGOCD_OPS` and upserts the seven
 curated read-core descriptors (``argocd.app.list`` / ``argocd.app.get`` /
 ``argocd.app.diff`` / ``argocd.app.resource_tree`` /
-``argocd.appproject.list`` / ``argocd.repo.list``) — all ``safety_level="safe"``,
-``requires_approval=False``, read-only. The approval-gated write ops
+``argocd.appproject.list`` / ``argocd.repo.list`` / ``argocd.cluster.list``) —
+all ``safety_level="safe"``, ``requires_approval=False``, read-only. The approval-gated write ops
 (``app.sync`` / ``rollback`` / ``set`` / ``refresh`` / ``delete`` +
 ``appproject.create`` / ``update``, every one ``requires_approval=True``)
 land on the same registrar walk in G3.12-T4 (#1405) — see

--- a/backend/src/meho_backplane/connectors/argocd/connector.py
+++ b/backend/src/meho_backplane/connectors/argocd/connector.py
@@ -406,7 +406,7 @@ class ArgoCdConnector(HttpConnector):
     # (see :func:`~meho_backplane.operations._branches.dispatch_typed`); the
     # ``operator`` is forwarded to :meth:`_get_json` so the credential loader
     # reads the per-target bearer token under the operator's identity. All
-    # six are read-only — no write/mutating op ships in this Task.
+    # seven are read-only — no write/mutating op ships in this section.
     # ------------------------------------------------------------------
 
     async def app_list(
@@ -535,6 +535,36 @@ class ArgoCdConnector(HttpConnector):
         """
         del params  # schema declares the param object empty
         return await self._get_json(target, "/api/v1/repositories", operator=operator)
+
+    async def cluster_list(
+        self,
+        operator: Operator,
+        target: ArgoCdTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``argocd.cluster.list`` — ``GET /api/v1/clusters``.
+
+        Returns the ``ClusterList`` (``{"items": [...], "metadata": {...}}``);
+        each item carries the destination cluster's ``server`` URL, ``name``,
+        ``connectionState`` (whether ArgoCD can currently reach and
+        authenticate to the cluster), ``serverVersion``, and ``info``
+        (``applicationsCount`` + the cached connection state).
+
+        Defense in depth: ArgoCD's ``Cluster.config`` carries the destination
+        cluster's own credentials (bearer token, TLS client cert/key,
+        basic-auth username/password, AWS/exec provider config). The handler
+        strips the whole ``config`` object from every item before returning so
+        no destination credential ever rides back in the envelope — even if a
+        broad-RBAC token makes ``argocd-server`` include it.
+        """
+        del params  # schema declares the param object empty
+        payload = await self._get_json(target, "/api/v1/clusters", operator=operator)
+        items = payload.get("items")
+        if isinstance(items, list):
+            for item in items:
+                if isinstance(item, dict):
+                    item.pop("config", None)
+        return payload
 
     # ------------------------------------------------------------------
     # Write primitive + approval-gated write handlers (G3.12-T4 #1405)

--- a/backend/src/meho_backplane/connectors/argocd/ops.py
+++ b/backend/src/meho_backplane/connectors/argocd/ops.py
@@ -22,9 +22,12 @@ ops that let an RDC operator see what ArgoCD sees without reaching for the
   allow-lists.
 * ``argocd.repo.list`` -- ``GET /api/v1/repositories``; configured repos +
   connection state.
+* ``argocd.cluster.list`` -- ``GET /api/v1/clusters``; destination clusters +
+  connection state (#2855). The credential-bearing ``config`` field is
+  stripped from every item before returning.
 
-All six are ``safety_level="safe"`` + ``requires_approval=False`` and carry a
-``read-only`` tag — this Task registers no write/mutating op (``app.sync`` /
+All seven are ``safety_level="safe"`` + ``requires_approval=False`` and carry a
+``read-only`` tag — these read ops register no write/mutating op (``app.sync`` /
 ``rollback`` / ``set`` are a deferred, approval-gated follow-up).
 
 The dataclass + tuple shape mirrors the bind9 (#367) and Kubernetes
@@ -86,9 +89,9 @@ class ArgoCdOp:
 
 #: Curated ``when_to_use`` blurbs per group. ``register_typed_operation``
 #: requires a non-empty string whenever ``group_key`` is set (G0.9-T4a #731);
-#: the registrar looks each op's ``group_key`` up here. Three groups: the
-#: application read surface, the project allow-list surface, and the
-#: repository inventory surface.
+#: the registrar looks each op's ``group_key`` up here. Four groups: the
+#: application read surface, the project allow-list surface, the repository
+#: inventory surface, and the destination-cluster inventory surface.
 ARGOCD_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     "argocd-apps": (
         "Use to inspect ArgoCD Applications and their GitOps reconciliation "
@@ -116,6 +119,17 @@ ARGOCD_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "diagnosing a 'ComparisonError'/'repository not accessible' app "
         "condition or confirming a repo is registered before pointing an "
         "Application at it."
+    ),
+    "argocd-clusters": (
+        "Use to inventory the Kubernetes destination clusters registered in "
+        "ArgoCD and each one's connection state (argocd.cluster.list): the "
+        "cluster API server URL, symbolic name, whether ArgoCD can currently "
+        "reach and authenticate to it (connectionState Successful / Failed), "
+        "and its Kubernetes serverVersion. The right group when the question "
+        "is 'which destination clusters does this ArgoCD manage?', 'is cluster "
+        "X reachable?', or when an Application reports its destination cluster "
+        "unreachable. Read-only — the per-cluster credential config is never "
+        "returned."
     ),
 }
 
@@ -497,9 +511,66 @@ _REPO_LIST = ArgoCdOp(
 )
 
 
+# ---------------------------------------------------------------------------
+# argocd.cluster.list
+# ---------------------------------------------------------------------------
+
+_CLUSTER_LIST = ArgoCdOp(
+    op_id="argocd.cluster.list",
+    handler_attr="cluster_list",
+    summary="List ArgoCD destination clusters and their connection state.",
+    description=(
+        "Lists the Kubernetes destination clusters registered in ArgoCD via "
+        "GET /api/v1/clusters. Each item carries the cluster's API server URL "
+        "(server), symbolic name, a connectionState (status Successful / "
+        "Failed plus a message and the attemptedAt timestamp) reflecting "
+        "whether ArgoCD can currently reach and authenticate to the cluster, "
+        "the Kubernetes serverVersion, and info (applicationsCount + the "
+        "cached connection state). Use to inventory which destination "
+        "clusters an ArgoCD instance manages and confirm each is reachable "
+        "before pointing an Application at it, or when an app reports "
+        "cluster-unreachable. The per-cluster credential material (the config "
+        "field: bearer token / TLS client cert+key / basic auth / AWS / exec "
+        "provider) is stripped from every item. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "items": {"type": ["array", "null"]},
+            "metadata": {"type": "object"},
+        },
+        "additionalProperties": True,
+    },
+    group_key="argocd-clusters",
+    tags=("read-only", "argocd", "gitops"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator asks which destination clusters ArgoCD "
+            "manages, or to check a destination cluster's reachability / "
+            "connection state and Kubernetes version before pointing an "
+            "Application at it or when diagnosing a cluster-unreachable app."
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "{items: [Cluster, ...], metadata: {...}}. Read each item's "
+            "connectionState.status (Successful / Failed) and .message, "
+            "serverVersion, and info.applicationsCount. The credential-bearing "
+            "config field is stripped and never returned."
+        ),
+    },
+)
+
+
 #: The ops :class:`ArgoCdConnector` registers at lifespan startup — the full
-#: G3.12-T2 read core. Ordered apps → projects → repos to match the
-#: operator's typical drill path.
+#: G3.12-T2 read core plus the #2855 cluster read. Ordered apps → projects →
+#: repos → clusters to match the operator's typical drill path.
 ARGOCD_OPS: tuple[ArgoCdOp, ...] = (
     _APP_LIST,
     _APP_GET,
@@ -507,4 +578,5 @@ ARGOCD_OPS: tuple[ArgoCdOp, ...] = (
     _APP_RESOURCE_TREE,
     _APPPROJECT_LIST,
     _REPO_LIST,
+    _CLUSTER_LIST,
 )

--- a/backend/tests/test_connectors_argocd_e2e.py
+++ b/backend/tests/test_connectors_argocd_e2e.py
@@ -26,18 +26,20 @@ meta-tools.
 Acceptance criteria verified (Issue #1392)
 ==========================================
 
-* All 6 read ops dispatch through ``call_operation`` against a registered
+* All 7 read ops dispatch through ``call_operation`` against a registered
   ``argocd`` target and return ``status="ok"`` with the recorded ArgoCD
   payload (the CLI-verb-equivalent invocation surface).
 * MCP ``search_operations(connector_id="argocd-api-3.x", …)`` surfaces all
-  6 ops; ``call_operation`` dispatches them.
+  7 ops; ``call_operation`` dispatches them.
 * Every dispatched op carries the Vault-sourced bearer token
   (``Authorization: Bearer <token>``) and the loader's secret never leaks
   into the returned envelope.
+* ``argocd.cluster.list`` strips the destination cluster's own credential
+  ``config`` (bearer token / TLS cert) from every item, end to end.
 
 Fixtures reproduce realistic-but-minimal ArgoCD 3.x ``argocd-server`` REST
 output (``ApplicationList`` / ``Application`` / managed-resources delta /
-resource tree / ``AppProjectList`` / ``RepositoryList``).
+resource tree / ``AppProjectList`` / ``RepositoryList`` / ``ClusterList``).
 """
 
 from __future__ import annotations
@@ -84,6 +86,7 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "argocd.app.resource_tree",
     "argocd.appproject.list",
     "argocd.repo.list",
+    "argocd.cluster.list",
 )
 
 _APP_NAME = "guestbook"
@@ -188,6 +191,32 @@ _FIXTURE_REPO_LIST: dict[str, Any] = {
     ],
 }
 
+#: The destination cluster's own bearer token — must never survive the handler.
+_DEST_CLUSTER_SECRET = "dest-cluster-bearer-e2e-DO-NOT-LEAK"
+
+#: ClusterList carrying the credential-bearing ``config`` block, so the E2E
+#: proves the handler strips it through the full call_operation stack.
+_FIXTURE_CLUSTER_LIST: dict[str, Any] = {
+    "metadata": {},
+    "items": [
+        {
+            "server": "https://10.0.4.10:6443",
+            "name": "prod-rke2",
+            "config": {
+                "bearerToken": _DEST_CLUSTER_SECRET,
+                "tlsClientConfig": {"insecure": False, "certData": "REDACT", "keyData": "REDACT"},
+            },
+            "connectionState": {
+                "status": "Successful",
+                "message": "",
+                "attemptedAt": "2026-08-06T09:00:00Z",
+            },
+            "serverVersion": "1.28",
+            "info": {"applicationsCount": 12, "connectionState": {"status": "Successful"}},
+        }
+    ],
+}
+
 
 def _mount_argocd_routes(mock: respx.MockRouter) -> None:
     """Register the 6 read-op fixture routes on *mock*."""
@@ -201,6 +230,7 @@ def _mount_argocd_routes(mock: respx.MockRouter) -> None:
     )
     mock.get("/api/v1/projects").respond(200, json=_FIXTURE_APPPROJECT_LIST)
     mock.get("/api/v1/repositories").respond(200, json=_FIXTURE_REPO_LIST)
+    mock.get("/api/v1/clusters").respond(200, json=_FIXTURE_CLUSTER_LIST)
 
 
 # ---------------------------------------------------------------------------
@@ -292,10 +322,10 @@ async def argocd_e2e() -> AsyncIterator[ArgoCdConnector]:
 # ---------------------------------------------------------------------------
 
 
-def test_argocd_e2e_op_set_is_exactly_the_six_read_ops() -> None:
-    """ARGOCD_OPS carries exactly the 6 curated read ops and no write op."""
+def test_argocd_e2e_op_set_is_exactly_the_seven_read_ops() -> None:
+    """ARGOCD_OPS carries exactly the 7 curated read ops and no write op."""
     assert {op.op_id for op in ARGOCD_OPS} == set(EXPECTED_OP_IDS)
-    assert len(ARGOCD_OPS) == 6
+    assert len(ARGOCD_OPS) == 7
 
 
 # ---------------------------------------------------------------------------
@@ -426,6 +456,31 @@ async def test_argocd_e2e_repo_list(argocd_e2e: ArgoCdConnector) -> None:
     assert repo["connectionState"]["status"] == "Successful"
 
 
+@pytest.mark.asyncio
+async def test_argocd_e2e_cluster_list(argocd_e2e: ArgoCdConnector) -> None:
+    """argocd.cluster.list returns destination clusters with config stripped."""
+    with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        _mount_argocd_routes(mock)
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": _CONNECTOR_ID,
+                "op_id": "argocd.cluster.list",
+                "target": {"name": _TARGET_NAME},
+                "params": {},
+            },
+        )
+    assert result["status"] == "ok", f"cluster.list failed: {result.get('error')}"
+    cluster = result["result"]["items"][0]
+    assert cluster["server"] == "https://10.0.4.10:6443"
+    assert cluster["name"] == "prod-rke2"
+    assert cluster["connectionState"]["status"] == "Successful"
+    assert cluster["serverVersion"] == "1.28"
+    # The credential-bearing config is stripped end to end; its secret is gone.
+    assert "config" not in cluster
+    assert _DEST_CLUSTER_SECRET not in str(result)
+
+
 # ---------------------------------------------------------------------------
 # Bearer-token + secret-leak guarantees across the full op set
 # ---------------------------------------------------------------------------
@@ -445,6 +500,7 @@ async def test_argocd_e2e_all_ops_carry_bearer_token_and_never_leak_secret(
             ("argocd.app.resource_tree", {"name": _APP_NAME}),
             ("argocd.appproject.list", {}),
             ("argocd.repo.list", {}),
+            ("argocd.cluster.list", {}),
         ):
             result = await call_operation(
                 _OPERATOR,
@@ -481,7 +537,7 @@ async def test_argocd_e2e_ops_visible_to_search_operations(
         _OPERATOR,
         {
             "connector_id": _CONNECTOR_ID,
-            "query": "argocd application sync health diff project repository",
+            "query": "argocd application sync health diff project repository cluster",
             "limit": 50,
         },
     )

--- a/backend/tests/test_connectors_argocd_reads.py
+++ b/backend/tests/test_connectors_argocd_reads.py
@@ -5,13 +5,17 @@
 
 Coverage matrix (per Task #1391 acceptance criteria):
 
-* **All six ops dispatch live** through :func:`~meho_backplane.operations.dispatch`
+* **All seven ops dispatch live** through :func:`~meho_backplane.operations.dispatch`
   against an ``argocd-server`` target: ``argocd.app.list`` / ``argocd.app.get``
   / ``argocd.app.diff`` / ``argocd.app.resource_tree`` /
-  ``argocd.appproject.list`` / ``argocd.repo.list`` each hit the correct
-  ArgoCD path with a bearer token and return ``status="ok"`` with the payload
-  in ``OperationResult.result``. respx mocks the wire; the in-process Vault
-  fake exercises the real default credential loader.
+  ``argocd.appproject.list`` / ``argocd.repo.list`` / ``argocd.cluster.list``
+  each hit the correct ArgoCD path with a bearer token and return
+  ``status="ok"`` with the payload in ``OperationResult.result``. respx mocks
+  the wire; the in-process Vault fake exercises the real default credential
+  loader.
+* **`argocd.cluster.list` strips per-cluster credentials** — the handler
+  removes the ``config`` object (bearer token / TLS client cert) from every
+  item, and dispatches ``GET /api/v1/clusters`` with no query params.
 * **`argocd.app.diff` returns the managed-resources delta** — the same
   desired-vs-live drift ``argocd app diff <app>`` renders (each item carries
   ``liveState`` / ``targetState``).
@@ -20,7 +24,7 @@ Coverage matrix (per Task #1391 acceptance criteria):
   the optional ``project`` scoping query.
 * **Visibility to `search_operations`** — after registration the ops are
   retrievable by their connector_id.
-* **`ARGOCD_OPS` registration shape** — all six carry ``safety_level="safe"``,
+* **`ARGOCD_OPS` registration shape** — all seven carry ``safety_level="safe"``,
   ``requires_approval=False``, a ``read-only`` tag, ``additionalProperties=False``
   on the parameter schema, and non-empty ``llm_instructions``. No write op is
   registered.
@@ -241,6 +245,44 @@ _REPO_LIST_RESPONSE: dict[str, Any] = {
         }
     ],
 }
+#: A cluster-list payload with no ``config`` block — the handler returns it
+#: verbatim (nothing to strip), so it doubles as the exact-equality fixture.
+_CLUSTER_LIST_RESPONSE: dict[str, Any] = {
+    "metadata": {},
+    "items": [
+        {
+            "server": "https://10.0.4.10:6443",
+            "name": "prod-rke2",
+            "connectionState": {
+                "status": "Successful",
+                "message": "",
+                "attemptedAt": "2026-08-06T09:00:00Z",
+            },
+            "serverVersion": "1.28",
+            "info": {"applicationsCount": 12},
+        }
+    ],
+}
+#: The destination cluster's own bearer token — must never survive the handler.
+_DEST_CLUSTER_SECRET = "destination-cluster-bearer-must-not-leak"
+#: A cluster-list payload that *does* carry the credential-bearing ``config``
+#: block, so the redaction test proves the handler strips it (rather than
+#: relying on argocd-server to omit it under a broad-RBAC token).
+_CLUSTER_LIST_WITH_CONFIG_RESPONSE: dict[str, Any] = {
+    "metadata": {},
+    "items": [
+        {
+            "server": "https://10.0.4.10:6443",
+            "name": "prod-rke2",
+            "config": {
+                "bearerToken": _DEST_CLUSTER_SECRET,
+                "tlsClientConfig": {"certData": "REDACT-ME", "keyData": "REDACT-ME"},
+            },
+            "connectionState": {"status": "Successful", "message": ""},
+            "serverVersion": "1.28",
+        }
+    ],
+}
 
 
 @pytest.mark.parametrize(
@@ -270,6 +312,7 @@ _REPO_LIST_RESPONSE: dict[str, Any] = {
         ),
         ("argocd.appproject.list", {}, "GET", "/api/v1/projects", _APPPROJECT_LIST_RESPONSE),
         ("argocd.repo.list", {}, "GET", "/api/v1/repositories", _REPO_LIST_RESPONSE),
+        ("argocd.cluster.list", {}, "GET", "/api/v1/clusters", _CLUSTER_LIST_RESPONSE),
     ],
 )
 @pytest.mark.asyncio
@@ -391,6 +434,74 @@ async def test_app_get_url_encodes_name_and_forwards_project_query(
     assert route.calls[0].request.url.params.get("project") == "default"
 
 
+@pytest.mark.asyncio
+async def test_cluster_list_redacts_config_from_items(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: cluster.list strips the credential-bearing ``config`` from every item.
+
+    The upstream payload deliberately includes ``config.bearerToken`` +
+    ``tlsClientConfig`` cert/key material — proving the redaction is enforced
+    by the handler, not merely assumed of the argocd-server API.
+    """
+    await _register_ops(_stub_embedding)
+    install_fake_client(monkeypatch, secret={"token": _CANARY_TOKEN})
+
+    async with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        mock.get("/api/v1/clusters").respond(200, json=_CLUSTER_LIST_WITH_CONFIG_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="argocd.cluster.list",
+            target=_ReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    item = result.result["items"][0]
+    # The non-secret fields survive; the whole config object is gone.
+    assert item["server"] == "https://10.0.4.10:6443"
+    assert item["connectionState"]["status"] == "Successful"
+    assert item["serverVersion"] == "1.28"
+    assert "config" not in item
+    # Belt and suspenders: no config key anywhere under items[], and the
+    # destination-cluster bearer never rides back in the envelope.
+    assert all("config" not in row for row in result.result["items"])
+    assert _DEST_CLUSTER_SECRET not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_cluster_list_dispatches_with_no_query_params(
+    _stub_embedding: AsyncMock,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: cluster.list calls GET /api/v1/clusters with no query params.
+
+    Mirrors the appproject_list / repo_list no-param dispatch — the op lists
+    every cluster the credential can see rather than server-side scoping.
+    """
+    await _register_ops(_stub_embedding)
+    install_fake_client(monkeypatch, secret={"token": _CANARY_TOKEN})
+
+    async with respx.mock(base_url=_ARGOCD_BASE_URL, assert_all_called=False) as mock:
+        route = mock.get("/api/v1/clusters").respond(200, json=_CLUSTER_LIST_RESPONSE)
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id=_CONNECTOR_ID,
+            op_id="argocd.cluster.list",
+            target=_ReadTarget(),
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+    assert route.called
+    assert route.calls[0].request.url.query == b""
+
+
 # ---------------------------------------------------------------------------
 # search_operations visibility
 # ---------------------------------------------------------------------------
@@ -424,10 +535,11 @@ _EXPECTED_OP_IDS = {
     "argocd.app.resource_tree",
     "argocd.appproject.list",
     "argocd.repo.list",
+    "argocd.cluster.list",
 }
 
 
-def test_argocd_ops_table_is_exactly_the_six_read_ops() -> None:
+def test_argocd_ops_table_is_exactly_the_seven_read_ops() -> None:
     assert {op.op_id for op in ARGOCD_OPS} == _EXPECTED_OP_IDS
 
 

--- a/docs/codebase/connectors-argocd.md
+++ b/docs/codebase/connectors-argocd.md
@@ -9,8 +9,9 @@ dispatches ArgoCD `argocd-server` REST operations under the
 skeleton — bearer-token auth, fingerprint, probe, the G0.6 dispatch shim, and
 dual registration. G3.12-T2 (#1391) layers the curated read core on top:
 `argocd.app.list` / `argocd.app.get` / `argocd.app.diff` /
-`argocd.app.resource_tree` / `argocd.appproject.list` / `argocd.repo.list` —
-all `safety_level="safe"`, `requires_approval=False`, read-only. G3.12-T3
+`argocd.app.resource_tree` / `argocd.appproject.list` / `argocd.repo.list`
+(plus `argocd.cluster.list`, added in #2855) — all `safety_level="safe"`,
+`requires_approval=False`, read-only. G3.12-T3
 (#1392) closes the connector out: the ops are operator-usable via the
 per-connector `meho argocd …` Cobra verb tree (`cli/internal/cmd/argocd/`,
 pre-baking `connector_id="argocd-api-3.x"`, mirroring the keycloak/harbor/nsx
@@ -49,12 +50,12 @@ Source: `backend/src/meho_backplane/connectors/argocd/`.
   (`"token"`) an operator stores under `target.secret_ref`. Shared by the
   connector, the loader, and the tests.
 - **`ArgoCdOp`** + **`ARGOCD_OPS`** (`ops.py`) — the typed-op metadata dataclass
-  and the six-entry registration tuple (the curated read core). Mirrors the
+  and the seven-entry registration tuple (the curated read core). Mirrors the
   bind9 `Bind9Op` / `BIND9_OPS` shape: one frozen dataclass per op carrying the
   `register_typed_operation` kwargs plus a `handler_attr` naming the bound
   method on `ArgoCdConnector`. **`ARGOCD_WHEN_TO_USE_BY_GROUP`** maps each op's
-  `group_key` (`argocd-apps` / `argocd-projects` / `argocd-repos`) to its
-  curated `when_to_use` blurb.
+  `group_key` (`argocd-apps` / `argocd-projects` / `argocd-repos` /
+  `argocd-clusters`) to its curated `when_to_use` blurb.
 - **`register_argocd_typed_operations`** (`__init__.py`) — the lifespan-driven
   registrar (queued via `register_typed_op_registrar`) that delegates to
   `ArgoCdConnector.register_operations()`.
@@ -128,15 +129,15 @@ unauthenticated `GET /api/version` probe is the right reachability surface.
 
 ### Curated read ops (G3.12-T2)
 
-Six read-only ops are upserted into `endpoint_descriptor` at lifespan startup
+Seven read-only ops are upserted into `endpoint_descriptor` at lifespan startup
 by `register_argocd_typed_operations` → `ArgoCdConnector.register_operations()`,
 which walks `ARGOCD_OPS` and routes each row through `register_typed_operation`
 (idempotent across pod restarts — re-embed is skipped on unchanged text). Each
 handler is a thin bound method on `ArgoCdConnector` (`app_list` / `app_get` /
-`app_diff` / `app_resource_tree` / `appproject_list` / `repo_list`) that the
-dispatcher binds to the per-process instance and threads `operator` into; the
-handler forwards `operator` to `_get_json` so the bearer token is read under
-the operator's identity.
+`app_diff` / `app_resource_tree` / `appproject_list` / `repo_list` /
+`cluster_list`) that the dispatcher binds to the per-process instance and
+threads `operator` into; the handler forwards `operator` to `_get_json` so the
+bearer token is read under the operator's identity.
 
 | op_id | endpoint | returns |
 |---|---|---|
@@ -146,6 +147,7 @@ the operator's identity.
 | `argocd.app.resource_tree` | `GET /api/v1/applications/{name}/resource-tree` | `{nodes, orphanedNodes, hosts, shardsCount}` |
 | `argocd.appproject.list` | `GET /api/v1/projects` | `{items, metadata}` — AppProjects + allow-lists |
 | `argocd.repo.list` | `GET /api/v1/repositories` | `{items, metadata}` — repos + connectionState |
+| `argocd.cluster.list` | `GET /api/v1/clusters` | `{items, metadata}` — destination clusters + connectionState/serverVersion (per-cluster `config` credentials stripped) |
 
 `argocd.app.diff` is the API-level equivalent of `argocd app diff <app>`: the
 managed-resources delta where each item's `liveState` (cluster) is compared
@@ -153,6 +155,16 @@ against `targetState` (Git-rendered desired). The per-app ops URL-encode the
 `name` param into the path (so a slash in the name stays one segment) and
 forward the optional `project` scoping query. `app.list` serialises `projects`
 as repeated query pairs (the gRPC-gateway repeated-field shape).
+
+`argocd.cluster.list` (#2855) inventories the Kubernetes destination clusters
+ArgoCD manages (`GET /api/v1/clusters`) with each cluster's `connectionState`
+and `serverVersion` — the governed answer to "which clusters does this ArgoCD
+manage and is each reachable?". It takes no query params (lists every cluster
+the credential can see). ArgoCD's `Cluster.config` carries the destination
+cluster's own credentials (bearer token, TLS client cert/key, basic-auth,
+AWS/exec provider); the handler strips the whole `config` object from every
+item before returning — defense in depth, so no destination credential leaks
+even if a broad-RBAC token makes argocd-server include it.
 
 ### Approval-gated write ops (G3.12-T4)
 
@@ -261,20 +273,23 @@ shim.
   respx-mocked ArgoCD, plus the canary-token leak assertions.
 - `tests/test_connectors_registry_v2.py::test_argocd_connector_registered_under_v2_triple_and_wildcard`
   — asserts the dual registration resolves.
-- `tests/test_connectors_argocd_reads.py` — the G3.12-T2 read-core suite: each
-  of the six ops dispatched live through `dispatch` against respx-mocked
+- `tests/test_connectors_argocd_reads.py` — the read-core suite: each
+  of the seven ops dispatched live through `dispatch` against respx-mocked
   `argocd-server` (right path + bearer token + payload), `app.diff` returns the
   managed-resources drift, query-param plumbing (`projects`/`selector`/`project`
-  + name URL-encoding), `search_operations` visibility, and the `ARGOCD_OPS`
-  registration-shape invariants (all `safe`/no-approval/`read-only`, no write op).
-- `tests/test_connectors_argocd_e2e.py` — the G3.12-T3 recorded-fixture E2E:
-  each of the six ops dispatched through the `call_operation` meta-tool (the
+  + name URL-encoding), `cluster.list`'s per-cluster `config` redaction +
+  no-query-param dispatch (#2855), `search_operations` visibility, and the
+  `ARGOCD_OPS` registration-shape invariants (all `safe`/no-approval/`read-only`,
+  no write op).
+- `tests/test_connectors_argocd_e2e.py` — the recorded-fixture E2E:
+  each of the seven ops dispatched through the `call_operation` meta-tool (the
   same narrow-waist surface the MCP server and the `meho operation call` CLI
   verb reach) against a respx-mocked `argocd-server`, resolving a real
   DB-seeded `targets` row through `resolve_target` and a stub bearer-token
   loader preseeded into the dispatcher instance cache; asserts the Vault-sourced
-  bearer rides every request, the token never leaks into the envelope, and all
-  six ops are visible to `search_operations`.
+  bearer rides every request, the token never leaks into the envelope,
+  `cluster.list` strips the destination cluster's own `config` credentials end
+  to end, and all seven ops are visible to `search_operations`.
 - `tests/test_connectors_argocd_write_e2e.py` — the G3.12-T4 write-op suite:
   the seven write ops' registration + safety-level/`requires_approval`
   invariants, the approve-queue routing of an un-approved `USER` dispatch
@@ -297,7 +312,9 @@ shim.
 ## References
 
 - Issues: #1390 (G3.12-T1 skeleton), #1391 (G3.12-T2 curated read core),
-  #1392 (G3.12-T3 CLI/MCP review + recorded-fixture E2E + onboarding doc).
+  #1392 (G3.12-T3 CLI/MCP review + recorded-fixture E2E + onboarding doc),
+  #2855 (`argocd.cluster.list` — destination-cluster inventory + connectionState,
+  under Initiative #2833 connector read-op coverage wave 2).
   Initiative: #1387 (G3.12 argocd connector). Goal: #214 (connector parity /
   wrapper retirement).
 - HttpConnector base: `backend/src/meho_backplane/connectors/adapters/http.py`


### PR DESCRIPTION
## Summary
- Add `argocd.cluster.list` (`GET /api/v1/clusters`), the seventh curated ArgoCD read op — destination-cluster inventory with each cluster's `connectionState`, `serverVersion`, and `info.applicationsCount`. The governed answer to "which clusters does this ArgoCD manage and is each reachable?", replacing an untracked `argocd cluster list` / raw `kubectl get secrets -l argocd.argoproj.io/secret-type=cluster` that bypasses policy/audit/broadcast.
- Mirrors `argocd.repo.list` exactly (safe, no-approval, `{items, metadata}` envelope, thin `_get_json` handler) under a new `argocd-clusters` op group.
- **Credential redaction (defense in depth):** ArgoCD's `Cluster.config` carries the destination cluster's own credentials (bearer token, TLS client cert/key, basic-auth, AWS/exec provider — and has no `omitempty` upstream). The handler strips the whole `config` object from every item before returning, so no destination credential leaks even if a broad-RBAC token makes argocd-server include it.
- Set-shaped result flows through the standard dispatch reducer (JSONFlux / result-handle wrapping) like the other list ops — no special-casing.

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/argocd/` — clean
- [x] `pytest` argocd suite — 91 passed (reads + e2e + write_e2e + credread + auth)
- [x] `code-quality.py --diff` — no agent-introduced violations
- [x] AC: `argocd.cluster.list` registered `safety_level="safe"`, `requires_approval=False`, `read-only` tag; dispatches live via `dispatch` and via the `call_operation` meta-tool against a respx-mocked `argocd-server`
- [x] AC: `_EXPECTED_OP_IDS` / `EXPECTED_OP_IDS` gain the op; the "…exactly the *seven* read ops" invariants + the parametrized safe/no-approval/`additionalProperties`/`llm_instructions` shape tests pass for it
- [x] AC: `test_no_write_or_mutating_op_is_registered` still passes (no write surface added)
- [x] AC: a test proves no `config` key survives anywhere under `items[]`, using an upstream payload that *does* carry `config.bearerToken` + `tlsClientConfig` (reads + e2e, end to end)
- [x] AC: a test asserts `GET /api/v1/clusters` is dispatched with no query params
- [x] AC: `ARGOCD_WHEN_TO_USE_BY_GROUP` carries `argocd-clusters`; `register_operations()` does not raise at startup
- [x] AC: `docs/codebase/connectors-argocd.md` op table bumped six → seven, new op + redaction documented
- [x] Vendor `GET /api/v1/clusters` shape confirmed against argoproj/argo-cd `server/cluster/cluster.proto` (optional query params `server`/`name`/`id.*`) + `pkg/apis/application/v1alpha1/types.go` (`Cluster`/`ClusterConfig`/`ClusterInfo`/`ConnectionState` structs)

## Out of scope
- No cluster **write** ops (`cluster.create`/`update`/`delete`) — a separate approval-gated Task if ever needed.
- No per-cluster `argocd.cluster.get` and no server-side `id.type`/`id.value` scoping — `cluster.list`'s `items[]` already carries full `ClusterInfo` per item.
- No new `meho argocd cluster list` CLI verb — the generic `meho operation call argocd-api-3.x argocd.cluster.list` covers operators, and no FastAPI route / OpenAPI schema changed, so the CLI OpenAPI snapshot needs no regen. (Adjacent finding: a convenience verb mirroring `cli/internal/cmd/argocd/repo.go` could be added later.)

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2855
