### PR TITLE
fix(targets): honour explicit-null secret_ref; drop PATCH re-home (#2872)

### DIFF
--- a/backend/src/meho_backplane/api/v1/targets.py
+++ b/backend/src/meho_backplane/api/v1/targets.py
@@ -1211,6 +1211,28 @@ async def probe_target(
     return fp
 
 
+def _resolve_create_secret_ref(body: TargetCreate, operator: Operator) -> str | None:
+    """Resolve the ``secret_ref`` to persist for a new target (#1723 / #2872).
+
+    Distinguishes an *omitted* ``secret_ref`` (derive the #1723 per-tenant
+    default ``tenants/<tenant_id>/<name>``) from an explicit
+    ``{"secret_ref": null}`` (persist ``NULL`` so the #2234 auth-optional
+    dispatch branch — an unauthenticated, network-scoped target such as a
+    port-forwarded Prometheus — is reachable in one request). The two
+    collapse to ``None`` under ``model_dump``; ``model_fields_set`` is the
+    only signal that separates them (the established in-repo pattern:
+    ``conventions/_internal.py``, ``memory/ttl.py``, ``mcp/tools/memory.py``).
+    A non-null explicit ref is honoured only inside the operator's tenant
+    subtree (#2091, see :func:`_enforce_secret_ref_tenant_scope`). Post-fix,
+    ``secret_ref IS NULL`` unambiguously means "operator chose no credential".
+    """
+    if "secret_ref" not in body.model_fields_set:
+        return tenant_secret_ref(operator.tenant_id, body.name)
+    if body.secret_ref is not None:
+        _enforce_secret_ref_tenant_scope(body.secret_ref, operator, body.name)
+    return body.secret_ref
+
+
 @router.post("", response_model=Target, status_code=201)
 async def create_target(
     body: TargetCreate,
@@ -1247,6 +1269,11 @@ async def create_target(
     ``permission denied``. Omitting ``secret_ref`` derives the
     per-tenant default (#1723) and always passes; no-op when the guard
     is disabled. See :func:`_enforce_secret_ref_tenant_scope`.
+
+    #2872. ``secret_ref`` resolution (omitted → derive the #1723 default;
+    explicit ``{"secret_ref": null}`` → persist ``NULL`` for the #2234
+    auth-optional branch) is delegated to
+    :func:`_resolve_create_secret_ref`.
     """
     # G0.18-T2 (#1355) / G0.27 / T3 (#1817). Validate the incoming product
     # token against the registered set so a value copied straight out of
@@ -1264,14 +1291,10 @@ async def create_target(
     # Persist the validated product token so the stored row matches the
     # registry / resolver spelling (G0.18-T2 #1355).
     create_fields["product"] = product
-    # #1723: default a fresh target's secret onto the per-tenant shared
-    # path ``tenants/<tenant_id>/<name>``. An explicit ``secret_ref`` is
-    # honoured verbatim — but only inside the operator's tenant subtree
-    # (#2091, see :func:`_enforce_secret_ref_tenant_scope`).
-    if create_fields.get("secret_ref") is None:
-        create_fields["secret_ref"] = tenant_secret_ref(operator.tenant_id, body.name)
-    else:
-        _enforce_secret_ref_tenant_scope(create_fields["secret_ref"], operator, body.name)
+    # #1723 / #2872: an omitted ``secret_ref`` derives the per-tenant
+    # default; an explicit ``{"secret_ref": null}`` persists verbatim. See
+    # :func:`_resolve_create_secret_ref`.
+    create_fields["secret_ref"] = _resolve_create_secret_ref(body, operator)
     t = TargetORM(
         id=uuid.uuid4(),
         tenant_id=operator.tenant_id,
@@ -1401,18 +1424,16 @@ async def update_target(
     _validate_update_body_fields(updates, t, operator)
     for k, v in updates.items():
         setattr(t, k, v)
-    # #1723: home an as-yet-unconfigured target onto the per-tenant shared
-    # path. A PATCH that does not touch ``secret_ref`` (the field is absent
-    # from the request body, so it is not in ``updates``) on a row whose
-    # ``secret_ref`` is still unset derives ``tenants/<tenant_id>/<name>``
-    # so the canonical layout is filled in without the operator typing it.
-    # A PATCH that *sends* ``secret_ref`` — including an explicit
-    # ``{"secret_ref": null}`` to clear it — is honoured verbatim and is
-    # never overwritten here (it is in ``updates`` and the branch is
-    # skipped); silent re-homing of an already-configured ref is the
-    # operator-driven migration runbook's job, not the route's.
-    if "secret_ref" not in updates and t.secret_ref is None:
-        t.secret_ref = tenant_secret_ref(operator.tenant_id, t.name)
+    # #2872: PATCH no longer re-homes an unset ``secret_ref``. The #1723
+    # auto-home branch that used to derive ``tenants/<tenant_id>/<name>``
+    # here — on any PATCH omitting ``secret_ref`` over a NULL row — was
+    # removed: post-fix a DB NULL is unambiguous, meaning the operator
+    # deliberately chose no credential (created with an explicit null, or
+    # cleared it later) to reach the #2234 auth-optional dispatch branch. An
+    # unrelated PATCH (e.g. one touching only ``verify_tls``) must not
+    # resurrect a credential path. The per-tenant default is derived once,
+    # at create time, and only when ``secret_ref`` is omitted (see
+    # :func:`create_target`).
     t.updated_at = datetime.now(UTC)
     _log.info(
         "target_updated",

--- a/backend/src/meho_backplane/api/v1/targets.py
+++ b/backend/src/meho_backplane/api/v1/targets.py
@@ -1269,11 +1269,6 @@ async def create_target(
     ``permission denied``. Omitting ``secret_ref`` derives the
     per-tenant default (#1723) and always passes; no-op when the guard
     is disabled. See :func:`_enforce_secret_ref_tenant_scope`.
-
-    #2872. ``secret_ref`` resolution (omitted → derive the #1723 default;
-    explicit ``{"secret_ref": null}`` → persist ``NULL`` for the #2234
-    auth-optional branch) is delegated to
-    :func:`_resolve_create_secret_ref`.
     """
     # G0.18-T2 (#1355) / G0.27 / T3 (#1817). Validate the incoming product
     # token against the registered set so a value copied straight out of

--- a/backend/src/meho_backplane/ui/routes/connectors/forms.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/forms.py
@@ -325,18 +325,30 @@ async def submit_create(
         "aliases": aliases_raw or "",
         "notes": notes or "",
     }
+    # #2872: pass ``secret_ref`` only when the operator actually typed one.
+    # A blank field must stay *omitted* so ``create_target`` derives the
+    # #1723 per-tenant default; passing ``secret_ref=None`` explicitly would
+    # now land in ``model_fields_set`` and register as a deliberate "no
+    # credential" (persisted NULL), which is not what a blank create form
+    # means. (``submit_edit`` keeps ``secret_ref or None`` on purpose:
+    # blanking a populated field there *is* an intentional clear.)
+    # Building the input as a dict + ``model_validate`` (mirroring the import
+    # path's ``_build_create_body``) keeps ``model_fields_set`` key-accurate:
+    # ``secret_ref`` is present only when the operator typed one.
     try:
-        body = TargetCreate(
-            name=name,
-            product=product,
-            host=host,
-            port=_coerce_port(port),
-            auth_model=AuthModel(auth_model),
-            secret_ref=secret_ref or None,
-            vpn_required=vpn_required,
-            aliases=parse_aliases(aliases_raw),
-            notes=notes or None,
-        )
+        create_data: dict[str, object] = {
+            "name": name,
+            "product": product,
+            "host": host,
+            "port": _coerce_port(port),
+            "auth_model": AuthModel(auth_model),
+            "vpn_required": vpn_required,
+            "aliases": parse_aliases(aliases_raw),
+            "notes": notes or None,
+        }
+        if secret_ref and secret_ref.strip():
+            create_data["secret_ref"] = secret_ref
+        body = TargetCreate.model_validate(create_data)
     except (ValidationError, ValueError) as exc:
         return _render_form_with_errors(
             request,

--- a/backend/tests/test_api_v1_targets.py
+++ b/backend/tests/test_api_v1_targets.py
@@ -2447,23 +2447,60 @@ def test_create_target_honours_explicit_secret_ref(client: TestClient) -> None:
     assert response.json()["secret_ref"] != f"tenants/{DEFAULT_TENANT_ID}/custom"
 
 
-@pytest.mark.asyncio
-async def test_update_target_homes_unconfigured_secret_ref(client: TestClient) -> None:
-    """A PATCH not touching ``secret_ref`` on a null-ref row derives the per-tenant path."""
+def test_create_target_persists_explicit_null_secret_ref(client: TestClient) -> None:
+    """#2872: POST with an explicit ``{"secret_ref": null}`` persists NULL, not the default.
+
+    The #2234 auth-optional dispatch branch — an unauthenticated,
+    network-scoped target such as a port-forwarded Prometheus — must be
+    registrable in a single request. ``model_fields_set`` distinguishes an
+    *omitted* ``secret_ref`` (derive ``tenants/<T>/<name>``, pinned by
+    ``test_create_target_derives_per_tenant_secret_ref``) from an explicit
+    null (persist NULL). A null-ref row then dispatches with no credential
+    load — pinned at the connector layer by ``test_connectors_prometheus``
+    — instead of failing with ``connector_vault_forbidden``.
+    """
     key = make_rsa_keypair("kid-A")
-    # Row created out-of-band with no secret_ref (e.g. pre-#1723).
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "prom-noauth",
+                "product": "ssh",
+                "host": "10.0.0.5",
+                "secret_ref": None,
+            },
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+    # Explicit null persisted verbatim — NOT re-derived to the per-tenant default.
+    assert response.json()["secret_ref"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_target_leaves_unconfigured_secret_ref_null(client: TestClient) -> None:
+    """#2872: a PATCH not touching ``secret_ref`` on a null-ref row leaves it NULL.
+
+    Inverts the pre-#2872 ``_homes_unconfigured_`` contract. The #1723
+    PATCH auto-home branch was removed, so a deliberately-cleared
+    ``secret_ref`` (the #2234 auth-optional branch) survives an unrelated
+    PATCH — here one touching only ``verify_tls``, the reporter's exact
+    repro — instead of being silently re-derived to ``tenants/<T>/<name>``.
+    """
+    key = make_rsa_keypair("kid-A")
+    # Null-ref row: an operator's auth-optional target (or a pre-#1723 legacy row).
     await _insert_target(name="legacy-target", product="ssh", host="10.0.0.9", secret_ref=None)
     with respx.mock as mock_router:
         mock_discovery_and_jwks(mock_router, public_jwks(key))
         response = client.patch(
             "/api/v1/targets/legacy-target",
-            json={"host": "moved.host"},
+            json={"verify_tls": False},
             headers={"Authorization": f"Bearer {_admin_token(key)}"},
         )
     assert response.status_code == 200
     data = response.json()
-    assert data["host"] == "moved.host"
-    assert data["secret_ref"] == f"tenants/{DEFAULT_TENANT_ID}/legacy-target"
+    assert data["verify_tls"] is False
+    assert data["secret_ref"] is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_ui_connectors_forms.py
+++ b/backend/tests/test_ui_connectors_forms.py
@@ -434,6 +434,42 @@ def test_create_submit_persists_target_and_redirects_to_list() -> None:
     assert row.notes == "created via UI"
 
 
+def test_create_submit_blank_secret_ref_derives_default() -> None:
+    """#2872: a blank ``secret_ref`` field derives the #1723 per-tenant default.
+
+    The create form field is ``Form(default=None)``; ``submit_create`` must
+    *omit* ``secret_ref`` from the ``TargetCreate`` (not pass an explicit
+    ``None``) so ``create_target`` derives ``tenants/<tenant_id>/<name>``.
+    Were it passed explicitly, ``model_fields_set`` would flag it and the
+    row would persist ``NULL`` (the #2234 auth-optional shape) — the wrong
+    result for a blank create form.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/create",
+            headers=_form_headers(csrf),
+            data={
+                "name": "blank-secret",
+                "product": _PRODUCT,
+                "host": "blank.example.test",
+                "auth_model": "shared_service_account",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+
+    row = _load_target(_TENANT_A, "blank-secret")
+    assert row is not None
+    assert row.secret_ref == f"tenants/{_TENANT_A}/blank-secret"
+
+
 def test_create_submit_rejects_port_out_of_range_with_field_error() -> None:
     """A port outside 1-65535 re-renders the form with a 422 + field error."""
     _seed_tenant(_TENANT_A, "tenant-a")

--- a/docs/codebase/connectors-vault-tenant-scope.md
+++ b/docs/codebase/connectors-vault-tenant-scope.md
@@ -88,9 +88,17 @@ automatically:
 [`connectors/vault/tenant_paths.py`](../../backend/src/meho_backplane/connectors/vault/tenant_paths.py)'s
 `tenant_secret_ref(tenant_id, target)` derives
 `tenants/<tenant_id>/<target>`, and `api/v1/targets.py`'s `create_target`
-(no explicit `secret_ref`) and `update_target` (PATCH not touching
-`secret_ref` on an unset row) apply it. An explicitly-supplied
-`secret_ref` is always honoured verbatim.
+applies it **only when `secret_ref` is omitted** — distinguished from an
+explicit `{"secret_ref": null}` via Pydantic's `model_fields_set` (#2872).
+An explicit null is persisted as `NULL` (the operator declaring "no
+credential" for the [#2234](https://github.com/evoila/meho/issues/2234)
+auth-optional dispatch branch — e.g. an unauthenticated, port-forwarded
+Prometheus); any explicitly-supplied non-null `secret_ref` is honoured
+verbatim. `update_target` does **not** derive the default: a PATCH that
+omits `secret_ref` leaves the persisted value untouched. The pre-#2872
+re-home branch that filled an unset row on any unrelated PATCH was removed,
+so a deliberately-cleared `NULL` survives — post-#2872, `secret_ref IS
+NULL` unambiguously means "operator chose no credential".
 
 This replaces the retired **per operator `sub`** layout
 (`secret/data/targets/<sub>/*`, `connector-vault-policy.md` §2), which

--- a/docs/cross-repo/vault-per-tenant-migration.md
+++ b/docs/cross-repo/vault-per-tenant-migration.md
@@ -47,17 +47,18 @@ the same rendering the guard's
 [`rendered_tenant_prefix`](../../backend/src/meho_backplane/connectors/vault/tenant_scope.py)
 produces and the same UUID that appears in audit rows and JWT claims.
 
-New targets created or PATCH-homed after #1723 land on the per-tenant
-path automatically (see "What the backplane does for you"). This runbook
+New targets created after #1723 land on the per-tenant path
+automatically (see "What the backplane does for you"). This runbook
 covers the **existing** secrets that predate the change.
 
 ## What the backplane does for you
 
 - **Create** (`POST /api/v1/targets`) with no explicit `secret_ref`
   derives `tenants/<tenant_id>/<name>` and stores it on the row.
-- **Update** (`PATCH /api/v1/targets/{name}`) that does not touch
-  `secret_ref`, on a row whose `secret_ref` is still unset, fills in the
-  same derived path.
+- **Update** (`PATCH /api/v1/targets/{name}`) never derives
+  `secret_ref`: a PATCH that omits it leaves the stored value unchanged
+  (an unset row stays unset). Derivation happens only at create time, on
+  omission (#2872).
 - An **explicitly-supplied** `secret_ref` (including a non-default mount
   layout, or an explicit `{"secret_ref": null}` to clear it) is always
   honoured verbatim — the backplane never silently re-homes a ref you set.


### PR DESCRIPTION
## Summary

- **POST `/api/v1/targets` now honours `{"secret_ref": null}` verbatim.** An omitted `secret_ref` still derives the #1723 per-tenant default (`tenants/<tenant>/<name>`); an explicit null is persisted as `NULL`. The two are distinguished via Pydantic `model_fields_set` (the established in-repo pattern — `conventions/_internal.py`, `memory/ttl.py`, `mcp/tools/memory.py`), since `model_dump` alone collapses both to `None`. Extracted into `_resolve_create_secret_ref` to keep the handler within the size budget (mirrors the existing `_validate_update_body_fields` extraction).
- **The #1723 PATCH re-home branch is deleted outright.** It used to re-derive the default on any PATCH that omitted `secret_ref` over a `NULL` row, so a deliberately-cleared ref did not survive an unrelated PATCH (e.g. one touching only `verify_tls`). Post-fix, `secret_ref IS NULL` unambiguously means "operator chose no credential", making the #2234 auth-optional dispatch branch reachable in a single request instead of dying with `connector_vault_forbidden`.
- **UI create form guard.** `submit_create` includes `secret_ref` in the model input only when the operator actually typed one, so a blank create form still derives the default (a plain `secret_ref=None` would now register as a deliberate explicit-null). The edit form's clear-on-blank semantics are intentionally unchanged.
- **No schema / OpenAPI change** (`str | null` stays on both write models — no Go client regen), the #2091 tenant-scope 422 gate and the sparse-PATCH `exclude_unset` contract are untouched, and there is **no `NULL`-row backfill** (existing `NULL` rows are an unresolvable mix of deliberately-cleared and legacy-unset).

## Test plan

- [x] `ruff check` / `ruff format --check` — clean on all changed files
- [x] `mypy src/meho_backplane/api/v1/targets.py src/…/ui/routes/connectors/forms.py` — clean (the sole `mypy src/` finding is a pre-existing macOS-only `socket.MSG_ERRQUEUE` artifact in `connectors/net/icmp.py`, outside this diff)
- [x] `code-quality.py --diff` — 0 blockers
- [x] POST explicit null → 201 `secret_ref: null` — new `test_create_target_persists_explicit_null_secret_ref`
- [x] POST omitted → derives default — existing `test_create_target_derives_per_tenant_secret_ref` (unchanged, still green)
- [x] PATCH touching only `verify_tls` leaves `NULL` untouched — inverted `test_update_target_leaves_unconfigured_secret_ref_null` (was `_homes_unconfigured_`)
- [x] null-ref target dispatches auth-optional (no credential load, no `connector_vault_forbidden`) — persistence proven here; dispatch behaviour pinned by existing `test_connectors_prometheus.py`
- [x] UI blank create form derives the default — new `test_create_submit_blank_secret_ref_derives_default`
- [x] #2091 tenant-scope gate + clear-on-explicit-null unchanged — `test_api_v1_targets.py` (87 passed), `test_ui_connectors_forms.py` (28), `test_ui_connectors_import.py` (23), `test_targets_schemas.py` (37)
- [x] `docs/codebase/connectors-vault-tenant-scope.md` updated (the now-removed PATCH auto-home behaviour)

## Out of scope

- MCP registration tool (#2861) / CLI verb (#2862) expressing explicit-null `secret_ref` — interaction noted on Initiative #2889; this PR makes the API honour it (and the YAML import path gains it for free via `model_validate`).
- UI "no credential (auth-optional)" create-form affordance and a `secret_ref`-change audit trail — #2872 follow-ups per the Initiative.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2872
