### PR TITLE
fix(cli): repoint stranded typed-connector verbs to dotted op_ids + exhaustive typed-dispatch guards (#2942)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,26 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed — CLI verbs stranded on retired ingested op_ids + exhaustive typed-dispatch guards (#2942)
+
+- `meho vcf-automation deployment list` now dispatches the typed
+  `vcfa.tenant.deployment.list` (#2839) instead of the ingested
+  `GET:/iaas/api/deployments`, which no longer resolves on a
+  zero-catalog boot — the operator verb was a dead end even though the
+  agent/backend path worked. The wave-2 cross-check found the same
+  stranding on `meho nsx segment list` (→ `nsx.segment.list`, #2835)
+  and `meho nsx node list` (→ `nsx.transport_node.list`, #2836); both
+  repointed. `deployment get` stays on `GET:/iaas/api/deployments/{id}`
+  until a typed detail op ships.
+- The five per-connector `typed_opid_dispatch_test.go` guards (nsx,
+  sddc-manager, vcf-automation, vcf-fleet, vcf-operations) are now
+  exhaustive: every verb is pinned to the exact op_id it dispatches
+  (typed or deliberately ingested, with the reason in a comment), and a
+  new `TestBackendTypedOpsAreClassified` reconciles each guard against
+  the backend's typed-op registry — a typed read op shipped without a
+  CLI-repoint decision fails CI instead of silently stranding the verb.
+  Contract recorded in `docs/codebase/cli.md`.
+
 ### Added — vmware `vm.disk.grow` + the governed mutating VI-JSON write substrate (#2893)
 
 - `vmware.composite.vm.disk.grow` grows a virtual disk's capacity — the

--- a/cli/internal/cmd/nsx/node.go
+++ b/cli/internal/cmd/nsx/node.go
@@ -24,7 +24,10 @@ func newNodeCmd() *cobra.Command {
 	return cmd
 }
 
-// newNodeListCmd returns `meho nsx node list` → GET:/api/v1/transport-nodes.
+// newNodeListCmd returns `meho nsx node list` → nsx.transport_node.list
+// (repointed from the ingested GET:/api/v1/transport-nodes op_id once
+// #2836 shipped the typed read — the legacy op_id no longer resolves
+// on a zero-catalog boot; #2942).
 func newNodeListCmd() *cobra.Command {
 	var (
 		targetName        string
@@ -34,7 +37,7 @@ func newNodeListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List NSX transport nodes (ESXi + edge)",
-		Long: "list dispatches GET:/api/v1/transport-nodes against connector_id=\n" +
+		Long: "list dispatches nsx.transport_node.list against connector_id=\n" +
 			"\"nsx-rest-4.2\". Renders id / display_name / type for human eyes;\n" +
 			"--json emits the full OperationResult envelope.\n\n" +
 			"Exit codes mirror meho operation call.",
@@ -59,15 +62,15 @@ func runNodeList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneO
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v1/transport-nodes", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "nsx.transport_node.list", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return conn.Render(cmd, "GET:/api/v1/transport-nodes", r, jsonOut, printNodeList)
+	return conn.Render(cmd, "nsx.transport_node.list", r, jsonOut, printNodeList)
 }
 
 func printNodeList(w io.Writer, r *CallResult) {
-	fmt.Fprintf(w, "%s GET:/api/v1/transport-nodes — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	fmt.Fprintf(w, "%s nsx.transport_node.list — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
 	if r.Status != "ok" {
 		printErrorTrailer(w, r)
 		return

--- a/cli/internal/cmd/nsx/nsx.go
+++ b/cli/internal/cmd/nsx/nsx.go
@@ -5,15 +5,18 @@
 // G3.5-T3 (#615) of Initiative #368. v0.2 ships the operator-facing
 // alias verbs over the 9 enabled NSX read-only core ops, each
 // pre-baking connector_id="nsx-rest-4.2" so operators don't type
-// the connector ID on every dispatch:
+// the connector ID on every dispatch. Verbs whose backend read went
+// typed dispatch the dotted typed op_id (#2355, #2942 — ingested
+// METHOD:/path op_ids no longer resolve on a zero-catalog boot); the
+// rest keep their ingested op_ids until a typed counterpart ships:
 //
-//   - `meho nsx about [--target T]`                        — GET:/api/v1/node
-//   - `meho nsx node list [--target T]`                    — GET:/api/v1/transport-nodes
-//   - `meho nsx cluster status [--target T]`               — GET:/api/v1/cluster/status
-//   - `meho nsx segment list [--target T]`                 — GET:/policy/api/v1/infra/segments
-//   - `meho nsx transport-zone list [--target T]`          — GET:/policy/.../transport-zones
+//   - `meho nsx about [--target T]`                        — nsx.node.status
+//   - `meho nsx node list [--target T]`                    — nsx.transport_node.list
+//   - `meho nsx cluster status [--target T]`               — nsx.cluster.status
+//   - `meho nsx segment list [--target T]`                 — nsx.segment.list
+//   - `meho nsx transport-zone list [--target T]`          — nsx.transport_zone.list
 //   - `meho nsx tier0 list [--target T]`                   — GET:/policy/api/v1/infra/tier-0s
-//   - `meho nsx tier1 list [--target T]`                   — GET:/policy/api/v1/infra/tier-1s
+//   - `meho nsx tier1 list [--target T]`                   — nsx.tier1.list
 //   - `meho nsx firewall policy list [--scope D] [--target T]`
 //   - `meho nsx firewall rule list <policy> [--scope D] [--target T]`
 //   - `meho nsx operation search/call`                     — meta-tool wrappers

--- a/cli/internal/cmd/nsx/segment.go
+++ b/cli/internal/cmd/nsx/segment.go
@@ -24,7 +24,10 @@ func newSegmentCmd() *cobra.Command {
 	return cmd
 }
 
-// newSegmentListCmd returns `meho nsx segment list` → GET:/policy/api/v1/infra/segments.
+// newSegmentListCmd returns `meho nsx segment list` → nsx.segment.list
+// (repointed from the ingested GET:/policy/api/v1/infra/segments op_id
+// once #2835 shipped the typed read — the legacy op_id no longer
+// resolves on a zero-catalog boot; #2942).
 func newSegmentListCmd() *cobra.Command {
 	var (
 		targetName        string
@@ -34,7 +37,7 @@ func newSegmentListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List NSX policy-API segments (logical + DVS-backed portgroups)",
-		Long: "list dispatches GET:/policy/api/v1/infra/segments against\n" +
+		Long: "list dispatches nsx.segment.list against\n" +
 			"connector_id=\"nsx-rest-4.2\". Renders id / display_name /\n" +
 			"transport_zone_path for human eyes; --json emits the full envelope.\n\n" +
 			"Exit codes mirror meho operation call.",
@@ -59,7 +62,7 @@ func runSegmentList(cmd *cobra.Command, targetName string, jsonOut bool, backpla
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	const opID = "GET:/policy/api/v1/infra/segments"
+	const opID = "nsx.segment.list"
 	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
@@ -68,7 +71,7 @@ func runSegmentList(cmd *cobra.Command, targetName string, jsonOut bool, backpla
 }
 
 func printSegmentList(w io.Writer, r *CallResult) {
-	const opID = "GET:/policy/api/v1/infra/segments"
+	const opID = "nsx.segment.list"
 	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
 	if r.Status != "ok" {
 		printErrorTrailer(w, r)

--- a/cli/internal/cmd/nsx/typed_opid_dispatch_test.go
+++ b/cli/internal/cmd/nsx/typed_opid_dispatch_test.go
@@ -8,52 +8,159 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/typedops"
 )
 
-// TestRepointedVerbsDispatchTypedOpIDs pins that the #2266-repointed
-// NSX verbs dispatch their typed op_ids (the legacy METHOD:/path op_ids
-// no longer resolve on a zero-catalog boot). All four are GET-list /
-// status reads with no params, so the swap is a pure op_id change.
+// typedDispatchCases pins every NSX verb whose backend read is typed
+// to the dotted typed op_id it must dispatch (#2266 repoint sweep
+// #2355; segment list / node list repointed by #2942 once #2835 /
+// #2836 shipped the typed reads). All are GET-list / status reads
+// with no params, so each swap is a pure op_id change.
+var typedDispatchCases = []struct {
+	name   string
+	args   []string
+	wantOp string
+}{
+	{"about", []string{"about"}, "nsx.node.status"},
+	{"cluster status", []string{"cluster", "status"}, "nsx.cluster.status"},
+	{"transport-zone list", []string{"transport-zone", "list"}, "nsx.transport_zone.list"},
+	{"tier1 list", []string{"tier1", "list"}, "nsx.tier1.list"},
+	{"segment list", []string{"segment", "list"}, "nsx.segment.list"},
+	{"node list", []string{"node", "list"}, "nsx.transport_node.list"},
+}
+
+// ingestedDispatchCases pins the NSX verbs that legitimately dispatch
+// ingested METHOD:/path op_ids — each entry records why no typed
+// op_id exists, so the intent is pinned rather than silently
+// unguarded (#2942). When the backend ships a typed counterpart, move
+// the verb to typedDispatchCases and reclassify it in
+// typedOpCLICoverage.
+var ingestedDispatchCases = []struct {
+	name   string
+	args   []string
+	wantOp string
+}{
+	// No typed tier-0 read (initiative #2833 ranks it medium tier).
+	{"tier0 list", []string{"tier0", "list"}, "GET:/policy/api/v1/infra/tier-0s"},
+	// No typed firewall/security-policy reads.
+	{
+		"firewall policy list",
+		[]string{"firewall", "policy", "list"},
+		"GET:/policy/api/v1/infra/domains/{domain-id}/security-policies",
+	},
+	{
+		"firewall rule list",
+		[]string{"firewall", "rule", "list", "pol-1"},
+		"GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules",
+	},
+}
+
+// typedOpCLICoverage classifies every typed op_id the backend registers
+// for nsx: the CLI verb that dispatches it, or "" when the op is
+// agent-surface-only (no CLI verb wraps it).
+// TestBackendTypedOpsAreClassified fails when the backend gains a
+// typed op that is not classified here — the "typed op ⇒ repoint the
+// CLI verb ⇒ pin it" contract (#2942).
+var typedOpCLICoverage = map[string]string{
+	"nsx.node.status":          "about",
+	"nsx.cluster.status":       "cluster status",
+	"nsx.transport_zone.list":  "transport-zone list",
+	"nsx.tier1.list":           "tier1 list",
+	"nsx.segment.list":         "segment list",
+	"nsx.transport_node.list":  "node list",
+	"nsx.transport_node.state": "", // per-node state detail — agent surface only
+	"nsx.alarm.list":           "", // agent surface only
+	"nsx.backup.config":        "", // agent surface only
+	"nsx.backup.status":        "", // agent surface only
+}
+
+// TestRepointedVerbsDispatchTypedOpIDs pins that the repointed NSX
+// verbs dispatch their typed op_ids (the legacy METHOD:/path op_ids
+// no longer resolve on a zero-catalog boot).
 func TestRepointedVerbsDispatchTypedOpIDs(t *testing.T) {
-	cases := []struct {
-		name   string
-		args   []string
-		wantOp string
-	}{
-		{"about", []string{"about"}, "nsx.node.status"},
-		{"cluster status", []string{"cluster", "status"}, "nsx.cluster.status"},
-		{"transport-zone list", []string{"transport-zone", "list"}, "nsx.transport_zone.list"},
-		{"tier1 list", []string{"tier1", "list"}, "nsx.tier1.list"},
-	}
-	for _, tc := range cases {
+	for _, tc := range typedDispatchCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			var gotOp string
-			srv := mockBackplane(t, map[string]mockHandler{
-				"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
-					var body callRequestBody
-					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-						t.Errorf("decode body: %v", err)
-						w.WriteHeader(400)
-						return
-					}
-					gotOp = body.OpID
-					writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
-				},
-			})
-			defer srv.Close()
-			primeToken(t, srv.URL)
-
-			root := NewRootCmd()
-			root.SetArgs(append(tc.args, "--target", "rdc-nsx", "--backplane", srv.URL))
-			root.SetOut(&bytes.Buffer{})
-			root.SetErr(&bytes.Buffer{})
-			if err := root.Execute(); err != nil {
-				t.Fatalf("execute %v: %v", tc.args, err)
-			}
-			if gotOp != tc.wantOp {
-				t.Errorf("op_id: got %q want %q", gotOp, tc.wantOp)
-			}
+			assertVerbDispatchesOpID(t, tc.args, tc.wantOp)
 		})
+	}
+}
+
+// TestIngestedVerbsDispatchPinnedOpIDs pins the verbs that stay on
+// ingested op_ids on purpose (see ingestedDispatchCases for the
+// per-verb reasons).
+func TestIngestedVerbsDispatchPinnedOpIDs(t *testing.T) {
+	for _, tc := range ingestedDispatchCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assertVerbDispatchesOpID(t, tc.args, tc.wantOp)
+		})
+	}
+}
+
+// TestBackendTypedOpsAreClassified reconciles the backend's typed-op
+// registry against typedOpCLICoverage so a typed op shipped without a
+// CLI-repoint decision fails this test instead of leaving the verb a
+// zero-catalog dead end (#2942).
+func TestBackendTypedOpsAreClassified(t *testing.T) {
+	inventory, err := typedops.BackendOpIDs("nsx")
+	if err != nil {
+		t.Fatalf("read backend typed-op inventory: %v", err)
+	}
+	invSet := make(map[string]bool, len(inventory))
+	for _, id := range inventory {
+		invSet[id] = true
+	}
+	for _, id := range inventory {
+		if _, ok := typedOpCLICoverage[id]; !ok {
+			t.Errorf("backend typed op %q is unclassified — repoint the CLI verb "+
+				"covering this read (and add it to typedDispatchCases) or record it "+
+				"as agent-surface-only in typedOpCLICoverage (#2942 contract)", id)
+		}
+	}
+	for id := range typedOpCLICoverage {
+		if !invSet[id] {
+			t.Errorf("typedOpCLICoverage entry %q no longer exists in the backend "+
+				"registry — drop or rename it", id)
+		}
+	}
+	for _, tc := range typedDispatchCases {
+		if !invSet[tc.wantOp] {
+			t.Errorf("typed dispatch case %q asserts op_id %q that the backend "+
+				"does not register", tc.name, tc.wantOp)
+		}
+	}
+}
+
+// assertVerbDispatchesOpID executes the verb against a mock backplane
+// and asserts the op_id it puts on the wire.
+func assertVerbDispatchesOpID(t *testing.T, args []string, wantOp string) {
+	t.Helper()
+	var gotOp string
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			gotOp = body.OpID
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	root.SetArgs(append(args, "--target", "rdc-nsx", "--backplane", srv.URL))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute %v: %v", args, err)
+	}
+	if gotOp != wantOp {
+		t.Errorf("op_id: got %q want %q", gotOp, wantOp)
 	}
 }

--- a/cli/internal/cmd/sddc-manager/typed_opid_dispatch_test.go
+++ b/cli/internal/cmd/sddc-manager/typed_opid_dispatch_test.go
@@ -8,98 +8,208 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/typedops"
 )
 
-// TestRepointedVerbsDispatchTypedOpIDs pins that the #2266-repointed
-// SDDC Manager verbs dispatch their typed op_ids. The param-bearing
-// verbs (cluster/host/workflow) also assert their filter params carry
-// the exact keys the typed parameter_schemas accept (domainId /
-// clusterId / status) — a closed schema rejects any other key.
+// typedDispatchCases pins every SDDC Manager verb whose backend read
+// is typed to the dotted typed op_id it must dispatch (#2266 repoint
+// sweep #2355; network-pool via #2837). The param-bearing verbs
+// (cluster/host/workflow) also assert their filter params carry the
+// exact keys the typed parameter_schemas accept (domainId / clusterId
+// / status) — a closed schema rejects any other key.
+var typedDispatchCases = []struct {
+	name       string
+	args       []string
+	wantOp     string
+	checkParam func(*testing.T, map[string]any)
+}{
+	{name: "domain list", args: []string{"domain", "list"}, wantOp: "sddc.domain.list"},
+	{name: "manager list", args: []string{"manager", "list"}, wantOp: "sddc.manager.list"},
+	{name: "network-pool list", args: []string{"network-pool", "list"}, wantOp: "sddc.network_pool.list"},
+	{
+		name:   "network-pool get",
+		args:   []string{"network-pool", "get", "np-01"},
+		wantOp: "sddc.network_pool.get",
+		checkParam: func(t *testing.T, p map[string]any) {
+			if p["id"] != "np-01" {
+				t.Errorf("network-pool get: id param not forwarded; got %v", p)
+			}
+		},
+	},
+	{
+		name:   "cluster list",
+		args:   []string{"cluster", "list", "--domain", "domain-mgmt"},
+		wantOp: "sddc.cluster.list",
+		checkParam: func(t *testing.T, p map[string]any) {
+			if p["domainId"] != "domain-mgmt" {
+				t.Errorf("cluster list: domainId param not forwarded; got %v", p)
+			}
+		},
+	},
+	{
+		name:   "host list",
+		args:   []string{"host", "list", "--domain", "domain-wld01", "--cluster", "cluster-1"},
+		wantOp: "sddc.host.list",
+		checkParam: func(t *testing.T, p map[string]any) {
+			if p["domainId"] != "domain-wld01" || p["clusterId"] != "cluster-1" {
+				t.Errorf("host list: domainId/clusterId params not forwarded; got %v", p)
+			}
+		},
+	},
+	{
+		name:   "workflow list",
+		args:   []string{"workflow", "list", "--status", "In_Progress"},
+		wantOp: "sddc.task.list",
+		checkParam: func(t *testing.T, p map[string]any) {
+			if p["status"] != "In_Progress" {
+				t.Errorf("workflow list: status param not forwarded; got %v", p)
+			}
+		},
+	},
+}
+
+// ingestedDispatchCases pins the SDDC Manager verbs that legitimately
+// dispatch ingested METHOD:/path op_ids — each entry records why no
+// typed op_id exists, so the intent is pinned rather than silently
+// unguarded (#2942). When the backend ships a typed counterpart, move
+// the verb to typedDispatchCases and reclassify it in
+// typedOpCLICoverage.
+var ingestedDispatchCases = []struct {
+	name   string
+	args   []string
+	wantOp string
+}{
+	// Release-train read; the typed sddc.system.info reads GET /v1/system
+	// (appliance settings), a different surface — no typed counterpart
+	// for /v1/releases/system.
+	{"about", []string{"about"}, "GET:/v1/releases/system"},
+	// No typed bundle read.
+	{"bundle list", []string{"bundle", "list"}, "GET:/v1/bundles"},
+	// Genuine ingested detail read (#2942 marks it correct): the typed
+	// surface ships sddc.domain.list only, no per-id detail op.
+	{"domain info", []string{"domain", "info", "d-1"}, "GET:/v1/domains/{id}"},
+}
+
+// typedOpCLICoverage classifies every typed op_id the backend registers
+// for sddc_manager: the CLI verb that dispatches it, or "" when the op
+// is agent-surface-only (no CLI verb wraps it).
+// TestBackendTypedOpsAreClassified fails when the backend gains a
+// typed op that is not classified here — the "typed op ⇒ repoint the
+// CLI verb ⇒ pin it" contract (#2942).
+var typedOpCLICoverage = map[string]string{
+	"sddc.domain.list":       "domain list",
+	"sddc.manager.list":      "manager list",
+	"sddc.network_pool.list": "network-pool list",
+	"sddc.network_pool.get":  "network-pool get",
+	"sddc.cluster.list":      "cluster list",
+	"sddc.host.list":         "host list",
+	"sddc.task.list":         "workflow list",
+	"sddc.credential.list":   "", // agent surface only
+	"sddc.license.list":      "", // agent surface only
+	"sddc.nsxt_cluster.list": "", // agent surface only
+	"sddc.vcenter.list":      "", // agent surface only
+	"sddc.vcf_service.list":  "", // agent surface only
+	"sddc.domain.status":     "", // agent surface only
+	"sddc.system.info":       "", // agent surface only (reads /v1/system, not the about verb's /v1/releases/system)
+}
+
+// TestRepointedVerbsDispatchTypedOpIDs pins that the repointed SDDC
+// Manager verbs dispatch their typed op_ids.
 func TestRepointedVerbsDispatchTypedOpIDs(t *testing.T) {
-	cases := []struct {
-		name       string
-		args       []string
-		wantOp     string
-		checkParam func(*testing.T, map[string]any)
-	}{
-		{name: "domain list", args: []string{"domain", "list"}, wantOp: "sddc.domain.list"},
-		{name: "manager list", args: []string{"manager", "list"}, wantOp: "sddc.manager.list"},
-		{name: "network-pool list", args: []string{"network-pool", "list"}, wantOp: "sddc.network_pool.list"},
-		{
-			name:   "network-pool get",
-			args:   []string{"network-pool", "get", "np-01"},
-			wantOp: "sddc.network_pool.get",
-			checkParam: func(t *testing.T, p map[string]any) {
-				if p["id"] != "np-01" {
-					t.Errorf("network-pool get: id param not forwarded; got %v", p)
-				}
-			},
-		},
-		{
-			name:   "cluster list",
-			args:   []string{"cluster", "list", "--domain", "domain-mgmt"},
-			wantOp: "sddc.cluster.list",
-			checkParam: func(t *testing.T, p map[string]any) {
-				if p["domainId"] != "domain-mgmt" {
-					t.Errorf("cluster list: domainId param not forwarded; got %v", p)
-				}
-			},
-		},
-		{
-			name:   "host list",
-			args:   []string{"host", "list", "--domain", "domain-wld01", "--cluster", "cluster-1"},
-			wantOp: "sddc.host.list",
-			checkParam: func(t *testing.T, p map[string]any) {
-				if p["domainId"] != "domain-wld01" || p["clusterId"] != "cluster-1" {
-					t.Errorf("host list: domainId/clusterId params not forwarded; got %v", p)
-				}
-			},
-		},
-		{
-			name:   "workflow list",
-			args:   []string{"workflow", "list", "--status", "In_Progress"},
-			wantOp: "sddc.task.list",
-			checkParam: func(t *testing.T, p map[string]any) {
-				if p["status"] != "In_Progress" {
-					t.Errorf("workflow list: status param not forwarded; got %v", p)
-				}
-			},
-		},
-	}
-	for _, tc := range cases {
+	for _, tc := range typedDispatchCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			var gotOp string
-			var gotParams map[string]any
-			srv := mockBackplane(t, map[string]mockHandler{
-				"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
-					var body callRequestBody
-					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-						t.Errorf("decode body: %v", err)
-						w.WriteHeader(400)
-						return
-					}
-					gotOp = body.OpID
-					gotParams = body.Params
-					writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
-				},
-			})
-			defer srv.Close()
-			primeToken(t, srv.URL)
-
-			root := NewRootCmd()
-			root.SetArgs(append(tc.args, "--target", "rdc-sddc-manager", "--backplane", srv.URL))
-			root.SetOut(&bytes.Buffer{})
-			root.SetErr(&bytes.Buffer{})
-			if err := root.Execute(); err != nil {
-				t.Fatalf("execute %v: %v", tc.args, err)
-			}
-			if gotOp != tc.wantOp {
-				t.Errorf("op_id: got %q want %q", gotOp, tc.wantOp)
-			}
-			if tc.checkParam != nil {
-				tc.checkParam(t, gotParams)
-			}
+			assertVerbDispatchesOpID(t, tc.args, tc.wantOp, tc.checkParam)
 		})
+	}
+}
+
+// TestIngestedVerbsDispatchPinnedOpIDs pins the verbs that stay on
+// ingested op_ids on purpose (see ingestedDispatchCases for the
+// per-verb reasons).
+func TestIngestedVerbsDispatchPinnedOpIDs(t *testing.T) {
+	for _, tc := range ingestedDispatchCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assertVerbDispatchesOpID(t, tc.args, tc.wantOp, nil)
+		})
+	}
+}
+
+// TestBackendTypedOpsAreClassified reconciles the backend's typed-op
+// registry against typedOpCLICoverage so a typed op shipped without a
+// CLI-repoint decision fails this test instead of leaving the verb a
+// zero-catalog dead end (#2942).
+func TestBackendTypedOpsAreClassified(t *testing.T) {
+	inventory, err := typedops.BackendOpIDs("sddc_manager")
+	if err != nil {
+		t.Fatalf("read backend typed-op inventory: %v", err)
+	}
+	invSet := make(map[string]bool, len(inventory))
+	for _, id := range inventory {
+		invSet[id] = true
+	}
+	for _, id := range inventory {
+		if _, ok := typedOpCLICoverage[id]; !ok {
+			t.Errorf("backend typed op %q is unclassified — repoint the CLI verb "+
+				"covering this read (and add it to typedDispatchCases) or record it "+
+				"as agent-surface-only in typedOpCLICoverage (#2942 contract)", id)
+		}
+	}
+	for id := range typedOpCLICoverage {
+		if !invSet[id] {
+			t.Errorf("typedOpCLICoverage entry %q no longer exists in the backend "+
+				"registry — drop or rename it", id)
+		}
+	}
+	for _, tc := range typedDispatchCases {
+		if !invSet[tc.wantOp] {
+			t.Errorf("typed dispatch case %q asserts op_id %q that the backend "+
+				"does not register", tc.name, tc.wantOp)
+		}
+	}
+}
+
+// assertVerbDispatchesOpID executes the verb against a mock backplane
+// and asserts the op_id (and optionally the params) it puts on the
+// wire.
+func assertVerbDispatchesOpID(
+	t *testing.T,
+	args []string,
+	wantOp string,
+	checkParam func(*testing.T, map[string]any),
+) {
+	t.Helper()
+	var gotOp string
+	var gotParams map[string]any
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			gotOp = body.OpID
+			gotParams = body.Params
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	root.SetArgs(append(args, "--target", "rdc-sddc-manager", "--backplane", srv.URL))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute %v: %v", args, err)
+	}
+	if gotOp != wantOp {
+		t.Errorf("op_id: got %q want %q", gotOp, wantOp)
+	}
+	if checkParam != nil {
+		checkParam(t, gotParams)
 	}
 }

--- a/cli/internal/cmd/vcf-automation/deployment.go
+++ b/cli/internal/cmd/vcf-automation/deployment.go
@@ -40,7 +40,7 @@ func newDeploymentListCmd() *cobra.Command {
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runTenantListVerb(cmd,
-				"GET:/iaas/api/deployments",
+				"vcfa.tenant.deployment.list",
 				targetName, jsonOut, backplaneOverride,
 				printDeploymentList,
 			)
@@ -64,6 +64,9 @@ func newDeploymentGetCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Ingested op_id on purpose: #2839 shipped the typed list op
+			// only — repointing `get` is blocked on a future
+			// vcfa.tenant.deployment.get typed op (#2942).
 			return runTenantGetVerb(cmd,
 				"GET:/iaas/api/deployments/{id}",
 				"id", args[0],
@@ -77,7 +80,7 @@ func newDeploymentGetCmd() *cobra.Command {
 }
 
 func printDeploymentList(w io.Writer, r *CallResult) {
-	const opID = "GET:/iaas/api/deployments"
+	const opID = "vcfa.tenant.deployment.list"
 	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
 	if r.Status != "ok" {
 		printErrorTrailer(w, r)

--- a/cli/internal/cmd/vcf-automation/typed_opid_dispatch_test.go
+++ b/cli/internal/cmd/vcf-automation/typed_opid_dispatch_test.go
@@ -8,52 +8,151 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/typedops"
 )
 
-// TestRepointedListVerbsDispatchTypedOpIDs pins that the
-// #2266-repointed VCFA list verbs dispatch their typed op_ids at the
-// command-constructor site. (The dual-plane `about` verb is covered by
-// TestAboutVerbDispatchesPerPlane / TestAboutOpForPlane.) The get-by-id
-// verbs keep their legacy op_ids and are deliberately not asserted here.
+// typedDispatchCases pins every VCFA verb whose backend read is typed
+// to the dotted typed op_id it must dispatch (#2266 repoint sweep
+// #2355; deployment list repointed by #2942 once #2839 shipped the
+// typed op). The dual-plane `about` verb is pinned separately by
+// TestAboutVerbDispatchesPerPlane / TestAboutOpForPlane.
+var typedDispatchCases = []struct {
+	name   string
+	args   []string
+	wantOp string
+}{
+	{"org list", []string{"org", "list"}, "vcfa.provider.org.list"},
+	{"region list", []string{"region", "list"}, "vcfa.provider.region.list"},
+	{"project list", []string{"project", "list"}, "vcfa.tenant.project.list"},
+	{"deployment list", []string{"deployment", "list"}, "vcfa.tenant.deployment.list"},
+}
+
+// ingestedDispatchCases pins the VCFA verbs that legitimately dispatch
+// ingested METHOD:/path op_ids — each entry records why no typed
+// op_id exists, so the intent is pinned rather than silently
+// unguarded (#2942). When the backend ships a typed counterpart, move
+// the verb to typedDispatchCases and reclassify it in
+// typedOpCLICoverage.
+var ingestedDispatchCases = []struct {
+	name   string
+	args   []string
+	wantOp string
+}{
+	// Detail reads with no typed counterpart (the typed surface ships
+	// list ops only).
+	{"org get", []string{"org", "get", "org-1"}, "GET:/cloudapi/1.0.0/orgs/{id}"},
+	{"region get", []string{"region", "get", "reg-1"}, "GET:/cloudapi/1.0.0/regions/{id}"},
+	// Blocked on a future vcfa.tenant.deployment.get typed op — #2839
+	// shipped list only (#2942 out-of-scope note).
+	{"deployment get", []string{"deployment", "get", "dep-1"}, "GET:/iaas/api/deployments/{id}"},
+	// No typed blueprint/user reads (initiative #2833 ranks them low
+	// tier, not planned).
+	{"blueprint list", []string{"blueprint", "list"}, "GET:/iaas/api/blueprints"},
+	{"user list", []string{"user", "list"}, "GET:/cloudapi/1.0.0/users"},
+}
+
+// typedOpCLICoverage classifies every typed op_id the backend registers
+// for vcf_automation: the CLI verb that dispatches it, or "" when the
+// op is agent-surface-only (no CLI verb wraps it).
+// TestBackendTypedOpsAreClassified fails when the backend gains a
+// typed op that is not classified here — the "typed op ⇒ repoint the
+// CLI verb ⇒ pin it" contract (#2942).
+var typedOpCLICoverage = map[string]string{
+	"vcfa.provider.org.list":      "org list",
+	"vcfa.provider.region.list":   "region list",
+	"vcfa.provider.health":        "about --plane provider", // pinned by TestAboutVerbDispatchesPerPlane
+	"vcfa.tenant.project.list":    "project list",
+	"vcfa.tenant.deployment.list": "deployment list",
+	"vcfa.tenant.about":           "about --plane tenant", // pinned by TestAboutVerbDispatchesPerPlane
+}
+
+// TestRepointedListVerbsDispatchTypedOpIDs pins that the repointed
+// VCFA list verbs dispatch their typed op_ids at the
+// command-constructor site.
 func TestRepointedListVerbsDispatchTypedOpIDs(t *testing.T) {
-	cases := []struct {
-		name   string
-		args   []string
-		wantOp string
-	}{
-		{"org list", []string{"org", "list"}, "vcfa.provider.org.list"},
-		{"region list", []string{"region", "list"}, "vcfa.provider.region.list"},
-		{"project list", []string{"project", "list"}, "vcfa.tenant.project.list"},
-	}
-	for _, tc := range cases {
+	for _, tc := range typedDispatchCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			var gotOp string
-			srv := mockBackplane(t, map[string]mockHandler{
-				"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
-					var body callRequestBody
-					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-						t.Errorf("decode body: %v", err)
-						w.WriteHeader(400)
-						return
-					}
-					gotOp = body.OpID
-					writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
-				},
-			})
-			defer srv.Close()
-			primeToken(t, srv.URL)
-
-			root := NewRootCmd()
-			root.SetArgs(append(tc.args, "--target", "rdc-vcfa", "--backplane", srv.URL))
-			root.SetOut(&bytes.Buffer{})
-			root.SetErr(&bytes.Buffer{})
-			if err := root.Execute(); err != nil {
-				t.Fatalf("execute %v: %v", tc.args, err)
-			}
-			if gotOp != tc.wantOp {
-				t.Errorf("op_id: got %q want %q", gotOp, tc.wantOp)
-			}
+			assertVerbDispatchesOpID(t, tc.args, tc.wantOp)
 		})
+	}
+}
+
+// TestIngestedVerbsDispatchPinnedOpIDs pins the verbs that stay on
+// ingested op_ids on purpose (see ingestedDispatchCases for the
+// per-verb reasons).
+func TestIngestedVerbsDispatchPinnedOpIDs(t *testing.T) {
+	for _, tc := range ingestedDispatchCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assertVerbDispatchesOpID(t, tc.args, tc.wantOp)
+		})
+	}
+}
+
+// TestBackendTypedOpsAreClassified reconciles the backend's typed-op
+// registry against typedOpCLICoverage so a typed op shipped without a
+// CLI-repoint decision fails this test instead of leaving the verb a
+// zero-catalog dead end (#2942).
+func TestBackendTypedOpsAreClassified(t *testing.T) {
+	inventory, err := typedops.BackendOpIDs("vcf_automation")
+	if err != nil {
+		t.Fatalf("read backend typed-op inventory: %v", err)
+	}
+	invSet := make(map[string]bool, len(inventory))
+	for _, id := range inventory {
+		invSet[id] = true
+	}
+	for _, id := range inventory {
+		if _, ok := typedOpCLICoverage[id]; !ok {
+			t.Errorf("backend typed op %q is unclassified — repoint the CLI verb "+
+				"covering this read (and add it to typedDispatchCases) or record it "+
+				"as agent-surface-only in typedOpCLICoverage (#2942 contract)", id)
+		}
+	}
+	for id := range typedOpCLICoverage {
+		if !invSet[id] {
+			t.Errorf("typedOpCLICoverage entry %q no longer exists in the backend "+
+				"registry — drop or rename it", id)
+		}
+	}
+	for _, tc := range typedDispatchCases {
+		if !invSet[tc.wantOp] {
+			t.Errorf("typed dispatch case %q asserts op_id %q that the backend "+
+				"does not register", tc.name, tc.wantOp)
+		}
+	}
+}
+
+// assertVerbDispatchesOpID executes the verb against a mock backplane
+// and asserts the op_id it puts on the wire.
+func assertVerbDispatchesOpID(t *testing.T, args []string, wantOp string) {
+	t.Helper()
+	var gotOp string
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			gotOp = body.OpID
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	root.SetArgs(append(args, "--target", "rdc-vcfa", "--backplane", srv.URL))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute %v: %v", args, err)
+	}
+	if gotOp != wantOp {
+		t.Errorf("op_id: got %q want %q", gotOp, wantOp)
 	}
 }

--- a/cli/internal/cmd/vcf-fleet/typed_opid_dispatch_test.go
+++ b/cli/internal/cmd/vcf-fleet/typed_opid_dispatch_test.go
@@ -8,50 +8,142 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/typedops"
 )
 
-// TestRepointedVerbsDispatchTypedOpIDs pins that the #2266-repointed
-// Fleet verbs dispatch their typed op_ids. Both are no-param reads, so
-// the swap is a pure op_id change (only `about` and `environment list`
-// were converted; environment info keeps its legacy op_id).
+// typedDispatchCases pins every Fleet verb whose backend read is typed
+// to the dotted typed op_id it must dispatch (#2266 repoint sweep
+// #2355). Both are no-param reads, so each swap was a pure op_id
+// change.
+var typedDispatchCases = []struct {
+	name   string
+	args   []string
+	wantOp string
+}{
+	{"about", []string{"about"}, "fleet.about"},
+	{"environment list", []string{"environment", "list"}, "fleet.environment.list"},
+}
+
+// ingestedDispatchCases pins the Fleet verbs that legitimately
+// dispatch ingested METHOD:/path op_ids — each entry records why no
+// typed op_id exists, so the intent is pinned rather than silently
+// unguarded (#2942). When the backend ships a typed counterpart, move
+// the verb to typedDispatchCases and reclassify it in
+// typedOpCLICoverage.
+var ingestedDispatchCases = []struct {
+	name   string
+	args   []string
+	wantOp string
+}{
+	// No typed datacenter/vcenter/product reads.
+	{"datacenter list", []string{"datacenter", "list"}, "GET:/lcm/lcops/api/v2/datacenters"},
+	{"vcenter list", []string{"vcenter", "list", "dc-1"}, "GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters"},
+	{"product list", []string{"product", "list", "env-1"}, "GET:/lcm/lcops/api/v2/environments/{environmentId}/products"},
+	// Detail read with no typed counterpart (fleet.environment.list is
+	// list-only).
+	{"environment info", []string{"environment", "info", "env-1"}, "GET:/lcm/lcops/api/v2/environments/{environmentId}"},
+	// No typed request reads (initiative #2833 ranks them medium tier).
+	{"request list", []string{"request", "list"}, "GET:/lcm/request/api/v2/requests"},
+	{"request info", []string{"request", "info", "req-1"}, "GET:/lcm/request/api/v2/requests/{requestId}"},
+}
+
+// typedOpCLICoverage classifies every typed op_id the backend registers
+// for vcf_fleet: the CLI verb that dispatches it, or "" when the op is
+// agent-surface-only (no CLI verb wraps it).
+// TestBackendTypedOpsAreClassified fails when the backend gains a
+// typed op that is not classified here — the "typed op ⇒ repoint the
+// CLI verb ⇒ pin it" contract (#2942).
+var typedOpCLICoverage = map[string]string{
+	"fleet.about":            "about",
+	"fleet.environment.list": "environment list",
+}
+
+// TestRepointedVerbsDispatchTypedOpIDs pins that the repointed Fleet
+// verbs dispatch their typed op_ids.
 func TestRepointedVerbsDispatchTypedOpIDs(t *testing.T) {
-	cases := []struct {
-		name   string
-		args   []string
-		wantOp string
-	}{
-		{"about", []string{"about"}, "fleet.about"},
-		{"environment list", []string{"environment", "list"}, "fleet.environment.list"},
-	}
-	for _, tc := range cases {
+	for _, tc := range typedDispatchCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			var gotOp string
-			srv := mockBackplane(t, map[string]mockHandler{
-				"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
-					var body callRequestBody
-					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-						t.Errorf("decode body: %v", err)
-						w.WriteHeader(400)
-						return
-					}
-					gotOp = body.OpID
-					writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
-				},
-			})
-			defer srv.Close()
-			primeToken(t, srv.URL)
-
-			root := NewRootCmd()
-			root.SetArgs(append(tc.args, "--target", "rdc-fleet", "--backplane", srv.URL))
-			root.SetOut(&bytes.Buffer{})
-			root.SetErr(&bytes.Buffer{})
-			if err := root.Execute(); err != nil {
-				t.Fatalf("execute %v: %v", tc.args, err)
-			}
-			if gotOp != tc.wantOp {
-				t.Errorf("op_id: got %q want %q", gotOp, tc.wantOp)
-			}
+			assertVerbDispatchesOpID(t, tc.args, tc.wantOp)
 		})
+	}
+}
+
+// TestIngestedVerbsDispatchPinnedOpIDs pins the verbs that stay on
+// ingested op_ids on purpose (see ingestedDispatchCases for the
+// per-verb reasons).
+func TestIngestedVerbsDispatchPinnedOpIDs(t *testing.T) {
+	for _, tc := range ingestedDispatchCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assertVerbDispatchesOpID(t, tc.args, tc.wantOp)
+		})
+	}
+}
+
+// TestBackendTypedOpsAreClassified reconciles the backend's typed-op
+// registry against typedOpCLICoverage so a typed op shipped without a
+// CLI-repoint decision fails this test instead of leaving the verb a
+// zero-catalog dead end (#2942).
+func TestBackendTypedOpsAreClassified(t *testing.T) {
+	inventory, err := typedops.BackendOpIDs("vcf_fleet")
+	if err != nil {
+		t.Fatalf("read backend typed-op inventory: %v", err)
+	}
+	invSet := make(map[string]bool, len(inventory))
+	for _, id := range inventory {
+		invSet[id] = true
+	}
+	for _, id := range inventory {
+		if _, ok := typedOpCLICoverage[id]; !ok {
+			t.Errorf("backend typed op %q is unclassified — repoint the CLI verb "+
+				"covering this read (and add it to typedDispatchCases) or record it "+
+				"as agent-surface-only in typedOpCLICoverage (#2942 contract)", id)
+		}
+	}
+	for id := range typedOpCLICoverage {
+		if !invSet[id] {
+			t.Errorf("typedOpCLICoverage entry %q no longer exists in the backend "+
+				"registry — drop or rename it", id)
+		}
+	}
+	for _, tc := range typedDispatchCases {
+		if !invSet[tc.wantOp] {
+			t.Errorf("typed dispatch case %q asserts op_id %q that the backend "+
+				"does not register", tc.name, tc.wantOp)
+		}
+	}
+}
+
+// assertVerbDispatchesOpID executes the verb against a mock backplane
+// and asserts the op_id it puts on the wire.
+func assertVerbDispatchesOpID(t *testing.T, args []string, wantOp string) {
+	t.Helper()
+	var gotOp string
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			gotOp = body.OpID
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	root.SetArgs(append(args, "--target", "rdc-fleet", "--backplane", srv.URL))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute %v: %v", args, err)
+	}
+	if gotOp != wantOp {
+		t.Errorf("op_id: got %q want %q", gotOp, wantOp)
 	}
 }

--- a/cli/internal/cmd/vcf-operations/typed_opid_dispatch_test.go
+++ b/cli/internal/cmd/vcf-operations/typed_opid_dispatch_test.go
@@ -8,67 +8,169 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/typedops"
 )
 
-// TestRepointedVerbsDispatchTypedOpIDs pins that the #2266-repointed
-// vROps verbs dispatch their typed op_ids (not the retired
-// METHOD:/path op_ids that no longer resolve on a zero-catalog boot).
-// The param-bearing `alert list` also asserts its --params payload is
-// forwarded verbatim — the keys must satisfy vrops.alert.list's closed
-// parameter_schema.
-func TestRepointedVerbsDispatchTypedOpIDs(t *testing.T) {
-	cases := []struct {
-		name       string
-		args       []string
-		wantOp     string
-		checkParam func(*testing.T, map[string]any)
-	}{
-		{name: "about", args: []string{"about"}, wantOp: "vrops.liveness"},
-		{
-			name:   "alert list",
-			args:   []string{"alert", "list", "--params", `{"activeOnly":true}`},
-			wantOp: "vrops.alert.list",
-			checkParam: func(t *testing.T, p map[string]any) {
-				if v, ok := p["activeOnly"].(bool); !ok || !v {
-					t.Errorf("alert list: activeOnly param not forwarded to typed op; got %v", p)
-				}
-			},
+// typedDispatchCases pins every vROps verb whose backend read is typed
+// to the dotted typed op_id it must dispatch (#2266 repoint sweep
+// #2355). The param-bearing `alert list` also asserts its --params
+// payload is forwarded verbatim — the keys must satisfy
+// vrops.alert.list's closed parameter_schema.
+var typedDispatchCases = []struct {
+	name       string
+	args       []string
+	wantOp     string
+	checkParam func(*testing.T, map[string]any)
+}{
+	{name: "about", args: []string{"about"}, wantOp: "vrops.liveness"},
+	{
+		name:   "alert list",
+		args:   []string{"alert", "list", "--params", `{"activeOnly":true}`},
+		wantOp: "vrops.alert.list",
+		checkParam: func(t *testing.T, p map[string]any) {
+			if v, ok := p["activeOnly"].(bool); !ok || !v {
+				t.Errorf("alert list: activeOnly param not forwarded to typed op; got %v", p)
+			}
 		},
-	}
-	for _, tc := range cases {
+	},
+}
+
+// ingestedDispatchCases pins the vROps verbs that legitimately
+// dispatch ingested METHOD:/path op_ids — each entry records why no
+// typed op_id exists, so the intent is pinned rather than silently
+// unguarded (#2942). When the backend ships a typed counterpart, move
+// the verb to typedDispatchCases and reclassify it in
+// typedOpCLICoverage.
+var ingestedDispatchCases = []struct {
+	name   string
+	args   []string
+	wantOp string
+}{
+	// The GET inventory list; the typed vrops.resource.query is the
+	// POST body-query surface — a deliberately different, richer read,
+	// not a counterpart for this plain list.
+	{"resource list", []string{"resource", "list"}, "GET:/suite-api/api/resources"},
+	// Detail read with no typed counterpart.
+	{"resource get", []string{"resource", "get", "r-1"}, "GET:/suite-api/api/resources/{id}"},
+	// No typed alert-definition / symptom / recommendation /
+	// supermetric reads.
+	{"alertdefinition list", []string{"alertdefinition", "list"}, "GET:/suite-api/api/alertdefinitions"},
+	{"symptom list", []string{"symptom", "list"}, "GET:/suite-api/api/symptoms"},
+	{"recommendation list", []string{"recommendation", "list"}, "GET:/suite-api/api/recommendations"},
+	{"supermetric list", []string{"supermetric", "list"}, "GET:/suite-api/api/supermetrics"},
+}
+
+// typedOpCLICoverage classifies every typed op_id the backend registers
+// for vcf_operations: the CLI verb that dispatches it, or "" when the
+// op is agent-surface-only (no CLI verb wraps it).
+// TestBackendTypedOpsAreClassified fails when the backend gains a
+// typed op that is not classified here — the "typed op ⇒ repoint the
+// CLI verb ⇒ pin it" contract (#2942).
+var typedOpCLICoverage = map[string]string{
+	"vrops.liveness":       "about",
+	"vrops.alert.list":     "alert list",
+	"vrops.resource.query": "", // agent surface only (POST query; `resource list` is the plain GET list)
+	"vrops.resource.stats": "", // agent surface only
+}
+
+// TestRepointedVerbsDispatchTypedOpIDs pins that the repointed vROps
+// verbs dispatch their typed op_ids (not the retired METHOD:/path
+// op_ids that no longer resolve on a zero-catalog boot).
+func TestRepointedVerbsDispatchTypedOpIDs(t *testing.T) {
+	for _, tc := range typedDispatchCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			var gotOp string
-			var gotParams map[string]any
-			srv := mockBackplane(t, map[string]mockHandler{
-				"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
-					var body callRequestBody
-					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-						t.Errorf("decode body: %v", err)
-						w.WriteHeader(400)
-						return
-					}
-					gotOp = body.OpID
-					gotParams = body.Params
-					writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
-				},
-			})
-			defer srv.Close()
-			primeToken(t, srv.URL)
-
-			root := NewRootCmd()
-			root.SetArgs(append(tc.args, "--target", "rdc-vrops", "--backplane", srv.URL))
-			root.SetOut(&bytes.Buffer{})
-			root.SetErr(&bytes.Buffer{})
-			if err := root.Execute(); err != nil {
-				t.Fatalf("execute %v: %v", tc.args, err)
-			}
-			if gotOp != tc.wantOp {
-				t.Errorf("op_id: got %q want %q", gotOp, tc.wantOp)
-			}
-			if tc.checkParam != nil {
-				tc.checkParam(t, gotParams)
-			}
+			assertVerbDispatchesOpID(t, tc.args, tc.wantOp, tc.checkParam)
 		})
+	}
+}
+
+// TestIngestedVerbsDispatchPinnedOpIDs pins the verbs that stay on
+// ingested op_ids on purpose (see ingestedDispatchCases for the
+// per-verb reasons).
+func TestIngestedVerbsDispatchPinnedOpIDs(t *testing.T) {
+	for _, tc := range ingestedDispatchCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			assertVerbDispatchesOpID(t, tc.args, tc.wantOp, nil)
+		})
+	}
+}
+
+// TestBackendTypedOpsAreClassified reconciles the backend's typed-op
+// registry against typedOpCLICoverage so a typed op shipped without a
+// CLI-repoint decision fails this test instead of leaving the verb a
+// zero-catalog dead end (#2942).
+func TestBackendTypedOpsAreClassified(t *testing.T) {
+	inventory, err := typedops.BackendOpIDs("vcf_operations")
+	if err != nil {
+		t.Fatalf("read backend typed-op inventory: %v", err)
+	}
+	invSet := make(map[string]bool, len(inventory))
+	for _, id := range inventory {
+		invSet[id] = true
+	}
+	for _, id := range inventory {
+		if _, ok := typedOpCLICoverage[id]; !ok {
+			t.Errorf("backend typed op %q is unclassified — repoint the CLI verb "+
+				"covering this read (and add it to typedDispatchCases) or record it "+
+				"as agent-surface-only in typedOpCLICoverage (#2942 contract)", id)
+		}
+	}
+	for id := range typedOpCLICoverage {
+		if !invSet[id] {
+			t.Errorf("typedOpCLICoverage entry %q no longer exists in the backend "+
+				"registry — drop or rename it", id)
+		}
+	}
+	for _, tc := range typedDispatchCases {
+		if !invSet[tc.wantOp] {
+			t.Errorf("typed dispatch case %q asserts op_id %q that the backend "+
+				"does not register", tc.name, tc.wantOp)
+		}
+	}
+}
+
+// assertVerbDispatchesOpID executes the verb against a mock backplane
+// and asserts the op_id (and optionally the params) it puts on the
+// wire.
+func assertVerbDispatchesOpID(
+	t *testing.T,
+	args []string,
+	wantOp string,
+	checkParam func(*testing.T, map[string]any),
+) {
+	t.Helper()
+	var gotOp string
+	var gotParams map[string]any
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			gotOp = body.OpID
+			gotParams = body.Params
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	root.SetArgs(append(args, "--target", "rdc-vrops", "--backplane", srv.URL))
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute %v: %v", args, err)
+	}
+	if gotOp != wantOp {
+		t.Errorf("op_id: got %q want %q", gotOp, wantOp)
+	}
+	if checkParam != nil {
+		checkParam(t, gotParams)
 	}
 }

--- a/cli/internal/typedops/typedops.go
+++ b/cli/internal/typedops/typedops.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package typedops reads the backplane's per-connector typed-op
+// registries so the per-connector typed_opid_dispatch_test.go guards
+// can reconcile the CLI's dispatched op_ids against the backend's
+// typed-op inventory (#2942). A typed connector resolves only dotted
+// typed op_ids on a zero-catalog boot, so a CLI verb left on a legacy
+// `METHOD:/path` op_id after its backend read went typed is a dead
+// end; the guards fail closed when the backend gains a typed op the
+// CLI has not classified. Test support only — no runtime code imports
+// this package.
+package typedops
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+)
+
+// opIDPattern matches typed-op registrations (`op_id="dotted.op.id"`)
+// in the backend connector modules. The dataclass field declaration
+// (`op_id: str`) and interpolated error messages (`{op.op_id!r}`) do
+// not match. The character class is deliberately wide so an
+// unconventionally named future op still lands in the inventory
+// instead of silently escaping the guard.
+var opIDPattern = regexp.MustCompile(`op_id="([A-Za-z0-9_.-]+)"`)
+
+// BackendOpIDs returns the sorted, de-duplicated set of typed op_ids
+// declared under backend/src/meho_backplane/connectors/<connectorDir>.
+//
+// The backend tree is located by ascending from the current working
+// directory (the package directory under `go test`), so the helper
+// works from any package depth inside cli/ as long as the monorepo
+// checkout is intact. A checkout without backend/ is an error, not a
+// skip — the guard must stay fail-closed.
+func BackendOpIDs(connectorDir string) ([]string, error) {
+	root, err := findRepoRoot()
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Join(root, "backend", "src", "meho_backplane", "connectors", connectorDir)
+	seen := map[string]struct{}{}
+	walkErr := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Ext(path) != ".py" {
+			return nil
+		}
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		for _, m := range opIDPattern.FindAllSubmatch(raw, -1) {
+			seen[string(m[1])] = struct{}{}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+	if len(seen) == 0 {
+		return nil, fmt.Errorf("no op_id=%q declarations found under %s", "...", dir)
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// findRepoRoot ascends from the working directory until it finds the
+// directory that contains backend/src/meho_backplane/connectors.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	start := dir
+	for {
+		marker := filepath.Join(dir, "backend", "src", "meho_backplane", "connectors")
+		if info, statErr := os.Stat(marker); statErr == nil && info.IsDir() {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf(
+				"backend/src/meho_backplane/connectors not found above %s "+
+					"(the typed-op dispatch guard needs the full monorepo checkout)",
+				start,
+			)
+		}
+		dir = parent
+	}
+}

--- a/cli/internal/typedops/typedops_test.go
+++ b/cli/internal/typedops/typedops_test.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package typedops
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestBackendOpIDsParsesVcfAutomation sanity-checks the parser against
+// a real registry: the vcf_automation connector must expose the #2839
+// deployment-list typed op and nothing that isn't a dotted op_id.
+func TestBackendOpIDsParsesVcfAutomation(t *testing.T) {
+	ids, err := BackendOpIDs("vcf_automation")
+	if err != nil {
+		t.Fatalf("BackendOpIDs: %v", err)
+	}
+	if !slices.Contains(ids, "vcfa.tenant.deployment.list") {
+		t.Errorf("expected vcfa.tenant.deployment.list in inventory; got %v", ids)
+	}
+	if !slices.IsSorted(ids) {
+		t.Errorf("inventory should be sorted; got %v", ids)
+	}
+}
+
+// TestBackendOpIDsUnknownConnector fails closed on a missing dir.
+func TestBackendOpIDsUnknownConnector(t *testing.T) {
+	if _, err := BackendOpIDs("no-such-connector"); err == nil {
+		t.Fatal("expected an error for a nonexistent connector dir")
+	}
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -1271,6 +1271,35 @@ instead of byte-near-identical `doAuthedRequest` / `sendRequest` /
 `dispatch.ErrOpError`), `2` auth_expired, `3` unreachable,
 `4` unexpected_response.
 
+### Typed op_id repoint contract (typed connectors, #2942)
+
+Typed connectors (nsx, sddc-manager, vcf-automation, vcf-fleet,
+vcf-operations, …) resolve only their dotted typed op_ids on a
+zero-catalog boot — a vendor verb left dispatching a legacy ingested
+`METHOD:/path` op_id after its backend read went typed is a dead end
+for operators even though the agent/backend path works (#2355 did the
+initial 19-verb sweep; #2942 closed the residual gap and added the
+recurrence guard). The contract for every future typed read op:
+
+1. **Repoint the CLI verb** that covers the read to the dotted typed
+   op_id (dispatch call + printer constant), aligning params to the
+   typed op's `parameter_schema`.
+2. **Pin it** in the connector's
+   `cli/internal/cmd/<vendor>/typed_opid_dispatch_test.go`:
+   - `typedDispatchCases` — every verb whose backend read is typed,
+     asserted to put the dotted op_id on the wire;
+   - `ingestedDispatchCases` — every verb that legitimately stays on
+     an ingested op_id (no typed counterpart), with the reason in a
+     comment;
+   - `typedOpCLICoverage` — classifies **every** backend typed op_id
+     (CLI verb or agent-surface-only).
+3. The guard's `TestBackendTypedOpsAreClassified` reconciles
+   `typedOpCLICoverage` against the backend registry
+   (`backend/src/meho_backplane/connectors/<name>/`, parsed by
+   `cli/internal/typedops`), so a typed op shipped without a CLI
+   repoint decision **fails CI** instead of silently stranding the
+   verb.
+
 ## Topology verbs (`meho topology`, G9.1-T6 #454 + G9.2-T6 #599)
 
 `cli/internal/cmd/topology/` registers seven operator-facing topology

--- a/docs/cross-repo/nsx-onboarding.md
+++ b/docs/cross-repo/nsx-onboarding.md
@@ -39,9 +39,9 @@ ops stay in the wrapper until v0.2.next ships policy + approval flow:
 | Group | CLI verb | `op_id` | Path |
 | --- | --- | --- | --- |
 | nsx-identity | `meho nsx about` | `GET:/api/v1/node` | Manager identity + version |
-| nsx-inventory | `meho nsx node list` | `GET:/api/v1/transport-nodes` | Transport-node inventory |
+| nsx-inventory | `meho nsx node list` | `nsx.transport_node.list` | Transport-node inventory |
 | nsx-cluster | `meho nsx cluster status` | `GET:/api/v1/cluster/status` | Management + control cluster health |
-| nsx-segments | `meho nsx segment list` | `GET:/policy/api/v1/infra/segments` | Policy-API overlay/VLAN segment listing |
+| nsx-segments | `meho nsx segment list` | `nsx.segment.list` | Policy-API overlay/VLAN segment listing |
 | nsx-transport-zones | `meho nsx transport-zone list` | `GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones` | Transport-zone listing |
 | nsx-routing | `meho nsx tier0 list` | `GET:/policy/api/v1/infra/tier-0s` | Provider-edge Tier-0 router listing |
 | nsx-routing | `meho nsx tier1 list` | `GET:/policy/api/v1/infra/tier-1s` | Tenant Tier-1 router listing |
@@ -199,7 +199,10 @@ nsx-rest-4.2 — node_version=4.2.1.0.0 (kernel 4.2.1.0.0 build) @ nsxmgr-rdc
 
 ### `meho nsx node list`
 
-Dispatches `GET:/api/v1/transport-nodes`. Renders `id` / `display_name`
+Dispatches `nsx.transport_node.list` (the typed read; repointed off
+the ingested `GET:/api/v1/transport-nodes` op_id by #2942 — the
+legacy op_id no longer resolves on a zero-catalog boot). Renders
+`id` / `display_name`
 and `resource_type` from `node_deployment_info`. The list covers all
 transport nodes registered on the manager (ESXi hosts, bare-metal
 endpoints, edge nodes).
@@ -213,7 +216,10 @@ detail list.
 
 ### `meho nsx segment list`
 
-Dispatches `GET:/policy/api/v1/infra/segments`. Renders `id` /
+Dispatches `nsx.segment.list` (the typed read; repointed off the
+ingested `GET:/policy/api/v1/infra/segments` op_id by #2942 — the
+legacy op_id no longer resolves on a zero-catalog boot). Renders
+`id` /
 `display_name` / `transport_zone_path`. This is the broadest list op —
 production deployments often have hundreds of segments. Use `--json |
 jq` to filter by transport zone path or subnet CIDR.

--- a/docs/cross-repo/vcf-automation-onboarding.md
+++ b/docs/cross-repo/vcf-automation-onboarding.md
@@ -102,7 +102,7 @@ working set as 11 curated ops, distributed across both planes:
 | provider | `provider-users` | `meho vcf-automation user list` | `GET:/cloudapi/1.0.0/users` |
 | tenant | `tenant-about` | `meho vcf-automation about --plane tenant` | `GET:/iaas/api/about` |
 | tenant | `tenant-projects` | `meho vcf-automation project list` | `GET:/iaas/api/projects` |
-| tenant | `tenant-deployments` | `meho vcf-automation deployment list` | `GET:/iaas/api/deployments` |
+| tenant | `tenant-deployments` | `meho vcf-automation deployment list` | `vcfa.tenant.deployment.list` |
 | tenant | `tenant-deployments` | `meho vcf-automation deployment get <id>` | `GET:/iaas/api/deployments/{id}` |
 | tenant | `tenant-blueprints` | `meho vcf-automation blueprint list` | `GET:/iaas/api/blueprints` |
 
@@ -283,7 +283,11 @@ controls reference project membership.
 
 ### `meho vcf-automation deployment list` / `deployment get <id>`
 
-Tenant-plane only. The largest payload on the tenant surface; large
+Tenant-plane only. `deployment list` dispatches the typed
+`vcfa.tenant.deployment.list` (repointed off the ingested
+`GET:/iaas/api/deployments` op_id by #2942); `deployment get` stays
+on `GET:/iaas/api/deployments/{id}` until a typed detail op ships.
+The largest payload on the tenant surface; large
 tenants return hundreds of deployments. The dispatcher's JSONFlux
 seam wraps oversized responses in a `ResultHandle`; use the
 `result_describe` / `result_query` meta-tools to navigate. The
@@ -325,7 +329,7 @@ the read-only surface never mutates state. The audit row carries:
 Broadcast events publish per-tenant on every successful dispatch.
 `meho audit query --connector vcfa-rest-9.0` retrieves the full
 dispatch history; filter by op_id to focus on one plane (`--op-id
-GET:/iaas/api/deployments`).
+vcfa.tenant.deployment.list`).
 
 ## Migrating off `scripts/vcf-automation.sh`
 


### PR DESCRIPTION
## Summary

- Repoints `meho vcf-automation deployment list` from the retired ingested `GET:/iaas/api/deployments` to the typed `vcfa.tenant.deployment.list` (#2839 / PR #2929). On a zero-catalog boot the ingested op_id does not resolve on a typed connector, so the operator verb was a dead end even though the agent/backend path worked. No param changes needed: the CLI sends no params and the typed op's `parameter_schema` is all-optional; the typed op passes the vendor `{content, totalElements, totalPages}` envelope through unmodified, so the printer is unchanged. `deployment get` stays on `GET:/iaas/api/deployments/{id}` with a code comment recording that its repoint is blocked on a future `vcfa.tenant.deployment.get` typed op.
- The mandated wave-2 cross-check found two more stranded verbs (see below) — `meho nsx segment list` and `meho nsx node list` — both repointed here for the same reason (their typed ops pass the vendor `{results, result_count}` envelope through unmodified and take no params, so each swap is a pure op_id change).
- Makes the five per-connector `typed_opid_dispatch_test.go` guards exhaustive: every verb is pinned to the exact op_id it puts on the wire (typed, or deliberately ingested with the reason in a comment), and a new `TestBackendTypedOpsAreClassified` per connector reconciles an in-test `typedOpCLICoverage` classification against the backend typed-op registry (parsed by the new `cli/internal/typedops` test-support package). A typed read op shipped without a CLI-repoint decision now fails CI instead of silently stranding a verb.
- Records the "typed op ⇒ repoint the CLI verb ⇒ pin it in `typed_opid_dispatch_test.go`" contract in `docs/codebase/cli.md`, and updates the operator onboarding docs (`docs/cross-repo/nsx-onboarding.md`, `docs/cross-repo/vcf-automation-onboarding.md`) for the three repointed verbs. CHANGELOG entry added under `[Unreleased]`.

## Wave-2 cross-check (issue Desired state item 4)

| Wave-2 typed op | CLI verb | Status at cross-check |
| --- | --- | --- |
| harbor #2856 / PR #2915 | `meho harbor …` | ✅ repointed at ship time (all harbor verbs dispatch dotted op_ids; verified in `cli/internal/cmd/harbor/`) |
| sddc network-pool #2837 / PR #2923 | `network-pool list` / `get` | ✅ repointed at ship time (`sddc.network_pool.list` / `.get`) |
| nsx segment #2835 / PR #2916 | `meho nsx segment list` | ❌ **stranded** — CLI verb predates the typed op (#655) and was never repointed → **repointed here** to `nsx.segment.list` |
| nsx transport-node #2836 / PR #2919 | `meho nsx node list` | ❌ **stranded** — same class → **repointed here** to `nsx.transport_node.list` |
| vcfa deployment #2839 / PR #2929 | `deployment list` | ❌ the anchor straggler → **repointed here** to `vcfa.tenant.deployment.list` |
| vrops #2838 (`vrops.resource.query` / `.stats`) | — | ✅ not stranded: no CLI verb wraps these surfaces; `resource list` is the plain `GET /suite-api/api/resources` read, deliberately distinct from the POST query surface — classified agent-surface-only in the guard |

The two nsx repoints are compelled by the issue's own contract (Desired state item 3 / acceptance criterion 3): the exhaustive guard must assert every typed-backed verb dispatches its dotted op_id, which is only truthful once the verbs are repointed.

## Guard coverage per connector (acceptance criterion 3)

| Connector | Typed-backed verbs asserted | Deliberately-ingested verbs pinned | Backend typed ops classified |
| --- | --- | --- | --- |
| nsx | 6 (`about`, `cluster status`, `transport-zone list`, `tier1 list`, `segment list`, `node list`) | 3 (`tier0 list`, `firewall policy list`, `firewall rule list`) | 10 |
| sddc-manager | 7 (`domain list`, `manager list`, `network-pool list/get`, `cluster list`, `host list`, `workflow list`) | 3 (`about`, `bundle list`, `domain info` — the issue's explicit leave-alone) | 14 |
| vcf-automation | 4 list verbs (+ dual-plane `about` pinned by `TestAboutVerbDispatchesPerPlane`) | 5 (`org get`, `region get`, `deployment get`, `blueprint list`, `user list`) | 6 |
| vcf-fleet | 2 (`about`, `environment list`) | 6 (`datacenter list`, `vcenter list`, `product list`, `environment info`, `request list`, `request info`) | 2 |
| vcf-operations | 2 (`about`, `alert list`) | 6 (`resource list/get`, `alertdefinition list`, `symptom list`, `recommendation list`, `supermetric list`) | 4 |

Negative proof: injecting a fake `op_id="vcfa.zz.fake"` into the backend registry makes `TestBackendTypedOpsAreClassified` fail with the classify-it instruction (verified locally, then reverted).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` (cli) — 47 packages ok, 0 failures; changed packages also green under `-race` (CI parity)
- [x] `golangci-lint run` — 0 issues
- [x] New `deployment list` case in `TestRepointedListVerbsDispatchTypedOpIDs` green (acceptance criterion 1)
- [x] `grep -n 'GET:/iaas/api/deployments' cli/internal/cmd/vcf-automation/deployment.go` → only the `deployment get` dispatch (with the blocked-on-detail-op comment) and its printer constant (acceptance criterion 2)
- [x] `cd cli && make snapshot-openapi && make generate` → no diff in `cli/api/` (acceptance criterion 6 — op_id string swaps add no FastAPI routes)
- [x] Contract note in `docs/codebase/cli.md` (acceptance criterion 5)
- [x] `.claude/hooks/code-quality.py --diff` — exit 0

## Out of scope

- A typed `vcfa.tenant.deployment.get` detail op (backend work; would unblock repointing `deployment get`) — noted in the issue for a follow-up.
- Repointing genuine ingested reads with no typed counterpart (all now explicitly pinned in the guards with reasons).
- Adjacent finding (pre-existing, not touched): `docs/cross-repo/nsx-onboarding.md` / `vcf-automation-onboarding.md` still carry stale `METHOD:/path` references for the verbs repointed back in #2355 (`about`, `cluster status`, `transport-zone list`, `tier1 list`, `project list`, …) — this PR only refreshed the rows/sections its own repoints invalidate. Same class: the `meho nsx operation call` example in `cli/internal/cmd/nsx/operation.go` still shows the ingested segments op_id.
- k8s and other typed connectors without a `typed_opid_dispatch_test.go` guard — the issue scopes the guard work to the five named connectors.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2942
