### PR TITLE
feat(connectors): harbor project quota/usage reads + fix project.info overpromise (#2858)

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -337,7 +337,16 @@ _WRITE_OPS: Final[frozenset[str]] = frozenset(
 #: #2857): a non-mutating supply-chain read whose noun suffix (like
 #: ``.health`` / ``.versions``) would otherwise fall through to the
 #: full-detail ``other`` class rather than broadcast at the same ``read``
-#: sensitivity as its ``harbor.artifact.info`` sibling.
+#: sensitivity as its ``harbor.artifact.info`` sibling. ``.summary`` is the
+#: Harbor project storage-occupancy read (``harbor.project.summary`` — #2858):
+#: a non-mutating quota/usage read whose noun suffix (like ``.health`` /
+#: ``.versions``) would otherwise fall through to the full-detail
+#: ``other`` class rather than broadcast at the same ``read`` sensitivity
+#: as its ``harbor.project.info`` sibling. Adding it also reclassifies
+#: the ``vmware.composite.performance.summary`` metrics composite from
+#: ``other`` to ``read`` — the correct class for a non-mutating read;
+#: neither class is sensitive (:data:`~meho_backplane.broadcast.overrides._SENSITIVE_OP_CLASSES`),
+#: so the broadcast detail level is unchanged for it.
 _READ_SUFFIXES: Final[tuple[str, ...]] = (
     ".list",
     ".info",
@@ -348,6 +357,7 @@ _READ_SUFFIXES: Final[tuple[str, ...]] = (
     ".seal_status",
     ".versions",
     ".vulnerabilities",
+    ".summary",
 )
 
 #: Underscore-spelled mirrors of the dotted verb suffixes, applied only to
@@ -570,7 +580,7 @@ def classify_op(op_id: str) -> str:
        patch) keeps its ``credential_write`` class.
     7. ``read`` — non-mutating verb suffixes (``.list`` / ``.info`` /
        ``.get`` / ``.about`` / ``.ls`` / ``.health`` / ``.seal_status``
-       / ``.versions``). ``.read`` is deliberately **not** a read
+       / ``.versions`` / ``.summary``). ``.read`` is deliberately **not** a read
        suffix: it would over-match the ``credential_read``-allowlisted
        ``vault.kv.read`` (the allowlist wins, but the exclusion keeps
        the policy single-sourced) and would reclassify the auth-config

--- a/backend/src/meho_backplane/connectors/harbor/__init__.py
+++ b/backend/src/meho_backplane/connectors/harbor/__init__.py
@@ -7,9 +7,9 @@ Importing this package registers :class:`HarborConnector` against the
 v2 connector registry under
 ``(product="harbor", version="2.x", impl_id="harbor-rest")``, and
 queues the typed-op upserts (the 9-op read core, the two robot
-lifecycle writes, and the standalone artifact CVE-detail read) onto the
-lifespan-driven registrar list so ``endpoint_descriptor`` rows land
-before the first dispatch.
+lifecycle writes, the standalone artifact CVE-detail read, and the two
+wave-2 storage-quota reads) onto the lifespan-driven registrar list so
+``endpoint_descriptor`` rows land before the first dispatch.
 
 Registration is split between two phases (mirroring the Vault precedent
 in :mod:`meho_backplane.connectors.vault`):
@@ -23,10 +23,14 @@ in :mod:`meho_backplane.connectors.vault`):
   :func:`~meho_backplane.connectors.harbor.typed_ops.register_harbor_typed_operations`
   (the audited read core),
   :func:`~meho_backplane.connectors.harbor.ops.register_harbor_robot_operations`
-  (the robot create/delete writes), and
+  (the robot create/delete writes),
   :func:`~meho_backplane.connectors.harbor.ops.register_harbor_artifact_operations`
   (the standalone ``harbor.artifact.vulnerabilities`` CVE-detail read,
-  #2857), upserting the ``endpoint_descriptor`` rows for each.
+  #2857), and
+  :func:`~meho_backplane.connectors.harbor.ops.register_harbor_project_quota_operations`
+  (the wave-2 storage-quota reads ``harbor.project.summary`` /
+  ``harbor.quota.list``, #2858), upserting the ``endpoint_descriptor``
+  rows for each.
 
 Both surfaces are **typed** (``source_kind="typed"``): they dispatch on
 a fresh boot with zero catalog ingest. The read core was converted from
@@ -49,6 +53,7 @@ from typing import Final
 from meho_backplane.connectors.harbor.connector import HarborConnector
 from meho_backplane.connectors.harbor.ops import (
     register_harbor_artifact_operations,
+    register_harbor_project_quota_operations,
     register_harbor_robot_operations,
 )
 from meho_backplane.connectors.harbor.session import (
@@ -112,6 +117,13 @@ register_typed_op_registrar(register_harbor_robot_operations)
 # scan_overview is reachable independent of the read-core ingest state.
 register_typed_op_registrar(register_harbor_artifact_operations)
 
+# Queue the wave-2 standalone storage-quota reads (harbor.project.summary,
+# harbor.quota.list, #2858). Typed reads that dispatch with zero catalog
+# ingest — the same shape as the robot ops above — so per-project and
+# fleet-wide storage-quota occupancy is reachable independent of the
+# deferred read-core ingest state.
+register_typed_op_registrar(register_harbor_project_quota_operations)
+
 __all__ = [
     "HARBOR_CONNECTOR_ID",
     "HARBOR_IMPL_ID",
@@ -126,6 +138,7 @@ __all__ = [
     "SessionCredentials",
     "load_credentials_from_vault",
     "register_harbor_artifact_operations",
+    "register_harbor_project_quota_operations",
     "register_harbor_robot_operations",
     "register_harbor_typed_operations",
 ]

--- a/backend/src/meho_backplane/connectors/harbor/connector.py
+++ b/backend/src/meho_backplane/connectors/harbor/connector.py
@@ -2,15 +2,16 @@
 # Copyright (c) 2026 evoila Group
 #
 # code-quality-allow: file-size — the connector hosts fingerprint / probe /
-# auth, the two robot write handlers, the nine typed-read shims (#2856), and
-# the artifact_vulnerabilities CVE read (#2857). The read *bodies* already
-# live in ``typed_reads`` (this file keeps only the thin shims); every op
-# handler must be a method on the connector class because the dispatcher
-# binds the resolved handler to the per-process connector instance at
-# dispatch time (``_maybe_bind_method``), so the handler bodies that remain
-# here cannot move off this file without losing that binding. Matches the
-# NSX/SDDC on-connector shim placement and the other >600-line connectors in
-# this package.
+# auth, the two robot write handlers, the nine typed-read shims (#2856), the
+# artifact_vulnerabilities CVE read (#2857), and the project.summary /
+# quota.list storage-quota reads (#2858). The nine core read *bodies* live in
+# ``typed_reads`` (this file keeps only their thin shims); the standalone
+# reads keep full bodies here. Every op handler must be a method on the
+# connector class because the dispatcher binds the resolved handler to the
+# per-process connector instance at dispatch time (``_maybe_bind_method``), so
+# the handler bodies that remain here cannot move off this file without losing
+# that binding. Matches the NSX/SDDC on-connector shim placement and the other
+# >600-line connectors in this package.
 
 """HarborConnector — hand-rolled HttpConnector subclass for Harbor 2.x.
 
@@ -767,6 +768,169 @@ class HarborConnector(HttpConnector):
             "scanner": report.get("scanner"),
             "generated_at": report.get("generated_at"),
             "vulnerabilities": vulnerabilities,
+        }
+
+    async def project_summary(
+        self,
+        operator: Operator,
+        target: HarborTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Read one project's storage-quota occupancy via Harbor 2.x.
+
+        Op-id: ``harbor.project.summary`` (#2858). Classified ``read``
+        (:func:`~meho_backplane.broadcast.events.classify_op`; ``.summary``
+        is a ``_READ_SUFFIXES`` entry), ``safety_level=safe``, no approval —
+        the per-project capacity pre-flight / denied-push diagnostic read.
+
+        ``GET /api/v2.0/projects/{project_name_or_id}/summary`` with the
+        ``X-Is-Resource-Name: true`` header so Harbor always resolves the
+        path segment as a project *name* (its default treats a
+        numeric-looking segment as an id). This is the storage-quota detail
+        ``harbor.project.info`` does NOT carry — the vendor ``Project``
+        object has no ``quota`` field; ``quota.hard`` / ``quota.used`` live
+        only on the summary endpoint.
+
+        The native ``ProjectSummary`` is projected to the fields the
+        operator question needs: ``repo_count``, the native ``quota`` object
+        (``{hard, used}``, each a ``ResourceList`` map keyed by resource
+        name — ``storage`` is bytes, hard ``-1`` = unlimited), and the
+        per-role ``member_counts``. The ``registry`` field (present only for
+        proxy-cache projects) is dropped.
+
+        Uses :meth:`_request_json` (not :meth:`_get_json`) because the read
+        needs the per-call ``X-Is-Resource-Name`` header, which
+        ``_get_json`` does not forward; GET stays idempotent so the tenacity
+        retry still applies. The dispatched ``operator`` threads to the
+        operator-context Vault credential read the same way the robot ops do.
+
+        Parameters
+        ----------
+        operator
+            Request-scoped operator; its validated JWT authenticates the
+            per-target Vault credential read.
+        target
+            Resolved Harbor target.
+        params
+            Schema-validated: ``project_name`` (str).
+
+        Returns
+        -------
+        dict[str, Any]
+            ``{repo_count, quota: {hard, used}, member_counts: {...}}`` —
+            ``quota.hard.storage`` / ``quota.used.storage`` are bytes.
+
+        Raises
+        ------
+        httpx.HTTPStatusError
+            On any 4xx/5xx from Harbor (e.g. 404 for an unknown project).
+            The dispatcher wraps it as a ``connector_error`` OperationResult.
+        """
+        project = quote(str(params["project_name"]), safe="")
+        path = f"/api/v2.0/projects/{project}/summary"
+        payload = await self._request_json(
+            target,
+            "GET",
+            path,
+            operator=operator,
+            extra_headers={"X-Is-Resource-Name": "true"},
+        )
+        quota = payload.get("quota") or {}
+        return {
+            "repo_count": payload.get("repo_count"),
+            "quota": {
+                "hard": quota.get("hard") or {},
+                "used": quota.get("used") or {},
+            },
+            "member_counts": {
+                "project_admin": payload.get("project_admin_count"),
+                "maintainer": payload.get("maintainer_count"),
+                "developer": payload.get("developer_count"),
+                "guest": payload.get("guest_count"),
+                "limited_guest": payload.get("limited_guest_count"),
+            },
+        }
+
+    async def quota_list(
+        self,
+        operator: Operator,
+        target: HarborTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """List project storage quotas fleet-wide via Harbor 2.x.
+
+        Op-id: ``harbor.quota.list`` (#2858). Classified ``read`` (``.list``
+        suffix), ``safety_level=safe``, no approval — the fleet-wide "which
+        projects are near their storage quota" read that saves the operator
+        an N-way per-project ``harbor.project.summary`` fan-out.
+
+        ``GET /api/v2.0/quotas?reference=project&sort=<sort>``. The
+        ``reference=project`` filter is fixed: project quotas are the only
+        quota reference type in the stable Harbor 2.x line. The default
+        ``sort=-used.storage`` returns the highest-usage projects first, so
+        the head of the list answers the capacity question directly.
+        ``page`` / ``page_size`` page a large fleet.
+
+        Each native ``Quota`` is projected to ``{id, ref, hard, used}``:
+        ``ref`` is the project reference object (``{id, name, owner_name}`` —
+        which project this quota belongs to) and ``hard`` / ``used`` are
+        ``ResourceList`` maps (``storage`` in bytes, hard ``-1`` = unlimited).
+        The projected rows are returned under a single ``quotas`` key — the
+        one set-shaped field — so the dispatcher's JSONFlux reducer
+        materialises them into a result handle once the fleet crosses the
+        ~50-row / 4 KB threshold (CLAUDE.md postulate 6); a "projects over N
+        bytes used" filter is a ``result_query`` away.
+
+        Uses :meth:`_get_json` (idempotent GET with query params; no per-call
+        header needed). The dispatched ``operator`` threads to the
+        operator-context Vault credential read the same way the robot ops do.
+
+        Parameters
+        ----------
+        operator
+            Request-scoped operator; its validated JWT authenticates the
+            per-target Vault credential read.
+        target
+            Resolved Harbor target.
+        params
+            Schema-validated: ``sort`` (str, default ``-used.storage``),
+            ``page`` (int ≥ 1, default 1), ``page_size`` (int, default 50).
+
+        Returns
+        -------
+        dict[str, Any]
+            ``{"quotas": [{id, ref, hard, used}, ...]}`` ordered per ``sort``;
+            ``quotas`` is ``[]`` when no project quotas exist and is
+            JSONFlux-reduced to a result handle by the dispatcher for large
+            fleets.
+
+        Raises
+        ------
+        httpx.HTTPStatusError
+            On any 4xx/5xx from Harbor. The dispatcher wraps it as a
+            ``connector_error`` OperationResult.
+        """
+        query: dict[str, Any] = {
+            "reference": "project",
+            "sort": str(params.get("sort") or "-used.storage"),
+            "page": int(params.get("page") or 1),
+            "page_size": int(params.get("page_size") or 50),
+        }
+        payload: Any = await self._get_json(
+            target, "/api/v2.0/quotas", operator=operator, params=query
+        )
+        quotas = payload if isinstance(payload, list) else []
+        return {
+            "quotas": [
+                {
+                    "id": quota.get("id"),
+                    "ref": quota.get("ref"),
+                    "hard": quota.get("hard") or {},
+                    "used": quota.get("used") or {},
+                }
+                for quota in quotas
+                if isinstance(quota, dict)
+            ]
         }
 
     async def invalidate_credentials(self, target: HarborTargetLike) -> None:

--- a/backend/src/meho_backplane/connectors/harbor/ops.py
+++ b/backend/src/meho_backplane/connectors/harbor/ops.py
@@ -1,9 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Harbor robot lifecycle typed ops (G3.5-T9 #621).
+"""Harbor typed ops — robot lifecycle writes + standalone typed reads.
 
-Registers two scoped-write ops against ``connector_id="harbor-rest-2.x"``:
+G3.5-T9 (#621) registered the two scoped-write robot-lifecycle ops.
+#2857 added the standalone artifact CVE-detail read
+``harbor.artifact.vulnerabilities`` via
+:func:`register_harbor_artifact_operations`.
+Wave-2 (#2858) adds two more standalone typed **reads** —
+``harbor.project.summary`` (per-project storage-quota occupancy) and
+``harbor.quota.list`` (fleet-wide project quotas) — via
+:func:`register_harbor_project_quota_operations`. They register the same
+way the robot ops do (independent of the deferred read-core ingest
+state), landing in the ``harbor-projects`` operation group; their handlers
+live on :class:`~meho_backplane.connectors.harbor.connector.HarborConnector`
+(``project_summary`` / ``quota_list``).
+
+Robot ops — registers two scoped-write ops against ``connector_id="harbor-rest-2.x"``:
 
 * ``harbor.robot.create`` — create a project-scoped robot account.
   Returns the minted secret in its response payload; classified
@@ -44,7 +57,11 @@ from typing import Any
 
 from meho_backplane.retrieval.embedding import EmbeddingService
 
-__all__ = ["register_harbor_artifact_operations", "register_harbor_robot_operations"]
+__all__ = [
+    "register_harbor_artifact_operations",
+    "register_harbor_project_quota_operations",
+    "register_harbor_robot_operations",
+]
 
 
 #: Curated ``when_to_use`` blurb for the Harbor ``robot`` group --
@@ -531,5 +548,294 @@ async def register_harbor_artifact_operations(
         safety_level="safe",
         requires_approval=False,
         llm_instructions=_HARBOR_ARTIFACT_VULN_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# harbor.project.summary + harbor.quota.list (#2858)
+# ---------------------------------------------------------------------------
+
+#: Curated ``when_to_use`` for the ``harbor-projects`` group. Both wave-2
+#: read ops register into the same group the typed project list/info
+#: reads live under (the typed read core, #2856). Typed-register group
+#: creation is first-write-wins, so ``register_harbor_typed_operations``
+#: (queued first) sets the canonical blurb from
+#: :data:`~meho_backplane.connectors.harbor.typed_ops.HARBOR_TYPED_WHEN_TO_USE_BY_GROUP`;
+#: ``register_typed_operation`` still requires a non-empty string whenever
+#: ``group_key`` is set, so this mirror is passed here and covers the
+#: storage-quota reads.
+_HARBOR_PROJECTS_WHEN_TO_USE: str = (
+    "Use this group to list or inspect Harbor projects (namespaces) and to "
+    "read their storage-quota occupancy. A project holds repositories which "
+    "hold artifacts, and each project has a storage quota. Use to answer "
+    "'what projects exist on this registry', 'is project X public or "
+    "private', 'how many repositories does project Y contain', 'how much "
+    "storage is project Z using vs. its hard limit' "
+    "(harbor.project.summary), or 'which projects are near their storage "
+    "quota' fleet-wide (harbor.quota.list)."
+)
+
+
+_HARBOR_PROJECT_SUMMARY_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "project_name": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "description": (
+                "Harbor project name (from harbor.project.list). Queried by "
+                "name; a numeric-looking name is still resolved as a name via "
+                "the X-Is-Resource-Name header, never as a project id."
+            ),
+        },
+    },
+    "required": ["project_name"],
+    "additionalProperties": False,
+}
+
+_HARBOR_PROJECT_SUMMARY_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "repo_count": {
+            "type": ["integer", "null"],
+            "description": "Number of repositories under the project.",
+        },
+        "quota": {
+            "type": "object",
+            "description": "Storage quota. hard/used are resource maps keyed by resource name.",
+            "properties": {
+                "hard": {
+                    "type": "object",
+                    "additionalProperties": {"type": "integer"},
+                    "description": "Hard limits, e.g. {storage: <bytes>}; storage -1 = unlimited.",
+                },
+                "used": {
+                    "type": "object",
+                    "additionalProperties": {"type": "integer"},
+                    "description": "Used amounts, e.g. {storage: <bytes>}.",
+                },
+            },
+        },
+        "member_counts": {
+            "type": "object",
+            "description": "Per-role member counts for the project.",
+            "properties": {
+                "project_admin": {"type": ["integer", "null"]},
+                "maintainer": {"type": ["integer", "null"]},
+                "developer": {"type": ["integer", "null"]},
+                "guest": {"type": ["integer", "null"]},
+                "limited_guest": {"type": ["integer", "null"]},
+            },
+        },
+    },
+    "additionalProperties": False,
+}
+
+_HARBOR_PROJECT_SUMMARY_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Read one Harbor project's storage-quota occupancy and membership "
+        "summary. Use for a capacity pre-flight before onboarding a new push "
+        "pipeline, or to diagnose a denied (quota-exceeded) push. This is "
+        "where storage quota lives -- harbor.project.info's Project object "
+        "does NOT carry a quota field. Requires project_name (from "
+        "harbor.project.list)."
+    ),
+    "parameter_hints": {
+        "project_name": "Harbor project name (from harbor.project.list).",
+    },
+    "output_shape": (
+        "{repo_count, quota: {hard: {storage: <bytes>, ...}, used: {storage: "
+        "<bytes>, ...}}, member_counts: {project_admin, maintainer, developer, "
+        "guest, limited_guest}}. Storage is bytes; a hard storage of -1 means "
+        "unlimited. Compare used.storage against hard.storage for pressure."
+    ),
+    "next_step": (
+        "If used.storage is close to hard.storage (and hard is not -1), surface "
+        "the storage pressure to the operator. For a fleet-wide 'which projects "
+        "are near quota' view, call harbor.quota.list instead of looping this "
+        "op per project."
+    ),
+}
+
+
+_HARBOR_QUOTA_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "sort": {
+            "type": "string",
+            "default": "-used.storage",
+            "description": (
+                "Sort key. '-used.storage' (default) lists the highest storage "
+                "consumers first -- the 'near quota' answer. Use 'used.storage' "
+                "for ascending, or 'hard.storage' / '-hard.storage' by limit."
+            ),
+        },
+        "page": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 1,
+            "description": "1-based page number for a large fleet.",
+        },
+        "page_size": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 50,
+            "description": "Quotas per page (max 100). Default 50.",
+        },
+    },
+    "additionalProperties": False,
+}
+
+_HARBOR_QUOTA_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "quotas": {
+            "type": "array",
+            "description": (
+                "Project quotas ordered per sort. The single set-shaped field: a "
+                "large fleet is reduced to a JSONFlux result handle with a "
+                "bounded inline sample."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": ["integer", "null"], "description": "Quota id."},
+                    "ref": {
+                        "type": ["object", "null"],
+                        "description": (
+                            "Project reference this quota belongs to ({id, name, owner_name})."
+                        ),
+                    },
+                    "hard": {
+                        "type": "object",
+                        "additionalProperties": {"type": "integer"},
+                        "description": "Hard limits, e.g. {storage: <bytes>}; -1 = unlimited.",
+                    },
+                    "used": {
+                        "type": "object",
+                        "additionalProperties": {"type": "integer"},
+                        "description": "Used amounts, e.g. {storage: <bytes>}.",
+                    },
+                },
+            },
+        },
+    },
+    "additionalProperties": False,
+}
+
+_HARBOR_QUOTA_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "List project storage quotas across the whole registry, sorted by "
+        "usage. Use to answer 'which projects are near their storage quota' in "
+        "one call instead of looping harbor.project.summary per project -- the "
+        "capacity-planning and quota-audit entry point. Default sort "
+        "'-used.storage' puts the fullest projects first."
+    ),
+    "parameter_hints": {
+        "sort": (
+            "Default '-used.storage' (fullest first). Other keys: 'used.storage', "
+            "'hard.storage', '-hard.storage'."
+        ),
+        "page": "1-based page number for a large fleet.",
+        "page_size": "Quotas per page (max 100, default 50).",
+    },
+    "output_shape": (
+        "{quotas: [{id, ref: {id, name, owner_name}, hard: {storage: <bytes>}, "
+        "used: {storage: <bytes>}}, ...]} ordered per sort. Storage is bytes; a "
+        "hard storage of -1 means unlimited; ref.name is the project. The "
+        "quotas list is reduced to a JSONFlux handle with a bounded inline "
+        "sample plus a fetch_more envelope for a large fleet."
+    ),
+    "next_step": (
+        "The head rows (default sort) are the projects nearest their quota -- "
+        "surface those with used vs. hard storage. Against a reduced handle, "
+        "drill in with result_query (e.g. filter on used.storage). For one "
+        "project's detail, call harbor.project.summary."
+    ),
+}
+
+
+async def register_harbor_project_quota_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert harbor.project.summary and harbor.quota.list into ``endpoint_descriptor``.
+
+    Standalone typed reads (source_kind="typed") so they dispatch on a fresh
+    boot with zero catalog ingest -- the same shape as ``harbor.robot.create``
+    / ``.delete`` above and ``harbor.artifact.vulnerabilities`` (#2857). Called
+    once per process from the FastAPI lifespan via
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`;
+    idempotent (the body-hash skip path in
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`).
+
+    Both ops register into the ``harbor-projects`` group (project-level
+    reads); ``harbor.quota.list`` is a fleet-wide project-quota read, so it is
+    discoverable next to the per-project ``harbor.project.summary`` there.
+
+    Test seam: ``embedding_service`` lets fixtures inject a stub so chassis
+    tests don't load the ONNX model.
+    """
+    from meho_backplane.connectors.harbor.connector import HarborConnector
+    from meho_backplane.operations.typed_register import register_typed_operation
+
+    await register_typed_operation(
+        product="harbor",
+        version="2.x",
+        impl_id="harbor-rest",
+        op_id="harbor.project.summary",
+        handler=HarborConnector.project_summary,
+        summary="Read a Harbor project's storage-quota occupancy and member counts.",
+        description=(
+            "Reads one project's storage-quota usage via "
+            "GET /api/v2.0/projects/{project_name_or_id}/summary (Harbor v2 "
+            "project API, operationId getProjectSummary) with the "
+            "X-Is-Resource-Name header set so the path segment resolves as a "
+            "project name. This is the storage quota that harbor.project.info "
+            "does NOT carry -- the vendor Project object has no quota field. "
+            "Projected to {repo_count, quota: {hard, used}, member_counts}; "
+            "quota.hard.storage / quota.used.storage are bytes. "
+            "safety_level=safe, read-only, no approval."
+        ),
+        parameter_schema=_HARBOR_PROJECT_SUMMARY_PARAMETER_SCHEMA,
+        response_schema=_HARBOR_PROJECT_SUMMARY_RESPONSE_SCHEMA,
+        group_key="harbor-projects",
+        when_to_use=_HARBOR_PROJECTS_WHEN_TO_USE,
+        tags=["read-only", "harbor", "project", "quota", "storage"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_HARBOR_PROJECT_SUMMARY_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )
+
+    await register_typed_operation(
+        product="harbor",
+        version="2.x",
+        impl_id="harbor-rest",
+        op_id="harbor.quota.list",
+        handler=HarborConnector.quota_list,
+        summary="List Harbor project storage quotas fleet-wide, sorted by usage.",
+        description=(
+            "Lists project storage quotas across the registry via "
+            "GET /api/v2.0/quotas?reference=project&sort=<sort> (Harbor v2 quota "
+            "API, operationId listQuotas). Default sort '-used.storage' returns "
+            "the highest-usage projects first, answering 'which projects are "
+            "near their storage quota' in one call instead of an N-way "
+            "harbor.project.summary fan-out. Each Quota is projected to "
+            "{id, ref, hard, used} under a 'quotas' key; storage is bytes. The "
+            "quotas list is JSONFlux-reduced to a result handle for large fleets "
+            "(CLAUDE.md postulate 6). safety_level=safe, read-only, no approval."
+        ),
+        parameter_schema=_HARBOR_QUOTA_LIST_PARAMETER_SCHEMA,
+        response_schema=_HARBOR_QUOTA_LIST_RESPONSE_SCHEMA,
+        group_key="harbor-projects",
+        when_to_use=_HARBOR_PROJECTS_WHEN_TO_USE,
+        tags=["read-only", "harbor", "quota", "storage", "capacity"],
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions=_HARBOR_QUOTA_LIST_LLM_INSTRUCTIONS,
         embedding_service=embedding_service,
     )

--- a/backend/src/meho_backplane/connectors/harbor/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/harbor/typed_reads.py
@@ -183,9 +183,11 @@ async def harbor_project_info_impl(
 ) -> dict[str, Any]:
     """``harbor.project.info`` -- ``GET /api/v2.0/projects/{project_name}``.
 
-    Reads the full detail of one Harbor project by name: quota usage, repo
-    count, and the metadata dict (public flag, content trust, auto-scan).
-    Requires ``project_name`` from ``harbor.project.list``.
+    Reads the full detail of one Harbor project by name: repo count and the
+    metadata dict (public flag, content trust, auto-scan). The vendor
+    ``Project`` object carries no quota field -- storage-quota usage lives on
+    the summary endpoint (``harbor.project.summary``, #2858). Requires
+    ``project_name`` from ``harbor.project.list``.
     """
     path = f"{_PROJECTS_PATH}/{_seg(params['project_name'])}"
     return await connector._get_json(target, path, operator=operator)
@@ -383,8 +385,9 @@ _PROJECT_LIST_INSTRUCTIONS: dict[str, object] = {
         "the 'public' flag as a string 'true'/'false')."
     ),
     "next_step": (
-        "Pick a project name for harbor.project.info to get quota and "
-        "full metadata, or pass it as project_name to "
+        "Pick a project name for harbor.project.info to get its full "
+        "metadata, or harbor.project.summary for storage quota usage "
+        "and member counts; or pass it as project_name to "
         "harbor.repository.list to enumerate its images."
     ),
 }
@@ -392,20 +395,23 @@ _PROJECT_LIST_INSTRUCTIONS: dict[str, object] = {
 _PROJECT_INFO_INSTRUCTIONS: dict[str, object] = {
     "when_to_call": (
         "Call to read the full detail of one Harbor project by name. "
-        "Returns quota usage, repository count, chart count, and the "
-        "full metadata dict including public flag and content trust, "
-        "vulnerability scanning, and auto-scan settings. Requires "
-        "a project_name path parameter obtained from harbor.project.list."
+        "Returns the repository count and the full metadata dict "
+        "including public flag and content trust, vulnerability "
+        "scanning, and auto-scan settings. For storage quota usage "
+        "(used vs. hard limit) and per-role member counts, call "
+        "harbor.project.summary instead. Requires a project_name path "
+        "parameter obtained from harbor.project.list."
     ),
     "output_shape": (
         "Project object with id, name, owner_name, repo_count, "
-        "chart_count, metadata (public, enable_content_trust, "
-        "auto_scan, severity), quota (used/hard storage in bytes), "
-        "creation_time, and update_time."
+        "metadata (public, enable_content_trust, auto_scan, severity), "
+        "creation_time, and update_time. The Project object carries no "
+        "quota field — call harbor.project.summary for storage quota "
+        "usage in bytes."
     ),
     "next_step": (
-        "If quota.used is close to quota.hard, surface the storage "
-        "pressure to the operator. Proceed to harbor.repository.list "
+        "For storage quota usage against the hard limit, call "
+        "harbor.project.summary. Proceed to harbor.repository.list "
         "to enumerate the project's images."
     ),
 }

--- a/backend/tests/acceptance/_harbor_canary_fixtures.py
+++ b/backend/tests/acceptance/_harbor_canary_fixtures.py
@@ -156,6 +156,12 @@ HARBOR_CANARY_HEALTH: dict[str, object] = {
 }
 
 #: Synthetic project list — one public project ("library").
+#:
+#: No ``quota`` key: the vendor ``Project`` schema (what ``GET /projects``
+#: and ``GET /projects/{name}`` return) carries no quota field. Storage
+#: quota lives only on the summary endpoint — ``harbor.project.summary``
+#: (#2858). Keeping the fixture quota-less stops the suite from masking the
+#: real (quota-less) shape.
 HARBOR_CANARY_PROJECTS: list[dict[str, object]] = [
     {
         "id": 1,
@@ -166,14 +172,15 @@ HARBOR_CANARY_PROJECTS: list[dict[str, object]] = [
         "repo_count": 3,
         "registry_id": None,
         "metadata": {"public": "true", "auto_scan": "true"},
-        "quota": {
-            "used": {"storage": 1073741824},
-            "hard": {"storage": -1},
-        },
     }
 ]
 
 #: Synthetic project detail for "library".
+#:
+#: No ``quota`` and no ``chart_count`` keys — neither is a field on the
+#: Harbor 2.11 ``Project`` schema (#2858). Storage quota is read via
+#: ``harbor.project.summary``; Harbor 2.x has no standalone chart count
+#: (Helm charts fold into the OCI artifact model).
 HARBOR_CANARY_PROJECT_DETAIL: dict[str, object] = {
     "id": 1,
     "name": "library",
@@ -181,7 +188,6 @@ HARBOR_CANARY_PROJECT_DETAIL: dict[str, object] = {
     "creation_time": "2026-01-01T00:00:00.000Z",
     "update_time": "2026-01-01T00:00:00.000Z",
     "repo_count": 3,
-    "chart_count": 0,
     "metadata": {
         "public": "true",
         "enable_content_trust": "false",
@@ -190,10 +196,6 @@ HARBOR_CANARY_PROJECT_DETAIL: dict[str, object] = {
         "reuse_sys_cve_allowlist": "true",
         "prevent_vul": "false",
         "retention_id": None,
-    },
-    "quota": {
-        "used": {"storage": 1073741824},
-        "hard": {"storage": -1},
     },
 }
 

--- a/backend/tests/test_connectors_harbor_quota.py
+++ b/backend/tests/test_connectors_harbor_quota.py
@@ -1,0 +1,512 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the Harbor storage-quota read typed ops (#2858).
+
+Covers the two standalone typed reads plus the ``harbor.project.info``
+overpromise fix:
+
+* ``harbor.project.summary`` — per-project storage-quota occupancy. The
+  handler projects Harbor's native ``ProjectSummary`` to
+  ``{repo_count, quota: {hard, used}, member_counts}`` (``quota.hard.storage``
+  / ``quota.used.storage`` in bytes) and sends the ``X-Is-Resource-Name``
+  header so a project *name* is never misread as an id.
+* ``harbor.quota.list`` — fleet-wide project quotas. The handler sends
+  ``reference=project`` + a ``-used.storage`` default sort and projects each
+  ``Quota`` to ``{id, ref, hard, used}`` as a bare list (JSONFlux-reducible).
+* Both op-ids classify as ``read`` (broadcast sensitivity), matching the
+  ``harbor.project.info`` sibling.
+* The overpromise fix: ``harbor.project.info``'s ``llm_instructions`` no
+  longer claim ``quota`` / ``chart_count``, and the acceptance ``Project``
+  fixtures carry neither field.
+
+Auth follows the robot-op suite: HTTP Basic (shared service account), the
+dispatched :class:`Operator` forwarded through
+:meth:`HarborConnector.auth_headers` to the operator-context Vault read
+against the in-process Vault fake (``install_fake_client``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.broadcast.events import classify_op
+from meho_backplane.connectors.harbor import HarborConnector
+from meho_backplane.connectors.harbor.typed_reads import HARBOR_READ_LLM_INSTRUCTIONS
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.operations._branches import dispatch_typed
+from meho_backplane.settings import get_settings
+from tests.acceptance._harbor_canary_fixtures import (
+    HARBOR_CANARY_PROJECT_DETAIL,
+    HARBOR_CANARY_PROJECTS,
+)
+
+from ._vault_fakes import install_fake_client
+
+_CANARY_USERNAME = "svc-harbor-quota-canary"
+_CANARY_PASSWORD = "p4ss-canary-must-not-leak-quota-harbor"
+
+_RESOURCE_NAME_HEADER = "x-is-resource-name"
+
+
+# ---------------------------------------------------------------------------
+# Isolation fixtures (mirror test_connectors_harbor_robot.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_harbor_registry() -> None:
+    """Re-register HarborConnector before each test, clear after."""
+    clear_registry()
+    register_connector_v2(
+        product=HarborConnector.product,
+        version=HarborConnector.version,
+        impl_id=HarborConnector.impl_id,
+        cls=HarborConnector,
+    )
+    yield
+    clear_registry()
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the chassis env vars Settings reads (Vault client construction)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET = _StubTarget(
+    name="harbor-test",
+    host="harbor.test.invalid",
+    port=443,
+    secret_ref="targets/harbor/harbor-test",
+)
+
+
+def _make_operator(raw_jwt: str = "op.quota.harbor.jwt") -> Any:
+    from meho_backplane.auth.operator import Operator, TenantRole
+
+    return Operator(
+        sub="op-quota-harbor",
+        name="Harbor Quota Operator",
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID("00000000-0000-0000-0000-0000000000d5"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _make_connector() -> HarborConnector:
+    """Connector with the DEFAULT (live) loader — no injected stub."""
+    return HarborConnector()
+
+
+def _summary_url(project: str) -> str:
+    return f"https://harbor.test.invalid/api/v2.0/projects/{project}/summary"
+
+
+_QUOTAS_URL = "https://harbor.test.invalid/api/v2.0/quotas"
+
+
+def _project_summary(*, used: int, hard: int, repo_count: int = 3) -> dict[str, Any]:
+    """A native Harbor ProjectSummary keyed as the vendor returns it."""
+    return {
+        "repo_count": repo_count,
+        "project_admin_count": 1,
+        "maintainer_count": 2,
+        "developer_count": 3,
+        "guest_count": 4,
+        "limited_guest_count": 0,
+        "quota": {"hard": {"storage": hard}, "used": {"storage": used}},
+        "registry": None,
+    }
+
+
+def _quota_row(quota_id: int, name: str, *, used: int, hard: int) -> dict[str, Any]:
+    """A native Harbor Quota object (reference=project)."""
+    return {
+        "id": quota_id,
+        "ref": {"id": quota_id, "name": name, "owner_name": "admin"},
+        "hard": {"storage": hard},
+        "used": {"storage": used},
+        "creation_time": "2026-01-01T00:00:00.000Z",
+        "update_time": "2026-08-01T00:00:00.000Z",
+    }
+
+
+# ---------------------------------------------------------------------------
+# harbor.project.summary — projection + quota bytes (AC2 / AC5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_project_summary_projects_quota_and_member_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The handler surfaces repo_count, quota.hard/used storage bytes, and
+    the per-role member counts, dropping the proxy-only registry field."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    with respx.mock(assert_all_called=True) as mock:
+        mock.get(_summary_url("library")).mock(
+            return_value=respx.MockResponse(
+                200, json=_project_summary(used=1073741824, hard=5368709120)
+            )
+        )
+        result = await connector.project_summary(
+            _make_operator(), _TARGET, {"project_name": "library"}
+        )
+
+    assert result["repo_count"] == 3
+    assert result["quota"]["used"]["storage"] == 1073741824
+    assert result["quota"]["hard"]["storage"] == 5368709120
+    assert result["member_counts"] == {
+        "project_admin": 1,
+        "maintainer": 2,
+        "developer": 3,
+        "guest": 4,
+        "limited_guest": 0,
+    }
+    # The projection is exactly the three curated keys — no registry leak.
+    assert set(result) == {"repo_count", "quota", "member_counts"}
+    assert "registry" not in result
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_project_summary_sends_resource_name_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The read pins X-Is-Resource-Name so a name is never misread as an id."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    captured: dict[str, str] = {}
+
+    def _capture(request: httpx.Request) -> respx.MockResponse:
+        captured.update(dict(request.headers))
+        return respx.MockResponse(200, json=_project_summary(used=0, hard=-1))
+
+    with respx.mock() as mock:
+        mock.get(_summary_url("library")).mock(side_effect=_capture)
+        await connector.project_summary(_make_operator(), _TARGET, {"project_name": "library"})
+
+    assert captured[_RESOURCE_NAME_HEADER] == "true"
+    assert captured["authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_project_summary_encodes_numeric_looking_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A numeric-looking project name is sent as a path segment (+ the header),
+    so Harbor resolves it as a name, not a project id."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    captured_url: dict[str, str] = {}
+
+    def _capture(request: httpx.Request) -> respx.MockResponse:
+        captured_url["path"] = request.url.raw_path.decode()
+        return respx.MockResponse(200, json=_project_summary(used=1, hard=2))
+
+    with respx.mock() as mock:
+        mock.get(url__regex=r".*/summary$").mock(side_effect=_capture)
+        await connector.project_summary(_make_operator(), _TARGET, {"project_name": "12345"})
+
+    assert captured_url["path"].endswith("/projects/12345/summary")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_project_summary_tolerates_missing_quota(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A summary without a quota object yields empty hard/used maps, not a crash."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    with respx.mock() as mock:
+        mock.get(_summary_url("library")).mock(
+            return_value=respx.MockResponse(200, json={"repo_count": 0})
+        )
+        result = await connector.project_summary(
+            _make_operator(), _TARGET, {"project_name": "library"}
+        )
+
+    assert result["quota"] == {"hard": {}, "used": {}}
+    assert result["repo_count"] == 0
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_project_summary_raises_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unknown project (Harbor 404) propagates httpx.HTTPStatusError."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    with respx.mock() as mock:
+        mock.get(_summary_url("ghost")).mock(
+            return_value=respx.MockResponse(404, json={"errors": [{"code": "NOT_FOUND"}]})
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await connector.project_summary(_make_operator(), _TARGET, {"project_name": "ghost"})
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_typed_threads_operator_into_project_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real dispatcher threads the dispatched operator into the handler."""
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    operator = _make_operator()
+    with respx.mock() as mock:
+        mock.get(_summary_url("library")).mock(
+            return_value=respx.MockResponse(200, json=_project_summary(used=10, hard=100))
+        )
+        result = await dispatch_typed(
+            handler=connector.project_summary,
+            operator=operator,
+            target=_TARGET,
+            params={"project_name": "library"},
+        )
+
+    assert result["quota"]["used"]["storage"] == 10
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == operator.raw_jwt
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# harbor.quota.list — fleet-wide projection + query params (AC3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_quota_list_projects_rows_and_sends_default_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The handler returns {quotas: [{id, ref, hard, used}, ...]}, and sends
+    reference=project + the -used.storage default sort."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    captured_params: dict[str, str] = {}
+
+    def _capture(request: httpx.Request) -> respx.MockResponse:
+        captured_params.update(dict(request.url.params))
+        return respx.MockResponse(
+            200,
+            json=[
+                _quota_row(1, "library", used=1073741824, hard=-1),
+                _quota_row(2, "sandbox", used=536870912, hard=1073741824),
+            ],
+        )
+
+    with respx.mock() as mock:
+        mock.get(_QUOTAS_URL).mock(side_effect=_capture)
+        result = await connector.quota_list(_make_operator(), _TARGET, {})
+
+    assert captured_params["reference"] == "project"
+    assert captured_params["sort"] == "-used.storage"
+    rows = result["quotas"]
+    assert [row["ref"]["name"] for row in rows] == ["library", "sandbox"]
+    first = rows[0]
+    assert set(first) == {"id", "ref", "hard", "used"}
+    assert first["used"]["storage"] == 1073741824
+    assert first["hard"]["storage"] == -1
+    # creation_time / update_time are dropped from the projection.
+    assert "creation_time" not in first
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_quota_list_passes_custom_sort_and_pagination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Custom sort / page / page_size reach the vendor query string."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    captured_params: dict[str, str] = {}
+
+    def _capture(request: httpx.Request) -> respx.MockResponse:
+        captured_params.update(dict(request.url.params))
+        return respx.MockResponse(200, json=[])
+
+    with respx.mock() as mock:
+        mock.get(_QUOTAS_URL).mock(side_effect=_capture)
+        await connector.quota_list(
+            _make_operator(),
+            _TARGET,
+            {"sort": "used.storage", "page": 2, "page_size": 25},
+        )
+
+    assert captured_params["sort"] == "used.storage"
+    assert captured_params["page"] == "2"
+    assert captured_params["page_size"] == "25"
+    assert captured_params["reference"] == "project"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_quota_list_empty_fleet_returns_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No project quotas yields an empty list (not None, not a crash)."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    with respx.mock() as mock:
+        mock.get(_QUOTAS_URL).mock(return_value=respx.MockResponse(200, json=[]))
+        result = await connector.quota_list(_make_operator(), _TARGET, {})
+
+    assert result == {"quotas": []}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_quota_list_raises_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A vendor 5xx propagates httpx.HTTPStatusError."""
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    with respx.mock() as mock:
+        mock.get(_QUOTAS_URL).mock(return_value=respx.MockResponse(500))
+        with pytest.raises(httpx.HTTPStatusError):
+            await connector.quota_list(_make_operator(), _TARGET, {})
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_typed_threads_operator_into_quota_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real dispatcher threads the dispatched operator into the handler."""
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+    connector = _make_connector()
+    operator = _make_operator()
+    with respx.mock() as mock:
+        mock.get(_QUOTAS_URL).mock(
+            return_value=respx.MockResponse(200, json=[_quota_row(1, "library", used=42, hard=-1)])
+        )
+        result = await dispatch_typed(
+            handler=connector.quota_list,
+            operator=operator,
+            target=_TARGET,
+            params={},
+        )
+
+    assert result["quotas"][0]["ref"]["name"] == "library"
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == operator.raw_jwt
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Broadcast classification — both reads match the info sibling
+# ---------------------------------------------------------------------------
+
+
+def test_classify_op_harbor_quota_reads_are_read() -> None:
+    """Both new ops classify as read, like harbor.project.info."""
+    assert classify_op("harbor.project.summary") == "read"
+    assert classify_op("harbor.quota.list") == "read"
+    assert classify_op("harbor.project.info") == "read"
+
+
+# ---------------------------------------------------------------------------
+# Overpromise fix — project.info + the acceptance fixtures (AC1 / AC4 / AC5)
+# ---------------------------------------------------------------------------
+
+
+def _project_info_instructions() -> dict[str, object]:
+    # The read core was promoted to typed ops (#2915/#2856): the
+    # harbor.project.info curation now lives in typed_reads, keyed by the
+    # dot-form op id, not the retired HARBOR_CORE_OPS METHOD:/path table.
+    return HARBOR_READ_LLM_INSTRUCTIONS["harbor.project.info"]
+
+
+def test_project_info_llm_instructions_drop_quota_and_chart_count() -> None:
+    """harbor.project.info no longer advertises quota / chart_count fields the
+    real Harbor Project object does not carry."""
+    blob = " ".join(str(v) for v in _project_info_instructions().values())
+    # No chart_count field claim (in either spelling) — Harbor 2.x has none.
+    assert "chart_count" not in blob
+    assert "chart count" not in blob
+    # The old output_shape's "quota (used/hard storage in bytes)" claim is gone;
+    # quota is now only mentioned as the repoint to the summary op.
+    assert "quota (used/hard storage in bytes)" not in blob
+    assert "harbor.project.summary" in blob
+
+
+def test_project_info_repoints_quota_at_summary_op() -> None:
+    """The overpromised quota guidance now points at harbor.project.summary."""
+    instructions = _project_info_instructions()
+    assert "harbor.project.summary" in str(instructions["next_step"])
+    assert "harbor.project.summary" in str(instructions["output_shape"])
+
+
+def test_acceptance_project_fixtures_carry_no_quota_or_chart_count() -> None:
+    """The Project canary fixtures stop masking the real (quota-less) shape."""
+    assert "quota" not in HARBOR_CANARY_PROJECT_DETAIL
+    assert "chart_count" not in HARBOR_CANARY_PROJECT_DETAIL
+    for project in HARBOR_CANARY_PROJECTS:
+        assert "quota" not in project
+        assert "chart_count" not in project

--- a/docs/codebase/connectors-harbor.md
+++ b/docs/codebase/connectors-harbor.md
@@ -13,7 +13,12 @@ broadcast classifier. G3.5-T10 (#622) added the `meho harbor …` CLI verb tree
 `goharbor/harbor-core:v2.11.0`, and `docs/cross-repo/harbor-onboarding.md`.
 Wave-2 (#2857) adds `harbor.artifact.vulnerabilities` — a standalone typed
 read for the per-artifact CVE list behind `harbor.artifact.info`'s
-`scan_overview` severity counts.
+`scan_overview` severity counts. Wave-2 (#2858) adds two more standalone
+typed storage-quota reads — `harbor.project.summary` (per-project quota/usage
+occupancy) and `harbor.quota.list` (fleet-wide project quotas) — and fixes the
+`harbor.project.info` overpromise: the vendor Harbor 2.11 `Project` object
+carries no `quota` or `chart_count` field, so those claims were dropped
+from its `llm_instructions` and repointed at `harbor.project.summary`.
 
 **#2856** converted the 9-op read core from the original ingested-curation
 apparatus (a retired `core_ops.py` whose ops only dispatched once a per-deploy
@@ -38,8 +43,9 @@ Source: `backend/src/meho_backplane/connectors/harbor/`.
   read shims (`about` / `health` / `project_list` / `project_info` /
   `repository_list` / `repository_info` / `artifact_list` / `artifact_info`
   / `robot_list`, each delegating to a `typed_reads` body), the two robot
-  writes (`robot_create` / `robot_delete`), and the standalone
-  `artifact_vulnerabilities` CVE-detail read (#2857).
+  writes (`robot_create` / `robot_delete`), the standalone
+  `artifact_vulnerabilities` CVE-detail read (#2857), and the two standalone
+  storage-quota reads (`project_summary` / `quota_list`, #2858).
 - **`HarborTargetLike`** (`session.py`) — runtime-checkable Protocol capturing
   the minimum target shape the connector reads: `name`, `host`, `port`,
   `secret_ref`, and `auth_model`. No `sso_realm` field — Harbor sends
@@ -95,6 +101,12 @@ Source: `backend/src/meho_backplane/connectors/harbor/`.
   (#2857) into `endpoint_descriptor` (group `harbor-artifacts`, `safety_level=safe`,
   no approval). Same lifespan/idempotency contract as the robot registrar; queued
   separately in `__init__.py`.
+- **`register_harbor_project_quota_operations`** (`ops.py`) — async lifespan
+  registrar that upserts the wave-2 standalone typed reads
+  `harbor.project.summary` and `harbor.quota.list` (#2858) into
+  `endpoint_descriptor` (group `harbor-projects`, `safety_level=safe`, no
+  approval). Same lifespan/idempotency contract as the robot registrar;
+  queued separately in `__init__.py`.
 
 ## Control flow
 
@@ -217,6 +229,53 @@ dispatched operator threads in and is forwarded to `auth_headers` →
    `SELECT ... WHERE id = 'CVE-…'` away. A never-scanned artifact returns
    Harbor 404 → `httpx.HTTPStatusError` → `connector_error`.
 
+### project_summary(operator, target, params)
+
+Typed op handler for `harbor.project.summary` (#2858) — a project's
+storage-quota occupancy. Classified `read` (`classify_op`; `.summary` is a
+`_READ_SUFFIXES` entry, so its broadcast sensitivity matches the
+`harbor.project.info` sibling rather than falling through to the full-detail
+`other` class — the same edit also reclassifies
+`vmware.composite.performance.summary` `other`→`read`, a correctness
+improvement; neither class is sensitive, so redaction is unchanged).
+`safety_level=safe`, no approval. Like the robot handlers, the `operator`
+signature threads the dispatched operator to `auth_headers` →
+`_load_credentials` for the operator-context Vault read.
+
+1. Percent-encodes `project_name` with `quote(value, safe="")`.
+2. Calls `_request_json(target, "GET",
+   "/api/v2.0/projects/{name}/summary", operator=operator,
+   extra_headers={"X-Is-Resource-Name": "true"})`. `_request_json` (not
+   `_get_json`) forwards the per-call header; the header makes Harbor resolve
+   the path segment as a project *name* even when it looks numeric (the vendor
+   default treats a numeric segment as an id). GET stays idempotent, so the
+   tenacity retry still applies.
+3. Projects the native `ProjectSummary` to
+   `{repo_count, quota: {hard, used}, member_counts}`. `quota.hard`/`quota.used`
+   are `ResourceList` maps (`storage` in bytes; hard `-1` = unlimited); the
+   proxy-only `registry` field is dropped. **This is the quota
+   `harbor.project.info` does not carry** — the vendor `Project` object has no
+   `quota` field.
+
+### quota_list(operator, target, params)
+
+Typed op handler for `harbor.quota.list` (#2858) — fleet-wide project storage
+quotas, the "which projects are near quota" read. Classified `read` (`.list`
+suffix), `safety_level=safe`, no approval. `operator` threads the same way.
+
+1. Builds the query `{reference: "project", sort, page, page_size}`.
+   `reference=project` is fixed (project quotas are the only reference type in
+   the stable Harbor 2.x line); `sort` defaults to `-used.storage` (fullest
+   projects first).
+2. Calls `_get_json(target, "/api/v2.0/quotas", operator=operator,
+   params=query)` — idempotent GET with query params, no per-call header.
+3. Projects each native `Quota` to `{id, ref, hard, used}` and returns a
+   **bare list**. `ref` is the project reference (`{id, name, owner_name}`);
+   `hard`/`used` are `ResourceList` maps (`storage` in bytes). The dispatcher's
+   JSONFlux reducer materialises the list into a result handle when the fleet
+   crosses the ~50-row / 4 KB threshold (postulate 6); a "projects over N bytes
+   used" filter is a `result_query` away.
+
 ### execute() shim
 
 `execute()` synthesises a system `Operator` and delegates to
@@ -245,15 +304,17 @@ construct a real `Operator` and call `dispatch` directly — they bypass this sh
   `.health` / `.list` / `.info` read suffixes plus `.vulnerabilities`, #2857)
   and `credential_mint` for `harbor.robot.create`.
 
-## The 9 read-only core ops
+## The read-only core ops
 
 All register under `connector_id="harbor-rest-2.x"` as `source_kind="typed"`
-and dispatch on a fresh boot with zero catalog ingest. The 9 rows below are the
-audited read core (`HARBOR_TYPED_OPS`, via `register_harbor_typed_operations`);
-the trailing `harbor.artifact.vulnerabilities` row (#2857) is a **standalone
-typed read** registered separately in `ops.py` via
-`register_harbor_artifact_operations` — read-only like the core, but not one of
-the 9.
+and dispatch on a fresh boot with zero catalog ingest. The first 9 rows below
+are the audited read core (`HARBOR_TYPED_OPS`, via
+`register_harbor_typed_operations`); the `harbor.artifact.vulnerabilities` row
+(#2857) is a **standalone typed read** registered separately in `ops.py` via
+`register_harbor_artifact_operations`, and the `harbor.project.summary` /
+`harbor.quota.list` rows (#2858) are **standalone typed reads** registered via
+`register_harbor_project_quota_operations` — all read-only like the core, but
+not one of the 9.
 
 | Op id | Group | Vendor path (Harbor 2.x) |
 |---|---|---|
@@ -267,6 +328,15 @@ the 9.
 | `harbor.artifact.info` | `harbor-artifacts` | `GET …/artifacts/{reference}` |
 | `harbor.robot.list` | `harbor-robots` | `GET /api/v2.0/robots` |
 | `harbor.artifact.vulnerabilities` *(standalone typed read, #2857)* | `harbor-artifacts` | `GET …/artifacts/{reference}/additions/vulnerabilities` |
+| `harbor.project.summary` *(standalone typed read, #2858)* | `harbor-projects` | `GET /api/v2.0/projects/{project_name}/summary` |
+| `harbor.quota.list` *(standalone typed read, #2858)* | `harbor-projects` | `GET /api/v2.0/quotas?reference=project` |
+
+**Quota lives on the summary endpoint, not on `Project`**: `harbor.project.info`
+(`GET /projects/{name}`) returns the vendor `Project` object, which has no
+`quota` and no `chart_count` field. Per-project storage occupancy
+(`quota.hard`/`quota.used` in bytes) comes from `harbor.project.summary`
+(`GET /projects/{name}/summary`); the fleet-wide "which projects are near
+quota" answer comes from `harbor.quota.list` (`GET /quotas`).
 
 **Robot id + secret invariant**: `harbor.robot.list` returns each robot's
 numeric `id` (needed for `harbor.robot.delete`) and never a `secret` — Harbor
@@ -295,6 +365,12 @@ this invariant explicitly.
   parity with `harbor.artifact.info`, MIME-keyed / bare envelope unwrap, empty
   and 404 paths, `dispatch_typed` operator threading, and the `read`
   classification.
+- `tests/test_connectors_harbor_quota.py` — unit tests for
+  `harbor.project.summary` and `harbor.quota.list` (#2858): quota-byte
+  projection, the `X-Is-Resource-Name` header, the `reference=project` +
+  `-used.storage` default query, `dispatch_typed` operator threading, `read`
+  classification, and the `harbor.project.info` overpromise fix (no `quota` /
+  `chart_count` in the op's `llm_instructions` or the `Project` fixtures).
 - `tests/integration/test_connectors_harbor_container.py` — env-gated real
   Harbor `v2.11.0` stack E2E: `harbor.about` + `harbor.robot.list` reads and
   the robot create/delete four-eyes flow, all `source_kind="typed"`.
@@ -314,7 +390,9 @@ this invariant explicitly.
 - Issues: #619 (G3.5-T7 skeleton), #621 (G3.5-T9 robot lifecycle +
   credential_mint classifier), #622 (G3.5-T10 CLI verbs + real-container E2E +
   harbor-onboarding.md), **#2856 (typed read-core conversion)**,
-  #2857 (wave-2 CVE-detail read `harbor.artifact.vulnerabilities`)
+  #2857 (wave-2 CVE-detail read `harbor.artifact.vulnerabilities`),
+  #2858 (wave-2 storage-quota reads `harbor.project.summary` /
+  `harbor.quota.list` + `harbor.project.info` overpromise fix)
 - Precedent: Task #2358 / Goal #2247 — the NSX (#2302) and SDDC Manager (#2306)
   typed-read conversions this task mirrors
 - Initiative: #368 (G3.5 tier-2 batch), #2833 (connector read-op coverage wave 2)


### PR DESCRIPTION
## Summary
- Add `harbor.project.summary` — per-project storage-quota occupancy via `GET /projects/{project_name_or_id}/summary` (`getProjectSummary`), pinning `X-Is-Resource-Name: true` so a project *name* is never resolved as an id. Projects the native `ProjectSummary` to `{repo_count, quota: {hard, used}, member_counts}`; `quota.hard.storage` / `quota.used.storage` are bytes. This is the storage quota `harbor.project.info` does **not** carry.
- Add `harbor.quota.list` — fleet-wide project quotas via `GET /quotas?reference=project&sort=-used.storage` (`listQuotas`), the one-call "which projects are near their storage quota" answer. Returns `{quotas: [{id, ref, hard, used}, ...]}`; the `quotas` list is JSONFlux-reduced to a result handle for large fleets (postulate 6).
- Fix the `harbor.project.info` **overpromise**: its `llm_instructions` claimed a `quota` and `chart_count` the Harbor 2.11 `Project` schema never carries. Dropped both claims and repointed the quota guidance at `harbor.project.summary`. De-faked the acceptance `Project` fixtures (`_harbor_canary_fixtures.py`) that baked the same synthetic `quota`/`chart_count` keys, so the suite stops masking the real quota-less shape.
- Both new ops register **standalone typed** (the `harbor.robot.create/.delete` pattern) in `ops.py` under the `harbor-projects` group, `safety_level=safe`, no approval — independent of the deferred read-core ingest (#2856).

Grounded against `goharbor/harbor` `v2.11.0` (`api/v2.0/swagger.yaml`): `Project` has no `quota`/`chart_count`; `ProjectSummary.quota` is `{hard, used}` (each a `ResourceList` = `{storage: int64}`); `Quota` carries `ref`/`hard`/`used`; `listQuotas` accepts `reference`/`sort`/`page`/`page_size`.

## Broadcast classification note
`.summary` is added to `_READ_SUFFIXES` so `harbor.project.summary` broadcasts at the same `read` sensitivity as its `harbor.project.info` sibling (mirrors #2857's `.vulnerabilities` addition). This also reclassifies `vmware.composite.performance.summary` `other`→`read` — a correctness improvement (it is a non-mutating read); **neither class is sensitive** (`_SENSITIVE_OP_CLASSES` excludes both), so redaction/detail is unchanged and no test pinned its class.

## Test plan
- [x] `ruff check` + `ruff format --check` — clean (touched files)
- [x] `mypy src/meho_backplane/connectors/harbor + broadcast/events.py` — clean
- [x] `pytest tests/test_connectors_harbor_quota.py` — 15 passed (projection incl. `quota.hard/used` bytes + `repo_count`; `X-Is-Resource-Name` header; numeric-name encoding; missing-quota tolerance; `reference=project` + `-used.storage` default query; custom sort/page; empty fleet; 404/5xx; `dispatch_typed` operator threading; `read` classification; project.info no longer references quota/chart_count; fixtures carry neither)
- [x] `pytest test_connectors_harbor_robot + _core_ops + broadcast_classifier_coverage + broadcast_events + overrides_resolver` — 199 passed (no regression from the `.summary` classifier + core_ops llm_instructions edits)
- [x] `pytest tests/acceptance/test_g35_harbor_dispatch_smoke + _jsonflux_force_handle` — 10 passed (de-faked `Project` fixtures still dispatch `ok`)
- [x] `pytest test_connectors_vmware_rest_composites_register + _read` — 41 passed (`performance.summary` reclassification is inert)
- [x] `code-quality.py --diff` — 0 blockers (`connector.py` carries a `# code-quality-allow: file-size` marker — handlers must be connector methods for dispatcher binding)

## Acceptance criteria
- [x] `harbor.project.info` `output_shape` no longer claims `quota` or `chart_count`
- [x] `harbor.project.summary` registered as a safe read, dispatching through `call_operation`, returning `quota.hard` / `quota.used` in bytes plus `repo_count`
- [x] `harbor.quota.list` registered as a safe read (fleet-wide) so "which projects are near quota" needs no N-way per-project fan-out
- [x] Synthetic `quota`/`chart_count` keys removed from the `GET /projects` and `GET /projects/{name}` fixtures; new fixtures back the new ops (in the new test module)
- [x] A test asserts the new op's shape includes `quota.hard`/`quota.used` storage bytes, and that `harbor.project.info` no longer references quota
- [x] `docs/codebase/connectors-harbor.md` updated (ops table gains the new ops; quota/chart_count claim removed from `harbor.project.info`)
- [x] CLI OpenAPI snapshot: **no regen needed** — no FastAPI route/schema changed (the typed ops register in `endpoint_descriptor` at lifespan, not as HTTP routes)

## Out of scope
- Any quota write path (`PUT /quotas/{id}`), non-storage quota resource types, registry-level accounting (all per the issue).
- Merge ordering: the `harbor.project.info` overpromise edit lands in `HARBOR_CORE_OPS` (`core_ops.py`) on current `main`; this trivially conflicts with #2856 (PR #2915), which moves `project.info` to typed. The human serializes the harbor merges (2856 → 2857 → 2858) and ports the edit. Both new ops here are standalone typed and do not depend on #2856.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2858
