### PR TITLE
feat(connectors): source k8s.secret.create values from Vault/GSM refs

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/ops_write_dangerous.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_write_dangerous.py
@@ -48,11 +48,18 @@ References
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 import yaml
 from kubernetes_asyncio import client
 from kubernetes_asyncio.dynamic import DynamicClient
+
+from meho_backplane.connectors._shared.vault_creds import (
+    DEFAULT_KV_MOUNT,
+    load_vault_secret_data,
+    strip_credential_value,
+)
 
 if TYPE_CHECKING:
     from meho_backplane.auth.operator import Operator
@@ -63,6 +70,7 @@ __all__ = [
     "DELETABLE_KINDS",
     "FIELD_MANAGER",
     "ApplyManifestError",
+    "KubernetesSecretRefError",
     "UndeletableKindError",
     "k8s_apply",
     "k8s_delete",
@@ -105,6 +113,19 @@ class ApplyManifestError(ValueError):
 
 class UndeletableKindError(ValueError):
     """The requested delete kind is outside the v1 pod/job/replicaset scope."""
+
+
+class KubernetesSecretRefError(ValueError):
+    """A ``*_secret_ref`` entry could not be resolved to a usable value.
+
+    Raised when a ref's resolved credential payload lacks the requested
+    field or carries a non-string / empty value. The message names the
+    Secret key + the resolved field (never the value), mirroring keycloak's
+    ``KeycloakPasswordSecretError``. Subclasses :class:`ValueError` so the
+    dispatcher's ``connector_error`` envelope tags
+    ``extras.exception_class="KubernetesSecretRefError"``, like the sibling
+    manifest / kind errors above.
+    """
 
 
 def _parse_manifest(manifest: str) -> list[dict[str, Any]]:
@@ -272,6 +293,73 @@ async def k8s_delete(
     }
 
 
+@dataclass(slots=True)
+class _SecretRefTarget:
+    """Adapter presenting one per-key secret ref to the credential seam.
+
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`
+    reads its ``secret_ref`` off a
+    :class:`~meho_backplane.connectors._shared.vault_creds.BasicCredentialsTargetLike`
+    (``name`` / ``host`` / ``secret_ref``). A ``k8s.secret.create`` ref
+    lives per Secret key in the op params, not at the connector target's
+    ``secret_ref`` -- so this adapter carries the connector target's
+    ``name`` / ``host`` for log + error attribution while pointing the seam
+    at the per-key ref (mirrors keycloak's ``_PasswordSecretTarget``).
+    """
+
+    name: str
+    host: str
+    secret_ref: str | None
+
+
+async def _resolve_secret_refs(
+    operator: Operator,
+    target: KubernetesTargetLike,
+    refs: dict[str, str],
+    *,
+    mount: str,
+) -> dict[str, str]:
+    """Resolve a ``{secret-key: ref}`` map to ``{secret-key: value}``.
+
+    Each ref is read under the operator's identity through the
+    credential-backend seam
+    (:func:`~meho_backplane.connectors._shared.vault_creds.load_vault_secret_data`,
+    the same seam the kubeconfig loader rides). The value NEVER transits the
+    op params -- only the ref does -- so a Vault/GSM-resident secret
+    materialises into the Secret without ever entering the caller's context
+    (mirrors keycloak's ``password_secret_ref``, #2401).
+
+    A ref may carry a trailing ``#<field>`` fragment naming which field of
+    the resolved payload to use; it defaults to the Secret key. The fragment
+    is split off **here**, before the seam read, because a Vault KV-v2 path
+    cannot carry a ``#`` (hvac would build a ``/data/<path>#<field>`` URL and
+    404) -- so the caller, not the backend, owns fragment->field selection,
+    uniformly for the ``vault:`` and ``gsm:`` schemes the issue's grammar
+    (``{key: "<scheme>:<path>#<field>"}``) spans.
+    """
+    resolved: dict[str, str] = {}
+    for secret_key, raw_ref in refs.items():
+        body, sep, fragment = str(raw_ref).rpartition("#")
+        store_ref = body.strip() if sep else str(raw_ref).strip()
+        field = fragment.strip() if (sep and fragment.strip()) else secret_key
+        payload = await load_vault_secret_data(
+            _SecretRefTarget(name=target.name, host=target.host, secret_ref=store_ref),
+            operator,
+            mount=mount,
+        )
+        value = payload.get(field) if isinstance(payload, dict) else None
+        stripped = strip_credential_value(value) if isinstance(value, str) else None
+        if not stripped:
+            raise KubernetesSecretRefError(
+                f"k8s.secret.create secret_ref for key {secret_key!r} (ref={store_ref!r}) "
+                f"carries no usable string value under field {field!r}. Store the value "
+                f"under that field (or name it with a '#field' fragment) so the Secret "
+                f"can source it without the value ever appearing in op params."
+            )
+        resolved[secret_key] = stripped
+    return resolved
+
+
 def secret_create_summary(
     name: str, namespace: str, secret_type: str, data_keys: list[str]
 ) -> dict[str, Any]:
@@ -302,17 +390,46 @@ async def k8s_secret_create(
     """Handler for ``k8s.secret.create`` -- create an Opaque (or typed) Secret.
 
     Accepts ``string_data`` (plaintext, base64-encoded by the API server)
-    and/or ``data`` (already base64-encoded). The values are written to
-    the cluster but never echoed back: the response is
+    and/or ``data`` (already base64-encoded), inline and/or by reference.
+    The ``string_data_secret_ref`` / ``data_secret_ref`` maps
+    (``{secret-key: "<scheme>:<path>#<field>"}``) are resolved server-side
+    through the credential-backend seam (:func:`_resolve_secret_refs`) and
+    merged into the respective inline map -- so a Vault/GSM-resident value
+    materialises into the Secret without the value ever transiting the op
+    params (mirrors keycloak's ``password_secret_ref``, #2401). The values
+    are written to the cluster but never echoed back: the response is
     :func:`secret_create_summary` (key names only). The op classifies
     ``credential_write`` so the broadcast event collapses to
-    aggregate-only -- the values in ``params`` never reach the feed.
+    aggregate-only -- the refs in ``params`` never reach the feed either.
     """
     name: str = params["name"]
     namespace: str = params["namespace"]
     secret_type: str = params.get("type", "Opaque")
     string_data: dict[str, str] = dict(params.get("string_data") or {})
     data: dict[str, str] = dict(params.get("data") or {})
+
+    # Resolve ref-valued siblings server-side and merge over the inline maps.
+    # Only the ref transits op params; the value materialises in-process.
+    string_ref = params.get("string_data_secret_ref")
+    if string_ref:
+        string_data.update(
+            await _resolve_secret_refs(
+                operator,
+                target,
+                dict(string_ref),
+                mount=str(params.get("string_data_secret_mount") or DEFAULT_KV_MOUNT).strip(),
+            )
+        )
+    data_ref = params.get("data_secret_ref")
+    if data_ref:
+        data.update(
+            await _resolve_secret_refs(
+                operator,
+                target,
+                dict(data_ref),
+                mount=str(params.get("data_secret_mount") or DEFAULT_KV_MOUNT).strip(),
+            )
+        )
 
     api_client = await connector._get_api_client(target, operator)
     core_v1 = client.CoreV1Api(api_client)

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_write_meta.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_write_meta.py
@@ -420,9 +420,47 @@ _SECRET_CREATE_SCHEMA: dict[str, Any] = {
             "additionalProperties": {"type": "string"},
             "description": "Already-base64-encoded key→value map.",
         },
+        "string_data_secret_ref": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "description": (
+                "Map {secret-key: '<scheme>:<path>#<field>'} resolved server-side under "
+                "your identity via the credential-backend seam and merged into string_data "
+                "(plaintext). The value NEVER transits op params — only the ref does. The "
+                "optional '#field' fragment names the payload field (defaults to the "
+                "secret-key). Schemeless/'vault:' → Vault KV-v2 (logical path, no mount "
+                "prefix); 'gsm:' → GCP Secret Manager."
+            ),
+        },
+        "string_data_secret_mount": {
+            "type": "string",
+            "description": (
+                "Vault KV-v2 mount for string_data_secret_ref reads (default 'secret'; "
+                "backends without a mount concept, e.g. GSM, ignore it)."
+            ),
+        },
+        "data_secret_ref": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "description": (
+                "Like string_data_secret_ref, but the resolved values are already base64 "
+                "and merged into data. Resolved server-side; never transits op params."
+            ),
+        },
+        "data_secret_mount": {
+            "type": "string",
+            "description": (
+                "Vault KV-v2 mount for data_secret_ref reads (default 'secret'; GSM ignores)."
+            ),
+        },
     },
     "required": ["name", "namespace"],
-    "anyOf": [{"required": ["string_data"]}, {"required": ["data"]}],
+    "anyOf": [
+        {"required": ["string_data"]},
+        {"required": ["data"]},
+        {"required": ["string_data_secret_ref"]},
+        {"required": ["data_secret_ref"]},
+    ],
     "additionalProperties": False,
 }
 
@@ -480,8 +518,11 @@ _DELETE_LLM: dict[str, Any] = {
 _SECRET_CREATE_LLM: dict[str, Any] = {
     "when_to_use": (
         "Create a Secret. Pass plaintext under string_data (API encodes) or "
-        "pre-encoded under data. Values are NEVER echoed back or broadcast "
-        "(credential_write redaction). Requires approval."
+        "pre-encoded under data. For a Vault/GSM-resident value, pass "
+        "string_data_secret_ref / data_secret_ref (a "
+        "{key: '<scheme>:<path>#<field>'} map) so the value is read "
+        "server-side and NEVER transits op params. Values are NEVER echoed "
+        "back or broadcast (credential_write redaction). Requires approval."
     ),
     "parameter_hints": {
         "name": "Secret name.",
@@ -489,6 +530,12 @@ _SECRET_CREATE_LLM: dict[str, Any] = {
         "type": "Opaque by default.",
         "string_data": "Plaintext key→value.",
         "data": "Base64-encoded key→value.",
+        "string_data_secret_ref": (
+            "{key: '<scheme>:<path>#<field>'} → resolved server-side into string_data."
+        ),
+        "data_secret_ref": (
+            "{key: '<scheme>:<path>#<field>'} → resolved server-side into data (base64)."
+        ),
     },
     "output_shape": "{name, namespace, type, data_keys, created} -- key names only, no values.",
 }
@@ -553,10 +600,14 @@ WRITE_DANGEROUS_OPS: tuple[KubernetesOp, ...] = (
         summary="Create a Secret; values are redacted from audit + broadcast.",
         description=(
             "Creates a Secret from string_data (plaintext) and/or data "
-            "(base64). The values are written to the cluster but never "
-            "echoed back -- the response is key-names-only -- and the op "
-            "classifies credential_write so the broadcast collapses to "
-            "aggregate-only. Requires approval."
+            "(base64), inline and/or by reference. string_data_secret_ref / "
+            "data_secret_ref ({key: '<scheme>:<path>#<field>'} maps) are "
+            "resolved server-side through the credential-backend seam and "
+            "merged in, so a Vault/GSM-resident value never transits op "
+            "params. The values are written to the cluster but never echoed "
+            "back -- the response is key-names-only -- and the op classifies "
+            "credential_write so the broadcast collapses to aggregate-only. "
+            "Requires approval."
         ),
         parameter_schema=_SECRET_CREATE_SCHEMA,
         response_schema=None,

--- a/backend/tests/test_connectors_k8s_write.py
+++ b/backend/tests/test_connectors_k8s_write.py
@@ -37,6 +37,7 @@ from kubernetes_asyncio.client.exceptions import ApiException
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast.events import classify_op, redact_payload
+from meho_backplane.connectors._shared import credential_backend as cb
 from meho_backplane.connectors.kubernetes import (
     KUBERNETES_OPS,
     KubernetesConnector,
@@ -45,6 +46,7 @@ from meho_backplane.connectors.kubernetes import (
 from meho_backplane.connectors.kubernetes.ops_write import UnsupportedKindError
 from meho_backplane.connectors.kubernetes.ops_write_dangerous import (
     ApplyManifestError,
+    KubernetesSecretRefError,
     UndeletableKindError,
     secret_create_summary,
 )
@@ -58,6 +60,8 @@ from meho_backplane.connectors.registry import (
     register_connector_v2,
 )
 from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
 
 # ---------------------------------------------------------------------------
 # Fixtures (mirror test_connectors_k8s_workload.py)
@@ -733,6 +737,214 @@ def test_secret_create_summary_helper_is_value_free() -> None:
     summary = secret_create_summary("s", "ns", "Opaque", ["b", "a"])
     assert summary["data_keys"] == ["a", "b"]
     assert "value" not in str(summary).lower() or "data_keys" in summary
+
+
+# ---------------------------------------------------------------------------
+# k8s.secret.create — credential-backend ref resolution (#2860)
+# ---------------------------------------------------------------------------
+
+#: The sentinel a ref resolves to. The whole point of the security assertion
+#: is that this string reaches the cluster but never the op params, the
+#: return value, or (via the credential_write pin) the broadcast.
+_SECRET_REF_SENTINEL = "vault-sourced-secret-DO-NOT-LEAK"
+
+
+def _core_v1_patch() -> Any:
+    return patch("meho_backplane.connectors.kubernetes.ops_write_dangerous.client.CoreV1Api")
+
+
+def test_secret_create_schema_exposes_ref_params_and_widened_anyof() -> None:
+    """Schema gains the four ref params; anyOf accepts inline-only, ref-only,
+    or both; additionalProperties stays closed (AC #1)."""
+    op = next(o for o in WRITE_DANGEROUS_OPS if o.op_id == "k8s.secret.create")
+    props = op.parameter_schema["properties"]
+    for key in (
+        "string_data_secret_ref",
+        "string_data_secret_mount",
+        "data_secret_ref",
+        "data_secret_mount",
+    ):
+        assert key in props, f"schema missing {key}"
+    required_sets = [set(clause["required"]) for clause in op.parameter_schema["anyOf"]]
+    assert {"string_data"} in required_sets
+    assert {"data"} in required_sets
+    assert {"string_data_secret_ref"} in required_sets
+    assert {"data_secret_ref"} in required_sets
+    assert op.parameter_schema["additionalProperties"] is False
+
+
+@pytest.mark.asyncio
+async def test_secret_create_resolves_vault_ref_never_leaks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A string_data_secret_ref is resolved server-side through the seam; the
+    value reaches the cluster but never the op params or the return value
+    (AC #2, #3) — mirrors keycloak's password_secret_ref test."""
+    fake = install_fake_client(monkeypatch, secret={"token": _SECRET_REF_SENTINEL})
+    conn = _make_connector()
+    operator = _make_operator()
+    params = {
+        "name": "argocd-spoke",
+        "namespace": "argocd",
+        "string_data_secret_ref": {"bearer": "argocd/rke2-mgmt#token"},
+    }
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.create_namespaced_secret = AsyncMock()
+        result = await conn.k8s_secret_create(operator=operator, target=_TARGET, params=params)
+    # The resolved value reached the cluster (the whole point) ...
+    body = core_cls.return_value.create_namespaced_secret.call_args.kwargs["body"]
+    assert body.string_data == {"bearer": _SECRET_REF_SENTINEL}
+    # ... but the response is key-names-only, and the value appears nowhere in
+    # the op params (what the audit row hashes) nor in the return value.
+    assert result["data_keys"] == ["bearer"]
+    assert _SECRET_REF_SENTINEL not in str(result)
+    assert _SECRET_REF_SENTINEL not in str(params)
+    # The KV-v2 read ran under the operator's own JWT (operator-context read),
+    # against the scheme-stripped, fragment-stripped logical path.
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == operator.raw_jwt
+    assert fake.secrets.kv.v2.read_calls[-1]["path"] == "argocd/rke2-mgmt"
+
+
+@pytest.mark.asyncio
+async def test_secret_create_multi_key_refs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two refs resolve into one Secret with two keys — the ArgoCD token+CA
+    shape the issue calls out (AC #4)."""
+    install_fake_client(monkeypatch, secret={"bearer": "TOKEN-VAL", "ca": "CA-VAL"})
+    conn = _make_connector()
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.create_namespaced_secret = AsyncMock()
+        result = await conn.k8s_secret_create(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={
+                "name": "argocd-spoke",
+                "namespace": "argocd",
+                "string_data_secret_ref": {
+                    "token": "argocd/rke2-mgmt#bearer",
+                    "ca.crt": "argocd/rke2-mgmt#ca",
+                },
+            },
+        )
+    body = core_cls.return_value.create_namespaced_secret.call_args.kwargs["body"]
+    assert body.string_data == {"token": "TOKEN-VAL", "ca.crt": "CA-VAL"}
+    assert result["data_keys"] == ["ca.crt", "token"]
+
+
+@pytest.mark.asyncio
+async def test_secret_create_inline_and_ref_merged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inline string_data and a ref map merge into one Secret (AC #4)."""
+    install_fake_client(monkeypatch, secret={"password": "REF-PW"})
+    conn = _make_connector()
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.create_namespaced_secret = AsyncMock()
+        result = await conn.k8s_secret_create(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={
+                "name": "db-creds",
+                "namespace": "argocd",
+                "string_data": {"username": "admin"},
+                "string_data_secret_ref": {"password": "db/creds#password"},
+            },
+        )
+    body = core_cls.return_value.create_namespaced_secret.call_args.kwargs["body"]
+    assert body.string_data == {"username": "admin", "password": "REF-PW"}
+    assert result["data_keys"] == ["password", "username"]
+
+
+@pytest.mark.asyncio
+async def test_secret_create_data_secret_ref_merges_into_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """data_secret_ref resolves into the base64 `data` map, not string_data."""
+    install_fake_client(monkeypatch, secret={"dockercfg": "eyJhdXRocyI6e319"})
+    conn = _make_connector()
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.create_namespaced_secret = AsyncMock()
+        await conn.k8s_secret_create(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={
+                "name": "regcred",
+                "namespace": "argocd",
+                "type": "kubernetes.io/dockerconfigjson",
+                "data_secret_ref": {".dockerconfigjson": "registry/pull#dockercfg"},
+            },
+        )
+    body = core_cls.return_value.create_namespaced_secret.call_args.kwargs["body"]
+    assert body.data == {".dockerconfigjson": "eyJhdXRocyI6e319"}
+    assert body.string_data is None
+
+
+@pytest.mark.asyncio
+async def test_secret_create_gsm_ref_resolves_through_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A gsm: ref routes through the seam's scheme dispatch to the gsm backend,
+    never a Vault read — backend-agnostic parity with keycloak (AC #5)."""
+    vault_fake = install_fake_client(monkeypatch, secret={"token": "SHOULD-NOT-BE-READ"})
+
+    class _FakeGsmBackend:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def load_secret_data(
+            self,
+            secret_ref: str,
+            operator: Operator,
+            *,
+            target_name: str,
+            mount: str,
+        ) -> dict[str, object]:
+            del operator, mount
+            self.calls.append({"secret_ref": secret_ref, "target_name": target_name})
+            return {"token": "GSM-TOKEN"}
+
+    fake_backend = _FakeGsmBackend()
+    monkeypatch.setitem(cb.CREDENTIAL_BACKEND_REGISTRY, "gsm", fake_backend)
+
+    conn = _make_connector()
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.create_namespaced_secret = AsyncMock()
+        await conn.k8s_secret_create(
+            operator=_make_operator(),
+            target=_TARGET,
+            params={
+                "name": "argocd-spoke",
+                "namespace": "argocd",
+                "string_data_secret_ref": {"bearer": "gsm:my-project/argocd-token#token"},
+            },
+        )
+    body = core_cls.return_value.create_namespaced_secret.call_args.kwargs["body"]
+    assert body.string_data == {"bearer": "GSM-TOKEN"}
+    # Dispatched to the gsm backend with the scheme stripped and the fragment
+    # removed (the caller owns fragment->field selection, uniformly).
+    assert fake_backend.calls[-1]["secret_ref"] == "my-project/argocd-token"
+    # Vault was never touched — the ref was not treated as a KV-v2 path.
+    assert vault_fake.secrets.kv.v2.read_calls == []
+    assert vault_fake.auth.jwt.login_calls == []
+
+
+@pytest.mark.asyncio
+async def test_secret_create_ref_missing_field_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ref whose resolved payload lacks the requested field raises a clear,
+    value-free error (never a bare KeyError)."""
+    install_fake_client(monkeypatch, secret={"other": "x"})
+    conn = _make_connector()
+    with _patch_kubeconfig(), _core_v1_patch() as core_cls:
+        core_cls.return_value.create_namespaced_secret = AsyncMock()
+        with pytest.raises(KubernetesSecretRefError, match="no usable string value"):
+            await conn.k8s_secret_create(
+                operator=_make_operator(),
+                target=_TARGET,
+                params={
+                    "name": "x",
+                    "namespace": "argocd",
+                    "string_data_secret_ref": {"token": "argocd/spoke#token"},
+                },
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -246,7 +246,7 @@ the same pattern `ops_workload.py` / `ops_logs.py` use. Every op is
 | `k8s.cordon`           | caution   | `CoreV1Api.patch_node(spec.unschedulable)`; `uncordon=true` reverses. Eviction-free. |
 | `k8s.apply`            | dangerous | Server-side apply over `DynamicClient.server_side_apply` (`field_manager="meho"`), GVK resolved per manifest doc from discovery. `dry_run="server"` -> API `?dryRun=All` (mutates nothing, returns the would-be object). |
 | `k8s.delete`           | dangerous | Kind dispatch **scoped to pod/job/replicaset in v1** (namespace/PVC/PV rejected); explicit `propagation_policy` / `grace_period_seconds`. |
-| `k8s.secret.create`    | dangerous | `CoreV1Api.create_namespaced_secret`; values written but never echoed (response is key-names only). |
+| `k8s.secret.create`    | dangerous | `CoreV1Api.create_namespaced_secret`; values written but never echoed (response is key-names only). Values may be inline (`string_data` / `data`) or ref-sourced (`string_data_secret_ref` / `data_secret_ref`, resolved server-side through the credential-backend seam). |
 | `k8s.job.create`       | dangerous | `BatchV1Api.create_namespaced_job` from a spec body; response is identity only. |
 
 **Secret redaction reuses the shipped `credential_write` op-class
@@ -258,6 +258,43 @@ material in `params`). `classify_op` returns `credential_write`, so
 `{op_class, result_status}` -- the secret never reaches the SSE stream or
 a Slack mirror. The handlers also return value-free summaries, so the
 `OperationResult` itself carries no secret.
+
+**`k8s.secret.create` ref-valued params (#2860).** Redaction keeps a
+secret off audit/broadcast once it is *in* `params`, but an agent driving
+the op still had to put the value there -- and an inline value transits
+the caller's context (the model API) before MEHO ever sees it. To close
+that leak vector, `k8s.secret.create` accepts ref-valued siblings that are
+resolved **server-side, mid-dispatch**, so a Vault/GSM-resident value
+materialises into the Secret without the value ever entering the caller's
+context (the same pattern as keycloak's `password_secret_ref`, #2401):
+
+- `string_data_secret_ref` / `data_secret_ref` -- a
+  `{secret-key: "<scheme>:<vault-or-gsm-path>#<field>"}` map. Each ref is
+  read under the operator's identity via
+  [`load_vault_secret_data`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py)
+  (the same credential-backend seam the kubeconfig loader rides -- no new
+  connector dependency), and the resolved key/value is merged into
+  `string_data` (plaintext) / `data` (base64) respectively.
+- `string_data_secret_mount` / `data_secret_mount` -- the Vault KV-v2
+  mount for the corresponding ref map (default `secret`; backends without
+  a mount concept, e.g. GSM, ignore it).
+- The `anyOf` widens so a call may supply inline maps, ref maps, or both
+  (merged into one Secret; refs win a key collision). Multi-key Secrets
+  (the ArgoCD spoke token + CA case) work natively -- one ref per key.
+- The optional `#<field>` fragment on a ref names which field of the
+  resolved payload to use (default: the Secret key). It is split off in
+  the connector *before* the seam read -- a Vault KV-v2 path cannot carry
+  a `#` (hvac would 404), so the caller owns fragment->field selection
+  uniformly across the `vault:` and `gsm:` schemes. Backend-agnostic for
+  free: the seam dispatches on scheme, so a `gsm:` ref resolves on a GSM
+  deployment with no extra connector code.
+
+The redaction above is unchanged and still applies: the op stays pinned in
+`_CREDENTIAL_WRITE_OPS`, and only the *ref* (never a value) is ever in
+`params`, so the audit row hashes a path and the broadcast stays
+aggregate-only. A resolved payload missing the requested field raises
+`KubernetesSecretRefError` (never a bare `KeyError`, never echoing a
+value).
 
 **`k8s.apply` dry-run preview.** The op supports `dry_run="server"` (maps
 to the API's `?dryRun=All`) so the would-be object is returned without


### PR DESCRIPTION
## Summary

- `k8s.secret.create` gains ref-valued sibling params — `string_data_secret_ref` / `data_secret_ref` (`{secret-key: "<scheme>:<path>#<field>"}` maps) plus the `*_secret_mount` companions — so a Vault/GSM-resident Secret payload materialises **server-side, mid-dispatch**, without the value ever transiting the caller's (agent) context. Closes the last leak vector on this op: redaction already keeps a value off audit/broadcast once it is *in* params, but an agent still had to read the value out and pass it inline, landing plaintext in the transcript sent to the model API before MEHO saw it. Recurring case: ArgoCD spoke registration (token + CA from Vault), consumer signal `evoila-bosnia/claude-rdc-hetzner-dc#2311`.
- Mirrors keycloak's `password_secret_ref` (#2401): the handler resolves each ref through the credential-backend seam `load_vault_secret_data(...)` — already imported in the k8s package for the kubeconfig loader, so no new connector dependency — and merges the resolved key/values into `string_data` / `data` before building `V1Secret`. `_shared/vault_creds.py` is **untouched**; `gsm:` refs resolve for free because the seam dispatches on scheme.
- The `anyOf` widens (inline maps, ref maps, or both); `additionalProperties: false` preserved. `safety_level`, the approval gate, the `_CREDENTIAL_WRITE_OPS` pin, and the key-names-only response are all unchanged.
- The optional `#field` fragment names which payload field to use (default: the Secret key); it is split off in the connector **before** the seam read, because a Vault KV-v2 path cannot carry a `#` (hvac would 404) — so the caller owns fragment→field selection uniformly across the `vault:` and `gsm:` schemes.

## Test plan

- [x] `ruff check` (changed files) — clean
- [x] `ruff format --check` — clean
- [x] `mypy` (changed src modules) — clean
- [x] `pytest tests/test_connectors_k8s_write.py` — 36 passed (7 new)
- [x] Regression sweep `test_connectors_k8s_auth.py` + `test_broadcast_events.py` + `test_broadcast_credential_write_dispatch.py` + `test_operations_preview.py` — 189 passed
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers

Acceptance criteria:

- [x] `_SECRET_CREATE_SCHEMA` gains `string_data_secret_ref` / `data_secret_ref` + `*_secret_mount`; `anyOf` accepts inline-only, ref-only, or both; `additionalProperties: false` preserved — `test_secret_create_schema_exposes_ref_params_and_widened_anyof`.
- [x] `k8s_secret_create` resolves each ref via `load_vault_secret_data(...)` server-side and merges into the Secret body; no value ever required in params — `test_secret_create_resolves_vault_ref_never_leaks`.
- [x] Vault-ref call produces a Secret with the resolved keys, and no plaintext value appears in op params or return value (value reaches the cluster only) — `test_secret_create_resolves_vault_ref_never_leaks` (broadcast/audit stay aggregate-only via the existing `_CREDENTIAL_WRITE_OPS` pin, covered by `test_secret_create_classifies_credential_write_and_redacts_broadcast`).
- [x] Multi-key case (two refs → one Secret with two keys) + inline+ref mixed — `test_secret_create_multi_key_refs`, `test_secret_create_inline_and_ref_merged`.
- [x] `gsm:`-scheme ref resolves through the seam (backend-agnostic parity) — `test_secret_create_gsm_ref_resolves_through_seam`.
- [x] `docs/codebase/connectors-kubernetes.md` documents the new ref params.
- [x] CLI OpenAPI snapshot — **not triggered**: the op param schema does not surface in `cli/api/openapi.json` (verified: `string_data` / `k8s.` / `secret.create` absent; only keycloak's dedicated `/ui/keycloak/users/*` REST form models carry `password_secret_ref`). k8s secret create dispatches solely through the generic `/api/v1/operations/call` path, which takes an opaque `params` object.

## Out of scope

- Sibling tasks under Goal #221 touch disjoint file sets: MCP-tools surface (#2861) and the Go CLI targets surface (#2862) — untouched here.
- Extending `secret.move` with a k8s-Secret destination (the deferred broker-extension alternative).
- Applying the same ref treatment to `k8s.job.create`'s inline `env` secrets (its own task if/when it bites).
- Any change to the credential-backend seam itself (`_shared/vault_creds.py`).

## Notes for reviewers (adjacent findings)

- `backend/.../ops_write_meta.py` is now 639 lines (soft cap 600). It was already ~588 (near the cap) before this task; the code-quality gate downgrades a pre-existing-file size overage to a non-blocking warning. Splitting the declarative op-metadata table (e.g. caution vs dangerous schemas) is a clean follow-up refactor, deliberately out of scope for this surgical, `effort:small` change.
- `ops_write_dangerous.py` is 480 lines (soft warn >400, block >600) — under the block limit.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2860
