### PR TITLE
feat(mcp): add meho_targets_register admin tool for agent-surface target writes

### DIFF
--- a/backend/src/meho_backplane/connectors/targets/__init__.py
+++ b/backend/src/meho_backplane/connectors/targets/__init__.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.targets — targetless target-registry write op (#2861).
+
+The third **synthetic** connector subpackage (after ``secret`` and
+``topology``): no vendor connector backs it. Importing the package (the
+lifespan's
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` pass
+walks ``connectors/<product>/`` and imports each subpackage) queues
+:func:`~meho_backplane.connectors.targets.ops.register_targets_registry_operations`
+onto the lifespan-driven registrar list via
+:func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`,
+so the ``targets.register`` ``endpoint_descriptor`` row lands before the
+first dispatch.
+
+Like the other synthetic packages, this one calls neither
+``register_connector`` nor ``register_connector_v2``: the synthetic
+``targets-registry-1.x`` identity has no connector class. The handler is a
+module-level function the dispatcher routes to with
+``connector_instance=None`` / ``target=None`` — the registry is
+tenant-scoped state, not a probed target.
+
+Why the op exists as a dispatchable descriptor at all: routing the MCP
+write front (``meho_targets_register``) through
+:func:`~meho_backplane.operations.dispatcher.dispatch` puts it behind
+:func:`~meho_backplane.operations._validate.policy_gate` — the seam where
+an AGENT principal's ``caution``-level write parks as a durable
+:class:`~meho_backplane.db.models.ApprovalRequest` while a human
+``tenant_admin`` keeps the immediate path. The REST / UI fronts are
+human-only and keep calling
+:func:`~meho_backplane.api.v1.targets.create_target` directly.
+"""
+
+from meho_backplane.connectors.targets.ops import register_targets_registry_operations
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+# Queue the targets.register typed-op upsert onto the lifespan-driven
+# registrar list (run after the connector eager-import pass).
+register_typed_op_registrar(register_targets_registry_operations)
+
+__all__ = [
+    "register_targets_registry_operations",
+]

--- a/backend/src/meho_backplane/connectors/targets/ops.py
+++ b/backend/src/meho_backplane/connectors/targets/ops.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Targetless typed ``targets.register`` op + its registrar (#2861).
+
+The third **synthetic** typed-op product (after ``secret`` and
+``topology``): no vendor connector backs it. The op is registered under
+the natural key ``(product="targets", version="1.x",
+impl_id="targets-registry")``, so the wire ``connector_id`` is
+``targets-registry-1.x`` — which round-trips through
+:func:`~meho_backplane.operations._lookup.parse_connector_id` back to
+``("targets", "1.x", "targets-registry")`` (digit-led version segment,
+product = the head's first hyphen segment; the ``secret-broker-1.x`` /
+``topology-graph-1.x`` mold, #1577).
+
+Why it exists (Goal #221)
+=========================
+
+The targets registry was the only CRUD-shaped registry in MEHO with no
+agent-surface write path: ``list_targets`` / ``query_topology`` are
+read-only, and REST ``POST /api/v1/targets`` (and the UI) both call
+:func:`~meho_backplane.api.v1.targets.create_target` — a human-only
+surface. An agent driving the onboarding path had no in-tool equivalent
+and fell back to a raw ``POST`` with a hand-minted JWT. Routing the MCP
+write front (``meho_targets_register``) through
+:func:`~meho_backplane.operations.dispatcher.dispatch` puts it behind
+:func:`~meho_backplane.operations._validate.policy_gate` — the single
+seam where an AGENT principal's ``caution``-level write parks as a
+durable :class:`~meho_backplane.db.models.ApprovalRequest`
+(propose-then-approve) while a human ``tenant_admin`` keeps the
+default-allow immediate path. REST and UI are human-only surfaces and
+keep calling the service primitive directly.
+
+Approval posture — the load-bearing dial (mirrors ``topology.*`` #2537):
+
+* ``safety_level="caution"`` + ``requires_approval=False`` parks **agent
+  principals only** (the AGENT ``caution`` verdict floor →
+  ``needs-approval`` in :mod:`meho_backplane.auth.permissions`), while a
+  human ``tenant_admin`` rides the default-allow branch and executes
+  immediately.
+* NOT ``requires_approval=True`` — that would park humans too.
+* NOT ``safety_level="dangerous"`` — that would DENY agents by default
+  rather than park them. Target registration is reversible
+  (``DELETE /api/v1/targets`` + the soft-delete tombstone), so caution
+  fits; dangerous does not.
+
+The handler is a **module-level** function (no connector instance to
+bind), so the dispatcher resolves it with ``connector_instance=None`` /
+``target=None``. It builds a
+:class:`~meho_backplane.targets.schemas.TargetCreate` from the validated
+params and calls :func:`~meho_backplane.api.v1.targets.create_target`
+unchanged — product-token validation, ``secret_ref`` tenant-scope guard,
+SSRF guard, ``preferred_impl_id`` validation, and JWT-derived
+``tenant_id`` all come for free; this shim re-implements none of them.
+``tenant_id`` is taken from *operator* inside the service, never from
+*params* (``additionalProperties: false`` already rejects a smuggled
+``tenant_id`` at the schema layer). ``create_target`` only ``flush``-es
+and relies on the caller's transaction, so the handler wraps it in
+``session.begin()`` (unlike the topology services, which own their own
+transaction).
+
+Validation failures are translated to :class:`ValueError` at this
+boundary — :class:`fastapi.HTTPException` (unknown product, out-of-scope
+``secret_ref``, unknown ``preferred_impl_id``, duplicate name) from the
+service and :class:`pydantic.ValidationError` (SSRF-blocked host, malformed
+CA-pin, ``verify_tls``/``tls_ca_pin`` contradiction, forbidden extra
+field) from the model — so the dispatcher's ``connector_error`` envelope
+carries a clean message the MCP front maps to ``-32602``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from meho_backplane.api.v1.targets import create_target
+from meho_backplane.connectors.targets.schemas import (
+    TARGETS_REGISTER_PARAMETER_SCHEMA,
+    TARGETS_REGISTER_RESPONSE_SCHEMA,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.operations.typed_register import register_typed_operation
+from meho_backplane.targets.schemas import TargetCreate
+
+if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
+    from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = [
+    "TARGETS_REGISTER_OP_ID",
+    "TARGETS_REGISTRY_CONNECTOR_ID",
+    "register_targets_registry_operations",
+    "targets_register",
+]
+
+#: Wire connector_id for the synthetic targets-registry product. Must
+#: stay parser-compatible: digit-led version suffix, product recoverable
+#: as the head's first hyphen segment (see module docstring).
+TARGETS_REGISTRY_CONNECTOR_ID = "targets-registry-1.x"
+
+#: Op id — the ``audit_log.path`` string this write correlates on.
+TARGETS_REGISTER_OP_ID = "targets.register"
+
+_GROUP_KEY = "registry"
+_GROUP_WHEN_TO_USE = (
+    "Write to the tenant's target registry: register a new target "
+    "(name + product + host, plus optional connection detail) so it can "
+    "be dispatched against. Use when onboarding a system the agent must "
+    "later drive — an rke2 cluster, a vCenter, a DNS server. "
+    "Agent-principal calls park as approval requests for a human "
+    "operator to approve; human tenant_admin calls execute immediately. "
+    "Target reads live on list_targets / query_topology, not here."
+)
+
+_DESCRIPTION = (
+    "Register a new target in the operator's tenant, reusing the same "
+    "service path as REST `POST /api/v1/targets`: product-token "
+    "validation, the `secret_ref` tenant-scope guard, the SSRF guard on "
+    "`host`/`fqdn`, and the JWT-derived `tenant_id` all apply. "
+    "Tenant-scoped automatically — no `tenant_id` argument (cross-tenant "
+    "registration is structurally impossible). `fingerprint` is "
+    "server-managed and rejected. Agent-principal calls park as approval "
+    "requests; human tenant_admin calls execute immediately."
+)
+
+_LLM_INSTRUCTIONS: dict[str, Any] = {
+    "when_to_use": (
+        "Onboard a new target from the agent surface instead of falling "
+        "back to a raw REST POST. Supply name + product + host (plus any "
+        "optional connection detail); the tenant is taken from your "
+        "identity."
+    ),
+    "parameter_hints": {
+        "name": "Required. Unique within the tenant; the dispatch handle.",
+        "product": "Required. A registered connector product token (e.g. 'rke2').",
+        "host": "Required. Dialable host/IP; SSRF-screened.",
+        "secret_ref": "Optional. Must sit in the tenant's Vault subtree; omit to derive it.",
+    },
+    "output_shape": "{'target_id', 'name', 'product', 'host', 'tenant_id'}",
+}
+
+
+async def targets_register(
+    operator: Operator, target: Any, params: dict[str, Any]
+) -> dict[str, Any]:
+    """Register a new target in the operator's tenant.
+
+    Op-id: ``targets.register``. Targetless typed op. The dispatcher has
+    already validated *params* against
+    :data:`~meho_backplane.connectors.targets.schemas.TARGETS_REGISTER_PARAMETER_SCHEMA`.
+    Builds a :class:`~meho_backplane.targets.schemas.TargetCreate` and
+    delegates to :func:`~meho_backplane.api.v1.targets.create_target`,
+    which owns every validation and the audit trail; this shim
+    re-implements none of it. ``tenant_id`` comes from *operator* inside
+    the service — never from *params*.
+
+    ``create_target`` relies on the caller's transaction (it ``flush``-es
+    but does not commit), so the call is wrapped in ``session.begin()``.
+    Model / service validation failures are re-raised as
+    :class:`ValueError` so the dispatcher's ``connector_error`` envelope
+    maps them to ``-32602`` with a clean message.
+    """
+    try:
+        body = TargetCreate(**params)
+    except ValidationError as exc:
+        raise ValueError(f"invalid target parameters: {exc}") from exc
+
+    sessionmaker = get_sessionmaker()
+    try:
+        async with sessionmaker() as session, session.begin():
+            created = await create_target(body=body, operator=operator, session=session)
+    except HTTPException as exc:
+        raise ValueError(_http_exception_message(exc)) from exc
+
+    return {
+        "target_id": str(created.id),
+        "name": created.name,
+        "product": created.product,
+        "host": created.host,
+        "tenant_id": str(created.tenant_id),
+    }
+
+
+def _http_exception_message(exc: HTTPException) -> str:
+    """Flatten a service ``HTTPException`` to a single operator-facing line.
+
+    ``create_target`` raises structured 422s (``detail`` is a dict for the
+    unknown-product and out-of-scope-``secret_ref`` cases) and plain-string
+    409/422s. Return the string detail verbatim; render a structured detail
+    prefixed with its status so the cause is still legible in the ``-32602``
+    message.
+    """
+    detail = exc.detail
+    if isinstance(detail, str):
+        return detail
+    return f"{exc.status_code}: {detail}"
+
+
+async def register_targets_registry_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert the ``targets.register`` typed op into ``endpoint_descriptor``.
+
+    Queued onto the lifespan-driven registrar list by the package
+    ``__init__`` (via ``register_typed_op_registrar``) and run by
+    :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+    after the connector eager-import pass. Idempotent: a re-run against
+    unchanged text is a no-op for the embedding pipeline. The
+    ``embedding_service`` kwarg is the test seam every connector registrar
+    carries.
+
+    ``safety_level="caution"`` + ``requires_approval=False`` is the
+    agents-park / humans-immediate combination — see the module docstring
+    for why neither ``requires_approval=True`` nor
+    ``safety_level="dangerous"`` fits.
+    """
+    await register_typed_operation(
+        product="targets",
+        version="1.x",
+        impl_id="targets-registry",
+        op_id=TARGETS_REGISTER_OP_ID,
+        handler=targets_register,
+        group_key=_GROUP_KEY,
+        when_to_use=_GROUP_WHEN_TO_USE,
+        summary="Register a new target in the operator's tenant.",
+        description=_DESCRIPTION,
+        parameter_schema=TARGETS_REGISTER_PARAMETER_SCHEMA,
+        response_schema=TARGETS_REGISTER_RESPONSE_SCHEMA,
+        tags=["targets", "write", "registry"],
+        safety_level="caution",
+        requires_approval=False,
+        llm_instructions=_LLM_INSTRUCTIONS,
+        embedding_service=embedding_service,
+    )

--- a/backend/src/meho_backplane/connectors/targets/schemas.py
+++ b/backend/src/meho_backplane/connectors/targets/schemas.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""JSON Schema documents for the synthetic ``targets.register`` typed op.
+
+Single source for both the ``endpoint_descriptor.parameter_schema`` (the
+dispatcher's validation layer) and the ``meho_targets_register`` MCP
+tool's ``inputSchema`` — sharing one object means the two validation
+layers cannot drift (the mold the topology graph ops use).
+
+The parameter schema mirrors
+:class:`~meho_backplane.targets.schemas.TargetCreate` field-for-field so
+an MCP client schema-validating ahead of the call sees the same
+constraints the service enforces: required ``name`` / ``product`` /
+``host``; the documented optional set; ``additionalProperties: false`` so
+the two server-managed inputs the create body forbids —
+``fingerprint`` (probe-written) and ``tenant_id`` (JWT-derived) — are
+rejected at the schema layer before the handler runs. ``vpn_required`` is
+deliberately not exposed on the agent surface (it is a network-topology
+concern, not an onboarding parameter); an omitted value takes the
+``TargetCreate`` default.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from meho_backplane.connectors.schemas import AuthModel
+
+__all__ = [
+    "TARGETS_REGISTER_PARAMETER_SCHEMA",
+    "TARGETS_REGISTER_RESPONSE_SCHEMA",
+]
+
+#: ``auth_model`` accepted values, materialised from the enum so the
+#: schema tracks :class:`~meho_backplane.connectors.schemas.AuthModel`
+#: automatically rather than hard-coding a list that could drift.
+_AUTH_MODEL_VALUES: Final[list[str]] = [m.value for m in AuthModel]
+
+
+TARGETS_REGISTER_PARAMETER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 200,
+            "description": (
+                "Unique target name within the tenant. Immutable after "
+                "creation (rename = delete + re-create). This is the "
+                "handle every dispatch resolves against (`--target <name>`)."
+            ),
+        },
+        "product": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "description": (
+                "Product token the target speaks, validated against the "
+                "registered connector products (e.g. `vmware`, `vault`, "
+                "`rke2`, `bind9`). An unknown product is rejected with the "
+                "valid set named. Copy it straight out of "
+                "`search_connectors` / `list_connectors`."
+            ),
+        },
+        "host": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 512,
+            "description": (
+                "Dialable host or IP. Screened by the SSRF guard: a "
+                "non-public destination (private / loopback / link-local / "
+                "metadata / CGNAT) is rejected unless the operator "
+                "allowlist exempts it."
+            ),
+        },
+        "aliases": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Alternate names the target also resolves under.",
+        },
+        "version": {
+            "type": ["string", "null"],
+            "maxLength": 100,
+            "description": (
+                "Optional operator-asserted product version (e.g. `9.0`). "
+                "Lets the first probe dispatch against the versioned "
+                "connector without a PATCH round-trip; omitted resolves "
+                "via the connector's wildcard registration."
+            ),
+        },
+        "port": {
+            "type": ["integer", "null"],
+            "minimum": 1,
+            "maximum": 65535,
+            "description": "Optional TCP port; omitted uses the connector default.",
+        },
+        "fqdn": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional fully-qualified domain name. Screened by the same SSRF guard as `host`."
+            ),
+        },
+        "secret_ref": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional Vault path to the target's credential. Must lie "
+                "within the tenant's secret subtree — an out-of-scope ref "
+                "is rejected. Omitting it derives the per-tenant default."
+            ),
+        },
+        "auth_model": {
+            "type": "string",
+            "enum": _AUTH_MODEL_VALUES,
+            "description": ("Per-target identity model. Defaults to `shared_service_account`."),
+        },
+        "verify_tls": {
+            "type": "boolean",
+            "description": (
+                "Whether dispatch verifies the target's TLS certificate "
+                "chain. Default-secure `true`; setting `false` is a "
+                "security-relevant choice that is audited. Mutually "
+                "exclusive with `tls_ca_pin`."
+            ),
+        },
+        "tls_ca_pin": {
+            "type": ["string", "null"],
+            "description": (
+                "Optional PEM CA bundle to trust for this target (the "
+                "secure way to reach a self-signed / internal-CA "
+                "appliance — verification stays on against the pin). "
+                "Mutually exclusive with `verify_tls=false`."
+            ),
+        },
+        "tls_server_name": {
+            "type": ["string", "null"],
+            "maxLength": 512,
+            "description": (
+                "Optional TLS SNI / cert-verification hostname, decoupled "
+                "from `host` (for an appliance whose cert pins an FQDN-CN "
+                "while it only accepts `Host: <IP>`). Omitted derives it "
+                "from `host`."
+            ),
+        },
+        "extras": {
+            "type": "object",
+            "description": "Optional free-form connector-specific metadata.",
+        },
+        "notes": {
+            "type": ["string", "null"],
+            "description": "Optional free-text operator notes.",
+        },
+        "preferred_impl_id": {
+            "type": ["string", "null"],
+            "maxLength": 200,
+            "description": (
+                "Optional connector-implementation override, validated "
+                "against the impls registered for `product`."
+            ),
+        },
+    },
+    "required": ["name", "product", "host"],
+    "additionalProperties": False,
+}
+
+
+TARGETS_REGISTER_RESPONSE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "target_id": {
+            "type": "string",
+            "description": "UUID of the newly-registered target row.",
+        },
+        "name": {"type": "string"},
+        "product": {"type": "string"},
+        "host": {"type": "string"},
+        "tenant_id": {
+            "type": "string",
+            "description": (
+                "Owning tenant — taken from the caller's identity, never "
+                "from params (cross-tenant registration is structurally "
+                "impossible)."
+            ),
+        },
+    },
+    "required": ["target_id", "name", "product", "host", "tenant_id"],
+}

--- a/backend/src/meho_backplane/mcp/tools/targets_register.py
+++ b/backend/src/meho_backplane/mcp/tools/targets_register.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho_targets_register`` — admin MCP tool to register a target (#2861).
+
+Closes the agent-surface gap Goal #221 surfaced: targets was the only
+CRUD-shaped registry in MEHO with no ``meho_*`` admin write tool
+(connectors, sensors, scheduler, agent principals, topology nodes all
+have one). An agent onboarding a new system had no in-tool path and fell
+back to a raw ``POST /api/v1/targets`` with a hand-minted JWT.
+
+The tool is a **thin admin meta-tool** in the ``meho_*`` namespace
+(``tenant_admin`` only, ``op_class='write'``) — explicitly outside
+CLAUDE.md's ~17-tool daily agent surface, which is exactly what the
+admin namespace holds. It routes through
+:func:`~meho_backplane.operations.dispatcher.dispatch` (op_id
+``targets.register`` on the synthetic ``targets-registry-1.x`` connector
+registered by :mod:`meho_backplane.connectors.targets.ops`) so the policy
+gate runs per call: an AGENT principal's registration parks as a durable
+approval request while a human ``tenant_admin`` executes immediately. The
+typed-op handler forwards to
+:func:`~meho_backplane.api.v1.targets.create_target` — the same service
+REST calls — so validation is reused, not re-implemented.
+
+The shape mirrors :mod:`meho_backplane.mcp.tools.topology_create_node`:
+a separate module (the registry auto-discovers every module under
+``meho_backplane.mcp.tools``), a shared parameter/response schema with
+the typed op, and the same parked-shape ``outputSchema`` union.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.targets.ops import (
+    TARGETS_REGISTER_OP_ID,
+    TARGETS_REGISTRY_CONNECTOR_ID,
+)
+from meho_backplane.connectors.targets.schemas import (
+    TARGETS_REGISTER_PARAMETER_SCHEMA,
+    TARGETS_REGISTER_RESPONSE_SCHEMA,
+)
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInternalError, McpInvalidParamsError
+from meho_backplane.mcp.tools.topology import with_parked_shape
+from meho_backplane.operations.dispatcher import dispatch
+
+__all__: list[str] = []
+
+
+_TOOL_NAME: Final[str] = "meho_targets_register"
+
+
+_DESCRIPTION: Final[str] = (
+    "Register a new target in the operator's tenant (tenant_admin only). "
+    "Reuses the same service path as REST `POST /api/v1/targets`, so the "
+    "product-token check, the `secret_ref` tenant-scope guard, the SSRF "
+    "guard on `host`/`fqdn`, and the JWT-derived `tenant_id` all apply "
+    "unchanged. Tenant-scoped automatically — no `tenant_id` argument "
+    "(cross-tenant registration is structurally impossible).\n\n"
+    "WHEN TO CALL: an onboarding flow reaches 'register this target' — an "
+    "rke2 cluster, a vCenter, a DNS server — and you need it in the "
+    "registry before dispatching against it. Supply `name` + `product` + "
+    "`host` (plus any optional connection detail); `product` must be a "
+    "registered connector product token (an unknown one is rejected with "
+    "the valid set named). This is the in-tool alternative to a raw REST "
+    "POST.\n\n"
+    "DO NOT use to auto-register a candidate returned by a `discover` "
+    "probe — that path is deliberately operator-reviewed (Initiative "
+    "#363). This tool is for explicit, named registrations.\n\n"
+    "`fingerprint` is server-managed (probe-written) and rejected. "
+    "Returns `{target_id, name, product, host, tenant_id}`. After it, "
+    "`list_targets` shows the new row in your tenant.\n\n"
+    "AGENT PRINCIPALS: the registration does not execute immediately — it "
+    "parks as a durable approval request and the tool returns "
+    "`{status: awaiting_approval, approval_request_id, ...}`; a human "
+    "operator approves it from the approvals surfaces (`/ui/approvals`, "
+    "`meho approvals list`, `meho_approvals_*`), which re-executes the "
+    "registration with the exact original params. Human tenant_admin "
+    "calls execute immediately."
+)
+
+
+#: Handler exceptions the dispatcher wraps as ``connector_error`` that
+#: are operator-actionable input problems on this write. The typed-op
+#: handler flattens every service/model validation failure
+#: (``HTTPException`` / ``ValidationError``) to ``ValueError`` at its
+#: boundary, so that is the one class to map back to ``-32602``.
+_TARGETS_WRITE_INVALID_PARAM_EXCEPTIONS: Final[frozenset[str]] = frozenset({"ValueError"})
+
+
+async def dispatch_targets_write(
+    operator: Operator,
+    op_id: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch one gated targets write and translate the result for MCP.
+
+    Routes through :func:`~meho_backplane.operations.dispatcher.dispatch`
+    with ``target=None`` (the registry is tenant-scoped state, not a
+    probed target) so the policy gate, audit, and broadcast run on the
+    same path every other governed op uses. Mirrors
+    :func:`~meho_backplane.mcp.tools.topology.dispatch_topology_write`.
+
+    Result translation:
+
+    * ``ok`` — return the typed-op handler's domain payload verbatim.
+    * ``awaiting_approval`` — the AGENT-principal park, returned as a
+      structured envelope (not an error): the proposal succeeded and the
+      approval id is what the agent references next.
+    * ``denied`` — policy refusal → ``-32602``.
+    * ``error`` with the flattened ``ValueError`` (or a schema
+      ``invalid_params``) → ``-32602`` with the service's message.
+    * anything else — ``-32603`` (misconfiguration, e.g. the registrar
+      never ran).
+    """
+    result = await dispatch(
+        operator=operator,
+        connector_id=TARGETS_REGISTRY_CONNECTOR_ID,
+        op_id=op_id,
+        target=None,
+        params=dict(arguments),
+    )
+    if result.status == "ok":
+        if not isinstance(result.result, dict):
+            raise McpInternalError(f"{op_id}: unexpected non-object result payload")
+        return result.result
+    if result.status == "awaiting_approval":
+        approval_request_id = str(result.extras.get("approval_request_id"))
+        return {
+            "status": "awaiting_approval",
+            "approval_request_id": approval_request_id,
+            "op_id": op_id,
+            "message": (
+                f"{op_id} parked for approval (request "
+                f"{approval_request_id}): the registration executes with "
+                "these exact params once a tenant operator approves it via "
+                "/ui/approvals, `meho approvals list`, or the "
+                "meho_approvals_* MCP tools."
+            ),
+        }
+    if result.status == "denied":
+        raise McpInvalidParamsError(f"denied: {result.error or 'policy denied'}")
+
+    exception_class = result.extras.get("exception_class")
+    message = str(result.extras.get("exception_message") or result.error or f"{op_id} failed")
+    if (
+        exception_class in _TARGETS_WRITE_INVALID_PARAM_EXCEPTIONS
+        or result.extras.get("error_code") == "invalid_params"
+    ):
+        raise McpInvalidParamsError(message)
+    raise McpInternalError(
+        message,
+        data={"error_code": result.extras.get("error_code"), "op_id": op_id},
+    )
+
+
+async def _register_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Route a ``meho_targets_register`` call through the dispatcher.
+
+    :func:`dispatch_targets_write` owns the whole translation: policy gate
+    (agents park, humans execute), the typed-op handler's call into
+    :func:`~meho_backplane.api.v1.targets.create_target`, and the result /
+    error mapping back to the MCP wire contract. Tenant scope comes from
+    *operator* inside the service — never from *arguments*
+    (``additionalProperties: false`` already rejects a smuggled
+    ``tenant_id`` at the schema layer).
+    """
+    return await dispatch_targets_write(operator, TARGETS_REGISTER_OP_ID, arguments)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        feature="targets",
+        name=_TOOL_NAME,
+        description=_DESCRIPTION,
+        inputSchema=TARGETS_REGISTER_PARAMETER_SCHEMA,
+        outputSchema=with_parked_shape(TARGETS_REGISTER_RESPONSE_SCHEMA),
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class="write",
+    ),
+    handler=_register_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -209,6 +209,7 @@ def isolated_registry() -> Iterator[None]:
         result_query,
         runbook_runs,
         runbooks,
+        targets_register,
         topology,
         topology_bulk_import,
         topology_create_node,
@@ -297,6 +298,13 @@ def isolated_registry() -> Iterator[None]:
     # above would otherwise leave it unregistered in any test file that
     # imports this fixture after the first one runs in the process.
     importlib.reload(topology_bulk_import)
+    # #2861: the target-registry admin write tool (``meho_targets_register``)
+    # lives in its own module (mirroring ``topology_create_node``) so it joins
+    # the reload list for the same reason every other tool module does -- the
+    # autouse ``clear_registries()`` above would otherwise leave it
+    # unregistered in any test file that imports this fixture after the first
+    # one runs in the process.
+    importlib.reload(targets_register)
     # G12.2-T4 (#1298): the runbook template MCP tools
     # (``meho_runbook_*_template`` x 6) join the reload list for the same
     # reason every other tool module does -- the autouse

--- a/backend/tests/test_mcp_output_schema_conformance.py
+++ b/backend/tests/test_mcp_output_schema_conformance.py
@@ -84,6 +84,7 @@ _COVERED_TOOLS: frozenset[str] = frozenset(
         "meho_topology_create_node",
         "meho_topology_delete_node",
         "meho_topology_unannotate",
+        "meho_targets_register",
         "preview_operation",
         "query_audit",
         "query_topology",
@@ -743,6 +744,72 @@ async def test_topology_annotate_parked_branch_conforms(
             client,
             "meho_topology_annotate",
             {"from_name": "svc-x", "kind": "depends-on", "to_name": "db-y"},
+        ),
+    )
+    assert payload["status"] == "awaiting_approval"
+    assert uuid.UUID(payload["approval_request_id"])
+
+
+# ---------------------------------------------------------------------------
+# Targets registry write (#2861) — executed (human) + parked (agent) branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_meho_targets_register_executed_conforms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A human tenant_admin registration executes immediately and conforms.
+
+    Real end-to-end dispatch through the synthetic ``targets-registry-1.x``
+    connector into ``create_target``; the reduced ``{target_id, name,
+    product, host, tenant_id}`` payload is validated against the executed
+    branch of the declared ``oneOf``.
+    """
+    client, op = client_with_operator
+    await _seed_tenant()
+    payload = _assert_conforms(
+        "meho_targets_register",
+        _call(
+            client,
+            "meho_targets_register",
+            {"name": "conf-target", "product": "vault", "host": "vault.example"},
+        ),
+    )
+    assert payload["name"] == "conf-target"
+    assert payload["product"] == "vault"
+    assert payload["host"] == "vault.example"
+    assert payload["tenant_id"] == str(op.tenant_id)
+    assert uuid.UUID(payload["target_id"])
+
+
+@pytest.mark.parametrize(
+    "custom_client",
+    [
+        {
+            "role": TenantRole.TENANT_ADMIN,
+            "principal_kind": PrincipalKind.AGENT,
+        }
+    ],
+    indirect=True,
+)
+async def test_meho_targets_register_parked_branch_conforms(
+    custom_client: tuple[TestClient, Operator],
+) -> None:
+    """An agent-principal registration parks: the ``awaiting_approval`` branch.
+
+    The parked envelope is a first-class success result (``isError:
+    false``), so it must validate against the declared ``oneOf`` union
+    exactly like the executed shape.
+    """
+    client, _op = custom_client
+    await _seed_tenant()
+    payload = _assert_conforms(
+        "meho_targets_register",
+        _call(
+            client,
+            "meho_targets_register",
+            {"name": "conf-target-agent", "product": "vault", "host": "vault.example"},
         ),
     )
     assert payload["status"] == "awaiting_approval"

--- a/backend/tests/test_mcp_structured_content.py
+++ b/backend/tests/test_mcp_structured_content.py
@@ -68,6 +68,7 @@ EXPECTED_DECLARING_TOOLS: frozenset[str] = frozenset(
         "meho_topology_create_node",
         "meho_topology_delete_node",
         "meho_topology_unannotate",
+        "meho_targets_register",
         "preview_operation",
         "query_audit",
         "query_topology",

--- a/backend/tests/test_mcp_tools_targets_register.py
+++ b/backend/tests/test_mcp_tools_targets_register.py
@@ -1,0 +1,371 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the ``meho_targets_register`` admin tool (#2861).
+
+Coverage matrix (Task #2861 acceptance criteria — the MCP-level half;
+the ``create_target`` service and its guards are covered end-to-end in
+:mod:`tests.test_api_v1_targets`):
+
+* The tool registers with ``required_role=TENANT_ADMIN`` +
+  ``op_class='write'`` + ``feature='targets'``, a conforming
+  ``^[a-zA-Z0-9_-]{1,64}$`` name, and a parked-union ``outputSchema``;
+  non-admin sessions do not see it in ``tools/list`` and a direct
+  ``tools/call`` from an operator returns -32602 ``forbidden``.
+* A human ``tenant_admin`` call creates the target immediately and
+  ``list_targets`` shows the new row (round-trip).
+* An **agent-principal** call parks as a durable ``ApprovalRequest``
+  (``awaiting_approval`` envelope) and writes no target row — the
+  G11.2 policy gate, mirroring ``meho_topology_create_node``.
+* The reused ``create_target`` guards fire through this path: unknown
+  ``product`` → error, ``secret_ref`` outside the tenant subtree →
+  error, SSRF-y ``host`` → error.
+* ``tenant_id`` and ``fingerprint`` are rejected at the schema layer
+  (``additionalProperties: false``) — ``tenant_id`` always comes from
+  the caller identity, ``fingerprint`` is server-managed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy import func, select
+
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import ApprovalRequest, Tenant
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.main import app
+from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
+from meho_backplane.mcp.registry import get_tool
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_TOOL = "meho_targets_register"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def _seeded_tenant() -> AsyncIterator[None]:
+    """Insert the operator's :class:`Tenant` row so the target FK resolves."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        session.add(Tenant(id=OPERATOR_TENANT_ID, slug="op-tenant", name="Op Tenant"))
+    yield
+
+
+def _register_call(client: TestClient, call_id: int, arguments: dict[str, Any]) -> Any:
+    return client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": _TOOL, "arguments": arguments},
+        },
+    )
+
+
+def _list_targets_call(client: TestClient, call_id: int) -> Any:
+    return client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": call_id,
+            "method": "tools/call",
+            "params": {"name": "list_targets", "arguments": {}},
+        },
+    )
+
+
+def _tools_list(client: TestClient) -> list[dict[str, Any]]:
+    body = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+    ).json()
+    return body["result"]["tools"]
+
+
+@pytest.fixture
+def _agent_admin_client() -> Iterator[tuple[TestClient, Operator]]:
+    """``TestClient`` bound to an AGENT-principal ``tenant_admin`` operator.
+
+    The shared ``client_with_operator`` fixture only builds USER-kind
+    operators; the policy gate's agent-parking branch keys off
+    ``principal_kind == AGENT``, so this fixture supplies one to exercise
+    the parked path.
+    """
+    op = Operator(
+        sub="agent:onboarder",
+        name="Onboarder",
+        email=None,
+        raw_jwt="fixture-jwt-not-real",
+        tenant_id=OPERATOR_TENANT_ID,
+        tenant_role=TenantRole.TENANT_ADMIN,
+        principal_kind=PrincipalKind.AGENT,
+    )
+
+    async def _fake_verify() -> Operator:
+        return op
+
+    app.dependency_overrides[verify_mcp_jwt_and_bind] = _fake_verify
+    try:
+        with TestClient(app) as client:
+            yield client, op
+    finally:
+        app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+
+
+async def _count(model: Any) -> int:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(func.count()).select_from(model).where(model.tenant_id == OPERATOR_TENANT_ID)
+        )
+        return int(result.scalar_one())
+
+
+# ---------------------------------------------------------------------------
+# Registration + conformance shape
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registers_with_tenant_admin_write_and_targets_feature() -> None:
+    """The admin tool lands with the TENANT_ADMIN gate + write op_class."""
+    entry = get_tool(_TOOL)
+    assert entry is not None
+    defn, _handler = entry
+    assert defn.required_role is TenantRole.TENANT_ADMIN
+    assert defn.op_class == "write"
+    assert defn.feature == "targets"
+
+
+def test_tool_name_matches_anthropic_pattern() -> None:
+    """The name satisfies the #2745 ``^[a-zA-Z0-9_-]{1,64}$`` gate."""
+    import re
+
+    assert re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", _TOOL)
+
+
+def test_output_schema_is_parked_union_object_root() -> None:
+    """The #2774 outputSchema is a ``type: object`` root with the parked union."""
+    entry = get_tool(_TOOL)
+    assert entry is not None
+    defn, _handler = entry
+    schema = defn.outputSchema
+    assert schema is not None
+    assert schema["type"] == "object"
+    branches = schema["oneOf"]
+    parked = next(b for b in branches if "awaiting_approval" in str(b))
+    assert parked["properties"]["status"]["const"] == "awaiting_approval"
+
+
+def test_input_schema_requires_core_fields_and_forbids_extras() -> None:
+    """Required ``name/product/host``; ``additionalProperties: false``."""
+    entry = get_tool(_TOOL)
+    assert entry is not None
+    defn, _handler = entry
+    schema = defn.inputSchema
+    assert schema["required"] == ["name", "product", "host"]
+    assert schema["additionalProperties"] is False
+    # The documented optional set is present; the two server-managed
+    # inputs are absent (so additionalProperties rejects them).
+    props = schema["properties"]
+    assert "fingerprint" not in props
+    assert "tenant_id" not in props
+    for optional in ("aliases", "version", "port", "fqdn", "secret_ref", "auth_model"):
+        assert optional in props
+
+
+# ---------------------------------------------------------------------------
+# RBAC
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_hidden_from_non_admin_tools_list(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An operator (non-admin) does not see the write tool in ``tools/list``."""
+    client, _op = client_with_operator
+    names = {t["name"] for t in _tools_list(client)}
+    assert _TOOL not in names
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_call_from_non_admin_is_forbidden(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A direct ``tools/call`` from an operator → -32602 ``forbidden``."""
+    client, _op = client_with_operator
+    body = _register_call(
+        client, 1, {"name": "x", "product": "vault", "host": "vault.example"}
+    ).json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Executed branch (human tenant_admin) + round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_human_admin_creates_and_round_trips_via_list_targets(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """A human tenant_admin registration executes immediately + is listable."""
+    client, op = client_with_operator
+    created = _register_call(
+        client, 1, {"name": "rdc-vault", "product": "vault", "host": "vault.example"}
+    ).json()["result"]
+    assert created["isError"] is False
+    payload = created["structuredContent"]
+    assert payload["name"] == "rdc-vault"
+    assert payload["product"] == "vault"
+    assert payload["tenant_id"] == str(op.tenant_id)
+
+    listed = _list_targets_call(client, 2).json()["result"]["structuredContent"]
+    assert [t["name"] for t in listed["targets"]] == ["rdc-vault"]
+    assert listed["targets"][0]["id"] == payload["target_id"]
+
+
+# ---------------------------------------------------------------------------
+# Parked branch (agent principal) — the G11.2 policy gate
+# ---------------------------------------------------------------------------
+
+
+async def test_agent_principal_parks_as_needs_approval(
+    _agent_admin_client: tuple[TestClient, Operator],
+    _seeded_tenant: None,
+) -> None:
+    """An agent-principal registration parks; no target row lands."""
+    client, _op = _agent_admin_client
+    result = _register_call(
+        client, 1, {"name": "agent-rke2", "product": "vault", "host": "vault.example"}
+    ).json()["result"]
+    assert result["isError"] is False
+    payload = result["structuredContent"]
+    assert payload["status"] == "awaiting_approval"
+    assert payload["op_id"] == "targets.register"
+
+    # The write parked as a durable ApprovalRequest and no target landed.
+    assert await _count(ApprovalRequest) == 1
+    assert await _count(TargetORM) == 0
+
+
+# ---------------------------------------------------------------------------
+# Reused guards fire through this path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_unknown_product_is_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """The reused product-token validation rejects an unknown product."""
+    client, _op = client_with_operator
+    body = _register_call(
+        client,
+        1,
+        {"name": "bad-prod", "product": "definitely-not-a-real-product", "host": "svc.example"},
+    ).json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_ssrf_host_is_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """The reused SSRF guard rejects a non-public ``host``.
+
+    ``169.254.169.254`` (cloud-metadata link-local) is the address the
+    suite-wide allowlist deliberately leaves blocked (see the
+    ``_default_target_ssrf_allowlist`` conftest fixture), and IP literals
+    are screened directly — so the guard fires without re-patching the
+    DNS seam.
+    """
+    client, _op = client_with_operator
+    body = _register_call(
+        client, 1, {"name": "ssrf", "product": "vault", "host": "169.254.169.254"}
+    ).json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+async def test_secret_ref_outside_tenant_scope_is_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _seeded_tenant: None,
+) -> None:
+    """The reused ``secret_ref`` tenant-scope guard rejects an out-of-subtree ref."""
+    client, _op = client_with_operator
+    body = _register_call(
+        client,
+        1,
+        {
+            "name": "oos-secret",
+            "product": "vault",
+            "host": "vault.example",
+            "secret_ref": "secret/meho/vcf-logs/logmaster",
+        },
+    ).json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# tenant_id / fingerprint are schema-rejected (never params)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_smuggled_tenant_id_is_rejected_at_schema_layer(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A ``tenant_id`` in arguments → -32602 (additionalProperties=false)."""
+    client, _op = client_with_operator
+    body = _register_call(
+        client,
+        1,
+        {
+            "name": "x",
+            "product": "vault",
+            "host": "vault.example",
+            "tenant_id": "00000000-0000-0000-0000-0000000000ff",
+        },
+    ).json()
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_smuggled_fingerprint_is_rejected_at_schema_layer(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A server-managed ``fingerprint`` in arguments → -32602."""
+    client, _op = client_with_operator
+    body = _register_call(
+        client,
+        1,
+        {
+            "name": "x",
+            "product": "vault",
+            "host": "vault.example",
+            "fingerprint": {"vendor": "spoofed"},
+        },
+    ).json()
+    assert body["error"]["code"] == INVALID_PARAMS

--- a/docs/codebase/mcp.md
+++ b/docs/codebase/mcp.md
@@ -291,6 +291,53 @@ A tool that cannot honestly declare its output shape should drop the
 declaration (spec-legal — proven by the ~60 non-declaring tools)
 rather than publish a schema its payloads violate.
 
+## Admin registry writes route through the dispatcher
+
+The `meho_*` admin namespace holds the `tenant_admin` write tools
+(`op_class="write"`) — outside CLAUDE.md's ~17-tool daily agent surface
+by design. A subset of them govern **registry** writes (create a graph
+node, register an agent principal, register a target). Where the write
+must be **approvable** — a human `tenant_admin` executes immediately
+while an agent-principal call parks for review — the MCP front does not
+call its service directly; it routes through
+`meho_backplane.operations.dispatcher.dispatch` so the single G11.2
+policy gate (`operations/_validate.py`) runs per call. The write is
+modelled as a **targetless typed op on a synthetic connector** (no
+vendor connector backs it), registered with `safety_level="caution"` +
+`requires_approval=False` — the dial that parks agent principals only
+(`caution` AGENT verdict floor → `needs-approval`) while a human rides
+the default-allow immediate branch. `requires_approval=True` would park
+humans too; `safety_level="dangerous"` would deny agents rather than
+park them.
+
+Three synthetic connectors follow this mould (natural key
+`(product, "1.x", impl_id)` → wire `connector_id`):
+
+| Wire `connector_id` | Op | MCP front | Since |
+|---|---|---|---|
+| `secret-broker-1.x` | `secret.move` | (dispatch-only) | #1577 |
+| `topology-graph-1.x` | `topology.create_node` / `.annotate` / … | `meho_topology_create_node` / `_annotate` / … | #2537 |
+| `targets-registry-1.x` | `targets.register` | `meho_targets_register` | #2861 |
+
+`meho_targets_register` (#2861,
+`mcp/tools/targets_register.py` + `connectors/targets/`) closes the last
+CRUD-shaped registry with no agent-surface write path: it reuses the
+`create_target` service that REST `POST /api/v1/targets` calls, so the
+product-token check, the `secret_ref` tenant-scope guard, the SSRF guard
+on `host`/`fqdn`, and the JWT-derived `tenant_id` all apply unchanged —
+none are re-implemented. `tenant_id` always comes from the caller
+identity; `additionalProperties: false` rejects a smuggled `tenant_id`
+and the server-managed `fingerprint` at the schema layer. Its
+`inputSchema` mirrors `TargetCreate` field-for-field (shared with the
+typed op's `parameter_schema` so the two validation layers cannot
+drift), and its `outputSchema` is the parked-shape `oneOf` union
+(`with_parked_shape`) so both the executed `{target_id, name, product,
+host, tenant_id}` payload and the `awaiting_approval` envelope conform
+(#2774). The dispatch shim flattens the service's `HTTPException` and the
+model's `ValidationError` to `ValueError` at its boundary so the
+dispatcher's `connector_error` maps them to `-32602` with a clean
+message.
+
 ## Audit URI redaction for query-bearing resources
 
 The `resources/read` dispatcher


### PR DESCRIPTION
## Summary

- Adds **`meho_targets_register`** — the missing agent-surface write path for the targets registry (the only CRUD-shaped registry in MEHO that had none; the RDC dogfooding consumer hit this and fell back to a raw `POST /api/v1/targets`). `required_role=TENANT_ADMIN`, `op_class="write"`, in the `meho_*` admin namespace.
- **Reuses the existing `create_target` service** (the same one REST `POST /api/v1/targets` calls) — product-token validation, the `secret_ref` tenant-scope guard, the SSRF guard on `host`/`fqdn`, and the JWT-derived `tenant_id` all apply unchanged. No validation is re-implemented. `tenant_id` always comes from caller identity; `additionalProperties:false` rejects a smuggled `tenant_id` and the server-managed `fingerprint` at the schema layer.
- Routes through `operations.dispatcher.dispatch` via a **new synthetic connector** (`targets-registry-1.x`, op `targets.register`) so the existing **G11.2 policy gate** runs per call — a human `tenant_admin` executes immediately while an **agent principal parks** as a durable approval request. `safety_level="caution"` + `requires_approval=False` (the `topology.*` dial: parks agents only, never humans; caution not dangerous because target registration is reversible). No new approval machinery.
- Mirrors `meho_topology_create_node` end to end: a separate MCP-tool module, a schema shared between the tool's `inputSchema` and the op's `parameter_schema`, and a parked-shape `oneOf` `outputSchema`.

## Design notes

- **Synthetic connector package (`connectors/targets/`)** is the tool's dispatch machinery — the third synthetic connector after `secret` (#1577) and `topology` (#2537). It's what lets the write ride the policy gate; the tool cannot park agents without it. `api/v1/targets.py` and `targets/schemas.py` are read/imported but **not modified** (sibling-task boundary respected).
- **Error translation:** the handler flattens the service's `HTTPException` (unknown product, out-of-scope `secret_ref`, unknown `preferred_impl_id`, duplicate name) and the model's `ValidationError` (SSRF-blocked host, malformed CA-pin, `verify_tls`/`tls_ca_pin` contradiction, forbidden extra) to `ValueError`, which the dispatch shim maps to `-32602` with a clean message.
- **`vpn_required` is intentionally not exposed** on the agent surface (it is a network-topology concern, not an onboarding parameter, and is absent from the issue's enumerated optional set); an omitted value takes the `TargetCreate` default. Trivial to add later if an agent workflow needs it.

## Conformance (#2745 / #2774)

- Name `meho_targets_register` satisfies `^[a-zA-Z0-9_-]{1,64}$`; `inputSchema` root is a plain `type:object` (no top-level combinator).
- `outputSchema` is `with_parked_shape(...)` — a `type:object` root whose `oneOf` covers both the executed `{target_id, name, product, host, tenant_id}` payload and the `awaiting_approval` envelope. Added to the pinned rosters in `test_mcp_structured_content.py` and `test_mcp_output_schema_conformance.py` with real-payload executed **and** parked conformance scenarios.

## Documentation deviation (please note)

The issue's acceptance criteria mention updating "CLAUDE.md's agent-surface note". **CLAUDE.md is deliberately not touched** — it is gitignored in `evoila/meho` and managed separately, and `meho_targets_register` is an admin-namespace tool that sits **outside** CLAUDE.md's ~17-tool daily agent surface (the issue body itself says so), so it does not belong in that table. The documentation obligation is satisfied in **`docs/codebase/mcp.md`** (new "Admin registry writes route through the dispatcher" section recording the tool + the synthetic-connector policy-gate pattern).

"CLI OpenAPI / MCP tool-list snapshot regenerated if applicable" — **not applicable**: this adds no REST route (so `cli/api/openapi.json` is unaffected), and there is no MCP tool-list golden snapshot file; the conformance test suites are the machine-checked tool surface and are extended here.

## Test plan

- [x] `ruff check` — clean (new source + touched tests)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/targets/ mcp/tools/targets_register.py` — Success, no issues
- [x] `code-quality.py --diff` — 0 blockers (1 warning: `dispatch_targets_write` 64 lines, mirrors the sibling `dispatch_topology_write`, under the 100-line block threshold)
- [x] `tests/test_mcp_tools_targets_register.py` — 13 passed (registration/RBAC, human-executes round-trip via `list_targets`, agent parks as `ApprovalRequest` with no target row, unknown-product / SSRF-host / out-of-scope-`secret_ref` guards fire, `tenant_id`/`fingerprint` schema-rejected)
- [x] `tests/test_mcp_output_schema_conformance.py tests/test_mcp_structured_content.py tests/test_published_tool_schema_shape.py tests/test_mcp_tools_list_shape_conventions.py` — 92 passed (executed + parked conformance scenarios; name/shape sweeps auto-cover the new tool)
- [x] Regression sweep — 283 passed across `operations_meta_tools`, `operations_dispatcher`, `connectors_registry_v2`, `topology_ops_approval`, `secret_move_approval`, `mcp_tools_topology_create_node`, `mcp_tools_topology_annotate`, `api_v1_targets`

Closes #2861
