### PR TITLE
feat(connectors): vmware vm.clone_from_template — CloneVM_Task folder-template clone with inline customization (#2894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,32 @@ connector-related release-notes line.
   header-injection / exfil surface on a body-less probe). Existing
   `net.http_probe` calls without the param behave byte-identically.
 
+### Added — vmware `vm.clone_from_template`: folder-template clone via `CloneVM_Task` with inline customization (#2894)
+
+- `vmware.composite.vm.clone_from_template` clones a **folder VM
+  template** (a marked-as-template VM in a VM folder) — the source
+  `vm.clone`'s content-library deploy path cannot serve. Goes through vim
+  `VirtualMachine.CloneVM_Task` (the folder-template deploy API govc and
+  terraform use), which uniquely supports inline guest customization at
+  clone time. Resolves `source_template` by name, asserts `config.template`
+  before any write (a non-template source is refused
+  `status='not_a_template'`, PropertyCollector-asserted), builds the
+  `CloneSpec` placement (folder / resource pool / datastore, optional host
+  pin), and polls the returned `CloneVM_Task` to a terminal state. `dangerous`
+  + approval-required, with a secret-safe param-echo preview naming the full
+  blast radius.
+- **Composes with the GOSC keystone (#2892):** passing
+  `customization_spec_name` resolves the stored spec via vim
+  `CustomizationSpecManager.GetCustomizationSpec` and embeds it inline in
+  `CloneSpec.customization`, so the clone yields a customized VM in one
+  dispatch — no separate customize call. Only the spec *name* ever reaches
+  the reviewer surface or the approval-request params; the resolved spec's
+  sysprep/password contents never serialize (secret hygiene, #1503).
+- Rides the #2893 substrate — the mutating `CloneVM_Task` flows through the
+  same `enforce_subop_policy` gate as the REST writes (`_write_vmomi_sub_op`)
+  and is polled via `poll_vim_task`. See
+  `docs/codebase/connectors-vmware-rest.md` for the two-clone-ops contrast.
+
 ## [0.28.0] - 2026-08-07
 
 ### Added — seven more Do-real-work guides on the docs site: topology, broadcast, memory/knowledge, audit forensics, runbooks, scheduler, satellite gateway (#2829)

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 15 composites land before
+``endpoint_descriptor`` upserts for the 16 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -29,13 +29,16 @@ Scope:
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 10 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
-  #2301, and the mutating VI-JSON ``vm.disk.grow`` / #2893) -- inherit
+* 11 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
+  #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, and the
+  folder-template ``vm.clone_from_template`` / #2894) -- inherit
   T4's ``safety_level="dangerous"`` +
   ``requires_approval=True`` defaults.
   They cover every state-mutating workflow Goal #214 names as
   required for govc-wrapper retirement: ``vm.create``, ``vm.clone``,
-  ``vm.snapshot.revert``, ``vm.migrate``, ``vm.power`` (single VM,
+  ``vm.clone_from_template`` (folder-template clone via CloneVM_Task,
+  with optional inline guest customization), ``vm.snapshot.revert``,
+  ``vm.migrate``, ``vm.power`` (single VM,
   incl. Tools soft shutdown), ``vm.power.bulk``, ``vm.disk.grow`` (the
   first mutating VI-JSON composite — disk capacity has no REST path),
   ``host.evacuate`` (first recursive composite),
@@ -57,6 +60,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     host_detach_from_vds_composite,
     host_evacuate_composite,
     vm_clone_composite,
+    vm_clone_from_template_composite,
     vm_create_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -72,7 +76,7 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 # registered by the time the runner iterates.
 register_typed_op_registrar(register_vmware_composite_operations)
 
-# Side-effect import: registers the 10 write composites' park-time
+# Side-effect import: registers the 11 write composites' park-time
 # ``proposed_effect`` preview builders (#1608) onto the per-op hook in
 # :mod:`meho_backplane.operations._preview` — mirrors how
 # ``connectors/argocd/__init__`` wires ``ops_write_preview``.
@@ -89,6 +93,7 @@ __all__ = [
     "performance_summary_composite",
     "register_vmware_composite_operations",
     "vm_clone_composite",
+    "vm_clone_from_template_composite",
     "vm_create_composite",
     "vm_disk_grow_composite",
     "vm_migrate_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 15 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 16 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -26,9 +26,10 @@ The 5 read composites (T5 / #508) pass
 T4's ``dangerous`` / ``True`` defaults. (The former
 ``host.network_uplinks`` and ``host.vsan_health`` reads were re-shipped
 as typed ops in #2258; see
-:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 10 write
-composites (T6 / #509, single-VM ``vm.power`` / #2301, and the mutating
-VI-JSON ``vm.disk.grow`` / #2893) inherit the T4
+:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 11 write
+composites (T6 / #509, single-VM ``vm.power`` / #2301, the mutating
+VI-JSON ``vm.disk.grow`` / #2893, and the folder-template
+``vm.clone_from_template`` / #2894) inherit the T4
 defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity at
 the call site; the helper would default to those values anyway).
 Each :class:`_CompositeSpec` row carries its own ``safety_level`` +
@@ -54,6 +55,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     host_detach_from_vds_composite,
     host_evacuate_composite,
     vm_clone_composite,
+    vm_clone_from_template_composite,
     vm_create_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -78,6 +80,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA,
     PERFORMANCE_SUMMARY_PARAMETER_SCHEMA,
     PERFORMANCE_SUMMARY_RESPONSE_SCHEMA,
+    VM_CLONE_FROM_TEMPLATE_PARAMETER_SCHEMA,
+    VM_CLONE_FROM_TEMPLATE_RESPONSE_SCHEMA,
     VM_CLONE_PARAMETER_SCHEMA,
     VM_CLONE_RESPONSE_SCHEMA,
     VM_CREATE_PARAMETER_SCHEMA,
@@ -171,7 +175,9 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "Use for VM-lifecycle write composites: create with NIC "
         "attach + optional power-on (rollback on partial failure), "
         "clone from a content-library template (long-running task "
-        "polling), revert to a named snapshot (ambiguity-rejecting), "
+        "polling) or from a folder VM template (CloneVM_Task, with "
+        "optional inline guest customization), revert to a named "
+        "snapshot (ambiguity-rejecting), "
         "migrate via DRS or explicit host, bulk power across a "
         "filter, or a single-VM power verb (on/off/reset plus a "
         "Tools-mediated guest_shutdown/guest_reboot for one-off "
@@ -493,6 +499,34 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         requires_approval=True,
     ),
     _CompositeSpec(
+        op_id="vmware.composite.vm.clone_from_template",
+        handler=vm_clone_from_template_composite,
+        summary="Clone a folder VM template via CloneVM_Task, with optional inline GOSC.",
+        description=(
+            "Clones a folder VM template (a marked-as-template VM) via vim "
+            "VirtualMachine.CloneVM_Task — the path vm.clone (content-library "
+            "only) cannot serve. Resolves source_template by name "
+            "(GET:/vcenter/vm?filter.names) and asserts config.template "
+            "(PropertyCollector) before any clone, refusing a non-template "
+            "source with status='not_a_template'. Builds the CloneSpec "
+            "placement (folder / resource pool / datastore, optional host), "
+            "optionally resolves customization_spec_name to an inline "
+            "CustomizationSpec via CustomizationSpecManager.GetCustomizationSpec "
+            "(composing with the GOSC surface so the clone customizes in one "
+            "dispatch), issues CloneVM_Task through the same governance seam as "
+            "the REST write composites, and polls the returned Task to a "
+            "terminal state before reporting status='cloned'. The connector's "
+            "folder-template deploy path — what govc/terraform use — and the "
+            "only clone that supports inline customization at clone time."
+        ),
+        parameter_schema=VM_CLONE_FROM_TEMPLATE_PARAMETER_SCHEMA,
+        response_schema=VM_CLONE_FROM_TEMPLATE_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "lifecycle", "vi-json"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
         op_id="vmware.composite.host.evacuate",
         handler=host_evacuate_composite,
         summary="Migrate every VM off a host (via recursive vm.migrate) then enter maintenance.",
@@ -579,9 +613,10 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 15 composites total -- 5 read (T5 / #508) + 10 write (T6 /
-    #509, single-VM ``vm.power`` / #2301, and the mutating VI-JSON
-    ``vm.disk.grow`` / #2893). (The former
+    Scope: 16 composites total -- 5 read (T5 / #508) + 11 write (T6 /
+    #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
+    ``vm.disk.grow`` / #2893, and the folder-template
+    ``vm.clone_from_template`` / #2894). (The former
     ``host.network_uplinks`` / ``host.vsan_health`` reads were re-shipped
     as typed ops in #2258.)
     Each composite's ``safety_level`` +

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
-# code-quality-allow: 9 protocol-driven composite handlers for the
+# code-quality-allow: protocol-driven composite handlers for the
 # vSphere REST + VI-JSON write surface ship in one module per the issue
 # body's design; splitting them by group would scatter the shared
 # sub-op_id constants + helpers across files for no readability gain. Each
 # handler's body is the documented orchestration workflow from #509's spec
-# (plus the mutating VI-JSON disk-grow from #2893).
+# (plus the mutating VI-JSON disk-grow from #2893 and folder-template clone
+# from #2894).
 
-"""Write-shaped ``vmware.composite.*`` handler functions (9 composites).
+"""Write-shaped ``vmware.composite.*`` handler functions (11 composites).
 
 Companion to :mod:`._read`. Post-#2256 each handler is a module-level
 ``async def`` taking the dispatcher's composite-branch keyword args
@@ -102,6 +103,7 @@ __all__ = [
     "host_detach_from_vds_composite",
     "host_evacuate_composite",
     "vm_clone_composite",
+    "vm_clone_from_template_composite",
     "vm_create_composite",
     "vm_disk_grow_composite",
     "vm_migrate_composite",
@@ -209,6 +211,51 @@ _PROP_CONFIG_HARDWARE_DEVICE = "config.hardware.device"
 # Default wall-clock bound for the ReconfigVM_Task poll — mirrors the 600s
 # ``vm.clone`` convention.
 _DISK_GROW_TASK_TIMEOUT_SECONDS = 600.0
+
+# vim (VI-JSON) op_ids for the folder-template clone write path (#2894).
+# Same ``METHOD:/path`` shape the ingest parser emits from ``vi-json.yaml``
+# (moId rides the path as ``{moId}``); kept out of the ``_SUB_OPS_*``
+# namespace so the vcenter.yaml reconcile sweep skips them (the pinned
+# ``vi-json.yaml`` reconcile lane asserts them instead). ``CloneVM_Task`` is
+# the canonical folder-template deploy API (what govc/terraform use) — the
+# REST ``vm.clone`` content-library path cannot deploy a marked-as-template
+# folder VM, and only the vim path supports inline customization at clone
+# time. ``GetCustomizationSpec`` resolves a stored GOSC spec (by name) to the
+# full ``CustomizationSpec`` embedded inline in the clone; the config read
+# (``RetrievePropertiesEx``, shared with disk-grow) asserts the source is a
+# template.
+_OP_CLONE_VM_TASK = "POST:/VirtualMachine/{moId}/CloneVM_Task"
+_OP_GET_CUSTOMIZATION_SPEC = "POST:/CustomizationSpecManager/{moId}/GetCustomizationSpec"
+
+#: vi-json sub-op manifest for ``vm.clone_from_template`` (parallel to
+#: ``_VIM_SUB_OPS_VM_DISK_GROW``; named out of the ``_SUB_OPS_*`` namespace so
+#: the vcenter.yaml sweep skips it). The pinned ``vi-json.yaml`` reconcile
+#: lane introspects this to assert every declared vim path exists in the spec.
+_VIM_SUB_OPS_VM_CLONE_FROM_TEMPLATE: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_GET_CUSTOMIZATION_SPEC,
+    _OP_CLONE_VM_TASK,
+)
+
+# vim ManagedObjectReference type discriminators for the clone placement
+# MoRefs. A vim MoRef serialises as ``{"type": <T>, "value": <moid>}`` — the
+# handler wraps the operator-supplied placement moids into these.
+_FOLDER_MO_TYPE = "Folder"
+_RESOURCE_POOL_MO_TYPE = "ResourcePool"
+_HOST_SYSTEM_MO_TYPE = "HostSystem"
+_DATASTORE_MO_TYPE = "Datastore"
+
+# The vim property the template assert reads off the resolved source VM.
+_PROP_CONFIG_TEMPLATE = "config.template"
+
+# Standard ``ServiceContent.customizationSpecManager`` singleton moid;
+# overridable via the ``customization_spec_manager_moid`` param (mirrors the
+# performance composite's ``perf_manager_moid`` default of ``"PerfMgr"``).
+_DEFAULT_CUSTOMIZATION_SPEC_MANAGER_MOID = "CustomizationSpecManager"
+
+# Default wall-clock bound for the CloneVM_Task poll — mirrors the 600s
+# ``vm.clone`` convention.
+_CLONE_FROM_TEMPLATE_TASK_TIMEOUT_SECONDS = 600.0
 
 
 def _power_vm_op_id(action: str) -> str:
@@ -1749,3 +1796,381 @@ async def vm_disk_grow_composite(
         "delta_bytes": delta,
         "guidance": None,
     }
+
+
+# ===========================================================================
+# vm.clone_from_template (folder-template CloneVM_Task — Task D, #2894)
+# ===========================================================================
+#
+# Clones a *folder VM template* (a marked-as-template VM in a VM folder) via
+# vim ``VirtualMachine.CloneVM_Task``. The existing ``vm.clone`` composite is
+# content-library-only (``POST:/vcenter/vm-template/library-items?action=deploy``)
+# and a folder template has no clone path on the REST surface at all;
+# ``CloneVM_Task`` is the canonical folder-template deploy API (what
+# govc/terraform use) and uniquely supports inline guest customization at
+# clone time. Rides the #2893 substrate: the mutating CloneVM_Task flows
+# through the governed vmomi write seam (:func:`_write_vmomi_sub_op` → the
+# #2254 gate) and the returned ``*_Task`` MoRef is driven to a terminal state
+# via the shared :func:`~...vim_task.poll_vim_task` helper.
+
+
+def _moref(mo_type: str, moid: str) -> dict[str, str]:
+    """A vim ``ManagedObjectReference`` JSON object (``{type, value}``)."""
+    return {"type": mo_type, "value": moid}
+
+
+def _build_config_template_retrieve_params(vm_moid: str) -> dict[str, Any]:
+    """Build the ``RetrievePropertiesEx`` body reading a VM's ``config.template``.
+
+    A single ``PropertyFilterSpec`` scoped to the VirtualMachine requesting
+    ``config.template`` -- the boolean that distinguishes a marked-as-template
+    VM from a regular one. The singleton ``propertyCollector`` moId rides the
+    path, so the body is only the method args (the shape the typed reads +
+    the disk-grow config read send).
+    """
+    return {
+        "specSet": [
+            {
+                "propSet": [{"type": _VIRTUAL_MACHINE_MO_TYPE, "pathSet": [_PROP_CONFIG_TEMPLATE]}],
+                "objectSet": [{"obj": {"type": _VIRTUAL_MACHINE_MO_TYPE, "value": vm_moid}}],
+            }
+        ],
+        "options": {},
+    }
+
+
+def _extract_config_template(retrieve_result: Any, vm_moid: str) -> bool | None:
+    """Pull the ``config.template`` bool off a RetrievePropertiesEx result.
+
+    Returns the boolean when present, else ``None`` (the caller treats an
+    absent / non-bool value as "cannot confirm a template" and refuses the
+    clone). Matches the object by moid when the ``obj`` MoRef is present.
+    """
+    payload = _unwrap_value(retrieve_result)
+    objects = payload.get("objects", []) if isinstance(payload, dict) else payload
+    if not isinstance(objects, list):
+        return None
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        obj_moid = obj.get("obj", {}).get("value") if isinstance(obj.get("obj"), dict) else None
+        if obj_moid is not None and obj_moid != vm_moid:
+            continue
+        for prop in obj.get("propSet", []) or []:
+            if isinstance(prop, dict) and prop.get("name") == _PROP_CONFIG_TEMPLATE:
+                val = prop.get("val")
+                return val if isinstance(val, bool) else None
+    return None
+
+
+def _extract_cloned_vm_moid(task_result: Any) -> str | None:
+    """Pull the new VM moid out of a SUCCEEDED CloneVM_Task ``result`` MoRef.
+
+    ``TaskInfo.result`` for ``CloneVM_Task`` is the new VirtualMachine
+    ``ManagedObjectReference`` (``{"type": "VirtualMachine", "value":
+    "vm-99"}``); a bare moid string is tolerated. ``None`` when the shape is
+    neither -- the clone still succeeded, the moid is just unreadable.
+    """
+    if isinstance(task_result, dict):
+        value = task_result.get("value")
+        return value if isinstance(value, str) else None
+    return task_result if isinstance(task_result, str) else None
+
+
+async def _resolve_template_moid(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    name: str,
+) -> tuple[str | None, str | None, list[str]]:
+    """Resolve a source-template display name to a unique VM moid.
+
+    Reads ``GET:/vcenter/vm?filter.names=<name>`` (a read sub-op, un-gated)
+    and returns ``(moid, error_status, candidates)``:
+
+    * ``(moid, None, [])`` -- exactly one match.
+    * ``(None, "template_not_found", [])`` -- no match.
+    * ``(None, "ambiguous_template", [moids])`` -- more than one match; the
+      operator re-issues against an unambiguous moid.
+
+    Name resolution (not a moid param) is the flow the #2894 body prescribes,
+    mirroring the ``vmware.vm.info`` typed read; the ``config.template``
+    assert that follows is what proves the resolved VM is actually a template.
+    """
+    listing = await _read_sub_op(
+        connector, target, operator, _OP_LIST_VMS, {"filter.names": [name]}
+    )
+    rows = _unwrap_value(listing)
+    if not isinstance(rows, list):
+        return None, "template_not_found", []
+    moids = [row["vm"] for row in rows if isinstance(row, dict) and isinstance(row.get("vm"), str)]
+    if not moids:
+        return None, "template_not_found", []
+    if len(moids) > 1:
+        return None, "ambiguous_template", moids
+    return moids[0], None, []
+
+
+async def _resolve_customization_spec(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    spec_name: str,
+    manager_moid: str,
+) -> dict[str, Any]:
+    """Resolve a stored GOSC spec by name to its inline vim ``CustomizationSpec``.
+
+    vim ``CloneSpec.customization`` takes a full ``CustomizationSpec`` inline,
+    not a by-name reference, so a stored spec (e.g. one created by #2892's
+    ``guest.customization_spec.create``) is resolved to its object form via
+    ``CustomizationSpecManager.GetCustomizationSpec`` (a *read* -- un-gated,
+    routed straight through ``_post_vmomi_json``) and its ``.spec`` field is
+    embedded in the clone. Composing here means the clone yields a customized
+    VM without a separate ``vm.customize`` dispatch. Raises when the spec name
+    does not resolve to a usable ``CustomizationSpecItem`` -- the operator
+    named a customization that vCenter cannot supply, so the clone must not
+    proceed with a silently-uncustomized VM.
+    """
+    item = await connector._post_vmomi_json(
+        target,
+        f"/CustomizationSpecManager/{manager_moid}/GetCustomizationSpec",
+        operator=operator,
+        json={"name": spec_name},
+    )
+    payload = _unwrap_value(item)
+    spec = payload.get("spec") if isinstance(payload, dict) else None
+    if not isinstance(spec, dict):
+        raise RuntimeError(
+            f"vm.clone_from_template: customization spec {spec_name!r} did not resolve to a "
+            f"CustomizationSpecItem with a spec (got {type(spec).__name__}); confirm the GOSC "
+            "spec name exists on this vCenter"
+        )
+    return spec
+
+
+def _build_clone_body(
+    *,
+    new_vm_name: str,
+    folder_moid: str,
+    pool_moid: str,
+    datastore_moid: str,
+    host_moid: str | None,
+    power_on: bool,
+    customization: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Assemble the ``CloneVM_Task`` request body from the placement params.
+
+    Shape (spec-verified against ``vi-json.yaml``): ``CloneVMRequestType`` =
+    ``{folder: Folder-MoRef, name, spec: VirtualMachineCloneSpec}`` where the
+    ``CloneSpec`` carries a ``VirtualMachineRelocateSpec`` ``location``
+    (``pool`` + ``datastore`` MoRefs, optional ``host`` pin), ``template:
+    false`` (clone to a VM, never a template) and ``powerOn``. ``customization``
+    (an inline ``CustomizationSpec``) is added only when a GOSC spec was
+    requested.
+    """
+    location: dict[str, Any] = {
+        "pool": _moref(_RESOURCE_POOL_MO_TYPE, pool_moid),
+        "datastore": _moref(_DATASTORE_MO_TYPE, datastore_moid),
+    }
+    if host_moid is not None:
+        location["host"] = _moref(_HOST_SYSTEM_MO_TYPE, host_moid)
+    clone_spec: dict[str, Any] = {"location": location, "template": False, "powerOn": power_on}
+    if customization is not None:
+        clone_spec["customization"] = customization
+    return {"folder": _moref(_FOLDER_MO_TYPE, folder_moid), "name": new_vm_name, "spec": clone_spec}
+
+
+def _clone_result(
+    status: str,
+    *,
+    source_template: str,
+    new_vm_name: str,
+    folder: str,
+    source_template_id: str | None = None,
+    new_vm_id: str | None = None,
+    task: str | None = None,
+    customization_spec_name: str | None = None,
+    candidates: list[str] | None = None,
+    guidance: str | None = None,
+) -> dict[str, Any]:
+    """Build the uniform ``vm.clone_from_template`` response envelope."""
+    return {
+        "status": status,
+        "source_template": source_template,
+        "source_template_id": source_template_id,
+        "new_vm_name": new_vm_name,
+        "new_vm_id": new_vm_id,
+        "folder": folder,
+        "task": task,
+        "customization_spec_name": customization_spec_name,
+        "candidates": candidates,
+        "guidance": guidance,
+    }
+
+
+async def vm_clone_from_template_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Clone a folder VM template via ``CloneVM_Task``, with optional GOSC.
+
+    Op-id: ``vmware.composite.vm.clone_from_template``. The folder-template
+    counterpart to ``vm.clone`` (content-library only). Flow:
+
+    1. Resolve ``source_template`` (a display name) to a unique VM moid via
+       ``GET:/vcenter/vm?filter.names=`` -- refuse on no / multiple matches.
+    2. Assert the resolved VM is a template (``config.template`` via a vmomi
+       ``RetrievePropertiesEx`` *read*) -- refuse a non-template source with
+       ``status='not_a_template'`` before any clone.
+    3. When ``customization_spec_name`` is set, resolve the stored GOSC spec
+       to its inline ``CustomizationSpec`` (``CustomizationSpecManager.
+       GetCustomizationSpec``) so the clone customizes in one dispatch.
+    4. Issue ``CloneVM_Task`` through the governed vmomi write seam
+       (:func:`_write_vmomi_sub_op` → the #2254 gate); a parked/denied gate
+       returns the :class:`OperationResult` verbatim and no clone fires.
+    5. Poll the returned Task to terminal via
+       :func:`~...vim_task.poll_vim_task`. A fault raises (dispatcher wraps
+       ``connector_error``, mirroring ``vm.disk.grow``); a timeout returns
+       ``status='timeout'`` with the task id; success returns
+       ``status='cloned'`` with the new VM moid from ``TaskInfo.result``.
+    """
+    source_template = params["source_template"]
+    new_vm_name = params["new_vm_name"]
+    folder_moid = params["folder"]
+    pool_moid = params["resource_pool"]
+    datastore_moid = params["datastore"]
+    host_moid = params.get("host")
+    power_on = bool(params.get("power_on", False))
+    customization_spec_name = params.get("customization_spec_name")
+    manager_moid = params.get(
+        "customization_spec_manager_moid", _DEFAULT_CUSTOMIZATION_SPEC_MANAGER_MOID
+    )
+
+    template_moid, resolve_error, candidates = await _resolve_template_moid(
+        connector, target, operator, name=source_template
+    )
+    if resolve_error is not None:
+        return _clone_result(
+            resolve_error,
+            source_template=source_template,
+            new_vm_name=new_vm_name,
+            folder=folder_moid,
+            candidates=candidates or None,
+            guidance=(
+                f"source_template {source_template!r} matched "
+                f"{'no VM' if resolve_error == 'template_not_found' else 'more than one VM'}; "
+                "re-issue against an unambiguous marked-as-template VM"
+            ),
+        )
+    # ``resolve_error is None`` implies a unique moid resolved (the two are
+    # correlated in ``_resolve_template_moid``'s return contract).
+    assert template_moid is not None
+
+    template_check = await connector._post_vmomi_json(
+        target,
+        _VMOMI_RETRIEVE_PROPERTIES_PATH,
+        operator=operator,
+        json=_build_config_template_retrieve_params(template_moid),
+    )
+    if _extract_config_template(template_check, template_moid) is not True:
+        return _clone_result(
+            "not_a_template",
+            source_template=source_template,
+            source_template_id=template_moid,
+            new_vm_name=new_vm_name,
+            folder=folder_moid,
+            guidance=(
+                f"{source_template!r} ({template_moid}) is not a marked-as-template VM "
+                "(config.template is not true); mark it as a template or clone it with "
+                "vmware.composite.vm.clone (content-library) instead"
+            ),
+        )
+
+    customization = None
+    if customization_spec_name is not None:
+        customization = await _resolve_customization_spec(
+            connector,
+            target,
+            operator,
+            spec_name=customization_spec_name,
+            manager_moid=manager_moid,
+        )
+
+    clone_body = _build_clone_body(
+        new_vm_name=new_vm_name,
+        folder_moid=folder_moid,
+        pool_moid=pool_moid,
+        datastore_moid=datastore_moid,
+        host_moid=host_moid,
+        power_on=power_on,
+        customization=customization,
+    )
+    # Identity-only gate params: they name the blast radius (source, target,
+    # placement, spec *name*) for the durable ApprovalRequest without ever
+    # serialising the resolved CustomizationSpec's secret-bearing fields
+    # (GOSC secret hygiene, #1503).
+    gate_params = {
+        "source_template": source_template,
+        "source_template_id": template_moid,
+        "new_vm_name": new_vm_name,
+        "folder": folder_moid,
+        "resource_pool": pool_moid,
+        "datastore": datastore_moid,
+        "host": host_moid,
+        "power_on": power_on,
+        "customization_spec_name": customization_spec_name,
+    }
+    gate, task_payload = await _write_vmomi_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_CLONE_VM_TASK,
+        vmomi_path=f"/VirtualMachine/{template_moid}/CloneVM_Task",
+        body=clone_body,
+        params=gate_params,
+    )
+    if gate is not None:
+        return gate
+
+    outcome = await poll_vim_task(
+        connector,
+        target,
+        operator,
+        task=_unwrap_value(task_payload),
+        timeout_seconds=_CLONE_FROM_TEMPLATE_TASK_TIMEOUT_SECONDS,
+    )
+    if outcome.state == "error":
+        raise RuntimeError(
+            f"vm.clone_from_template: CloneVM_Task cloning {source_template!r} ({template_moid}) "
+            f"to {new_vm_name!r} faulted: {outcome.error_message or '<no fault reported>'}"
+        )
+    if outcome.timed_out:
+        return _clone_result(
+            "timeout",
+            source_template=source_template,
+            source_template_id=template_moid,
+            new_vm_name=new_vm_name,
+            folder=folder_moid,
+            task=outcome.task,
+            customization_spec_name=customization_spec_name,
+            guidance=(
+                f"CloneVM_Task {outcome.task} did not reach a terminal state within "
+                f"{int(_CLONE_FROM_TEMPLATE_TASK_TIMEOUT_SECONDS)}s; poll the task or list the "
+                f"folder — the clone {new_vm_name!r} may still complete in the background"
+            ),
+        )
+    return _clone_result(
+        "cloned",
+        source_template=source_template,
+        source_template_id=template_moid,
+        new_vm_name=new_vm_name,
+        new_vm_id=_extract_cloned_vm_moid(outcome.result),
+        folder=folder_moid,
+        task=outcome.task,
+        customization_spec_name=customization_spec_name,
+    )

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` preview builders for the 10 vmware write composites.
+"""Park-time ``proposed_effect`` preview builders for the 11 vmware write composites.
 
 G0.22-T3 (#1608). Before this module, a parked ``vmware.composite.*``
 write stored only the identifier default ``{op_id, connector_id,
@@ -9,7 +9,7 @@ target_id}`` in :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect
 — and because the original dispatch ``params`` are deliberately never
 serialised onto a reviewer-facing surface (#1503), the four-eyes
 approver could not tell a one-VM power cycle from a 1000-VM outage.
-This wires all 10 write composites onto the per-op preview hook shipped
+This wires all 11 write composites onto the per-op preview hook shipped
 by #1437 (:mod:`meho_backplane.operations._preview`), following the
 argocd pattern (#1452): reuse the handlers' own read-only resolution
 helpers, never the mutating sub-ops.
@@ -25,6 +25,9 @@ helpers, never the mutating sub-ops.
 ``cluster.patch``         ``{cluster, patch_method, resolved, total_resolved}``
 ``vm.create``             echo: name, guest_os, sizing, networks, power-on
 ``vm.clone``              echo: source_vm, target_name, library_item, wait flag
+``vm.clone_from_template`` echo: source_template, new_vm_name, folder,
+                          resource_pool, datastore, host, power_on,
+                          customization_spec_name
 ``vm.snapshot.revert``    echo: vm, snapshot_name
 ``vm.migrate``            echo: vm, cluster, target_host + resolution source
 ``vm.power``              echo: vm, verb, power_kind (hard vs Tools-soft)
@@ -50,8 +53,11 @@ Two preview depths, chosen per composite
   echoes the requested capacity so the approver sees the disk grows (never
   shrinks) and by how much.
 * **Param echo** (no I/O — the ``secret.move`` precedent, #1580) for the
-  five single-entity composites whose params fully name the blast
-  radius. ``vm.power`` additionally echoes ``power_kind`` so the approver
+  six single-entity composites whose params fully name the blast
+  radius. ``vm.clone_from_template`` echoes only the customization spec
+  *name*, never its secret-bearing contents (#1503), so the GOSC keystone
+  composes without leaking sysprep/password material onto the reviewer
+  surface. ``vm.power`` additionally echoes ``power_kind`` so the approver
   sees the soft-vs-hard distinction (a Tools-mediated ``guest_shutdown``
   is a very different blast radius from a hard ``off``).
   ``vm.migrate`` deliberately does **not** pre-resolve a DRS
@@ -82,9 +88,10 @@ Redaction posture
 
 The whole-builder ``classify_op`` gate runs in
 :func:`~meho_backplane.operations._preview.build_proposed_effect` before
-any builder fires: the 10 op_ids classify as ``write`` (``.create`` /
-``.patch`` suffixes) or ``other`` (``vm.disk.grow`` — ``.grow`` is not a
-write suffix) — none is a credential class, so none is suppressed. The
+any builder fires: the 11 op_ids classify as ``write`` (``.create`` /
+``.patch`` suffixes) or ``other`` (``vm.disk.grow`` — ``.grow`` — and
+``vm.clone_from_template`` — ``_template`` — are not write suffixes) —
+none is a credential class, so none is suppressed. The
 previews themselves carry only vSphere inventory identity (moids, display
 names, power states, disk capacities) and the operator's own dispatch
 params — infrastructure topology, never credential material.
@@ -286,6 +293,45 @@ async def _vm_clone_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     }
 
 
+async def _vm_clone_from_template_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.clone_from_template`` — echo the clone coordinates (no I/O).
+
+    Param-echo: the params fully name the blast radius — which template, where
+    it lands (folder / resource pool / datastore / optional host pin), whether
+    it powers on, and which GOSC spec (if any) applies. Only the customization
+    spec *name* is echoed, never its secret-bearing contents (#1503), and no
+    live read is issued, so the preview cannot drift from what the approved
+    dispatch does. Declines (``None``) on malformed params.
+    """
+    source_template = ctx.params.get("source_template")
+    new_vm_name = ctx.params.get("new_vm_name")
+    folder = ctx.params.get("folder")
+    resource_pool = ctx.params.get("resource_pool")
+    datastore = ctx.params.get("datastore")
+    if (
+        not isinstance(source_template, str)
+        or not isinstance(new_vm_name, str)
+        or not isinstance(folder, str)
+        or not isinstance(resource_pool, str)
+        or not isinstance(datastore, str)
+    ):
+        return None
+    host = ctx.params.get("host")
+    customization_spec_name = ctx.params.get("customization_spec_name")
+    return {
+        "source_template": source_template,
+        "new_vm_name": new_vm_name,
+        "folder": folder,
+        "resource_pool": resource_pool,
+        "datastore": datastore,
+        "host": host if isinstance(host, str) else None,
+        "power_on": bool(ctx.params.get("power_on", False)),
+        "customization_spec_name": (
+            customization_spec_name if isinstance(customization_spec_name, str) else None
+        ),
+    }
+
+
 async def _vm_snapshot_revert_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     """Preview ``vm.snapshot.revert`` — echo the revert coordinates (no I/O).
 
@@ -411,6 +457,7 @@ async def _vm_disk_grow_preview(ctx: PreviewContext) -> dict[str, Any] | None:
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.create": _vm_create_preview,
     "vmware.composite.vm.clone": _vm_clone_preview,
+    "vmware.composite.vm.clone_from_template": _vm_clone_from_template_preview,
     "vmware.composite.vm.snapshot.revert": _vm_snapshot_revert_preview,
     "vmware.composite.vm.migrate": _vm_migrate_preview,
     "vmware.composite.vm.power": _vm_power_preview,
@@ -423,7 +470,7 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 10 write-composite park-time preview builders. Import-time.
+    """Wire the 11 write-composite park-time preview builders. Import-time.
 
     The 5 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -56,6 +56,8 @@ __all__ = [
     "NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA",
     "PERFORMANCE_SUMMARY_PARAMETER_SCHEMA",
     "PERFORMANCE_SUMMARY_RESPONSE_SCHEMA",
+    "VM_CLONE_FROM_TEMPLATE_PARAMETER_SCHEMA",
+    "VM_CLONE_FROM_TEMPLATE_RESPONSE_SCHEMA",
     "VM_CLONE_PARAMETER_SCHEMA",
     "VM_CLONE_RESPONSE_SCHEMA",
     "VM_CREATE_PARAMETER_SCHEMA",
@@ -690,6 +692,116 @@ VM_CLONE_PARAMETER_SCHEMA: dict[str, Any] = {
 }
 
 
+#: ``vmware.composite.vm.clone_from_template`` parameter schema.
+#:
+#: Clones a **folder VM template** (a marked-as-template VM) via vim
+#: ``VirtualMachine.CloneVM_Task`` — the path ``vm.clone`` (content-library
+#: only) cannot serve. Placement moids (``folder`` / ``resource_pool`` /
+#: ``datastore`` / ``host``) are vim MoRef values the operator resolves from
+#: list ops; ``source_template`` is a display **name** resolved to a moid at
+#: dispatch time and asserted to be a template before any clone fires.
+VM_CLONE_FROM_TEMPLATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "source_template": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Display name of the source **folder VM template** (a "
+                "marked-as-template VM). Resolved to a moid via "
+                "``GET:/vcenter/vm?filter.names=`` and asserted to carry "
+                "``config.template=true`` (PropertyCollector read) before any "
+                "clone is issued — a non-template source is refused with "
+                "``status='not_a_template'``, an unknown name with "
+                "``'template_not_found'``, an ambiguous name with "
+                "``'ambiguous_template'``."
+            ),
+        },
+        "new_vm_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Display name for the newly cloned virtual machine.",
+        },
+        "folder": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Destination VM ``Folder`` moid (e.g. 'group-v42'). The "
+                "``CloneVM_Task`` ``folder`` argument — where the new VM is "
+                "placed in the inventory tree."
+            ),
+        },
+        "resource_pool": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "``ResourcePool`` moid the clone attaches to (e.g. "
+                "'resgroup-8'). Required by vim for a template→VM clone — it "
+                "determines the compute resources available to the clone. For "
+                "a DRS cluster, pass the cluster's root resource pool moid."
+            ),
+        },
+        "datastore": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "``Datastore`` moid the clone's files are copied to (e.g. "
+                "'datastore-15'). Always required — it names where the new "
+                "VM lands on physical storage."
+            ),
+        },
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional ``HostSystem`` moid to pin the clone onto a specific "
+                "host (e.g. 'host-19'). When unset the resource pool (and DRS, "
+                "if enabled) place the VM."
+            ),
+        },
+        "power_on": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "Power the clone on after creation (``CloneSpec.powerOn``). "
+                "When a customization spec is applied, the first power-on "
+                "completes the guest customization; defaults to false."
+            ),
+        },
+        "customization_spec_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional name of an existing guest OS customization "
+                "specification (GOSC, e.g. one created by "
+                "``vmware.composite.guest.customization_spec.create``). "
+                "Resolved to its full ``CustomizationSpec`` via vim "
+                "``CustomizationSpecManager.GetCustomizationSpec`` and applied "
+                "inline in the clone (``CloneSpec.customization``), so the "
+                "clone yields a customized VM without a separate customize "
+                "dispatch. Secret-bearing customization fields are never "
+                "echoed onto the approval preview — only the spec name is."
+            ),
+        },
+        "customization_spec_manager_moid": {
+            "type": "string",
+            "minLength": 1,
+            "default": "CustomizationSpecManager",
+            "description": (
+                "vim ``CustomizationSpecManager`` singleton moid used to "
+                "resolve ``customization_spec_name``. Defaults to the standard "
+                "``ServiceContent.customizationSpecManager`` value; overridable "
+                "for a deploy whose singleton moid differs (mirrors the "
+                "performance composite's ``perf_manager_moid``). Ignored when "
+                "``customization_spec_name`` is unset."
+            ),
+        },
+    },
+    "required": ["source_template", "new_vm_name", "folder", "resource_pool", "datastore"],
+    "additionalProperties": False,
+}
+
+
 #: ``vmware.composite.vm.snapshot.revert`` parameter schema.
 #:
 #: Idempotent revert by snapshot name. Ambiguity (multiple snapshots
@@ -1049,6 +1161,94 @@ VM_CLONE_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["status", "task_id"],
+}
+
+
+#: ``vmware.composite.vm.clone_from_template`` response schema.
+VM_CLONE_FROM_TEMPLATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "cloned",
+                "template_not_found",
+                "ambiguous_template",
+                "not_a_template",
+                "timeout",
+            ],
+            "description": (
+                "``'cloned'`` — the CloneVM_Task reached terminal success; "
+                "``'template_not_found'`` — the source name matched no VM; "
+                "``'ambiguous_template'`` — the name matched more than one VM; "
+                "``'not_a_template'`` — the source resolved but is not a "
+                "marked-as-template VM (``config.template`` is not true); "
+                "``'timeout'`` — the clone task did not reach a terminal state "
+                "within the poll bound (it may still complete in the "
+                "background). A vim task *fault* raises (wrapped "
+                "``connector_error``), it is not a status here."
+            ),
+        },
+        "source_template": {
+            "type": "string",
+            "description": "The source template display name that was requested.",
+        },
+        "source_template_id": {
+            "type": ["string", "null"],
+            "description": (
+                "The resolved source VM moid; ``null`` on ``template_not_found`` "
+                "/ ``ambiguous_template`` (nothing uniquely resolved)."
+            ),
+        },
+        "new_vm_name": {
+            "type": "string",
+            "description": "The requested display name for the clone.",
+        },
+        "new_vm_id": {
+            "type": ["string", "null"],
+            "description": (
+                "The cloned VM's moid, read from the CloneVM_Task result on "
+                "success; ``null`` on every non-``cloned`` status."
+            ),
+        },
+        "folder": {
+            "type": "string",
+            "description": "The destination folder moid the clone was placed in.",
+        },
+        "task": {
+            "type": ["string", "null"],
+            "description": (
+                "CloneVM_Task moid — present once the clone write was issued "
+                "(``cloned`` / ``timeout``); ``null`` on the pre-write "
+                "refusals (``template_not_found`` / ``ambiguous_template`` / "
+                "``not_a_template``)."
+            ),
+        },
+        "customization_spec_name": {
+            "type": ["string", "null"],
+            "description": (
+                "Echo of the applied GOSC spec name, or ``null`` when the "
+                "clone requested no inline customization."
+            ),
+        },
+        "candidates": {
+            "type": ["array", "null"],
+            "items": {"type": "string"},
+            "description": (
+                "On ``ambiguous_template``, the moids the name matched so the "
+                "operator can re-issue against an unambiguous template; "
+                "``null`` otherwise."
+            ),
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Operator-facing next-step hint on non-``cloned`` statuses; "
+                "``null`` when ``status='cloned'``."
+            ),
+        },
+    },
+    "required": ["status", "source_template", "new_vm_name"],
 }
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -327,3 +327,74 @@ def test_vm_disk_grow_vi_json_paths_exist_in_the_pinned_spec() -> None:
             f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
             "disk-grow vi-json sub-op targets a path the spec does not serve"
         )
+
+
+# ---------------------------------------------------------------------------
+# vm.clone_from_template VI-JSON sub-op reconciliation (#2894)
+# ---------------------------------------------------------------------------
+#
+# vm.clone_from_template's mutating path is vi-json, not vcenter REST:
+# ``POST:/VirtualMachine/{moId}/CloneVM_Task`` (the folder-template clone) plus
+# its config-template assert read
+# ``POST:/PropertyCollector/{moId}/RetrievePropertiesEx`` and the optional GOSC
+# resolve ``POST:/CustomizationSpecManager/{moId}/GetCustomizationSpec``. These
+# are declared in ``_write._VIM_SUB_OPS_VM_CLONE_FROM_TEMPLATE`` (deliberately
+# NOT in the ``_SUB_OPS_*`` namespace, so the vcenter.yaml sweep above skips
+# them). Same ``METHOD:/path`` keying as disk-grow — the moId rides the path as
+# ``{moId}`` — so the same reconciliation proof applies, and it is additionally
+# checked against the pinned ``vi-json.yaml`` when the spec-shelf is configured.
+
+
+def test_vm_clone_from_template_vi_json_sub_op_manifest_is_the_expected_triple() -> None:
+    """Pin the clone manifest so a drift can't shrink the reconcile."""
+    assert set(_write._VIM_SUB_OPS_VM_CLONE_FROM_TEMPLATE) == {
+        "POST:/VirtualMachine/{moId}/CloneVM_Task",
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/CustomizationSpecManager/{moId}/GetCustomizationSpec",
+    }
+
+
+def test_vm_clone_from_template_vi_json_sub_ops_round_trip_through_ingest() -> None:
+    """The clone vi-json op_ids are byte-for-byte what the parser emits.
+
+    Proves the ``METHOD:/path`` op_id strings the composite gates on match what
+    ``parse_openapi`` produces from a vi-json-shaped spec (the ``{moId}`` path
+    template survives), so ``enforce_subop_policy``'s op_id / a grant's
+    op_pattern resolve against the ingested rows once the operator ingests
+    ``vi-json.yaml`` — the vi-json analogue of the vcenter reconcile above.
+    """
+    required = set(_write._VIM_SUB_OPS_VM_CLONE_FROM_TEMPLATE)
+    spec = _build_vcenter_fixture(required)
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vi-json.yaml"
+
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200, content=spec_bytes, headers={"content-type": "application/json"}
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+    ingested_op_ids = {row.op_id for row in rows}
+    assert required <= ingested_op_ids
+
+
+def test_vm_clone_from_template_vi_json_paths_exist_in_the_pinned_spec() -> None:
+    """Each clone vi-json sub-op path is a real POST path in the pinned vi-json.yaml.
+
+    The definitive #2894 grounding: the folder-template clone's mutating call
+    (and its config-template assert + GOSC resolve reads) must target paths
+    that actually exist in the pinned spec. Skips when the spec-shelf is not
+    configured (the canary's convention), so CI — where the env vars are wired
+    — is the operator-visible signal.
+    """
+    spec_path = resolve_vi_json_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    spec_text = spec_path.read_text(encoding="utf-8")
+    for op_id in _write._VIM_SUB_OPS_VM_CLONE_FROM_TEMPLATE:
+        _, _, path = op_id.partition(":")
+        assert _vi_json_path_item_has_post(spec_text, path), (
+            f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
+            "clone-from-template vi-json sub-op targets a path the spec does not serve"
+        )

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -175,11 +175,12 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 15 total: 5 reads
-    # (T5 #508) + 10 writes (T6 #509 + single-VM vm.power #2301 + mutating
-    # VI-JSON vm.disk.grow #2893). (The former host.network_uplinks /
-    # host.vsan_health reads were re-shipped as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 15
+    # Embedding service called once per composite -- 16 total: 5 reads
+    # (T5 #508) + 11 writes (T6 #509 + single-VM vm.power #2301 + mutating
+    # VI-JSON vm.disk.grow #2893 + folder-template vm.clone_from_template
+    # #2894). (The former host.network_uplinks / host.vsan_health reads
+    # were re-shipped as typed ops in #2258.)
+    assert stub_embedding_service.encode_one.call_count == 16
 
 
 @pytest.mark.asyncio
@@ -426,16 +427,17 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 5 read rows persist; embedding stays at 15.
+    """Running the registrar twice -> 5 read rows persist; embedding stays at 16.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (5 reads + 10 writes / T6 +
-    single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893).
+    persist after the combined registrar (5 reads + 11 writes / T6 +
+    single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
+    folder-template vm.clone_from_template #2894).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 15
+    assert first_count == 16
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Unit tests for the 10 vmware-rest write-composite handler functions.
+"""Unit tests for the 11 vmware-rest write-composite handler functions.
 
 Post-#2256 the write composites dispatch their sub-ops **directly on the
 connector session** -- ``connector._get_json`` / ``connector._post_json``
@@ -57,6 +57,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     host_detach_from_vds_composite,
     host_evacuate_composite,
     vm_clone_composite,
+    vm_clone_from_template_composite,
     vm_create_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -1454,5 +1455,469 @@ async def test_vm_disk_grow_reconfig_body_reaches_the_wire_respx(
         assert change["device"]["_typeName"] == "VirtualDisk"
         assert change["device"]["key"] == 2000
         assert change["device"]["capacityInBytes"] == _TWENTY_GIB
+    finally:
+        await connector.aclose()
+
+
+# ===========================================================================
+# vm.clone_from_template (folder-template CloneVM_Task — Task D, #2894)
+# ===========================================================================
+
+
+_CLONE_OP_ID = "POST:/VirtualMachine/{moId}/CloneVM_Task"
+_TEMPLATE_ROWS = [{"vm": "vm-42", "name": "ubuntu-2404-template"}]
+# A minimal-but-valid vim CustomizationSpec shape (identity + globalIPSettings
+# are the required fields per vi-json.yaml); the handler embeds whatever
+# GetCustomizationSpec returns verbatim, so the exact contents are opaque.
+_RESOLVED_GOSC_SPEC = {
+    "_typeName": "CustomizationSpec",
+    "identity": {"_typeName": "CustomizationLinuxPrep", "hostName": {"name": "web-01"}},
+    "globalIPSettings": {"_typeName": "CustomizationGlobalIPSettings"},
+}
+
+
+class _CloneFromTemplateConnector:
+    """Recording double serving the clone-from-template REST + VI-JSON sub-ops.
+
+    ``vm.clone_from_template`` resolves the template name (REST
+    ``GET:/vcenter/vm``), asserts ``config.template`` (vmomi
+    ``RetrievePropertiesEx`` on a VirtualMachine), optionally resolves a GOSC
+    spec (``GetCustomizationSpec``), writes ``CloneVM_Task``, then polls
+    ``Task.info`` (``RetrievePropertiesEx`` on a Task). The two
+    ``RetrievePropertiesEx`` reads are keyed apart by the request body's
+    ``specSet`` object type — exactly the seam a real vCenter keys them by.
+    """
+
+    _MOUNT = "/api"
+
+    def __init__(
+        self,
+        *,
+        template_rows: list[dict[str, Any]] | None = None,
+        is_template: bool = True,
+        task_state: str = "success",
+        task_error: str | None = None,
+        task_result: Any = None,
+        customization_spec: dict[str, Any] | None = None,
+        clone_task: str = "task-clone-1",
+    ) -> None:
+        self.template_rows = _TEMPLATE_ROWS if template_rows is None else template_rows
+        self.is_template = is_template
+        self.task_state = task_state
+        self.task_error = task_error
+        self.task_result = (
+            task_result
+            if task_result is not None
+            else {
+                "_typeName": "ManagedObjectReference",
+                "type": "VirtualMachine",
+                "value": "vm-99",
+            }
+        )
+        self.customization_spec = customization_spec
+        self.clone_task = clone_task
+        self.rest_calls: list[tuple[str, Any]] = []
+        self.vmomi_calls: list[tuple[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    def _spec(self, path: str) -> str:
+        return path[len(self._MOUNT) :] if path.startswith(self._MOUNT) else path
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        spec = self._spec(path)
+        self.rest_calls.append((spec, params))
+        if spec == "/vcenter/vm":
+            return {"value": self.template_rows}
+        return {"value": {}}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append((path, json))
+        if path.endswith("/CloneVM_Task"):
+            return {"type": "Task", "value": self.clone_task}
+        if path.endswith("/GetCustomizationSpec"):
+            return {"spec": self.customization_spec}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "VirtualMachine":
+            moid = json["specSet"][0]["objectSet"][0]["obj"]["value"]
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "VirtualMachine", "value": moid},
+                        "propSet": [{"name": "config.template", "val": self.is_template}],
+                    }
+                ]
+            }
+        info: dict[str, Any] = {"state": self.task_state}
+        if self.task_error is not None:
+            info["error"] = {"localizedMessage": self.task_error}
+        if self.task_state == "success":
+            info["result"] = self.task_result
+        return {
+            "objects": [
+                {
+                    "obj": {"type": "Task", "value": self.clone_task},
+                    "propSet": [{"name": "info", "val": info}],
+                }
+            ]
+        }
+
+    @property
+    def clone_bodies(self) -> list[Any]:
+        return [body for path, body in self.vmomi_calls if path.endswith("/CloneVM_Task")]
+
+    @property
+    def get_customization_calls(self) -> list[tuple[str, Any]]:
+        return [(p, b) for p, b in self.vmomi_calls if p.endswith("/GetCustomizationSpec")]
+
+
+def _clone_params(**overrides: Any) -> dict[str, Any]:
+    """Schema-valid clone params with the required placement moids filled in."""
+    params: dict[str, Any] = {
+        "source_template": "ubuntu-2404-template",
+        "new_vm_name": "web-01",
+        "folder": "group-v10",
+        "resource_pool": "resgroup-8",
+        "datastore": "datastore-15",
+    }
+    params.update(overrides)
+    return params
+
+
+async def test_vm_clone_from_template_happy_path_clones_and_polls(gate: _GateRecorder) -> None:
+    """Resolve template -> assert template -> gated CloneVM_Task -> poll -> status=cloned."""
+    conn = _CloneFromTemplateConnector()
+    out = await vm_clone_from_template_composite(
+        operator=_make_operator(),
+        target=object(),
+        params=_clone_params(power_on=True),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "cloned"
+    assert out["source_template"] == "ubuntu-2404-template"
+    assert out["source_template_id"] == "vm-42"
+    assert out["new_vm_name"] == "web-01"
+    assert out["new_vm_id"] == "vm-99"
+    assert out["folder"] == "group-v10"
+    assert out["task"] == "task-clone-1"
+    assert out["customization_spec_name"] is None
+
+    # The template name was resolved via GET:/vcenter/vm and the CloneVM_Task
+    # was issued on the resolved template moid.
+    assert ("/vcenter/vm", {"names": ["ubuntu-2404-template"]}) in conn.rest_calls
+    clone_paths = [p for p, _ in conn.vmomi_calls if p.endswith("/CloneVM_Task")]
+    assert clone_paths == ["/VirtualMachine/vm-42/CloneVM_Task"]
+
+    # The single mutating sub-op was gated with the vi-json CloneVM_Task op_id
+    # + identity-only params (never the resolved CustomizationSpec).
+    assert gate.gated_op_ids == [_CLONE_OP_ID]
+    gated = gate.calls[0]
+    assert gated["safety_level"] == "dangerous"
+    assert gated["requires_approval"] is False
+    assert gated["params"] == {
+        "source_template": "ubuntu-2404-template",
+        "source_template_id": "vm-42",
+        "new_vm_name": "web-01",
+        "folder": "group-v10",
+        "resource_pool": "resgroup-8",
+        "datastore": "datastore-15",
+        "host": None,
+        "power_on": True,
+        "customization_spec_name": None,
+    }
+
+    # The CloneVM_Task body: folder MoRef + name + CloneSpec (template:false,
+    # powerOn, relocate placement pool+datastore, no host pin, no customization).
+    assert len(conn.clone_bodies) == 1
+    body = conn.clone_bodies[0]
+    assert body["folder"] == {"type": "Folder", "value": "group-v10"}
+    assert body["name"] == "web-01"
+    spec = body["spec"]
+    assert spec["template"] is False
+    assert spec["powerOn"] is True
+    assert spec["location"]["pool"] == {"type": "ResourcePool", "value": "resgroup-8"}
+    assert spec["location"]["datastore"] == {"type": "Datastore", "value": "datastore-15"}
+    assert "host" not in spec["location"]
+    assert "customization" not in spec
+
+
+async def test_vm_clone_from_template_host_pin_included_when_given(gate: _GateRecorder) -> None:
+    """An explicit host moid rides the RelocateSpec as a HostSystem MoRef."""
+    conn = _CloneFromTemplateConnector()
+    out = await vm_clone_from_template_composite(
+        operator=_make_operator(),
+        target=object(),
+        params=_clone_params(host="host-19"),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "cloned"
+    body = conn.clone_bodies[0]
+    assert body["spec"]["location"]["host"] == {"type": "HostSystem", "value": "host-19"}
+    assert gate.calls[0]["params"]["host"] == "host-19"
+
+
+async def test_vm_clone_from_template_with_customization_embeds_resolved_spec(
+    gate: _GateRecorder,
+) -> None:
+    """customization_spec_name -> GetCustomizationSpec -> spec embedded inline (composes #2892).
+
+    Proves acceptance criterion 3: a clone with ``customization_spec_name``
+    yields a customized clone in one dispatch — the resolved
+    ``CustomizationSpec`` rides the ``CloneSpec.customization`` field, with no
+    separate ``vm.customize`` call, and the gate params echo only the spec
+    *name* (never the secret-bearing spec contents).
+    """
+    conn = _CloneFromTemplateConnector(customization_spec=_RESOLVED_GOSC_SPEC)
+    out = await vm_clone_from_template_composite(
+        operator=_make_operator(),
+        target=object(),
+        params=_clone_params(customization_spec_name="linux-web-gosc"),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "cloned"
+    assert out["customization_spec_name"] == "linux-web-gosc"
+
+    # The GOSC spec was resolved by name on the CustomizationSpecManager singleton.
+    assert conn.get_customization_calls == [
+        (
+            "/CustomizationSpecManager/CustomizationSpecManager/GetCustomizationSpec",
+            {"name": "linux-web-gosc"},
+        )
+    ]
+    # The resolved spec is embedded verbatim into CloneSpec.customization.
+    assert conn.clone_bodies[0]["spec"]["customization"] == _RESOLVED_GOSC_SPEC
+    # The gate params carry the spec name, NOT the resolved secret-bearing spec.
+    assert gate.calls[0]["params"]["customization_spec_name"] == "linux-web-gosc"
+    assert "customization" not in gate.calls[0]["params"]
+
+
+async def test_vm_clone_from_template_custom_manager_moid_overrides_default(
+    gate: _GateRecorder,
+) -> None:
+    """An operator-supplied customization_spec_manager_moid is used for the resolve."""
+    conn = _CloneFromTemplateConnector(customization_spec=_RESOLVED_GOSC_SPEC)
+    await vm_clone_from_template_composite(
+        operator=_make_operator(),
+        target=object(),
+        params=_clone_params(
+            customization_spec_name="linux-web-gosc",
+            customization_spec_manager_moid="custom-spec-mgr",
+        ),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert conn.get_customization_calls[0][0] == (
+        "/CustomizationSpecManager/custom-spec-mgr/GetCustomizationSpec"
+    )
+
+
+async def test_vm_clone_from_template_refuses_non_template_source(gate: _GateRecorder) -> None:
+    """A resolved-but-non-template source is refused before any clone; no gate."""
+    conn = _CloneFromTemplateConnector(is_template=False)
+    out = await vm_clone_from_template_composite(
+        operator=_make_operator(),
+        target=object(),
+        params=_clone_params(),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "not_a_template"
+    assert out["source_template_id"] == "vm-42"
+    assert out["task"] is None
+    # The config.template read fired; no CloneVM_Task, never gated.
+    assert conn.clone_bodies == []
+    assert gate.calls == []
+
+
+async def test_vm_clone_from_template_template_not_found(gate: _GateRecorder) -> None:
+    """An unresolvable source name -> template_not_found; no template read, no gate."""
+    conn = _CloneFromTemplateConnector(template_rows=[])
+    out = await vm_clone_from_template_composite(
+        operator=_make_operator(),
+        target=object(),
+        params=_clone_params(),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "template_not_found"
+    assert out["source_template_id"] is None
+    assert conn.clone_bodies == []
+    assert conn.vmomi_calls == []
+    assert gate.calls == []
+
+
+async def test_vm_clone_from_template_ambiguous_template(gate: _GateRecorder) -> None:
+    """A source name matching >1 VM -> ambiguous_template with candidate moids; no gate."""
+    conn = _CloneFromTemplateConnector(
+        template_rows=[{"vm": "vm-42", "name": "dup"}, {"vm": "vm-43", "name": "dup"}]
+    )
+    out = await vm_clone_from_template_composite(
+        operator=_make_operator(),
+        target=object(),
+        params=_clone_params(source_template="dup"),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "ambiguous_template"
+    assert out["candidates"] == ["vm-42", "vm-43"]
+    assert out["source_template_id"] is None
+    assert conn.clone_bodies == []
+    assert gate.calls == []
+
+
+async def test_vm_clone_from_template_gate_short_circuits_before_the_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked gate on the CloneVM_Task write returns verbatim; no clone fires."""
+    gate = _install_gate(
+        monkeypatch,
+        _GateRecorder(gate_for={_CLONE_OP_ID: _awaiting(_CLONE_OP_ID)}),
+    )
+    conn = _CloneFromTemplateConnector()
+    out = await vm_clone_from_template_composite(
+        operator=_make_operator(),
+        target=object(),
+        params=_clone_params(),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _CLONE_OP_ID
+    # The resolve + template reads fired; the CloneVM_Task write was gated off the wire.
+    assert conn.clone_bodies == []
+    assert gate.gated_op_ids == [_CLONE_OP_ID]
+
+
+async def test_vm_clone_from_template_task_fault_raises(gate: _GateRecorder) -> None:
+    """A terminal CloneVM_Task error raises (the dispatcher wraps it connector_error)."""
+    conn = _CloneFromTemplateConnector(
+        task_state="error",
+        task_error="The name 'web-01' already exists.",
+    )
+    with pytest.raises(RuntimeError, match="already exists"):
+        await vm_clone_from_template_composite(
+            operator=_make_operator(),
+            target=object(),
+            params=_clone_params(),
+            connector=conn,  # type: ignore[arg-type]
+        )
+
+
+async def test_vm_clone_from_template_poll_timeout_returns_timeout_status(
+    monkeypatch: pytest.MonkeyPatch, gate: _GateRecorder
+) -> None:
+    """A poll that never sees a terminal state returns status=timeout with the task id."""
+    monkeypatch.setattr(_write, "_CLONE_FROM_TEMPLATE_TASK_TIMEOUT_SECONDS", 0.0)
+    conn = _CloneFromTemplateConnector(task_state="running")
+    out = await vm_clone_from_template_composite(
+        operator=_make_operator(),
+        target=object(),
+        params=_clone_params(),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "timeout"
+    assert out["task"] == "task-clone-1"
+    assert out["new_vm_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# respx-verified CloneVM_Task wire body (through a real connector)
+# ---------------------------------------------------------------------------
+
+
+async def test_vm_clone_from_template_clone_body_reaches_the_wire_respx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """respx-verified: the CloneVM_Task POST body carries template:false + the
+    relocate placement, mounted on the /sdk/vim25 base.
+
+    Drives the real handler through a real ``VmwareRestConnector`` over an
+    httpx (respx) transport, so the assertion is on the actual wire bytes, not
+    a recording double. The #2254 gate is auto-executed here (its governance
+    is proven end-to-end in the gate + e2e lanes) so the write reaches the wire.
+    """
+
+    async def _auto_execute(**_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(_write, "enforce_subop_policy", _auto_execute)
+
+    base = "https://vc-clone.test.invalid"
+    vijson = "/sdk/vim25/8.0.3.0"
+    template_check = {
+        "objects": [
+            {
+                "obj": {"type": "VirtualMachine", "value": "vm-42"},
+                "propSet": [{"name": "config.template", "val": True}],
+            }
+        ]
+    }
+    task_poll = {
+        "objects": [
+            {
+                "obj": {"type": "Task", "value": "task-1"},
+                "propSet": [
+                    {
+                        "name": "info",
+                        "val": {
+                            "state": "success",
+                            "result": {"type": "VirtualMachine", "value": "vm-99"},
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    connector = VmwareRestConnector(session_loader=_stub_loader)
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=base) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            mock.get("/api/about").respond(200, json={"version": "8.0.3"})
+            mock.get("/api/vcenter/vm").respond(200, json={"value": _TEMPLATE_ROWS})
+            # config.template read then Task poll share the RetrievePropertiesEx URL.
+            mock.post(f"{vijson}/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
+                side_effect=[
+                    httpx.Response(200, json=template_check),
+                    httpx.Response(200, json=task_poll),
+                ]
+            )
+            clone = mock.post(f"{vijson}/VirtualMachine/vm-42/CloneVM_Task").respond(
+                200, json={"type": "Task", "value": "task-1"}
+            )
+            out = await vm_clone_from_template_composite(
+                operator=_make_operator(),
+                target=_StubTarget(name="vc-clone", host="vc-clone.test.invalid"),
+                params=_clone_params(power_on=True),
+                connector=connector,
+            )
+        assert isinstance(out, dict)
+        assert out["status"] == "cloned"
+        assert out["new_vm_id"] == "vm-99"
+        assert clone.called
+        body = json.loads(clone.calls[0].request.content)
+        assert body["folder"] == {"type": "Folder", "value": "group-v10"}
+        assert body["name"] == "web-01"
+        assert body["spec"]["template"] is False
+        assert body["spec"]["powerOn"] is True
+        assert body["spec"]["location"]["pool"] == {"type": "ResourcePool", "value": "resgroup-8"}
+        assert body["spec"]["location"]["datastore"] == {
+            "type": "Datastore",
+            "value": "datastore-15",
+        }
     finally:
         await connector.aclose()

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -1101,3 +1101,221 @@ async def test_disk_grow_fresh_boot_dispatchable_without_ingest(
     assert result.status == "ok", result.error
     assert result.result["status"] == "grown"
     assert recorder.reconfig_writes == ["/VirtualMachine/vm-1/ReconfigVM_Task"]
+
+
+# ===========================================================================
+# vm.clone_from_template — mutating VI-JSON: park → approve → resume, #2681
+# envelope (#2894)
+# ===========================================================================
+
+
+class _CloneFromTemplateVmwareConnector:
+    """Recording double for the clone-from-template park→approve→resume E2E.
+
+    ``vm.clone_from_template``'s preview is a pure param-echo (no park-time
+    I/O), so this double is exercised only on dispatch: the template
+    resolution (REST ``GET:/vcenter/vm``) and the VI-JSON sub-ops
+    (``_post_vmomi_json``: the ``config.template`` assert, the
+    ``CloneVM_Task`` write, and the ``Task.info`` poll — the two
+    ``RetrievePropertiesEx`` reads keyed apart by the request body's
+    ``specSet`` object type). Records both surfaces so the test can prove the
+    mutating vmomi write fires only on the approved-resume path.
+    """
+
+    _MOUNT = "/api"
+
+    def __init__(self) -> None:
+        self.rest_calls: list[tuple[str, str]] = []
+        self.vmomi_calls: list[str] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    def _spec(self, path: str) -> str:
+        return path[len(self._MOUNT) :] if path.startswith(self._MOUNT) else path
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        spec = self._spec(path)
+        self.rest_calls.append(("GET", spec))
+        if spec == "/vcenter/vm":
+            return {"value": [{"vm": "vm-42", "name": "ubuntu-template"}]}
+        return {"value": {}}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append(path)
+        if path.endswith("/CloneVM_Task"):
+            return {"type": "Task", "value": "task-clone-e2e"}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "VirtualMachine":
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "VirtualMachine", "value": "vm-42"},
+                        "propSet": [{"name": "config.template", "val": True}],
+                    }
+                ]
+            }
+        return {
+            "objects": [
+                {
+                    "obj": {"type": "Task", "value": "task-clone-e2e"},
+                    "propSet": [
+                        {
+                            "name": "info",
+                            "val": {
+                                "state": "success",
+                                "result": {"type": "VirtualMachine", "value": "vm-99"},
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+
+    @property
+    def clone_writes(self) -> list[str]:
+        return [p for p in self.vmomi_calls if p.endswith("/CloneVM_Task")]
+
+
+_CLONE_PARAMS: dict[str, Any] = {
+    "source_template": "ubuntu-template",
+    "new_vm_name": "web-01",
+    "folder": "group-v10",
+    "resource_pool": "resgroup-8",
+    "datastore": "datastore-15",
+}
+
+
+@pytest.mark.asyncio
+async def test_clone_from_template_queue_approve_resume_with_2681_envelope(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """vm.clone_from_template: park (with #2681 op-identity envelope) → approve → resume → clone.
+
+    1. A USER dispatch parks at ``awaiting_approval``; the durable row's
+       ``proposed_effect`` carries the uniform #2681 op-identity envelope
+       (``op_id`` / ``connector_id`` / ``target_id`` / ``op_class`` /
+       ``safety_level``) plus the param-echo clone-coordinates preview. No
+       CloneVM_Task fires (the preview is pure param-echo — no reads either).
+    2. A distinct human reviewer approves.
+    3. The ``_approved=True`` resume executes the composite: the template
+       resolution + config.template assert + the (now auto-executed) governed
+       CloneVM_Task + the Task poll run, and the result is ``status='cloned'``.
+    """
+    recorder = _CloneFromTemplateVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name="prod-vcenter",
+                product="vmware",
+                host="vcenter.prod.invalid",
+                aliases=[],
+            )
+        )
+        await s.commit()
+
+    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
+    target = _FakeVmwareTarget(target_id=target_id)
+
+    # Step 1: human dispatch -> awaiting_approval; the clone never ran.
+    result1 = await dispatch(
+        operator=requester,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.clone_from_template",
+        target=target,
+        params=_CLONE_PARAMS,
+    )
+    assert result1.status == "awaiting_approval", result1.error
+    assert recorder.clone_writes == [], "no clone before approval"
+    # Param-echo preview does no reads.
+    assert recorder.rest_calls == []
+    assert recorder.vmomi_calls == []
+    approval_request_id = UUID(result1.extras["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        pending = await s.get(ApprovalRequest, approval_request_id)
+    assert pending is not None
+    assert pending.target_id == target_id
+    # #2681 uniform op-identity + metadata envelope on the parked row.
+    effect = pending.proposed_effect
+    assert effect["op_id"] == "vmware.composite.vm.clone_from_template"
+    assert effect["connector_id"] == _CONNECTOR_ID
+    assert effect["target_id"] == str(target_id)
+    assert effect["op_class"] == "other"
+    assert effect["safety_level"] == "dangerous"
+    assert effect["preview_populated"] is True
+    # The param-echo blast-radius preview — what the approver decides on.
+    assert effect["preview"] == {
+        "source_template": "ubuntu-template",
+        "new_vm_name": "web-01",
+        "folder": "group-v10",
+        "resource_pool": "resgroup-8",
+        "datastore": "datastore-15",
+        "host": None,
+        "power_on": False,
+        "customization_spec_name": None,
+    }
+
+    # Step 2: a distinct human reviewer approves.
+    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
+    async with get_sessionmaker()() as s:
+        row = await approve_request(s, approval_request_id, operator=reviewer, params=_CLONE_PARAMS)
+        await s.commit()
+    assert row.status == ApprovalRequestStatus.APPROVED.value
+
+    # Step 3: resume re-dispatch with the gate bypass -> the clone executes.
+    result2 = await dispatch(
+        operator=reviewer,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.clone_from_template",
+        target=target,
+        params=_CLONE_PARAMS,
+        _approved=True,
+    )
+    assert result2.status == "ok", result2.error
+    assert result2.result["status"] == "cloned"
+    assert result2.result["source_template_id"] == "vm-42"
+    assert result2.result["new_vm_id"] == "vm-99"
+    # The mutating CloneVM_Task fired exactly once, on the approved resume.
+    assert recorder.clone_writes == ["/VirtualMachine/vm-42/CloneVM_Task"]
+
+
+@pytest.mark.asyncio
+async def test_clone_from_template_fresh_boot_dispatchable_without_ingest(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """vm.clone_from_template runs to ``cloned`` on the direct session with ZERO ingested rows."""
+    recorder = _CloneFromTemplateVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.vm.clone_from_template"}, recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.clone_from_template",
+        target=_FakeVmwareTarget(),
+        params=_CLONE_PARAMS,
+    )
+    assert "composite_l2_missing" not in (result.error or ""), result.error
+    assert result.status == "ok", result.error
+    assert result.result["status"] == "cloned"
+    assert recorder.clone_writes == ["/VirtualMachine/vm-42/CloneVM_Task"]

--- a/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
@@ -41,6 +41,7 @@ from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.connectors import OperationResult
 from meho_backplane.connectors.vmware_rest._mount import adapt_filter_params
 from meho_backplane.connectors.vmware_rest.composites._write import (
+    vm_clone_from_template_composite,
     vm_create_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -372,5 +373,163 @@ async def test_disk_grow_human_operator_vmomi_write_auto_executes(
     assert out["status"] == "grown"
     # The reconfigure write executed on the session; the sub-op auto-executed.
     assert len(conn.reconfig_writes) == 1
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+
+
+# ===========================================================================
+# vm.clone_from_template — the mutating VI-JSON CloneVM_Task flows through the
+# same gate (#2894)
+# ===========================================================================
+
+
+_CLONE_OP_ID = "POST:/VirtualMachine/{moId}/CloneVM_Task"
+
+
+class _CloneRecordingConnector:
+    """Recording double for the clone-from-template governance tests.
+
+    Serves the template resolution (REST ``GET:/vcenter/vm``), the
+    ``config.template`` assert + ``Task.info`` poll (both vmomi
+    ``RetrievePropertiesEx``, keyed apart by the request body's ``specSet``
+    object type) and records every ``CloneVM_Task`` write, so the tests can
+    assert the mutating vmomi POST never fired when the gate parks / denies.
+    """
+
+    def __init__(self) -> None:
+        self.clone_writes: list[Any] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"/api{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params("/api", query)
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        return {"value": [{"vm": "vm-42", "name": "ubuntu-template"}]}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        if path.endswith("/CloneVM_Task"):
+            self.clone_writes.append(json)
+            return {"type": "Task", "value": "task-clone-1"}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "VirtualMachine":
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "VirtualMachine", "value": "vm-42"},
+                        "propSet": [{"name": "config.template", "val": True}],
+                    }
+                ]
+            }
+        return {
+            "objects": [
+                {
+                    "obj": {"type": "Task", "value": "task-clone-1"},
+                    "propSet": [
+                        {
+                            "name": "info",
+                            "val": {
+                                "state": "success",
+                                "result": {"type": "VirtualMachine", "value": "vm-99"},
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+
+
+def _clone_gate_params() -> dict[str, Any]:
+    return {
+        "source_template": "ubuntu-template",
+        "new_vm_name": "web-01",
+        "folder": "group-v10",
+        "resource_pool": "resgroup-8",
+        "datastore": "datastore-15",
+    }
+
+
+@pytest.mark.asyncio
+async def test_clone_from_template_gated_vmomi_write_queues_and_never_reaches_wire(
+    session: AsyncSession,
+) -> None:
+    """An agent-gated CloneVM_Task queues for approval; the vmomi write never fires.
+
+    The #2894 gate rides #2893's ``_write_vmomi_sub_op`` seam: a *mutating
+    VI-JSON* CloneVM_Task is a write, not transport detail, so with a
+    ``needs_approval`` grant on the vim method the composite returns
+    ``awaiting_approval``, writes a durable pending row, and issues no clone.
+    """
+    await _grant(
+        principal_sub="agent-write-composite",
+        op_pattern=_CLONE_OP_ID,
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _CloneRecordingConnector()
+
+    out = await vm_clone_from_template_composite(
+        operator=_operator(),
+        target=None,
+        params=_clone_gate_params(),
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _CLONE_OP_ID
+    request_id = uuid.UUID(out.extras["approval_request_id"])
+    row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.op_id == _CLONE_OP_ID
+    assert row.connector_id == "vmware-rest-9.0"
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    # The mutating CloneVM_Task never reached the wire.
+    assert conn.clone_writes == []
+
+
+@pytest.mark.asyncio
+async def test_clone_from_template_dangerous_vmomi_write_denied_without_grant(
+    session: AsyncSession,
+) -> None:
+    """An agent with no grant is denied the dangerous CloneVM_Task; it never runs."""
+    conn = _CloneRecordingConnector()
+    out = await vm_clone_from_template_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params=_clone_gate_params(),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == _CLONE_OP_ID
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+    assert conn.clone_writes == []
+
+
+@pytest.mark.asyncio
+async def test_clone_from_template_human_operator_vmomi_write_auto_executes(
+    session: AsyncSession,
+) -> None:
+    """A human operator's already-approved composite auto-executes the CloneVM_Task."""
+    conn = _CloneRecordingConnector()
+    out = await vm_clone_from_template_composite(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        target=None,
+        params=_clone_gate_params(),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "cloned"
+    # The CloneVM_Task executed on the session; the sub-op auto-executed.
+    assert len(conn.clone_writes) == 1
     count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
     assert count == 0

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` previews for the 10 vmware write composites.
+"""Park-time ``proposed_effect`` previews for the 11 vmware write composites.
 
 G0.22-T3 (#1608) acceptance criteria, under the post-#2256 direct-session
 model:
@@ -19,9 +19,11 @@ model:
    directly on the connector session (no ``dispatch_child``, no ingested
    descriptor), so the park-time preview works on a fresh boot with zero
    catalog ingest.
-4. All 10 write composites register a builder (5 live-read + 5 param
+4. All 11 write composites register a builder (5 live-read + 6 param
    echo); the wiring test pins the full set. ``vm.disk.grow`` is the fifth
    live-read builder — its from→to capacity delta is a live vCenter read.
+   ``vm.clone_from_template`` is a param-echo builder — its params fully
+   name the blast radius (secret-bearing GOSC contents are never echoed).
 
 Plus the #1628 follow-up: a *failed* live-read preview parks with the
 identifier fields **and** an explicit ``preview_unavailable`` marker +
@@ -68,6 +70,7 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
     {
         "vmware.composite.vm.create",
         "vmware.composite.vm.clone",
+        "vmware.composite.vm.clone_from_template",
         "vmware.composite.vm.snapshot.revert",
         "vmware.composite.vm.migrate",
         "vmware.composite.vm.power",
@@ -290,10 +293,10 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 # ===========================================================================
 
 
-def test_all_ten_write_composites_register_a_preview_builder() -> None:
+def test_all_eleven_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 10
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 11
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 
@@ -393,6 +396,59 @@ async def test_vm_clone_preview_echoes_clone_coordinates() -> None:
     }
 
 
+async def test_vm_clone_from_template_preview_echoes_clone_coordinates() -> None:
+    """The clone-coordinates echo names the full blast radius, minus GOSC secrets."""
+    preview = await _write_preview._vm_clone_from_template_preview(
+        _make_preview_ctx(
+            {
+                "source_template": "ubuntu-2404-template",
+                "new_vm_name": "web-01",
+                "folder": "group-v10",
+                "resource_pool": "resgroup-8",
+                "datastore": "datastore-15",
+                "host": "host-19",
+                "power_on": True,
+                "customization_spec_name": "linux-web-gosc",
+            }
+        )
+    )
+    assert preview == {
+        "source_template": "ubuntu-2404-template",
+        "new_vm_name": "web-01",
+        "folder": "group-v10",
+        "resource_pool": "resgroup-8",
+        "datastore": "datastore-15",
+        "host": "host-19",
+        "power_on": True,
+        "customization_spec_name": "linux-web-gosc",
+    }
+
+
+async def test_vm_clone_from_template_preview_defaults_optional_fields_to_none() -> None:
+    """Only the required placement params supplied → host / customization echo as None."""
+    preview = await _write_preview._vm_clone_from_template_preview(
+        _make_preview_ctx(
+            {
+                "source_template": "ubuntu-2404-template",
+                "new_vm_name": "web-01",
+                "folder": "group-v10",
+                "resource_pool": "resgroup-8",
+                "datastore": "datastore-15",
+            }
+        )
+    )
+    assert preview == {
+        "source_template": "ubuntu-2404-template",
+        "new_vm_name": "web-01",
+        "folder": "group-v10",
+        "resource_pool": "resgroup-8",
+        "datastore": "datastore-15",
+        "host": None,
+        "power_on": False,
+        "customization_spec_name": None,
+    }
+
+
 async def test_vm_snapshot_revert_preview_echoes_revert_coordinates() -> None:
     preview = await _write_preview._vm_snapshot_revert_preview(
         _make_preview_ctx({"vm": "vm-1", "snapshot_name": "pre-upgrade"})
@@ -436,6 +492,7 @@ async def test_echo_builders_decline_on_malformed_params() -> None:
     """Missing required params decline (→ identifier-only default), never raise."""
     assert await _write_preview._vm_create_preview(_make_preview_ctx({})) is None
     assert await _write_preview._vm_clone_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._vm_clone_from_template_preview(_make_preview_ctx({})) is None
     assert await _write_preview._vm_snapshot_revert_preview(_make_preview_ctx({})) is None
     assert await _write_preview._vm_migrate_preview(_make_preview_ctx({})) is None
     assert await _write_preview._vm_power_preview(_make_preview_ctx({})) is None

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 10 vmware-rest write composites.
+"""Registration tests for the 11 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 ``vm.power`` / #2301):
 
-* All 10 expected write ``op_id`` rows land in ``endpoint_descriptor``
+* All 11 expected write ``op_id`` rows land in ``endpoint_descriptor``
   with ``source_kind="composite"``, ``safety_level="dangerous"``,
   ``requires_approval=True`` (T4's defaults intentionally inherited).
 * Each row's ``handler_ref`` resolves to the module-level dotted path
@@ -14,7 +14,7 @@ Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster``
   per the canary's stub-LLM taxonomy.
 * Combined with #508's 5 read composites, the registrar produces
-  **15 rows** total. (The former host.network_uplinks / host.vsan_health
+  **16 rows** total. (The former host.network_uplinks / host.vsan_health
   reads were re-shipped as typed ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
   with the documented required keys.
@@ -45,6 +45,7 @@ from meho_backplane.connectors.vmware_rest.composites import (
     host_evacuate_composite,
     register_vmware_composite_operations,
     vm_clone_composite,
+    vm_clone_from_template_composite,
     vm_create_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -57,11 +58,13 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 10 write composites (T6 / #509, single-VM vm.power / #2301, and the
-# mutating VI-JSON vm.disk.grow / #2893).
+# 11 write composites (T6 / #509, single-VM vm.power / #2301, the
+# mutating VI-JSON vm.disk.grow / #2893, and the folder-template
+# vm.clone_from_template / #2894).
 _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.create",
     "vmware.composite.vm.clone",
+    "vmware.composite.vm.clone_from_template",
     "vmware.composite.vm.snapshot.revert",
     "vmware.composite.vm.migrate",
     "vmware.composite.vm.power",
@@ -84,8 +87,8 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.network.portgroup.audit",
 )
 
-# 15 total -- 5 read (T5 / #508) + 10 write (T6 / #509 + vm.power / #2301 +
-# vm.disk.grow / #2893).
+# 16 total -- 5 read (T5 / #508) + 11 write (T6 / #509 + vm.power / #2301 +
+# vm.disk.grow / #2893 + vm.clone_from_template / #2894).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -95,6 +98,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     ),
     "vmware.composite.vm.clone": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_clone_composite"
+    ),
+    "vmware.composite.vm.clone_from_template": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_clone_from_template_composite"
     ),
     "vmware.composite.vm.snapshot.revert": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_snapshot_revert_composite"
@@ -126,6 +132,7 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
 _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.create": "vm",
     "vmware.composite.vm.clone": "vm",
+    "vmware.composite.vm.clone_from_template": "vm",
     "vmware.composite.vm.snapshot.revert": "vm",
     "vmware.composite.vm.migrate": "vm",
     "vmware.composite.vm.power": "vm",
@@ -182,10 +189,10 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_inserts_ten_write_rows(
+async def test_register_vmware_composite_operations_inserts_eleven_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 10 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 11 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -202,10 +209,11 @@ async def test_register_vmware_composite_operations_inserts_ten_write_rows(
 
 
 @pytest.mark.asyncio
-async def test_full_registration_produces_fifteen_composite_rows(
+async def test_full_registration_produces_sixteen_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """5 reads (#508) + 10 writes (#509 + vm.power #2301 + vm.disk.grow #2893) = 15 rows."""
+    """5 reads (#508) + 11 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
+    vm.clone_from_template #2894) = 16 rows."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -219,7 +227,7 @@ async def test_full_registration_produces_fifteen_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 15
+    assert len(rows) == 16
 
 
 @pytest.mark.asyncio
@@ -475,17 +483,17 @@ async def test_write_composite_tags_include_composite_and_write(
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_is_idempotent_across_fifteen(
+async def test_register_vmware_composite_operations_is_idempotent_across_sixteen(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 15 rows total, embedding called 15x once."""
+    """Running the registrar twice -> 16 rows total, embedding called 16x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 15
+    assert first_count == 16
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 15.
+    # pipeline; the row count stays at 16.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -499,7 +507,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_fifteen
             .scalars()
             .all()
         )
-    assert len(rows) == 15
+    assert len(rows) == 16
 
 
 # ---------------------------------------------------------------------------
@@ -520,6 +528,7 @@ def test_all_write_handlers_are_module_level_coroutine_functions() -> None:
     for handler in (
         vm_create_composite,
         vm_clone_composite,
+        vm_clone_from_template_composite,
         vm_snapshot_revert_composite,
         vm_migrate_composite,
         vm_power_composite,

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,12 +8,14 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 14 hand-authored composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 16 hand-authored composites
 that orchestrate cross-spec workflows: 5 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`) and 9 write composites (G3.1-T6 / `#509`, plus the
-single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`). The
+in `#2258`) and 11 write composites (G3.1-T6 / `#509`, plus the
+single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
+mutating VI-JSON `vm.disk.grow` / `#2893`, and the folder-template
+`vm.clone_from_template` / `#2894`). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
 govc-wrapper retirement.
@@ -457,6 +459,7 @@ enum) are:
 | `vm.power` | `ok`, `error`, `tools_unavailable` (single VM; `tools_unavailable` when a soft `guest_shutdown`/`guest_reboot` finds Tools down) |
 | `vm.power.bulk` | (per-VM `results` + aggregate `summary` + `aborted_on_failure`) |
 | `vm.disk.grow` | `grown`, `invalid_shrink`, `disk_not_found`, `timeout` (grow-only; `invalid_shrink` refuses a request ≤ current capacity before any write; `timeout` when the `ReconfigVM_Task` poll gives up) |
+| `vm.clone_from_template` | `cloned`, `template_not_found`, `ambiguous_template`, `not_a_template`, `timeout` (name-resolution refusals + the template assert are pre-write; `timeout` when the `CloneVM_Task` poll gives up; a task *fault* raises `connector_error`) |
 | `host.evacuate` | `evacuated`, `partial`, `aborted` |
 | `host.detach_from_vds` | `detached`, `incomplete` |
 | `cluster.patch` | `completed`, `stopped` |
@@ -529,6 +532,64 @@ capacity diff (`{vm, name, disk, disk_label, current_capacity_bytes,
 requested_capacity_bytes, delta_bytes}`) — the delta is the decision the
 approver makes; a failing disk read parks with the #1628
 `preview_unavailable` marker (the delta is unknowable).
+
+### Two clone ops: content-library vs folder-template (`vm.clone_from_template`, #2894)
+
+The connector ships **two** clone composites, and they deploy from two
+different kinds of source — an operator picks by where the golden image
+lives:
+
+| Op | Source | Path | When |
+| --- | --- | --- | --- |
+| `vm.clone` | a **content-library** template item | REST `POST:/vcenter/vm-template/library-items?action=deploy`, poll `GET:/cis/tasks/{task}` | the golden image is published to a content library |
+| `vm.clone_from_template` | a **folder VM template** (a marked-as-template VM in a VM folder) | vim `POST:/VirtualMachine/{moId}/CloneVM_Task`, poll via `poll_vim_task` | the golden image is a plain marked-as-template VM (govc/terraform's `CloneVM_Task` path) |
+
+`vm.clone`'s content-library deploy path **cannot** clone a folder
+template — a marked-as-template VM has no content-library item to deploy
+— and the REST `POST:/vcenter/vm?action=clone` template-source acceptance
+is undocumented (MEDIUM confidence). The vim `VirtualMachine.CloneVM_Task`
+path is unambiguous (it is what govc/terraform use for a folder-template
+deploy) and it **uniquely** supports inline guest customization at clone
+time. `vm.clone_from_template` (#2894) rides the #2893 substrate: the
+mutating `CloneVM_Task` flows through the governed vmomi write seam
+(`_write_vmomi_sub_op` → the #2254 gate) and the returned `*_Task` MoRef
+is driven to a terminal state via `poll_vim_task`.
+
+**Flow** (spec-verified against the pinned `vi-json.yaml`): resolve
+`source_template` — a display **name** — to a unique VM moid via
+`GET:/vcenter/vm?filter.names=` (refuse `template_not_found` /
+`ambiguous_template`); assert `config.template` is true via a vmomi
+`RetrievePropertiesEx` *read* (refuse `not_a_template` before any clone —
+a regular VM named by mistake never gets cloned); when
+`customization_spec_name` is set, resolve the stored GOSC spec to its full
+`CustomizationSpec` via `CustomizationSpecManager.GetCustomizationSpec`
+(a *read*) and embed it inline in `CloneSpec.customization`; build the
+`CloneVMRequestType` body `{folder: Folder-MoRef, name,
+spec: CloneSpec{location: RelocateSpec(pool + datastore, optional host),
+template: false, powerOn, customization?}}`; issue `CloneVM_Task` through
+the governed seam; poll the returned Task — success reports `cloned` with
+the new VM moid from `TaskInfo.result`, a fault raises (dispatcher wraps
+`connector_error`), a poll timeout returns `timeout` with the task id.
+
+**Composes with the GOSC keystone (#2892).** vim `CloneSpec.customization`
+takes a full `CustomizationSpec` inline, not a by-name reference, so a
+stored GOSC spec (e.g. one created by `guest.customization_spec.create`)
+is resolved to its object form and embedded — the clone yields a
+customized VM in **one** dispatch, no separate `vm.customize` call. The
+`customization_spec_manager_moid` param defaults to the standard
+`ServiceContent.customizationSpecManager` singleton moid and is
+overridable (mirrors the performance composite's `perf_manager_moid`).
+
+The preview is a **param echo** (no I/O — the params name the full blast
+radius): `{source_template, new_vm_name, folder, resource_pool,
+datastore, host, power_on, customization_spec_name}`. Only the
+customization spec **name** is echoed — never the resolved spec's
+secret-bearing sysprep/password contents (#1503); the identity-only gate
+params carry the same, so the durable `ApprovalRequest` names the blast
+radius without leaking credential material. New vim sub-op paths
+(`CloneVM_Task`, `RetrievePropertiesEx`, `GetCustomizationSpec`) are
+declared in `_VIM_SUB_OPS_VM_CLONE_FROM_TEMPLATE` and reconciled against
+the pinned `vi-json.yaml`.
 
 ### Read-composite best-effort enrichment (`datastore.usage`, #1908)
 
@@ -757,8 +818,9 @@ they never park.
   #2080 + #2135 add two more reads (`host.network_uplinks` /
   `host.vsan_health`, later re-shipped as typed ops in #2258); T6
   (#509) ships 8 write composites, #2301 adds a 9th (single-VM
-  `vm.power`, incl. Tools soft shutdown), and #2893 adds a 10th (the
-  mutating VI-JSON `vm.disk.grow`) — 15 composites today. The
+  `vm.power`, incl. Tools soft shutdown), #2893 adds a 10th (the
+  mutating VI-JSON `vm.disk.grow`), and #2894 an 11th (the
+  folder-template `vm.clone_from_template`) — 16 composites today. The
   "All hand-authored composites land as endpoint_descriptor rows with
   source_kind='composite'" Definition-of-done line in [#227](https://github.com/evoila/meho/issues/227)
   is fully ticked.


### PR DESCRIPTION
## Summary

- Adds `vmware.composite.vm.clone_from_template` (Task D of Initiative #2890), the **folder-template** counterpart to `vm.clone`. A marked-as-template VM in a VM folder has no content-library item to deploy, so the clone goes through vim `VirtualMachine.CloneVM_Task` — the folder-template deploy API govc/terraform use, and the only clone that supports **inline guest customization** at clone time.
- Resolves `source_template` by name, asserts `config.template` (PropertyCollector) before any write — a non-template source is refused with a structured `status='not_a_template'`. Builds the `CloneSpec` placement (folder / resource pool / datastore, optional host pin), issues `CloneVM_Task` through the governed vmomi write seam, and polls the returned Task to a terminal state.
- Rides #2893's now-landed substrate: `_write_vmomi_sub_op` (the mutating vmomi POST flows through the same `enforce_subop_policy` gate as the REST writes) and `poll_vim_task`. `dangerous` + `requires_approval=True`, with a secret-safe param-echo preview.
- **Composes with the GOSC keystone (#2892):** `customization_spec_name` is resolved via vim `CustomizationSpecManager.GetCustomizationSpec` and embedded inline in `CloneSpec.customization` — a customized clone in one dispatch, no separate customize call. Only the spec *name* reaches the reviewer surface / approval params; the resolved spec's sysprep/password contents never serialize (#1503).

All vim shapes (`CloneVMRequestType`, `VirtualMachineCloneSpec`, `VirtualMachineRelocateSpec`, `CustomizationSpecItem`) were fresh-cited against the pinned `vi-json.yaml`.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean (26 files)
- [x] `mypy src/meho_backplane/connectors/vmware_rest/` — clean (17 files)
- [x] `code-quality.py --diff` — 0 blockers (new handler under the size limit; 8 warnings are pre-existing debt)
- [x] `pytest -k vmware_rest_composites` — **179 passed**; cross-cutting sweep (typed-connectors-metadata, composite-register, recursive-e2e, retrieval-eval, vmomi-mount) — 48 passed
- [x] **Registered + fresh-boot dispatchable; non-template refused (PropertyCollector-asserted)** — register lanes assert 16 rows; `test_clone_from_template_fresh_boot_dispatchable_without_ingest`; `test_vm_clone_from_template_refuses_non_template_source`
- [x] **respx-verified `CloneVM_Task` body** (`template:false`, relocate placement, customization present exactly when requested; task poll success/error/timeout) — `..._clone_body_reaches_the_wire_respx`, `..._with_customization_embeds_resolved_spec` / `..._happy_path` (no-customization omits the field), `..._task_fault_raises`, `..._poll_timeout_returns_timeout_status`
- [x] **Composes with #2892** — `test_vm_clone_from_template_with_customization_embeds_resolved_spec` (resolved spec embedded inline; gate params carry only the name)
- [x] **Park→approve→resume in `_write_e2e` with the #2681 envelope; preview covered** — `test_clone_from_template_queue_approve_resume_with_2681_envelope` (asserts `op_class`/`safety_level`/`preview_populated` + the param-echo preview) + the preview lane
- [x] **VI-JSON sub-op paths reconciled against the pinned `vi-json.yaml`** — `test_vm_clone_from_template_vi_json_paths_exist_in_the_pinned_spec` executed against the real spec (all three vim paths confirmed as POST path items)
- [x] **Docs + CHANGELOG** — `docs/codebase/connectors-vmware-rest.md` gains a two-clone-ops (content-library vs folder-template) section; `[Unreleased]` bullet added

> Note: GitHub CI runners are wedged (#2325); verification is the local gate run above.

## Out of scope

- Wave-2 sibling #2895 (`cluster.drs_rule.create` + `folder.create`) also rides the #2893 substrate and touches the same append-only guards; diffs kept append-only to minimise the serial-merge conflict.
- A raw-inline-`CustomizationSpec` param was deliberately not added — the acceptance criteria and preview bind only `customization_spec_name` (the by-name path), which is the tested + previewed mechanism; a raw-inline param would be speculative optionality.
- Adjacent findings (pre-existing, recorded, not touched): `_write.py` / `schemas.py` file sizes and several pre-existing write-handler function sizes flagged as code-quality warnings.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2894
