### PR TITLE
feat(connectors): add vcfa.tenant.deployment.get typed detail read + repoint the deployment get CLI verb (#2960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — vcfa tenant deployment detail read + `deployment get` repoint (#2960)
+
+- `vcfa.tenant.deployment.get` (`GET /iaas/api/deployments/{id}`,
+  tenant plane) joins the typed VCFA read surface — the per-id
+  drill-down after `vcfa.tenant.deployment.list` surfaced a failed or
+  stuck deployment. `meho vcf-automation deployment get <id>` now
+  dispatches the typed op_id instead of the ingested
+  `GET:/iaas/api/deployments/{id}`, which does not resolve on a
+  zero-catalog boot (the same stranding class #2942 closed for
+  `deployment list`); the verb moved from the pinned-ingested table to
+  the typed table in the `typed_opid_dispatch_test.go` guard.
+
 ### Fixed — CLI verbs stranded on retired ingested op_ids + exhaustive typed-dispatch guards (#2942)
 
 - `meho vcf-automation deployment list` now dispatches the typed
@@ -99,8 +111,8 @@ connector-related release-notes line.
   agent/backend path worked. The wave-2 cross-check found the same
   stranding on `meho nsx segment list` (→ `nsx.segment.list`, #2835)
   and `meho nsx node list` (→ `nsx.transport_node.list`, #2836); both
-  repointed. `deployment get` stays on `GET:/iaas/api/deployments/{id}`
-  until a typed detail op ships.
+  repointed. `deployment get` stayed on `GET:/iaas/api/deployments/{id}`
+  until #2960 shipped the typed detail op (see Added above).
 - The five per-connector `typed_opid_dispatch_test.go` guards (nsx,
   sddc-manager, vcf-automation, vcf-fleet, vcf-operations) are now
   exhaustive: every verb is pinned to the exact op_id it dispatches

--- a/backend/src/meho_backplane/connectors/vcf_automation/__init__.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/__init__.py
@@ -110,7 +110,7 @@ register_connector_v2(
 
 # Queue the typed-op upsert onto the lifespan-driven registrar list. The
 # runner (``run_typed_op_registrars``) iterates after
-# ``_eager_import_connectors`` so the six typed read descriptors land
+# ``_eager_import_connectors`` so the seven typed read descriptors land
 # before the first dispatch — no ingested catalog state required (VCFA
 # ships no vendor spec; typed conversion is the only working read path).
 register_typed_op_registrar(register_vcfa_typed_operations)

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -90,6 +90,7 @@ import asyncio
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import structlog
@@ -130,6 +131,7 @@ from meho_backplane.connectors.vcf_automation.typed_ops import (
     PROVIDER_REGIONS_PATH,
     PROVIDER_SITE_PATH,
     TENANT_ABOUT_PATH,
+    TENANT_DEPLOYMENT_DETAIL_PATH,
     TENANT_DEPLOYMENTS_PATH,
     TENANT_PROJECTS_PATH,
 )
@@ -744,6 +746,24 @@ class VcfAutomationConnector(HttpConnector):
             operator=operator,
             params=_tenant_odata_query(params),
         )
+
+    async def tenant_deployment_get(
+        self,
+        operator: Operator,
+        target: VcfAutomationTargetLike,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """``vcfa.tenant.deployment.get`` — ``GET /iaas/api/deployments/{id}`` (tenant plane).
+
+        ``params["id"]`` is guaranteed present by the dispatcher's
+        JSON Schema validation (``required: ["id"]``). The value is
+        percent-encoded with an empty safe set — OpenAPI ``style:
+        simple`` semantics, same as the ingested-dispatch path's
+        ``{var}`` expansion — so an id carrying a reserved char can
+        never traverse out of the ``/iaas/api/deployments/`` segment.
+        """
+        path = TENANT_DEPLOYMENT_DETAIL_PATH.format(id=quote(str(params["id"]), safe=""))
+        return await self._request_json(target, "GET", path, operator=operator)
 
     async def tenant_about(
         self,

--- a/backend/src/meho_backplane/connectors/vcf_automation/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/typed_ops.py
@@ -16,8 +16,9 @@ This module converts the **audited read set** (evoila/meho#2294 row 22:
 "org/region list + provider health"; the VCFA follow-up: "org/region
 list, /iaas/api/projects + about") to ``source_kind="typed"`` operations
 that dispatch through the connector's own dual-plane session — no
-``endpoint_descriptor`` catalog state required. Six ops — the five
-#2294 audited reads plus the #2839 tenant deployment list:
+``endpoint_descriptor`` catalog state required. Seven ops — the five
+#2294 audited reads plus the #2839 tenant deployment list and the
+#2960 tenant deployment detail read:
 
 Provider plane (``/cloudapi/1.0.0/*`` — Basic-auth →
 ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` JWT session):
@@ -34,6 +35,7 @@ session):
 
 * ``vcfa.tenant.project.list`` — ``GET /iaas/api/projects``
 * ``vcfa.tenant.deployment.list`` — ``GET /iaas/api/deployments``
+* ``vcfa.tenant.deployment.get`` — ``GET /iaas/api/deployments/{id}``
 * ``vcfa.tenant.about`` — ``GET /iaas/api/about``
 
 Every op declares the **plane it rides** (``provider`` / ``tenant``).
@@ -77,6 +79,7 @@ __all__ = [
     "PROVIDER_SITE_PATH",
     "TENANT_ABOUT_PATH",
     "TENANT_DEPLOYMENTS_PATH",
+    "TENANT_DEPLOYMENT_DETAIL_PATH",
     "TENANT_PROJECTS_PATH",
     "VCFA_TYPED_OPS",
     "VCFA_TYPED_WHEN_TO_USE_BY_GROUP",
@@ -92,6 +95,11 @@ PROVIDER_REGIONS_PATH: Final[str] = "/cloudapi/1.0.0/regions"
 PROVIDER_SITE_PATH: Final[str] = "/cloudapi/1.0.0/site"
 TENANT_PROJECTS_PATH: Final[str] = "/iaas/api/projects"
 TENANT_DEPLOYMENTS_PATH: Final[str] = "/iaas/api/deployments"
+#: Path template for the per-id deployment detail read. The ``{id}``
+#: placeholder is substituted (percent-encoded, empty safe set) by the
+#: connector handler; ``plane_for_path`` classifies the template itself,
+#: so the declared plane is validated before any substitution happens.
+TENANT_DEPLOYMENT_DETAIL_PATH: Final[str] = "/iaas/api/deployments/{id}"
 TENANT_ABOUT_PATH: Final[str] = "/iaas/api/about"
 
 
@@ -160,7 +168,8 @@ VCFA_TYPED_WHEN_TO_USE_BY_GROUP: Final[dict[str, str]] = {
         "every deployment belongs to (vcfa.tenant.project.list), list "
         "deployments — which exist, which failed, which are stuck "
         "in-progress, narrowable with a status $filter "
-        "(vcfa.tenant.deployment.list), or read "
+        "(vcfa.tenant.deployment.list), read one deployment's detail by "
+        "id (vcfa.tenant.deployment.get), or read "
         "the IaaS API self-describe surface — supported API versions + "
         "latest version — as a tenant-plane reachability/version probe "
         "(vcfa.tenant.about). Tenant-plane ops authenticate with the "
@@ -495,9 +504,74 @@ _TENANT_DEPLOYMENT_LIST = VcfaTypedOp(
             "ownedBy, createdAt, lastUpdatedAt, resources[]."
         ),
         "next_step": (
-            "Cross-reference projectId against vcfa.tenant.project.list, or "
-            "inspect a failed deployment's status to triage the failure."
+            "Drill into one deployment's full detail with "
+            "vcfa.tenant.deployment.get, or cross-reference projectId "
+            "against vcfa.tenant.project.list."
         ),
+    },
+)
+
+_TENANT_DEPLOYMENT_GET = VcfaTypedOp(
+    op_id="vcfa.tenant.deployment.get",
+    handler_attr="tenant_deployment_get",
+    plane="tenant",
+    path=TENANT_DEPLOYMENT_DETAIL_PATH,
+    summary="Read one deployment by id within the tenant organization (tenant plane).",
+    description=(
+        "Reads one deployment's detail via GET /iaas/api/deployments/{id} "
+        "on the tenant plane — the drill-down after "
+        "vcfa.tenant.deployment.list surfaced a deployment worth "
+        "inspecting (a failure to triage, a stuck in-progress create). "
+        "Requires the deployment id (from vcfa.tenant.deployment.list). "
+        "Returns the single deployment object: id, name, description, "
+        "status, projectId, blueprintId, ownedBy, createdAt, "
+        "lastUpdatedAt, and resources[] — the same shape as one "
+        "'content' entry of the list op. safety_level=safe, read-only."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The deployment id (from vcfa.tenant.deployment.list).",
+            },
+        },
+        "required": ["id"],
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "id": {"type": ["string", "null"]},
+            "name": {"type": ["string", "null"]},
+            "status": {"type": ["string", "null"]},
+            "projectId": {"type": ["string", "null"]},
+            "resources": {"type": ["array", "null"]},
+        },
+        "additionalProperties": True,
+    },
+    group_key="vcfa-tenant-reads",
+    tags=("read-only", "vcfa", "tenant"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_call": (
+            "Call on the tenant plane with a deployment id to read one "
+            "deployment's full detail — the drill-down after "
+            "vcfa.tenant.deployment.list surfaced a failed or stuck "
+            "deployment worth inspecting."
+        ),
+        "output_shape": (
+            "{id, name, status, projectId, blueprintId, ownedBy, "
+            "createdAt, lastUpdatedAt, resources: [...]}. One deployment "
+            "object — the same shape as one 'content' entry of the list op."
+        ),
+        "next_step": (
+            "Inspect status and resources[] to triage the deployment, or "
+            "cross-reference projectId against vcfa.tenant.project.list."
+        ),
+        "parameter_hints": {"id": "The deployment id from vcfa.tenant.deployment.list."},
     },
 )
 
@@ -547,17 +621,18 @@ _TENANT_ABOUT = VcfaTypedOp(
 )
 
 
-#: The six typed VCFA read ops the connector registers at lifespan
+#: The seven typed VCFA read ops the connector registers at lifespan
 #: startup — the #2294 audited read set plus the #2839 tenant deployment
-#: list. Ordered provider → tenant, probe last within each plane, to
-#: match the operator's typical drill path (inventory first, health as
-#: needed).
+#: list and the #2960 tenant deployment detail read. Ordered provider →
+#: tenant, probe last within each plane, to match the operator's typical
+#: drill path (inventory first, detail next, health as needed).
 VCFA_TYPED_OPS: Final[tuple[VcfaTypedOp, ...]] = (
     _PROVIDER_ORG_LIST,
     _PROVIDER_REGION_LIST,
     _PROVIDER_HEALTH,
     _TENANT_PROJECT_LIST,
     _TENANT_DEPLOYMENT_LIST,
+    _TENANT_DEPLOYMENT_GET,
     _TENANT_ABOUT,
 )
 

--- a/backend/tests/test_connectors_vcf_automation_typed_reads.py
+++ b/backend/tests/test_connectors_vcf_automation_typed_reads.py
@@ -12,9 +12,9 @@ state**. Acceptance contract (#2305):
 
 * **Typed dispatch on a fresh boot with zero catalog state** — after
   ``register_typed_operations()`` and with **no** ingested
-  ``endpoint_descriptor`` rows seeded, all six typed read ops (org list,
-  region list, provider health, tenant project list, tenant deployment
-  list, tenant about)
+  ``endpoint_descriptor`` rows seeded, all seven typed read ops (org
+  list, region list, provider health, tenant project list, tenant
+  deployment list, tenant deployment get, tenant about)
   dispatch through ``call_operation`` against a respx-mocked VCFA
   appliance and return ``status="ok"``, with ``source_kind="typed"`` on
   every registered row.
@@ -178,6 +178,11 @@ _TENANT_ABOUT: dict[str, Any] = {
     "supportedApis": [{"apiVersion": "9.0"}],
 }
 
+#: The id the detail-read routes/params use; its payload is the single
+#: deployment object (one ``content`` entry of ``_TENANT_DEPLOYMENTS``).
+_DETAIL_DEPLOYMENT_ID = "deployment-1"
+_TENANT_DEPLOYMENT_DETAIL: dict[str, Any] = _TENANT_DEPLOYMENTS["content"][0]
+
 #: op_id -> the JSON body its respx route returns.
 _PAYLOAD_BY_OP: dict[str, dict[str, Any]] = {
     "vcfa.provider.org.list": _PROVIDER_ORGS,
@@ -185,7 +190,14 @@ _PAYLOAD_BY_OP: dict[str, dict[str, Any]] = {
     "vcfa.provider.health": _PROVIDER_SITE,
     "vcfa.tenant.project.list": _TENANT_PROJECTS,
     "vcfa.tenant.deployment.list": _TENANT_DEPLOYMENTS,
+    "vcfa.tenant.deployment.get": _TENANT_DEPLOYMENT_DETAIL,
     "vcfa.tenant.about": _TENANT_ABOUT,
+}
+
+#: op_id -> the params the parametrized dispatch test sends. Ops absent
+#: here dispatch with ``{}``; the detail read requires its ``id``.
+_DISPATCH_PARAMS_BY_OP: dict[str, dict[str, Any]] = {
+    "vcfa.tenant.deployment.get": {"id": _DETAIL_DEPLOYMENT_ID},
 }
 
 
@@ -293,10 +305,13 @@ def _resolve_connector() -> VcfAutomationConnector:
 
 
 def _register_routes(mock: respx.MockRouter, *, capture: dict[str, str] | None = None) -> None:
-    """Register the dual-plane login + six typed-op GET routes on *mock*.
+    """Register the dual-plane login + seven typed-op GET routes on *mock*.
 
     When *capture* is passed, every GET records its ``Accept`` header under
     the request path so the plane-selection tests can assert the media type.
+    A templated op path (the ``{id}`` detail read) is resolved with
+    ``_DETAIL_DEPLOYMENT_ID`` — respx path matching is exact, so the
+    resolved detail route and the bare list route coexist.
     """
     mock.post("/cloudapi/1.0.0/sessions/provider").respond(
         200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": _PROVIDER_JWT}
@@ -313,7 +328,8 @@ def _register_routes(mock: respx.MockRouter, *, capture: dict[str, str] | None =
                 capture[request.url.path] = request.headers.get("Accept", "")
             return httpx.Response(200, json=_payload)
 
-        mock.get(op.path).mock(side_effect=_responder)
+        route_path = op.path.format(id=_DETAIL_DEPLOYMENT_ID) if "{id}" in op.path else op.path
+        mock.get(route_path).mock(side_effect=_responder)
 
 
 @dataclass(frozen=True)
@@ -324,7 +340,7 @@ class _Bundle:
 
 @pytest.fixture
 async def typed_bundle(captured_events: list[Any]) -> AsyncIterator[_Bundle]:
-    """Register the six typed ops (zero ingested state) + respx-mock the appliance."""
+    """Register the seven typed ops (zero ingested state) + respx-mock the appliance."""
     await VcfAutomationConnector.register_typed_operations()
     seeded = await _seed_target(host="10.20.30.5", fqdn=_FQDN)
     instance = _resolve_connector()
@@ -393,7 +409,7 @@ def test_every_typed_op_declares_the_plane_its_path_rides() -> None:
     misrouted HTTP 401 — both planes carry a Bearer header but reject the
     other plane's token).
     """
-    assert len(VCFA_TYPED_OPS) == 6
+    assert len(VCFA_TYPED_OPS) == 7
     for op in VCFA_TYPED_OPS:
         assert plane_for_path(op.path) == op.plane, (
             f"op {op.op_id!r} declares plane={op.plane!r} but "
@@ -410,14 +426,14 @@ _TYPED_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in VCFA_TYPED_OPS)
 
 @pytest.mark.parametrize("op_id", _TYPED_OP_IDS, ids=lambda op: op)
 async def test_typed_ops_dispatch_ok(op_id: str, typed_bundle: _Bundle) -> None:
-    """All six typed ops dispatch through ``call_operation`` and return ``status='ok'``."""
+    """All seven typed ops dispatch through ``call_operation`` and return ``status='ok'``."""
     result = await call_operation(
         _OPERATOR,
         {
             "connector_id": VCFA_CONNECTOR_ID,
             "op_id": op_id,
             "target": {"name": _TARGET_NAME},
-            "params": {},
+            "params": _DISPATCH_PARAMS_BY_OP.get(op_id, {}),
         },
     )
     assert result["status"] == "ok", (
@@ -596,3 +612,129 @@ async def test_tenant_deployment_list_forwards_odata_and_returns_content(
     content = result["result"]["content"]
     assert {d["status"] for d in content} == {"CREATE_SUCCESSFUL", "CREATE_FAILED"}, content
     assert {"id", "name", "status", "projectId", "resources"} <= content[0].keys(), content[0]
+
+
+async def test_tenant_deployment_get_requests_detail_path_and_returns_object(
+    captured_events: list[Any],
+) -> None:
+    """``vcfa.tenant.deployment.get`` hits ``/iaas/api/deployments/<id>``, returns the object.
+
+    Pins the PassThrough reducer for the same reason as the list test —
+    a sibling module may leave a force-handle reducer set; the single
+    deployment object must round-trip inline.
+    """
+    await VcfAutomationConnector.register_typed_operations()
+    await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    instance = _resolve_connector()
+    requested_paths: list[str] = []
+
+    def _detail_responder(request: httpx.Request) -> httpx.Response:
+        requested_paths.append(request.url.path)
+        return httpx.Response(200, json=_TENANT_DEPLOYMENT_DETAIL)
+
+    set_default_reducer(PassThroughReducer())
+    try:
+        async with respx.mock(
+            base_url=_BASE_URL, assert_all_called=False, assert_all_mocked=False
+        ) as m:
+            m.post("/iaas/api/login").respond(200, json={"token": _TENANT_TOKEN})
+            m.get(f"/iaas/api/deployments/{_DETAIL_DEPLOYMENT_ID}").mock(
+                side_effect=_detail_responder
+            )
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VCFA_CONNECTOR_ID,
+                    "op_id": "vcfa.tenant.deployment.get",
+                    "target": {"name": _TARGET_NAME},
+                    "params": {"id": _DETAIL_DEPLOYMENT_ID},
+                },
+            )
+    finally:
+        await instance.aclose()
+        set_default_reducer(PassThroughReducer())
+        reset_dispatcher_caches()
+
+    assert result["status"] == "ok", result
+    # The handler substituted the id into the detail path — not the list path.
+    assert requested_paths == [f"/iaas/api/deployments/{_DETAIL_DEPLOYMENT_ID}"]
+    # The single deployment object round-trips inline (no content[] envelope).
+    detail = result["result"]
+    assert detail["id"] == _DETAIL_DEPLOYMENT_ID, detail
+    assert {"id", "name", "status", "projectId", "blueprintId", "resources"} <= detail.keys(), (
+        detail
+    )
+
+
+async def test_tenant_deployment_get_percent_encodes_the_id(
+    captured_events: list[Any],
+) -> None:
+    """A reserved char in the id is percent-encoded — it cannot extend the path.
+
+    OpenAPI ``style: simple`` semantics (the same contract the ingested
+    dispatch path's ``{var}`` expansion honours): ``quote(value,
+    safe="")`` turns ``/`` into ``%2F``, so a hostile id like
+    ``../requests`` stays one path segment under
+    ``/iaas/api/deployments/``.
+    """
+    await VcfAutomationConnector.register_typed_operations()
+    await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    instance = _resolve_connector()
+    tricky_id = "dep/../other"
+    encoded = "dep%2F..%2Fother"
+
+    try:
+        async with respx.mock(
+            base_url=_BASE_URL, assert_all_called=False, assert_all_mocked=False
+        ) as m:
+            m.post("/iaas/api/login").respond(200, json={"token": _TENANT_TOKEN})
+            detail_route = m.get(f"/iaas/api/deployments/{encoded}").respond(
+                200, json=_TENANT_DEPLOYMENT_DETAIL
+            )
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VCFA_CONNECTOR_ID,
+                    "op_id": "vcfa.tenant.deployment.get",
+                    "target": {"name": _TARGET_NAME},
+                    "params": {"id": tricky_id},
+                },
+            )
+    finally:
+        await instance.aclose()
+        reset_dispatcher_caches()
+
+    assert result["status"] == "ok", result
+    assert detail_route.called, "the encoded detail route was never hit"
+
+
+async def test_tenant_deployment_get_missing_id_is_invalid_params(
+    captured_events: list[Any],
+) -> None:
+    """Omitting the required ``id`` fails schema validation before any request."""
+    await VcfAutomationConnector.register_typed_operations()
+    await _seed_target(host="10.20.30.5", fqdn=_FQDN)
+    instance = _resolve_connector()
+
+    try:
+        async with respx.mock(
+            base_url=_BASE_URL, assert_all_called=False, assert_all_mocked=False
+        ) as m:
+            login_route = m.post("/iaas/api/login").respond(200, json={"token": _TENANT_TOKEN})
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VCFA_CONNECTOR_ID,
+                    "op_id": "vcfa.tenant.deployment.get",
+                    "target": {"name": _TARGET_NAME},
+                    "params": {},
+                },
+            )
+    finally:
+        await instance.aclose()
+        reset_dispatcher_caches()
+
+    assert result["status"] == "error", result
+    assert "invalid_params" in (result.get("error") or ""), result
+    # Validation fails before the connector ever authenticates.
+    assert not login_route.called, "param validation must reject before any wire call"

--- a/cli/internal/cmd/vcf-automation/deployment.go
+++ b/cli/internal/cmd/vcf-automation/deployment.go
@@ -64,11 +64,8 @@ func newDeploymentGetCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Ingested op_id on purpose: #2839 shipped the typed list op
-			// only — repointing `get` is blocked on a future
-			// vcfa.tenant.deployment.get typed op (#2942).
 			return runTenantGetVerb(cmd,
-				"GET:/iaas/api/deployments/{id}",
+				"vcfa.tenant.deployment.get",
 				"id", args[0],
 				targetName, jsonOut, backplaneOverride,
 				printDeploymentGet,
@@ -111,7 +108,7 @@ func printDeploymentList(w io.Writer, r *CallResult) {
 }
 
 func printDeploymentGet(w io.Writer, r *CallResult) {
-	const opID = "GET:/iaas/api/deployments/{id}"
+	const opID = "vcfa.tenant.deployment.get"
 	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
 	if r.Status != "ok" {
 		printErrorTrailer(w, r)

--- a/cli/internal/cmd/vcf-automation/typed_opid_dispatch_test.go
+++ b/cli/internal/cmd/vcf-automation/typed_opid_dispatch_test.go
@@ -15,7 +15,8 @@ import (
 // typedDispatchCases pins every VCFA verb whose backend read is typed
 // to the dotted typed op_id it must dispatch (#2266 repoint sweep
 // #2355; deployment list repointed by #2942 once #2839 shipped the
-// typed op). The dual-plane `about` verb is pinned separately by
+// typed op; deployment get repointed by #2960 once the typed detail
+// op shipped). The dual-plane `about` verb is pinned separately by
 // TestAboutVerbDispatchesPerPlane / TestAboutOpForPlane.
 var typedDispatchCases = []struct {
 	name   string
@@ -26,6 +27,7 @@ var typedDispatchCases = []struct {
 	{"region list", []string{"region", "list"}, "vcfa.provider.region.list"},
 	{"project list", []string{"project", "list"}, "vcfa.tenant.project.list"},
 	{"deployment list", []string{"deployment", "list"}, "vcfa.tenant.deployment.list"},
+	{"deployment get", []string{"deployment", "get", "dep-1"}, "vcfa.tenant.deployment.get"},
 }
 
 // ingestedDispatchCases pins the VCFA verbs that legitimately dispatch
@@ -39,13 +41,10 @@ var ingestedDispatchCases = []struct {
 	args   []string
 	wantOp string
 }{
-	// Detail reads with no typed counterpart (the typed surface ships
-	// list ops only).
+	// Provider-plane detail reads with no typed counterpart (the typed
+	// provider surface ships list ops only).
 	{"org get", []string{"org", "get", "org-1"}, "GET:/cloudapi/1.0.0/orgs/{id}"},
 	{"region get", []string{"region", "get", "reg-1"}, "GET:/cloudapi/1.0.0/regions/{id}"},
-	// Blocked on a future vcfa.tenant.deployment.get typed op — #2839
-	// shipped list only (#2942 out-of-scope note).
-	{"deployment get", []string{"deployment", "get", "dep-1"}, "GET:/iaas/api/deployments/{id}"},
 	// No typed blueprint/user reads (initiative #2833 ranks them low
 	// tier, not planned).
 	{"blueprint list", []string{"blueprint", "list"}, "GET:/iaas/api/blueprints"},
@@ -64,13 +63,13 @@ var typedOpCLICoverage = map[string]string{
 	"vcfa.provider.health":        "about --plane provider", // pinned by TestAboutVerbDispatchesPerPlane
 	"vcfa.tenant.project.list":    "project list",
 	"vcfa.tenant.deployment.list": "deployment list",
+	"vcfa.tenant.deployment.get":  "deployment get",
 	"vcfa.tenant.about":           "about --plane tenant", // pinned by TestAboutVerbDispatchesPerPlane
 }
 
-// TestRepointedListVerbsDispatchTypedOpIDs pins that the repointed
-// VCFA list verbs dispatch their typed op_ids at the
-// command-constructor site.
-func TestRepointedListVerbsDispatchTypedOpIDs(t *testing.T) {
+// TestRepointedVerbsDispatchTypedOpIDs pins that the repointed VCFA
+// verbs dispatch their typed op_ids at the command-constructor site.
+func TestRepointedVerbsDispatchTypedOpIDs(t *testing.T) {
 	for _, tc := range typedDispatchCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/codebase/connectors-vcf-automation.md
+++ b/docs/codebase/connectors-vcf-automation.md
@@ -13,7 +13,8 @@ G3.6-T11 (#836) added the dual-plane spec ingestion + operator-review
 curation. G3.6-T12 (#840) shipped the recorded-fixture E2E. The operator
 runbook lives at `docs/cross-repo/g36-vcfa-canary.md`.
 
-**Typed reads (T5 #2305; deployment list #2839).** VCFA ships **no
+**Typed reads (T5 #2305; deployment list #2839; deployment get
+#2960).** VCFA ships **no
 vendor OpenAPI spec** (the provider plane publishes none; the tenant
 plane ships only Swagger 2.0 fragments the ingest parser rejects by
 decision #2090), so there is nothing to ingest — the hand-curated
@@ -21,9 +22,10 @@ decision #2090), so there is nothing to ingest — the hand-curated
 dispatch-inert on a real deploy and was **retired in #2362**. The
 **audited read set** (evoila/meho#2294: org/region list, provider
 health, `/iaas/api/projects` + tenant `about`), plus the tenant
-**deployment list** (#2839), is served by `source_kind="typed"` ops
+**deployment list** (#2839) and per-id **deployment detail** (#2960),
+is served by `source_kind="typed"` ops
 (`typed_ops.py`) that dispatch through the connector's own dual-plane
-session with **zero catalog state**. Six ops:
+session with **zero catalog state**. Seven ops:
 
 | op_id | plane | path |
 |---|---|---|
@@ -32,17 +34,21 @@ session with **zero catalog state**. Six ops:
 | `vcfa.provider.health` | provider | `GET /cloudapi/1.0.0/site` |
 | `vcfa.tenant.project.list` | tenant | `GET /iaas/api/projects` |
 | `vcfa.tenant.deployment.list` | tenant | `GET /iaas/api/deployments` |
+| `vcfa.tenant.deployment.get` | tenant | `GET /iaas/api/deployments/{id}` |
 | `vcfa.tenant.about` | tenant | `GET /iaas/api/about` |
 
 Each op **declares the plane it rides**; `typed_ops._validate_typed_op_planes`
 asserts at import time that the declared `plane` matches
 `plane_for_path(op.path)`, so a drift fails the import rather than
-surfacing as a misrouted HTTP 401. The `org create` write
+surfacing as a misrouted HTTP 401. The detail read's `{id}` path
+template is percent-encoded (empty safe set) by the handler at
+substitution time — OpenAPI `style: simple` semantics, matching the
+ingested dispatch path's `{var}` expansion. The `org create` write
 (`POST /cloudapi/1.0.0/orgs`) is deliberately out of scope — a first
 write on a read-only connector belongs in a G3.x-mold approval-gated
-write-surface initiative. Per-id deployment detail
-(`vcfa.tenant.deployment.get`), blueprint listing, and the provider
-users list remain unconverted — a natural fast-follow, not part of the
+write-surface initiative. Blueprint listing and the provider
+users list remain unconverted (initiative #2833 ranks them low tier) —
+not part of the
 "which deployments exist / which failed" answer this surface delivers.
 The hand-curated ingested-enable apparatus (`core_ops.py` / `_core_data`)
 those once lived under was retired in #2362; the wider ingested catalog
@@ -52,7 +58,7 @@ it does not.
 
 `register_typed_operations` (a classmethod on the connector, queued onto
 the lifespan registrar list via `register_vcfa_typed_operations` in
-`__init__.py`) upserts the six descriptors on startup — the same
+`__init__.py`) upserts the seven descriptors on startup — the same
 argocd / bind9 / Kubernetes typed-registrar shape.
 
 Source: `backend/src/meho_backplane/connectors/vcf_automation/`.
@@ -101,8 +107,9 @@ domains.
   and `load_session_credentials_from_vault` in `connectors/nsx/` /
   `connectors/vmware_rest/`.
 - **`VCFA_TYPED_OPS` / `VcfaTypedOp` / `VCFA_TYPED_WHEN_TO_USE_BY_GROUP`**
-  (`typed_ops.py`) — the six typed read ops (T5 #2305; tenant deployment
-  list #2839) and their two per-plane groups (`vcfa-provider-reads`,
+  (`typed_ops.py`) — the seven typed read ops (T5 #2305; tenant
+  deployment list #2839; tenant deployment get #2960) and their two
+  per-plane groups (`vcfa-provider-reads`,
   `vcfa-tenant-reads`). Each `VcfaTypedOp` carries a `plane` + `path`;
   the module's `_validate_typed_op_planes()` cross-checks them at import
   so a declared-plane / path drift fails the import rather than
@@ -132,7 +139,7 @@ domains.
    idempotency check (in `ensure_connector_class_registered`) no-ops on
    subsequent ingests against the same triple.
 4. `run_typed_op_registrars()` (lifespan) invokes the registrar, which
-   upserts the five `typed_ops.VCFA_TYPED_OPS` descriptors — no ingest
+   upserts the seven `typed_ops.VCFA_TYPED_OPS` descriptors — no ingest
    needed, so the audited read surface works on a fresh boot.
 
 ### Vhost routing (load-bearing)

--- a/docs/cross-repo/vcf-automation-onboarding.md
+++ b/docs/cross-repo/vcf-automation-onboarding.md
@@ -103,7 +103,7 @@ working set as 11 curated ops, distributed across both planes:
 | tenant | `tenant-about` | `meho vcf-automation about --plane tenant` | `GET:/iaas/api/about` |
 | tenant | `tenant-projects` | `meho vcf-automation project list` | `GET:/iaas/api/projects` |
 | tenant | `tenant-deployments` | `meho vcf-automation deployment list` | `vcfa.tenant.deployment.list` |
-| tenant | `tenant-deployments` | `meho vcf-automation deployment get <id>` | `GET:/iaas/api/deployments/{id}` |
+| tenant | `tenant-deployments` | `meho vcf-automation deployment get <id>` | `vcfa.tenant.deployment.get` |
 | tenant | `tenant-blueprints` | `meho vcf-automation blueprint list` | `GET:/iaas/api/blueprints` |
 
 Every op dispatches through the same `POST /api/v1/operations/call`
@@ -285,8 +285,8 @@ controls reference project membership.
 
 Tenant-plane only. `deployment list` dispatches the typed
 `vcfa.tenant.deployment.list` (repointed off the ingested
-`GET:/iaas/api/deployments` op_id by #2942); `deployment get` stays
-on `GET:/iaas/api/deployments/{id}` until a typed detail op ships.
+`GET:/iaas/api/deployments` op_id by #2942); `deployment get`
+dispatches the typed `vcfa.tenant.deployment.get` (#2960).
 The largest payload on the tenant surface; large
 tenants return hundreds of deployments. The dispatcher's JSONFlux
 seam wraps oversized responses in a `ResultHandle`; use the


### PR DESCRIPTION
## Summary
- Registers `vcfa.tenant.deployment.get` (`GET /iaas/api/deployments/{id}`, tenant plane, required `id`, `safety_level=safe`) as the seventh typed VCFA read op, following the `tenant_deployment_list` handler/registration/group-hint pattern — the per-id drill-down after the list op surfaces a failed or stuck deployment.
- Repoints `meho vcf-automation deployment get <id>` (dispatch call + print constant) off the ingested `GET:/iaas/api/deployments/{id}` op_id, which does not resolve on a zero-catalog boot (the stranding class #2942 closed for `deployment list`), and removes the blocked-on comment.
- The handler percent-encodes the id with an empty safe set (OpenAPI `style: simple` semantics, matching the ingested dispatch path's `{var}` expansion) so a reserved char in the id can never extend the request path.
- Moves the `deployment get` guard row from the pinned-ingested table to the typed table in `typed_opid_dispatch_test.go`; `TestBackendTypedOpsAreClassified` reconciles the new backend op via the classified-coverage contract (#2942).
- Refreshes the docs rows the repoint invalidates: onboarding `tenant-deployments` get row + deployment verb reference, `docs/codebase/connectors-vcf-automation.md` (six→seven ops, table row, unconverted-list correction), CHANGELOG entry.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean; `ruff format --check` — clean
- [x] `uv run mypy src/` — no new errors (single pre-existing `net/icmp.py` `MSG_ERRQUEUE` finding is a darwin-only artifact; Linux CI has the attribute)
- [x] `pytest tests/test_connectors_vcf_automation_*.py` — 78 passed (registration shape, all-seven dispatch, detail-path happy path, id percent-encoding, missing-id `invalid_params` before any wire call)
- [x] `go build ./... && go vet ./... && go test ./...` in `cli/` — all green; `deployment get` pinned to `vcfa.tenant.deployment.get`, negative pins intact
- [x] `grep -r "GET:/iaas/api/deployments/{id}" cli/` — no ingested op_id string remains in the CLI
- [x] `make snapshot-openapi && make generate` — no diff (typed op registration is not part of the REST API schema)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (4 pre-existing-size warnings, see below)

## Out of scope
- Provider-plane deployment surfaces and the other pinned-ingested verbs (`org get`, `region get`, `blueprint list`, `user list`) — each stays pinned with its reason.
- The #2355-era doc-row sweep in `docs/cross-repo/vcf-automation-onboarding.md` / `nsx-onboarding.md` — tracked by #2961 (only the deployment-get row + deployment verb reference are touched here to minimize conflict surface).
- Adjacent finding: `typed_ops.py` is now 667 lines (warn-level; sibling declarative op-metadata modules run 753–844 lines — sddc 844, keycloak 753). A split (`typed_ops.py` + `typed_reads.py`, the sddc shape) is a natural refactor if the surface grows again.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2960

🤖 Generated with [Claude Code](https://claude.com/claude-code)
