### PR TITLE
feat(connectors): holodeck deploy-lifecycle typed ops (config.apply / instance.start / instance.status / router.patch) (#2908)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — holodeck deploy-lifecycle typed ops: `config.apply` / `instance.start` / `instance.status` / `router.patch` (#2908)
+
+- The `holodeck` connector gains four typed ops that make the consumer's
+  hand-run fresh-deploy procedure dispatchable as governed steps (17 ops total):
+  - `holodeck.config.apply` — `New-HoloDeckConfig` (never `-Default`) +
+    `Import-HoloDeckConfig`. Refuses depot params for a VCF 5.2.x version
+    (5.2 uses Cloud Builder, no offline depot) in `validate_params`.
+    `dangerous`, approval-gated, with a param-echo preview.
+  - `holodeck.instance.start` — a single-shot fail-fast `Connect-VIServer`
+    precheck (so a stale/locked deploy-target credential can't storm-lock the
+    SSO account) then a detached `New-HoloDeckInstance` launch. `dangerous`,
+    approval-gated.
+  - `holodeck.instance.status` — `Get-HoloDeckInstance` → a flat status
+    envelope (running/completed/failed) usable as a runbook
+    `OperationCallVerify` target and a deploy-in-progress Sensor op. Tolerates
+    the benign VCF 5.2.x `Sync-HolodeckComponents` "No route to host" terminal
+    quirk as a structured note, not a failure. `safe`, no approval.
+  - `holodeck.router.patch` — idempotent verify-then-apply of the three
+    per-appliance HoloRouter patches (C1/C2/C3), verify-only on a 9.1
+    HoloRouter. `dangerous`, approval-gated; the Broadcom build token and any
+    credential material never reach an approval / audit / broadcast surface
+    (#1503).
+
 ### Breaking changes — vmware composite param schemas tightened by the #2970 repoint
 
 - `vmware.composite.vm.clone` no longer accepts `wait_for_completion` /

--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
+#
+# code-quality-allow: pre-existing legacy debt not introduced by this task.
+# The module was already >1000 lines (the wire-shape contract + the full op
+# sensitivity classifier + redaction rules) before this task; #2908 only adds
+# two op-ids to the fixed `_CREDENTIAL_WRITE_OPS` frozenset. Splitting the
+# classifier out of the schema module is a behaviour-preserving refactor out
+# of scope for a two-line allowlist pin and would balloon the review surface.
 
 """Broadcast event schema + PII classifier (G6.1-T2).
 
@@ -183,6 +190,18 @@ _CREDENTIAL_WRITE_OPS: Final[frozenset[str]] = frozenset(
         # sibling ``vmware.composite.vm.customize`` carries only a spec-name
         # reference (no secret) and is not pinned.
         "vmware.composite.guest.customization_spec.create",
+        # #2908 — the Holodeck HoloRouter patch op. Its C2 patch wraps the
+        # BroadcomBuildToken *read* and its fixed patch strings reference
+        # ``$env:brcm_build_token`` by name, never a value; the op takes no
+        # params today. The pin is defence-in-depth per the
+        # ``rke2.node.config.update`` precedent: should a future param-shape
+        # change ever place a token/credential in params, the broadcast
+        # collapses to aggregate-only rather than shipping it on the feed. The
+        # sibling ``holodeck.config.apply`` carries only non-secret config +
+        # Vault *refs* (the vCenter/depot creds are read on the appliance from
+        # its staged env, never a param), so it keeps its param-echo preview
+        # and is deliberately NOT pinned.
+        "holodeck.router.patch",
     }
 )
 

--- a/backend/src/meho_backplane/connectors/holodeck/connector.py
+++ b/backend/src/meho_backplane/connectors/holodeck/connector.py
@@ -3,10 +3,12 @@
 #
 # code-quality-allow: pre-existing legacy debt not introduced by this task.
 # On main the module was already 723 lines (> 600) with fingerprint (109) /
-# probe (111, C901 14) over budget; G3.18-T2 (#2154) only appends three
-# small write-op shims + the WRITE_OPS wiring. Splitting the connector or
-# refactoring fingerprint/probe is out of scope for an approval-gated write
-# addition and would balloon the review surface; tracked separately.
+# probe (111, C901 14) over budget; G3.18-T2 (#2154) appended three small
+# write-op shims + the WRITE_OPS wiring, and #2908 appends four more small
+# deploy-op delegating shims + the DEPLOY when_to_use merge. Every shim is a
+# 3-line delegate to ops_deploy; splitting the connector or refactoring
+# fingerprint/probe is out of scope for a typed-op addition and would balloon
+# the review surface; tracked separately.
 
 """HolodeckConnector -- typed SSH-transport connector for VMware Holodeck 9.0.
 
@@ -72,6 +74,9 @@ from meho_backplane.connectors._shared.vault_creds import CredentialsReadError
 from meho_backplane.connectors.adapters.ssh import SshConnector
 from meho_backplane.connectors.holodeck._pwsh import PwshRunError, pwsh_run
 from meho_backplane.connectors.holodeck.ops import HOLODECK_OPS
+from meho_backplane.connectors.holodeck.ops_deploy import (
+    HOLODECK_WHEN_TO_USE_DEPLOY_BY_GROUP,
+)
 from meho_backplane.connectors.holodeck.ops_write import (
     HOLODECK_WHEN_TO_USE_WRITE_BY_GROUP,
 )
@@ -215,6 +220,11 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
     # group keys above; the blurbs are the single source of truth in
     # ``ops_write`` and are merged in here for the registration walk.
     **HOLODECK_WHEN_TO_USE_WRITE_BY_GROUP,
+    # #2908 deploy-lifecycle groups (config.apply / instance.start /
+    # instance.status / router.patch). The keys carry a ``deploy-`` prefix
+    # so they never collide with the read/write group keys above; the blurbs
+    # are the single source of truth in ``ops_deploy``.
+    **HOLODECK_WHEN_TO_USE_DEPLOY_BY_GROUP,
 }
 
 
@@ -737,6 +747,82 @@ class HolodeckConnector(SshConnector):
         )
 
         return await _holodeck_images_import(self, target, params, operator)
+
+    async def config_apply(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.config.apply`` (#2908).
+
+        **Approval-gated write.** Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_deploy.holodeck_config_apply`;
+        runs New-HoloDeckConfig (never ``-Default``) + Import-HoloDeckConfig on
+        the ``_approved=True`` resume path.
+        """
+        from meho_backplane.connectors.holodeck.ops_deploy import (
+            holodeck_config_apply as _holodeck_config_apply,
+        )
+
+        return await _holodeck_config_apply(self, target, params, operator)
+
+    async def instance_start(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.instance.start`` (#2908).
+
+        **Approval-gated write.** Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_deploy.holodeck_instance_start`;
+        runs the fail-fast Connect-VIServer precheck then the detached
+        New-HoloDeckInstance launch on the ``_approved=True`` resume path.
+        """
+        from meho_backplane.connectors.holodeck.ops_deploy import (
+            holodeck_instance_start as _holodeck_instance_start,
+        )
+
+        return await _holodeck_instance_start(self, target, params, operator)
+
+    async def instance_status(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.instance.status`` (#2908).
+
+        Safe read. Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_deploy.holodeck_instance_status`;
+        maps Get-HoloDeckInstance into the structured deploy-status envelope
+        (serves both a runbook OperationCallVerify target and a Sensor op).
+        """
+        from meho_backplane.connectors.holodeck.ops_deploy import (
+            holodeck_instance_status as _holodeck_instance_status,
+        )
+
+        return await _holodeck_instance_status(self, target, params, operator)
+
+    async def router_patch(
+        self,
+        target: Target,
+        params: dict[str, Any],
+        operator: Operator | None = None,
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.router.patch`` (#2908).
+
+        **Approval-gated write.** Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_deploy.holodeck_router_patch`;
+        idempotently verify-then-applies the three per-appliance patches
+        (verify-only on 9.1) on the ``_approved=True`` resume path.
+        """
+        from meho_backplane.connectors.holodeck.ops_deploy import (
+            holodeck_router_patch as _holodeck_router_patch,
+        )
+
+        return await _holodeck_router_patch(self, target, params, operator)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/holodeck/ops.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops.py
@@ -156,12 +156,17 @@ def _holodeck_ops() -> tuple[HolodeckOp, ...]:
     surface). G3.18-T2 (#2154) appends the 3 approval-gated remediation
     write ops (:data:`~meho_backplane.connectors.holodeck.ops_write.WRITE_OPS`:
     ``holodeck.k8s.pods.gc`` / ``holodeck.backups.prune`` /
-    ``holodeck.images.import``) onto the tuple -- 13 ops total.
+    ``holodeck.images.import``) onto the tuple -- 13 ops. #2908 appends the
+    4 deploy-lifecycle ops
+    (:data:`~meho_backplane.connectors.holodeck.ops_deploy.DEPLOY_OPS`:
+    ``holodeck.config.apply`` / ``holodeck.instance.start`` /
+    ``holodeck.instance.status`` / ``holodeck.router.patch``) -- 17 ops total.
     """
+    from meho_backplane.connectors.holodeck.ops_deploy import DEPLOY_OPS
     from meho_backplane.connectors.holodeck.ops_read import READ_OPS
     from meho_backplane.connectors.holodeck.ops_write import WRITE_OPS
 
-    return (_HOLODECK_ABOUT_OP, *READ_OPS, *WRITE_OPS)
+    return (_HOLODECK_ABOUT_OP, *READ_OPS, *WRITE_OPS, *DEPLOY_OPS)
 
 
 #: The ops :class:`HolodeckConnector` registers at lifespan startup.

--- a/backend/src/meho_backplane/connectors/holodeck/ops_deploy.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_deploy.py
@@ -1,0 +1,1140 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# code-quality-allow: the four deploy-lifecycle ops each carry a JSON-Schema
+# parameter block + curated llm_instructions + a focused handler; keeping the
+# op metadata beside its handler (the ops_write.py / ops_read.py precedent in
+# this same connector) is more cohesive than splitting the tuple into a second
+# module purely to sit under the 600-line file bound.
+
+"""Deploy-lifecycle typed ops for :class:`HolodeckConnector` (#2908, Initiative #2907).
+
+G3.8 shipped identity + read ops; G3.18-T2 (#2154) shipped three narrow
+remediation writes. This module closes the last hand-run gap on the
+fresh-deploy path: the consumer's ``New-HoloDeckConfig`` /
+``New-HoloDeckInstance`` / per-appliance-patch procedure ran by hand in a
+detached tmux on the HoloRouter and could not be encoded as governed
+runbook/workflow steps. Four typed ops make the full lifecycle
+dispatchable:
+
+============================  ===========  ===================================
+op_id                         safety       action
+============================  ===========  ===================================
+``holodeck.config.apply``     dangerous    ``New-HoloDeckConfig`` (NEVER
+                                           ``-Default``) + ``Import-HoloDeckConfig``
+``holodeck.instance.start``   dangerous    fail-fast ``Connect-VIServer``
+                                           precheck, then detached
+                                           ``New-HoloDeckInstance``
+``holodeck.instance.status``  safe         ``Get-HoloDeckInstance`` -> envelope
+``holodeck.router.patch``     dangerous    idempotent verify-then-apply of the
+                                           three per-appliance patches
+============================  ===========  ===================================
+
+Secret hygiene (#1503)
+======================
+
+None of these ops carries credential material in its *params*. The
+deploy-target vCenter SSO credentials and the Broadcom build token live in
+the HoloRouter's own deploy environment (staged by the consumer's
+Vault-to-env discipline) and in the on-appliance persisted config
+(``/holodeck-runtime/config/<config-id>.json``, written by
+``New-HoloDeckConfig``). MEHO's ops *orchestrate* the cmdlets that read
+those on-appliance secrets; MEHO never handles the secret bytes, so nothing
+credential-shaped can reach the params-echo, audit, or broadcast surfaces.
+
+The PowerShell scripts these handlers compose reference the credentials only
+by variable **name** (``$env:VC_USER`` / ``$env:VC_PW``, the persisted
+``$config.Target.password``) -- never an interpolated value -- honouring the
+``_pwsh`` safety contract that the encoded script body (visible on the remote
+argv) must carry no credential material.
+
+``holodeck.router.patch`` is additionally pinned into
+:data:`~meho_backplane.broadcast.events._CREDENTIAL_WRITE_OPS` as
+defence-in-depth: should a future param-shape change ever place credential
+material in its params, the broadcast collapses to aggregate-only rather than
+shipping it on the feed (the ``rke2.node.config.update`` / ``keycloak.*``
+precedent). ``holodeck.config.apply`` is deliberately NOT pinned -- it carries
+only non-secret config + Vault *refs*, so it keeps its generic params-echo
+preview (a param-echo the credential-class suppression would otherwise remove);
+its hygiene holds by construction because no secret is ever a param.
+
+References
+----------
+
+* Task: https://github.com/evoila/meho/issues/2908
+* Parent initiative (backplane-first register): #2907
+* Op-identity envelope: #2681 (stamped by the dispatcher, not here).
+* Secret hygiene: #1503; credential-write classification #1401.
+* Consumer ground truth: evoila-bosnia/claude-rdc-hetzner-dc
+  ``kb/holodeck-9.0-deploy-runbook.md`` (7-phase procedure),
+  ``.claude/skills/deploy-holodeck-instance/SKILL.md`` (patch details +
+  precheck lesson), ``kb/holodeck-9.0-overview.md`` (5.2 divergences).
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.holodeck._pwsh import PwshRunError, pwsh_run
+from meho_backplane.connectors.holodeck.ops import SSH_TRANSPORT_NOTE, HolodeckOp
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.connectors.holodeck.connector import HolodeckConnector
+
+__all__ = [
+    "DEPLOY_OPS",
+    "HOLODECK_DEPLOY_CREDENTIAL_OPS",
+    "HOLODECK_WHEN_TO_USE_DEPLOY_BY_GROUP",
+    "ROUTER_PATCHES",
+    "RouterPatchSpec",
+    "holodeck_config_apply",
+    "holodeck_instance_start",
+    "holodeck_instance_status",
+    "holodeck_router_patch",
+    "map_instance_status_envelope",
+    "target_hr_version",
+    "validate_config_apply_params",
+]
+
+# ---------------------------------------------------------------------------
+# Version helpers
+# ---------------------------------------------------------------------------
+
+#: The VCF version enum ``holodeck.config.apply`` / ``holodeck.instance.start``
+#: accept. Mirrors the consumer overview's supported-version set plus the 9.1
+#: line the fresh-deploy runbook now covers. ``5.2.x`` selects the Cloud
+#: Builder path (no offline depot); ``9.x`` selects the VCF Installer +
+#: offline-depot path.
+_DEPLOY_VERSION_ENUM: tuple[str, ...] = (
+    "5.2",
+    "5.2.1",
+    "5.2.2",
+    "9.0.0.0",
+    "9.0.1.0",
+    "9.0.2.0",
+    "9.1.0.0",
+)
+
+
+def _is_cloud_builder_version(version: str) -> bool:
+    """Return ``True`` when *version* is a VCF 5.2.x line (Cloud Builder, no depot).
+
+    VCF 5.2.x deploys via Cloud Builder and has no offline-depot concept, so
+    depot params are invalid for it (the ``holodeck.config.apply`` refusal).
+    9.x lines deploy via VCF Installer + an offline depot.
+    """
+    return version.startswith("5.2")
+
+
+def target_hr_version(target: Any) -> str | None:
+    """Resolve the HoloRouter's Holodeck-toolkit version from *target*.
+
+    Prefers the operator-asserted ``Target.version`` column, falling back to
+    the probe-derived ``fingerprint.version``. Used by
+    :func:`holodeck_router_patch` to select the verify-only posture on a 9.1
+    HoloRouter (where the three per-appliance patches are already fixed
+    upstream). ``None`` when the target carries neither -- treated as a
+    non-9.1 (patchable) appliance so the verify-then-apply path still runs.
+    """
+    version = getattr(target, "version", None)
+    if isinstance(version, str) and version.strip():
+        return version.strip()
+    fingerprint = getattr(target, "fingerprint", None)
+    if isinstance(fingerprint, dict):
+        fp_version = fingerprint.get("version")
+        if isinstance(fp_version, str) and fp_version.strip():
+            return fp_version.strip()
+    return None
+
+
+def _is_ninety_one(version: str | None) -> bool:
+    """Return ``True`` when *version* names a 9.1.x HoloRouter (verify-only)."""
+    return bool(version) and version.startswith("9.1")  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# config.apply -- param validation (depot refusal for 5.2.x)
+# ---------------------------------------------------------------------------
+
+
+def validate_config_apply_params(params: dict[str, Any]) -> list[str]:
+    """Return semantic-validation errors for ``holodeck.config.apply`` params.
+
+    The one domain rule the JSON Schema also enforces (via ``if``/``then``)
+    but that is surfaced here as a clear message for the direct-call and
+    handler belt-and-braces paths: **depot params are invalid for a VCF
+    5.2.x deploy** -- 5.2 uses Cloud Builder and has no offline depot. The
+    schema-level ``if``/``then`` rejects the combination pre-park (before the
+    approval queue), so an operator never approves a config that would fail;
+    this function is the same rule expressed as an operator-actionable string
+    for tests and for a handler called directly (bypassing the dispatcher's
+    schema validation). Returns ``[]`` when the params are consistent.
+    """
+    errors: list[str] = []
+    version = params.get("version")
+    if isinstance(version, str) and _is_cloud_builder_version(version) and "depot" in params:
+        errors.append(
+            f"depot params are not valid for VCF {version} (5.2.x deploys via "
+            "Cloud Builder and has no offline depot); omit 'depot' for a 5.2.x target"
+        )
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+async def holodeck_config_apply(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Apply a Holodeck deploy config: ``New-HoloDeckConfig`` + ``Import-HoloDeckConfig``.
+
+    Op-id: ``holodeck.config.apply``. Composes the canonical deploy-config
+    step from the consumer runbook's Phase F wrapper:
+
+    * ``New-HoloDeckConfig`` **without** ``-Default`` (the ``-Default`` flag
+      triggers a buggy internal ``Set-HoloDeckConfig`` call -- the storm-lock
+      lesson from consumer #258). The vCenter deploy-target SSO credentials
+      are read on the appliance from ``$env:VC_USER`` / ``$env:VC_PW`` (staged
+      by the consumer's Vault-to-env discipline); this handler references them
+      by name only, never a value.
+    * ``$null = Import-HoloDeckConfig -ConfigID <id>`` -- required to set
+      ``$Global:config`` for the downstream ``New-HoloDeckInstance``; the
+      ``$null =`` suppresses the auto-print that would dump the persisted
+      cleartext password to stdout.
+
+    The depot-vs-5.2.x contradiction is rejected pre-park by the parameter
+    schema; :func:`validate_config_apply_params` re-checks it here as
+    belt-and-braces for a direct call that bypassed the dispatcher.
+
+    Runs only on the ``_approved=True`` resume path (``requires_approval``).
+    Returns ``{applied, config_id, deploy: {version, variant, ...}}`` -- a
+    param-echo of the non-secret applied config; no credential material is
+    read or echoed.
+    """
+    semantic_errors = validate_config_apply_params(params)
+    if semantic_errors:
+        return {"applied": False, "error": "; ".join(semantic_errors)}
+
+    version = str(params["version"])
+    variant = str(params["variant"])
+    description = str(params.get("description") or f"MEHO holodeck deploy ({version} {variant})")
+    external_ip = params.get("external_ip")
+
+    # New-HoloDeckConfig reads the deploy-target creds on the appliance from
+    # $env:VC_USER / $env:VC_PW (staged out-of-band per the runbook). NEVER
+    # -Default. The description is the only operator-supplied string
+    # interpolated into the script body, and it carries no credential.
+    quoted_desc = _pwsh_single_quote(description)
+    quoted_host = _pwsh_single_quote(str(external_ip)) if external_ip else "$env:VC_HOST"
+    script = (
+        "$Global:ProgressPreference = 'SilentlyContinue'; "
+        f"$cfg = New-HoloDeckConfig -Description {quoted_desc} "
+        f"-TargetHost {quoted_host} -UserName $env:VC_USER -Password $env:VC_PW; "
+        "$null = Import-HoloDeckConfig -ConfigID $cfg.configID; "
+        "@{ configID = $cfg.configID } | ConvertTo-Json -Compress"
+    )
+
+    try:
+        payload = await pwsh_run(self, target, script, operator=operator)
+    except PwshRunError as exc:
+        return {"applied": False, "error": str(exc)}
+
+    config_id = payload.get("configID") if isinstance(payload, dict) else None
+    return {
+        "applied": True,
+        "config_id": config_id,
+        "deploy": _echo_deploy_config(params),
+    }
+
+
+async def holodeck_instance_start(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Launch ``New-HoloDeckInstance`` detached, after a fail-fast auth precheck.
+
+    Op-id: ``holodeck.instance.start``. Two phases, ordered so the
+    retry-storm never fires against a bad credential:
+
+    1. **Single-shot fail-fast precheck.** Reads the persisted config on the
+       appliance (``/holodeck-runtime/config/<config_id>.json``), builds a
+       ``PSCredential`` from ``$config.Target``, and makes exactly **one**
+       ``Connect-VIServer ... -ErrorAction Stop`` attempt. This catches a
+       stale / locked deploy-target credential *before* Holodeck's
+       4-retry-in-13s pattern storm-locks the SSO account (consumer #258
+       lesson). On any precheck failure the handler returns immediately and
+       the instance is **never** launched.
+
+    2. **Detached launch.** On a green precheck, ``New-HoloDeckInstance`` is
+       started under ``tmux new-session -d`` so it survives the dispatch
+       returning / the SSH channel closing, and the handler returns at once
+       with the instance id + a start marker (the tmux session + log path).
+
+    Runs only on the ``_approved=True`` resume path (``requires_approval``).
+    The precheck reads the persisted password on the appliance and returns
+    only ``ok`` / a sanitised message -- the credential never crosses back to
+    MEHO.
+    """
+    config_id = str(params["config_id"])
+    instance_id = str(params["instance_id"])
+    version = str(params["version"])
+
+    precheck = await _run_connect_precheck(self, target, config_id, operator)
+    if not precheck.get("ok"):
+        return {
+            "started": False,
+            "precheck": precheck,
+            "error": "fail-fast Connect-VIServer precheck failed; instance not launched",
+        }
+
+    session_name = f"holodeck-deploy-{instance_id}"
+    log_path = f"/holodeck-runtime/logs/{instance_id}-deploy.log"
+    launch_cmd = _compose_detached_launch(params, session_name=session_name, log_path=log_path)
+    try:
+        await self._run_command(target, launch_cmd, operator=operator)
+    except Exception as exc:
+        return {"started": False, "precheck": precheck, "error": str(exc)}
+
+    return {
+        "started": True,
+        "detached": True,
+        "instance_id": instance_id,
+        "version": version,
+        "config_id": config_id,
+        "precheck": precheck,
+        "start_marker": {"tmux_session": session_name, "log_path": log_path},
+    }
+
+
+async def holodeck_instance_status(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Read ``Get-HoloDeckInstance`` into a structured deploy-status envelope.
+
+    Op-id: ``holodeck.instance.status``. Runs ``Get-HoloDeckInstance``
+    (optionally scoped to ``instance_id``) and maps the cmdlet output into a
+    flat, deterministic envelope -- ``status`` (``running`` | ``completed`` |
+    ``failed`` | ``unknown``), ``current_step``, ``started_at``,
+    ``updated_at``, plus a ``notes`` list. The flat ``status`` field is what a
+    runbook ``OperationCallVerify`` step matches against and what a deploy-in-
+    progress Sensor asserts on, so the op is ``safe`` / no-approval and its
+    shape never depends on approval state.
+
+    The known-benign VCF 5.2.x terminal quirk -- the final
+    ``Sync-HolodeckComponents`` step throwing *"No route to host"* because VCF
+    Operations is not deployed in 5.2 -- is surfaced as a structured
+    ``notes`` entry with ``status="completed"``, **not** a failure, so a
+    verify/Sensor built on this op does not read a fully-deployed 5.2.x lab as
+    broken.
+    """
+    instance_id = params.get("instance_id")
+    if instance_id:
+        select = f"Get-HoloDeckInstance -InstanceID {_pwsh_single_quote(str(instance_id))}"
+    else:
+        select = "Get-HoloDeckInstance"
+    script = f"{select} | ConvertTo-Json -Depth 6 -Compress"
+
+    try:
+        payload = await pwsh_run(self, target, script, operator=operator)
+    except PwshRunError as exc:
+        return {"status": "unknown", "error": str(exc), "notes": []}
+
+    return map_instance_status_envelope(payload, hr_version=target_hr_version(target))
+
+
+async def holodeck_router_patch(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+    operator: Operator | None = None,
+) -> dict[str, Any]:
+    """Idempotently verify-then-apply the three per-appliance HoloRouter patches.
+
+    Op-id: ``holodeck.router.patch``. For each of the three patches (C1
+    bundle-count ``-eq 7`` -> ``-ge 7``; C2 ``BroadcomBuildToken`` SecureString
+    wrap; C3 ``Auth.psm1`` ``Connect-VIServer`` PSCredential) the handler:
+
+    1. greps the appliance module for the **applied** marker. Present at the
+       expected count -> ``already_applied`` (no write).
+    2. otherwise greps for the **unpatched** marker. Present ->
+       run the ``sed`` fix (after a timestamped backup), re-verify -> ``applied``.
+    3. neither marker present -> ``not_applicable`` (the OVA's module shape
+       drifted; nothing safe to sed).
+
+    On a **9.1 HoloRouter** all three patches are already fixed upstream, so
+    the op runs **verify-only**: it greps but never seds -- each patch reports
+    ``already_applied`` (marker present) or ``not_applicable`` (absent),
+    matching the runbook's "grep the sites; if the OLD pattern is absent
+    you're done" posture.
+
+    Runs only on the ``_approved=True`` resume path (``requires_approval``).
+    Secret hygiene: the patch strings are fixed constants (the C2 replacement
+    references ``$env:brcm_build_token`` by name, never a token value), and the
+    result reports only patch id / state / grep counts -- no file content and
+    no credential-shaped substring reaches any governance surface.
+    """
+    del params  # no operator-supplied params; the patch set is fixed in code
+    hr_version = target_hr_version(target)
+    verify_only = _is_ninety_one(hr_version)
+
+    results: list[dict[str, Any]] = []
+    any_applied = False
+    for patch in ROUTER_PATCHES:
+        outcome = await _reconcile_patch(
+            self, target, patch, verify_only=verify_only, operator=operator
+        )
+        if outcome["state"] == "applied":
+            any_applied = True
+        results.append(outcome)
+
+    return {
+        "patched": any_applied,
+        "verify_only": verify_only,
+        "hr_version": hr_version,
+        "patches": results,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Router-patch specs + reconcile
+# ---------------------------------------------------------------------------
+
+_HOLODECK_MODULES = "/root/.local/share/powershell/Modules/HoloDeck"
+
+
+@dataclass(frozen=True)
+class RouterPatchSpec:
+    """One per-appliance HoloRouter patch: how to verify it and how to apply it.
+
+    All fields are fixed constants -- no operator input reaches a grep or sed
+    -- so the composed commands carry no injection surface and the C2 spec's
+    ``$env:brcm_build_token`` reference is a PowerShell variable name, never a
+    secret value.
+    """
+
+    patch_id: str
+    label: str
+    file_path: str
+    applied_marker: str
+    applied_count: int
+    unpatched_marker: str
+    sed_expr: str
+
+
+#: The three per-appliance patches, in C1 / C2 / C3 order. Grounded on the
+#: consumer runbook Phase C + ``kb/holodeck-9.0-known-issues.md`` (expected
+#: grep counts: C1=1, C2=2 lines 363+542, C3=1).
+ROUTER_PATCHES: tuple[RouterPatchSpec, ...] = (
+    RouterPatchSpec(
+        patch_id="C1",
+        label="bundle-count off-by-one (-eq 7 -> -ge 7)",
+        file_path=f"{_HOLODECK_MODULES}/Modules/SddcMgmtDeployment.psm1",
+        applied_marker="vcf9_bundle_details.count -ge 7",
+        applied_count=1,
+        unpatched_marker="vcf9_bundle_details.count -eq 7",
+        sed_expr="s|$vcf9_bundle_details.count -eq 7|$vcf9_bundle_details.count -ge 7|",
+    ),
+    RouterPatchSpec(
+        patch_id="C2",
+        label="BroadcomBuildToken SecureString wrap",
+        file_path=f"{_HOLODECK_MODULES}/HoloDeck.psm1",
+        applied_marker="ConvertTo-SecureString -AsPlainText -Force -String $env:brcm_build_token",
+        applied_count=2,
+        unpatched_marker="$Global:BroadcomBuildToken = $env:brcm_build_token",
+        sed_expr=(
+            "s|$Global:BroadcomBuildToken = $env:brcm_build_token|"
+            "$Global:BroadcomBuildToken = (ConvertTo-SecureString -AsPlainText -Force "
+            "-String $env:brcm_build_token)|g"
+        ),
+    ),
+    RouterPatchSpec(
+        patch_id="C3",
+        label="Auth.psm1 Connect-VIServer PSCredential",
+        file_path=f"{_HOLODECK_MODULES}/Modules/Auth.psm1",
+        applied_marker="-Credential $_hd_cred",
+        applied_count=1,
+        unpatched_marker="-User $config.Target.username -Password $config.Target.password",
+        sed_expr=(
+            "s|Connect-VIServer -Server $config.target.hostname -User "
+            "$config.Target.username -Password $config.Target.password -Force|"
+            "$_hd_cred = New-Object System.Management.Automation.PSCredential("
+            "$config.Target.username, (ConvertTo-SecureString -AsPlainText -Force "
+            "-String $config.Target.password)); Connect-VIServer -Server "
+            "$config.target.hostname -Credential $_hd_cred -Force|"
+        ),
+    ),
+)
+
+
+async def _grep_count(
+    self: HolodeckConnector,
+    target: Any,
+    marker: str,
+    file_path: str,
+    operator: Operator | None,
+) -> int:
+    """Return the count of *marker* (fixed-string) occurrences in *file_path*.
+
+    ``grep -cF -e`` counts fixed-string matches; ``-e`` guards a marker that
+    starts with ``-``. A no-match (grep exit 1) or a missing file (exit 2)
+    parses to ``0`` rather than raising -- an absent marker is a legitimate
+    "not in this state" answer, not an error.
+    """
+    cmd = f"grep -cF -e {shlex.quote(marker)} {shlex.quote(file_path)}"
+    proc = await self._run_command(target, cmd, operator=operator)
+    stdout = getattr(proc, "stdout", "") or ""
+    if not isinstance(stdout, str):
+        return 0
+    try:
+        return int(stdout.strip() or "0")
+    except ValueError:
+        return 0
+
+
+async def _reconcile_patch(
+    self: HolodeckConnector,
+    target: Any,
+    patch: RouterPatchSpec,
+    *,
+    verify_only: bool,
+    operator: Operator | None,
+) -> dict[str, Any]:
+    """Verify -> (optionally) apply -> re-verify one patch; return its state.
+
+    States: ``already_applied`` (applied marker present at count), ``applied``
+    (unpatched marker sed-fixed then re-verified), ``not_applicable`` (neither
+    marker present, or 9.1 verify-only with the applied marker absent). On a
+    9.1 HoloRouter (``verify_only``) the ``sed`` branch is never taken.
+    """
+    applied = await _grep_count(self, target, patch.applied_marker, patch.file_path, operator)
+    if applied >= patch.applied_count:
+        return {"patch_id": patch.patch_id, "label": patch.label, "state": "already_applied"}
+
+    if verify_only:
+        # 9.1: the patches are fixed upstream. If the applied marker is absent
+        # the module shape is unexpected -- report, never sed.
+        return {"patch_id": patch.patch_id, "label": patch.label, "state": "not_applicable"}
+
+    unpatched = await _grep_count(self, target, patch.unpatched_marker, patch.file_path, operator)
+    if unpatched < 1:
+        return {"patch_id": patch.patch_id, "label": patch.label, "state": "not_applicable"}
+
+    quoted_file = shlex.quote(patch.file_path)
+    backup = f"cp -av {quoted_file} {quoted_file}.bak.$(date +%Y%m%d-%H%M%S)"
+    sed = f"sed -i {shlex.quote(patch.sed_expr)} {quoted_file}"
+    await self._run_command(target, f"{backup} && {sed}", operator=operator)
+
+    reverified = await _grep_count(self, target, patch.applied_marker, patch.file_path, operator)
+    state = "applied" if reverified >= patch.applied_count else "not_applicable"
+    return {"patch_id": patch.patch_id, "label": patch.label, "state": state}
+
+
+# ---------------------------------------------------------------------------
+# instance.start -- precheck + detached launch
+# ---------------------------------------------------------------------------
+
+#: The single-shot fail-fast Connect-VIServer precheck. Reads the persisted
+#: config on the appliance, builds a PSCredential, and makes exactly ONE
+#: Connect-VIServer attempt (ErrorAction Stop). Emits ``{ok, server?, message}``
+#: as JSON -- the password is read on the appliance and never returned. The
+#: ``{config_json}`` placeholder is filled with the shell-quoted config path.
+_PRECHECK_SCRIPT = (
+    "$ErrorActionPreference = 'Stop'; "
+    "$null = Set-PowerCLIConfiguration -InvalidCertificateAction Ignore "
+    "-Scope User -Confirm:$false; "
+    "try {{ "
+    "$c = (Get-Content -Raw {config_json} | ConvertFrom-Json).Target; "
+    "$pw = ConvertTo-SecureString -AsPlainText -Force -String $c.password; "
+    "$cred = New-Object System.Management.Automation.PSCredential($c.username, $pw); "
+    "$r = Connect-VIServer -Server $c.hostname -Credential $cred -ErrorAction Stop; "
+    "Disconnect-VIServer -Server * -Confirm:$false -ErrorAction SilentlyContinue; "
+    "@{{ ok = $true; server = $r.Name }} | ConvertTo-Json -Compress "
+    "}} catch {{ @{{ ok = $false; message = $_.Exception.Message }} | ConvertTo-Json -Compress }}"
+)
+
+
+async def _run_connect_precheck(
+    self: HolodeckConnector,
+    target: Any,
+    config_id: str,
+    operator: Operator | None,
+) -> dict[str, Any]:
+    """Run the single-shot Connect-VIServer precheck; return ``{ok, ...}``.
+
+    A ``PwshRunError`` (the pwsh process itself failing) is folded into
+    ``{ok: False, message}`` so the caller's fail-fast branch is the single
+    place that decides not to launch.
+    """
+    config_json = shlex.quote(f"/holodeck-runtime/config/{config_id}.json")
+    script = _PRECHECK_SCRIPT.format(config_json=config_json)
+    try:
+        payload = await pwsh_run(self, target, script, operator=operator)
+    except PwshRunError as exc:
+        return {"ok": False, "message": str(exc)}
+    if isinstance(payload, dict):
+        return {"ok": bool(payload.get("ok")), **{k: v for k, v in payload.items() if k != "ok"}}
+    return {"ok": False, "message": "precheck returned an unexpected shape"}
+
+
+def _compose_detached_launch(
+    params: dict[str, Any],
+    *,
+    session_name: str,
+    log_path: str,
+) -> str:
+    """Compose the detached ``New-HoloDeckInstance`` launch command.
+
+    ``New-HoloDeckInstance`` is started under ``tmux new-session -d`` so it
+    survives the dispatch returning. The deploy env vars (cluster, datastore,
+    depot, brcm_build_token, ...) are staged on the appliance by the consumer
+    tooling and read by the cmdlet from ``$env:``; this handler never
+    interpolates a credential value. Non-secret deploy knobs come from
+    *params* and are shell-quoted.
+    """
+    # Build the New-HoloDeckInstance argument list from bounded, non-secret
+    # params. Each token is a fixed flag or a quoted scalar.
+    args = [f"-Version {_pwsh_single_quote(str(params['version']))}"]
+    args.append(f"-InstanceID {_pwsh_single_quote(str(params['instance_id']))}")
+    variant = str(params.get("variant") or "management_only")
+    if variant == "management_only":
+        args.append("-ManagementOnly")
+    args.append(f"-Site {_pwsh_single_quote(str(params.get('site') or 'a'))}")
+    args.append(f"-vSANMode {_pwsh_single_quote(str(params.get('vsan_mode') or 'OSA'))}")
+    version = str(params["version"])
+    if not _is_cloud_builder_version(version):
+        depot_type = str(params.get("depot_type") or "Offline")
+        args.append(f"-DepotType {_pwsh_single_quote(depot_type)}")
+    args.append("-DeveloperMode")
+    inner = "New-HoloDeckInstance " + " ".join(args)
+    # Import the persisted config first so $Global:config is set for the
+    # cmdlet; $null = suppresses the cleartext-password auto-print.
+    config_id = str(params["config_id"])
+    pwsh_body = f"$null = Import-HoloDeckConfig -ConfigID {_pwsh_single_quote(config_id)}; {inner}"
+    encoded = _pwsh_encoded(pwsh_body)
+    remote = (
+        f"pwsh -NoProfile -NonInteractive -EncodedCommand {encoded} > {shlex.quote(log_path)} 2>&1"
+    )
+    return f"tmux new-session -d -s {shlex.quote(session_name)} {shlex.quote(remote)}"
+
+
+# ---------------------------------------------------------------------------
+# instance.status -- envelope mapping
+# ---------------------------------------------------------------------------
+
+_RUNNING_TOKENS = frozenset({"inprogress", "in_progress", "running", "started", "deploying"})
+_COMPLETED_TOKENS = frozenset({"completed", "complete", "succeeded", "success", "finished", "done"})
+_FAILED_TOKENS = frozenset({"failed", "failure", "error", "aborted", "completed_with_failure"})
+
+#: The benign VCF 5.2.x terminal quirk: the final Sync-HolodeckComponents step
+#: throws "No route to host" because VCF Operations is not deployed in 5.2.
+_SYNC_STEP = "sync-holodeckcomponents"
+_NO_ROUTE = "no route to host"
+
+
+def _normalise_status(raw: Any) -> str:
+    """Map a cmdlet status token to ``running`` | ``completed`` | ``failed`` | ``unknown``."""
+    token = str(raw).strip().lower().replace(" ", "_") if raw is not None else ""
+    if token in _RUNNING_TOKENS:
+        return "running"
+    if token in _COMPLETED_TOKENS:
+        return "completed"
+    if token in _FAILED_TOKENS:
+        return "failed"
+    return "unknown"
+
+
+def _first(record: dict[str, Any], *keys: str) -> Any:
+    """Return the first present, non-empty value among *keys* (case-insensitive)."""
+    lowered = {str(k).lower(): v for k, v in record.items()}
+    for key in keys:
+        value = lowered.get(key.lower())
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _is_benign_5_2_quirk(record: dict[str, Any], hr_version: str | None) -> bool:
+    """Return ``True`` when the failure is the known-benign 5.2.x Sync quirk.
+
+    The final ``Sync-HolodeckComponents`` step reporting *"No route to host"*
+    on a 5.2.x deploy is expected (VCF Operations is not deployed in 5.2) and
+    is not a real failure. Detected by the step name + the message, gated on a
+    5.2.x deploy version when one is discernible from the record or target.
+    """
+    step = str(_first(record, "current_step", "currentstep", "step", "stage") or "").lower()
+    message = str(_first(record, "message", "error", "detail", "laststep") or "").lower()
+    version = str(_first(record, "version") or hr_version or "")
+    looks_like_sync = _SYNC_STEP in step or _SYNC_STEP in message
+    no_route = _NO_ROUTE in message
+    return (
+        (looks_like_sync or no_route)
+        and no_route
+        and (_is_cloud_builder_version(version) or version == "")
+    )
+
+
+def map_instance_status_envelope(
+    payload: Any,
+    *,
+    hr_version: str | None = None,
+) -> dict[str, Any]:
+    """Map ``Get-HoloDeckInstance`` output into the structured status envelope.
+
+    Accepts the cmdlet's dict (single instance) or list (first element used)
+    shape and returns ``{status, current_step, started_at, updated_at,
+    instance_id, notes}``. ``status`` is the flat verify/Sensor target. A
+    ``failed`` status that is actually the benign 5.2.x
+    ``Sync-HolodeckComponents`` / "No route to host" terminal quirk is
+    re-mapped to ``completed`` with an explanatory ``notes`` entry.
+    """
+    record = payload[0] if isinstance(payload, list) and payload else payload
+    if not isinstance(record, dict):
+        return {"status": "unknown", "current_step": None, "notes": []}
+
+    status = _normalise_status(_first(record, "status", "state", "deploystatus"))
+    notes: list[str] = []
+    if status in ("failed", "unknown") and _is_benign_5_2_quirk(record, hr_version):
+        notes.append(
+            "benign VCF 5.2.x terminal quirk: the final Sync-HolodeckComponents step "
+            "throws 'No route to host' because VCF Operations is not deployed in 5.2 -- "
+            "the VCF environment is fully deployed; not a failure"
+        )
+        status = "completed"
+
+    return {
+        "status": status,
+        "current_step": _first(record, "current_step", "currentstep", "step", "stage"),
+        "started_at": _first(record, "started_at", "starttime", "started", "createtime"),
+        "updated_at": _first(record, "updated_at", "lastupdate", "updated", "modifiedtime"),
+        "instance_id": _first(record, "instance_id", "instanceid", "id", "name"),
+        "notes": notes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Small pwsh-composition helpers
+# ---------------------------------------------------------------------------
+
+
+def _pwsh_single_quote(value: str) -> str:
+    """Single-quote *value* for a PowerShell string literal (doubling any ``'``).
+
+    PowerShell single-quoted strings are literal (no ``$`` expansion), so this
+    is the safe way to embed an operator-supplied non-secret scalar (a
+    description, an instance id) into a composed script without it being
+    parsed as a variable or subexpression.
+    """
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _pwsh_encoded(script: str) -> str:
+    """Return the ``-EncodedCommand`` base64 for *script* (UTF-16LE, no BOM)."""
+    from meho_backplane.connectors.holodeck._pwsh import encode_pwsh_command
+
+    return encode_pwsh_command(script)
+
+
+def _echo_deploy_config(params: dict[str, Any]) -> dict[str, Any]:
+    """Return the non-secret applied-config echo for ``config.apply``'s result.
+
+    Mirrors the parked param-echo preview so the executed result and the
+    approval-time preview agree on the applied config. Carries no credential
+    field (none exists in the params).
+    """
+    echo: dict[str, Any] = {
+        "version": params.get("version"),
+        "variant": params.get("variant"),
+    }
+    for key in ("external_ip", "master_cidr", "vlan_range", "placement", "instance_id"):
+        if key in params:
+            echo[key] = params[key]
+    if "depot" in params:
+        depot = params["depot"]
+        # Echo only the non-secret depot addressing -- never a credential_ref
+        # value beyond its presence is needed, and username is non-secret.
+        if isinstance(depot, dict):
+            echo["depot"] = {
+                k: depot.get(k) for k in ("host", "port", "protocol", "username") if k in depot
+            }
+    return echo
+
+
+#: Deploy-lifecycle ops pinned into
+#: :data:`~meho_backplane.broadcast.events._CREDENTIAL_WRITE_OPS` as broadcast
+#: defence-in-depth. Only ``holodeck.router.patch`` (BroadcomBuildToken
+#: adjacency); ``holodeck.config.apply`` keeps its param-echo preview (no
+#: secret is ever a param) and is intentionally absent. Kept in sync with the
+#: literal pin in ``broadcast/events.py`` by the deploy secret-hygiene test.
+HOLODECK_DEPLOY_CREDENTIAL_OPS: frozenset[str] = frozenset({"holodeck.router.patch"})
+
+
+# ---------------------------------------------------------------------------
+# Curated when_to_use blurbs (one per deploy op group)
+# ---------------------------------------------------------------------------
+
+_WHEN_TO_USE_DEPLOY_CONFIG = (
+    "Use to lay down a Holodeck deploy configuration before launching an "
+    "instance: ``holodeck.config.apply`` runs ``New-HoloDeckConfig`` (never "
+    "-Default) + ``Import-HoloDeckConfig`` on the HoloRouter, capturing the "
+    "VCF version, variant, external IP, master CIDR/VLAN, placement, and (for "
+    "9.x only) the offline-depot connection. Approval-gated. Depot params are "
+    "refused for a VCF 5.2.x deploy (5.2 uses Cloud Builder, no offline "
+    "depot). The vCenter deploy-target credentials are read on the appliance "
+    "from its staged environment -- they are never a parameter. Pair with "
+    "``holodeck.instance.start`` to launch. " + SSH_TRANSPORT_NOTE
+)
+
+_WHEN_TO_USE_DEPLOY_LIFECYCLE = (
+    "Use to launch a nested-VCF deploy from a config already applied by "
+    "``holodeck.config.apply``: ``holodeck.instance.start`` runs a single-shot "
+    "fail-fast ``Connect-VIServer`` precheck (so a stale/locked deploy-target "
+    "credential can't storm-lock the SSO account via Holodeck's retry loop), "
+    "then launches ``New-HoloDeckInstance`` detached (survives the call "
+    "returning) and returns the instance id + start marker immediately. "
+    "Approval-gated. Poll progress with ``holodeck.instance.status``. " + SSH_TRANSPORT_NOTE
+)
+
+_WHEN_TO_USE_DEPLOY_STATUS = (
+    "Use to read a Holodeck deploy's progress: ``holodeck.instance.status`` "
+    "maps ``Get-HoloDeckInstance`` into a flat envelope (status "
+    "running|completed|failed, current step, timestamps). Safe / no approval, "
+    "so it doubles as a runbook OperationCallVerify target and a "
+    "deploy-in-progress Sensor op. It treats the benign VCF 5.2.x terminal "
+    "quirk (final Sync-HolodeckComponents 'No route to host', VCF Ops absent "
+    "in 5.2) as a structured note, not a failure. " + SSH_TRANSPORT_NOTE
+)
+
+_WHEN_TO_USE_DEPLOY_PATCH = (
+    "Use to bring a HoloRouter's three mandatory per-appliance patches into "
+    "the applied state before a fresh deploy: ``holodeck.router.patch`` "
+    "verify-then-applies C1 (bundle-count -eq 7 -> -ge 7), C2 "
+    "(BroadcomBuildToken SecureString) and C3 (Auth.psm1 PSCredential), "
+    "reporting per-patch state (already_applied|applied|not_applicable). It is "
+    "idempotent -- a second run reports all already_applied -- and runs "
+    "verify-only on a 9.1 HoloRouter (patches fixed upstream). Approval-gated; "
+    "no token or credential value ever appears in the result. " + SSH_TRANSPORT_NOTE
+)
+
+#: Curated ``when_to_use`` per deploy op group. Keys carry a ``deploy-``
+#: prefix so they never collide with the read/write group keys the connector's
+#: ``register_operations`` walk merges alongside them.
+HOLODECK_WHEN_TO_USE_DEPLOY_BY_GROUP: dict[str, str] = {
+    "deploy-config": _WHEN_TO_USE_DEPLOY_CONFIG,
+    "deploy-lifecycle": _WHEN_TO_USE_DEPLOY_LIFECYCLE,
+    "deploy-status": _WHEN_TO_USE_DEPLOY_STATUS,
+    "deploy-patch": _WHEN_TO_USE_DEPLOY_PATCH,
+}
+
+
+# ---------------------------------------------------------------------------
+# Op metadata
+# ---------------------------------------------------------------------------
+
+_CONFIG_APPLY_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "version": {
+            "type": "string",
+            "enum": list(_DEPLOY_VERSION_ENUM),
+            "description": (
+                "VCF version to deploy. 5.2.x uses Cloud Builder (no depot); "
+                "9.x uses VCF Installer + offline depot."
+            ),
+        },
+        "variant": {
+            "type": "string",
+            "enum": ["management_only", "vvf", "full"],
+            "description": (
+                "Deploy profile: management_only (mgmt domain only), vvf, or "
+                "full (mgmt + workload)."
+            ),
+        },
+        "external_ip": {
+            "type": "string",
+            "description": "Deploy-target vCenter host/IP (New-HoloDeckConfig -TargetHost).",
+        },
+        "master_cidr": {
+            "type": "string",
+            "description": "Master management CIDR for the nested lab network.",
+        },
+        "vlan_range": {
+            "type": "string",
+            "description": "VLAN range for the nested lab fabric (e.g. 3000-3010).",
+        },
+        "placement": {
+            "type": "object",
+            "properties": {
+                "host": {"type": "string"},
+                "cluster": {"type": "string"},
+                "datastore": {"type": "string"},
+            },
+            "additionalProperties": False,
+            "description": "vSphere placement refs for the HoloRouter + nested ESXi.",
+        },
+        "depot": {
+            "type": "object",
+            "properties": {
+                "host": {"type": "string", "minLength": 1},
+                "port": {"type": "integer", "minimum": 1, "maximum": 65535},
+                "protocol": {"type": "string", "enum": ["http", "https"]},
+                "username": {"type": "string"},
+                "credential_ref": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Vault path (NOT a plaintext password) for the offline-depot credential."
+                    ),
+                },
+            },
+            "required": ["host"],
+            "additionalProperties": False,
+            "description": (
+                "Offline-depot connection (9.x only). Rejected for a 5.2.x "
+                "version. Credentials are referenced by Vault path, never inline."
+            ),
+        },
+        "instance_id": {
+            "type": "string",
+            "pattern": r"^[A-Za-z0-9]{1,8}$",
+            "description": (
+                "Optional 8-char alphanumeric instance id to embed in the config description."
+            ),
+        },
+        "description": {
+            "type": "string",
+            "description": "Human description persisted onto the Holodeck config.",
+        },
+    },
+    "required": ["version", "variant"],
+    "additionalProperties": False,
+    # Depot params are invalid for a VCF 5.2.x deploy (Cloud Builder, no
+    # offline depot). Encoded as if/then/not so the framework validate_params
+    # (Draft 2020-12) rejects the combination pre-park, before the approval
+    # queue -- an operator never approves a config that would fail.
+    "allOf": [
+        {
+            "if": {"properties": {"version": {"pattern": r"^5\.2"}}, "required": ["version"]},
+            "then": {"not": {"required": ["depot"]}},
+        }
+    ],
+}
+
+_INSTANCE_START_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "config_id": {
+            "type": "string",
+            "minLength": 1,
+            "description": "The New-HoloDeckConfig configID from holodeck.config.apply.",
+        },
+        "instance_id": {
+            "type": "string",
+            "pattern": r"^[A-Za-z0-9]{1,8}$",
+            "description": "8-char alphanumeric InstanceID for New-HoloDeckInstance.",
+        },
+        "version": {"type": "string", "enum": list(_DEPLOY_VERSION_ENUM)},
+        "variant": {"type": "string", "enum": ["management_only", "vvf", "full"]},
+        "site": {"type": "string", "enum": ["a", "b"], "description": "Holodeck site (default a)."},
+        "vsan_mode": {
+            "type": "string",
+            "enum": ["OSA", "ESA"],
+            "description": "Nested vSAN mode (default OSA).",
+        },
+        "depot_type": {"type": "string", "enum": ["Offline", "Online", "CloudBuilder"]},
+    },
+    "required": ["config_id", "instance_id", "version"],
+    "additionalProperties": False,
+}
+
+_INSTANCE_STATUS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "instance_id": {
+            "type": "string",
+            "description": (
+                "Optional InstanceID to scope Get-HoloDeckInstance to a single instance."
+            ),
+        },
+    },
+    "additionalProperties": False,
+}
+
+_ROUTER_PATCH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+_STATUS_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string", "enum": ["running", "completed", "failed", "unknown"]},
+        "current_step": {"type": ["string", "null"]},
+        "started_at": {"type": ["string", "null"]},
+        "updated_at": {"type": ["string", "null"]},
+        "instance_id": {"type": ["string", "null"]},
+        "notes": {"type": "array", "items": {"type": "string"}},
+    },
+    "required": ["status", "notes"],
+    "additionalProperties": True,
+}
+
+_WRITE_RESPONSE_SCHEMA: dict[str, Any] = {"type": "object", "additionalProperties": True}
+
+
+DEPLOY_OPS: tuple[HolodeckOp, ...] = (
+    HolodeckOp(
+        op_id="holodeck.config.apply",
+        handler_attr="config_apply",
+        summary=(
+            "Apply a Holodeck deploy config (New-HoloDeckConfig, never -Default) "
+            "+ import it (approval-gated)."
+        ),
+        description=(
+            "Runs New-HoloDeckConfig (WITHOUT -Default -- the flag triggers a "
+            "buggy internal Set-HoloDeckConfig) + Import-HoloDeckConfig on the "
+            "HoloRouter to lay down a deploy configuration: VCF version, variant, "
+            "external IP, master CIDR/VLAN, placement, and (9.x only) the offline "
+            "depot connection. Depot params are REFUSED for a VCF 5.2.x version "
+            "(5.2 uses Cloud Builder, no offline depot) -- the schema rejects the "
+            "combination before the approval park. The vCenter deploy-target "
+            "credentials are read on the appliance from its staged environment "
+            "($env:VC_USER/$env:VC_PW); they are never a parameter and never "
+            "appear in the result. safety_level=dangerous, requires_approval=True."
+        ),
+        parameter_schema=_CONFIG_APPLY_SCHEMA,
+        response_schema=_WRITE_RESPONSE_SCHEMA,
+        group_key="deploy-config",
+        tags=("write", "deploy", "config", "holodeck"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_DEPLOY_CONFIG,
+            "parameter_hints": {
+                "version": "5.2.x -> Cloud Builder (omit depot); 9.x -> VCF Installer + depot.",
+                "depot": "9.x only; credential_ref is a Vault path, never a plaintext password.",
+            },
+            "output_shape": (
+                "{applied, config_id, deploy: {version, variant, ...non-secret echo}}. "
+                "On a bound violation: {applied: false, error}."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.instance.start",
+        handler_attr="instance_start",
+        summary=(
+            "Launch New-HoloDeckInstance detached after a fail-fast "
+            "Connect-VIServer precheck (approval-gated)."
+        ),
+        description=(
+            "Launches a nested-VCF deploy from a config already applied by "
+            "holodeck.config.apply. FIRST runs a single-shot fail-fast "
+            "Connect-VIServer precheck (reads the persisted config on the "
+            "appliance, one attempt, ErrorAction Stop) so a stale/locked "
+            "deploy-target credential can't storm-lock the SSO account via "
+            "Holodeck's 4-retry-in-13s loop; on any precheck failure the "
+            "instance is NEVER launched. On a green precheck, New-HoloDeckInstance "
+            "runs under tmux new-session -d (survives the call returning) and the "
+            "op returns immediately with the instance id + start marker. Poll with "
+            "holodeck.instance.status. safety_level=dangerous, requires_approval=True."
+        ),
+        parameter_schema=_INSTANCE_START_SCHEMA,
+        response_schema=_WRITE_RESPONSE_SCHEMA,
+        group_key="deploy-lifecycle",
+        tags=("write", "deploy", "lifecycle", "holodeck"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_DEPLOY_LIFECYCLE,
+            "parameter_hints": {
+                "config_id": "The configID returned by holodeck.config.apply.",
+                "instance_id": "8-char alphanumeric; mirror the cluster name where possible.",
+            },
+            "output_shape": (
+                "{started, detached, instance_id, config_id, precheck: {ok, ...}, "
+                "start_marker: {tmux_session, log_path}}. On precheck fail: "
+                "{started: false, precheck, error} and nothing is launched."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.instance.status",
+        handler_attr="instance_status",
+        summary="Read Get-HoloDeckInstance into a structured deploy-status envelope (safe).",
+        description=(
+            "Reads Get-HoloDeckInstance and maps it into a flat, deterministic "
+            "envelope: status (running|completed|failed|unknown), current_step, "
+            "started_at, updated_at, instance_id, notes. The flat status field is "
+            "a runbook OperationCallVerify target and a deploy-in-progress Sensor "
+            "assertion target. The benign VCF 5.2.x terminal quirk (final "
+            "Sync-HolodeckComponents 'No route to host' -- VCF Operations absent in "
+            "5.2) is surfaced as a structured note with status=completed, NOT a "
+            "failure. safety_level=safe, no approval."
+        ),
+        parameter_schema=_INSTANCE_STATUS_SCHEMA,
+        response_schema=_STATUS_RESPONSE_SCHEMA,
+        group_key="deploy-status",
+        tags=("read-only", "deploy", "status", "holodeck"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_DEPLOY_STATUS,
+            "parameter_hints": {
+                "instance_id": "Optional; omit to read the appliance's current/only instance.",
+            },
+            "output_shape": (
+                "{status, current_step, started_at, updated_at, instance_id, notes[]}. "
+                "status is the verify/Sensor target; notes[] carries the benign 5.2 quirk."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.router.patch",
+        handler_attr="router_patch",
+        summary=(
+            "Idempotently verify-then-apply the three per-appliance HoloRouter "
+            "patches (approval-gated)."
+        ),
+        description=(
+            "Verify-then-applies the three mandatory per-appliance patches on a "
+            "HoloRouter: C1 (bundle-count -eq 7 -> -ge 7), C2 (BroadcomBuildToken "
+            "SecureString wrap) and C3 (Auth.psm1 Connect-VIServer PSCredential). "
+            "For each patch it greps the applied marker (present -> already_applied), "
+            "else greps the unpatched marker (present -> backup + sed + re-verify -> "
+            "applied), else not_applicable. Idempotent: a second run reports all "
+            "already_applied. On a 9.1 HoloRouter it runs VERIFY-ONLY (patches fixed "
+            "upstream) -- greps but never seds. The patch strings are fixed constants "
+            "(C2 references $env:brcm_build_token by NAME, never a token value) and "
+            "the result carries only patch id/state/counts -- no token or credential "
+            "reaches any governance surface. safety_level=dangerous, requires_approval=True."
+        ),
+        parameter_schema=_ROUTER_PATCH_SCHEMA,
+        response_schema=_WRITE_RESPONSE_SCHEMA,
+        group_key="deploy-patch",
+        tags=("write", "deploy", "patch", "holodeck"),
+        safety_level="dangerous",
+        requires_approval=True,
+        llm_instructions={
+            "when_to_use": _WHEN_TO_USE_DEPLOY_PATCH,
+            "parameter_hints": {},
+            "output_shape": (
+                "{patched, verify_only, hr_version, patches: [{patch_id, label, "
+                "state: already_applied|applied|not_applicable}]}."
+            ),
+        },
+    ),
+)

--- a/backend/tests/test_connectors_holodeck_auth.py
+++ b/backend/tests/test_connectors_holodeck_auth.py
@@ -216,12 +216,13 @@ def test_about_canary_op_remains_at_index_zero() -> None:
     """``holodeck.about`` is the T1 canary; T2 (#854) appends the 7 read ops
     and G3.18-T2 (#2154) the 3 write ops onto the same tuple while preserving
     the canary at index 0; #2847 later appends the ``holodeck.backups.list``
-    read op. The full registration shape lives in
-    ``test_connectors_holodeck_ops.py`` / ``test_connectors_holodeck_write.py``.
+    read op and #2908 the 4 deploy-lifecycle ops. The full registration shape
+    lives in ``test_connectors_holodeck_ops.py`` /
+    ``test_connectors_holodeck_write.py`` / ``test_connectors_holodeck_deploy.py``.
     """
     assert HOLODECK_OPS[0].op_id == "holodeck.about"
     assert HOLODECK_OPS[0].handler_attr == "about"
-    assert len(HOLODECK_OPS) == 13
+    assert len(HOLODECK_OPS) == 17
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_holodeck_deploy.py
+++ b/backend/tests/test_connectors_holodeck_deploy.py
@@ -1,0 +1,774 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# code-quality-allow: a per-op acceptance-criteria matrix (registration /
+# depot-refusal / precheck / status-envelope / idempotency / op-identity /
+# secret-hygiene) for four deploy ops; the length is independent test cases,
+# not logic complexity. Mirrors test_connectors_holodeck_write.py.
+
+"""Tests for the Holodeck deploy-lifecycle typed ops (#2908, Initiative #2907).
+
+Acceptance-criteria coverage matrix:
+
+* Registration: 4 ops via the two-phase typed registration (register_connector_v2
+  at import + register_typed_operation at register_operations), JSON-Schema
+  params, curated group when_to_use, llm_instructions.
+* ``config.apply``: depot params refused for a VCF 5.2.x version by the real
+  framework ``validate_params`` (schema if/then) AND the direct semantic helper;
+  New-HoloDeckConfig composed WITHOUT ``-Default``.
+* ``instance.start``: the single-shot fail-fast Connect-VIServer precheck runs
+  BEFORE launch, and a locked/failed precheck blocks the launch entirely.
+* ``instance.status``: the structured envelope covers running/completed/failed
+  and re-maps the benign VCF 5.2.x Sync-HolodeckComponents "No route to host"
+  terminal quirk to completed + a note (usable as an OperationCallVerify target).
+* ``router.patch``: idempotent verify-then-apply (second run -> all
+  already_applied) + the 9.1 verify-only path (greps, never seds).
+* Uniform op-identity envelope (#2681) on all four (parked proposed_effect for
+  the three gated ops; op_id on the safe op's result).
+* Secret hygiene (#1503): router.patch parks op-identity-only (no token) and is
+  pinned credential-class; config.apply's schema admits no plaintext credential.
+
+Tests mirror the windows_dns / holodeck mocked-pwsh transport pattern
+(test_connectors_holodeck_write.py): pure helpers unit-tested directly, handler
+paths driven with a mocked ``pwsh_run`` / ``_run_command``, and a DB-backed
+dispatch harness for the park + op-identity + audit surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jsonschema
+import pytest
+
+import meho_backplane.connectors.holodeck  # noqa: F401 -- registry side-effects
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast.events import classify_op
+from meho_backplane.connectors.holodeck import HolodeckConnector
+from meho_backplane.connectors.holodeck._pwsh import PwshRunError
+from meho_backplane.connectors.holodeck.connector import _WHEN_TO_USE_BY_GROUP
+from meho_backplane.connectors.holodeck.ops_deploy import (
+    DEPLOY_OPS,
+    HOLODECK_DEPLOY_CREDENTIAL_OPS,
+    ROUTER_PATCHES,
+    map_instance_status_envelope,
+    target_hr_version,
+    validate_config_apply_params,
+)
+from meho_backplane.operations._validate import validate_params
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str = "holorouter-deploy-test"
+    host: str = "holorouter.test.invalid"
+    port: int | None = 22
+    secret_ref: str = "meho/testing/holodeck/holorouter-deploy-test"
+    version: str | None = "9.0.2.0"
+    fingerprint: dict[str, Any] = field(default_factory=dict)
+
+
+def _proc(*, stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+def _op(op_id: str) -> Any:
+    return next(op for op in DEPLOY_OPS if op.op_id == op_id)
+
+
+EXPECTED_DEPLOY_OP_IDS: frozenset[str] = frozenset(
+    {
+        "holodeck.config.apply",
+        "holodeck.instance.start",
+        "holodeck.instance.status",
+        "holodeck.router.patch",
+    }
+)
+
+
+# ===========================================================================
+# A. Registration contract (AC1, AC6)
+# ===========================================================================
+
+
+def test_deploy_ops_registration_set() -> None:
+    assert {op.op_id for op in DEPLOY_OPS} == EXPECTED_DEPLOY_OP_IDS
+    assert len(DEPLOY_OPS) == 4
+
+
+def test_deploy_ops_safety_and_approval() -> None:
+    expected = {
+        "holodeck.config.apply": ("dangerous", True),
+        "holodeck.instance.start": ("dangerous", True),
+        "holodeck.instance.status": ("safe", False),
+        "holodeck.router.patch": ("dangerous", True),
+    }
+    for op in DEPLOY_OPS:
+        assert (op.safety_level, op.requires_approval) == expected[op.op_id], op.op_id
+
+
+def test_deploy_ops_carry_transport_note_and_instructions() -> None:
+    for op in DEPLOY_OPS:
+        instr = op.llm_instructions or {}
+        assert "Holodeck has no REST API" in instr.get("when_to_use", ""), op.op_id
+        assert instr.get("output_shape"), f"{op.op_id} missing output_shape"
+
+
+def test_deploy_ops_group_keys_are_curated() -> None:
+    """Every deploy op's group_key has a curated when_to_use on the connector.
+
+    The connector's register_operations walk fails closed with ValueError when
+    a group_key lacks a curated blurb; this asserts the merge landed.
+    """
+    for op in DEPLOY_OPS:
+        assert op.group_key in _WHEN_TO_USE_BY_GROUP, op.group_key
+        assert _WHEN_TO_USE_BY_GROUP[op.group_key].strip()
+
+
+def test_deploy_ops_handlers_resolve_on_connector() -> None:
+    for op in DEPLOY_OPS:
+        assert getattr(HolodeckConnector, op.handler_attr, None) is not None, op.handler_attr
+
+
+# ===========================================================================
+# B. config.apply depot refusal for 5.2.x (AC2)
+# ===========================================================================
+
+_CONFIG_SCHEMA = _op("holodeck.config.apply").parameter_schema
+_DEPOT = {"host": "depot.lab", "port": 8443, "protocol": "https", "credential_ref": "secret/depot"}
+
+
+@pytest.mark.parametrize("version", ["5.2", "5.2.1", "5.2.2"])
+def test_config_apply_validate_params_rejects_depot_on_5_2(version: str) -> None:
+    """The real framework validate_params (schema if/then) rejects depot on 5.2.x."""
+    errors = validate_params(
+        _CONFIG_SCHEMA, {"version": version, "variant": "full", "depot": _DEPOT}
+    )
+    assert errors, f"depot must be refused for {version}"
+
+
+@pytest.mark.parametrize("version", ["9.0.2.0", "9.1.0.0"])
+def test_config_apply_validate_params_accepts_depot_on_9_x(version: str) -> None:
+    errors = validate_params(
+        _CONFIG_SCHEMA, {"version": version, "variant": "full", "depot": _DEPOT}
+    )
+    assert errors == [], (version, errors)
+
+
+def test_config_apply_validate_params_accepts_5_2_without_depot() -> None:
+    errors = validate_params(_CONFIG_SCHEMA, {"version": "5.2.1", "variant": "management_only"})
+    assert errors == []
+
+
+def test_config_apply_schema_admits_no_plaintext_credential() -> None:
+    """Secret hygiene: config.apply's schema has no plaintext credential field.
+
+    additionalProperties=False + the absence of any password/token property
+    means a caller CANNOT pass a plaintext deploy-target credential as a param.
+    The only credential reference is depot.credential_ref -- a Vault path.
+    """
+    props = _CONFIG_SCHEMA["properties"]
+    for name in props:
+        assert "password" not in name.lower(), name
+        assert name.lower() != "token", name
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            {"version": "9.0.2.0", "variant": "full", "password": "hunter2"}, _CONFIG_SCHEMA
+        )
+    # depot carries a Vault *ref*, never a plaintext password field.
+    depot_props = _CONFIG_SCHEMA["properties"]["depot"]["properties"]
+    assert "credential_ref" in depot_props
+    assert "password" not in depot_props
+
+
+def test_validate_config_apply_params_direct() -> None:
+    assert validate_config_apply_params({"version": "5.2.1", "variant": "full", "depot": _DEPOT})
+    assert (
+        validate_config_apply_params({"version": "9.0.2.0", "variant": "full", "depot": _DEPOT})
+        == []
+    )
+    assert validate_config_apply_params({"version": "5.2.1", "variant": "full"}) == []
+
+
+# ===========================================================================
+# C. config.apply handler (mocked pwsh) -- never -Default (AC "Outcome")
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_config_apply_composes_new_holodeckconfig_without_default() -> None:
+    connector = HolodeckConnector()
+    with patch(
+        "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+        new_callable=AsyncMock,
+    ) as mock_pwsh:
+        mock_pwsh.return_value = {"configID": "hd9mgmt1"}
+        result = await connector.config_apply(
+            _StubTarget(),
+            {
+                "version": "9.0.2.0",
+                "variant": "management_only",
+                "external_ip": "vcenter.example.lab",
+                "depot": _DEPOT,
+            },
+        )
+    assert result["applied"] is True
+    assert result["config_id"] == "hd9mgmt1"
+    assert result["deploy"]["version"] == "9.0.2.0"
+    script = mock_pwsh.await_args.args[2]
+    assert "New-HoloDeckConfig" in script
+    assert "-Default" not in script, "New-HoloDeckConfig must NEVER use -Default"
+    assert "Import-HoloDeckConfig" in script
+    # Credentials referenced by env-var NAME only -- no interpolated value.
+    assert "$env:VC_USER" in script and "$env:VC_PW" in script
+
+
+@pytest.mark.asyncio
+async def test_config_apply_handler_rejects_depot_on_5_2_belt_and_braces() -> None:
+    """A direct handler call bypassing schema validation still refuses depot on 5.2.x."""
+    connector = HolodeckConnector()
+    with patch(
+        "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+        new_callable=AsyncMock,
+    ) as mock_pwsh:
+        result = await connector.config_apply(
+            _StubTarget(), {"version": "5.2.1", "variant": "full", "depot": _DEPOT}
+        )
+        mock_pwsh.assert_not_awaited()
+    assert result["applied"] is False
+    assert "Cloud Builder" in result["error"]
+
+
+# ===========================================================================
+# D. instance.start fail-fast precheck (AC2 second half)
+# ===========================================================================
+
+_LOCKED_ACCOUNT = {
+    "ok": False,
+    "message": "Cannot complete login: incorrect user name or password; account is locked.",
+}
+_START_PARAMS = {"config_id": "hd9mgmt1", "instance_id": "hd9mgmt", "version": "9.0.2.0"}
+
+
+@pytest.mark.asyncio
+async def test_instance_start_precheck_failure_blocks_launch() -> None:
+    """A locked/failed Connect-VIServer precheck blocks the launch entirely.
+
+    The precheck runs via pwsh_run; the launch runs via _run_command. On a
+    failed precheck the handler returns started=False and _run_command (the
+    launch) is NEVER awaited -- the retry-storm never fires against the bad
+    credential.
+    """
+    connector = HolodeckConnector()
+    with (
+        patch(
+            "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+            new_callable=AsyncMock,
+        ) as mock_pwsh,
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_launch,
+    ):
+        mock_pwsh.return_value = _LOCKED_ACCOUNT
+        result = await connector.instance_start(_StubTarget(), _START_PARAMS)
+        mock_launch.assert_not_awaited()
+    assert result["started"] is False
+    assert result["precheck"]["ok"] is False
+    assert "not launched" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_instance_start_happy_path_launches_detached() -> None:
+    connector = HolodeckConnector()
+    with (
+        patch(
+            "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+            new_callable=AsyncMock,
+        ) as mock_pwsh,
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_launch,
+    ):
+        mock_pwsh.return_value = {"ok": True, "server": "vcenter.example.lab"}
+        mock_launch.return_value = _proc(stdout="")
+        result = await connector.instance_start(_StubTarget(), _START_PARAMS)
+    assert result["started"] is True
+    assert result["detached"] is True
+    assert result["precheck"]["ok"] is True
+    assert result["start_marker"]["tmux_session"] == "holodeck-deploy-hd9mgmt"
+    launch_cmd = mock_launch.await_args.args[1]
+    assert launch_cmd.startswith("tmux new-session -d")
+
+
+@pytest.mark.asyncio
+async def test_instance_start_precheck_pwsh_error_is_fail_fast() -> None:
+    """A pwsh process failure in the precheck also blocks the launch."""
+    connector = HolodeckConnector()
+    with (
+        patch(
+            "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+            new_callable=AsyncMock,
+        ) as mock_pwsh,
+        patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_launch,
+    ):
+        mock_pwsh.side_effect = PwshRunError("precheck blew up", exit_status=1, stderr="")
+        result = await connector.instance_start(_StubTarget(), _START_PARAMS)
+        mock_launch.assert_not_awaited()
+    assert result["started"] is False
+
+
+# ===========================================================================
+# E. instance.status envelope + benign 5.2 quirk (AC3)
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    ("raw_status", "expected"),
+    [
+        ("InProgress", "running"),
+        ("Running", "running"),
+        ("Completed", "completed"),
+        ("Succeeded", "completed"),
+        ("Failed", "failed"),
+        ("COMPLETED_WITH_FAILURE", "failed"),
+        ("weird-token", "unknown"),
+    ],
+)
+def test_map_status_envelope_normalises_status(raw_status: str, expected: str) -> None:
+    envelope = map_instance_status_envelope(
+        {"Status": raw_status, "CurrentStep": "Deploy-VcfInstaller"}
+    )
+    assert envelope["status"] == expected
+    assert envelope["current_step"] == "Deploy-VcfInstaller"
+    assert envelope["notes"] == []
+
+
+def test_map_status_envelope_flat_fields_for_verify_and_sensor() -> None:
+    """The flat status/current_step fields are the OperationCallVerify/Sensor target."""
+    envelope = map_instance_status_envelope(
+        {
+            "Status": "InProgress",
+            "CurrentStep": "Install-VcfInstallerBundles",
+            "StartTime": "2026-08-17T10:00:00Z",
+            "LastUpdate": "2026-08-17T10:12:00Z",
+            "InstanceID": "hd9mgmt",
+        }
+    )
+    assert envelope == {
+        "status": "running",
+        "current_step": "Install-VcfInstallerBundles",
+        "started_at": "2026-08-17T10:00:00Z",
+        "updated_at": "2026-08-17T10:12:00Z",
+        "instance_id": "hd9mgmt",
+        "notes": [],
+    }
+
+
+def test_map_status_envelope_benign_5_2_sync_quirk_is_completed() -> None:
+    """The 5.2.x Sync-HolodeckComponents 'No route to host' terminal quirk -> completed + note."""
+    envelope = map_instance_status_envelope(
+        {
+            "Status": "COMPLETED_WITH_FAILURE",
+            "CurrentStep": "Sync-HolodeckComponents",
+            "Message": "java.net.NoRouteToHostException: No route to host (vc-mgmt-a...)",
+            "Version": "5.2.1",
+        }
+    )
+    assert envelope["status"] == "completed"
+    assert len(envelope["notes"]) == 1
+    assert "5.2" in envelope["notes"][0] and "not a failure" in envelope["notes"][0]
+
+
+def test_map_status_envelope_real_9_x_failure_stays_failed() -> None:
+    """A genuine 9.x failure (not the Sync/no-route quirk) stays failed -- no note."""
+    envelope = map_instance_status_envelope(
+        {
+            "Status": "Failed",
+            "CurrentStep": "Deploy-VcfInstaller",
+            "Message": "duplicate VM name",
+            "Version": "9.0.2.0",
+        }
+    )
+    assert envelope["status"] == "failed"
+    assert envelope["notes"] == []
+
+
+def test_map_status_envelope_list_shape_uses_first() -> None:
+    envelope = map_instance_status_envelope([{"Status": "Completed"}, {"Status": "Failed"}])
+    assert envelope["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_instance_status_handler_maps_running() -> None:
+    connector = HolodeckConnector()
+    with patch(
+        "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+        new_callable=AsyncMock,
+    ) as mock_pwsh:
+        mock_pwsh.return_value = {"Status": "InProgress", "CurrentStep": "ESXBuild"}
+        result = await connector.instance_status(_StubTarget(), {})
+    assert result["status"] == "running"
+    assert result["current_step"] == "ESXBuild"
+
+
+@pytest.mark.asyncio
+async def test_instance_status_handler_pwsh_error_is_unknown() -> None:
+    connector = HolodeckConnector()
+    with patch(
+        "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+        new_callable=AsyncMock,
+    ) as mock_pwsh:
+        mock_pwsh.side_effect = PwshRunError("no instance", exit_status=1, stderr="")
+        result = await connector.instance_status(_StubTarget(), {})
+    assert result["status"] == "unknown"
+    assert "error" in result
+
+
+# ===========================================================================
+# F. router.patch idempotency + 9.1 verify-only (AC4)
+# ===========================================================================
+
+
+class _FakePatchFS:
+    """A stateful fake HoloRouter module tree for router.patch idempotency tests.
+
+    Tracks per-file applied state. A grep for the applied marker returns the
+    expected count iff the patch has been applied; a grep for the unpatched
+    marker returns 1 iff not yet applied; a ``sed -i`` flips the file to
+    applied. The ``sed -i`` check runs first because a patch's sed command
+    embeds BOTH markers (pattern + replacement).
+    """
+
+    def __init__(self, *, all_applied: bool) -> None:
+        self.applied: dict[str, bool] = {p.file_path: all_applied for p in ROUTER_PATCHES}
+        self.sed_calls: list[str] = []
+
+    async def run(
+        self, target: Any, cmd: str, *, operator: Any = None, timeout: float = 30.0
+    ) -> Any:
+        patch_spec = next((p for p in ROUTER_PATCHES if p.file_path in cmd), None)
+        if patch_spec is None:
+            return _proc(stdout="0")
+        if "sed -i" in cmd:
+            self.sed_calls.append(cmd)
+            self.applied[patch_spec.file_path] = True
+            return _proc(stdout="")
+        if patch_spec.applied_marker in cmd:
+            count = patch_spec.applied_count if self.applied[patch_spec.file_path] else 0
+            return _proc(stdout=str(count))
+        if patch_spec.unpatched_marker in cmd:
+            return _proc(stdout="0" if self.applied[patch_spec.file_path] else "1")
+        return _proc(stdout="0")
+
+
+def _states(result: dict[str, Any]) -> dict[str, str]:
+    return {p["patch_id"]: p["state"] for p in result["patches"]}
+
+
+@pytest.mark.asyncio
+async def test_router_patch_applies_then_second_run_is_idempotent() -> None:
+    """First run applies all three unpatched patches; the second run -> all already_applied."""
+    connector = HolodeckConnector()
+    fs = _FakePatchFS(all_applied=False)
+    target = _StubTarget(version="9.0.2.0")
+
+    with patch.object(connector, "_run_command", side_effect=fs.run):
+        first = await connector.router_patch(target, {})
+        assert _states(first) == {"C1": "applied", "C2": "applied", "C3": "applied"}
+        assert first["patched"] is True
+        assert first["verify_only"] is False
+        assert len(fs.sed_calls) == 3
+
+        second = await connector.router_patch(target, {})
+    assert _states(second) == {
+        "C1": "already_applied",
+        "C2": "already_applied",
+        "C3": "already_applied",
+    }
+    assert second["patched"] is False
+    assert len(fs.sed_calls) == 3, "the idempotent second run must run no new sed"
+
+
+@pytest.mark.asyncio
+async def test_router_patch_9_1_is_verify_only_never_seds() -> None:
+    """On a 9.1 HoloRouter the patches are fixed upstream -> verify-only, no sed."""
+    connector = HolodeckConnector()
+    fs = _FakePatchFS(all_applied=True)
+    target = _StubTarget(version="9.1.0.0912")
+
+    with patch.object(connector, "_run_command", side_effect=fs.run):
+        result = await connector.router_patch(target, {})
+    assert result["verify_only"] is True
+    assert _states(result) == {
+        "C1": "already_applied",
+        "C2": "already_applied",
+        "C3": "already_applied",
+    }
+    assert fs.sed_calls == [], "9.1 verify-only must never sed"
+
+
+@pytest.mark.asyncio
+async def test_router_patch_9_1_marker_absent_is_not_applicable_no_sed() -> None:
+    """9.1 with the applied marker absent reports not_applicable, still never seds."""
+    connector = HolodeckConnector()
+    fs = _FakePatchFS(all_applied=False)  # applied marker absent on this fake
+    target = _StubTarget(version="9.1.0.0912")
+
+    with patch.object(connector, "_run_command", side_effect=fs.run):
+        result = await connector.router_patch(target, {})
+    assert result["verify_only"] is True
+    assert set(_states(result).values()) == {"not_applicable"}
+    assert fs.sed_calls == []
+
+
+def test_target_hr_version_prefers_version_then_fingerprint() -> None:
+    assert target_hr_version(_StubTarget(version="9.1.0")) == "9.1.0"
+    assert target_hr_version(_StubTarget(version=None, fingerprint={"version": "9.0.2"})) == "9.0.2"
+    assert target_hr_version(_StubTarget(version=None, fingerprint={})) is None
+
+
+# ===========================================================================
+# G. DB-backed dispatch: two-phase registration, op-identity envelope (#2681),
+#    secret hygiene (#1503) -- AC1 / AC5
+# ===========================================================================
+
+_CONNECTOR_ID = "holodeck-ssh-9.0"
+_TARGET_NAME = "holodeck-deploy-e2e"
+_TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000029a8")
+_OPERATOR = Operator(
+    sub="holodeck-deploy-e2e-test",
+    name="Holodeck Deploy E2E Operator",
+    email=None,
+    raw_jwt="<holodeck-deploy-e2e-raw-jwt>",
+    tenant_id=_TENANT_ID,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+# Non-secret park params per gated op (all pass schema validation).
+_PARK_PARAMS: dict[str, dict[str, Any]] = {
+    "holodeck.config.apply": {
+        "version": "9.0.2.0",
+        "variant": "management_only",
+        "external_ip": "vcenter.example.lab",
+        "depot": {"host": "depot.lab", "credential_ref": "secret/holodeck/depot"},
+    },
+    "holodeck.instance.start": {
+        "config_id": "hd9mgmt1",
+        "instance_id": "hd9mgmt",
+        "version": "9.0.2.0",
+    },
+    "holodeck.router.patch": {},
+}
+_EXPECTED_SAFETY = {
+    "holodeck.config.apply": "dangerous",
+    "holodeck.instance.start": "dangerous",
+    "holodeck.router.patch": "dangerous",
+}
+_ENVELOPE_IDENTITY_KEYS = frozenset(
+    {"op_id", "connector_id", "target_id", "op_class", "safety_level"}
+)
+
+
+@pytest.fixture(scope="module")
+def event_loop_policy() -> asyncio.DefaultEventLoopPolicy:
+    return asyncio.DefaultEventLoopPolicy()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    from meho_backplane.operations import reset_dispatcher_caches
+
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+async def _seed_target() -> None:
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.db.models import Target as TargetORM
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            TargetORM(
+                tenant_id=_TENANT_ID,
+                name=_TARGET_NAME,
+                aliases=[],
+                product="holodeck",
+                host="holorouter.e2e.invalid",
+                port=22,
+                fqdn=None,
+                secret_ref="kv/dev/holodeck/deploy-e2e",
+                auth_model="shared_service_account",
+                vpn_required=False,
+                extras={},
+                fingerprint={"version": "9.0.2.0"},
+                version="9.0.2.0",
+                notes="seeded by test_connectors_holodeck_deploy",
+            )
+        )
+        await session.commit()
+
+
+@pytest.fixture
+async def holodeck_deploy_e2e() -> AsyncIterator[HolodeckConnector]:
+    from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+    from meho_backplane.operations.dispatcher import set_default_reducer
+    from meho_backplane.operations.reducer import PassThroughReducer
+
+    set_default_reducer(PassThroughReducer())
+    await HolodeckConnector.register_operations()
+    await _seed_target()
+    connector = HolodeckConnector()
+    _CONNECTOR_INSTANCE_CACHE[HolodeckConnector] = connector  # type: ignore[assignment]
+    yield connector
+    await connector.aclose()
+
+
+async def _dispatch(op_id: str, params: dict[str, Any], *, approved: bool) -> dict[str, Any]:
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.operations import dispatch
+    from meho_backplane.targets.resolver import resolve_target
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        resolved = await resolve_target(session, _OPERATOR.tenant_id, _TARGET_NAME)
+    result = await dispatch(
+        operator=_OPERATOR,
+        connector_id=_CONNECTOR_ID,
+        op_id=op_id,
+        target=resolved,
+        params=params,
+        _approved=approved,
+    )
+    dumped: dict[str, Any] = result.model_dump(mode="json")
+    return dumped
+
+
+async def _parked_effect(approval_request_id: str) -> dict[str, Any]:
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.operations.approval_queue import get_request
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        request = await get_request(
+            session, tenant_id=_TENANT_ID, request_id=uuid.UUID(approval_request_id)
+        )
+        return dict(request.proposed_effect)
+
+
+@pytest.mark.asyncio
+async def test_two_phase_registration_lands_all_four_descriptors(
+    holodeck_deploy_e2e: HolodeckConnector,
+) -> None:
+    """register_operations (phase 2) upserts endpoint_descriptor rows for all four ops."""
+    from sqlalchemy import select
+
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.db.models import EndpointDescriptor
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = await session.execute(
+            select(EndpointDescriptor.op_id).where(
+                EndpointDescriptor.product == "holodeck",
+                EndpointDescriptor.op_id.in_(tuple(EXPECTED_DEPLOY_OP_IDS)),
+            )
+        )
+        found = {r for (r,) in rows.all()}
+    assert found == EXPECTED_DEPLOY_OP_IDS
+
+
+@pytest.mark.asyncio
+async def test_gated_ops_carry_uniform_op_identity_envelope(
+    holodeck_deploy_e2e: HolodeckConnector,
+) -> None:
+    """#2681: every parked gated op carries the uniform op-identity + metadata envelope."""
+    identity_sets: list[frozenset[str]] = []
+    for op_id, params in _PARK_PARAMS.items():
+        result = await _dispatch(op_id, params, approved=False)
+        assert result["status"] == "awaiting_approval", (op_id, result)
+        effect = await _parked_effect(result["extras"]["approval_request_id"])
+        assert effect["op_id"] == op_id
+        assert effect["connector_id"] == _CONNECTOR_ID
+        assert effect["op_class"] == classify_op(op_id)
+        assert effect["safety_level"] == _EXPECTED_SAFETY[op_id]
+        present = _ENVELOPE_IDENTITY_KEYS & frozenset(effect)
+        identity_sets.append(present)
+        assert present == _ENVELOPE_IDENTITY_KEYS, (op_id, sorted(effect))
+    assert all(s == identity_sets[0] for s in identity_sets)
+
+
+@pytest.mark.asyncio
+async def test_router_patch_parks_op_identity_only_no_token(
+    holodeck_deploy_e2e: HolodeckConnector,
+) -> None:
+    """Secret hygiene: router.patch is credential-class -> parked op-identity-only, no token."""
+    assert classify_op("holodeck.router.patch") == "credential_write"
+    assert set(HOLODECK_DEPLOY_CREDENTIAL_OPS) == {"holodeck.router.patch"}
+    result = await _dispatch("holodeck.router.patch", {}, approved=False)
+    assert result["status"] == "awaiting_approval"
+    effect = await _parked_effect(result["extras"]["approval_request_id"])
+    # Credential-class + no bespoke builder -> params-echo suppressed.
+    assert effect["preview_populated"] is False
+    assert "params_echo" not in effect and "preview" not in effect
+    blob = json.dumps(effect).lower()
+    assert "brcm_build_token" not in blob
+    assert "broadcombuildtoken" not in blob
+
+
+@pytest.mark.asyncio
+async def test_config_apply_parks_with_param_echo_no_secret_value(
+    holodeck_deploy_e2e: HolodeckConnector,
+) -> None:
+    """config.apply keeps its param-echo preview and leaks no credential value."""
+    assert classify_op("holodeck.config.apply") != "credential_write"
+    result = await _dispatch(
+        "holodeck.config.apply", _PARK_PARAMS["holodeck.config.apply"], approved=False
+    )
+    assert result["status"] == "awaiting_approval"
+    effect = await _parked_effect(result["extras"]["approval_request_id"])
+    # Param-echo preview is populated (the issue's "param-echo preview").
+    assert effect["preview_populated"] is True
+    assert "params_echo" in effect
+    # No plaintext credential value exists in the params, so none can leak.
+    blob = json.dumps(effect)
+    assert "hunter2" not in blob and "VMware123" not in blob
+
+
+@pytest.mark.asyncio
+async def test_instance_status_result_carries_op_identity(
+    holodeck_deploy_e2e: HolodeckConnector,
+) -> None:
+    """The safe op's result envelope carries its op-identity (op_id) -- #2681 for all four."""
+    with patch(
+        "meho_backplane.connectors.holodeck.ops_deploy.pwsh_run",
+        new_callable=AsyncMock,
+    ) as mock_pwsh:
+        mock_pwsh.return_value = {"Status": "InProgress", "CurrentStep": "ESXBuild"}
+        result = await _dispatch("holodeck.instance.status", {}, approved=False)
+    assert result["status"] == "ok", result.get("error")
+    assert result["op_id"] == "holodeck.instance.status"
+    assert result["result"]["status"] == "running"

--- a/backend/tests/test_connectors_holodeck_e2e.py
+++ b/backend/tests/test_connectors_holodeck_e2e.py
@@ -500,17 +500,18 @@ async def holodeck_e2e(
 
 
 def test_holodeck_ops_registration_count() -> None:
-    """All 10 read ops + 3 G3.18-T2 write ops = 13 ops registered in HOLODECK_OPS.
+    """10 read ops + 3 G3.18-T2 write ops + 4 #2908 deploy ops = 17 in HOLODECK_OPS.
 
     ``EXPECTED_OP_IDS`` enumerates the 10 read ops (about + 7 T2 reads +
     ``holodeck.disk.usage`` + #2847 ``holodeck.backups.list``); the 3
     approval-gated write ids are asserted in
-    ``test_connectors_holodeck_write.py``.
+    ``test_connectors_holodeck_write.py`` and the 4 deploy-lifecycle ids in
+    ``test_connectors_holodeck_deploy.py``.
     """
     op_ids = {op.op_id for op in HOLODECK_OPS}
     missing = set(EXPECTED_OP_IDS) - op_ids
     assert not missing, f"Missing ops: {missing}"
-    assert len(HOLODECK_OPS) == 13, f"Expected 13 ops, got {len(HOLODECK_OPS)}"
+    assert len(HOLODECK_OPS) == 17, f"Expected 17 ops, got {len(HOLODECK_OPS)}"
 
 
 def test_holodeck_read_ops_all_safe_and_no_approval_required() -> None:
@@ -528,7 +529,7 @@ def test_holodeck_read_ops_all_safe_and_no_approval_required() -> None:
 
 
 def test_holodeck_ops_all_have_llm_instructions() -> None:
-    """All 13 ops carry non-empty llm_instructions for agent discoverability."""
+    """All 17 ops carry non-empty llm_instructions for agent discoverability."""
     for op in HOLODECK_OPS:
         assert op.llm_instructions, f"{op.op_id}: llm_instructions must not be empty"
         instr = op.llm_instructions
@@ -545,7 +546,7 @@ def test_holodeck_ops_all_carry_ssh_only_transport_note() -> None:
 
     The exact phrase to look for is "Holodeck has no REST API"; the
     shared :data:`SSH_TRANSPORT_NOTE` constant guarantees consistency
-    across all 13 ops.
+    across all 17 ops.
     """
     canonical_phrase = "Holodeck has no REST API"
     pwsh_phrase = "PowerShell-over-SSH"

--- a/backend/tests/test_connectors_holodeck_ops.py
+++ b/backend/tests/test_connectors_holodeck_ops.py
@@ -1442,9 +1442,10 @@ _READ_OP_IDS: frozenset[str] = frozenset(
 )
 
 
-def test_holodeck_ops_has_thirteen_entries() -> None:
-    """about + 7 T2 reads + disk.usage + #2847 backups.list + 3 write ops = 13 total."""
-    assert len(HOLODECK_OPS) == 13
+def test_holodeck_ops_has_seventeen_entries() -> None:
+    """about + 7 T2 reads + disk.usage + #2847 backups.list + 3 write ops +
+    #2908 4 deploy-lifecycle ops = 17 total."""
+    assert len(HOLODECK_OPS) == 17
 
 
 def test_holodeck_ops_about_remains_at_index_zero() -> None:
@@ -1457,6 +1458,11 @@ def test_holodeck_ops_covers_expected_op_ids() -> None:
         "holodeck.k8s.pods.gc",
         "holodeck.backups.prune",
         "holodeck.images.import",
+        # #2908 deploy-lifecycle ops.
+        "holodeck.config.apply",
+        "holodeck.instance.start",
+        "holodeck.instance.status",
+        "holodeck.router.patch",
     }
     assert op_ids == expected
 
@@ -1534,6 +1540,11 @@ def test_holodeck_ops_group_keys_include_new_groups() -> None:
         "k8s-write",
         "backups-write",
         "images-write",
+        # #2908 deploy-lifecycle groups (``deploy-`` prefix avoids collision).
+        "deploy-config",
+        "deploy-lifecycle",
+        "deploy-status",
+        "deploy-patch",
     } == group_keys
 
 

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -28,7 +28,9 @@ set for pre-eviction disk diagnosis — bringing the total to 9 ops. #2847
 appends `holodeck.backups.list` — a safe per-file inventory of
 `/var/backups` reusing `holodeck.backups.prune`'s own `find` listing —
 taking the read surface to **10 ops** (13 total, including the 3
-approval-gated write ops).
+approval-gated write ops). #2908 (Initiative #2907) appends the 4
+deploy-lifecycle ops (`config.apply`, `instance.start`, `instance.status`,
+`router.patch`) — **17 ops total**.
 
 Source: `backend/src/meho_backplane/connectors/holodeck/`.
 
@@ -78,8 +80,19 @@ Source: `backend/src/meho_backplane/connectors/holodeck/`.
 - **Op metadata** (`ops.py`) — the `HolodeckOp` dataclass and the
   `HOLODECK_OPS` tuple. T1 shipped the single `holodeck.about` canary; T2
   (#854) extends the tuple via `_holodeck_ops()` which splats `READ_OPS`
-  (the 7 read ops defined in `ops_read.py`) onto the canary. The pattern
-  mirrors bind9's `_bind9_ops()` and pfSense's `_pfsense_ops()`.
+  (the 7 read ops defined in `ops_read.py`) onto the canary, and later tasks
+  append `WRITE_OPS` (`ops_write.py`, #2154) and `DEPLOY_OPS` (`ops_deploy.py`,
+  #2908) — **17 ops total**. The pattern mirrors bind9's `_bind9_ops()` and
+  pfSense's `_pfsense_ops()`.
+
+- **Deploy-lifecycle op handlers + helpers** (`ops_deploy.py`, #2908) —
+  `holodeck_config_apply`, `holodeck_instance_start`, `holodeck_instance_status`,
+  `holodeck_router_patch`, plus the pure helpers `validate_config_apply_params`
+  (the depot-vs-5.2.x refusal, also unit-tested directly),
+  `map_instance_status_envelope` (the `Get-HoloDeckInstance` → flat envelope
+  mapper), `target_hr_version` (reads `Target.version` then `fingerprint.version`),
+  and `ROUTER_PATCHES` (the three `RouterPatchSpec` records: applied/unpatched
+  grep markers + the `sed` expression per patch).
 
 - **`parse_photon_version`** (`connector.py`) — pure parser for
   `/etc/photon-release` output; recovers the `<major>.<minor>(.<patch>)?`
@@ -348,6 +361,71 @@ resolver `backups.prune` and `backups.list` (#2847) both call.
 These three retire the recovery fallback where the VCF-9.x backup-fill outage
 (Initiative #2145) was fixed by hand-run local root SSH with no MEHO audit
 row.
+
+### Deploy-lifecycle ops (#2908 surface, Initiative #2907)
+
+`ops_deploy.py` (module `DEPLOY_OPS`, appended to `HOLODECK_OPS`) adds four ops
+that make the consumer's hand-run fresh-deploy procedure (`New-HoloDeckConfig`
+/ `New-HoloDeckInstance` / the three per-appliance patches) dispatchable as
+governed steps. Three are `dangerous` / `requires_approval=True`; one is a
+`safe` read.
+
+**Secret hygiene is by construction.** `_run_command` has no `env`/`stdin`
+seam and the `_pwsh` contract forbids credential material in the (argv-visible)
+script body, so **none of these ops handles secret bytes**. The vCenter
+deploy-target SSO credentials and the Broadcom build token live on the
+appliance — in its staged deploy environment (`$env:VC_USER`/`$env:VC_PW`) and
+in the persisted config (`/holodeck-runtime/config/<id>.json`, written by
+`New-HoloDeckConfig`) — and the composed PowerShell references them by variable
+**name** only. Nothing credential-shaped can reach the params-echo, audit, or
+broadcast surfaces.
+
+- **`holodeck.config.apply`** (group `deploy-config`). Composes
+  `New-HoloDeckConfig` **without `-Default`** (the flag triggers a buggy
+  internal `Set-HoloDeckConfig`) + `$null = Import-HoloDeckConfig`. Params carry
+  only non-secret config (version enum, variant, external IP, master CIDR / VLAN,
+  placement refs, and a 9.x-only `depot` whose `credential_ref` is a Vault
+  **path**). **Depot params are refused for a VCF 5.2.x version** (5.2 deploys
+  via Cloud Builder, no offline depot): the refusal is encoded in the parameter
+  schema as `if version~5.2 then not required depot`, so the framework
+  `validate_params` (Draft 2020-12) rejects it **pre-park** — an operator never
+  approves a config that would fail. `validate_config_apply_params` re-expresses
+  the same rule as a clear string for the handler belt-and-braces and the direct
+  test. It is deliberately **not** pinned credential-class, so it keeps its
+  generic param-echo preview (no secret is ever a param).
+- **`holodeck.instance.start`** (group `deploy-lifecycle`). Runs a **single-shot
+  fail-fast `Connect-VIServer` precheck before launch**: a pwsh script reads the
+  persisted config on the appliance, builds a `PSCredential`, and makes exactly
+  one `Connect-VIServer … -ErrorAction Stop` attempt. This catches a
+  stale/locked deploy-target credential *before* Holodeck's 4-retry-in-13s loop
+  storm-locks the SSO account (consumer #258 lesson). On any precheck failure
+  the instance is **never** launched. On a green precheck `New-HoloDeckInstance`
+  is started under `tmux new-session -d` (survives the dispatch returning) and
+  the op returns immediately with the instance id + a start marker.
+- **`holodeck.instance.status`** (group `deploy-status`, `safe`, no approval).
+  Maps `Get-HoloDeckInstance` into a flat envelope (`status`
+  running/completed/failed/unknown, `current_step`, `started_at`,
+  `updated_at`, `instance_id`, `notes`). The flat `status` field is the target
+  a runbook `OperationCallVerify` step matches and a deploy-in-progress Sensor
+  asserts on, so its shape never depends on approval state. `map_instance_status_envelope`
+  re-maps the **benign VCF 5.2.x terminal quirk** — the final
+  `Sync-HolodeckComponents` step throwing *"No route to host"* because VCF
+  Operations is not deployed in 5.2 — to `status="completed"` plus a structured
+  `notes` entry, so a verify/Sensor built on it never reads a fully-deployed
+  5.2.x lab as broken.
+- **`holodeck.router.patch`** (group `deploy-patch`). Idempotent
+  verify-then-apply of the three per-appliance patches (C1 `SddcMgmtDeployment.psm1`
+  `-eq 7`→`-ge 7`; C2 `HoloDeck.psm1` `BroadcomBuildToken` SecureString wrap; C3
+  `Auth.psm1` `Connect-VIServer` PSCredential). Per patch it greps the *applied*
+  marker (present at the expected count → `already_applied`), else the
+  *unpatched* marker (present → timestamped backup + `sed` + re-verify →
+  `applied`), else `not_applicable`. A **second run reports all
+  `already_applied`** (no `sed`). On a **9.1 HoloRouter it runs verify-only**
+  (patches fixed upstream) — it greps but never `sed`s. The patch strings are
+  fixed code constants (C2 references `$env:brcm_build_token` by name), and the
+  result reports only patch id / label / state — no file content. It **is**
+  pinned into `_CREDENTIAL_WRITE_OPS` (broadcast defence-in-depth) per the
+  `rke2.node.config.update` precedent.
 
 ### `execute(target, op_id, params)`
 


### PR DESCRIPTION
## Summary

- Adds four typed ops to the existing `holodeck` connector so the consumer's
  hand-run fresh-deploy procedure (`New-HoloDeckConfig` / `New-HoloDeckInstance`
  / the three per-appliance patches) becomes governed, dispatchable steps:
  `holodeck.config.apply`, `holodeck.instance.start`, `holodeck.instance.status`,
  `holodeck.router.patch` (13 → 17 ops).
- Each registers through the standard two-phase typed registration
  (`register_connector_v2` at import + `register_typed_operation` at
  `register_operations`) with a JSON-Schema param block, a curated group
  `when_to_use`, `llm_instructions`, and the uniform op-identity envelope (#2681).
- **Secret hygiene (#1503) holds by construction**: `_run_command` has no
  `env`/`stdin` seam and `_pwsh` forbids credential material in the argv-visible
  script body, so none of these ops handles secret bytes — the vCenter
  deploy-target creds and the Broadcom build token stay on the appliance and are
  referenced by variable name only. `router.patch` is additionally pinned into
  `_CREDENTIAL_WRITE_OPS` (broadcast defence-in-depth); `config.apply` carries
  only non-secret config + Vault refs, so it keeps its param-echo preview.
- New module `ops_deploy.py`; wiring in `ops.py` (`DEPLOY_OPS` append),
  `connector.py` (four delegating shims + the `deploy-*` `when_to_use` merge),
  and `broadcast/events.py` (the `router.patch` credential-write pin).

### Op behaviour

- **`config.apply`** — `New-HoloDeckConfig` (**never `-Default`**) +
  `Import-HoloDeckConfig`. Depot params are **refused for a VCF 5.2.x version**
  (5.2 uses Cloud Builder, no offline depot) via an `if/then` in the parameter
  schema, so the framework `validate_params` rejects the combination **pre-park**.
  `dangerous`, approval-gated.
- **`instance.start`** — a single-shot fail-fast `Connect-VIServer` precheck
  **before** a detached `New-HoloDeckInstance` launch, so a stale/locked
  credential can't storm-lock the SSO account via Holodeck's retry loop.
  `dangerous`, approval-gated.
- **`instance.status`** — `Get-HoloDeckInstance` → a flat status envelope
  (running/completed/failed) usable as a runbook `OperationCallVerify` target
  and a Sensor op; the benign VCF 5.2.x `Sync-HolodeckComponents` "No route to
  host" terminal quirk is surfaced as a note, not a failure. `safe`, no approval.
- **`router.patch`** — idempotent verify-then-apply of the three per-appliance
  patches (C1/C2/C3), **verify-only on a 9.1 HoloRouter**. `dangerous`,
  approval-gated.

## Test plan

- [x] `ruff check` — clean (all changed files)
- [x] `ruff format --check` — clean (8 files already formatted)
- [x] `mypy … --ignore-missing-imports` — Success: no issues
- [x] `code-quality.py --diff` — 0 blockers (2 non-blocking warnings)
- [x] `pytest tests/test_connectors_holodeck_deploy.py` — 40 passed
- [x] holodeck + broadcast regression — 514 passed
- [x] broader regression (`-k "holodeck or preview or dispatcher or approval_queue"`) — 659 passed, 1 skipped

Acceptance criteria evidence:

- [x] Four ops via two-phase registration, JSON-Schema params, curated group
  `when_to_use`, `llm_instructions` — `test_deploy_ops_registration_set`,
  `test_two_phase_registration_lands_all_four_descriptors`,
  `test_deploy_ops_group_keys_are_curated`,
  `test_deploy_ops_carry_transport_note_and_instructions`.
- [x] `config.apply` refuses depot on 5.2.x in `validate_params` —
  `test_config_apply_validate_params_rejects_depot_on_5_2` (5.2 / 5.2.1 / 5.2.2)
  + `_accepts_depot_on_9_x` + handler belt-and-braces.
- [x] `instance.start` fail-fast precheck (locked-account mocked) —
  `test_instance_start_precheck_failure_blocks_launch` (launch never runs)
  + `_precheck_pwsh_error_is_fail_fast` + `_happy_path_launches_detached`.
- [x] `instance.status` envelope running/completed/failed + benign 5.2 quirk —
  `test_map_status_envelope_*` (incl. `_benign_5_2_sync_quirk_is_completed`,
  `_real_9_x_failure_stays_failed`) + handler tests.
- [x] `router.patch` idempotency (2nd run → all `already_applied`) + 9.1
  verify-only — `test_router_patch_applies_then_second_run_is_idempotent`,
  `_9_1_is_verify_only_never_seds`, `_9_1_marker_absent_is_not_applicable_no_sed`.
- [x] Uniform op-identity envelope on all four + secret hygiene for
  `router.patch`/`config.apply` — `test_gated_ops_carry_uniform_op_identity_envelope`,
  `test_instance_status_result_carries_op_identity`,
  `test_router_patch_parks_op_identity_only_no_token`,
  `test_config_apply_parks_with_param_echo_no_secret_value`,
  `test_config_apply_schema_admits_no_plaintext_credential`.
- [x] Tests mirror the windows_dns/holodeck mocked-pwsh pattern;
  `docs/codebase/connectors-holodeck.md` updated; CHANGELOG entry added.

## Out of scope

- No CLI verbs added (not in the task's acceptance criteria; the ops are
  dispatchable through the shared `call_operation` surface).
- Real MEHO-side secret injection into the deploy is intentionally not built —
  the transport (`_run_command`) has no `env`/`stdin` seam and `_pwsh` forbids
  secrets in the script body, so the deploy reads credentials from the
  appliance's own staged environment / persisted config, keeping MEHO's
  governance surfaces free of secret bytes. A future `_run_command` env/stdin
  seam would be a separate, additive change.
- Adjacent (non-blocking) code-quality warnings, deferred: `holodeck_config_apply`
  is 65 lines (mostly docstring; >60 warn) and the pre-existing
  `broadcast/events.py::redact_payload` is 69 lines — neither touched beyond
  this task's needs.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2908
