### PR TITLE
feat(events): add event_outbox dedupe_key + origin columns (#2879)

### DIFF
--- a/backend/alembic/versions/0073_event_outbox_dedupe_key_origin.py
+++ b/backend/alembic/versions/0073_event_outbox_dedupe_key_origin.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``event_outbox.dedupe_key`` + ``origin`` columns (#2879).
+
+Revision ID: 0073
+Revises: 0072
+Create Date: 2026-08-17
+
+Task #2879 under Initiative #2877. Two additive, nullable columns plus one
+partial unique index on the ``event_outbox`` table (migration ``0027``),
+the substrate for at-least-once external event ingest (the ingest handler
+that populates them lands in #2881 -- out of scope here, schema only):
+
+* ``dedupe_key`` -- Text, nullable. Producer-supplied idempotency token.
+  Webhook senders retry by nature, so at-least-once ingest needs
+  DB-enforced idempotency: a duplicate ``(tenant_id, dedupe_key)`` must
+  collide at insert instead of double-firing a subscriber. NULL for the
+  existing internal producers (agent-run completion, ...), which leave it
+  unset -- so this migration is behaviour-preserving on its own and the
+  ``events.publish`` call site (operations/agent_run.py) is untouched.
+
+* ``origin`` -- Text, nullable. Event provenance: NULL means an internal
+  MEHO producer, a non-NULL value is the external event-source id. Gives
+  audit / policy surfaces a column to key "external input" on instead of
+  parsing the free-text ``event_kind``.
+
+Partial unique index -- and why partial
+---------------------------------------
+
+``event_outbox_tenant_dedupe_idx`` is ``UNIQUE (tenant_id, dedupe_key)
+WHERE dedupe_key IS NOT NULL``. The ``WHERE`` predicate keeps every
+NULL-``dedupe_key`` internal-producer row (the overwhelming majority) out
+of the index entirely, so the index carries only the externally-ingested
+rows the dedupe check actually consults and its size stays flat as the
+internal outbox grows. Uniqueness is per tenant: two tenants may reuse the
+same ``dedupe_key`` string. A duplicate insert raises ``IntegrityError``,
+which the #2881 ingest endpoint maps to an idempotent ``200``.
+
+Dialect portability
+-------------------
+
+The partial predicate is emitted on **both** dialects via the
+``postgresql_where`` / ``sqlite_where`` keyword pair on
+:func:`op.create_index` -- the same pattern migration ``0072`` uses for
+``targets_tenant_name_idx``. PostgreSQL supports partial indexes natively;
+SQLite has since 3.8.0 (we run 3.45+), so the unit-test path enforces the
+exact same partial-unique shape production does. (This is a deliberate
+departure from ``0027``'s original ``event_outbox_unprocessed_idx``, which
+predates the repo's move to ``sqlite_where`` and fell back to a plain
+b-tree on SQLite.)
+
+Additive-only forward, reversible back
+--------------------------------------
+
+``upgrade()`` only adds nullable columns and creates an index -- purely
+additive, so it clears ``scripts/ci/check_migration_compat.py`` and an
+older image reading the newer schema simply never references the two new
+columns (the ``helm rollback`` = image-revert + forward-compat-schema
+contract, ``docs/codebase/migrations.md`` / #1607, holds).
+
+``downgrade()`` drops the index, then drops the two columns inside a
+``batch_alter_table`` block (reverse add order). Batch mode is required
+because SQLite adds column-drop support only via the table-recreate
+cookbook; the index is dropped first, outside the batch, so the recreate
+reflects a table that no longer carries it.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0073"
+down_revision: str | None = "0072"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the two nullable columns + the partial unique dedupe index."""
+    op.add_column("event_outbox", sa.Column("dedupe_key", sa.Text(), nullable=True))
+    op.add_column("event_outbox", sa.Column("origin", sa.Text(), nullable=True))
+    op.create_index(
+        "event_outbox_tenant_dedupe_idx",
+        "event_outbox",
+        ["tenant_id", "dedupe_key"],
+        unique=True,
+        postgresql_using="btree",
+        postgresql_where=sa.text("dedupe_key IS NOT NULL"),
+        sqlite_where=sa.text("dedupe_key IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the dedupe index, then the two columns (reverse add order)."""
+    op.drop_index("event_outbox_tenant_dedupe_idx", table_name="event_outbox")
+    with op.batch_alter_table("event_outbox") as batch_op:
+        batch_op.drop_column("origin")
+        batch_op.drop_column("dedupe_key")

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -5388,6 +5388,18 @@ class EventOutbox(Base):
 
     * ``created_at`` -- ``timestamptz`` NOT NULL DEFAULT ``now()``.
 
+    * ``dedupe_key`` -- Text, nullable (migration 0073). Producer-
+      supplied idempotency token for at-least-once external ingest.
+      NULL for internal producers; when set it is unique per tenant
+      (see ``event_outbox_tenant_dedupe_idx``) so a retried delivery
+      collides at insert instead of double-firing a subscriber. The
+      ingest path that populates it lands in #2881.
+
+    * ``origin`` -- Text, nullable (migration 0073). Event provenance:
+      NULL = internal MEHO producer, else the external event-source id.
+      Gives audit / policy surfaces a column to key "external input" on
+      instead of parsing the free-text ``event_kind``.
+
     Indexes
     -------
 
@@ -5398,6 +5410,11 @@ class EventOutbox(Base):
       ``event_id`` ``WHERE processed_at IS NULL`` on PG (plain b-tree
       on SQLite). Drives the global drain scan; partial keeps the
       index size flat as processed rows are tombstoned.
+    * ``event_outbox_tenant_dedupe_idx`` -- partial **unique** b-tree
+      on ``(tenant_id, dedupe_key)`` ``WHERE dedupe_key IS NOT NULL``
+      (migration 0073, emitted on both dialects). DB-enforced
+      idempotency for external ingest; NULL-``dedupe_key`` internal
+      rows stay out of the index and are unconstrained.
     """
 
     __tablename__ = "event_outbox"
@@ -5443,6 +5460,25 @@ class EventOutbox(Base):
         nullable=False,
         default=lambda: datetime.now(UTC),
     )
+    # Producer-supplied idempotency token (#2879). NULL for internal
+    # producers (agent-run completion, ...); a non-NULL value is unique
+    # per tenant via ``event_outbox_tenant_dedupe_idx`` below, so a
+    # retried at-least-once delivery (webhook ingest, #2881) collides at
+    # insert instead of double-firing a subscriber.
+    dedupe_key: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
+    # Event provenance (#2879). NULL means an internal MEHO producer; a
+    # non-NULL value is the external event-source id, so audit / policy
+    # surfaces key "external input" on this column instead of parsing the
+    # free-text ``event_kind``.
+    origin: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(
@@ -5457,6 +5493,23 @@ class EventOutbox(Base):
             "event_id",
             postgresql_using="btree",
             postgresql_where=sa.text("processed_at IS NULL"),
+        ),
+        # DB-enforced idempotency for external at-least-once ingest
+        # (#2879): a duplicate ``(tenant_id, dedupe_key)`` collides at
+        # insert. Partial (``WHERE dedupe_key IS NOT NULL``) so internal
+        # producers -- which leave ``dedupe_key`` NULL -- never enter the
+        # index and stay unconstrained. Emitted on both dialects
+        # (``sqlite_where`` alongside ``postgresql_where``) so the SQLite
+        # unit-test path enforces the same partial-unique shape PG does;
+        # SQLite has supported partial indexes since 3.8.0.
+        Index(
+            "event_outbox_tenant_dedupe_idx",
+            "tenant_id",
+            "dedupe_key",
+            unique=True,
+            postgresql_using="btree",
+            postgresql_where=sa.text("dedupe_key IS NOT NULL"),
+            sqlite_where=sa.text("dedupe_key IS NOT NULL"),
         ),
     )
 

--- a/backend/tests/migrations/test_migration_0073_event_outbox_dedupe.py
+++ b/backend/tests/migrations/test_migration_0073_event_outbox_dedupe.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0073_event_outbox_dedupe_key_origin``.
+
+Initiative #2877, Task #2879. The migration adds two additive nullable
+columns to ``event_outbox`` (migration ``0027``) plus a partial unique
+index:
+
+* ``dedupe_key`` -- Text, nullable. Producer-supplied idempotency token
+  for at-least-once external ingest.
+* ``origin`` -- Text, nullable. Event provenance (NULL = internal MEHO
+  producer, else the external event-source id).
+* ``event_outbox_tenant_dedupe_idx`` -- ``UNIQUE (tenant_id, dedupe_key)
+  WHERE dedupe_key IS NOT NULL``, emitted on both dialects.
+
+Coverage (mapped to the issue's acceptance criteria):
+
+* **Additive schema** -- ``upgrade 0073`` leaves both columns present and
+  nullable, and the partial unique index in place.
+* **SQLite partial-index parity** -- the index's stored DDL carries the
+  ``UNIQUE ... WHERE dedupe_key IS NOT NULL`` predicate on SQLite, so the
+  unit-test path enforces the same shape PostgreSQL does.
+* **DB-enforced dedupe** -- a duplicate ``(tenant_id, dedupe_key)`` raises
+  :class:`IntegrityError` (the #2881 ingest endpoint maps this to an
+  idempotent ``200``).
+* **Internal producers unaffected** -- many rows with ``dedupe_key`` NULL
+  coexist in one tenant (the partial predicate excludes them), and the
+  uniqueness is per tenant (two tenants may reuse the same key).
+* **Reversibility round-trip** -- ``downgrade 0072`` drops the two columns
+  and the dedupe index while preserving the two original indexes; a
+  subsequent ``upgrade 0073`` restores the additive shape.
+
+Every step targets this migration's own revision (``0073``) and its
+``down_revision`` (``0072``), never ``head`` -- so a future head migration
+cannot silently change what these tests exercise (the 0049/0054 footgun).
+SQLite is the test driver; the migration emits ``sqlite_where`` so PG
+parity holds via the equivalent native partial index.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+_REVISION = "0073"
+_DOWN_REVISION = "0072"
+
+_NEW_COLUMNS: frozenset[str] = frozenset({"dedupe_key", "origin"})
+_DEDUPE_INDEX = "event_outbox_tenant_dedupe_idx"
+#: Indexes migration 0027 installed -- must survive the downgrade's
+#: batch-mode table recreate.
+_ORIGINAL_INDEXES: frozenset[str] = frozenset(
+    {
+        "event_outbox_tenant_unprocessed_idx",
+        "event_outbox_unprocessed_idx",
+    }
+)
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0073.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _table_columns(sync_url: str, table: str) -> set[str]:
+    """Return the set of column names on *table* via ``PRAGMA``."""
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _column_is_nullable(sync_url: str, table: str, column: str) -> bool:
+    """Return True when *column* on *table* permits NULL."""
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            return int(row[3]) == 0
+    raise AssertionError(f"column {column!r} not present on {table}")
+
+
+def _table_indexes(sync_url: str, table: str) -> set[str]:
+    """Return the set of index names declared on *table*."""
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA index_list({table})")).all()
+    finally:
+        eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _index_sql(sync_url: str, name: str) -> str:
+    """Return the stored ``CREATE INDEX`` DDL for index *name*."""
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.connect() as conn:
+            row = conn.execute(
+                text("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = :n"),
+                {"n": name},
+            ).first()
+    finally:
+        eng.dispose()
+    if row is None or row[0] is None:
+        raise AssertionError(f"index {name!r} has no stored DDL")
+    return str(row[0])
+
+
+def _seed_tenant(sync_url: str) -> str:
+    """Insert one tenant (FK enforcement on); return its id string."""
+    eng = sa_create_engine(sync_url)
+    tenant_id = str(uuid.uuid4())
+    now = datetime.now(UTC).isoformat()
+    try:
+        with eng.begin() as conn:
+            conn.execute(text("PRAGMA foreign_keys = ON"))
+            conn.execute(
+                text(
+                    "INSERT INTO tenant (id, slug, name, created_at) "
+                    "VALUES (:id, :slug, :name, :created_at)"
+                ),
+                {
+                    "id": tenant_id,
+                    "slug": f"t-{tenant_id[:8]}",
+                    "name": "Dedupe Tenant",
+                    "created_at": now,
+                },
+            )
+    finally:
+        eng.dispose()
+    return tenant_id
+
+
+def _insert_event(
+    sync_url: str,
+    tenant_id: str,
+    *,
+    dedupe_key: str | None,
+    origin: str | None = None,
+    event_kind: str = "ingest.test",
+) -> None:
+    """Insert one ``event_outbox`` row. Fresh connection so each row commits."""
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO event_outbox "
+                    "(tenant_id, event_kind, payload, created_at, dedupe_key, origin) "
+                    "VALUES (:tenant_id, :event_kind, '{}', :created_at, :dedupe_key, :origin)"
+                ),
+                {
+                    "tenant_id": tenant_id,
+                    "event_kind": event_kind,
+                    "created_at": datetime.now(UTC).isoformat(),
+                    "dedupe_key": dedupe_key,
+                    "origin": origin,
+                },
+            )
+    finally:
+        eng.dispose()
+
+
+def test_upgrade_adds_columns_nullable_and_partial_unique_index(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``upgrade 0073`` adds nullable ``dedupe_key`` / ``origin`` + the dedupe index."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+
+    columns = _table_columns(sync_url, "event_outbox")
+    assert columns >= _NEW_COLUMNS, f"missing new columns: {_NEW_COLUMNS - columns}"
+    for col in _NEW_COLUMNS:
+        assert _column_is_nullable(sync_url, "event_outbox", col), f"{col} must be nullable"
+
+    indexes = _table_indexes(sync_url, "event_outbox")
+    assert _DEDUPE_INDEX in indexes, "upgrade must create the dedupe index"
+    assert indexes >= _ORIGINAL_INDEXES, "upgrade must leave the 0027 indexes in place"
+
+    # SQLite partial-index parity: the stored DDL must carry the UNIQUE
+    # partial predicate, proving SQLite enforces the same shape PG does.
+    ddl = _index_sql(sync_url, _DEDUPE_INDEX).upper()
+    assert "UNIQUE" in ddl, f"dedupe index must be UNIQUE; got: {ddl}"
+    assert "WHERE" in ddl and "DEDUPE_KEY IS NOT NULL" in ddl, (
+        f"dedupe index must be partial on dedupe_key IS NOT NULL; got: {ddl}"
+    )
+
+
+def test_dedupe_key_unique_per_tenant_rejects_duplicate(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A duplicate ``(tenant_id, dedupe_key)`` raises :class:`IntegrityError`."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    tenant_id = _seed_tenant(sync_url)
+
+    _insert_event(sync_url, tenant_id, dedupe_key="dup-1", origin="src-A")
+    with pytest.raises(IntegrityError):
+        _insert_event(sync_url, tenant_id, dedupe_key="dup-1", origin="src-B")
+
+
+def test_null_dedupe_key_unconstrained_and_uniqueness_is_per_tenant(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """NULL ``dedupe_key`` rows are unconstrained; the key is unique *per tenant*."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    tenant_a = _seed_tenant(sync_url)
+    tenant_b = _seed_tenant(sync_url)
+
+    # Internal producers leave dedupe_key NULL -- the partial predicate
+    # keeps them out of the index, so many coexist in one tenant.
+    for _ in range(3):
+        _insert_event(sync_url, tenant_a, dedupe_key=None)
+
+    # Same key under two tenants is fine (uniqueness is per tenant)...
+    _insert_event(sync_url, tenant_a, dedupe_key="shared-key")
+    _insert_event(sync_url, tenant_b, dedupe_key="shared-key")
+
+    # ...but a second use within tenant_a still collides.
+    with pytest.raises(IntegrityError):
+        _insert_event(sync_url, tenant_a, dedupe_key="shared-key")
+
+
+def test_downgrade_drops_columns_and_index_keeping_originals(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``downgrade 0072`` removes the columns + dedupe index; 0027 indexes survive."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    command.downgrade(cfg, _DOWN_REVISION)
+
+    columns = _table_columns(sync_url, "event_outbox")
+    assert not (_NEW_COLUMNS & columns), f"downgrade must drop {_NEW_COLUMNS & columns}"
+
+    indexes = _table_indexes(sync_url, "event_outbox")
+    assert _DEDUPE_INDEX not in indexes, "downgrade must drop the dedupe index"
+    assert indexes >= _ORIGINAL_INDEXES, "the batch-mode recreate must preserve the 0027 indexes"
+
+
+def test_downgrade_then_upgrade_round_trips(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``upgrade 0073`` → ``downgrade 0072`` → ``upgrade 0073`` restores the shape."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _REVISION)
+    tenant_id = _seed_tenant(sync_url)
+    _insert_event(sync_url, tenant_id, dedupe_key="round-trip", origin="src")
+
+    command.downgrade(cfg, _DOWN_REVISION)
+    assert not (_NEW_COLUMNS & _table_columns(sync_url, "event_outbox"))
+
+    command.upgrade(cfg, _REVISION)
+    assert _table_columns(sync_url, "event_outbox") >= _NEW_COLUMNS
+    assert _DEDUPE_INDEX in _table_indexes(sync_url, "event_outbox")
+
+    # Enforcement works again post-round-trip (the dropped column's old
+    # value is gone, so this fresh key inserts, then collides on reuse).
+    _insert_event(sync_url, tenant_id, dedupe_key="post-rt")
+    with pytest.raises(IntegrityError):
+        _insert_event(sync_url, tenant_id, dedupe_key="post-rt")
+
+
+def test_pre_upgrade_lacks_dedupe_columns(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """At revision 0072 the columns + dedupe index do not yet exist."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, _DOWN_REVISION)
+
+    columns = _table_columns(sync_url, "event_outbox")
+    assert not (_NEW_COLUMNS & columns), "0072 must predate the dedupe columns"
+    assert _DEDUPE_INDEX not in _table_indexes(sync_url, "event_outbox")

--- a/docs/codebase/events.md
+++ b/docs/codebase/events.md
@@ -49,14 +49,21 @@ Plus the persistence shape in
   `BIGSERIAL` / SQLite `Integer`), `tenant_id` (FK), `event_kind`
   (free-text discriminator), `payload` (JSONB / JSON), `created_at`,
   `claimed_at` (observability), `claimed_by` (observability),
-  `processed_at` (`NULL` until claimed and dispatched), and a partial
-  index `(processed_at, event_id)` on `processed_at IS NULL` to drive
-  the drain's claim query.
+  `processed_at` (`NULL` until claimed and dispatched), `dedupe_key`
+  (`NULL` for internal producers; a producer-supplied idempotency token
+  for at-least-once external ingest), and `origin` (`NULL` = internal
+  producer, else the external event-source id). Two partial indexes:
+  `(processed_at, event_id)` on `processed_at IS NULL` drives the
+  drain's claim query, and the **unique** `event_outbox_tenant_dedupe_idx`
+  on `(tenant_id, dedupe_key)` `WHERE dedupe_key IS NOT NULL` makes a
+  duplicate external delivery collide at insert.
 - `EVENT_OUTBOX_NOTIFY_CHANNEL` — the PG channel name the producer
   side `NOTIFY`s on and the drain side `LISTEN`s on.
 
-Migration: `backend/alembic/versions/0027_create_event_outbox.py`
-(revises `0026`, which is #1125's agent-run lease/reaper columns).
+Migrations: `backend/alembic/versions/0027_create_event_outbox.py`
+(revises `0026`, #1125's agent-run lease/reaper columns) created the
+table; `0073_event_outbox_dedupe_key_origin.py` (#2879) adds the
+`dedupe_key` / `origin` columns and the partial unique dedupe index.
 
 ## The producer side — `publish()`
 
@@ -275,6 +282,10 @@ Both gated via env vars (defaults shown in parens):
     simulate kill → restart → tick drains the row
 - [backend/tests/migrations/test_migration_0027_event_outbox.py](backend/tests/migrations/test_migration_0027_event_outbox.py)
   — schema + index migration round-trip
+- [backend/tests/migrations/test_migration_0073_event_outbox_dedupe.py](backend/tests/migrations/test_migration_0073_event_outbox_dedupe.py)
+  — `dedupe_key` / `origin` additive columns + partial unique dedupe
+  index (per-tenant uniqueness, NULL-unconstrained, SQLite partial-index
+  parity, downgrade round-trip)
 
 ## References
 


### PR DESCRIPTION
## Summary

- Adds Alembic migration **0073** (two additive nullable columns + one partial unique index on `event_outbox`) plus the matching `EventOutbox` model changes — the schema substrate for at-least-once external event ingest. Schema only; no behaviour wiring (the ingest handler that populates the columns lands in #2881).
- `dedupe_key` (Text, nullable): producer-supplied idempotency token. `event_outbox_tenant_dedupe_idx` enforces `UNIQUE (tenant_id, dedupe_key) WHERE dedupe_key IS NOT NULL`, so a retried at-least-once delivery collides at insert (`IntegrityError`, which #2881 maps to an idempotent 200) instead of double-firing a subscriber. Partial + NULL for internal producers means the existing `publish()` call site is untouched and unaffected.
- `origin` (Text, nullable): event provenance — `NULL` = internal MEHO producer, else the external event-source id — giving audit/policy surfaces a column to key "external input" on instead of parsing the free-text `event_kind`.
- **Numbering note:** the issue was filed against head `0071` and asked for `0072`, but `0072_targets_partial_unique_name_index` (#2874) has since landed, so this correctly chains as **0073** (`down_revision = "0072"`).

## Design notes

- The partial predicate is emitted on **both** dialects (`postgresql_where` + `sqlite_where`, the `0072` pattern), so the SQLite unit-test path enforces the same partial-unique shape production does (SQLite has had partial indexes since 3.8.0; we run 3.45+). This is a deliberate departure from `0027`'s SQLite-plain-b-tree fallback, which predates the repo's move to `sqlite_where`.
- `upgrade()` is purely additive (nullable `add_column` ×2 + `create_index`), so it clears `scripts/ci/check_migration_compat.py` and stays forward-compatible per the `helm rollback` contract (`docs/codebase/migrations.md` / #1607). `downgrade()` drops the index, then the columns via `batch_alter_table` (SQLite-safe).

## Test plan

- [x] `scripts/ci/check_migration_compat.py backend/alembic/versions` — PASS (additive-only `upgrade()`)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/` (strict) — clean for this change (711 files)
- [x] `pytest tests/migrations/test_migration_0073_event_outbox_dedupe.py` — 6 passed
- [x] `pytest tests/test_event_outbox.py tests/migrations/test_migration_0027_event_outbox.py` — pass (internal producers + drain unaffected)
- [x] Acceptance criteria, all proven in the new round-trip test:
  - Internal producers unaffected — nullable columns; existing `event_outbox` suite green, `publish()` / `agent_run.py` untouched.
  - Duplicate `(tenant_id, dedupe_key)` raises `IntegrityError` cleanly.
  - Migration round-trip test per the 0027 pattern (upgrade → downgrade `0072` → re-upgrade).
  - SQLite partial-index parity — the stored index DDL carries `UNIQUE … WHERE dedupe_key IS NOT NULL`; per-tenant uniqueness and NULL-unconstrained behaviour verified behaviourally on SQLite.

## Out of scope

- The webhook ingest path that populates `dedupe_key` / `origin` and maps the unique violation to an idempotent 200 — #2881.
- `event_kind` stays free-text (no migration), per the issue.
- Pre-existing adjacent finding (not touched): `backend/src/meho_backplane/db/models.py` is 6748 lines (over the 600-line quality threshold) — the monolithic models module, out of scope here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2879
