### PR TITLE
fix(connectors): repoint vmware composite op_ids at paths the real vcenter.yaml serves (#2970)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,46 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Breaking changes — vmware composite param schemas tightened by the #2970 repoint
+
+- `vmware.composite.vm.clone` no longer accepts `wait_for_completion` /
+  `timeout_seconds` (the pinned deploy operation is synchronous — there
+  is no task to wait on). Migration: drop both keys from the params;
+  the response is always `status="completed"` with `vm_id` set and
+  `task_id` null.
+- `vmware.composite.cluster.patch` no longer accepts `patch_method` (it
+  fed a body field of the fictional `POST:/vcenter/host/{host}?action=patch`;
+  the real per-host vLCM apply takes an `ApplySpec`, sent empty =
+  latest desired-state commit). Migration: drop the key.
+- `vmware.composite.vm.create`'s `nics` entries gain an optional
+  `backing_type` (default `STANDARD_PORTGROUP`); entries with only
+  `network` keep working.
+
+### Fixed — vmware composites repointed at paths the real vcenter.yaml serves (#2970)
+
+- Running the #2944/#2949 real-spec reconcile lanes against the pinned
+  vendor shelf surfaced 11 composite op_ids the canonical `vcenter.yaml`
+  does not serve (shape-correct-but-nonexistent REST paths — every one
+  would 404 on a live vCenter 9.0). REST repoints: `vm.clone`'s deploy →
+  the per-item
+  `POST:/vcenter/vm-template/library-items/{templateLibraryItem}?action=deploy`
+  (synchronous — the 200 body is the new VM id, so the cis-task poll and
+  the `wait_for_completion`/`timeout_seconds` params went away),
+  cluster-host listing → `GET:/vcenter/host` + `clusters` filter,
+  `vm.create` NIC attach → `POST:/vcenter/vm/{vm}/hardware/ethernet`,
+  `host.detach_from_vds` NIC migration → per-adapter
+  `PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}`, and
+  `cluster.patch`'s patch step → the vLCM
+  `POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true`
+  with its cis task polled before maintenance-exit. Surfaces with no
+  REST path in the pinned spec switched to the governed vim seam
+  (snapshot list/revert, host maintenance enter/exit, DRS
+  recommendations, DVS host removal), each `*_Task` polled to terminal;
+  the portgroup audit's DVS-list step was dropped with a documented
+  degradation (`dvs_name` always null; `filter_dvs` inert). All five
+  spec lanes are green against the real shelf — the gate for arming
+  `SPEC_SHELF_TOKEN` (#2949 ADR).
+
 ### Added — vcfa tenant deployment detail read + `deployment get` repoint (#2960)
 
 - `vcfa.tenant.deployment.get` (`GET /iaas/api/deployments/{id}`,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -158,19 +158,17 @@ _OP_POST_QUERY_PERF = "POST:/PerformanceManager/{moId}/QueryPerf"
 _OP_LIST_DATASTORES = "GET:/vcenter/datastore"
 _OP_GET_DATASTORE = "GET:/vcenter/datastore/{datastore}"
 _OP_LIST_VMS = "GET:/vcenter/vm"
-# vSphere Automation REST keys the distributed-switch listing under the
-# *plural* resource path (a preview feature on the appliance-served
-# ``vcenter.yaml``); the singular ``distributed-switch`` spelling that
-# G3.1-T5 #508 shipped does not exist in the spec and never resolved
-# against a real ingest (#1602). The DVS-list response carries a
-# ``vds``/``distributed_switch`` moid per entry, which drives the
-# ``dvs_index`` enrichment below.
-_OP_LIST_DVS = "GET:/vcenter/network/distributed-switches"
-# There is NO dedicated ``distributed-portgroup(s)`` list resource in
-# the REST Automation API: distributed portgroups are enumerated via the
-# generic network resource filtered to ``DISTRIBUTED_PORTGROUP`` (the
-# singular ``distributed-portgroup`` op_id #508 declared was absent from
-# every ingest -- #1602). The generic ``Network`` summary returns only
+# There is NO distributed-switch list resource in the pinned REST spec at
+# all: the plural ``distributed-switches`` path #1602 repointed to exists
+# only under ``/vcenter/namespace-management/networks/nsx/`` (NSX-scoped)
+# in the canonical ``vcenter.yaml`` -- the #2970 real-spec reconcile
+# finding. The audit's DVS-list step is therefore dropped (see the
+# handler's degradation note); enumerating switches is a vim-only surface.
+# There is likewise NO dedicated ``distributed-portgroup(s)`` list
+# resource: distributed portgroups are enumerated via the generic network
+# resource filtered to ``DISTRIBUTED_PORTGROUP`` (the singular
+# ``distributed-portgroup`` op_id #508 declared was absent from every
+# ingest -- #1602). The generic ``Network`` summary returns only
 # ``{network (id), name, type}`` -- it carries no parent-DVS field, so
 # the per-portgroup ``dvs``/``dvs_name`` enrichment is best-effort (see
 # the handler note).
@@ -201,7 +199,6 @@ _SUB_OPS_DATASTORE_USAGE: tuple[str, ...] = (
     _OP_LIST_VMS,
 )
 _SUB_OPS_NETWORK_PORTGROUP_AUDIT: tuple[str, ...] = (
-    _OP_LIST_DVS,
     _OP_LIST_NETWORK,
     _OP_LIST_VMS,
 )
@@ -644,26 +641,18 @@ async def network_portgroup_audit_composite(
     params: dict[str, Any],
     connector: VmwareRestConnector,
 ) -> dict[str, Any]:
-    """Audit distributed portgroups with parent DVS + connected-VM aggregation.
+    """Audit distributed portgroups with connected-VM aggregation.
 
     Op-id: ``vmware.composite.network.portgroup.audit``.
 
     Sub-ops read directly on the connector session:
 
-    1. ``GET:/vcenter/network/distributed-switches`` -- list DVS
-       entries (filtered to ``filter_dvs`` via the resource's
-       ``filter.vdses`` query when supplied). Drives the DVS index
-       used to enrich each portgroup with its switch name.
-    2. ``GET:/vcenter/network`` with ``filter.types=[DISTRIBUTED_PORTGROUP]``
+    1. ``GET:/vcenter/network`` with ``filter.types=[DISTRIBUTED_PORTGROUP]``
        -- list distributed portgroups. The REST Automation API has no
        dedicated distributed-portgroup resource; portgroups are
        enumerated through the generic ``Network`` resource filtered to
-       the ``DISTRIBUTED_PORTGROUP`` type (#1602). ``filter_dvs`` is
-       *not* applied here -- the generic ``Network`` FilterSpec exposes
-       ``types``/``names``/``networks``/``datacenters``/``folders`` but
-       no per-DVS filter, so DVS scoping narrows the index (and thus the
-       enriched ``dvs_name``) rather than the portgroup set.
-    3. Per portgroup: ``GET:/vcenter/vm`` with ``filter.networks`` --
+       the ``DISTRIBUTED_PORTGROUP`` type (#1602).
+    2. Per portgroup: ``GET:/vcenter/vm`` with ``filter.networks`` --
        VMs connected to the portgroup. Drives the ``vm_count`` +
        ``vm_names`` aggregation.
 
@@ -674,39 +663,26 @@ async def network_portgroup_audit_composite(
         "dvs_name": <str|None>, "type": ..., "vm_count": ...,
         "vm_names": [...]}, ...]}``.
 
-    The generic ``Network`` summary carries only ``{network (id), name,
-    type}`` -- it has no parent-DVS reference -- so ``dvs``/``dvs_name``
-    are best-effort: populated when the upstream payload happens to
-    expose a ``vds``/``distributed_switch`` field (e.g. a richer target
-    or a future spec revision), ``None`` otherwise.
+    Degradation note (#2970): the pre-#2970 step 1 listed distributed
+    switches via ``GET:/vcenter/network/distributed-switches`` to build a
+    moid->name index for ``dvs_name`` enrichment -- but the pinned
+    ``vcenter.yaml`` serves that path only under the NSX-scoped
+    ``/vcenter/namespace-management/`` tree, so the step 404s on a real
+    vCenter 9.0 and is dropped. ``dvs_name`` is therefore always ``None``
+    (it already was in practice: the generic ``Network`` summary carries
+    only ``{network (id), name, type}`` -- no parent-DVS reference to
+    join on -- so the index was never consulted with a hit). ``dvs``
+    stays best-effort: populated when the upstream payload happens to
+    expose a ``vds``/``distributed_switch`` field, ``None`` otherwise.
+    ``filter_dvs`` only ever scoped that index, so it is accepted but
+    inert -- see the parameter schema note.
     """
-    filter_dvs = params.get("filter_dvs")
     include_disconnected = bool(params.get("include_disconnected_vms", False))
-
-    dvs_query: dict[str, Any] = {}
-    if isinstance(filter_dvs, str):
-        dvs_query["filter.vdses"] = [filter_dvs]
-
-    dvs_listing = await _read_sub_op(connector, target, operator, _OP_LIST_DVS, query=dvs_query)
-    dvs_entries = _unwrap_value(dvs_listing)
-    if not isinstance(dvs_entries, list):
-        dvs_entries = []
-    # Build a moid->name lookup so the per-portgroup row carries the
-    # DVS name in addition to its id.
-    dvs_index: dict[str, str | None] = {}
-    for entry in dvs_entries:
-        if not isinstance(entry, dict):
-            continue
-        dvs_id = entry.get("vds") or entry.get("distributed_switch")
-        if isinstance(dvs_id, str):
-            name = entry.get("name") if isinstance(entry.get("name"), str) else None
-            dvs_index[dvs_id] = name
 
     # Distributed portgroups come from the generic network resource
     # filtered to the DISTRIBUTED_PORTGROUP type -- there is no
-    # standalone distributed-portgroup list endpoint. ``filter_dvs`` has
-    # no analogue on this FilterSpec, so it is deliberately not threaded
-    # in here (it scopes the DVS index above instead).
+    # standalone distributed-portgroup list endpoint (and no DVS list
+    # resource at all; see the degradation note above).
     pg_query: dict[str, Any] = {"filter.types": [_NETWORK_TYPE_DISTRIBUTED_PORTGROUP]}
 
     pg_listing = await _read_sub_op(connector, target, operator, _OP_LIST_NETWORK, query=pg_query)
@@ -744,7 +720,11 @@ async def network_portgroup_audit_composite(
                 "id": pg_id,
                 "name": entry.get("name"),
                 "dvs": dvs_ref_str,
-                "dvs_name": dvs_index.get(dvs_ref_str) if dvs_ref_str else None,
+                # Always None post-#2970: the DVS-list step that built the
+                # moid->name index is not served by the pinned spec (see
+                # the handler degradation note). Key retained for
+                # response-envelope stability.
+                "dvs_name": None,
                 "type": entry.get("type"),
                 "vm_count": len(vm_names),
                 "vm_names": vm_names,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -362,14 +362,15 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         handler=network_portgroup_audit_composite,
         summary="Audit distributed portgroups with parent DVS + connected VMs.",
         description=(
-            "Reads the distributed-switches listing (for parent-DVS name "
-            "enrichment) plus the distributed portgroups via "
+            "Lists the distributed portgroups via "
             "'GET:/vcenter/network?filter.types=DISTRIBUTED_PORTGROUP', "
             "then per-portgroup queries the VM list via "
             "'GET:/vcenter/vm?filter.networks=...'. Aggregates one row "
-            "per portgroup with its parent DVS + connected VM names. "
-            "Equivalent of 'govc dvs.portgroup.info' rolled up across "
-            "every portgroup. Read-only -- never mutates network "
+            "per portgroup with connected VM names. Parent-DVS name "
+            "enrichment is degraded (dvs_name always null): the pinned "
+            "spec serves no DVS list resource (#2970). Equivalent of "
+            "'govc dvs.portgroup.info' rolled up across every "
+            "portgroup. Read-only -- never mutates network "
             "configuration."
         ),
         parameter_schema=NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA,
@@ -388,7 +389,8 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         summary="Create a VM with NIC attach + optional power-on; rollback on failure.",
         description=(
             "Orchestrates folder lookup, POST:/vcenter/vm create, per-NIC "
-            "attach via PATCH:/vcenter/vm/{vm}/network, and optional "
+            "adapter create via POST:/vcenter/vm/{vm}/hardware/ethernet, "
+            "and optional "
             "POST:/vcenter/vm/{vm}/power start. Partial-failure rollback: "
             "if any step after the create succeeds fails, the half-"
             "created VM is removed via DELETE:/vcenter/vm/{vm} so the "
@@ -405,21 +407,20 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
     _CompositeSpec(
         op_id="vmware.composite.vm.clone",
         handler=vm_clone_composite,
-        summary="Clone a VM from a content-library template; poll the deploy task.",
+        summary="Clone a VM from a content-library template (synchronous deploy).",
         description=(
-            "Reads source VM config, dispatches "
-            "POST:/vcenter/vm-template/library-items?action=deploy, then "
-            "polls GET:/cis/tasks/{task} until completion or timeout. "
-            "Long-running -- blocks for up to timeout_seconds when "
-            "wait_for_completion=True (default). Setting "
-            "wait_for_completion=False returns the task id for caller "
-            "polling. Equivalent of 'govc vm.clone' for operator-facing "
+            "Reads source VM config, then dispatches "
+            "POST:/vcenter/vm-template/library-items/{templateLibraryItem}"
+            "?action=deploy. The pinned deploy operation is synchronous "
+            "-- its 200 body is the deployed VM id, so the composite "
+            "returns status='completed' with vm_id directly (no task "
+            "poll). Equivalent of 'govc vm.clone' for operator-facing "
             "dispatch."
         ),
         parameter_schema=VM_CLONE_PARAMETER_SCHEMA,
         response_schema=VM_CLONE_RESPONSE_SCHEMA,
         group_key="vm",
-        tags=["composite", "write", "vm", "lifecycle", "long-running"],
+        tags=["composite", "write", "vm", "lifecycle"],
         safety_level="dangerous",
         requires_approval=True,
     ),
@@ -428,10 +429,12 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         handler=vm_snapshot_revert_composite,
         summary="Revert a VM to a named snapshot; reject on name ambiguity.",
         description=(
-            "Lists the VM's snapshot tree via "
-            "GET:/vcenter/vm/{vm}/snapshot, matches by snapshot name, "
-            "and dispatches "
-            "POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert when "
+            "Reads the VM's snapshot tree (vim RetrievePropertiesEx on "
+            "VirtualMachine.snapshot -- the pinned REST spec serves no "
+            "snapshot resource, #2970), matches by snapshot name, and "
+            "dispatches the vim "
+            "VirtualMachineSnapshot.RevertToSnapshot_Task (polled to a "
+            "terminal state) when "
             "exactly one match is found. Multiple-match cases return "
             "status='ambiguous' with candidates listed so the operator "
             "can re-dispatch by snapshot moid. Idempotent within a "
@@ -452,8 +455,10 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         handler=vm_migrate_composite,
         summary="Migrate a VM via DRS recommendation or explicit target host.",
         description=(
-            "Consults "
-            "GET:/vcenter/cluster/{cluster}/drs/recommendations for the "
+            "Consults the cluster's DRS migration recommendations (vim "
+            "RetrievePropertiesEx on "
+            "ClusterComputeResource.drsRecommendation -- the pinned REST "
+            "spec serves no DRS resource, #2970) for the "
             "VM, then dispatches POST:/vcenter/vm/{vm}?action=relocate "
             "with the recommended host. If DRS returns no recommendation "
             "and no target_host override is supplied, the composite "
@@ -575,8 +580,10 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
             "vmware.composite.vm.migrate per VM (recursive composite "
             "call -- first production composite that calls another "
             "composite). On full migration success, the host enters "
-            "maintenance via "
-            "PATCH:/vcenter/host/{host}/maintenance?action=enter. "
+            "maintenance via the vim "
+            "HostSystem.EnterMaintenanceMode_Task (polled to a terminal "
+            "state -- the pinned REST spec serves no host-maintenance "
+            "path, #2970). "
             "tolerate_partial_failure=True lets maintenance-enter fire "
             "even with VMs left behind. Equivalent of 'govc host.evacuate' "
             "operator workflow."
@@ -594,10 +601,13 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         summary="Migrate host VM NICs off a DVS to a fallback network, then remove host from DVS.",
         description=(
             "Lists DVS portgroups on the host and VMs on the host, "
-            "migrates each VM's NICs off the DVS to the supplied "
-            "fallback_network via PATCH:/vcenter/vm/{vm}/network, and "
-            "then dispatches "
-            "POST:/vcenter/network/dvs/{dvs}?action=remove_host. "
+            "migrates each VM's NICs to the supplied fallback_network "
+            "per adapter (GET + "
+            "PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}), and then "
+            "removes the host via the vim "
+            "DistributedVirtualSwitch.ReconfigureDvs_Task host-member "
+            "remove (polled to a terminal state -- the pinned REST spec "
+            "serves no DVS write path, #2970). "
             "vSphere refuses the host detach when any VM still has "
             "active NICs on the DVS -- the composite verifies every NIC "
             "migrated before attempting the detach; on partial NIC "
@@ -617,11 +627,13 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         handler=cluster_patch_composite,
         summary="Sequentially patch every host in a cluster: maintenance + patch + exit.",
         description=(
-            "Lists cluster hosts via GET:/vcenter/cluster/{cluster}/host, "
-            "then iterates each host sequentially: "
-            "PATCH:/vcenter/host/{host}/maintenance?action=enter -> "
-            "POST:/vcenter/host/{host}?action=patch -> "
-            "PATCH:/vcenter/host/{host}/maintenance?action=exit. "
+            "Lists cluster hosts via GET:/vcenter/host?clusters=..., "
+            "then iterates each host sequentially: vim "
+            "EnterMaintenanceMode_Task -> vLCM "
+            "POST:/esx/settings/hosts/{host}/software?action=apply"
+            "&vmw-task=true (cis task polled to terminal) -> vim "
+            "ExitMaintenanceMode_Task, every task polled before the "
+            "next step. "
             "Sequential by design -- concurrent host patches would "
             "force every VM in the cluster to vMotion at once, "
             "overwhelming DRS. Per-host failure stops the loop; the "

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -95,7 +95,7 @@ import httpx
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors import OperationResult
-from meho_backplane.connectors.vmware_rest.vim_task import poll_vim_task
+from meho_backplane.connectors.vmware_rest.vim_task import TASK_STATE_ERROR, poll_vim_task
 from meho_backplane.operations.composite import DispatchChild, enforce_subop_policy
 
 if TYPE_CHECKING:
@@ -148,22 +148,41 @@ _PATH_VAR_RE = re.compile(r"\{([^{}]+)\}")
 # ``POST:/vcenter/vm/{vm}/power?action=start``; the ``?action=<verb>`` rides on
 # the mounted path verbatim (httpx sends it as the request query string), so no
 # ``action`` body param is ever constructed. Endpoints whose action verb is
-# operator-chosen (power start/stop, maintenance enter/exit) build the op_id
-# per-call via :func:`_power_vm_op_id` / :func:`_host_maintenance_op_id`.
+# operator-chosen (power start/stop) build the op_id per-call via
+# :func:`_power_vm_op_id`.
 _OP_LIST_FOLDERS = "GET:/vcenter/folder"
 _OP_LIST_VMS = "GET:/vcenter/vm"
 _OP_GET_VM = "GET:/vcenter/vm/{vm}"
 _OP_CREATE_VM = "POST:/vcenter/vm"
 _OP_DELETE_VM = "DELETE:/vcenter/vm/{vm}"
-_OP_ATTACH_VM_NIC = "PATCH:/vcenter/vm/{vm}/network"
+# NIC attach on vm.create is the Ethernet adapter *create* resource. The
+# pinned spec serves no ``PATCH:/vcenter/vm/{vm}/network`` (the #2970
+# reconcile finding); attaching a NIC to a network is
+# ``Vcenter.Vm.Hardware.Ethernet_create`` with the network in the
+# ``backing`` spec.
+_OP_CREATE_VM_NIC = "POST:/vcenter/vm/{vm}/hardware/ethernet"
+# Per-VM adapter listing for host.detach_from_vds's NIC repoint fan-out
+# (``Vcenter.Vm.Hardware.Ethernet_list``).
+_OP_LIST_VM_NICS = "GET:/vcenter/vm/{vm}/hardware/ethernet"
 _OP_RELOCATE_VM = "POST:/vcenter/vm/{vm}?action=relocate"
-_OP_LIST_VM_SNAPSHOTS = "GET:/vcenter/vm/{vm}/snapshot"
-_OP_REVERT_VM_SNAPSHOT = "POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert"
-_OP_LIST_CLUSTER_HOSTS = "GET:/vcenter/cluster/{cluster}/host"
-_OP_GET_DRS_RECOMMENDATIONS = "GET:/vcenter/cluster/{cluster}/drs/recommendations"
-_OP_DEPLOY_LIBRARY_VM = "POST:/vcenter/vm-template/library-items?action=deploy"
+# Host listing (``Vcenter.Host_list``). The pinned spec serves no
+# per-cluster ``GET:/vcenter/cluster/{cluster}/host`` (#2970); cluster
+# scoping rides the ``Host.FilterSpec.clusters`` query filter instead.
+_OP_LIST_HOSTS = "GET:/vcenter/host"
+# Content-library template deploy. The pinned spec keys the deploy on the
+# template item as a *path* param
+# (``Vcenter.VmTemplate.LibraryItems_deploy``) and the operation is
+# synchronous -- its 200 body is the deployed VM id, NOT a cis task
+# (#2970; there is no ``vmw-task=true`` variant of this path).
+_OP_DEPLOY_LIBRARY_VM = (
+    "POST:/vcenter/vm-template/library-items/{templateLibraryItem}?action=deploy"
+)
 _OP_GET_TASK = "GET:/cis/tasks/{task}"
-_OP_HOST_PATCH = "POST:/vcenter/host/{host}?action=patch"
+# Per-host vLCM remediation (``Esx.Settings.Hosts.Software_apply$Task``).
+# The pinned spec serves no ``POST:/vcenter/host/{host}?action=patch``
+# (#2970); patching a host is the vLCM apply, whose 202 body is the cis
+# task id the composite polls via ``_OP_GET_TASK``.
+_OP_HOST_SOFTWARE_APPLY = "POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true"
 # There is NO dedicated ``distributed-portgroup(s)`` list resource in the
 # REST Automation API: distributed portgroups are enumerated via the
 # generic network resource filtered to ``DISTRIBUTED_PORTGROUP`` (the
@@ -172,7 +191,9 @@ _OP_HOST_PATCH = "POST:/vcenter/host/{host}?action=patch"
 # row is ``{network (id), name, type}``. Mirrors ``_read._OP_LIST_NETWORK``.
 _OP_LIST_NETWORK = "GET:/vcenter/network"
 _NETWORK_TYPE_DISTRIBUTED_PORTGROUP = "DISTRIBUTED_PORTGROUP"
-_OP_REMOVE_DVS_HOST = "POST:/vcenter/network/dvs/{dvs}?action=remove_host"
+# ``Vcenter.Vm.Hardware.Ethernet.BackingSpec.type`` value for a standard
+# portgroup -- the default backing the NIC create / repoint specs target.
+_NIC_BACKING_STANDARD_PORTGROUP = "STANDARD_PORTGROUP"
 # REST Disk.Info read — the disk-grow park-time preview reads label +
 # current capacity (bytes) off this; the disk id is the vim device key.
 _OP_GET_VM_DISK = "GET:/vcenter/vm/{vm}/hardware/disk/{disk}"
@@ -351,6 +372,78 @@ _VIM_SUB_OPS_CLUSTER_DRS_RULE_CREATE: tuple[str, ...] = (
 )
 _VIM_SUB_OPS_FOLDER_CREATE: tuple[str, ...] = (_OP_CREATE_FOLDER,)
 
+# vim (VI-JSON) op_ids for the #2970 real-spec repoints. The pinned
+# ``vcenter.yaml`` serves NO REST path for VM snapshots, host maintenance
+# mode, DRS migration recommendations, or DVS host membership -- those
+# surfaces are vim-only in the pinned 9.0 spec (spec-verified), so the
+# affected composite steps ride the same governed vmomi seam the
+# disk-grow / clone / drs_rule writes established (#2893-#2895).
+#
+# * ``RevertToSnapshot_Task`` -- the only revert route; the snapshot
+#   *listing* is a ``RetrievePropertiesEx`` read of the VM's ``snapshot``
+#   property (``VirtualMachineSnapshotInfo.rootSnapshotList``).
+# * ``EnterMaintenanceMode_Task`` / ``ExitMaintenanceMode_Task`` -- the
+#   only maintenance routes. Both request types carry a required int
+#   ``timeout`` (``<= 0`` means no vim-side timeout).
+# * ``ReconfigureDvs_Task`` -- host removal from a DVS is a
+#   ``DVSConfigSpec.host`` member spec with ``operation="remove"``; the
+#   spec's required ``configVersion`` is read off ``config.configVersion``
+#   first (``RetrievePropertiesEx``).
+# * DRS recommendations are the ``ClusterComputeResource.drsRecommendation``
+#   property (``ClusterDrsRecommendation[]`` with the per-VM
+#   ``migrationList``), read via ``RetrievePropertiesEx``. Deprecated
+#   since VI API 2.5 in favour of the generic ``recommendation`` action
+#   list, but still served by the pinned spec and the only shape that
+#   directly carries the vm -> destination-host migration pairs.
+_OP_REVERT_TO_SNAPSHOT_TASK = "POST:/VirtualMachineSnapshot/{moId}/RevertToSnapshot_Task"
+_OP_ENTER_MAINTENANCE_TASK = "POST:/HostSystem/{moId}/EnterMaintenanceMode_Task"
+_OP_EXIT_MAINTENANCE_TASK = "POST:/HostSystem/{moId}/ExitMaintenanceMode_Task"
+_OP_RECONFIGURE_DVS_TASK = "POST:/DistributedVirtualSwitch/{moId}/ReconfigureDvs_Task"
+
+# vim MO/property names for the #2970 reads (``_HOST_SYSTEM_MO_TYPE`` and
+# ``_CLUSTER_COMPUTE_RESOURCE_MO_TYPE`` above are reused for the MoRefs).
+_DVS_MO_TYPE = "DistributedVirtualSwitch"
+_VM_SNAPSHOT_MO_TYPE = "VirtualMachineSnapshot"
+_PROP_SNAPSHOT = "snapshot"
+_PROP_DRS_RECOMMENDATION = "drsRecommendation"
+_PROP_DVS_CONFIG_VERSION = "config.configVersion"
+
+# Required int ``timeout`` on the maintenance request types; ``0`` defers
+# entirely to the poll's wall-clock bound below.
+_MAINTENANCE_VIM_TIMEOUT: Final[int] = 0
+
+# Wall-clock bounds for the #2970 vim task polls + the cluster.patch cis
+# task poll -- the 600s ``vm.disk.grow`` / ``vm.clone_from_template``
+# convention.
+_SNAPSHOT_REVERT_TASK_TIMEOUT_SECONDS = 600.0
+_MAINTENANCE_TASK_TIMEOUT_SECONDS = 600.0
+_DVS_RECONFIGURE_TASK_TIMEOUT_SECONDS = 600.0
+_HOST_APPLY_TASK_TIMEOUT_SECONDS = 600.0
+
+#: vi-json sub-op manifests for the #2970 repoints (parallel to
+#: ``_VIM_SUB_OPS_VM_DISK_GROW``; named out of the ``_SUB_OPS_*`` namespace
+#: so the vcenter.yaml ingest-reconcile sweep skips them). The pinned
+#: ``vi-json.yaml`` reconcile lane introspects these to assert every
+#: declared vim path exists in the spec.
+_VIM_SUB_OPS_VM_SNAPSHOT_REVERT: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_REVERT_TO_SNAPSHOT_TASK,
+)
+_VIM_SUB_OPS_VM_MIGRATE: tuple[str, ...] = (_OP_RETRIEVE_PROPERTIES,)
+_VIM_SUB_OPS_HOST_EVACUATE: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_ENTER_MAINTENANCE_TASK,
+)
+_VIM_SUB_OPS_CLUSTER_PATCH: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_ENTER_MAINTENANCE_TASK,
+    _OP_EXIT_MAINTENANCE_TASK,
+)
+_VIM_SUB_OPS_HOST_DETACH_FROM_VDS: tuple[str, ...] = (
+    _OP_RETRIEVE_PROPERTIES,
+    _OP_RECONFIGURE_DVS_TASK,
+)
+
 # Hardware write ops (#2891). Post-clone reconfigure of a VM's virtual
 # hardware, straight vSphere Automation REST. CPU/memory update and the
 # ethernet/cdrom device sub-resources take the update spec wrapped in the
@@ -408,15 +501,6 @@ def _guest_power_vm_op_id(action: str) -> str:
     return f"POST:/vcenter/vm/{{vm}}/guest/power?action={action}"
 
 
-def _host_maintenance_op_id(action: str) -> str:
-    """Build the per-action canonical op_id for ``PATCH:/vcenter/host/{host}/maintenance``.
-
-    Maintenance enter / exit are two keys under ``?action=enter`` /
-    ``?action=exit``; same reasoning as :func:`_power_vm_op_id`.
-    """
-    return f"PATCH:/vcenter/host/{{host}}/maintenance?action={action}"
-
-
 # Recursive composite sub-op_id (host.evacuate -> vm.migrate). Routed
 # through ``dispatch_child`` (a registrar-guaranteed ``source_kind="composite"``
 # row), not the direct session -- per #2248 the composite->composite recursion
@@ -472,22 +556,14 @@ _SUB_OPS_VM_CREATE: tuple[str, ...] = (
     _OP_LIST_FOLDERS,
     _OP_CREATE_VM,
     _OP_DELETE_VM,
-    _OP_ATTACH_VM_NIC,
+    _OP_CREATE_VM_NIC,
     _power_vm_op_id("start"),
 )
 _SUB_OPS_VM_CLONE: tuple[str, ...] = (
     _OP_GET_VM,
     _OP_DEPLOY_LIBRARY_VM,
-    _OP_GET_TASK,
 )
-_SUB_OPS_VM_SNAPSHOT_REVERT: tuple[str, ...] = (
-    _OP_LIST_VM_SNAPSHOTS,
-    _OP_REVERT_VM_SNAPSHOT,
-)
-_SUB_OPS_VM_MIGRATE: tuple[str, ...] = (
-    _OP_GET_DRS_RECOMMENDATIONS,
-    _OP_RELOCATE_VM,
-)
+_SUB_OPS_VM_MIGRATE: tuple[str, ...] = (_OP_RELOCATE_VM,)
 _SUB_OPS_VM_POWER_BULK: tuple[str, ...] = (
     _OP_LIST_VMS,
     *(_power_vm_op_id(action) for action in _POWER_ACTIONS),
@@ -496,19 +572,17 @@ _SUB_OPS_VM_POWER: tuple[str, ...] = tuple(dict.fromkeys(_SINGLE_POWER_VERB_OP_I
 _SUB_OPS_HOST_EVACUATE: tuple[str, ...] = (
     _OP_LIST_VMS,
     _OP_COMPOSITE_VM_MIGRATE,
-    _host_maintenance_op_id("enter"),
 )
 _SUB_OPS_HOST_DETACH_FROM_VDS: tuple[str, ...] = (
     _OP_LIST_NETWORK,
     _OP_LIST_VMS,
-    _OP_ATTACH_VM_NIC,
-    _OP_REMOVE_DVS_HOST,
+    _OP_LIST_VM_NICS,
+    _OP_UPDATE_VM_NIC,
 )
 _SUB_OPS_CLUSTER_PATCH: tuple[str, ...] = (
-    _OP_LIST_CLUSTER_HOSTS,
-    _host_maintenance_op_id("enter"),
-    _host_maintenance_op_id("exit"),
-    _OP_HOST_PATCH,
+    _OP_LIST_HOSTS,
+    _OP_HOST_SOFTWARE_APPLY,
+    _OP_GET_TASK,
 )
 _SUB_OPS_VM_RESIZE: tuple[str, ...] = (
     _OP_GET_VM,
@@ -755,9 +829,13 @@ async def _resolve_cluster_hosts(
     operator: Operator,
     cluster_moid: str,
 ) -> list[dict[str, Any]]:
-    """Resolve a cluster's host listing rows via ``GET:/vcenter/cluster/{cluster}/host``.
+    """Resolve a cluster's host listing rows via ``GET:/vcenter/host``.
 
-    Read-only single GET directly on the connector session. Shared between
+    Read-only single GET directly on the connector session, scoped to the
+    cluster via the ``Host.FilterSpec.clusters`` query filter -- the pinned
+    spec serves no per-cluster ``GET:/vcenter/cluster/{cluster}/host``
+    resource (#2970). Each ``Vcenter.Host.Summary`` row keeps the ``host``
+    moid key the callers extract. Shared between
     :func:`cluster_patch_composite` (dispatch time) and its park-time preview
     builder in :mod:`._write_preview` (#1608) — same rationale as
     :func:`_resolve_vm_list`.
@@ -766,13 +844,11 @@ async def _resolve_cluster_hosts(
     :exc:`httpx.HTTPError` on a transport fault. Non-dict rows are dropped.
     """
     listing = await _read_sub_op(
-        connector, target, operator, _OP_LIST_CLUSTER_HOSTS, {"cluster": cluster_moid}
+        connector, target, operator, _OP_LIST_HOSTS, {"filter.clusters": [cluster_moid]}
     )
     entries = _unwrap_value(listing)
     if not isinstance(entries, list):
-        raise RuntimeError(
-            f"expected list from {_OP_LIST_CLUSTER_HOSTS!r}, got {type(entries).__name__}"
-        )
+        raise RuntimeError(f"expected list from {_OP_LIST_HOSTS!r}, got {type(entries).__name__}")
     return [entry for entry in entries if isinstance(entry, dict)]
 
 
@@ -886,9 +962,18 @@ async def vm_create_composite(
     steps.append("create")
 
     for nic in nics:
+        # ``Ethernet.CreateSpec``: the network rides the ``backing`` spec
+        # (type + network id); a bare top-level ``network`` key exists on no
+        # NIC resource in the pinned spec (#2970).
+        nic_spec = {
+            "backing": {
+                "type": nic.get("backing_type", _NIC_BACKING_STANDARD_PORTGROUP),
+                "network": nic.get("network"),
+            }
+        }
         try:
             gate, _ = await _write_sub_op(
-                connector, target, operator, _OP_ATTACH_VM_NIC, {"vm": vm_id, "spec": nic}
+                connector, target, operator, _OP_CREATE_VM_NIC, {"vm": vm_id, "spec": nic_spec}
             )
         except httpx.HTTPError as exc:
             await _rollback_created_vm(
@@ -936,9 +1021,14 @@ async def vm_create_composite(
 # ===========================================================================
 
 
-def _extract_clone_task_id(deploy_payload: Any) -> str | None:
-    """Pull the task id out of a deploy response in either canonical shape."""
-    unwrapped = _unwrap_value(deploy_payload)
+def _extract_cis_task_id(payload: Any) -> str | None:
+    """Pull a cis task id out of a ``vmw-task=true`` 202 response payload.
+
+    The pinned spec types the 202 body as the bare task-id string; the
+    legacy ``/rest`` mount wraps it (``{"value": ...}``) and some builds
+    key it ``{"task": ...}`` -- all three shapes are tolerated.
+    """
+    unwrapped = _unwrap_value(payload)
     if isinstance(unwrapped, dict):
         candidate = unwrapped.get("task") or unwrapped.get("value")
         if isinstance(candidate, str):
@@ -948,30 +1038,20 @@ def _extract_clone_task_id(deploy_payload: Any) -> str | None:
     return None
 
 
-def _extract_clone_vm_id(task_result_payload: Any) -> str | None:
-    """Pull the new VM id out of a SUCCEEDED clone task's ``result`` field."""
-    if isinstance(task_result_payload, str):
-        return task_result_payload
-    if isinstance(task_result_payload, dict):
-        candidate = task_result_payload.get("vm") or task_result_payload.get("id")
-        if isinstance(candidate, str):
-            return candidate
-    return None
-
-
-async def _poll_clone_task(
+async def _poll_cis_task(
     *,
     connector: VmwareRestConnector,
     target: Any,
     operator: Operator,
     task_id: str,
-    timeout_seconds: int,
-) -> dict[str, Any]:
-    """Poll ``GET:/cis/tasks/{task}`` until SUCCEEDED/FAILED/timeout.
+    timeout_seconds: float,
+) -> str | None:
+    """Poll ``GET:/cis/tasks/{task}`` to a terminal state; ``None`` on success.
 
-    Returns the completed-or-timeout response envelope directly (the
-    composite's outer status enum). Raises on FAILED so the dispatcher
-    can wrap as ``connector_error``.
+    Returns an operator-facing failure reason on FAILED / deadline elapse
+    so the caller can fold it into its own status envelope (the
+    cluster.patch per-host loop maps it to ``status='stopped'``).
+    Transport faults raise :exc:`httpx.HTTPError` for the caller.
     """
     deadline = time.monotonic() + timeout_seconds
     poll_interval = 1.0
@@ -983,28 +1063,16 @@ async def _poll_clone_task(
         if isinstance(task, dict):
             status = task.get("status")
             if status == "SUCCEEDED":
-                return {
-                    "status": "completed",
-                    "task_id": task_id,
-                    "vm_id": _extract_clone_vm_id(task.get("result")),
-                    "guidance": None,
-                }
+                return None
             if status == "FAILED":
-                raise RuntimeError(
-                    f"vm.clone: deploy task {task_id!r} reported FAILED: "
-                    f"{task.get('error') or '<no error reported>'}"
+                return f"cis task {task_id!r} reported FAILED: " + str(
+                    task.get("error") or "<no error reported>"
                 )
         await asyncio.sleep(poll_interval)
-
-    return {
-        "status": "timeout",
-        "task_id": task_id,
-        "vm_id": None,
-        "guidance": (
-            f"poll GET:/cis/tasks/{task_id} for final state -- the "
-            f"composite gave up after {timeout_seconds}s"
-        ),
-    }
+    return (
+        f"cis task {task_id!r} did not reach a terminal state within "
+        f"{int(timeout_seconds)}s (poll GET:/cis/tasks/{task_id} for final state)"
+    )
 
 
 async def vm_clone_composite(
@@ -1014,17 +1082,17 @@ async def vm_clone_composite(
     params: dict[str, Any],
     connector: VmwareRestConnector,
 ) -> dict[str, Any] | OperationResult:
-    """Clone a VM from a content-library template; poll the deploy task.
+    """Clone a VM from a content-library template via the synchronous deploy.
 
-    Op-id: ``vmware.composite.vm.clone``. Long-running -- blocks for
-    up to ``timeout_seconds`` (default 600) when
-    ``wait_for_completion=True``.
+    Op-id: ``vmware.composite.vm.clone``. The pinned spec's
+    ``Vcenter.VmTemplate.LibraryItems_deploy`` is synchronous -- its 200
+    body is the deployed VM id, and no ``vmw-task=true`` variant of the
+    path exists (#2970) -- so the composite returns ``status='completed'``
+    with the new VM id directly; there is no task to poll.
     """
     source_vm = params["source_vm"]
     target_name = params["target_name"]
     library_item = params["library_item"]
-    wait_for_completion = bool(params.get("wait_for_completion", True))
-    timeout_seconds = int(params.get("timeout_seconds", 600))
 
     # Source config drives CloneSpec; the read is a no-op when the
     # source VM lookup fails (httpx.HTTPError surfaces upstream).
@@ -1035,34 +1103,95 @@ async def vm_clone_composite(
         target,
         operator,
         _OP_DEPLOY_LIBRARY_VM,
-        {"library_item": library_item, "spec": {"name": target_name}},
+        {"templateLibraryItem": library_item, "spec": {"name": target_name}},
     )
     if gate is not None:
         return gate
-    task_id = _extract_clone_task_id(deploy_payload)
-    if task_id is None:
-        raise RuntimeError(f"vm.clone: deploy returned no task id (payload={deploy_payload!r})")
+    vm_id = _unwrap_value(deploy_payload)
+    if not isinstance(vm_id, str):
+        raise RuntimeError(
+            f"vm.clone: deploy returned no VM id (payload={deploy_payload!r}); the "
+            "pinned deploy operation is synchronous and its 200 body is the "
+            "deployed VirtualMachine id"
+        )
 
-    if not wait_for_completion:
-        return {
-            "status": "pending",
-            "task_id": task_id,
-            "vm_id": None,
-            "guidance": "poll GET:/cis/tasks/{task} for final state",
-        }
-
-    return await _poll_clone_task(
-        connector=connector,
-        target=target,
-        operator=operator,
-        task_id=task_id,
-        timeout_seconds=timeout_seconds,
-    )
+    return {
+        "status": "completed",
+        "task_id": None,
+        "vm_id": vm_id,
+        "guidance": None,
+    }
 
 
 # ===========================================================================
-# vm.snapshot.revert
+# vm.snapshot.revert (VI-JSON -- #2970)
 # ===========================================================================
+#
+# The pinned vcenter.yaml serves NO snapshot resource at all (no
+# ``GET:/vcenter/vm/{vm}/snapshot``, no ``?action=revert`` path -- the
+# #2970 reconcile finding), so both halves ride vim: the listing is a
+# ``RetrievePropertiesEx`` read of ``VirtualMachine.snapshot``
+# (``VirtualMachineSnapshotInfo.rootSnapshotList``, a recursive
+# ``VirtualMachineSnapshotTree``), and the revert is the governed
+# ``VirtualMachineSnapshot.RevertToSnapshot_Task`` write polled to a
+# terminal state -- the #2893 substrate.
+
+
+def _build_single_prop_retrieve_params(mo_type: str, moid: str, prop: str) -> dict[str, Any]:
+    """Build a ``RetrievePropertiesEx`` body reading one property of one object.
+
+    A single ``PropertyFilterSpec`` scoped directly to the managed object;
+    the singleton ``propertyCollector`` moId rides the path, so the body is
+    only the method args (the shape the typed reads + the disk-grow /
+    clone-template config reads send).
+    """
+    return {
+        "specSet": [
+            {
+                "propSet": [{"type": mo_type, "pathSet": [prop]}],
+                "objectSet": [{"obj": {"type": mo_type, "value": moid}}],
+            }
+        ],
+        "options": {},
+    }
+
+
+def _extract_single_prop(retrieve_result: Any, prop: str) -> Any:
+    """Pull one property's ``val`` off a single-object RetrievePropertiesEx result."""
+    payload = _unwrap_value(retrieve_result)
+    objects = payload.get("objects", []) if isinstance(payload, dict) else payload
+    if not isinstance(objects, list):
+        return None
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        for entry in obj.get("propSet", []) or []:
+            if isinstance(entry, dict) and entry.get("name") == prop:
+                return entry.get("val")
+    return None
+
+
+def _flatten_snapshot_tree(nodes: Any) -> list[dict[str, Any]]:
+    """Flatten a ``VirtualMachineSnapshotTree`` list into ``{name, snapshot}`` rows.
+
+    Walks ``childSnapshotList`` depth-first. Each row carries the snapshot
+    display ``name`` and the ``VirtualMachineSnapshot`` moid (the MoRef's
+    ``value``) -- the same two keys the pre-#2970 REST listing rows carried,
+    so the ambiguity / not-found envelopes keep their candidate shape.
+    """
+    rows: list[dict[str, Any]] = []
+    if not isinstance(nodes, list):
+        return rows
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        moref = node.get("snapshot")
+        moid = moref.get("value") if isinstance(moref, dict) else None
+        name = node.get("name")
+        if isinstance(moid, str) and isinstance(name, str):
+            rows.append({"name": name, "snapshot": moid})
+        rows.extend(_flatten_snapshot_tree(node.get("childSnapshotList")))
+    return rows
 
 
 async def vm_snapshot_revert_composite(
@@ -1076,21 +1205,23 @@ async def vm_snapshot_revert_composite(
 
     Op-id: ``vmware.composite.vm.snapshot.revert``. Multiple snapshots
     sharing the name -> ``status='ambiguous'``; missing -> ``not_found``.
-    Revert never dispatches on either.
+    Revert never dispatches on either. The revert is a vim ``*_Task``:
+    a task fault raises (the dispatcher wraps it ``connector_error``);
+    a poll timeout returns ``status='timeout'`` with the task id.
     """
     vm_moid = params["vm"]
     snapshot_name = params["snapshot_name"]
 
-    listing = await _read_sub_op(
-        connector, target, operator, _OP_LIST_VM_SNAPSHOTS, {"vm": vm_moid}
+    tree_result = await connector._post_vmomi_json(
+        target,
+        _VMOMI_RETRIEVE_PROPERTIES_PATH,
+        operator=operator,
+        json=_build_single_prop_retrieve_params(_VIRTUAL_MACHINE_MO_TYPE, vm_moid, _PROP_SNAPSHOT),
     )
-    entries = _unwrap_value(listing)
-    if not isinstance(entries, list):
-        raise RuntimeError(
-            f"vm.snapshot.revert: expected list from {_OP_LIST_VM_SNAPSHOTS!r}, "
-            f"got {type(entries).__name__}"
-        )
-    matches = [e for e in entries if isinstance(e, dict) and e.get("name") == snapshot_name]
+    snapshot_info = _extract_single_prop(tree_result, _PROP_SNAPSHOT)
+    root_list = snapshot_info.get("rootSnapshotList") if isinstance(snapshot_info, dict) else None
+    entries = _flatten_snapshot_tree(root_list)
+    matches = [e for e in entries if e["name"] == snapshot_name]
     if not matches:
         return {
             "status": "not_found",
@@ -1108,23 +1239,41 @@ async def vm_snapshot_revert_composite(
                 "``snapshot_id`` explicitly to disambiguate"
             ),
         }
-    snapshot_moid = matches[0].get("snapshot")
-    if not isinstance(snapshot_moid, str):
-        return {
-            "status": "not_found",
-            "snapshot_id": None,
-            "candidates": matches,
-            "guidance": "matched snapshot row missing ``snapshot`` key",
-        }
-    gate, _ = await _write_sub_op(
+    snapshot_moid = matches[0]["snapshot"]
+    gate, task_payload = await _write_vmomi_sub_op(
         connector,
         target,
         operator,
-        _OP_REVERT_VM_SNAPSHOT,
-        {"vm": vm_moid, "snap": snapshot_moid},
+        op_id=_OP_REVERT_TO_SNAPSHOT_TASK,
+        vmomi_path=f"/{_VM_SNAPSHOT_MO_TYPE}/{snapshot_moid}/RevertToSnapshot_Task",
+        body={},
+        params={"vm": vm_moid, "snapshot_name": snapshot_name, "snapshot": snapshot_moid},
     )
     if gate is not None:
         return gate
+    outcome = await poll_vim_task(
+        connector,
+        target,
+        operator,
+        task=_unwrap_value(task_payload),
+        timeout_seconds=_SNAPSHOT_REVERT_TASK_TIMEOUT_SECONDS,
+    )
+    if outcome.state == TASK_STATE_ERROR:
+        raise RuntimeError(
+            f"vm.snapshot.revert: RevertToSnapshot_Task on vm {vm_moid!r} snapshot "
+            f"{snapshot_moid!r} faulted: {outcome.error_message or '<no fault reported>'}"
+        )
+    if outcome.timed_out:
+        return {
+            "status": "timeout",
+            "snapshot_id": snapshot_moid,
+            "candidates": [],
+            "guidance": (
+                f"RevertToSnapshot_Task {outcome.task} did not reach a terminal state "
+                f"within {int(_SNAPSHOT_REVERT_TASK_TIMEOUT_SECONDS)}s; poll the task -- "
+                "the revert may still complete in the background"
+            ),
+        }
     return {
         "status": "reverted",
         "snapshot_id": snapshot_moid,
@@ -1139,17 +1288,28 @@ async def vm_snapshot_revert_composite(
 
 
 def _pick_drs_target_host(recs: Any, vm_moid: str) -> str | None:
-    """Walk a DRS recommendations payload for ``vm_moid``'s target host."""
+    """Walk ``ClusterComputeResource.drsRecommendation`` for ``vm_moid``'s target.
+
+    The property is a ``ClusterDrsRecommendation[]``; each recommendation
+    carries a ``migrationList`` of ``ClusterDrsMigration`` rows whose
+    ``vm`` / ``destination`` MoRefs name the VM and its recommended target
+    host (spec-verified against the pinned ``vi-json.yaml``).
+    """
     if not isinstance(recs, list):
         return None
     for rec in recs:
         if not isinstance(rec, dict):
             continue
-        if rec.get("vm") != vm_moid:
-            continue
-        candidate = rec.get("target_host") or rec.get("host")
-        if isinstance(candidate, str):
-            return candidate
+        for migration in rec.get("migrationList") or []:
+            if not isinstance(migration, dict):
+                continue
+            vm_ref = migration.get("vm")
+            if not isinstance(vm_ref, dict) or vm_ref.get("value") != vm_moid:
+                continue
+            destination = migration.get("destination")
+            candidate = destination.get("value") if isinstance(destination, dict) else None
+            if isinstance(candidate, str):
+                return candidate
     return None
 
 
@@ -1164,7 +1324,10 @@ async def vm_migrate_composite(
 
     Op-id: ``vmware.composite.vm.migrate``. ``target_host`` overrides
     the DRS lookup. No-recommendation path returns
-    ``status='no_recommendation'`` so the caller can re-dispatch.
+    ``status='no_recommendation'`` so the caller can re-dispatch. The
+    DRS lookup is a vim ``RetrievePropertiesEx`` read of the cluster's
+    ``drsRecommendation`` property -- the pinned vcenter.yaml serves no
+    DRS REST resource at all (#2970).
 
     Also the recursion target of :func:`host_evacuate_composite`: invoked
     through ``dispatch_child`` there, the dispatcher resolves this composite
@@ -1181,14 +1344,16 @@ async def vm_migrate_composite(
         target_host = explicit_target
         source = "operator"
     else:
-        recs_payload = await _read_sub_op(
-            connector,
+        recs_payload = await connector._post_vmomi_json(
             target,
-            operator,
-            _OP_GET_DRS_RECOMMENDATIONS,
-            {"cluster": cluster_moid},
+            _VMOMI_RETRIEVE_PROPERTIES_PATH,
+            operator=operator,
+            json=_build_single_prop_retrieve_params(
+                _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, cluster_moid, _PROP_DRS_RECOMMENDATION
+            ),
         )
-        target_host = _pick_drs_target_host(_unwrap_value(recs_payload), vm_moid)
+        recommendations = _extract_single_prop(recs_payload, _PROP_DRS_RECOMMENDATION)
+        target_host = _pick_drs_target_host(recommendations, vm_moid)
         if target_host is not None:
             source = "drs"
 
@@ -1383,6 +1548,58 @@ async def vm_power_composite(
 # ===========================================================================
 
 
+async def _host_maintenance_vim_step(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    host_moid: str,
+    op_id: str,
+) -> tuple[OperationResult | None, str | None]:
+    """Run one governed vim maintenance transition on a host, polled to terminal.
+
+    The pinned vcenter.yaml serves no host-maintenance REST path (#2970);
+    enter / exit are the vim ``HostSystem.EnterMaintenanceMode_Task`` /
+    ``ExitMaintenanceMode_Task`` methods, whose request types carry a
+    required int ``timeout`` (``<= 0`` = no vim-side bound -- the poll's
+    wall clock is the bound here). Returns ``(gate, None)`` when the
+    governance seam parks/denies the write, ``(None, reason)`` when the
+    returned Task faults or the poll deadline elapses, ``(None, None)`` on
+    success. Shared by :func:`host_evacuate_composite` (enter) and
+    :func:`cluster_patch_composite` (enter + exit).
+    """
+    method_name = op_id.rsplit("/", 1)[-1]
+    gate, task_payload = await _write_vmomi_sub_op(
+        connector,
+        target,
+        operator,
+        op_id=op_id,
+        vmomi_path=f"/{_HOST_SYSTEM_MO_TYPE}/{host_moid}/{method_name}",
+        body={"timeout": _MAINTENANCE_VIM_TIMEOUT},
+        params={"host": host_moid},
+    )
+    if gate is not None:
+        return gate, None
+    outcome = await poll_vim_task(
+        connector,
+        target,
+        operator,
+        task=_unwrap_value(task_payload),
+        timeout_seconds=_MAINTENANCE_TASK_TIMEOUT_SECONDS,
+    )
+    if outcome.state == TASK_STATE_ERROR:
+        return None, (
+            f"{method_name} on host {host_moid!r} faulted: "
+            f"{outcome.error_message or '<no fault reported>'}"
+        )
+    if outcome.timed_out:
+        return None, (
+            f"{method_name} task {outcome.task} on host {host_moid!r} did not reach a "
+            f"terminal state within {int(_MAINTENANCE_TASK_TIMEOUT_SECONDS)}s"
+        )
+    return None, None
+
+
 def _classify_vm_migrate_outcome(
     migrate_result: OperationResult,
 ) -> tuple[bool, str]:
@@ -1465,11 +1682,21 @@ async def host_evacuate_composite(
                 "maintenance_entered": False,
             }
 
-    gate, _ = await _write_sub_op(
-        connector, target, operator, _host_maintenance_op_id("enter"), {"host": host_moid}
+    gate, reason = await _host_maintenance_vim_step(
+        connector=connector,
+        target=target,
+        operator=operator,
+        host_moid=host_moid,
+        op_id=_OP_ENTER_MAINTENANCE_TASK,
     )
     if gate is not None:
         return gate
+    if reason is not None:
+        # The maintenance-enter is the load-bearing final step; a task
+        # fault / poll timeout raises so the dispatcher wraps it
+        # ``connector_error`` (mirrors the pre-#2970 propagate-on-HTTPError
+        # semantics of the synchronous REST fiction).
+        raise RuntimeError(f"host.evacuate: {reason}")
     return {
         "status": "partial" if failed else "evacuated",
         "host": host_moid,
@@ -1484,6 +1711,53 @@ async def host_evacuate_composite(
 # ===========================================================================
 
 
+async def _repoint_vm_nics_to_fallback(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    vm_moid: str,
+    fallback_network: str,
+) -> tuple[OperationResult | None, str | None]:
+    """Repoint every NIC of one VM to *fallback_network* (standard portgroup).
+
+    The pinned spec serves no VM-level ``PATCH:/vcenter/vm/{vm}/network``
+    (#2970); NIC backing changes are per-adapter --
+    ``Vcenter.Vm.Hardware.Ethernet_list`` enumerates the adapters, then
+    each is updated via ``PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}``
+    with a ``STANDARD_PORTGROUP`` backing spec. Returns ``(gate, None)``
+    on a parked/denied write, ``(None, error)`` on a transport fault
+    (folded into the per-VM failure row), ``(None, None)`` on success.
+    """
+    listing = await _read_sub_op(connector, target, operator, _OP_LIST_VM_NICS, {"vm": vm_moid})
+    nic_rows = _unwrap_value(listing)
+    if not isinstance(nic_rows, list):
+        return None, f"expected list from {_OP_LIST_VM_NICS!r}, got {type(nic_rows).__name__}"
+    for row in nic_rows:
+        nic_id = row.get("nic") if isinstance(row, dict) else None
+        if not isinstance(nic_id, str):
+            continue
+        gate, _ = await _write_sub_op(
+            connector,
+            target,
+            operator,
+            _OP_UPDATE_VM_NIC,
+            {
+                "vm": vm_moid,
+                "nic": nic_id,
+                "spec": {
+                    "backing": {
+                        "type": _NIC_BACKING_STANDARD_PORTGROUP,
+                        "network": fallback_network,
+                    }
+                },
+            },
+        )
+        if gate is not None:
+            return gate, None
+    return None, None
+
+
 async def host_detach_from_vds_composite(
     *,
     operator: Operator,
@@ -1495,7 +1769,13 @@ async def host_detach_from_vds_composite(
 
     Op-id: ``vmware.composite.host.detach_from_vds``. Refuses the DVS
     detach when any NIC migration failed -- vSphere would reject the
-    step-4 detach anyway.
+    detach anyway. The detach itself is the vim
+    ``DistributedVirtualSwitch.ReconfigureDvs_Task`` (host member spec
+    with ``operation="remove"``): the pinned vcenter.yaml serves no DVS
+    write path at all (#2970). The spec's required ``configVersion`` is
+    read off ``config.configVersion`` first; the returned Task is polled
+    to a terminal state (fault raises; poll timeout returns
+    ``status='timeout'`` with the task id).
     """
     host_moid = params["host"]
     dvs_moid = params["dvs"]
@@ -1519,18 +1799,21 @@ async def host_detach_from_vds_composite(
         if not isinstance(vm_moid, str):
             continue
         try:
-            gate, _ = await _write_sub_op(
-                connector,
-                target,
-                operator,
-                _OP_ATTACH_VM_NIC,
-                {"vm": vm_moid, "spec": {"network": fallback_network}},
+            gate, failure = await _repoint_vm_nics_to_fallback(
+                connector=connector,
+                target=target,
+                operator=operator,
+                vm_moid=vm_moid,
+                fallback_network=fallback_network,
             )
         except httpx.HTTPError as exc:
             migration_failures.append({"vm": vm_moid, "error": str(exc)})
             continue
         if gate is not None:
             return gate
+        if failure is not None:
+            migration_failures.append({"vm": vm_moid, "error": failure})
+            continue
         vms_migrated.append(vm_moid)
 
     if migration_failures:
@@ -1541,15 +1824,66 @@ async def host_detach_from_vds_composite(
             "vms_migrated": vms_migrated,
         }
 
-    gate, _ = await _write_sub_op(
+    # ``DVSConfigSpec.configVersion`` must echo the switch's current
+    # ``DVSConfigInfo.configVersion`` for the reconfigure to be accepted.
+    config_result = await connector._post_vmomi_json(
+        target,
+        _VMOMI_RETRIEVE_PROPERTIES_PATH,
+        operator=operator,
+        json=_build_single_prop_retrieve_params(_DVS_MO_TYPE, dvs_moid, _PROP_DVS_CONFIG_VERSION),
+    )
+    config_version = _extract_single_prop(config_result, _PROP_DVS_CONFIG_VERSION)
+    if not isinstance(config_version, str):
+        raise RuntimeError(
+            f"host.detach_from_vds: could not read config.configVersion off dvs "
+            f"{dvs_moid!r} (payload={config_result!r})"
+        )
+
+    gate, task_payload = await _write_vmomi_sub_op(
         connector,
         target,
         operator,
-        _OP_REMOVE_DVS_HOST,
-        {"dvs": dvs_moid, "host": host_moid},
+        op_id=_OP_RECONFIGURE_DVS_TASK,
+        vmomi_path=f"/{_DVS_MO_TYPE}/{dvs_moid}/ReconfigureDvs_Task",
+        body={
+            "spec": {
+                "configVersion": config_version,
+                "host": [
+                    {
+                        "operation": "remove",
+                        "host": _moref(_HOST_SYSTEM_MO_TYPE, host_moid),
+                    }
+                ],
+            }
+        },
+        params={"dvs": dvs_moid, "host": host_moid},
     )
     if gate is not None:
         return gate
+    outcome = await poll_vim_task(
+        connector,
+        target,
+        operator,
+        task=_unwrap_value(task_payload),
+        timeout_seconds=_DVS_RECONFIGURE_TASK_TIMEOUT_SECONDS,
+    )
+    if outcome.state == TASK_STATE_ERROR:
+        raise RuntimeError(
+            f"host.detach_from_vds: ReconfigureDvs_Task on dvs {dvs_moid!r} (remove host "
+            f"{host_moid!r}) faulted: {outcome.error_message or '<no fault reported>'}"
+        )
+    if outcome.timed_out:
+        return {
+            "status": "timeout",
+            "host": host_moid,
+            "vm_migration_failures": [],
+            "vms_migrated": vms_migrated,
+            "guidance": (
+                f"ReconfigureDvs_Task {outcome.task} did not reach a terminal state within "
+                f"{int(_DVS_RECONFIGURE_TASK_TIMEOUT_SECONDS)}s; poll the task -- the "
+                "detach may still complete in the background"
+            ),
+        }
     return {
         "status": "detached",
         "host": host_moid,
@@ -1563,31 +1897,44 @@ async def host_detach_from_vds_composite(
 # ===========================================================================
 
 
-# Per-step (step-name, op_id) tuples. The op_id yields the concrete
-# ``?action=<verb>`` key per step; the patch step additionally carries a
-# ``method`` body field (the patch verb has a non-trivial body schema; the
-# maintenance verbs do not).
-_CLUSTER_PATCH_STEPS: tuple[tuple[str, str], ...] = (
-    ("maintenance_enter", _host_maintenance_op_id("enter")),
-    ("patch", _OP_HOST_PATCH),
-    ("maintenance_exit", _host_maintenance_op_id("exit")),
-)
-
-
-def _cluster_patch_step_params(
+async def _apply_host_software(
     *,
-    step: str,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
     host_moid: str,
-    patch_method: str,
-) -> dict[str, Any]:
-    """Build the per-step params dict for a cluster.patch sub-op.
+) -> tuple[OperationResult | None, str | None]:
+    """Fire the per-host vLCM apply and poll its cis task to a terminal state.
 
-    Action verbs live on the op_id (``?action=enter`` / ``?action=patch`` /
-    ``?action=exit``); only the patch step adds a body-shaped ``method``.
+    ``POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true``
+    (the pinned spec's only per-host remediation path -- #2970; the
+    fictional ``POST:/vcenter/host/{host}?action=patch`` never existed).
+    An empty ``Esx.Settings.Hosts.Software.ApplySpec`` (every field
+    optional) remediates to the latest desired-state commit. The 202 body
+    is the cis task id, polled via ``GET:/cis/tasks/{task}`` before the
+    host leaves maintenance -- exiting mid-remediation would defeat the
+    sequential rolling-patch contract.
     """
-    if step == "patch":
-        return {"host": host_moid, "method": patch_method}
-    return {"host": host_moid}
+    gate, apply_payload = await _write_sub_op(
+        connector, target, operator, _OP_HOST_SOFTWARE_APPLY, {"host": host_moid, "spec": {}}
+    )
+    if gate is not None:
+        return gate, None
+    task_id = _extract_cis_task_id(apply_payload)
+    if task_id is None:
+        return None, (
+            f"software apply on {host_moid!r} returned no cis task id (payload={apply_payload!r})"
+        )
+    reason = await _poll_cis_task(
+        connector=connector,
+        target=target,
+        operator=operator,
+        task_id=task_id,
+        timeout_seconds=_HOST_APPLY_TASK_TIMEOUT_SECONDS,
+    )
+    if reason is not None:
+        return None, f"software apply on {host_moid!r} failed: {reason}"
+    return None, None
 
 
 async def _patch_one_host(
@@ -1596,25 +1943,45 @@ async def _patch_one_host(
     target: Any,
     operator: Operator,
     host_moid: str,
-    patch_method: str,
 ) -> tuple[OperationResult | None, str | None]:
-    """Sequential maintenance + patch + exit on a single host.
+    """Sequential maintenance-enter + vLCM apply + maintenance-exit on one host.
 
-    Returns ``(gate, None)`` when a step's governance seam parks/denies the
-    write (the caller returns the :class:`OperationResult` verbatim),
-    ``(None, error_reason)`` when a step's transport fails, or
-    ``(None, None)`` on full success.
+    Maintenance transitions are vim ``*_Task`` methods polled to terminal
+    (:func:`_host_maintenance_vim_step`); the patch step is the cis-task-
+    polled vLCM apply (:func:`_apply_host_software`). Returns
+    ``(gate, None)`` when a step's governance seam parks/denies the write
+    (the caller returns the :class:`OperationResult` verbatim),
+    ``(None, error_reason)`` when a step fails (transport fault, task
+    fault, or poll timeout), or ``(None, None)`` on full success.
     """
-    for step, op_id in _CLUSTER_PATCH_STEPS:
-        step_params = _cluster_patch_step_params(
-            step=step, host_moid=host_moid, patch_method=patch_method
-        )
+    steps: tuple[tuple[str, Any], ...] = (
+        ("maintenance_enter", _OP_ENTER_MAINTENANCE_TASK),
+        ("patch", None),
+        ("maintenance_exit", _OP_EXIT_MAINTENANCE_TASK),
+    )
+    for step, maintenance_op_id in steps:
         try:
-            gate, _ = await _write_sub_op(connector, target, operator, op_id, step_params)
+            if maintenance_op_id is not None:
+                gate, reason = await _host_maintenance_vim_step(
+                    connector=connector,
+                    target=target,
+                    operator=operator,
+                    host_moid=host_moid,
+                    op_id=maintenance_op_id,
+                )
+            else:
+                gate, reason = await _apply_host_software(
+                    connector=connector,
+                    target=target,
+                    operator=operator,
+                    host_moid=host_moid,
+                )
         except httpx.HTTPError as exc:
             return None, f"{step} on {host_moid!r} failed: {exc}"
         if gate is not None:
             return gate, None
+        if reason is not None:
+            return None, f"{step} on {host_moid!r} failed: {reason}"
     return None, None
 
 
@@ -1632,7 +1999,6 @@ async def cluster_patch_composite(
     at once.
     """
     cluster_moid = params["cluster"]
-    patch_method = params.get("patch_method", "default")
 
     entries = await _resolve_cluster_hosts(
         connector=connector, target=target, operator=operator, cluster_moid=cluster_moid
@@ -1650,7 +2016,6 @@ async def cluster_patch_composite(
             target=target,
             operator=operator,
             host_moid=host_moid,
-            patch_method=patch_method,
         )
         if gate is not None:
             return gate

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -22,9 +22,9 @@ helpers, never the mutating sub-ops.
                           total_resolved}``
 ``host.detach_from_vds``  ``{host, dvs, fallback_network, resolved,
                           total_resolved}``
-``cluster.patch``         ``{cluster, patch_method, resolved, total_resolved}``
+``cluster.patch``         ``{cluster, resolved, total_resolved}``
 ``vm.create``             echo: name, guest_os, sizing, networks, power-on
-``vm.clone``              echo: source_vm, target_name, library_item, wait flag
+``vm.clone``              echo: source_vm, target_name, library_item
 ``vm.clone_from_template`` echo: source_template, new_vm_name, folder,
                           resource_pool, datastore, host, power_on,
                           customization_spec_name
@@ -286,7 +286,6 @@ async def _cluster_patch_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     )
     return {
         "cluster": cluster,
-        "patch_method": ctx.params.get("patch_method", "default"),
         **_capped_resolution(rows, _host_identity),
     }
 
@@ -330,7 +329,6 @@ async def _vm_clone_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         "source_vm": source_vm,
         "target_name": target_name,
         "library_item": library_item,
-        "wait_for_completion": bool(ctx.params.get("wait_for_completion", True)),
     }
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -275,12 +275,13 @@ NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA: dict[str, Any] = {
             "type": "string",
             "minLength": 1,
             "description": (
-                "Optional Distributed-Virtual-Switch managed-object ID. "
-                "When supplied, scopes the distributed-switch listing "
-                "(and thus the parent-DVS name enrichment) to this DVS. "
-                "Distributed portgroups are listed via the generic "
-                "network resource, which has no per-DVS filter, so the "
-                "returned portgroup set is not narrowed by this value."
+                "Accepted but inert (#2970 degradation): this only ever "
+                "scoped the distributed-switch listing that fed the "
+                "``dvs_name`` enrichment, and the pinned vcenter.yaml "
+                "serves no DVS list resource, so that step was dropped. "
+                "The generic network resource has no per-DVS filter "
+                "either, so the returned portgroup set was never "
+                "narrowed by this value."
             ),
         },
         "include_disconnected_vms": {
@@ -541,9 +542,10 @@ NETWORK_PORTGROUP_AUDIT_RESPONSE_SCHEMA: dict[str, Any] = {
                     "dvs_name": {
                         "type": ["string", "null"],
                         "description": (
-                            "Parent DVS display name resolved via the "
-                            "DVS listing; ``null`` when the parent DVS "
-                            "is unknown or unnamed."
+                            "Always ``null`` (#2970 degradation): the "
+                            "DVS listing that resolved display names is "
+                            "not served by the pinned spec. Key retained "
+                            "for response-envelope stability."
                         ),
                     },
                     "type": {
@@ -631,14 +633,30 @@ VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
                         "type": "string",
                         "description": "Network moid the NIC attaches to.",
                     },
+                    "backing_type": {
+                        "type": "string",
+                        "enum": [
+                            "STANDARD_PORTGROUP",
+                            "DISTRIBUTED_PORTGROUP",
+                            "OPAQUE_NETWORK",
+                        ],
+                        "default": "STANDARD_PORTGROUP",
+                        "description": (
+                            "``Ethernet.BackingSpec.type`` for the NIC's "
+                            "network backing. Defaults to a standard "
+                            "portgroup."
+                        ),
+                    },
                 },
                 "required": ["network"],
             },
             "default": [],
             "description": (
                 "Per-NIC spec. Each entry drives a "
-                "``PATCH:/vcenter/vm/{vm}/network`` after the VM is "
-                "created. Empty list creates the VM with no NICs."
+                "``POST:/vcenter/vm/{vm}/hardware/ethernet`` adapter "
+                "create (the network rides the ``backing`` spec) after "
+                "the VM is created. Empty list creates the VM with no "
+                "NICs."
             ),
         },
         "power_on_after_create": {
@@ -658,9 +676,10 @@ VM_CREATE_PARAMETER_SCHEMA: dict[str, Any] = {
 
 #: ``vmware.composite.vm.clone`` parameter schema.
 #:
-#: Orchestrates a content-library deploy. Long-running: blocks until
-#: the vSphere task completes or ``timeout_seconds`` elapses. The
-#: caller can opt into fire-and-forget via ``wait_for_completion=False``.
+#: Orchestrates a content-library deploy. The pinned spec's deploy
+#: operation is synchronous (its 200 body is the deployed VM id -- no
+#: ``vmw-task=true`` variant exists, #2970), so there is no task wait to
+#: configure.
 VM_CLONE_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -681,28 +700,9 @@ VM_CLONE_PARAMETER_SCHEMA: dict[str, Any] = {
             "type": "string",
             "minLength": 1,
             "description": (
-                "Content-library template item id. Passed to "
-                "``POST:/vcenter/vm-template/library-items?action=deploy``."
-            ),
-        },
-        "wait_for_completion": {
-            "type": "boolean",
-            "default": True,
-            "description": (
-                "When true (default), block on the vSphere task until "
-                "``timeout_seconds`` elapses. When false, return "
-                "immediately with the task id for caller-side polling."
-            ),
-        },
-        "timeout_seconds": {
-            "type": "integer",
-            "minimum": 1,
-            "default": 600,
-            "description": (
-                "Upper bound on the task wait when "
-                "``wait_for_completion=True``. On timeout the composite "
-                "returns ``status='timeout'`` with the task id; the "
-                "task itself may still complete in the background."
+                "Content-library template item id. Rides the deploy path as "
+                "``POST:/vcenter/vm-template/library-items/"
+                "{templateLibraryItem}?action=deploy``."
             ),
         },
     },
@@ -1029,17 +1029,6 @@ CLUSTER_PATCH_PARAMETER_SCHEMA: dict[str, Any] = {
             "minLength": 1,
             "description": "Cluster moid.",
         },
-        "patch_method": {
-            "type": "string",
-            "minLength": 1,
-            "default": "default",
-            "description": (
-                "Patch backend selector. The handler forwards the "
-                "string verbatim to the per-host patch sub-op so vendor "
-                "patch flows can dispatch into ``vlcm`` / ``vum`` / "
-                "``firmware`` without changing the composite's contract."
-            ),
-        },
     },
     "required": ["cluster"],
     "additionalProperties": False,
@@ -1239,32 +1228,28 @@ VM_CLONE_RESPONSE_SCHEMA: dict[str, Any] = {
     "properties": {
         "status": {
             "type": "string",
-            "enum": ["completed", "pending", "timeout"],
+            "enum": ["completed"],
             "description": (
-                "``'completed'`` when the deploy task finished and "
-                "wait_for_completion was true; ``'pending'`` when "
-                "wait_for_completion was false (caller-side polling); "
-                "``'timeout'`` when wait_for_completion expired."
+                "``'completed'`` -- the synchronous deploy returned the "
+                "new VM id. Deploy failures raise and surface as "
+                "``connector_error`` rather than a status."
             ),
         },
         "task_id": {
-            "type": "string",
+            "type": ["string", "null"],
             "description": (
-                "vSphere task id from the deploy. Always present so callers can poll independently."
+                "Always ``null``: the pinned deploy operation is "
+                "synchronous (no cis task). Key retained for "
+                "response-envelope stability (#2970)."
             ),
         },
         "vm_id": {
             "type": ["string", "null"],
-            "description": (
-                "New VM moid surfaced when the task completed. ``null`` on pending/timeout."
-            ),
+            "description": "Deployed VM moid (the deploy operation's 200 body).",
         },
         "guidance": {
             "type": ["string", "null"],
-            "description": (
-                "Operator-facing next-step hint on non-completed "
-                "statuses; ``null`` when ``status='completed'``."
-            ),
+            "description": "``null`` on ``status='completed'``.",
         },
     },
     "required": ["status", "task_id"],
@@ -1365,11 +1350,14 @@ VM_SNAPSHOT_REVERT_RESPONSE_SCHEMA: dict[str, Any] = {
     "properties": {
         "status": {
             "type": "string",
-            "enum": ["reverted", "ambiguous", "not_found"],
+            "enum": ["reverted", "ambiguous", "not_found", "timeout"],
             "description": (
                 "``'reverted'`` on a successful revert; "
                 "``'ambiguous'`` when multiple snapshots share the "
-                "name; ``'not_found'`` when no snapshot matches."
+                "name; ``'not_found'`` when no snapshot matches; "
+                "``'timeout'`` when the RevertToSnapshot_Task poll "
+                "deadline elapsed (the revert may still complete in "
+                "the background)."
             ),
         },
         "snapshot_id": {
@@ -1571,16 +1559,23 @@ HOST_DETACH_FROM_VDS_RESPONSE_SCHEMA: dict[str, Any] = {
     "properties": {
         "status": {
             "type": "string",
-            "enum": ["detached", "incomplete"],
+            "enum": ["detached", "incomplete", "timeout"],
             "description": (
                 "``'detached'`` -- every NIC migrated and the host "
                 "removed from the DVS; ``'incomplete'`` -- one or more "
-                "NIC migrations failed, the DVS detach was skipped."
+                "NIC migrations failed, the DVS detach was skipped; "
+                "``'timeout'`` -- the ReconfigureDvs_Task poll deadline "
+                "elapsed (the detach may still complete in the "
+                "background)."
             ),
         },
         "host": {
             "type": "string",
             "description": "Host moid the operator targeted.",
+        },
+        "guidance": {
+            "type": ["string", "null"],
+            "description": ("Operator hint on ``timeout``; absent/``null`` otherwise."),
         },
         "vm_migration_failures": {
             "type": "array",

--- a/backend/tests/acceptance/test_portgroup_audit_op_id_reconcile.py
+++ b/backend/tests/acceptance/test_portgroup_audit_op_id_reconcile.py
@@ -15,11 +15,15 @@ on a miss.
 
 The original constants (``GET:/vcenter/network/distributed-switch`` +
 ``GET:/vcenter/network/distributed-portgroup``, both singular) never
-resolved against a real ``vmware/9.0`` ingest:
+resolved against a real ``vmware/9.0`` ingest (#1602), and the plural
+``distributed-switches`` respelling #1602 shipped did not survive the
+first run against the canonical pinned spec either (#2970):
 
-* The vSphere Automation REST distributed-switch resource is **plural** --
-  ``GET:/vcenter/network/distributed-switches`` (a preview feature). The
-  singular spelling exists in no spec revision.
+* The pinned ``vcenter.yaml`` serves **no** distributed-switch list
+  resource at all -- the plural path exists only under the NSX-scoped
+  ``/vcenter/namespace-management/networks/nsx/`` tree. The audit's
+  DVS-list step was therefore dropped (parent-DVS name enrichment
+  degraded; see the handler's degradation note).
 * There is **no** dedicated distributed-portgroup list resource at all;
   distributed portgroups are enumerated via the generic
   ``GET:/vcenter/network`` resource filtered to the
@@ -65,17 +69,21 @@ def test_portgroup_audit_sub_op_constants_are_the_reconciled_rest_keys() -> None
     The spec-backed guard below skips when the vendor specs are not
     configured; this test runs everywhere and freezes the exact
     ``METHOD:/path`` keys the REST Automation ingest produces, so a
-    regression to the singular ``distributed-switch`` /
-    ``distributed-portgroup`` spelling (the #1602 defect) is caught
-    even without the spec shelf.
+    regression to the dropped ``distributed-switch(es)`` /
+    ``distributed-portgroup`` spellings (the #1602 defect, re-litigated
+    against the real shelf in #2970) is caught even without the spec
+    shelf.
     """
-    assert _read._OP_LIST_DVS == "GET:/vcenter/network/distributed-switches"
     assert _read._OP_LIST_NETWORK == "GET:/vcenter/network"
     assert _read._SUB_OPS_NETWORK_PORTGROUP_AUDIT == (
-        "GET:/vcenter/network/distributed-switches",
         "GET:/vcenter/network",
         "GET:/vcenter/vm",
     )
+    # #2970: no DVS-list constant exists any more -- the pinned spec serves
+    # no distributed-switch list resource (the plural path #1602 repointed
+    # to lives only under /vcenter/namespace-management/, NSX-scoped), so
+    # the audit's DVS enrichment step was dropped rather than repointed.
+    assert not hasattr(_read, "_OP_LIST_DVS")
 
 
 def test_portgroup_audit_sub_ops_resolve_against_pinned_vcenter_spec() -> None:

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -743,7 +743,7 @@ async def test_vm_create_composite_over_modern_mount(
         mock.post("/api/session").respond(200, json=SESSION_TOKEN)
         mock.get("/api/vcenter/folder").respond(200, json=[{"folder": "group-1", "name": "prod"}])
         create_route = mock.post("/api/vcenter/vm").respond(200, json="vm-1")
-        nic_route = mock.patch("/api/vcenter/vm/vm-1/network").respond(200, json={})
+        nic_route = mock.post("/api/vcenter/vm/vm-1/hardware/ethernet").respond(200, json="nic-1")
         power_route = mock.post("/api/vcenter/vm/vm-1/power").respond(200, json={})
         mock.delete("/api/session").respond(204)
         try:
@@ -773,6 +773,9 @@ async def test_vm_create_composite_over_modern_mount(
     create_body = json.loads(create_route.calls.last.request.content)
     assert create_body["spec"]["name"] == "web-01"
     assert create_body["spec"]["placement"]["folder"] == "group-1"
+    # The NIC create body is the Ethernet.CreateSpec backing shape (#2970).
+    nic_body = json.loads(nic_route.calls.last.request.content)
+    assert nic_body["spec"]["backing"] == {"type": "STANDARD_PORTGROUP", "network": "net-1"}
 
 
 @pytest.mark.asyncio
@@ -782,9 +785,11 @@ async def test_cluster_patch_composite_over_legacy_mount_routes_to_rest(
     """A legacy-only target mounts cluster.patch's writes onto /rest.
 
     The modern ``POST /api/session`` 404s, the connector falls back to the
-    legacy path, and every write sub-op (maintenance enter/exit PATCH, host
-    patch POST) must route through ``/rest`` via ``mount_op_path`` or it 404s
-    — the modern+legacy mount coverage on the #2256 write path.
+    legacy path, and every sub-op must route through ``/rest``: the host
+    listing GET, the vim maintenance ``*_Task`` methods + their ``Task.info``
+    polls (a legacy session mounts vmomi paths onto ``/rest`` too, per
+    ``_post_vmomi_json``), the vLCM apply POST, and its cis-task poll — the
+    modern+legacy mount coverage on the #2256 write path, post-#2970.
     """
     from meho_backplane.connectors.vmware_rest.composites._write import cluster_patch_composite
 
@@ -793,6 +798,21 @@ async def test_cluster_patch_composite_over_legacy_mount_routes_to_rest(
 
     connector = VmwareRestConnector(session_loader=_loader)
 
+    def _task_info_success(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        task_moid = body["specSet"][0]["objectSet"][0]["obj"]["value"]
+        return httpx.Response(
+            200,
+            json={
+                "objects": [
+                    {
+                        "obj": {"type": "Task", "value": task_moid},
+                        "propSet": [{"name": "info", "val": {"state": "success"}}],
+                    }
+                ]
+            },
+        )
+
     async with respx.mock(
         base_url=VCENTER_BASE_URL,
         assert_all_called=False,
@@ -800,9 +820,22 @@ async def test_cluster_patch_composite_over_legacy_mount_routes_to_rest(
     ) as mock:
         mock.post("/api/session").respond(404)
         mock.post("/rest/com/vmware/cis/session").respond(200, json=SESSION_TOKEN)
-        mock.get("/rest/vcenter/cluster/domain-c1/host").respond(200, json=[{"host": "host-1"}])
-        enter_route = mock.patch("/rest/vcenter/host/host-1/maintenance").respond(200, json={})
-        patch_route = mock.post("/rest/vcenter/host/host-1").respond(200, json={})
+        mock.get("/rest/vcenter/host").respond(200, json=[{"host": "host-1"}])
+        enter_route = mock.post("/rest/HostSystem/host-1/EnterMaintenanceMode_Task").respond(
+            200, json={"type": "Task", "value": "t-enter-1"}
+        )
+        exit_route = mock.post("/rest/HostSystem/host-1/ExitMaintenanceMode_Task").respond(
+            200, json={"type": "Task", "value": "t-exit-1"}
+        )
+        mock.post("/rest/PropertyCollector/propertyCollector/RetrievePropertiesEx").mock(
+            side_effect=_task_info_success
+        )
+        apply_route = mock.post("/rest/esx/settings/hosts/host-1/software").respond(
+            200, json="task-apply-1"
+        )
+        cis_route = mock.get("/rest/cis/tasks/task-apply-1").respond(
+            200, json={"value": {"status": "SUCCEEDED"}}
+        )
         mock.delete("/rest/com/vmware/cis/session").respond(204)
         try:
             out = await cluster_patch_composite(
@@ -816,9 +849,13 @@ async def test_cluster_patch_composite_over_legacy_mount_routes_to_rest(
 
     assert out["status"] == "completed"
     assert out["patched_hosts"] == ["host-1"]
-    # maintenance enter + exit both hit the same PATCH route; the patch POST hit /rest.
-    assert enter_route.call_count == 2
-    assert patch_route.called
+    # Every step routed through /rest: vim enter/exit, the vLCM apply
+    # (with its ?action=apply&vmw-task=true query), and the cis poll.
+    assert enter_route.called
+    assert exit_route.called
+    assert apply_route.called
+    assert "action=apply" in str(apply_route.calls.last.request.url)
+    assert cis_route.called
 
 
 @pytest.mark.asyncio
@@ -857,18 +894,57 @@ async def test_host_evacuate_recursion_over_modern_mount(
         )
         return OperationResult(status="ok", op_id=op_id, result=inner, duration_ms=1.0)
 
+    def _vmomi_reads(request: httpx.Request) -> httpx.Response:
+        # One RetrievePropertiesEx route serves both the recursion's DRS
+        # read (ClusterComputeResource) and the maintenance Task.info poll.
+        body = json.loads(request.content)
+        spec = body["specSet"][0]
+        spec_type = spec["propSet"][0]["type"]
+        moid = spec["objectSet"][0]["obj"]["value"]
+        if spec_type == "ClusterComputeResource":
+            val: Any = [
+                {
+                    "migrationList": [
+                        {
+                            "vm": {"type": "VirtualMachine", "value": "vm-a"},
+                            "destination": {"type": "HostSystem", "value": "host-target"},
+                        }
+                    ]
+                }
+            ]
+            prop = "drsRecommendation"
+        else:
+            assert spec_type == "Task", spec_type
+            val = {"state": "success"}
+            prop = "info"
+        return httpx.Response(
+            200,
+            json={
+                "objects": [
+                    {
+                        "obj": {"type": spec_type, "value": moid},
+                        "propSet": [{"name": prop, "val": val}],
+                    }
+                ]
+            },
+        )
+
     async with respx.mock(
         base_url=VCENTER_BASE_URL,
         assert_all_called=False,
         assert_all_mocked=False,
     ) as mock:
         mock.post("/api/session").respond(200, json=SESSION_TOKEN)
+        # The vmomi calls derive their VI-JSON {release} from about.version (#2466).
+        mock.get("/api/about").respond(200, json=ABOUT_PAYLOAD)
         mock.get("/api/vcenter/vm").respond(200, json=[{"vm": "vm-a", "cluster": "domain-c1"}])
-        mock.get("/api/vcenter/cluster/domain-c1/drs/recommendations").respond(
-            200, json=[{"vm": "vm-a", "target_host": "host-target"}]
-        )
+        mock.post(
+            "/sdk/vim25/9.0.0.0/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+        ).mock(side_effect=_vmomi_reads)
         relocate_route = mock.post("/api/vcenter/vm/vm-a").respond(200, json={})
-        maintenance_route = mock.patch("/api/vcenter/host/host-1/maintenance").respond(200, json={})
+        maintenance_route = mock.post(
+            "/sdk/vim25/9.0.0.0/HostSystem/host-1/EnterMaintenanceMode_Task"
+        ).respond(200, json={"type": "Task", "value": "t-enter-1"})
         mock.delete("/api/session").respond(204)
         try:
             out = await host_evacuate_composite(
@@ -884,12 +960,14 @@ async def test_host_evacuate_recursion_over_modern_mount(
     assert out["status"] == "evacuated"
     assert out["migrated_vms"] == ["vm-a"]
     assert out["maintenance_entered"] is True
-    # The recursion's relocate write and the host maintenance-enter write both
-    # reached the /api session.
+    # The recursion's relocate write reached the /api session; the
+    # maintenance-enter reached the VI-JSON mount (#2970).
     assert relocate_route.called
     assert maintenance_route.called
     relocate_body = json.loads(relocate_route.calls.last.request.content)
     assert relocate_body["spec"]["placement"]["host"] == "host-target"
+    enter_body = json.loads(maintenance_route.calls.last.request.content)
+    assert enter_body == {"timeout": 0}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -3,15 +3,18 @@
 
 """op_id reconciliation between the write composites and the ingest pipeline.
 
-G3.16-T1 (#1414). The 14 REST-sub-op vmware-rest write composites each
+G3.16-T1 (#1414). The 13 REST-sub-op vmware-rest write composites each
 declare the L2 sub-ops they dispatch into via ``_SUB_OPS_*`` tuples in
-:mod:`~meho_backplane.connectors.vmware_rest.composites._write` (the nine
+:mod:`~meho_backplane.connectors.vmware_rest.composites._write` (the
 T6/#509 + vm.power writes, the #2891 hardware trio, and the two GOSC
 composites / #2892); the four vi-json write composites (``vm.disk.grow`` /
 #2893, ``vm.clone_from_template`` / #2894, and the vim cluster / inventory
 writes ``cluster.drs_rule.create`` + ``folder.create`` / #2895) dispatch
 into vi-json instead and declare their sub-ops in ``_VIM_SUB_OPS_*`` tuples
-(reconciled in the dedicated vi-json section at the end of this module). At
+(reconciled in the dedicated vi-json section at the end of this module),
+as do the composite steps #2970 switched to vim because the pinned
+vcenter.yaml serves no REST path for them (snapshot list/revert, host
+maintenance, DRS recommendations, DVS host removal). At
 dispatch time :func:`~...composites._preflight.preflight_l2_dependencies`
 looks each sub-op_id up in ``endpoint_descriptor`` and raises
 :class:`~meho_backplane.operations.composite.CompositeL2DependencyMissing`
@@ -29,8 +32,7 @@ the parser emits from ``vcenter.yaml``. The two surfaces that could drift:
   query suffix *in the path key itself* (it does not model the verb as a
   body/query parameter on a shared base path). The parser passes the path
   key through verbatim into the op_id, so the action suffix survives. The
-  composites' ``_power_vm_op_id`` / ``_host_maintenance_op_id`` helpers
-  build the same string.
+  composites' ``_power_vm_op_id`` helper builds the same string.
 
 This module proves the match automatically, without a live backplane:
 
@@ -105,13 +107,13 @@ _GETADDRINFO_PATCH = patch(
 
 
 def _required_raw_sub_op_ids() -> set[str]:
-    """Union of every ``_SUB_OPS_*`` op_id across the 14 REST write composites.
+    """Union of every ``_SUB_OPS_*`` op_id across the 13 REST write composites.
 
-    The four vi-json write composites' sub-ops live in ``_VIM_SUB_OPS_*``
-    tuples (a distinct namespace this ``_SUB_OPS_*`` sweep deliberately
-    skips), so a vcenter.yaml-shaped fixture never has to model a vi-json
-    path; the vi-json section at the end of this module reconciles them
-    separately.
+    The vi-json sub-ops live in ``_VIM_SUB_OPS_*`` tuples (a distinct
+    namespace this ``_SUB_OPS_*`` sweep deliberately skips), so a
+    vcenter.yaml-shaped fixture never has to model a vi-json path; the
+    vi-json sections at the end of this module reconcile them separately
+    (the four vi-json write composites plus the #2970 vim-switched steps).
 
     Excludes composite-to-composite references (``vmware.composite.*``):
     those are not ``endpoint_descriptor`` rows and the pre-flight walk
@@ -131,11 +133,15 @@ def _required_raw_sub_op_ids() -> set[str]:
 def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
     """Guard: the introspection finds every write composite's sub-op tuple.
 
-    Fourteen ``_SUB_OPS_*`` module constants today, one per REST write
-    composite (the nine T6/#509 + vm.power writes, the #2891 hardware trio,
-    plus the two GOSC composites / #2892). Pinning the exact set means a
-    renamed or dropped constant can't silently shrink the reconciled set to
-    a vacuous pass.
+    Thirteen ``_SUB_OPS_*`` module constants today (the T6/#509 + vm.power
+    writes, the #2891 hardware trio, plus the two GOSC composites / #2892).
+    ``vm.snapshot.revert`` no longer appears: both of its sub-ops moved to
+    the vim surface in #2970 (the pinned vcenter.yaml serves no snapshot
+    REST resource), so its manifest lives in
+    ``_VIM_SUB_OPS_VM_SNAPSHOT_REVERT`` and is reconciled against
+    ``vi-json.yaml`` below. Pinning the exact set means a renamed or
+    dropped constant can't silently shrink the reconciled set to a
+    vacuous pass.
     """
     tuple_names = sorted(n for n in dir(_write) if n.startswith("_SUB_OPS_"))
     assert tuple_names == [
@@ -152,7 +158,6 @@ def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
         "_SUB_OPS_VM_POWER",
         "_SUB_OPS_VM_POWER_BULK",
         "_SUB_OPS_VM_RESIZE",
-        "_SUB_OPS_VM_SNAPSHOT_REVERT",
     ]
 
 
@@ -245,10 +250,13 @@ def test_action_discriminated_sub_ops_keep_query_suffix_through_ingest() -> None
     """
     action_op_ids = {op_id for op_id in _required_raw_sub_op_ids() if "?action=" in op_id}
     # Sanity: the write composites really do depend on action-bearing ops.
+    # (Host maintenance left this set in #2970 -- it is vim-only in the
+    # pinned spec; the vLCM apply carries the compound
+    # ``?action=apply&vmw-task=true`` suffix instead.)
     assert {
         "POST:/vcenter/vm/{vm}/power?action=start",
         "POST:/vcenter/vm/{vm}/power?action=stop",
-        "PATCH:/vcenter/host/{host}/maintenance?action=enter",
+        "POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true",
         "POST:/vcenter/vm/{vm}?action=relocate",
     } <= action_op_ids
 
@@ -581,4 +589,88 @@ def test_folder_create_vi_json_paths_exist_in_the_pinned_spec() -> None:
         assert _vi_json_path_item_has_post(spec_text, path), (
             f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
             "folder.create vi-json sub-op targets a path the spec does not serve"
+        )
+
+
+# ---------------------------------------------------------------------------
+# #2970 vim-switched composite steps — snapshot revert, DRS recommendations,
+# host maintenance, DVS host removal. The pinned vcenter.yaml serves no REST
+# path for any of these surfaces, so the affected steps ride vim and their
+# manifests reconcile against the pinned vi-json.yaml like the #2893-#2895
+# write composites above.
+# ---------------------------------------------------------------------------
+
+#: Expected #2970 vim manifests, pinned so a drift can't shrink a reconcile.
+_EXPECTED_2970_VIM_MANIFESTS: dict[str, set[str]] = {
+    "_VIM_SUB_OPS_VM_SNAPSHOT_REVERT": {
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/VirtualMachineSnapshot/{moId}/RevertToSnapshot_Task",
+    },
+    "_VIM_SUB_OPS_VM_MIGRATE": {
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+    },
+    "_VIM_SUB_OPS_HOST_EVACUATE": {
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/HostSystem/{moId}/EnterMaintenanceMode_Task",
+    },
+    "_VIM_SUB_OPS_CLUSTER_PATCH": {
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/HostSystem/{moId}/EnterMaintenanceMode_Task",
+        "POST:/HostSystem/{moId}/ExitMaintenanceMode_Task",
+    },
+    "_VIM_SUB_OPS_HOST_DETACH_FROM_VDS": {
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+        "POST:/DistributedVirtualSwitch/{moId}/ReconfigureDvs_Task",
+    },
+}
+
+
+@pytest.mark.parametrize("manifest_name", sorted(_EXPECTED_2970_VIM_MANIFESTS))
+def test_2970_vim_sub_op_manifests_are_pinned(manifest_name: str) -> None:
+    """Pin each #2970 vim manifest so a drift can't shrink the reconcile."""
+    assert set(getattr(_write, manifest_name)) == _EXPECTED_2970_VIM_MANIFESTS[manifest_name]
+
+
+@pytest.mark.parametrize("manifest_name", sorted(_EXPECTED_2970_VIM_MANIFESTS))
+def test_2970_vim_sub_ops_round_trip_through_ingest(manifest_name: str) -> None:
+    """The #2970 vim op_ids are byte-for-byte what ``parse_openapi`` emits.
+
+    Same proof shape as the #2893-#2895 round-trips above: the ``{moId}``
+    path template survives the parser, so governance op_ids / grants
+    resolve against the ingested rows once ``vi-json.yaml`` is ingested.
+    """
+    required = set(getattr(_write, manifest_name))
+    spec = _build_vcenter_fixture(required)
+    spec_bytes = json.dumps(spec).encode()
+    spec_url = "https://specs.example.test/vi-json.yaml"
+
+    with _GETADDRINFO_PATCH, respx.mock(assert_all_called=False) as router:
+        router.get(spec_url).mock(
+            return_value=httpx.Response(
+                200, content=spec_bytes, headers={"content-type": "application/json"}
+            )
+        )
+        rows = parse_openapi(spec_url, spec_source="spec:vi-json.yaml")
+    ingested_op_ids = {row.op_id for row in rows}
+    assert required <= ingested_op_ids
+
+
+@pytest.mark.parametrize("manifest_name", sorted(_EXPECTED_2970_VIM_MANIFESTS))
+def test_2970_vim_paths_exist_in_the_pinned_spec(manifest_name: str) -> None:
+    """Each #2970 vim sub-op path is a real POST path in the pinned vi-json.yaml.
+
+    The definitive #2970 grounding: the vim-switched steps must target
+    paths the pinned spec actually serves. Skips when the spec-shelf is
+    not configured (the canary's convention), so CI is the
+    operator-visible signal.
+    """
+    spec_path = resolve_vi_json_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    spec_text = spec_path.read_text(encoding="utf-8")
+    for op_id in getattr(_write, manifest_name):
+        _, _, path = op_id.partition(":")
+        assert _vi_json_path_item_has_post(spec_text, path), (
+            f"{path!r} is not a POST path item in the pinned vi-json.yaml — the "
+            f"{manifest_name} vim sub-op targets a path the spec does not serve"
         )

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -785,9 +785,13 @@ async def test_datastore_usage_detail_error_propagates() -> None:
 
 
 @pytest.mark.asyncio
-async def test_network_portgroup_audit_reads_three_phases() -> None:
-    """DVS + portgroup listings + per-portgroup VM listings aggregate to the expected shape."""
-    dvs_listing = [{"vds": "dvs-1", "name": "DVS-A"}]
+async def test_network_portgroup_audit_reads_two_phases() -> None:
+    """Portgroup listing + per-portgroup VM listings aggregate to the expected shape.
+
+    Two phases post-#2970: the DVS-listing step was dropped (the pinned
+    vcenter.yaml serves no DVS list resource), so ``dvs_name`` is always
+    ``None`` and ``dvs`` is the pg row's own best-effort field.
+    """
     pg_listing = [
         {"network": "pg-1", "name": "PG-A", "vds": "dvs-1", "type": "DISTRIBUTED_PORTGROUP"},
         {"network": "pg-2", "name": "PG-B", "type": "DISTRIBUTED_PORTGROUP"},
@@ -796,7 +800,7 @@ async def test_network_portgroup_audit_reads_three_phases() -> None:
         "pg-1": [{"name": "vm-pg1-a"}, {"name": "vm-pg1-b"}],
         "pg-2": [],
     }
-    sequence: list[Any] = [dvs_listing, pg_listing]
+    sequence: list[Any] = [pg_listing]
     for pg in pg_listing:
         sequence.append(vms_per_pg[pg["network"]])
     conn = _RecordingConnector(sequence)
@@ -808,16 +812,15 @@ async def test_network_portgroup_audit_reads_three_phases() -> None:
         connector=conn,  # type: ignore[arg-type]
     )
 
-    # 1 + 1 + 2 portgroups = 4 calls.
-    assert len(conn.calls) == 4
-    assert conn.calls[0]["path"] == "/api/vcenter/network/distributed-switches"
+    # 1 + 2 portgroups = 3 calls (no DVS listing -- #2970).
+    assert len(conn.calls) == 3
     # Portgroups come from the generic network resource, type-filtered.
     # On the modern /api mount the filter params are sent bare (#2298).
-    assert conn.calls[1]["path"] == "/api/vcenter/network"
-    assert conn.calls[1]["query"] == {"types": ["DISTRIBUTED_PORTGROUP"]}
+    assert conn.calls[0]["path"] == "/api/vcenter/network"
+    assert conn.calls[0]["query"] == {"types": ["DISTRIBUTED_PORTGROUP"]}
     # Per-PG VM call filters by network + power state, bare on /api.
-    assert conn.calls[2]["path"] == "/api/vcenter/vm"
-    assert conn.calls[2]["query"] == {
+    assert conn.calls[1]["path"] == "/api/vcenter/vm"
+    assert conn.calls[1]["query"] == {
         "networks": ["pg-1"],
         "power_states": ["POWERED_ON"],
     }
@@ -826,7 +829,7 @@ async def test_network_portgroup_audit_reads_three_phases() -> None:
             "id": "pg-1",
             "name": "PG-A",
             "dvs": "dvs-1",
-            "dvs_name": "DVS-A",
+            "dvs_name": None,
             "type": "DISTRIBUTED_PORTGROUP",
             "vm_count": 2,
             "vm_names": ["vm-pg1-a", "vm-pg1-b"],
@@ -844,9 +847,13 @@ async def test_network_portgroup_audit_reads_three_phases() -> None:
 
 
 @pytest.mark.asyncio
-async def test_network_portgroup_audit_filter_dvs_scopes_dvs_listing_only() -> None:
-    """``filter_dvs`` scopes the DVS listing; the portgroup call is type-only."""
-    sequence = [[], []]
+async def test_network_portgroup_audit_filter_dvs_is_inert() -> None:
+    """``filter_dvs`` is accepted but changes nothing (#2970 degradation).
+
+    It only ever scoped the dropped DVS listing; the portgroup call stays
+    type-filtered only, and no extra sub-op fires.
+    """
+    sequence: list[Any] = [[]]
     conn = _RecordingConnector(sequence)
     await network_portgroup_audit_composite(
         operator=_make_operator(),
@@ -854,16 +861,15 @@ async def test_network_portgroup_audit_filter_dvs_scopes_dvs_listing_only() -> N
         params={"filter_dvs": "dvs-prod"},
         connector=conn,  # type: ignore[arg-type]
     )
-    assert conn.calls[0]["query"] == {"vdses": ["dvs-prod"]}
-    # Portgroup call is type-filtered only -- no vdses filter.
-    assert conn.calls[1]["query"] == {"types": ["DISTRIBUTED_PORTGROUP"]}
+    assert len(conn.calls) == 1
+    # Portgroup call is type-filtered only -- no vdses filter anywhere.
+    assert conn.calls[0]["query"] == {"types": ["DISTRIBUTED_PORTGROUP"]}
 
 
 @pytest.mark.asyncio
 async def test_network_portgroup_audit_include_disconnected_drops_power_filter() -> None:
     """``include_disconnected_vms=True`` removes the ``POWERED_ON`` filter on the VM call."""
     sequence = [
-        [],
         [{"network": "pg-1", "name": "PG-A", "type": "DISTRIBUTED_PORTGROUP"}],
         [],
     ]
@@ -874,7 +880,7 @@ async def test_network_portgroup_audit_include_disconnected_drops_power_filter()
         params={"include_disconnected_vms": True},
         connector=conn,  # type: ignore[arg-type]
     )
-    vm_call = conn.calls[2]
+    vm_call = conn.calls[1]
     assert "networks" in vm_call["query"]
     assert "power_states" not in vm_call["query"]
 
@@ -919,21 +925,19 @@ async def test_portgroup_audit_keeps_filter_prefix_on_legacy_mount() -> None:
     ``filter.networks`` / ``filter.power_states`` on the legacy mount vcsim
     serves, or the existing vcsim fixtures break.
     """
-    dvs_listing = [{"vds": "dvs-1", "name": "DVS-A"}]
     pg_listing = [{"network": "pg-1", "name": "PG-A", "type": "DISTRIBUTED_PORTGROUP"}]
     conn = _RecordingConnector(
-        [dvs_listing, pg_listing, [{"name": "vm-a"}]],
+        [pg_listing, [{"name": "vm-a"}]],
         mount_prefix="/rest",
     )
     await network_portgroup_audit_composite(
         operator=_make_operator(),
         target=object(),
-        params={"filter_dvs": "dvs-1"},
+        params={},
         connector=conn,  # type: ignore[arg-type]
     )
-    assert conn.calls[0]["query"] == {"filter.vdses": ["dvs-1"]}
-    assert conn.calls[1]["query"] == {"filter.types": ["DISTRIBUTED_PORTGROUP"]}
-    assert conn.calls[2]["query"] == {
+    assert conn.calls[0]["query"] == {"filter.types": ["DISTRIBUTED_PORTGROUP"]}
+    assert conn.calls[1]["query"] == {
         "filter.networks": ["pg-1"],
         "filter.power_states": ["POWERED_ON"],
     }

--- a/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_recursive_e2e.py
@@ -72,9 +72,9 @@ from meho_backplane.settings import get_settings
 # each runs directly on the connector session (no descriptor row, no audit
 # row) -- the test asserts these paths produce ZERO ``AuditLog`` rows.
 _LEAF_OP_LIST_VMS = "GET:/vcenter/vm"
-_LEAF_OP_GET_DRS_RECS = "GET:/vcenter/cluster/{cluster}/drs/recommendations"
+_LEAF_OP_GET_DRS_RECS = "POST:/PropertyCollector/{moId}/RetrievePropertiesEx"
 _LEAF_OP_RELOCATE_VM = "POST:/vcenter/vm/{vm}?action=relocate"
-_LEAF_OP_HOST_MAINTENANCE_ENTER = "PATCH:/vcenter/host/{host}/maintenance?action=enter"
+_LEAF_OP_HOST_MAINTENANCE_ENTER = "POST:/HostSystem/{moId}/EnterMaintenanceMode_Task"
 
 
 # ---------------------------------------------------------------------------
@@ -220,6 +220,35 @@ class _DepthRecordingConnector:
         self.calls.append((verb, spec))
         return self.responses.get(spec, {"value": {}})
 
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        """Serve the vim sub-calls the #2970-switched steps issue.
+
+        The DRS read (depth 1, inside the recursion) + the maintenance
+        ``*_Task`` + its ``Task.info`` poll (depth 0). Same keying as the
+        write-e2e recorder: method paths verbatim, ``RetrievePropertiesEx``
+        by queried object type with a default terminal-success Task read.
+        """
+        self.depths.append(composite_depth_var.get())
+        self.calls.append(("VMOMI", path))
+        if path.endswith("/RetrievePropertiesEx"):
+            spec_type = json["specSet"][0]["propSet"][0]["type"]
+            if spec_type in self.responses:
+                return self.responses[spec_type]
+            if spec_type == "Task":
+                task_moid = json["specSet"][0]["objectSet"][0]["obj"]["value"]
+                return {
+                    "objects": [
+                        {
+                            "obj": {"type": "Task", "value": task_moid},
+                            "propSet": [{"name": "info", "val": {"state": "success"}}],
+                        }
+                    ]
+                }
+            raise AssertionError(f"unexpected RetrievePropertiesEx type {spec_type!r}")
+        return self.responses[path]
+
 
 # ---------------------------------------------------------------------------
 # Tests
@@ -252,11 +281,49 @@ async def test_host_evacuate_e2e_through_production_dispatch_audit_tree(
                     {"vm": "vm-bb", "cluster": "cluster-1"},
                 ]
             },
-            "/vcenter/cluster/cluster-1/drs/recommendations": {
-                "value": [
-                    {"vm": "vm-aa", "target_host": "host-target"},
-                    {"vm": "vm-bb", "target_host": "host-target"},
+            # vim drsRecommendation property read (#2970), keyed by object type.
+            "ClusterComputeResource": {
+                "objects": [
+                    {
+                        "obj": {"type": "ClusterComputeResource", "value": "cluster-1"},
+                        "propSet": [
+                            {
+                                "name": "drsRecommendation",
+                                "val": [
+                                    {
+                                        "migrationList": [
+                                            {
+                                                "vm": {
+                                                    "type": "VirtualMachine",
+                                                    "value": "vm-aa",
+                                                },
+                                                "destination": {
+                                                    "type": "HostSystem",
+                                                    "value": "host-target",
+                                                },
+                                            },
+                                            {
+                                                "vm": {
+                                                    "type": "VirtualMachine",
+                                                    "value": "vm-bb",
+                                                },
+                                                "destination": {
+                                                    "type": "HostSystem",
+                                                    "value": "host-target",
+                                                },
+                                            },
+                                        ]
+                                    }
+                                ],
+                            }
+                        ],
+                    }
                 ]
+            },
+            # vim maintenance-enter (#2970): the *_Task MoRef the poll drives.
+            "/HostSystem/host-source/EnterMaintenanceMode_Task": {
+                "type": "Task",
+                "value": "t-enter-src",
             },
         }
     )

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -110,12 +110,15 @@ class _RecordingConnector:
         responses: dict[str, Any] | list[Any],
         *,
         mount_prefix: str = "/api",
+        vmomi: dict[str, Any] | None = None,
     ) -> None:
         self._responses = responses
         self._seq_index = 0
         self._mount_prefix = mount_prefix
+        self._vmomi = vmomi or {}
         self.calls: list[dict[str, Any]] = []
         self.mount_calls: list[str] = []
+        self.vmomi_calls: list[tuple[str, Any]] = []
 
     async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
         self.mount_calls.append(path)
@@ -158,6 +161,37 @@ class _RecordingConnector:
         else:
             payload = self._responses[self._seq_index]
             self._seq_index += 1
+        if isinstance(payload, Exception):
+            raise payload
+        return payload
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        """Serve the vim (VI-JSON) sub-calls the #2970 composite steps issue.
+
+        Recorded into ``vmomi_calls``. Responses are keyed by the vmomi
+        method path (``/HostSystem/h-1/EnterMaintenanceMode_Task``);
+        ``RetrievePropertiesEx`` bodies are instead keyed by the queried
+        object type (``VirtualMachine`` / ``ClusterComputeResource`` /
+        ``DistributedVirtualSwitch`` / ``Task`` -- the seam a real vCenter
+        keys them by, mirroring ``_DiskGrowConnector``). An unkeyed
+        ``Task`` read serves a terminal-success ``Task.info`` so tests
+        only model the poll when a fault/timeout is the point.
+        """
+        self.vmomi_calls.append((path, json))
+        if path.endswith("/RetrievePropertiesEx"):
+            spec_type = json["specSet"][0]["propSet"][0]["type"]
+            if spec_type in self._vmomi:
+                payload = self._vmomi[spec_type]
+                if isinstance(payload, Exception):
+                    raise payload
+                return payload
+            if spec_type == "Task":
+                task_moid = json["specSet"][0]["objectSet"][0]["obj"]["value"]
+                return _task_info_result(task_moid, "success")
+            raise AssertionError(f"unexpected RetrievePropertiesEx type {spec_type!r}")
+        payload = self._vmomi[path]
         if isinstance(payload, Exception):
             raise payload
         return payload
@@ -237,6 +271,45 @@ def _http_error(status: int, url: str) -> httpx.HTTPStatusError:
     )
 
 
+# --- vim (VI-JSON) canned-payload builders for the #2970 composite steps ---
+
+
+def _task_moref(value: str) -> dict[str, str]:
+    """A vim Task ``ManagedObjectReference`` as a ``*_Task`` method returns it."""
+    return {"type": "Task", "value": value}
+
+
+def _retrieve_result(obj_type: str, moid: str, prop: str, val: Any) -> dict[str, Any]:
+    """A single-object ``RetrievePropertiesEx`` result carrying one property."""
+    return {
+        "objects": [
+            {
+                "obj": {"type": obj_type, "value": moid},
+                "propSet": [{"name": prop, "val": val}],
+            }
+        ]
+    }
+
+
+def _task_info_result(task_moid: str, state: str, error: str | None = None) -> dict[str, Any]:
+    """A ``Task.info`` RetrievePropertiesEx result in the requested state."""
+    info: dict[str, Any] = {"state": state}
+    if error is not None:
+        info["error"] = {"localizedMessage": error}
+    return _retrieve_result("Task", task_moid, "info", info)
+
+
+def _snapshot_tree_node(
+    moid: str, name: str, children: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    """A ``VirtualMachineSnapshotTree`` node as the ``snapshot`` property returns it."""
+    return {
+        "snapshot": {"type": "VirtualMachineSnapshot", "value": moid},
+        "name": name,
+        "childSnapshotList": children or [],
+    }
+
+
 # ===========================================================================
 # vm.create
 # ===========================================================================
@@ -244,12 +317,12 @@ def _http_error(status: int, url: str) -> httpx.HTTPStatusError:
 
 @pytest.mark.asyncio
 async def test_vm_create_happy_path_direct_session(gate: _GateRecorder) -> None:
-    """Folder GET -> create POST -> NIC PATCH -> power POST; every write gated."""
+    """Folder GET -> create POST -> NIC adapter POST -> power POST; every write gated."""
     conn = _RecordingConnector(
         {
             "/api/vcenter/folder": [{"folder": "folder-7", "name": "Prod"}],
             "/api/vcenter/vm": {"value": "vm-99"},
-            "/api/vcenter/vm/vm-99/network": {},
+            "/api/vcenter/vm/vm-99/hardware/ethernet": {"value": "nic-1"},
             "/api/vcenter/vm/vm-99/power?action=start": {},
         }
     )
@@ -271,15 +344,18 @@ async def test_vm_create_happy_path_direct_session(gate: _GateRecorder) -> None:
     assert [(c["method"], c["path"]) for c in conn.calls] == [
         ("GET", "/api/vcenter/folder"),
         ("POST", "/api/vcenter/vm"),
-        ("PATCH", "/api/vcenter/vm/vm-99/network"),
+        ("POST", "/api/vcenter/vm/vm-99/hardware/ethernet"),
         ("POST", "/api/vcenter/vm/vm-99/power?action=start"),
     ]
     # Folder GET forwards the name filter as a query param; bare on /api (#2298).
     assert conn.calls[0]["query"] == {"names": ["Prod"]}
     # Create body carries the spec; folder moid resolved in.
     assert conn.calls[1]["body"]["spec"]["placement"]["folder"] == "folder-7"
-    # NIC PATCH body is the spec; vm rides the path, not the body.
-    assert conn.calls[2]["body"] == {"spec": {"network": "net-3"}}
+    # NIC create body is the Ethernet.CreateSpec: the network rides the
+    # backing spec (#2970); vm rides the path, not the body.
+    assert conn.calls[2]["body"] == {
+        "spec": {"backing": {"type": "STANDARD_PORTGROUP", "network": "net-3"}}
+    }
     # Power POST carries no body (action rides the path).
     assert conn.calls[3]["body"] is None
 
@@ -287,7 +363,7 @@ async def test_vm_create_happy_path_direct_session(gate: _GateRecorder) -> None:
     # the folder GET was never gated.
     assert gate.gated_op_ids == [
         "POST:/vcenter/vm",
-        "PATCH:/vcenter/vm/{vm}/network",
+        "POST:/vcenter/vm/{vm}/hardware/ethernet",
         "POST:/vcenter/vm/{vm}/power?action=start",
     ]
     for call in gate.calls:
@@ -385,13 +461,12 @@ async def test_vm_create_gated_create_returns_awaiting_approval_no_write(
 
 
 @pytest.mark.asyncio
-async def test_vm_clone_happy_path_polls_task_to_completion(gate: _GateRecorder) -> None:
-    """Source GET -> deploy POST (gated) -> task-poll GET until SUCCEEDED."""
+async def test_vm_clone_happy_path_synchronous_deploy(gate: _GateRecorder) -> None:
+    """Source GET -> per-item deploy POST (gated); 200 body IS the new VM id (#2970)."""
     conn = _RecordingConnector(
         {
             "/api/vcenter/vm/vm-src": {"name": "src"},
-            "/api/vcenter/vm-template/library-items?action=deploy": {"task": "task-42"},
-            "/api/cis/tasks/task-42": {"status": "SUCCEEDED", "result": {"vm": "vm-clone-1"}},
+            "/api/vcenter/vm-template/library-items/li-7?action=deploy": "vm-clone-1",
         }
     )
     out = await vm_clone_composite(
@@ -401,70 +476,58 @@ async def test_vm_clone_happy_path_polls_task_to_completion(gate: _GateRecorder)
             "source_vm": "vm-src",
             "target_name": "vm-clone-1",
             "library_item": "li-7",
-            "timeout_seconds": 30,
         },
         connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "completed"
-    assert out["task_id"] == "task-42"
+    assert out["task_id"] is None
     assert out["vm_id"] == "vm-clone-1"
     assert [(c["method"], c["path"]) for c in conn.calls] == [
         ("GET", "/api/vcenter/vm/vm-src"),
-        ("POST", "/api/vcenter/vm-template/library-items?action=deploy"),
-        ("GET", "/api/cis/tasks/task-42"),
+        ("POST", "/api/vcenter/vm-template/library-items/li-7?action=deploy"),
     ]
-    # Deploy body carries library_item + spec (no ``action`` body key).
-    assert conn.calls[1]["body"] == {"library_item": "li-7", "spec": {"name": "vm-clone-1"}}
-    # Only the deploy write was gated.
-    assert gate.gated_op_ids == ["POST:/vcenter/vm-template/library-items?action=deploy"]
+    # The template item rides the path (#2970); the body is only the DeploySpec.
+    assert conn.calls[1]["body"] == {"spec": {"name": "vm-clone-1"}}
+    # Only the deploy write was gated, under the per-item op_id.
+    assert gate.gated_op_ids == [
+        "POST:/vcenter/vm-template/library-items/{templateLibraryItem}?action=deploy"
+    ]
 
 
 @pytest.mark.asyncio
-async def test_vm_clone_wait_false_returns_pending(gate: _GateRecorder) -> None:
-    """wait_for_completion=False returns pending; no task poll fires."""
+async def test_vm_clone_legacy_value_envelope_unwraps(gate: _GateRecorder) -> None:
+    """A legacy ``{"value": ...}``-wrapped deploy response unwraps to the VM id."""
     conn = _RecordingConnector(
         {
             "/api/vcenter/vm/vm-src": {"name": "src"},
-            "/api/vcenter/vm-template/library-items?action=deploy": {"task": "task-99"},
+            "/api/vcenter/vm-template/library-items/li-3?action=deploy": {"value": "vm-88"},
         }
     )
     out = await vm_clone_composite(
         operator=_make_operator(),
         target=object(),
-        params={
-            "source_vm": "vm-src",
-            "target_name": "tgt",
-            "library_item": "li-3",
-            "wait_for_completion": False,
-        },
+        params={"source_vm": "vm-src", "target_name": "tgt", "library_item": "li-3"},
         connector=conn,  # type: ignore[arg-type]
     )
-    assert out["status"] == "pending"
-    assert out["task_id"] == "task-99"
-    assert out["vm_id"] is None
+    assert out["status"] == "completed"
+    assert out["vm_id"] == "vm-88"
     assert len(conn.calls) == 2
 
 
 @pytest.mark.asyncio
-async def test_vm_clone_task_failed_raises_runtime_error(gate: _GateRecorder) -> None:
-    """A FAILED task raises -- dispatcher wraps as connector_error."""
+async def test_vm_clone_non_string_deploy_payload_raises(gate: _GateRecorder) -> None:
+    """A deploy payload that is not the VM id string raises -- wrapped connector_error."""
     conn = _RecordingConnector(
         {
             "/api/vcenter/vm/vm-src": {},
-            "/api/vcenter/vm-template/library-items?action=deploy": {"task": "task-bad"},
-            "/api/cis/tasks/task-bad": {"status": "FAILED", "error": "deploy failed"},
+            "/api/vcenter/vm-template/library-items/li-1?action=deploy": {"task": "task-bad"},
         }
     )
-    with pytest.raises(RuntimeError, match="FAILED"):
+    with pytest.raises(RuntimeError, match="no VM id"):
         await vm_clone_composite(
             operator=_make_operator(),
             target=object(),
-            params={
-                "source_vm": "vm-src",
-                "target_name": "tgt",
-                "library_item": "li-1",
-                "timeout_seconds": 30,
-            },
+            params={"source_vm": "vm-src", "target_name": "tgt", "library_item": "li-1"},
             connector=conn,  # type: ignore[arg-type]
         )
 
@@ -474,14 +537,20 @@ async def test_vm_clone_task_failed_raises_runtime_error(gate: _GateRecorder) ->
 # ===========================================================================
 
 
+def _snapshot_info_vmomi(nodes: list[dict[str, Any]]) -> dict[str, Any]:
+    """Canned ``VirtualMachine.snapshot`` property read for the vmomi stub."""
+    return _retrieve_result("VirtualMachine", "vm-1", "snapshot", {"rootSnapshotList": nodes})
+
+
 @pytest.mark.asyncio
 async def test_vm_snapshot_revert_happy_path(gate: _GateRecorder) -> None:
-    """List GET + match + revert POST (gated); status=reverted."""
+    """vim tree read + match + RevertToSnapshot_Task (gated, polled); status=reverted."""
     conn = _RecordingConnector(
-        {
-            "/api/vcenter/vm/vm-1/snapshot": [{"snapshot": "snap-1", "name": "before-patch"}],
-            "/api/vcenter/vm/vm-1/snapshot/snap-1?action=revert": {},
-        }
+        {},
+        vmomi={
+            "VirtualMachine": _snapshot_info_vmomi([_snapshot_tree_node("snap-1", "before-patch")]),
+            "/VirtualMachineSnapshot/snap-1/RevertToSnapshot_Task": _task_moref("task-revert-1"),
+        },
     )
     out = await vm_snapshot_revert_composite(
         operator=_make_operator(),
@@ -491,22 +560,27 @@ async def test_vm_snapshot_revert_happy_path(gate: _GateRecorder) -> None:
     )
     assert out["status"] == "reverted"
     assert out["snapshot_id"] == "snap-1"
-    assert conn.calls[1]["method"] == "POST"
-    assert conn.calls[1]["path"] == "/api/vcenter/vm/vm-1/snapshot/snap-1?action=revert"
-    assert conn.calls[1]["body"] is None
-    assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert"]
+    # No REST sub-call fired -- the snapshot surface is vim-only (#2970).
+    assert conn.calls == []
+    revert_calls = [(p, b) for p, b in conn.vmomi_calls if p.endswith("/RevertToSnapshot_Task")]
+    assert revert_calls == [("/VirtualMachineSnapshot/snap-1/RevertToSnapshot_Task", {})]
+    assert gate.gated_op_ids == ["POST:/VirtualMachineSnapshot/{moId}/RevertToSnapshot_Task"]
 
 
 @pytest.mark.asyncio
 async def test_vm_snapshot_revert_ambiguous_no_revert(gate: _GateRecorder) -> None:
-    """Multiple snapshots share the name -> status=ambiguous; no revert dispatched."""
+    """Snapshots sharing the name across the tree -> ambiguous; no revert dispatched.
+
+    The duplicate lives in a ``childSnapshotList`` to prove the tree walk
+    recurses (the flat pre-#2970 REST listing had no nesting).
+    """
     conn = _RecordingConnector(
-        {
-            "/api/vcenter/vm/vm-1/snapshot": [
-                {"snapshot": "snap-1", "name": "x"},
-                {"snapshot": "snap-2", "name": "x"},
-            ]
-        }
+        {},
+        vmomi={
+            "VirtualMachine": _snapshot_info_vmomi(
+                [_snapshot_tree_node("snap-1", "x", [_snapshot_tree_node("snap-2", "x")])]
+            ),
+        },
     )
     out = await vm_snapshot_revert_composite(
         operator=_make_operator(),
@@ -515,8 +589,11 @@ async def test_vm_snapshot_revert_ambiguous_no_revert(gate: _GateRecorder) -> No
         connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "ambiguous"
-    assert len(out["candidates"]) == 2
-    assert len(conn.calls) == 1
+    assert out["candidates"] == [
+        {"name": "x", "snapshot": "snap-1"},
+        {"name": "x", "snapshot": "snap-2"},
+    ]
+    assert len(conn.vmomi_calls) == 1
     assert gate.calls == []
 
 
@@ -524,7 +601,8 @@ async def test_vm_snapshot_revert_ambiguous_no_revert(gate: _GateRecorder) -> No
 async def test_vm_snapshot_revert_not_found(gate: _GateRecorder) -> None:
     """Snapshot name not in tree -> status=not_found; no revert dispatched."""
     conn = _RecordingConnector(
-        {"/api/vcenter/vm/vm-1/snapshot": [{"snapshot": "s-1", "name": "other"}]}
+        {},
+        vmomi={"VirtualMachine": _snapshot_info_vmomi([_snapshot_tree_node("s-1", "other")])},
     )
     out = await vm_snapshot_revert_composite(
         operator=_make_operator(),
@@ -533,7 +611,7 @@ async def test_vm_snapshot_revert_not_found(gate: _GateRecorder) -> None:
         connector=conn,  # type: ignore[arg-type]
     )
     assert out["status"] == "not_found"
-    assert len(conn.calls) == 1
+    assert len(conn.vmomi_calls) == 1
     assert gate.calls == []
 
 
@@ -542,16 +620,32 @@ async def test_vm_snapshot_revert_not_found(gate: _GateRecorder) -> None:
 # ===========================================================================
 
 
+def _drs_recommendation_vmomi(vm_moid: str, destination: str) -> dict[str, Any]:
+    """Canned ``ClusterComputeResource.drsRecommendation`` property read."""
+    return _retrieve_result(
+        "ClusterComputeResource",
+        "cluster-7",
+        "drsRecommendation",
+        [
+            {
+                "key": "1",
+                "migrationList": [
+                    {
+                        "vm": {"type": "VirtualMachine", "value": vm_moid},
+                        "destination": {"type": "HostSystem", "value": destination},
+                    }
+                ],
+            }
+        ],
+    )
+
+
 @pytest.mark.asyncio
 async def test_vm_migrate_drs_recommendation_dispatches_relocate(gate: _GateRecorder) -> None:
-    """DRS recommendation GET -> relocate POST (gated) against the recommended host."""
+    """vim drsRecommendation read -> relocate POST (gated) against the recommended host."""
     conn = _RecordingConnector(
-        {
-            "/api/vcenter/cluster/cluster-7/drs/recommendations": [
-                {"vm": "vm-1", "target_host": "host-A"}
-            ],
-            "/api/vcenter/vm/vm-1?action=relocate": {},
-        }
+        {"/api/vcenter/vm/vm-1?action=relocate": {}},
+        vmomi={"ClusterComputeResource": _drs_recommendation_vmomi("vm-1", "host-A")},
     )
     out = await vm_migrate_composite(
         operator=_make_operator(),
@@ -562,8 +656,12 @@ async def test_vm_migrate_drs_recommendation_dispatches_relocate(gate: _GateReco
     assert out["status"] == "migrated"
     assert out["target_host"] == "host-A"
     assert out["source"] == "drs"
-    assert conn.calls[1]["path"] == "/api/vcenter/vm/vm-1?action=relocate"
-    assert conn.calls[1]["body"] == {"spec": {"placement": {"host": "host-A"}}}
+    # The DRS read is vim (#2970 -- no DRS REST resource in the pinned spec).
+    assert [p for p, _ in conn.vmomi_calls] == [
+        "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+    ]
+    assert conn.calls[0]["path"] == "/api/vcenter/vm/vm-1?action=relocate"
+    assert conn.calls[0]["body"] == {"spec": {"placement": {"host": "host-A"}}}
     assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}?action=relocate"]
 
 
@@ -586,7 +684,14 @@ async def test_vm_migrate_explicit_target_bypasses_drs(gate: _GateRecorder) -> N
 @pytest.mark.asyncio
 async def test_vm_migrate_no_recommendation(gate: _GateRecorder) -> None:
     """DRS returns empty + no override -> status=no_recommendation; no relocate."""
-    conn = _RecordingConnector({"/api/vcenter/cluster/cluster-1/drs/recommendations": []})
+    conn = _RecordingConnector(
+        {},
+        vmomi={
+            "ClusterComputeResource": _retrieve_result(
+                "ClusterComputeResource", "cluster-1", "drsRecommendation", []
+            )
+        },
+    )
     out = await vm_migrate_composite(
         operator=_make_operator(),
         target=object(),
@@ -595,7 +700,8 @@ async def test_vm_migrate_no_recommendation(gate: _GateRecorder) -> None:
     )
     assert out["status"] == "no_recommendation"
     assert out["source"] == "none"
-    assert len(conn.calls) == 1
+    assert conn.calls == []
+    assert len(conn.vmomi_calls) == 1
     assert gate.calls == []
 
 
@@ -874,15 +980,17 @@ def _no_rec() -> OperationResult:
 
 @pytest.mark.asyncio
 async def test_host_evacuate_recurses_then_enters_maintenance(gate: _GateRecorder) -> None:
-    """VM listing GET -> per-VM vm.migrate via dispatch_child -> maintenance-enter write."""
+    """VM listing GET -> per-VM vm.migrate via dispatch_child -> vim maintenance-enter."""
     conn = _RecordingConnector(
         {
             "/api/vcenter/vm": [
                 {"vm": "vm-a", "cluster": "c-1"},
                 {"vm": "vm-b", "cluster": "c-2"},
             ],
-            "/api/vcenter/host/host-1/maintenance?action=enter": {},
-        }
+        },
+        vmomi={
+            "/HostSystem/host-1/EnterMaintenanceMode_Task": _task_moref("task-mm-1"),
+        },
     )
     dispatch = _RecordingDispatchChild([_migrated(), _migrated()])
     out = await host_evacuate_composite(
@@ -901,13 +1009,14 @@ async def test_host_evacuate_recurses_then_enters_maintenance(gate: _GateRecorde
     assert dispatch.calls[0]["params"] == {"vm": "vm-a", "cluster": "c-1"}
     assert dispatch.calls[1]["params"] == {"vm": "vm-b", "cluster": "c-2"}
     assert all(c["connector_id"] == "vmware-rest-9.0" for c in dispatch.calls)
-    # The listing read + the maintenance-enter write are the only direct calls.
-    assert [(c["method"], c["path"]) for c in conn.calls] == [
-        ("GET", "/api/vcenter/vm"),
-        ("PATCH", "/api/vcenter/host/host-1/maintenance?action=enter"),
-    ]
+    # The listing read is the only REST call; maintenance-enter is vim
+    # (#2970) -- the write POST plus its Task.info poll.
+    assert [(c["method"], c["path"]) for c in conn.calls] == [("GET", "/api/vcenter/vm")]
+    enter_calls = [(p, b) for p, b in conn.vmomi_calls if p.endswith("/EnterMaintenanceMode_Task")]
+    # ``EnterMaintenanceModeRequestType.timeout`` is required (int).
+    assert enter_calls == [("/HostSystem/host-1/EnterMaintenanceMode_Task", {"timeout": 0})]
     # Only the maintenance-enter write was gated (the recursion self-gates).
-    assert gate.gated_op_ids == ["PATCH:/vcenter/host/{host}/maintenance?action=enter"]
+    assert gate.gated_op_ids == ["POST:/HostSystem/{moId}/EnterMaintenanceMode_Task"]
     assert out["status"] == "evacuated"
     assert out["maintenance_entered"] is True
     assert out["migrated_vms"] == ["vm-a", "vm-b"]
@@ -942,8 +1051,10 @@ async def test_host_evacuate_tolerate_partial_still_enters_maintenance(gate: _Ga
                 {"vm": "vm-a", "cluster": "c-1"},
                 {"vm": "vm-b", "cluster": "c-1"},
             ],
-            "/api/vcenter/host/host-2/maintenance?action=enter": {},
-        }
+        },
+        vmomi={
+            "/HostSystem/host-2/EnterMaintenanceMode_Task": _task_moref("task-mm-2"),
+        },
     )
     dispatch = _RecordingDispatchChild([_migrated(), _no_rec()])
     out = await host_evacuate_composite(
@@ -966,17 +1077,25 @@ async def test_host_evacuate_tolerate_partial_still_enters_maintenance(gate: _Ga
 
 @pytest.mark.asyncio
 async def test_host_detach_from_vds_happy_path(gate: _GateRecorder) -> None:
-    """Portgroup GET + VM GET + per-VM NIC PATCH + DVS remove POST; status=detached."""
+    """Portgroup GET + VM GET + per-NIC repoint + vim DVS reconfigure; status=detached."""
     conn = _RecordingConnector(
         {
             # #1602 fix: distributed portgroups are listed via the generic
             # /vcenter/network resource (no dedicated portgroup path).
             "/api/vcenter/network": [],
             "/api/vcenter/vm": [{"vm": "vm-1"}, {"vm": "vm-2"}],
-            "/api/vcenter/vm/vm-1/network": {},
-            "/api/vcenter/vm/vm-2/network": {},
-            "/api/vcenter/network/dvs/dvs-1?action=remove_host": {},
-        }
+            "/api/vcenter/vm/vm-1/hardware/ethernet": [{"nic": "4000"}],
+            "/api/vcenter/vm/vm-1/hardware/ethernet/4000": {},
+            "/api/vcenter/vm/vm-2/hardware/ethernet": [{"nic": "4000"}, {"nic": "4001"}],
+            "/api/vcenter/vm/vm-2/hardware/ethernet/4000": {},
+            "/api/vcenter/vm/vm-2/hardware/ethernet/4001": {},
+        },
+        vmomi={
+            "DistributedVirtualSwitch": _retrieve_result(
+                "DistributedVirtualSwitch", "dvs-1", "config.configVersion", "42"
+            ),
+            "/DistributedVirtualSwitch/dvs-1/ReconfigureDvs_Task": _task_moref("task-dvs-1"),
+        },
     )
     out = await host_detach_from_vds_composite(
         operator=_make_operator(),
@@ -986,29 +1105,56 @@ async def test_host_detach_from_vds_happy_path(gate: _GateRecorder) -> None:
     )
     assert out["status"] == "detached"
     assert out["vms_migrated"] == ["vm-1", "vm-2"]
-    last = conn.calls[-1]
-    assert last["method"] == "POST"
-    assert last["path"] == "/api/vcenter/network/dvs/dvs-1?action=remove_host"
-    assert last["body"] == {"host": "host-9"}
-    # NIC PATCH body carries the fallback network spec.
-    assert conn.calls[2]["body"] == {"spec": {"network": "standard-net"}}
-    # 2 NIC writes + 1 DVS remove write gated; the two reads were not.
+    # Per-NIC repoint (#2970): adapter listing + per-adapter PATCH with the
+    # standard-portgroup backing spec.
+    nic_patches = [c for c in conn.calls if c["method"] == "PATCH"]
+    assert [c["path"] for c in nic_patches] == [
+        "/api/vcenter/vm/vm-1/hardware/ethernet/4000",
+        "/api/vcenter/vm/vm-2/hardware/ethernet/4000",
+        "/api/vcenter/vm/vm-2/hardware/ethernet/4001",
+    ]
+    assert nic_patches[0]["body"] == {
+        "spec": {"backing": {"type": "STANDARD_PORTGROUP", "network": "standard-net"}}
+    }
+    # The DVS detach is the vim ReconfigureDvs_Task: configVersion echoed,
+    # host member spec with operation=remove.
+    reconfig = [(p, b) for p, b in conn.vmomi_calls if p.endswith("/ReconfigureDvs_Task")]
+    assert reconfig == [
+        (
+            "/DistributedVirtualSwitch/dvs-1/ReconfigureDvs_Task",
+            {
+                "spec": {
+                    "configVersion": "42",
+                    "host": [
+                        {
+                            "operation": "remove",
+                            "host": {"type": "HostSystem", "value": "host-9"},
+                        }
+                    ],
+                }
+            },
+        )
+    ]
+    # 3 NIC writes + 1 vim DVS reconfigure gated; the reads were not.
     assert gate.gated_op_ids == [
-        "PATCH:/vcenter/vm/{vm}/network",
-        "PATCH:/vcenter/vm/{vm}/network",
-        "POST:/vcenter/network/dvs/{dvs}?action=remove_host",
+        "PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}",
+        "PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}",
+        "PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}",
+        "POST:/DistributedVirtualSwitch/{moId}/ReconfigureDvs_Task",
     ]
 
 
 @pytest.mark.asyncio
 async def test_host_detach_from_vds_incomplete_on_nic_failure(gate: _GateRecorder) -> None:
-    """A NIC migration transport error -> status=incomplete; DVS remove skipped."""
+    """A NIC migration transport error -> status=incomplete; DVS reconfigure skipped."""
     conn = _RecordingConnector(
         [
             [],  # portgroup GET
             [{"vm": "vm-1"}, {"vm": "vm-2"}],  # VM GET
-            {},  # vm-1 NIC ok
-            _http_error(409, "https://vc/api/vcenter/vm/vm-2/network"),  # vm-2 NIC fails
+            [{"nic": "4000"}],  # vm-1 adapter listing
+            {},  # vm-1 nic 4000 ok
+            [{"nic": "4000"}],  # vm-2 adapter listing
+            _http_error(409, "https://vc/api/vcenter/vm/vm-2/hardware/ethernet/4000"),
         ]
     )
     out = await host_detach_from_vds_composite(
@@ -1020,8 +1166,8 @@ async def test_host_detach_from_vds_incomplete_on_nic_failure(gate: _GateRecorde
     assert out["status"] == "incomplete"
     assert out["vms_migrated"] == ["vm-1"]
     assert len(out["vm_migration_failures"]) == 1
-    # No DVS remove call -- the last recorded call is the failed NIC PATCH.
-    assert all("remove_host" not in c["path"] for c in conn.calls)
+    # No vim DVS reconfigure fired -- the detach was skipped.
+    assert conn.vmomi_calls == []
 
 
 # ===========================================================================
@@ -1031,17 +1177,21 @@ async def test_host_detach_from_vds_incomplete_on_nic_failure(gate: _GateRecorde
 
 @pytest.mark.asyncio
 async def test_cluster_patch_happy_path(gate: _GateRecorder) -> None:
-    """Per-host: maintenance-enter -> patch -> maintenance-exit; status=completed."""
+    """Per-host: vim maintenance-enter -> vLCM apply (cis poll) -> vim exit; completed."""
     conn = _RecordingConnector(
         {
-            "/api/vcenter/cluster/c-1/host": [{"host": "h1"}, {"host": "h2"}],
-            "/api/vcenter/host/h1/maintenance?action=enter": {},
-            "/api/vcenter/host/h1?action=patch": {},
-            "/api/vcenter/host/h1/maintenance?action=exit": {},
-            "/api/vcenter/host/h2/maintenance?action=enter": {},
-            "/api/vcenter/host/h2?action=patch": {},
-            "/api/vcenter/host/h2/maintenance?action=exit": {},
-        }
+            "/api/vcenter/host": [{"host": "h1"}, {"host": "h2"}],
+            "/api/esx/settings/hosts/h1/software?action=apply&vmw-task=true": "task-apply-1",
+            "/api/cis/tasks/task-apply-1": {"status": "SUCCEEDED"},
+            "/api/esx/settings/hosts/h2/software?action=apply&vmw-task=true": "task-apply-2",
+            "/api/cis/tasks/task-apply-2": {"status": "SUCCEEDED"},
+        },
+        vmomi={
+            "/HostSystem/h1/EnterMaintenanceMode_Task": _task_moref("t-enter-1"),
+            "/HostSystem/h1/ExitMaintenanceMode_Task": _task_moref("t-exit-1"),
+            "/HostSystem/h2/EnterMaintenanceMode_Task": _task_moref("t-enter-2"),
+            "/HostSystem/h2/ExitMaintenanceMode_Task": _task_moref("t-exit-2"),
+        },
     )
     out = await cluster_patch_composite(
         operator=_make_operator(),
@@ -1051,29 +1201,51 @@ async def test_cluster_patch_happy_path(gate: _GateRecorder) -> None:
     )
     assert out["status"] == "completed"
     assert out["patched_hosts"] == ["h1", "h2"]
-    # The patch step carries a ``method`` body; the maintenance verbs do not.
-    patch_call = next(c for c in conn.calls if c["path"] == "/api/vcenter/host/h1?action=patch")
-    assert patch_call["body"] == {"method": "default"}
-    enter_call = next(
-        c for c in conn.calls if c["path"] == "/api/vcenter/host/h1/maintenance?action=enter"
-    )
-    assert enter_call["body"] is None
+    # The host listing is the cluster-scoped Host_list (#2970 -- there is
+    # no per-cluster /vcenter/cluster/{cluster}/host resource); bare filter
+    # keys on /api (#2298).
+    assert conn.calls[0]["path"] == "/api/vcenter/host"
+    assert conn.calls[0]["query"] == {"clusters": ["c-1"]}
+    # The vLCM apply carries an empty ApplySpec body (latest commit) and
+    # its cis task is polled to SUCCEEDED before maintenance-exit.
+    apply_call = next(c for c in conn.calls if "software?action=apply" in c["path"])
+    assert apply_call["body"] == {"spec": {}}
+    assert any(c["path"] == "/api/cis/tasks/task-apply-1" for c in conn.calls)
+    # Maintenance transitions are vim *_Task methods with the required
+    # int timeout, polled to terminal.
+    maintenance_calls = [(p, b) for p, b in conn.vmomi_calls if "MaintenanceMode_Task" in p]
+    assert maintenance_calls == [
+        ("/HostSystem/h1/EnterMaintenanceMode_Task", {"timeout": 0}),
+        ("/HostSystem/h1/ExitMaintenanceMode_Task", {"timeout": 0}),
+        ("/HostSystem/h2/EnterMaintenanceMode_Task", {"timeout": 0}),
+        ("/HostSystem/h2/ExitMaintenanceMode_Task", {"timeout": 0}),
+    ]
     # 3 writes per host x 2 hosts were gated.
     assert len(gate.calls) == 6
+    assert gate.gated_op_ids[:3] == [
+        "POST:/HostSystem/{moId}/EnterMaintenanceMode_Task",
+        "POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true",
+        "POST:/HostSystem/{moId}/ExitMaintenanceMode_Task",
+    ]
 
 
 @pytest.mark.asyncio
 async def test_cluster_patch_per_host_failure_stops_loop(gate: _GateRecorder) -> None:
-    """A per-host transport error stops the loop; status=stopped with remaining_hosts."""
+    """A per-host apply transport error stops the loop; status=stopped."""
     conn = _RecordingConnector(
         [
             [{"host": "h1"}, {"host": "h2"}, {"host": "h3"}],  # host listing GET
-            {},  # h1 enter
-            {},  # h1 patch
-            {},  # h1 exit
-            {},  # h2 enter
-            _http_error(500, "https://vc/api/vcenter/host/h2?action=patch"),  # h2 patch fails
-        ]
+            "task-apply-1",  # h1 apply -> cis task id
+            {"status": "SUCCEEDED"},  # h1 cis poll
+            _http_error(
+                500, "https://vc/api/esx/settings/hosts/h2/software?action=apply&vmw-task=true"
+            ),  # h2 apply fails
+        ],
+        vmomi={
+            "/HostSystem/h1/EnterMaintenanceMode_Task": _task_moref("t-enter-1"),
+            "/HostSystem/h1/ExitMaintenanceMode_Task": _task_moref("t-exit-1"),
+            "/HostSystem/h2/EnterMaintenanceMode_Task": _task_moref("t-enter-2"),
+        },
     )
     out = await cluster_patch_composite(
         operator=_make_operator(),
@@ -1086,6 +1258,32 @@ async def test_cluster_patch_per_host_failure_stops_loop(gate: _GateRecorder) ->
     assert out["failed_host"] == "h2"
     assert out["remaining_hosts"] == ["h3"]
     assert out["failure_reason"]
+
+
+@pytest.mark.asyncio
+async def test_cluster_patch_failed_cis_task_stops_loop(gate: _GateRecorder) -> None:
+    """A FAILED vLCM apply cis task stops the loop before maintenance-exit."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/host": [{"host": "h1"}, {"host": "h2"}],
+            "/api/esx/settings/hosts/h1/software?action=apply&vmw-task=true": "task-apply-1",
+            "/api/cis/tasks/task-apply-1": {"status": "FAILED", "error": "image scan failed"},
+        },
+        vmomi={
+            "/HostSystem/h1/EnterMaintenanceMode_Task": _task_moref("t-enter-1"),
+        },
+    )
+    out = await cluster_patch_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "c-1"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "stopped"
+    assert out["failed_host"] == "h1"
+    assert "image scan failed" in out["failure_reason"]
+    # Maintenance-exit never fired for h1 -- the loop stopped mid-host.
+    assert not any(p.endswith("/ExitMaintenanceMode_Task") for p, _ in conn.vmomi_calls)
 
 
 # ===========================================================================
@@ -1102,12 +1300,8 @@ async def test_reads_are_never_gated_only_writes(gate: _GateRecorder) -> None:
     write is gated with the declared dangerous / no-approval posture.
     """
     conn = _RecordingConnector(
-        {
-            "/api/vcenter/cluster/c-9/drs/recommendations": [
-                {"vm": "vm-1", "target_host": "host-A"}
-            ],
-            "/api/vcenter/vm/vm-1?action=relocate": {},
-        }
+        {"/api/vcenter/vm/vm-1?action=relocate": {}},
+        vmomi={"ClusterComputeResource": _drs_recommendation_vmomi("vm-1", "host-A")},
     )
     await vm_migrate_composite(
         operator=_make_operator(),
@@ -1115,10 +1309,11 @@ async def test_reads_are_never_gated_only_writes(gate: _GateRecorder) -> None:
         params={"vm": "vm-1", "cluster": "c-9"},
         connector=conn,  # type: ignore[arg-type]
     )
-    # The DRS recommendations read fired but was not gated; only the relocate
-    # write was gated.
-    read_paths = [c["path"] for c in conn.calls if c["method"] == "GET"]
-    assert read_paths == ["/api/vcenter/cluster/c-9/drs/recommendations"]
+    # The vim DRS-recommendation read fired but was not gated; only the
+    # relocate write was gated.
+    assert [p for p, _ in conn.vmomi_calls] == [
+        "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+    ]
     assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}?action=relocate"]
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -174,6 +174,23 @@ class _FakeVmwareTarget:
 # ---------------------------------------------------------------------------
 
 
+def _vmomi_retrieve_result(obj_type: str, moid: str, prop: str, val: Any) -> dict[str, Any]:
+    """A single-object ``RetrievePropertiesEx`` result carrying one property."""
+    return {
+        "objects": [
+            {
+                "obj": {"type": obj_type, "value": moid},
+                "propSet": [{"name": prop, "val": val}],
+            }
+        ]
+    }
+
+
+def _vmomi_task_moref(value: str) -> dict[str, str]:
+    """A vim Task ``ManagedObjectReference`` as a ``*_Task`` method returns it."""
+    return {"type": "Task", "value": value}
+
+
 def _http_error(status: int, url: str) -> httpx.HTTPStatusError:
     request = httpx.Request("POST", url)
     response = httpx.Response(status, request=request)
@@ -202,6 +219,8 @@ class _RecordingVmwareConnector:
         self.responses: dict[str, Any] = {}
         self.failures: dict[str, str] = {}
         self.calls: list[tuple[str, str]] = []
+        self.vmomi_responses: dict[str, Any] = {}
+        self.vmomi_calls: list[tuple[str, Any]] = []
 
     async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
         return f"{self._MOUNT}{path}"
@@ -238,6 +257,27 @@ class _RecordingVmwareConnector:
         if spec in self.failures:
             raise _http_error(500, f"https://vc{self._MOUNT}{spec}")
         return self.responses.get(spec, {"value": {}})
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        """Serve the vim sub-calls the #2970-switched composite steps issue.
+
+        Method paths are keyed verbatim in ``vmomi_responses``;
+        ``RetrievePropertiesEx`` bodies are keyed by the queried object
+        type instead, with an unkeyed ``Task`` read serving a
+        terminal-success ``Task.info`` (mirrors the unit-test stubs).
+        """
+        self.vmomi_calls.append((path, json))
+        if path.endswith("/RetrievePropertiesEx"):
+            spec_type = json["specSet"][0]["propSet"][0]["type"]
+            if spec_type in self.vmomi_responses:
+                return self.vmomi_responses[spec_type]
+            if spec_type == "Task":
+                task_moid = json["specSet"][0]["objectSet"][0]["obj"]["value"]
+                return _vmomi_retrieve_result("Task", task_moid, "info", {"state": "success"})
+            raise AssertionError(f"unexpected RetrievePropertiesEx type {spec_type!r}")
+        return self.vmomi_responses[path]
 
 
 def _seed_connector(recorder: _RecordingVmwareConnector) -> None:
@@ -322,7 +362,6 @@ def _benign_params_for(composite_op_id: str) -> dict[str, Any]:
             "source_vm": "vm-1",
             "target_name": "vm-clone",
             "library_item": "lib-1",
-            "wait_for_completion": False,
         },
         "vmware.composite.vm.snapshot.revert": {
             "vm": "vm-1",
@@ -366,18 +405,18 @@ def _benign_responses_for(composite_op_id: str) -> dict[str, Any]:
 
     Composites whose first sub-op is a listing read unwrap ``value`` and
     expect a *list*; an empty *list* envelope lets the composite short-circuit
-    to a benign no-work business status. ``vm.clone`` is fire-and-forget here
-    (``wait_for_completion=False``): it reads the source VM then deploys, so it
-    needs a deploy envelope carrying a task id to reach ``pending``.
+    to a benign no-work business status. ``vm.clone`` deploys synchronously
+    (#2970): its deploy envelope carries the new VM id string, reaching
+    ``completed``.
     """
     empty: dict[str, Any] = {"value": []}
     per_composite: dict[str, dict[str, Any]] = {
         "vmware.composite.vm.create": {"/vcenter/folder": empty},
         "vmware.composite.vm.clone": {
-            "/vcenter/vm-template/library-items?action=deploy": {"value": {"task": "task-benign"}},
+            "/vcenter/vm-template/library-items/lib-1?action=deploy": {"value": "vm-benign"},
         },
-        "vmware.composite.vm.snapshot.revert": {"/vcenter/vm/vm-1/snapshot": empty},
-        "vmware.composite.vm.migrate": {"/vcenter/cluster/domain-c1/drs/recommendations": empty},
+        "vmware.composite.vm.snapshot.revert": {},
+        "vmware.composite.vm.migrate": {},
         "vmware.composite.vm.power": {},
         "vmware.composite.vm.power.bulk": {"/vcenter/vm": empty},
         "vmware.composite.vm.resize": {
@@ -418,13 +457,49 @@ def _benign_responses_for(composite_op_id: str) -> dict[str, Any]:
             "/vcenter/network": empty,
             "/vcenter/vm": empty,
         },
-        "vmware.composite.cluster.patch": {"/vcenter/cluster/domain-c1/host": empty},
+        "vmware.composite.cluster.patch": {"/vcenter/host": empty},
         # create: the POST default ({"value": {}}) is enough -> status='created'.
         "vmware.composite.guest.customization_spec.create": {},
         # customize: empty VM listing -> status='not_found' (benign no-work).
         "vmware.composite.vm.customize": {"/vcenter/vm": empty},
     }
     return per_composite[composite_op_id]
+
+
+def _benign_vmomi_for(composite_op_id: str) -> dict[str, Any]:
+    """Per-op vim (VI-JSON) responses for the #2970 vim-switched benign paths.
+
+    ``snapshot.revert`` / ``vm.migrate`` read empty vim properties and
+    short-circuit (``not_found`` / ``no_recommendation``); ``host.evacuate``
+    (no VMs) still enters maintenance via the vim ``*_Task``;
+    ``host.detach_from_vds`` (no VMs) still reads the DVS configVersion and
+    fires the ReconfigureDvs_Task. Task polls serve the default
+    terminal-success ``Task.info``.
+    """
+    per_composite: dict[str, dict[str, Any]] = {
+        "vmware.composite.vm.snapshot.revert": {
+            "VirtualMachine": _vmomi_retrieve_result(
+                "VirtualMachine", "vm-1", "snapshot", {"rootSnapshotList": []}
+            ),
+        },
+        "vmware.composite.vm.migrate": {
+            "ClusterComputeResource": _vmomi_retrieve_result(
+                "ClusterComputeResource", "domain-c1", "drsRecommendation", []
+            ),
+        },
+        "vmware.composite.host.evacuate": {
+            "/HostSystem/host-1/EnterMaintenanceMode_Task": _vmomi_task_moref("t-enter-benign"),
+        },
+        "vmware.composite.host.detach_from_vds": {
+            "DistributedVirtualSwitch": _vmomi_retrieve_result(
+                "DistributedVirtualSwitch", "dvs-1", "config.configVersion", "1"
+            ),
+            "/DistributedVirtualSwitch/dvs-1/ReconfigureDvs_Task": _vmomi_task_moref(
+                "t-dvs-benign"
+            ),
+        },
+    }
+    return per_composite.get(composite_op_id, {})
 
 
 # ===========================================================================
@@ -472,6 +547,7 @@ async def test_write_composite_executes_through_dispatch_without_ingest(
     """
     recorder = _RecordingVmwareConnector()
     recorder.responses.update(_benign_responses_for(composite_op_id))
+    recorder.vmomi_responses.update(_benign_vmomi_for(composite_op_id))
     await _bootstrap(recorder, stub_embedding_service)
     await _clear_requires_approval(set(_WRITE_COMPOSITES), recorder)
 
@@ -530,7 +606,7 @@ async def test_vm_create_happy_path_sub_op_sequence(
     assert recorder.calls == [
         ("GET", "/vcenter/folder"),
         ("POST", "/vcenter/vm"),
-        ("PATCH", "/vcenter/vm/vm-123/network"),
+        ("POST", "/vcenter/vm/vm-123/hardware/ethernet"),
         ("POST", "/vcenter/vm/vm-123/power?action=start"),
     ]
 
@@ -549,7 +625,7 @@ async def test_vm_create_rollback_on_nic_failure(
             "/vcenter/vm": {"value": "vm-123"},
         }
     )
-    recorder.failures["/vcenter/vm/vm-123/network"] = "nic backend rejected the attach"
+    recorder.failures["/vcenter/vm/vm-123/hardware/ethernet"] = "nic backend rejected the attach"
     await _bootstrap(recorder, stub_embedding_service)
     await _clear_requires_approval({"vmware.composite.vm.create"}, recorder)
 
@@ -573,23 +649,23 @@ async def test_vm_create_rollback_on_nic_failure(
     assert recorder.calls == [
         ("GET", "/vcenter/folder"),
         ("POST", "/vcenter/vm"),
-        ("PATCH", "/vcenter/vm/vm-123/network"),
+        ("POST", "/vcenter/vm/vm-123/hardware/ethernet"),
         ("DELETE", "/vcenter/vm/vm-123"),
     ]
 
 
 @pytest.mark.asyncio
-async def test_vm_clone_pending_path_sub_op_sequence(
+async def test_vm_clone_synchronous_deploy_sub_op_sequence(
     stub_embedding_service: AsyncMock,
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """vm.clone (fire-and-forget): source read -> deploy -> return task id."""
+    """vm.clone: source read -> synchronous per-item deploy -> completed (#2970)."""
     recorder = _RecordingVmwareConnector()
     recorder.responses.update(
         {
             "/vcenter/vm/vm-1": {"value": {"name": "src"}},
-            "/vcenter/vm-template/library-items?action=deploy": {"value": {"task": "task-9"}},
+            "/vcenter/vm-template/library-items/lib-1?action=deploy": {"value": "vm-cloned-9"},
         }
     )
     await _bootstrap(recorder, stub_embedding_service)
@@ -604,16 +680,16 @@ async def test_vm_clone_pending_path_sub_op_sequence(
             "source_vm": "vm-1",
             "target_name": "vm-clone",
             "library_item": "lib-1",
-            "wait_for_completion": False,
         },
     )
 
     assert result.status == "ok", result.error
-    assert result.result["status"] == "pending"
-    assert result.result["task_id"] == "task-9"
+    assert result.result["status"] == "completed"
+    assert result.result["task_id"] is None
+    assert result.result["vm_id"] == "vm-cloned-9"
     assert recorder.calls == [
         ("GET", "/vcenter/vm/vm-1"),
-        ("POST", "/vcenter/vm-template/library-items?action=deploy"),
+        ("POST", "/vcenter/vm-template/library-items/lib-1?action=deploy"),
     ]
 
 
@@ -623,11 +699,29 @@ async def test_vm_snapshot_revert_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """vm.snapshot.revert: list -> match-by-name -> revert."""
+    """vm.snapshot.revert: vim tree read -> match-by-name -> vim revert (#2970)."""
     recorder = _RecordingVmwareConnector()
-    recorder.responses["/vcenter/vm/vm-1/snapshot"] = {
-        "value": [{"name": "snap-a", "snapshot": "snap-moid-1"}]
-    }
+    recorder.vmomi_responses.update(
+        {
+            "VirtualMachine": _vmomi_retrieve_result(
+                "VirtualMachine",
+                "vm-1",
+                "snapshot",
+                {
+                    "rootSnapshotList": [
+                        {
+                            "snapshot": {"type": "VirtualMachineSnapshot", "value": "snap-moid-1"},
+                            "name": "snap-a",
+                            "childSnapshotList": [],
+                        }
+                    ]
+                },
+            ),
+            "/VirtualMachineSnapshot/snap-moid-1/RevertToSnapshot_Task": _vmomi_task_moref(
+                "t-revert-1"
+            ),
+        }
+    )
     await _bootstrap(recorder, stub_embedding_service)
     await _clear_requires_approval({"vmware.composite.vm.snapshot.revert"}, recorder)
 
@@ -642,9 +736,10 @@ async def test_vm_snapshot_revert_sub_op_sequence(
     assert result.status == "ok", result.error
     assert result.result["status"] == "reverted"
     assert result.result["snapshot_id"] == "snap-moid-1"
-    assert recorder.calls == [
-        ("GET", "/vcenter/vm/vm-1/snapshot"),
-        ("POST", "/vcenter/vm/vm-1/snapshot/snap-moid-1?action=revert"),
+    # The whole snapshot surface is vim-only: no REST sub-call fired.
+    assert recorder.calls == []
+    assert [p for p, _ in recorder.vmomi_calls if p.endswith("/RevertToSnapshot_Task")] == [
+        "/VirtualMachineSnapshot/snap-moid-1/RevertToSnapshot_Task"
     ]
 
 
@@ -654,11 +749,23 @@ async def test_vm_migrate_drs_path_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """vm.migrate: DRS recommendation -> relocate."""
+    """vm.migrate: vim drsRecommendation read -> relocate (#2970)."""
     recorder = _RecordingVmwareConnector()
-    recorder.responses["/vcenter/cluster/domain-c1/drs/recommendations"] = {
-        "value": [{"vm": "vm-1", "target_host": "host-target"}]
-    }
+    recorder.vmomi_responses["ClusterComputeResource"] = _vmomi_retrieve_result(
+        "ClusterComputeResource",
+        "domain-c1",
+        "drsRecommendation",
+        [
+            {
+                "migrationList": [
+                    {
+                        "vm": {"type": "VirtualMachine", "value": "vm-1"},
+                        "destination": {"type": "HostSystem", "value": "host-target"},
+                    }
+                ]
+            }
+        ],
+    )
     await _bootstrap(recorder, stub_embedding_service)
     await _clear_requires_approval({"vmware.composite.vm.migrate"}, recorder)
 
@@ -673,9 +780,10 @@ async def test_vm_migrate_drs_path_sub_op_sequence(
     assert result.status == "ok", result.error
     assert result.result["status"] == "migrated"
     assert result.result["target_host"] == "host-target"
-    assert recorder.calls == [
-        ("GET", "/vcenter/cluster/domain-c1/drs/recommendations"),
-        ("POST", "/vcenter/vm/vm-1?action=relocate"),
+    # The DRS read is vim; the relocate is the only REST call.
+    assert recorder.calls == [("POST", "/vcenter/vm/vm-1?action=relocate")]
+    assert [p for p, _ in recorder.vmomi_calls] == [
+        "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
     ]
 
 
@@ -726,9 +834,26 @@ async def test_host_evacuate_recursive_sub_op_sequence(
     recorder.responses.update(
         {
             "/vcenter/vm": {"value": [{"vm": "vm-a", "cluster": "domain-c1"}]},
-            "/vcenter/cluster/domain-c1/drs/recommendations": {
-                "value": [{"vm": "vm-a", "target_host": "host-target"}]
-            },
+        }
+    )
+    recorder.vmomi_responses.update(
+        {
+            "ClusterComputeResource": _vmomi_retrieve_result(
+                "ClusterComputeResource",
+                "domain-c1",
+                "drsRecommendation",
+                [
+                    {
+                        "migrationList": [
+                            {
+                                "vm": {"type": "VirtualMachine", "value": "vm-a"},
+                                "destination": {"type": "HostSystem", "value": "host-target"},
+                            }
+                        ]
+                    }
+                ],
+            ),
+            "/HostSystem/host-1/EnterMaintenanceMode_Task": _vmomi_task_moref("t-enter-1"),
         }
     )
     await _bootstrap(recorder, stub_embedding_service)
@@ -748,11 +873,14 @@ async def test_host_evacuate_recursive_sub_op_sequence(
     assert result.result["status"] == "evacuated"
     assert result.result["maintenance_entered"] is True
     assert result.result["migrated_vms"] == ["vm-a"]
+    # The DRS read + maintenance-enter are vim (#2970); the REST calls are
+    # the listing + the recursion's relocate.
     assert recorder.calls == [
         ("GET", "/vcenter/vm"),
-        ("GET", "/vcenter/cluster/domain-c1/drs/recommendations"),
         ("POST", "/vcenter/vm/vm-a?action=relocate"),
-        ("PATCH", "/vcenter/host/host-1/maintenance?action=enter"),
+    ]
+    assert [p for p, _ in recorder.vmomi_calls if p.endswith("/EnterMaintenanceMode_Task")] == [
+        "/HostSystem/host-1/EnterMaintenanceMode_Task"
     ]
 
 
@@ -762,15 +890,17 @@ async def test_host_detach_from_vds_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """host.detach_from_vds: portgroups -> VMs -> per-VM NIC migrate -> DVS detach."""
+    """host.detach_from_vds: portgroups -> VMs -> per-NIC migrate -> vim DVS detach."""
     recorder = _RecordingVmwareConnector()
     recorder.responses.update(
         {
             # #1602 fix: distributed portgroups list via /vcenter/network.
             "/vcenter/network": {"value": []},
             "/vcenter/vm": {"value": [{"vm": "vm-a"}]},
+            "/vcenter/vm/vm-a/hardware/ethernet": {"value": [{"nic": "4000"}]},
         }
     )
+    recorder.vmomi_responses.update(_benign_vmomi_for("vmware.composite.host.detach_from_vds"))
     await _bootstrap(recorder, stub_embedding_service)
     await _clear_requires_approval({"vmware.composite.host.detach_from_vds"}, recorder)
 
@@ -785,11 +915,15 @@ async def test_host_detach_from_vds_sub_op_sequence(
     assert result.status == "ok", result.error
     assert result.result["status"] == "detached"
     assert result.result["vms_migrated"] == ["vm-a"]
+    # Per-adapter NIC repoint (#2970) + vim ReconfigureDvs_Task detach.
     assert recorder.calls == [
         ("GET", "/vcenter/network"),
         ("GET", "/vcenter/vm"),
-        ("PATCH", "/vcenter/vm/vm-a/network"),
-        ("POST", "/vcenter/network/dvs/dvs-1?action=remove_host"),
+        ("GET", "/vcenter/vm/vm-a/hardware/ethernet"),
+        ("PATCH", "/vcenter/vm/vm-a/hardware/ethernet/4000"),
+    ]
+    assert [p for p, _ in recorder.vmomi_calls if p.endswith("/ReconfigureDvs_Task")] == [
+        "/DistributedVirtualSwitch/dvs-1/ReconfigureDvs_Task"
     ]
 
 
@@ -799,9 +933,23 @@ async def test_cluster_patch_sequential_sub_op_sequence(
     session: AsyncSession,
     captured_events: list[BroadcastEvent],
 ) -> None:
-    """cluster.patch: list hosts -> per-host maintenance enter -> patch -> exit."""
+    """cluster.patch: list hosts -> per-host vim enter -> vLCM apply -> vim exit (#2970)."""
     recorder = _RecordingVmwareConnector()
-    recorder.responses["/vcenter/cluster/domain-c1/host"] = {"value": [{"host": "host-1"}]}
+    recorder.responses.update(
+        {
+            "/vcenter/host": {"value": [{"host": "host-1"}]},
+            "/esx/settings/hosts/host-1/software?action=apply&vmw-task=true": {
+                "value": "task-apply-1"
+            },
+            "/cis/tasks/task-apply-1": {"value": {"status": "SUCCEEDED"}},
+        }
+    )
+    recorder.vmomi_responses.update(
+        {
+            "/HostSystem/host-1/EnterMaintenanceMode_Task": _vmomi_task_moref("t-enter-1"),
+            "/HostSystem/host-1/ExitMaintenanceMode_Task": _vmomi_task_moref("t-exit-1"),
+        }
+    )
     await _bootstrap(recorder, stub_embedding_service)
     await _clear_requires_approval({"vmware.composite.cluster.patch"}, recorder)
 
@@ -816,11 +964,16 @@ async def test_cluster_patch_sequential_sub_op_sequence(
     assert result.status == "ok", result.error
     assert result.result["status"] == "completed"
     assert result.result["patched_hosts"] == ["host-1"]
+    # REST: cluster-scoped host listing + vLCM apply + its cis-task poll.
     assert recorder.calls == [
-        ("GET", "/vcenter/cluster/domain-c1/host"),
-        ("PATCH", "/vcenter/host/host-1/maintenance?action=enter"),
-        ("POST", "/vcenter/host/host-1?action=patch"),
-        ("PATCH", "/vcenter/host/host-1/maintenance?action=exit"),
+        ("GET", "/vcenter/host"),
+        ("POST", "/esx/settings/hosts/host-1/software?action=apply&vmw-task=true"),
+        ("GET", "/cis/tasks/task-apply-1"),
+    ]
+    # vim: maintenance enter + exit, in order.
+    assert [p for p, _ in recorder.vmomi_calls if "MaintenanceMode_Task" in p] == [
+        "/HostSystem/host-1/EnterMaintenanceMode_Task",
+        "/HostSystem/host-1/ExitMaintenanceMode_Task",
     ]
 
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
@@ -116,11 +116,14 @@ class _RecordingConnector:
 
     Serves canned read payloads and records writes. The governance tests
     assert on whether a *write* ``_post_json`` ever fires -- the read
-    payloads only need to steer the handler to its first write.
+    payloads only need to steer the handler to its first write. ``vmomi``
+    serves the VI-JSON reads the #2970 vim-switched steps issue (keyed by
+    the ``RetrievePropertiesEx`` object type).
     """
 
-    def __init__(self, reads: dict[str, Any]) -> None:
+    def __init__(self, reads: dict[str, Any], *, vmomi: dict[str, Any] | None = None) -> None:
         self._reads = reads
+        self._vmomi = vmomi or {}
         self.writes: list[dict[str, Any]] = []
 
     async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
@@ -150,6 +153,44 @@ class _RecordingConnector:
     ) -> Any:
         self.writes.append({"verb": verb, "path": path, "body": json})
         return {"value": "vm-should-not-exist"}
+
+    async def _post_vmomi_json(
+        self, target: Any, path: str, *, operator: Operator, json: Any = None
+    ) -> Any:
+        assert path.endswith("/RetrievePropertiesEx"), (
+            f"governance tests only expect vmomi reads here, got {path!r}"
+        )
+        spec_type = json["specSet"][0]["propSet"][0]["type"]
+        return self._vmomi[spec_type]
+
+
+def _drs_recommendation_vmomi(vm_moid: str, destination: str) -> dict[str, Any]:
+    """Canned ``ClusterComputeResource.drsRecommendation`` property read (#2970)."""
+    return {
+        "objects": [
+            {
+                "obj": {"type": "ClusterComputeResource", "value": "c-1"},
+                "propSet": [
+                    {
+                        "name": "drsRecommendation",
+                        "val": [
+                            {
+                                "migrationList": [
+                                    {
+                                        "vm": {"type": "VirtualMachine", "value": vm_moid},
+                                        "destination": {
+                                            "type": "HostSystem",
+                                            "value": destination,
+                                        },
+                                    }
+                                ]
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
 
 
 @pytest.mark.asyncio
@@ -196,7 +237,7 @@ async def test_gated_write_subop_queues_for_approval_via_composite(session: Asyn
 async def test_dangerous_write_subop_denied_without_grant(session: AsyncSession) -> None:
     """An agent with no grant is denied the dangerous relocate write; it never runs."""
     conn = _RecordingConnector(
-        {"/api/vcenter/cluster/c-1/drs/recommendations": [{"vm": "vm-1", "target_host": "host-A"}]}
+        {}, vmomi={"ClusterComputeResource": _drs_recommendation_vmomi("vm-1", "host-A")}
     )
     out = await vm_migrate_composite(
         operator=_operator(sub="agent-no-grant"),
@@ -224,7 +265,7 @@ async def test_human_operator_subop_auto_executes(session: AsyncSession) -> None
     gate and the write proceeds -- no double-gate on the resume path.
     """
     conn = _RecordingConnector(
-        {"/api/vcenter/cluster/c-1/drs/recommendations": [{"vm": "vm-1", "target_host": "host-A"}]}
+        {}, vmomi={"ClusterComputeResource": _drs_recommendation_vmomi("vm-1", "host-A")}
     )
     out = await vm_migrate_composite(
         operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -415,7 +415,6 @@ async def test_vm_clone_preview_echoes_clone_coordinates() -> None:
                 "source_vm": "vm-1",
                 "target_name": "vm-clone",
                 "library_item": "lib-1",
-                "wait_for_completion": False,
             }
         )
     )
@@ -423,7 +422,6 @@ async def test_vm_clone_preview_echoes_clone_coordinates() -> None:
         "source_vm": "vm-1",
         "target_name": "vm-clone",
         "library_item": "lib-1",
-        "wait_for_completion": False,
     }
 
 
@@ -814,7 +812,9 @@ async def test_cluster_patch_park_resolves_host_set(
     stub_embedding_service: AsyncMock,
 ) -> None:
     recorder = await _bootstrap_registry(stub_embedding_service)
-    recorder.responses["/vcenter/cluster/domain-c1/host"] = {
+    # #2970: cluster hosts resolve via the cluster-filtered Host_list --
+    # the pinned spec serves no per-cluster /vcenter/cluster/{c}/host.
+    recorder.responses["/vcenter/host"] = {
         "value": [
             {"host": "host-1", "name": "esx-1"},
             {"host": "host-2", "name": "esx-2"},
@@ -827,7 +827,6 @@ async def test_cluster_patch_park_resolves_host_set(
         "op_class": "write",
         "preview": {
             "cluster": "domain-c1",
-            "patch_method": "default",
             "resolved": [
                 {"host": "host-1", "name": "esx-1"},
                 {"host": "host-2", "name": "esx-2"},
@@ -838,7 +837,7 @@ async def test_cluster_patch_park_resolves_host_set(
         "safety_level": "dangerous",
     }
     # Only the host listing fired — no maintenance / patch sub-ops.
-    assert recorder.specs == ["/vcenter/cluster/domain-c1/host"]
+    assert recorder.specs == ["/vcenter/host"]
 
 
 # ===========================================================================

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -496,13 +496,18 @@ async def test_write_composite_response_schemas_persist_with_status_enums(
     # Every row has a non-empty response_schema with a status enum.
     expected_status_values: dict[str, set[str]] = {
         "vmware.composite.vm.create": {"created", "rolled_back"},
-        "vmware.composite.vm.clone": {"completed", "pending", "timeout"},
-        "vmware.composite.vm.snapshot.revert": {"reverted", "ambiguous", "not_found"},
+        # #2970: the pinned deploy operation is synchronous, so the
+        # pending/timeout task-wait statuses are gone.
+        "vmware.composite.vm.clone": {"completed"},
+        # #2970: the revert is a polled vim *_Task -> a poll timeout is a
+        # legible status.
+        "vmware.composite.vm.snapshot.revert": {"reverted", "ambiguous", "not_found", "timeout"},
         "vmware.composite.vm.migrate": {"migrated", "no_recommendation"},
         "vmware.composite.vm.power": {"ok", "error", "tools_unavailable"},
         "vmware.composite.vm.disk.grow": {"grown", "invalid_shrink", "disk_not_found", "timeout"},
         "vmware.composite.host.evacuate": {"evacuated", "partial", "aborted"},
-        "vmware.composite.host.detach_from_vds": {"detached", "incomplete"},
+        # #2970: the DVS detach is a polled vim ReconfigureDvs_Task.
+        "vmware.composite.host.detach_from_vds": {"detached", "incomplete", "timeout"},
         "vmware.composite.cluster.patch": {"completed", "stopped"},
         "vmware.composite.vm.resize": {"resized", "requires_power_off", "no_change", "partial"},
         "vmware.composite.vm.nic.repoint": {"repointed", "not_found", "ambiguous"},

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -452,9 +452,9 @@ calls another composite via `dispatch_child`. Two-level nesting:
 host.evacuate                                            # depth 0 (top-level dispatch)
   ├─ GET:/vcenter/vm                                     # depth 0 (direct session read)
   └─ vmware.composite.vm.migrate (× N)                  # depth 1 (dispatch_child of a composite)
-       ├─ GET:/vcenter/cluster/{c}/drs/recommendations  # depth 1 (direct session read)
+       ├─ vim RetrievePropertiesEx (drsRecommendation)  # depth 1 (direct vmomi read, #2970)
        └─ POST:/vcenter/vm/{vm}?action=relocate         # depth 1 (direct session write, gated)
-  └─ PATCH:/vcenter/host/{host}/maintenance?action=enter # depth 0 (direct session write, gated)
+  └─ vim POST:/HostSystem/{moId}/EnterMaintenanceMode_Task # depth 0 (gated vmomi write + Task poll, #2970)
 ```
 
 `composite_depth_var` (default cap 8) handles the one nesting level
@@ -513,16 +513,16 @@ enum) are:
 | Composite | Status values |
 | --- | --- |
 | `vm.create` | `created`, `rolled_back` |
-| `vm.clone` | `completed`, `pending`, `timeout` |
-| `vm.snapshot.revert` | `reverted`, `ambiguous`, `not_found` |
+| `vm.clone` | `completed` (the pinned deploy operation is synchronous — its 200 body is the new VM id, #2970; deploy failures raise `connector_error`) |
+| `vm.snapshot.revert` | `reverted`, `ambiguous`, `not_found`, `timeout` (vim `RevertToSnapshot_Task` polled; a task fault raises `connector_error`, #2970) |
 | `vm.migrate` | `migrated`, `no_recommendation` |
 | `vm.power` | `ok`, `error`, `tools_unavailable` (single VM; `tools_unavailable` when a soft `guest_shutdown`/`guest_reboot` finds Tools down) |
 | `vm.power.bulk` | (per-VM `results` + aggregate `summary` + `aborted_on_failure`) |
 | `vm.disk.grow` | `grown`, `invalid_shrink`, `disk_not_found`, `timeout` (grow-only; `invalid_shrink` refuses a request ≤ current capacity before any write; `timeout` when the `ReconfigVM_Task` poll gives up) |
 | `vm.clone_from_template` | `cloned`, `template_not_found`, `ambiguous_template`, `not_a_template`, `timeout` (name-resolution refusals + the template assert are pre-write; `timeout` when the `CloneVM_Task` poll gives up; a task *fault* raises `connector_error`) |
-| `host.evacuate` | `evacuated`, `partial`, `aborted` |
-| `host.detach_from_vds` | `detached`, `incomplete` |
-| `cluster.patch` | `completed`, `stopped` |
+| `host.evacuate` | `evacuated`, `partial`, `aborted` (the maintenance-enter is the vim `EnterMaintenanceMode_Task`, polled; fault/timeout raises `connector_error`, #2970) |
+| `host.detach_from_vds` | `detached`, `incomplete`, `timeout` (the detach is the vim `ReconfigureDvs_Task` host-member remove, polled, #2970) |
+| `cluster.patch` | `completed`, `stopped` (per-host vim maintenance `*_Task`s + the vLCM `software?action=apply&vmw-task=true` cis task, every task polled before the next step, #2970) |
 | `cluster.drs_rule.create` | `created`, `rule_exists`, `insufficient_vms`, `timeout` (idempotent on rule name — a duplicate `rule_exists` is refused before any write; `insufficient_vms` when fewer than two named VMs resolve to the cluster; `timeout` when the `ReconfigureComputeResource_Task` poll gives up) |
 | `folder.create` | `created`, `parent_not_found`, `ambiguous_parent` (synchronous `CreateFolder` — the resolution refusals are structured, not raw vim faults) |
 | `vm.resize` | `resized`, `requires_power_off`, `no_change`, `partial` |
@@ -662,7 +662,7 @@ lives:
 
 | Op | Source | Path | When |
 | --- | --- | --- | --- |
-| `vm.clone` | a **content-library** template item | REST `POST:/vcenter/vm-template/library-items?action=deploy`, poll `GET:/cis/tasks/{task}` | the golden image is published to a content library |
+| `vm.clone` | a **content-library** template item | REST `POST:/vcenter/vm-template/library-items/{templateLibraryItem}?action=deploy` (synchronous — the 200 body is the new VM id; #2970) | the golden image is published to a content library |
 | `vm.clone_from_template` | a **folder VM template** (a marked-as-template VM in a VM folder) | vim `POST:/VirtualMachine/{moId}/CloneVM_Task`, poll via `poll_vim_task` | the golden image is a plain marked-as-template VM (govc/terraform's `CloneVM_Task` path) |
 
 `vm.clone`'s content-library deploy path **cannot** clone a folder
@@ -853,7 +853,7 @@ composite on the generic per-op hook (`register_preview_builder`,
 | `vm.power.bulk` | `{action, filter, resolved, total_resolved}` | live read (`GET:/vcenter/vm`) |
 | `host.evacuate` | `{host, tolerate_partial_failure, resolved, total_resolved}` | live read (`GET:/vcenter/vm`) |
 | `host.detach_from_vds` | `{host, dvs, fallback_network, resolved, total_resolved}` | live read (`GET:/vcenter/vm`) |
-| `cluster.patch` | `{cluster, patch_method, resolved, total_resolved}` | live read (`GET:/vcenter/cluster/{cluster}/host`) |
+| `cluster.patch` | `{cluster, resolved, total_resolved}` | live read (`GET:/vcenter/host?clusters=...`) |
 | `vm.resize` | `{vm, name, power_state, current, requested}` sizing from->to | live read (`GET:/vcenter/vm/{vm}`) |
 | `vm.nic.repoint` | `{vm, name, nic, mac_address, current_backing, requested_backing}` network from->to | live read (`ethernet/{nic}` + `GET:/vcenter/network`) |
 | `vm.device.cdrom` | `{vm, name, cdrom, action, current_backing, state}` (the host-local ISO path) | live read (`cdrom/{cdrom}`) |
@@ -1029,11 +1029,16 @@ they never park.
   there is **no** dedicated distributed-portgroup list resource at all —
   distributed portgroups are enumerated via the generic
   `GET:/vcenter/network` resource filtered to the
-  `DISTRIBUTED_PORTGROUP` type. Both corrected sub-ops live in the REST
-  Automation `vcenter.yaml` (this is **not** a VI-JSON MoRef family
-  swap). The generic `Network` summary carries no parent-DVS field, so
-  the per-portgroup `dvs`/`dvs_name` enrichment is best-effort and
-  `filter_dvs` scopes only the DVS-name index, not the portgroup set.
+  `DISTRIBUTED_PORTGROUP` type. **#2970 update:** the first run against
+  the *canonical pinned* `vcenter.yaml` showed the plural
+  `distributed-switches` path exists only under the NSX-scoped
+  `/vcenter/namespace-management/` tree — there is **no** generic DVS
+  list resource in the pinned REST spec at all — so the audit's DVS-list
+  step was dropped entirely. `dvs_name` is now always `null` (the
+  generic `Network` summary carries no parent-DVS field to join on, so
+  the name index was never consulted with a hit anyway), `dvs` stays
+  best-effort from the portgroup row itself, and `filter_dvs` is
+  accepted but inert.
   A build-time guard
   (`tests/acceptance/test_portgroup_audit_op_id_reconcile.py`) parses
   the pinned `vcenter.yaml` and asserts every audit sub-op_id is emitted
@@ -1055,6 +1060,27 @@ they never park.
   parses the real pinned `vcenter.yaml` and asserts every `_SUB_OPS_*`
   REST path actually **exists** — skipping in CI where the spec-shelf is
   unprovisioned (the #1602 convention), running wherever it is wired.
+- **#2970 real-spec repoint** — running the #2944 guard against the real
+  shelf (the #2949 verification) found 11 op_ids the pinned
+  `vcenter.yaml` does not serve. The composites were repointed:
+  `vm.clone`'s deploy moved to the per-item
+  `POST:/vcenter/vm-template/library-items/{templateLibraryItem}?action=deploy`
+  (synchronous — the cis-task poll went away), cluster-host listing to
+  `GET:/vcenter/host` + `clusters` filter, `vm.create`'s NIC attach to
+  `POST:/vcenter/vm/{vm}/hardware/ethernet`, `host.detach_from_vds`'s
+  NIC migration to per-adapter
+  `PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}`, and `cluster.patch`'s
+  patch step to the vLCM
+  `POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true`.
+  Surfaces with **no** REST path in the pinned spec switched to vim
+  (`_VIM_SUB_OPS_*`, reconciled against `vi-json.yaml`): snapshot
+  list/revert (`VirtualMachine.snapshot` +
+  `VirtualMachineSnapshot.RevertToSnapshot_Task`), host maintenance
+  (`HostSystem.EnterMaintenanceMode_Task` / `ExitMaintenanceMode_Task`),
+  DRS recommendations (`ClusterComputeResource.drsRecommendation`), and
+  DVS host removal (`DistributedVirtualSwitch.ReconfigureDvs_Task` with
+  the `config.configVersion` read). The audit's DVS listing was dropped
+  (degradation note above).
 
 ## References
 


### PR DESCRIPTION
## Summary

- Repoints the 11 vmware composite op_ids that the real pinned `vcenter.yaml` does not serve (the #2949 verification finding recorded in `docs/decisions/vendor-spec-ci-provisioning.md`) — the activation gate for arming `SPEC_SHELF_TOKEN`.
- Every repoint was verified against the pinned shelf specs themselves (`vcenter.yaml` 961 paths / `vi-json.yaml` 2195 paths): path shape, query-action encoding, request-body schema, and response shape. Where the pinned spec has **no** REST equivalent, the step switched to the governed vim (VI-JSON) seam the #2893–#2895 composites established (`_VIM_SUB_OPS_*`, `_write_vmomi_sub_op`, `poll_vim_task`) — no path was invented.
- All five spec lanes are green against the real shelf: **35 passed / 0 failed / 28 skipped** (baseline on `main`: 18 / 2 / 28). The 28 skips are the pre-existing Docker-sandbox skips in the g07 canary's dispatch tests ("Docker socket unavailable in this sandbox"); they run in CI where containers are provisioned — identical skip set to the baseline.

## Per-op decision table

| # | Old op_id (not served) | Decision | New surface (serving spec section) |
|---|---|---|---|
| 1 | `GET:/vcenter/network/distributed-switches` (`_read._OP_LIST_DVS`, portgroup audit) | **Drop the step** (sanctioned degradation) | The pinned `vcenter.yaml` serves distributed-switch paths only under the NSX-scoped `/vcenter/namespace-management/networks/nsx/` tree — no generic DVS list resource exists. vim enumeration would need the ContainerView machinery for a name-enrichment that was documented best-effort and could never join anyway (`Vcenter.Network.Summary` carries no parent-DVS field). Degradation: `dvs_name` is now always `null` (it already was in practice), `filter_dvs` accepted but inert — both documented in handler/schema. |
| 2 | `GET:/vcenter/cluster/{cluster}/host` (`_OP_LIST_CLUSTER_HOSTS`) | **REST repoint** | `GET:/vcenter/host` + `clusters` query filter (`Vcenter.Host_list`, `Vcenter.Host.FilterSpec.clusters`; rows are `Vcenter.Host.Summary` keeping the `host` moid key the callers extract). Shared `_resolve_cluster_hosts` seam → dispatch + park-time preview follow together. |
| 3 | `GET:/vcenter/vm/{vm}/snapshot` (`_OP_LIST_VM_SNAPSHOTS`) | **vim switch** | `RetrievePropertiesEx` read of `VirtualMachine.snapshot` (`VirtualMachineSnapshotInfo.rootSnapshotList`, recursive `VirtualMachineSnapshotTree` — `snapshot` MoRef + `name` + `childSnapshotList`, spec-verified). The pinned `vcenter.yaml` serves **no** snapshot resource at all. |
| 4 | `POST:/vcenter/vm/{vm}/snapshot/{snap}?action=revert` (`_OP_REVERT_VM_SNAPSHOT`) | **vim switch** | `POST:/VirtualMachineSnapshot/{moId}/RevertToSnapshot_Task` (`RevertToSnapshotRequestType`, all args optional → `{}` body) + `poll_vim_task`; fault raises `connector_error`, poll timeout returns `status="timeout"` (new enum value, mirrors disk-grow). |
| 5 | `PATCH:/vcenter/host/{host}/maintenance?action=enter` | **vim switch** | `POST:/HostSystem/{moId}/EnterMaintenanceMode_Task` (`EnterMaintenanceModeRequestType` — required int `timeout`, sent `0` = no vim-side bound; the 600 s poll wall clock is the bound) + `poll_vim_task`. Used by `host.evacuate` + `cluster.patch`; shared `_host_maintenance_vim_step`. |
| 6 | `PATCH:/vcenter/host/{host}/maintenance?action=exit` | **vim switch** | `POST:/HostSystem/{moId}/ExitMaintenanceMode_Task` (`ExitMaintenanceModeRequestType` — required int `timeout`), same seam as #5. |
| 7 | `PATCH:/vcenter/vm/{vm}/network` (vm.create NIC attach) | **REST repoint** | `POST:/vcenter/vm/{vm}/hardware/ethernet` (`Vcenter.Vm.Hardware.Ethernet_create`); the network rides `Ethernet.CreateSpec.backing` (`{type, network}` — `BackingSpec.type` required), so the `nics` param items gained an optional `backing_type` (default `STANDARD_PORTGROUP`). |
| 8 | `PATCH:/vcenter/vm/{vm}/network` (host.detach_from_vds NIC migration) | **REST restructure** | Per-adapter: `GET:/vcenter/vm/{vm}/hardware/ethernet` (`Ethernet_list`, rows keyed `nic`) then `PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}` (`Ethernet_update`) with the `STANDARD_PORTGROUP` backing spec to `fallback_network`. The pinned spec has no VM-level NIC write; per-adapter is the only real shape. |
| 9 | `POST:/vcenter/host/{host}?action=patch` (`_OP_HOST_PATCH`, cluster.patch) | **REST repoint (vLCM)** | `POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true` (`Esx.Settings.Hosts.Software_apply$Task`; `ApplySpec` all-optional → empty spec = latest desired-state commit; 202 body = cis task id). The returned cis task is polled via the already-declared `GET:/cis/tasks/{task}` **before** maintenance-exit — exiting mid-remediation would defeat the sequential rolling-patch contract. The fictional `patch_method` param (fed a body field of the nonexistent path) was dropped. |
| 10 | `POST:/vcenter/network/dvs/{dvs}?action=remove_host` (`_OP_REMOVE_DVS_HOST`) | **vim switch** | `POST:/DistributedVirtualSwitch/{moId}/ReconfigureDvs_Task` (`ReconfigureDvsRequestType.spec` = `DVSConfigSpec`) with `host: [{operation: "remove", host: <HostSystem MoRef>}]` (`DistributedVirtualSwitchHostMemberConfigSpec` — `operation` + `host` required; `ConfigSpecOperation_enum` `remove`). `DVSConfigSpec.configVersion` is required for reconfigure, so it is read off `config.configVersion` (`RetrievePropertiesEx`) first; Task polled. The pinned `vcenter.yaml` serves no DVS write path at all. |
| 11 | `POST:/vcenter/vm-template/library-items?action=deploy` (`_OP_DEPLOY_LIBRARY_VM`) | **REST repoint + response realignment** | `POST:/vcenter/vm-template/library-items/{templateLibraryItem}?action=deploy` (`Vcenter.VmTemplate.LibraryItems_deploy`; the template item is a **path** param; `DeploySpec` requires only `name`). The operation is **synchronous** — its 200 body is the deployed `VirtualMachine` id, and no `vmw-task=true` variant of the path exists — so `vm.clone`'s cis-task poll went away, and the `wait_for_completion` / `timeout_seconds` params with it. Envelope keys retained (`task_id` always `null`) for stability. |

**DRS recommendations** (`GET:/vcenter/cluster/{cluster}/drs/recommendations`, `_OP_GET_DRS_RECOMMENDATIONS`, one of the ten `_SUB_OPS_*` findings): **vim switch** to a `RetrievePropertiesEx` read of `ClusterComputeResource.drsRecommendation` (`ClusterDrsRecommendation[].migrationList[]` → `vm` / `destination` MoRefs, spec-verified). Note: `drsRecommendation` is marked deprecated in the vim API (since VI 2.5, in favour of the generic `recommendation` action list) but is served by the pinned spec and is the only property that directly carries the vm → destination-host migration pairs the composite consumes; the generic list would require `_typeName`-discriminated action walking for no gain. Recorded as a deliberate tradeoff.

## Governance & test posture

- Every new vim mutation flows through the same #2254 `enforce_subop_policy` seam (`_write_vmomi_sub_op`) under the vim governance op_ids; every `*_Task` is polled to terminal via the shared `poll_vim_task` before success is reported (fault → `connector_error`; poll timeout → typed `timeout` status or step-failure reason per composite — conventions mirror #2893–#2895).
- The vim-switched manifests moved out of the `_SUB_OPS_*` namespace into `_VIM_SUB_OPS_*` (so the vcenter.yaml sweep skips them) and gained three parametrized reconcile tests in the l2 lane: manifest pin, ingest round-trip, and env-gated real-`vi-json.yaml` POST-path existence — the same three-tier proof the #2893–#2895 composites carry.
- `vm.snapshot.revert` left the `_SUB_OPS_*` pin list (both sub-ops are vim now); the discovery-pin test freezes the remaining 13 names.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/meho_backplane --ignore-missing-imports` — no new errors (one pre-existing darwin-only `net/icmp.py` `MSG_ERRQUEUE` artifact; Linux CI unaffected)
- [x] Five spec lanes vs the real shelf (`MEHO_CONSUMER_DOCS_ROOT` → pinned `vcenter-9.0/`): **35 passed / 0 failed / 28 skipped** (skips = pre-existing Docker-sandbox canary skips, run in CI)
- [x] Both reconcile lanes also green **without** the shelf (shape tier, CI default)
- [x] Composite behavior tests updated + green: `composites_write` (90), `composites_read` (30), `write_gate` (15), `write_e2e` (55), `recursive_e2e` (1), `write_preview` (41), respx vcsim lane (17)
- [x] Full backend suite (minus testcontainers integration) — green
- [x] `code-quality.py --diff` — 0 blockers (12 warnings, all pre-existing legacy debt in touched files)

## Out of scope / adjacent findings

- **Arming `SPEC_SHELF_TOKEN`** — operator action per the #2949 ADR runbook (signoff → this fix on `main` → full five-lane pre-verify on a Docker machine → secret).
- **`_read._OP_GET_CLUSTER_DRS = "GET:/vcenter/cluster/{cluster}/drs"`** (the `cluster.drs_recommendations` *read* composite) is **also not served** by the pinned `vcenter.yaml` — it is not among this task's 11 op_ids and no real-spec lane guards `_SUB_OPS_CLUSTER_DRS_RECS`, so it is recorded here for a follow-up rather than stealth-fixed.
- **Write-body `{"spec": ...}` wrapping** — the composites author legacy-`/rest`-style wrapped bodies while the modern `/api` wire takes the spec object directly; this is a pre-existing, file-wide convention across all write composites (this PR keeps it for consistency) and deserves its own systemic ticket.
- `docs/cross-repo/*.md` still shows the old paths in narrative examples — deliberately untouched (concurrent #2971 docs sweep owns that surface; trivial follow-up otherwise).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2970
