### PR TITLE
feat(events): subscription matcher + enable kind=event triggers

### DIFF
--- a/backend/src/meho_backplane/api/v1/scheduler.py
+++ b/backend/src/meho_backplane/api/v1/scheduler.py
@@ -73,7 +73,6 @@ from meho_backplane.scheduler.schemas import (
 )
 from meho_backplane.scheduler.service import (
     AgentDefinitionMissingError,
-    EventTriggersNotImplementedError,
     SchedulerAdminService,
 )
 
@@ -194,14 +193,6 @@ async def create_trigger(
             created_by_sub=operator.sub,
             payload=body,
         )
-    except EventTriggersNotImplementedError as exc:
-        # 422 -- kind=event is refused at create until #826 wires the
-        # event-subscription matcher (the drain matcher is a no-op today,
-        # so an accepted event trigger would never fire).
-        raise HTTPException(
-            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=exc.error_code,
-        ) from exc
     except AgentDefinitionMissingError as exc:
         # 422 -- the payload is well-formed but its
         # ``agent_definition_id`` does not resolve to a definition in

--- a/backend/src/meho_backplane/checks/investigate.py
+++ b/backend/src/meho_backplane/checks/investigate.py
@@ -30,9 +30,10 @@ provenance), the pre-run budget gate + kill switch, bounded waiting, and
 The trigger seam
 ================
 
-There is no event machinery to ride (``kind=event`` trigger creation is refused
-until the #826 matcher lands, #2325) and #2506's rollup is read-path-only by
-decision, so the seam is a **hook at #2505's runner result-persist path**:
+The investigator does not ride the event-outbox machinery (the ``kind=event``
+matcher, #2878, dispatches subscribed agent triggers, not the diagnose-only
+investigator) and #2506's rollup is read-path-only by decision, so the seam is
+a **hook at #2505's runner result-persist path**:
 :func:`investigate_on_transition` is called immediately after every
 ``record_sensor_result`` persist. It recomputes the rollup for exactly the
 Dashboards containing the just-evaluated Sensor, compares against the

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -5326,9 +5326,10 @@ class EventOutbox(Base):
     ``cancelled``; future kinds: audit predicates, connector alerts).
     A separate drain loop (:mod:`meho_backplane.events.drain`) scans the
     outbox via ``SELECT ... FOR UPDATE SKIP LOCKED``, claims unprocessed
-    rows, and dispatches them to subscribed
-    :class:`ScheduledTrigger` rows of kind ``'event'`` once the
-    subscription matcher lands (T5 #826).
+    rows, and dispatches them through the subscription matcher
+    (:mod:`meho_backplane.events.matcher`, #2878), which fires every
+    subscribed :class:`ScheduledTrigger` row of kind ``'event'`` whose
+    ``event_filter`` the payload contains.
 
     Why a transactional outbox (not raw ``LISTEN/NOTIFY``)
     ------------------------------------------------------
@@ -5366,7 +5367,7 @@ class EventOutbox(Base):
       / :attr:`ScheduledTrigger.tenant_id`.
 
     * ``event_kind`` -- Text NOT NULL. The discriminator the matcher
-      will use once the subscription-junction lands. Free-text (not a
+      keys a subscriber's filter against. Free-text (not a
       closed enum) because event kinds are added per-Initiative
       without coordinated DB migrations; the matching policy lives in
       the subscriber. v0.2 values shipped: ``agent_run.completed``.
@@ -5382,9 +5383,9 @@ class EventOutbox(Base):
       observe which replica is handling a stuck claim.
 
     * ``processed_at`` -- ``timestamptz`` nullable. Stamped after the
-      event has been dispatched (or marked no-op in v0.2 when no
-      subscriber matches). NULL means "not yet processed"; the partial
-      index keys on this column.
+      event has been dispatched to the matcher (an event that matches
+      no subscriber is still stamped, with no fire). NULL means "not
+      yet processed"; the partial index keys on this column.
 
     * ``created_at`` -- ``timestamptz`` NOT NULL DEFAULT ``now()``.
 
@@ -5392,8 +5393,8 @@ class EventOutbox(Base):
     -------
 
     * ``event_outbox_tenant_unprocessed_idx`` -- b-tree on
-      ``(tenant_id, processed_at, event_id)``. Drives the future
-      tenant-scoped scan once the matcher lands.
+      ``(tenant_id, processed_at, event_id)``. Reserved for a future
+      tenant-scoped drain scan; the drain scans globally today.
     * ``event_outbox_unprocessed_idx`` -- partial b-tree on
       ``event_id`` ``WHERE processed_at IS NULL`` on PG (plain b-tree
       on SQLite). Drives the global drain scan; partial keeps the

--- a/backend/src/meho_backplane/events/__init__.py
+++ b/backend/src/meho_backplane/events/__init__.py
@@ -23,14 +23,14 @@ that wakes the drain loop's sleep early, dropping per-event latency
 from "next 5-10s tick" to "sub-second". A dropped notification is
 benign -- the next polled tick picks the row up anyway.
 
-The subscription-matcher (looking up
-:class:`~meho_backplane.db.models.ScheduledTrigger` rows of
-``kind='event'`` and matching their ``event_filter`` against
-``event_outbox.payload``) is intentionally deferred. It depends on
-T5 #826's admin surface to ship the trigger-creation path. v1 of the
-drain loop processes events by stamping ``processed_at`` (no
-subscriber matched); the matcher is folded in as a follow-up once
-T5 lands.
+The subscription matcher (:mod:`meho_backplane.events.matcher`) fires
+every active ``kind='event'``
+:class:`~meho_backplane.db.models.ScheduledTrigger` whose
+``event_filter`` the drained ``event_outbox.payload`` contains
+(``payload @> event_filter``), through the same
+``AgentInvoker.run_scheduled`` seam the cron / one-off scheduler uses.
+Each fire is deduped per (event, trigger) on the run's work_ref, so a
+redelivered event never double-fires an agent.
 
 Public surface
 ==============

--- a/backend/src/meho_backplane/events/drain.py
+++ b/backend/src/meho_backplane/events/drain.py
@@ -18,14 +18,13 @@ event-subscription trigger. On each cadence (default 10s, settable via
    receive the same row even with the advisory-lock guard removed.
    Stamp ``claimed_at`` + ``claimed_by`` for observability.
 
-3. **Dispatch each row.** In v0.2 the subscription matcher
-   (``scheduled_trigger`` rows of ``kind='event'`` whose
-   ``event_filter`` matches the payload) is not yet built -- T5 #826's
-   admin surface ships the trigger-creation path that populates such
-   rows. The drain therefore stamps ``processed_at`` directly: the
-   event is durably consumed even though no subscriber fires. When T5
-   lands the matcher is folded in here (one ``SELECT`` against
-   ``scheduled_trigger`` per drained event) without a migration.
+3. **Dispatch each row** through the subscription matcher
+   (:mod:`meho_backplane.events.matcher`): for each claimed event it
+   fires every active ``kind='event'`` :class:`~meho_backplane.db.models.ScheduledTrigger`
+   whose ``event_filter`` is contained by the payload (``payload @>
+   event_filter``), then stamps ``processed_at``. An event that matches
+   no subscriber is still durably consumed (stamped, no fire, no log
+   noise).
 
 4. **Release the advisory lock** in a ``finally`` so a crash mid-tick
    never strands the lock for the rest of the connection's life.
@@ -71,12 +70,17 @@ The outbox row carries the durable state. On restart:
 Delivery semantics
 ==================
 
-At-least-once. A dispatch that crashes between "marked processed" and
-"side-effect committed" is acceptable; the v1 dispatch (mark
-processed, no subscriber) is idempotent by construction. When the
-T5 matcher lands the subscriber's dispatch will need to be idempotent
-or the matcher will need to record a per-subscriber dedupe key in the
-trigger's audit row. Documented as a follow-up.
+At-least-once. A fired subscriber's ``agent_run`` commits in its own
+transaction, *before* the drain stamps ``processed_at`` -- so a crash
+between the two leaves the event unprocessed and the next tick
+re-matches it. Double-firing is prevented by the matcher's
+``event:{event_id}:{trigger_id}`` work_ref dedupe
+(:mod:`meho_backplane.events.matcher`), not by exactly-once delivery:
+the redelivered event finds the first delivery's run and skips it. The
+claim stamps are committed *before* the per-event fire so the drain
+holds no open write across a subscriber's run-row commit (which lands
+in its own session); the drain advisory lock plus the ``processed_at
+IS NULL`` conditional stay the single-processing guards.
 """
 
 from __future__ import annotations
@@ -86,6 +90,7 @@ import contextlib
 import os
 import socket
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 import structlog
 from sqlalchemy import select, text, update
@@ -94,6 +99,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.db.engine import get_engine, get_sessionmaker
 from meho_backplane.db.models import EVENT_OUTBOX_NOTIFY_CHANNEL, EventOutbox
 from meho_backplane.settings import get_settings
+
+if TYPE_CHECKING:
+    # Type-only: the concrete import (and the matcher import in
+    # `_dispatch_event`) stay lazy so `events` -> `agent.invocation` ->
+    # `operations.agent_run` -> `events.outbox` does not close an import cycle
+    # at module-load time. Same lazy-import discipline the scheduler loop uses
+    # for its Vault-credential helpers.
+    from meho_backplane.agent.invocation import AgentInvoker
 
 __all__ = [
     "run_one_drain_tick",
@@ -248,36 +261,49 @@ async def _dispatch_event(
     row: EventOutbox,
     *,
     now: datetime,
+    invoker: AgentInvoker,
 ) -> bool:
-    """Dispatch one event -- v0.2 stamps processed; matcher TBD (T5).
+    """Fire every matching subscription for one event, then mark it processed.
 
-    The v0.2 dispatch path is a no-op subscriber match: the event is
-    consumed (``processed_at`` stamped) but no agent run fires
-    because the subscription junction (``scheduled_trigger`` rows of
-    ``kind='event'`` whose ``event_filter`` matches the payload) has
-    no admin-surface path to populate it until T5 #826 lands.
+    The subscription matcher (:mod:`meho_backplane.events.matcher`) fires each
+    active ``kind='event'`` trigger whose ``event_filter`` the payload contains
+    (``payload @> event_filter``) via ``AgentInvoker.run_scheduled``. Firing
+    runs first, in the matcher's own sessions (each run row commits
+    independently), so this drain session holds no open write across it; the
+    fired run's ``event:{event_id}:{trigger_id}`` work_ref makes a redelivered
+    event idempotent. Marking processed happens last -- a crash after a fire
+    but before the stamp re-delivers the event, and the work_ref dedupe skips
+    the already-fired run. An event that matches no subscriber is stamped with
+    no fire and no per-event log noise.
 
-    When T5 ships, this function gains a ``SELECT`` against
-    ``scheduled_trigger`` (``WHERE kind='event' AND status='active'
-    AND tenant_id = row.tenant_id``) and a JSONB containment match
-    against ``event_filter``. For each matching trigger, the function
-    fires the agent via the same :class:`AgentInvoker.run_scheduled`
-    path the scheduler loop uses (Hard rule: subscribers are
-    idempotent or carry a dedupe key in their audit row).
-
-    Returns ``True`` when the event was successfully dispatched and
-    marked processed; ``False`` when another drainer beat us to it.
+    Returns ``True`` when this drainer stamped ``processed_at``; ``False`` when
+    another drainer beat it to the row (the conditional stamp matched zero
+    rows).
     """
-    # v0.2 no-op match (T5 follow-up wires the junction here).
+    # Lazy import: keeps `events` -> `events.matcher` -> `scheduler.loop` ->
+    # `agent.invocation` off the module-load path (see the top-of-module
+    # TYPE_CHECKING note). Cached after the first tick.
+    from meho_backplane.events.matcher import fire_matching_triggers
+
+    await fire_matching_triggers(row, invoker)
     return await _mark_processed(session, row, now=now)
 
 
-async def run_one_drain_tick() -> int:
+async def run_one_drain_tick(invoker: AgentInvoker | None = None) -> int:
     """Execute one drain tick. Returns the number of events processed.
 
     Public so tests can drive a deterministic single-tick without the
-    cadence sleep.
+    cadence sleep. The optional *invoker* override lets tests inject a
+    deterministic :class:`AgentInvoker` over a ``FunctionModel`` so a
+    subscription fire executes end-to-end without a real LLM call (mirrors
+    :func:`meho_backplane.scheduler.loop.run_one_tick`).
     """
+    if invoker is None:
+        # Lazy import (see `_dispatch_event`): the default invoker is only
+        # resolved at runtime, off the module-load path.
+        from meho_backplane.agent.invocation import get_agent_invoker
+
+        invoker = get_agent_invoker()
     sessionmaker = get_sessionmaker()
     processed = 0
     async with sessionmaker() as session:
@@ -298,16 +324,29 @@ async def run_one_drain_tick() -> int:
                 now=now,
                 claimed_by=_claimer_identity(),
             )
+            # Commit the claim stamps before dispatching: a matched
+            # subscription fires an agent run that commits in its own session,
+            # and the drain must hold no open write across that commit (the
+            # scheduler-fire precedent -- loop.py commits the trigger-state
+            # write before dispatching). The advisory lock (session-scoped, so
+            # a mid-tick commit does not release it) plus the ``processed_at IS
+            # NULL`` conditional in `_mark_processed` remain the single-
+            # processing guards once the claim's row locks release here.
+            await session.commit()
             for row in rows:
                 try:
-                    dispatched = await _dispatch_event(session, row, now=now)
+                    dispatched = await _dispatch_event(session, row, now=now, invoker=invoker)
                     if dispatched:
                         processed += 1
+                    # Commit each event's processed stamp on its own so the
+                    # next event's fire again finds no open write held.
+                    await session.commit()
                 except Exception:
-                    # Per-row isolation: one bad row never stalls the
-                    # tick. The row stays unprocessed (next tick
-                    # retries); the SKIP LOCKED row lock is released
-                    # on session commit.
+                    # Per-row isolation: one bad row never stalls the tick. Roll
+                    # back this row's partial work so the next row starts clean;
+                    # the row stays unprocessed and the next tick retries it
+                    # (the work_ref dedupe covers any subscriber already fired).
+                    await session.rollback()
                     _log.exception(
                         "event_drain_dispatch_failed",
                         event_id=row.event_id,

--- a/backend/src/meho_backplane/events/matcher.py
+++ b/backend/src/meho_backplane/events/matcher.py
@@ -87,6 +87,7 @@ from meho_backplane.db.models import (
     ScheduledTriggerKind,
     ScheduledTriggerStatus,
 )
+from meho_backplane.operations.agent_run import AGENT_RUN_COMPLETED_EVENT_KIND
 from meho_backplane.scheduler.loop import (
     _coerce_inputs,
     _dispatch_invocation,
@@ -115,8 +116,8 @@ _EMPTY_DICT_RENDER = "{}"
 def _payload_contains(container: object, subset: object) -> bool:
     """Return ``True`` when *container* contains *subset* (jsonb ``@>`` semantics).
 
-    Portable equivalent of the Postgres ``container @> subset`` operator, used
-    for ``payload @> event_filter``:
+    A portable **approximation** of the Postgres ``container @> subset``
+    operator for the payload shapes we match (``payload @> event_filter``):
 
     * object contains object -- every key of *subset* is present in *container*
       and its value is (recursively) contained;
@@ -126,6 +127,14 @@ def _payload_contains(container: object, subset: object) -> bool:
 
     An empty object subset is contained by any object (vacuously true), so an
     empty ``event_filter`` matches every payload.
+
+    Two edges of the real ``@>`` are deliberately not modelled -- neither is
+    reachable with the ``agent_run.completed`` payloads and operator-authored
+    filters we match, and one predicate shared by both dialects is worth more
+    than bit-exact parity: PG treats a top-level array as containing a bare
+    scalar it holds (``'[1,2]'::jsonb @> '2'``), which the array branch below
+    does not; and Python conflates ``True == 1`` / ``False == 0`` where PG's
+    jsonb keeps ``true`` and ``1`` distinct.
     """
     if isinstance(subset, dict):
         return isinstance(container, dict) and all(
@@ -221,6 +230,26 @@ def _event_inputs(trigger: ScheduledTrigger, event: EventOutbox) -> str:
     return _synthesize_event_prompt(event)
 
 
+def _is_self_trigger_completion(event: EventOutbox, trigger: ScheduledTrigger) -> bool:
+    """Return ``True`` when firing *trigger* off *event* is a direct self-loop.
+
+    A ``kind=event`` trigger that spawns agent X, subscribed with a filter broad
+    enough to match X's own ``agent_run.completed`` event, would re-fire itself
+    on every completion -- and on a default install with no budget row that loop
+    is bounded only by the manual kill switch. This guard breaks the *direct*
+    one-hop loop with no schema change: it suppresses the fire when the draining
+    event is the completion of the very agent this trigger spawns
+    (``event_kind == agent_run.completed`` and the event payload's
+    ``agent_definition_id`` is this trigger's target). A cross-agent chain -- X's
+    completion firing a trigger that spawns a *different* definition Y -- is
+    unaffected, since the ids differ. A longer cycle (X -> Y -> X) is still the
+    subscription filter's job to avoid (see the module docstring).
+    """
+    if event.event_kind != AGENT_RUN_COMPLETED_EVENT_KIND:
+        return False
+    return event.payload.get("agent_definition_id") == str(trigger.agent_definition_id)
+
+
 async def _fire_event_trigger(
     trigger: ScheduledTrigger,
     event: EventOutbox,
@@ -228,11 +257,20 @@ async def _fire_event_trigger(
 ) -> bool:
     """Fire one matched event trigger; return ``True`` when a run was started.
 
-    Resolves definition + credentials via the scheduler's precondition gate,
+    Suppresses a direct self-trigger loop (:func:`_is_self_trigger_completion`),
+    resolves definition + credentials via the scheduler's precondition gate,
     dedupes on the ``event:{event_id}:{trigger_id}`` work_ref, then dispatches
     through the shared fire seam with the event prompt + dedupe work_ref
     overridden onto the prepared invocation.
     """
+    if _is_self_trigger_completion(event, trigger):
+        _log.info(
+            "event_trigger_self_fire_suppressed",
+            event_id=event.event_id,
+            trigger_id=str(trigger.id),
+            agent_definition_id=str(trigger.agent_definition_id),
+        )
+        return False
     prepared = await _prepare_invocation(trigger)
     if isinstance(prepared, _PreconditionSkip):
         # _prepare_invocation already logged the cause (definition

--- a/backend/src/meho_backplane/events/matcher.py
+++ b/backend/src/meho_backplane/events/matcher.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Subscription matcher -- fire ``kind=event`` triggers off drained events (G11.3).
+
+The drain loop (:mod:`meho_backplane.events.drain`) claims unprocessed
+``event_outbox`` rows; for each one it calls :func:`fire_matching_triggers`
+here. The matcher looks up the tenant's active ``kind=event``
+:class:`~meho_backplane.db.models.ScheduledTrigger` rows, keeps the ones
+whose ``event_filter`` is *contained by* the event ``payload``, and fires
+each through the same
+:meth:`~meho_backplane.agent.invocation.AgentInvoker.run_scheduled` seam the
+cron / one-off scheduler loop uses.
+
+Match semantics -- ``payload @> event_filter``
+==============================================
+
+An event matches a trigger when the event ``payload`` **contains** every
+key/value the trigger's ``event_filter`` names -- the Postgres jsonb ``@>``
+direction (the retrieval-metadata-filter precedent,
+:mod:`meho_backplane.retrieval.retriever`). A filter that is a subset of the
+payload matches; a payload that is a subset of the filter does **not**
+(unless they are equal). An empty filter (``{}``) contains no constraints and
+so matches every event of the tenant.
+
+The containment check is a single pure-Python predicate
+(:func:`_payload_contains`) used on **both** dialects rather than the native
+Postgres ``@>`` on PG and a portable fallback on SQLite. One code path is a
+deliberate choice: the drain's tests run on SQLite, so a single predicate
+means those tests exercise the exact code that also runs on Postgres --
+there is no second implementation that can silently diverge from the first,
+which is what the "works on PG and SQLite" contract needs. There is no GIN
+index on ``scheduled_trigger.event_filter``, so a native ``@>`` would give no
+index-backed speed-up over loading the tenant's (dozens of) event triggers
+and filtering them in Python, which the drain already does row-by-row.
+
+Firing -- reuse of the scheduler fire recipe
+============================================
+
+Resolving the agent definition + credentials, holding the client secret as a
+:class:`~pydantic.SecretStr` end-to-end (CWE-532), and treating
+:class:`~meho_backplane.agent.invocation.BudgetExceededError` as a
+do-not-retry single-log refusal are all identical to the cron / one-off fire
+path, so the matcher reuses
+:func:`~meho_backplane.scheduler.loop._prepare_invocation` and
+:func:`~meho_backplane.scheduler.loop._dispatch_invocation` verbatim. Only two
+values differ for an event fire and are overridden on the prepared invocation:
+
+* **inputs** -- ``kind=event`` triggers are exempt from the create-time
+  non-empty-inputs rule (:mod:`meho_backplane.scheduler.schemas`), so an
+  input-less event trigger reaches here with no operator prompt. Rather than
+  let the fire fail typed at the no-input guard
+  (:meth:`AgentInvoker._launch_scheduled_run`), the matcher synthesises a
+  prompt from the matched event. Event bodies are untrusted, so the composed
+  text is wrapped with
+  :func:`~meho_backplane.untrusted_text.wrap_untrusted_text`.
+* **work_ref** -- the fired run's work_ref is ``event:{event_id}:{trigger_id}``,
+  the fire-dedupe key. It rides the existing ``agent_run_tenant_work_ref_idx``
+  (the checks-investigator precedent) so a **redelivered** event -- one whose
+  fire committed but whose ``processed_at`` stamp did not, then re-claimed on a
+  later tick -- does not double-fire: :func:`_run_exists_for_work_ref` finds
+  the run from the first delivery and the matcher skips it. The run inherits
+  the work_ref through the trigger->run ``work_ref_var`` inheritance seam
+  ``run_scheduled`` already plumbs.
+
+Delivery is at-least-once (fire, then the drain stamps ``processed_at`` in a
+separate transaction); the work_ref dedupe is what makes a duplicate delivery
+idempotent. A single drain replica runs at a time (the drain advisory lock),
+so the check-then-fire dedupe never races itself in production.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import structlog
+from sqlalchemy import select
+
+from meho_backplane.agent.invocation import AgentInvoker
+from meho_backplane.agent.run import prompt_is_effectively_empty
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AgentRun,
+    EventOutbox,
+    ScheduledTrigger,
+    ScheduledTriggerKind,
+    ScheduledTriggerStatus,
+)
+from meho_backplane.scheduler.loop import (
+    _coerce_inputs,
+    _dispatch_invocation,
+    _PreconditionSkip,
+    _prepare_invocation,
+)
+from meho_backplane.untrusted_text import wrap_untrusted_text
+
+__all__ = ["fire_matching_triggers"]
+
+_log = structlog.get_logger(__name__)
+
+#: work_ref prefix for an event-fired run. The full ref is
+#: ``event:{event_id}:{trigger_id}`` -- unique per (event, trigger) pair, so it
+#: doubles as the fire-dedupe key on ``agent_run_tenant_work_ref_idx``.
+_EVENT_WORK_REF_PREFIX = "event:"
+
+#: The ``_coerce_inputs`` render of an empty ``inputs`` dict. ``{}`` is
+#: non-whitespace, so ``prompt_is_effectively_empty`` reads it as a real prompt;
+#: an event trigger created with ``inputs: {}`` must still synthesise a prompt,
+#: so it is treated as no-prompt here (matching the create-time
+#: ``_payload_yields_prompt`` tightening).
+_EMPTY_DICT_RENDER = "{}"
+
+
+def _payload_contains(container: object, subset: object) -> bool:
+    """Return ``True`` when *container* contains *subset* (jsonb ``@>`` semantics).
+
+    Portable equivalent of the Postgres ``container @> subset`` operator, used
+    for ``payload @> event_filter``:
+
+    * object contains object -- every key of *subset* is present in *container*
+      and its value is (recursively) contained;
+    * array contains array -- every element of *subset* is contained in some
+      element of *container* (order-independent subset);
+    * scalar contains scalar -- equality.
+
+    An empty object subset is contained by any object (vacuously true), so an
+    empty ``event_filter`` matches every payload.
+    """
+    if isinstance(subset, dict):
+        return isinstance(container, dict) and all(
+            key in container and _payload_contains(container[key], value)
+            for key, value in subset.items()
+        )
+    if isinstance(subset, list):
+        return isinstance(container, list) and all(
+            any(_payload_contains(item, sub_element) for item in container)
+            for sub_element in subset
+        )
+    return container == subset
+
+
+async def _matching_event_triggers(event: EventOutbox) -> list[ScheduledTrigger]:
+    """Return the tenant's active event triggers whose filter the payload contains.
+
+    A fresh session (separate from the drain's claim transaction) reads the
+    candidate rows -- ``kind=event`` triggers have ``next_fire_at IS NULL`` so
+    they are invisible to the scheduler's due-row scan; this is the only query
+    that wakes them. Containment is applied in Python (see the module
+    docstring). Trigger corpora are "dozens per tenant" per the consumer doc,
+    so the per-event candidate load stays small.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(ScheduledTrigger).where(
+                ScheduledTrigger.kind == ScheduledTriggerKind.EVENT.value,
+                ScheduledTrigger.status == ScheduledTriggerStatus.ACTIVE.value,
+                ScheduledTrigger.tenant_id == event.tenant_id,
+            )
+        )
+        triggers = list(result.scalars().all())
+    return [t for t in triggers if _payload_contains(event.payload, t.event_filter or {})]
+
+
+async def _run_exists_for_work_ref(tenant_id: object, work_ref: str) -> bool:
+    """Return ``True`` iff any run already carries this (tenant, work_ref).
+
+    The fire-dedupe read. Unlike the checks-investigator's in-flight check this
+    matches a run in **any** status: ``event:{event_id}:{trigger_id}`` is unique
+    per delivery, so a run in that work_ref -- terminal or not -- means the
+    (event, trigger) pair already fired and a redelivery must not fire it again.
+    Rides ``agent_run_tenant_work_ref_idx`` on ``(tenant_id, work_ref)``.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AgentRun.id)
+            .where(
+                AgentRun.tenant_id == tenant_id,
+                AgentRun.work_ref == work_ref,
+            )
+            .limit(1)
+        )
+        return result.first() is not None
+
+
+def _synthesize_event_prompt(event: EventOutbox) -> str:
+    """Compose a prompt describing *event*, wrapped in the untrusted-text guard.
+
+    Used for an input-less event trigger. The event kind + payload are
+    agent-authored / externally-sourced untrusted data, so the composed body
+    is wrapped with :func:`wrap_untrusted_text` -- the reading agent sees it as
+    data to act on, not a directive channel.
+    """
+    body = json.dumps(
+        {"event_kind": event.event_kind, "payload": event.payload},
+        sort_keys=True,
+        indent=2,
+        default=str,
+    )
+    return (
+        "A subscribed MEHO event matched this trigger's filter and started this "
+        "run. The event that fired it is described below; decide what to do "
+        "based on it.\n\n" + wrap_untrusted_text(body)
+    )
+
+
+def _event_inputs(trigger: ScheduledTrigger, event: EventOutbox) -> str:
+    """Render the fire-time prompt string for an event trigger.
+
+    Prefers the operator-supplied ``inputs`` when it renders a usable prompt
+    (the ``"prompt"`` key or a non-empty structured payload, via
+    :func:`_coerce_inputs`); otherwise synthesises one from the matched event
+    so an input-less event trigger still fires with a real user turn instead of
+    failing typed at the no-input guard.
+    """
+    coerced = _coerce_inputs(trigger.inputs)
+    if coerced and coerced != _EMPTY_DICT_RENDER and not prompt_is_effectively_empty(coerced):
+        return coerced
+    return _synthesize_event_prompt(event)
+
+
+async def _fire_event_trigger(
+    trigger: ScheduledTrigger,
+    event: EventOutbox,
+    invoker: AgentInvoker,
+) -> bool:
+    """Fire one matched event trigger; return ``True`` when a run was started.
+
+    Resolves definition + credentials via the scheduler's precondition gate,
+    dedupes on the ``event:{event_id}:{trigger_id}`` work_ref, then dispatches
+    through the shared fire seam with the event prompt + dedupe work_ref
+    overridden onto the prepared invocation.
+    """
+    prepared = await _prepare_invocation(trigger)
+    if isinstance(prepared, _PreconditionSkip):
+        # _prepare_invocation already logged the cause (definition
+        # missing/disabled, credentials unresolved). Unlike the scheduler loop
+        # there is nothing to advance or park: an event trigger carries no
+        # next_fire_at, so a transient precondition miss simply means this
+        # event does not fire it and a later matching event re-attempts once
+        # the operator fixes the cause.
+        return False
+    work_ref = f"{_EVENT_WORK_REF_PREFIX}{event.event_id}:{trigger.id}"
+    if await _run_exists_for_work_ref(trigger.tenant_id, work_ref):
+        _log.info(
+            "event_trigger_deduped",
+            event_id=event.event_id,
+            trigger_id=str(trigger.id),
+            work_ref=work_ref,
+        )
+        return False
+    prepared = replace(
+        prepared,
+        inputs_str=_event_inputs(trigger, event),
+        work_ref=work_ref,
+    )
+    return await _dispatch_invocation(trigger, prepared, invoker)
+
+
+async def fire_matching_triggers(event: EventOutbox, invoker: AgentInvoker) -> int:
+    """Fire every active event trigger whose filter the *event* payload contains.
+
+    Returns the number of triggers that started a run. Per-trigger failures are
+    isolated (one bad subscription never stalls the others or the drain tick);
+    a budget refusal / precondition skip / dedupe hit returns ``False`` for
+    that trigger without raising.
+    """
+    triggers = await _matching_event_triggers(event)
+    if not triggers:
+        return 0
+    fired = 0
+    for trigger in triggers:
+        try:
+            if await _fire_event_trigger(trigger, event, invoker):
+                fired += 1
+        except Exception:
+            _log.exception(
+                "event_trigger_fire_failed",
+                event_id=event.event_id,
+                trigger_id=str(trigger.id),
+            )
+    if fired:
+        _log.info(
+            "event_subscriptions_fired",
+            event_id=event.event_id,
+            event_kind=event.event_kind,
+            matched=len(triggers),
+            fired=fired,
+        )
+    return fired

--- a/backend/src/meho_backplane/gateway/errors.py
+++ b/backend/src/meho_backplane/gateway/errors.py
@@ -10,7 +10,7 @@ descriptor the runner can actually execute. A failing item raises one of
 these — each carrying a class-level ``error_code`` the route surfaces as a
 structured 422 via :mod:`meho_backplane.api.v1._errors`, the same
 machine-readable-code discipline as
-:class:`~meho_backplane.scheduler.service.EventTriggersNotImplementedError`.
+:class:`~meho_backplane.checks.service.SensorOperationNotFoundError`.
 
 Fail at the *first* offending item and write nothing: an assignment PUT is
 a full-document replace, so a partial store would leave the runner with a

--- a/backend/src/meho_backplane/mcp/tools/scheduler.py
+++ b/backend/src/meho_backplane/mcp/tools/scheduler.py
@@ -73,7 +73,6 @@ from meho_backplane.scheduler.schemas import (
 )
 from meho_backplane.scheduler.service import (
     AgentDefinitionMissingError,
-    EventTriggersNotImplementedError,
     SchedulerAdminService,
 )
 
@@ -263,10 +262,6 @@ async def _create_handler(
             created_by_sub=operator.sub,
             payload=payload,
         )
-    except EventTriggersNotImplementedError as exc:
-        # kind=event is refused at create until #826 wires the event-
-        # subscription matcher; same error code the REST route surfaces.
-        raise McpInvalidParamsError(exc.error_code) from exc
     except AgentDefinitionMissingError as exc:
         raise McpInvalidParamsError("agent_definition_not_found") from exc
     structlog.contextvars.bind_contextvars(audit_trigger_id=str(entry.id))
@@ -283,13 +278,15 @@ register_mcp_tool(
             "('cron'|'one_off'|'event'), agent_definition_id (UUID of an "
             "agent definition in the operator's tenant), and exactly one "
             "of cron_expr (for kind=cron), fire_at (ISO 8601 string for "
-            "kind=one_off), or event_filter (object for kind=event). NOTE: "
-            "kind=event is refused at create with 'event_triggers_not_"
-            "implemented' until #826 wires the event-subscription matcher "
-            "(an accepted event trigger cannot fire today). For "
+            "kind=one_off), or event_filter (object for kind=event). A "
+            "kind=event trigger fires whenever a MEHO event's payload "
+            "contains its event_filter (payload @> event_filter); it is "
+            "dispatched by the event drain, not the clock. For "
             "kind=cron/one_off, inputs (JSON object) is REQUIRED and must "
             "render a non-empty prompt (a 'prompt' string, or any non-empty "
-            "object; inputs: {} is rejected); it is optional for kind=event. "
+            "object; inputs: {} is rejected); it is optional for kind=event "
+            "(the matcher synthesises a prompt from the matched event when "
+            "inputs is omitted). "
             "Optional: timezone (IANA name, default 'UTC'), "
             "identity_sub (default '__scheduler__'), "
             "in_flight_policy ('fail_into_audit'|'resume', default "

--- a/backend/src/meho_backplane/operations/agent_run.py
+++ b/backend/src/meho_backplane/operations/agent_run.py
@@ -82,10 +82,10 @@ from meho_backplane.db.models import (
 from meho_backplane.events.outbox import publish as publish_event
 
 #: Event kind the agent-run terminal-transition emits onto the outbox.
-#: Subscribers (``scheduled_trigger`` rows of ``kind='event'``) match
-#: against this discriminator. v0.2 ships the producer; the
-#: subscription matcher follows in T5 #826's admin surface. The
-#: ``<resource>.<action>`` shape mirrors the audit-trail convention.
+#: The event drain's subscription matcher (:mod:`meho_backplane.events.matcher`)
+#: fires ``scheduled_trigger`` rows of ``kind='event'`` whose ``event_filter``
+#: is contained by the event ``payload`` (below). The ``<resource>.<action>``
+#: shape mirrors the audit-trail convention.
 AGENT_RUN_COMPLETED_EVENT_KIND: Final[str] = "agent_run.completed"
 
 __all__ = [
@@ -533,10 +533,10 @@ async def transition(
     # G11.3-T3 #824: emit ``agent_run.completed`` onto the transactional
     # outbox in the same session as the status write. The outbox row
     # commits with the status change so a producer rollback discards
-    # both. Subscribers (``scheduled_trigger`` rows of ``kind='event'``)
-    # consume the event via the drain loop; v0.2 ships the producer
-    # only -- the subscription matcher lands in T5 #826's admin
-    # surface follow-up. The payload carries the fields a subscriber's
+    # both. The drain loop's subscription matcher
+    # (:mod:`meho_backplane.events.matcher`) consumes the event and fires
+    # each ``kind='event'`` trigger whose ``event_filter`` this payload
+    # contains. The payload carries the fields a subscriber's
     # JSONB filter needs to match against: the run id (so a
     # cheap-to-deep escalation pattern can fire the next agent against
     # a specific prior run), the tenant id (subscribers are

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -160,16 +160,10 @@ from meho_backplane.scheduler.repository import (
 from meho_backplane.settings import get_settings
 
 __all__ = [
-    "reconcile_active_event_triggers",
     "run_one_tick",
     "start_scheduler",
     "stop_scheduler",
 ]
-
-#: Logged reason (and the code an operator greps) for an event trigger
-#: parked by the #2325 startup reconcile -- event dispatch is refused at
-#: create until #826 wires the event-subscription matcher.
-_EVENT_PARK_REASON: str = "event_triggers_not_implemented:826"
 
 _log = structlog.get_logger(__name__)
 
@@ -903,46 +897,6 @@ async def run_one_tick(invoker: AgentInvoker | None = None) -> int:
     return fires
 
 
-async def reconcile_active_event_triggers() -> int:
-    """Park any pre-existing ``active`` event triggers (#2325). Return the count.
-
-    ``kind=event`` triggers are refused at create until #826 wires the
-    event-subscription matcher (:mod:`meho_backplane.events.drain` is
-    still a no-op, so an event trigger sits ``active`` but can never
-    fire). Rows created ``active`` before that refusal landed would sit
-    silently dead. This one-shot startup reconcile transitions every
-    ``active`` event trigger to ``paused`` so an operator sees it parked
-    (via ``GET /api/v1/scheduler/triggers?kind=event&status=paused`` or
-    the UI list) rather than misleadingly ``active``; the reason is
-    logged under ``scheduler_event_triggers_parked`` -- mirroring the
-    :func:`_park_trigger` "reason is logged for audit" precedent, since
-    the row carries no reason column.
-
-    Idempotent: a second run finds no ``active`` event rows and parks
-    nothing. Removed in the change that lands the #826 matcher (event
-    triggers become dispatchable and no longer need parking).
-    """
-    sessionmaker = get_sessionmaker()
-    async with sessionmaker() as session:
-        result = await session.execute(
-            update(ScheduledTrigger)
-            .where(
-                ScheduledTrigger.kind == ScheduledTriggerKind.EVENT.value,
-                ScheduledTrigger.status == ScheduledTriggerStatus.ACTIVE.value,
-            )
-            .values(status=ScheduledTriggerStatus.PAUSED.value)
-        )
-        await session.commit()
-    parked: int = result.rowcount or 0  # type: ignore[attr-defined]
-    if parked:
-        _log.warning(
-            "scheduler_event_triggers_parked",
-            count=parked,
-            reason=_EVENT_PARK_REASON,
-        )
-    return parked
-
-
 async def _check_scheduler_vault_token(*, reason: str) -> None:
     """Run the scheduler Vault-token ``lookup-self`` health check (#2328).
 
@@ -988,7 +942,7 @@ async def _renew_scheduler_vault_token(*, reason: str) -> None:
 
 
 async def _scheduler_loop() -> None:
-    """The forever loop: reconcile once, then sleep one cadence, tick, repeat.
+    """The forever loop: sleep one cadence, tick, repeat.
 
     Sleep-then-tick (rather than tick-then-sleep) so the first tick
     after process start is delayed by one cadence -- letting the rest
@@ -1006,15 +960,6 @@ async def _scheduler_loop() -> None:
     """
     interval = get_settings().scheduler_tick_interval_seconds
     _log.info("scheduler_started", interval_seconds=interval)
-    # #2325 one-shot startup reconcile: park any pre-existing active event
-    # triggers -- event dispatch is refused at create pending #826, so an
-    # active event row is silently dead. Guarded so a reconcile failure
-    # never stops the tick loop from starting.
-    try:
-        await reconcile_active_event_triggers()
-    except Exception:
-        _log.warning("scheduler_event_reconcile_failed", exc_info=True)
-
     await _check_scheduler_vault_token(reason="startup")
     await _renew_scheduler_vault_token(reason="startup")
     last_token_check = time.monotonic()

--- a/backend/src/meho_backplane/scheduler/service.py
+++ b/backend/src/meho_backplane/scheduler/service.py
@@ -79,7 +79,6 @@ from meho_backplane.scheduler.schemas import (
 
 __all__ = [
     "AgentDefinitionMissingError",
-    "EventTriggersNotImplementedError",
     "SchedulerAdminService",
 ]
 
@@ -112,43 +111,6 @@ class AgentDefinitionMissingError(Exception):
         self.agent_definition_id = agent_definition_id
         super().__init__(
             f"agent definition {agent_definition_id} not found in this tenant",
-        )
-
-
-class EventTriggersNotImplementedError(Exception):
-    """Raised when a create body carries ``kind=event`` (#2325).
-
-    Event-subscription triggers are refused at create until #826 wires
-    the event-outbox subscription matcher. Today
-    :mod:`meho_backplane.events.drain` is the documented T5 no-op matcher
-    -- it stamps ``processed_at`` on drained rows without ever consulting
-    ``scheduled_trigger`` -- so a persisted event trigger sits ``active``
-    but can never fire. Real producers already emit onto the outbox
-    (:mod:`meho_backplane.operations.agent_run` publishes agent-run
-    terminal-transition events), so those events are silently swallowed.
-    Accepting a trigger that can never fire is dishonest to the operator;
-    the honest shape until #826 lands is a refusal at create.
-
-    The refusal is a single create-site guard, removed in the same change
-    that lands the #826 matcher (at which point the
-    :func:`~meho_backplane.scheduler.repository.create_event_trigger`
-    branch in :meth:`SchedulerAdminService.create` comes back into play).
-    The REST route maps it to 422 ``event_triggers_not_implemented``; the
-    MCP tool to an invalid-params error with the same code; the UI to a
-    modal banner naming #826.
-    """
-
-    #: Machine-readable error code the boundary surfaces on every
-    #: transport so a caller branches on the string, not on prose.
-    error_code = "event_triggers_not_implemented"
-
-    def __init__(self) -> None:
-        super().__init__(
-            "kind=event triggers are not yet dispatchable: the "
-            "event-subscription matcher is a no-op pending #826, so an "
-            "accepted event trigger would stay active but never fire. "
-            "Refused at create until #826 lands -- use kind=cron or "
-            "kind=one_off.",
         )
 
 
@@ -220,23 +182,11 @@ class SchedulerAdminService:
 
         Raises
         ------
-        EventTriggersNotImplementedError
-            When ``payload.kind`` is ``event``. Refused at create until
-            #826 wires the event-subscription matcher (the drain matcher
-            is a no-op today, so an accepted event trigger never fires).
-            The boundary maps this to 422 ``event_triggers_not_implemented``.
         AgentDefinitionMissingError
             When ``agent_definition_id`` does not name a definition in
             *tenant_id*. The boundary maps this to 422
             ``agent_definition_not_found``.
         """
-        # #2325: refuse kind=event before any DB work. events/drain.py is
-        # still the documented T5 no-op, so a persisted event trigger is
-        # active-but-never-fires. Single create-site guard -- removed when
-        # #826 lands, at which point the create_event_trigger branch below
-        # dispatches for real.
-        if payload.kind == ScheduledTriggerKind.EVENT:
-            raise EventTriggersNotImplementedError()
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session:
             await self._assert_agent_definition_exists(
@@ -275,9 +225,10 @@ class SchedulerAdminService:
                         work_ref=payload.work_ref,
                     )
                 else:  # payload.kind == ScheduledTriggerKind.EVENT
-                    # Unreachable while the #2325 guard above stands; kept
-                    # so #826 re-enables event dispatch by deleting the
-                    # guard, not by re-authoring this branch.
+                    # The discriminated-union validator already proved
+                    # event_filter is non-null; assert to narrow for mypy. The
+                    # event drain's subscription matcher dispatches these rows
+                    # when a matching event lands (events/matcher.py).
                     assert payload.event_filter is not None
                     row = await create_event_trigger(
                         session,

--- a/backend/src/meho_backplane/ui/routes/scheduler/create.py
+++ b/backend/src/meho_backplane/ui/routes/scheduler/create.py
@@ -61,7 +61,6 @@ from meho_backplane.scheduler.cron import (
 from meho_backplane.scheduler.schemas import ScheduledTriggerCreate
 from meho_backplane.scheduler.service import (
     AgentDefinitionMissingError,
-    EventTriggersNotImplementedError,
     SchedulerAdminService,
 )
 from meho_backplane.ui.auth.middleware import UISessionContext
@@ -406,15 +405,6 @@ async def create_trigger(
             tenant_id=operator.tenant_id,
             created_by_sub=operator.sub,
             payload=payload,
-        )
-    except EventTriggersNotImplementedError as exc:
-        # kind=event is refused at create until #826 wires the event-
-        # subscription matcher; re-render the modal with the reason
-        # (names #826) rather than tearing the operator out of the flow.
-        return await _rerender_modal_with_error(
-            request,
-            session_ctx,
-            error_message=str(exc),
         )
     except AgentDefinitionMissingError:
         return await _rerender_modal_with_error(

--- a/backend/tests/integration/test_event_matcher_pg.py
+++ b/backend/tests/integration/test_event_matcher_pg.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Real-Postgres end-to-end for the event-subscription matcher (#2878).
+
+The SQLite unit suite (:mod:`tests.test_event_matcher`) proves the matcher's
+logic; this module runs the same chain -- publish an ``agent_run.completed``
+event -> drain -> ``payload @> event_filter`` match -> fire an agent run with
+the ``event:{event_id}:{trigger_id}`` work_ref -- against a real
+``pgvector/pgvector:pg16`` container so the JSONB ``payload`` / ``event_filter``
+round-trip, the drain's ``pg_try_advisory_lock`` + ``FOR UPDATE SKIP LOCKED``
+mechanics, and the subscriber run committing on its own PG connection are all
+exercised on the production dialect.
+
+The ``pg_engine`` fixture from :mod:`tests.integration.conftest` points the
+process-wide engine at the container and truncates the chassis tables between
+tests; it skips the whole module when Docker is unavailable (agent sandboxes),
+so this runs in CI where containers are provisioned.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.events.drain import run_one_drain_tick
+from tests.test_event_matcher import (
+    _TENANT_A,
+    _all_runs,
+    _create_event_trigger,
+    _is_processed,
+    _make_invoker,
+    _make_no_call_invoker,
+    _publish_completed_event,
+    _seed_tenant_and_agent,
+    _wait_for_runs,
+)
+
+
+@pytest.fixture(autouse=True)
+def _agent_fire_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Stub the autonomous-auth seams + the seeded agent's client secret.
+
+    Layers on top of the integration conftest's ``_integration_default_env``
+    (KEYCLOAK_* / VAULT_*) so ``run_scheduled`` runs offline against the seeded
+    ``agent:reporter`` definition, exactly as :mod:`tests.test_event_matcher`
+    does at the unit level.
+    """
+    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    monkeypatch.setattr(
+        "meho_backplane.agent.invocation.get_client_credentials_token",
+        AsyncMock(return_value="agent-token"),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.agent.invocation.verify_jwt_for_audience",
+        AsyncMock(
+            return_value=Operator(
+                sub=f"agent-{_TENANT_A.hex[:8]}",
+                name=None,
+                email=None,
+                raw_jwt="agent-token",
+                tenant_id=_TENANT_A,
+                tenant_role=TenantRole.OPERATOR,
+            ),
+        ),
+    )
+    yield
+
+
+async def test_matching_event_fires_run_with_work_ref_on_pg(pg_engine: None) -> None:
+    """On real PG: a matching event fires a run whose work_ref keys the pair."""
+    def_id = await _seed_tenant_and_agent()
+    trigger = await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"status": "succeeded"},
+        inputs={"prompt": "follow up"},
+    )
+    event_id = await _publish_completed_event(status="succeeded")
+
+    processed = await run_one_drain_tick(invoker=_make_invoker())
+    assert processed == 1
+    assert await _is_processed(event_id)
+
+    runs = await _wait_for_runs(1)
+    assert len(runs) == 1
+    assert runs[0].work_ref == f"event:{event_id}:{trigger.id}"
+    assert runs[0].tenant_id == _TENANT_A
+
+
+async def test_non_matching_filter_fires_nothing_on_pg(pg_engine: None) -> None:
+    """On real PG: an event that does not contain the filter drains without firing."""
+    def_id = await _seed_tenant_and_agent()
+    await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"status": "succeeded"},
+        inputs={"prompt": "follow up"},
+    )
+    event_id = await _publish_completed_event(status="failed")
+
+    processed = await run_one_drain_tick(invoker=_make_no_call_invoker())
+    assert processed == 1
+    assert await _is_processed(event_id)
+    assert await _all_runs() == []

--- a/backend/tests/test_event_matcher.py
+++ b/backend/tests/test_event_matcher.py
@@ -1,0 +1,609 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the G11.3 event-subscription matcher (#2878).
+
+Coverage matrix mapped to the issue's acceptance criteria:
+
+* **Containment direction** -- ``payload @> event_filter``: a filter that is a
+  subset of the payload matches; a payload that is a subset of the filter does
+  not. Pinned as a pure-predicate test plus an end-to-end fire.
+* **End-to-end fire** -- an ``agent_run.completed`` event drains, matches a
+  ``kind=event`` trigger, and fires an agent run whose ``work_ref`` is
+  ``event:{event_id}:{trigger_id}``; a non-matching filter fires nothing.
+* **Redelivery dedupe** -- an event whose fire committed but whose
+  ``processed_at`` stamp was lost (re-marked unprocessed) does not double-fire
+  on the next tick -- the work_ref dedupe skips the already-fired run.
+* **BudgetExceededError** -- a budget-refused fire logs
+  ``scheduler_invoke_refused`` once, creates no run, and the drain tick still
+  completes.
+* **Input-less trigger** -- an event trigger created with no ``inputs`` fires
+  with a prompt synthesised from the matched event, wrapped in the
+  untrusted-text envelope.
+
+Agent invocation is stubbed through a
+:class:`~pydantic_ai.models.function.FunctionModel` so no real LLM is hit; the
+Keycloak token + JWT-verify seams ``run_scheduled`` uses are stubbed the same
+way :mod:`tests.test_scheduler` stubs them. The tests run on the autouse
+SQLite engine from :mod:`tests.conftest`; the real-Postgres end-to-end lives in
+:mod:`tests.integration.test_event_matcher_pg`.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+import structlog
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from sqlalchemy import select
+
+from meho_backplane.agent.invocation import AgentInvoker
+from meho_backplane.agent.run import PydanticAgentRun
+from meho_backplane.agents.schemas import AgentDefinitionCreate, AgentModelTier
+from meho_backplane.agents.service import AgentDefinitionService
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AgentPrincipal,
+    AgentRun,
+    AgentRunStatus,
+    EventOutbox,
+    ScheduledTrigger,
+    Tenant,
+)
+from meho_backplane.events.drain import run_one_drain_tick
+from meho_backplane.events.matcher import (
+    _event_inputs,
+    _payload_contains,
+    _synthesize_event_prompt,
+    fire_matching_triggers,
+)
+from meho_backplane.events.outbox import publish
+from meho_backplane.operations.agent_run import AGENT_RUN_COMPLETED_EVENT_KIND
+from meho_backplane.scheduler.repository import create_event_trigger
+from meho_backplane.settings import get_settings
+from meho_backplane.untrusted_text import BLOCK_END, BLOCK_START
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+# A sentinel "upstream" agent definition id the seeded events carry. It is
+# distinct from the seeded ``reporter`` agent's id, so a subscription that
+# targets this upstream (the realistic shape) never re-matches the *fired*
+# reporter run's own ``agent_run.completed`` event -- avoiding the
+# self-triggering feedback loop a broad ``{"status": "succeeded"}`` filter
+# would create against the ``agent_run.completed`` producer.
+_UPSTREAM_DEF_ID = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin Settings env vars incl. the seeded agent's client-credentials secret."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    # identity_ref ``agent:reporter`` -> ``AGENT_REPORTER`` env var.
+    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REPORTER", "test-secret")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _stub_autonomous_auth(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Stub ``run_scheduled``'s Keycloak token + JWT-verify seams (offline)."""
+    monkeypatch.setattr(
+        "meho_backplane.agent.invocation.get_client_credentials_token",
+        AsyncMock(return_value="agent-token"),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.agent.invocation.verify_jwt_for_audience",
+        AsyncMock(
+            return_value=Operator(
+                sub=f"agent-{_TENANT_A.hex[:8]}",
+                name=None,
+                email=None,
+                raw_jwt="agent-token",
+                tenant_id=_TENANT_A,
+                tenant_role=TenantRole.OPERATOR,
+            ),
+        ),
+    )
+    yield
+
+
+def _final_text(text: str) -> FunctionModel:
+    """A deterministic model that answers immediately with *text*."""
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart(text)])
+
+    return FunctionModel(fn)
+
+
+def _make_invoker() -> AgentInvoker:
+    """An invoker over a deterministic FunctionModel (no real LLM)."""
+    return AgentInvoker(runtime=PydanticAgentRun(model_factory=lambda: _final_text("done")))
+
+
+def _exploding_model() -> FunctionModel:
+    """A model that fails the test if the loop ever reaches it."""
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        pytest.fail("model was invoked; the fire should have been refused before launch")
+
+    return FunctionModel(fn)
+
+
+def _make_no_call_invoker() -> AgentInvoker:
+    """An invoker whose model raises if the loop ever reaches it."""
+    return AgentInvoker(runtime=PydanticAgentRun(model_factory=_exploding_model))
+
+
+async def _seed_tenant_and_agent(name: str = "reporter") -> uuid.UUID:
+    """Insert one Tenant + AgentPrincipal + enabled AgentDefinition; return def id.
+
+    Mirrors :func:`tests.test_scheduler._seed_tenant_and_agent`: the principal
+    satisfies ``AgentDefinitionService`` identity-ref validation, and the
+    definition is what an event trigger's ``agent_definition_id`` points at.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if await session.get(Tenant, _TENANT_A) is None:
+            session.add(Tenant(id=_TENANT_A, slug="tenant-a", name="Tenant A"))
+            await session.commit()
+        existing = await session.execute(
+            select(AgentPrincipal).where(
+                AgentPrincipal.tenant_id == _TENANT_A,
+                AgentPrincipal.keycloak_client_id == f"agent:{name}",
+            )
+        )
+        if existing.scalar_one_or_none() is None:
+            session.add(
+                AgentPrincipal(
+                    id=uuid.uuid4(),
+                    tenant_id=_TENANT_A,
+                    name=name,
+                    keycloak_client_id=f"agent:{name}",
+                    keycloak_internal_id=f"kc-internal-{name}",
+                    owner_sub="seed-admin",
+                    revoked=False,
+                    created_by_sub="seed-admin",
+                )
+            )
+            await session.commit()
+    service = AgentDefinitionService()
+    entry = await service.create(
+        tenant_id=_TENANT_A,
+        created_by_sub="seed-admin",
+        payload=AgentDefinitionCreate(
+            name=name,
+            identity_ref=f"agent:{name}",
+            model_tier=AgentModelTier.STANDARD,
+            system_prompt="You react to events.",
+            toolset={},
+            turn_budget=2,
+            enabled=True,
+        ),
+    )
+    return entry.id
+
+
+async def _create_event_trigger(
+    *,
+    agent_definition_id: uuid.UUID,
+    event_filter: dict[str, object],
+    inputs: dict[str, object] | None = None,
+    tenant_id: uuid.UUID = _TENANT_A,
+) -> ScheduledTrigger:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await create_event_trigger(
+            session,
+            tenant_id=tenant_id,
+            agent_definition_id=agent_definition_id,
+            event_filter=event_filter,
+            inputs=inputs,
+            identity_sub="__scheduler__",
+            created_by_sub="seed-admin",
+            in_flight_policy="fail_into_audit",
+        )
+        await session.commit()
+        return row
+
+
+async def _publish_completed_event(
+    *,
+    status: str = "succeeded",
+    tenant_id: uuid.UUID = _TENANT_A,
+    agent_definition_id: uuid.UUID = _UPSTREAM_DEF_ID,
+    extra: dict[str, object] | None = None,
+) -> int:
+    """Publish an ``agent_run.completed`` event; return its ``event_id``."""
+    payload: dict[str, object] = {
+        "run_id": str(uuid.uuid4()),
+        "tenant_id": str(tenant_id),
+        "status": status,
+        "agent_definition_id": str(agent_definition_id),
+        "work_ref": None,
+    }
+    if extra:
+        payload.update(extra)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await publish(
+            session,
+            tenant_id=tenant_id,
+            event_kind=AGENT_RUN_COMPLETED_EVENT_KIND,
+            payload=payload,
+        )
+        await session.flush()
+        event_id = row.event_id
+        await session.commit()
+    return event_id
+
+
+async def _all_runs() -> list[AgentRun]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        return list((await session.execute(select(AgentRun))).scalars().all())
+
+
+async def _wait_for_runs(expected: int, *, timeout: float = 3.0) -> list[AgentRun]:
+    """Poll the ``agent_run`` table until *expected* rows land, or fail."""
+    import asyncio
+
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        runs = await _all_runs()
+        if len(runs) >= expected:
+            return runs
+        await asyncio.sleep(0.05)
+    pytest.fail(f"expected {expected} agent_run rows, found {len(await _all_runs())}")
+
+
+async def _reset_processed(event_id: int) -> None:
+    """Re-mark a processed event unprocessed (simulate a lost processed stamp)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(EventOutbox, event_id)
+        assert row is not None
+        row.processed_at = None
+        await session.commit()
+
+
+async def _is_processed(event_id: int) -> bool:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(EventOutbox, event_id)
+        assert row is not None
+        return row.processed_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Containment predicate -- direction is load-bearing
+# ---------------------------------------------------------------------------
+
+
+def test_containment_filter_subset_of_payload_matches() -> None:
+    """A filter that is a subset of the payload matches (``payload @> filter``)."""
+    payload = {"run_id": "r1", "status": "succeeded", "tenant_id": "t1"}
+    assert _payload_contains(payload, {"status": "succeeded"})
+    assert _payload_contains(payload, {"status": "succeeded", "tenant_id": "t1"})
+
+
+def test_containment_payload_subset_of_filter_does_not_match() -> None:
+    """The reverse direction never matches: payload subset-of filter is False."""
+    payload = {"status": "succeeded"}
+    # Filter names a key the payload lacks -> not contained.
+    assert not _payload_contains(payload, {"status": "succeeded", "tenant_id": "t1"})
+
+
+def test_containment_value_mismatch_does_not_match() -> None:
+    """A present key with a different value is not a match."""
+    assert not _payload_contains({"status": "failed"}, {"status": "succeeded"})
+
+
+def test_containment_empty_filter_matches_everything() -> None:
+    """An empty filter names no constraints, so it matches any payload."""
+    assert _payload_contains({"status": "succeeded"}, {})
+    assert _payload_contains({}, {})
+
+
+def test_containment_is_recursive_for_nested_objects() -> None:
+    """Nested objects use recursive containment (jsonb ``@>`` semantics)."""
+    payload = {"meta": {"a": 1, "b": 2}, "status": "ok"}
+    assert _payload_contains(payload, {"meta": {"a": 1}})
+    assert not _payload_contains(payload, {"meta": {"a": 9}})
+
+
+def test_containment_array_subset() -> None:
+    """Array containment is order-independent subset."""
+    assert _payload_contains({"tags": ["x", "y", "z"]}, {"tags": ["y", "x"]})
+    assert not _payload_contains({"tags": ["x"]}, {"tags": ["y"]})
+
+
+# ---------------------------------------------------------------------------
+# Prompt synthesis for input-less triggers
+# ---------------------------------------------------------------------------
+
+
+async def test_input_less_trigger_synthesises_untrusted_prompt() -> None:
+    """An input-less event trigger renders a prompt wrapping the event, untrusted."""
+    def_id = await _seed_tenant_and_agent()
+    trigger = await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"status": "succeeded"},
+        inputs=None,
+    )
+    event = EventOutbox(
+        event_id=1,
+        tenant_id=_TENANT_A,
+        event_kind=AGENT_RUN_COMPLETED_EVENT_KIND,
+        payload={"status": "succeeded", "run_id": "r1"},
+    )
+    prompt = _event_inputs(trigger, event)
+    # Untrusted envelope wraps the event body.
+    assert BLOCK_START in prompt
+    assert BLOCK_END in prompt
+    # The event payload is present inside the envelope.
+    assert "succeeded" in prompt
+    assert AGENT_RUN_COMPLETED_EVENT_KIND in prompt
+    # The synthesiser is what produced it (not the empty coerced inputs).
+    assert prompt == _event_inputs(trigger, event)
+    assert _synthesize_event_prompt(event) in prompt
+
+
+async def test_trigger_with_prompt_inputs_uses_operator_prompt() -> None:
+    """A trigger carrying a usable ``inputs`` prompt uses it, not the synthesiser."""
+    def_id = await _seed_tenant_and_agent()
+    trigger = await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"status": "succeeded"},
+        inputs={"prompt": "investigate the completed run"},
+    )
+    event = EventOutbox(
+        event_id=1,
+        tenant_id=_TENANT_A,
+        event_kind=AGENT_RUN_COMPLETED_EVENT_KIND,
+        payload={"status": "succeeded"},
+    )
+    assert _event_inputs(trigger, event) == "investigate the completed run"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: event -> matching trigger -> agent run with work_ref
+# ---------------------------------------------------------------------------
+
+
+async def test_matching_event_fires_run_with_work_ref() -> None:
+    """A drained matching event fires an agent run whose work_ref keys the pair."""
+    def_id = await _seed_tenant_and_agent()
+    # Subscribe to a specific upstream agent (the realistic shape) so the fired
+    # run's own completion event does not re-match.
+    trigger = await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"agent_definition_id": str(_UPSTREAM_DEF_ID), "status": "succeeded"},
+        inputs={"prompt": "follow up"},
+    )
+    event_id = await _publish_completed_event(status="succeeded")
+
+    processed = await run_one_drain_tick(invoker=_make_invoker())
+    assert processed == 1
+    assert await _is_processed(event_id)
+
+    runs = await _wait_for_runs(1)
+    assert len(runs) == 1
+    assert runs[0].work_ref == f"event:{event_id}:{trigger.id}"
+    assert runs[0].tenant_id == _TENANT_A
+
+
+async def test_non_matching_filter_fires_nothing() -> None:
+    """An event whose payload does not contain the filter fires no run, but drains."""
+    def_id = await _seed_tenant_and_agent()
+    await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"status": "succeeded"},
+        inputs={"prompt": "follow up"},
+    )
+    # status=failed -> the filter {"status": "succeeded"} is not contained.
+    event_id = await _publish_completed_event(status="failed")
+
+    processed = await run_one_drain_tick(invoker=_make_no_call_invoker())
+    assert processed == 1
+    assert await _is_processed(event_id)
+    assert await _all_runs() == []
+
+
+async def test_input_less_event_trigger_fires_successfully() -> None:
+    """An input-less event trigger fires a run that succeeds (prompt was synthesised)."""
+    def_id = await _seed_tenant_and_agent()
+    await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={},  # empty filter -> matches every event
+        inputs=None,
+    )
+    await _publish_completed_event(status="succeeded")
+
+    processed = await run_one_drain_tick(invoker=_make_invoker())
+    assert processed == 1
+
+    runs = await _wait_for_runs(1)
+    assert len(runs) == 1
+    # The synthesised prompt is a real user turn -> the run is not the typed
+    # no-input failure; it runs to success against the deterministic model.
+    assert runs[0].status == AgentRunStatus.SUCCEEDED.value
+
+
+# ---------------------------------------------------------------------------
+# Redelivery dedupe -- a re-marked-unprocessed event does not double-fire
+# ---------------------------------------------------------------------------
+
+
+async def test_redelivery_does_not_double_fire() -> None:
+    """A claimed-but-unprocessed event re-drained does not fire a second run."""
+    def_id = await _seed_tenant_and_agent()
+    # Target a specific upstream agent so the *fired* run's own completion event
+    # (drained on the second tick) does not itself re-match and fire.
+    trigger = await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"agent_definition_id": str(_UPSTREAM_DEF_ID)},
+        inputs={"prompt": "follow up"},
+    )
+    event_id = await _publish_completed_event(status="succeeded")
+
+    # First delivery fires exactly one run.
+    assert await run_one_drain_tick(invoker=_make_invoker()) == 1
+    runs = await _wait_for_runs(1)
+    assert len(runs) == 1
+    assert runs[0].work_ref == f"event:{event_id}:{trigger.id}"
+
+    # Simulate a crash between the fire commit and the processed stamp: the
+    # event is re-marked unprocessed and re-drained. The exploding invoker
+    # proves no fire reaches a model on this tick.
+    await _reset_processed(event_id)
+    await run_one_drain_tick(invoker=_make_no_call_invoker())
+
+    # No second run: the work_ref dedupe found the first delivery's run for the
+    # redelivered event, and the fired run's own completion event (also pending)
+    # does not match the upstream-scoped filter. The count is the invariant --
+    # the number of events processed on this tick races background publishing.
+    assert len(await _all_runs()) == 1
+
+
+# ---------------------------------------------------------------------------
+# BudgetExceededError -- no retry, one structured log, tick completes
+# ---------------------------------------------------------------------------
+
+
+def _capture_loop_log_to_buffer(monkeypatch: pytest.MonkeyPatch) -> io.StringIO:
+    """Redirect the scheduler-loop logger to a buffer (fire-refusal logs land here).
+
+    The matcher reuses ``scheduler.loop._dispatch_invocation``, which logs the
+    budget refusal via that module's ``_log``. Mirrors
+    :func:`tests.test_scheduler._capture_structlog_to_buffer`: rebind the
+    module-level proxy so emissions bypass the cached BoundLogger.
+    """
+    import logging as _stdlib_logging
+
+    from meho_backplane.scheduler import loop as _loop_module
+
+    buf = io.StringIO()
+    structlog.reset_defaults()
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.processors.dict_tracebacks,
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(_stdlib_logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(file=buf),
+        cache_logger_on_first_use=False,
+    )
+    monkeypatch.setattr(_loop_module, "_log", structlog.get_logger(_loop_module.__name__))
+    return buf
+
+
+def _invoke_refused_lines(buf: io.StringIO) -> list[dict[str, object]]:
+    out: list[dict[str, object]] = []
+    for line in buf.getvalue().splitlines():
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("event") == "scheduler_invoke_refused":
+            out.append(entry)
+    return out
+
+
+async def test_budget_refused_fire_does_not_retry_and_logs_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A budget-refused subscription fire creates no run, logs once, tick completes."""
+    def_id = await _seed_tenant_and_agent()
+    trigger = await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"status": "succeeded"},
+        inputs={"prompt": "follow up"},
+    )
+    event_id = await _publish_completed_event(status="succeeded")
+
+    monkeypatch.setenv("AGENT_RUNS_DISABLED_GLOBAL", "true")
+    get_settings.cache_clear()
+
+    buf = _capture_loop_log_to_buffer(monkeypatch)
+    try:
+        # The model must never be reached -- the budget gate refuses before
+        # the run row is even created.
+        processed = await run_one_drain_tick(invoker=_make_no_call_invoker())
+    finally:
+        structlog.reset_defaults()
+
+    # The event is still consumed and the tick completed.
+    assert processed == 1
+    assert await _is_processed(event_id)
+    # No run row -- the refusal short-circuits before persistence.
+    assert await _all_runs() == []
+    # Exactly one structured refusal log carrying the budget tag.
+    refused = [
+        line for line in _invoke_refused_lines(buf) if line.get("reason") == "BudgetExceededError"
+    ]
+    assert len(refused) == 1, buf.getvalue()
+    assert refused[0]["trigger_id"] == str(trigger.id)
+    assert "global kill switch" in refused[0]["budget_reason"]
+
+
+# ---------------------------------------------------------------------------
+# Tenant + status scoping
+# ---------------------------------------------------------------------------
+
+
+async def test_paused_event_trigger_does_not_fire() -> None:
+    """A non-active (paused) event trigger is not fired."""
+    def_id = await _seed_tenant_and_agent()
+    trigger = await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"status": "succeeded"},
+        inputs={"prompt": "follow up"},
+    )
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await session.get(ScheduledTrigger, trigger.id)
+        assert row is not None
+        row.status = "paused"
+        await session.commit()
+
+    await _publish_completed_event(status="succeeded")
+    assert await run_one_drain_tick(invoker=_make_no_call_invoker()) == 1
+    assert await _all_runs() == []
+
+
+async def test_fire_matching_triggers_returns_fired_count() -> None:
+    """The public entry returns the number of triggers it fired."""
+    def_id = await _seed_tenant_and_agent()
+    await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"status": "succeeded"},
+        inputs={"prompt": "one"},
+    )
+    await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={},  # also matches
+        inputs={"prompt": "two"},
+    )
+    event_id = await _publish_completed_event(status="succeeded")
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        event = await session.get(EventOutbox, event_id)
+        assert event is not None
+        fired = await fire_matching_triggers(event, _make_invoker())
+    assert fired == 2
+    await _wait_for_runs(2)

--- a/backend/tests/test_event_matcher.py
+++ b/backend/tests/test_event_matcher.py
@@ -607,3 +607,60 @@ async def test_fire_matching_triggers_returns_fired_count() -> None:
         fired = await fire_matching_triggers(event, _make_invoker())
     assert fired == 2
     await _wait_for_runs(2)
+
+
+# ---------------------------------------------------------------------------
+# Self-trigger loop guard -- a trigger never fires off its own agent's completion
+# ---------------------------------------------------------------------------
+
+
+async def test_self_trigger_completion_event_is_suppressed() -> None:
+    """A trigger subscribed to its own agent's completion does not re-fire.
+
+    The direct feedback loop: a ``kind=event`` trigger spawns agent X with a
+    filter broad enough to match X's own ``agent_run.completed`` event. The
+    matcher guard suppresses the fire so the loop never starts -- no run, even
+    though the filter matches. The exploding invoker proves the guard short-
+    circuits before any model call.
+    """
+    def_id = await _seed_tenant_and_agent()
+    # Filter matches the completion event of the very agent this trigger spawns.
+    await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"agent_definition_id": str(def_id)},
+        inputs={"prompt": "follow up"},
+    )
+    # The event is *def_id*'s own completion -> the guard must suppress the fire.
+    event_id = await _publish_completed_event(status="succeeded", agent_definition_id=def_id)
+
+    processed = await run_one_drain_tick(invoker=_make_no_call_invoker())
+
+    assert processed == 1
+    assert await _is_processed(event_id)
+    assert await _all_runs() == []
+
+
+async def test_cross_agent_completion_event_still_fires() -> None:
+    """The guard leaves legitimate cross-agent chains intact.
+
+    A trigger spawning definition *def_id*, subscribed to a *different* upstream's
+    completion, fires normally -- the guard only blocks the one-hop self-loop
+    (matching ``agent_definition_id``), not a chain across two definitions.
+    """
+    def_id = await _seed_tenant_and_agent()
+    trigger = await _create_event_trigger(
+        agent_definition_id=def_id,
+        event_filter={"agent_definition_id": str(_UPSTREAM_DEF_ID)},
+        inputs={"prompt": "follow up"},
+    )
+    # Completion of a *different* agent (the upstream) -> the guard does not fire.
+    event_id = await _publish_completed_event(
+        status="succeeded", agent_definition_id=_UPSTREAM_DEF_ID
+    )
+
+    processed = await run_one_drain_tick(invoker=_make_invoker())
+
+    assert processed == 1
+    runs = await _wait_for_runs(1)
+    assert len(runs) == 1
+    assert runs[0].work_ref == f"event:{event_id}:{trigger.id}"

--- a/backend/tests/test_examples_r4_local_claude.py
+++ b/backend/tests/test_examples_r4_local_claude.py
@@ -202,10 +202,11 @@ def test_scheduler_payload_parses_against_live_schema() -> None:
     raw["agent_definition_id"] = str(uuid.uuid4())
     parsed = ScheduledTriggerCreate.model_validate(raw)
     assert parsed.kind.value == "cron", (
-        "R4 trigger ships as cron because the kind=event dispatcher "
-        "is not yet wired (see backend/src/meho_backplane/events/drain.py "
-        "-- v0.2 no-op subscriber match). If a future PR flips this "
-        "to event, update GUIDE.md Step 2 too."
+        "R4 trigger ships as cron: it is a periodic (every-15-min) reporter, "
+        "not an event subscriber. The kind=event dispatcher is wired now "
+        "(see backend/src/meho_backplane/events/matcher.py), so this is a "
+        "deliberate example choice; if a future PR flips R4 to event, update "
+        "GUIDE.md Step 2 too."
     )
     # The shipped cron expression is the cheap-tier-friendly cadence
     # (every 15 minutes). Per-minute (``* * * * *``) burns one

--- a/backend/tests/test_scheduler_admin.py
+++ b/backend/tests/test_scheduler_admin.py
@@ -62,7 +62,6 @@ from meho_backplane.mcp.registry import get_tool
 from meho_backplane.scheduler.schemas import ScheduledTriggerCreate
 from meho_backplane.scheduler.service import (
     AgentDefinitionMissingError,
-    EventTriggersNotImplementedError,
     SchedulerAdminService,
 )
 from meho_backplane.settings import get_settings
@@ -413,38 +412,31 @@ async def test_service_create_one_off_trigger() -> None:
 
 
 @pytest.mark.asyncio
-async def test_service_create_rejects_event_trigger() -> None:
-    """kind=event is refused at create until #826 wires the matcher (#2325).
+async def test_service_create_persists_event_trigger() -> None:
+    """kind=event creates a persisted trigger with next_fire_at NULL (#2878).
 
-    events/drain.py is still the documented no-op, so an accepted event
-    trigger sits active-but-never-fires. The service refuses it before
-    any DB write; no row is persisted.
+    The event drain's subscription matcher dispatches these rows when a
+    matching event lands; they carry no wall-clock fire time.
     """
     def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="event-bot")
     service = SchedulerAdminService()
-    with pytest.raises(EventTriggersNotImplementedError):
-        await service.create(
-            tenant_id=_TENANT_A,
-            created_by_sub="op-admin",
-            payload=ScheduledTriggerCreate(
-                kind=ScheduledTriggerKind.EVENT,
-                agent_definition_id=def_id,
-                event_filter={"connector_id": "bind9", "op_class": "write"},
-            ),
-        )
-    # No trigger row was persisted by the refused create.
-    sessionmaker = get_sessionmaker()
-    async with sessionmaker() as session:
-        rows = (
-            (
-                await session.execute(
-                    select(ScheduledTrigger).where(ScheduledTrigger.tenant_id == _TENANT_A)
-                )
-            )
-            .scalars()
-            .all()
-        )
-    assert rows == []
+    entry = await service.create(
+        tenant_id=_TENANT_A,
+        created_by_sub="op-admin",
+        payload=ScheduledTriggerCreate(
+            kind=ScheduledTriggerKind.EVENT,
+            agent_definition_id=def_id,
+            event_filter={"connector_id": "bind9", "op_class": "write"},
+        ),
+    )
+    assert entry.kind == ScheduledTriggerKind.EVENT
+    assert entry.event_filter == {"connector_id": "bind9", "op_class": "write"}
+    assert entry.next_fire_at is None
+    assert entry.cron_expr is None
+    assert entry.fire_at is None
+    assert entry.status == ScheduledTriggerStatus.ACTIVE
+    # An input-less event trigger is allowed (the matcher synthesises a prompt).
+    assert entry.inputs is None
 
 
 @pytest.mark.asyncio
@@ -988,10 +980,10 @@ async def test_rest_unknown_agent_definition_returns_422(client: TestClient) -> 
 
 
 @pytest.mark.asyncio
-async def test_rest_event_trigger_returns_422(client: TestClient) -> None:
-    """POST kind=event -> 422 'event_triggers_not_implemented' naming #826 (#2325)."""
-    def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="event-422")
-    key = make_rsa_keypair("kid-event-422")
+async def test_rest_event_trigger_returns_201(client: TestClient) -> None:
+    """POST kind=event -> 201; the event trigger is persisted (#2878)."""
+    def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="event-201")
+    key = make_rsa_keypair("kid-event-201")
     with respx.mock as r:
         mock_discovery_and_jwks(r, public_jwks(key))
         headers = {"Authorization": f"Bearer {_token(key)}"}
@@ -1004,11 +996,15 @@ async def test_rest_event_trigger_returns_422(client: TestClient) -> None:
             },
             headers=headers,
         )
-        assert result.status_code == 422, result.text
-        assert result.json()["detail"] == "event_triggers_not_implemented"
-        # The refused create persisted no row.
+        assert result.status_code == 201, result.text
+        body = result.json()
+        assert body["kind"] == "event"
+        assert body["event_filter"] == {"connector_id": "bind9", "op_class": "write"}
+        assert body["next_fire_at"] is None
+        # The create persisted the row.
         listed = client.get("/api/v1/scheduler/triggers", headers=headers)
-        assert listed.json()["triggers"] == []
+        kinds = [t["kind"] for t in listed.json()["triggers"]]
+        assert kinds == ["event"]
 
 
 @pytest.mark.asyncio
@@ -1125,13 +1121,8 @@ async def test_mcp_create_rejects_cron_without_inputs() -> None:
 
 
 @pytest.mark.asyncio
-async def test_mcp_create_rejects_event_trigger() -> None:
-    """meho_scheduler_create refuses kind=event as invalid-params (#2325).
-
-    Same 'event_triggers_not_implemented' code the REST route surfaces;
-    kind=event stays refused until #826 wires the matcher.
-    """
-    from meho_backplane.mcp.server import McpInvalidParamsError
+async def test_mcp_create_persists_event_trigger() -> None:
+    """meho_scheduler_create accepts kind=event and persists the trigger (#2878)."""
     from meho_backplane.mcp.tools.scheduler import _create_handler  # type: ignore[attr-defined]
 
     def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="mcp-event-bot")
@@ -1141,15 +1132,20 @@ async def test_mcp_create_rejects_event_trigger() -> None:
         tenant_id=_TENANT_A,
         tenant_role=TenantRole.TENANT_ADMIN,
     )
-    with pytest.raises(McpInvalidParamsError, match="event_triggers_not_implemented"):
-        await _create_handler(
-            operator,
-            {
-                "kind": "event",
-                "agent_definition_id": str(def_id),
-                "event_filter": {"connector_id": "bind9", "op_class": "write"},
-            },
-        )
+    result = await _create_handler(
+        operator,
+        {
+            "kind": "event",
+            "agent_definition_id": str(def_id),
+            "event_filter": {"connector_id": "bind9", "op_class": "write"},
+        },
+    )
+    trigger_id = uuid.UUID(result["trigger_id"])
+    fetched = await SchedulerAdminService().get(_TENANT_A, trigger_id)
+    assert fetched is not None
+    assert fetched.kind == ScheduledTriggerKind.EVENT
+    assert fetched.event_filter == {"connector_id": "bind9", "op_class": "write"}
+    assert fetched.next_fire_at is None
 
 
 @pytest.mark.asyncio
@@ -1380,69 +1376,3 @@ async def test_durability_trigger_survives_scheduler_restart(
     second_tick_fires = await run_one_tick()
     assert second_tick_fires == 0
     assert fire_calls.count(entry.id) == 1
-
-
-# ---------------------------------------------------------------------------
-# Startup reconcile of pre-existing active event triggers (#2325)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_reconcile_parks_active_event_triggers() -> None:
-    """Pre-existing active event triggers are parked to 'paused' (#2325).
-
-    An event trigger created active before the create-time refusal landed
-    would sit silently dead (the drain matcher is a no-op pending #826).
-    The one-shot startup reconcile transitions it to 'paused' so an
-    operator sees it parked; cron / one_off rows are untouched. The
-    reconcile is idempotent -- a second run parks nothing.
-    """
-    from meho_backplane.scheduler.loop import reconcile_active_event_triggers
-    from meho_backplane.scheduler.repository import create_event_trigger
-
-    def_id = await _seed_agent_definition(tenant_id=_TENANT_A, name="reconcile-bot")
-
-    # Seed an active event trigger directly via the repository (the
-    # service refuses kind=event, which is exactly the state this
-    # reconcile cleans up for rows that predate the refusal).
-    sessionmaker = get_sessionmaker()
-    async with sessionmaker() as session:
-        event_row = await create_event_trigger(
-            session,
-            tenant_id=_TENANT_A,
-            agent_definition_id=def_id,
-            event_filter={"connector_id": "bind9", "op_class": "write"},
-            inputs=None,
-            identity_sub="__scheduler__",
-            created_by_sub="op-admin",
-            in_flight_policy="fail_into_audit",
-        )
-        event_id = event_row.id
-        await session.commit()
-
-    # A live cron trigger the reconcile must leave alone.
-    service = SchedulerAdminService()
-    cron = await service.create(
-        tenant_id=_TENANT_A,
-        created_by_sub="op-admin",
-        payload=ScheduledTriggerCreate(
-            kind=ScheduledTriggerKind.CRON,
-            agent_definition_id=def_id,
-            cron_expr="*/5 * * * *",
-            inputs={"prompt": "scheduled run"},
-        ),
-    )
-
-    parked = await reconcile_active_event_triggers()
-    assert parked == 1
-
-    async with sessionmaker() as session:
-        event_after = await session.get(ScheduledTrigger, event_id)
-        assert event_after is not None
-        assert event_after.status == ScheduledTriggerStatus.PAUSED.value
-    cron_after = await service.get(_TENANT_A, cron.id)
-    assert cron_after is not None
-    assert cron_after.status == ScheduledTriggerStatus.ACTIVE
-
-    # Idempotent: a second reconcile finds no active event rows.
-    assert await reconcile_active_event_triggers() == 0

--- a/backend/tests/test_scheduler_vault_credentials.py
+++ b/backend/tests/test_scheduler_vault_credentials.py
@@ -752,7 +752,6 @@ async def test_scheduler_loop_renews_vault_token_on_dedicated_timer(
     async def _tick_noop(*_args: Any, **_kwargs: Any) -> int:
         return 0
 
-    monkeypatch.setattr(loop, "reconcile_active_event_triggers", _anoop)
     monkeypatch.setattr(loop, "run_one_tick", _tick_noop)
     monkeypatch.setattr(loop, "_check_scheduler_vault_token", _anoop)
     # Trip the renewal cadence on the first post-tick check.

--- a/backend/tests/test_ui_scheduler.py
+++ b/backend/tests/test_ui_scheduler.py
@@ -809,8 +809,12 @@ def test_create_submit_input_less_cron_rerenders_modal_with_error() -> None:
     assert _trigger_count(_TENANT_A) == 0
 
 
-def test_create_submit_event_rerenders_modal_with_error() -> None:
-    """A kind=event create surfaces the 422 as a banner naming #826 (#2325)."""
+def test_create_submit_event_persists_and_redirects() -> None:
+    """A kind=event create persists the trigger and HX-Redirects to the list (#2878).
+
+    Event triggers carry no ``inputs`` (the matcher synthesises a prompt from
+    the matched event), so the create omits the inputs field and still succeeds.
+    """
     _seed_tenant(_TENANT_A, "tenant-a")
     _seed_agent(tenant_id=_TENANT_A)
     client, mock, csrf = _client_with_role(
@@ -830,10 +834,9 @@ def test_create_submit_event_rerenders_modal_with_error() -> None:
         )
     finally:
         mock.stop()
-    assert response.status_code == 200, response.text
-    assert "alert-error" in response.text
-    assert "#826" in response.text
-    assert _trigger_count(_TENANT_A) == 0
+    assert response.status_code == 204, response.text
+    assert response.headers["HX-Redirect"] == "/ui/scheduler"
+    assert _trigger_count(_TENANT_A) == 1
 
 
 def test_create_submit_rejects_operator_with_403() -> None:

--- a/docs/codebase/checks-broadcast.md
+++ b/docs/codebase/checks-broadcast.md
@@ -199,7 +199,8 @@ layers and pinned together by a test rather than shared as a constant.
   a test pins both tables to the enum.
 - **No event-outbox routing and no durable event table.** The Valkey
   stream plus its retention window is the carrier, exactly as for
-  `approval.*` (the outbox matcher is a no-op pending #826).
+  `approval.*` (the outbox matcher, #2878, fires `kind=event` agent
+  triggers, not checks-broadcast events).
 
 ## References
 

--- a/docs/codebase/checks-investigator.md
+++ b/docs/codebase/checks-investigator.md
@@ -295,10 +295,10 @@ principal, so no execution path inherits the role.
     processes) — i.e. the reservation protocol `budget_enforcement.py` defers.
     That is a separate, larger change; until it exists, serial-to-completion is
     the only fan-out shape that keeps the cap honest.
-- **Trigger seam.** The runner-persist hook is the v1 seam because event
-  triggers are refused until the #826 matcher lands (#2325) and #2506's rollup
-  is read-path-only. Migrating to an event trigger when the matcher exists is
-  a separate task.
+- **Trigger seam.** The runner-persist hook is the v1 seam because the
+  `kind=event` matcher (#2878) dispatches subscribed agent triggers, not the
+  diagnose-only investigator, and #2506's rollup is read-path-only. Migrating
+  the investigator onto an event trigger is a separate task.
 - **Remote Sensors.** Investigation of remote / isolated-network Sensors
   (#2415 gateway workload) is out of scope here (soft link).
 

--- a/docs/codebase/events.md
+++ b/docs/codebase/events.md
@@ -39,7 +39,8 @@ disk; `NOTIFY` is a tail-latency optimisation.
 backend/src/meho_backplane/events/
 ├── __init__.py        # re-exports publish, start_event_drain, stop_event_drain
 ├── outbox.py          # producer-side publish() + post-commit NOTIFY hint
-└── drain.py           # background drain loop + advisory-lock + claim + dispatch
+├── drain.py           # background drain loop + advisory-lock + claim + dispatch
+└── matcher.py         # subscription matcher: payload @> event_filter -> fire triggers
 ```
 
 Plus the persistence shape in
@@ -169,11 +170,14 @@ On each tick (default 10s, settable via
    the same open session as the SELECT; the FOR UPDATE row-lock
    carries through to the UPDATE.
 
-4. **Dispatch each row.** In v0.2 the subscription-matcher is not
-   yet built (see [Deferred work](#deferred-work) below). The drain
-   therefore stamps `processed_at` directly and emits a structlog
-   event — events are visible in the log stream, and the drain's
-   stamp-and-skip behaviour proves the substrate works end-to-end.
+4. **Dispatch each row** through the subscription matcher
+   ([The subscription matcher](#the-subscription-matcher) below): fire
+   every active `kind='event'` trigger whose `event_filter` the payload
+   contains, then stamp `processed_at`. An event that matches no
+   subscriber is still durably consumed (stamped, no fire, no log
+   noise). The claim stamps are committed *before* this fire step so
+   the drain holds no open write across a subscriber's independently-
+   committed run row (mirrors the scheduler-fire ordering).
 
 5. **Mark each row processed** via a conditional UPDATE
    (`processed_at IS NULL` predicate). The conditional UPDATE is the
@@ -208,27 +212,114 @@ each other — the scheduler's lock holder does not block the drain's
 claim, and vice versa. The ASCII spellings make the keys easy to
 recognise in `pg_locks` during operator triage.
 
+## The subscription matcher
+
+`backend/src/meho_backplane/events/matcher.py` is the junction between a
+drained event and the agent runs it fires. The drain calls
+`fire_matching_triggers(event, invoker)` for each claimed row (#2878).
+
+### Match semantics — `payload @> event_filter` (direction is load-bearing)
+
+An event matches a trigger when the event **`payload` contains** every
+key/value the trigger's **`event_filter`** names — the Postgres jsonb
+`@>` direction, the same one the retrieval metadata-filter path uses
+(`doc_metadata @> :filters`). Concretely:
+
+- A filter `{"status": "succeeded"}` matches a payload
+  `{"run_id": "…", "status": "succeeded", …}` — the filter is a subset
+  of the payload.
+- The **reverse never matches**: a payload that is a subset of the
+  filter is not a match (unless they are equal). Inverting the
+  operands would match nothing useful, so the direction is pinned by a
+  test.
+- An **empty filter `{}` matches every event** of the tenant (it names
+  no constraints). `event_filter` is matched, `event_kind` is not — a
+  subscriber filters on payload fields (for `agent_run.completed`:
+  `run_id` / `tenant_id` / `status` / `agent_definition_id` /
+  `work_ref`).
+
+### Why one pure-Python predicate on both dialects (not native `@>` on PG)
+
+`_payload_contains` is a single pure-Python containment predicate
+(recursive: object ⊇ object, array ⊇ array subset, scalar equality)
+used on **both** PG and SQLite, rather than the native jsonb `@>` on PG
+with a portable fallback on SQLite. One code path is deliberate:
+
+- The drain's tests run on SQLite, so a single predicate means those
+  tests exercise the **exact** code that also runs on Postgres. Two
+  implementations (native `@>` + a fallback) could silently diverge on
+  nested/array shapes — precisely the "works on PG **and** SQLite"
+  contract this Task must hold.
+- There is **no GIN index** on `scheduled_trigger.event_filter`, so a
+  native `@>` gives no index-backed speed-up over loading the tenant's
+  (dozens of) event triggers and filtering them in Python — which the
+  drain already does row-by-row.
+
+### The fire recipe — reuse of the scheduler seam
+
+The matcher reuses the cron/one-off fire recipe verbatim
+(`scheduler/loop.py`): `_prepare_invocation` resolves the definition +
+credentials (the agent's `client_credentials` secret stays a
+`SecretStr` end-to-end, CWE-532), and `_dispatch_invocation` calls
+`AgentInvoker.run_scheduled` and treats `BudgetExceededError` as a
+do-not-retry single-log refusal (`scheduler_invoke_refused` with the
+`budget_reason` tag). An event storm therefore never blasts through a
+budget kill switch — the refusal is logged once per matched trigger and
+the drain tick completes. Only two values are overridden on the
+prepared invocation:
+
+- **`work_ref` = `event:{event_id}:{trigger_id}`** — the fire-dedupe
+  key (below). The dispatched run inherits it through the trigger→run
+  `work_ref_var` seam `run_scheduled` already plumbs.
+- **`inputs`** — a `kind=event` trigger is exempt from the create-time
+  non-empty-inputs rule (`scheduler/schemas.py`), so an input-less
+  trigger reaches the matcher with no operator prompt. Rather than let
+  the fire fail typed at the no-input guard, the matcher **synthesises
+  a prompt from the matched event**. The event kind + payload are
+  untrusted, so the composed body is wrapped with
+  `wrap_untrusted_text` (`untrusted_text.py`). A trigger that *does*
+  carry a usable `inputs` prompt uses that instead.
+
+### Redelivery dedupe — the `work_ref`
+
+Delivery is **at-least-once**: a fired subscriber's `agent_run` commits
+in its own transaction, and the drain stamps `processed_at` in a
+separate one. A crash between the two leaves the event unprocessed and
+the next tick re-matches it. `_run_exists_for_work_ref` makes that
+idempotent: before firing, the matcher checks
+`agent_run_tenant_work_ref_idx` for **any** run (terminal or not)
+carrying `event:{event_id}:{trigger_id}` — a hit means the first
+delivery already fired, so the redelivery is skipped. A single drain
+replica runs at a time (the drain advisory lock), so this check-then-
+fire never races itself in production. (This overloads `work_ref` — a
+change-ticket field for scheduled triggers — as the dedupe key; a
+sibling Task, #2879, adds a first-class `dedupe_key` column, out of
+scope here.)
+
+### Storm controls
+
+- **Budget gate**: `BudgetExceededError` refusals do not retry and log
+  once — an event storm cannot repeatedly blast a kill switch.
+- **Zero-match quiet**: an event matching no subscriber is stamped with
+  no per-event log line.
+- **Per-trigger isolation**: one subscription raising never stalls the
+  others or the drain tick.
+
+### Avoiding self-triggering loops
+
+A fired agent run reaches a terminal state, which the producer emits as
+its own `agent_run.completed` event. A subscription with a filter broad
+enough to match *that* event (e.g. `{"status": "succeeded"}` — every
+successful run) would fire again on the run it just spawned, and so on:
+a feedback loop, bounded only by per-run budgets. The mitigation is the
+subscription filter, not a matcher guard: subscribe to a **specific
+upstream** by including `agent_definition_id` (or a `run_id`) in the
+`event_filter`, which the payload carries for exactly this reason. The
+spawned follow-up agent is a different definition, so its completion
+does not re-match. Work_ref dedupe does **not** help here — each
+distinct event has a distinct `event_id`, hence a distinct work_ref.
+
 ## Deferred work
-
-### Subscription matcher (depends on T5 #826)
-
-The drain loop in v0.2 stamps `processed_at` directly without
-matching subscribers. The matcher — looking up `scheduled_trigger`
-rows where `kind='event'` and `event_filter` matches `payload` — is
-deferred because:
-
-- The trigger-creation surface that populates `kind='event'` rows is
-  the admin surface in T5 #826. Until T5 ships, no `event` trigger
-  exists, so the matcher would always return zero matches.
-- The substrate proof — durable across restart, no double-fire,
-  same-transaction discipline — is independent of the matcher and is
-  the load-bearing correctness property this Task ships.
-
-When T5 lands, the matcher folds into the dispatch step: for each
-claimed row, `SELECT ... FROM scheduled_trigger WHERE kind='event' AND
-event_filter @> payload`, then fire each matched trigger through
-`AgentInvoker.run_scheduled` (the same seam the scheduler's cron /
-one-off paths use, G11.2-T2 #1096).
 
 ### Reconnect-with-backoff for the `LISTEN` connection
 
@@ -273,6 +364,14 @@ Both gated via env vars (defaults shown in parens):
     ticks, sum of processed == N exactly
   - `test_restart_durability_drains_unprocessed_rows` — publish →
     simulate kill → restart → tick drains the row
+- [backend/tests/test_event_matcher.py](backend/tests/test_event_matcher.py)
+  — subscription-matcher unit tests (#2878): containment direction,
+  end-to-end `agent_run.completed` → matching trigger → agent run with
+  work_ref, non-matching filter fires nothing, redelivery dedupe,
+  `BudgetExceededError` no-retry, input-less trigger fires with a
+  synthesised untrusted-enveloped prompt.
+- [backend/tests/integration/test_event_matcher_pg.py](backend/tests/integration/test_event_matcher_pg.py)
+  — the same end-to-end chain against a real Postgres container (#2878).
 - [backend/tests/migrations/test_migration_0027_event_outbox.py](backend/tests/migrations/test_migration_0027_event_outbox.py)
   — schema + index migration round-trip
 
@@ -283,8 +382,9 @@ Both gated via env vars (defaults shown in parens):
 - This Task #824 — research note (transactional-outbox vs
   LISTEN/NOTIFY durability)
 - Sibling Tasks: T1 #822 (substrate-decision spike), T2 #1065 (cron +
-  one-off, merged), T4 #825 (in-flight resume), T5 #826 (admin
-  surface — owns the subscription-matcher)
+  one-off, merged), T4 #825 (in-flight resume), T5 #826 (admin surface)
+- Task #2878 — the subscription matcher + `kind=event` dispatch
+  (`events/matcher.py`); Initiative #2877 (inbound event ingestion)
 - Companion: [scheduler.md](scheduler.md) — the cron + one-off
   substrate this layer joins on
 - PG `LISTEN`/`NOTIFY` durability:

--- a/docs/codebase/events.md
+++ b/docs/codebase/events.md
@@ -298,6 +298,10 @@ scope here.)
 
 ### Storm controls
 
+- **Self-trigger guard**: a `kind=event` trigger never fires from the
+  `agent_run.completed` event of the agent it spawns (the direct
+  self-loop), suppressed in `_fire_event_trigger` and logged once as
+  `event_trigger_self_fire_suppressed` (see below).
 - **Budget gate**: `BudgetExceededError` refusals do not retry and log
   once — an event storm cannot repeatedly blast a kill switch.
 - **Zero-match quiet**: an event matching no subscriber is stamped with
@@ -311,13 +315,28 @@ A fired agent run reaches a terminal state, which the producer emits as
 its own `agent_run.completed` event. A subscription with a filter broad
 enough to match *that* event (e.g. `{"status": "succeeded"}` — every
 successful run) would fire again on the run it just spawned, and so on:
-a feedback loop, bounded only by per-run budgets. The mitigation is the
-subscription filter, not a matcher guard: subscribe to a **specific
-upstream** by including `agent_definition_id` (or a `run_id`) in the
-`event_filter`, which the payload carries for exactly this reason. The
-spawned follow-up agent is a different definition, so its completion
-does not re-match. Work_ref dedupe does **not** help here — each
-distinct event has a distinct `event_id`, hence a distinct work_ref.
+a feedback loop that, on a default install with no budget row, is
+bounded only by the manual kill switch. Two controls contain it:
+
+- **Matcher self-trigger guard (defence in depth).**
+  `_fire_event_trigger` refuses to fire a trigger from the
+  `agent_run.completed` event of the very agent that trigger spawns: it
+  skips when `event_kind == agent_run.completed` and the event payload's
+  `agent_definition_id` equals the trigger's `agent_definition_id`,
+  logging `event_trigger_self_fire_suppressed` once. This breaks the
+  *direct* one-hop self-loop with no schema change, while leaving
+  legitimate cross-agent chains intact — a trigger that spawns a
+  *different* definition Y off X's completion still fires because the
+  ids differ.
+- **Subscription filter (the recommended discipline).** The guard only
+  covers the one-hop self-loop; a longer cycle (X → Y → X) slips past
+  it. Subscribe to a **specific upstream** by including
+  `agent_definition_id` (or a `run_id`) in the `event_filter`, which the
+  payload carries for exactly this reason, so a subscription only wakes
+  on the intended producer.
+
+Work_ref dedupe does **not** help here — each distinct event has a
+distinct `event_id`, hence a distinct work_ref.
 
 ## Deferred work
 

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -507,9 +507,10 @@ interval at the cost of one extra scan query per elapsed tick.
   the `inputs: {}` edge, which `_coerce_inputs` renders to the literal
   `"{}"` — non-whitespace, so it slips past the fire-time guard and reaches
   the model as a meaningless `"{}"` turn. `kind=event` is **exempt**: its
-  future payload-dispatch junction (`events/drain.py`, still a no-op at
-  HEAD) may legitimately derive the prompt from the matched event, so an
-  input-less event trigger stays creatable.
+  payload-dispatch junction (the event drain's subscription matcher,
+  `events/matcher.py`) derives the prompt from the matched event when the
+  trigger carries no usable `inputs`, so an input-less event trigger stays
+  creatable.
 
   The fire-time guard is retained as defense-in-depth for the paths the
   create check does not cover — an `event` trigger, or a row inserted
@@ -555,43 +556,33 @@ invalid cron expression surfaces as `invalid_arguments` at the
 boundary; an unknown `agent_definition_id` surfaces as
 `agent_definition_not_found` (422 / MCP invalid-params).
 
-### `kind=event` is refused at create until #826 (#2325)
+### `kind=event` triggers dispatch via the event drain (#2878)
 
-`kind=event` trigger creation is **refused** with a structured 422
-`event_triggers_not_implemented` (MCP invalid-params with the same
-code; UI modal banner naming #826) on every transport. The refusal
-lives in one place — `SchedulerAdminService.create` raises
-`EventTriggersNotImplementedError` before any DB write — so the wire
-schema still models the `event` kind but no `event` row is ever
-persisted.
+`kind=event` trigger creation returns **201** on every transport
+(`SchedulerAdminService.create` dispatches to `create_event_trigger`,
+which persists a row with `next_fire_at=NULL`). Such a row is invisible
+to the tick loop's `claim_due_triggers` scan — it is dispatched not on
+the clock but when a matching event lands.
 
-Why: the event-subscription matcher in
-`backend/src/meho_backplane/events/drain.py` is still the documented
-T5 no-op (it stamps `processed_at` on drained rows without consulting
-`scheduled_trigger`). Real producers already emit onto the outbox —
-`backend/src/meho_backplane/operations/agent_run.py` publishes
-agent-run terminal-transition events — so those events land in
-`event_outbox` and are silently swallowed. Accepting a trigger that
-reports `status=active` but can never fire is dishonest to the
-operator; refusing at create is the honest shape until #826 wires the
-matcher. The guard is a single create-site check (not a feature-flag
-system) and is removed in the same change that lands #826, at which
-point the `create_event_trigger` branch below the guard dispatches for
-real.
+The dispatcher is the **event drain's subscription matcher**
+(`backend/src/meho_backplane/events/matcher.py`, documented in
+[events.md](events.md)). For each drained `event_outbox` row it fires
+every active `kind=event` trigger in that tenant whose `event_filter`
+the event `payload` contains (`payload @> event_filter`), through the
+same `AgentInvoker.run_scheduled` seam the cron / one-off loop uses. The
+fired run's work_ref is `event:{event_id}:{trigger_id}`, which dedupes a
+redelivered event so it never double-fires.
 
-**Pre-existing rows.** Event triggers created `active` before this
-refusal landed are parked to `paused` by a one-shot startup reconcile
-(`reconcile_active_event_triggers` in `scheduler/loop.py`, run once at
-the top of `_scheduler_loop` before the first tick). Because an event
-trigger carries no `next_fire_at`, the tick loop's `claim_due_triggers`
-scan never sees it, so an in-loop park path would never fire — the
-reconcile is the deliberate cleanup. The park reason is logged under
-`scheduler_event_triggers_parked` (`reason=event_triggers_not_implemented:826`),
-mirroring the `_park_trigger` "reason is logged for audit" precedent
-since the row has no reason column; the parked state is visible via
-`GET /api/v1/scheduler/triggers?kind=event&status=paused` and the UI
-list. The reconcile is idempotent and removed alongside the guard when
-#826 lands.
+`kind=event` triggers are the one kind **exempt** from the create-time
+non-empty-inputs rule (`_payload_yields_prompt` in `schemas.py`): an
+input-less event trigger is creatable because the matcher synthesises a
+prompt from the matched event (untrusted-enveloped) at fire time, rather
+than requiring the operator to author one up front.
+
+Until #2878 this create was refused with `event_triggers_not_implemented`
+(#2325) and pre-existing `active` event rows were parked by a startup
+reconcile; both the create guard and the reconcile were removed when the
+matcher landed.
 
 ### Cross-tenant admin
 


### PR DESCRIPTION
## Summary

- **Ships the G11.3 event-subscription matcher** (`events/matcher.py`): the outbox drain now fires every active `kind=event` trigger whose `event_filter` the drained event `payload` contains (`payload @> event_filter`), through the same `AgentInvoker.run_scheduled` seam the cron/one-off scheduler uses. This delivers internal event chaining day one — `agent_run.completed` → spawn a subscribed follow-up agent — with no webhook.
- **Enables `kind=event` trigger creation**: removes the #2325 `EventTriggersNotImplementedError` create-guard and its REST/MCP/UI 422 mappings, plus `reconcile_active_event_triggers` + its park constant. `kind=event` create now returns 201.
- **Dedupe is load-bearing**: fired runs carry `work_ref = event:{event_id}:{trigger_id}` on `agent_run_tenant_work_ref_idx`, so a redelivered event (its fire committed but the drain's `processed_at` stamp lost to a crash) never double-fires. Input-less event triggers get a prompt **synthesised from the matched event**, wrapped in the untrusted-text envelope.
- **Design note — one containment predicate, both dialects.** Containment is a single pure-Python `payload @> event_filter` used on PG *and* SQLite, not native `@>` on PG with a fallback. The task explicitly blesses "a Python-side containment check"; one code path means the SQLite unit tests exercise the exact code that runs on Postgres (the parity the "works on both" criterion needs, with no second impl to diverge), and there is no GIN index on `scheduled_trigger.event_filter` so native `@>` would give no index benefit. Documented in `docs/codebase/events.md`.

## Test plan

- [x] `ruff check` — clean; `ruff format --check` — clean
- [x] `mypy` (strict, `files=["src"]`) — clean (the one reported error, `icmp.py` `MSG_ERRQUEUE`, is a pre-existing macOS-only socket-attr quirk present on `main`; passes on Linux CI)
- [x] `code-quality.py --diff` — 0 blockers (warnings are pre-existing legacy debt in touched files)
- [x] `pytest tests/test_event_matcher.py` — 15 passed (containment direction both ways, nested/array/empty, end-to-end fire with work_ref, non-match fires nothing, redelivery dedupe, `BudgetExceededError` no-retry + one structured log, input-less untrusted-prompt synthesis)
- [x] Impacted suites green: `test_event_outbox`, `test_scheduler`, `test_scheduler_admin` (event create now 201 on REST/MCP/service; reconcile test removed), `test_scheduler_vault_credentials`, `test_ui_scheduler` (event create → 204 + HX-Redirect) — 284 passed across the scheduler/events/lifespan blast radius
- [x] Import-cycle smoke: `import meho_backplane.main` + `events.matcher` OK (matcher is lazy-imported in the drain to keep the `events → scheduler → agent → operations → events` chain off the module-load path)

**Acceptance criteria**

- [x] E2E on SQLite: `agent_run.completed` → matching trigger → agent run with work_ref; non-matching filter fires nothing (`test_event_matcher.py`)
- [x] E2E on PG: same chain against a real `pgvector/pgvector:pg16` container (`tests/integration/test_event_matcher_pg.py`) — skips locally without Docker, **runs in CI where containers are provisioned**
- [x] Containment direction: filter ⊆ payload matches; payload ⊆ filter does not
- [x] Redelivery of a claimed-but-unprocessed event does not double-fire (work_ref dedupe)
- [x] `BudgetExceededError`: no retry, one structured log, drain tick completes
- [x] `kind=event` create returns 201; guard, park-reconcile, park constant, and stale #826 refs removed
- [x] Input-less event trigger fires with a synthesised, untrusted-enveloped prompt
- [x] `docs/codebase/events.md` documents the shipped matcher (containment direction, storm controls, self-trigger-loop caveat)

## Out of scope

- **`dedupe_key` migration** — sibling Task #2879 adds a first-class `dedupe_key` column + `origin`; this PR uses the existing work_ref/fire-dedupe mechanism per the task scope.
- **Inbound webhook ingest** — Tasks #2880–#2883 (registry, endpoint, normalizers, netpol).
- **Self-triggering-loop guard** — **now shipped in the iteration-1 fix (M1)**, no longer caveat-only: `_fire_event_trigger` suppresses the direct one-hop self-loop (a trigger firing off its own agent's `agent_run.completed`) and logs `event_trigger_self_fire_suppressed`. Subscribing to a specific upstream `agent_definition_id` remains the recommended discipline for longer (X→Y→X) cycles the one-hop guard cannot see.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2878

---

## Follow-up (auto-implement-issue, iteration 1 fix, 2026-08-17)

Addressed both findings from the iteration-1 `/auto-review-pr` REQUEST_CHANGES:

- **B1** (blocker) `bc1c08ac` — refreshed every newly-stale `#826`/matcher-status reference now that the matcher ships: `db/models.py` EventOutbox docstring (dispatch-through-matcher, `event_kind` discriminator, no-subscriber stamp, tenant-index reserved), `checks-broadcast.md`, `checks-investigator.md` (mirrors the `investigate.py` correction), and the `test_examples_r4_local_claude.py` assertion message (the cron/kind assertion itself is unchanged). Mechanical, no behaviour change.
- **M1** (major) `a9c7879f` — added the cheap self-trigger guard in `_fire_event_trigger`: a `kind=event` trigger no longer fires from the `agent_run.completed` event of the very agent it spawns (`event_kind == agent_run.completed` and matching `agent_definition_id`), breaking the direct one-hop storm loop with no schema change while leaving cross-agent chains intact; suppression logs `event_trigger_self_fire_suppressed`. New tests pin both directions (`test_self_trigger_completion_event_is_suppressed`, `test_cross_agent_completion_event_still_fires`); `events.md` storm-controls now documents the guard. Also softened the `_payload_contains` docstring to "portable approximation" (it models neither PG's top-level-array-contains-scalar case nor Python's `True==1`, neither reachable here).

Local verification (green): `ruff check` / `ruff format --check` clean; `mypy` clean on touched files (the lone `icmp.py` `MSG_ERRQUEUE` error is the same pre-existing macOS-only quirk noted above); impacted pytest suites 125 passed (incl. `test_event_matcher.py`); `code-quality.py --diff` 0 blockers.

<!-- auto-implement-issue: continue, iteration 1 -->

