### PR TITLE
feat(connectors): vmware cluster.drs_rule.create + folder.create — vim cluster/inventory writes (#2895)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,28 @@ connector-related release-notes line.
   and is polled via `poll_vim_task`. See
   `docs/codebase/connectors-vmware-rest.md` for the two-clone-ops contrast.
 
+### Added — vmware `cluster.drs_rule.create` + `folder.create` (vim cluster/inventory writes, #2895)
+
+- `vmware.composite.cluster.drs_rule.create` adds a DRS affinity /
+  anti-affinity rule to a cluster **by explicit VM list** — the last write
+  the #2859 provisioning flow had to drop to `govc` for. No cluster-rules
+  REST path exists (and the tag-based compute-policies surface is
+  semantically wrong — tag-scoped, not an explicit VM list), so the add goes
+  through vim `ClusterComputeResource.ReconfigureComputeResource_Task` with a
+  single-rule `ClusterConfigSpecEx.rulesSpec` delta (`modify=true`), polled
+  to a terminal state. Rule names are the idempotence key: a duplicate
+  returns a structured `status='rule_exists'` (not a raw vim `DuplicateName`
+  fault) before any write.
+- `vmware.composite.folder.create` creates a VM folder under a named parent
+  through vim `Folder.CreateFolder` — which is **synchronous**: it returns
+  the new folder's MoRef directly (no task poll), unlike every other vim
+  write. `/vcenter/folder` is GET-only, so vim is the sole write path.
+- Both are `dangerous` + approval-required and ride the #2893 substrate
+  (`_write_vmomi_sub_op` governed gate; `poll_vim_task` drives the DRS-rule
+  task, while the synchronous folder create is never polled). Park-time
+  previews: a capped VM fan-out (cluster + cluster name + resolved VM set)
+  for the rule op, a parent + new-folder-name echo for the folder op.
+
 ## [0.28.0] - 2026-08-07
 
 ### Added — seven more Do-real-work guides on the docs site: topology, broadcast, memory/knowledge, audit forensics, runbooks, scheduler, satellite gateway (#2829)

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 16 composites land before
+``endpoint_descriptor`` upserts for the 18 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -29,9 +29,11 @@ Scope:
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 11 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
-  #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, and the
-  folder-template ``vm.clone_from_template`` / #2894) -- inherit
+* 13 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
+  #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, the
+  folder-template ``vm.clone_from_template`` / #2894, and the vim
+  cluster / inventory writes ``cluster.drs_rule.create`` +
+  ``folder.create`` / #2895) -- inherit
   T4's ``safety_level="dangerous"`` +
   ``requires_approval=True`` defaults.
   They cover every state-mutating workflow Goal #214 names as
@@ -42,7 +44,9 @@ Scope:
   incl. Tools soft shutdown), ``vm.power.bulk``, ``vm.disk.grow`` (the
   first mutating VI-JSON composite — disk capacity has no REST path),
   ``host.evacuate`` (first recursive composite),
-  ``host.detach_from_vds``, ``cluster.patch``.
+  ``host.detach_from_vds``, ``cluster.patch``,
+  ``cluster.drs_rule.create`` (DRS rule by explicit VM list, no REST
+  path) and ``folder.create`` (synchronous vim ``CreateFolder``).
 """
 
 from meho_backplane.connectors.vmware_rest.composites._read import (
@@ -56,7 +60,9 @@ from meho_backplane.connectors.vmware_rest.composites._register import (
     register_vmware_composite_operations,
 )
 from meho_backplane.connectors.vmware_rest.composites._write import (
+    cluster_drs_rule_create_composite,
     cluster_patch_composite,
+    folder_create_composite,
     host_detach_from_vds_composite,
     host_evacuate_composite,
     vm_clone_composite,
@@ -76,7 +82,7 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 # registered by the time the runner iterates.
 register_typed_op_registrar(register_vmware_composite_operations)
 
-# Side-effect import: registers the 11 write composites' park-time
+# Side-effect import: registers the 13 write composites' park-time
 # ``proposed_effect`` preview builders (#1608) onto the per-op hook in
 # :mod:`meho_backplane.operations._preview` — mirrors how
 # ``connectors/argocd/__init__`` wires ``ops_write_preview``.
@@ -84,9 +90,11 @@ from meho_backplane.connectors.vmware_rest.composites import _write_preview  # n
 
 __all__ = [
     "cluster_drs_recommendations_composite",
+    "cluster_drs_rule_create_composite",
     "cluster_patch_composite",
     "datastore_usage_composite",
     "event_tail_composite",
+    "folder_create_composite",
     "host_detach_from_vds_composite",
     "host_evacuate_composite",
     "network_portgroup_audit_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 16 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 18 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -26,10 +26,11 @@ The 5 read composites (T5 / #508) pass
 T4's ``dangerous`` / ``True`` defaults. (The former
 ``host.network_uplinks`` and ``host.vsan_health`` reads were re-shipped
 as typed ops in #2258; see
-:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 11 write
+:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 13 write
 composites (T6 / #509, single-VM ``vm.power`` / #2301, the mutating
-VI-JSON ``vm.disk.grow`` / #2893, and the folder-template
-``vm.clone_from_template`` / #2894) inherit the T4
+VI-JSON ``vm.disk.grow`` / #2893, the folder-template
+``vm.clone_from_template`` / #2894, and the vim cluster / inventory writes
+``cluster.drs_rule.create`` + ``folder.create`` / #2895) inherit the T4
 defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity at
 the call site; the helper would default to those values anyway).
 Each :class:`_CompositeSpec` row carries its own ``safety_level`` +
@@ -51,7 +52,9 @@ from meho_backplane.connectors.vmware_rest.composites._read import (
     performance_summary_composite,
 )
 from meho_backplane.connectors.vmware_rest.composites._write import (
+    cluster_drs_rule_create_composite,
     cluster_patch_composite,
+    folder_create_composite,
     host_detach_from_vds_composite,
     host_evacuate_composite,
     vm_clone_composite,
@@ -66,12 +69,16 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
 from meho_backplane.connectors.vmware_rest.composites.schemas import (
     CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA,
     CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA,
+    CLUSTER_DRS_RULE_CREATE_PARAMETER_SCHEMA,
+    CLUSTER_DRS_RULE_CREATE_RESPONSE_SCHEMA,
     CLUSTER_PATCH_PARAMETER_SCHEMA,
     CLUSTER_PATCH_RESPONSE_SCHEMA,
     DATASTORE_USAGE_PARAMETER_SCHEMA,
     DATASTORE_USAGE_RESPONSE_SCHEMA,
     EVENT_TAIL_PARAMETER_SCHEMA,
     EVENT_TAIL_RESPONSE_SCHEMA,
+    FOLDER_CREATE_PARAMETER_SCHEMA,
+    FOLDER_CREATE_RESPONSE_SCHEMA,
     HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA,
     HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA,
     HOST_EVACUATE_PARAMETER_SCHEMA,
@@ -597,6 +604,54 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         safety_level="dangerous",
         requires_approval=True,
     ),
+    # ----------------------------------------------------------------
+    # vim cluster / inventory writes (#2895) -- dangerous / requires approval
+    # ----------------------------------------------------------------
+    _CompositeSpec(
+        op_id="vmware.composite.cluster.drs_rule.create",
+        handler=cluster_drs_rule_create_composite,
+        summary="Add a DRS affinity / anti-affinity rule to a cluster by explicit VM list.",
+        description=(
+            "Adds a classic DRS affinity ('keep these VMs together') or "
+            "anti-affinity ('keep these VMs apart') rule by explicit VM "
+            "list. No cluster-rules REST path exists and the tag-based "
+            "compute-policies surface is semantically wrong (tag-scoped, not "
+            "an explicit VM list), so the add goes through vim "
+            "ClusterComputeResource.ReconfigureComputeResource_Task with a "
+            "single-rule ClusterConfigSpecEx.rulesSpec delta (modify=true) "
+            "and polls the returned task to a terminal state. Resolves the VM "
+            "names to MoRefs scoped to the cluster; rule names are the "
+            "idempotence key, so a duplicate returns status='rule_exists' "
+            "before any write. Equivalent of 'govc cluster.rule.create'."
+        ),
+        parameter_schema=CLUSTER_DRS_RULE_CREATE_PARAMETER_SCHEMA,
+        response_schema=CLUSTER_DRS_RULE_CREATE_RESPONSE_SCHEMA,
+        group_key="cluster",
+        tags=["composite", "write", "cluster", "drs", "vi-json"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.folder.create",
+        handler=folder_create_composite,
+        summary="Create a VM folder under a named parent (synchronous vim CreateFolder).",
+        description=(
+            "Creates a VM folder under a named parent. /vcenter/folder is "
+            "GET-only, so the create goes through vim Folder.CreateFolder — "
+            "which is synchronous: it returns the new folder's "
+            "ManagedObjectReference directly (no task poll). Resolves the "
+            "parent by display name among the VIRTUAL_MACHINE folders; an "
+            "unknown name returns status='parent_not_found' and an ambiguous "
+            "one status='ambiguous_parent', both before any write. Equivalent "
+            "of 'govc folder.create' for the VM-folder inventory tree."
+        ),
+        parameter_schema=FOLDER_CREATE_PARAMETER_SCHEMA,
+        response_schema=FOLDER_CREATE_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "inventory", "vi-json"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
 )
 
 
@@ -613,10 +668,11 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 16 composites total -- 5 read (T5 / #508) + 11 write (T6 /
+    Scope: 18 composites total -- 5 read (T5 / #508) + 13 write (T6 /
     #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
-    ``vm.disk.grow`` / #2893, and the folder-template
-    ``vm.clone_from_template`` / #2894). (The former
+    ``vm.disk.grow`` / #2893, the folder-template
+    ``vm.clone_from_template`` / #2894, and the vim cluster / inventory writes
+    ``cluster.drs_rule.create`` + ``folder.create`` / #2895). (The former
     ``host.network_uplinks`` / ``host.vsan_health`` reads were re-shipped
     as typed ops in #2258.)
     Each composite's ``safety_level`` +

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
-# code-quality-allow: protocol-driven composite handlers for the
+# code-quality-allow: 13 protocol-driven composite handlers for the
 # vSphere REST + VI-JSON write surface ship in one module per the issue
 # body's design; splitting them by group would scatter the shared
 # sub-op_id constants + helpers across files for no readability gain. Each
 # handler's body is the documented orchestration workflow from #509's spec
-# (plus the mutating VI-JSON disk-grow from #2893 and folder-template clone
-# from #2894).
+# (plus the mutating VI-JSON disk-grow from #2893, the folder-template clone
+# from #2894, and the vim cluster / inventory writes — DRS-rule + folder
+# create — from #2895).
 
-"""Write-shaped ``vmware.composite.*`` handler functions (11 composites).
+"""Write-shaped ``vmware.composite.*`` handler functions (13 composites).
 
 Companion to :mod:`._read`. Post-#2256 each handler is a module-level
 ``async def`` taking the dispatcher's composite-branch keyword args
@@ -99,7 +100,9 @@ if TYPE_CHECKING:
     from meho_backplane.connectors.vmware_rest.connector import VmwareRestConnector
 
 __all__ = [
+    "cluster_drs_rule_create_composite",
     "cluster_patch_composite",
+    "folder_create_composite",
     "host_detach_from_vds_composite",
     "host_evacuate_composite",
     "vm_clone_composite",
@@ -159,6 +162,11 @@ _OP_REMOVE_DVS_HOST = "POST:/vcenter/network/dvs/{dvs}?action=remove_host"
 # REST Disk.Info read — the disk-grow park-time preview reads label +
 # current capacity (bytes) off this; the disk id is the vim device key.
 _OP_GET_VM_DISK = "GET:/vcenter/vm/{vm}/hardware/disk/{disk}"
+# REST Cluster.Info read — the drs_rule park-time preview reads the
+# cluster's display name off this (``Vcenter.Cluster.Info.name``); cosmetic,
+# best-effort. ``/vcenter/cluster/{cluster}`` is the get half of the
+# cluster module's list/get/evc-mode surface (spec-verified).
+_OP_GET_CLUSTER = "GET:/vcenter/cluster/{cluster}"
 
 # vim (VI-JSON) op_ids for the disk-grow write path. These are the
 # canonical ``METHOD:/path`` keys the ingest parser emits from
@@ -256,6 +264,78 @@ _DEFAULT_CUSTOMIZATION_SPEC_MANAGER_MOID = "CustomizationSpecManager"
 # Default wall-clock bound for the CloneVM_Task poll — mirrors the 600s
 # ``vm.clone`` convention.
 _CLONE_FROM_TEMPLATE_TASK_TIMEOUT_SECONDS = 600.0
+
+# vim (VI-JSON) op_ids for the #2895 cluster / inventory writes. Same
+# governance-op_id discipline as the disk-grow vim constants: the
+# ``METHOD:/path`` key the ingest parser emits from ``vi-json.yaml`` is the
+# key fed to :func:`enforce_subop_policy`; the concrete path (moId
+# substituted) is what :meth:`VmwareRestConnector._post_vmomi_json` POSTs.
+# Kept out of the ``_SUB_OPS_*`` namespace so the vCenter-REST
+# ingest-reconcile sweep does not treat a vi-json path as a ``vcenter.yaml``
+# row; the pinned ``vi-json.yaml`` reconcile asserts them instead.
+#
+# ``ReconfigureComputeResource_Task`` is the only route to add a DRS
+# affinity / anti-affinity rule by explicit VM list: no cluster-rules REST
+# path exists and the tag-based compute-policies surface is semantically
+# wrong (tag-scoped, spec-verified). It rides the pinned spec's
+# ``ClusterConfigSpecEx.rulesSpec`` delta with ``modify=true`` and returns a
+# ``*_Task`` MoRef to poll. ``Folder.CreateFolder`` is the only route to
+# create a VM folder (``/vcenter/folder`` is GET-only, spec-verified) and is
+# **synchronous** — it returns the new Folder MoRef directly, NOT a Task, so
+# it is never polled.
+_OP_RECONFIGURE_COMPUTE_RESOURCE_TASK = (
+    "POST:/ClusterComputeResource/{moId}/ReconfigureComputeResource_Task"
+)
+_OP_CREATE_FOLDER = "POST:/Folder/{moId}/CreateFolder"
+
+# vim data-object type discriminators (``_typeName``) for the DRS-rule
+# reconfigure body. ``ReconfigureComputeResourceRequestType.spec`` is
+# declared as the base ``ComputeResourceConfigSpec``, so a cluster
+# reconfigure must tag the spec ``ClusterConfigSpecEx`` for the vim25-JSON
+# binding to deserialise the subtype; likewise ``ClusterRuleSpec.info`` is
+# declared as the base ``ClusterRuleInfo``, so the affinity / anti-affinity
+# subtype is tagged. The ``ClusterRuleSpec`` array item and the
+# ``VirtualMachine`` MoRefs need no ``_typeName`` (declared type == runtime
+# type), mirroring the disk-grow ``VirtualDeviceConfigSpec`` precedent
+# (spec-verified against the pinned ``vi-json.yaml``).
+_CLUSTER_CONFIG_SPEC_EX_TYPE = "ClusterConfigSpecEx"
+_CLUSTER_AFFINITY_RULE_TYPE = "ClusterAffinityRuleSpec"
+_CLUSTER_ANTI_AFFINITY_RULE_TYPE = "ClusterAntiAffinityRuleSpec"
+_CLUSTER_COMPUTE_RESOURCE_MO_TYPE = "ClusterComputeResource"
+# Property path the collision / idempotence read queries on the cluster:
+# ``ClusterComputeResource.configurationEx`` is a ``ClusterConfigInfoEx``
+# whose ``rule`` array holds the existing ``ClusterRuleInfo`` rules
+# (spec-verified). Read un-gated via the shared ``RetrievePropertiesEx``.
+_PROP_CONFIGURATION_EX_RULE = "configurationEx.rule"
+
+# operator-facing ``rule_type`` -> vim rule-info ``_typeName``.
+_DRS_RULE_TYPE_TYPE_NAMES: dict[str, str] = {
+    "affinity": _CLUSTER_AFFINITY_RULE_TYPE,
+    "anti_affinity": _CLUSTER_ANTI_AFFINITY_RULE_TYPE,
+}
+
+# A DRS affinity / anti-affinity rule constrains the relative placement of
+# >=2 VMs; a single-VM (or empty) rule is meaningless, so the handler
+# refuses one (``status="insufficient_vms"``) before any write.
+_DRS_RULE_MIN_VMS = 2
+
+# Default wall-clock bound for the ReconfigureComputeResource_Task poll —
+# mirrors the 600s disk-grow / vm.clone convention.
+_DRS_RULE_TASK_TIMEOUT_SECONDS = 600.0
+
+#: vi-json sub-op manifests for the #2895 writes (parallel to
+#: ``_VIM_SUB_OPS_VM_DISK_GROW``; named out of the ``_SUB_OPS_*`` namespace
+#: so the vcenter.yaml ingest-reconcile sweep skips them). The pinned
+#: ``vi-json.yaml`` reconcile lane introspects these to assert every
+#: declared vim path exists in the spec. drs_rule reads existing rules via
+#: ``RetrievePropertiesEx`` then writes ``ReconfigureComputeResource_Task``;
+#: folder.create is a single synchronous ``CreateFolder`` (no poll → no
+#: ``RetrievePropertiesEx``).
+_VIM_SUB_OPS_CLUSTER_DRS_RULE_CREATE: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_RECONFIGURE_COMPUTE_RESOURCE_TASK,
+)
+_VIM_SUB_OPS_FOLDER_CREATE: tuple[str, ...] = (_OP_CREATE_FOLDER,)
 
 
 def _power_vm_op_id(action: str) -> str:
@@ -2174,3 +2254,410 @@ async def vm_clone_from_template_composite(
         task=outcome.task,
         customization_spec_name=customization_spec_name,
     )
+
+
+# ===========================================================================
+# cluster.drs_rule.create (vim ClusterComputeResource reconfigure — #2895)
+# ===========================================================================
+#
+# Add a DRS affinity / anti-affinity rule by *explicit VM list*. No REST
+# path exists (the /vcenter/cluster module is list/get/evc-mode only; the
+# tag-based compute-policies surface is tag-scoped, not an explicit VM list
+# — spec-verified), so the rule add rides vim
+# ``ClusterComputeResource.ReconfigureComputeResource_Task`` with a
+# ``ClusterConfigSpecEx.rulesSpec`` delta (``modify=true`` — touches nothing
+# else). Rides the #2893 substrate: the governed ``_write_vmomi_sub_op``
+# seam + the ``poll_vim_task`` helper (the reconfigure returns a ``*_Task``).
+
+
+def _build_cluster_rules_retrieve_params(cluster_moid: str) -> dict[str, Any]:
+    """Build the ``RetrievePropertiesEx`` body reading a cluster's DRS rules.
+
+    A single ``PropertyFilterSpec`` scoped to the ClusterComputeResource
+    object requesting ``configurationEx.rule`` — the array of existing
+    ``ClusterRuleInfo`` rules, each carrying its ``name``. The idempotence /
+    name-collision check reads this before any write so a duplicate rule
+    name returns a structured status instead of a raw vim ``DuplicateName``
+    fault. The singleton ``propertyCollector`` moId rides the path, so the
+    body is only the method args (the shape the typed reads send).
+    """
+    return {
+        "specSet": [
+            {
+                "propSet": [
+                    {
+                        "type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE,
+                        "pathSet": [_PROP_CONFIGURATION_EX_RULE],
+                    }
+                ],
+                "objectSet": [
+                    {"obj": {"type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, "value": cluster_moid}}
+                ],
+            }
+        ],
+        "options": {},
+    }
+
+
+def _extract_cluster_rule_names(retrieve_result: Any) -> set[str]:
+    """Pull the existing DRS rule names off a ``RetrievePropertiesEx`` result."""
+    payload = _unwrap_value(retrieve_result)
+    objects = payload.get("objects", []) if isinstance(payload, dict) else payload
+    names: set[str] = set()
+    if not isinstance(objects, list):
+        return names
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        for prop in obj.get("propSet", []) or []:
+            if not isinstance(prop, dict) or prop.get("name") != _PROP_CONFIGURATION_EX_RULE:
+                continue
+            for rule in prop.get("val") or []:
+                if isinstance(rule, dict) and isinstance(rule.get("name"), str):
+                    names.add(rule["name"])
+    return names
+
+
+async def _resolve_cluster_name(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    cluster: str,
+) -> str | None:
+    """Best-effort cluster display name via ``GET:/vcenter/cluster/{cluster}``.
+
+    Cosmetic for the drs_rule preview — a transport fault nulls the name
+    rather than sinking the preview, since the cluster moid + resolved VM
+    set (not the name) is the decision. Mirrors :func:`_resolve_vm_name`.
+    """
+    try:
+        info = await _read_sub_op(
+            connector, target, operator, _OP_GET_CLUSTER, {"cluster": cluster}
+        )
+    except httpx.HTTPError:
+        return None
+    payload = _unwrap_value(info)
+    name = payload.get("name") if isinstance(payload, dict) else None
+    return name if isinstance(name, str) else None
+
+
+async def _resolve_drs_rule_vms(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    cluster_moid: str,
+    vm_names: list[str],
+) -> list[dict[str, Any]]:
+    """Resolve the rule's VM names to ``[{vm, name}]`` rows, scoped to the cluster.
+
+    Read-only single ``GET:/vcenter/vm`` (via the shared
+    :func:`_resolve_vm_list`) filtered by both ``names`` and ``clusters`` — a
+    DRS rule is cluster-local, so scoping the resolution to the cluster
+    disambiguates same-named VMs in other clusters and drops any name that
+    does not name a VM in this cluster. Shared with the park-time preview
+    builder so the reviewer sees the same resolved set the approved write
+    references.
+    """
+    rows = await _resolve_vm_list(
+        connector=connector,
+        target=target,
+        operator=operator,
+        filter_dict={"names": vm_names, "clusters": [cluster_moid]},
+    )
+    resolved: list[dict[str, Any]] = []
+    for row in rows:
+        moid = row.get("vm")
+        if isinstance(moid, str):
+            name = row.get("name")
+            resolved.append({"vm": moid, "name": name if isinstance(name, str) else None})
+    return resolved
+
+
+async def cluster_drs_rule_create_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Add a DRS affinity / anti-affinity rule via ReconfigureComputeResource_Task.
+
+    Op-id: ``vmware.composite.cluster.drs_rule.create``. No REST path exists
+    for a classic DRS rule by explicit VM list, so the add rides vim
+    ``ClusterComputeResource.ReconfigureComputeResource_Task`` with a
+    single-rule ``ClusterConfigSpecEx.rulesSpec`` delta (``modify=true``).
+
+    Flow:
+
+    1. Resolve the rule's VM *names* to MoRefs, scoped to the cluster (a
+       *read*, un-gated). Fewer than two resolve → ``status="insufficient_vms"``
+       before any write (an affinity / anti-affinity rule needs >=2 VMs).
+    2. Read the cluster's existing rules (``configurationEx.rule``, a *read*)
+       for the idempotence / name-collision check: a duplicate name returns
+       ``status="rule_exists"`` — a structured status, not a raw vim
+       ``DuplicateName`` fault.
+    3. Issue the single ``ReconfigureComputeResource_Task`` add through the
+       governed vmomi write seam (:func:`_write_vmomi_sub_op` → the #2254
+       gate); a parked/denied gate returns the :class:`OperationResult`
+       verbatim and no reconfigure fires.
+    4. Poll the returned ``*_Task`` MoRef to a terminal state via the shared
+       :func:`~meho_backplane.connectors.vmware_rest.vim_task.poll_vim_task`
+       helper before reporting ``status="created"``. A task fault raises (the
+       dispatcher wraps it ``connector_error``); a poll timeout returns
+       ``status="timeout"`` with the task id.
+    """
+    cluster_moid = params["cluster"]
+    rule_name = params["rule_name"]
+    rule_type = params["rule_type"]
+    enabled = bool(params.get("enabled", True))
+    vm_names = [n for n in (params.get("vms") or []) if isinstance(n, str)]
+    rule_info_type = _DRS_RULE_TYPE_TYPE_NAMES[rule_type]
+
+    resolved = await _resolve_drs_rule_vms(
+        connector=connector,
+        target=target,
+        operator=operator,
+        cluster_moid=cluster_moid,
+        vm_names=vm_names,
+    )
+    if len(resolved) < _DRS_RULE_MIN_VMS:
+        return {
+            "status": "insufficient_vms",
+            "cluster": cluster_moid,
+            "rule_name": rule_name,
+            "rule_type": rule_type,
+            "enabled": enabled,
+            "task": None,
+            "resolved_vms": resolved,
+            "guidance": (
+                f"a DRS {rule_type} rule needs at least {_DRS_RULE_MIN_VMS} VMs in the cluster; "
+                f"{len(resolved)} of {len(vm_names)} requested name(s) resolved to a VM in "
+                f"cluster {cluster_moid!r}"
+            ),
+        }
+
+    existing = await connector._post_vmomi_json(
+        target,
+        _VMOMI_RETRIEVE_PROPERTIES_PATH,
+        operator=operator,
+        json=_build_cluster_rules_retrieve_params(cluster_moid),
+    )
+    if rule_name in _extract_cluster_rule_names(existing):
+        return {
+            "status": "rule_exists",
+            "cluster": cluster_moid,
+            "rule_name": rule_name,
+            "rule_type": rule_type,
+            "enabled": enabled,
+            "task": None,
+            "resolved_vms": resolved,
+            "guidance": (
+                f"a DRS rule named {rule_name!r} already exists on cluster {cluster_moid!r}; "
+                "rule names are the idempotence key — pick a new name or remove the existing rule"
+            ),
+        }
+
+    reconfig_spec = {
+        "spec": {
+            _VMOMI_TYPE_NAME_KEY: _CLUSTER_CONFIG_SPEC_EX_TYPE,
+            "rulesSpec": [
+                {
+                    "operation": "add",
+                    "info": {
+                        _VMOMI_TYPE_NAME_KEY: rule_info_type,
+                        "name": rule_name,
+                        "enabled": enabled,
+                        "vm": [
+                            {"type": _VIRTUAL_MACHINE_MO_TYPE, "value": row["vm"]}
+                            for row in resolved
+                        ],
+                    },
+                }
+            ],
+        },
+        "modify": True,
+    }
+    gate, task_payload = await _write_vmomi_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_RECONFIGURE_COMPUTE_RESOURCE_TASK,
+        vmomi_path=f"/ClusterComputeResource/{cluster_moid}/ReconfigureComputeResource_Task",
+        body=reconfig_spec,
+        params={
+            "cluster": cluster_moid,
+            "rule_name": rule_name,
+            "rule_type": rule_type,
+            "vms": [row["vm"] for row in resolved],
+        },
+    )
+    if gate is not None:
+        return gate
+
+    outcome = await poll_vim_task(
+        connector,
+        target,
+        operator,
+        task=_unwrap_value(task_payload),
+        timeout_seconds=_DRS_RULE_TASK_TIMEOUT_SECONDS,
+    )
+    if outcome.state == "error":
+        raise RuntimeError(
+            f"cluster.drs_rule.create: ReconfigureComputeResource_Task on cluster "
+            f"{cluster_moid!r} faulted: {outcome.error_message or '<no fault reported>'}"
+        )
+    if outcome.timed_out:
+        return {
+            "status": "timeout",
+            "cluster": cluster_moid,
+            "rule_name": rule_name,
+            "rule_type": rule_type,
+            "enabled": enabled,
+            "task": outcome.task,
+            "resolved_vms": resolved,
+            "guidance": (
+                f"ReconfigureComputeResource_Task {outcome.task} did not reach a terminal state "
+                f"within {int(_DRS_RULE_TASK_TIMEOUT_SECONDS)}s; poll the task or re-read the "
+                "cluster's DRS rules — the rule add may still complete in the background"
+            ),
+        }
+    return {
+        "status": "created",
+        "cluster": cluster_moid,
+        "rule_name": rule_name,
+        "rule_type": rule_type,
+        "enabled": enabled,
+        "task": outcome.task,
+        "resolved_vms": resolved,
+        "guidance": None,
+    }
+
+
+# ===========================================================================
+# folder.create (vim Folder.CreateFolder — synchronous, #2895)
+# ===========================================================================
+#
+# Create a VM folder under a named parent. ``/vcenter/folder`` is GET-only
+# (spec-verified), so the create rides vim ``Folder.CreateFolder`` — which
+# is **synchronous**: it returns the new Folder ``ManagedObjectReference``
+# directly (NOT a ``*_Task``), so unlike drs_rule / disk-grow there is no
+# poll. Rides the #2893 governed vmomi write seam (``_write_vmomi_sub_op``).
+
+
+def _moref_value(moref: Any) -> str | None:
+    """Return the ``value`` field of a vim ``ManagedObjectReference``, else ``None``.
+
+    A synchronous vim method that returns an object reference (e.g.
+    ``Folder.CreateFolder`` → the new Folder MoRef) serialises as
+    ``{"type": "Folder", "value": "group-v123"}``. A bare moid string is
+    tolerated so a caller that already unwrapped the MoRef passes through.
+    """
+    if isinstance(moref, dict):
+        value = moref.get("value")
+        return value if isinstance(value, str) else None
+    return moref if isinstance(moref, str) else None
+
+
+async def _resolve_parent_vm_folder(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    parent_name: str,
+) -> tuple[str | None, str | None]:
+    """Resolve a VM-folder parent by display name to its moid.
+
+    Read-only ``GET:/vcenter/folder`` filtered by ``names`` + the
+    ``VIRTUAL_MACHINE`` folder type (the same listing ``vm.create`` resolves
+    its placement folder from). Returns ``(moid, None)`` on a unique match,
+    ``(None, "parent_not_found")`` on no match, or ``(None,
+    "ambiguous_parent")`` when the name resolves to more than one VM folder —
+    a structured status the caller surfaces instead of guessing a parent.
+    """
+    listing = await _read_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_LIST_FOLDERS,
+        {"filter.names": [parent_name], "filter.type": "VIRTUAL_MACHINE"},
+    )
+    entries = _unwrap_value(listing)
+    rows = [e for e in entries if isinstance(e, dict)] if isinstance(entries, list) else []
+    if not rows:
+        return None, "parent_not_found"
+    if len(rows) > 1:
+        return None, "ambiguous_parent"
+    moid = rows[0].get("folder")
+    if not isinstance(moid, str):
+        return None, "parent_not_found"
+    return moid, None
+
+
+async def folder_create_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Create a VM folder under a named parent via the synchronous vim CreateFolder.
+
+    Op-id: ``vmware.composite.folder.create``. ``/vcenter/folder`` is
+    GET-only (spec-verified), so the create rides vim ``Folder.CreateFolder``,
+    which is **synchronous** — it returns the new Folder
+    ``ManagedObjectReference`` directly, not a ``*_Task``, so (unlike
+    drs_rule / disk-grow) the returned MoRef is **not** polled.
+
+    Flow: resolve the parent folder *name* to a moid (a *read*; no match →
+    ``status="parent_not_found"``, >1 match → ``status="ambiguous_parent"``),
+    then issue the single ``CreateFolder`` through the governed vmomi write
+    seam (:func:`_write_vmomi_sub_op` → the #2254 gate). A parked/denied gate
+    returns the :class:`OperationResult` verbatim and no folder is created;
+    otherwise the new folder MoRef is unwrapped into ``status="created"``.
+    """
+    parent_name = params["parent_folder"]
+    new_name = params["folder_name"]
+
+    parent_moid, resolve_error = await _resolve_parent_vm_folder(
+        connector=connector, target=target, operator=operator, parent_name=parent_name
+    )
+    if parent_moid is None:
+        return {
+            "status": resolve_error,
+            "parent_folder": parent_name,
+            "parent_folder_id": None,
+            "new_folder_name": new_name,
+            "folder": None,
+            "guidance": (
+                f"parent VM folder name {parent_name!r} "
+                + (
+                    "resolved to more than one folder — pass a unique parent name"
+                    if resolve_error == "ambiguous_parent"
+                    else "did not resolve to a VM folder"
+                )
+            ),
+        }
+
+    gate, folder_payload = await _write_vmomi_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=_OP_CREATE_FOLDER,
+        vmomi_path=f"/Folder/{parent_moid}/CreateFolder",
+        body={"name": new_name},
+        params={"parent_folder": parent_moid, "folder_name": new_name},
+    )
+    if gate is not None:
+        return gate
+
+    new_folder_moid = _moref_value(folder_payload)
+    return {
+        "status": "created",
+        "parent_folder": parent_name,
+        "parent_folder_id": parent_moid,
+        "new_folder_name": new_name,
+        "folder": new_folder_moid,
+        "guidance": None,
+    }

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` preview builders for the 11 vmware write composites.
+"""Park-time ``proposed_effect`` preview builders for the 13 vmware write composites.
 
 G0.22-T3 (#1608). Before this module, a parked ``vmware.composite.*``
 write stored only the identifier default ``{op_id, connector_id,
@@ -9,7 +9,7 @@ target_id}`` in :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect
 — and because the original dispatch ``params`` are deliberately never
 serialised onto a reviewer-facing surface (#1503), the four-eyes
 approver could not tell a one-VM power cycle from a 1000-VM outage.
-This wires all 11 write composites onto the per-op preview hook shipped
+This wires all 13 write composites onto the per-op preview hook shipped
 by #1437 (:mod:`meho_backplane.operations._preview`), following the
 argocd pattern (#1452): reuse the handlers' own read-only resolution
 helpers, never the mutating sub-ops.
@@ -34,6 +34,9 @@ helpers, never the mutating sub-ops.
 ``vm.disk.grow``          live-read: vm, name, disk, disk_label,
                           current_capacity_bytes, requested_capacity_bytes,
                           delta_bytes
+``cluster.drs_rule.create`` live-read: cluster, cluster_name, rule_type,
+                          rule_name, enabled, resolved, total_resolved
+``folder.create``         echo: parent_folder, new_folder_name
 ========================  ====================================================
 
 Two preview depths, chosen per composite
@@ -112,6 +115,7 @@ from typing import Any
 from meho_backplane.connectors.vmware_rest.composites._write import (
     _GUEST_POWER_VERBS,
     _resolve_cluster_hosts,
+    _resolve_cluster_name,
     _resolve_disk_info,
     _resolve_vm_list,
     _resolve_vm_name,
@@ -452,7 +456,69 @@ async def _vm_disk_grow_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     }
 
 
-#: op_id → builder for the 10 write composites. Module-level so the
+async def _cluster_drs_rule_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``cluster.drs_rule.create`` — resolve the VM set the rule would govern.
+
+    The fan-out blast-radius pattern (like ``vm.power.bulk``): resolves the
+    rule's VM names to the same ``[{vm, name}]`` set the approved write
+    references — scoped to the cluster — via the shared
+    :func:`._write._resolve_vm_list` (one read-only GET), capped at
+    :data:`_PREVIEW_RESOLVED_CAP` with ``total_resolved`` carrying the
+    uncapped count. Best-effort reads the cluster display name
+    (:func:`._write._resolve_cluster_name`) so the reviewer sees which
+    cluster + which VMs the affinity / anti-affinity rule pins. The
+    ReconfigureComputeResource_Task write never fires here. Declines
+    (``None``) without a resolved connector or on malformed params.
+    """
+    cluster = ctx.params.get("cluster")
+    rule_name = ctx.params.get("rule_name")
+    rule_type = ctx.params.get("rule_type")
+    if (
+        not isinstance(cluster, str)
+        or not isinstance(rule_name, str)
+        or not isinstance(rule_type, str)
+        or ctx.connector_instance is None
+    ):
+        return None
+    vm_names = [n for n in (ctx.params.get("vms") or []) if isinstance(n, str)]
+    rows = await _resolve_vm_list(
+        connector=ctx.connector_instance,  # type: ignore[arg-type]
+        target=ctx.target,
+        operator=ctx.operator,
+        filter_dict={"names": vm_names, "clusters": [cluster]},
+    )
+    cluster_name = await _resolve_cluster_name(
+        ctx.connector_instance,  # type: ignore[arg-type]
+        ctx.target,
+        ctx.operator,
+        cluster=cluster,
+    )
+    return {
+        "cluster": cluster,
+        "cluster_name": cluster_name,
+        "rule_type": rule_type,
+        "rule_name": rule_name,
+        "enabled": bool(ctx.params.get("enabled", True)),
+        **_capped_resolution(rows, _vm_identity),
+    }
+
+
+async def _folder_create_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``folder.create`` — echo the parent + new folder name (no I/O).
+
+    Param echo (the ``secret.move`` precedent, #1580): the params fully name
+    the blast radius — one new folder under one named parent. Parent-name
+    resolution and the synchronous ``CreateFolder`` write stay the handler's
+    job at dispatch time.
+    """
+    parent_folder = ctx.params.get("parent_folder")
+    folder_name = ctx.params.get("folder_name")
+    if not isinstance(parent_folder, str) or not isinstance(folder_name, str):
+        return None
+    return {"parent_folder": parent_folder, "new_folder_name": folder_name}
+
+
+#: op_id → builder for the 13 write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.create": _vm_create_preview,
@@ -466,11 +532,13 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.host.evacuate": _host_evacuate_preview,
     "vmware.composite.host.detach_from_vds": _host_detach_from_vds_preview,
     "vmware.composite.cluster.patch": _cluster_patch_preview,
+    "vmware.composite.cluster.drs_rule.create": _cluster_drs_rule_create_preview,
+    "vmware.composite.folder.create": _folder_create_preview,
 }
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 11 write-composite park-time preview builders. Import-time.
+    """Wire the 13 write-composite park-time preview builders. Import-time.
 
     The 5 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""JSON Schema 2020-12 parameter + response schemas for the 15 vmware-rest composites.
+"""JSON Schema 2020-12 parameter + response schemas for the 18 vmware-rest composites.
 
 Each schema is the operator-facing input contract; the dispatcher
 validates inbound ``params`` against the registered schema before
@@ -25,10 +25,12 @@ Conventions
   schema verbatim on ``describe_operation`` calls.
 * The 5 read composites are read-only -- the registration call site
   pins ``safety_level="safe"`` and ``requires_approval=False`` on
-  each. The 10 write composites inherit T4's
+  each. The 13 write composites inherit T4's
   ``safety_level="dangerous"`` + ``requires_approval=True`` defaults
-  (G3.1-T6 / #509, single-VM ``vm.power`` / #2301, and the mutating
-  VI-JSON ``vm.disk.grow`` / #2893). The schema
+  (G3.1-T6 / #509, single-VM ``vm.power`` / #2301, the mutating
+  VI-JSON ``vm.disk.grow`` / #2893, the folder-template
+  ``vm.clone_from_template`` / #2894, and the vim cluster / inventory
+  writes ``cluster.drs_rule.create`` + ``folder.create`` / #2895). The schema
   text reflects which side of that line
   each composite sits on; the registration call site enforces the
   policy.
@@ -41,6 +43,8 @@ from typing import Any
 __all__ = [
     "CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA",
     "CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA",
+    "CLUSTER_DRS_RULE_CREATE_PARAMETER_SCHEMA",
+    "CLUSTER_DRS_RULE_CREATE_RESPONSE_SCHEMA",
     "CLUSTER_PATCH_PARAMETER_SCHEMA",
     "CLUSTER_PATCH_RESPONSE_SCHEMA",
     "DATASTORE_USAGE_MAX_VM_NAMES",
@@ -48,6 +52,8 @@ __all__ = [
     "DATASTORE_USAGE_RESPONSE_SCHEMA",
     "EVENT_TAIL_PARAMETER_SCHEMA",
     "EVENT_TAIL_RESPONSE_SCHEMA",
+    "FOLDER_CREATE_PARAMETER_SCHEMA",
+    "FOLDER_CREATE_RESPONSE_SCHEMA",
     "HOST_DETACH_FROM_VDS_PARAMETER_SCHEMA",
     "HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA",
     "HOST_EVACUATE_PARAMETER_SCHEMA",
@@ -555,7 +561,7 @@ NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA: dict[str, Any] = {
 # Write composites (G3.1-T6 / #509)
 # ===========================================================================
 #
-# The 10 write composites inherit T4's ``safety_level="dangerous"`` +
+# The 13 write composites inherit T4's ``safety_level="dangerous"`` +
 # ``requires_approval=True`` defaults. The registrar passes those
 # explicitly anyway to keep the policy posture obvious at the call site
 # alongside the read overrides.
@@ -1065,6 +1071,94 @@ VM_DISK_GROW_PARAMETER_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["vm", "disk", "capacity_bytes"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.cluster.drs_rule.create`` parameter schema.
+#:
+#: Add a DRS affinity / anti-affinity rule by *explicit VM list* via vim
+#: ``ClusterComputeResource.ReconfigureComputeResource_Task`` (no cluster-rules
+#: REST path exists; the tag-based compute-policies surface is semantically
+#: wrong — tag-scoped, not an explicit VM list). Rule names are the
+#: idempotence key: a duplicate returns ``status='rule_exists'`` before any
+#: write. VM names resolve to MoRefs scoped to the cluster; fewer than two
+#: resolve → ``status='insufficient_vms'``.
+CLUSTER_DRS_RULE_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "cluster": {
+            "type": "string",
+            "minLength": 1,
+            "description": "ClusterComputeResource moid the rule is added to (e.g. 'domain-c1').",
+        },
+        "rule_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Name of the new rule. Rule names are the idempotence key — a "
+                "name already present on the cluster returns "
+                "``status='rule_exists'`` before any write, not a raw vim "
+                "``DuplicateName`` fault."
+            ),
+        },
+        "rule_type": {
+            "type": "string",
+            "enum": ["affinity", "anti_affinity"],
+            "description": (
+                "``'affinity'`` keeps the VMs on the same host "
+                "(``ClusterAffinityRuleSpec``); ``'anti_affinity'`` keeps them "
+                "on separate hosts (``ClusterAntiAffinityRuleSpec``)."
+            ),
+        },
+        "vms": {
+            "type": "array",
+            "items": {"type": "string", "minLength": 1},
+            "minItems": 2,
+            "description": (
+                "Display names of the VMs the rule governs. Resolved to MoRefs "
+                "scoped to the cluster (a name not naming a VM in the cluster is "
+                "dropped); fewer than two resolve → ``status='insufficient_vms'``."
+            ),
+        },
+        "enabled": {
+            "type": "boolean",
+            "default": True,
+            "description": "Whether the rule is enabled on creation. Defaults to true.",
+        },
+    },
+    "required": ["cluster", "rule_name", "rule_type", "vms"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.folder.create`` parameter schema.
+#:
+#: Create a VM folder under a named parent via the **synchronous** vim
+#: ``Folder.CreateFolder`` (``/vcenter/folder`` is GET-only, so vim is the
+#: sole write path). The parent is resolved by display name among the
+#: ``VIRTUAL_MACHINE`` folders; no match → ``status='parent_not_found'``,
+#: more than one → ``status='ambiguous_parent'``.
+FOLDER_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "parent_folder": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Display name of the parent VM folder the new folder is created "
+                "under. Resolved to its moid via ``GET:/vcenter/folder`` filtered "
+                "to VIRTUAL_MACHINE folders; an ambiguous or unknown name is "
+                "refused with a structured status before any write."
+            ),
+        },
+        "folder_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Name of the new sub-folder to create under the parent.",
+        },
+    },
+    "required": ["parent_folder", "folder_name"],
     "additionalProperties": False,
 }
 
@@ -1600,4 +1694,100 @@ VM_DISK_GROW_RESPONSE_SCHEMA: dict[str, Any] = {
         },
     },
     "required": ["status", "vm", "disk", "to_capacity_bytes"],
+}
+
+
+#: ``vmware.composite.cluster.drs_rule.create`` response schema.
+CLUSTER_DRS_RULE_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["created", "rule_exists", "insufficient_vms", "timeout"],
+            "description": (
+                "``'created'`` — the ReconfigureComputeResource_Task add reached "
+                "terminal success; ``'rule_exists'`` — a rule with this name is "
+                "already present (idempotence key; refused before any write); "
+                "``'insufficient_vms'`` — fewer than two of the requested VM names "
+                "resolved to a VM in the cluster (refused before any write); "
+                "``'timeout'`` — the reconfigure task did not reach a terminal "
+                "state within the poll bound (it may still complete in the "
+                "background)."
+            ),
+        },
+        "cluster": {"type": "string", "description": "ClusterComputeResource moid."},
+        "rule_name": {"type": "string", "description": "Name of the rule."},
+        "rule_type": {
+            "type": "string",
+            "enum": ["affinity", "anti_affinity"],
+            "description": "Rule kind requested.",
+        },
+        "enabled": {"type": "boolean", "description": "Whether the rule was created enabled."},
+        "task": {
+            "type": ["string", "null"],
+            "description": (
+                "ReconfigureComputeResource_Task moid — present once the write was "
+                "issued (``created`` / ``timeout``); ``null`` on the pre-write refusals."
+            ),
+        },
+        "resolved_vms": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "vm": {"type": "string"},
+                    "name": {"type": ["string", "null"]},
+                },
+            },
+            "description": "The ``[{vm, name}]`` MoRefs the rule references, resolved from names.",
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Operator-facing next-step hint on a non-``created`` status; ``null`` on success."
+            ),
+        },
+    },
+    "required": ["status", "cluster", "rule_name", "rule_type"],
+}
+
+
+#: ``vmware.composite.folder.create`` response schema.
+FOLDER_CREATE_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": ["created", "parent_not_found", "ambiguous_parent"],
+            "description": (
+                "``'created'`` — the synchronous CreateFolder returned the new "
+                "folder MoRef; ``'parent_not_found'`` — the parent name matched no "
+                "VM folder; ``'ambiguous_parent'`` — it matched more than one "
+                "(both refused before any write)."
+            ),
+        },
+        "parent_folder": {
+            "type": "string",
+            "description": "The parent folder display name the operator supplied.",
+        },
+        "parent_folder_id": {
+            "type": ["string", "null"],
+            "description": "Resolved parent folder moid; ``null`` on a resolution refusal.",
+        },
+        "new_folder_name": {"type": "string", "description": "The requested new folder name."},
+        "folder": {
+            "type": ["string", "null"],
+            "description": (
+                "The new folder's moid — CreateFolder is synchronous and returns "
+                "the MoRef directly (no task poll). ``null`` on a resolution refusal."
+            ),
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": (
+                "Operator-facing next-step hint on a non-``created`` status; ``null`` on success."
+            ),
+        },
+    },
+    "required": ["status", "parent_folder", "new_folder_name"],
 }

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -398,3 +398,99 @@ def test_vm_clone_from_template_vi_json_paths_exist_in_the_pinned_spec() -> None
             f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
             "clone-from-template vi-json sub-op targets a path the spec does not serve"
         )
+
+
+# ---------------------------------------------------------------------------
+# #2895 vim cluster / inventory writes — the drs_rule + folder vi-json paths
+# reconcile against the same pinned spec as the disk-grow substrate.
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_drs_rule_create_vi_json_sub_op_manifest_is_the_expected_pair() -> None:
+    """Pin the drs_rule vi-json manifest so a drift can't shrink the reconcile."""
+    assert set(_write._VIM_SUB_OPS_CLUSTER_DRS_RULE_CREATE) == {
+        "POST:/ClusterComputeResource/{moId}/ReconfigureComputeResource_Task",
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+    }
+
+
+def test_folder_create_vi_json_sub_op_manifest_is_the_expected_single() -> None:
+    """Pin the folder.create vi-json manifest — one synchronous CreateFolder, no poll."""
+    assert set(_write._VIM_SUB_OPS_FOLDER_CREATE) == {
+        "POST:/Folder/{moId}/CreateFolder",
+    }
+
+
+def test_cluster_drs_rule_create_vi_json_sub_ops_round_trip_through_ingest() -> None:
+    """The drs_rule vi-json op_ids are byte-for-byte what ``parse_openapi`` emits."""
+    required = set(_write._VIM_SUB_OPS_CLUSTER_DRS_RULE_CREATE)
+    spec = _build_vcenter_fixture(required)
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vi-json.yaml"
+
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200, content=spec_bytes, headers={"content-type": "application/json"}
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+    ingested_op_ids = {row.op_id for row in rows}
+    assert required <= ingested_op_ids
+
+
+def test_folder_create_vi_json_sub_ops_round_trip_through_ingest() -> None:
+    """The folder.create vi-json op_id is byte-for-byte what ``parse_openapi`` emits."""
+    required = set(_write._VIM_SUB_OPS_FOLDER_CREATE)
+    spec = _build_vcenter_fixture(required)
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vi-json.yaml"
+
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200, content=spec_bytes, headers={"content-type": "application/json"}
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+    ingested_op_ids = {row.op_id for row in rows}
+    assert required <= ingested_op_ids
+
+
+def test_cluster_drs_rule_create_vi_json_paths_exist_in_the_pinned_spec() -> None:
+    """Each drs_rule vi-json sub-op path is a real POST path in the pinned vi-json.yaml.
+
+    The definitive #2895 grounding for the DRS-rule write: the
+    ``ReconfigureComputeResource_Task`` + collision-read ``RetrievePropertiesEx``
+    paths must exist in the pinned spec. Skips when the spec-shelf is not
+    configured (the canary's convention), so CI is the operator-visible signal.
+    """
+    spec_path = resolve_vi_json_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    spec_text = spec_path.read_text(encoding="utf-8")
+    for op_id in _write._VIM_SUB_OPS_CLUSTER_DRS_RULE_CREATE:
+        _, _, path = op_id.partition(":")
+        assert _vi_json_path_item_has_post(spec_text, path), (
+            f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
+            "drs_rule vi-json sub-op targets a path the spec does not serve"
+        )
+
+
+def test_folder_create_vi_json_paths_exist_in_the_pinned_spec() -> None:
+    """The folder.create vi-json sub-op path is a real POST path in the pinned vi-json.yaml.
+
+    The definitive #2895 grounding for the folder write: ``Folder.CreateFolder``
+    must exist as a POST path in the pinned spec (``/vcenter/folder`` is GET-only,
+    so vim is the sole write path). Skips when the spec-shelf is unconfigured.
+    """
+    spec_path = resolve_vi_json_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    spec_text = spec_path.read_text(encoding="utf-8")
+    for op_id in _write._VIM_SUB_OPS_FOLDER_CREATE:
+        _, _, path = op_id.partition(":")
+        assert _vi_json_path_item_has_post(spec_text, path), (
+            f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
+            "folder.create vi-json sub-op targets a path the spec does not serve"
+        )

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -175,12 +175,13 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 16 total: 5 reads
-    # (T5 #508) + 11 writes (T6 #509 + single-VM vm.power #2301 + mutating
+    # Embedding service called once per composite -- 18 total: 5 reads
+    # (T5 #508) + 13 writes (T6 #509 + single-VM vm.power #2301 + mutating
     # VI-JSON vm.disk.grow #2893 + folder-template vm.clone_from_template
-    # #2894). (The former host.network_uplinks / host.vsan_health reads
-    # were re-shipped as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 16
+    # #2894 + vim cluster/inventory writes cluster.drs_rule.create +
+    # folder.create #2895). (The former host.network_uplinks /
+    # host.vsan_health reads were re-shipped as typed ops in #2258.)
+    assert stub_embedding_service.encode_one.call_count == 18
 
 
 @pytest.mark.asyncio
@@ -427,17 +428,18 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 5 read rows persist; embedding stays at 16.
+    """Running the registrar twice -> 5 read rows persist; embedding stays at 18.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (5 reads + 11 writes / T6 +
+    persist after the combined registrar (5 reads + 13 writes / T6 +
     single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
-    folder-template vm.clone_from_template #2894).
+    folder-template vm.clone_from_template #2894 + vim cluster/inventory
+    writes cluster.drs_rule.create + folder.create #2895).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 16
+    assert first_count == 18
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -53,7 +53,9 @@ from meho_backplane.connectors.vmware_rest import VmwareRestConnector
 from meho_backplane.connectors.vmware_rest._mount import adapt_filter_params
 from meho_backplane.connectors.vmware_rest.composites import _write
 from meho_backplane.connectors.vmware_rest.composites._write import (
+    cluster_drs_rule_create_composite,
     cluster_patch_composite,
+    folder_create_composite,
     host_detach_from_vds_composite,
     host_evacuate_composite,
     vm_clone_composite,
@@ -1919,5 +1921,523 @@ async def test_vm_clone_from_template_clone_body_reaches_the_wire_respx(
             "type": "Datastore",
             "value": "datastore-15",
         }
+    finally:
+        await connector.aclose()
+
+
+# ===========================================================================
+# cluster.drs_rule.create (vim ClusterComputeResource reconfigure — #2895)
+# ===========================================================================
+
+
+def _vm_row(vm: str, name: str) -> dict[str, Any]:
+    """A VM listing row as ``GET:/vcenter/vm`` returns it (moid + display name)."""
+    return {"vm": vm, "name": name, "power_state": "POWERED_ON"}
+
+
+class _DrsRuleConnector:
+    """Recording double for the drs_rule.create REST reads + vim writes.
+
+    Serves the VM-name resolution (``GET:/vcenter/vm``), the existing-rules
+    collision read + the ``ReconfigureComputeResource_Task`` write + the Task
+    poll (the two ``RetrievePropertiesEx`` reads keyed apart by the request
+    body's ``specSet`` object type — ``ClusterComputeResource`` vs ``Task``).
+    """
+
+    _MOUNT = "/api"
+
+    def __init__(
+        self,
+        *,
+        vms: list[dict[str, Any]] | None = None,
+        existing_rules: list[dict[str, Any]] | None = None,
+        task_state: str = "success",
+        task_error: str | None = None,
+        reconfig_task: str = "task-rule-1",
+    ) -> None:
+        self.vms = [_vm_row("vm-1", "web-01"), _vm_row("vm-2", "web-02")] if vms is None else vms
+        self.existing_rules = existing_rules or []
+        self.task_state = task_state
+        self.task_error = task_error
+        self.reconfig_task = reconfig_task
+        self.rest_calls: list[tuple[str, Any]] = []
+        self.vmomi_calls: list[tuple[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        self.rest_calls.append((path, params))
+        return {"value": self.vms}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append((path, json))
+        if path.endswith("/ReconfigureComputeResource_Task"):
+            return {"type": "Task", "value": self.reconfig_task}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "ClusterComputeResource":
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "ClusterComputeResource", "value": "domain-c1"},
+                        "propSet": [{"name": "configurationEx.rule", "val": self.existing_rules}],
+                    }
+                ]
+            }
+        if spec_type == "Task":
+            info: dict[str, Any] = {"state": self.task_state}
+            if self.task_error is not None:
+                info["error"] = {"localizedMessage": self.task_error}
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "Task", "value": self.reconfig_task},
+                        "propSet": [{"name": "info", "val": info}],
+                    }
+                ]
+            }
+        raise AssertionError(f"unexpected RetrievePropertiesEx type {spec_type!r}")
+
+    @property
+    def reconfig_bodies(self) -> list[Any]:
+        return [
+            body
+            for path, body in self.vmomi_calls
+            if path.endswith("/ReconfigureComputeResource_Task")
+        ]
+
+
+async def test_drs_rule_create_happy_path_adds_anti_affinity_and_polls(gate: _GateRecorder) -> None:
+    """Anti-affinity: resolve VMs -> gated reconfigure add -> poll success -> status=created."""
+    conn = _DrsRuleConnector()
+    out = await cluster_drs_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "keep-apart",
+            "rule_type": "anti_affinity",
+            "vms": ["web-01", "web-02"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "created"
+    assert out["task"] == "task-rule-1"
+    assert out["rule_type"] == "anti_affinity"
+    assert out["resolved_vms"] == [
+        {"vm": "vm-1", "name": "web-01"},
+        {"vm": "vm-2", "name": "web-02"},
+    ]
+
+    # The single mutating sub-op was gated with its vi-json governance op_id +
+    # logical params (resolved moids name the entities the write touches).
+    assert gate.gated_op_ids == [
+        "POST:/ClusterComputeResource/{moId}/ReconfigureComputeResource_Task"
+    ]
+    gated = gate.calls[0]
+    assert gated["safety_level"] == "dangerous"
+    assert gated["requires_approval"] is False
+    assert gated["params"]["vms"] == ["vm-1", "vm-2"]
+
+    # The reconfigure body is a single-rule add with modify:true + MoRefs.
+    assert len(conn.reconfig_bodies) == 1
+    body = conn.reconfig_bodies[0]
+    assert body["modify"] is True
+    assert body["spec"]["_typeName"] == "ClusterConfigSpecEx"
+    rules_spec = body["spec"]["rulesSpec"]
+    assert len(rules_spec) == 1
+    assert rules_spec[0]["operation"] == "add"
+    info = rules_spec[0]["info"]
+    assert info["_typeName"] == "ClusterAntiAffinityRuleSpec"
+    assert info["name"] == "keep-apart"
+    assert info["enabled"] is True
+    assert info["vm"] == [
+        {"type": "VirtualMachine", "value": "vm-1"},
+        {"type": "VirtualMachine", "value": "vm-2"},
+    ]
+
+
+async def test_drs_rule_create_affinity_uses_affinity_type(gate: _GateRecorder) -> None:
+    """rule_type=affinity tags the rule info ``ClusterAffinityRuleSpec``."""
+    conn = _DrsRuleConnector()
+    out = await cluster_drs_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "keep-together",
+            "rule_type": "affinity",
+            "vms": ["web-01", "web-02"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "created"
+    info = conn.reconfig_bodies[0]["spec"]["rulesSpec"][0]["info"]
+    assert info["_typeName"] == "ClusterAffinityRuleSpec"
+
+
+async def test_drs_rule_create_name_collision_returns_structured_status(
+    gate: _GateRecorder,
+) -> None:
+    """An existing rule with the same name -> status=rule_exists; no write, no gate."""
+    conn = _DrsRuleConnector(existing_rules=[{"name": "keep-apart", "key": 1}])
+    out = await cluster_drs_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "keep-apart",
+            "rule_type": "anti_affinity",
+            "vms": ["web-01", "web-02"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "rule_exists"
+    assert out["task"] is None
+    # The reconfigure never fired, and the gate was never consulted.
+    assert conn.reconfig_bodies == []
+    assert gate.calls == []
+
+
+async def test_drs_rule_create_insufficient_vms_refused_before_write(gate: _GateRecorder) -> None:
+    """Fewer than two VMs resolve -> status=insufficient_vms; no write, no gate."""
+    conn = _DrsRuleConnector(vms=[_vm_row("vm-1", "web-01")])
+    out = await cluster_drs_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "keep-apart",
+            "rule_type": "anti_affinity",
+            "vms": ["web-01", "ghost"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "insufficient_vms"
+    assert out["resolved_vms"] == [{"vm": "vm-1", "name": "web-01"}]
+    assert conn.reconfig_bodies == []
+    assert gate.calls == []
+
+
+async def test_drs_rule_create_gate_short_circuits_before_the_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked gate on the reconfigure returns verbatim; no write fires."""
+    op_id = "POST:/ClusterComputeResource/{moId}/ReconfigureComputeResource_Task"
+    _install_gate(monkeypatch, _GateRecorder(gate_for={op_id: _awaiting(op_id)}))
+    conn = _DrsRuleConnector()
+    out = await cluster_drs_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "keep-apart",
+            "rule_type": "anti_affinity",
+            "vms": ["web-01", "web-02"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == op_id
+    assert conn.reconfig_bodies == []
+
+
+async def test_drs_rule_create_task_fault_raises(gate: _GateRecorder) -> None:
+    """A terminal task error raises (the dispatcher wraps it connector_error)."""
+    conn = _DrsRuleConnector(task_state="error", task_error="Cluster rule conflict.")
+    with pytest.raises(RuntimeError, match="Cluster rule conflict"):
+        await cluster_drs_rule_create_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={
+                "cluster": "domain-c1",
+                "rule_name": "keep-apart",
+                "rule_type": "anti_affinity",
+                "vms": ["web-01", "web-02"],
+            },
+            connector=conn,  # type: ignore[arg-type]
+        )
+
+
+async def test_drs_rule_create_poll_timeout_returns_timeout_status(
+    monkeypatch: pytest.MonkeyPatch, gate: _GateRecorder
+) -> None:
+    """A poll that never sees a terminal state returns status=timeout with the task id."""
+    monkeypatch.setattr(_write, "_DRS_RULE_TASK_TIMEOUT_SECONDS", 0.0)
+    conn = _DrsRuleConnector(task_state="running")
+    out = await cluster_drs_rule_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "keep-apart",
+            "rule_type": "anti_affinity",
+            "vms": ["web-01", "web-02"],
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "timeout"
+    assert out["task"] == "task-rule-1"
+
+
+async def test_drs_rule_create_reconfig_body_reaches_the_wire_respx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """respx-verified: the ReconfigureComputeResource_Task POST body carries
+    modify:true + a single ClusterRuleSpec add with the resolved VM MoRefs,
+    mounted on the /sdk/vim25 base.
+    """
+
+    async def _auto_execute(**_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(_write, "enforce_subop_policy", _auto_execute)
+
+    base = "https://vc-grow.test.invalid"
+    vijson = "/sdk/vim25/8.0.3.0"
+    vm_list = {"value": [_vm_row("vm-1", "web-01"), _vm_row("vm-2", "web-02")]}
+    rules_result = {
+        "objects": [
+            {
+                "obj": {"type": "ClusterComputeResource", "value": "domain-c1"},
+                "propSet": [{"name": "configurationEx.rule", "val": []}],
+            }
+        ]
+    }
+    task_result = {
+        "objects": [
+            {
+                "obj": {"type": "Task", "value": "task-1"},
+                "propSet": [{"name": "info", "val": {"state": "success"}}],
+            }
+        ]
+    }
+    connector = VmwareRestConnector(session_loader=_stub_loader)
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=base) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            mock.get("/api/about").respond(200, json={"version": "8.0.3"})
+            mock.get("/api/vcenter/vm").respond(200, json=vm_list)
+            # collision read then Task poll share the RetrievePropertiesEx URL.
+            mock.post(f"{vijson}/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
+                side_effect=[
+                    httpx.Response(200, json=rules_result),
+                    httpx.Response(200, json=task_result),
+                ]
+            )
+            reconfig = mock.post(
+                f"{vijson}/ClusterComputeResource/domain-c1/ReconfigureComputeResource_Task"
+            ).respond(200, json={"type": "Task", "value": "task-1"})
+            out = await cluster_drs_rule_create_composite(
+                operator=_make_operator(),
+                target=_StubTarget(),
+                params={
+                    "cluster": "domain-c1",
+                    "rule_name": "keep-apart",
+                    "rule_type": "anti_affinity",
+                    "vms": ["web-01", "web-02"],
+                },
+                connector=connector,
+            )
+        assert isinstance(out, dict)
+        assert out["status"] == "created"
+        assert reconfig.called
+        body = json.loads(reconfig.calls[0].request.content)
+        assert body["modify"] is True
+        assert body["spec"]["_typeName"] == "ClusterConfigSpecEx"
+        assert len(body["spec"]["rulesSpec"]) == 1
+        assert body["spec"]["rulesSpec"][0]["operation"] == "add"
+        info = body["spec"]["rulesSpec"][0]["info"]
+        assert info["_typeName"] == "ClusterAntiAffinityRuleSpec"
+        assert info["vm"] == [
+            {"type": "VirtualMachine", "value": "vm-1"},
+            {"type": "VirtualMachine", "value": "vm-2"},
+        ]
+    finally:
+        await connector.aclose()
+
+
+# ===========================================================================
+# folder.create (synchronous vim Folder.CreateFolder — #2895)
+# ===========================================================================
+
+
+class _FolderCreateConnector:
+    """Recording double for folder.create: parent REST read + vim CreateFolder.
+
+    Serves the parent-folder resolution (``GET:/vcenter/folder``) and the
+    synchronous ``Folder.CreateFolder`` vim POST — which returns the new
+    Folder MoRef directly, so **no** ``RetrievePropertiesEx`` poll ever fires.
+    """
+
+    _MOUNT = "/api"
+
+    def __init__(
+        self,
+        *,
+        parents: list[dict[str, Any]] | None = None,
+        new_folder_moid: str = "group-v99",
+    ) -> None:
+        self.parents = [{"folder": "group-v1", "name": "prod"}] if parents is None else parents
+        self.new_folder_moid = new_folder_moid
+        self.rest_calls: list[tuple[str, Any]] = []
+        self.vmomi_calls: list[tuple[str, Any]] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        self.rest_calls.append((path, params))
+        return {"value": self.parents}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append((path, json))
+        return {"type": "Folder", "value": self.new_folder_moid}
+
+
+async def test_folder_create_happy_path_is_synchronous_no_poll(gate: _GateRecorder) -> None:
+    """Resolve parent -> gated CreateFolder -> new folder MoRef returned; NO task poll."""
+    conn = _FolderCreateConnector()
+    out = await folder_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"parent_folder": "prod", "folder_name": "cluster-nodes"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "created"
+    assert out["folder"] == "group-v99"
+    assert out["parent_folder"] == "prod"
+    assert out["parent_folder_id"] == "group-v1"
+    assert out["new_folder_name"] == "cluster-nodes"
+
+    # Gated with the CreateFolder governance op_id + resolved-parent params.
+    assert gate.gated_op_ids == ["POST:/Folder/{moId}/CreateFolder"]
+    assert gate.calls[0]["params"] == {"parent_folder": "group-v1", "folder_name": "cluster-nodes"}
+
+    # Exactly one vmomi call — the CreateFolder itself. No RetrievePropertiesEx
+    # poll: CreateFolder is synchronous and returns the folder MoRef directly.
+    assert len(conn.vmomi_calls) == 1
+    path, body = conn.vmomi_calls[0]
+    assert path == "/Folder/group-v1/CreateFolder"
+    assert body == {"name": "cluster-nodes"}
+
+
+async def test_folder_create_parent_not_found_refused_before_write(gate: _GateRecorder) -> None:
+    """No parent match -> status=parent_not_found; no write, no gate."""
+    conn = _FolderCreateConnector(parents=[])
+    out = await folder_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"parent_folder": "ghost", "folder_name": "cluster-nodes"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "parent_not_found"
+    assert out["folder"] is None
+    assert conn.vmomi_calls == []
+    assert gate.calls == []
+
+
+async def test_folder_create_ambiguous_parent_refused_before_write(gate: _GateRecorder) -> None:
+    """A parent name matching >1 folder -> status=ambiguous_parent; no write."""
+    conn = _FolderCreateConnector(
+        parents=[{"folder": "group-v1", "name": "prod"}, {"folder": "group-v2", "name": "prod"}]
+    )
+    out = await folder_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"parent_folder": "prod", "folder_name": "cluster-nodes"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "ambiguous_parent"
+    assert conn.vmomi_calls == []
+    assert gate.calls == []
+
+
+async def test_folder_create_gate_short_circuits_before_the_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked gate on CreateFolder returns verbatim; no folder is created."""
+    op_id = "POST:/Folder/{moId}/CreateFolder"
+    _install_gate(monkeypatch, _GateRecorder(gate_for={op_id: _awaiting(op_id)}))
+    conn = _FolderCreateConnector()
+    out = await folder_create_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"parent_folder": "prod", "folder_name": "cluster-nodes"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == op_id
+    assert conn.vmomi_calls == []
+
+
+async def test_folder_create_body_reaches_the_wire_respx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """respx-verified: the CreateFolder POST body carries {name}, mounted on
+    /sdk/vim25, and the returned Folder MoRef is unwrapped into the result.
+    """
+
+    async def _auto_execute(**_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(_write, "enforce_subop_policy", _auto_execute)
+
+    base = "https://vc-grow.test.invalid"
+    vijson = "/sdk/vim25/8.0.3.0"
+    parents = {"value": [{"folder": "group-v1", "name": "prod"}]}
+    connector = VmwareRestConnector(session_loader=_stub_loader)
+    _patch_no_revoke_aclose(connector)
+    try:
+        async with respx.mock(base_url=base) as mock:
+            mock.post("/api/session").respond(200, json="tok")
+            mock.get("/api/about").respond(200, json={"version": "8.0.3"})
+            mock.get("/api/vcenter/folder").respond(200, json=parents)
+            create = mock.post(f"{vijson}/Folder/group-v1/CreateFolder").respond(
+                200, json={"type": "Folder", "value": "group-v42"}
+            )
+            out = await folder_create_composite(
+                operator=_make_operator(),
+                target=_StubTarget(),
+                params={"parent_folder": "prod", "folder_name": "cluster-nodes"},
+                connector=connector,
+            )
+        assert isinstance(out, dict)
+        assert out["status"] == "created"
+        assert out["folder"] == "group-v42"
+        assert create.called
+        body = json.loads(create.calls[0].request.content)
+        assert body == {"name": "cluster-nodes"}
     finally:
         await connector.aclose()

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -259,7 +259,7 @@ def _seed_connector(recorder: _RecordingVmwareConnector) -> None:
 async def _bootstrap(
     recorder: _RecordingVmwareConnector, stub_embedding_service: AsyncMock
 ) -> None:
-    """Register the connector + all 15 composites and seed the recorder."""
+    """Register the connector + all 17 composites and seed the recorder."""
     _seed_connector(recorder)
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
 
@@ -1319,3 +1319,367 @@ async def test_clone_from_template_fresh_boot_dispatchable_without_ingest(
     assert result.status == "ok", result.error
     assert result.result["status"] == "cloned"
     assert recorder.clone_writes == ["/VirtualMachine/vm-42/CloneVM_Task"]
+
+
+# ===========================================================================
+# cluster.drs_rule.create — park→approve→resume + fresh-boot (#2895)
+# ===========================================================================
+
+
+class _DrsRuleVmwareConnector:
+    """Recording double for the drs_rule.create park→approve→resume E2E.
+
+    Serves the VM-resolution + cluster-name REST reads (``_get_json``) and the
+    dispatch-time VI-JSON sub-ops (``_post_vmomi_json``: the existing-rules
+    collision read, the ``ReconfigureComputeResource_Task`` write, and the
+    ``Task.info`` poll — the two ``RetrievePropertiesEx`` reads keyed apart by
+    the request body's ``specSet`` object type). Records both surfaces so the
+    test can prove the mutating vmomi write fires only on the approved resume.
+    """
+
+    _MOUNT = "/api"
+
+    def __init__(self, *, existing_rules: list[dict[str, Any]] | None = None) -> None:
+        self.existing_rules = existing_rules or []
+        self.rest_calls: list[tuple[str, str]] = []
+        self.vmomi_calls: list[str] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    def _spec(self, path: str) -> str:
+        return path[len(self._MOUNT) :] if path.startswith(self._MOUNT) else path
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        spec = self._spec(path)
+        self.rest_calls.append(("GET", spec))
+        if spec == "/vcenter/vm":
+            return {
+                "value": [
+                    {"vm": "vm-1", "name": "web-01", "power_state": "POWERED_ON"},
+                    {"vm": "vm-2", "name": "web-02", "power_state": "POWERED_ON"},
+                ]
+            }
+        if spec == "/vcenter/cluster/domain-c1":
+            return {"name": "prod-cluster"}
+        return {"value": {}}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append(path)
+        if path.endswith("/ReconfigureComputeResource_Task"):
+            return {"type": "Task", "value": "task-rule-e2e"}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "ClusterComputeResource":
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "ClusterComputeResource", "value": "domain-c1"},
+                        "propSet": [{"name": "configurationEx.rule", "val": self.existing_rules}],
+                    }
+                ]
+            }
+        return {
+            "objects": [
+                {
+                    "obj": {"type": "Task", "value": "task-rule-e2e"},
+                    "propSet": [{"name": "info", "val": {"state": "success"}}],
+                }
+            ]
+        }
+
+    @property
+    def reconfig_writes(self) -> list[str]:
+        return [p for p in self.vmomi_calls if p.endswith("/ReconfigureComputeResource_Task")]
+
+
+@pytest.mark.asyncio
+async def test_drs_rule_create_queue_approve_resume_with_2681_envelope(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """drs_rule.create: park (#2681 envelope + fan-out preview) → approve → resume → created.
+
+    1. A USER dispatch parks at ``awaiting_approval``; the durable row carries
+       the uniform #2681 op-identity envelope plus the capped VM fan-out
+       preview (cluster + cluster_name + resolved VMs). No
+       ReconfigureComputeResource_Task fires — only the read-only preview GETs.
+    2. A distinct human reviewer approves.
+    3. The ``_approved=True`` resume executes: VM resolution + collision read +
+       the (now auto-executed) governed reconfigure + the Task poll run, and
+       the result is ``status='created'``.
+    """
+    recorder = _DrsRuleVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name="prod-vcenter",
+                product="vmware",
+                host="vcenter.prod.invalid",
+                aliases=[],
+            )
+        )
+        await s.commit()
+
+    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
+    target = _FakeVmwareTarget(target_id=target_id)
+    params = {
+        "cluster": "domain-c1",
+        "rule_name": "keep-apart",
+        "rule_type": "anti_affinity",
+        "vms": ["web-01", "web-02"],
+    }
+
+    result1 = await dispatch(
+        operator=requester,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.cluster.drs_rule.create",
+        target=target,
+        params=params,
+    )
+    assert result1.status == "awaiting_approval", result1.error
+    assert recorder.reconfig_writes == [], "no reconfigure before approval"
+    approval_request_id = UUID(result1.extras["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        pending = await s.get(ApprovalRequest, approval_request_id)
+    assert pending is not None
+    assert pending.target_id == target_id
+    effect = pending.proposed_effect
+    assert effect["op_id"] == "vmware.composite.cluster.drs_rule.create"
+    assert effect["connector_id"] == _CONNECTOR_ID
+    assert effect["target_id"] == str(target_id)
+    assert effect["op_class"] == "write"
+    assert effect["safety_level"] == "dangerous"
+    assert effect["preview_populated"] is True
+    assert effect["preview"] == {
+        "cluster": "domain-c1",
+        "cluster_name": "prod-cluster",
+        "rule_type": "anti_affinity",
+        "rule_name": "keep-apart",
+        "enabled": True,
+        "resolved": [
+            {"vm": "vm-1", "name": "web-01", "power_state": "POWERED_ON"},
+            {"vm": "vm-2", "name": "web-02", "power_state": "POWERED_ON"},
+        ],
+        "total_resolved": 2,
+    }
+
+    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
+    async with get_sessionmaker()() as s:
+        row = await approve_request(s, approval_request_id, operator=reviewer, params=params)
+        await s.commit()
+    assert row.status == ApprovalRequestStatus.APPROVED.value
+
+    result2 = await dispatch(
+        operator=reviewer,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.cluster.drs_rule.create",
+        target=target,
+        params=params,
+        _approved=True,
+    )
+    assert result2.status == "ok", result2.error
+    assert result2.result["status"] == "created"
+    assert result2.result["rule_name"] == "keep-apart"
+    # The mutating reconfigure fired exactly once, on the approved resume.
+    assert recorder.reconfig_writes == [
+        "/ClusterComputeResource/domain-c1/ReconfigureComputeResource_Task"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_drs_rule_create_fresh_boot_dispatchable_without_ingest(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """drs_rule.create runs to ``created`` on the direct session with ZERO ingested rows."""
+    recorder = _DrsRuleVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.cluster.drs_rule.create"}, recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.cluster.drs_rule.create",
+        target=_FakeVmwareTarget(),
+        params={
+            "cluster": "domain-c1",
+            "rule_name": "keep-apart",
+            "rule_type": "anti_affinity",
+            "vms": ["web-01", "web-02"],
+        },
+    )
+    assert "composite_l2_missing" not in (result.error or ""), result.error
+    assert result.status == "ok", result.error
+    assert result.result["status"] == "created"
+    assert recorder.reconfig_writes == [
+        "/ClusterComputeResource/domain-c1/ReconfigureComputeResource_Task"
+    ]
+
+
+# ===========================================================================
+# folder.create — park→approve→resume + fresh-boot (synchronous, #2895)
+# ===========================================================================
+
+
+class _FolderCreateVmwareConnector:
+    """Recording double for the folder.create park→approve→resume E2E.
+
+    Serves the parent-folder resolution REST read (``_get_json``) and the
+    synchronous ``Folder.CreateFolder`` vim POST (``_post_vmomi_json``) — which
+    returns the new Folder MoRef directly, so **no** ``RetrievePropertiesEx``
+    poll ever fires. Records both surfaces so the test can prove the mutating
+    CreateFolder fires only on the approved resume and is never polled.
+    """
+
+    _MOUNT = "/api"
+
+    def __init__(self, *, new_folder_moid: str = "group-v99") -> None:
+        self.new_folder_moid = new_folder_moid
+        self.rest_calls: list[tuple[str, str]] = []
+        self.vmomi_calls: list[str] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    def _spec(self, path: str) -> str:
+        return path[len(self._MOUNT) :] if path.startswith(self._MOUNT) else path
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        self.rest_calls.append(("GET", self._spec(path)))
+        return {"value": [{"folder": "group-v1", "name": "prod"}]}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.vmomi_calls.append(path)
+        return {"type": "Folder", "value": self.new_folder_moid}
+
+    @property
+    def create_writes(self) -> list[str]:
+        return [p for p in self.vmomi_calls if p.endswith("/CreateFolder")]
+
+
+@pytest.mark.asyncio
+async def test_folder_create_queue_approve_resume_with_2681_envelope(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """folder.create: park (#2681 + param-echo preview) → approve → resume → created.
+
+    The synchronous-write proof end-to-end: on the approved resume the
+    ``CreateFolder`` fires exactly once and its returned Folder MoRef is the
+    result, with **no** ``RetrievePropertiesEx`` task poll (the whole vmomi
+    call log is the single CreateFolder).
+    """
+    recorder = _FolderCreateVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name="prod-vcenter",
+                product="vmware",
+                host="vcenter.prod.invalid",
+                aliases=[],
+            )
+        )
+        await s.commit()
+
+    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
+    target = _FakeVmwareTarget(target_id=target_id)
+    params = {"parent_folder": "prod", "folder_name": "cluster-nodes"}
+
+    result1 = await dispatch(
+        operator=requester,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.folder.create",
+        target=target,
+        params=params,
+    )
+    assert result1.status == "awaiting_approval", result1.error
+    assert recorder.create_writes == [], "no CreateFolder before approval"
+    approval_request_id = UUID(result1.extras["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        pending = await s.get(ApprovalRequest, approval_request_id)
+    assert pending is not None
+    effect = pending.proposed_effect
+    assert effect["op_id"] == "vmware.composite.folder.create"
+    assert effect["op_class"] == "write"
+    assert effect["safety_level"] == "dangerous"
+    assert effect["preview_populated"] is True
+    assert effect["preview"] == {"parent_folder": "prod", "new_folder_name": "cluster-nodes"}
+
+    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
+    async with get_sessionmaker()() as s:
+        row = await approve_request(s, approval_request_id, operator=reviewer, params=params)
+        await s.commit()
+    assert row.status == ApprovalRequestStatus.APPROVED.value
+
+    result2 = await dispatch(
+        operator=reviewer,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.folder.create",
+        target=target,
+        params=params,
+        _approved=True,
+    )
+    assert result2.status == "ok", result2.error
+    assert result2.result["status"] == "created"
+    assert result2.result["folder"] == "group-v99"
+    # CreateFolder is synchronous: exactly one vmomi call, never polled.
+    assert recorder.vmomi_calls == ["/Folder/group-v1/CreateFolder"]
+
+
+@pytest.mark.asyncio
+async def test_folder_create_fresh_boot_dispatchable_without_ingest(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """folder.create runs to ``created`` on the direct session with ZERO ingested rows."""
+    recorder = _FolderCreateVmwareConnector()
+    await _bootstrap(recorder, stub_embedding_service)
+    await _clear_requires_approval({"vmware.composite.folder.create"}, recorder)
+
+    result = await dispatch(
+        operator=_make_operator(),
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.folder.create",
+        target=_FakeVmwareTarget(),
+        params={"parent_folder": "prod", "folder_name": "cluster-nodes"},
+    )
+    assert "composite_l2_missing" not in (result.error or ""), result.error
+    assert result.status == "ok", result.error
+    assert result.result["status"] == "created"
+    assert recorder.create_writes == ["/Folder/group-v1/CreateFolder"]

--- a/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
@@ -41,6 +41,8 @@ from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
 from meho_backplane.connectors import OperationResult
 from meho_backplane.connectors.vmware_rest._mount import adapt_filter_params
 from meho_backplane.connectors.vmware_rest.composites._write import (
+    cluster_drs_rule_create_composite,
+    folder_create_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
     vm_disk_grow_composite,
@@ -531,5 +533,254 @@ async def test_clone_from_template_human_operator_vmomi_write_auto_executes(
     assert out["status"] == "cloned"
     # The CloneVM_Task executed on the session; the sub-op auto-executed.
     assert len(conn.clone_writes) == 1
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# cluster.drs_rule.create — the governed ReconfigureComputeResource_Task vim
+# write flows through the same #2254 seam as the disk-grow ReconfigVM_Task.
+# ---------------------------------------------------------------------------
+
+_RECONFIGURE_OP_ID = "POST:/ClusterComputeResource/{moId}/ReconfigureComputeResource_Task"
+_CREATE_FOLDER_OP_ID = "POST:/Folder/{moId}/CreateFolder"
+
+_DRS_RULE_PARAMS = {
+    "cluster": "domain-c1",
+    "rule_name": "keep-apart",
+    "rule_type": "anti_affinity",
+    "vms": ["web-01", "web-02"],
+}
+_FOLDER_PARAMS = {"parent_folder": "prod", "folder_name": "cluster-nodes"}
+
+
+class _DrsRuleRecordingConnector:
+    """Recording double for the drs_rule.create governance tests.
+
+    Serves the VM-name resolution (REST ``_get_json``), the existing-rules
+    collision read + the ``Task.info`` poll (both vmomi ``RetrievePropertiesEx``,
+    keyed apart by the request body's ``specSet`` object type) and records every
+    ``ReconfigureComputeResource_Task`` write so the tests can assert the
+    mutating vmomi POST never fired when the gate parks / denies.
+    """
+
+    _MOUNT = "/api"
+
+    def __init__(self) -> None:
+        self.reconfig_writes: list[Any] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        return {"value": [{"vm": "vm-1", "name": "web-01"}, {"vm": "vm-2", "name": "web-02"}]}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        if path.endswith("/ReconfigureComputeResource_Task"):
+            self.reconfig_writes.append(json)
+            return {"type": "Task", "value": "task-rule-1"}
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        if spec_type == "ClusterComputeResource":
+            return {
+                "objects": [
+                    {
+                        "obj": {"type": "ClusterComputeResource", "value": "domain-c1"},
+                        "propSet": [{"name": "configurationEx.rule", "val": []}],
+                    }
+                ]
+            }
+        return {
+            "objects": [
+                {
+                    "obj": {"type": "Task", "value": "task-rule-1"},
+                    "propSet": [{"name": "info", "val": {"state": "success"}}],
+                }
+            ]
+        }
+
+
+@pytest.mark.asyncio
+async def test_drs_rule_gated_vmomi_write_queues_and_never_reaches_wire(
+    session: AsyncSession,
+) -> None:
+    """An agent-gated ReconfigureComputeResource_Task queues; the vmomi write never fires."""
+    await _grant(
+        principal_sub="agent-write-composite",
+        op_pattern=_RECONFIGURE_OP_ID,
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _DrsRuleRecordingConnector()
+    out = await cluster_drs_rule_create_composite(
+        operator=_operator(),
+        target=None,
+        params=dict(_DRS_RULE_PARAMS),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _RECONFIGURE_OP_ID
+    request_id = uuid.UUID(out.extras["approval_request_id"])
+    row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.op_id == _RECONFIGURE_OP_ID
+    assert row.connector_id == "vmware-rest-9.0"
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    assert conn.reconfig_writes == []
+
+
+@pytest.mark.asyncio
+async def test_drs_rule_dangerous_vmomi_write_denied_without_grant(
+    session: AsyncSession,
+) -> None:
+    """An agent with no grant is denied the dangerous reconfigure; it never runs."""
+    conn = _DrsRuleRecordingConnector()
+    out = await cluster_drs_rule_create_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params=dict(_DRS_RULE_PARAMS),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == _RECONFIGURE_OP_ID
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+    assert conn.reconfig_writes == []
+
+
+@pytest.mark.asyncio
+async def test_drs_rule_human_operator_vmomi_write_auto_executes(
+    session: AsyncSession,
+) -> None:
+    """A human operator's already-approved composite auto-executes the reconfigure."""
+    conn = _DrsRuleRecordingConnector()
+    out = await cluster_drs_rule_create_composite(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        target=None,
+        params=dict(_DRS_RULE_PARAMS),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "created"
+    assert len(conn.reconfig_writes) == 1
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# folder.create — the synchronous CreateFolder vim write is governed by the
+# same #2254 seam (no task poll follows it).
+# ---------------------------------------------------------------------------
+
+
+class _FolderRecordingConnector:
+    """Recording double for the folder.create governance tests.
+
+    Serves the parent-folder resolution (REST ``_get_json``) and records every
+    ``CreateFolder`` vim write. CreateFolder is synchronous, so the double
+    returns the new Folder MoRef directly with no ``RetrievePropertiesEx`` poll.
+    """
+
+    _MOUNT = "/api"
+
+    def __init__(self) -> None:
+        self.create_writes: list[Any] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"{self._MOUNT}{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params(self._MOUNT, query)
+
+    async def _get_json(
+        self, target: Any, path: str, *, operator: Operator, params: Any = None
+    ) -> Any:
+        return {"value": [{"folder": "group-v1", "name": "prod"}]}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        self.create_writes.append(json)
+        return {"type": "Folder", "value": "group-v42"}
+
+
+@pytest.mark.asyncio
+async def test_folder_create_gated_vmomi_write_queues_and_never_reaches_wire(
+    session: AsyncSession,
+) -> None:
+    """An agent-gated CreateFolder queues for approval; the vmomi write never fires."""
+    await _grant(
+        principal_sub="agent-write-composite",
+        op_pattern=_CREATE_FOLDER_OP_ID,
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _FolderRecordingConnector()
+    out = await folder_create_composite(
+        operator=_operator(),
+        target=None,
+        params=dict(_FOLDER_PARAMS),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _CREATE_FOLDER_OP_ID
+    request_id = uuid.UUID(out.extras["approval_request_id"])
+    row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.op_id == _CREATE_FOLDER_OP_ID
+    assert row.connector_id == "vmware-rest-9.0"
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    assert conn.create_writes == []
+
+
+@pytest.mark.asyncio
+async def test_folder_create_dangerous_vmomi_write_denied_without_grant(
+    session: AsyncSession,
+) -> None:
+    """An agent with no grant is denied the dangerous CreateFolder; it never runs."""
+    conn = _FolderRecordingConnector()
+    out = await folder_create_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params=dict(_FOLDER_PARAMS),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == _CREATE_FOLDER_OP_ID
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+    assert conn.create_writes == []
+
+
+@pytest.mark.asyncio
+async def test_folder_create_human_operator_vmomi_write_auto_executes(
+    session: AsyncSession,
+) -> None:
+    """A human operator's already-approved composite auto-executes the CreateFolder."""
+    conn = _FolderRecordingConnector()
+    out = await folder_create_composite(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        target=None,
+        params=dict(_FOLDER_PARAMS),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "created"
+    assert out["folder"] == "group-v42"
+    assert len(conn.create_writes) == 1
     count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
     assert count == 0

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -79,6 +79,8 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
         "vmware.composite.host.evacuate",
         "vmware.composite.host.detach_from_vds",
         "vmware.composite.cluster.patch",
+        "vmware.composite.cluster.drs_rule.create",
+        "vmware.composite.folder.create",
     }
 )
 
@@ -289,14 +291,14 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 
 
 # ===========================================================================
-# Wiring — all 9 write composites register a builder (criterion 4)
+# Wiring — all 13 write composites register a builder (criterion 4)
 # ===========================================================================
 
 
-def test_all_eleven_write_composites_register_a_preview_builder() -> None:
+def test_all_thirteen_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 11
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 13
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 
@@ -332,6 +334,15 @@ async def test_live_read_builders_decline_without_a_connector_instance() -> None
             {"host": "host-1", "dvs": "dvs-1", "fallback_network": "net"},
         ),
         (_write_preview._cluster_patch_preview, {"cluster": "domain-c1"}),
+        (
+            _write_preview._cluster_drs_rule_create_preview,
+            {
+                "cluster": "domain-c1",
+                "rule_name": "keep-apart",
+                "rule_type": "anti_affinity",
+                "vms": ["web-01", "web-02"],
+            },
+        ),
     ):
         assert await builder(_make_preview_ctx(params, connector_instance=None)) is None
 
@@ -500,6 +511,8 @@ async def test_echo_builders_decline_on_malformed_params() -> None:
     assert await _write_preview._host_evacuate_preview(_make_preview_ctx({})) is None
     assert await _write_preview._host_detach_from_vds_preview(_make_preview_ctx({})) is None
     assert await _write_preview._cluster_patch_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._folder_create_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._cluster_drs_rule_create_preview(_make_preview_ctx({})) is None
 
 
 # ===========================================================================
@@ -877,3 +890,87 @@ async def test_disk_grow_preview_vm_name_is_best_effort() -> None:
     assert preview["disk_label"] == "Hard disk 1"
     assert preview["current_capacity_bytes"] == _TEN_GIB
     assert preview["delta_bytes"] == _TWENTY_GIB - _TEN_GIB
+
+
+# ===========================================================================
+# cluster.drs_rule.create — the capped VM fan-out + cluster-name preview (#2895)
+# ===========================================================================
+
+
+async def test_drs_rule_create_park_carries_capped_vm_fanout(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The parked row's preview names the cluster + resolved VM set (fan-out pattern)."""
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses["/vcenter/vm"] = {
+        "value": [
+            {"vm": "vm-1", "name": "web-01", "power_state": "POWERED_ON"},
+            {"vm": "vm-2", "name": "web-02", "power_state": "POWERED_OFF"},
+        ]
+    }
+    recorder.responses["/vcenter/cluster/domain-c1"] = {"name": "prod-cluster"}
+
+    _, row = await _park(
+        "vmware.composite.cluster.drs_rule.create",
+        {
+            "cluster": "domain-c1",
+            "rule_name": "keep-apart",
+            "rule_type": "anti_affinity",
+            "vms": ["web-01", "web-02"],
+        },
+    )
+
+    assert _strip_uniform_identity(
+        row.proposed_effect, op_id="vmware.composite.cluster.drs_rule.create"
+    ) == {
+        "op_class": "write",
+        "preview": {
+            "cluster": "domain-c1",
+            "cluster_name": "prod-cluster",
+            "rule_type": "anti_affinity",
+            "rule_name": "keep-apart",
+            "enabled": True,
+            "resolved": [
+                {"vm": "vm-1", "name": "web-01", "power_state": "POWERED_ON"},
+                {"vm": "vm-2", "name": "web-02", "power_state": "POWERED_OFF"},
+            ],
+            "total_resolved": 2,
+        },
+        "preview_populated": True,
+        "safety_level": "dangerous",
+    }
+    # The VM resolution is load-bearing (first read); the cluster name is a
+    # second best-effort GET. No ReconfigureComputeResource_Task mutation fires.
+    assert recorder.read_calls[0][0] == "/vcenter/vm"
+    assert ("/vcenter/cluster/domain-c1", None) in recorder.read_calls
+    assert all(verb == "GET" for verb, _, _ in recorder.calls)
+
+
+async def test_drs_rule_create_preview_caps_resolved_at_twenty(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A rule over >20 VMs caps ``resolved`` at 20 but keeps the true ``total_resolved``."""
+    recorder = await _bootstrap_registry(stub_embedding_service)
+    recorder.responses["/vcenter/vm"] = {
+        "value": [{"vm": f"vm-{i}", "name": f"web-{i}"} for i in range(25)]
+    }
+    _, row = await _park(
+        "vmware.composite.cluster.drs_rule.create",
+        {
+            "cluster": "domain-c1",
+            "rule_name": "spread",
+            "rule_type": "anti_affinity",
+            "vms": [f"web-{i}" for i in range(25)],
+        },
+    )
+    preview = row.proposed_effect["preview"]
+    assert len(preview["resolved"]) == 20
+    assert preview["total_resolved"] == 25
+
+
+async def test_folder_create_preview_echoes_parent_and_new_name() -> None:
+    """folder.create preview is a param echo — parent + new folder name, no I/O."""
+    preview = await _write_preview._folder_create_preview(
+        _make_preview_ctx({"parent_folder": "prod", "folder_name": "cluster-nodes"})
+    )
+    assert preview == {"parent_folder": "prod", "new_folder_name": "cluster-nodes"}

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,12 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 11 vmware-rest write composites.
+"""Registration tests for the 13 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
-``vm.power`` / #2301):
+``vm.power`` / #2301 and the vim writes ``vm.disk.grow`` / #2893 +
+``cluster.drs_rule.create`` / ``folder.create`` / #2895):
 
-* All 11 expected write ``op_id`` rows land in ``endpoint_descriptor``
+* All 13 expected write ``op_id`` rows land in ``endpoint_descriptor``
   with ``source_kind="composite"``, ``safety_level="dangerous"``,
   ``requires_approval=True`` (T4's defaults intentionally inherited).
 * Each row's ``handler_ref`` resolves to the module-level dotted path
@@ -14,7 +15,7 @@ Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 * Each row's ``group_key`` resolves to ``vm`` / ``host`` / ``cluster``
   per the canary's stub-LLM taxonomy.
 * Combined with #508's 5 read composites, the registrar produces
-  **16 rows** total. (The former host.network_uplinks / host.vsan_health
+  **18 rows** total. (The former host.network_uplinks / host.vsan_health
   reads were re-shipped as typed ops in #2258.)
 * Per-composite ``parameter_schema`` + ``response_schema`` persist
   with the documented required keys.
@@ -58,9 +59,10 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 11 write composites (T6 / #509, single-VM vm.power / #2301, the
-# mutating VI-JSON vm.disk.grow / #2893, and the folder-template
-# vm.clone_from_template / #2894).
+# 13 write composites (T6 / #509, single-VM vm.power / #2301, the
+# mutating VI-JSON vm.disk.grow / #2893, the folder-template
+# vm.clone_from_template / #2894, and the vim cluster/inventory writes
+# cluster.drs_rule.create + folder.create / #2895).
 _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.create",
     "vmware.composite.vm.clone",
@@ -73,6 +75,8 @@ _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.host.evacuate",
     "vmware.composite.host.detach_from_vds",
     "vmware.composite.cluster.patch",
+    "vmware.composite.cluster.drs_rule.create",
+    "vmware.composite.folder.create",
 )
 
 # 5 reads (T5 / #508) -- carried over so the combined-count assertion
@@ -87,8 +91,9 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.network.portgroup.audit",
 )
 
-# 16 total -- 5 read (T5 / #508) + 11 write (T6 / #509 + vm.power / #2301 +
-# vm.disk.grow / #2893 + vm.clone_from_template / #2894).
+# 18 total -- 5 read (T5 / #508) + 13 write (T6 / #509 + vm.power / #2301 +
+# vm.disk.grow / #2893 + vm.clone_from_template / #2894 + vim cluster/inventory
+# writes cluster.drs_rule.create + folder.create / #2895).
 _ALL_OP_IDS: tuple[str, ...] = _READ_OP_IDS + _WRITE_OP_IDS
 
 
@@ -126,6 +131,12 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     "vmware.composite.cluster.patch": (
         "meho_backplane.connectors.vmware_rest.composites._write.cluster_patch_composite"
     ),
+    "vmware.composite.cluster.drs_rule.create": (
+        "meho_backplane.connectors.vmware_rest.composites._write.cluster_drs_rule_create_composite"
+    ),
+    "vmware.composite.folder.create": (
+        "meho_backplane.connectors.vmware_rest.composites._write.folder_create_composite"
+    ),
 }
 
 
@@ -141,6 +152,8 @@ _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.host.evacuate": "host",
     "vmware.composite.host.detach_from_vds": "host",
     "vmware.composite.cluster.patch": "cluster",
+    "vmware.composite.cluster.drs_rule.create": "cluster",
+    "vmware.composite.folder.create": "vm",
 }
 
 
@@ -184,15 +197,15 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 10 write composites land alongside the 5 reads (15 total)
+# 13 write composites land alongside the 5 reads (18 total)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_inserts_eleven_write_rows(
+async def test_register_vmware_composite_operations_inserts_thirteen_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 11 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 13 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -209,11 +222,12 @@ async def test_register_vmware_composite_operations_inserts_eleven_write_rows(
 
 
 @pytest.mark.asyncio
-async def test_full_registration_produces_sixteen_composite_rows(
+async def test_full_registration_produces_eighteen_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """5 reads (#508) + 11 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
-    vm.clone_from_template #2894) = 16 rows."""
+    """5 reads (#508) + 13 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
+    vm.clone_from_template #2894 + cluster.drs_rule.create + folder.create #2895)
+    = 18 rows."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -227,7 +241,7 @@ async def test_full_registration_produces_sixteen_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 16
+    assert len(rows) == 18
 
 
 @pytest.mark.asyncio
@@ -253,7 +267,7 @@ async def test_every_write_composite_row_uses_dangerous_requires_approval(
             .scalars()
             .all()
         )
-    # Prove the query actually returned all 10 write rows before iterating —
+    # Prove the query actually returned all 13 write rows before iterating —
     # otherwise the loop is vacuous when the set is empty / partial.
     assert {row.op_id for row in rows} == set(_WRITE_OP_IDS)
     for row in rows:
@@ -483,17 +497,17 @@ async def test_write_composite_tags_include_composite_and_write(
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_is_idempotent_across_sixteen(
+async def test_register_vmware_composite_operations_is_idempotent_across_eighteen(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 16 rows total, embedding called 16x once."""
+    """Running the registrar twice -> 18 rows total, embedding called 18x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 16
+    assert first_count == 18
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 16.
+    # pipeline; the row count stays at 18.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -507,7 +521,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_sixteen
             .scalars()
             .all()
         )
-    assert len(rows) == 16
+    assert len(rows) == 18
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,11 +8,11 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 16 hand-authored composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 18 hand-authored composites
 that orchestrate cross-spec workflows: 5 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`) and 11 write composites (G3.1-T6 / `#509`, plus the
+in `#2258`) and 13 write composites (G3.1-T6 / `#509`, plus the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
 mutating VI-JSON `vm.disk.grow` / `#2893`, and the folder-template
 `vm.clone_from_template` / `#2894`). The
@@ -118,8 +118,8 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   the direct session under the same governance seam.
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 14
-  `_CompositeSpec` rows (5 read + 9 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 18
+  `_CompositeSpec` rows (5 read + 13 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -344,7 +344,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 15 composites (5 reads + 10 writes) land as `source_kind="composite"`
+The 18 composites (5 reads + 13 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -411,7 +411,7 @@ caller.
 
 ### L1/L2 dispatch — direct-session (two-world migration, Goal #2247)
 
-The 15 composites are hand-authored aggregators the connector ships as
+The 18 composites are hand-authored aggregators the connector ships as
 `source_kind='composite'` descriptors. Each composite's body issues its
 raw-REST sub-ops (`GET:/vcenter/datastore`,
 `POST:/vcenter/vm/{vm}/power?action=start`, etc.) **directly on the
@@ -463,6 +463,8 @@ enum) are:
 | `host.evacuate` | `evacuated`, `partial`, `aborted` |
 | `host.detach_from_vds` | `detached`, `incomplete` |
 | `cluster.patch` | `completed`, `stopped` |
+| `cluster.drs_rule.create` | `created`, `rule_exists`, `insufficient_vms`, `timeout` (idempotent on rule name — a duplicate `rule_exists` is refused before any write; `insufficient_vms` when fewer than two named VMs resolve to the cluster; `timeout` when the `ReconfigureComputeResource_Task` poll gives up) |
+| `folder.create` | `created`, `parent_not_found`, `ambiguous_parent` (synchronous `CreateFolder` — the resolution refusals are structured, not raw vim faults) |
 
 `vm.create` is the only composite that issues a compensating
 mutation (`DELETE:/vcenter/vm/{vm}`) on partial failure. The other
@@ -591,6 +593,50 @@ radius without leaking credential material. New vim sub-op paths
 declared in `_VIM_SUB_OPS_VM_CLONE_FROM_TEMPLATE` and reconciled against
 the pinned `vi-json.yaml`.
 
+### vim cluster / inventory writes (`cluster.drs_rule.create` + `folder.create`, #2895)
+
+Two more vim-only writes ride the #2893 substrate (Task E). Neither has a
+usable REST write path (`/vcenter/cluster` is list/get/evc-mode only, and
+the tag-based compute-policies surface is tag-scoped rather than an explicit
+VM list; `/vcenter/folder` is GET-only — both spec-verified against the
+pinned `vi-json.yaml`).
+
+**`cluster.drs_rule.create`** adds a DRS affinity / anti-affinity rule by
+*explicit VM list* through vim
+`ClusterComputeResource.ReconfigureComputeResource_Task`. Flow: resolve the
+rule's VM names to MoRefs **scoped to the cluster** (a *read*
+`GET:/vcenter/vm?filter.names&filter.clusters`, un-gated) — fewer than two
+resolve → `status='insufficient_vms'` before any write; read the cluster's
+existing rules (`configurationEx.rule` via `RetrievePropertiesEx`, un-gated)
+for the idempotence / name-collision check — a duplicate name →
+`status='rule_exists'`, a **structured status rather than a raw vim
+`DuplicateName` fault**; then issue a single-rule `ClusterConfigSpecEx`
+delta with `modify=true` — `rulesSpec=[{operation: "add", info:
+{_typeName: "ClusterA(nti)AffinityRuleSpec", name, enabled, vm:
+[MoRefs]}}]` — through `_write_vmomi_sub_op`, and poll the returned Task via
+`poll_vim_task`. The `_typeName` discriminator is required on the `spec`
+(the request type declares the base `ComputeResourceConfigSpec`) and on the
+`info` (the base `ClusterRuleInfo`); the `ClusterRuleSpec` array item and
+the VM MoRefs need none (declared type == runtime type), mirroring the
+disk-grow `VirtualDeviceConfigSpec` precedent. The park-time preview is the
+fan-out blast-radius pattern (like `vm.power.bulk`): `{cluster,
+cluster_name, rule_type, rule_name, enabled, resolved, total_resolved}`,
+`resolved` capped at 20.
+
+**`folder.create`** creates a VM folder under a named parent through vim
+`Folder.CreateFolder` — which is **synchronous**: it returns the new Folder
+`ManagedObjectReference` directly, **not** a `*_Task`, so (unlike
+disk-grow / drs_rule) the returned MoRef is unwrapped into the result and
+**never polled** (`poll_vim_task` is not called). Flow: resolve the parent
+folder *name* to a moid (`GET:/vcenter/folder?filter.names&filter.type=VIRTUAL_MACHINE`,
+un-gated; no match → `status='parent_not_found'`, >1 → `ambiguous_parent`,
+both before any write), then issue the single `CreateFolder` through
+`_write_vmomi_sub_op`. The preview is a param echo `{parent_folder,
+new_folder_name}` (no I/O — the params fully name the blast radius). Both
+mutating writes flow through the same `enforce_subop_policy` gate the REST
+and disk-grow writes do, so an agent principal without a grant is denied and
+a policy-parked write never reaches the wire.
+
 ### Read-composite best-effort enrichment (`datastore.usage`, #1908)
 
 Read composites distinguish **load-bearing** sub-ops from **optional
@@ -670,7 +716,7 @@ so existing string-matching consumers keep working.
 
 ### Park-time approval previews (#1608)
 
-All 9 write composites ship `requires_approval=True`, so a human/agent
+All 13 write composites ship `requires_approval=True`, so a human/agent
 dispatch parks as a durable `ApprovalRequest` row. Pre-#1608 that row's
 `proposed_effect` was the identifier-only default `{op_id, connector_id,
 target_id}` — and since the dispatch `params` are deliberately never
@@ -694,6 +740,8 @@ composite on the generic per-op hook (`register_preview_builder`,
 | `vm.snapshot.revert` | `{vm, snapshot_name}` echo | param echo, no I/O |
 | `vm.migrate` | `{vm, cluster, target_host, target_host_source}` | param echo, no I/O |
 | `vm.power` | `{vm, verb, power_kind}` echo (`power_kind` = `hard` vs Tools-soft `guest`) | param echo, no I/O |
+| `cluster.drs_rule.create` | `{cluster, cluster_name, rule_type, rule_name, enabled, resolved, total_resolved}` | live read (`GET:/vcenter/vm` + `GET:/vcenter/cluster/{cluster}`) |
+| `folder.create` | `{parent_folder, new_folder_name}` echo | param echo, no I/O |
 
 The live-read previews resolve the same entity set the approved
 dispatch would act on, through the **same shared helpers** the handlers
@@ -819,8 +867,10 @@ they never park.
   `host.vsan_health`, later re-shipped as typed ops in #2258); T6
   (#509) ships 8 write composites, #2301 adds a 9th (single-VM
   `vm.power`, incl. Tools soft shutdown), #2893 adds a 10th (the
-  mutating VI-JSON `vm.disk.grow`), and #2894 an 11th (the
-  folder-template `vm.clone_from_template`) — 16 composites today. The
+  mutating VI-JSON `vm.disk.grow`), #2894 an 11th (the folder-template
+  `vm.clone_from_template`), and #2895 a 12th + 13th (the vim cluster /
+  inventory writes `cluster.drs_rule.create` + `folder.create`) — 18
+  composites today. The
   "All hand-authored composites land as endpoint_descriptor rows with
   source_kind='composite'" Definition-of-done line in [#227](https://github.com/evoila/meho/issues/227)
   is fully ticked.


### PR DESCRIPTION
## Summary

- Task E of the vmware write-surface wave (#2890): adds the last two provisioning primitives the #2859 flow dropped to `govc` for — `vmware.composite.cluster.drs_rule.create` and `vmware.composite.folder.create`. Both are vim-only writes (no usable REST write path exists — spec-verified against the pinned `vi-json.yaml`) riding the #2893 substrate.
- `cluster.drs_rule.create` adds a DRS affinity / anti-affinity rule **by explicit VM list** via `ClusterComputeResource.ReconfigureComputeResource_Task` (a single-rule `ClusterConfigSpecEx.rulesSpec` delta, `modify=true`), polled to terminal via `poll_vim_task`. Rule name is the idempotence key → `status='rule_exists'` on a duplicate; `<2` resolved VMs → `status='insufficient_vms'` — both structured, before any write.
- `folder.create` creates a VM folder under a named parent via `Folder.CreateFolder` — **synchronous**: it returns the new folder MoRef directly (NOT a Task), so it is never polled (the key contrast with every other vim write).
- Both are `dangerous` + `requires_approval` `_CompositeSpec` rows whose mutating vmomi POST flows through the same `enforce_subop_policy` gate (`_write_vmomi_sub_op`) the REST + disk-grow writes use. Previews: capped VM fan-out (cluster + name + resolved set) for the rule op; parent + new-folder-name echo for the folder op.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (strict, `files=["src"]`) — clean on the changed modules (only pre-existing unrelated error remains: `net/icmp.py` `MSG_ERRQUEUE`, Linux-only symbol flagged on darwin)
- [x] `code-quality.py --diff` — exit 0
- [x] `pytest` full vmware_rest composite suite (8 lanes) — **168 passed**
- [x] respx-verified `ReconfigureComputeResource_Task` body: `modify: true`, exactly one `ClusterRuleSpec{operation: add}`, resolved VM MoRefs, `_typeName` discriminators on `spec`/`info`; polled to terminal state
- [x] `CreateFolder` handled synchronously (asserted single vmomi call, no `RetrievePropertiesEx` poll) and the new folder MoRef returned in the envelope
- [x] rule-name collision → `status='rule_exists'` (structured, not a raw vim fault)
- [x] park→approve→resume in `_write_e2e` with the #2681 op-identity envelope, for both ops; both previews covered (capped fan-out on the rule op)
- [x] VI-JSON sub-op paths asserted against the **pinned `vi-json.yaml`** (ran with the spec-shelf configured, not skipped)
- [x] register + write_register counts bumped 15 → 17 (12 write); cross-lanes (`test_typed_connectors_metadata`, `test_operations_composite_register`) green

## Out of scope

- Sibling Task D (#2894 `vm.clone_from_template`) rides the same #2893 seams — separate PR.
- Pre-existing docs nit (`connectors-vmware-rest.md` "The 7 read composites register no builder" — there are 5) left untouched; pre-existing `net/icmp.py` mypy error left untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2895
