### PR TITLE
test(holodeck): bump op-count canary 12→13 for backups.list (#2847)

### DIFF
--- a/backend/tests/test_connectors_holodeck_auth.py
+++ b/backend/tests/test_connectors_holodeck_auth.py
@@ -215,12 +215,13 @@ def test_package_import_registers_v2_entry_only() -> None:
 def test_about_canary_op_remains_at_index_zero() -> None:
     """``holodeck.about`` is the T1 canary; T2 (#854) appends the 7 read ops
     and G3.18-T2 (#2154) the 3 write ops onto the same tuple while preserving
-    the canary at index 0. The full registration shape lives in
+    the canary at index 0; #2847 later appends the ``holodeck.backups.list``
+    read op. The full registration shape lives in
     ``test_connectors_holodeck_ops.py`` / ``test_connectors_holodeck_write.py``.
     """
     assert HOLODECK_OPS[0].op_id == "holodeck.about"
     assert HOLODECK_OPS[0].handler_attr == "about"
-    assert len(HOLODECK_OPS) == 12
+    assert len(HOLODECK_OPS) == 13
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Main's `Python (ruff + mypy + pytest)` CI job is red:
`test_connectors_holodeck_auth.py::test_about_canary_op_remains_at_index_zero`
asserts `len(HOLODECK_OPS) == 12`, but the holodeck connector now has **13** ops.

## Cause

#2847 (PR #2911, part of Initiative #2833 wave-2) added the
`holodeck.backups.list` read op — a legitimate, reviewed addition. Its
op-count canary lives in a *different* test file (`..._auth.py`) than
holodeck's main op tests (`..._ops.py` / `..._write.py`), and per-PR CI was
bypassed during the wave-2 admin-merge, so the stale `== 12` only surfaced on
`main`'s full unit suite (which is green on all 11,958 other tests).

## Fix

Bless the intended new count: `12 → 13`, plus a one-line docstring note. This
is a **test-only** change — no production code touched.

## Verification

- `uv run pytest tests/test_connectors_holodeck_auth.py` → **28 passed**
- `ruff check` / `ruff format --check` on the file → clean
- Full local unit suite otherwise green; the only other failures were
  local-environment-only (a chart test that shells out to the `helm` binary,
  and the `net` connector's real DNS/ICMP tests — none touched by wave-2, and
  their CI jobs are green).

Refs #2847, #2833.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
