### PR TITLE
feat(targets): add `meho targets add` single-target CLI verb (#2862)

### DIFF
--- a/cli/internal/cmd/targets/add.go
+++ b/cli/internal/cmd/targets/add.go
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newAddCmd returns the `meho targets add` command (alias `create`).
+//
+// CLI shape:
+//
+//	meho targets add <name> --product <p> --host <h> \
+//	  [--alias a --alias b] [--version v] [--port n] [--fqdn f] \
+//	  [--secret-ref <ref>] [--auth-model <m>] [--verify-tls=false] \
+//	  [--tls-ca-pin <pin>] [--tls-server-name <sni>] \
+//	  [--preferred-impl <id>] [--note <n>] [--json] [--backplane <url>]
+//
+// It POSTs a single TargetCreate to POST /api/v1/targets — the same
+// route `meho targets import` drives for each new row — reusing this
+// package's `doAuthedRequest` plumbing (bearer injection + one-shot
+// 401-refresh-retry). On 201 it renders the created Target in the same
+// key-value shape as `meho targets describe`; a 422 (unknown product,
+// out-of-tenant secret_ref, SSRF-guarded host) surfaces the server's
+// error body so the operator sees exactly what the backplane rejected.
+//
+// The verb is a thin transport over the server contract: it runs no
+// validation of its own — that stays entirely server-side. `tenant_id`
+// is never sent; the backplane binds it from the operator's JWT (the
+// TargetCreate body shape has no tenant_id field to populate).
+//
+// Only flags the operator explicitly set land in the request body.
+// Unset optionals are omitted rather than serialised as JSON null so
+// the server applies its documented defaults — most importantly, an
+// omitted `secret_ref` derives the per-tenant default
+// (`tenants/<tenant_id>/<name>`, #1723), whereas an explicit null would
+// persist "no credential" (#2872). This mirrors `import`'s
+// entryToCreateBody, which likewise carries only the keys present in
+// the source descriptor.
+//
+// Exit codes (shared with the sibling verbs):
+//   - 0   target created; row rendered
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 409 duplicate name, 422 rejected
+//     body, malformed response)
+//   - 5   insufficient_role
+func newAddCmd() *cobra.Command {
+	var (
+		product           string
+		host              string
+		aliases           []string
+		version           string
+		port              int
+		fqdn              string
+		secretRef         string
+		authModel         string
+		verifyTLS         bool
+		tlsCaPin          string
+		tlsServerName     string
+		preferredImpl     string
+		note              string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:     "add <name>",
+		Aliases: []string{"create"},
+		Short:   "Register a single target (alias `create`)",
+		Long: "add registers one target in the operator's tenant via " +
+			"POST /api/v1/targets — the single-target counterpart to the " +
+			"bulk `meho targets import`. `--product` and `--host` are " +
+			"required; `<name>` is the positional canonical name. Every " +
+			"other flag maps 1:1 to an optional TargetCreate field and is " +
+			"sent only when set, so the server's defaults apply to the " +
+			"rest (a target created without `--secret-ref` derives the " +
+			"per-tenant default credential path; `--verify-tls=false` opts " +
+			"out of TLS verification).\n\n" +
+			"All validation is server-side: an unknown `--product`, a " +
+			"`--secret-ref` outside the operator's tenant subtree, or an " +
+			"SSRF-guarded `--host` come back as a 422 whose body the CLI " +
+			"prints verbatim. On success the created target is rendered in " +
+			"the same shape as `meho targets describe` (use `--json` for " +
+			"the raw Target).\n\n" +
+			"Authentication uses the token `meho login` wrote, with the " +
+			"same one-shot 401-refresh-retry as every other targets verb. " +
+			"The tenant is the operator's JWT-bound tenant — `tenant_id` is " +
+			"never sent by the client.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body := map[string]any{
+				"name":    args[0],
+				"product": product,
+				"host":    host,
+			}
+			// Carry only the optionals the operator explicitly set (see
+			// the doc comment: omit-vs-null is load-bearing for
+			// secret_ref). Each flag maps to its snake_case TargetCreate
+			// field name.
+			fs := cmd.Flags()
+			if fs.Changed("alias") {
+				body["aliases"] = aliases
+			}
+			if fs.Changed("version") {
+				body["version"] = version
+			}
+			if fs.Changed("port") {
+				body["port"] = port
+			}
+			if fs.Changed("fqdn") {
+				body["fqdn"] = fqdn
+			}
+			if fs.Changed("secret-ref") {
+				body["secret_ref"] = secretRef
+			}
+			if fs.Changed("auth-model") {
+				body["auth_model"] = authModel
+			}
+			if fs.Changed("verify-tls") {
+				body["verify_tls"] = verifyTLS
+			}
+			if fs.Changed("tls-ca-pin") {
+				body["tls_ca_pin"] = tlsCaPin
+			}
+			if fs.Changed("tls-server-name") {
+				body["tls_server_name"] = tlsServerName
+			}
+			if fs.Changed("preferred-impl") {
+				body["preferred_impl_id"] = preferredImpl
+			}
+			if fs.Changed("note") {
+				body["notes"] = note
+			}
+			return runAdd(cmd, addOptions{
+				Body:              body,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&product, "product", "",
+		"connector product slug (required; must match a registered connector — see `meho connector list`)")
+	cmd.Flags().StringVar(&host, "host", "",
+		"host or IP the connector dials (required)")
+	cmd.Flags().StringArrayVar(&aliases, "alias", nil,
+		"additional name the target resolves by (repeatable)")
+	cmd.Flags().StringVar(&version, "version", "",
+		"operator-asserted product version (e.g. 9.0) the resolver consults before the first probe")
+	cmd.Flags().IntVar(&port, "port", 0,
+		"connection port (default: the connector's product default)")
+	cmd.Flags().StringVar(&fqdn, "fqdn", "",
+		"fully-qualified domain name, when distinct from --host")
+	cmd.Flags().StringVar(&secretRef, "secret-ref", "",
+		"Vault path of the target's credential (omit to derive the per-tenant default)")
+	cmd.Flags().StringVar(&authModel, "auth-model", "",
+		"per-target identity model (default: shared_service_account)")
+	cmd.Flags().BoolVar(&verifyTLS, "verify-tls", true,
+		"verify the target's TLS certificate; pass --verify-tls=false to opt out")
+	cmd.Flags().StringVar(&tlsCaPin, "tls-ca-pin", "",
+		"PEM CA bundle to pin for this target (mutually exclusive with --verify-tls=false)")
+	cmd.Flags().StringVar(&tlsServerName, "tls-server-name", "",
+		"TLS SNI / certificate-verification hostname, decoupled from --host")
+	cmd.Flags().StringVar(&preferredImpl, "preferred-impl", "",
+		"connector impl_id override for the G0.6 resolver's tie-break")
+	cmd.Flags().StringVar(&note, "note", "",
+		"free-form operator note stored on the target")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the created target as JSON instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to create the target in (defaults to the URL recorded by `meho login`)")
+	_ = cmd.MarkFlagRequired("product")
+	_ = cmd.MarkFlagRequired("host")
+	return cmd
+}
+
+// addOptions carries the resolved inputs for runAdd. Body is the JSON
+// request payload already partitioned by the RunE closure (name /
+// product / host plus only the optionals the operator set); keeping it
+// pre-built lets runAdd stay a thin marshal-POST-render step and lets
+// tests drive the cobra command end-to-end against an httptest server.
+type addOptions struct {
+	Body              map[string]any
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+// runAdd marshals the TargetCreate body, POSTs it to /api/v1/targets
+// through the shared doAuthedRequest plumbing, and renders the created
+// Target. Non-2xx responses arrive as *httpError and route through the
+// same renderImportRequestError ladder the import path uses, so a 422
+// body reaches the operator verbatim and a 401 triggers the one-shot
+// refresh inside doAuthedRequest before surfacing auth_expired.
+func runAdd(cmd *cobra.Command, opts addOptions) error {
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	payload, err := json.Marshal(opts.Body)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("marshal request body: %v", err)), opts.JSONOut)
+	}
+	raw, err := doAuthedRequest(cmd.Context(), backplaneURL, http.MethodPost, "/api/v1/targets", payload)
+	if err != nil {
+		return renderImportRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	var t api.Target
+	if err := json.Unmarshal(raw, &t); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("decode created target: %v", err)), opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), &t)
+	}
+	printTargetSummary(cmd.OutOrStdout(), &t)
+	return nil
+}

--- a/cli/internal/cmd/targets/add_test.go
+++ b/cli/internal/cmd/targets/add_test.go
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package targets
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// createdTargetJSON is a complete Target row as POST /api/v1/targets
+// returns it on 201 (response_model=Target). It must decode cleanly
+// into api.Target — UUIDs, RFC3339 timestamps, and the nullable
+// columns are all present so printTargetSummary renders every line.
+const createdTargetJSON = `{
+  "id": "11111111-1111-1111-1111-111111111111",
+  "tenant_id": "22222222-2222-2222-2222-222222222222",
+  "name": "rdc-vault",
+  "aliases": [],
+  "product": "vault",
+  "host": "vault.evba.lab",
+  "port": null,
+  "fqdn": null,
+  "auth_model": "shared_service_account",
+  "vpn_required": false,
+  "secret_ref": "tenants/22222222-2222-2222-2222-222222222222/rdc-vault",
+  "preferred_impl_id": null,
+  "fingerprint": null,
+  "notes": null,
+  "extras": {},
+  "tls_ca_pin": null,
+  "tls_server_name": null,
+  "verify_tls": true,
+  "version": null,
+  "deleted_at": null,
+  "created_at": "2026-08-17T12:00:00Z",
+  "updated_at": "2026-08-17T12:00:00Z"
+}`
+
+// runAddCmd drives a fresh `meho targets add` command end-to-end
+// through cobra (flag parsing, required-flag + ExactArgs validation,
+// RunE) with stdout/stderr buffers attached. When backplaneURL is set
+// it is appended as --backplane so the verb talks to the caller's
+// httptest server. Mirrors the newRunCmd helper but exercises the real
+// command wiring rather than a bare cobra.Command.
+func runAddCmd(t *testing.T, backplaneURL string, args ...string) (*bytes.Buffer, *bytes.Buffer, error) {
+	t.Helper()
+	cmd := newAddCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cmd.SetContext(ctx)
+	full := append([]string{}, args...)
+	if backplaneURL != "" {
+		full = append(full, "--backplane", backplaneURL)
+	}
+	cmd.SetArgs(full)
+	err := cmd.Execute()
+	return &stdout, &stderr, err
+}
+
+// TestNewAddCmdRegisteredWithCreateAlias pins the acceptance criterion
+// that newAddCmd() is grafted onto `meho targets` and carries the
+// documented `create` alias.
+func TestNewAddCmdRegisteredWithCreateAlias(t *testing.T) {
+	t.Parallel()
+	root := NewRootCmd()
+	var add *cobra.Command
+	for _, c := range root.Commands() {
+		if c.Name() == "add" {
+			add = c
+			break
+		}
+	}
+	if add == nil {
+		t.Fatalf("`meho targets add` not registered on the root command")
+	}
+	found := false
+	for _, a := range add.Aliases {
+		if a == "create" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected `create` alias on add; got %v", add.Aliases)
+	}
+}
+
+// TestAddHelpListsFlags asserts `meho targets add --help` surfaces the
+// full flag set mirroring TargetCreate, so operators discover the verb
+// from its help alone.
+func TestAddHelpListsFlags(t *testing.T) {
+	t.Parallel()
+	cmd := newAddCmd()
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"--help"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("`add --help`: %v", err)
+	}
+	help := buf.String()
+	for _, want := range []string{
+		"--product", "--host", "--alias", "--version", "--port", "--fqdn",
+		"--secret-ref", "--auth-model", "--verify-tls", "--tls-ca-pin",
+		"--tls-server-name", "--preferred-impl", "--note",
+	} {
+		if !strings.Contains(help, want) {
+			t.Errorf("`add --help` missing flag %q; got:\n%s", want, help)
+		}
+	}
+}
+
+// TestAddMissingRequiredFlags pins that --product and --host are
+// required: cobra rejects the invocation before RunE (no network), and
+// the error names the missing flag.
+func TestAddMissingRequiredFlags(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing product", []string{"rdc-vault", "--host", "vault.evba.lab"}, "product"},
+		{"missing host", []string{"rdc-vault", "--product", "vault"}, "host"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := newAddCmd()
+			var buf bytes.Buffer
+			cmd.SetOut(&buf)
+			cmd.SetErr(&buf)
+			cmd.SetArgs(c.args)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error when %s", c.name)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error %q should name the missing flag %q", err.Error(), c.want)
+			}
+		})
+	}
+}
+
+// TestAddSuccessRendersTargetAndOmitsTenantID is the happy path: a 201
+// with the created Target body renders the same key-value summary as
+// describe, the POST body carries the required fields, never carries
+// tenant_id (server binds it from the JWT), and omits every optional
+// the operator did not set.
+func TestAddSuccessRendersTargetAndOmitsTenantID(t *testing.T) {
+	// No t.Parallel(): seedXDGAndToken calls t.Setenv.
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("add issued %s; want POST", r.Method)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(raw, &gotBody); err != nil {
+			t.Errorf("request body is not JSON: %v (%s)", err, raw)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(createdTargetJSON))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	stdout, stderr, err := runAddCmd(t, srv.URL,
+		"rdc-vault", "--product", "vault", "--host", "vault.evba.lab")
+	if err != nil {
+		t.Fatalf("add: %v\nstderr=%s", err, stderr.String())
+	}
+
+	// Required fields present, tenant_id absent.
+	if gotBody["name"] != "rdc-vault" || gotBody["product"] != "vault" || gotBody["host"] != "vault.evba.lab" {
+		t.Errorf("request body missing required fields: %v", gotBody)
+	}
+	if _, leaked := gotBody["tenant_id"]; leaked {
+		t.Errorf("request body must never carry tenant_id: %v", gotBody)
+	}
+	// Unset optionals are omitted, not sent as JSON null — the
+	// omit-vs-null distinction is load-bearing for secret_ref (an
+	// omitted ref derives the per-tenant default; a null persists "no
+	// credential").
+	for _, k := range []string{"secret_ref", "aliases", "version", "port", "verify_tls", "notes"} {
+		if _, present := gotBody[k]; present {
+			t.Errorf("unset optional %q should be omitted from the body: %v", k, gotBody)
+		}
+	}
+
+	out := stdout.String()
+	for _, want := range []string{"rdc-vault", "vault", "vault.evba.lab", "shared_service_account"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout should render created-target field %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestAddSetOptionalsMapToSnakeCaseFields asserts every optional flag
+// the operator does set lands in the body under its snake_case
+// TargetCreate key with the right type (repeatable --alias → JSON
+// array, --port → number, --verify-tls=false → bool false).
+func TestAddSetOptionalsMapToSnakeCaseFields(t *testing.T) {
+	// No t.Parallel(): seedXDGAndToken calls t.Setenv.
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(createdTargetJSON))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	_, stderr, err := runAddCmd(t, srv.URL,
+		"rdc-vault", "--product", "vault", "--host", "vault.evba.lab",
+		"--alias", "vault-a", "--alias", "vault-b",
+		"--version", "1.x", "--port", "8200", "--fqdn", "vault.corp",
+		"--secret-ref", "tenants/22222222-2222-2222-2222-222222222222/rdc-vault",
+		"--auth-model", "shared_service_account", "--verify-tls=false",
+		"--tls-server-name", "vault.san", "--preferred-impl", "vault-1.x",
+		"--note", "primary lab vault")
+	if err != nil {
+		t.Fatalf("add with optionals: %v\nstderr=%s", err, stderr.String())
+	}
+
+	if aliases, ok := gotBody["aliases"].([]any); !ok || len(aliases) != 2 ||
+		aliases[0] != "vault-a" || aliases[1] != "vault-b" {
+		t.Errorf("aliases should be the two repeated values; got %v", gotBody["aliases"])
+	}
+	// JSON numbers decode to float64.
+	if p, ok := gotBody["port"].(float64); !ok || p != 8200 {
+		t.Errorf("port should be 8200; got %v", gotBody["port"])
+	}
+	if v, ok := gotBody["verify_tls"].(bool); !ok || v {
+		t.Errorf("verify_tls should be false; got %v", gotBody["verify_tls"])
+	}
+	for k, want := range map[string]any{
+		"version":           "1.x",
+		"fqdn":              "vault.corp",
+		"secret_ref":        "tenants/22222222-2222-2222-2222-222222222222/rdc-vault",
+		"auth_model":        "shared_service_account",
+		"tls_server_name":   "vault.san",
+		"preferred_impl_id": "vault-1.x",
+		"notes":             "primary lab vault",
+	} {
+		if gotBody[k] != want {
+			t.Errorf("body[%q]: got %v; want %v", k, gotBody[k], want)
+		}
+	}
+	// tenant_id is still never present, even on the fully-populated path.
+	if _, leaked := gotBody["tenant_id"]; leaked {
+		t.Errorf("request body must never carry tenant_id: %v", gotBody)
+	}
+}
+
+// TestAddServer422SurfacesBodyVerbatim pins that a server rejection
+// (unknown product, out-of-tenant secret_ref, SSRF-guarded host) is
+// surfaced to the operator with the response body intact and the
+// unexpected_response exit class (4) — the CLI runs no client-side
+// validation of its own.
+func TestAddServer422SurfacesBodyVerbatim(t *testing.T) {
+	// No t.Parallel(): seedXDGAndToken calls t.Setenv.
+	const detail = "unknown product 'nope'; known: vault, vcenter"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":"` + detail + `"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	_, stderr, err := runAddCmd(t, srv.URL,
+		"rdc-vault", "--product", "nope", "--host", "vault.evba.lab")
+	if err == nil {
+		t.Fatalf("expected a non-nil error on 422")
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 4 {
+		t.Errorf("422 should classify as unexpected_response (exit 4); got %v", err)
+	}
+	if !strings.Contains(stderr.String(), detail) {
+		t.Errorf("stderr should surface the 422 body verbatim; got:\n%s", stderr.String())
+	}
+}

--- a/cli/internal/cmd/targets/targets.go
+++ b/cli/internal/cmd/targets/targets.go
@@ -3,8 +3,15 @@
 
 // Package targets hosts the cobra commands under `meho targets ...`
 // for Initiative #224's targets registry (G0.3-T5 / Task #256 +
-// G0.3-T6 / Task #257). v0.2 ships three operator-facing read verbs
-// plus a bulk-import migration tool:
+// G0.3-T6 / Task #257). v0.2 ships a single-target `add` write verb,
+// three operator-facing read verbs, and a bulk-import migration tool:
+//
+//   - `meho targets add <name> --product P --host H [optional flags]`
+//     (alias `create`; Task #2862) — POST /api/v1/targets for one
+//     target. The single-target counterpart to `import`: reuses the
+//     same authed POST plumbing, sends only the flags the operator
+//     set (so server defaults apply), renders the created row like
+//     `describe`, and keeps all validation server-side.
 //
 //   - `meho targets list [--product P] [--json]` —
 //     GET /api/v1/targets, keyset-paginated, optionally narrowed by
@@ -53,9 +60,11 @@
 // token meho login wrote — same pattern as `meho operation` and
 // `meho retrieval eval`.
 //
-// Write verbs (`create` / `update` / `delete`) are out of scope for
-// v0.2 per the issue body — operators use `import --update` for
-// bulk reconciliation.
+// Single-target create ships as `meho targets add <name>` (alias
+// `create`; Task #2862) — see add.go, which reuses import.go's
+// `doAuthedRequest` POST plumbing. The remaining write verbs
+// (`update` / `delete`) stay out of scope; operators use
+// `import --update` for bulk reconciliation.
 package targets
 
 import (
@@ -82,10 +91,11 @@ import (
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "targets",
-		Short:        "Operate the MEHO targets registry (list / describe / probe / import / discover)",
-		Long:         "List, describe, probe, bulk-import, and discover candidate targets in the operator's tenant.",
+		Short:        "Operate the MEHO targets registry (add / list / describe / probe / import / discover)",
+		Long:         "Add, list, describe, probe, bulk-import, and discover targets in the operator's tenant.",
 		SilenceUsage: true,
 	}
+	cmd.AddCommand(newAddCmd())
 	cmd.AddCommand(newListCmd())
 	cmd.AddCommand(newDescribeCmd())
 	cmd.AddCommand(newProbeCmd())

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -1088,13 +1088,34 @@ verb. The verbs are the operator-side surface for the per-tenant
 operator manages (vCenter hosts, Vault instances, k8s clusters, …)
 that the G0.6 dispatcher resolves at `call` time. Registration and
 updates flow through `meho targets import` (POST for new rows, PATCH
-under `--update`); a standalone `create` verb was explicitly ruled out
-in favour of file-based import (#1574 / #1559). No standalone `delete`
-verb is surfaced yet, though the API supports `DELETE
-/api/v1/targets/{name}` (`tenant_admin`).
+under `--update`) for bulk reconciliation, or through `meho targets
+add` (Task #2862) for a single target without authoring a YAML file —
+the earlier blanket deferral of a standalone `create` verb (#1574 /
+#1559) is lifted for the single-target create case only. No standalone
+`update` / `delete` verb is surfaced yet, though the API supports
+`PATCH` / `DELETE /api/v1/targets/{name}` (`tenant_admin`).
 
 ### Subcommands
 
+- `meho targets add <name> --product P --host H [optional flags]`
+  (alias `create`) — calls `POST /api/v1/targets` to register one
+  target, the single-target counterpart to `import`. `--product` and
+  `--host` are required; `<name>` is the positional canonical name.
+  The optional flags mirror the `TargetCreate` fields one-for-one
+  (`--alias` repeatable, `--version`, `--port`, `--fqdn`,
+  `--secret-ref`, `--auth-model`, `--verify-tls`, `--tls-ca-pin`,
+  `--tls-server-name`, `--preferred-impl`, `--note`) and are sent only
+  when set, so the server's defaults apply to the rest — notably an
+  omitted `--secret-ref` derives the per-tenant default credential path
+  (#1723) rather than persisting "no credential". `tenant_id` is never
+  sent; the backplane binds it from the operator's JWT. All validation
+  stays server-side: an unknown product, an out-of-tenant `secret_ref`,
+  or an SSRF-guarded host come back as a 422 whose body the CLI prints
+  verbatim. On 201 the created row renders in the same shape as
+  `describe` (`--json` for the raw `Target`). The verb reuses
+  `import.go`'s `doAuthedRequest` POST plumbing, so a static-bearer
+  escape hatch is deliberately **not** offered — auth stays interactive
+  `meho login` only.
 - `meho targets list [--product P] [--limit N] [--cursor C]` — calls
   `GET /api/v1/targets`. Renders the operator's tenant-scoped targets
   as a `NAME / ALIASES / PRODUCT / HOST` table. Results are keyset-
@@ -1137,7 +1158,8 @@ verb is surfaced yet, though the API supports `DELETE
 ### Reserved flags (same shape across the verbs)
 
 - `--json` — emit the raw JSON envelope to stdout instead of the human
-  render. Stable schemas: `list` → `[]TargetSummary`; `describe` →
+  render. Stable schemas: `add` → full `Target` (the created row);
+  `list` → `[]TargetSummary`; `describe` →
   full `Target` (including `fingerprint` + `preferred_impl_id`);
   `probe` → `FingerprintResult`; `discover` →
   `DiscoverResult` (`discovered` + `skipped`).
@@ -1159,11 +1181,18 @@ structured `{"error": "no_target", "query": "...", "matches": [...]}`
 envelope, 409 carries `ambiguous_target` with colliding names, and
 501 carries the "no connector registered" detail.
 
-`import` keeps its own untyped HTTP plumbing
-(`doAuthedRequest` / `httpDoer` / local `httpError`) in `import.go`
-because the YAML-to-API mapping emits a sparse `map[string]any`
-body to preserve the partial-PATCH + extras-spill semantics — see
-the comment block on `httpDoer` for the rationale.
+`import` and `add` keep the untyped HTTP plumbing
+(`doAuthedRequest` / `httpDoer` / local `httpError`) in `import.go`.
+`import` needs it because the YAML-to-API mapping emits a sparse
+`map[string]any` body to preserve the partial-PATCH + extras-spill
+semantics — see the comment block on `httpDoer` for the rationale.
+`add` reuses the same `doAuthedRequest` POST path and builds its body
+as a `map[string]any` holding only the flags the operator set, so an
+unset optional is omitted rather than sent as JSON null (load-bearing
+for `secret_ref`, whose omitted-vs-null distinction the server keys on
+via `model_fields_set`). Both route non-2xx responses through the
+shared `renderHTTPStatus` ladder, so a 422 body reaches the operator
+verbatim.
 
 ### Exit codes
 
@@ -1180,11 +1209,11 @@ the comment block on `httpDoer` for the rationale.
 
 ### Out of scope (v0.2)
 
-- Standalone `delete` verb. The API supports `DELETE
-  /api/v1/targets/{name}` (`tenant_admin`); the CLI surfaces it in a
-  follow-up task when operators ask. Create and update are already
-  covered by `meho targets import` (POST for new rows, PATCH under
-  `--update`), so no separate `create` / `update` verb is planned.
+- Standalone `update` / `delete` verbs. The API supports `PATCH` /
+  `DELETE /api/v1/targets/{name}` (`tenant_admin`); the CLI surfaces
+  them in a follow-up task when operators ask. Single-target **create**
+  now ships as `meho targets add` (Task #2862); bulk reconciliation of
+  updates stays with `meho targets import --update`.
 - Auto-completion of target names. Operators type names; tab-completion
   would need a separate `cobra-complete`-style design pass.
 - Client-side caching. Every CLI invocation hits the API fresh — the


### PR DESCRIPTION
## Summary

- Adds `meho targets add <name>` (alias `create`) — register a single target from the CLI without hand-authoring a `targets.yaml` + `import`, or curling the REST route.
- POSTs one `TargetCreate` to `POST /api/v1/targets` (the route `import` drives per new row), reusing `import.go`'s `doAuthedRequest` plumbing (bearer + one-shot 401-refresh-retry). On 201 it renders the created row exactly like `meho targets describe`; a 422 (unknown product, out-of-tenant `secret_ref`, SSRF-guarded host) surfaces the server's error body verbatim.
- `--product` and `--host` are required; `<name>` is positional (`ExactArgs(1)`). Optional flags mirror the `TargetCreate` fields one-for-one: `--alias` (repeatable), `--version`, `--port`, `--fqdn`, `--secret-ref`, `--auth-model`, `--verify-tls`, `--tls-ca-pin`, `--tls-server-name`, `--preferred-impl`, `--note` (plus the two cross-verb reserved flags `--backplane` / `--json`, present on every targets verb).
- All validation stays server-side; `tenant_id` is **never** sent (the backplane binds it from the JWT; `TargetCreate` has no `tenant_id` field). No static-bearer escape hatch is added — auth stays interactive `meho login` only (explicit out-of-scope guard from the issue).

## Key design decision — omit-vs-null body

The request body is a `map[string]any` (mirroring `import`'s `entryToCreateBody`) holding **only the flags the operator set**, so unset optionals are omitted rather than serialised as JSON `null`. This is load-bearing for `secret_ref`: the server's `_resolve_create_secret_ref` keys on Pydantic `model_fields_set`, so an *omitted* ref derives the per-tenant default `tenants/<tenant_id>/<name>` (#1723) while an *explicit null* would persist "no credential" (#2872). A typed `api.TargetCreate` struct would serialise the no-`omitempty` `secret_ref` field as `null` and silently pick the wrong branch — hence the untyped map. It also makes "`tenant_id` never sent" structural.

## Test plan

- [x] `gofmt -l` — clean (both new files)
- [x] `go build ./...` — clean
- [x] `go vet ./internal/cmd/targets/...` — clean
- [x] `golangci-lint run ./internal/cmd/targets/...` — 0 issues
- [x] `go test -race -cover ./...` — all packages pass; `targets` 85.5% coverage
- [x] `.claude/hooks/code-quality.py --diff` — pass (no agent-introduced violations)
- [x] AC — `newAddCmd()` registered + `create` alias; `add --help` lists all flags; `--product`/`--host` required, `<name>` `ExactArgs(1)` (`TestNewAddCmdRegisteredWithCreateAlias`, `TestAddHelpListsFlags`, `TestAddMissingRequiredFlags`)
- [x] AC — 201 prints created target; 422 surfaces body verbatim; body omits `tenant_id`; set optionals map to snake_case keys (`TestAddSuccessRendersTargetAndOmitsTenantID`, `TestAddSetOptionalsMapToSnakeCaseFields`, `TestAddServer422SurfacesBodyVerbatim` — all httptest-server driven, mirroring `import_test.go`)
- [x] AC — `targets.go` "write verbs out of scope" comment updated; parent help + `docs/codebase/cli.md` updated
- [x] AC — OpenAPI snapshot: no client-contract change (consumes the existing `POST /api/v1/targets` route + existing `api.Target`), so `make snapshot-openapi`/`generate` is a no-op — generated client + `openapi.json` untouched

## Out of scope / adjacent findings

- `update` / `delete` verbs remain deferred (this Task is single-target create only).
- The sibling `meho_targets_register` MCP tool (#2861) and the k8s connector surface (#2860) are separate Tasks under Goal #221; this PR touches only `cli/internal/cmd/targets/`.
- **409 duplicate-name rendering**: a duplicate `<name>` hits the server 409, which routes through the shared `renderHTTPStatus` 409 branch and renders as `Ambiguous query: target '<n>' already exists in tenant`. The server's "already exists" detail is present, but the "Ambiguous query" prefix (correct for the read verbs' resolver-ambiguity 409) reads oddly here. Left consistent with the shared error ladder per the issue's "reuse import.go's path" instruction rather than special-casing one verb; noted for a possible follow-up.

Closes #2862
