### PR TITLE
docs(cross-repo): reconcile sddc/fleet/vrops onboarding + CLI examples with dotted typed op_ids (#2971)

### DIFF
--- a/cli/internal/cmd/sddc-manager/operation.go
+++ b/cli/internal/cmd/sddc-manager/operation.go
@@ -117,8 +117,8 @@ func newOperationCallCmd() *cobra.Command {
 			"\"sddc-rest-9.0\" pre-baked. Use when an op doesn't have a\n" +
 			"dedicated alias yet.\n\n" +
 			"Exit codes mirror meho operation call.",
-		Example: "  meho sddc-manager operation call GET:/v1/domains --target rdc-sddc-manager\n" +
-			"  meho sddc-manager operation call GET:/v1/hosts --target rdc-sddc-manager --json",
+		Example: "  meho sddc-manager operation call GET:/v1/bundles --target rdc-sddc-manager\n" +
+			"  meho sddc-manager operation call GET:/v1/releases/system --target rdc-sddc-manager --json",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cli/internal/cmd/sddc-manager/sddc_manager.go
+++ b/cli/internal/cmd/sddc-manager/sddc_manager.go
@@ -5,18 +5,21 @@
 // for G3.5-T6 (#618) of Initiative #368. v0.2 ships the operator-facing
 // alias verbs over the 9 enabled SDDC Manager read-only core ops, each
 // pre-baking connector_id="sddc-rest-9.0" so operators don't type the
-// connector ID on every dispatch:
+// connector ID on every dispatch. Verbs whose backend read went typed
+// dispatch the dotted typed op_id (#2355, #2837 — ingested
+// METHOD:/path op_ids no longer resolve on a zero-catalog boot); the
+// rest keep their ingested op_ids until a typed counterpart ships:
 //
 //   - `meho sddc-manager about [--target T]`                — GET:/v1/releases/system
-//   - `meho sddc-manager manager list [--target T]`         — GET:/v1/sddc-managers
-//   - `meho sddc-manager domain list [--target T]`          — GET:/v1/domains
+//   - `meho sddc-manager manager list [--target T]`         — sddc.manager.list
+//   - `meho sddc-manager domain list [--target T]`          — sddc.domain.list
 //   - `meho sddc-manager domain info <id> [--target T]`     — GET:/v1/domains/{id}
-//   - `meho sddc-manager cluster list [--domain D] [--target T]`   — GET:/v1/clusters
-//   - `meho sddc-manager host list [--domain D] [--cluster C] [--target T]` — GET:/v1/hosts
+//   - `meho sddc-manager cluster list [--domain D] [--target T]`   — sddc.cluster.list
+//   - `meho sddc-manager host list [--domain D] [--cluster C] [--target T]` — sddc.host.list
 //   - `meho sddc-manager network-pool list [--target T]`    — sddc.network_pool.list
 //   - `meho sddc-manager network-pool get <id> [--target T]` — sddc.network_pool.get
 //   - `meho sddc-manager bundle list [--target T]`          — GET:/v1/bundles
-//   - `meho sddc-manager workflow list [--status S] [--target T]`  — GET:/v1/tasks
+//   - `meho sddc-manager workflow list [--status S] [--target T]`  — sddc.task.list
 //   - `meho sddc-manager operation search/call`             — meta-tool wrappers
 //
 // Every verb is a thin Cobra command that POSTs to

--- a/cli/internal/cmd/vcf-automation/operation.go
+++ b/cli/internal/cmd/vcf-automation/operation.go
@@ -131,8 +131,8 @@ func newOperationCallCmd() *cobra.Command {
 			"via its path prefix; the --plane flag is ignored on this verb.\n" +
 			"The persistent --fqdn flag still threads into the body.\n\n" +
 			"Exit codes mirror meho operation call.",
-		Example: "  meho vcf-automation operation call GET:/cloudapi/1.0.0/site --target rdc-vcfa\n" +
-			"  meho vcf-automation operation call GET:/iaas/api/about --target rdc-vcfa --json",
+		Example: "  meho vcf-automation operation call GET:/cloudapi/1.0.0/users --target rdc-vcfa\n" +
+			"  meho vcf-automation operation call GET:/iaas/api/blueprints --target rdc-vcfa --json",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cli/internal/cmd/vcf-fleet/vcf_fleet.go
+++ b/cli/internal/cmd/vcf-fleet/vcf_fleet.go
@@ -5,12 +5,15 @@
 // for G3.6-T9 (#839) of Initiative #369. v0.5 ships operator-facing
 // alias verbs over the 8 enabled VCF Fleet (vRSLCM-derived) read-only
 // core ops, each pre-baking connector_id="fleet-rest-9.0" so operators
-// don't type the connector ID on every dispatch:
+// don't type the connector ID on every dispatch. Verbs whose backend
+// read went typed dispatch the dotted typed op_id (#2355 — ingested
+// METHOD:/path op_ids no longer resolve on a zero-catalog boot); the
+// rest keep their ingested op_ids until a typed counterpart ships:
 //
-//   - `meho vcf-fleet about [--target T]`                                  — GET:/lcm/lcops/api/v2/about
+//   - `meho vcf-fleet about [--target T]`                                  — fleet.about
 //   - `meho vcf-fleet datacenter list [--target T]`                        — GET:/lcm/lcops/api/v2/datacenters
 //   - `meho vcf-fleet vcenter list <datacenter-vmid> [--target T]`         — GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters
-//   - `meho vcf-fleet environment list [--target T]`                       — GET:/lcm/lcops/api/v2/environments
+//   - `meho vcf-fleet environment list [--target T]`                       — fleet.environment.list
 //   - `meho vcf-fleet environment info <environment-id> [--target T]`      — GET:/lcm/lcops/api/v2/environments/{environmentId}
 //   - `meho vcf-fleet product list <environment-id> [--target T]`          — GET:/lcm/lcops/api/v2/environments/{environmentId}/products
 //   - `meho vcf-fleet request list [--target T]`                           — GET:/lcm/request/api/v2/requests

--- a/cli/internal/cmd/vcf-operations/operation.go
+++ b/cli/internal/cmd/vcf-operations/operation.go
@@ -124,7 +124,7 @@ func newOperationCallCmd() *cobra.Command {
 			"\"vrops-rest-9.0\" pre-baked. Use when an op doesn't have a\n" +
 			"dedicated alias yet.\n\n" +
 			"Exit codes mirror meho operation call.",
-		Example: "  meho vcf-operations operation call GET:/suite-api/api/versions/current --target rdc-vrops\n" +
+		Example: "  meho vcf-operations operation call GET:/suite-api/api/alertdefinitions --target rdc-vrops\n" +
 			"  meho vcf-operations operation call GET:/suite-api/api/resources --target rdc-vrops --json",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,

--- a/cli/internal/cmd/vcf-operations/vcf_operations.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations.go
@@ -6,12 +6,15 @@
 // v0.5 ships the operator-facing alias verbs over the 8 enabled vROps
 // read-only core ops (G3.6-T2 #833), each pre-baking
 // connector_id="vrops-rest-9.0" so operators don't type the connector
-// ID on every dispatch:
+// ID on every dispatch. Verbs whose backend read went typed dispatch
+// the dotted typed op_id (#2355 — ingested METHOD:/path op_ids no
+// longer resolve on a zero-catalog boot); the rest keep their
+// ingested op_ids until a typed counterpart ships:
 //
-//   - `meho vcf-operations about [--target T]`                   — GET:/suite-api/api/versions/current
+//   - `meho vcf-operations about [--target T]`                   — vrops.liveness
 //   - `meho vcf-operations resource list [--target T] [--params J]` — GET:/suite-api/api/resources
 //   - `meho vcf-operations resource get <id> [--target T]`        — GET:/suite-api/api/resources/{id}
-//   - `meho vcf-operations alert list [--target T] [--params J]`  — GET:/suite-api/api/alerts
+//   - `meho vcf-operations alert list [--target T] [--params J]`  — vrops.alert.list
 //   - `meho vcf-operations alertdefinition list [--target T] [--params J]` — GET:/suite-api/api/alertdefinitions
 //   - `meho vcf-operations symptom list [--target T] [--params J]` — GET:/suite-api/api/symptoms
 //   - `meho vcf-operations recommendation list [--target T] [--params J]` — GET:/suite-api/api/recommendations

--- a/docs/cross-repo/sddc-manager-onboarding.md
+++ b/docs/cross-repo/sddc-manager-onboarding.md
@@ -38,14 +38,14 @@ ops stay in the wrapper until v0.2.next ships policy + approval flow:
 | Group | CLI verb | `op_id` | Path |
 | --- | --- | --- | --- |
 | sddc-releases | `meho sddc-manager about` | `GET:/v1/releases/system` | VCF release info + BOM |
-| sddc-managers | `meho sddc-manager manager list` | `GET:/v1/sddc-managers` | SDDC Manager appliance inventory |
-| sddc-domains | `meho sddc-manager domain list` | `GET:/v1/domains` | All VCF workload domain listing |
+| sddc-managers | `meho sddc-manager manager list` | `sddc.manager.list` | SDDC Manager appliance inventory |
+| sddc-domains | `meho sddc-manager domain list` | `sddc.domain.list` | All VCF workload domain listing |
 | sddc-domains | `meho sddc-manager domain info <id>` | `GET:/v1/domains/{id}` | Per-domain detail (vCenters, NSX, clusters, SSO) |
-| sddc-clusters | `meho sddc-manager cluster list [--domain <id>]` | `GET:/v1/clusters` | Cluster listing (optionally scoped to a domain) |
-| sddc-hosts | `meho sddc-manager host list [--domain <id>] [--cluster <id>]` | `GET:/v1/hosts` | Host inventory (optionally scoped to domain or cluster) |
-| sddc-network-pools | `meho sddc-manager network-pool list` | `GET:/v1/network-pools` | Network pool listing |
+| sddc-clusters | `meho sddc-manager cluster list [--domain <id>]` | `sddc.cluster.list` | Cluster listing (optionally scoped to a domain) |
+| sddc-hosts | `meho sddc-manager host list [--domain <id>] [--cluster <id>]` | `sddc.host.list` | Host inventory (optionally scoped to domain or cluster) |
+| sddc-network-pools | `meho sddc-manager network-pool list` | `sddc.network_pool.list` | Network pool listing |
 | sddc-bundles | `meho sddc-manager bundle list` | `GET:/v1/bundles` | LCM bundle listing |
-| sddc-tasks | `meho sddc-manager workflow list [--status <state>]` | `GET:/v1/tasks` | VCF workflow task listing |
+| sddc-tasks | `meho sddc-manager workflow list [--status <state>]` | `sddc.task.list` | VCF workflow task listing |
 
 Every op dispatches through the same `POST /api/v1/operations/call`
 route the agent surface uses — auth, policy, audit, broadcast, and
@@ -206,7 +206,7 @@ meho sddc-manager workflow list --status In_Progress --target rdc-sddc-manager
 meho sddc-manager host list --target rdc-sddc-manager --json | jq '.result.elements[] | .fqdn'
 
 # Escape hatch: run any sddc-rest-9.0 op by op_id
-meho sddc-manager operation call GET:/v1/domains --target rdc-sddc-manager
+meho sddc-manager operation call GET:/v1/bundles --target rdc-sddc-manager
 meho sddc-manager operation search "host inventory"
 ```
 
@@ -230,13 +230,18 @@ sddc-rest-9.0 — VCF 9.0.0.0-24000000 (2026-01-15)
 
 ### `meho sddc-manager manager list`
 
-Dispatches `GET:/v1/sddc-managers`. Renders `id` / `fqdn` / `version` /
-`management_domain` from the `elements[]` pagination envelope. Production
+Dispatches `sddc.manager.list` (the typed read; repointed off the
+ingested `GET:/v1/sddc-managers` op_id by #2355 — the legacy op_id no
+longer resolves on a zero-catalog boot). Renders `id` / `fqdn` /
+`version` / `management_domain` from the `elements[]` pagination
+envelope. Production
 VCF deployments have exactly one appliance per management domain.
 
 ### `meho sddc-manager domain list`
 
-Dispatches `GET:/v1/domains`. Renders `id` / `name` / `type`
+Dispatches `sddc.domain.list` (the typed read; repointed off the
+ingested `GET:/v1/domains` op_id by #2355 — the legacy op_id no longer
+resolves on a zero-catalog boot). Renders `id` / `name` / `type`
 (`MANAGEMENT` or `WORKLOAD`). The management domain is always present;
 each `meho sddc-manager domain deploy` (out of scope for v0.2) adds a
 workload domain row.
@@ -254,14 +259,18 @@ meho sddc-manager domain info domain-wld01 --target rdc-sddc-manager
 
 ### `meho sddc-manager cluster list [--domain <id>]`
 
-Dispatches `GET:/v1/clusters`. Without `--domain`, lists every cluster
+Dispatches `sddc.cluster.list` (the typed read; repointed off the
+ingested `GET:/v1/clusters` op_id by #2355 — the legacy op_id no
+longer resolves on a zero-catalog boot). Without `--domain`, lists every cluster
 across all domains. With `--domain <domain-id>`, passes `domainId` as a
 query param to scope the response. Renders `id` / `name` /
 `primaryDatastoreType` / `domainId`.
 
 ### `meho sddc-manager host list [--domain <id>] [--cluster <id>]`
 
-Dispatches `GET:/v1/hosts`. Optional `--domain` and `--cluster` flags
+Dispatches `sddc.host.list` (the typed read; repointed off the
+ingested `GET:/v1/hosts` op_id by #2355 — the legacy op_id no longer
+resolves on a zero-catalog boot). Optional `--domain` and `--cluster` flags
 filter the listing. Both flags can be combined. Renders `id` / `fqdn` /
 `esxiVersion` / `status`. The host list is the largest SDDC Manager read
 surface in production (dozens to hundreds of rows); use `--json | jq` to
@@ -269,7 +278,9 @@ filter by cluster or status.
 
 ### `meho sddc-manager network-pool list`
 
-Dispatches `GET:/v1/network-pools`. Renders `id` / `name` for each pool.
+Dispatches `sddc.network_pool.list` (the typed read; repointed off the
+ingested `GET:/v1/network-pools` op_id by #2837 — the legacy op_id no
+longer resolves on a zero-catalog boot). Renders `id` / `name` for each pool.
 Network pools are referenced in cluster expand and workload domain deploy
 workflows — this listing is the prerequisite lookup.
 
@@ -282,7 +293,9 @@ current VCF version.
 
 ### `meho sddc-manager workflow list [--status <state>]`
 
-Dispatches `GET:/v1/tasks`. Optional `--status` filters by task status.
+Dispatches `sddc.task.list` (the typed read; repointed off the
+ingested `GET:/v1/tasks` op_id by #2355 — the legacy op_id no longer
+resolves on a zero-catalog boot). Optional `--status` filters by task status.
 Valid values: `Successful`, `Failed`, `In_Progress`, `Pending`, `Cancelled`.
 Renders `id` / `status` / `name` / `type`. Use this after a cluster expand
 or domain deploy to track async task progress.
@@ -307,7 +320,7 @@ aliases.
 
 ```bash
 meho sddc-manager operation search "host inventory" --group sddc-hosts
-meho sddc-manager operation call GET:/v1/domains --target rdc-sddc-manager
+meho sddc-manager operation call GET:/v1/bundles --target rdc-sddc-manager
 meho sddc-manager operation call GET:/v1/domains/{id} \
   --target rdc-sddc-manager --params '{"id": "domain-wld01"}'
 ```

--- a/docs/cross-repo/vcf-automation-onboarding.md
+++ b/docs/cross-repo/vcf-automation-onboarding.md
@@ -231,7 +231,7 @@ meho vcf-automation about --plane provider --target rdc-vcfa \
   --fqdn vcfa.maintenance.evoila.io
 
 # Escape hatch — run any vcfa-rest-9.0 op_id by name
-meho vcf-automation operation call GET:/cloudapi/1.0.0/site --target rdc-vcfa
+meho vcf-automation operation call GET:/cloudapi/1.0.0/users --target rdc-vcfa
 meho vcf-automation operation search "deployment status" --group tenant-deployments
 ```
 
@@ -318,7 +318,7 @@ op_id). The persistent `--fqdn` flag still threads into the body.
 
 ```bash
 meho vcf-automation operation search "deployments" --group tenant-deployments
-meho vcf-automation operation call GET:/iaas/api/about --target rdc-vcfa
+meho vcf-automation operation call GET:/iaas/api/blueprints --target rdc-vcfa
 ```
 
 ## Audit and broadcast classification

--- a/docs/cross-repo/vcf-fleet-onboarding.md
+++ b/docs/cross-repo/vcf-fleet-onboarding.md
@@ -45,10 +45,10 @@ v0.5.next ships policy + approval flow.
 
 | Group | CLI verb | `op_id` | Path |
 | --- | --- | --- | --- |
-| fleet-about | `meho vcf-fleet about` | `GET:/lcm/lcops/api/v2/about` | vRSLCM appliance identity (HTTP 500 in 9.0 — see below) |
+| fleet-about | `meho vcf-fleet about` | `fleet.about` | vRSLCM appliance identity (HTTP 500 in 9.0 — see below) |
 | fleet-datacenter | `meho vcf-fleet datacenter list` | `GET:/lcm/lcops/api/v2/datacenters` | Datacenter inventory + wrapper-verified probe |
 | fleet-vcenter | `meho vcf-fleet vcenter list <vmid>` | `GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters` | vCenters registered under one datacenter |
-| fleet-environment | `meho vcf-fleet environment list` | `GET:/lcm/lcops/api/v2/environments` | Environment inventory (primary Fleet entry point) |
+| fleet-environment | `meho vcf-fleet environment list` | `fleet.environment.list` | Environment inventory (primary Fleet entry point) |
 | fleet-environment | `meho vcf-fleet environment info <id>` | `GET:/lcm/lcops/api/v2/environments/{environmentId}` | Per-environment detail (products + nodes) |
 | fleet-product | `meho vcf-fleet product list <env-id>` | `GET:/lcm/lcops/api/v2/environments/{environmentId}/products` | Products deployed under one environment |
 | fleet-request | `meho vcf-fleet request list` | `GET:/lcm/request/api/v2/requests` | Lifecycle request listing (deploy / patch / upgrade) |
@@ -81,7 +81,8 @@ Workarounds the connector implements:
   any working endpoint in 9.0. The fingerprint carries the LCM API version
   (e.g. `"8.0"`) under `extras.lcm_api_version`. Operators needing the
   product version cross-source from SDDC Manager (`meho sddc-manager
-  operation call GET:/v1/vcf-services`).
+  operation call sddc.vcf_service.list` — the typed read over
+  `/v1/vcf-services`).
 
 Track the upstream fix at [Broadcom developer portal](https://developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager/latest/);
 when the endpoint is restored, the `meho vcf-fleet about` verb starts working
@@ -208,7 +209,11 @@ meho vcf-fleet operation search "list environments"
 
 ### `meho vcf-fleet about`
 
-Dispatches `GET:/lcm/lcops/api/v2/about` against `connector_id="fleet-rest-9.0"`.
+Dispatches `fleet.about` (the typed read; repointed off the ingested
+`GET:/lcm/lcops/api/v2/about` op_id by #2355 — the legacy op_id no
+longer resolves on a zero-catalog boot; the typed op reads the same
+upstream `/lcm/lcops/api/v2/about` surface) against
+`connector_id="fleet-rest-9.0"`.
 **Warning**: returns HTTP 500 in current VCF 9.0 builds — use
 `vcf-fleet datacenter list` as the reachability probe instead. Kept for spec
 parity + future Broadcom fix. When working, renders `apiVersion`,
@@ -238,7 +243,9 @@ identifier for cross-referencing against vSphere targets.
 
 ### `meho vcf-fleet environment list`
 
-Dispatches `GET:/lcm/lcops/api/v2/environments`. The primary Fleet inventory
+Dispatches `fleet.environment.list` (the typed read; repointed off the
+ingested `GET:/lcm/lcops/api/v2/environments` op_id by #2355 — the
+legacy op_id no longer resolves on a zero-catalog boot). The primary Fleet inventory
 entry point — every vRA / vROps / vRLI / vIDM deploy lives under an
 environment. Large appliances return a JSONFlux handle through the shared
 `HandleStore`; use `result_describe` / `result_query` to filter when the
@@ -281,7 +288,7 @@ aliases.
 
 ```bash
 meho vcf-fleet operation search "upgrade workflow" --group fleet-request
-meho vcf-fleet operation call GET:/lcm/lcops/api/v2/environments --target rdc-fleet
+meho vcf-fleet operation call GET:/lcm/request/api/v2/requests --target rdc-fleet
 meho vcf-fleet operation call GET:/lcm/request/api/v2/requests/{requestId} \
   --target rdc-fleet --params '{"requestId":"req-vmid-001"}'
 ```
@@ -443,7 +450,7 @@ the canary-fixture vs recorded-fixture distinction.
 | --- | --- | --- |
 | `no backplane URL configured` (exit 2) | Never logged in / no `--backplane`. | `meho login <url>` or pass `--backplane <url>`. |
 | `auth_expired` / stored token rejected | Keycloak token expired. | `meho login <url>` again. |
-| `status=error connector_error: HTTP 500` on `vcf-fleet about` | VCF 9.0 known issue — Fleet's `/about` endpoint is broken in current builds. | Use `vcf-fleet datacenter list` as the reachability probe; cross-source product version from SDDC Manager `/v1/vcf-services`. |
+| `status=error connector_error: HTTP 500` on `vcf-fleet about` | VCF 9.0 known issue — Fleet's `/about` endpoint is broken in current builds. | Use `vcf-fleet datacenter list` as the reachability probe; cross-source product version from SDDC Manager (`sddc.vcf_service.list`). |
 | `status=error connector_error: … HTTP 401` | Fleet credentials invalid. HTTP Basic 401 is terminal — no re-login path. | Verify the Vault secret at `target.secret_ref`; confirm `admin@local` (or the configured local user) is enabled in the LCM user store; confirm the password hasn't been rotated. |
 | `status=error … unknown_op` | The 8 core ops are not registered/enabled. | Re-run `apply_fleet_core_curation` against the Fleet connector. |
 | `status=denied` | `read_only` role, or a tenant policy denied the dispatch. | Use an `operator`-role token. |

--- a/docs/cross-repo/vcf-operations-onboarding.md
+++ b/docs/cross-repo/vcf-operations-onboarding.md
@@ -52,10 +52,10 @@ stay in the wrapper until v0.5.next ships policy + approval flow:
 
 | Group | CLI verb | `op_id` | Path |
 | --- | --- | --- | --- |
-| vrops-system | `meho vcf-operations about` | `GET:/suite-api/api/versions/current` | Appliance release name + build number |
+| vrops-system | `meho vcf-operations about` | `vrops.liveness` | Appliance release name + build number |
 | vrops-resources | `meho vcf-operations resource list` | `GET:/suite-api/api/resources` | Resource inventory (VMs, hosts, datastores, adapters) |
 | vrops-resources | `meho vcf-operations resource get <id>` | `GET:/suite-api/api/resources/{id}` | Per-resource detail by UUID |
-| vrops-alerts | `meho vcf-operations alert list` | `GET:/suite-api/api/alerts` | Currently firing or recently resolved alerts |
+| vrops-alerts | `meho vcf-operations alert list` | `vrops.alert.list` | Currently firing or recently resolved alerts |
 | vrops-alert-definitions | `meho vcf-operations alertdefinition list` | `GET:/suite-api/api/alertdefinitions` | Alert definitions (the policy surface) |
 | vrops-symptoms | `meho vcf-operations symptom list` | `GET:/suite-api/api/symptoms` | Per-condition signals beneath alerts |
 | vrops-recommendations | `meho vcf-operations recommendation list` | `GET:/suite-api/api/recommendations` | Operator-facing remediation hints |
@@ -205,7 +205,7 @@ meho vcf-operations resource list --target rdc-vrops --json \
   | jq '.result.resourceList[] | .identifier'
 
 # Escape hatch: run any vrops-rest-9.0 op by op_id
-meho vcf-operations operation call GET:/suite-api/api/versions/current --target rdc-vrops
+meho vcf-operations operation call GET:/suite-api/api/resources --target rdc-vrops
 meho vcf-operations operation search "alerts" --target rdc-vrops
 ```
 
@@ -213,14 +213,17 @@ meho vcf-operations operation search "alerts" --target rdc-vrops
 
 ### `meho vcf-operations about`
 
-Dispatches `GET:/suite-api/api/versions/current` against
-`connector_id="vrops-rest-9.0"`. Human output: `release` (e.g.
+Dispatches `vrops.liveness` (the typed read; repointed off the
+ingested `GET:/suite-api/api/versions/current` op_id by #2355 — the
+legacy op_id no longer resolves on a zero-catalog boot; the typed op
+reads the same upstream `/suite-api/api/versions/current` surface)
+against `connector_id="vrops-rest-9.0"`. Human output: `release` (e.g.
 `9.0.0.1.23456789`), `build`, `human` (the humanly readable name when
 the appliance emits it).
 
 ```text
 $ meho vcf-operations about --target rdc-vrops
-vrops-rest-9.0 GET:/suite-api/api/versions/current — status=ok (42ms)
+vrops-rest-9.0 vrops.liveness — status=ok (42ms)
   release:  9.0.0.1.23456789
   build:    23456789
   human:    VMware Aria Operations 9.0
@@ -243,10 +246,13 @@ Renders identifier / name / kind / status / state.
 
 ### `meho vcf-operations alert list`
 
-Dispatches `GET:/suite-api/api/alerts`. Renders `alertId` /
+Dispatches `vrops.alert.list` (the typed read; repointed off the
+ingested `GET:/suite-api/api/alerts` op_id by #2355 — the legacy
+op_id no longer resolves on a zero-catalog boot). Renders `alertId` /
 `alertDefinitionName` / `alertLevel` / `status`. Filter via `--params`
 (`activeOnly`, `alertCriticality`, `alertStatus`, `resourceId`,
-`page`, `pageSize`).
+`page`, `pageSize` — the typed op's closed parameter schema accepts
+exactly these keys).
 
 ### `meho vcf-operations alertdefinition list`
 
@@ -283,7 +289,7 @@ dedicated CLI aliases.
 
 ```bash
 meho vcf-operations operation search "list resources" --group vrops-resources
-meho vcf-operations operation call GET:/suite-api/api/versions/current --target rdc-vrops
+meho vcf-operations operation call GET:/suite-api/api/resources --target rdc-vrops
 ```
 
 ## Audit and broadcast classification


### PR DESCRIPTION
## Summary
- Per-verb reconciliation of the three remaining VMware-family onboarding docs against the authoritative `typed_opid_dispatch_test.go` guard tables — the second half of the sweep #2965 (issue #2961) did for nsx / vcf-automation. Verb-table rows and verb-reference prose whose CLI verbs were repointed to dotted typed op_ids now document those op_ids, each with the #2950-style "repointed off the ingested op_id by #NNNN" note: sddc-manager `manager list` → `sddc.manager.list`, `domain list` → `sddc.domain.list`, `cluster list` → `sddc.cluster.list`, `host list` → `sddc.host.list`, `network-pool list` → `sddc.network_pool.list` (#2837), `workflow list` → `sddc.task.list`; vcf-fleet `about` → `fleet.about`, `environment list` → `fleet.environment.list`; vcf-operations `about` → `vrops.liveness` (incl. the sample-output header line), `alert list` → `vrops.alert.list`.
- NOT a blanket find/replace: rows pinned ingested in the guards stay byte-identical — sddc `about` (`GET:/v1/releases/system`), `bundle list` (`GET:/v1/bundles`), `domain info` (`GET:/v1/domains/{id}`, explicitly confirmed correct by #2942); fleet `datacenter list` / `vcenter list` / `environment info` / `product list` / `request list` / `request info`; vrops `resource list` / `resource get` / `alertdefinition list` / `symptom list` / `recommendation list` / `supermetric list`.
- Raw `operation call` escape-hatch examples now use guard-pinned ingested op_ids that still resolve (the tier-0s pattern from #2965): sddc docs + `operation.go` use `GET:/v1/bundles` / `GET:/v1/releases/system`; vcf-automation `operation.go` + its doc's two raw examples use `GET:/cloudapi/1.0.0/users` / `GET:/iaas/api/blueprints` (preserving the plane-via-path-prefix teaching); vcf-operations uses `GET:/suite-api/api/resources` / `GET:/suite-api/api/alertdefinitions`; vcf-fleet's stale raw `GET:/lcm/lcops/api/v2/environments` example → guard-pinned `GET:/lcm/request/api/v2/requests`. The fleet doc's cross-source tip now calls `sddc.vcf_service.list` (typed, agent-surface) instead of the retired `GET:/v1/vcf-services`.
- Opportunistic comment-only fix, clearly out of the issue's named file list: the package doc-comment verb tables in `sddc_manager.go` / `vcf_fleet.go` / `vcf_operations.go` carried the same retired op_ids; they are brought to the same mixed typed/ingested state `nsx.go` already has (incl. the nsx-style preamble sentence). No dispatch constant, string, or behavior changed outside `Example:` fields.

## Test plan
- [x] `go build ./...` (cli) — clean
- [x] `go vet` on the four touched packages — clean
- [x] `go test ./...` (cli) — 47 packages ok, including all five `typed_opid_dispatch_test.go` guard packages (untouched)
- [x] Every changed row/prose op_id cross-checked against `typedDispatchCases` / `ingestedDispatchCases` / `typedOpCLICoverage` in the sddc-manager, vcf-fleet, vcf-operations, and vcf-automation guards
- [x] Backend cross-check: `fleet.about` and `vrops.liveness` read the same upstream paths as the retired op_ids (typed_ops.py), so the fleet HTTP-500 warning and the vrops about output fields stay accurate; `vrops.alert.list`'s closed parameter schema accepts exactly the filter keys the doc lists
- [x] Closing grep across `docs/cross-repo/*-onboarding.md`: every remaining `METHOD:/path` token is a guard-pinned ingested row/prose mention, a "repointed off" historical note, or a never-repointed ingested-breadth example on another connector (nsx `GET:/api/v1/node` kept per #2965's determination; fleet `GET:/lcm/locker/api/v2/passwords` non-curated escape hatch; vcf-logs / hetzner-robot / vmware-rest surfaces are out of this sweep's scope)
- [x] `.claude/hooks/code-quality.py --diff` — pass

## Out of scope
- The #2358-retired curation-apparatus references ("9 curated ops" framing, `apply_*_core_curation` prerequisites, `core_ops.py` links) present in all three docs — pre-existing drift of a different class, per the issue's out-of-scope list.
- `source_kind: "ingested"` audit-payload claims in the three docs' audit sections — same class; #2965 left the identical claims in the nsx/vcfa docs (adjacent finding: they are now mixed typed/ingested per verb).
- `docs/codebase/connectors-sddc-manager.md` and `connectors-vcf-operations.md` verb→op_id tables carry the same retired op_ids (adjacent finding — the issue and #2965 scoped the sweep to the cross-repo onboarding docs).
- The sddc doc does not document the `network-pool get` verb at all (adjacent finding, missing row rather than a mismatch).
- Test-file mock payloads using old `METHOD:/path` strings (`sddc_manager_test.go`, `vcfa_test.go`, `vcf_operations_test.go`) — arbitrary mock op_ids on the operation-call plumbing tests, same as the nsx equivalents #2965 left.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2971
