### PR TITLE
test(connectors): reconcile vmware write _SUB_OPS_* against real vcenter.yaml spec

### DIFF
--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -48,6 +48,25 @@ once the operator ingests the vSphere specs and enables the carrying
 groups (acceptance criterion 2 on #1414, verified in code rather than
 against a deploy). If anyone edits a ``_SUB_OPS_*`` op_id into a shape
 the ingest pipeline cannot emit, this test goes red.
+
+**Two tiers of proof -- shape vs. real-path existence.** The hand-built
+fixture assertion
+(:func:`test_every_write_composite_sub_op_resolves_to_an_ingested_op_id`)
+proves op_id *shape*: that every ``_SUB_OPS_*`` string is a well-formed
+``METHOD:/path`` the parser emits, keyed vCenter's action-verb-in-path
+way. It synthesises the fixture *from* those same constants, so it
+**cannot** prove a path actually exists in vCenter 9.0 -- a typo, a
+renamed endpoint, or a wrong API-version path passes it. The env-gated
+:func:`test_every_write_composite_sub_op_resolves_against_pinned_vcenter_spec`
+closes that gap: it parses the canonical pinned ``vcenter.yaml`` and
+asserts real *path existence*. It skips when the vendor-licensed
+spec-shelf is unconfigured (the #1602 / G0.7-canary convention -- the
+specs live in the operator's separate spec-shelf repo, not this chassis
+repo), so the default local run and CI stay green on the shape assertion
+with zero external dependency; wherever ``MEHO_VCENTER_OPENAPI_VCENTER``
+/ ``MEHO_CONSUMER_DOCS_ROOT`` is wired it runs for real. The vi-json
+write composites get the same real-path treatment in the
+``*_paths_exist_in_the_pinned_spec`` checks lower down.
 """
 
 from __future__ import annotations
@@ -63,7 +82,11 @@ import respx
 
 from meho_backplane.connectors.vmware_rest.composites import _write
 from meho_backplane.operations.ingest import parse_openapi
-from tests.acceptance._vcenter_spec import VCENTER_SPEC_REASON, resolve_vi_json_yaml
+from tests.acceptance._vcenter_spec import (
+    VCENTER_SPEC_REASON,
+    resolve_vcenter_yaml,
+    resolve_vi_json_yaml,
+)
 
 # Public IP returned by the mock getaddrinfo for specs.example.test.
 _PUBLIC_TEST_IP = "93.184.216.34"
@@ -248,6 +271,60 @@ def test_action_discriminated_sub_ops_keep_query_suffix_through_ingest() -> None
     assert action_op_ids <= ingested_op_ids
     # And no op_id lost its query suffix (proves no stripping).
     assert all("?action=" in op_id for op_id in ingested_op_ids)
+
+
+def test_every_write_composite_sub_op_resolves_against_pinned_vcenter_spec() -> None:
+    """Every REST ``_SUB_OPS_*`` op_id is emitted by parsing the real vcenter.yaml.
+
+    The env-gated real-spec analogue of
+    :func:`test_every_write_composite_sub_op_resolves_to_an_ingested_op_id`.
+    That test synthesises its OpenAPI fixture *from* the ``_SUB_OPS_*``
+    constants, so it proves op_id **shape** (a well-formed ``METHOD:/path``
+    that survives the parser, keyed vCenter's action-verb-in-path way) but
+    cannot prove a path actually **exists** in vCenter 9.0 -- a typo, a
+    renamed endpoint, or a wrong API-version path passes it. This parses the
+    canonical pinned ``vcenter.yaml`` through the real :func:`parse_openapi`
+    and asserts every REST ``_SUB_OPS_*`` op_id is in the emitted descriptor
+    set, i.e. real path existence -- the vcenter.yaml/REST analogue of the
+    vi-json ``*_paths_exist_in_the_pinned_spec`` checks below, mirroring
+    #1602's ``test_portgroup_audit_op_id_reconcile.py``.
+
+    Skips when the spec-shelf is unconfigured (the canary's convention), so
+    the default local run and CI stay green on the hand-built-fixture
+    assertion above with zero external dependency; wherever
+    ``MEHO_VCENTER_OPENAPI_VCENTER`` / ``MEHO_CONSUMER_DOCS_ROOT`` is wired
+    it runs for real. A shelf-backed red is the guard surfacing a real
+    finding (a ``_SUB_OPS_*`` path the pinned spec does not serve), not a
+    reason to withhold the guard.
+    """
+    spec_path = resolve_vcenter_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+
+    required = _required_raw_sub_op_ids()
+    assert required, "introspection found no raw sub-op_ids -- wiring broke"
+
+    spec_text = spec_path.read_text(encoding="utf-8")
+    # ``content=`` feeds the bytes verbatim (the https-only SSRF guard
+    # applies only to the URL-fetch path); the URI arg is just the audit
+    # label. Mirrors #1602's portgroup-audit real-spec reconcile.
+    rows = parse_openapi(
+        f"file://{spec_path}",
+        spec_source="spec:vcenter.yaml",
+        content=spec_text,
+    )
+    ingested_op_ids = {row.op_id for row in rows}
+
+    missing = required - ingested_op_ids
+    assert not missing, (
+        "vmware write composites declare _SUB_OPS_* REST op_ids the real "
+        f"vcenter.yaml ingest does not emit: {sorted(missing)}. Either a "
+        "_SUB_OPS_* constant references a path vCenter 9.0 does not serve "
+        "(a typo, a renamed endpoint, or a wrong API-version path -- the "
+        "class of defect the hand-built fixture cannot catch), or the pinned "
+        "spec revision moved the resource (re-check against the vSphere "
+        "Automation REST API)."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -1037,18 +1037,24 @@ they never park.
   A build-time guard
   (`tests/acceptance/test_portgroup_audit_op_id_reconcile.py`) parses
   the pinned `vcenter.yaml` and asserts every audit sub-op_id is emitted
-  by the ingest, so a future drift goes red in CI.
-- **`host.detach_from_vds` write composite carries the same singular
-  `distributed-portgroup` defect (out of scope for #1602)** —
-  `_write.py`'s `_OP_LIST_PORTGROUPS =
-  "GET:/vcenter/network/distributed-portgroup"` has the identical
-  unresolvable spelling. #1602 is scoped to the read
-  `network.portgroup.audit` composite only; the write-side fix plus a
-  reconcile guard over the 14 write composites' `_SUB_OPS_*` against the
-  real pinned spec (the existing
-  `test_connectors_vmware_rest_composites_l2_ingest_reconcile.py`
-  synthesises its fixture *from* the constants, so it cannot catch a
-  wrong key) is a follow-up under the #1529 cleanup.
+  by the ingest. The vendor-licensed spec-shelf is not provisioned in
+  public-repo CI, so that guard **skips** there (the #1602 convention);
+  it runs wherever the spec-shelf is wired — an operator deploy or a
+  spec-shelf-backed run — which is where a future drift surfaces.
+- **`host.detach_from_vds` write-side portgroup fix: done (#2891);
+  real-spec reconcile guard: done (#2944)** — `_write.py` once carried
+  `_OP_LIST_PORTGROUPS = "GET:/vcenter/network/distributed-portgroup"`
+  (singular, absent from the pinned spec — the same class of defect
+  #1602 fixed on the read side). #2891 corrected it to `_OP_LIST_NETWORK
+  = "GET:/vcenter/network"`, so `_SUB_OPS_HOST_DETACH_FROM_VDS` now
+  dispatches the resolvable path (see "Portgroup resolution — the #1602
+  lesson" above). #2944 then closed the guard gap: the always-on
+  reconcile in `test_connectors_vmware_rest_composites_l2_ingest_reconcile.py`
+  synthesises its fixture *from* the constants (proves op_id **shape**,
+  cannot catch a wrong key), so #2944 added an env-gated assertion that
+  parses the real pinned `vcenter.yaml` and asserts every `_SUB_OPS_*`
+  REST path actually **exists** — skipping in CI where the spec-shelf is
+  unprovisioned (the #1602 convention), running wherever it is wired.
 
 ## References
 


### PR DESCRIPTION
## Summary

- The vmware write-composite ingest-reconcile lane proved op_id **shape** only — it synthesises a vCenter-shaped OpenAPI fixture *from* the `_SUB_OPS_*` constants, so a well-formed `METHOD:/path` that vCenter 9.0 does not actually serve (typo, renamed endpoint, wrong API-version path) slipped through. This adds an **env-gated real-spec assertion** that parses the canonical pinned `vcenter.yaml` (via the existing `tests/acceptance/_vcenter_spec.py` resolver) and asserts every REST `_SUB_OPS_*` op_id is emitted by the real ingest — real **path existence**, bringing the REST side to parity with the vi-json seam that already reconciles against its pinned spec.
- **Additive and test+docs only.** The retained hand-built-fixture assertion still proves shape with zero dependency; the new check **skips** (pytest.skip) when the vendor-licensed spec-shelf env is unset — exactly like #1602's `test_portgroup_audit_op_id_reconcile.py` and the vi-json `*_paths_exist_in_the_pinned_spec` checks. No production code, no CI wiring, no secret. Provisioning the spec-shelf into public CI is a separate operator/infra follow-up (out of scope, per the rescoped AC#3).
- **Docs corrected**: the `docs/codebase/connectors-vmware-rest.md` "Known issues" bullet claiming `host.detach_from_vds` still "carries the singular `distributed-portgroup` defect" is stale — the write-side fix landed in **#2891** (`_SUB_OPS_HOST_DETACH_FROM_VDS` now uses `_OP_LIST_NETWORK`; `_OP_LIST_PORTGROUPS` is gone). Reframed to "write-side fix: done (#2891); reconcile guard: this ticket", and the #1602 audit-guard's "goes red in CI" wording softened (it skips in CI too). The module docstring now states plainly which assertion proves shape vs. real-path existence.

## Test plan

- [x] `ruff check src/ tests/` — All checks passed
- [x] `ruff format --check src/ tests/` — 1419 files already formatted
- [x] `mypy` — n/a (change is `tests/` + `docs/` only; CI scopes mypy to `src/`, untouched)
- [x] Reconcile lane `pytest tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py -v` — **11 passed, 5 skipped**. The new `test_every_write_composite_sub_op_resolves_against_pinned_vcenter_spec` **SKIPPED** (no spec-shelf in sandbox/CI, as designed); the existing hand-built-fixture `test_every_write_composite_sub_op_resolves_to_an_ingested_op_id` still **PASSED**.
- [x] `pytest tests/ -k vmware_rest_composites` sweep — **264 passed, 5 skipped, 12058 deselected**
- [x] `code-quality.py --diff` — exit 0

## Verification against the settled pushback

Both prior pushback reasons were independently re-verified against `origin/main` (`4ce34423`) before implementing:

- **Reason 1 (production bug) does NOT hold.** `_OP_LIST_PORTGROUPS` has 0 occurrences in `_write.py`; `_SUB_OPS_HOST_DETACH_FROM_VDS` uses `_OP_LIST_NETWORK = "GET:/vcenter/network"`. The write-side fix landed via PR #2914 ("…(#2891)"). No red-when-active path; the guard is purely additive.
- **Reason 2 (CI wiring) rescoped.** Zero `MEHO_VCENTER_OPENAPI*` in `.github/workflows/`; the guard skips in CI like #1602. No CI change made.

Note: the ticket's line references (`730-740`, "9 write composites / 8 vmware-rest") were from a pre-#2914 revision — #2914 already advanced the docstring to "14 composites" and pushed the stale bullet down to ~line 1041. The substance of every AC was applied at the correct current locations.

## Out of scope

- Provisioning the vendor-licensed spec-shelf into public-repo CI (lights up all three currently-skipping lanes at once — a licensing + secret decision).
- Hoisting the env-gated real-spec check into a shared helper for other generic connectors (deliberately deferred until a second connector needs it).

Closes #2944
