### PR TITLE
ci: secret-gated vCenter spec-shelf so the real-spec lanes can run on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,29 @@ jobs:
       # the 1.18 LTS minor (not `:latest`) so an upstream Vault release
       # never breaks an unrelated PR.
       MEHO_TEST_VAULT_IMAGE: harbor.evba.lab/dockerhub-proxy/hashicorp/vault:1.18
+      # #2949 — vendor vCenter spec-shelf wiring (see the checkout step
+      # below + docs/decisions/vendor-spec-ci-provisioning.md).
+      # SPEC_SHELF_TOKEN_PRESENT surfaces *presence* of the
+      # SPEC_SHELF_TOKEN secret as a job-level boolean so the shelf
+      # checkout step can gate on it — the `secrets` context is NOT
+      # available in a step-level `if:` (same constraint the
+      # DOCKERHUB_USERNAME row above works around). Unlike that row,
+      # only the presence flag is surfaced, never the token value, so
+      # the secret is not exported into every step's environment.
+      SPEC_SHELF_TOKEN_PRESENT: ${{ secrets.SPEC_SHELF_TOKEN != '' }}
+      # Points the vCenter spec resolvers (tests/acceptance/
+      # _vcenter_spec.py + tests/integration/test_operations_ingest_
+      # vcenter.py) at the spec-shelf checkout. Set UNCONDITIONALLY:
+      # when the shelf checkout was skipped (secret absent — fork PRs,
+      # Dependabot runs, not-yet-provisioned repos) the directory does
+      # not exist, the resolvers return None, and the spec-backed lanes
+      # pytest.skip exactly as they did before #2949. When the checkout
+      # ran, the lanes run for real. The docs-root form (not
+      # MEHO_VCENTER_OPENAPI_VCENTER / _VI_JSON) is deliberate: it is
+      # the only single setting that lights every spec lane, because
+      # test_operations_ingest_vcenter.py predates the explicit
+      # per-file env vars and reads only the legacy var or this root.
+      MEHO_CONSUMER_DOCS_ROOT: ${{ github.workspace }}/spec-shelf/docs
     defaults:
       run:
         # backend/ is the only Python project today; pyproject.toml
@@ -237,6 +260,68 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Checkout vendor vCenter spec-shelf (secret-gated, #2949)
+        # The vSphere OpenAPI specs (vcenter.yaml ~961 paths,
+        # vi-json.yaml ~2,195 paths) are Broadcom/VMware
+        # vendor-licensed and deliberately NOT committed to this public
+        # repo — they live in the operator's private spec-shelf repo.
+        # This step fetches ONLY the pinned vcenter-9.0 shelf directory
+        # into the ephemeral runner workspace so the real-spec
+        # ingest/reconcile lanes stop skipping. Licensing record +
+        # provisioning runbook (secret scope, signoff gate):
+        # docs/decisions/vendor-spec-ci-provisioning.md. The specs are
+        # never committed, never uploaded as artifacts (the
+        # upload-artifact steps in this workflow enumerate exact
+        # coverage files only), and never printed to logs.
+        #
+        # SPEC_SHELF_TOKEN is a fine-grained PAT: Contents read-only on
+        # the single private shelf repo, nothing else. Secret absent →
+        # this step skips → the spec lanes pytest.skip exactly as
+        # before this step existed. Fork PRs never reach this step (the
+        # job-level fork guard skips the whole job) and would not see
+        # the secret anyway (GitHub withholds secrets from fork-PR
+        # runs). Dependabot runs read the Dependabot secret store,
+        # where this secret is deliberately not mirrored, so they skip
+        # too.
+        if: env.SPEC_SHELF_TOKEN_PRESENT == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          repository: evoila-bosnia/claude-rdc-hetzner-dc
+          token: ${{ secrets.SPEC_SHELF_TOKEN }}
+          path: spec-shelf
+          # Cone-mode sparse checkout of the shelf directory only +
+          # lazy blob filter: the runner materialises just the
+          # vcenter-9.0 spec files (~18 MB), not the whole consumer
+          # repo. No `ref:` pin — the shelf's default branch IS the
+          # operator-curated pin (the directory is version-named
+          # vcenter-9.0/), matching the local-dev contract documented
+          # in tests/acceptance/_vcenter_spec.py.
+          sparse-checkout: docs/vcenter-9.0
+          filter: blob:none
+          # Read-only consumer; never pushes. Don't leave the token in
+          # the shelf clone's local git config after checkout.
+          persist-credentials: false
+
+      - name: Verify spec-shelf provisioned the pinned vCenter specs
+        # Fail-loud layout guard: once the secret exists, a shelf
+        # layout move (or a sparse-checkout typo here) must fail THIS
+        # job — otherwise the resolvers would return None and the spec
+        # lanes would silently go back to skipping, undetected (the
+        # exact regression #2949 closes). Without the secret this step
+        # skips and lane-skip stays the documented degraded mode.
+        # Prints file *presence* only — never spec content.
+        if: env.SPEC_SHELF_TOKEN_PRESENT == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          for f in spec-shelf/docs/vcenter-9.0/vcenter.yaml spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
+            if [ ! -f "$f" ]; then
+              echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the vCenter real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
+              exit 1
+            fi
+          done
+          echo "spec-shelf OK: vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -797,12 +882,52 @@ jobs:
       # any future fork PR job that doesn't see this env) the test
       # skips cleanly with a clear remediation message.
       MEHO_TEST_KEYCLOAK_IMAGE: harbor.evba.lab/dockerhub-proxy/keycloak/keycloak:26.0
+      # #2949 — vendor vCenter spec-shelf wiring; this job runs the
+      # tests/integration real-spec ingest lanes
+      # (test_operations_ingest_vcenter.py / _vi_json.py). See the
+      # comment on the python-lint-test job's occurrence of these two
+      # rows for the full rationale (presence-flag gating; the
+      # unconditional docs-root that degrades to lane-skip when the
+      # shelf checkout was skipped).
+      SPEC_SHELF_TOKEN_PRESENT: ${{ secrets.SPEC_SHELF_TOKEN != '' }}
+      MEHO_CONSUMER_DOCS_ROOT: ${{ github.workspace }}/spec-shelf/docs
     defaults:
       run:
         working-directory: backend
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Checkout vendor vCenter spec-shelf (secret-gated, #2949)
+        # Same secret-gated sparse checkout as the python-lint-test
+        # job's spec-shelf step — see that step's comment for the
+        # licensing pointer (docs/decisions/vendor-spec-ci-
+        # provisioning.md), the secret scope, and the fork/Dependabot
+        # degrade-to-skip analysis.
+        if: env.SPEC_SHELF_TOKEN_PRESENT == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          repository: evoila-bosnia/claude-rdc-hetzner-dc
+          token: ${{ secrets.SPEC_SHELF_TOKEN }}
+          path: spec-shelf
+          sparse-checkout: docs/vcenter-9.0
+          filter: blob:none
+          persist-credentials: false
+
+      - name: Verify spec-shelf provisioned the pinned vCenter specs
+        # Fail-loud layout guard — same rationale as the
+        # python-lint-test job's occurrence.
+        if: env.SPEC_SHELF_TOKEN_PRESENT == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          for f in spec-shelf/docs/vcenter-9.0/vcenter.yaml spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
+            if [ ! -f "$f" ]; then
+              echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the vCenter real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
+              exit 1
+            fi
+          done
+          echo "spec-shelf OK: vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-lint-test's login step — the

--- a/backend/tests/integration/test_operations_ingest_vi_json.py
+++ b/backend/tests/integration/test_operations_ingest_vi_json.py
@@ -19,15 +19,16 @@ Skipped when no spec source is configured, mirroring the
 retrieval are downstream Tasks (T3 under #227 G3.1); this test only
 asserts the parser does not raise.
 
-G0.16-T8 (#95): the fetcher now accepts only ``https://`` URIs. When the
-resolver returns a local filesystem path the test wraps the file content
-in a respx-mocked HTTPS endpoint so the guard is exercised on real spec
-bytes without requiring an outbound network connection.
+G0.16-T8 (#95): the fetcher accepts only ``https://`` URIs. The resolver
+returns a local filesystem :class:`~pathlib.Path` (never a URL — see
+:mod:`tests.acceptance._vcenter_spec`), so the test uploads the spec
+bytes via the ``content=`` channel — the ``file://`` URI is just the
+audit label — skipping the https guard + DNS lookup without any network
+mock. Same shape as
+:mod:`tests.acceptance.test_portgroup_audit_op_id_reconcile`.
 """
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import pytest
 
@@ -41,18 +42,15 @@ from tests.acceptance._vcenter_spec import VCENTER_SPEC_REASON, resolve_vi_json_
 )
 def test_parse_vi_json_does_not_raise() -> None:
     """vi-json.yaml parses end-to-end after T11's parameter-ref resolver landed."""
-    spec_source_raw = resolve_vi_json_yaml()
-    assert spec_source_raw is not None  # guarded by skipif above
+    spec_path = resolve_vi_json_yaml()
+    assert spec_path is not None  # guarded by skipif above
 
-    if spec_source_raw.startswith("https://"):
-        # Already a public HTTPS URL — fetch directly; no mock needed.
-        rows = parse_openapi(spec_source_raw, spec_source="spec:vi-json.yaml")
-    else:
-        # Local filesystem path — upload the bytes via the content channel
-        # (mirrors how the CLI uploads docs:/file:// specs), so the https
-        # guard + DNS lookup are skipped without a respx mock.
-        spec_text = Path(spec_source_raw).read_text()
-        rows = parse_openapi(spec_source_raw, spec_source="spec:vi-json.yaml", content=spec_text)
+    # Upload the bytes via the content channel (mirrors how the CLI
+    # uploads docs:/file:// specs); the resolver returns a Path, so the
+    # pre-#2949 ``startswith("https://")`` branch was dead code that
+    # raised AttributeError the first time the lane actually ran.
+    spec_text = spec_path.read_text(encoding="utf-8")
+    rows = parse_openapi(f"file://{spec_path}", spec_source="spec:vi-json.yaml", content=spec_text)
 
     assert len(rows) >= 2000, f"got {len(rows)} rows; acceptance threshold is 2000"
     # Spot-check the parameter-ref resolution path: every row that

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -796,6 +796,43 @@ smaller `-n`. Target: request 4000m / limit 7000m (pending
 do not raise `-n` above the current value to chase wall-clock gains — the
 heartbeat failures will return.
 
+### Vendor vCenter spec-shelf in CI (#2949)
+
+The five real-spec vCenter lanes (`test_g07_vsphere_canary.py`, the two
+`tests/integration/test_operations_ingest_*` lanes,
+`test_portgroup_audit_op_id_reconcile.py`,
+`test_connectors_vmware_rest_composites_l2_ingest_reconcile.py`) validate
+ingest + op_id reconciliation against the **real** Broadcom/VMware-licensed
+`vcenter.yaml` / `vi-json.yaml`, which are deliberately not in this public
+repo. `ci.yml` provisions them at runtime, gated on a secret:
+
+- Both Python test jobs (`python-lint-test`, `python-integration`) carry a
+  secret-gated "Checkout vendor vCenter spec-shelf" step: a cone-mode sparse
+  checkout of `docs/vcenter-9.0/` from the private
+  `evoila-bosnia/claude-rdc-hetzner-dc` shelf repo into
+  `$GITHUB_WORKSPACE/spec-shelf`, authenticated by the **`SPEC_SHELF_TOKEN`**
+  repo secret (fine-grained PAT, Contents read-only, that single repo).
+- `MEHO_CONSUMER_DOCS_ROOT` is set **unconditionally** to
+  `$GITHUB_WORKSPACE/spec-shelf/docs` on both jobs. When the secret is absent
+  (fork PRs, Dependabot runs, not-yet-provisioned repos) the checkout step
+  skips, the directory doesn't exist, and the resolvers
+  (`backend/tests/acceptance/_vcenter_spec.py`) return `None` → the lanes
+  `pytest.skip()` exactly as before the wiring. When the secret exists, all
+  five lanes run for real, and a fail-loud verify step turns any shelf-layout
+  drift into a job failure instead of a silent regression to lane-skip.
+- The `secrets` context is unavailable in step-level `if:`, so the gate is
+  the job-env boolean `SPEC_SHELF_TOKEN_PRESENT` — presence only, never the
+  token value.
+
+Licensing record, signoff gate, and the full provisioning/rotation runbook:
+[`docs/decisions/vendor-spec-ci-provisioning.md`](../decisions/vendor-spec-ci-provisioning.md).
+**Do not provision `SPEC_SHELF_TOKEN` before that ADR's signoff-of-record
+section is completed AND its "Known findings" prerequisite is fixed on
+`main`** — the two reconcile lanes are known-red against the real shelf
+(real op_id findings, the guard working), and both live inside required
+merge-gate jobs, so premature provisioning turns CI red for every PR. The
+wiring is deliberately inert until then.
+
 ### Fail-loud posture
 
 No step in `ci.yml` carries `continue-on-error: true` except the Python

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -1,0 +1,224 @@
+# Vendor vCenter spec-shelf in CI — licensing record + provisioning runbook (decision)
+
+**Status:** facts recorded; rationale stated; **decision routed for human
+legal/maintainer signoff** (see "Signoff of record" below — deliberately not
+filled by this ADR). The CI wiring ships **disarmed**: nothing is fetched until
+a repository admin provisions the `SPEC_SHELF_TOKEN` secret, and provisioning
+is gated on the signoff below.
+**Date:** 2026-08-17
+**Task:** [#2949](https://github.com/evoila/meho/issues/2949) (split out of
+[#2944](https://github.com/evoila/meho/issues/2944) precisely because this is a
+licensing + secret-provisioning decision, not a code-only change)
+
+## The matter this records
+
+Five CI test lanes validate MEHO's OpenAPI ingest and op_id reconciliation
+against the **real** pinned vSphere OpenAPI specs:
+
+- `backend/tests/acceptance/test_g07_vsphere_canary.py` — the G0.7 vSphere
+  ingest + dispatch canary
+- `backend/tests/integration/test_operations_ingest_vcenter.py` — real-spec
+  `vcenter.yaml` ingest
+- `backend/tests/integration/test_operations_ingest_vi_json.py` — real-spec
+  `vi-json.yaml` ingest
+- `backend/tests/acceptance/test_portgroup_audit_op_id_reconcile.py` — the
+  #1602 read-side audit reconcile
+- `backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py`
+  — the #2944 write-composite `_SUB_OPS_*` real-spec reconcile guard
+
+The specs (`vcenter.yaml` ~961 paths, `vi-json.yaml` ~2,195 paths) are
+**Broadcom/VMware vendor-licensed** and deliberately **not** committed to this
+public repo — they live in the operator's private spec-shelf (the
+`evoila-bosnia/claude-rdc-hetzner-dc` consumer repo, `docs/vcenter-9.0/`; see
+`backend/tests/acceptance/_vcenter_spec.py`). Consequence: every one of the
+five lanes `pytest.skip()`s in CI, so a shape-correct-but-nonexistent path (a
+typo, a renamed endpoint, a wrong API version) sails through CI and only fails
+against a live vCenter.
+
+#2949 wires a **secret-gated fetch** of the spec-shelf into
+`.github/workflows/ci.yml` so the lanes run on same-repo PRs. Whether fetching
+the vendor-licensed specs into an ephemeral CI job is within the license is a
+**legal/maintainer call**. This ADR records the technical facts and rationale
+and **routes** that question — it does not decide it. Precedent for this
+pattern: [`shipped-spec-provenance.md`](shipped-spec-provenance.md) and
+[`jsonflux-license.md`](jsonflux-license.md).
+
+## What CI does with the specs (technical facts)
+
+- **Source.** The private repo `evoila-bosnia/claude-rdc-hetzner-dc`
+  (verified private), directory `docs/vcenter-9.0/` only, fetched via
+  `actions/checkout` with a cone-mode sparse checkout + `filter: blob:none` —
+  the runner materialises the shelf directory (~18 MB), not the whole repo.
+- **Destination.** The ephemeral runner workspace of an ARC (Actions Runner
+  Controller) pod on the internal `rke2-ci` cluster. The pod — including the
+  workspace and the fetched specs — is destroyed when the job ends.
+- **Use.** Read-only input to pytest: the lanes parse the specs
+  (`operations.ingest.parse_openapi`) and assert that every declared op_id /
+  sub-op path exists in the real spec. Nothing transforms or re-publishes the
+  content.
+- **Never redistributed.** The specs are never committed to the public repo
+  tree; never uploaded as build artifacts (the `upload-artifact` steps in
+  `ci.yml` enumerate exact coverage files only — `backend/coverage.xml`,
+  `cli/coverage.out`); never printed to logs (the workflow's verify step
+  prints file *presence* only; the tests print pass/skip/fail counts).
+  `persist-credentials: false` keeps the checkout token out of the clone's
+  git config.
+- **Audience.** Same-repo PRs, pushes to `main`, and merge-queue runs only.
+  Fork PRs never execute these jobs (job-level
+  `head.repo.full_name == github.repository` guard) **and** GitHub withholds
+  Actions secrets from fork-PR runs regardless — two independent layers.
+  Dependabot-triggered runs read the separate Dependabot secret store, where
+  this secret is deliberately not mirrored, so the fetch step skips there too.
+- **Degraded mode.** When the secret is absent — the shipped state until the
+  signoff below is completed — the fetch step skips and the five lanes
+  `pytest.skip()` exactly as they did before #2949. The wiring is inert
+  without a human provisioning act.
+
+## Rationale (why fetch at all)
+
+1. **The guard only has teeth against the real spec.** The in-tree fixture
+   variants of these lanes prove op_id *shape*, not real-spec *path
+   existence* (the gap #2944 documented). Only the vendor's own
+   `vcenter.yaml` / `vi-json.yaml` can answer "does this path actually exist
+   in vCenter 9.0?" on every PR.
+2. **Strictly weaker exposure than the already-recorded shipped-spec
+   question.** [`shipped-spec-provenance.md`](shipped-spec-provenance.md)
+   records the reproduction of vendor *interface names* inside shipped
+   Apache-2.0 files. This ADR's mechanism reproduces **nothing**: the vendor
+   content stays in the private shelf and an ephemeral runner; the public
+   repo gains only a fetch instruction and a secret name.
+3. **Minimal credential.** The secret is a fine-grained PAT scoped to
+   read-only Contents on the single private shelf repo — it can read that
+   repo and do nothing else anywhere.
+
+## Known findings at recording time (activation prerequisite)
+
+Running the five lanes locally against the real shelf (2026-08-17, the
+#2949 verification run) surfaced real findings — the exact defect class the
+guard exists to catch, anticipated verbatim by #2944 ("a shelf-backed red is
+the guard surfacing a real finding … not a reason to withhold the guard"):
+
+- `test_portgroup_audit_op_id_reconcile.py` — **red**: `_OP_LIST_DVS =
+  "GET:/vcenter/network/distributed-switches"`
+  (`connectors/vmware_rest/composites/_read.py`) is not served by the real
+  `vcenter.yaml` (the only distributed-switch paths are under
+  `/vcenter/namespace-management/…`).
+- `test_connectors_vmware_rest_composites_l2_ingest_reconcile.py` — **red**:
+  ten `_SUB_OPS_*` REST op_ids in `composites/_write.py` reference paths the
+  real `vcenter.yaml` does not serve:
+  `GET:/vcenter/cluster/{cluster}/drs/recommendations`,
+  `GET:/vcenter/cluster/{cluster}/host`, `GET:/vcenter/vm/{vm}/snapshot`,
+  `PATCH:/vcenter/host/{host}/maintenance?action=enter`,
+  `PATCH:/vcenter/host/{host}/maintenance?action=exit`,
+  `PATCH:/vcenter/vm/{vm}/network`, `POST:/vcenter/host/{host}?action=patch`,
+  `POST:/vcenter/network/dvs/{dvs}?action=remove_host`,
+  `POST:/vcenter/vm-template/library-items?action=deploy`,
+  `POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert`.
+- The other three lanes are green against the real shelf (the vi-json
+  ingest lane after #2949's one-line lane repair — its pre-existing
+  `Path.startswith` bug had made it un-runnable, masked by the permanent
+  skip).
+
+**Why this gates provisioning:** both red lanes run inside **required**
+merge-gate jobs (`Python (ruff + mypy + pytest)` /
+`Python (integration testcontainers)`). Provisioning the secret before the
+product-code findings are fixed would turn CI red for **every** PR. The
+follow-up fix (re-point the affected composites at op_ids the pinned specs
+actually serve — likely their vi-json / vim analogues) must merge first.
+
+## Provisioning runbook (repo admin; do NOT execute before signoff)
+
+1. **Complete the Signoff of record below** (or link the attestation
+   comment from #2949). Provisioning the secret is the act that arms the
+   fetch; it must not precede the signoff.
+1a. **Confirm the "Known findings" above are fixed on `main`** (the
+   follow-up task re-pointing the affected `_SUB_OPS_*` / `_OP_LIST_DVS`
+   op_ids). Verify locally:
+   `MEHO_CONSUMER_DOCS_ROOT=<shelf>/docs uv run pytest
+   tests/acceptance/test_portgroup_audit_op_id_reconcile.py
+   tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py`
+   must be green before the secret exists, or every PR's required checks
+   go red the moment it does.
+2. **Mint the credential** — recommended shape: a **fine-grained PAT**
+   - Resource owner: `evoila-bosnia`
+   - Repository access: *Only select repositories* →
+     `evoila-bosnia/claude-rdc-hetzner-dc`
+   - Permissions: **Contents: Read-only** (Metadata: Read is implied)
+   - Expiration: per org policy; record the rotation date. On rotation,
+     repeat step 3 with the new token — no workflow change needed.
+
+   Alternative shape: a read-only **deploy key** on the shelf repo. That
+   requires a one-line workflow change (swap `token:` for `ssh-key:` in the
+   two "Checkout vendor vCenter spec-shelf" steps of `ci.yml`) and SSH
+   egress from the runner pool; the PAT/HTTPS shape is the shipped default
+   because the runners' 443 egress is already proven.
+3. **Set the secret** on the public repo (interactive paste — keep the token
+   out of shell history):
+
+   ```bash
+   gh secret set SPEC_SHELF_TOKEN --repo evoila/meho
+   ```
+
+4. **Verify activation.** Re-run CI on any open same-repo PR (or push a
+   no-op branch). Expect:
+   - the "Checkout vendor vCenter spec-shelf" and "Verify spec-shelf
+     provisioned the pinned vCenter specs" steps run (not skipped) and pass
+     in both `Python (ruff + mypy + pytest)` and
+     `Python (integration testcontainers)`;
+   - the five lanes above **run, not skip** — the skip reason string
+     `"vCenter OpenAPI spec not configured"` (and the
+     `test_operations_ingest_vcenter.py` variant `"vcenter.yaml
+     unavailable"`) no longer appears in the pytest output.
+5. **Do not mirror the secret into the Dependabot secret store.** Dependabot
+   PRs gain nothing from the spec lanes; least exposure wins.
+
+## Signoff of record
+
+**This section is deliberately left for a human (legal / maintainer) to
+complete.** This ADR records the facts above and routes the question —
+*fetching the Broadcom/VMware vendor-licensed vSphere OpenAPI specs from the
+operator's private spec-shelf into ephemeral CI jobs, never committed, never
+in artifacts or logs* — for the signoff of record. It does **not** assert a
+legal conclusion.
+
+- **Reviewer:** _(name / GitHub handle — to be completed)_
+- **Date:** _(to be completed)_
+- **Determination:** _(to be completed — e.g. an attestation that the
+  ephemeral CI use recorded above is acceptable under the operator's vendor
+  license; or a request for changes)_
+- **Attestation link:** _(comment / issue URL — to be completed)_
+
+Until this section is completed, the question stands as **recorded and
+routed**, not resolved — and the `SPEC_SHELF_TOKEN` secret must not be
+provisioned.
+
+## Consequences
+
+- The five real-spec lanes light up together the moment the secret exists;
+  until then CI behaviour is byte-for-byte today's (lanes skip). Because two
+  lanes are known-red against the real shelf (see "Known findings" above),
+  activation is sequenced: signoff → findings fix on `main` → secret.
+- A shelf layout move or sparse-checkout typo after activation fails the job
+  loudly (the verify step) instead of silently regressing to lane-skip.
+- The shelf's `docs/` also carries other vendor spec directories (`nsx-9.0/`,
+  `sddc-manager-9.0/`, …). The same checkout could serve future sibling
+  canaries by widening the `sparse-checkout` list — deliberately not done
+  here (#2949's DoD is the vCenter lanes). The G4.1 consumer-kb canary does
+  **not** light up: it resolves `<docs-root>/kb`, which does not exist under
+  the shelf's `docs/` (the consumer's `kb/` is a repo-root sibling).
+- Rotation is a secret-value swap (runbook step 3); revocation (delete the
+  secret) restores the degraded skip mode with no code change.
+
+## References
+
+- Task [#2949](https://github.com/evoila/meho/issues/2949); parent context
+  [#2944](https://github.com/evoila/meho/issues/2944) (the reconcile guard
+  whose real-spec mode this activates).
+- Resolver contract: `backend/tests/acceptance/_vcenter_spec.py` (env-var
+  priority; skip semantics).
+- Workflow wiring: `.github/workflows/ci.yml` — the two "Checkout vendor
+  vCenter spec-shelf" steps and the `SPEC_SHELF_TOKEN_PRESENT` /
+  `MEHO_CONSUMER_DOCS_ROOT` job env rows; operator-facing summary in
+  [`docs/codebase/devops.md`](../codebase/devops.md).
+- Precedent ADRs: [`shipped-spec-provenance.md`](shipped-spec-provenance.md)
+  (signoff-of-record pattern), [`jsonflux-license.md`](jsonflux-license.md).

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -131,35 +131,46 @@ actually serve — likely their vi-json / vim analogues) must merge first.
 1. **Complete the Signoff of record below** (or link the attestation
    comment from #2949). Provisioning the secret is the act that arms the
    fetch; it must not precede the signoff.
-1a. **Confirm the "Known findings" above are fixed on `main`** (the
+2. **Confirm the "Known findings" above are fixed on `main`** (the
    follow-up task re-pointing the affected `_SUB_OPS_*` / `_OP_LIST_DVS`
-   op_ids). Verify locally:
-   `MEHO_CONSUMER_DOCS_ROOT=<shelf>/docs uv run pytest
-   tests/acceptance/test_portgroup_audit_op_id_reconcile.py
-   tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py`
-   must be green before the secret exists, or every PR's required checks
-   go red the moment it does.
-2. **Mint the credential** — recommended shape: a **fine-grained PAT**
+   op_ids), then pre-verify the **full** five-lane set locally against
+   the shelf, on a machine with Docker available (the g07 canary's
+   dispatch tests need containers — a sandbox without Docker
+   under-verifies exactly the subset CI will run):
+
+   ```bash
+   cd backend && MEHO_CONSUMER_DOCS_ROOT=<shelf>/docs uv run pytest \
+     tests/acceptance/test_g07_vsphere_canary.py \
+     tests/integration/test_operations_ingest_vcenter.py \
+     tests/integration/test_operations_ingest_vi_json.py \
+     tests/acceptance/test_portgroup_audit_op_id_reconcile.py \
+     tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+   ```
+
+   This must be green before the secret exists — both reconcile lanes
+   sit inside required merge-gate jobs, so every PR's checks go red the
+   moment the secret lands otherwise.
+3. **Mint the credential** — recommended shape: a **fine-grained PAT**
    - Resource owner: `evoila-bosnia`
    - Repository access: *Only select repositories* →
      `evoila-bosnia/claude-rdc-hetzner-dc`
    - Permissions: **Contents: Read-only** (Metadata: Read is implied)
    - Expiration: per org policy; record the rotation date. On rotation,
-     repeat step 3 with the new token — no workflow change needed.
+     repeat step 4 with the new token — no workflow change needed.
 
    Alternative shape: a read-only **deploy key** on the shelf repo. That
    requires a one-line workflow change (swap `token:` for `ssh-key:` in the
    two "Checkout vendor vCenter spec-shelf" steps of `ci.yml`) and SSH
    egress from the runner pool; the PAT/HTTPS shape is the shipped default
    because the runners' 443 egress is already proven.
-3. **Set the secret** on the public repo (interactive paste — keep the token
+4. **Set the secret** on the public repo (interactive paste — keep the token
    out of shell history):
 
    ```bash
    gh secret set SPEC_SHELF_TOKEN --repo evoila/meho
    ```
 
-4. **Verify activation.** Re-run CI on any open same-repo PR (or push a
+5. **Verify activation.** Re-run CI on any open same-repo PR (or push a
    no-op branch). Expect:
    - the "Checkout vendor vCenter spec-shelf" and "Verify spec-shelf
      provisioned the pinned vCenter specs" steps run (not skipped) and pass
@@ -169,7 +180,7 @@ actually serve — likely their vi-json / vim analogues) must merge first.
      `"vCenter OpenAPI spec not configured"` (and the
      `test_operations_ingest_vcenter.py` variant `"vcenter.yaml
      unavailable"`) no longer appears in the pytest output.
-5. **Do not mirror the secret into the Dependabot secret store.** Dependabot
+6. **Do not mirror the secret into the Dependabot secret store.** Dependabot
    PRs gain nothing from the spec lanes; least exposure wins.
 
 ## Signoff of record


### PR DESCRIPTION
## Summary

- **Wires the vendor vCenter spec-shelf into CI behind a new secret** so the five real-spec ingest/reconcile lanes can run on same-repo PRs instead of skipping. Both Python test jobs (`python-lint-test`, `python-integration`) gain a secret-gated cone-mode sparse checkout of `docs/vcenter-9.0/` from the private `evoila-bosnia/claude-rdc-hetzner-dc` shelf (`SPEC_SHELF_TOKEN`: fine-grained PAT, Contents read-only, that single repo; `filter: blob:none`; `persist-credentials: false`) plus a fail-loud verify step that turns shelf-layout drift into a job failure instead of a silent regression to lane-skip.
- **Degrade-to-skip is structural, not conditional logic in tests**: `MEHO_CONSUMER_DOCS_ROOT` is set unconditionally to the checkout path; when the secret is absent the checkout step skips, the directory doesn't exist, and the resolvers (`_vcenter_spec.py`) return `None` → today's skip behaviour, byte-for-byte. The docs-root form (not the per-file env vars) is deliberate — it is the only single setting that lights all five lanes (`test_operations_ingest_vcenter.py` predates the explicit vars).
- **Fork-PR safety (the primary review concern)** is three independent layers: (1) the existing job-level `head.repo.full_name == github.repository` guard means fork PRs never execute these jobs at all; (2) GitHub withholds Actions secrets from fork-PR runs regardless; (3) even with an empty secret, the presence-flag gate (`SPEC_SHELF_TOKEN_PRESENT` job-env boolean — the `secrets` context is unavailable in step-level `if:`; only presence is surfaced, never the value) skips the fetch and the lanes skip. Dependabot runs read the separate Dependabot secret store (secret deliberately not mirrored) → same graceful skip.
- **Licensing is recorded and routed, not asserted**: `docs/decisions/vendor-spec-ci-provisioning.md` (pattern: `shipped-spec-provenance.md`) records what CI does with the specs (ephemeral ARC pod, never committed / never in artifacts / never in logs), routes the license question to a human signoff-of-record, and carries the exact provisioning + rotation runbook. `docs/codebase/devops.md` gains the operator-facing summary.
- **One in-scope lane repair**: `test_operations_ingest_vi_json.py` called `.startswith()` on the `Path` returned by `resolve_vi_json_yaml()` — an `AttributeError` on the lane's first-ever real run, masked until now by the permanent skip. Fixed to the proven content-channel shape the portgroup lane uses. (The issue's "the tests … need no change" claim was disproven by execution.)

## Delivered mode: wired-behind-secret (operator seam remains)

Everything code-side is done and inert-by-default. Two things only a human can do, in order (full runbook in the ADR):

1. **Licensing signoff** — complete the ADR's Signoff-of-record section.
2. **Fix the real findings this wiring surfaced** (see below) — both reconcile lanes are **required merge gates**, so provisioning the secret before that fix would turn CI red for every PR.
3. **Mint + set the secret** — fine-grained PAT (resource owner `evoila-bosnia`; only `claude-rdc-hetzner-dc`; Contents: Read-only), then `gh secret set SPEC_SHELF_TOKEN --repo evoila/meho`.

## Real findings surfaced (the guard already earned its keep)

Running the five lanes locally against the real shelf:

- `_OP_LIST_DVS = "GET:/vcenter/network/distributed-switches"` (`composites/_read.py`, portgroup audit) — **not served** by the real `vcenter.yaml`.
- Ten `_SUB_OPS_*` REST op_ids in `composites/_write.py` — **not served** (DRS recommendations, cluster host list, VM snapshot read/revert, host maintenance enter/exit, VM network PATCH, host patch action, DVS remove_host, vm-template deploy).

Exactly the defect class #2944 predicted ("a shelf-backed red is the guard surfacing a real finding … not a reason to withhold the guard"). Product-code fixes are explicitly out of this ticket's scope ("No product code") — a follow-up task should re-point those composites at op_ids the pinned specs actually serve, and must land **before** secret provisioning.

## Test plan

- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] `ci.yml` parses as valid YAML
- [x] `ruff check` + `ruff format --check` on the changed test file — clean
- [x] Five lanes **without** env: `12 passed, 36 skipped, 0 failed` — CI-today behaviour preserved (AC5: degrade-to-skip)
- [x] Five lanes **with** the real shelf (`MEHO_CONSUMER_DOCS_ROOT=<shelf>/docs`): `18 passed, 2 failed, 28 skipped` — the 2 failures are the documented real product-code findings above; vi-json lane green after the repair (AC4 evidence: lanes *run*; full green in CI requires the findings fix + the operator-provisioned secret)
- [x] Fork-PR / Dependabot gating verified by config inspection against GitHub's context-availability docs (secrets unavailable in step-level `if:`; fork guard job-level)
- [ ] AC1/AC2 (licensing signoff, secret provisioning) — **operator actions**, documented in the ADR runbook; deliberately not performed by automation
- [ ] AC4 end-to-end (all five lanes green *in CI*) — reachable only after the operator seam + findings follow-up; the fail-loud verify step makes any silent-skip regression impossible once armed

## Out of scope

- The 11 op_id product-code findings (`composites/_read.py` / `_write.py`) — follow-up task recommended, prerequisite to secret provisioning.
- Bonus lanes: none light up — the G4.1 consumer-kb canary resolves `<docs-root>/kb`, which doesn't exist under the shelf's `docs/` (consumer `kb/` is a repo-root sibling). The same checkout could later serve `nsx-9.0/` / `sddc-manager-9.0/` sibling canaries by widening `sparse-checkout`; deliberately not chased.
- `python-coverage` (push-only, non-required, non-blocking) deliberately not wired — the spec lanes add existence-assertions, not coverage of new code paths.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2949
