### PR TITLE
fix(connectors): vcfa dials target host, presents fqdn per-request (#2863)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,38 @@ connector-related release-notes line.
   `deployment list`); the verb moved from the pinned-ingested table to
   the typed table in the `typed_opid_dispatch_test.go` guard.
 
+### Fixed — vcf-automation connector dials `target.host` and presents `target.fqdn` per-request as the vhost `Host:` + TLS SNI (#2863)
+
+- The vcf-automation connector baked `target.fqdn` into the pooled
+  client's `base_url`, so httpx derived the TCP connect address, the
+  `Host:` header, and the TLS SNI / cert-verify name all from the FQDN.
+  That made "connect by IP, route by vhost" — the shape a VCFA appliance
+  behind a NAT alias (reachable only by IP) needs — structurally
+  unreachable, could not disambiguate several appliances that share one
+  vhost FQDN behind distinct NAT aliases, and let the transport dial an
+  address the SSRF guard (which screens `target.host`) never screened.
+  The connector now always dials `target.host` (`https://{host}[:port]`,
+  the reachable address the guard screens) and applies `target.fqdn`
+  per-request as the `Host:` header and as TLS SNI (precedence
+  `tls_server_name` > `fqdn` > derive-from-host), threaded through the
+  data path, both plane logins, and both fingerprint probes. Under
+  `verify_tls=true` the certificate is still verified against the FQDN
+  (httpcore uses `sni_hostname` for both SNI and cert CN/SAN
+  verification, confirmed against pinned httpx 0.28.1 / httpcore 1.0.9).
+- **Operator migration:** a vcf-automation `target.host` must now be the
+  *dialable* address (an IP, or a name that resolves where the backplane
+  runs), with the vhost in `target.fqdn`. Previously the FQDN was baked
+  into `base_url`, so a target that carried a **stale** `host` still
+  worked as long as split-DNS resolved the FQDN — the stale `host` was
+  screened by the SSRF guard but never actually dialled. Now that `host`
+  is the dial address, such a target fails loud at its first dispatch
+  against that host instead of silently reaching whatever the baked-in
+  FQDN resolved to. Move the vhost into `fqdn` (CLI `--fqdn`;
+  `targets.yaml: fqdn:`) and set `host` to the reachable address. An
+  IP-literal `host` with no `fqdn` is refused at construction with a
+  message naming the host and the `--fqdn` knob — there is no vhost to
+  present.
+
 ### Fixed — CLI verbs stranded on retired ingested op_ids + exhaustive typed-dispatch guards (#2942)
 
 - `meho vcf-automation deployment list` now dispatches the typed

--- a/backend/src/meho_backplane/connectors/vcf_automation/_auth.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/_auth.py
@@ -27,6 +27,7 @@ from meho_backplane.connectors.vcf_automation._routing import (
     PROVIDER_TOKEN_HEADER,
     TENANT_ACCEPT,
     TENANT_SESSION_PATH,
+    vhost_header,
 )
 from meho_backplane.connectors.vcf_automation.session import (
     VcfAutomationCredentialsLoader,
@@ -124,8 +125,12 @@ async def vcfa_provider_login(
 
     ``request_extensions`` (evoila/meho#2398) carries the caller's
     ``HttpConnector._request_extensions(target)`` so the login handshake
-    honours a target's ``tls_server_name`` SNI / cert-verify override;
-    ``None`` normalises to an empty dict (byte-identical when unset).
+    honours a target's ``tls_server_name`` / ``fqdn`` SNI + cert-verify
+    name; ``None`` normalises to an empty dict (byte-identical when
+    unset). The login also presents ``target.fqdn`` as the ``Host:``
+    header (:func:`._routing.vhost_header`) so VCFA's strict vhost
+    routing accepts the login POST when the transport dials the host IP
+    (evoila/meho#2863).
     """
     username, password = _require_username_password(creds, target.name, "provider")
     provider_username = getattr(target, "provider_username", None)
@@ -135,7 +140,10 @@ async def vcfa_provider_login(
         resp = await client.post(
             PROVIDER_SESSION_PATH,
             auth=(basic_user, password),
-            headers={"Accept": PROVIDER_CLOUDAPI_ACCEPT},
+            headers={
+                "Accept": PROVIDER_CLOUDAPI_ACCEPT,
+                **vhost_header(getattr(target, "fqdn", None), getattr(target, "port", None)),
+            },
             extensions=request_extensions or {},
         )
         resp.raise_for_status()
@@ -183,8 +191,12 @@ async def tenant_login(
 
     ``request_extensions`` (evoila/meho#2398) carries the caller's
     ``HttpConnector._request_extensions(target)`` so the login handshake
-    honours a target's ``tls_server_name`` SNI / cert-verify override;
-    ``None`` normalises to an empty dict (byte-identical when unset).
+    honours a target's ``tls_server_name`` / ``fqdn`` SNI + cert-verify
+    name; ``None`` normalises to an empty dict (byte-identical when
+    unset). The login also presents ``target.fqdn`` as the ``Host:``
+    header (:func:`._routing.vhost_header`) so VCFA's strict vhost
+    routing accepts the login POST when the transport dials the host IP
+    (evoila/meho#2863).
     """
     username, password = _require_username_password(creds, target.name, "tenant")
     body: dict[str, str] = {"username": username, "password": password}
@@ -195,7 +207,11 @@ async def tenant_login(
         resp = await client.post(
             TENANT_SESSION_PATH,
             json=body,
-            headers={"Accept": TENANT_ACCEPT, "Content-Type": TENANT_ACCEPT},
+            headers={
+                "Accept": TENANT_ACCEPT,
+                "Content-Type": TENANT_ACCEPT,
+                **vhost_header(getattr(target, "fqdn", None), getattr(target, "port", None)),
+            },
             extensions=request_extensions or {},
         )
         resp.raise_for_status()

--- a/backend/src/meho_backplane/connectors/vcf_automation/_routing.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/_routing.py
@@ -32,6 +32,7 @@ __all__ = [
     "is_acceptable_auth_model",
     "plane_for_path",
     "provider_accept_for_path",
+    "vhost_header",
 ]
 
 # Per-plane login endpoints. Verified against scripts/vcf-automation.sh
@@ -137,26 +138,64 @@ def provider_accept_for_path(path: str) -> str:
     return PROVIDER_CLOUDAPI_ACCEPT
 
 
-def compose_base_url(target_name: str, host: str, port: int | None, fqdn: str | None) -> str:
-    """Build the per-target base URL honouring vhost routing.
+def _port_suffix(port: int | None) -> str:
+    """Return ``":{port}"`` for a non-default HTTPS port, else ``""``.
 
-    When *fqdn* is set, the URL host is the FQDN (httpx's request will
-    carry it as the ``Host:`` header, satisfying VCFA's strict vhost
-    match). When *fqdn* is unset and *host* is an IP literal, raise
-    :exc:`VcfAutomationConfigurationError` -- the consumer wrapper
-    documents this as the silent-404 failure mode and we surface it
-    at base-URL construction time. When *host* is itself an FQDN, the
-    URL already carries the right vhost.
+    Shared by :func:`compose_base_url` (the dialled authority) and
+    :func:`vhost_header` (the ``Host:`` authority) so both render the
+    port identically -- matching httpx's own ``Host:``-header derivation,
+    which appends the port only when it is not the scheme default (443).
     """
-    scheme = "https"
-    port_suffix = f":{port}" if port and port != 443 else ""
-    if fqdn:
-        return f"{scheme}://{fqdn}{port_suffix}"
-    if _is_ip_literal(host):
+    return f":{port}" if port and port != 443 else ""
+
+
+def compose_base_url(target_name: str, host: str, port: int | None, fqdn: str | None) -> str:
+    """Build the per-target base URL -- always the dialled ``host``.
+
+    VCFA enforces strict vhost routing, but the vhost belongs in the
+    per-request ``Host:`` header and TLS SNI (see :func:`vhost_header`
+    and :meth:`.connector.VcfAutomationConnector._request_extensions`),
+    **not** in the pooled client's ``base_url``. So the base URL is
+    always ``https://{host}[:port]`` -- the reachable address the
+    transport dials (an IP behind a NAT alias, or an FQDN) -- and
+    ``fqdn`` is presented per-request. Baking ``fqdn`` into ``base_url``
+    is what made "connect by IP, route by vhost" structurally
+    unreachable and let the connector dial an address the SSRF guard
+    never screened (evoila/meho#2863); it also could not disambiguate
+    several appliances that share one vhost FQDN behind distinct NAT
+    aliases.
+
+    The one shape still refused at construction time is an IP-literal
+    *host* with no *fqdn*: there is no vhost to present, so every path
+    would 404 with an empty body before the application sees it. Raising
+    :exc:`VcfAutomationConfigurationError` here surfaces a clear
+    configuration message rather than a post-login 404 storm.
+    """
+    if not fqdn and _is_ip_literal(host):
         raise VcfAutomationConfigurationError(
             f"vcf-automation target {target_name!r} is reached by IP ({host!r}) "
-            "but has no fqdn set. VCFA enforces strict vhost routing and "
-            "returns 404 on every path otherwise. Set target.fqdn (CLI: "
-            "--fqdn; targets.yaml: fqdn:) to the appliance's canonical FQDN."
+            "but has no fqdn set. VCFA enforces strict vhost routing, so the "
+            "connector needs a vhost to present as the Host: header -- an IP "
+            "alone matches no vhost and returns 404 on every path. Set "
+            "target.fqdn (CLI: --fqdn; targets.yaml: fqdn:) to the appliance's "
+            "canonical FQDN; the connector still dials this host address."
         )
-    return f"{scheme}://{host}{port_suffix}"
+    return f"https://{host}{_port_suffix(port)}"
+
+
+def vhost_header(fqdn: str | None, port: int | None = None) -> dict[str, str]:
+    """Return the per-request ``Host:`` header presenting the vhost, or ``{}``.
+
+    When *fqdn* is set, VCFA's strict vhost routing needs it as the
+    ``Host:`` header even though the transport dials ``target.host``
+    (:func:`compose_base_url`). The port is appended on the same
+    non-default-port rule httpx uses when it derives ``Host:`` from a
+    ``base_url``, so a target on a non-443 port renders
+    ``Host: {fqdn}:{port}`` -- byte-identical to the pre-#2863 shape that
+    put the FQDN in ``base_url``. When *fqdn* is unset, returns an empty
+    mapping so httpx derives ``Host:`` from ``base_url`` (the host, which
+    in that shape already carries the right vhost).
+    """
+    if not fqdn:
+        return {}
+    return {"Host": f"{fqdn}{_port_suffix(port)}"}

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -54,15 +54,23 @@ re-login once on session-expiry, not a retry loop.
 Vhost routing
 -------------
 
-VCFA 9.x enforces strict ``Host:`` header matching. When ``target.fqdn``
-is set, the per-target httpx ``AsyncClient`` is built with
-``base_url=https://<fqdn>``; standard DNS resolution targets the FQDN.
-When ``target.fqdn`` is unset and ``target.host`` is an IP literal,
-:func:`._routing.compose_base_url` raises
-:exc:`VcfAutomationConfigurationError` at first session-establish --
-the consumer wrapper documents this as the silent-404 failure mode.
-When ``target.host`` is itself an FQDN, ``fqdn`` is optional -- the
-URL host already carries the right vhost.
+VCFA 9.x enforces strict ``Host:`` header matching. The per-target
+httpx ``AsyncClient`` always dials ``target.host`` (``base_url=
+https://<host>`` -- the reachable NAT-alias IP or FQDN); ``target.fqdn``
+is presented **per-request** as the ``Host:`` header
+(:func:`._routing.vhost_header`) and as TLS SNI + cert-verify name (the
+#2002 ``sni_hostname`` extension, precedence ``tls_server_name`` >
+``fqdn`` > derive-from-host -- see :meth:`._request_extensions`). This
+is the standard "connect by IP, route by vhost" posture: it reaches an
+appliance addressable only by IP behind a NAT alias, and disambiguates
+several appliances that share one vhost FQDN. Nothing ``fqdn``-derived
+is baked into the pooled client, so a per-request ``fqdn`` override
+never serves a stale client. When ``target.fqdn`` is unset and
+``target.host`` is an IP literal, :func:`._routing.compose_base_url`
+raises :exc:`VcfAutomationConfigurationError` -- there is no vhost to
+present, the consumer wrapper's documented silent-404 failure mode.
+When ``target.host`` is itself an FQDN, ``fqdn`` is optional -- httpx
+derives ``Host:`` from the host, which already carries the right vhost.
 
 Auth model gating
 -----------------
@@ -120,6 +128,7 @@ from meho_backplane.connectors.vcf_automation._routing import (
     is_acceptable_auth_model,
     plane_for_path,
     provider_accept_for_path,
+    vhost_header,
 )
 from meho_backplane.connectors.vcf_automation.session import (
     VcfAutomationCredentialsLoader,
@@ -193,13 +202,43 @@ class VcfAutomationConnector(HttpConnector):
     # ------------------------------------------------------------------
 
     def _base_url(self, target: VcfAutomationTargetLike) -> str:
-        """Delegate to :func:`._routing.compose_base_url` for vhost handling."""
+        """Delegate to :func:`._routing.compose_base_url` (always the dialled host)."""
         return compose_base_url(
             target_name=target.name,
             host=target.host,
             port=getattr(target, "port", None),
             fqdn=getattr(target, "fqdn", None),
         )
+
+    def _request_extensions(self, target: VcfAutomationTargetLike) -> dict[str, Any]:
+        """Per-request httpx ``extensions`` -- SNI precedence for vhost routing.
+
+        Extends the base seam (evoila/meho#2002, which honours a target's
+        ``tls_server_name``) with the ``fqdn`` fallback this connector's
+        connect-by-IP/route-by-vhost posture needs. The transport dials
+        ``target.host`` (which may be an IP), so the TLS SNI + cert-verify
+        name must be set explicitly or httpcore would derive it from the
+        dialled IP and fail hostname verification under ``verify_tls=true``.
+        Precedence, highest first:
+
+        1. ``target.tls_server_name`` -- explicit operator override (the
+           base seam), unchanged.
+        2. ``target.fqdn`` -- the vhost; presented as SNI so the appliance
+           routes the handshake and the presented cert is verified against
+           the same FQDN the pre-#2863 ``base_url=https://<fqdn>`` shape
+           verified against (httpcore uses ``sni_hostname`` for both SNI and
+           cert CN/SAN verification).
+        3. Neither set -- empty dict; httpcore derives the name from the
+           dialled ``base_url`` host (which, in that shape, is itself the
+           FQDN).
+        """
+        base = super()._request_extensions(target)
+        if base:
+            return base
+        fqdn = getattr(target, "fqdn", None)
+        if fqdn:
+            return {"sni_hostname": fqdn}
+        return {}
 
     # ------------------------------------------------------------------
     # auth_headers -- ABC + plane-aware path argument
@@ -483,6 +522,12 @@ class VcfAutomationConnector(HttpConnector):
         form-encoded body.
         """
 
+        # vhost routing is applied per-request (never baked into the pooled
+        # client): the FQDN as the ``Host:`` header and as TLS SNI. Computed
+        # once so both the initial fire and the post-401 retry carry them.
+        vhost = vhost_header(getattr(target, "fqdn", None), getattr(target, "port", None))
+        extensions = self._request_extensions(target)
+
         async def _fire(headers: Mapping[str, str]) -> httpx.Response:
             client = await self._http_client(target)
             params_dict = dict(params) if params is not None else None
@@ -493,7 +538,8 @@ class VcfAutomationConnector(HttpConnector):
                 params=params_dict,
                 json=json_dict,
                 data=data,
-                headers=dict(headers),
+                headers={**dict(headers), **vhost},
+                extensions=extensions,
             )
 
         plane = plane_for_path(path)
@@ -553,12 +599,21 @@ class VcfAutomationConnector(HttpConnector):
             client = await self._http_client(target)
         except VcfAutomationConfigurationError as exc:
             return self._unreachable_fingerprint(probed_at, probe_method, exc, failed_plane=None)
-        provider_resp = await _try_probe(client, PROVIDER_VERSION_PATH)
+        # Both unauthenticated probes dial ``target.host`` but must present
+        # the vhost as ``Host:`` + SNI, same as the data path -- the #2398
+        # SNI seam previously reached only the two login POSTs, not the probes.
+        vhost = vhost_header(getattr(target, "fqdn", None), getattr(target, "port", None))
+        extensions = self._request_extensions(target)
+        provider_resp = await _try_probe(
+            client, PROVIDER_VERSION_PATH, headers=vhost, extensions=extensions
+        )
         if isinstance(provider_resp, Exception):
             return self._unreachable_fingerprint(
                 probed_at, probe_method, provider_resp, failed_plane="provider"
             )
-        tenant_resp = await _try_probe(client, TENANT_VERSION_PATH, accept=TENANT_ACCEPT)
+        tenant_resp = await _try_probe(
+            client, TENANT_VERSION_PATH, accept=TENANT_ACCEPT, headers=vhost, extensions=extensions
+        )
         if isinstance(tenant_resp, Exception):
             return self._unreachable_fingerprint(
                 probed_at, probe_method, tenant_resp, failed_plane="tenant"
@@ -863,16 +918,24 @@ async def _try_probe(
     client: httpx.AsyncClient,
     path: str,
     accept: str | None = None,
+    *,
+    headers: Mapping[str, str] | None = None,
+    extensions: dict[str, Any] | None = None,
 ) -> httpx.Response | Exception:
     """GET *path* on *client*, returning the response or the captured exception.
 
     Used by :meth:`VcfAutomationConnector.fingerprint` to probe each
     plane and produce a structured ``reachable=False`` result on
-    failure rather than letting the exception bubble.
+    failure rather than letting the exception bubble. *headers* carries
+    the per-request vhost ``Host:`` header and *extensions* the TLS SNI
+    override, so the probe dials ``target.host`` while presenting the
+    vhost -- the same routing the data path applies.
     """
     try:
-        headers = {"Accept": accept} if accept else None
-        resp = await client.get(path, headers=headers)
+        hdrs: dict[str, str] = dict(headers) if headers else {}
+        if accept:
+            hdrs["Accept"] = accept
+        resp = await client.get(path, headers=hdrs or None, extensions=extensions or {})
         resp.raise_for_status()
     except (httpx.HTTPError, OSError) as exc:
         return exc

--- a/backend/tests/test_connectors_vcf_automation_auth.py
+++ b/backend/tests/test_connectors_vcf_automation_auth.py
@@ -1343,3 +1343,109 @@ async def test_fingerprint_probes_present_fqdn_host_and_sni_while_dialing_ip() -
         assert host_header == _NAT_FQDN
         assert sni == _NAT_FQDN
     await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Same vhost FQDN, two NAT-alias IPs -- disambiguation (#2863)
+#
+# The bug's headline scenario: several lab appliances publish the *same*
+# vhost FQDN yet are reachable only through distinct per-site NAT-alias
+# IPs. Each target must dial its own ``host`` while presenting the shared
+# vhost, and the two must not share a pooled client or a cached token --
+# the client pool and both token caches key on ``target_cache_key``
+# (``(tenant_id, id)``), which the shared FQDN never enters.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_same_fqdn_two_alias_ips_dial_own_host_and_stay_isolated() -> None:
+    """Two targets sharing one vhost FQDN but on distinct IPs never cross-contaminate.
+
+    Seeds two same-tenant targets with an identical ``fqdn`` (the shared
+    vhost) but different reachable ``host`` IPs, drives a provider-plane
+    data GET against each, and asserts: (a) each request dials its OWN IP
+    while presenting the shared vhost as ``Host:`` + TLS SNI, (b) the two
+    targets get distinct pooled ``AsyncClient`` identities each bound to
+    its own dialled IP, and (c) the provider token cache holds one
+    independent entry per target. The mechanism (pool + token caches keyed
+    on ``target_cache_key``, not on the FQDN) is already in place, so this
+    passes with no production change -- it pins the bug's headline
+    scenario against regression.
+    """
+    connector = _make_connector()
+    target_a = _StubTarget(
+        name="vcfa-site-a",
+        host="10.0.0.5",
+        port=443,
+        secret_ref="vcfa/site-a",
+        fqdn=_NAT_FQDN,
+    )
+    target_b = _StubTarget(
+        name="vcfa-site-b",
+        host="10.0.0.6",
+        port=443,
+        secret_ref="vcfa/site-b",
+        fqdn=_NAT_FQDN,
+    )
+    dialed: dict[str, dict[str, Any]] = {}
+
+    def _responder_a(request: httpx.Request) -> httpx.Response:
+        dialed["a"] = {
+            "url_host": request.url.host,
+            "host_header": request.headers.get("host"),
+            "sni": request.extensions.get("sni_hostname"),
+        }
+        return httpx.Response(200, json={"values": ["a"]})
+
+    def _responder_b(request: httpx.Request) -> httpx.Response:
+        dialed["b"] = {
+            "url_host": request.url.host,
+            "host_header": request.headers.get("host"),
+            "sni": request.extensions.get("sni_hostname"),
+        }
+        return httpx.Response(200, json={"values": ["b"]})
+
+    # Separate respx routers, one per dialled IP: a request that dialled the
+    # wrong host would miss its router and fail, so a green run proves each
+    # target reached its own ``host``.
+    async with respx.mock(base_url="https://10.0.0.5") as mock_a:
+        mock_a.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt-a"}
+        )
+        mock_a.get("/cloudapi/1.0.0/orgs").mock(side_effect=_responder_a)
+        result_a = await connector._request_json(
+            target_a, "GET", "/cloudapi/1.0.0/orgs", operator=_make_operator()
+        )
+
+    async with respx.mock(base_url="https://10.0.0.6") as mock_b:
+        mock_b.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt-b"}
+        )
+        mock_b.get("/cloudapi/1.0.0/orgs").mock(side_effect=_responder_b)
+        result_b = await connector._request_json(
+            target_b, "GET", "/cloudapi/1.0.0/orgs", operator=_make_operator()
+        )
+
+    # (a) Each request dialled its OWN IP while presenting the shared vhost.
+    assert result_a == {"values": ["a"]}
+    assert result_b == {"values": ["b"]}
+    assert dialed["a"] == {"url_host": "10.0.0.5", "host_header": _NAT_FQDN, "sni": _NAT_FQDN}
+    assert dialed["b"] == {"url_host": "10.0.0.6", "host_header": _NAT_FQDN, "sni": _NAT_FQDN}
+
+    # (b) Distinct pooled AsyncClient identities -- the shared FQDN does not
+    # enter the pool key, so the two targets get two clients, each bound to
+    # its own dialled IP.
+    pooled = list(connector._clients.values())
+    assert len(pooled) == 2
+    assert pooled[0] is not pooled[1]
+    assert {client.base_url.host for client in pooled} == {"10.0.0.5", "10.0.0.6"}
+
+    # (c) Independent per-plane token caches -- one entry per target keyed on
+    # ``target_cache_key``, no cross-contamination; the tenant plane, never
+    # exercised by these ``/cloudapi`` calls, stays empty.
+    assert connector._provider_tokens == {
+        target_cache_key(target_a): "p-jwt-a",
+        target_cache_key(target_b): "p-jwt-b",
+    }
+    assert connector._tenant_tokens == {}
+    await connector.aclose()

--- a/backend/tests/test_connectors_vcf_automation_auth.py
+++ b/backend/tests/test_connectors_vcf_automation_auth.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import base64
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from typing import Any
 from uuid import UUID, uuid4
 
 import httpx
@@ -51,6 +52,7 @@ from meho_backplane.connectors.vcf_automation import (
     VcfAutomationConnector,
     VcfAutomationTargetLike,
 )
+from meho_backplane.connectors.vcf_automation._routing import vhost_header
 from meho_backplane.settings import get_settings
 
 
@@ -224,8 +226,15 @@ def test_default_loader_fails_closed_for_system_initiated_call() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_base_url_uses_fqdn_when_set() -> None:
-    """``target.fqdn`` overrides ``target.host`` in the base URL."""
+def test_base_url_dials_host_even_when_fqdn_set() -> None:
+    """The base URL is always the dialled ``host``; ``fqdn`` is per-request (#2863).
+
+    Pre-#2863 the FQDN was baked into ``base_url`` so the pooled transport
+    dialled it -- unreachable for an appliance addressable only by a
+    NAT-alias IP, and unable to disambiguate several appliances sharing one
+    vhost FQDN. Now the base URL is the reachable host and the FQDN rides
+    the ``Host:`` header + TLS SNI per request.
+    """
     target = _StubTarget(
         name="vcfa-vhost",
         host="10.0.0.5",
@@ -234,7 +243,20 @@ def test_base_url_uses_fqdn_when_set() -> None:
         fqdn="vcfa.canonical.invalid",
     )
     connector = _make_connector()
-    assert connector._base_url(target) == "https://vcfa.canonical.invalid"
+    assert connector._base_url(target) == "https://10.0.0.5"
+
+
+def test_base_url_dials_host_with_non_default_port_when_fqdn_set() -> None:
+    """A non-443 port stays on the dialled host authority even with ``fqdn`` set."""
+    target = _StubTarget(
+        name="vcfa-vhost-port",
+        host="10.0.0.5",
+        port=8443,
+        secret_ref="vcfa/vhost-port",
+        fqdn="vcfa.canonical.invalid",
+    )
+    connector = _make_connector()
+    assert connector._base_url(target) == "https://10.0.0.5:8443"
 
 
 def test_base_url_uses_host_when_host_is_fqdn() -> None:
@@ -1128,4 +1150,196 @@ async def test_tenant_login_threads_sni_extension() -> None:
 
     assert login.called
     assert login.calls[0].request.extensions["sni_hostname"] == "vcfa-tenant.corp.example"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Connect-by-IP / route-by-vhost (#2863)
+#
+# The connector dials ``target.host`` (a reachable NAT-alias IP) and presents
+# ``target.fqdn`` per-request as the ``Host:`` header + TLS SNI. Nothing
+# fqdn-derived is baked into the pooled client. These pin the four request
+# paths: the data path, both plane logins, and both fingerprint probes.
+# ---------------------------------------------------------------------------
+
+_NAT_FQDN = "auto-a.site-a.vcf.lab"
+
+
+def _nat_target(name: str, secret_ref: str, **overrides: Any) -> _StubTarget:
+    """A target reached only by a private NAT-alias IP with a vhost FQDN set."""
+    return _StubTarget(
+        name=name,
+        host="10.0.0.5",
+        port=443,
+        secret_ref=secret_ref,
+        fqdn=_NAT_FQDN,
+        **overrides,
+    )
+
+
+def test_vhost_header_renders_host_for_fqdn() -> None:
+    """``vhost_header`` returns the ``Host:`` mapping (port appended only when non-default)."""
+    assert vhost_header(_NAT_FQDN) == {"Host": _NAT_FQDN}
+    assert vhost_header(_NAT_FQDN, 443) == {"Host": _NAT_FQDN}
+    assert vhost_header(_NAT_FQDN, 8443) == {"Host": f"{_NAT_FQDN}:8443"}
+    assert vhost_header(None) == {}
+    assert vhost_header("") == {}
+
+
+def test_request_extensions_prefers_tls_server_name_over_fqdn() -> None:
+    """SNI precedence: an explicit ``tls_server_name`` wins over ``fqdn``."""
+    connector = _make_connector()
+    target = _nat_target("vcfa-sni-prec", "vcfa/sni-prec", tls_server_name="sni.corp.example")
+    assert connector._request_extensions(target) == {"sni_hostname": "sni.corp.example"}
+
+
+def test_request_extensions_falls_back_to_fqdn_for_sni() -> None:
+    """SNI precedence: ``fqdn`` drives SNI when no ``tls_server_name`` is set."""
+    connector = _make_connector()
+    target = _nat_target("vcfa-sni-fqdn", "vcfa/sni-fqdn")
+    assert connector._request_extensions(target) == {"sni_hostname": _NAT_FQDN}
+
+
+def test_request_extensions_empty_when_neither_set() -> None:
+    """No override → empty extensions; httpcore derives SNI from the dialled host."""
+    connector = _make_connector()
+    assert connector._request_extensions(_TARGET_A) == {}
+
+
+@pytest.mark.asyncio
+async def test_data_path_presents_fqdn_as_host_and_sni_while_dialing_ip() -> None:
+    """A data-path GET dials the host IP but carries ``Host: fqdn`` + ``sni_hostname=fqdn``.
+
+    This is the load-bearing #2863 fix: pre-fix there was no target shape
+    in which the connector dialled the stored host while presenting the
+    vhost. The respx router is rooted at the IP, proving the transport now
+    dials ``target.host`` and not the FQDN.
+    """
+    connector = _make_connector()
+    target = _nat_target("vcfa-nat-data", "vcfa/nat-data")
+    captured: dict[str, Any] = {}
+
+    def _orgs_responder(request: httpx.Request) -> httpx.Response:
+        captured["url_host"] = request.url.host
+        captured["host_header"] = request.headers.get("host")
+        captured["sni"] = request.extensions.get("sni_hostname")
+        return httpx.Response(200, json={"values": []})
+
+    async with respx.mock(base_url="https://10.0.0.5") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt"}
+        )
+        mock.get("/cloudapi/1.0.0/orgs").mock(side_effect=_orgs_responder)
+        result = await connector._request_json(
+            target, "GET", "/cloudapi/1.0.0/orgs", operator=_make_operator()
+        )
+
+    assert result == {"values": []}
+    assert captured["url_host"] == "10.0.0.5"
+    assert captured["host_header"] == _NAT_FQDN
+    assert captured["sni"] == _NAT_FQDN
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_data_path_derives_host_and_omits_sni_when_fqdn_unset() -> None:
+    """No fqdn + FQDN host: ``Host`` derives from the host, no SNI extension is set.
+
+    Byte-identical request shape to the pre-#2863 no-fqdn path — a
+    regression guard that the fix does not perturb the FQDN-host targets.
+    """
+    connector = _make_connector()
+    captured: dict[str, Any] = {}
+
+    def _orgs_responder(request: httpx.Request) -> httpx.Response:
+        captured["url_host"] = request.url.host
+        captured["host_header"] = request.headers.get("host")
+        captured["sni"] = request.extensions.get("sni_hostname")
+        return httpx.Response(200, json={"values": []})
+
+    async with respx.mock(base_url="https://vcfa-a.test.invalid") as mock:
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt"}
+        )
+        mock.get("/cloudapi/1.0.0/orgs").mock(side_effect=_orgs_responder)
+        await connector._request_json(
+            _TARGET_A, "GET", "/cloudapi/1.0.0/orgs", operator=_make_operator()
+        )
+
+    assert captured["url_host"] == "vcfa-a.test.invalid"
+    assert captured["host_header"] == "vcfa-a.test.invalid"
+    assert captured["sni"] is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_provider_login_presents_fqdn_host_and_sni_while_dialing_ip() -> None:
+    """#2863: the provider login POST dials the IP but presents ``Host: fqdn`` + SNI."""
+    connector = _make_connector()
+    target = _nat_target("vcfa-nat-plogin", "vcfa/nat-plogin")
+
+    async with respx.mock(base_url="https://10.0.0.5") as mock:
+        login = mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": "p-jwt"}
+        )
+        await connector.auth_headers(target, operator=_make_operator(), path="/cloudapi/1.0.0/orgs")
+
+    req = login.calls[0].request
+    assert req.url.host == "10.0.0.5"
+    assert req.headers.get("host") == _NAT_FQDN
+    assert req.extensions["sni_hostname"] == _NAT_FQDN
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tenant_login_presents_fqdn_host_and_sni_while_dialing_ip() -> None:
+    """#2863: the tenant login POST dials the IP but presents ``Host: fqdn`` + SNI."""
+    connector = _make_connector()
+    target = _nat_target("vcfa-nat-tlogin", "vcfa/nat-tlogin")
+
+    async with respx.mock(base_url="https://10.0.0.5") as mock:
+        login = mock.post("/iaas/api/login").respond(200, json={"token": "t-tok"})
+        await connector.auth_headers(target, operator=_make_operator(), path="/iaas/api/projects")
+
+    req = login.calls[0].request
+    assert req.url.host == "10.0.0.5"
+    assert req.headers.get("host") == _NAT_FQDN
+    assert req.extensions["sni_hostname"] == _NAT_FQDN
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_probes_present_fqdn_host_and_sni_while_dialing_ip() -> None:
+    """#2863: both unauthenticated probes dial the IP but present ``Host: fqdn`` + SNI.
+
+    Closes the #2398 gap — the SNI seam previously reached only the two
+    login POSTs, so the probes verified against the dialled IP.
+    """
+    connector = _make_connector()
+    target = _nat_target("vcfa-nat-fp", "vcfa/nat-fp")
+    seen: list[tuple[str | None, str | None, Any]] = []
+
+    def _probe_responder(request: httpx.Request) -> httpx.Response:
+        seen.append(
+            (
+                request.url.host,
+                request.headers.get("host"),
+                request.extensions.get("sni_hostname"),
+            )
+        )
+        if request.url.path == "/iaas/api/about":
+            return httpx.Response(200, json={"latestApiVersion": "9.0"})
+        return httpx.Response(200, content=b"<x/>")
+
+    async with respx.mock(base_url="https://10.0.0.5") as mock:
+        mock.get("/api/versions").mock(side_effect=_probe_responder)
+        mock.get("/iaas/api/about").mock(side_effect=_probe_responder)
+        fp = await connector.fingerprint(target)
+
+    assert fp.reachable is True
+    assert len(seen) == 2
+    for url_host, host_header, sni in seen:
+        assert url_host == "10.0.0.5"
+        assert host_header == _NAT_FQDN
+        assert sni == _NAT_FQDN
     await connector.aclose()

--- a/backend/tests/test_connectors_vcf_automation_e2e.py
+++ b/backend/tests/test_connectors_vcf_automation_e2e.py
@@ -97,10 +97,13 @@ from meho_backplane.operations.reducer import PassThroughReducer
 VCFA_E2E_OPERATOR_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000000fa")
 
 # ``.test.invalid`` (RFC 6761 reserved) so no real network egress fires.
-# The IP-host scenario uses a different host so both routers can coexist
-# in their respective tests without contention.
 VCFA_E2E_FQDN: str = "vcfa-e2e.test.invalid"
-VCFA_E2E_FQDN_BASE_URL: str = f"https://{VCFA_E2E_FQDN}"
+# The reachable dial address (a private NAT-alias IP). Since #2863 the
+# connector always dials ``target.host`` and presents ``VCFA_E2E_FQDN``
+# per-request as the ``Host:`` header + TLS SNI, so the respx routers are
+# rooted at the host IP, not the FQDN.
+VCFA_E2E_HOST: str = "10.10.10.5"
+VCFA_E2E_HOST_BASE_URL: str = f"https://{VCFA_E2E_HOST}"
 VCFA_E2E_TARGET_NAME: str = "vcfa-e2e-target"
 
 # JWT + token values the respx routes return on the per-plane login
@@ -602,24 +605,24 @@ async def vcfa_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_VcfaE2EB
        per-test SQLite DB.
     2. Seed a :class:`Target` row carrying :data:`_FINGERPRINT` so the
        resolver binds :class:`VcfAutomationConnector`. The target's
-       ``host`` is an IP literal and ``fqdn`` is the canonical vhost
-       -- this combination is the load-bearing one (vhost routing
-       working when reached by IP). Without ``fqdn``,
-       :func:`_base_url` raises ``VcfAutomationConfigurationError`` at
-       session-establish (see the
-       :func:`test_vcfa_e2e_ip_without_fqdn_surfaces_structured_error`
-       test below).
+       ``host`` is a NAT-alias IP literal and ``fqdn`` is the canonical
+       vhost -- this combination is the load-bearing one (#2863: the
+       transport dials the IP and presents the vhost per-request as the
+       ``Host:`` header + SNI). Without ``fqdn``, :func:`_base_url`
+       raises ``VcfAutomationConfigurationError`` at session-establish
+       (see :func:`test_vcfa_e2e_ip_host_without_fqdn_surfaces_descriptive_error`
+       below).
     3. Resolve + cache the connector instance; patch its
        ``_credentials_loader`` to bypass Vault.
-    4. Activate a respx router for the FQDN-rooted base URL and
-       register the dual-plane login + 11 read-op routes.
+    4. Activate a respx router rooted at the host IP (the dialled
+       address) and register the dual-plane login + 11 read-op routes.
     """
     await _insert_vcfa_descriptors()
-    seeded_target = await _seed_target(host="10.10.10.5", fqdn=VCFA_E2E_FQDN)
+    seeded_target = await _seed_target(host=VCFA_E2E_HOST, fqdn=VCFA_E2E_FQDN)
     instance = _resolve_connector()
 
     async with respx.mock(
-        base_url=VCFA_E2E_FQDN_BASE_URL,
+        base_url=VCFA_E2E_HOST_BASE_URL,
         assert_all_called=False,
         assert_all_mocked=False,
     ) as mock:
@@ -846,30 +849,40 @@ async def test_vcfa_e2e_per_call_fqdn_override_threads_to_connector(
 ) -> None:
     """Per-call ``target.fqdn`` override on the dispatch body wins over the DB row.
 
-    Exercises acceptance criterion (e). The seeded Target has its
-    ``fqdn`` column set to the **wrong** value; the dispatch body
-    supplies the correct vhost as a per-call override. The connector
-    uses the override at base-URL composition time so the request
-    lands on the FQDN-rooted respx router. Without the override,
-    the dispatch would land on a different (un-mocked) host and the
-    request would fail.
+    Exercises acceptance criterion (e) under the #2863 posture: the
+    connector always dials ``target.host`` (the NAT-alias IP), so the
+    per-call override no longer changes *which host is dialled* -- it
+    changes the ``Host:`` header + TLS SNI the request presents. The
+    seeded Target carries the **wrong** vhost; the dispatch body supplies
+    the correct one, and the captured request proves the override (not the
+    stale DB value) reached the wire.
 
-    The DB row is **not** modified by the override -- a follow-up
-    fetch confirms the persisted ``fqdn`` is still the wrong value.
+    The DB row is **not** modified by the override -- a follow-up fetch
+    confirms the persisted ``fqdn`` is still the wrong value.
     """
     await _insert_vcfa_descriptors()
-    # Seed the target with the *wrong* fqdn so the per-call override
-    # is the only way the dispatch can find the mocked appliance.
+    # Seed the target with the *wrong* fqdn so only the per-call override
+    # can put the correct vhost on the wire.
     wrong_fqdn = "vcfa-wrong.test.invalid"
-    await _seed_target(host="10.10.10.5", fqdn=wrong_fqdn)
+    await _seed_target(host=VCFA_E2E_HOST, fqdn=wrong_fqdn)
     instance = _resolve_connector()
 
+    captured: dict[str, str | None] = {}
+
+    def _users_responder(request: httpx.Request) -> httpx.Response:
+        captured["host"] = request.headers.get("host")
+        captured["sni"] = request.extensions.get("sni_hostname")
+        return httpx.Response(200, json=_PROVIDER_USERS)
+
     async with respx.mock(
-        base_url=VCFA_E2E_FQDN_BASE_URL,
+        base_url=VCFA_E2E_HOST_BASE_URL,
         assert_all_called=False,
         assert_all_mocked=False,
     ) as mock:
-        _register_vcfa_routes(mock)
+        mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": _PROVIDER_JWT}
+        )
+        mock.get("/cloudapi/1.0.0/users").mock(side_effect=_users_responder)
         try:
             result = await call_operation(
                 _OPERATOR,
@@ -881,7 +894,14 @@ async def test_vcfa_e2e_per_call_fqdn_override_threads_to_connector(
                 },
             )
             assert result["status"] == "ok", (
-                f"Per-call fqdn override should reach the mocked appliance; got {result!r}"
+                f"Per-call fqdn override dispatch should succeed; got {result!r}"
+            )
+            # The per-call override -- not the DB row's wrong fqdn -- rode the wire.
+            assert captured["host"] == VCFA_E2E_FQDN, (
+                f"Per-call fqdn override must ride the Host: header; got {captured['host']!r}"
+            )
+            assert captured["sni"] == VCFA_E2E_FQDN, (
+                f"Per-call fqdn override must ride the TLS SNI; got {captured['sni']!r}"
             )
 
             # DB row's fqdn must NOT have been mutated by the per-call override.
@@ -913,7 +933,7 @@ async def test_vcfa_e2e_ip_host_without_fqdn_surfaces_descriptive_error(
     than a confusing post-login 404 storm.
     """
     await _insert_vcfa_descriptors()
-    await _seed_target(host="10.10.10.5", fqdn=None)
+    await _seed_target(host=VCFA_E2E_HOST, fqdn=None)
     instance = _resolve_connector()
 
     try:
@@ -962,19 +982,22 @@ async def test_vcfa_e2e_provider_request_carries_bearer_jwt(
     than re-using the fixture's static responder.
     """
     await _insert_vcfa_descriptors()
-    await _seed_target(host="10.10.10.5", fqdn=VCFA_E2E_FQDN)
+    await _seed_target(host=VCFA_E2E_HOST, fqdn=VCFA_E2E_FQDN)
     instance = _resolve_connector()
 
     captured: dict[str, str] = {}
+    routing: dict[str, str | None] = {}
     repr_path = "/cloudapi/1.0.0/users"
 
     def _users_responder(request: httpx.Request) -> httpx.Response:
         captured[request.url.path] = request.headers.get("Authorization", "")
+        routing["url_host"] = request.url.host
+        routing["host_header"] = request.headers.get("host")
         return httpx.Response(200, json=_PROVIDER_USERS)
 
     try:
         async with respx.mock(
-            base_url=VCFA_E2E_FQDN_BASE_URL,
+            base_url=VCFA_E2E_HOST_BASE_URL,
             assert_all_called=False,
             assert_all_mocked=False,
         ) as mock:
@@ -994,6 +1017,9 @@ async def test_vcfa_e2e_provider_request_carries_bearer_jwt(
                 },
             )
             assert result["status"] == "ok"
+            # #2863: the request dialled the host IP but presented the vhost FQDN.
+            assert routing["url_host"] == VCFA_E2E_HOST, routing
+            assert routing["host_header"] == VCFA_E2E_FQDN, routing
             assert captured.get(repr_path) == f"Bearer {_PROVIDER_JWT}", (
                 "Provider-plane GET must carry the provider JWT as Bearer; "
                 f"got Authorization={captured.get(repr_path)!r}"

--- a/backend/tests/test_connectors_vcf_automation_typed_reads.py
+++ b/backend/tests/test_connectors_vcf_automation_typed_reads.py
@@ -86,7 +86,11 @@ from meho_backplane.operations.meta_tools import call_operation
 
 _OPERATOR_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000000fb")
 _FQDN = "vcfa-typed.test.invalid"
-_BASE_URL = f"https://{_FQDN}"
+# The reachable dial address (a NAT-alias IP). Since #2863 the connector
+# dials ``target.host`` and presents ``_FQDN`` per-request as the ``Host:``
+# header + SNI, so the respx router is rooted at the host, not the FQDN.
+_HOST = "10.20.30.5"
+_BASE_URL = f"https://{_HOST}"
 _TARGET_NAME = "vcfa-typed-target"
 
 _PROVIDER_JWT = "vcfa-typed-provider-jwt"
@@ -342,7 +346,7 @@ class _Bundle:
 async def typed_bundle(captured_events: list[Any]) -> AsyncIterator[_Bundle]:
     """Register the seven typed ops (zero ingested state) + respx-mock the appliance."""
     await VcfAutomationConnector.register_typed_operations()
-    seeded = await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    seeded = await _seed_target(host=_HOST, fqdn=_FQDN)
     instance = _resolve_connector()
     async with respx.mock(
         base_url=_BASE_URL, assert_all_called=False, assert_all_mocked=False
@@ -450,7 +454,7 @@ async def test_typed_ops_dispatch_ok(op_id: str, typed_bundle: _Bundle) -> None:
 async def test_provider_typed_op_rides_provider_plane(captured_events: list[Any]) -> None:
     """Provider typed op establishes the provider session + Accept; tenant cache stays empty."""
     await VcfAutomationConnector.register_typed_operations()
-    seeded = await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    seeded = await _seed_target(host=_HOST, fqdn=_FQDN)
     instance = _resolve_connector()
     cache_key = target_cache_key(seeded)
     accept_by_path: dict[str, str] = {}
@@ -489,7 +493,7 @@ async def test_provider_typed_op_rides_provider_plane(captured_events: list[Any]
 async def test_tenant_typed_op_rides_tenant_plane(captured_events: list[Any]) -> None:
     """Tenant typed op establishes the tenant session + Accept; provider cache stays empty."""
     await VcfAutomationConnector.register_typed_operations()
-    seeded = await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    seeded = await _seed_target(host=_HOST, fqdn=_FQDN)
     instance = _resolve_connector()
     cache_key = target_cache_key(seeded)
     accept_by_path: dict[str, str] = {}
@@ -528,7 +532,7 @@ async def test_tenant_typed_op_rides_tenant_plane(captured_events: list[Any]) ->
 async def test_provider_op_query_params_forward_pagination(captured_events: list[Any]) -> None:
     """``vcfa.provider.org.list`` forwards ``page`` / ``pageSize`` as query params."""
     await VcfAutomationConnector.register_typed_operations()
-    await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    await _seed_target(host=_HOST, fqdn=_FQDN)
     instance = _resolve_connector()
     captured: dict[str, str] = {}
 
@@ -572,7 +576,7 @@ async def test_tenant_deployment_list_forwards_odata_and_returns_content(
     sibling test module might leave set (the E2E force-handle test).
     """
     await VcfAutomationConnector.register_typed_operations()
-    await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    await _seed_target(host=_HOST, fqdn=_FQDN)
     instance = _resolve_connector()
     captured: dict[str, str] = {}
 

--- a/docs/codebase/connectors-vcf-automation.md
+++ b/docs/codebase/connectors-vcf-automation.md
@@ -142,25 +142,41 @@ domains.
    upserts the seven `typed_ops.VCFA_TYPED_OPS` descriptors — no ingest
    needed, so the audited read surface works on a fresh boot.
 
-### Vhost routing (load-bearing)
+### Vhost routing (load-bearing, #2863)
 
 VCFA 9.x enforces strict `Host:` header matching — the consumer wrapper
-(`scripts/vcf-automation.sh`) uses `curl --resolve fqdn:443:<ip>` to override
-DNS while keeping the FQDN in the request line. In httpx terms, the
-connector's per-target `AsyncClient` is built with
-`base_url=https://<fqdn-or-host>`; the cleanest equivalent of `--resolve` is
-to use the FQDN as the URL host and rely on operator-side DNS resolution.
+(`scripts/vcf-automation.sh`) uses `curl --resolve fqdn:443:<ip>` to keep
+the FQDN in the request line while dialling a specific IP. The connector
+implements the same "connect by IP, route by vhost" posture in httpx
+terms: the per-target `AsyncClient` **always** dials `target.host`
+(`base_url=https://<host>[:port]` — the reachable NAT-alias IP, or an
+FQDN), and `target.fqdn` is applied **per-request** as:
 
-The decision tree in `VcfAutomationConnector._base_url`:
+- the `Host:` header — via `_routing.vhost_header(fqdn, port)`, merged
+  onto the auth headers on the data path, both plane logins, and both
+  fingerprint probes; and
+- the TLS SNI + certificate-verify name — via the `sni_hostname`
+  request extension (the #2002 seam), so under `verify_tls=true` the
+  presented cert is still verified against the FQDN, not the dialled IP.
+  `VcfAutomationConnector._request_extensions` sets it with precedence
+  `tls_server_name` > `fqdn` > derive-from-host.
 
-1. `target.fqdn` is set → base URL host is the FQDN.
-2. `target.fqdn` is unset and `target.host` is an IP literal (IPv4 or IPv6,
-   bracket-wrapped accepted) → raise `VcfAutomationConfigurationError` with
-   a clear message naming the target and pointing operators at the `--fqdn`
-   / `fqdn:` configuration knob. Without this guard every path returns 404
-   with empty body post-login.
-3. `target.fqdn` is unset and `target.host` is itself an FQDN → use
-   `target.host` as the URL host (the right vhost is already on the wire).
+Nothing FQDN-derived is baked into the pooled `AsyncClient`, so this is
+compatible with the client-pool key (a per-request `fqdn` override never
+serves a stale client), and the SSRF guard — which screens `target.host`
+— now screens the address actually dialled. Before #2863 the FQDN was
+put into `base_url`, which (a) made an appliance reachable only by a
+NAT-alias IP structurally undialable, (b) could not disambiguate several
+appliances sharing one vhost FQDN behind distinct aliases, and (c) let
+the transport dial a host the SSRF guard never screened.
+
+`compose_base_url` returns `https://{host}[:port]` for every valid shape
+and refuses exactly one: an IP-literal `host` (IPv4 / IPv6, bracket-wrapped
+accepted) with no `fqdn` — there is no vhost to present, so it raises
+`VcfAutomationConfigurationError` naming the target + IP and pointing at
+the `--fqdn` / `fqdn:` knob rather than emitting a post-login 404 storm.
+An FQDN `host` with no `fqdn` is fine — httpx derives `Host:` from the
+host, which already carries the right vhost.
 
 `fingerprint()` catches the configuration error and reports a structured
 `reachable=False` with `extras["error"]` rather than bubbling the exception
@@ -243,7 +259,9 @@ the consumer repo, validated 2026-05-17):
 ### Fingerprint + probe
 
 - `fingerprint(target)` issues both unauthenticated version probes in series
-  through the per-target httpx client:
+  through the per-target httpx client. Each probe carries the vhost `Host:`
+  header and TLS SNI the same way the data path does (#2863 closed the
+  #2398 gap where the SNI seam reached only the two login POSTs):
   - Provider: `GET /api/versions` — returns vCD-API version XML. The
     connector reads the status only; XML parsing for the "latest
     non-deprecated" string lives in the consumer wrapper, which the
@@ -302,7 +320,12 @@ for ingested breadth on connectors that *do* publish a convertible spec.
   headers without rerouting through `_request_json`'s tenacity decorator.
   The connection-error / 5xx retry layer lives on the base method and
   applies to callers that use the base `_get_json` / `_post_json` paths
-  (the dispatcher always uses the overridden ones here).
+  (the dispatcher always uses the overridden ones here). Verified against
+  the pinned httpx 0.28.1 / httpcore 1.0.9: an explicit `Host` header
+  survives onto the built request (httpx does not overwrite it from
+  `base_url`) and the `sni_hostname` request extension drives httpcore's
+  `server_hostname` for both TLS SNI and cert CN/SAN verification — the two
+  facts the per-request vhost routing (#2863) relies on.
 - **tenacity 9.x** — installed dependency; not in direct use on this
   connector's overrides (the per-plane 401 retry-once is the only retry
   layer). Inherited use of tenacity persists on the base `_request_json`.
@@ -345,13 +368,17 @@ for ingested breadth on connectors that *do* publish a convertible spec.
   `typed_ops.py` dispatch with zero catalog state, so they never touch
   the vra-sdk-go 2.0 fragments — converting those would only *widen* the
   ingested browse breadth, not change the typed reads.
-- `--resolve`-style DNS override (consumer-wrapper-only) has no direct
-  httpx equivalent in the connector — operators are expected to make the
-  appliance's FQDN resolvable on the meho-backplane host (typical: split-DNS
-  for the management network) when the target uses the IP-host-plus-FQDN
-  shape. A future enhancement could use httpx's transport-level resolver
-  hook, but the v0.2 posture matches MEHO's standard "operator-owned DNS"
-  assumption.
+- `--resolve`-style DNS override no longer needs split-DNS (#2863). The
+  connector dials `target.host` directly and presents `target.fqdn` as the
+  `Host:` header + TLS SNI per request, so the IP-host-plus-FQDN shape works
+  without making the appliance's FQDN resolvable on the meho-backplane host.
+  This is the `curl --resolve fqdn:443:<ip>` behaviour the consumer wrapper
+  uses, done at the request layer rather than the transport resolver — and
+  it is **required** (not merely convenient) when several appliances share
+  one vhost FQDN behind distinct NAT aliases, since a single DNS name cannot
+  map to N alias IPs. Operator note: a vcfa target must set `host` to the
+  dialable address; a target whose `host` held a stale value while split-DNS
+  carried the FQDN fails loud at first dispatch with the host named.
 
 ## References
 
@@ -359,6 +386,13 @@ for ingested breadth on connectors that *do* publish a convertible spec.
   (skeleton — this Task); [G3.6-T11 #836](https://github.com/evoila/meho/issues/836)
   (dual-plane spec ingestion + read ops); [G3.6-T12 #840](https://github.com/evoila/meho/issues/840)
   (CLI verbs + E2E + onboarding doc).
+- Connect-by-IP / route-by-vhost: [#2863](https://github.com/evoila/meho/issues/2863)
+  (dial `target.host`, present `target.fqdn` per-request as `Host:` + TLS
+  SNI; closes the #2398 probe/data-path SNI-seam gap) — builds on the
+  `tls_server_name` SNI seam [#2002](https://github.com/evoila/meho/issues/2002)
+  / [#2398](https://github.com/evoila/meho/issues/2398). The generic
+  `net.http_probe` counterpart is split out as
+  [#2896](https://github.com/evoila/meho/issues/2896).
 - Swagger-2.0 on-ramp decision: [#2090](https://github.com/evoila/meho/issues/2090)
   (parser stays OpenAPI-3.x-only; convert vra-sdk-go fragments
   out-of-band — see Known issues above).


### PR DESCRIPTION
## Summary

- The vcfa connector baked `target.fqdn` into the pooled client's `base_url`, so httpx derived the TCP connect address, the `Host:` header, and the TLS SNI/verify name all from the FQDN. That made "connect by IP, route by vhost" structurally unreachable — an appliance addressable only by a NAT-alias IP (and labs sharing one vhost FQDN behind distinct aliases) could never be dialled — and let the transport dial a host the SSRF guard (which screens `target.host`) never screened.
- `compose_base_url` now always returns `https://{host}[:port]` (the reachable address); `target.fqdn` is applied **per-request** as the `Host:` header (new `_routing.vhost_header`) and as TLS SNI via the #2002 `sni_hostname` extension, with precedence `tls_server_name` > `fqdn` > derive-from-host (`_request_extensions`). Threaded through the data path, **both** plane logins, and **both** fingerprint probes — the probes + data path closing the #2398 gap where the SNI seam reached only the two login POSTs.
- Under `verify_tls=true` the certificate is still verified against the FQDN (httpcore uses `sni_hostname` for both SNI and cert CN/SAN verification — confirmed against pinned httpx 0.28.1 / httpcore 1.0.9). Nothing fqdn-derived is baked into the pooled client, keeping this compatible with the #2873 pool-key fix (a per-request `fqdn` override never serves a stale client).
- The only refused shape is an IP-literal `host` with no `fqdn` (no vhost to present) — `VcfAutomationConfigurationError` with a rewritten message naming the host + the `--fqdn` knob.

## Test plan

- [x] `ruff check` (src + tests) — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (vcf_automation package) — clean
- [x] `code-quality.py --diff` — 0 blockers
- [x] `pytest` vcfa suite + base HTTP adapter — 153 passed (19 new/updated `#2863` cases: base-URL dials host, `vhost_header`, SNI precedence, data path, both logins, both probes, e2e per-call override rides `Host:`/SNI, e2e bearer dials IP + presents FQDN)
- [x] full-suite `--collect-only` — clean (no import breakage)
- [x] Acceptance: connector dials `target.host`; `fqdn` presented per-request as `Host:` + SNI (never in pooled base_url); threaded through data path + both logins + both probes; cert verified against FQDN under `verify_tls=true`; IP-host-no-fqdn still hard-refuses.

## Out of scope

- The generic `net.http_probe` host-header/SNI counterpart is tracked separately as #2896.
- Code-quality warnings (non-blocking, pre-existing/borderline): `connector.py` file size (947 lines, pre-existing debt > 600); `_do_request_with_retry` (66) and `fingerprint` (73) cross the 60-line soft warn after +6 lines each. Splitting `connector.py` is a separate refactor, not this fix.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2863
