### PR TITLE
feat(connectors): add rke2.node.config.get redacted config read (#2854)

### DIFF
--- a/backend/src/meho_backplane/connectors/rke2/connector.py
+++ b/backend/src/meho_backplane/connectors/rke2/connector.py
@@ -366,7 +366,8 @@ class Rke2SshConnector(SshConnector):
 
         Delegates to
         :func:`~meho_backplane.connectors.rke2.ops_read.rke2_config_get`,
-        which ``cat``s a bounded ``/etc/rancher/rke2/*.yaml`` file over SSH and
+        which ``cat``s the RKE2 server ``config.yaml`` (or a ``config.yaml.d``
+        drop-in) over SSH and
         returns its parsed content with the join tokens + etcd S3 credentials
         redacted. Read-only / safe -- the write-side reader lives in
         ``config_update``.
@@ -664,8 +665,9 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     "rke2-config-read": (
         "Use to read an RKE2 node's ``config.yaml`` CONTENT (not just its "
         "permission modes) before or after an ``rke2.node.config.update`` "
-        "patch: ``rke2.node.config.get`` ``cat``s one bounded "
-        "``/etc/rancher/rke2/*.yaml`` file and returns the parsed top-level "
+        "patch: ``rke2.node.config.get`` ``cat``s the server ``config.yaml`` "
+        "(or a ``config.yaml.d/*.yaml`` drop-in) and returns the parsed "
+        "top-level "
         "mapping so an operator can verify ``tls-san`` / ``datastore-endpoint`` "
         "/ ``node-taint``. The join tokens and etcd S3 credentials are "
         "redacted (names surfaced in ``redacted_keys``, values never), so it "

--- a/backend/src/meho_backplane/connectors/rke2/connector.py
+++ b/backend/src/meho_backplane/connectors/rke2/connector.py
@@ -356,6 +356,27 @@ class Rke2SshConnector(SshConnector):
 
         return await _rke2_service_status(self, target, params, operator)
 
+    async def config_get(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``rke2.node.config.get`` (#2854).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.rke2.ops_read.rke2_config_get`,
+        which ``cat``s a bounded ``/etc/rancher/rke2/*.yaml`` file over SSH and
+        returns its parsed content with the join tokens + etcd S3 credentials
+        redacted. Read-only / safe -- the write-side reader lives in
+        ``config_update``.
+        """
+        from meho_backplane.connectors.rke2.ops_read import (
+            rke2_config_get as _rke2_config_get,
+        )
+
+        return await _rke2_config_get(self, target, params, operator)
+
     async def token_rotate(
         self,
         target: Target,
@@ -639,6 +660,17 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "cannot answer 'is rke2-server actually up, and is it crash-looping?'. "
         "Read-only -- the restart itself is the approval-gated "
         "``rke2.node.service.restart``. Transport: plain SSH."
+    ),
+    "rke2-config-read": (
+        "Use to read an RKE2 node's ``config.yaml`` CONTENT (not just its "
+        "permission modes) before or after an ``rke2.node.config.update`` "
+        "patch: ``rke2.node.config.get`` ``cat``s one bounded "
+        "``/etc/rancher/rke2/*.yaml`` file and returns the parsed top-level "
+        "mapping so an operator can verify ``tls-san`` / ``datastore-endpoint`` "
+        "/ ``node-taint``. The join tokens and etcd S3 credentials are "
+        "redacted (names surfaced in ``redacted_keys``, values never), so it "
+        "replaces the untracked ``ssh cat`` that would leak the token. "
+        "Read-only / safe. Transport: plain SSH."
     ),
     "rke2-etcd-snapshot": (
         "Use for managed-etcd snapshots on an RKE2 server node. "

--- a/backend/src/meho_backplane/connectors/rke2/ops_read.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_read.py
@@ -94,6 +94,7 @@ __all__ = [
     "STATUS_UNKNOWN",
     "Rke2PostureProbeError",
     "Rke2ServiceStatusProbeError",
+    "bound_read_config_path",
     "build_posture_probe_command",
     "build_service_status_command",
     "parse_posture",
@@ -822,6 +823,52 @@ def redact_config_content(content: dict[str, Any]) -> tuple[dict[str, Any], list
     return redacted, sorted(touched)
 
 
+#: ``rke2.node.config.get`` is confined to the RKE2 *server config* only: the
+#: main ``config.yaml`` and its documented drop-in directory
+#: ``config.yaml.d/*.yaml`` (both read by RKE2 in alphabetical order --
+#: https://docs.rke2.io/install/configuration). Sibling files under
+#: ``/etc/rancher/rke2/`` -- the admin kubeconfig ``rke2.yaml`` and
+#: ``registries.yaml`` -- keep their credentials in NESTED keys the flat
+#: top-level redaction set (:func:`redact_config_content`) never reaches, so
+#: this read op refuses them outright rather than return a cleartext secret.
+_READ_CONFIG_PATH: str = "/etc/rancher/rke2/config.yaml"
+_READ_CONFIG_DROPIN_PREFIX: str = "/etc/rancher/rke2/config.yaml.d/"
+
+
+def bound_read_config_path(raw_path: Any) -> str:
+    """Return the read-confined config path, or raise ``ConfigPathRejectedError``.
+
+    Layers the read op's tighter allow-set on top of the write op's
+    :func:`~meho_backplane.connectors.rke2.ops_write.bound_config_path`
+    traversal / root / ``.yaml`` checks: the resolved path must be exactly
+    ``/etc/rancher/rke2/config.yaml`` or a single-level
+    ``/etc/rancher/rke2/config.yaml.d/<name>.yaml`` drop-in. Every other
+    ``*.yaml`` under the root -- notably the admin kubeconfig ``rke2.yaml`` and
+    ``registries.yaml``, whose secrets live in nested keys
+    :func:`redact_config_content` cannot mask -- is rejected before any SSH
+    round trip, so a ``safe`` / no-approval call can never spill a cluster-admin
+    private key or a registry password in cleartext.
+    """
+    from meho_backplane.connectors.rke2.ops_write import (
+        ConfigPathRejectedError,
+        bound_config_path,
+    )
+
+    path = bound_config_path(raw_path)
+    if path == _READ_CONFIG_PATH:
+        return path
+    if path.startswith(_READ_CONFIG_DROPIN_PREFIX):
+        leaf = path[len(_READ_CONFIG_DROPIN_PREFIX) :]
+        if leaf and "/" not in leaf:
+            return path
+    raise ConfigPathRejectedError(
+        f"path {path!r} is not the RKE2 server config: only "
+        "/etc/rancher/rke2/config.yaml and config.yaml.d/*.yaml drop-ins are "
+        "readable (sibling files such as rke2.yaml / registries.yaml hold "
+        "nested secrets this read op cannot redact)"
+    )
+
+
 async def rke2_config_get(
     connector: Rke2SshConnector,
     target: Target,
@@ -830,7 +877,8 @@ async def rke2_config_get(
 ) -> dict[str, Any]:
     """Handler for ``rke2.node.config.get`` -- redacted config.yaml read (#2854).
 
-    Reads a single bounded ``/etc/rancher/rke2/*.yaml`` file over SSH with the
+    Reads the RKE2 server ``config.yaml`` (or a ``config.yaml.d/*.yaml``
+    drop-in) over SSH with the
     same ``cat`` + :func:`yaml.safe_load` step ``rke2.node.config.update``
     already runs, and returns the parsed top-level mapping with secret-bearing
     keys redacted (:func:`redact_config_content`) -- so an operator can verify
@@ -838,19 +886,18 @@ async def rke2_config_get(
     config patch without an untracked ``ssh cat`` that would spill the join
     token into shell history.
 
-    The path is confined by :func:`~meho_backplane.connectors.rke2.ops_write.bound_config_path`
-    (the same ``/etc/rancher/rke2/*.yaml`` filter the write op uses), so a
-    traversal attempt is rejected before any SSH round trip. Non-mapping or
-    unparseable YAML surfaces a structured ``error`` rather than crashing the
-    dispatch. Never mutates the node.
+    The path is confined by :func:`bound_read_config_path` to the RKE2 server
+    config only -- ``config.yaml`` or a ``config.yaml.d/*.yaml`` drop-in -- so a
+    traversal attempt *and* a sibling file whose nested secrets this op cannot
+    redact (the admin kubeconfig ``rke2.yaml``, ``registries.yaml``) are
+    rejected before any SSH round trip. Non-mapping or unparseable YAML surfaces
+    a structured ``error`` rather than crashing the dispatch. Never mutates the
+    node.
     """
-    from meho_backplane.connectors.rke2.ops_write import (
-        Rke2WriteSafetyError,
-        bound_config_path,
-    )
+    from meho_backplane.connectors.rke2.ops_write import Rke2WriteSafetyError
 
     try:
-        path = bound_config_path(params.get("path"))
+        path = bound_read_config_path(params.get("path"))
     except Rke2WriteSafetyError as exc:
         return {"error": f"config.get path check: {exc}"}
 
@@ -879,8 +926,8 @@ _RKE2_CONFIG_GET_OP = Rke2Op(
     handler_attr="config_get",
     summary="Read an RKE2 config.yaml file's content with join/S3 secrets redacted.",
     description=(
-        "Reads a single ``/etc/rancher/rke2/*.yaml`` file (default "
-        "``config.yaml``) over SSH -- the same ``cat`` + YAML parse "
+        "Reads the RKE2 server ``config.yaml`` (or a ``config.yaml.d/*.yaml`` "
+        "drop-in) over SSH -- the same ``cat`` + YAML parse "
         "``rke2.node.config.update`` runs -- and returns the parsed top-level "
         "mapping so an operator can verify ``tls-san`` / ``datastore-endpoint`` "
         "/ ``node-taint`` before or after a config patch. Secret-bearing keys "
@@ -889,8 +936,10 @@ _RKE2_CONFIG_GET_OP = Rke2Op(
         "``etcd-s3-session-token``) are replaced with ``***redacted***``, and "
         "``datastore-endpoint`` has only its ``user:pass@`` DSN userinfo "
         "masked (host/port/db preserved). The masked key NAMES are listed in "
-        "``redacted_keys``. The path is confined to ``/etc/rancher/rke2/*.yaml`` "
-        "(traversal rejected before any SSH); non-mapping / invalid YAML "
+        "``redacted_keys``. The path is confined to the server config "
+        "``config.yaml`` + ``config.yaml.d/*.yaml`` drop-ins -- sibling files "
+        "like ``rke2.yaml`` / ``registries.yaml`` and traversal are rejected "
+        "before any SSH; non-mapping / invalid YAML "
         "returns a structured ``error``. safety_level=safe, "
         "requires_approval=False, read-only."
     ),
@@ -899,11 +948,13 @@ _RKE2_CONFIG_GET_OP = Rke2Op(
         "properties": {
             "path": {
                 "type": "string",
-                "pattern": r"^/etc/rancher/rke2/[^\x00\n\r]*\.yaml$",
+                "pattern": r"^/etc/rancher/rke2/config\.yaml(\.d/[^/\x00\n\r]+\.yaml)?$",
                 "description": (
-                    "Absolute path to the RKE2 config file to read. Must be a "
-                    ".yaml file under /etc/rancher/rke2/ (default "
-                    "/etc/rancher/rke2/config.yaml). Omit for the default."
+                    "Absolute path to the RKE2 server config to read: "
+                    "/etc/rancher/rke2/config.yaml or a "
+                    "/etc/rancher/rke2/config.yaml.d/<name>.yaml drop-in. Omit "
+                    "for the default config.yaml. Sibling files such as "
+                    "rke2.yaml / registries.yaml are not readable here."
                 ),
             },
         },
@@ -936,12 +987,15 @@ _RKE2_CONFIG_GET_OP = Rke2Op(
             "S3 credentials so they never reach the transcript. It reports "
             "content, not permission modes -- use ``rke2.posture.show`` for "
             "file modes / token presence. Transport: plain SSH (read-only "
-            "``cat`` of one bounded ``/etc/rancher/rke2/*.yaml`` path)."
+            "``cat`` of the server ``config.yaml`` / a ``config.yaml.d`` "
+            "drop-in)."
         ),
         "parameter_hints": {
             "path": (
-                "Optional; a .yaml file under /etc/rancher/rke2/ (e.g. a "
-                "config.yaml.d drop-in). Omit for /etc/rancher/rke2/config.yaml."
+                "Optional; the server config.yaml or a config.yaml.d/<name>.yaml "
+                "drop-in under /etc/rancher/rke2/. Omit for "
+                "/etc/rancher/rke2/config.yaml. Sibling files (rke2.yaml, "
+                "registries.yaml) are rejected."
             ),
         },
         "output_shape": (

--- a/backend/src/meho_backplane/connectors/rke2/ops_read.py
+++ b/backend/src/meho_backplane/connectors/rke2/ops_read.py
@@ -69,8 +69,11 @@ means the probe finished, and anything less raises.
 
 from __future__ import annotations
 
+import re
 import shlex
 from typing import TYPE_CHECKING, Any
+
+import yaml
 
 from meho_backplane.connectors.rke2.ops import SSH_TRANSPORT_NOTE, Rke2Op
 
@@ -81,7 +84,9 @@ if TYPE_CHECKING:
 __all__ = [
     "POSTURE_CONFIG_PATHS",
     "READ_OPS",
+    "REDACTED_SENTINEL",
     "RKE2_TOKEN_PATH",
+    "SECRET_CONFIG_KEYS",
     "SERVICE_STATUS_PROPERTIES",
     "SERVICE_UNITS",
     "STATUS_ABSENT",
@@ -94,6 +99,8 @@ __all__ = [
     "parse_posture",
     "parse_posture_probe_output",
     "parse_service_status",
+    "redact_config_content",
+    "rke2_config_get",
     "rke2_posture_show",
     "rke2_service_status",
 ]
@@ -733,6 +740,229 @@ _RKE2_SERVICE_STATUS_OP = Rke2Op(
 )
 
 
-#: The read-only tier ops. ``rke2.about`` (the identity canary) is composed
-#: alongside these in :func:`meho_backplane.connectors.rke2.ops._rke2_ops`.
-READ_OPS: tuple[Rke2Op, ...] = (_RKE2_POSTURE_OP, _RKE2_SERVICE_STATUS_OP)
+# ---------------------------------------------------------------------------
+# rke2.node.config.get -- redacted config.yaml content read (#2854)
+# ---------------------------------------------------------------------------
+
+#: The value substituted for a fully-redacted secret key. Matches the
+#: names-only-disclosure discipline ``changed_config_keys`` established on
+#: the write side: the operator learns the key is set without seeing it.
+REDACTED_SENTINEL: str = "***redacted***"
+
+#: RKE2 ``config.yaml`` top-level keys whose value is a secret in itself and
+#: is replaced wholesale with :data:`REDACTED_SENTINEL`. Grounded against the
+#: RKE2 server-config reference (docs.rke2.io/reference/server_config): the
+#: two join tokens the connector's own write-side docstring names
+#: (``token`` / ``agent-token``, ``ops_write.py``) plus the three etcd S3
+#: snapshot credentials (mapped to ``AWS_ACCESS_KEY_ID`` /
+#: ``AWS_SECRET_ACCESS_KEY`` / ``AWS_SESSION_TOKEN``). Matching is
+#: case-sensitive because RKE2 only honours the exact lowercase-hyphenated
+#: flag names, so a mis-cased key is not a live credential. Sibling ``*-file``
+#: keys and ``private-registry`` are on-disk paths, not secret values, and are
+#: deliberately NOT redacted -- the operator asked to verify them.
+SECRET_CONFIG_KEYS: frozenset[str] = frozenset(
+    {
+        "token",
+        "agent-token",
+        "etcd-s3-access-key",
+        "etcd-s3-secret-key",
+        "etcd-s3-session-token",
+    }
+)
+
+#: The one config key whose value is a datastore DSN that may embed
+#: ``user:password@`` userinfo (external MySQL/Postgres/NATS datastore). Only
+#: the userinfo segment is masked -- the operator's stated need is to verify
+#: the host/port/database, which stays visible.
+_DATASTORE_ENDPOINT_KEY: str = "datastore-endpoint"
+
+#: Matches the ``scheme://userinfo@`` prefix of a DSN so the userinfo (which
+#: may itself contain ``:``) can be masked without disturbing the host/port/
+#: path that follow. ``[^/@\s]+`` stops at the first ``@`` and never crosses a
+#: ``/``, so a credential-less endpoint (no ``@``) is left untouched.
+_DSN_USERINFO_RE = re.compile(r"(?P<scheme>[A-Za-z][A-Za-z0-9+.\-]*://)[^/@\s]+@")
+
+
+def _mask_dsn_userinfo(value: Any) -> tuple[Any, bool]:
+    """Mask the ``user:pass@`` userinfo of a datastore DSN string.
+
+    Returns ``(masked_value, changed)``. A non-string value or a DSN with no
+    userinfo is returned unchanged with ``changed=False``; the host/port/
+    database portion is always preserved so the operator can still verify it.
+    """
+    if not isinstance(value, str):
+        return value, False
+    masked, count = _DSN_USERINFO_RE.subn(rf"\g<scheme>{REDACTED_SENTINEL}@", value)
+    return masked, count > 0
+
+
+def redact_config_content(content: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Return a redacted copy of *content* plus the sorted redacted key names.
+
+    Secret-bearing top-level keys (:data:`SECRET_CONFIG_KEYS`) have their value
+    replaced by :data:`REDACTED_SENTINEL`; ``datastore-endpoint`` has only its
+    DSN userinfo masked. The input mapping is not mutated. A key lands in the
+    returned name list only when it was actually present and masked, mirroring
+    the write side's ``changed_config_keys`` names-only discipline -- so the
+    secret VALUE never appears in the result envelope (and therefore never in
+    the audit ``raw_payload``, which stores the raw handler result), while its
+    NAME is disclosed so the operator knows the key is set.
+    """
+    redacted = dict(content)
+    touched: set[str] = set()
+    for key, value in content.items():
+        if key in SECRET_CONFIG_KEYS:
+            redacted[key] = REDACTED_SENTINEL
+            touched.add(key)
+        elif key == _DATASTORE_ENDPOINT_KEY:
+            masked, changed = _mask_dsn_userinfo(value)
+            if changed:
+                redacted[key] = masked
+                touched.add(key)
+    return redacted, sorted(touched)
+
+
+async def rke2_config_get(
+    connector: Rke2SshConnector,
+    target: Target,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Handler for ``rke2.node.config.get`` -- redacted config.yaml read (#2854).
+
+    Reads a single bounded ``/etc/rancher/rke2/*.yaml`` file over SSH with the
+    same ``cat`` + :func:`yaml.safe_load` step ``rke2.node.config.update``
+    already runs, and returns the parsed top-level mapping with secret-bearing
+    keys redacted (:func:`redact_config_content`) -- so an operator can verify
+    ``tls-san`` / ``datastore-endpoint`` / ``node-taint`` before or after a
+    config patch without an untracked ``ssh cat`` that would spill the join
+    token into shell history.
+
+    The path is confined by :func:`~meho_backplane.connectors.rke2.ops_write.bound_config_path`
+    (the same ``/etc/rancher/rke2/*.yaml`` filter the write op uses), so a
+    traversal attempt is rejected before any SSH round trip. Non-mapping or
+    unparseable YAML surfaces a structured ``error`` rather than crashing the
+    dispatch. Never mutates the node.
+    """
+    from meho_backplane.connectors.rke2.ops_write import (
+        Rke2WriteSafetyError,
+        bound_config_path,
+    )
+
+    try:
+        path = bound_config_path(params.get("path"))
+    except Rke2WriteSafetyError as exc:
+        return {"error": f"config.get path check: {exc}"}
+
+    quoted_path = shlex.quote(path)
+    read_cmd = f"if [ -e {quoted_path} ]; then cat -- {quoted_path}; fi"
+    read_proc = await connector._run_command(target, read_cmd, operator=operator)
+    if getattr(read_proc, "exit_status", None) not in (0, None):
+        return {"path": path, "error": "failed to read the config file"}
+
+    stdout_raw = read_proc.stdout if hasattr(read_proc, "stdout") else ""
+    stdout = stdout_raw if isinstance(stdout_raw, str) else ""
+    try:
+        parsed = yaml.safe_load(stdout)
+    except yaml.YAMLError as exc:
+        return {"path": path, "error": f"config file is not valid YAML: {exc}"}
+    content: dict[str, Any] = parsed if parsed is not None else {}
+    if not isinstance(content, dict):
+        return {"path": path, "error": "config file is not a YAML mapping"}
+
+    redacted, redacted_keys = redact_config_content(content)
+    return {"path": path, "content": redacted, "redacted_keys": redacted_keys}
+
+
+_RKE2_CONFIG_GET_OP = Rke2Op(
+    op_id="rke2.node.config.get",
+    handler_attr="config_get",
+    summary="Read an RKE2 config.yaml file's content with join/S3 secrets redacted.",
+    description=(
+        "Reads a single ``/etc/rancher/rke2/*.yaml`` file (default "
+        "``config.yaml``) over SSH -- the same ``cat`` + YAML parse "
+        "``rke2.node.config.update`` runs -- and returns the parsed top-level "
+        "mapping so an operator can verify ``tls-san`` / ``datastore-endpoint`` "
+        "/ ``node-taint`` before or after a config patch. Secret-bearing keys "
+        "are REDACTED, not withheld: ``token`` / ``agent-token`` and the etcd "
+        "S3 credentials (``etcd-s3-access-key`` / ``etcd-s3-secret-key`` / "
+        "``etcd-s3-session-token``) are replaced with ``***redacted***``, and "
+        "``datastore-endpoint`` has only its ``user:pass@`` DSN userinfo "
+        "masked (host/port/db preserved). The masked key NAMES are listed in "
+        "``redacted_keys``. The path is confined to ``/etc/rancher/rke2/*.yaml`` "
+        "(traversal rejected before any SSH); non-mapping / invalid YAML "
+        "returns a structured ``error``. safety_level=safe, "
+        "requires_approval=False, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "pattern": r"^/etc/rancher/rke2/[^\x00\n\r]*\.yaml$",
+                "description": (
+                    "Absolute path to the RKE2 config file to read. Must be a "
+                    ".yaml file under /etc/rancher/rke2/ (default "
+                    "/etc/rancher/rke2/config.yaml). Omit for the default."
+                ),
+            },
+        },
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "path": {"type": "string"},
+            "content": {"type": "object"},
+            "redacted_keys": {"type": "array", "items": {"type": "string"}},
+            "error": {"type": "string"},
+        },
+        "required": [],
+        "additionalProperties": True,
+    },
+    group_key="rke2-config-read",
+    tags=("read-only", "rke2", "config"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call to read an RKE2 node's config.yaml content and verify "
+            "non-secret settings (``tls-san``, ``datastore-endpoint`` host, "
+            "``node-taint``, ``cni``, ...) before or after "
+            "``rke2.node.config.update`` -- e.g. re-confirming a "
+            "post-token-rotation config edit landed on every server. Prefer "
+            "this over an untracked ``ssh cat`` of the file: it is governed "
+            "(policy/audit/broadcast) and it REDACTS the join tokens + etcd "
+            "S3 credentials so they never reach the transcript. It reports "
+            "content, not permission modes -- use ``rke2.posture.show`` for "
+            "file modes / token presence. Transport: plain SSH (read-only "
+            "``cat`` of one bounded ``/etc/rancher/rke2/*.yaml`` path)."
+        ),
+        "parameter_hints": {
+            "path": (
+                "Optional; a .yaml file under /etc/rancher/rke2/ (e.g. a "
+                "config.yaml.d drop-in). Omit for /etc/rancher/rke2/config.yaml."
+            ),
+        },
+        "output_shape": (
+            "``{path, content: {<parsed keys>}, redacted_keys: [names]}``. "
+            "``content`` is the parsed top-level YAML mapping with "
+            "``token`` / ``agent-token`` / ``etcd-s3-*`` keys shown as "
+            "``***redacted***`` and ``datastore-endpoint`` userinfo masked; "
+            "``redacted_keys`` lists exactly which keys were masked (empty "
+            "when the file holds no secrets). A missing or empty file yields "
+            "``content: {}``. On a path-bound violation or unparseable YAML: "
+            "``{error}`` (plus ``path`` when the path was valid)."
+        ),
+    },
+)
+
+
+#: The read-only tier ops (posture + service status + redacted config
+#: read). ``rke2.about`` (the identity canary) is composed alongside
+#: these in :func:`meho_backplane.connectors.rke2.ops._rke2_ops`.
+READ_OPS: tuple[Rke2Op, ...] = (
+    _RKE2_POSTURE_OP,
+    _RKE2_SERVICE_STATUS_OP,
+    _RKE2_CONFIG_GET_OP,
+)

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -30,19 +30,27 @@ Coverage matrix (per Task #2221 acceptance criteria):
   ``LoadState=not-found`` nulls the live-state fields; a non-zero
   ``NRestarts`` surfaces as the crash-loop signal; the probe raises
   :class:`Rke2ServiceStatusProbeError` when ``systemctl`` is absent.
-* ``RKE2_OPS`` registration shape -- 8 ops: three read (``rke2.about`` /
-  ``rke2.posture.show``, T1 #2221; ``rke2.node.service.status``, #2852),
-  three approval-gated write (``rke2.token.rotate`` T2 #2429,
+* ``RKE2_OPS`` registration shape -- 9 ops: four read (``rke2.about`` /
+  ``rke2.posture.show``, T1 #2221; ``rke2.node.service.status``, #2852;
+  ``rke2.node.config.get``, the redacted config-content read #2854), three
+  approval-gated write (``rke2.token.rotate`` T2 #2429,
   ``rke2.node.service.restart`` / ``rke2.node.config.update`` T3 #2430), and
   two safe non-gated snapshot (``rke2.etcd-snapshot.save`` T4 #2431,
   ``rke2.etcd-snapshot.list`` #2853). Read ops are safe / read-only /
-  no-approval and take no params; write ops are dangerous / approval-gated;
-  ``.save`` is safe / no-approval but active (neither read-only nor write)
-  and takes an optional charset-bounded ``name``; ``.list`` is safe /
-  no-approval / read-only and takes no params. Every op has
-  ``additionalProperties=False`` on its parameter schema, a non-empty
+  no-approval; ``rke2.about`` / ``rke2.posture.show`` /
+  ``rke2.node.service.status`` take no params while ``rke2.node.config.get``
+  takes an optional path-bounded ``path``; write ops are dangerous /
+  approval-gated; ``.save`` is safe / no-approval but active (neither
+  read-only nor write) and takes an optional charset-bounded ``name``;
+  ``.list`` is safe / no-approval / read-only and takes no params. Every op
+  has ``additionalProperties=False`` on its parameter schema, a non-empty
   SSH-transport ``when_to_use``, and a ``rke2.`` op_id with a handler method
   on the class.
+* ``rke2.node.config.get`` handler (#2854) -- reuses the write op's
+  ``bound_config_path`` confinement (traversal rejected before any SSH), the
+  ``cat`` + ``yaml.safe_load`` read step, and redacts the join tokens + etcd
+  S3 credentials (``redact_config_content``) so no secret VALUE reaches the
+  result envelope.
 * ``rke2.etcd-snapshot.save`` handler -- name charset re-check
   (fail-closed), the shared embedded-etcd-server precondition guard, and a
   bounded-name save parsed from the RKE2 ``Snapshot <name> saved.`` log.
@@ -69,7 +77,9 @@ from meho_backplane.connectors.rke2.connector import (
 )
 from meho_backplane.connectors.rke2.ops_read import (
     POSTURE_CONFIG_PATHS,
+    REDACTED_SENTINEL,
     RKE2_TOKEN_PATH,
+    SECRET_CONFIG_KEYS,
     SERVICE_STATUS_PROPERTIES,
     SERVICE_UNITS,
     STATUS_ABSENT,
@@ -82,6 +92,7 @@ from meho_backplane.connectors.rke2.ops_read import (
     parse_posture,
     parse_posture_probe_output,
     parse_service_status,
+    redact_config_content,
 )
 from meho_backplane.connectors.rke2.ops_snapshot import (
     SNAPSHOT_DEFAULT_DIR,
@@ -89,6 +100,10 @@ from meho_backplane.connectors.rke2.ops_snapshot import (
     Rke2SnapshotPreconditionError,
     parse_saved_snapshot_name,
     parse_snapshot_list,
+)
+from meho_backplane.connectors.rke2.ops_write import (
+    ConfigPathRejectedError,
+    bound_config_path,
 )
 from meho_backplane.settings import get_settings
 from tests._ssh_vault_stub import stub_ssh_vault_secrets
@@ -120,6 +135,26 @@ _CANARY_SSH_KEY = "RKE2-CANARY-KEY-MARKER-QWER5678ZX"  # gitleaks:allow -- synth
 # A token *value* canary. The posture tier must NEVER read the token
 # content, so this string must never surface anywhere.
 _CANARY_TOKEN_VALUE = "K10rke2canarytokenvalueDONOTLEAK::server:abc123"  # gitleaks:allow NOSONAR
+# Secret-value canaries planted in the rke2.node.config.get fixture (#2854).
+# The op reads the config body but must REDACT every secret key, so none of
+# these may surface anywhere in the result.
+_CONFIG_TOKEN_CANARY = "K10rke2configREADcanaryDONOTLEAK::server:ccc333"  # gitleaks:allow NOSONAR
+_CONFIG_AGENT_TOKEN_CANARY = "rke2configAGENTcanaryDONOTLEAKddd444"  # gitleaks:allow NOSONAR
+_CONFIG_S3_SECRET_CANARY = "rke2configS3secretDONOTLEAKeee555"  # gitleaks:allow NOSONAR
+_CONFIG_DSN_PASS_CANARY = "dsnPassDONOTLEAKfff666"  # gitleaks:allow NOSONAR
+# A config.yaml body carrying secret + non-secret keys the operator wants to
+# read back (tls-san / node-taint) alongside the redacted ones.
+_CONFIG_YAML_FIXTURE = (
+    f"token: {_CONFIG_TOKEN_CANARY}\n"
+    f"agent-token: {_CONFIG_AGENT_TOKEN_CANARY}\n"
+    f"etcd-s3-secret-key: {_CONFIG_S3_SECRET_CANARY}\n"
+    "tls-san:\n"
+    "  - 10.0.0.5\n"
+    "  - rke2.lab.example\n"
+    "node-taint:\n"
+    "  - dedicated=infra:NoSchedule\n"
+    f"datastore-endpoint: postgres://dbuser:{_CONFIG_DSN_PASS_CANARY}@db.lab.example:5432/kine\n"
+)
 
 
 @dataclass
@@ -720,14 +755,205 @@ async def test_service_status_propagates_ssh_failure() -> None:
 
 
 # ---------------------------------------------------------------------------
+# rke2.node.config.get -- redacted config-content read (#2854)
+# ---------------------------------------------------------------------------
+
+
+def test_redact_config_content_masks_all_secret_keys() -> None:
+    """Every documented secret-bearing key is fully redacted; names sorted."""
+    raw: dict[str, Any] = {key: f"secret-value-of-{key}" for key in SECRET_CONFIG_KEYS}
+    raw["tls-san"] = ["10.0.0.5", "rke2.lab.example"]
+    redacted, names = redact_config_content(raw)
+    for key in SECRET_CONFIG_KEYS:
+        assert redacted[key] == REDACTED_SENTINEL, f"{key!r} not redacted"
+    # Non-secret operator-facing keys pass through untouched.
+    assert redacted["tls-san"] == ["10.0.0.5", "rke2.lab.example"]
+    assert names == sorted(SECRET_CONFIG_KEYS)
+    # The input mapping is not mutated in place.
+    assert raw["token"] == "secret-value-of-token"
+
+
+def test_redact_config_content_masks_only_datastore_userinfo() -> None:
+    """datastore-endpoint keeps host/port/db; only the user:pass@ is masked."""
+    raw = {"datastore-endpoint": "mysql://kine:s3cr3t@tcp(10.0.0.9:3306)/kine"}
+    redacted, names = redact_config_content(raw)
+    assert redacted["datastore-endpoint"] == (
+        f"mysql://{REDACTED_SENTINEL}@tcp(10.0.0.9:3306)/kine"
+    )
+    assert names == ["datastore-endpoint"]
+
+
+def test_redact_config_content_leaves_credential_less_datastore() -> None:
+    """An embedded-etcd datastore endpoint (no userinfo) is left untouched."""
+    raw = {"datastore-endpoint": "https://etcd.lab.example:2379"}
+    redacted, names = redact_config_content(raw)
+    assert redacted["datastore-endpoint"] == "https://etcd.lab.example:2379"
+    assert names == []
+
+
+def test_redact_config_content_no_secrets_is_noop() -> None:
+    """A config with no secret keys returns unchanged content + empty names.
+
+    ``token-file`` is a filesystem PATH, not a secret value, so it is never
+    redacted -- verifying it is exactly what an operator asked to read.
+    """
+    raw = {
+        "tls-san": ["a", "b"],
+        "write-kubeconfig-mode": "0644",
+        "token-file": "/var/lib/rancher/rke2/server/token",
+    }
+    redacted, names = redact_config_content(raw)
+    assert redacted == raw
+    assert names == []
+
+
+@pytest.mark.asyncio
+async def test_config_get_returns_redacted_content() -> None:
+    """AC: config.get returns parsed content with every secret redacted, not withheld."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_CONFIG_YAML_FIXTURE)
+        result = await connector.config_get(_TARGET, {})
+    # One bounded SSH round-trip; the same cat+parse the update op runs.
+    mock_cmd.assert_awaited_once()
+    cmd = mock_cmd.await_args.args[1]
+    assert "cat -- /etc/rancher/rke2/config.yaml" in cmd
+    assert result["path"] == "/etc/rancher/rke2/config.yaml"
+    content = result["content"]
+    # Non-secret operator-facing keys are returned verbatim.
+    assert content["tls-san"] == ["10.0.0.5", "rke2.lab.example"]
+    assert content["node-taint"] == ["dedicated=infra:NoSchedule"]
+    # Secret keys are redacted to the sentinel...
+    assert content["token"] == REDACTED_SENTINEL
+    assert content["agent-token"] == REDACTED_SENTINEL
+    assert content["etcd-s3-secret-key"] == REDACTED_SENTINEL
+    # ...datastore-endpoint keeps host/port/db but masks the userinfo.
+    assert content["datastore-endpoint"] == (
+        f"postgres://{REDACTED_SENTINEL}@db.lab.example:5432/kine"
+    )
+    # redacted_keys lists exactly the masked names, sorted (write-side discipline).
+    assert set(result["redacted_keys"]) == {
+        "agent-token",
+        "datastore-endpoint",
+        "etcd-s3-secret-key",
+        "token",
+    }
+    assert result["redacted_keys"] == sorted(result["redacted_keys"])
+    # THE guarantee: no planted secret VALUE surfaces anywhere in the result.
+    rendered = repr(result)
+    for canary in (
+        _CONFIG_TOKEN_CANARY,
+        _CONFIG_AGENT_TOKEN_CANARY,
+        _CONFIG_S3_SECRET_CANARY,
+        _CONFIG_DSN_PASS_CANARY,
+    ):
+        assert canary not in rendered, f"{canary!r} leaked into the result"
+
+
+@pytest.mark.asyncio
+async def test_config_get_rejects_path_traversal_before_ssh() -> None:
+    """AC: a traversal path is rejected via bound_config_path -- no SSH round trip."""
+    # The op relies on the write side's confinement; a traversal escapes the
+    # /etc/rancher/rke2 root and raises before any transport is touched.
+    with pytest.raises(ConfigPathRejectedError):
+        bound_config_path("../../etc/passwd")
+
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.config_get(_TARGET, {"path": "../../etc/passwd"})
+    mock_cmd.assert_not_awaited()
+    assert "content" not in result
+    assert "path check" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_config_get_non_mapping_yaml_returns_structured_error() -> None:
+    """AC: a YAML sequence/scalar (not a mapping) surfaces an error, not a crash."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="- just\n- a\n- list\n")
+        result = await connector.config_get(_TARGET, {})
+    assert "content" not in result
+    assert result["error"] == "config file is not a YAML mapping"
+    assert result["path"] == "/etc/rancher/rke2/config.yaml"
+
+
+@pytest.mark.asyncio
+async def test_config_get_invalid_yaml_returns_structured_error() -> None:
+    """AC: unparseable YAML surfaces a structured error rather than crashing."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="key: [unterminated\n")
+        result = await connector.config_get(_TARGET, {})
+    assert "content" not in result
+    assert "not valid YAML" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_config_get_missing_or_empty_file_returns_empty_content() -> None:
+    """A missing/empty config.yaml (the ``[ -e ]`` guard) yields content: {}."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="")
+        result = await connector.config_get(_TARGET, {})
+    assert result["content"] == {}
+    assert result["redacted_keys"] == []
+
+
+@pytest.mark.asyncio
+async def test_config_get_read_failure_returns_structured_error() -> None:
+    """A non-zero read exit surfaces a structured error, not a partial parse."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="", stderr="cat: permission denied", exit_status=1)
+        result = await connector.config_get(_TARGET, {})
+    assert "content" not in result
+    assert result["error"] == "failed to read the config file"
+
+
+@pytest.mark.asyncio
+async def test_config_get_never_leaks_secret_material(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The config-get envelope + logs carry no credential material."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_CONFIG_YAML_FIXTURE)
+        with caplog.at_level("DEBUG"):
+            result = await connector.config_get(_TARGET, {})
+    rendered = repr(result)
+    for canary in (
+        _CONFIG_TOKEN_CANARY,
+        _CONFIG_AGENT_TOKEN_CANARY,
+        _CONFIG_S3_SECRET_CANARY,
+        _CONFIG_DSN_PASS_CANARY,
+    ):
+        assert canary not in rendered
+        assert canary not in caplog.text
+
+
+# ---------------------------------------------------------------------------
 # RKE2_OPS registration shape
 # ---------------------------------------------------------------------------
 
 
-#: The read-only tier: ``rke2.about`` + ``rke2.posture.show`` (T1 #2221) and
-#: ``rke2.node.service.status`` (Initiative #2833 / #2852). Every entry is
-#: safe-tier / no-approval and takes no operator parameters.
+#: The read-only tier: ``rke2.about`` + ``rke2.posture.show`` (T1 #2221),
+#: ``rke2.node.service.status`` (Initiative #2833 / #2852), and the redacted
+#: config-content read ``rke2.node.config.get`` (#2854). Every entry is
+#: safe-tier / no-approval.
 _READ_OP_IDS: frozenset[str] = frozenset(
+    {
+        "rke2.about",
+        "rke2.posture.show",
+        "rke2.node.service.status",
+        "rke2.node.config.get",
+    }
+)
+
+#: The read ops that take no operator parameters at all (fixed paths/units).
+#: The sibling ``rke2.node.config.get`` takes an optional path-bounded
+#: ``path``, so it is excluded from the no-params invariant.
+_PARAMETERLESS_READ_OP_IDS: frozenset[str] = frozenset(
     {"rke2.about", "rke2.posture.show", "rke2.node.service.status"}
 )
 
@@ -756,9 +982,9 @@ _EXPECTED_OP_IDS: frozenset[str] = _READ_OP_IDS | _WRITE_OP_IDS | _SNAPSHOT_OP_I
 
 
 def test_rke2_ops_count_matches_expected() -> None:
-    # Three read ops (#2221 posture/about + #2852 service.status) + three
-    # approval-gated write ops (#2429 / #2430) + two safe non-gated snapshot
-    # ops (.save #2431, .list #2853) = eight.
+    # Four read ops (#2221 posture/about + #2852 service.status + #2854
+    # config.get) + three approval-gated write ops (#2429 / #2430) + two safe
+    # non-gated snapshot ops (.save #2431, .list #2853) = nine.
     assert len(RKE2_OPS) == len(_EXPECTED_OP_IDS)
 
 
@@ -850,9 +1076,17 @@ def test_rke2_read_ops_parameter_schemas_closed() -> None:
         if op.op_id not in _READ_OP_IDS:
             continue
         assert op.parameter_schema.get("additionalProperties") is False
-    # The read tier takes no operator parameters -- fixed paths only.
-    for op_id in _READ_OP_IDS:
+    # rke2.about / rke2.posture.show / rke2.node.service.status take no
+    # operator parameters -- fixed paths/units.
+    for op_id in _PARAMETERLESS_READ_OP_IDS:
         assert by_id[op_id].parameter_schema.get("properties") == {}
+    # rke2.node.config.get (#2854) exposes exactly one optional param -- a path
+    # bounded to /etc/rancher/rke2/*.yaml (the write op's confinement pattern).
+    get_schema = by_id["rke2.node.config.get"].parameter_schema
+    get_props = get_schema.get("properties", {})
+    assert set(get_props) == {"path"}
+    assert get_props["path"].get("pattern") == r"^/etc/rancher/rke2/[^\x00\n\r]*\.yaml$"
+    assert get_schema.get("required", []) == []  # path is optional
     # The snapshot op exposes exactly one optional, charset-bounded param.
     save_schema = by_id["rke2.etcd-snapshot.save"].parameter_schema
     props = save_schema.get("properties", {})

--- a/backend/tests/test_connectors_rke2.py
+++ b/backend/tests/test_connectors_rke2.py
@@ -87,6 +87,7 @@ from meho_backplane.connectors.rke2.ops_read import (
     STATUS_UNKNOWN,
     Rke2PostureProbeError,
     Rke2ServiceStatusProbeError,
+    bound_read_config_path,
     build_posture_probe_command,
     build_service_status_command,
     parse_posture,
@@ -154,6 +155,36 @@ _CONFIG_YAML_FIXTURE = (
     "node-taint:\n"
     "  - dedicated=infra:NoSchedule\n"
     f"datastore-endpoint: postgres://dbuser:{_CONFIG_DSN_PASS_CANARY}@db.lab.example:5432/kine\n"
+)
+
+# Nested-secret canaries for the sibling files config.get must REJECT (#2854 B1).
+# The flat top-level redaction set only covers config.yaml's schema, so these
+# secrets -- the admin kubeconfig's cluster-admin private key and a registry
+# password, both nested -- would leak verbatim if the op ever read the file.
+# The op must therefore refuse rke2.yaml / registries.yaml before any SSH read.
+_KUBECONFIG_KEY_CANARY = "RKE2-ADMIN-KEY-MARKER-DONOTLEAK-8842"  # gitleaks:allow NOSONAR
+_REGISTRIES_PASSWORD_CANARY = "registryPassDONOTLEAKggg777"  # gitleaks:allow NOSONAR
+# /etc/rancher/rke2/rke2.yaml -- the admin kubeconfig; client-key-data is nested
+# under users[].user, not a top-level config.yaml key.
+_RKE2_KUBECONFIG_FIXTURE = (
+    "apiVersion: v1\n"
+    "clusters:\n"
+    "  - name: default\n"
+    "    cluster:\n"
+    "      server: https://127.0.0.1:6443\n"
+    "users:\n"
+    "  - name: default\n"
+    "    user:\n"
+    f"      client-key-data: {_KUBECONFIG_KEY_CANARY}\n"
+)
+# /etc/rancher/rke2/registries.yaml -- the private-registry config; the password
+# is nested under configs.<registry>.auth, not a top-level config.yaml key.
+_REGISTRIES_YAML_FIXTURE = (
+    "configs:\n"
+    "  registry.lab.example:\n"
+    "    auth:\n"
+    "      username: admin\n"
+    f"      password: {_REGISTRIES_PASSWORD_CANARY}\n"
 )
 
 
@@ -866,6 +897,77 @@ async def test_config_get_rejects_path_traversal_before_ssh() -> None:
     assert "path check" in result["error"]
 
 
+def test_bound_read_config_path_confines_to_server_config() -> None:
+    """B1: only config.yaml + config.yaml.d/*.yaml pass; sibling files are rejected."""
+    # The server config and a single-level drop-in are accepted.
+    assert bound_read_config_path(None) == "/etc/rancher/rke2/config.yaml"
+    assert (
+        bound_read_config_path("/etc/rancher/rke2/config.yaml") == "/etc/rancher/rke2/config.yaml"
+    )
+    assert (
+        bound_read_config_path("/etc/rancher/rke2/config.yaml.d/10-tls.yaml")
+        == "/etc/rancher/rke2/config.yaml.d/10-tls.yaml"
+    )
+    # Sibling files (nested secrets the flat redaction set cannot mask) and a
+    # nested drop-in subdir are rejected outright.
+    for rejected in (
+        "/etc/rancher/rke2/rke2.yaml",
+        "/etc/rancher/rke2/registries.yaml",
+        "/etc/rancher/rke2/config.yaml.d/nested/dir.yaml",
+        "/etc/rancher/rke2/config.yaml.d/../rke2.yaml",
+    ):
+        with pytest.raises(ConfigPathRejectedError):
+            bound_read_config_path(rejected)
+
+
+@pytest.mark.asyncio
+async def test_config_get_rejects_sibling_files_before_ssh() -> None:
+    """B1: rke2.yaml / registries.yaml -- whose nested secrets the flat redaction
+    set cannot mask -- are rejected before any SSH read, so a safe/no-approval call
+    never returns the cluster-admin private key or the registry password.
+    """
+    connector = Rke2SshConnector()
+    cases = (
+        (
+            "/etc/rancher/rke2/rke2.yaml",
+            _RKE2_KUBECONFIG_FIXTURE,
+            _KUBECONFIG_KEY_CANARY,
+        ),
+        (
+            "/etc/rancher/rke2/registries.yaml",
+            _REGISTRIES_YAML_FIXTURE,
+            _REGISTRIES_PASSWORD_CANARY,
+        ),
+    )
+    for path, fixture, canary in cases:
+        with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+            # Even if the file WOULD read back with a nested secret, the op must
+            # refuse it before the `cat` ever runs.
+            mock_cmd.return_value = _proc(stdout=fixture)
+            result = await connector.config_get(_TARGET, {"path": path})
+        mock_cmd.assert_not_awaited()
+        assert "content" not in result
+        assert "path check" in result["error"]
+        assert "server config" in result["error"]
+        assert canary not in repr(result), f"{canary!r} leaked for {path}"
+
+
+@pytest.mark.asyncio
+async def test_config_get_accepts_config_yaml_d_dropin() -> None:
+    """A config.yaml.d/*.yaml drop-in stays in scope (same flat schema, redacted)."""
+    connector = Rke2SshConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_CONFIG_YAML_FIXTURE)
+        result = await connector.config_get(
+            _TARGET, {"path": "/etc/rancher/rke2/config.yaml.d/99-custom.yaml"}
+        )
+    mock_cmd.assert_awaited_once()
+    cmd = mock_cmd.await_args.args[1]
+    assert "cat -- /etc/rancher/rke2/config.yaml.d/99-custom.yaml" in cmd
+    assert result["path"] == "/etc/rancher/rke2/config.yaml.d/99-custom.yaml"
+    assert result["content"]["token"] == REDACTED_SENTINEL
+
+
 @pytest.mark.asyncio
 async def test_config_get_non_mapping_yaml_returns_structured_error() -> None:
     """AC: a YAML sequence/scalar (not a mapping) surfaces an error, not a crash."""
@@ -1081,11 +1183,16 @@ def test_rke2_read_ops_parameter_schemas_closed() -> None:
     for op_id in _PARAMETERLESS_READ_OP_IDS:
         assert by_id[op_id].parameter_schema.get("properties") == {}
     # rke2.node.config.get (#2854) exposes exactly one optional param -- a path
-    # bounded to /etc/rancher/rke2/*.yaml (the write op's confinement pattern).
+    # bounded to the server config.yaml + its config.yaml.d/*.yaml drop-ins
+    # (sibling files like rke2.yaml / registries.yaml are rejected; the
+    # handler-side bound_read_config_path check is authoritative).
     get_schema = by_id["rke2.node.config.get"].parameter_schema
     get_props = get_schema.get("properties", {})
     assert set(get_props) == {"path"}
-    assert get_props["path"].get("pattern") == r"^/etc/rancher/rke2/[^\x00\n\r]*\.yaml$"
+    assert (
+        get_props["path"].get("pattern")
+        == r"^/etc/rancher/rke2/config\.yaml(\.d/[^/\x00\n\r]+\.yaml)?$"
+    )
     assert get_schema.get("required", []) == []  # path is optional
     # The snapshot op exposes exactly one optional, charset-bounded param.
     save_schema = by_id["rke2.etcd-snapshot.save"].parameter_schema

--- a/backend/tests/test_connectors_rke2_e2e.py
+++ b/backend/tests/test_connectors_rke2_e2e.py
@@ -4,7 +4,8 @@
 """RKE2 connector recorded-fixture / asyncssh fake-shell E2E test (#2221).
 
 Drives ``rke2.about``, ``rke2.posture.show``, the service-state read
-``rke2.node.service.status`` (#2852) and the safe, non-gated snapshot ops
+``rke2.node.service.status`` (#2852), the redacted config-content read
+``rke2.node.config.get`` (#2854), and the safe, non-gated snapshot ops
 ``rke2.etcd-snapshot.save`` (T4 #2431) + the read-only
 ``rke2.etcd-snapshot.list`` (#2853) through the full ``call_operation``
 dispatch stack against an in-process asyncssh fake-shell server that
@@ -115,6 +116,19 @@ _SNAPSHOT_LIST_FIXTURE = (
 # token content). Asserted absent from every dispatch result.
 _TOKEN_VALUE_CANARY = "K10rke2e2ecanarytokenDONOTLEAK::server:zzz999"  # NOSONAR
 
+# rke2.node.config.get (#2854): a config.yaml body whose join token must be
+# REDACTED as it flows through the full dispatch stack. The canary value is
+# asserted absent from the result; tls-san (a non-secret) survives verbatim.
+_CONFIG_TOKEN_CANARY = "K10rke2e2eCONFIGcanaryDONOTLEAK::server:ggg777"  # gitleaks:allow NOSONAR
+_CONFIG_YAML_FIXTURE = (
+    f"token: {_CONFIG_TOKEN_CANARY}\n"
+    "tls-san:\n"
+    "  - 10.0.0.5\n"
+    "  - rke2.lab.example\n"
+    "node-taint:\n"
+    "  - dedicated=infra:NoSchedule\n"
+)
+
 
 # ---------------------------------------------------------------------------
 # In-process fake-shell SSH server
@@ -144,6 +158,9 @@ async def _fake_shell_process_factory(process: Any) -> None:
     elif cmd.startswith("command -v systemctl"):
         # rke2.node.service.status -- the systemctl-show service probe (#2852).
         response = _SERVICE_STATUS_FIXTURE
+    elif cmd.startswith("if [ -e "):
+        # rke2.node.config.get -- the bounded `cat` of config.yaml (#2854).
+        response = _CONFIG_YAML_FIXTURE
     elif cmd.startswith("printf 'ACTIVE="):
         # rke2.token.rotate fingerprint preflight: server node, active,
         # patched version (1.29 is above the CVE-fix range).
@@ -467,6 +484,39 @@ async def test_rke2_e2e_service_status_dispatches_ok(
     # The other unit is not installed here -- not-found nulls its live state.
     assert by_unit["rke2-agent"]["load_state"] == "not-found"
     assert by_unit["rke2-agent"]["active_state"] is None
+
+
+@pytest.mark.asyncio
+async def test_rke2_e2e_config_get_dispatches_ok_and_redacts(
+    rke2_e2e: _Rke2E2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """rke2.node.config.get returns parsed config content with the token redacted.
+
+    Proves the redacted config-content read (#2854) is dispatchable end to end:
+    the non-secret ``tls-san`` survives verbatim while the join ``token`` is
+    masked before it can reach the result envelope (and therefore the audit
+    ``raw_payload``, which stores the raw handler result).
+    """
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": _CONNECTOR_ID,
+            "op_id": "rke2.node.config.get",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"rke2.node.config.get failed: {result.get('error')}"
+    payload = result["result"]
+    assert payload["path"] == "/etc/rancher/rke2/config.yaml"
+    assert payload["content"]["tls-san"] == ["10.0.0.5", "rke2.lab.example"]
+    assert payload["content"]["node-taint"] == ["dedicated=infra:NoSchedule"]
+    assert payload["content"]["token"] == "***redacted***"
+    assert payload["redacted_keys"] == ["token"]
+    # The planted join token never survives the dispatch (result view + audit).
+    assert _CONFIG_TOKEN_CANARY not in repr(result)
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -30,8 +30,8 @@ T1 (#2221) ships the **connector scaffold + the read-only posture tier only**:
 
 A later read op (#2854) reads config **content** rather than modes:
 
-- `rke2.node.config.get` — the redacted **config-content** read. `cat`s one
-  bounded `/etc/rancher/rke2/*.yaml` file (default `config.yaml`) over SSH —
+- `rke2.node.config.get` — the redacted **config-content** read. `cat`s the
+  RKE2 server `config.yaml` (or a `config.yaml.d/*.yaml` drop-in) over SSH —
   the same read + `yaml.safe_load` step `rke2.node.config.update` runs — and
   returns the parsed top-level mapping so an operator can verify `tls-san` /
   `datastore-endpoint` / `node-taint` before or after a patch (the
@@ -41,8 +41,11 @@ A later read op (#2854) reads config **content** rather than modes:
   `etcd-s3-session-token`) become `***redacted***`, and `datastore-endpoint`
   keeps its host/port/db while masking only the `user:pass@` DSN userinfo. The
   masked key **names** are surfaced in `redacted_keys`. The `path` is confined
-  by the write op's own `bound_config_path` (traversal rejected before any SSH
-  round-trip — no new confinement logic); non-mapping / invalid YAML returns a
+  by `bound_read_config_path` to the server config's flat schema — `config.yaml`
+  and its `config.yaml.d/*.yaml` drop-ins — so sibling files whose secrets live
+  in nested keys the flat redaction set cannot mask (the admin kubeconfig
+  `rke2.yaml`, `registries.yaml`) and traversal are both rejected before any SSH
+  round-trip; non-mapping / invalid YAML returns a
   structured `error`. See [Redaction guarantee](#redaction-guarantee).
 
 All three `safety_level="safe"` / `requires_approval=false`. `rke2.about` and
@@ -181,14 +184,16 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
   the probe cannot run (no `systemctl` on the node).
 
 - **Config-content read + redaction** (`ops_read.py`, #2854) —
-  `rke2_config_get` (the async handler: `bound_config_path` confinement →
+  `rke2_config_get` (the async handler: `bound_read_config_path` confinement →
   `cat` + `yaml.safe_load` → redact), and `redact_config_content` (the pure
   redaction step). `SECRET_CONFIG_KEYS` is the frozenset of fully-masked
   secret keys (`token` / `agent-token` / the three `etcd-s3-*` credentials);
   `REDACTED_SENTINEL` (`***redacted***`) is the replacement value; the
   `datastore-endpoint` DSN userinfo is masked via a scheme-anchored regex that
-  leaves host/port/db intact. It reuses the write op's `bound_config_path`
-  rather than re-deriving the `/etc/rancher/rke2/*.yaml` filter.
+  leaves host/port/db intact. `bound_read_config_path` layers the read op's
+  tighter allow-set (`config.yaml` + `config.yaml.d/*.yaml` only, sibling files
+  like `rke2.yaml` / `registries.yaml` rejected) on top of the write op's
+  `bound_config_path` traversal/root/`.yaml` checks.
 
 - **Op metadata** (`ops.py`) — `Rke2Op` frozen dataclass (mirrors
   `Bind9Op` / `HolodeckOp`), `SSH_TRANSPORT_NOTE` (the plain-SSH reminder
@@ -362,9 +367,16 @@ envelope, the `raw_payload`, or the logs. Redaction is names-not-values: the
 masked key names are disclosed in `redacted_keys` (the `changed_config_keys`
 precedent) while the values are gone. The secret-key set is grounded in the
 RKE2 server-config reference, not just the two join tokens — the etcd S3
-credentials are equally secret-bearing and equally masked. Custom, non-standard
-keys an operator hand-added are out of scope (this is not a general secret
-scanner); the bounded single-file read never enumerates drop-ins.
+credentials are equally secret-bearing and equally masked. The guarantee holds
+because the read is confined to the server config's flat schema — `config.yaml`
+and its `config.yaml.d/*.yaml` drop-ins (same top-level keys) — by
+`bound_read_config_path`: sibling files whose secrets live in nested keys the
+flat redaction set cannot reach (the admin kubeconfig `rke2.yaml`'s
+`client-key-data`, `registries.yaml`'s `configs.<reg>.auth.password`) are
+rejected before any SSH round-trip, not read-and-partially-redacted. Custom,
+non-standard keys an operator hand-added to `config.yaml` are out of scope
+(this is not a general secret scanner); the bounded single-file read never
+enumerates drop-ins.
 
 `rke2.token.rotate` (T2) is the write-side application of the same rule. The
 dispatcher persists the **raw** handler result on the audit row and

--- a/docs/codebase/connectors-rke2.md
+++ b/docs/codebase/connectors-rke2.md
@@ -28,7 +28,26 @@ T1 (#2221) ships the **connector scaffold + the read-only posture tier only**:
   `present` / `absent` / `unknown` (#2698, see
   [Posture tri-state](#posture-tri-state-2698)).
 
-Both `safety_level="safe"` / `requires_approval=false`.
+A later read op (#2854) reads config **content** rather than modes:
+
+- `rke2.node.config.get` — the redacted **config-content** read. `cat`s one
+  bounded `/etc/rancher/rke2/*.yaml` file (default `config.yaml`) over SSH —
+  the same read + `yaml.safe_load` step `rke2.node.config.update` runs — and
+  returns the parsed top-level mapping so an operator can verify `tls-san` /
+  `datastore-endpoint` / `node-taint` before or after a patch (the
+  `claude-rdc-hetzner-dc#615` re-confirm-config step). Secret-bearing keys are
+  **redacted, not withheld**: `token` / `agent-token` and the etcd S3
+  credentials (`etcd-s3-access-key` / `etcd-s3-secret-key` /
+  `etcd-s3-session-token`) become `***redacted***`, and `datastore-endpoint`
+  keeps its host/port/db while masking only the `user:pass@` DSN userinfo. The
+  masked key **names** are surfaced in `redacted_keys`. The `path` is confined
+  by the write op's own `bound_config_path` (traversal rejected before any SSH
+  round-trip — no new confinement logic); non-mapping / invalid YAML returns a
+  structured `error`. See [Redaction guarantee](#redaction-guarantee).
+
+All three `safety_level="safe"` / `requires_approval=false`. `rke2.about` and
+`rke2.posture.show` take no params; `rke2.node.config.get` takes one optional
+path-bounded `path`.
 
 T2 (#2429) adds the **first approval-gated write op** (in the
 `rke2-token-write` group):
@@ -117,13 +136,14 @@ argv) — like the sibling T3 node-write ops, the connector already
 authenticates as root, so no sudo construction is needed and the repo-wide
 sudo-guard stays satisfied.
 
-Eight ops total: three safe read-only (T1 `about` / `posture.show` + the
-#2852 `node.service.status`), three `dangerous` / `requires_approval=true`
-write ops (T2 + T3), and two safe non-gated snapshot ops (`.save` T4 #2431,
-`.list` #2853). `.save` is safe / no-approval but active, so it is neither
-`read-only`-tagged nor in the dangerous write tier — it belongs to neither
-sweep set; `.list` is safe / no-approval and genuinely read-only, so it
-carries the `read-only` tag alongside the T1 read tier.
+Nine ops total: four safe read-only (T1 `about` / `posture.show`, the #2852
+`node.service.status`, and the #2854 redacted `node.config.get` read), three
+`dangerous` / `requires_approval=true` write ops (T2 + T3), and two safe
+non-gated snapshot ops (`.save` T4 #2431, `.list` #2853). `.save` is safe /
+no-approval but active, so it is neither `read-only`-tagged nor in the
+dangerous write tier — it belongs to neither sweep set; `.list` is safe /
+no-approval and genuinely read-only, so it carries the `read-only` tag
+alongside the T1 read tier.
 
 Source: `backend/src/meho_backplane/connectors/rke2/`.
 
@@ -134,7 +154,8 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
   Inherits the per-target asyncssh connection pool, `_auth_config`,
   `_run_command`, `_assert_reachable`, and `aclose()` from the adapter.
   Ships `fingerprint`, `probe`, `execute`, `about`, `posture_show`,
-  `service_status`, `register_operations`. Two module-level pure parsers live here:
+  `service_status`, `config_get`, `register_operations`. Two module-level pure
+  parsers live here:
   `parse_rke2_version` (release string from `rke2 --version`) and
   `parse_os_pretty_name` (`PRETTY_NAME` from `/etc/os-release`).
 
@@ -159,11 +180,22 @@ Source: `backend/src/meho_backplane/connectors/rke2/`.
   unit, so no arbitrary-unit surface. `Rke2ServiceStatusProbeError` fires when
   the probe cannot run (no `systemctl` on the node).
 
+- **Config-content read + redaction** (`ops_read.py`, #2854) —
+  `rke2_config_get` (the async handler: `bound_config_path` confinement →
+  `cat` + `yaml.safe_load` → redact), and `redact_config_content` (the pure
+  redaction step). `SECRET_CONFIG_KEYS` is the frozenset of fully-masked
+  secret keys (`token` / `agent-token` / the three `etcd-s3-*` credentials);
+  `REDACTED_SENTINEL` (`***redacted***`) is the replacement value; the
+  `datastore-endpoint` DSN userinfo is masked via a scheme-anchored regex that
+  leaves host/port/db intact. It reuses the write op's `bound_config_path`
+  rather than re-deriving the `/etc/rancher/rke2/*.yaml` filter.
+
 - **Op metadata** (`ops.py`) — `Rke2Op` frozen dataclass (mirrors
   `Bind9Op` / `HolodeckOp`), `SSH_TRANSPORT_NOTE` (the plain-SSH reminder
   copied into every op's `when_to_use`), `_RKE2_ABOUT_OP`, and `RKE2_OPS`
-  (`about` + the `READ_OPS` posture tuple + the `WRITE_OPS` write tuple +
-  the `SNAPSHOT_OPS` tuple — the latter now `.save` + `.list`).
+  (`about` + the `READ_OPS` read tuple — posture + `.service.status` +
+  `.config.get` — + the `WRITE_OPS` write tuple + the `SNAPSHOT_OPS` tuple,
+  the latter now `.save` + `.list`).
 
 - **Write ops** (`ops_write.py`, #2429 + #2430) — the three approval-gated
   write ops share one module:
@@ -318,6 +350,21 @@ make the guarantee explicit to agents reading the schema. This is the T1
 foundation for the load-bearing Initiative #2172 rule: a secret-returning
 handler must never return the secret (the audit `raw_payload` stores the raw
 result).
+
+`rke2.node.config.get` (#2854) is the same rule applied to a handler that
+*does* read the config body. Because `raw_payload` persists the raw handler
+result, the redaction must happen **inside the handler, before it returns** —
+which it does: `redact_config_content` masks every secret-bearing key
+(`token` / `agent-token` / `etcd-s3-access-key` / `etcd-s3-secret-key` /
+`etcd-s3-session-token`) to `***redacted***` and masks the
+`datastore-endpoint` DSN userinfo, so no secret value ever reaches the result
+envelope, the `raw_payload`, or the logs. Redaction is names-not-values: the
+masked key names are disclosed in `redacted_keys` (the `changed_config_keys`
+precedent) while the values are gone. The secret-key set is grounded in the
+RKE2 server-config reference, not just the two join tokens — the etcd S3
+credentials are equally secret-bearing and equally masked. Custom, non-standard
+keys an operator hand-added are out of scope (this is not a general secret
+scanner); the bounded single-file read never enumerates drop-ins.
 
 `rke2.token.rotate` (T2) is the write-side application of the same rule. The
 dispatcher persists the **raw** handler result on the audit row and


### PR DESCRIPTION
## Summary

- Adds `rke2.node.config.get` (safe / no-approval, read-only) — a governed,
  **redacted** read of an RKE2 node's `config.yaml` **content** so an operator
  can verify `tls-san` / `datastore-endpoint` / `node-taint` before or after
  an `rke2.node.config.update` patch, instead of an untracked `ssh cat` that
  bypasses policy/audit/broadcast and leaks the join token.
- Reuses the write op's `bound_config_path` confinement (traversal rejected
  before any SSH round-trip) and the same `cat` + `yaml.safe_load` step
  `rke2.node.config.update` runs — no new transport or path logic.
- **Secret redaction happens inside the handler, before it returns**, so the
  raw handler result the audit `raw_payload` persists never carries a
  credential. The redaction set is grounded in the RKE2 server-config
  reference, not just the two join tokens: `token` / `agent-token` **and** the
  three etcd S3 credentials (`etcd-s3-access-key` / `etcd-s3-secret-key` /
  `etcd-s3-session-token`) are masked to `***redacted***`; `datastore-endpoint`
  keeps host/port/db while masking only its `user:pass@` DSN userinfo. Masked
  key **names** surface in `redacted_keys` (the `changed_config_keys`
  names-only precedent); values do not.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy` (`files=["src"]`) — clean for changed files (the lone repo-wide
      error is a pre-existing macOS-only `socket.MSG_ERRQUEUE` artifact in
      unrelated `net/icmp.py`; Linux CI passes)
- [x] `pytest tests/test_connectors_rke2.py tests/test_connectors_rke2_e2e.py`
      — 89 passed
- [x] AC: registered `safety_level="safe"`, `requires_approval=False`,
      dispatches via `call_operation` end-to-end
      (`test_rke2_e2e_config_get_dispatches_ok_and_redacts`)
- [x] AC: `_READ_OP_IDS` gains `rke2.node.config.get`; count/covers tests pass
- [x] AC: planted `token` / `agent-token` values are **absent** from the whole
      result, present only as names in `redacted_keys`
      (`test_config_get_returns_redacted_content`,
      `test_config_get_never_leaks_secret_material`)
- [x] AC: `../../etc/passwd` rejected with `ConfigPathRejectedError` before any
      SSH round-trip (`test_config_get_rejects_path_traversal_before_ssh`)
- [x] AC: non-mapping / invalid YAML → structured error, no crash
- [x] AC: `_WHEN_TO_USE_BY_GROUP` gains `rke2-config-read`;
      `register_operations()` does not raise
- [x] AC: `docs/codebase/connectors-rke2.md` updated (six → seven ops, new op
      documented, Redaction guarantee section extended)
- [x] AC: CLI OpenAPI snapshot regenerated — **no diff** (connector ops are
      DB-registered typed ops, not FastAPI routes)

## Out of scope

- No change to `rke2.node.config.update` (this is a read-only sibling).
- No drop-in (`config.yaml.d/*.yaml`) enumeration — one bounded path per call.
- Not a general secret-scanner: only the documented RKE2 secret-bearing keys
  are redacted, not custom keys an operator may have hand-added.
- Sibling wave-2 rke2 PRs #2931 (#2852) and #2934 (#2853) touch the same
  registration/count/docs anchors; trivial merge conflicts expected, handled
  at merge time by the orchestrator. Branched off `main`; no dependency.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2854


---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-12)

Addressed review finding **B1** (SECURITY) from the iteration-1 `REQUEST_CHANGES` review:

- **B1** `a175f65b` — confine `rke2.node.config.get` to the RKE2 **server config only** (`config.yaml` + the documented `config.yaml.d/*.yaml` drop-in dir). Sibling files under `/etc/rancher/rke2/` whose nested secrets the flat top-level redaction set cannot mask — the admin kubeconfig `rke2.yaml` (`client-key-data`) and `registries.yaml` (`configs.<reg>.auth.password`) — are now **rejected before any SSH round-trip** via the new `bound_read_config_path` (`ConfigPathRejectedError` → structured `{error}`, no content). The parameter-schema `pattern` is tightened to match (handler check remains authoritative). Regression tests plant those nested secrets and assert pre-SSH rejection with no cleartext leak; a `config.yaml.d` drop-in is proven to stay in scope. Drop-in path verified against https://docs.rke2.io/install/configuration. The write op is unchanged (out of scope — it returns no file content to the agent).

Local verification re-run: `ruff` + `ruff format --check` clean, `mypy` clean, `pytest tests/test_connectors_rke2.py tests/test_connectors_rke2_e2e.py` — **92 passed** (89 original + 3 new rejection/drop-in tests).

<!-- auto-implement-issue: continue, iteration 1 -->
