### PR TITLE
docs(cross-repo): reconcile onboarding verb tables + CLI example with dotted typed op_ids (#2961)

### DIFF
--- a/cli/internal/cmd/nsx/operation.go
+++ b/cli/internal/cmd/nsx/operation.go
@@ -125,7 +125,7 @@ func newOperationCallCmd() *cobra.Command {
 			"dedicated alias yet.\n\n" +
 			"Exit codes mirror meho operation call.",
 		Example: "  meho nsx operation call GET:/api/v1/node --target rdc-nsx\n" +
-			"  meho nsx operation call GET:/policy/api/v1/infra/segments --target rdc-nsx --json",
+			"  meho nsx operation call GET:/policy/api/v1/infra/tier-0s --target rdc-nsx --json",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/docs/cross-repo/nsx-onboarding.md
+++ b/docs/cross-repo/nsx-onboarding.md
@@ -38,13 +38,13 @@ ops stay in the wrapper until v0.2.next ships policy + approval flow:
 
 | Group | CLI verb | `op_id` | Path |
 | --- | --- | --- | --- |
-| nsx-identity | `meho nsx about` | `GET:/api/v1/node` | Manager identity + version |
+| nsx-identity | `meho nsx about` | `nsx.node.status` | Manager identity + version |
 | nsx-inventory | `meho nsx node list` | `nsx.transport_node.list` | Transport-node inventory |
-| nsx-cluster | `meho nsx cluster status` | `GET:/api/v1/cluster/status` | Management + control cluster health |
+| nsx-cluster | `meho nsx cluster status` | `nsx.cluster.status` | Management + control cluster health |
 | nsx-segments | `meho nsx segment list` | `nsx.segment.list` | Policy-API overlay/VLAN segment listing |
-| nsx-transport-zones | `meho nsx transport-zone list` | `GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones` | Transport-zone listing |
+| nsx-transport-zones | `meho nsx transport-zone list` | `nsx.transport_zone.list` | Transport-zone listing |
 | nsx-routing | `meho nsx tier0 list` | `GET:/policy/api/v1/infra/tier-0s` | Provider-edge Tier-0 router listing |
-| nsx-routing | `meho nsx tier1 list` | `GET:/policy/api/v1/infra/tier-1s` | Tenant Tier-1 router listing |
+| nsx-routing | `meho nsx tier1 list` | `nsx.tier1.list` | Tenant Tier-1 router listing |
 | nsx-policy-firewall | `meho nsx firewall policy list [--scope <domain>]` | `GET:/policy/api/v1/infra/domains/{domain-id}/security-policies` | Security policy listing per domain |
 | nsx-policy-firewall | `meho nsx firewall rule list <policy-id> [--scope <domain>]` | `GET:/policy/api/v1/infra/domains/{domain-id}/security-policies/{security-policy-id}/rules` | Per-policy rule listing |
 
@@ -187,7 +187,10 @@ meho nsx operation search "firewall rules" --target rdc-nsx
 
 ### `meho nsx about`
 
-Dispatches `GET:/api/v1/node` against `connector_id="nsx-rest-4.2"`.
+Dispatches `nsx.node.status` (the typed read; repointed off the
+ingested `GET:/api/v1/node` op_id by #2355 — the legacy op_id no
+longer resolves on a zero-catalog boot) against
+`connector_id="nsx-rest-4.2"`.
 Human output: `node_version`, `kernel_version`, `hostname`, `node_uuid`.
 
 ```text
@@ -209,7 +212,9 @@ endpoints, edge nodes).
 
 ### `meho nsx cluster status`
 
-Dispatches `GET:/api/v1/cluster/status`. Renders management-cluster
+Dispatches `nsx.cluster.status` (the typed read; repointed off the
+ingested `GET:/api/v1/cluster/status` op_id by #2355 — the legacy
+op_id no longer resolves on a zero-catalog boot). Renders management-cluster
 and control-cluster aggregate status. A healthy deployment shows
 `STABLE` / `STABLE`; a degraded member shows the member UUID in the
 detail list.
@@ -226,13 +231,18 @@ jq` to filter by transport zone path or subnet CIDR.
 
 ### `meho nsx transport-zone list`
 
-Dispatches the long enforcement-point-qualified path. Renders `id` /
+Dispatches `nsx.transport_zone.list` (the typed read; repointed off
+the ingested long enforcement-point-qualified path by #2355 — the
+legacy op_id no longer resolves on a zero-catalog boot). Renders `id` /
 `display_name` / `tz_type` (`OVERLAY` or `VLAN`).
 
 ### `meho nsx tier0 list` / `meho nsx tier1 list`
 
-Dispatch `GET:/policy/api/v1/infra/tier-0s` and
-`GET:/policy/api/v1/infra/tier-1s` respectively. Render `id` /
+`tier0 list` dispatches the ingested `GET:/policy/api/v1/infra/tier-0s`
+(no typed tier-0 read exists); `tier1 list` dispatches `nsx.tier1.list`
+(the typed read; repointed off the ingested
+`GET:/policy/api/v1/infra/tier-1s` op_id by #2355 — the legacy op_id
+no longer resolves on a zero-catalog boot). Render `id` /
 `display_name` / `ha_mode` (Tier-0) or `tier0_path` (Tier-1). Tier-0s
 are provider-owned; Tier-1s are tenant-owned and attach to a Tier-0.
 

--- a/docs/cross-repo/vcf-automation-onboarding.md
+++ b/docs/cross-repo/vcf-automation-onboarding.md
@@ -94,14 +94,14 @@ working set as 11 curated ops, distributed across both planes:
 
 | Plane | Group | CLI verb | `op_id` |
 | --- | --- | --- | --- |
-| provider | `provider-site` | `meho vcf-automation about --plane provider` | `GET:/cloudapi/1.0.0/site` |
-| provider | `provider-orgs` | `meho vcf-automation org list` | `GET:/cloudapi/1.0.0/orgs` |
+| provider | `provider-site` | `meho vcf-automation about --plane provider` | `vcfa.provider.health` |
+| provider | `provider-orgs` | `meho vcf-automation org list` | `vcfa.provider.org.list` |
 | provider | `provider-orgs` | `meho vcf-automation org get <id>` | `GET:/cloudapi/1.0.0/orgs/{id}` |
-| provider | `provider-regions` | `meho vcf-automation region list` | `GET:/cloudapi/1.0.0/regions` |
+| provider | `provider-regions` | `meho vcf-automation region list` | `vcfa.provider.region.list` |
 | provider | `provider-regions` | `meho vcf-automation region get <id>` | `GET:/cloudapi/1.0.0/regions/{id}` |
 | provider | `provider-users` | `meho vcf-automation user list` | `GET:/cloudapi/1.0.0/users` |
-| tenant | `tenant-about` | `meho vcf-automation about --plane tenant` | `GET:/iaas/api/about` |
-| tenant | `tenant-projects` | `meho vcf-automation project list` | `GET:/iaas/api/projects` |
+| tenant | `tenant-about` | `meho vcf-automation about --plane tenant` | `vcfa.tenant.about` |
+| tenant | `tenant-projects` | `meho vcf-automation project list` | `vcfa.tenant.project.list` |
 | tenant | `tenant-deployments` | `meho vcf-automation deployment list` | `vcfa.tenant.deployment.list` |
 | tenant | `tenant-deployments` | `meho vcf-automation deployment get <id>` | `GET:/iaas/api/deployments/{id}` |
 | tenant | `tenant-blueprints` | `meho vcf-automation blueprint list` | `GET:/iaas/api/blueprints` |
@@ -242,10 +242,14 @@ meho vcf-automation operation search "deployment status" --group tenant-deployme
 Dual-plane verb. `--plane` is **required** because the resource name
 "about" exists on both planes with different shapes:
 
-- **`--plane provider`** dispatches `GET:/cloudapi/1.0.0/site` and
-  renders site identity (`id`, `name`, `restName`, `productVersion`).
-- **`--plane tenant`** dispatches `GET:/iaas/api/about` and renders
-  IaaS API self-describe (`latestApiVersion`, `supportedApis[]`).
+- **`--plane provider`** dispatches `vcfa.provider.health` (the typed
+  read; repointed off the ingested `GET:/cloudapi/1.0.0/site` op_id by
+  #2355) and renders site identity (`id`, `name`, `restName`,
+  `productVersion`).
+- **`--plane tenant`** dispatches `vcfa.tenant.about` (the typed read;
+  repointed off the ingested `GET:/iaas/api/about` op_id by #2355) and
+  renders IaaS API self-describe (`latestApiVersion`,
+  `supportedApis[]`).
 
 Omitting `--plane` fails fast with an explicit message — no silent
 default.


### PR DESCRIPTION
## Summary
- Per-verb reconciliation of the two cross-repo onboarding docs against the authoritative `typed_opid_dispatch_test.go` guard tables: verb-table rows whose CLI verbs were repointed to dotted typed op_ids in the #2355 sweep now document those op_ids (nsx: `about` → `nsx.node.status`, `cluster status` → `nsx.cluster.status`, `transport-zone list` → `nsx.transport_zone.list`, `tier1 list` → `nsx.tier1.list`; vcf-automation: `about --plane provider` → `vcfa.provider.health`, `about --plane tenant` → `vcfa.tenant.about`, `org list` → `vcfa.provider.org.list`, `region list` → `vcfa.provider.region.list`, `project list` → `vcfa.tenant.project.list`), each with the #2950-style "repointed off the ingested op_id" note in the verb reference.
- NOT a blanket find/replace: rows pinned ingested in the guards keep their `METHOD:/path` op_ids (nsx `tier0 list` + firewall policy/rule list; vcfa `org get` / `region get` / `user list` / `deployment get` / `blueprint list`), and raw `operation call METHOD:/path` escape-hatch examples stay where the op_id still resolves via the ingested browse breadth (`GET:/api/v1/node`, `GET:/cloudapi/1.0.0/site`, `GET:/iaas/api/about`).
- `cli/internal/cmd/nsx/operation.go` example: the retired ingested segments op_id (`nsx segment list` was repointed away from it in #2950) is replaced with the guard-pinned ingested `GET:/policy/api/v1/infra/tier-0s`.
- The vcf-automation `deployment get` table row and its verb-reference sentence are deliberately untouched — #2960 repoints that verb concurrently.

## Test plan
- [x] `go build ./...` (cli) — clean
- [x] `go vet ./internal/cmd/nsx/` — clean
- [x] `go test ./...` (cli) — all packages ok, including the five `typed_opid_dispatch_test.go` guard packages (untouched)
- [x] Every verb-table row cross-checked against `typedDispatchCases` / `ingestedDispatchCases` / `typedOpCLICoverage` in the nsx + vcf-automation guards
- [x] Grep audit: remaining `METHOD:/path` occurrences in both docs are only pinned-ingested rows, raw escape-hatch examples, or "repointed off" historical notes — no prose claims a repointed verb dispatches its old op_id
- [x] `.claude/hooks/code-quality.py --diff` — pass

## Out of scope
- The vcf-automation `deployment get` row (#2960's concurrent repoint).
- Onboarding docs for other connectors: the issue scoped this sweep to nsx + vcf-automation with "a grep confirming absence is enough" — the grep instead **confirmed presence** of the same drift class in `sddc-manager-onboarding.md` (manager/domain/cluster/host/network-pool/workflow list rows), `vcf-fleet-onboarding.md` (`about`, `environment list`), and `vcf-operations-onboarding.md` (`about`, `alert list`), plus the same retired-op_id example strings in those connectors' `operation.go` files (sddc-manager `GET:/v1/domains`+`GET:/v1/hosts`, vcf-automation `GET:/cloudapi/1.0.0/site`+`GET:/iaas/api/about`, vcf-operations `GET:/suite-api/api/versions/current`). Recorded as adjacent findings for a follow-up task rather than silently expanding this PR past the issue's stated scope.
- Other stale prose in the same docs predating this task (retired `apply_*_core_curation` references, dead `core_ops.py` links, "9/11 curated ops" framing — the #2358 curation-apparatus retirement never got a doc sweep); adjacent findings, not op_id claims.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2961
