### PR TITLE
fix(targets): partial unique index frees name after soft-delete (#2874)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,17 @@ connector-related release-notes line.
   invalid `extras.scheme` fails loud at key derivation rather than
   silently serving the stale client.
 
+### Fixed — target names free for re-registration after a soft-delete (#2874)
+
+- `targets_tenant_name_idx` is now a **partial** unique index —
+  `(tenant_id, name) WHERE deleted_at IS NULL` (migration 0072) — so a
+  soft-deleted target no longer 409-blocks re-using its name: `DELETE` +
+  re-`POST` of the same name now succeeds with a fresh UUID, while a *live*
+  duplicate still 409s. Names already wedged by an existing tombstone free
+  the moment the migration lands (no manual purge). The three unfiltered
+  console / keycloak target reads that previously surfaced tombstones now
+  exclude them, so the operator UI matches the re-registration semantics.
+
 ### Fixed — CLI verbs stranded on retired ingested op_ids + exhaustive typed-dispatch guards (#2942)
 
 - `meho vcf-automation deployment list` now dispatches the typed

--- a/backend/alembic/versions/0072_targets_partial_unique_name_index.py
+++ b/backend/alembic/versions/0072_targets_partial_unique_name_index.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Rebuild ``targets_tenant_name_idx`` as a partial unique index.
+
+Revision ID: 0072
+Revises: 0071
+Create Date: 2026-08-17
+
+Fixes #2874 (G0.39). ``DELETE /api/v1/targets/{name}`` soft-deletes by
+stamping ``deleted_at`` (migration ``0029``, G0.14-T4 #1145) and every
+read path filters ``deleted_at IS NULL`` -- but ``targets_tenant_name_idx``
+was created by migration ``0004`` as a **FULL** unique b-tree on
+``(tenant_id, name)`` two weeks before soft-delete existed, and ``0029``
+never converted it. The tombstone therefore keeps occupying the unique
+slot forever: invisible to every read, yet permanently blocking a
+re-create of the same name with a 409 (``create_target`` inserts and maps
+the flush-time ``IntegrityError`` to the 409 -- there is no app-level
+uniqueness check to relax). An operator who does DELETE + POST to get a
+fresh row is stuck: GET says 404, POST says 409, with no path out.
+
+The fix is to make uniqueness apply only to **live** rows:
+
+    UNIQUE (tenant_id, name) WHERE deleted_at IS NULL
+
+A live duplicate still collides (both rows have ``deleted_at IS NULL``),
+so ``create_target``'s 409 path is unchanged; an insert whose only
+same-name neighbours are tombstones no longer collides and simply
+succeeds. No handler code changes.
+
+Why drop + recreate (not alter)
+-------------------------------
+
+Neither PostgreSQL nor SQLite can alter an existing index's ``WHERE``
+predicate in place -- the only way to add the partial predicate is to
+drop the index and recreate it. ``op.drop_index`` is **not** a
+destructive operation under the additive-only rollback contract
+(``docs/codebase/migrations.md``): it removes no data and no column, and
+``scripts/ci/check_migration_compat.py`` bans ``drop_column`` /
+``drop_table`` / ``rename`` / ``alter ... nullable=False`` but not
+``drop_index``. The rebuild is forward-compatible: an older image still
+running against the new partial index enforces live-duplicate uniqueness
+exactly as before and still 409s on a live duplicate -- it merely also
+tolerates an insert over a tombstone, which is harmless. The
+``helm rollback`` = image-revert + forward-compat-schema contract
+(#1607) therefore holds.
+
+No backfill, and every wedged name frees immediately
+----------------------------------------------------
+
+The upgrade needs **no** data migration. The old FULL unique index was
+strictly *stricter* than the partial one -- it already guaranteed at
+most one row per ``(tenant_id, name)`` regardless of ``deleted_at`` --
+so the ``targets`` table trivially satisfies the partial constraint and
+``CREATE UNIQUE INDEX ... WHERE deleted_at IS NULL`` cannot fail on any
+existing data. Every name currently wedged by a tombstone frees the
+moment this migration lands: the tombstone rows stay in the table (so
+``audit_log.target_id`` soft-FKs keep resolving and ``query_audit
+target=<name>`` still spans the deleted incarnation), they just stop
+participating in the uniqueness check.
+
+``targets`` is an operator-scale table (tens to low hundreds of rows per
+tenant), so a plain ``CREATE UNIQUE INDEX`` inside the migration
+transaction is fine; ``CONCURRENTLY`` (which cannot run in a transaction)
+is unnecessary and would break the single-transaction migration model.
+
+Dialect-portability
+-------------------
+
+The partial predicate is emitted on both dialects via the
+``postgresql_where`` / ``sqlite_where`` keyword pair on
+:func:`op.create_index` -- the same pattern migration ``0005`` uses for
+the ``operation_group`` / ``endpoint_descriptor`` partial unique indexes.
+PostgreSQL supports partial indexes natively; SQLite has since 3.8.0 (we
+run 3.45+). ``postgresql_using="btree"`` is preserved from ``0004``.
+
+Reversibility contract -- and its caveat
+----------------------------------------
+
+``downgrade()`` drops the partial index and recreates the original FULL
+unique index. **Caveat:** the downgrade raises ``IntegrityError`` if any
+``(tenant_id, name)`` pair has been legitimately re-used after the
+upgrade -- i.e. a live row plus one or more tombstones sharing the pair,
+which is exactly the state this migration makes reachable. The FULL
+index cannot be built over such data. This is an accepted, documented
+limitation: production **never** runs ``alembic downgrade`` (rollback is
+image-revert + forward-compat schema discipline, ``migrations.md``); the
+downgrade exists for development-time symmetry and manual operator use,
+where the operator must first resolve any re-used names (hard-delete the
+tombstones) before downgrading. Silent partial recovery would be worse
+than an explicit failure.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0072"
+down_revision: str | None = "0071"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Rebuild ``targets_tenant_name_idx`` as ``UNIQUE ... WHERE deleted_at IS NULL``."""
+    op.drop_index("targets_tenant_name_idx", table_name="targets")
+    op.create_index(
+        "targets_tenant_name_idx",
+        "targets",
+        ["tenant_id", "name"],
+        unique=True,
+        postgresql_using="btree",
+        postgresql_where=sa.text("deleted_at IS NULL"),
+        sqlite_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Restore the original FULL unique index (see the reused-name caveat).
+
+    Fails with ``IntegrityError`` if a ``(tenant_id, name)`` pair was
+    re-used post-upgrade (a live row coexisting with a tombstone). Resolve
+    such duplicates before downgrading.
+    """
+    op.drop_index("targets_tenant_name_idx", table_name="targets")
+    op.create_index(
+        "targets_tenant_name_idx",
+        "targets",
+        ["tenant_id", "name"],
+        unique=True,
+        postgresql_using="btree",
+    )

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -137,7 +137,9 @@ Schema decisions for :class:`Target`:
   adds the FK.
 * ``name`` — Text NOT NULL. Human-readable handle within the tenant.
   Uniqueness enforced by the named ``targets_tenant_name_idx``
-  (unique b-tree on ``(tenant_id, name)``).
+  (partial unique b-tree on ``(tenant_id, name)``
+  ``WHERE deleted_at IS NULL`` — live rows only, so a soft-deleted
+  tombstone frees the name for re-use; migration ``0072`` / #2874).
 * ``aliases`` — JSON/TEXT[], nullable. Secondary names for the target
   (DNS aliases, legacy hostnames). Stored as native ``TEXT[]`` on
   PostgreSQL (GIN-indexed for containment queries) and as a JSON
@@ -216,8 +218,11 @@ Schema decisions for :class:`Target`:
 
 Indexes on :class:`Target`:
 
-* ``targets_tenant_name_idx`` — unique b-tree on ``(tenant_id, name)``
-  — enforces the one-name-per-tenant invariant.
+* ``targets_tenant_name_idx`` — partial unique b-tree on
+  ``(tenant_id, name)`` ``WHERE deleted_at IS NULL`` — enforces the
+  one-*live*-name-per-tenant invariant. Soft-deleted tombstones are
+  excluded so a deleted name can be re-registered (migration ``0072``,
+  #2874); a live duplicate still collides.
 * ``targets_tenant_product_idx`` — b-tree on ``(tenant_id, product)``
   — drives the "list targets by product in tenant" query.
 * ``targets_aliases_gin_idx`` — GIN on ``aliases`` (PostgreSQL only).
@@ -887,10 +892,11 @@ class Target(Base):
     enforces referential integrity at insert time until a tightening
     migration adds the FK.
 
-    ``name`` is unique within a tenant (enforced by the named
-    ``targets_tenant_name_idx`` unique b-tree). Operators reference
-    targets by name in CLI commands and policy rules; the UUID is
-    the stable cross-system identifier.
+    ``name`` is unique among *live* rows within a tenant (enforced by
+    the named ``targets_tenant_name_idx`` partial unique b-tree,
+    ``WHERE deleted_at IS NULL``). Operators reference targets by name
+    in CLI commands and policy rules; the UUID is the stable
+    cross-system identifier.
 
     ``aliases`` stores secondary names (DNS aliases, legacy hostnames)
     as a native ``TEXT[]`` on PostgreSQL (GIN-indexed for containment
@@ -1048,15 +1054,24 @@ class Target(Base):
     )
 
     __table_args__ = (
-        # Unique index matches migration op.create_index(..., unique=True).
-        # Using Index rather than UniqueConstraint avoids Alembic autogenerate
-        # drift (autogenerate sees constraint vs index as different objects).
+        # Partial unique index: matches migration 0072's
+        # op.create_index(..., unique=True, postgresql_where/sqlite_where).
+        # The ``WHERE deleted_at IS NULL`` predicate scopes uniqueness to
+        # live rows so a soft-deleted tombstone (migration 0029) no longer
+        # occupies the name slot -- DELETE + POST of the same name now
+        # succeeds while a live duplicate still collides (#2874). Using
+        # Index rather than UniqueConstraint avoids Alembic autogenerate
+        # drift (autogenerate sees constraint vs index as different objects);
+        # the postgresql_where / sqlite_where pair keeps the predicate
+        # matched on both dialects so autogenerate stays clean.
         Index(
             "targets_tenant_name_idx",
             "tenant_id",
             "name",
             unique=True,
             postgresql_using="btree",
+            postgresql_where=sa.text("deleted_at IS NULL"),
+            sqlite_where=sa.text("deleted_at IS NULL"),
         ),
         Index(
             "targets_tenant_product_idx",

--- a/backend/src/meho_backplane/ui/routes/connectors/list_view.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/list_view.py
@@ -257,8 +257,16 @@ async def _list_targets(
     exact-match (matching the ``/api/v1/targets`` list route's
     ``?product=`` shape from #254) so the dropdown's
     selected-or-cleared state maps 1:1 to the active query.
+
+    Soft-deleted rows are excluded (``deleted_at IS NULL``) -- the same
+    filter the resolver and the ``/api/v1/targets`` list route apply, so
+    the console never renders a tombstone the API surfaces have already
+    hidden (#2874).
     """
-    stmt = select(TargetORM).where(TargetORM.tenant_id == tenant_id)
+    stmt = select(TargetORM).where(
+        TargetORM.tenant_id == tenant_id,
+        TargetORM.deleted_at.is_(None),
+    )
     if product_filter:
         stmt = stmt.where(TargetORM.product == product_filter)
     stmt = _apply_sort(stmt, sort=sort, direction=direction)
@@ -281,10 +289,17 @@ async def _distinct_products(
     the same tenant. A ``SELECT DISTINCT`` round trip on the
     targets table costs one extra query per page render; the table
     is already paged so the cost is bounded.
+
+    Soft-deleted rows are excluded (``deleted_at IS NULL``) so the
+    dropdown never offers a product whose only carrier is a tombstone
+    filtered out of the list itself (#2874).
     """
     stmt = (
         select(TargetORM.product)
-        .where(TargetORM.tenant_id == tenant_id)
+        .where(
+            TargetORM.tenant_id == tenant_id,
+            TargetORM.deleted_at.is_(None),
+        )
         .distinct()
         .order_by(TargetORM.product)
     )

--- a/backend/src/meho_backplane/ui/routes/keycloak/routes.py
+++ b/backend/src/meho_backplane/ui/routes/keycloak/routes.py
@@ -239,7 +239,9 @@ async def _list_keycloak_targets(operator: Operator) -> list[dict[str, Any]]:
     Tenant-scoped to ``operator.tenant_id`` only -- no query/header/path
     tenant override, so a cross-tenant keycloak target never enters the
     rendered set. Filtered to ``product == "keycloak"`` so the picker lists
-    only deployments the keycloak read ops can dispatch against.
+    only deployments the keycloak read ops can dispatch against, and to
+    ``deleted_at IS NULL`` so a soft-deleted target never surfaces as a
+    pickable option the resolver would then 404 on (#2874).
     """
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as db_session:
@@ -248,6 +250,7 @@ async def _list_keycloak_targets(operator: Operator) -> list[dict[str, Any]]:
             .where(
                 TargetORM.tenant_id == operator.tenant_id,
                 TargetORM.product == KEYCLOAK_PRODUCT,
+                TargetORM.deleted_at.is_(None),
             )
             .order_by(TargetORM.name)
         )

--- a/backend/tests/test_api_v1_targets.py
+++ b/backend/tests/test_api_v1_targets.py
@@ -2810,3 +2810,116 @@ def test_create_target_gsm_scheme_ref_bypasses_gate_on_vault_backend(
         )
     assert response.status_code == 201
     assert response.json()["secret_ref"] == gsm_ref
+
+
+# ---------------------------------------------------------------------------
+# DELETE + re-create: soft-delete tombstones free the name (0072 / #2874)
+# ---------------------------------------------------------------------------
+
+
+def test_delete_then_recreate_same_name_returns_201_with_fresh_uuid(
+    client: TestClient,
+) -> None:
+    """Reporter repro (#2874): DELETE frees the name for a fresh re-create.
+
+    POST → 201, DELETE → 204, GET → 404, POST same name → 201 with a
+    **new** id. Before the fix the tombstone kept the full unique-index
+    slot and the final POST returned 409 forever, stranding the name.
+    """
+    key = make_rsa_keypair("kid-A")
+    admin = {"Authorization": f"Bearer {_admin_token(key)}"}
+    operator = {"Authorization": f"Bearer {_operator_token(key)}"}
+    name = "rke2-mgmt-prometheus"
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+
+        created = client.post(
+            "/api/v1/targets",
+            json={"name": name, "product": "ssh", "host": "10.0.0.1"},
+            headers=admin,
+        )
+        assert created.status_code == 201
+        first_id = created.json()["id"]
+
+        deleted = client.delete(f"/api/v1/targets/{name}", headers=admin)
+        assert deleted.status_code == 204
+
+        gone = client.get(f"/api/v1/targets/{name}", headers=operator)
+        assert gone.status_code == 404
+
+        recreated = client.post(
+            "/api/v1/targets",
+            json={"name": name, "product": "kubernetes", "host": "10.0.0.2"},
+            headers=admin,
+        )
+        assert recreated.status_code == 201
+        second_id = recreated.json()["id"]
+
+    assert second_id != first_id
+
+
+@pytest.mark.asyncio
+async def test_repeated_delete_recreate_accumulates_coexisting_tombstones(
+    client: TestClient,
+) -> None:
+    """Repeated delete/recreate cycles pile up tombstones; live dup still 409s.
+
+    Three POST→DELETE cycles leave three tombstones; a fourth POST lands
+    a live row alongside them; a fifth POST of the *same live* name still
+    returns 409 (the partial index keeps enforcing one-live-name-per-
+    tenant). The DB ends with three tombstones + one live row.
+    """
+    from sqlalchemy import select as _select
+
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.db.models import Target as TargetORM
+
+    key = make_rsa_keypair("kid-A")
+    admin = {"Authorization": f"Bearer {_admin_token(key)}"}
+    name = "cycle-host"
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+
+        for _ in range(3):
+            created = client.post(
+                "/api/v1/targets",
+                json={"name": name, "product": "ssh", "host": "10.0.0.1"},
+                headers=admin,
+            )
+            assert created.status_code == 201
+            deleted = client.delete(f"/api/v1/targets/{name}", headers=admin)
+            assert deleted.status_code == 204
+
+        # Fourth create lands a live row over the three tombstones.
+        live = client.post(
+            "/api/v1/targets",
+            json={"name": name, "product": "ssh", "host": "10.0.0.9"},
+            headers=admin,
+        )
+        assert live.status_code == 201
+
+        # A live duplicate still collides — the 409 path is unchanged.
+        dup = client.post(
+            "/api/v1/targets",
+            json={"name": name, "product": "ssh", "host": "10.0.0.9"},
+            headers=admin,
+        )
+        assert dup.status_code == 409
+
+    sm = get_sessionmaker()
+    async with sm() as session:
+        rows = (
+            (
+                await session.execute(
+                    _select(TargetORM).where(
+                        TargetORM.tenant_id == uuid.UUID(DEFAULT_TENANT_ID),
+                        TargetORM.name == name,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 4
+    assert sum(1 for r in rows if r.deleted_at is not None) == 3
+    assert sum(1 for r in rows if r.deleted_at is None) == 1

--- a/backend/tests/test_db_targets.py
+++ b/backend/tests/test_db_targets.py
@@ -889,3 +889,158 @@ def test_migration_0045_adds_tls_ca_pin_nullable_and_is_reversible(
             assert "tls_ca_pin" in cols_reupgraded
     finally:
         sync_eng.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Partial unique index — soft-delete tombstones free the name (0072 / #2874)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_partial_unique_index_allows_reinsert_over_soft_deleted_row() -> None:
+    """A soft-deleted row no longer blocks re-inserting the same (tenant, name).
+
+    Regression for #2874. ``targets_tenant_name_idx`` is a *partial*
+    unique index (``WHERE deleted_at IS NULL``, migration ``0072``), so
+    once a row is soft-deleted its ``(tenant_id, name)`` slot is free: a
+    fresh live row with the same name inserts cleanly and the two
+    incarnations coexist (one tombstone, one live). Before the fix the
+    full unique index kept the tombstone in the slot forever and this
+    second insert raised ``IntegrityError``.
+    """
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    first_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            Target(
+                id=first_id,
+                tenant_id=tenant_id,
+                name="reused",
+                product="ssh",
+                host="10.0.0.1",
+            )
+        )
+        await session.commit()
+
+    # Soft-delete it — the effect DELETE /api/v1/targets/{name} has.
+    async with sessionmaker() as session:
+        row = (await session.execute(select(Target).where(Target.id == first_id))).scalar_one()
+        row.deleted_at = datetime.now(UTC)
+        await session.commit()
+
+    # Same (tenant_id, name), fresh id — must not raise.
+    second_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            Target(
+                id=second_id,
+                tenant_id=tenant_id,
+                name="reused",
+                product="kubernetes",
+                host="10.0.0.2",
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(Target).where(
+                        Target.tenant_id == tenant_id,
+                        Target.name == "reused",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert {r.id for r in rows} == {first_id, second_id}
+    live = [r for r in rows if r.deleted_at is None]
+    assert len(live) == 1
+    assert live[0].id == second_id
+
+
+def _name_index_sql(conn: object) -> str:
+    """Return the stored ``CREATE INDEX`` DDL for ``targets_tenant_name_idx``.
+
+    SQLite records the full index definition — including any partial
+    ``WHERE`` predicate — in ``sqlite_master.sql``, which is the
+    dialect-portable way to prove the index is (or is not) partial.
+    """
+    return conn.execute(  # type: ignore[attr-defined]
+        text(
+            "SELECT sql FROM sqlite_master "
+            "WHERE type = 'index' AND name = 'targets_tenant_name_idx'"
+        )
+    ).scalar_one()
+
+
+def test_migration_0072_installs_partial_unique_name_index(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``alembic upgrade head`` leaves ``targets_tenant_name_idx`` partial.
+
+    The index stays present and unique, and its stored DDL carries the
+    ``WHERE deleted_at IS NULL`` predicate (migration ``0072`` / #2874).
+    """
+    sync_url, _ = _alembic_upgrade_against_fresh_sqlite(monkeypatch, tmp_path, "partial.db")
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            indexes = {idx["name"] for idx in sa_inspect(conn).get_indexes("targets")}
+            assert "targets_tenant_name_idx" in indexes
+
+            # The stored DDL proves uniqueness, column set, and the partial
+            # predicate in one shot (SQLite's inspector reports ``unique``
+            # as an int, so the DDL string is the robust source of truth).
+            idx_sql = _name_index_sql(conn).lower()
+            assert "unique" in idx_sql
+            assert "(tenant_id, name)" in idx_sql
+            assert "where" in idx_sql, f"index must be partial, got: {idx_sql!r}"
+            assert "deleted_at" in idx_sql
+    finally:
+        sync_eng.dispose()
+
+
+def test_migration_0072_upgrade_then_downgrade_is_reversible(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``0072`` is reversible on clean data: partial → full → partial.
+
+    Downgrading to ``0071`` restores the original full unique index (no
+    ``WHERE`` predicate); re-upgrading restores the partial one. Run
+    against a fresh DB with no re-used names, so the downgrade's
+    full-index rebuild cannot hit the documented reused-name caveat.
+    """
+    from alembic import command
+
+    sync_url, cfg = _alembic_upgrade_against_fresh_sqlite(monkeypatch, tmp_path, "rev0072.db")
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            assert "where" in _name_index_sql(conn).lower()
+
+        # Downgrade exactly one revision (head -> 0071): full index returns.
+        command.downgrade(cfg, "0071")
+        with sync_eng.connect() as conn:
+            indexes = {idx["name"] for idx in sa_inspect(conn).get_indexes("targets")}
+            assert "targets_tenant_name_idx" in indexes
+            full_sql = _name_index_sql(conn).lower()
+            assert "unique" in full_sql
+            assert "where" not in full_sql, (
+                "downgrade must restore the full (non-partial) unique index"
+            )
+
+        # Re-upgrade is idempotent and restores the partial index.
+        command.upgrade(cfg, "head")
+        with sync_eng.connect() as conn:
+            assert "where" in _name_index_sql(conn).lower()
+    finally:
+        sync_eng.dispose()

--- a/backend/tests/test_ui_connectors_view.py
+++ b/backend/tests/test_ui_connectors_view.py
@@ -212,8 +212,13 @@ def _seed_target(
     fingerprint: dict[str, Any] | None = None,
     vpn_required: bool = False,
     updated_at: datetime | None = None,
+    deleted_at: datetime | None = None,
 ) -> uuid.UUID:
-    """Insert one ``targets`` row and return its id."""
+    """Insert one ``targets`` row and return its id.
+
+    Pass ``deleted_at`` to seed a soft-deleted tombstone (the state a
+    ``DELETE /api/v1/targets/{name}`` leaves behind).
+    """
     target_id = uuid.uuid4()
     now = updated_at if updated_at is not None else datetime.now(UTC)
 
@@ -239,6 +244,7 @@ def _seed_target(
                     preferred_impl_id=None,
                     created_at=now,
                     updated_at=now,
+                    deleted_at=deleted_at,
                 ),
             )
 
@@ -558,6 +564,56 @@ def test_list_handles_empty_inventory() -> None:
         response = client.get("/ui/connectors")
     assert response.status_code == 200, response.text
     assert "No targets match the current filter." in response.text
+
+
+def test_list_excludes_soft_deleted_targets() -> None:
+    """A soft-deleted target is absent from the console list (#2874).
+
+    The list read filters ``deleted_at IS NULL`` — the same filter the
+    resolver and the ``/api/v1/targets`` route apply — so a tombstone the
+    API surfaces already hide never renders in the console either.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="live-target", product="vmware")
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="deleted-target",
+        product="vmware",
+        deleted_at=datetime.now(UTC),
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "live-target" in body
+    assert "deleted-target" not in body
+
+
+def test_list_product_dropdown_excludes_soft_deleted_only_product() -> None:
+    """The product filter omits a product whose only carrier is a tombstone.
+
+    ``_distinct_products`` filters ``deleted_at IS NULL`` too, so a
+    product present solely on a soft-deleted target never appears as a
+    selectable option (#2874).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="live-vmware", product="vmware")
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="dead-ssh",
+        product="ssh",
+        deleted_at=datetime.now(UTC),
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert ">vmware<" in body
+    assert ">ssh<" not in body
 
 
 def test_list_htmx_request_returns_fragment_only() -> None:

--- a/backend/tests/test_ui_keycloak.py
+++ b/backend/tests/test_ui_keycloak.py
@@ -37,7 +37,7 @@ import asyncio
 import uuid
 import warnings
 from collections.abc import Iterator
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -153,8 +153,12 @@ def _seed_keycloak_target(
     tenant_id: uuid.UUID,
     name: str = _TARGET_NAME,
     product: str = "keycloak",
+    deleted_at: datetime | None = None,
 ) -> None:
-    """Seed one keycloak ``Target`` row scoped to *tenant_id*."""
+    """Seed one keycloak ``Target`` row scoped to *tenant_id*.
+
+    Pass ``deleted_at`` to seed a soft-deleted tombstone.
+    """
 
     async def _do() -> None:
         sessionmaker = get_sessionmaker()
@@ -166,6 +170,7 @@ def _seed_keycloak_target(
                     name=name,
                     product=product,
                     host="keycloak.test",
+                    deleted_at=deleted_at,
                 ),
             )
 
@@ -445,6 +450,29 @@ def test_keycloak_ui_index_ignores_cross_tenant_target(
     with mock:
         response = client.get("/ui/keycloak?target=other-keycloak")
     assert response.status_code == 200, response.text
+    assert received == []
+
+
+def test_keycloak_ui_index_excludes_soft_deleted_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A soft-deleted keycloak target is absent from the picker (#2874).
+
+    ``_list_keycloak_targets`` filters ``deleted_at IS NULL``, so a
+    tombstone never becomes a pickable option the resolver would then
+    404 on. With the sole target soft-deleted the index prompts for
+    selection and dispatches nothing.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_keycloak_target(tenant_id=_TENANT_A, deleted_at=datetime.now(UTC))
+    received = _patch_call_operation(monkeypatch, {})
+    client, mock = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    with mock:
+        response = client.get("/ui/keycloak")
+    assert response.status_code == 200, response.text
+    assert "No Keycloak targets registered" in response.text
     assert received == []
 
 

--- a/docs/codebase/migrations.md
+++ b/docs/codebase/migrations.md
@@ -161,6 +161,23 @@ image-revert plus forward-compatible schema discipline (`helm rollback`
 contract, Goal #11 DoD). The additive-only rule is what makes that safe: any
 older image can read any newer schema. See the rollback contract below.
 
+### Index rebuilds are permitted
+
+`op.drop_index(...)` is **not** on the banned list, and rebuilding an index
+(`drop_index` then `create_index`, e.g. to add or change a partial `WHERE`
+predicate that neither PostgreSQL nor SQLite can alter in place) is an allowed
+`upgrade()` operation. It removes no data and no column, and it stays
+forward-compatible: an older image running against the rebuilt index sees the
+same name and columns and enforces at least the same or a superset of what it
+expects. Migration `0072` is the reference — it converts the full unique
+`targets_tenant_name_idx` into a partial `UNIQUE (tenant_id, name) WHERE
+deleted_at IS NULL` so soft-delete tombstones stop blocking name re-use
+(#2874); an older image still 409s on a live duplicate and merely also
+tolerates an insert over a tombstone. A rebuild whose new predicate is
+*stricter* than the old one is not automatically safe — verify the existing
+data satisfies it (or backfill first), exactly as a new `create_index` on a
+populated table would.
+
 ## Rollback contract (readiness ↔ migrations, #1607)
 
 The chart applies migrations from a `helm.sh/hook: pre-install,pre-upgrade`


### PR DESCRIPTION
## Summary
- Fixes #2874: `DELETE /api/v1/targets/{name}` soft-deletes by stamping `deleted_at`, but `targets_tenant_name_idx` was a **FULL** unique index on `(tenant_id, name)` (migration 0004, predating soft-delete) that migration 0029 never converted. The tombstone kept occupying the unique slot forever — invisible to every read, yet permanently **409-blocking** a re-create of the same name, with no operator path out.
- Migration **0072** rebuilds it as a **partial** unique index `UNIQUE (tenant_id, name) WHERE deleted_at IS NULL` (`postgresql_where` + `sqlite_where`, the migration-0005 dialect-portable pattern), with the ORM `Index` matched so alembic autogenerate shows no drift. A live duplicate still collides (the create handler's 409 path is unchanged); an insert whose only same-name neighbours are tombstones simply succeeds — **no create/delete handler changes**.
- Upgrade is **backfill-free** and frees every currently-wedged name the moment it lands (the old FULL index was strictly stricter, so the rebuild cannot fail on existing data); tombstones stay in the table so `audit_log.target_id` soft-FKs keep resolving. Downgrade caveat (documented in the migration docstring): the full-index rebuild fails if a name was legitimately re-used post-upgrade.
- Adds the missing `deleted_at IS NULL` filter to the three previously-unfiltered UI reads that same-name tombstone accumulation would otherwise expose: the console targets list and `_distinct_products` (`ui/routes/connectors/list_view.py`), and `_list_keycloak_targets` (`ui/routes/keycloak/routes.py`).

## Test plan
- [x] `ruff check` + `ruff format --check` — clean on all changed files
- [x] `mypy src` (strict) — clean (only a pre-existing, macOS-only `MSG_ERRQUEUE` error in `connectors/net/icmp.py`, unrelated; passes on Linux CI)
- [x] `alembic check` — **no new autogenerate drift** (byte-identical to the pre-change baseline; `targets_tenant_name_idx` absent from the diff, confirming the ORM `Index` and migration match)
- [x] `scripts/ci/check_migration_compat.py` — PASS (`op.drop_index` is not a banned destructive op; the rebuild is forward-compat safe under the `helm rollback` contract)
- [x] `alembic heads` — single head `0072`, chained from `0071`
- [x] `pytest` on the 4 affected files — **160 passed**; migration integrity suite — **96 passed**
- [x] Reporter repro regression: POST -> DELETE 204 -> GET 404 -> POST same name -> 201 with a **fresh UUID** (`test_delete_then_recreate_same_name_returns_201_with_fresh_uuid`)
- [x] Live-duplicate 409 stays green (existing `test_create_target_duplicate_returns_409` + asserted mid-cycle in the accumulation test)
- [x] Repeated delete/recreate cycles accumulate coexisting tombstones (`test_repeated_delete_recreate_accumulates_coexisting_tombstones`)
- [x] Partial-index behaviour + 0072 partiality/reversibility (`test_partial_unique_index_allows_reinsert_over_soft_deleted_row`, `test_migration_0072_installs_partial_unique_name_index`, `test_migration_0072_upgrade_then_downgrade_is_reversible`)
- [x] UI reads exclude tombstones (console list, product dropdown, keycloak picker)

## Out of scope
- Hard-delete / tombstone-revival / name-mangling / purge-endpoint alternatives — all rejected in the issue analysis (audit append-only per v0.1-spec §6, UUID stability, `query_audit` name->id resolution for deleted incarnations).
- Pre-existing code-quality size warnings on the large files this PR touches (`db/models.py`, `keycloak/routes.py`, `list_view.py`) — not introduced here; the diff gate reports **0 blockers**.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2874
