### PR TITLE
feat(connectors): add vmware.composite.vm.deploy_from_library — OVF/OVA content-library deploy (#2909)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,26 @@ connector-related release-notes line.
     credential material never reach an approval / audit / broadcast surface
     (#1503).
 
+### Added — `vmware.composite.vm.deploy_from_library` OVF/OVA content-library deploy (#2909)
+
+- Add `vmware.composite.vm.deploy_from_library` — a curated OVF/OVA
+  content-library deploy composite on the vmware-rest connector,
+  retiring the `govc library.deploy` pivot in the consumer's
+  deploy/clone procedures (#2909). Resolves the OVF item by id
+  (passthrough) or by name (`POST:/content/library/item?action=find`,
+  filtered to `type=ovf`, optionally scoped by a library name), refusing
+  ambiguity before any deploy; issues the synchronous
+  `POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy`
+  through the governed direct-session seam (zero-ingest, `#2247`); and
+  maps the `DeploymentResult` to a structured envelope — `deployed`,
+  `deploy_failed` (OVF/network/placement validation, with the report's
+  per-issue messages), or `deploy_error` (HTTP 400/404) — so a
+  placement/mapping error is never a raw vendor error. Params cover
+  placement (resource pool / host / folder / datastore), OVF-network →
+  portgroup mappings, storage/provisioning options, additional OVF
+  properties, and optional power-on. `safety_level=dangerous`,
+  `requires_approval=True`, with a secret-hygienic param-echo preview.
+
 ### Breaking changes — vmware composite param schemas tightened by the #2970 repoint
 
 - `vmware.composite.vm.clone` no longer accepts `wait_for_completion` /

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/__init__.py
@@ -13,7 +13,7 @@ The chassis lifespan's
 invokes every registered registrar in registration order after
 :func:`~meho_backplane.connectors.registry._eager_import_connectors`
 has walked every ``connectors/<product>/`` subpackage, so the
-``endpoint_descriptor`` upserts for the 23 composites land before
+``endpoint_descriptor`` upserts for the 24 composites land before
 any dispatch can fire.
 
 Layout mirrors the :mod:`meho_backplane.connectors.vault` pattern: the
@@ -29,13 +29,14 @@ Scope:
   (The former ``host.network_uplinks`` / ``host.vsan_health`` reads
   were re-shipped as ``source_kind="typed"`` ops in #2258; see
   :mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.)
-* 18 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
+* 19 write composites (G3.1-T6 / #509, single-VM ``vm.power`` /
   #2301, the mutating VI-JSON ``vm.disk.grow`` / #2893, the
   folder-template ``vm.clone_from_template`` / #2894, the vim
   cluster / inventory writes ``cluster.drs_rule.create`` +
   ``folder.create`` / #2895, the #2891 post-clone hardware
   reconfigure trio ``vm.resize`` / ``vm.nic.repoint`` /
-  ``vm.device.cdrom``, and the two GOSC composites / #2892) -- inherit
+  ``vm.device.cdrom``, the two GOSC composites / #2892, and the OVF/OVA
+  content-library deploy ``vm.deploy_from_library`` / #2909) -- inherit
   T4's ``safety_level="dangerous"`` +
   ``requires_approval=True`` defaults.
   They cover every state-mutating workflow Goal #214 names as
@@ -52,7 +53,9 @@ Scope:
   post-clone hardware reconfigure trio ``vm.resize``,
   ``vm.nic.repoint``, ``vm.device.cdrom`` (#2891), plus guest OS
   customization: ``guest.customization_spec.create`` and
-  ``vm.customize`` (GOSC create + apply, secret-hygienic) (#2892).
+  ``vm.customize`` (GOSC create + apply, secret-hygienic) (#2892), plus
+  ``vm.deploy_from_library`` (OVF/OVA content-library deploy, retiring
+  ``govc library.deploy``) (#2909).
 """
 
 from meho_backplane.connectors.vmware_rest.composites._read import (
@@ -76,6 +79,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_clone_from_template_composite,
     vm_create_composite,
     vm_customize_composite,
+    vm_deploy_from_library_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -93,7 +97,7 @@ from meho_backplane.operations.typed_register import register_typed_op_registrar
 # registered by the time the runner iterates.
 register_typed_op_registrar(register_vmware_composite_operations)
 
-# Side-effect import: registers the 18 write composites' park-time
+# Side-effect import: registers the 19 write composites' park-time
 # ``proposed_effect`` preview builders (#1608) onto the per-op hook in
 # :mod:`meho_backplane.operations._preview` — mirrors how
 # ``connectors/argocd/__init__`` wires ``ops_write_preview``.
@@ -116,6 +120,7 @@ __all__ = [
     "vm_clone_from_template_composite",
     "vm_create_composite",
     "vm_customize_composite",
+    "vm_deploy_from_library_composite",
     "vm_device_cdrom_composite",
     "vm_disk_grow_composite",
     "vm_migrate_composite",

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``register_vmware_composite_operations`` -- registrar for the 23 composites.
+"""``register_vmware_composite_operations`` -- registrar for the 24 composites.
 
 Module-level async function called from the lifespan-driven
 :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
@@ -26,14 +26,15 @@ The 5 read composites (T5 / #508) pass
 T4's ``dangerous`` / ``True`` defaults. (The former
 ``host.network_uplinks`` and ``host.vsan_health`` reads were re-shipped
 as typed ops in #2258; see
-:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 18 write
+:mod:`~meho_backplane.connectors.vmware_rest.typed_ops`.) The 19 write
 composites (T6 / #509, single-VM ``vm.power`` / #2301, the mutating
 VI-JSON ``vm.disk.grow`` / #2893, the folder-template
 ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
 ``cluster.drs_rule.create`` + ``folder.create`` / #2895, the #2891
 hardware writes -- ``vm.resize`` / ``vm.nic.repoint`` /
-``vm.device.cdrom``, and the two GOSC composites
-``guest.customization_spec.create`` / ``vm.customize`` / #2892) inherit
+``vm.device.cdrom``, the two GOSC composites
+``guest.customization_spec.create`` / ``vm.customize`` / #2892, and the
+OVF/OVA content-library deploy ``vm.deploy_from_library`` / #2909) inherit
 the T4 defaults explicitly (pass ``"dangerous"`` / ``True`` for clarity
 at the call site; the helper would default to those values anyway).
 Each :class:`_CompositeSpec` row carries its own ``safety_level`` +
@@ -65,6 +66,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_clone_from_template_composite,
     vm_create_composite,
     vm_customize_composite,
+    vm_deploy_from_library_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -105,6 +107,8 @@ from meho_backplane.connectors.vmware_rest.composites.schemas import (
     VM_CREATE_RESPONSE_SCHEMA,
     VM_CUSTOMIZE_PARAMETER_SCHEMA,
     VM_CUSTOMIZE_RESPONSE_SCHEMA,
+    VM_DEPLOY_FROM_LIBRARY_PARAMETER_SCHEMA,
+    VM_DEPLOY_FROM_LIBRARY_RESPONSE_SCHEMA,
     VM_DEVICE_CDROM_PARAMETER_SCHEMA,
     VM_DEVICE_CDROM_RESPONSE_SCHEMA,
     VM_DISK_GROW_PARAMETER_SCHEMA,
@@ -201,7 +205,10 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "attach + optional power-on (rollback on partial failure), "
         "clone from a content-library template (long-running task "
         "polling) or from a folder VM template (CloneVM_Task, with "
-        "optional inline guest customization), revert to a named "
+        "optional inline guest customization), deploy an OVF/OVA "
+        "content-library item to a new VM (deploy_from_library — "
+        "OVF-network→portgroup mappings, ambiguity-rejecting name "
+        "lookup, structured deploy-report statuses), revert to a named "
         "snapshot (ambiguity-rejecting), "
         "migrate via DRS or explicit host, bulk power across a "
         "filter, or a single-VM power verb (on/off/reset plus a "
@@ -421,6 +428,37 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
         response_schema=VM_CLONE_RESPONSE_SCHEMA,
         group_key="vm",
         tags=["composite", "write", "vm", "lifecycle"],
+        safety_level="dangerous",
+        requires_approval=True,
+    ),
+    _CompositeSpec(
+        op_id="vmware.composite.vm.deploy_from_library",
+        handler=vm_deploy_from_library_composite,
+        summary="Deploy an OVF/OVA content-library item to a new VM (retires govc library.deploy).",
+        description=(
+            "Deploys an OVF/OVA package from a content library to a new VM via "
+            "the synchronous "
+            "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy. "
+            "The library item is referenced by id (passthrough) or by name — "
+            "resolved via POST:/content/library/item?action=find (filtered to "
+            "type=ovf), optionally scoped by library name through "
+            "POST:/content/library?action=find, with ambiguity refused "
+            "(status='ambiguous_item' / 'ambiguous_library') before any deploy. "
+            "resource_pool is the required placement anchor; host / folder / "
+            "datastore refine it, and network_mappings maps each OVF network key "
+            "to a portgroup. Unlike vm.clone (200 body is a bare VM id) the OVF "
+            "deploy's 200 body is a DeploymentResult: a failed OVF / network / "
+            "placement validation returns succeeded=false and surfaces as "
+            "status='deploy_failed' with per-issue messages, and an invalid / "
+            "missing placement resource (HTTP 400/404) as status='deploy_error' "
+            "— structured statuses, never a raw vendor error. With power_on the "
+            "deployed VM is started best-effort. Equivalent of 'govc "
+            "library.deploy' for operator-facing dispatch."
+        ),
+        parameter_schema=VM_DEPLOY_FROM_LIBRARY_PARAMETER_SCHEMA,
+        response_schema=VM_DEPLOY_FROM_LIBRARY_RESPONSE_SCHEMA,
+        group_key="vm",
+        tags=["composite", "write", "vm", "lifecycle", "ovf"],
         safety_level="dangerous",
         requires_approval=True,
     ),
@@ -839,14 +877,15 @@ async def register_vmware_composite_operations(
     on every lifespan startup; the skip-re-embed branch keeps that
     cheap.
 
-    Scope: 23 composites total -- 5 read (T5 / #508) + 18 write (T6 /
+    Scope: 24 composites total -- 5 read (T5 / #508) + 19 write (T6 /
     #509, single-VM ``vm.power`` / #2301, the mutating VI-JSON
     ``vm.disk.grow`` / #2893, the folder-template
     ``vm.clone_from_template`` / #2894, the vim cluster / inventory writes
     ``cluster.drs_rule.create`` + ``folder.create`` / #2895, the #2891
     hardware writes ``vm.resize`` / ``vm.nic.repoint`` /
-    ``vm.device.cdrom``, and the two GOSC composites
-    ``guest.customization_spec.create`` / ``vm.customize`` / #2892). (The
+    ``vm.device.cdrom``, the two GOSC composites
+    ``guest.customization_spec.create`` / ``vm.customize`` / #2892, and the
+    OVF/OVA content-library deploy ``vm.deploy_from_library`` / #2909). (The
     former ``host.network_uplinks`` / ``host.vsan_health`` reads were
     re-shipped as typed ops in #2258.)
     Each composite's ``safety_level`` +

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
-# code-quality-allow: 18 protocol-driven composite handlers for the
+# code-quality-allow: 19 protocol-driven composite handlers for the
 # vSphere REST + VI-JSON write surface ship in one module per the issue
 # body's design; splitting them by group would scatter the shared
 # sub-op_id constants + helpers across files for no readability gain. Each
@@ -8,10 +8,11 @@
 # (plus the single-VM vm.power from #2301, the mutating VI-JSON disk-grow
 # from #2893, the folder-template clone from #2894, the vim cluster /
 # inventory writes — DRS-rule + folder create — from #2895, the #2891
-# hardware writes — vm.resize / vm.nic.repoint / vm.device.cdrom, and the
-# GOSC create/apply from #2892).
+# hardware writes — vm.resize / vm.nic.repoint / vm.device.cdrom, the
+# GOSC create/apply from #2892, and the OVF/OVA content-library deploy
+# from #2909).
 
-"""Write-shaped ``vmware.composite.*`` handler functions (18 composites).
+"""Write-shaped ``vmware.composite.*`` handler functions (19 composites).
 
 Companion to :mod:`._read`. Post-#2256 each handler is a module-level
 ``async def`` taking the dispatcher's composite-branch keyword args
@@ -112,6 +113,7 @@ __all__ = [
     "vm_clone_from_template_composite",
     "vm_create_composite",
     "vm_customize_composite",
+    "vm_deploy_from_library_composite",
     "vm_device_cdrom_composite",
     "vm_disk_grow_composite",
     "vm_migrate_composite",
@@ -177,6 +179,31 @@ _OP_LIST_HOSTS = "GET:/vcenter/host"
 _OP_DEPLOY_LIBRARY_VM = (
     "POST:/vcenter/vm-template/library-items/{templateLibraryItem}?action=deploy"
 )
+# OVF/OVA content-library deploy (``vm.deploy_from_library`` / #2909). The
+# pinned spec keys the deploy on the OVF item as a *path* param
+# (``Vcenter.Ovf.LibraryItem_deploy``); like the VMTX deploy it is
+# synchronous, but its 200 body is a ``DeploymentResult`` structure
+# (``succeeded`` / ``resource_id`` / ``error``) — a deploy that fails OVF /
+# placement / network validation returns ``succeeded=false`` with an error
+# report rather than raising, so the composite surfaces it as a structured
+# status. Name-based item resolution rides the content-library find actions
+# (both served by the pinned ``vcenter.yaml``): items via
+# ``Content.Library.Item_find`` (filtered to ``type=ovf``), the optional
+# scoping library via ``Content.Library_find`` — both return a bare array of
+# id strings and mutate nothing, so they run un-gated like the REST listing
+# reads.
+_OP_DEPLOY_OVF_LIBRARY_ITEM = "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy"
+_OP_FIND_LIBRARY = "POST:/content/library?action=find"
+_OP_FIND_LIBRARY_ITEM = "POST:/content/library/item?action=find"
+# Content-library item type discriminator for OVF/OVA templates — the find
+# filter that keeps a colliding non-OVF item name (ISO, other) from matching.
+_OVF_LIBRARY_ITEM_TYPE = "ovf"
+# ``Vcenter.Ovf.OvfParams`` subtype discriminator for injected OVF
+# product-section properties. The pinned 9.0 ``/api`` schema keys the union on
+# ``type`` (the legacy ``/rest`` ``@class`` form is not used on the modern
+# mount); a single ``PropertyParams`` entry carries the operator's
+# ``ovf_properties`` map as ``{id, value}`` rows.
+_OVF_PROPERTY_PARAMS_TYPE = "PropertyParams"
 _OP_GET_TASK = "GET:/cis/tasks/{task}"
 # Per-host vLCM remediation (``Esx.Settings.Hosts.Software_apply$Task``).
 # The pinned spec serves no ``POST:/vcenter/host/{host}?action=patch``
@@ -562,6 +589,12 @@ _SUB_OPS_VM_CREATE: tuple[str, ...] = (
 _SUB_OPS_VM_CLONE: tuple[str, ...] = (
     _OP_GET_VM,
     _OP_DEPLOY_LIBRARY_VM,
+)
+_SUB_OPS_VM_DEPLOY_FROM_LIBRARY: tuple[str, ...] = (
+    _OP_FIND_LIBRARY,
+    _OP_FIND_LIBRARY_ITEM,
+    _OP_DEPLOY_OVF_LIBRARY_ITEM,
+    _power_vm_op_id("start"),
 )
 _SUB_OPS_VM_MIGRATE: tuple[str, ...] = (_OP_RELOCATE_VM,)
 _SUB_OPS_VM_POWER_BULK: tuple[str, ...] = (
@@ -1120,6 +1153,359 @@ async def vm_clone_composite(
         "task_id": None,
         "vm_id": vm_id,
         "guidance": None,
+    }
+
+
+# ===========================================================================
+# vm.deploy_from_library (OVF/OVA content-library deploy -- #2909)
+# ===========================================================================
+#
+# Retires ``govc library.deploy`` for OVF/OVA appliances (the HoloRouter OVA
+# and friends). The deploy is the synchronous
+# ``POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy``; unlike
+# ``vm.clone`` (whose 200 body is a bare VM id) its 200 body is a
+# ``DeploymentResult`` structure, so a deploy that fails OVF / network-mapping
+# / placement validation returns ``succeeded=false`` with an error report —
+# surfaced here as a structured ``deploy_failed`` status, never a raw fault.
+# Name-based item resolution rides the content-library find actions (both in
+# the pinned ``vcenter.yaml``), un-gated reads that mutate nothing.
+
+
+def _deploy_issue(category: str, severity: str, message: str) -> dict[str, Any]:
+    """Build one issue projection ``{category, severity, message}``."""
+    return {"category": category, "severity": severity, "message": message}
+
+
+def _deploy_failure(
+    status: str,
+    *,
+    library_item_id: str | None = None,
+    candidates: list[str] | None = None,
+    issues: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a non-``deployed`` response envelope (resolution / deploy failure)."""
+    return {
+        "status": status,
+        "vm_id": None,
+        "resource_type": None,
+        "library_item_id": library_item_id,
+        "powered_on": False,
+        "issues": issues or [],
+        "candidates": candidates,
+    }
+
+
+def _ovf_message(entry: dict[str, Any]) -> str:
+    """Best human-readable message from one OVF error/warning/info entry.
+
+    An ``Vcenter.Ovf.OvfError`` carries the localizable text under
+    ``message.default_message`` (INPUT category), or under
+    ``error.messages[].default_message`` (SERVER category); a VALIDATION
+    entry may carry only a ``name``. Defensive: any missing shape yields a
+    placeholder, never a raise.
+    """
+    message = entry.get("message")
+    if isinstance(message, dict):
+        default = message.get("default_message")
+        if isinstance(default, str) and default:
+            return default
+    error = entry.get("error")
+    if isinstance(error, dict):
+        for msg in error.get("messages") or []:
+            if isinstance(msg, dict):
+                default = msg.get("default_message")
+                if isinstance(default, str) and default:
+                    return default
+    name = entry.get("name")
+    if isinstance(name, str) and name:
+        return f"invalid OVF input parameter {name!r}"
+    return "<no message reported>"
+
+
+def _extract_ovf_issues(error_report: Any) -> list[dict[str, Any]]:
+    """Flatten an OVF ``ResultInfo`` (errors / warnings / information) to issues.
+
+    Returns one projection per reported message, severity-tagged. Empty when
+    the report is missing/malformed or carries no messages — so a clean
+    deploy yields ``[]`` and a warning-only deploy still surfaces the
+    warnings on the ``deployed`` envelope.
+    """
+    if not isinstance(error_report, dict):
+        return []
+    issues: list[dict[str, Any]] = []
+    for severity, key in (("error", "errors"), ("warning", "warnings"), ("info", "information")):
+        for entry in error_report.get(key) or []:
+            if isinstance(entry, dict):
+                category = entry.get("category")
+                issues.append(
+                    _deploy_issue(
+                        category if isinstance(category, str) else "unknown",
+                        severity,
+                        _ovf_message(entry),
+                    )
+                )
+    return issues
+
+
+async def _find_content_library_ids(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    *,
+    op_id: str,
+    spec: dict[str, Any],
+) -> list[str]:
+    """Issue one content-library ``?action=find`` POST as an un-gated read.
+
+    The find actions (``Content.Library_find`` / ``Content.Library.Item_find``)
+    return a bare array of id strings and mutate nothing, so they skip the
+    :func:`enforce_subop_policy` seam like the REST listing reads — but they
+    are POST-shaped, so they ride ``_post_json`` rather than :func:`_read_sub_op`
+    (which is GET-only). The ``FindSpec`` is wrapped in the ``{"spec": ...}``
+    envelope the ``/api`` protocol expects for a single structured input
+    parameter (the same wrapping the ``CreateSpec`` writes use). Transport
+    faults raise :exc:`httpx.HTTPError` for the caller.
+    """
+    method, _, path = op_id.partition(":")
+    mounted = await connector.mount_op_path(target, path, operator)
+    payload = await connector._post_json(
+        target, mounted, operator=operator, verb=method, json={"spec": spec}
+    )
+    ids = _unwrap_value(payload)
+    if not isinstance(ids, list):
+        raise RuntimeError(f"expected id list from {op_id!r}, got {type(ids).__name__}")
+    return [entry for entry in ids if isinstance(entry, str)]
+
+
+async def _resolve_deploy_library_item(
+    *,
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    params: dict[str, Any],
+) -> tuple[str | None, dict[str, Any] | None]:
+    """Resolve the OVF library-item id from *params*.
+
+    Returns ``(item_id, None)`` on success or ``(None, envelope)`` with a
+    terminal response dict on failure (``invalid_reference`` /
+    ``library_not_found`` / ``ambiguous_library`` / ``item_not_found`` /
+    ``ambiguous_item``). ``library_item`` (an id) short-circuits; otherwise
+    ``library_item_name`` is resolved via ``Content.Library.Item_find``
+    (filtered to ``type=ovf``), optionally scoped to the library
+    ``library_name`` resolves to via ``Content.Library_find``. Ambiguity is
+    refused before any deploy so the operator re-dispatches by explicit id.
+    """
+    passthrough = params.get("library_item")
+    if isinstance(passthrough, str) and passthrough:
+        return passthrough, None
+
+    item_name = params.get("library_item_name")
+    if not isinstance(item_name, str) or not item_name:
+        return None, _deploy_failure(
+            "invalid_reference",
+            issues=[
+                _deploy_issue(
+                    "input",
+                    "error",
+                    "supply library_item (id) or library_item_name to identify the OVF item",
+                )
+            ],
+        )
+
+    library_id: str | None = None
+    library_name = params.get("library_name")
+    if isinstance(library_name, str) and library_name:
+        library_ids = await _find_content_library_ids(
+            connector, target, operator, op_id=_OP_FIND_LIBRARY, spec={"name": library_name}
+        )
+        if not library_ids:
+            return None, _deploy_failure(
+                "library_not_found",
+                issues=[
+                    _deploy_issue("input", "error", f"library {library_name!r} matched no library")
+                ],
+            )
+        if len(library_ids) > 1:
+            return None, _deploy_failure(
+                "ambiguous_library",
+                candidates=library_ids,
+                issues=[
+                    _deploy_issue(
+                        "input",
+                        "error",
+                        f"library {library_name!r} matched {len(library_ids)} libraries",
+                    )
+                ],
+            )
+        library_id = library_ids[0]
+
+    item_spec: dict[str, Any] = {"name": item_name, "type": _OVF_LIBRARY_ITEM_TYPE}
+    if library_id is not None:
+        item_spec["library_id"] = library_id
+    item_ids = await _find_content_library_ids(
+        connector, target, operator, op_id=_OP_FIND_LIBRARY_ITEM, spec=item_spec
+    )
+    if not item_ids:
+        return None, _deploy_failure(
+            "item_not_found",
+            issues=[
+                _deploy_issue("input", "error", f"OVF item {item_name!r} matched no library item")
+            ],
+        )
+    if len(item_ids) > 1:
+        return None, _deploy_failure(
+            "ambiguous_item",
+            candidates=item_ids,
+            issues=[
+                _deploy_issue(
+                    "input", "error", f"OVF item {item_name!r} matched {len(item_ids)} items"
+                )
+            ],
+        )
+    return item_ids[0], None
+
+
+def _build_ovf_deploy_body(params: dict[str, Any]) -> dict[str, Any]:
+    """Build the ``{deployment_spec, target}`` OVF deploy request body.
+
+    ``resource_pool`` is the required deploy-target anchor; ``host`` / ``folder``
+    refine it. ``network_mappings`` is sent verbatim as the OVF-key → network-moid
+    map (the pinned 9.0 spec models it as a map, not an array). ``ovf_properties``
+    folds into a single ``PropertyParams`` entry in ``additional_parameters``.
+    ``accept_all_eula`` defaults to true (deploying a curated item accepts its
+    EULA).
+    """
+    deployment_spec: dict[str, Any] = {"accept_all_eula": bool(params.get("accept_all_eula", True))}
+    _put_if_str(deployment_spec, "name", params.get("name"))
+    network_mappings = params.get("network_mappings")
+    if isinstance(network_mappings, dict) and network_mappings:
+        deployment_spec["network_mappings"] = {str(k): str(v) for k, v in network_mappings.items()}
+    _put_if_str(deployment_spec, "storage_provisioning", params.get("storage_provisioning"))
+    _put_if_str(deployment_spec, "storage_profile_id", params.get("storage_profile"))
+    _put_if_str(deployment_spec, "default_datastore_id", params.get("datastore"))
+    ovf_properties = params.get("ovf_properties")
+    if isinstance(ovf_properties, dict) and ovf_properties:
+        deployment_spec["additional_parameters"] = [
+            {
+                "type": _OVF_PROPERTY_PARAMS_TYPE,
+                "properties": [{"id": str(k), "value": str(v)} for k, v in ovf_properties.items()],
+            }
+        ]
+
+    deploy_target: dict[str, Any] = {"resource_pool_id": params["resource_pool"]}
+    _put_if_str(deploy_target, "host_id", params.get("host"))
+    _put_if_str(deploy_target, "folder_id", params.get("folder"))
+    return {"deployment_spec": deployment_spec, "target": deploy_target}
+
+
+async def _power_on_deployed_vm(
+    connector: VmwareRestConnector,
+    target: Any,
+    operator: Operator,
+    vm_id: str,
+) -> tuple[bool, dict[str, Any] | None]:
+    """Best-effort power-on of a freshly deployed VM; ``(powered_on, issue?)``.
+
+    A power-on fault (or, defensively, a parked gate that cannot occur once
+    the deploy write cleared the same posture) never demotes the already-
+    successful deploy — it returns ``(False, issue)`` so the caller keeps
+    ``status='deployed'`` and folds the issue into the report.
+    """
+    try:
+        gate, _ = await _write_sub_op(
+            connector, target, operator, _power_vm_op_id("start"), {"vm": vm_id}
+        )
+    except httpx.HTTPError as exc:
+        return False, _deploy_issue(
+            "power_on", "warning", f"deploy succeeded but power-on failed: {exc}"
+        )
+    if gate is not None:
+        return False, _deploy_issue(
+            "power_on", "warning", "deploy succeeded but the follow-on power-on was not authorized"
+        )
+    return True, None
+
+
+async def vm_deploy_from_library_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    connector: VmwareRestConnector,
+) -> dict[str, Any] | OperationResult:
+    """Deploy an OVF/OVA content-library item to a new VM.
+
+    Op-id: ``vmware.composite.vm.deploy_from_library``. Resolves the library
+    item (id passthrough or name lookup, ambiguity-refusing), issues the
+    synchronous OVF deploy through the governed direct-session seam, and maps
+    the ``DeploymentResult`` to a structured envelope: ``deployed`` on
+    ``succeeded=true``, ``deploy_failed`` on ``succeeded=false`` (with the
+    report's per-issue messages), or ``deploy_error`` when the deploy call
+    itself faults (HTTP 400/404 for invalid / missing placement resources) —
+    so a placement or network-mapping error is a structured status, never a
+    raw vendor error. With ``power_on`` the deployed VM is started best-effort.
+    """
+    item_id, resolution_error = await _resolve_deploy_library_item(
+        connector=connector, target=target, operator=operator, params=params
+    )
+    if resolution_error is not None:
+        return resolution_error
+    assert item_id is not None  # resolution_error is None ⇒ item_id resolved
+
+    deploy_params = {"ovfLibraryItemId": item_id, **_build_ovf_deploy_body(params)}
+    try:
+        gate, deploy_payload = await _write_sub_op(
+            connector, target, operator, _OP_DEPLOY_OVF_LIBRARY_ITEM, deploy_params
+        )
+    except httpx.HTTPError as exc:
+        status, error_type = _parse_vsphere_error(exc)
+        detail = f"HTTP {status}" if status is not None else "transport fault"
+        if error_type:
+            detail += f" ({error_type})"
+        return _deploy_failure(
+            "deploy_error",
+            library_item_id=item_id,
+            issues=[
+                _deploy_issue("placement", "error", f"OVF deploy call faulted: {detail}: {exc}")
+            ],
+        )
+    if gate is not None:
+        return gate
+
+    result = _unwrap_value(deploy_payload)
+    if not isinstance(result, dict):
+        raise RuntimeError(
+            f"vm.deploy_from_library: deploy returned no DeploymentResult "
+            f"(payload={deploy_payload!r}); the pinned deploy is synchronous and its "
+            "200 body is a DeploymentResult structure"
+        )
+    issues = _extract_ovf_issues(result.get("error"))
+    if not result.get("succeeded"):
+        return _deploy_failure("deploy_failed", library_item_id=item_id, issues=issues)
+
+    resource = result.get("resource_id")
+    vm_id = resource.get("id") if isinstance(resource, dict) else None
+    resource_type = resource.get("type") if isinstance(resource, dict) else None
+    if not isinstance(vm_id, str):
+        raise RuntimeError(
+            "vm.deploy_from_library: deploy reported succeeded=true but no "
+            f"resource_id.id (resource_id={resource!r})"
+        )
+
+    powered_on = False
+    if bool(params.get("power_on", False)):
+        powered_on, power_issue = await _power_on_deployed_vm(connector, target, operator, vm_id)
+        if power_issue is not None:
+            issues.append(power_issue)
+
+    return {
+        "status": "deployed",
+        "vm_id": vm_id,
+        "resource_type": resource_type if isinstance(resource_type, str) else None,
+        "library_item_id": item_id,
+        "powered_on": powered_on,
+        "issues": issues,
+        "candidates": None,
     }
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write_preview.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Park-time ``proposed_effect`` preview builders for the 18 vmware write composites.
+"""Park-time ``proposed_effect`` preview builders for the 19 vmware write composites.
 
 G0.22-T3 (#1608). Before this module, a parked ``vmware.composite.*``
 write stored only the identifier default ``{op_id, connector_id,
@@ -9,7 +9,7 @@ target_id}`` in :attr:`~meho_backplane.db.models.ApprovalRequest.proposed_effect
 — and because the original dispatch ``params`` are deliberately never
 serialised onto a reviewer-facing surface (#1503), the four-eyes
 approver could not tell a one-VM power cycle from a 1000-VM outage.
-This wires all 18 write composites onto the per-op preview hook shipped
+This wires all 19 write composites onto the per-op preview hook shipped
 by #1437 (:mod:`meho_backplane.operations._preview`), following the
 argocd pattern (#1452): reuse the handlers' own read-only resolution
 helpers, never the mutating sub-ops.
@@ -124,7 +124,7 @@ Redaction posture
 
 The whole-builder ``classify_op`` gate runs in
 :func:`~meho_backplane.operations._preview.build_proposed_effect` before
-any builder fires: the 18 op_ids classify as ``write`` (``.create`` /
+any builder fires: the 19 op_ids classify as ``write`` (``.create`` /
 ``.patch`` suffixes) or ``other`` (``vm.disk.grow`` — ``.grow`` — and
 ``vm.clone_from_template`` — ``_template`` — are not write suffixes) —
 none is a credential class, so none is suppressed. The
@@ -329,6 +329,58 @@ async def _vm_clone_preview(ctx: PreviewContext) -> dict[str, Any] | None:
         "source_vm": source_vm,
         "target_name": target_name,
         "library_item": library_item,
+    }
+
+
+async def _vm_deploy_from_library_preview(ctx: PreviewContext) -> dict[str, Any] | None:
+    """Preview ``vm.deploy_from_library`` — echo the deploy coordinates (no I/O).
+
+    Param-echo: the params name the blast radius — which library item (id or
+    name, plus scoping library), where it lands (resource pool / host / folder
+    / datastore), the OVF-network→portgroup map, provisioning, and whether it
+    powers on. ``ovf_properties`` may carry secret values (appliance
+    passwords), so only its **keys** (property ids) are echoed, never the
+    values (#1503 secret-hygiene). No live read is issued, so the preview
+    cannot drift from the approved dispatch. Declines (``None``) when neither
+    library reference nor the required ``resource_pool`` is a string.
+    """
+    library_item = ctx.params.get("library_item")
+    library_item_name = ctx.params.get("library_item_name")
+    resource_pool = ctx.params.get("resource_pool")
+    has_reference = isinstance(library_item, str) or isinstance(library_item_name, str)
+    if not has_reference or not isinstance(resource_pool, str):
+        return None
+    network_mappings = ctx.params.get("network_mappings")
+    ovf_properties = ctx.params.get("ovf_properties")
+    return {
+        "library_item": library_item if isinstance(library_item, str) else None,
+        "library_item_name": library_item_name if isinstance(library_item_name, str) else None,
+        "library_name": (
+            ctx.params.get("library_name")
+            if isinstance(ctx.params.get("library_name"), str)
+            else None
+        ),
+        "name": ctx.params.get("name") if isinstance(ctx.params.get("name"), str) else None,
+        "resource_pool": resource_pool,
+        "host": ctx.params.get("host") if isinstance(ctx.params.get("host"), str) else None,
+        "folder": ctx.params.get("folder") if isinstance(ctx.params.get("folder"), str) else None,
+        "datastore": (
+            ctx.params.get("datastore") if isinstance(ctx.params.get("datastore"), str) else None
+        ),
+        "network_mappings": (
+            {str(k): str(v) for k, v in network_mappings.items()}
+            if isinstance(network_mappings, dict)
+            else {}
+        ),
+        "storage_provisioning": (
+            ctx.params.get("storage_provisioning")
+            if isinstance(ctx.params.get("storage_provisioning"), str)
+            else None
+        ),
+        "ovf_property_keys": (
+            sorted(str(k) for k in ovf_properties) if isinstance(ovf_properties, dict) else []
+        ),
+        "power_on": bool(ctx.params.get("power_on", False)),
     }
 
 
@@ -762,11 +814,12 @@ async def _vm_customize_preview(ctx: PreviewContext) -> dict[str, Any] | None:
     return preview
 
 
-#: op_id → builder for the 18 write composites. Module-level so the
+#: op_id → builder for the 19 write composites. Module-level so the
 #: registration below and the wiring tests share one source of truth.
 _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
     "vmware.composite.vm.create": _vm_create_preview,
     "vmware.composite.vm.clone": _vm_clone_preview,
+    "vmware.composite.vm.deploy_from_library": _vm_deploy_from_library_preview,
     "vmware.composite.vm.clone_from_template": _vm_clone_from_template_preview,
     "vmware.composite.vm.snapshot.revert": _vm_snapshot_revert_preview,
     "vmware.composite.vm.migrate": _vm_migrate_preview,
@@ -787,7 +840,7 @@ _WRITE_PREVIEW_BUILDERS: dict[str, PreviewBuilder] = {
 
 
 def _register_vmware_write_preview_builders() -> None:
-    """Wire the 18 write-composite park-time preview builders. Import-time.
+    """Wire the 19 write-composite park-time preview builders. Import-time.
 
     The 5 read composites register no builder — they are
     ``requires_approval=False`` and never park, so a preview would be

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -2446,3 +2446,243 @@ VM_CUSTOMIZE_RESPONSE_SCHEMA: dict[str, Any] = {
     },
     "required": ["status", "name", "spec_name"],
 }
+
+
+#: ``vmware.composite.vm.deploy_from_library`` parameter schema.
+#:
+#: Deploys an OVF/OVA content-library item to a new VM via the synchronous
+#: ``POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy``. The
+#: library item is referenced either by ``library_item`` (id passthrough) or
+#: by ``library_item_name`` (resolved via ``POST:/content/library/item?action=find``,
+#: optionally scoped by ``library_name`` through
+#: ``POST:/content/library?action=find``) with ambiguity refused before any
+#: deploy. ``resource_pool`` is the one required placement (the vendor's
+#: ``DeploymentTarget.resource_pool_id`` is required); ``host`` / ``folder`` /
+#: ``datastore`` refine it. ``network_mappings`` is the OVF-network-key →
+#: portgroup-moid map the OVF descriptor's NetworkSection identifiers key
+#: into (spec: ``ResourcePoolDeploymentSpec.network_mappings`` is a map, not
+#: an array).
+VM_DEPLOY_FROM_LIBRARY_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "library_item": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Content-library OVF/OVA item id (passthrough). Rides the deploy "
+                "path as ``POST:/vcenter/ovf/library-item/{ovfLibraryItemId}"
+                "?action=deploy``. Supply this **or** ``library_item_name`` — not "
+                "both needed; ``library_item`` wins when both are present."
+            ),
+        },
+        "library_item_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "OVF/OVA item display name, resolved to an id via "
+                "``POST:/content/library/item?action=find`` (filtered to "
+                "``type='ovf'``). A name matching no item returns "
+                "``status='item_not_found'``, more than one "
+                "``status='ambiguous_item'`` with the candidate ids — no deploy "
+                "fires. Ignored when ``library_item`` is given."
+            ),
+        },
+        "library_name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional library display name that scopes the "
+                "``library_item_name`` lookup to one library. Resolved to a "
+                "library id via ``POST:/content/library?action=find``; an unknown "
+                "name returns ``status='library_not_found'`` and an ambiguous one "
+                "``status='ambiguous_library'`` before any item lookup."
+            ),
+        },
+        "resource_pool": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Target ``ResourcePool`` moid — the deploy target's required "
+                "``resource_pool_id``. When it is a stand-alone host or a "
+                "DRS-enabled cluster the server picks the host itself unless "
+                "``host`` is pinned."
+            ),
+        },
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional target ``HostSystem`` moid (``DeploymentTarget.host_id``). "
+                "Must be a member of the cluster owning ``resource_pool``."
+            ),
+        },
+        "folder": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional destination VM ``Folder`` moid "
+                "(``DeploymentTarget.folder_id``); the server chooses one if absent."
+            ),
+        },
+        "datastore": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional default ``Datastore`` moid "
+                "(``ResourcePoolDeploymentSpec.default_datastore_id``) for OVF "
+                "storage sections without an explicit mapping."
+            ),
+        },
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional display name for the deployed VM; the server uses the "
+                "OVF descriptor's name when omitted."
+            ),
+        },
+        "network_mappings": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "description": (
+                "Map of OVF NetworkSection identifier → target ``Network`` moid "
+                "(portgroup). Sent verbatim as "
+                "``ResourcePoolDeploymentSpec.network_mappings`` (a map in the "
+                "pinned 9.0 spec). Keys the OVF descriptor does not declare come "
+                "back as a structured ``deploy_failed`` issue, not a raw fault."
+            ),
+        },
+        "storage_provisioning": {
+            "type": "string",
+            "enum": ["thin", "thick", "eagerZeroedThick"],
+            "description": (
+                "Optional default disk provisioning for all OVF storage sections "
+                "(``ResourcePoolDeploymentSpec.storage_provisioning``)."
+            ),
+        },
+        "storage_profile": {
+            "type": "string",
+            "minLength": 1,
+            "description": (
+                "Optional default ``StorageProfile`` id "
+                "(``ResourcePoolDeploymentSpec.storage_profile_id``)."
+            ),
+        },
+        "ovf_properties": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "description": (
+                "Optional OVF product-section properties as ``{property_id: value}``. "
+                "Folded into a single ``PropertyParams`` entry in "
+                "``ResourcePoolDeploymentSpec.additional_parameters``. Property "
+                "values may be secret (e.g. appliance passwords), so the "
+                "park-time preview echoes only the property **ids**, never the "
+                "values."
+            ),
+        },
+        "accept_all_eula": {
+            "type": "boolean",
+            "description": (
+                "Whether to accept all EULAs declared by the OVF package "
+                "(``ResourcePoolDeploymentSpec.accept_all_eula``). Defaults to "
+                "``true`` — deploying a curated library item accepts its EULA; a "
+                "package with an unaccepted EULA returns ``status='deploy_failed'``."
+            ),
+        },
+        "power_on": {
+            "type": "boolean",
+            "description": (
+                "Power the deployed VM on afterward via "
+                "``POST:/vcenter/vm/{vm}/power?action=start`` (OVF deploy itself "
+                "never powers on). Best-effort: a power-on fault leaves "
+                "``status='deployed'`` with ``powered_on=false`` and an issue."
+            ),
+        },
+    },
+    "required": ["resource_pool"],
+    "additionalProperties": False,
+}
+
+
+#: ``vmware.composite.vm.deploy_from_library`` response schema.
+VM_DEPLOY_FROM_LIBRARY_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {
+            "type": "string",
+            "enum": [
+                "deployed",
+                "deploy_failed",
+                "deploy_error",
+                "invalid_reference",
+                "library_not_found",
+                "ambiguous_library",
+                "item_not_found",
+                "ambiguous_item",
+            ],
+            "description": (
+                "``'deployed'`` — the OVF deploy report returned "
+                "``succeeded=true`` and a resource id; ``'deploy_failed'`` — the "
+                "report returned ``succeeded=false`` (network-mapping / placement "
+                "/ EULA / descriptor validation), with per-issue messages under "
+                "``issues``; ``'deploy_error'`` — the deploy call itself faulted "
+                "(HTTP 400/404 for invalid or missing placement resources), "
+                "surfaced as a structured message rather than a raw vendor error; "
+                "``'invalid_reference'`` — neither ``library_item`` nor "
+                "``library_item_name`` was supplied; ``'library_not_found'`` / "
+                "``'ambiguous_library'`` — the ``library_name`` lookup matched "
+                "zero / many libraries; ``'item_not_found'`` / ``'ambiguous_item'`` "
+                "— the ``library_item_name`` lookup matched zero / many items. "
+                "Every non-``deployed`` status is reached before or without a "
+                "successful mutation."
+            ),
+        },
+        "vm_id": {
+            "type": ["string", "null"],
+            "description": (
+                "Deployed resource moid (``DeploymentResult.resource_id.id``); "
+                "``null`` unless ``status='deployed'``."
+            ),
+        },
+        "resource_type": {
+            "type": ["string", "null"],
+            "description": (
+                "``'VirtualMachine'`` or ``'VirtualApp'`` "
+                "(``DeploymentResult.resource_id.type``); ``null`` unless deployed."
+            ),
+        },
+        "library_item_id": {
+            "type": ["string", "null"],
+            "description": (
+                "The library-item id the deploy used — the passthrough id, or the "
+                "id resolved from ``library_item_name``. ``null`` when resolution "
+                "failed before deploy."
+            ),
+        },
+        "powered_on": {
+            "type": "boolean",
+            "description": (
+                "Whether the follow-on power-on succeeded. Always ``false`` when "
+                "``power_on`` was not requested or the deploy did not succeed."
+            ),
+        },
+        "issues": {
+            "type": "array",
+            "items": {"type": "object"},
+            "description": (
+                "Per-issue projections ``{category, severity, message}`` drawn "
+                "from the OVF deploy report (errors / warnings / information) or "
+                "the resolution / power-on failure. Empty on a clean deploy."
+            ),
+        },
+        "candidates": {
+            "type": ["array", "null"],
+            "items": {"type": "string"},
+            "description": (
+                "Candidate ids on ``ambiguous_item`` (library-item ids) or "
+                "``ambiguous_library`` (library ids); ``null`` otherwise."
+            ),
+        },
+    },
+    "required": ["status", "vm_id", "powered_on", "issues"],
+}

--- a/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py
@@ -3,11 +3,12 @@
 
 """op_id reconciliation between the write composites and the ingest pipeline.
 
-G3.16-T1 (#1414). The 13 REST-sub-op vmware-rest write composites each
+G3.16-T1 (#1414). The 14 REST-sub-op vmware-rest write composites each
 declare the L2 sub-ops they dispatch into via ``_SUB_OPS_*`` tuples in
 :mod:`~meho_backplane.connectors.vmware_rest.composites._write` (the
-T6/#509 + vm.power writes, the #2891 hardware trio, and the two GOSC
-composites / #2892); the four vi-json write composites (``vm.disk.grow`` /
+T6/#509 + vm.power writes, the #2891 hardware trio, the two GOSC
+composites / #2892, and the OVF/OVA content-library deploy / #2909); the
+four vi-json write composites (``vm.disk.grow`` /
 #2893, ``vm.clone_from_template`` / #2894, and the vim cluster / inventory
 writes ``cluster.drs_rule.create`` + ``folder.create`` / #2895) dispatch
 into vi-json instead and declare their sub-ops in ``_VIM_SUB_OPS_*`` tuples
@@ -107,7 +108,7 @@ _GETADDRINFO_PATCH = patch(
 
 
 def _required_raw_sub_op_ids() -> set[str]:
-    """Union of every ``_SUB_OPS_*`` op_id across the 13 REST write composites.
+    """Union of every ``_SUB_OPS_*`` op_id across the 14 REST write composites.
 
     The vi-json sub-ops live in ``_VIM_SUB_OPS_*`` tuples (a distinct
     namespace this ``_SUB_OPS_*`` sweep deliberately skips), so a
@@ -133,8 +134,10 @@ def _required_raw_sub_op_ids() -> set[str]:
 def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
     """Guard: the introspection finds every write composite's sub-op tuple.
 
-    Thirteen ``_SUB_OPS_*`` module constants today (the T6/#509 + vm.power
-    writes, the #2891 hardware trio, plus the two GOSC composites / #2892).
+    Fourteen ``_SUB_OPS_*`` module constants today (the T6/#509 + vm.power
+    writes, the #2891 hardware trio, the two GOSC composites / #2892, plus
+    the OVF/OVA content-library deploy / #2909 — whose reads ride the
+    content-library find actions, both served by the pinned vcenter.yaml).
     ``vm.snapshot.revert`` no longer appears: both of its sub-ops moved to
     the vim surface in #2970 (the pinned vcenter.yaml serves no snapshot
     REST resource), so its manifest lives in
@@ -152,6 +155,7 @@ def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
         "_SUB_OPS_VM_CLONE",
         "_SUB_OPS_VM_CREATE",
         "_SUB_OPS_VM_CUSTOMIZE",
+        "_SUB_OPS_VM_DEPLOY_FROM_LIBRARY",
         "_SUB_OPS_VM_DEVICE_CDROM",
         "_SUB_OPS_VM_MIGRATE",
         "_SUB_OPS_VM_NIC_REPOINT",
@@ -159,6 +163,49 @@ def test_write_composite_sub_op_tuples_are_all_discovered() -> None:
         "_SUB_OPS_VM_POWER_BULK",
         "_SUB_OPS_VM_RESIZE",
     ]
+
+
+def test_vm_deploy_from_library_sub_op_manifest_is_expected() -> None:
+    """Pin the deploy_from_library manifest so a drift can't shrink the reconcile.
+
+    All four sub-ops are ``vcenter.yaml``-served REST paths (the OVF deploy,
+    both content-library find actions used for name resolution, and the
+    power-on), so — unlike the vim-shaped writes — they reconcile through the
+    generic ``_SUB_OPS_*`` sweep above rather than a ``_VIM_SUB_OPS_*`` lane.
+    """
+    assert set(_write._SUB_OPS_VM_DEPLOY_FROM_LIBRARY) == {
+        "POST:/content/library?action=find",
+        "POST:/content/library/item?action=find",
+        "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy",
+        "POST:/vcenter/vm/{vm}/power?action=start",
+    }
+
+
+def test_vm_deploy_from_library_sub_ops_resolve_against_pinned_vcenter_spec() -> None:
+    """The #2909 OVF deploy + find + power paths are real ``vcenter.yaml`` paths.
+
+    The definitive #2909 grounding (the issue's ingest-reconcile-against-the-
+    pinned-spec-rows criterion, scoped to the ovf/library-item deploy paths):
+    parse the canonical pinned ``vcenter.yaml`` through the real
+    :func:`parse_openapi` and assert every ``_SUB_OPS_VM_DEPLOY_FROM_LIBRARY``
+    op_id is in the emitted descriptor set — real path existence for the OVF
+    library-item deploy, both content-library find actions, and the power-on.
+    Skips when the spec-shelf is unconfigured (the canary's convention), so CI
+    — where the env vars are wired — is the operator-visible signal.
+    """
+    spec_path = resolve_vcenter_yaml()
+    if spec_path is None:
+        pytest.skip(VCENTER_SPEC_REASON)
+    required = set(_write._SUB_OPS_VM_DEPLOY_FROM_LIBRARY)
+    spec_text = spec_path.read_text(encoding="utf-8")
+    rows = parse_openapi(f"file://{spec_path}", spec_source="spec:vcenter.yaml", content=spec_text)
+    ingested_op_ids = {row.op_id for row in rows}
+    missing = required - ingested_op_ids
+    assert not missing, (
+        "vm.deploy_from_library declares REST sub-op_ids the real vcenter.yaml "
+        f"ingest does not emit: {sorted(missing)} — re-check the OVF deploy / "
+        "content-library find paths against the pinned 9.0 spec."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_composites_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_register.py
@@ -175,15 +175,16 @@ async def test_register_vmware_composite_operations_inserts_five_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
-    # Embedding service called once per composite -- 23 total: 5 reads
-    # (T5 #508) + 18 writes (T6 #509 + single-VM vm.power #2301 + mutating
+    # Embedding service called once per composite -- 24 total: 5 reads
+    # (T5 #508) + 19 writes (T6 #509 + single-VM vm.power #2301 + mutating
     # VI-JSON vm.disk.grow #2893 + folder-template vm.clone_from_template
     # #2894 + vim cluster/inventory writes cluster.drs_rule.create +
     # folder.create #2895 + the #2891 hardware writes vm.resize /
-    # vm.nic.repoint / vm.device.cdrom + GOSC create/apply #2892). (The
-    # former host.network_uplinks / host.vsan_health reads were re-shipped
-    # as typed ops in #2258.)
-    assert stub_embedding_service.encode_one.call_count == 23
+    # vm.nic.repoint / vm.device.cdrom + GOSC create/apply #2892 + OVF/OVA
+    # content-library deploy vm.deploy_from_library #2909). (The former
+    # host.network_uplinks / host.vsan_health reads were re-shipped as
+    # typed ops in #2258.)
+    assert stub_embedding_service.encode_one.call_count == 24
 
 
 @pytest.mark.asyncio
@@ -430,20 +431,21 @@ async def test_tags_include_composite_and_read_only(
 async def test_register_vmware_composite_operations_is_idempotent(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 5 read rows persist; embedding stays at 23.
+    """Running the registrar twice -> 5 read rows persist; embedding stays at 24.
 
     The second run's body-hash skip path is what holds across both
     read and write composites; this test asserts the read rows still
-    persist after the combined registrar (5 reads + 18 writes / T6 +
+    persist after the combined registrar (5 reads + 19 writes / T6 +
     single-VM vm.power #2301 + mutating VI-JSON vm.disk.grow #2893 +
     folder-template vm.clone_from_template #2894 + vim cluster/inventory
     writes cluster.drs_rule.create + folder.create #2895 + the #2891
     hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC
-    create/apply #2892).
+    create/apply #2892 + OVF/OVA content-library deploy
+    vm.deploy_from_library #2909).
     """
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 23
+    assert first_count == 24
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Skip-re-embed path -- second run is a no-op for the embedding

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -65,6 +65,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     vm_clone_from_template_composite,
     vm_create_composite,
     vm_customize_composite,
+    vm_deploy_from_library_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -530,6 +531,369 @@ async def test_vm_clone_non_string_deploy_payload_raises(gate: _GateRecorder) ->
             params={"source_vm": "vm-src", "target_name": "tgt", "library_item": "li-1"},
             connector=conn,  # type: ignore[arg-type]
         )
+
+
+# ===========================================================================
+# vm.deploy_from_library (OVF/OVA content-library deploy -- #2909)
+# ===========================================================================
+
+_DEPLOY_OVF_OP = "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy"
+_FIND_LIBRARY_PATH = "/api/content/library?action=find"
+_FIND_ITEM_PATH = "/api/content/library/item?action=find"
+
+
+def _deployment_result(
+    *,
+    succeeded: bool,
+    vm_id: str = "vm-ovf-9",
+    resource_type: str = "VirtualMachine",
+    errors: list[dict[str, Any]] | None = None,
+    warnings: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Canned ``Vcenter.Ovf.LibraryItem.DeploymentResult`` for the deploy stub."""
+    result: dict[str, Any] = {"succeeded": succeeded}
+    if succeeded:
+        result["resource_id"] = {"type": resource_type, "id": vm_id}
+    error_block: dict[str, Any] = {}
+    if errors is not None:
+        error_block["errors"] = errors
+    if warnings is not None:
+        error_block["warnings"] = warnings
+    if error_block:
+        result["error"] = error_block
+    return result
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_id_passthrough_deployed(gate: _GateRecorder) -> None:
+    """library_item id passthrough → one gated deploy → status='deployed' with the VM id."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/ovf/library-item/li-ovf?action=deploy": _deployment_result(
+                succeeded=True, vm_id="vm-ovf-1"
+            ),
+        }
+    )
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item": "li-ovf", "resource_pool": "resgroup-8"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "deployed"
+    assert out["vm_id"] == "vm-ovf-1"
+    assert out["resource_type"] == "VirtualMachine"
+    assert out["library_item_id"] == "li-ovf"
+    assert out["powered_on"] is False
+    assert out["issues"] == []
+    # No name-resolution reads on the id path; only the deploy was gated.
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("POST", "/api/vcenter/ovf/library-item/li-ovf?action=deploy"),
+    ]
+    assert gate.gated_op_ids == [_DEPLOY_OVF_OP]
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_deploy_body_shape(gate: _GateRecorder) -> None:
+    """The deploy body carries the {deployment_spec, target} shape the pinned spec keys."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/ovf/library-item/li-ovf?action=deploy": _deployment_result(
+                succeeded=True
+            ),
+        }
+    )
+    await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "library_item": "li-ovf",
+            "name": "router-01",
+            "resource_pool": "resgroup-8",
+            "host": "host-19",
+            "folder": "group-v10",
+            "datastore": "datastore-15",
+            "network_mappings": {"nat": "dvportgroup-42", "mgmt": "dvportgroup-43"},
+            "storage_provisioning": "thin",
+            "storage_profile": "profile-1",
+            "ovf_properties": {"guestinfo.hostname": "router-01"},
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    body = conn.calls[0]["body"]
+    assert body["deployment_spec"] == {
+        "accept_all_eula": True,
+        "name": "router-01",
+        "network_mappings": {"nat": "dvportgroup-42", "mgmt": "dvportgroup-43"},
+        "storage_provisioning": "thin",
+        "storage_profile_id": "profile-1",
+        "default_datastore_id": "datastore-15",
+        "additional_parameters": [
+            {
+                "type": "PropertyParams",
+                "properties": [{"id": "guestinfo.hostname", "value": "router-01"}],
+            }
+        ],
+    }
+    assert body["target"] == {
+        "resource_pool_id": "resgroup-8",
+        "host_id": "host-19",
+        "folder_id": "group-v10",
+    }
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_name_resolution_scoped_by_library(gate: _GateRecorder) -> None:
+    """library_item_name + library_name → find library → find item (type=ovf) → deploy."""
+    conn = _RecordingConnector(
+        {
+            _FIND_LIBRARY_PATH: ["lib-7"],
+            _FIND_ITEM_PATH: ["li-resolved"],
+            "/api/vcenter/ovf/library-item/li-resolved?action=deploy": _deployment_result(
+                succeeded=True, vm_id="vm-ovf-2"
+            ),
+        }
+    )
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "library_item_name": "holorouter-ova",
+            "library_name": "lab-templates",
+            "resource_pool": "resgroup-8",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "deployed"
+    assert out["library_item_id"] == "li-resolved"
+    # Library find, then item find (scoped + type=ovf), then the deploy.
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("POST", _FIND_LIBRARY_PATH),
+        ("POST", _FIND_ITEM_PATH),
+        ("POST", "/api/vcenter/ovf/library-item/li-resolved?action=deploy"),
+    ]
+    assert conn.calls[0]["body"] == {"spec": {"name": "lab-templates"}}
+    assert conn.calls[1]["body"] == {
+        "spec": {"name": "holorouter-ova", "type": "ovf", "library_id": "lib-7"}
+    }
+    # The finds are un-gated reads; only the deploy hit the policy seam.
+    assert gate.gated_op_ids == [_DEPLOY_OVF_OP]
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_ambiguous_item_refused(gate: _GateRecorder) -> None:
+    """An item name matching >1 item → ambiguous_item with candidates; no deploy, no gate."""
+    conn = _RecordingConnector({_FIND_ITEM_PATH: ["li-a", "li-b"]})
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item_name": "dup-ova", "resource_pool": "resgroup-8"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "ambiguous_item"
+    assert out["candidates"] == ["li-a", "li-b"]
+    assert out["vm_id"] is None
+    assert out["library_item_id"] is None
+    assert [c["path"] for c in conn.calls] == [_FIND_ITEM_PATH]
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_ambiguous_library_refused(gate: _GateRecorder) -> None:
+    """A library name matching >1 library → ambiguous_library before any item lookup."""
+    conn = _RecordingConnector({_FIND_LIBRARY_PATH: ["lib-1", "lib-2"]})
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={
+            "library_item_name": "ova",
+            "library_name": "dup-lib",
+            "resource_pool": "resgroup-8",
+        },
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "ambiguous_library"
+    assert out["candidates"] == ["lib-1", "lib-2"]
+    # Stopped at the library find; the item find never fired.
+    assert [c["path"] for c in conn.calls] == [_FIND_LIBRARY_PATH]
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_item_not_found(gate: _GateRecorder) -> None:
+    """An item name matching zero items → item_not_found; no deploy."""
+    conn = _RecordingConnector({_FIND_ITEM_PATH: []})
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item_name": "missing-ova", "resource_pool": "resgroup-8"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "item_not_found"
+    assert out["candidates"] is None
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_invalid_reference(gate: _GateRecorder) -> None:
+    """Neither library_item nor library_item_name → invalid_reference; nothing touched."""
+    conn = _RecordingConnector({})
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"resource_pool": "resgroup-8"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "invalid_reference"
+    assert conn.calls == []
+    assert gate.calls == []
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_deploy_failed_surfaces_report_issues(
+    gate: _GateRecorder,
+) -> None:
+    """succeeded=false → deploy_failed with the report's per-issue messages (not a raw fault)."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/ovf/library-item/li-ovf?action=deploy": _deployment_result(
+                succeeded=False,
+                errors=[
+                    {
+                        "category": "INPUT",
+                        "message": {"default_message": "network 'nat' not mapped"},
+                    },
+                    {
+                        "category": "SERVER",
+                        "error": {"messages": [{"default_message": "host busy"}]},
+                    },
+                ],
+                warnings=[
+                    {"category": "VALIDATION", "message": {"default_message": "deprecated hw"}}
+                ],
+            ),
+        }
+    )
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item": "li-ovf", "resource_pool": "resgroup-8"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "deploy_failed"
+    assert out["vm_id"] is None
+    assert out["library_item_id"] == "li-ovf"
+    assert out["issues"] == [
+        {"category": "INPUT", "severity": "error", "message": "network 'nat' not mapped"},
+        {"category": "SERVER", "severity": "error", "message": "host busy"},
+        {"category": "VALIDATION", "severity": "warning", "message": "deprecated hw"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_deploy_error_on_http_fault(gate: _GateRecorder) -> None:
+    """A 404 on the deploy (missing placement resource) → structured deploy_error, not a raise."""
+    fault = httpx.HTTPStatusError(
+        "not found",
+        request=httpx.Request(
+            "POST", "https://vc/api/vcenter/ovf/library-item/li-ovf?action=deploy"
+        ),
+        response=httpx.Response(404, json={"error_type": "NOT_FOUND"}),
+    )
+    conn = _RecordingConnector({"/api/vcenter/ovf/library-item/li-ovf?action=deploy": fault})
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item": "li-ovf", "resource_pool": "resgroup-missing"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "deploy_error"
+    assert out["library_item_id"] == "li-ovf"
+    assert len(out["issues"]) == 1
+    assert out["issues"][0]["category"] == "placement"
+    assert "404" in out["issues"][0]["message"]
+    assert "NOT_FOUND" in out["issues"][0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_gate_short_circuits_before_deploy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A parked gate on the OVF deploy returns verbatim; the deploy never reaches the wire."""
+    gate = _install_gate(
+        monkeypatch,
+        _GateRecorder(gate_for={_DEPLOY_OVF_OP: _awaiting(_DEPLOY_OVF_OP)}),
+    )
+    conn = _RecordingConnector({})
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item": "li-ovf", "resource_pool": "resgroup-8"},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _DEPLOY_OVF_OP
+    # id passthrough → no resolution reads, and the deploy was gated off the wire.
+    assert conn.calls == []
+    assert gate.gated_op_ids == [_DEPLOY_OVF_OP]
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_power_on_after_deploy(gate: _GateRecorder) -> None:
+    """power_on=true → deploy then a gated power-start; powered_on=true."""
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/ovf/library-item/li-ovf?action=deploy": _deployment_result(
+                succeeded=True, vm_id="vm-ovf-7"
+            ),
+            "/api/vcenter/vm/vm-ovf-7/power?action=start": {},
+        }
+    )
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item": "li-ovf", "resource_pool": "resgroup-8", "power_on": True},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "deployed"
+    assert out["powered_on"] is True
+    assert out["issues"] == []
+    assert [(c["method"], c["path"]) for c in conn.calls] == [
+        ("POST", "/api/vcenter/ovf/library-item/li-ovf?action=deploy"),
+        ("POST", "/api/vcenter/vm/vm-ovf-7/power?action=start"),
+    ]
+    assert gate.gated_op_ids == [_DEPLOY_OVF_OP, "POST:/vcenter/vm/{vm}/power?action=start"]
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_power_on_failure_stays_deployed(gate: _GateRecorder) -> None:
+    """A power-on fault leaves status='deployed' with powered_on=false + a warning issue."""
+    fault = httpx.HTTPStatusError(
+        "conflict",
+        request=httpx.Request("POST", "https://vc/api/vcenter/vm/vm-ovf-7/power?action=start"),
+        response=httpx.Response(500, json={}),
+    )
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/ovf/library-item/li-ovf?action=deploy": _deployment_result(
+                succeeded=True, vm_id="vm-ovf-7"
+            ),
+            "/api/vcenter/vm/vm-ovf-7/power?action=start": fault,
+        }
+    )
+    out = await vm_deploy_from_library_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"library_item": "li-ovf", "resource_pool": "resgroup-8", "power_on": True},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["status"] == "deployed"
+    assert out["vm_id"] == "vm-ovf-7"
+    assert out["powered_on"] is False
+    assert len(out["issues"]) == 1
+    assert out["issues"][0]["category"] == "power_on"
+    assert out["issues"][0]["severity"] == "warning"
 
 
 # ===========================================================================

--- a/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_e2e.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""End-to-end activation tests for the 14 vmware-rest write composites.
+"""End-to-end activation tests for the 15 vmware-rest write composites.
 
 Post-#2256 the write composites dispatch every raw-REST sub-op **directly
 on the connector session** (``connector._get_json`` / ``connector._post_json``
@@ -335,6 +335,7 @@ async def _clear_requires_approval(op_ids: set[str], recorder: _RecordingVmwareC
 _WRITE_COMPOSITES: dict[str, str] = {
     "vmware.composite.vm.create": "vm.create",
     "vmware.composite.vm.clone": "vm.clone",
+    "vmware.composite.vm.deploy_from_library": "vm.deploy_from_library",
     "vmware.composite.vm.snapshot.revert": "vm.snapshot.revert",
     "vmware.composite.vm.migrate": "vm.migrate",
     "vmware.composite.vm.power": "vm.power",
@@ -362,6 +363,10 @@ def _benign_params_for(composite_op_id: str) -> dict[str, Any]:
             "source_vm": "vm-1",
             "target_name": "vm-clone",
             "library_item": "lib-1",
+        },
+        "vmware.composite.vm.deploy_from_library": {
+            "library_item": "li-1",
+            "resource_pool": "resgroup-8",
         },
         "vmware.composite.vm.snapshot.revert": {
             "vm": "vm-1",
@@ -414,6 +419,14 @@ def _benign_responses_for(composite_op_id: str) -> dict[str, Any]:
         "vmware.composite.vm.create": {"/vcenter/folder": empty},
         "vmware.composite.vm.clone": {
             "/vcenter/vm-template/library-items/lib-1?action=deploy": {"value": "vm-benign"},
+        },
+        # deploy_from_library: id passthrough → no finds; the synchronous OVF
+        # deploy returns a DeploymentResult that succeeds → status='deployed'.
+        "vmware.composite.vm.deploy_from_library": {
+            "/vcenter/ovf/library-item/li-1?action=deploy": {
+                "succeeded": True,
+                "resource_id": {"type": "VirtualMachine", "id": "vm-benign"},
+            },
         },
         "vmware.composite.vm.snapshot.revert": {},
         "vmware.composite.vm.migrate": {},
@@ -507,12 +520,13 @@ def _benign_vmomi_for(composite_op_id: str) -> dict[str, Any]:
 # ===========================================================================
 
 
-def test_write_composite_set_is_the_expected_fourteen() -> None:
+def test_write_composite_set_is_the_expected_fifteen() -> None:
     """Pins the REST-sub-op write set so a renamed / dropped composite can't shrink coverage.
 
-    Covers the 14 REST-sub-op write composites the parametrized fresh-boot +
+    Covers the 15 REST-sub-op write composites the parametrized fresh-boot +
     park machinery below drives (the 12 T6/#509 + vm.power + #2891 hardware
-    writes, plus the two GOSC composites / #2892). The four vi-json write
+    writes, the two GOSC composites / #2892, plus the OVF/OVA content-library
+    deploy ``vm.deploy_from_library`` / #2909). The four vi-json write
     composites (``vm.disk.grow`` / #2893, ``vm.clone_from_template`` / #2894,
     ``cluster.drs_rule.create`` + ``folder.create`` / #2895) are
     dispatch-shaped differently (vmomi sub-ops keyed by request body, not
@@ -521,7 +535,7 @@ def test_write_composite_set_is_the_expected_fourteen() -> None:
     """
     registrar_write_op_ids = {f"vmware.composite.{name}" for name in _WRITE_COMPOSITES.values()}
     assert set(_WRITE_COMPOSITES) == registrar_write_op_ids
-    assert len(_WRITE_COMPOSITES) == 14
+    assert len(_WRITE_COMPOSITES) == 15
 
 
 # ===========================================================================
@@ -540,7 +554,7 @@ async def test_write_composite_executes_through_dispatch_without_ingest(
     """Each composite runs to a benign business status on the direct session.
 
     No ingested ``endpoint_descriptor`` rows exist in the catalog here — only
-    the 23 composite rows the registrar upserts. Reaching a business status
+    the 24 composite rows the registrar upserts. Reaching a business status
     (``created`` / ``no_recommendation`` / ``detached`` / ...) rather than a
     generic execution error proves every raw-REST sub-op resolved via the
     connector session, not a catalog lookup (the two-world / fresh-boot DoD).
@@ -995,7 +1009,7 @@ async def test_write_composite_human_dispatch_parks_for_approval(
     Every write composite ships ``requires_approval=True``; G11.7-T1 (#1401)
     routes a human/service principal to the approval queue
     (``awaiting_approval``) at the top-level gate — before the handler (and
-    thus any sub-op) runs. Proves the park half for all 14; the recorder
+    thus any sub-op) runs. Proves the park half for all 15; the recorder
     stays empty of writes because the composite never executed (the
     live-read preview builders issue read-only GETs, which is expected).
     """
@@ -1537,6 +1551,126 @@ async def test_clone_from_template_fresh_boot_dispatchable_without_ingest(
     assert result.status == "ok", result.error
     assert result.result["status"] == "cloned"
     assert recorder.clone_writes == ["/VirtualMachine/vm-42/CloneVM_Task"]
+
+
+# ===========================================================================
+# vm.deploy_from_library — park (with #2681 envelope) → approve → resume → deploy
+# ===========================================================================
+
+
+_DEPLOY_FROM_LIBRARY_PARAMS: dict[str, Any] = {
+    "library_item": "li-1",
+    "resource_pool": "resgroup-8",
+    "network_mappings": {"nat": "dvportgroup-9"},
+}
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_queue_approve_resume_with_2681_envelope(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """vm.deploy_from_library: park (with #2681 op-identity envelope) → approve → resume → deploy.
+
+    1. A USER dispatch parks at ``awaiting_approval``; the durable row's
+       ``proposed_effect`` carries the uniform #2681 op-identity envelope
+       (``op_id`` / ``connector_id`` / ``target_id`` / ``op_class`` /
+       ``safety_level`` / ``preview_populated``) plus the param-echo deploy
+       preview. The OVF deploy never fires (the preview is pure param-echo —
+       no reads either).
+    2. A distinct human reviewer approves.
+    3. The ``_approved=True`` resume executes the composite: the (now
+       auto-executed) governed OVF deploy runs and the result is
+       ``status='deployed'``.
+    """
+    recorder = _RecordingVmwareConnector()
+    recorder.responses["/vcenter/ovf/library-item/li-1?action=deploy"] = {
+        "succeeded": True,
+        "resource_id": {"type": "VirtualMachine", "id": "vm-ovf-9"},
+    }
+    await _bootstrap(recorder, stub_embedding_service)
+
+    target_id = uuid.uuid4()
+    async with get_sessionmaker()() as s:
+        s.add(
+            TargetORM(
+                id=target_id,
+                tenant_id=_TENANT_ID,
+                name="prod-vcenter",
+                product="vmware",
+                host="vcenter.prod.invalid",
+                aliases=[],
+            )
+        )
+        await s.commit()
+
+    requester = _make_operator(sub="ops-human", principal_kind=PrincipalKind.USER)
+    target = _FakeVmwareTarget(target_id=target_id)
+
+    # Step 1: human dispatch -> awaiting_approval; the deploy never ran.
+    result1 = await dispatch(
+        operator=requester,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.deploy_from_library",
+        target=target,
+        params=_DEPLOY_FROM_LIBRARY_PARAMS,
+    )
+    assert result1.status == "awaiting_approval", result1.error
+    assert recorder.calls == [], "no deploy before approval"
+    approval_request_id = UUID(result1.extras["approval_request_id"])
+
+    async with get_sessionmaker()() as s:
+        pending = await s.get(ApprovalRequest, approval_request_id)
+    assert pending is not None
+    assert pending.target_id == target_id
+    # #2681 uniform op-identity + metadata envelope on the parked row.
+    effect = pending.proposed_effect
+    assert effect["op_id"] == "vmware.composite.vm.deploy_from_library"
+    assert effect["connector_id"] == _CONNECTOR_ID
+    assert effect["target_id"] == str(target_id)
+    assert effect["op_class"] == "other"
+    assert effect["safety_level"] == "dangerous"
+    assert effect["preview_populated"] is True
+    # The param-echo blast-radius preview — what the approver decides on.
+    assert effect["preview"] == {
+        "library_item": "li-1",
+        "library_item_name": None,
+        "library_name": None,
+        "name": None,
+        "resource_pool": "resgroup-8",
+        "host": None,
+        "folder": None,
+        "datastore": None,
+        "network_mappings": {"nat": "dvportgroup-9"},
+        "storage_provisioning": None,
+        "ovf_property_keys": [],
+        "power_on": False,
+    }
+
+    # Step 2: a distinct human reviewer approves.
+    reviewer = _make_operator(sub="ops-reviewer", principal_kind=PrincipalKind.USER)
+    async with get_sessionmaker()() as s:
+        row = await approve_request(
+            s, approval_request_id, operator=reviewer, params=_DEPLOY_FROM_LIBRARY_PARAMS
+        )
+        await s.commit()
+    assert row.status == ApprovalRequestStatus.APPROVED.value
+
+    # Step 3: resume re-dispatch with the gate bypass -> the deploy executes.
+    result2 = await dispatch(
+        operator=reviewer,
+        connector_id=_CONNECTOR_ID,
+        op_id="vmware.composite.vm.deploy_from_library",
+        target=target,
+        params=_DEPLOY_FROM_LIBRARY_PARAMS,
+        _approved=True,
+    )
+    assert result2.status == "ok", result2.error
+    assert result2.result["status"] == "deployed"
+    assert result2.result["vm_id"] == "vm-ovf-9"
+    # The synchronous OVF deploy fired exactly once, on the approved resume.
+    assert recorder.calls == [("POST", "/vcenter/ovf/library-item/li-1?action=deploy")]
 
 
 # ===========================================================================

--- a/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_gate.py
@@ -45,6 +45,7 @@ from meho_backplane.connectors.vmware_rest.composites._write import (
     folder_create_composite,
     vm_clone_from_template_composite,
     vm_create_composite,
+    vm_deploy_from_library_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
 )
@@ -574,6 +575,127 @@ async def test_clone_from_template_human_operator_vmomi_write_auto_executes(
     assert out["status"] == "cloned"
     # The CloneVM_Task executed on the session; the sub-op auto-executed.
     assert len(conn.clone_writes) == 1
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+
+
+# ===========================================================================
+# vm.deploy_from_library — the synchronous OVF deploy flows through the same
+# #2254 REST write-sub-op gate (#2909)
+# ===========================================================================
+
+
+_DEPLOY_OVF_OP_ID = "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy"
+
+
+class _DeployRecordingConnector:
+    """Recording double for the OVF-deploy governance tests.
+
+    Serves the synchronous OVF deploy and records every deploy write, so the
+    tests can assert the mutating POST never fired when the gate parks/denies.
+    id-passthrough params → no content-library find reads are needed.
+    """
+
+    def __init__(self) -> None:
+        self.deploy_writes: list[Any] = []
+
+    async def mount_op_path(self, target: Any, path: str, operator: Operator) -> str:
+        return f"/api{path}"
+
+    async def adapt_op_query(
+        self, target: Any, query: dict[str, Any] | None, operator: Operator
+    ) -> dict[str, Any] | None:
+        del target, operator
+        return adapt_filter_params("/api", query)
+
+    async def _post_json(
+        self,
+        target: Any,
+        path: str,
+        *,
+        operator: Operator,
+        verb: str = "POST",
+        json: Any = None,
+        data: Any = None,
+        extra_headers: Any = None,
+    ) -> Any:
+        self.deploy_writes.append((path, json))
+        return {"succeeded": True, "resource_id": {"type": "VirtualMachine", "id": "vm-ovf-1"}}
+
+
+def _deploy_gate_params() -> dict[str, Any]:
+    return {"library_item": "li-ovf", "resource_pool": "resgroup-8"}
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_gated_deploy_queues_and_never_reaches_wire(
+    session: AsyncSession,
+) -> None:
+    """An agent-gated OVF deploy queues for approval; the deploy POST never fires."""
+    await _grant(
+        principal_sub="agent-write-composite",
+        op_pattern=_DEPLOY_OVF_OP_ID,
+        verdict=PermissionVerdict.NEEDS_APPROVAL,
+    )
+    conn = _DeployRecordingConnector()
+
+    out = await vm_deploy_from_library_composite(
+        operator=_operator(),
+        target=None,
+        params=_deploy_gate_params(),
+        connector=conn,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(out, OperationResult)
+    assert out.status == "awaiting_approval"
+    assert out.op_id == _DEPLOY_OVF_OP_ID
+    request_id = uuid.UUID(out.extras["approval_request_id"])
+    row = await session.get(ApprovalRequest, request_id)
+    assert row is not None
+    assert row.op_id == _DEPLOY_OVF_OP_ID
+    assert row.connector_id == "vmware-rest-9.0"
+    assert row.status == ApprovalRequestStatus.PENDING.value
+    # The mutating OVF deploy never reached the wire.
+    assert conn.deploy_writes == []
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_dangerous_deploy_denied_without_grant(
+    session: AsyncSession,
+) -> None:
+    """An agent with no grant is denied the dangerous OVF deploy; it never runs."""
+    conn = _DeployRecordingConnector()
+    out = await vm_deploy_from_library_composite(
+        operator=_operator(sub="agent-no-grant"),
+        target=None,
+        params=_deploy_gate_params(),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, OperationResult)
+    assert out.status == "denied"
+    assert out.op_id == _DEPLOY_OVF_OP_ID
+    count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
+    assert count == 0
+    assert conn.deploy_writes == []
+
+
+@pytest.mark.asyncio
+async def test_deploy_from_library_human_operator_deploy_auto_executes(
+    session: AsyncSession,
+) -> None:
+    """A human operator's already-approved composite auto-executes the OVF deploy."""
+    conn = _DeployRecordingConnector()
+    out = await vm_deploy_from_library_composite(
+        operator=_operator(principal_kind=PrincipalKind.USER, sub="human-op"),
+        target=None,
+        params=_deploy_gate_params(),
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert isinstance(out, dict)
+    assert out["status"] == "deployed"
+    assert out["vm_id"] == "vm-ovf-1"
+    # The deploy executed on the session; the sub-op auto-executed.
+    assert len(conn.deploy_writes) == 1
     count = await session.scalar(select(func.count()).select_from(ApprovalRequest))
     assert count == 0
 

--- a/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_preview.py
@@ -74,6 +74,7 @@ _WRITE_COMPOSITE_OP_IDS: frozenset[str] = frozenset(
     {
         "vmware.composite.vm.create",
         "vmware.composite.vm.clone",
+        "vmware.composite.vm.deploy_from_library",
         "vmware.composite.vm.clone_from_template",
         "vmware.composite.vm.snapshot.revert",
         "vmware.composite.vm.migrate",
@@ -304,10 +305,10 @@ def _strip_uniform_identity(effect: dict[str, Any], *, op_id: str) -> dict[str, 
 # ===========================================================================
 
 
-def test_all_eighteen_write_composites_register_a_preview_builder() -> None:
+def test_all_nineteen_write_composites_register_a_preview_builder() -> None:
     """Importing the composites package wires a builder per write composite."""
     assert set(_write_preview._WRITE_PREVIEW_BUILDERS) == set(_WRITE_COMPOSITE_OP_IDS)
-    assert len(_WRITE_COMPOSITE_OP_IDS) == 18
+    assert len(_WRITE_COMPOSITE_OP_IDS) == 19
     for op_id, builder in _write_preview._WRITE_PREVIEW_BUILDERS.items():
         assert _PREVIEW_BUILDERS.get(op_id) is builder, op_id
 
@@ -425,6 +426,63 @@ async def test_vm_clone_preview_echoes_clone_coordinates() -> None:
     }
 
 
+async def test_vm_deploy_from_library_preview_echoes_deploy_coordinates() -> None:
+    """The deploy echo names the blast radius — item, placement, mappings — no I/O."""
+    preview = await _write_preview._vm_deploy_from_library_preview(
+        _make_preview_ctx(
+            {
+                "library_item_name": "holorouter-ova",
+                "library_name": "lab-templates",
+                "name": "router-01",
+                "resource_pool": "resgroup-8",
+                "host": "host-19",
+                "folder": "group-v10",
+                "datastore": "datastore-15",
+                "network_mappings": {"nat": "dvportgroup-42"},
+                "storage_provisioning": "thin",
+                "ovf_properties": {"guestinfo.password": "s3cret", "guestinfo.hostname": "r1"},
+                "power_on": True,
+            }
+        )
+    )
+    assert preview == {
+        "library_item": None,
+        "library_item_name": "holorouter-ova",
+        "library_name": "lab-templates",
+        "name": "router-01",
+        "resource_pool": "resgroup-8",
+        "host": "host-19",
+        "folder": "group-v10",
+        "datastore": "datastore-15",
+        "network_mappings": {"nat": "dvportgroup-42"},
+        "storage_provisioning": "thin",
+        # Only property IDs — never the (possibly secret) values (#1503).
+        "ovf_property_keys": ["guestinfo.hostname", "guestinfo.password"],
+        "power_on": True,
+    }
+
+
+async def test_vm_deploy_from_library_preview_defaults_optional_fields() -> None:
+    """id passthrough + only the required resource_pool → optional fields default cleanly."""
+    preview = await _write_preview._vm_deploy_from_library_preview(
+        _make_preview_ctx({"library_item": "li-ovf", "resource_pool": "resgroup-8"})
+    )
+    assert preview == {
+        "library_item": "li-ovf",
+        "library_item_name": None,
+        "library_name": None,
+        "name": None,
+        "resource_pool": "resgroup-8",
+        "host": None,
+        "folder": None,
+        "datastore": None,
+        "network_mappings": {},
+        "storage_provisioning": None,
+        "ovf_property_keys": [],
+        "power_on": False,
+    }
+
+
 async def test_vm_clone_from_template_preview_echoes_clone_coordinates() -> None:
     """The clone-coordinates echo names the full blast radius, minus GOSC secrets."""
     preview = await _write_preview._vm_clone_from_template_preview(
@@ -521,6 +579,7 @@ async def test_echo_builders_decline_on_malformed_params() -> None:
     """Missing required params decline (→ identifier-only default), never raise."""
     assert await _write_preview._vm_create_preview(_make_preview_ctx({})) is None
     assert await _write_preview._vm_clone_preview(_make_preview_ctx({})) is None
+    assert await _write_preview._vm_deploy_from_library_preview(_make_preview_ctx({})) is None
     assert await _write_preview._vm_clone_from_template_preview(_make_preview_ctx({})) is None
     assert await _write_preview._vm_snapshot_revert_preview(_make_preview_ctx({})) is None
     assert await _write_preview._vm_migrate_preview(_make_preview_ctx({})) is None

--- a/backend/tests/test_connectors_vmware_rest_composites_write_register.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_register.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Registration tests for the 18 vmware-rest write composites.
+"""Registration tests for the 19 vmware-rest write composites.
 
 Coverage matrix (G3.1-T6 / #509 acceptance criteria, plus single-VM
 ``vm.power`` / #2301, the vim writes ``vm.disk.grow`` / #2893 +
@@ -10,7 +10,7 @@ hardware writes ``vm.resize`` / ``vm.nic.repoint`` / ``vm.device.cdrom``,
 and the GOSC composites ``guest.customization_spec.create`` /
 ``vm.customize`` / #2892):
 
-* All 18 expected write ``op_id`` rows land in ``endpoint_descriptor``
+* All 19 expected write ``op_id`` rows land in ``endpoint_descriptor``
   with ``source_kind="composite"``, ``safety_level="dangerous"``,
   ``requires_approval=True`` (T4's defaults intentionally inherited).
 * Each row's ``handler_ref`` resolves to the module-level dotted path
@@ -53,6 +53,7 @@ from meho_backplane.connectors.vmware_rest.composites import (
     vm_clone_from_template_composite,
     vm_create_composite,
     vm_customize_composite,
+    vm_deploy_from_library_composite,
     vm_device_cdrom_composite,
     vm_disk_grow_composite,
     vm_migrate_composite,
@@ -67,7 +68,7 @@ from meho_backplane.db.models import EndpointDescriptor, OperationGroup
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.settings import get_settings
 
-# 18 write composites (T6 / #509, single-VM vm.power / #2301, the
+# 19 write composites (T6 / #509, single-VM vm.power / #2301, the
 # mutating VI-JSON vm.disk.grow / #2893, the folder-template
 # vm.clone_from_template / #2894, the vim cluster/inventory writes
 # cluster.drs_rule.create + folder.create / #2895, the #2891
@@ -76,6 +77,7 @@ from meho_backplane.settings import get_settings
 _WRITE_OP_IDS: tuple[str, ...] = (
     "vmware.composite.vm.create",
     "vmware.composite.vm.clone",
+    "vmware.composite.vm.deploy_from_library",
     "vmware.composite.vm.clone_from_template",
     "vmware.composite.vm.snapshot.revert",
     "vmware.composite.vm.migrate",
@@ -106,7 +108,7 @@ _READ_OP_IDS: tuple[str, ...] = (
     "vmware.composite.network.portgroup.audit",
 )
 
-# 23 total -- 5 read (T5 / #508) + 18 write (T6 / #509 + vm.power / #2301 +
+# 24 total -- 5 read (T5 / #508) + 19 write (T6 / #509 + vm.power / #2301 +
 # vm.disk.grow / #2893 + vm.clone_from_template / #2894 + vim cluster/inventory
 # writes cluster.drs_rule.create + folder.create / #2895 + #2891 hardware
 # writes vm.resize / vm.nic.repoint / vm.device.cdrom + GOSC create/apply / #2892).
@@ -119,6 +121,9 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
     ),
     "vmware.composite.vm.clone": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_clone_composite"
+    ),
+    "vmware.composite.vm.deploy_from_library": (
+        "meho_backplane.connectors.vmware_rest.composites._write.vm_deploy_from_library_composite"
     ),
     "vmware.composite.vm.clone_from_template": (
         "meho_backplane.connectors.vmware_rest.composites._write.vm_clone_from_template_composite"
@@ -175,6 +180,7 @@ _EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
 _EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
     "vmware.composite.vm.create": "vm",
     "vmware.composite.vm.clone": "vm",
+    "vmware.composite.vm.deploy_from_library": "vm",
     "vmware.composite.vm.clone_from_template": "vm",
     "vmware.composite.vm.snapshot.revert": "vm",
     "vmware.composite.vm.migrate": "vm",
@@ -234,15 +240,15 @@ async def session() -> AsyncIterator[AsyncSession]:
 
 
 # ---------------------------------------------------------------------------
-# 18 write composites land alongside the 5 reads (23 total)
+# 19 write composites land alongside the 5 reads (24 total)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_inserts_eighteen_write_rows(
+async def test_register_vmware_composite_operations_inserts_nineteen_write_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar lands all 18 write op_ids in ``endpoint_descriptor``."""
+    """Running the registrar lands all 19 write op_ids in ``endpoint_descriptor``."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -259,13 +265,13 @@ async def test_register_vmware_composite_operations_inserts_eighteen_write_rows(
 
 
 @pytest.mark.asyncio
-async def test_full_registration_produces_twenty_three_composite_rows(
+async def test_full_registration_produces_twenty_four_composite_rows(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """5 reads (#508) + 18 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
+    """5 reads (#508) + 19 writes (#509 + vm.power #2301 + vm.disk.grow #2893 +
     vm.clone_from_template #2894 + cluster.drs_rule.create + folder.create #2895 +
     #2891 hardware writes vm.resize / vm.nic.repoint / vm.device.cdrom +
-    GOSC create/apply #2892) = 23 rows. DoD bar."""
+    GOSC create/apply #2892 + OVF deploy #2909) = 24 rows. DoD bar."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as fresh:
@@ -279,7 +285,7 @@ async def test_full_registration_produces_twenty_three_composite_rows(
             .all()
         )
     assert {row.op_id for row in rows} == set(_ALL_OP_IDS)
-    assert len(rows) == 23
+    assert len(rows) == 24
 
 
 @pytest.mark.asyncio
@@ -499,6 +505,17 @@ async def test_write_composite_response_schemas_persist_with_status_enums(
         # #2970: the pinned deploy operation is synchronous, so the
         # pending/timeout task-wait statuses are gone.
         "vmware.composite.vm.clone": {"completed"},
+        # #2909: OVF/OVA content-library deploy — resolution + deploy-report statuses.
+        "vmware.composite.vm.deploy_from_library": {
+            "deployed",
+            "deploy_failed",
+            "deploy_error",
+            "invalid_reference",
+            "library_not_found",
+            "ambiguous_library",
+            "item_not_found",
+            "ambiguous_item",
+        },
         # #2970: the revert is a polled vim *_Task -> a poll timeout is a
         # legible status.
         "vmware.composite.vm.snapshot.revert": {"reverted", "ambiguous", "not_found", "timeout"},
@@ -560,17 +577,17 @@ async def test_write_composite_tags_include_composite_and_write(
 
 
 @pytest.mark.asyncio
-async def test_register_vmware_composite_operations_is_idempotent_across_twenty_three(
+async def test_register_vmware_composite_operations_is_idempotent_across_twenty_four(
     stub_embedding_service: AsyncMock,
 ) -> None:
-    """Running the registrar twice -> 23 rows total, embedding called 23x once."""
+    """Running the registrar twice -> 24 rows total, embedding called 24x once."""
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     first_count = stub_embedding_service.encode_one.call_count
-    assert first_count == 23
+    assert first_count == 24
 
     await register_vmware_composite_operations(embedding_service=stub_embedding_service)
     # Body-hash skip path -> second run is a no-op for the embedding
-    # pipeline; the row count stays at 23.
+    # pipeline; the row count stays at 24.
     assert stub_embedding_service.encode_one.call_count == first_count
 
     sessionmaker = get_sessionmaker()
@@ -584,7 +601,7 @@ async def test_register_vmware_composite_operations_is_idempotent_across_twenty_
             .scalars()
             .all()
         )
-    assert len(rows) == 23
+    assert len(rows) == 24
 
 
 # ---------------------------------------------------------------------------
@@ -605,6 +622,7 @@ def test_all_write_handlers_are_module_level_coroutine_functions() -> None:
     for handler in (
         vm_create_composite,
         vm_clone_composite,
+        vm_deploy_from_library_composite,
         vm_clone_from_template_composite,
         vm_snapshot_revert_composite,
         vm_migrate_composite,

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -8,18 +8,19 @@ that dispatches ingested vCenter REST operations under the
 triple. It pairs with the G0.7 ingestion pipeline's auto-shim (which
 makes ~1,275 + ~2,195 `endpoint_descriptor` rows resolvable but not
 dispatchable) to deliver real session-authenticated calls against
-vSphere 8.5+ / ESXi 8.5+ targets, plus 23 hand-authored composites
+vSphere 8.5+ / ESXi 8.5+ targets, plus 24 hand-authored composites
 that orchestrate cross-spec workflows: 5 read composites
 (G3.1-T5 / `#508`; the `host.network_uplinks` / `#2080` and
 `host.vsan_health` / `#2135` reads were later re-shipped as typed ops
-in `#2258`) and 18 write composites (G3.1-T6 / `#509`, the
+in `#2258`) and 19 write composites (G3.1-T6 / `#509`, the
 single-VM `vm.power` verb incl. Tools soft shutdown / `#2301`, the
 mutating VI-JSON `vm.disk.grow` / `#2893`, the folder-template
 `vm.clone_from_template` / `#2894`, the vim cluster / inventory writes
 `cluster.drs_rule.create` + `folder.create` / `#2895`, the `#2891`
 post-clone hardware reconfigure trio `vm.resize` / `vm.nic.repoint` /
-`vm.device.cdrom`, and the two guest-customization (GOSC) composites
-`guest.customization_spec.create` + `vm.customize` / `#2892`). The
+`vm.device.cdrom`, the two guest-customization (GOSC) composites
+`guest.customization_spec.create` + `vm.customize` / `#2892`, and the
+OVF/OVA content-library deploy `vm.deploy_from_library` / `#2909`). The
 write composites cover every state-mutating operator workflow named
 in [#214](https://github.com/evoila/meho/issues/214) as required for
 govc-wrapper retirement.
@@ -74,8 +75,9 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   cluster-wide `overall_health` colour plus the health-test `groups`
   list. It is likewise best-effort (a failed health-service read nulls
   `groups` / `overall_health` with a `read_note`).
-- **Write composites** (`composites/_write.py`) — fourteen module-level
+- **Write composites** (`composites/_write.py`) — fifteen module-level
   `async def` handlers (`vm_create_composite`, `vm_clone_composite`,
+  `vm_deploy_from_library_composite`,
   `vm_snapshot_revert_composite`, `vm_migrate_composite`,
   `vm_power_composite`, `vm_power_bulk_composite`,
   `vm_resize_composite`, `vm_nic_repoint_composite`,
@@ -178,8 +180,8 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   (`test_gosc_create_secret_hygiene_across_all_surfaces`).
 - **`register_vmware_composite_operations`** (`composites/_register.py`)
   — async registrar function called from `run_typed_op_registrars` at
-  lifespan startup. Iterates a single `_COMPOSITES` tuple of 23
-  `_CompositeSpec` rows (5 read + 18 write); each row carries its
+  lifespan startup. Iterates a single `_COMPOSITES` tuple of 24
+  `_CompositeSpec` rows (5 read + 19 write); each row carries its
   own `safety_level` + `requires_approval` so the policy posture is
   implied by the spec, not by global defaults. Idempotent on re-run
   via the body-hash skip path.
@@ -308,7 +310,7 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
 5. Lifespan calls `run_typed_op_registrars()`, which iterates every
    queued registrar and upserts: the 23 `vmware.composite.*` rows with
    `source_kind="composite"` (5 reads with `safety_level="safe"` +
-   `requires_approval=False`; 18 writes with `safety_level="dangerous"`
+   `requires_approval=False`; 19 writes with `safety_level="dangerous"`
    + `requires_approval=True`), plus the `vmware.host.usage` row with
    `source_kind="typed"` (`safety_level="safe"` + `requires_approval=False`).
    The typed row resolves and dispatches with **zero catalog ingest** —
@@ -404,7 +406,7 @@ reach this method.
 
 ### Composite dispatch
 
-The 23 composites (5 reads + 18 writes) land as `source_kind="composite"`
+The 24 composites (5 reads + 19 writes) land as `source_kind="composite"`
 rows in `endpoint_descriptor`. At dispatch time:
 
 1. Dispatcher resolves `(vmware-rest-9.0, vmware.composite.<verb>)`
@@ -471,7 +473,7 @@ caller.
 
 ### L1/L2 dispatch — direct-session (two-world migration, Goal #2247)
 
-The 23 composites are hand-authored aggregators the connector ships as
+The 24 composites are hand-authored aggregators the connector ships as
 `source_kind='composite'` descriptors. Each composite's body issues its
 raw-REST sub-ops (`GET:/vcenter/datastore`,
 `POST:/vcenter/vm/{vm}/power?action=start`, etc.) **directly on the
@@ -514,6 +516,7 @@ enum) are:
 | --- | --- |
 | `vm.create` | `created`, `rolled_back` |
 | `vm.clone` | `completed` (the pinned deploy operation is synchronous — its 200 body is the new VM id, #2970; deploy failures raise `connector_error`) |
+| `vm.deploy_from_library` | `deployed`, `deploy_failed`, `deploy_error`, `invalid_reference`, `library_not_found`, `ambiguous_library`, `item_not_found`, `ambiguous_item` (OVF/OVA deploy, #2909; the synchronous deploy's 200 body is a `DeploymentResult` — `succeeded=false` → `deploy_failed` with the report's per-issue messages, an HTTP 400/404 for an invalid/missing placement resource → `deploy_error` with a structured message, and the name-resolution refusals are pre-deploy — so a placement/mapping error is a structured status, never a raw vendor fault) |
 | `vm.snapshot.revert` | `reverted`, `ambiguous`, `not_found`, `timeout` (vim `RevertToSnapshot_Task` polled; a task fault raises `connector_error`, #2970) |
 | `vm.migrate` | `migrated`, `no_recommendation` |
 | `vm.power` | `ok`, `error`, `tools_unavailable` (single VM; `tools_unavailable` when a soft `guest_shutdown`/`guest_reboot` finds Tools down) |
@@ -665,6 +668,19 @@ lives:
 | `vm.clone` | a **content-library** template item | REST `POST:/vcenter/vm-template/library-items/{templateLibraryItem}?action=deploy` (synchronous — the 200 body is the new VM id; #2970) | the golden image is published to a content library |
 | `vm.clone_from_template` | a **folder VM template** (a marked-as-template VM in a VM folder) | vim `POST:/VirtualMachine/{moId}/CloneVM_Task`, poll via `poll_vim_task` | the golden image is a plain marked-as-template VM (govc/terraform's `CloneVM_Task` path) |
 
+A third content-library deploy path, `vm.deploy_from_library` (#2909,
+retiring `govc library.deploy`), covers a different **item type**: an
+**OVF/OVA** library item (content-library item `type=ovf`) rather than a
+VM-template item. It deploys via the synchronous REST
+`POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy` whose
+200 body is a `DeploymentResult` (not a bare VM id), so it can surface
+OVF-descriptor / network-mapping / placement validation failures as a
+structured `deploy_failed` / `deploy_error` status. It also resolves the
+item by name (`POST:/content/library/item?action=find`, filtered to
+`type=ovf`, optionally scoped by a library name resolved via
+`POST:/content/library?action=find`), refusing ambiguity before any
+deploy. See the OVF/OVA deploy section below.
+
 `vm.clone`'s content-library deploy path **cannot** clone a folder
 template — a marked-as-template VM has no content-library item to deploy
 — and the REST `POST:/vcenter/vm?action=clone` template-source acceptance
@@ -711,6 +727,55 @@ radius without leaking credential material. New vim sub-op paths
 (`CloneVM_Task`, `RetrievePropertiesEx`, `GetCustomizationSpec`) are
 declared in `_VIM_SUB_OPS_VM_CLONE_FROM_TEMPLATE` and reconciled against
 the pinned `vi-json.yaml`.
+
+### OVF/OVA content-library deploy (`vm.deploy_from_library`, #2909)
+
+Retires `govc library.deploy` for OVF/OVA appliances (the HoloRouter OVA
+and friends). Pure vSphere Automation REST — no `pyvmomi`. All four
+sub-ops are `vcenter.yaml`-served paths, so the composite reconciles
+through the generic `_SUB_OPS_VM_DEPLOY_FROM_LIBRARY` sweep (not a
+`_VIM_SUB_OPS_*` lane).
+
+**Item resolution.** `library_item` (an id) is a passthrough. Otherwise
+`library_item_name` is resolved to an id via
+`POST:/content/library/item?action=find` (a *read* — returns a bare id
+array — issued un-gated through the `_find_content_library_ids` helper,
+which rides `_post_json` since find is POST-shaped), filtered to
+`type=ovf` so a colliding non-OVF item name never matches. An optional
+`library_name` first resolves to a library id via
+`POST:/content/library?action=find` to scope the item lookup. Zero
+matches → `item_not_found` / `library_not_found`; more than one →
+`ambiguous_item` / `ambiguous_library` with the candidate ids — every
+refusal is **pre-deploy**, so the operator re-dispatches by explicit id.
+
+**Deploy.** The body is `{deployment_spec, target}` (two top-level params
+— not the single-`spec` wrapper the `find` reads and `CreateSpec` writes
+use). `target.resource_pool_id` is the one **required** placement
+(`host_id` / `folder_id` refine it); `deployment_spec` carries
+`accept_all_eula` (defaults true), `name`, the OVF-network-key →
+portgroup-moid **map** `network_mappings` (a map in the pinned 9.0 spec,
+not an array), `storage_provisioning` / `storage_profile_id` /
+`default_datastore_id`, and any `ovf_properties` folded into a single
+`PropertyParams` entry in `additional_parameters`. Note the pinned 9.0
+spec keys the EULA field `accept_all_eula` (lowercase) — divergent from
+`govmomi`'s legacy `accept_all_EULA`; the connector follows the pinned
+spec it ingests.
+
+**Result mapping — structured statuses, never a raw vendor error.** The
+deploy is synchronous, but unlike `vm.clone` its 200 body is a
+`DeploymentResult` structure. `succeeded=true` → `deployed` with the VM
+moid from `resource_id.id` (+ `resource_type`); `succeeded=false` →
+`deploy_failed` with the report's per-issue messages
+(`error.errors/warnings/information`, each projected to
+`{category, severity, message}`) — this is how a bad network-mapping key
+or OVF-descriptor validation surfaces. An HTTP 400/404 (invalid args, or
+a placement moid that does not exist) is **caught** and mapped to
+`deploy_error` with a parsed message rather than re-raised — so a
+placement/mapping error is always a structured status. With `power_on`,
+a best-effort `POST:/vcenter/vm/{vm}/power?action=start` follows a
+successful deploy; a power-on fault leaves `status='deployed'` with
+`powered_on=false` and a `power_on` warning issue (a deployed appliance
+is never rolled back over a power-on hiccup).
 
 ### vim cluster / inventory writes (`cluster.drs_rule.create` + `folder.create`, #2895)
 
@@ -835,7 +900,7 @@ so existing string-matching consumers keep working.
 
 ### Park-time approval previews (#1608)
 
-All 18 write composites ship `requires_approval=True`, so a human/agent
+All 19 write composites ship `requires_approval=True`, so a human/agent
 dispatch parks as a durable `ApprovalRequest` row. Pre-#1608 that row's
 `proposed_effect` was the identifier-only default `{op_id, connector_id,
 target_id}` — and since the dispatch `params` are deliberately never
@@ -859,6 +924,7 @@ composite on the generic per-op hook (`register_preview_builder`,
 | `vm.device.cdrom` | `{vm, name, cdrom, action, current_backing, state}` (the host-local ISO path) | live read (`cdrom/{cdrom}`) |
 | `vm.create` | creation-spec echo (name, guest_os, sizing, networks, power-on) | param echo, no I/O |
 | `vm.clone` | clone-coordinates echo | param echo, no I/O |
+| `vm.deploy_from_library` | deploy-coordinates echo (item ref, placement, network mappings, provisioning, `ovf_property_keys` — **ids only**, never values #1503, power-on) | param echo, no I/O |
 | `vm.snapshot.revert` | `{vm, snapshot_name}` echo | param echo, no I/O |
 | `vm.migrate` | `{vm, cluster, target_host, target_host_source}` | param echo, no I/O |
 | `vm.power` | `{vm, verb, power_kind}` echo (`power_kind` = `hard` vs Tools-soft `guest`) | param echo, no I/O |


### PR DESCRIPTION
## Summary

- Adds **`vmware.composite.vm.deploy_from_library`** — a curated OVF/OVA
  content-library deploy composite on the vmware-rest connector, retiring the
  `govc library.deploy` pivot in the consumer's deploy/clone procedures
  (register row on #2907). Registered per the standard `_CompositeSpec`
  pattern with a preview builder; dispatchable on a **fresh boot with zero
  catalog ingest** (direct-session rule, Goal #2247) — every mutating
  sub-call flows through `enforce_subop_policy`.
- **Name-based library-item resolution**: id passthrough, or resolve
  `library_item_name` via `POST:/content/library/item?action=find` (filtered
  to `type=ovf`), optionally scoped by `library_name` through
  `POST:/content/library?action=find`, refusing ambiguity
  (`ambiguous_item` / `ambiguous_library`) before any deploy.
- **Structured statuses, never raw vendor errors**: the synchronous
  `POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy` returns a
  `DeploymentResult` — `succeeded=false` → `deploy_failed` with the report's
  per-issue messages (network-mapping / placement / OVF validation), an HTTP
  400/404 for an invalid/missing placement resource → `deploy_error` with a
  parsed message. Optional best-effort power-on after a successful deploy.
- `safety_level=dangerous`, `requires_approval=True`, uniform op-identity
  envelope (#2681), secret-hygienic param-echo preview (OVF property **ids**
  only, never values). Follows #2890's write-wave conventions.

## Test plan

- [x] `ruff check` — clean (composites source + all touched tests)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (no issues in the composites module)
- [x] `code-quality.py --diff` — 0 blockers (only pre-existing warnings)
- [x] **Unit lane** — id passthrough, name resolution (library+item find),
      ambiguity refusal, `item_not_found`, `invalid_reference`, deploy body
      shape, `deploy_failed` (report issues), `deploy_error` (HTTP fault),
      gate short-circuit, power-on success + failure
- [x] **Mocked-session e2e lane** — fresh-boot dispatch (zero ingest) via the
      parametrized set, top-level park, and a bespoke park → approve → resume
      test asserting the **#2681** op-identity envelope + param-echo preview
- [x] **Policy-gate lane** — agent needs-approval queues (durable
      `ApprovalRequest`, deploy never on the wire), agent no-grant denied,
      human operator auto-executes
- [x] **Preview lane** — echo assertions (incl. `ovf_property_keys` scrub),
      defaults, and the malformed-decline sweep
- [x] **Ingest-reconcile** — manifest pin + real-spec assertion; the four
      sub-op paths (OVF deploy + both content-library finds + power-on) are
      verified present in the pinned 9.0 `vcenter.yaml`
- [x] Full composites suite: **306 passed** (with the pinned spec-shelf wired)
- [x] `docs/codebase/connectors-vmware-rest.md` composite tables + dedicated
      section, and CHANGELOG updated

## Out of scope

- Per-section OVF `storage_mappings` and arbitrary `additional_parameters`
  shapes beyond `ovf_properties` (product-section properties) — not required
  by the register row; can follow if a concrete need surfaces.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2909
