### PR TITLE
feat(connectors): derived numeric samples on prometheus.query/query_range (#2871)

### DIFF
--- a/backend/src/meho_backplane/connectors/prometheus/ops.py
+++ b/backend/src/meho_backplane/connectors/prometheus/ops.py
@@ -115,7 +115,12 @@ _INSTANT_QUERY_OP = PrometheusOp(
         "Returns Prometheus's standard result envelope "
         "(``{resultType, result}``) where ``resultType`` is one of "
         "``vector`` / ``scalar`` / ``string`` / ``matrix``. Serves "
-        "Prometheus, Thanos Query, and Mimir/Cortex identically."
+        "Prometheus, Thanos Query, and Mimir/Cortex identically. Each vector "
+        "sample also carries a derived numeric sibling ``value_num`` (float "
+        "or null), and the envelope carries ``first_sample_value`` (float or "
+        "null), so threshold sensors can assert the observed number directly "
+        "instead of the raw JSON-string ``value`` (which stays untouched); "
+        "``NaN`` / ``+-Inf`` / unparseable derive to null."
     ),
     parameter_schema={
         "type": "object",
@@ -141,8 +146,13 @@ _INSTANT_QUERY_OP = PrometheusOp(
             "any instant PromQL expression."
         ),
         "output_shape": (
-            "``{resultType, result}``. For an instant vector, ``result`` "
-            "is a list of ``{metric: {...labels}, value: [ts, 'val']}``."
+            "``{data: {resultType, result}, first_sample_value}``. For an "
+            "instant vector, ``result`` is a list of ``{metric: {...labels}, "
+            "value: [ts, 'val'], value_num: <float|null>}`` -- ``value_num`` "
+            "is the sample value parsed to a float (``NaN`` / ``+-Inf`` / "
+            "unparseable -> null). ``first_sample_value`` (float|null) on the "
+            "envelope aliases the first sample's number for a direct "
+            "``$.first_sample_value`` threshold assertion."
         ),
     },
 )
@@ -157,7 +167,12 @@ _RANGE_QUERY_OP = PrometheusOp(
         "``end`` (RFC3339 or Unix timestamps) and ``step`` (duration or "
         "float seconds). Returns a ``matrix`` result -- one series of "
         "``[timestamp, value]`` pairs per matching label set. Use for "
-        "trends, rates, and charting over a window."
+        "trends, rates, and charting over a window. Each series also carries "
+        "``values_num`` (a list of floats/nulls parallel to ``values``), and "
+        "the envelope carries ``first_sample_value`` (float or null), so "
+        "threshold sensors can assert observed numbers directly instead of "
+        "the raw JSON-string values (which stay untouched); ``NaN`` / "
+        "``+-Inf`` / unparseable derive to null."
     ),
     parameter_schema={
         "type": "object",
@@ -185,7 +200,12 @@ _RANGE_QUERY_OP = PrometheusOp(
             "rates, deltas, anything you would chart."
         ),
         "output_shape": (
-            "``{resultType: 'matrix', result: [{metric, values: [[ts, 'val'], ...]}]}``."
+            "``{data: {resultType: 'matrix', result: [{metric, values: "
+            "[[ts, 'val'], ...], values_num: [<float|null>, ...]}]}, "
+            "first_sample_value}``. ``values_num`` parallels ``values`` per "
+            "series (``NaN`` / ``+-Inf`` / unparseable -> null); "
+            "``first_sample_value`` (float|null) is the first series' first "
+            "sample, assertable as ``$.first_sample_value``."
         ),
     },
 )

--- a/backend/src/meho_backplane/connectors/prometheus/ops_read.py
+++ b/backend/src/meho_backplane/connectors/prometheus/ops_read.py
@@ -21,6 +21,7 @@ concrete connector's gated transport (:meth:`_api_get`) at dispatch time.
 
 from __future__ import annotations
 
+import math
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -48,6 +49,104 @@ if TYPE_CHECKING:
     _Base = _ConnectorProto
 else:
     _Base = object
+
+
+def _numeric_sample_value(raw: Any) -> float | None:
+    """Parse one Prometheus sample-value string to a finite float, else ``None``.
+
+    The Prometheus HTTP API encodes every sample value as a JSON string
+    (``"1"``, ``"3.14"``, ``"1.5e9"``, and the non-finite sentinels ``"NaN"``
+    / ``"+Inf"`` / ``"-Inf"``). A finite float parses; a non-finite sentinel
+    or anything unparseable derives to ``None`` so the augmented payload stays
+    strict-JSON-serialisable (JSON has no NaN/Inf literal) and a threshold
+    sensor asserting the derived field lands in ``unknown`` (fail-safe) rather
+    than on a bogus number.
+    """
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _sample_pair_value(sample: Any) -> float | None:
+    """Numeric value of a Prometheus ``[timestamp, "value"]`` sample pair."""
+    if isinstance(sample, list) and len(sample) == 2:
+        return _numeric_sample_value(sample[1])
+    return None
+
+
+def _augment_vector(result: list[Any]) -> float | None:
+    """Add ``value_num`` to each instant-vector sample dict in place.
+
+    Returns the first sample's derived value for the envelope alias.
+    """
+    for entry in result:
+        if isinstance(entry, dict):
+            entry["value_num"] = _sample_pair_value(entry.get("value"))
+    if result and isinstance(result[0], dict):
+        first: float | None = result[0].get("value_num")
+        return first
+    return None
+
+
+def _augment_matrix(result: list[Any]) -> float | None:
+    """Add ``values_num`` (parallel to ``values``) to each series dict in place.
+
+    Returns the first series' first sample value for the envelope alias.
+    """
+    for entry in result:
+        if isinstance(entry, dict):
+            values = entry.get("values")
+            entry["values_num"] = (
+                [_sample_pair_value(sample) for sample in values]
+                if isinstance(values, list)
+                else []
+            )
+    if result and isinstance(result[0], dict):
+        nums = result[0].get("values_num")
+        return nums[0] if nums else None
+    return None
+
+
+def _augment_numeric_samples(payload: dict[str, Any]) -> dict[str, Any]:
+    """Attach derived numeric siblings to a ``query`` / ``query_range`` envelope.
+
+    Every raw sample value the Prometheus API returns is a JSON string, which
+    the checks threshold comparator maps to ``unknown`` (it requires a real
+    number by contract, #2504). This adds numeric siblings a sensor can assert
+    directly -- the #2772/#2808 ``days_to_expiry`` shape -- while leaving the
+    raw ``value`` / ``values`` fields byte-identical (wire fidelity):
+
+    * ``vector`` result -> ``value_num`` (float|null) on each sample dict.
+    * ``matrix`` result -> ``values_num`` (list[float|null], parallel to
+      ``values``) on each series dict.
+    * ``first_sample_value`` (float|null) on the envelope -- the numeric of the
+      first series' first sample, mirroring #2808's top-level leaf alias, so a
+      sensor asserts ``$.first_sample_value`` directly. ``scalar`` / ``string``
+      results (whose ``result`` is a bare ``[ts, "val"]`` pair, not a list of
+      dicts) surface only through this envelope alias.
+
+    Mutates *payload* in place -- it is the freshly parsed body ``_api_get``
+    owns per call -- and returns it. Bodies that are not one of the four PromQL
+    result types (errors, unexpected shapes) get ``first_sample_value: null``
+    and are otherwise untouched.
+    """
+    first: float | None = None
+    data = payload.get("data")
+    if isinstance(data, dict):
+        result_type = data.get("resultType")
+        result = data.get("result")
+        if result_type == "vector" and isinstance(result, list):
+            first = _augment_vector(result)
+        elif result_type == "matrix" and isinstance(result, list):
+            first = _augment_matrix(result)
+        elif result_type in ("scalar", "string"):
+            first = _sample_pair_value(result)
+    payload["first_sample_value"] = first
+    return payload
 
 
 class PrometheusReadOps(_Base):
@@ -104,18 +203,33 @@ class PrometheusReadOps(_Base):
     async def query(
         self, operator: Operator, target: Any, params: dict[str, Any]
     ) -> dict[str, Any]:
-        """``prometheus.query`` -- ``GET /api/v1/query``."""
+        """``prometheus.query`` -- ``GET /api/v1/query``.
+
+        The raw envelope is augmented with derived numeric sample fields
+        (``value_num`` per vector sample, ``first_sample_value`` on the
+        envelope) so threshold sensors can assert observed values; the raw
+        ``value`` strings stay byte-identical. See
+        :func:`_augment_numeric_samples`.
+        """
         query: dict[str, Any] = {"query": params["query"]}
         for key in ("time", "timeout"):
             value = params.get(key)
             if value is not None:
                 query[key] = value
-        return await self._api_get(target, "/api/v1/query", operator=operator, params=query)
+        payload = await self._api_get(target, "/api/v1/query", operator=operator, params=query)
+        return _augment_numeric_samples(payload)
 
     async def query_range(
         self, operator: Operator, target: Any, params: dict[str, Any]
     ) -> dict[str, Any]:
-        """``prometheus.query_range`` -- ``GET /api/v1/query_range``."""
+        """``prometheus.query_range`` -- ``GET /api/v1/query_range``.
+
+        The raw matrix envelope is augmented with derived numeric sample
+        fields (``values_num`` parallel to each series' ``values``,
+        ``first_sample_value`` on the envelope) so threshold sensors can
+        assert observed values; the raw ``values`` pairs stay byte-identical.
+        See :func:`_augment_numeric_samples`.
+        """
         query: dict[str, Any] = {
             "query": params["query"],
             "start": params["start"],
@@ -125,7 +239,10 @@ class PrometheusReadOps(_Base):
         timeout = params.get("timeout")
         if timeout is not None:
             query["timeout"] = timeout
-        return await self._api_get(target, "/api/v1/query_range", operator=operator, params=query)
+        payload = await self._api_get(
+            target, "/api/v1/query_range", operator=operator, params=query
+        )
+        return _augment_numeric_samples(payload)
 
     async def series(
         self, operator: Operator, target: Any, params: dict[str, Any]

--- a/backend/tests/test_connectors_prometheus.py
+++ b/backend/tests/test_connectors_prometheus.py
@@ -19,6 +19,11 @@ Coverage matrix (per the Task #2234 acceptance criteria):
   prometheus.
 * **Recorded-fixture ops** — ``query`` / ``query_range`` / ``targets``
   round-trip recorded response fixtures and hit the correct wire path.
+* **Derived numeric samples (#2871)** — ``query`` / ``query_range`` carry
+  ``value_num`` / ``values_num`` per sample and ``first_sample_value`` on the
+  envelope (``NaN`` / ``+-Inf`` / unparseable -> null); the raw ``value`` /
+  ``values`` stay byte-identical; and a real result drives a threshold sensor
+  end-to-end through the untouched checks evaluator (#2504).
 
 The wire is mocked with ``respx``; the credential loader is injected so
 Vault is never touched. Handlers are invoked directly (not through the DB
@@ -28,6 +33,7 @@ dispatcher) so the suite stays a pure unit test.
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 
@@ -36,6 +42,8 @@ import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.checks.assertions import AssertionSpec, SelectSpec, ThresholdCompare
+from meho_backplane.checks.evaluate import evaluate_assertion
 from meho_backplane.connectors.prometheus import (
     PROMETHEUS_OPS,
     PROMETHEUS_WHEN_TO_USE_BY_GROUP,
@@ -44,6 +52,11 @@ from meho_backplane.connectors.prometheus import (
 from meho_backplane.connectors.prometheus.connector import (
     PrometheusReadOnlyError,
     _enforce_read_only,
+)
+from meho_backplane.connectors.prometheus.ops_read import (
+    _augment_numeric_samples,
+    _numeric_sample_value,
+    _sample_pair_value,
 )
 from meho_backplane.connectors.registry import all_connectors_v2
 
@@ -291,7 +304,11 @@ async def test_query_roundtrips_fixture() -> None:
         _operator(), _target(), {"query": "up", "time": "2024-07-15T00:00:00Z"}
     )
     assert result["data"]["resultType"] == "vector"
+    # Raw wire value is left byte-identical.
     assert result["data"]["result"][0]["value"] == [1721000000, "1"]
+    # Derived numerics: per-sample value_num + envelope first_sample_value.
+    assert result["data"]["result"][0]["value_num"] == 1.0
+    assert result["first_sample_value"] == 1.0
     assert route.calls.last.request.url.params.get("time") == "2024-07-15T00:00:00Z"
     await connector.aclose()
 
@@ -308,6 +325,12 @@ async def test_query_range_roundtrips_fixture() -> None:
         {"query": "up", "start": "1721000000", "end": "1721000015", "step": "15s"},
     )
     assert result["data"]["resultType"] == "matrix"
+    series = result["data"]["result"][0]
+    # Raw wire values are left byte-identical.
+    assert series["values"] == [[1721000000, "1"], [1721000015, "1"]]
+    # Derived numerics: values_num parallel to values + envelope alias.
+    assert series["values_num"] == [1.0, 1.0]
+    assert result["first_sample_value"] == 1.0
     params = route.calls.last.request.url.params
     assert params.get("query") == "up"
     assert params.get("step") == "15s"
@@ -479,3 +502,188 @@ async def test_probe_ok_and_failure() -> None:
     assert bad.ok is False
     assert bad.reason
     await connector2.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Derived numeric samples (#2871)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("1", 1.0),
+        ("0", 0.0),
+        ("3.14", 3.14),
+        ("-2.5", -2.5),
+        ("1.5e9", 1.5e9),
+        ("NaN", None),
+        ("+Inf", None),
+        ("-Inf", None),
+        ("Inf", None),
+        ("", None),
+        ("not-a-number", None),
+    ],
+)
+def test_numeric_sample_value_parses_finite_floats_only(raw: str, expected: float | None) -> None:
+    """Finite floats parse; NaN / +-Inf / unparseable derive to None (fail-safe null)."""
+    result = _numeric_sample_value(raw)
+    if expected is None:
+        assert result is None
+    else:
+        assert result == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("raw", [1, 1.0, None, ["1"], {"v": "1"}, True])
+def test_numeric_sample_value_non_string_is_none(raw: Any) -> None:
+    """Only JSON-string samples derive a number; a non-string never coerces."""
+    assert _numeric_sample_value(raw) is None
+
+
+@pytest.mark.parametrize(
+    "sample,expected",
+    [
+        ([1721000000, "1"], 1.0),
+        ([1721000000.5, "2.5"], 2.5),
+        ([1721000000, "NaN"], None),
+        ([1721000000, "oops"], None),
+        ([1721000000], None),  # too short to be a sample pair
+        ([1, "2", "3"], None),  # too long to be a sample pair
+        ("nope", None),  # not a list
+        (None, None),
+        ([1721000000, 5], None),  # value slot is not a string
+    ],
+)
+def test_sample_pair_value(sample: Any, expected: float | None) -> None:
+    result = _sample_pair_value(sample)
+    if expected is None:
+        assert result is None
+    else:
+        assert result == pytest.approx(expected)
+
+
+def test_augment_vector_adds_value_num_and_envelope_alias() -> None:
+    payload = {
+        "status": "success",
+        "data": {
+            "resultType": "vector",
+            "result": [
+                {"metric": {"__name__": "up"}, "value": [1721000000, "7"]},
+                {"metric": {"__name__": "up", "n": "2"}, "value": [1721000000, "NaN"]},
+            ],
+        },
+    }
+    out = _augment_numeric_samples(payload)
+    assert out is payload  # mutated in place, same object returned
+    assert out["data"]["result"][0]["value_num"] == 7.0
+    assert out["data"]["result"][1]["value_num"] is None  # NaN -> null
+    # Raw wire values left byte-identical.
+    assert out["data"]["result"][0]["value"] == [1721000000, "7"]
+    assert out["data"]["result"][1]["value"] == [1721000000, "NaN"]
+    # Envelope alias = first sample's number.
+    assert out["first_sample_value"] == 7.0
+
+
+def test_augment_matrix_adds_values_num_parallel_to_values() -> None:
+    payload = {
+        "status": "success",
+        "data": {
+            "resultType": "matrix",
+            "result": [
+                {
+                    "metric": {"__name__": "up"},
+                    "values": [[1721000000, "1"], [1721000015, "+Inf"], [1721000030, "3"]],
+                },
+                {"metric": {"n": "2"}, "values": [[1721000000, "9"]]},
+            ],
+        },
+    }
+    out = _augment_numeric_samples(payload)
+    assert out["data"]["result"][0]["values_num"] == [1.0, None, 3.0]  # +Inf -> null
+    assert out["data"]["result"][1]["values_num"] == [9.0]
+    # Raw wire values left byte-identical.
+    assert out["data"]["result"][0]["values"][1] == [1721000015, "+Inf"]
+    # Envelope alias = first series' first sample.
+    assert out["first_sample_value"] == 1.0
+
+
+def test_augment_scalar_surfaces_only_envelope_alias() -> None:
+    """A scalar result is a bare [ts, 'val'] pair -- only the envelope alias applies."""
+    payload = {"status": "success", "data": {"resultType": "scalar", "result": [1721000000, "42"]}}
+    out = _augment_numeric_samples(payload)
+    assert out["first_sample_value"] == 42.0
+    # The bare pair is untouched (no dict to hang value_num on).
+    assert out["data"]["result"] == [1721000000, "42"]
+
+
+def test_augment_string_result_alias_null_for_label_string() -> None:
+    payload = {
+        "status": "success",
+        "data": {"resultType": "string", "result": [1721000000, "hello"]},
+    }
+    out = _augment_numeric_samples(payload)
+    assert out["first_sample_value"] is None
+
+
+def test_augment_empty_vector_alias_is_null() -> None:
+    payload = {"status": "success", "data": {"resultType": "vector", "result": []}}
+    out = _augment_numeric_samples(payload)
+    assert out["first_sample_value"] is None
+    assert out["data"]["result"] == []
+
+
+def test_augment_error_envelope_gets_null_alias_and_is_otherwise_untouched() -> None:
+    payload = {"status": "error", "errorType": "bad_data", "error": "parse error at char 3"}
+    out = _augment_numeric_samples(payload)
+    assert out["first_sample_value"] is None
+    assert out["status"] == "error"
+    assert out["error"] == "parse error at char 3"
+
+
+@respx.mock
+async def test_first_sample_value_drives_threshold_sensor_end_to_end() -> None:
+    """The reporter's live repro end-to-end through the untouched checks evaluator.
+
+    ``vector(1)`` -> ``$.first_sample_value`` with ``threshold gt critical: 0``
+    fires ``critical``, because the derived alias is a real float. Asserting
+    the raw JSON-string path (``$.data.result[0].value[1]``) still lands in
+    ``unknown`` -- the exact ergonomic gap #2871 closes -- proving the fix is
+    the derived field, not any change to ``_compare_threshold`` (#2504).
+    """
+    respx.get(f"{_BASE}/api/v1/query").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "status": "success",
+                "data": {
+                    "resultType": "vector",
+                    "result": [{"metric": {}, "value": [1786369537.197, "1"]}],
+                },
+            },
+        )
+    )
+    connector = PrometheusConnector()
+    body = await connector.query(_operator(), _target(), {"query": "vector(1)"})
+    await connector.aclose()
+
+    now = datetime.now(UTC)
+    fires = evaluate_assertion(
+        AssertionSpec(
+            select=SelectSpec(path="$.first_sample_value"),
+            compare=ThresholdCompare(type="threshold", op="gt", critical=0),
+        ),
+        body,
+        now=now,
+    )
+    assert fires.state == "critical"
+    assert fires.value == 1.0
+
+    raw = evaluate_assertion(
+        AssertionSpec(
+            select=SelectSpec(path="$.data.result[0].value[1]"),
+            compare=ThresholdCompare(type="threshold", op="gt", critical=0),
+        ),
+        body,
+        now=now,
+    )
+    assert raw.state == "unknown"

--- a/docs/codebase/connectors-prometheus.md
+++ b/docs/codebase/connectors-prometheus.md
@@ -70,6 +70,44 @@ curated ops do not cover (`/api/v1/status/tsdb`, `/api/v1/metadata`, …);
 its `path` param is re-validated by the same gate, so the passthrough
 cannot leave the read-only surface.
 
+## Derived numeric sample values (#2871)
+
+The Prometheus HTTP API encodes every sample value as a JSON **string**
+(`"value": [1786369537.197, "1"]`). The checks threshold comparator
+(`_compare_threshold`) requires a real number by contract (#2504) and maps
+a string to `unknown`, so a sensor could not assert an observed metric
+value directly — only the alert-shaped workaround (push the threshold into
+the PromQL, then assert the result-set count) worked.
+
+`query` and `query_range` therefore run their raw envelope through
+`_augment_numeric_samples` (`connectors/prometheus/ops_read.py`) before
+returning, adding derived numeric siblings in the `net.tls_inspect`
+`days_to_expiry` shape (#2772 / #2808):
+
+- **vector** result → `value_num` (float or null) on each sample dict,
+  beside the untouched `value`.
+- **matrix** result (`query_range`, and `query` with a range selector) →
+  `values_num` (a list of floats/nulls **parallel** to `values`) on each
+  series dict.
+- **`first_sample_value`** (float or null) on the top-level envelope — the
+  numeric of the first series' first sample, mirroring #2808's top-level
+  leaf alias. A sensor asserts `$.first_sample_value` directly. `scalar` /
+  `string` results (whose `result` is a bare `[ts, "val"]` pair, not a list
+  of dicts) surface only through this envelope alias.
+
+Non-finite (`NaN` / `+Inf` / `-Inf`) and unparseable values derive to
+**null**: JSON has no NaN/Inf literal (so the payload stays strict-JSON
+serialisable), and a null lands the sensor in `unknown` — fail-safe, never a
+bogus reading. The raw `value` / `values` fields are left **byte-identical**
+(wire fidelity); the derivation is purely additive.
+
+The fix lives entirely at the op layer. The checks evaluator's strict type
+contract is **untouched** — a central numeric coercion there was rejected
+because it would silently flip any existing sensor whose string field
+happens to parse (a port `"443"`, a version, a serial) from `unknown` to a
+live state on upgrade. `prometheus.alerts`' per-alert string `value` is left
+as-is (out of the minimal scope).
+
 ## Optional auth
 
 In-cluster Prometheus is typically reached via port-forward and is


### PR DESCRIPTION
## Summary
- `prometheus.query` / `query_range` now carry derived numeric siblings so threshold sensors can assert observed metric values directly. Prometheus encodes every sample value as a JSON string (`"value": [ts, "1"]`), which the checks threshold comparator maps to `unknown` — a PromQL sensor could previously only assert a result-set count, not the value itself.
- Added at the **op layer** in the #2772/#2808 `days_to_expiry` shape: `value_num` (float|null) per vector sample, `values_num` (list, parallel to `values`) per matrix series, and `first_sample_value` (float|null) on the envelope — assertable as `$.first_sample_value`. `NaN` / `±Inf` / unparseable derive to `null` (payload stays strict-JSON serialisable; a null lands the sensor in `unknown`, fail-safe). Raw `value` / `values` stay **byte-identical** (wire fidelity); the derivation is purely additive.
- The checks evaluator's strict type contract (#2504, non-finite→`unknown`) is **untouched** — a central numeric coercion was rejected because it would silently flip any existing string-field sensor (a port `"443"`, a version, a serial) from `unknown` to a live state on upgrade. `checks/` tests pass unmodified.
- Op metadata (description + `llm_instructions.output_shape`) names the derived fields so `search_operations` surfaces them.

## Test plan
- [x] `ruff check src/ tests/` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/prometheus/` — clean (repo-wide `mypy src/` has one pre-existing macOS-only `net/icmp.py` `MSG_ERRQUEUE` error, unrelated to this PR; passes on Linux CI)
- [x] `pytest tests/test_connectors_prometheus.py tests/test_checks_assertions.py` — 168 passed (checks contract intact, unmodified)
- [x] Derived-field unit tests: vector `value_num`, matrix `values_num`, scalar/string envelope alias, empty + error envelopes, `NaN`/`±Inf`/unparseable → null, raw fields byte-identical
- [x] End-to-end regression (reporter repro): `vector(1)` → `$.first_sample_value` with `threshold gt critical: 0` → `critical` through the untouched `evaluate_assertion`; the raw `$.data.result[0].value[1]` string path still lands `unknown` (the gap this closes)
- [x] `code-quality.py --diff` — 0 blockers (1 warning: `ops.py` is 436 lines, pre-existing growth; block threshold is >600)
- [x] `docs/codebase/connectors-prometheus.md` updated

## Out of scope
- `prometheus.alerts`' per-alert string `value` — noted in the issue as the deferrable extension; left as-is.
- `loki.query` / `loki.query_range` — separate connector, not in this issue.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2871
