### PR TITLE
feat(connectors): add harbor.artifact.vulnerabilities CVE-detail read (#2857)

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -320,7 +320,12 @@ _WRITE_OPS: Final[frozenset[str]] = frozenset(
 #: the full-detail ``other`` class. ``.versions`` is the KV-v2
 #: version-metadata browse (``vault.kv.versions`` — G3.3-T1 #545): a
 #: read of metadata only (no secret values), so it likewise classifies
-#: ``read`` rather than ``credential_read``.
+#: ``read`` rather than ``credential_read``. ``.vulnerabilities`` is the
+#: Harbor per-artifact CVE-list read (``harbor.artifact.vulnerabilities`` --
+#: #2857): a non-mutating supply-chain read whose noun suffix (like
+#: ``.health`` / ``.versions``) would otherwise fall through to the
+#: full-detail ``other`` class rather than broadcast at the same ``read``
+#: sensitivity as its ``harbor.artifact.info`` sibling.
 _READ_SUFFIXES: Final[tuple[str, ...]] = (
     ".list",
     ".info",
@@ -330,6 +335,7 @@ _READ_SUFFIXES: Final[tuple[str, ...]] = (
     ".health",
     ".seal_status",
     ".versions",
+    ".vulnerabilities",
 )
 
 #: Underscore-spelled mirrors of the dotted verb suffixes, applied only to

--- a/backend/src/meho_backplane/connectors/harbor/__init__.py
+++ b/backend/src/meho_backplane/connectors/harbor/__init__.py
@@ -6,9 +6,10 @@
 Importing this package registers :class:`HarborConnector` against the
 v2 connector registry under
 ``(product="harbor", version="2.x", impl_id="harbor-rest")``, and
-queues the typed-op upserts (the 9-op read core + the two robot
-lifecycle writes) onto the lifespan-driven registrar list so
-``endpoint_descriptor`` rows land before the first dispatch.
+queues the typed-op upserts (the 9-op read core, the two robot
+lifecycle writes, and the standalone artifact CVE-detail read) onto the
+lifespan-driven registrar list so ``endpoint_descriptor`` rows land
+before the first dispatch.
 
 Registration is split between two phases (mirroring the Vault precedent
 in :mod:`meho_backplane.connectors.vault`):
@@ -20,10 +21,12 @@ in :mod:`meho_backplane.connectors.vault`):
   :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
   invokes
   :func:`~meho_backplane.connectors.harbor.typed_ops.register_harbor_typed_operations`
-  (the audited read core) and
+  (the audited read core),
   :func:`~meho_backplane.connectors.harbor.ops.register_harbor_robot_operations`
-  (the robot create/delete writes), upserting the ``endpoint_descriptor``
-  rows for each.
+  (the robot create/delete writes), and
+  :func:`~meho_backplane.connectors.harbor.ops.register_harbor_artifact_operations`
+  (the standalone ``harbor.artifact.vulnerabilities`` CVE-detail read,
+  #2857), upserting the ``endpoint_descriptor`` rows for each.
 
 Both surfaces are **typed** (``source_kind="typed"``): they dispatch on
 a fresh boot with zero catalog ingest. The read core was converted from
@@ -44,7 +47,10 @@ ladder. Same pattern :mod:`meho_backplane.connectors.sddc_manager` and
 from typing import Final
 
 from meho_backplane.connectors.harbor.connector import HarborConnector
-from meho_backplane.connectors.harbor.ops import register_harbor_robot_operations
+from meho_backplane.connectors.harbor.ops import (
+    register_harbor_artifact_operations,
+    register_harbor_robot_operations,
+)
 from meho_backplane.connectors.harbor.session import (
     HarborCredentialsLoader,
     HarborTargetLike,
@@ -100,6 +106,12 @@ register_connector_v2(
 register_typed_op_registrar(register_harbor_typed_operations)
 register_typed_op_registrar(register_harbor_robot_operations)
 
+# Queue the standalone artifact CVE-detail read (harbor.artifact.vulnerabilities,
+# #2857). A typed read that dispatches with zero catalog ingest — the same shape
+# as the robot ops above — so the per-CVE surface behind harbor.artifact.info's
+# scan_overview is reachable independent of the read-core ingest state.
+register_typed_op_registrar(register_harbor_artifact_operations)
+
 __all__ = [
     "HARBOR_CONNECTOR_ID",
     "HARBOR_IMPL_ID",
@@ -113,6 +125,7 @@ __all__ = [
     "HarborTypedOp",
     "SessionCredentials",
     "load_credentials_from_vault",
+    "register_harbor_artifact_operations",
     "register_harbor_robot_operations",
     "register_harbor_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/harbor/connector.py
+++ b/backend/src/meho_backplane/connectors/harbor/connector.py
@@ -2,12 +2,15 @@
 # Copyright (c) 2026 evoila Group
 #
 # code-quality-allow: file-size — the connector hosts fingerprint / probe /
-# auth + the two robot write handlers, and #2856 adds the nine typed-read
-# shims. The read *bodies* already live in ``typed_reads`` (this file keeps
-# only the thin shims); the shims must be methods on the connector class
-# because the dispatcher binds the resolved handler to the connector
-# instance. Matches the NSX/SDDC on-connector shim placement and the other
-# >600-line connectors in this package.
+# auth, the two robot write handlers, the nine typed-read shims (#2856), and
+# the artifact_vulnerabilities CVE read (#2857). The read *bodies* already
+# live in ``typed_reads`` (this file keeps only the thin shims); every op
+# handler must be a method on the connector class because the dispatcher
+# binds the resolved handler to the per-process connector instance at
+# dispatch time (``_maybe_bind_method``), so the handler bodies that remain
+# here cannot move off this file without losing that binding. Matches the
+# NSX/SDDC on-connector shim placement and the other >600-line connectors in
+# this package.
 
 """HarborConnector — hand-rolled HttpConnector subclass for Harbor 2.x.
 
@@ -58,6 +61,7 @@ import asyncio
 import base64
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import structlog
@@ -122,6 +126,76 @@ def _parse_harbor_version(harbor_version: str) -> tuple[str | None, str | None]:
         version_str, build_str = harbor_version.split("-", 1)
         return version_str or None, build_str or None
     return harbor_version, None
+
+
+#: The current-format native vulnerability report media type. Sent as the
+#: ``X-Accept-Vulnerabilities`` request header so Harbor renders the report
+#: in the pluggable-scanner-spec v1.1 shape (per-item field names ``id`` /
+#: ``fix_version`` / ``description``). Harbor's own ``acceptVulnerabilities``
+#: parameter default comma-joins this type with the legacy
+#: ``vnd.scanner.adapter.vuln.report.harbor+json; version=1.0`` (first-match
+#: wins); pinning the current type alone keeps the projected field names
+#: stable instead of depending on which format Harbor falls back to.
+_VULN_REPORT_MIME = "application/vnd.security.vulnerability.report; version=1.1"
+
+
+def _encode_segment(value: Any) -> str:
+    """Percent-encode one URL path segment (OpenAPI ``style: simple``).
+
+    Matches how the generic dispatcher expands a ``{var}`` path template
+    (:func:`meho_backplane.operations._branches._substitute_path`): every
+    reserved char is encoded (empty safe set), so a nested ``repository_name``
+    (``team/nginx`` -> ``team%2Fnginx``) cannot leak a path separator and a
+    ``sha256:`` digest reference has its ``:`` encoded to ``%3A``. This is the
+    same resolution ``harbor.artifact.info`` uses, one segment shallower.
+    """
+    return quote(str(value), safe="")
+
+
+def _project_vulnerability(item: dict[str, Any]) -> dict[str, Any]:
+    """Project one native-report ``VulnerabilityItem`` to the agent shape.
+
+    Reads the pluggable-scanner-spec v1.1 field names (``id`` / ``fix_version``
+    / ``description``), NOT the Harbor Security-Hub ``VulnerabilityItem``
+    spellings (``cve_id`` / ``fixed_version`` / ``desc``) — the
+    ``additions/vulnerabilities`` endpoint returns the scanner-native report,
+    not a Security-Hub row. ``links`` is coerced to a list so the projected
+    shape stays uniform even when a scanner omits it.
+    """
+    links = item.get("links")
+    return {
+        "id": item.get("id"),
+        "package": item.get("package"),
+        "version": item.get("version"),
+        "fix_version": item.get("fix_version"),
+        "severity": item.get("severity"),
+        "description": item.get("description"),
+        "links": links if isinstance(links, list) else [],
+    }
+
+
+def _extract_vuln_report(payload: Any) -> dict[str, Any]:
+    """Pull the ``HarborVulnerabilityReport`` out of the endpoint response.
+
+    Harbor keys the report by the resolved MIME type (mirroring
+    ``scan_overview``): ``{"application/vnd.security.vulnerability.report;
+    version=1.1": {..report..}}``. Prefer the exact requested key, then a bare
+    already-unwrapped report, then any single MIME-keyed value carrying a
+    ``vulnerabilities`` array (tolerating whitespace / version variance in the
+    returned key). Returns ``{}`` when no report shape is recognisable so the
+    handler yields an empty list rather than raising.
+    """
+    if not isinstance(payload, dict):
+        return {}
+    report = payload.get(_VULN_REPORT_MIME)
+    if isinstance(report, dict):
+        return report
+    if "vulnerabilities" in payload:
+        return payload
+    for value in payload.values():
+        if isinstance(value, dict) and "vulnerabilities" in value:
+            return value
+    return {}
 
 
 class HarborConnector(HttpConnector):
@@ -603,6 +677,97 @@ class HarborConnector(HttpConnector):
         from meho_backplane.connectors.harbor.typed_reads import harbor_robot_list_impl
 
         return await harbor_robot_list_impl(self, operator, target, params)
+
+    async def artifact_vulnerabilities(
+        self,
+        operator: Operator,
+        target: HarborTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Read one artifact's full CVE list via Harbor 2.x.
+
+        Op-id: ``harbor.artifact.vulnerabilities``. Classified ``read``
+        (:func:`~meho_backplane.broadcast.events.classify_op`), safety_level
+        ``safe``, no approval — a non-mutating supply-chain / promotion-gate
+        read.
+
+        ``GET .../artifacts/{reference}/additions/vulnerabilities`` with the
+        ``X-Accept-Vulnerabilities`` header pinned to the current native report
+        format. This is the detail behind ``harbor.artifact.info``'s
+        ``scan_overview`` (which carries severity *counts* only); it answers
+        "is CVE-X in image Y" and "what is the fixed-in version for package P"
+        that counts alone cannot.
+
+        The response is the scanner-native report keyed by MIME type; the
+        handler unwraps it, projects each ``VulnerabilityItem`` to
+        ``{id, package, version, fix_version, severity, description, links}``,
+        and returns ``{severity, scanner, generated_at, vulnerabilities}``.
+        ``vulnerabilities`` is the single set-shaped field, so the dispatcher's
+        JSONFlux reducer materialises it into a result handle when a real
+        image's CVE list crosses the ~50-row / 4 KB threshold (CLAUDE.md
+        postulate 6); a named-CVE lookup against that handle is a
+        ``result_query`` ``WHERE id = ...`` away.
+
+        Uses :meth:`_request_json` (not :meth:`_get_json`) because the read
+        needs the per-call ``X-Accept-Vulnerabilities`` header, which
+        ``_get_json`` does not forward; GET stays idempotent so the tenacity
+        retry still applies. The dispatched ``operator`` threads to the
+        operator-context Vault credential read the same way the robot ops
+        thread it.
+
+        Parameters
+        ----------
+        operator
+            Request-scoped operator; its validated JWT authenticates the
+            per-target Vault credential read.
+        target
+            Resolved Harbor target.
+        params
+            Schema-validated: ``project_name`` (str), ``repository_name``
+            (str), ``reference`` (str — a tag name or a ``sha256:`` digest).
+
+        Returns
+        -------
+        dict[str, Any]
+            ``{severity, scanner, generated_at, vulnerabilities: [...]}`` — the
+            overall severity, scanner provenance, and the projected per-CVE
+            list. ``vulnerabilities`` is ``[]`` for a clean (scanned,
+            zero-finding) artifact.
+
+        Raises
+        ------
+        httpx.HTTPStatusError
+            On any 4xx/5xx from Harbor (e.g. 404 when the artifact has never
+            been scanned). The dispatcher wraps it as a ``connector_error``
+            OperationResult.
+        """
+        project = _encode_segment(params["project_name"])
+        repository = _encode_segment(params["repository_name"])
+        reference = _encode_segment(params["reference"])
+        path = (
+            f"/api/v2.0/projects/{project}/repositories/{repository}"
+            f"/artifacts/{reference}/additions/vulnerabilities"
+        )
+        payload = await self._request_json(
+            target,
+            "GET",
+            path,
+            operator=operator,
+            extra_headers={"X-Accept-Vulnerabilities": _VULN_REPORT_MIME},
+        )
+        report = _extract_vuln_report(payload)
+        raw_vulnerabilities = report.get("vulnerabilities")
+        vulnerabilities = [
+            _project_vulnerability(item)
+            for item in (raw_vulnerabilities if isinstance(raw_vulnerabilities, list) else [])
+            if isinstance(item, dict)
+        ]
+        return {
+            "severity": report.get("severity"),
+            "scanner": report.get("scanner"),
+            "generated_at": report.get("generated_at"),
+            "vulnerabilities": vulnerabilities,
+        }
 
     async def invalidate_credentials(self, target: HarborTargetLike) -> None:
         """Duck-typed credential-eviction hook for the dispatch path (#2396).

--- a/backend/src/meho_backplane/connectors/harbor/ops.py
+++ b/backend/src/meho_backplane/connectors/harbor/ops.py
@@ -44,7 +44,7 @@ from typing import Any
 
 from meho_backplane.retrieval.embedding import EmbeddingService
 
-__all__ = ["register_harbor_robot_operations"]
+__all__ = ["register_harbor_artifact_operations", "register_harbor_robot_operations"]
 
 
 #: Curated ``when_to_use`` blurb for the Harbor ``robot`` group --
@@ -343,5 +343,193 @@ async def register_harbor_robot_operations(
         # full-detail-broadcast contrast the credential_mint tests pin.
         requires_approval=False,
         llm_instructions=_HARBOR_ROBOT_DELETE_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# harbor.artifact.vulnerabilities
+# ---------------------------------------------------------------------------
+
+#: Curated ``when_to_use`` for the ``harbor-artifacts`` group.
+#: ``harbor.artifact.vulnerabilities`` registers into the same group the
+#: artifact list/info reads live under (the sibling harbor-read-core typed
+#: promotion, #2856); ``register_typed_operation`` requires a non-empty
+#: string whenever ``group_key`` is set, and typed-register group creation is
+#: first-write-wins. Kept close to the sibling artifact-read blurb so the two
+#: Harbor wave-2 tasks reconcile trivially at merge.
+_HARBOR_ARTIFACTS_WHEN_TO_USE: str = (
+    "Use this group to list or inspect artifacts (images, Helm charts, OCI "
+    "artifacts) within a repository and to read an artifact's full "
+    "vulnerability detail. Each artifact carries its tags, digest, push time, "
+    "SBOM accessor, and signature status; harbor.artifact.vulnerabilities "
+    "returns the per-CVE list (id, severity, affected package, installed and "
+    "fixed-in version, description) that sits behind harbor.artifact.info's "
+    "severity-count scan overview. The right group for 'what tags exist for "
+    "image X', 'what digest does tag Y resolve to', 'has this image been "
+    "signed', 'does this artifact have an SBOM', and 'which CVEs are in image "
+    "X:tag / is CVE-NNNN present before I promote it'."
+)
+
+_HARBOR_ARTIFACT_VULN_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "project_name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": "Harbor project name (from harbor.project.list).",
+        },
+        "repository_name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Bare repository/image name within the project (from "
+                "harbor.repository.list) -- e.g. 'nginx', or 'team/nginx' for a "
+                "nested repository. The project prefix is NOT repeated here."
+            ),
+        },
+        "reference": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Artifact reference: a tag name (e.g. 'v1.2.3') or a digest "
+                "('sha256:...'). A digest pins an exact artifact; a tag may move."
+            ),
+        },
+    },
+    "required": ["project_name", "repository_name", "reference"],
+    "additionalProperties": False,
+}
+
+_HARBOR_ARTIFACT_VULN_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "severity": {
+            "type": ["string", "null"],
+            "description": "Overall severity of the scan report (e.g. 'Critical').",
+        },
+        "scanner": {
+            "type": ["object", "null"],
+            "description": "Scanner provenance ({name, vendor, version}).",
+        },
+        "generated_at": {
+            "type": ["string", "null"],
+            "description": "When the scan report was generated (ISO-8601).",
+        },
+        "vulnerabilities": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": ["string", "null"]},
+                    "package": {"type": ["string", "null"]},
+                    "version": {"type": ["string", "null"]},
+                    "fix_version": {"type": ["string", "null"]},
+                    "severity": {"type": ["string", "null"]},
+                    "description": {"type": ["string", "null"]},
+                    "links": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+            "description": (
+                "Per-CVE list. A large list is reduced to a JSONFlux handle "
+                "with a bounded inline sample; the full set is reachable via "
+                "result_query."
+            ),
+        },
+    },
+    "additionalProperties": True,
+}
+
+_HARBOR_ARTIFACT_VULN_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Read the full per-CVE vulnerability list for one Harbor artifact -- "
+        "the detail behind harbor.artifact.info's scan_overview, which carries "
+        "severity COUNTS only. Use when answering 'which CVEs are in image "
+        "X:tag', 'is CVE-2024-NNNN present', or 'what is the fixed-in version "
+        "for package P' before promoting an image. Requires project_name + "
+        "repository_name + reference (a tag or sha256 digest) -- the same "
+        "coordinates as harbor.artifact.info, one segment deeper. The artifact "
+        "must already be scanned; an unscanned artifact returns a "
+        "connector_error (Harbor 404)."
+    ),
+    "parameter_hints": {
+        "project_name": "Harbor project name (from harbor.project.list).",
+        "repository_name": (
+            "Bare image name within the project (from harbor.repository.list); "
+            "e.g. 'nginx', or 'team/nginx' for a nested repo. No project prefix."
+        ),
+        "reference": (
+            "A tag (e.g. 'v1.2.3') or a digest ('sha256:...'). Digests pin an "
+            "exact artifact; tags may move."
+        ),
+    },
+    "output_shape": (
+        "{severity (overall, e.g. 'Critical'), scanner {name, vendor, version}, "
+        "generated_at, vulnerabilities: [{id (CVE/GHSA id), package, version, "
+        "fix_version, severity, description, links[]}, ...]}. A large list is "
+        "reduced to a JSONFlux handle with a bounded inline sample plus a "
+        "fetch_more envelope; the full set is reachable via result_query."
+    ),
+    "next_step": (
+        "For a named-CVE lookup against a reduced handle, drill in with "
+        "result_query, e.g. SELECT id, severity, package, fix_version FROM "
+        "result WHERE id = 'CVE-2024-3094'. For a promotion gate, filter on "
+        "severity or on fix_version (non-empty = fixable). Pair with "
+        "harbor.artifact.info for the at-a-glance severity counts."
+    ),
+}
+
+
+async def register_harbor_artifact_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert harbor.artifact.vulnerabilities into ``endpoint_descriptor``.
+
+    Standalone typed read (source_kind="typed") so it dispatches on a fresh
+    boot with zero catalog ingest -- the same shape as ``harbor.robot.create``
+    / ``.delete`` above and the sibling harbor-read-core promotion (#2856).
+    Called once per process from the FastAPI lifespan via
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`;
+    idempotent (the body-hash skip path in
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`).
+
+    Test seam: ``embedding_service`` lets fixtures inject a stub so chassis
+    tests don't load the ONNX model.
+    """
+    from meho_backplane.connectors.harbor.connector import HarborConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    await register_typed_operation(
+        product="harbor",
+        version="2.x",
+        impl_id="harbor-rest",
+        op_id="harbor.artifact.vulnerabilities",
+        handler=HarborConnector.artifact_vulnerabilities,
+        summary="Read an artifact's per-CVE vulnerability list in Harbor.",
+        description=(
+            "Reads one artifact's full vulnerability report via "
+            "GET /api/v2.0/projects/{project_name}/repositories/{repository_name}"
+            "/artifacts/{reference}/additions/vulnerabilities (Harbor v2 artifact "
+            "API, operationId getVulnerabilitiesAddition) with the "
+            "X-Accept-Vulnerabilities header pinned to the current native report "
+            "format 'application/vnd.security.vulnerability.report; version=1.1'. "
+            "The detail behind harbor.artifact.info's scan_overview severity "
+            "counts: each vulnerability is projected to {id, package, version, "
+            "fix_version, severity, description, links}. safety_level=safe, "
+            "read-only, no approval. A large CVE list is JSONFlux-reduced to a "
+            "result handle (CLAUDE.md postulate 6)."
+        ),
+        parameter_schema=_HARBOR_ARTIFACT_VULN_PARAMETER_SCHEMA,
+        response_schema=_HARBOR_ARTIFACT_VULN_RESPONSE_SCHEMA,
+        group_key="harbor-artifacts",
+        when_to_use=_HARBOR_ARTIFACTS_WHEN_TO_USE,
+        tags=["read-only", "harbor", "artifact", "vulnerability", "security"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_HARBOR_ARTIFACT_VULN_LLM_INSTRUCTIONS,
         embedding_service=embedding_service,
     )

--- a/backend/src/meho_backplane/connectors/harbor/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/harbor/typed_reads.py
@@ -463,9 +463,9 @@ _ARTIFACT_LIST_INSTRUCTIONS: dict[str, object] = {
     ),
     "output_shape": (
         "Array of Artifact objects; each carries digest (sha256:…), "
-        "tags[] (name + push_time), size, push_time, media_type, "
-        "accessories[] (SBOM, signature, cosign entries), and "
-        "addition_links (for detailed scan reports)."
+        "tags[] (name + push_time), size, push_time, media_type, and "
+        "accessories[] (SBOM, signature, cosign entries). Per-artifact "
+        "CVE detail is available via harbor.artifact.vulnerabilities."
     ),
     "next_step": (
         "Pick a tag or digest as the reference for harbor.artifact.info "
@@ -480,20 +480,25 @@ _ARTIFACT_INFO_INSTRUCTIONS: dict[str, object] = {
         "Call to read the full metadata of one Harbor artifact by "
         "project_name, repository_name, and reference (a tag name "
         "or digest 'sha256:…'). Returns all tags, labels, "
-        "vulnerability summary, SBOM accessors, signature status, "
-        "and addition_links for detailed scan reports. Use when "
+        "vulnerability summary (severity counts), SBOM accessors, and "
+        "signature status. For the per-CVE vulnerability list (id, "
+        "severity, package, fixed-in version) behind the scan, call "
+        "harbor.artifact.vulnerabilities. Use when "
         "answering 'what vulnerabilities does image X:tag have', "
         "'is this artifact signed', or 'what SBOM is attached'."
     ),
     "output_shape": (
         "Artifact object with digest, tags[], size, push_time, "
         "media_type, labels[], accessories[] (SBOM + signature entries), "
-        "scan_overview (vulnerability counts by severity), and "
-        "addition_links mapping to detailed report endpoints."
+        "and scan_overview (vulnerability counts by severity). The "
+        "per-CVE detail behind those counts lives in "
+        "harbor.artifact.vulnerabilities."
     ),
     "next_step": (
-        "Surface scan_overview severity counts to the operator; "
-        "for a signed artifact, confirm the signature in accessories[] "
+        "Surface scan_overview severity counts to the operator, then "
+        "call harbor.artifact.vulnerabilities for the per-CVE list when "
+        "a named-CVE or fixed-in-version answer is needed. For a signed "
+        "artifact, confirm the signature in accessories[] "
         "where type == 'notation.signature' or 'cosign.signature'. "
         "Cross-reference the digest with harbor.robot.list if "
         "investigating which robot pushed the artifact."

--- a/backend/tests/test_connectors_harbor_cve.py
+++ b/backend/tests/test_connectors_harbor_cve.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the Harbor CVE-detail read typed op (#2857).
+
+Covers ``harbor.artifact.vulnerabilities`` — the per-artifact vulnerability
+list behind ``harbor.artifact.info``'s ``scan_overview`` severity counts:
+
+* The handler projects Harbor's native scan report (pluggable-scanner-spec
+  v1.1) down to ``{id, package, version, fix_version, severity, description,
+  links}`` — the acceptance-criterion shape (a CVE id field is present).
+* The ``X-Accept-Vulnerabilities`` header pins the current native report
+  format.
+* Path resolution matches ``harbor.artifact.info`` (project / repository /
+  reference percent-encoded; a nested ``repository_name`` slash and a
+  ``sha256:`` digest ``:`` are encoded).
+* The MIME-keyed report envelope is unwrapped (and a bare report tolerated).
+* A clean (scanned, zero-finding) artifact yields an empty list; a 404
+  (never-scanned) propagates as ``httpx.HTTPStatusError``.
+* The dispatched operator threads into the handler via ``dispatch_typed``.
+* ``classify_op`` maps the op-id to ``read`` (broadcast sensitivity).
+
+Auth follows the robot-op suite: HTTP Basic (shared service account), the
+dispatched :class:`Operator` forwarded through
+:meth:`HarborConnector.auth_headers` to the operator-context Vault read
+against the in-process Vault fake (``install_fake_client``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.broadcast.events import classify_op
+from meho_backplane.connectors.harbor import HarborConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.operations._branches import dispatch_typed
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+_CANARY_USERNAME = "svc-harbor-cve-canary"
+_CANARY_PASSWORD = "p4ss-canary-must-not-leak-cve-harbor"
+
+_ACCEPT_HEADER = "x-accept-vulnerabilities"
+_ACCEPT_VALUE = "application/vnd.security.vulnerability.report; version=1.1"
+
+
+# ---------------------------------------------------------------------------
+# Isolation fixtures (mirror test_connectors_harbor_robot.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_harbor_registry() -> None:
+    """Re-register HarborConnector before each test, clear after."""
+    clear_registry()
+    register_connector_v2(
+        product=HarborConnector.product,
+        version=HarborConnector.version,
+        impl_id=HarborConnector.impl_id,
+        cls=HarborConnector,
+    )
+    yield
+    clear_registry()
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the chassis env vars Settings reads (Vault client construction)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET = _StubTarget(
+    name="harbor-test",
+    host="harbor.test.invalid",
+    port=443,
+    secret_ref="targets/harbor/harbor-test",
+)
+
+
+def _make_operator(raw_jwt: str = "op.cve.harbor.jwt") -> Any:
+    from meho_backplane.auth.operator import Operator, TenantRole
+
+    return Operator(
+        sub="op-cve-harbor",
+        name="Harbor CVE Operator",
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000c5"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _make_connector() -> HarborConnector:
+    """Connector with the DEFAULT (live) loader — no injected stub."""
+    return HarborConnector()
+
+
+def _vuln_url(project: str, repository: str, reference: str) -> str:
+    return (
+        f"https://harbor.test.invalid/api/v2.0/projects/{project}"
+        f"/repositories/{repository}/artifacts/{reference}/additions/vulnerabilities"
+    )
+
+
+def _native_report(vulnerabilities: list[dict[str, Any]], *, severity: str = "Critical") -> dict:
+    """A HarborVulnerabilityReport keyed by the resolved MIME type."""
+    return {
+        _ACCEPT_VALUE: {
+            "generated_at": "2026-08-01T12:00:00Z",
+            "scanner": {"name": "Trivy", "vendor": "Aqua Security", "version": "0.52.0"},
+            "severity": severity,
+            "vulnerabilities": vulnerabilities,
+        }
+    }
+
+
+_TWO_VULNS = [
+    {
+        "id": "CVE-2024-3094",
+        "package": "xz-utils",
+        "version": "5.6.0",
+        "fix_version": "5.6.2",
+        "severity": "Critical",
+        "description": "Malicious backdoor in the upstream xz release tarballs.",
+        "links": ["https://nvd.nist.gov/vuln/detail/CVE-2024-3094"],
+        "cwe_ids": ["CWE-506"],
+    },
+    {
+        "id": "CVE-2023-45853",
+        "package": "zlib",
+        "version": "1.2.13",
+        "fix_version": "",
+        "severity": "High",
+        "description": "MiniZip integer overflow.",
+        "links": [],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Projection — the acceptance-criterion shape (CVE id field present)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_artifact_vulnerabilities_projects_native_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The handler projects each native VulnerabilityItem to the agent shape,
+    including the CVE id, and surfaces the overall severity + scanner."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    with respx.mock(assert_all_called=True) as mock:
+        mock.get(_vuln_url("library", "nginx", "v1.0.0")).mock(
+            return_value=respx.MockResponse(200, json=_native_report(_TWO_VULNS))
+        )
+        result = await connector.artifact_vulnerabilities(
+            _make_operator(),
+            _TARGET,
+            {"project_name": "library", "repository_name": "nginx", "reference": "v1.0.0"},
+        )
+
+    assert result["severity"] == "Critical"
+    assert result["scanner"] == {"name": "Trivy", "vendor": "Aqua Security", "version": "0.52.0"}
+    assert result["generated_at"] == "2026-08-01T12:00:00Z"
+    assert [v["id"] for v in result["vulnerabilities"]] == ["CVE-2024-3094", "CVE-2023-45853"]
+    first = result["vulnerabilities"][0]
+    # Exactly the projected keys — no scanner-native extras (cwe_ids) leak.
+    assert set(first) == {
+        "id",
+        "package",
+        "version",
+        "fix_version",
+        "severity",
+        "description",
+        "links",
+    }
+    assert first["package"] == "xz-utils"
+    assert first["version"] == "5.6.0"
+    assert first["fix_version"] == "5.6.2"
+    assert first["severity"] == "Critical"
+    assert first["description"].startswith("Malicious backdoor")
+    assert first["links"] == ["https://nvd.nist.gov/vuln/detail/CVE-2024-3094"]
+    # A scanner that omits links yields [] rather than None.
+    assert result["vulnerabilities"][1]["links"] == []
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_artifact_vulnerabilities_sends_accept_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The read pins X-Accept-Vulnerabilities to the current native format."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    captured: dict[str, str] = {}
+
+    def _capture(request: httpx.Request) -> respx.MockResponse:
+        captured.update(dict(request.headers))
+        return respx.MockResponse(200, json=_native_report([]))
+
+    with respx.mock() as mock:
+        mock.get(_vuln_url("library", "nginx", "v1.0.0")).mock(side_effect=_capture)
+        await connector.artifact_vulnerabilities(
+            _make_operator(),
+            _TARGET,
+            {"project_name": "library", "repository_name": "nginx", "reference": "v1.0.0"},
+        )
+
+    assert captured[_ACCEPT_HEADER] == _ACCEPT_VALUE
+    assert captured["authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_artifact_vulnerabilities_encodes_path_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nested repository_name slash and sha256: reference colon are encoded —
+    the same resolution harbor.artifact.info uses (OpenAPI simple style)."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    captured_url: dict[str, str] = {}
+
+    def _capture(request: httpx.Request) -> respx.MockResponse:
+        captured_url["path"] = request.url.raw_path.decode()
+        return respx.MockResponse(200, json=_native_report([]))
+
+    with respx.mock() as mock:
+        mock.get(url__regex=r".*/additions/vulnerabilities$").mock(side_effect=_capture)
+        await connector.artifact_vulnerabilities(
+            _make_operator(),
+            _TARGET,
+            {
+                "project_name": "library",
+                "repository_name": "team/nginx",
+                "reference": "sha256:abc123",
+            },
+        )
+
+    assert "team%2Fnginx" in captured_url["path"]
+    assert "sha256%3Aabc123" in captured_url["path"]
+    # The encoded separators must not leak as literal path structure.
+    assert "team/nginx" not in captured_url["path"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_artifact_vulnerabilities_handles_bare_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A report NOT keyed by MIME type (bare shape) is still unwrapped."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    bare = {
+        "severity": "Low",
+        "scanner": {"name": "Trivy"},
+        "vulnerabilities": [
+            {"id": "CVE-2020-0001", "package": "p", "version": "1", "severity": "Low"}
+        ],
+    }
+    with respx.mock() as mock:
+        mock.get(_vuln_url("library", "nginx", "v1.0.0")).mock(
+            return_value=respx.MockResponse(200, json=bare)
+        )
+        result = await connector.artifact_vulnerabilities(
+            _make_operator(),
+            _TARGET,
+            {"project_name": "library", "repository_name": "nginx", "reference": "v1.0.0"},
+        )
+
+    assert result["severity"] == "Low"
+    assert result["vulnerabilities"][0]["id"] == "CVE-2020-0001"
+    # A missing field (fix_version) projects to None, links to [].
+    assert result["vulnerabilities"][0]["fix_version"] is None
+    assert result["vulnerabilities"][0]["links"] == []
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_artifact_vulnerabilities_empty_report_returns_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A clean (scanned, zero-finding) artifact yields an empty list."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    with respx.mock() as mock:
+        mock.get(_vuln_url("library", "nginx", "clean")).mock(
+            return_value=respx.MockResponse(200, json=_native_report([], severity="None"))
+        )
+        result = await connector.artifact_vulnerabilities(
+            _make_operator(),
+            _TARGET,
+            {"project_name": "library", "repository_name": "nginx", "reference": "clean"},
+        )
+
+    assert result["vulnerabilities"] == []
+    assert result["severity"] == "None"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_artifact_vulnerabilities_raises_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A never-scanned artifact (Harbor 404) propagates httpx.HTTPStatusError."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    with respx.mock() as mock:
+        mock.get(_vuln_url("library", "nginx", "unscanned")).mock(
+            return_value=respx.MockResponse(404, json={"errors": [{"code": "NOT_FOUND"}]})
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await connector.artifact_vulnerabilities(
+                _make_operator(),
+                _TARGET,
+                {"project_name": "library", "repository_name": "nginx", "reference": "unscanned"},
+            )
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_typed_threads_operator_into_artifact_vulnerabilities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real dispatcher threads the dispatched operator into the handler."""
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    operator = _make_operator()
+    with respx.mock() as mock:
+        mock.get(_vuln_url("library", "nginx", "v1.0.0")).mock(
+            return_value=respx.MockResponse(200, json=_native_report(_TWO_VULNS))
+        )
+        result = await dispatch_typed(
+            handler=connector.artifact_vulnerabilities,
+            operator=operator,
+            target=_TARGET,
+            params={"project_name": "library", "repository_name": "nginx", "reference": "v1.0.0"},
+        )
+
+    assert [v["id"] for v in result["vulnerabilities"]] == ["CVE-2024-3094", "CVE-2023-45853"]
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == operator.raw_jwt
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Broadcast classification — a non-mutating read
+# ---------------------------------------------------------------------------
+
+
+def test_classify_op_harbor_artifact_vulnerabilities_is_read() -> None:
+    """harbor.artifact.vulnerabilities classifies as read, like its info sibling."""
+    assert classify_op("harbor.artifact.vulnerabilities") == "read"
+    assert classify_op("harbor.artifact.info") == "read"

--- a/docs/codebase/connectors-harbor.md
+++ b/docs/codebase/connectors-harbor.md
@@ -11,6 +11,9 @@ the G0.6 dispatch shim. G3.5-T9 (#621) added the robot lifecycle typed ops
 broadcast classifier. G3.5-T10 (#622) added the `meho harbor …` CLI verb tree
 (`cli/internal/cmd/harbor/`), the real-container E2E test against
 `goharbor/harbor-core:v2.11.0`, and `docs/cross-repo/harbor-onboarding.md`.
+Wave-2 (#2857) adds `harbor.artifact.vulnerabilities` — a standalone typed
+read for the per-artifact CVE list behind `harbor.artifact.info`'s
+`scan_overview` severity counts.
 
 **#2856** converted the 9-op read core from the original ingested-curation
 apparatus (a retired `core_ops.py` whose ops only dispatched once a per-deploy
@@ -34,8 +37,9 @@ Source: `backend/src/meho_backplane/connectors/harbor/`.
   resolves and binds to the per-process instance at dispatch time: the 9
   read shims (`about` / `health` / `project_list` / `project_info` /
   `repository_list` / `repository_info` / `artifact_list` / `artifact_info`
-  / `robot_list`, each delegating to a `typed_reads` body) and the two robot
-  writes (`robot_create` / `robot_delete`).
+  / `robot_list`, each delegating to a `typed_reads` body), the two robot
+  writes (`robot_create` / `robot_delete`), and the standalone
+  `artifact_vulnerabilities` CVE-detail read (#2857).
 - **`HarborTargetLike`** (`session.py`) — runtime-checkable Protocol capturing
   the minimum target shape the connector reads: `name`, `host`, `port`,
   `secret_ref`, and `auth_model`. No `sso_realm` field — Harbor sends
@@ -86,6 +90,11 @@ Source: `backend/src/meho_backplane/connectors/harbor/`.
 - **`register_harbor_robot_operations`** (`ops.py`) — async lifespan registrar
   that upserts `harbor.robot.create` and `harbor.robot.delete` (also
   `source_kind="typed"`). Idempotent.
+- **`register_harbor_artifact_operations`** (`ops.py`) — async lifespan
+  registrar that upserts the standalone typed read `harbor.artifact.vulnerabilities`
+  (#2857) into `endpoint_descriptor` (group `harbor-artifacts`, `safety_level=safe`,
+  no approval). Same lifespan/idempotency contract as the robot registrar; queued
+  separately in `__init__.py`.
 
 ## Control flow
 
@@ -170,6 +179,44 @@ executes. `robot_delete` (op `harbor.robot.delete`) stays ungated — a
 through `auth_headers` → `_load_credentials` for the operator-context Vault
 read and use non-retried HTTP calls (Harbor write endpoints are non-idempotent).
 
+### artifact_vulnerabilities(operator, target, params)
+
+Typed op handler for `harbor.artifact.vulnerabilities` (#2857) — the per-CVE
+vulnerability list behind `harbor.artifact.info`'s `scan_overview` (which
+carries severity **counts** only). Classified `read` (`classify_op`;
+`.vulnerabilities` is a `_READ_SUFFIXES` entry, so the broadcast sensitivity
+matches its `harbor.artifact.info` sibling rather than falling through to the
+full-detail `other` class). `safety_level=safe`, no approval.
+
+Like the robot handlers, the signature carries `operator: Operator` so the
+dispatched operator threads in and is forwarded to `auth_headers` →
+`_load_credentials` for the operator-context Vault read.
+
+1. Percent-encodes `project_name`, `repository_name`, `reference` with
+   `quote(value, safe="")` — the OpenAPI simple-style encoding the generic
+   dispatcher uses for `harbor.artifact.info`, so a nested `repository_name`
+   slash (`team/nginx` → `team%2Fnginx`) and a `sha256:` reference colon
+   (`→ %3A`) never leak path structure.
+2. Calls `_request_json(target, "GET", path, operator=operator,
+   extra_headers={"X-Accept-Vulnerabilities": "application/vnd.security.vulnerability.report; version=1.1"})`.
+   `_request_json` (not `_get_json`) is used because `_get_json` does not
+   forward per-call headers; GET stays idempotent, so the tenacity retry still
+   applies.
+3. Unwraps the MIME-keyed `HarborVulnerabilityReport` (Harbor keys the report
+   by the resolved media type, mirroring `scan_overview`; a bare already-unwrapped
+   report is tolerated) and projects each native `VulnerabilityItem` to
+   `{id, package, version, fix_version, severity, description, links}`. Field
+   names follow the pluggable-scanner-spec v1.1 (`id` / `fix_version` /
+   `description`), **not** the Harbor Security-Hub `VulnerabilityItem` spellings
+   (`cve_id` / `fixed_version` / `desc`).
+4. Returns `{severity, scanner, generated_at, vulnerabilities: [...]}`.
+   `vulnerabilities` is the single set-shaped field, so the dispatcher's
+   JSONFlux reducer materialises it into a result handle when a real image's
+   CVE list crosses the ~50-row / 4 KB threshold (postulate 6). A named-CVE
+   lookup against that handle is a `result_query`
+   `SELECT ... WHERE id = 'CVE-…'` away. A never-scanned artifact returns
+   Harbor 404 → `httpx.HTTPStatusError` → `connector_error`.
+
 ### execute() shim
 
 `execute()` synthesises a system `Operator` and delegates to
@@ -193,14 +240,20 @@ construct a real `Operator` and call `dispatch` directly — they bypass this sh
   `OperationResult`, `AuthModel`.
 - **`meho_backplane.operations.typed_register`** — `register_typed_operation`,
   `register_typed_op_registrar`, `run_typed_op_registrars`, `derive_handler_ref`.
-- **`meho_backplane.broadcast.events`** — `classify_op` returns `read` for all
-  9 read ops (via the `.about` / `.health` / `.list` / `.info` read suffixes)
+- **`meho_backplane.broadcast.events`** — `classify_op` returns `read` for the
+  9 read-core ops and `harbor.artifact.vulnerabilities` (via the `.about` /
+  `.health` / `.list` / `.info` read suffixes plus `.vulnerabilities`, #2857)
   and `credential_mint` for `harbor.robot.create`.
 
 ## The 9 read-only core ops
 
-All ops register under `connector_id="harbor-rest-2.x"` as `source_kind="typed"`
-and dispatch on a fresh boot with zero catalog ingest.
+All register under `connector_id="harbor-rest-2.x"` as `source_kind="typed"`
+and dispatch on a fresh boot with zero catalog ingest. The 9 rows below are the
+audited read core (`HARBOR_TYPED_OPS`, via `register_harbor_typed_operations`);
+the trailing `harbor.artifact.vulnerabilities` row (#2857) is a **standalone
+typed read** registered separately in `ops.py` via
+`register_harbor_artifact_operations` — read-only like the core, but not one of
+the 9.
 
 | Op id | Group | Vendor path (Harbor 2.x) |
 |---|---|---|
@@ -213,6 +266,7 @@ and dispatch on a fresh boot with zero catalog ingest.
 | `harbor.artifact.list` | `harbor-artifacts` | `GET …/repositories/{repository_name}/artifacts` |
 | `harbor.artifact.info` | `harbor-artifacts` | `GET …/artifacts/{reference}` |
 | `harbor.robot.list` | `harbor-robots` | `GET /api/v2.0/robots` |
+| `harbor.artifact.vulnerabilities` *(standalone typed read, #2857)* | `harbor-artifacts` | `GET …/artifacts/{reference}/additions/vulnerabilities` |
 
 **Robot id + secret invariant**: `harbor.robot.list` returns each robot's
 numeric `id` (needed for `harbor.robot.delete`) and never a `secret` — Harbor
@@ -235,6 +289,12 @@ this invariant explicitly.
 - `tests/acceptance/test_g35_harbor_jsonflux_force_handle.py` — JSONFlux
   force-handle seam test using `harbor.artifact.list` (bare JSON array shape,
   distinct from NSX/SDDC's pagination envelopes).
+- `tests/test_connectors_harbor_cve.py` — unit tests for
+  `harbor.artifact.vulnerabilities` (#2857): native-report projection (CVE id
+  field present), the `X-Accept-Vulnerabilities` header, path-segment encoding
+  parity with `harbor.artifact.info`, MIME-keyed / bare envelope unwrap, empty
+  and 404 paths, `dispatch_typed` operator threading, and the `read`
+  classification.
 - `tests/integration/test_connectors_harbor_container.py` — env-gated real
   Harbor `v2.11.0` stack E2E: `harbor.about` + `harbor.robot.list` reads and
   the robot create/delete four-eyes flow, all `source_kind="typed"`.
@@ -253,10 +313,16 @@ this invariant explicitly.
 
 - Issues: #619 (G3.5-T7 skeleton), #621 (G3.5-T9 robot lifecycle +
   credential_mint classifier), #622 (G3.5-T10 CLI verbs + real-container E2E +
-  harbor-onboarding.md), **#2856 (typed read-core conversion)**
+  harbor-onboarding.md), **#2856 (typed read-core conversion)**,
+  #2857 (wave-2 CVE-detail read `harbor.artifact.vulnerabilities`)
 - Precedent: Task #2358 / Goal #2247 — the NSX (#2302) and SDDC Manager (#2306)
   typed-read conversions this task mirrors
 - Initiative: #368 (G3.5 tier-2 batch), #2833 (connector read-op coverage wave 2)
+- Harbor `getVulnerabilitiesAddition` + `acceptVulnerabilities` header:
+  https://github.com/goharbor/harbor/blob/v2.11.0/api/v2.0/swagger.yaml
+- Native report `VulnerabilityItem` shape (`id` / `fix_version` /
+  `description`): goharbor/pluggable-scanner-spec v1.1
+  (`application/vnd.security.vulnerability.report; version=1.1`)
 - HttpConnector base: `backend/src/meho_backplane/connectors/adapters/http.py`
 - Broadcast classifier: `backend/src/meho_backplane/broadcast/events.py` (`classify_op`)
 - Handler resolution: `backend/src/meho_backplane/operations/_handler_resolve.py`


### PR DESCRIPTION
## Summary
- Add `harbor.artifact.vulnerabilities` — a standalone typed read (dispatches with zero catalog ingest, the same shape as `harbor.robot.create/.delete`) for the per-artifact CVE list behind `harbor.artifact.info`'s `scan_overview` severity **counts**. Answers "which CVEs are in image X:tag / is CVE-NNNN present / what is the fixed-in version" before a promotion gate, through MEHO's policy/audit/broadcast/JSONFlux instead of the Harbor UI or a raw vendor call.
- Vendor: `GET .../artifacts/{reference}/additions/vulnerabilities` (`getVulnerabilitiesAddition`) with `X-Accept-Vulnerabilities: application/vnd.security.vulnerability.report; version=1.1`. Each native `VulnerabilityItem` is projected to `{id, package, version, fix_version, severity, description, links}` — pluggable-scanner-spec v1.1 field names, verified against `goharbor/harbor` v2.11.0 (distinct from Harbor's Security-Hub `VulnerabilityItem` spellings `cve_id`/`fixed_version`/`desc`).
- `vulnerabilities` is the single set-shaped field, so a large report is JSONFlux-reduced to a result handle + `fetch_more` (postulate 6); a named-CVE lookup is a `result_query WHERE id = 'CVE-…'` away (documented in `llm_instructions`).
- Repoint the `addition_links` dead-end note in `harbor.artifact.info`/`.list` `llm_instructions` at the new op (#2833 DoD); classify `.vulnerabilities` as a `_READ_SUFFIXES` entry so its broadcast sensitivity matches the `info` sibling; update `docs/codebase/connectors-harbor.md`.

## Test plan
- [x] `ruff check` + `ruff format --check` — clean (touched files)
- [x] `mypy src/meho_backplane` — clean
- [x] `pytest tests/test_connectors_harbor_cve.py` — 8 passed (projection incl. CVE id; `X-Accept-Vulnerabilities` header; path-segment encoding parity with `artifact.info`; MIME-keyed + bare unwrap; empty + 404; `dispatch_typed` operator threading; `read` classification)
- [x] `pytest test_broadcast_classifier_coverage + test_connectors_harbor_robot + test_connectors_harbor_core_ops` — 61 passed (no regression from the `_READ_SUFFIXES` + `core_ops` llm_instructions edits)
- [x] `code-quality.py --diff` — 0 blockers (`connector.py` carries the same `# code-quality-allow: file-size` marker #2856 uses — handlers must be connector methods for dispatcher binding)

## Acceptance criteria
- [x] Registered as a safe read (`safety_level=safe`, no approval) dispatching through `call_operation`, resolving `project_name`+`repository_name`+`reference` like `harbor.artifact.info` (same `quote(…, safe="")` simple-style encoding — nested repo `/` and digest `:` encoded)
- [x] Per-vuln fields include CVE id, severity, package, installed version, fixed-in version, description
- [x] Named-CVE lookup answerable without a full client-side scan — documented `result_query` recipe in `llm_instructions.next_step`
- [x] Large reports JSONFlux-wrapped (handle + `fetch_more`) — `vulnerabilities` is the single detectable collection, reduced by the dispatcher
- [x] Test asserts dispatch + projected CVE id field
- [x] `docs/codebase/connectors-harbor.md` updated (ops table gains the op; `addition_links` note repointed)
- [x] CLI OpenAPI snapshot: **no regen needed** — no FastAPI route/schema changed (the typed op registers in `endpoint_descriptor` at lifespan, not as an HTTP route)

## Out of scope
- Fleet-wide `GET /security/vul` Security Hub surface; other `additions/{addition}` sub-resources; any write path (all per the issue).
- Registered in `ops.py` (the robot-op pattern the issue names) to stay compatible with the sibling typed-read promotion PR #2915 (#2856, approved/unmerged). Trivial merge conflicts with #2856/#2858 on the `harbor-artifacts` group blurb + the `connector.py` file-size marker are expected — the human serializes the harbor merges.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2857
