### PR TITLE
feat(tests): nsx real-spec reconcile lane — armed via manager-served specs, B1 probe evidence recorded (#2981)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,15 +264,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Checkout vendor vCenter spec-shelf (secret-gated, #2949)
-        # The vSphere OpenAPI specs (vcenter.yaml ~961 paths,
-        # vi-json.yaml ~2,195 paths) are Broadcom/VMware
-        # vendor-licensed and deliberately NOT committed to this public
-        # repo — they live in the operator's private spec-shelf repo.
-        # This step fetches ONLY the pinned vcenter-9.0 shelf directory
-        # into the ephemeral runner workspace so the real-spec
-        # ingest/reconcile lanes stop skipping. Licensing record +
-        # provisioning runbook (secret scope, signoff gate):
+      - name: Checkout vendor spec-shelf (secret-gated, #2949; nsx #2981)
+        # The vendor OpenAPI specs (vSphere: vcenter.yaml ~961 paths +
+        # vi-json.yaml ~2,195 paths; NSX: the manager-served
+        # nsx_api / nsx_policy_api pair, ~3,510 paths) are
+        # Broadcom/VMware vendor-licensed and deliberately NOT
+        # committed to this public repo — they live in the operator's
+        # private spec-shelf repo. This step fetches ONLY the pinned
+        # shelf directories into the ephemeral runner workspace so the
+        # real-spec ingest/reconcile lanes stop skipping. Licensing
+        # record + provisioning runbook (secret scope, signoff gate):
         # docs/decisions/vendor-spec-ci-provisioning.md. The specs are
         # never committed, never uploaded as artifacts (the
         # upload-artifact steps in this workflow enumerate exact
@@ -295,12 +296,15 @@ jobs:
           path: spec-shelf
           # Cone-mode sparse checkout of the shelf directories only +
           # lazy blob filter: the runner materialises just the pinned
-          # spec files (~20 MB), not the whole consumer repo. No `ref:`
-          # pin — the shelf's default branch IS the operator-curated
-          # pin (the directories are version-named, e.g. vcenter-9.0/),
+          # spec files (~33 MB nsx-9.0 + ~2 MB sddc-manager-9.0 +
+          # ~18 MB vcenter-9.0), not the whole consumer repo. No
+          # `ref:` pin — the shelf's default branch IS the
+          # operator-curated pin (the directories are version-named),
           # matching the local-dev contract documented in
-          # tests/acceptance/_vcenter_spec.py. Keep the list sorted.
+          # tests/acceptance/_vcenter_spec.py + tests/_spec_shelf.py.
+          # Keep the list sorted.
           sparse-checkout: |
+            docs/nsx-9.0
             docs/sddc-manager-9.0
             docs/vcenter-9.0
           filter: blob:none
@@ -308,7 +312,7 @@ jobs:
           # the shelf clone's local git config after checkout.
           persist-credentials: false
 
-      - name: Verify spec-shelf provisioned the pinned vCenter specs
+      - name: Verify spec-shelf provisioned the pinned specs
         # Fail-loud layout guard: once the secret exists, a shelf
         # layout move (or a sparse-checkout typo here) must fail THIS
         # job — otherwise the resolvers would return None and the spec
@@ -320,13 +324,18 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          for f in spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json spec-shelf/docs/vcenter-9.0/vcenter.yaml spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
+          for f in \
+            spec-shelf/docs/nsx-9.0/nsx_api.openapi3.json \
+            spec-shelf/docs/nsx-9.0/nsx_policy_api.openapi3.json \
+            spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json \
+            spec-shelf/docs/vcenter-9.0/vcenter.yaml \
+            spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
             if [ ! -f "$f" ]; then
               echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
               exit 1
             fi
           done
-          echo "spec-shelf OK: sddc-manager-openapi.json + vcenter.yaml + vi-json.yaml present under spec-shelf/docs/"
+          echo "spec-shelf OK: nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -932,7 +941,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - name: Checkout vendor vCenter spec-shelf (secret-gated, #2949)
+      - name: Checkout vendor spec-shelf (secret-gated, #2949; nsx #2981)
         # Same secret-gated sparse checkout as the python-lint-test
         # job's spec-shelf step — see that step's comment for the
         # licensing pointer (docs/decisions/vendor-spec-ci-
@@ -945,25 +954,31 @@ jobs:
           token: ${{ secrets.SPEC_SHELF_TOKEN }}
           path: spec-shelf
           sparse-checkout: |
+            docs/nsx-9.0
             docs/sddc-manager-9.0
             docs/vcenter-9.0
           filter: blob:none
           persist-credentials: false
 
-      - name: Verify spec-shelf provisioned the pinned vCenter specs
+      - name: Verify spec-shelf provisioned the pinned specs
         # Fail-loud layout guard — same rationale as the
         # python-lint-test job's occurrence.
         if: env.SPEC_SHELF_TOKEN_PRESENT == 'true'
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          for f in spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json spec-shelf/docs/vcenter-9.0/vcenter.yaml spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
+          for f in \
+            spec-shelf/docs/nsx-9.0/nsx_api.openapi3.json \
+            spec-shelf/docs/nsx-9.0/nsx_policy_api.openapi3.json \
+            spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json \
+            spec-shelf/docs/vcenter-9.0/vcenter.yaml \
+            spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
             if [ ! -f "$f" ]; then
               echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
               exit 1
             fi
           done
-          echo "spec-shelf OK: sddc-manager-openapi.json + vcenter.yaml + vi-json.yaml present under spec-shelf/docs/"
+          echo "spec-shelf OK: nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-lint-test's login step — the

--- a/backend/src/meho_backplane/connectors/nsx/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/nsx/typed_ops.py
@@ -461,7 +461,7 @@ _TRANSPORT_NODE_STATE = NsxTypedOp(
     summary="Realization + maintenance-mode + tunnel state of one NSX transport node.",
     description=(
         "Reads one transport node's realization + fabric health via "
-        "GET /api/v1/transport-nodes/{id}/state -- requires a node id from "
+        "GET /api/v1/transport-nodes/{transport-node-id}/state -- requires a node id from "
         "nsx.transport_node.list. NSX's TransportNodeState carries state "
         "(overall realization result), maintenance_mode_state (whether the "
         "node is already draining -- the datum that says whether the "

--- a/backend/src/meho_backplane/connectors/nsx/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/nsx/typed_reads.py
@@ -46,7 +46,8 @@ The audited set:
 * ``nsx.transport_node.list`` -- ``GET /api/v1/transport-nodes`` (the
   edge/host transport-node fabric inventory; live per-node state lives on
   the ``.../state`` sub-resource below, not on the list row).
-* ``nsx.transport_node.state`` -- ``GET /api/v1/transport-nodes/{id}/state``
+* ``nsx.transport_node.state`` --
+  ``GET /api/v1/transport-nodes/{transport-node-id}/state``
   (one node's realization + maintenance-mode + tunnel/host-switch state --
   the edge-health read before a maintenance-mode or failover action).
 * ``nsx.alarm.list`` -- ``GET /api/v1/alarms`` with optional
@@ -95,13 +96,17 @@ _NODE_PATH = "/api/v1/node"
 _CLUSTER_STATUS_PATH = "/api/v1/cluster/status"
 _BACKUP_CONFIG_PATH = "/api/v1/cluster/backups/config"
 _BACKUP_STATUS_PATH = "/api/v1/cluster/backups/status"
+# Vendor template paths carry the vendor's own parameter names (the
+# spec-reconcile lane asserts these literals against the pinned specs);
+# call sites instantiate them via .format(**{...}) — str.format accepts
+# hyphenated keys through keyword-dict unpacking.
 _TRANSPORT_ZONES_PATH = (
-    "/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones"
+    "/policy/api/v1/infra/sites/{site-id}/enforcement-points/{enforcementpoint-id}/transport-zones"
 )
 _TIER1S_PATH = "/policy/api/v1/infra/tier-1s"
 _SEGMENTS_PATH = "/policy/api/v1/infra/segments"
 _TRANSPORT_NODES_PATH = "/api/v1/transport-nodes"
-_TRANSPORT_NODE_STATE_PATH = "/api/v1/transport-nodes/{id}/state"
+_TRANSPORT_NODE_STATE_PATH = "/api/v1/transport-nodes/{transport-node-id}/state"
 _ALARMS_PATH = "/api/v1/alarms"
 
 #: Sentinel written in place of a scrubbed secret value. A non-empty
@@ -250,14 +255,17 @@ async def nsx_transport_zone_list_impl(
 ) -> dict[str, Any]:
     """``nsx.transport_zone.list`` -- policy-API transport zones.
 
-    ``GET /policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones``
-    -- the transport-zone inventory under the default enforcement point.
-    Returns ``{"results": [...]}`` where each zone carries ``id``,
-    ``display_name``, ``tz_type`` (OVERLAY / VLAN), and
-    ``host_switch_name``.
+    ``GET /policy/api/v1/infra/sites/{site-id}/enforcement-points``
+    ``/{enforcementpoint-id}/transport-zones``
+    (vendor template), always instantiated at the ``default`` site and
+    ``default`` enforcement point -- the transport-zone inventory under
+    the default enforcement point. Returns ``{"results": [...]}`` where
+    each zone carries ``id``, ``display_name``, ``tz_type``
+    (OVERLAY / VLAN), and ``host_switch_name``.
     """
     del params  # schema declares the param object empty
-    return await connector._get_json(target, _TRANSPORT_ZONES_PATH, operator=operator)
+    path = _TRANSPORT_ZONES_PATH.format(**{"site-id": "default", "enforcementpoint-id": "default"})
+    return await connector._get_json(target, path, operator=operator)
 
 
 async def nsx_tier1_list_impl(
@@ -329,7 +337,8 @@ async def nsx_transport_node_state_impl(
     target: NsxTargetLike,
     params: dict[str, Any],
 ) -> dict[str, Any]:
-    """``nsx.transport_node.state`` -- ``GET /api/v1/transport-nodes/{id}/state``.
+    """``nsx.transport_node.state`` --
+    ``GET /api/v1/transport-nodes/{transport-node-id}/state``.
 
     Reads one transport node's realization + fabric health, given a node
     ``id`` from ``nsx.transport_node.list``. The read an operator runs
@@ -345,7 +354,7 @@ async def nsx_transport_node_state_impl(
     paired with its ``.list`` op.
     """
     node_id = params["id"]
-    path = _TRANSPORT_NODE_STATE_PATH.format(id=node_id)
+    path = _TRANSPORT_NODE_STATE_PATH.format(**{"transport-node-id": node_id})
     return await connector._get_json(target, path, operator=operator)
 
 

--- a/backend/tests/test_connectors_nsx_spec_reconcile.py
+++ b/backend/tests/test_connectors_nsx_spec_reconcile.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""nsx real-spec reconcile lane — hand-coded paths vs the pinned nsx-9.0 spec.
+
+#2981 (initiative #2979): every hand-coded ``METHOD:/path`` literal in the
+nsx connector asserts against the pinned ``nsx-9.0`` spec through the
+#2980 harness (:mod:`tests._spec_shelf`). The declared set is introspected
+from the connector's live module constants — the ten ``*_PATH`` typed-read
+paths in :mod:`meho_backplane.connectors.nsx.typed_reads` (all dispatched
+via ``HttpConnector._get_json``, hence ``GET``) plus the session-establish
+``POST`` path in :mod:`meho_backplane.connectors.nsx.connector`. The
+fingerprint probe's inline ``/api/v1/node`` literal collapses into the
+``GET:/api/v1/node`` typed-read op_id, so the sweep covers it too.
+
+**This lane ships dormant.** No public NSX 9 OpenAPI spec exists to pin as
+of 2026-04-29: the shelf's ``nsx-9.0/`` directory carries only a
+``MANIFEST.md`` recording the negative result (five public locations
+checked; 30 candidate spec endpoints probed on a live NSX 9.0.2 manager
+under both HTTP Basic and session auth — all 404 or 302 to the UI). The
+harness's uniform skip covers exactly this shape, so the lane skips with
+a reason naming the missing file and arms itself the day a spec lands at
+``nsx-9.0/nsx-openapi.json`` on the shelf — no code change needed here.
+Evidence + activation steps: the "Evidenced exclusions" section of
+``docs/decisions/spec-reconcile-guards-standard.md``.
+
+The manifest-pin test below runs unconditionally, so the enumeration
+wiring stays proven while the lane itself is dormant: a renamed constant,
+a dropped path, or a new hand-coded path shows up as a loud diff there,
+never as a silently shrunk (or vacuously green) reconcile.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.nsx import connector as _connector_module
+from meho_backplane.connectors.nsx import typed_reads as _typed_reads_module
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+_SPEC_DIR = "nsx-9.0"
+_SPEC_FILE = "nsx-openapi.json"
+
+
+def _declared_op_ids() -> set[str]:
+    """Introspect the nsx connector's hand-coded ``METHOD:/path`` op_ids.
+
+    Sweeps every ``*_PATH`` string constant in the typed-reads module
+    (each is issued through ``HttpConnector._get_json``, so the method is
+    ``GET``) and adds the connector module's session-establish ``POST``.
+    Live constants, never a hardcoded mirror — a path edit in the
+    connector flows into the reconcile automatically (the #2944 pattern).
+    """
+    declared = {
+        f"GET:{value}"
+        for name, value in vars(_typed_reads_module).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+    declared.add(f"POST:{_connector_module._SESSION_CREATE_PATH}")
+    return declared
+
+
+def test_nsx_hand_coded_op_id_manifest_is_pinned() -> None:
+    """Pin the swept op_id set so drift can't silently shrink the reconcile.
+
+    Runs unconditionally (no shelf needed), so the enumeration is proven
+    on every sweep even while the lane below is dormant. A new hand-coded
+    path, a renamed ``*_PATH`` constant, or a typed op that stops using
+    ``GET`` must update this manifest consciously — and the lane's
+    declared set moves with it.
+    """
+    assert _declared_op_ids() == {
+        "GET:/api/v1/alarms",
+        "GET:/api/v1/cluster/backups/config",
+        "GET:/api/v1/cluster/backups/status",
+        "GET:/api/v1/cluster/status",
+        "GET:/api/v1/node",
+        "GET:/api/v1/transport-nodes",
+        "GET:/api/v1/transport-nodes/{id}/state",
+        "GET:/policy/api/v1/infra/segments",
+        "GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones",
+        "GET:/policy/api/v1/infra/tier-1s",
+        "POST:/api/session/create",
+    }
+
+
+def test_nsx_hand_coded_paths_are_served_by_the_pinned_spec() -> None:
+    """Every hand-coded nsx op_id is served by the pinned nsx-9.0 spec.
+
+    Dormant until a spec lands on the shelf (see the module docstring);
+    skips with the harness's uniform reason today. Wherever
+    ``MEHO_CONSUMER_DOCS_ROOT`` resolves ``nsx-9.0/nsx-openapi.json`` the
+    lane runs for real, and a red first run is the guard surfacing a
+    finding — triage per docs/decisions/spec-reconcile-guards-standard.md
+    (expect at least the ``{id}`` template segment of the transport-node
+    state path to need reconciling against the vendor's parameter name).
+    """
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = openapi_served_op_ids(spec_path)
+    assert_op_ids_served(
+        _declared_op_ids(),
+        served,
+        spec_label=f"{_SPEC_DIR}/{_SPEC_FILE}",
+    )

--- a/backend/tests/test_connectors_nsx_spec_reconcile.py
+++ b/backend/tests/test_connectors_nsx_spec_reconcile.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""nsx real-spec reconcile lane — hand-coded paths vs the pinned nsx-9.0 spec.
+"""nsx real-spec reconcile lane — hand-coded paths vs the pinned nsx-9.0 specs.
 
 #2981 (initiative #2979): every hand-coded ``METHOD:/path`` literal in the
-nsx connector asserts against the pinned ``nsx-9.0`` spec through the
+nsx connector asserts against the pinned ``nsx-9.0`` specs through the
 #2980 harness (:mod:`tests._spec_shelf`). The declared set is introspected
 from the connector's live module constants — the ten ``*_PATH`` typed-read
 paths in :mod:`meho_backplane.connectors.nsx.typed_reads` (all dispatched
@@ -13,21 +13,37 @@ via ``HttpConnector._get_json``, hence ``GET``) plus the session-establish
 fingerprint probe's inline ``/api/v1/node`` literal collapses into the
 ``GET:/api/v1/node`` typed-read op_id, so the sweep covers it too.
 
-**This lane ships dormant.** No public NSX 9 OpenAPI spec exists to pin as
-of 2026-04-29: the shelf's ``nsx-9.0/`` directory carries only a
-``MANIFEST.md`` recording the negative result (five public locations
-checked; 30 candidate spec endpoints probed on a live NSX 9.0.2 manager
-under both HTTP Basic and session auth — all 404 or 302 to the UI). The
-harness's uniform skip covers exactly this shape, so the lane skips with
-a reason naming the missing file and arms itself the day a spec lands at
-``nsx-9.0/nsx-openapi.json`` on the shelf — no code change needed here.
-Evidence + activation steps: the "Evidenced exclusions" section of
+**This lane is armed** (PR #3007 review blocker B1 resolution,
+2026-08-18). NSX serves its own specs from every live manager at the
+vendor-documented ``GET /api/v1/spec/openapi/nsx_api.{json,yaml}`` and
+``nsx_policy_api.{json,yaml}`` endpoints — the shelf's earlier
+"no pinnable spec" negative (2026-04-29, 30 probed paths) never covered
+that family. The shelf's ``nsx-9.0/`` directory pins the fetched JSON
+artifacts plus deterministic OpenAPI 3.0 conversions (``parse_openapi``
+accepts 3.0/3.1 only; the conversion recipe and provenance live in the
+shelf's ``nsx-9.0/MANIFEST.md``). NSX splits its surface across two
+specs — the Manager API (``servers[0].url = /api/v1``) and the Policy
+API (``/policy/api/v1``) — so the lane resolves both files and unions
+their served sets per the standard's multi-spec guidance.
+
+One vendor-spec quirk is mapped rather than repointed: the Manager API
+spec models the session-establish endpoint as path key
+``/api/session/create`` **under** ``basePath: /api/v1``, so its ingested
+op_id is ``POST:/api/v1/api/session/create``. The live manager serves
+both concatenations (probed 2026-08-18: the canonical documented
+``/api/session/create`` is the working session-auth flow; the
+base-folded path answers HTTP 400 on an empty body where garbage-path
+controls answer 404). The connector keeps the canonical endpoint;
+:data:`_SPEC_MODELED_OP_IDS` translates it to the spec's modeling for
+the reconcile only.
+
+Evidence + activation record: the ``nsx-9.0`` entry of
 ``docs/decisions/spec-reconcile-guards-standard.md``.
 
 The manifest-pin test below runs unconditionally, so the enumeration
-wiring stays proven while the lane itself is dormant: a renamed constant,
-a dropped path, or a new hand-coded path shows up as a loud diff there,
-never as a silently shrunk (or vacuously green) reconcile.
+wiring stays proven even where the shelf is not provisioned: a renamed
+constant, a dropped path, or a new hand-coded path shows up as a loud
+diff there, never as a silently shrunk (or vacuously green) reconcile.
 """
 
 from __future__ import annotations
@@ -41,7 +57,17 @@ from tests._spec_shelf import (
 )
 
 _SPEC_DIR = "nsx-9.0"
-_SPEC_FILE = "nsx-openapi.json"
+#: Both manager-served specs, converted to OpenAPI 3.0 on the shelf
+#: (see the module docstring); the lane unions their served sets.
+_SPEC_FILES = ("nsx_api.openapi3.json", "nsx_policy_api.openapi3.json")
+
+#: Live-truth op_ids translated to the pinned spec's modeling for the
+#: reconcile assert only. Every entry is a documented vendor-spec quirk,
+#: never a repoint of working connector code — see the module docstring
+#: for the single current case (session-create under ``basePath``).
+_SPEC_MODELED_OP_IDS = {
+    "POST:/api/session/create": "POST:/api/v1/api/session/create",
+}
 
 
 def _declared_op_ids() -> set[str]:
@@ -66,10 +92,11 @@ def test_nsx_hand_coded_op_id_manifest_is_pinned() -> None:
     """Pin the swept op_id set so drift can't silently shrink the reconcile.
 
     Runs unconditionally (no shelf needed), so the enumeration is proven
-    on every sweep even while the lane below is dormant. A new hand-coded
-    path, a renamed ``*_PATH`` constant, or a typed op that stops using
-    ``GET`` must update this manifest consciously — and the lane's
-    declared set moves with it.
+    on every sweep. A new hand-coded path, a renamed ``*_PATH``
+    constant, or a typed op that stops using ``GET`` must update this
+    manifest consciously — and the lane's declared set moves with it.
+    Template segments carry the vendor's own parameter names (reconciled
+    against the pinned specs in the lane below).
     """
     assert _declared_op_ids() == {
         "GET:/api/v1/alarms",
@@ -78,29 +105,31 @@ def test_nsx_hand_coded_op_id_manifest_is_pinned() -> None:
         "GET:/api/v1/cluster/status",
         "GET:/api/v1/node",
         "GET:/api/v1/transport-nodes",
-        "GET:/api/v1/transport-nodes/{id}/state",
+        "GET:/api/v1/transport-nodes/{transport-node-id}/state",
         "GET:/policy/api/v1/infra/segments",
-        "GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones",
+        "GET:/policy/api/v1/infra/sites/{site-id}/enforcement-points"
+        "/{enforcementpoint-id}/transport-zones",
         "GET:/policy/api/v1/infra/tier-1s",
         "POST:/api/session/create",
     }
 
 
-def test_nsx_hand_coded_paths_are_served_by_the_pinned_spec() -> None:
-    """Every hand-coded nsx op_id is served by the pinned nsx-9.0 spec.
+def test_nsx_hand_coded_paths_are_served_by_the_pinned_specs() -> None:
+    """Every hand-coded nsx op_id is served by the pinned nsx-9.0 specs.
 
-    Dormant until a spec lands on the shelf (see the module docstring);
-    skips with the harness's uniform reason today. Wherever
-    ``MEHO_CONSUMER_DOCS_ROOT`` resolves ``nsx-9.0/nsx-openapi.json`` the
-    lane runs for real, and a red first run is the guard surfacing a
-    finding — triage per docs/decisions/spec-reconcile-guards-standard.md
-    (expect at least the ``{id}`` template segment of the transport-node
-    state path to need reconciling against the vendor's parameter name).
+    Resolves both shelf specs (skipping with the harness's uniform
+    reason wherever either is unprovisioned), unions their served sets,
+    and asserts the declared set — with :data:`_SPEC_MODELED_OP_IDS`
+    applied — against the union. A red run here is the guard surfacing
+    a finding; triage per docs/decisions/spec-reconcile-guards-standard.md.
     """
-    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
-    served = openapi_served_op_ids(spec_path)
+    served: set[str] = set()
+    for spec_file in _SPEC_FILES:
+        spec_path = require_shelf_spec(_SPEC_DIR, spec_file)
+        served |= openapi_served_op_ids(spec_path)
+    declared = {_SPEC_MODELED_OP_IDS.get(op_id, op_id) for op_id in _declared_op_ids()}
     assert_op_ids_served(
-        _declared_op_ids(),
+        declared,
         served,
-        spec_label=f"{_SPEC_DIR}/{_SPEC_FILE}",
+        spec_label=f"{_SPEC_DIR}/{{{' + '.join(_SPEC_FILES)}}}",
     )

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -315,6 +315,12 @@ The hand-curated ingested-enable apparatus (the `core_ops.py` module with its
     — install a test-only `ForceHandleReducer`, dispatch the
     segment-list op, assert `OperationResult.handle` is populated
     by the dispatcher seam.
+- Spec-reconcile lane: `backend/tests/test_connectors_nsx_spec_reconcile.py`
+  (#2981) — asserts the 11 hand-coded `METHOD:/path` literals against a
+  pinned `nsx-9.0` shelf spec through the #2980 harness. Ships dormant
+  (uniform skip): no public NSX 9 OpenAPI spec is pinnable today —
+  evidence + activation steps in the "Evidenced exclusions" section of
+  `docs/decisions/spec-reconcile-guards-standard.md`.
 - Precedent: `connectors/vmware_rest/connector.py` (session auth +
   fingerprint + probe + dispatch shim);
   `connectors/vmware_rest/__init__.py` (registration);

--- a/docs/codebase/connectors-nsx.md
+++ b/docs/codebase/connectors-nsx.md
@@ -316,10 +316,19 @@ The hand-curated ingested-enable apparatus (the `core_ops.py` module with its
     segment-list op, assert `OperationResult.handle` is populated
     by the dispatcher seam.
 - Spec-reconcile lane: `backend/tests/test_connectors_nsx_spec_reconcile.py`
-  (#2981) — asserts the 11 hand-coded `METHOD:/path` literals against a
-  pinned `nsx-9.0` shelf spec through the #2980 harness. Ships dormant
-  (uniform skip): no public NSX 9 OpenAPI spec is pinnable today —
-  evidence + activation steps in the "Evidenced exclusions" section of
+  (#2981) — asserts the 11 hand-coded `METHOD:/path` literals against
+  the pinned `nsx-9.0` shelf specs through the #2980 harness,
+  **armed 2026-08-18** (PR #3007): NSX serves its own specs from every
+  live manager (`GET /api/v1/spec/openapi/nsx_api.{json,yaml}` /
+  `nsx_policy_api.{json,yaml}`); the shelf pins the fetched JSON pair
+  plus OpenAPI 3.0 conversions (`nsx_api.openapi3.json` +
+  `nsx_policy_api.openapi3.json` — the files the lane parses and
+  unions). Template constants carry the vendor's parameter names
+  (`{transport-node-id}`, `{site-id}`/`{enforcementpoint-id}` —
+  call sites instantiate `default`/`default`); the session-establish
+  op is translated to the spec's under-basePath modeling via the
+  lane's `_SPEC_MODELED_OP_IDS` map. Activation record + first-run
+  findings: the `nsx-9.0` entry of
   `docs/decisions/spec-reconcile-guards-standard.md`.
 - Precedent: `connectors/vmware_rest/connector.py` (session auth +
   fingerprint + probe + dispatch shim);

--- a/docs/decisions/spec-reconcile-guards-standard.md
+++ b/docs/decisions/spec-reconcile-guards-standard.md
@@ -33,14 +33,16 @@ Scope boundaries:
 - **Generic (ingested) connectors are immune by construction** and need
   no lane: their op_ids are emitted *from* the spec by the ingest
   pipeline, so an unserved path cannot exist.
-- **Where no spec exists or can be pinned** (e.g. `nsx-9.0` publishes
-  no OpenAPI spec as of 2026-04-29 — see the shelf's
-  `nsx-9.0/MANIFEST.md`), the lane still ships and skips uniformly; it
-  arms itself the day the spec lands on the shelf. A task that proves a
-  spec is unobtainable records the evidenced exclusion instead
-  (#2993's contract; the entries live in the
+- **Where no spec exists or can be pinned**, the lane still ships and
+  skips uniformly; it arms itself the day the spec lands on the shelf.
+  A task that proves a spec is unobtainable records the evidenced
+  exclusion instead (#2993's contract; the entries live in the
   [Evidenced exclusions](#evidenced-exclusions-no-pinnable-spec-today)
-  section below).
+  section below). Cautionary precedent: `nsx-9.0` shipped as exactly
+  such an exclusion and was falsified in review — its 30-path probe
+  never covered the vendor-documented spec endpoints (see the
+  activation record below). An exclusion's evidence must cover every
+  endpoint family the vendor documents, not just conventional guesses.
 
 ## The harness (what a lane is)
 
@@ -194,43 +196,78 @@ skipping uniformly, and the day a spec lands the activating task runs
 the full extension mechanics above (CI checkout widened, signoff
 extended, first-run red triaged per the protocol below).
 
-### nsx-9.0 (#2981, recorded 2026-08-18)
+### nsx-9.0 — **ACTIVATED 2026-08-18** (#2981; exclusion withdrawn, retained as history)
+
+This entry shipped on 2026-08-17/18 as an evidenced exclusion ("no
+pinnable NSX 9 spec"). Review of PR #3007 (blocker B1) falsified it:
+the exclusion's probe record had a **coverage gap**, and the specs are
+pinnable. The record below replaces the exclusion; the lane is armed.
 
 - **Lane:** `backend/tests/test_connectors_nsx_spec_reconcile.py` — 11
   hand-coded op_ids introspected live (ten `GET` typed-read paths +
-  the session-establish `POST`); dormant, skips with the harness's
-  uniform reason.
-- **Why no spec is pinnable** (evidence grounded 2026-04-29, per the
-  shelf's `nsx-9.0/MANIFEST.md`): no public NSX 9 OpenAPI artifact
-  exists in any checked location — `vmware/vcf-api-specs` covers the
-  sibling VCF components (SDDC Manager, vSphere, VCF Installer, VCF
-  Operations, vSAN DP) but **not NSX**; the `vmware-nsx` GitHub org
-  publishes no 9.x spec; `vmware/go-vmware-nsxt` is Go bindings, not a
-  spec; `vmware-archive/nsxraml` predates NSX-T. Live-manager fetch is
-  also closed: 30 candidate spec endpoints
-  (`/api/v1/spec/openapi.json`, `/policy/api/v1/openapi.json`,
-  `/v3/api-docs`, `/swagger`, …) probed against a live NSX 9.0.2
-  manager returned 404 or 302-to-UI under **both** HTTP Basic and the
-  session-cookie + `X-XSRF-TOKEN` flow (per-path table in the shelf's
-  `kb/nsx-9.0-overview.md` and `kb/vcf-9.0-in-ui-explorer-survey.md`).
-  The vendor's NSX REST API reference exists only as a documentation
-  portal (`developer.broadcom.com/xapis/nsx-t-data-center-rest-api/`),
-  with no downloadable machine-readable spec.
-- **Deliberately not done while dormant:** no `ci.yml`
-  sparse-checkout/verify widening (the shelf dir carries only the
-  manifest — fetching it adds CI surface for zero guard value) and no
-  `vendor-spec-ci-provisioning.md` signoff extension (that signoff
-  covers vendor content fetched in CI; none is fetched for nsx).
-- **Activation:** a spec landing at `nsx-9.0/nsx-openapi.json` on the
-  shelf (re-ground seeds in the shelf manifest: re-check
-  `vcf-api-specs`, the VCF 9 doc hub, PowerCLI's bundled
-  `VMware.Sdk.Nsx.*` spec files, and the live-manager endpoints on
-  maintenance releases) arms the lane automatically wherever
-  `MEHO_CONSUMER_DOCS_ROOT` resolves it. The activating task then
-  widens the CI checkout, extends the signoff, and triages any
-  first-run red — expect at least the `{id}` template segment of
-  `GET:/api/v1/transport-nodes/{id}/state` to need reconciling against
-  the vendor's parameter naming.
+  the session-establish `POST`), asserted against the **union** of the
+  two pinned specs per the harness's multi-spec guidance.
+- **Why the exclusion fell.** The 2026-04-29 evidence (30 candidate
+  spec endpoints probed 404/302 on a live NSX 9.0.2 manager under both
+  auth flows; no public artifact in `vcf-api-specs` / `vmware-nsx` /
+  `go-vmware-nsxt` / `nsxraml`) was real but incomplete: **none of the
+  30 paths covered the vendor-documented
+  `/api/v1/spec/openapi/nsx_*` family** the NSX REST API portal
+  (`developer.broadcom.com/xapis/nsx-t-data-center-rest-api/latest/`)
+  actually names. Probed 2026-08-18 against the live lab manager
+  (`c2fs1-nsx` / `nsx-mgmt-01a`, NSX 9.1.0.0.25318225, session-auth):
+  `GET /api/v1/spec/openapi/nsx_api.json` (200; 4,417,173 B),
+  `nsx_api.yaml` (200; 5,429,995 B), `nsx_policy_api.json` (200;
+  12,195,576 B), `nsx_policy_api.yaml` (200; 14,683,229 B). The public
+  half of the negative stands (no public artifact); the "live-manager
+  fetch is closed" half was never evidenced and is false. The shelf's
+  probe-history records carry dated corrections
+  (`kb/nsx-9.0-overview.md`, `kb/vcf-9.0-in-ui-explorer-survey.md`).
+- **What is pinned** (shelf `nsx-9.0/MANIFEST.md`, full provenance +
+  sha256): `nsx_api.json` (Manager API, Swagger 2.0, `basePath:
+  /api/v1`, 1,193 paths) and `nsx_policy_api.json` (Policy API,
+  `basePath: /policy/api/v1`, 2,317 paths) byte-identical as fetched,
+  plus deterministic OpenAPI 3.0 conversions
+  (`nsx_api.openapi3.json` / `nsx_policy_api.openapi3.json` —
+  swagger2openapi@7.0.8, placeholder `host`/`schemes` stripped so the
+  relative basePath lands in `servers[0].url` for the #1796 fold,
+  minified under ingest's 20 MiB cap). The lane pins the conversions:
+  `parse_openapi` accepts 3.0/3.1 only and documents conversion as the
+  Swagger-2.0 remediation, so they are byte-for-byte what an operator
+  ingest consumes.
+- **First-run reconcile findings (the protocol working), all
+  dispositioned in PR #3007:**
+  1. `GET:/api/v1/transport-nodes/{id}/state` — unserved; vendor
+     template is `{transport-node-id}`. **Mechanical rename** of the
+     constant's template segment (anticipated verbatim by the dormant
+     entry).
+  2. `GET:/policy/api/v1/infra/sites/default/enforcement-points/default/transport-zones`
+     — unserved; the constant hard-coded the `default`/`default`
+     instantiation of the served template
+     `…/sites/{site-id}/enforcement-points/{enforcementpoint-id}/transport-zones`.
+     **Mechanical**: constant now carries the vendor template; the
+     call site instantiates `default`/`default` — runtime request path
+     byte-identical.
+  3. `POST:/api/session/create` — the Manager API spec models the
+     session endpoints as path keys under `basePath: /api/v1`, so the
+     ingested op_id is `POST:/api/v1/api/session/create`. Live probe
+     2026-08-18: **both** concatenations serve (the canonical
+     documented `/api/session/create` is the working session-auth
+     flow; the base-folded path returns 400 on an empty body where
+     garbage-path controls return 404). **Not a repoint** — the
+     connector keeps the canonical endpoint; the lane translates via
+     its documented `_SPEC_MODELED_OP_IDS` map. A repoint of working
+     production auth to satisfy a literal comparison would invert the
+     protocol's "never invent a path" rule.
+- **Extension mechanics run** (per the section above): CI
+  sparse-checkout + fail-loud verify widened to `docs/nsx-9.0` in both
+  Python jobs; signoff extended in
+  [`vendor-spec-ci-provisioning.md`](vendor-spec-ci-provisioning.md)
+  (vendor-licensed form — NSX manager-served content is fetched into
+  ephemeral CI); local pre-verify green against a full local shelf.
+  **Sequencing:** the shelf pin lands via consumer-repo PR
+  (`claude-rdc-hetzner-dc#2514`) which must merge before this repo's
+  widened verify step can pass.
 
 ## Red lane = finding (the protocol)
 

--- a/docs/decisions/spec-reconcile-guards-standard.md
+++ b/docs/decisions/spec-reconcile-guards-standard.md
@@ -38,7 +38,9 @@ Scope boundaries:
   `nsx-9.0/MANIFEST.md`), the lane still ships and skips uniformly; it
   arms itself the day the spec lands on the shelf. A task that proves a
   spec is unobtainable records the evidenced exclusion instead
-  (#2993's contract).
+  (#2993's contract; the entries live in the
+  [Evidenced exclusions](#evidenced-exclusions-no-pinnable-spec-today)
+  section below).
 
 ## The harness (what a lane is)
 
@@ -181,6 +183,54 @@ Each lane task (#2981-#2993) ships all of:
    (`MEHO_CONSUMER_DOCS_ROOT=<shelf>/docs`) before merge. CI is armed:
    a lane that would go red lands red on the PR itself, which is the
    next section — but discovering it locally first is cheaper.
+
+## Evidenced exclusions (no pinnable spec today)
+
+The per-product record for lanes that ship **dormant** because no vendor
+spec exists or can be pinned. Each entry states what was checked (with
+dates), why nothing is pinnable, and what activates the lane. An entry
+here is not an exemption from the standard — the lane still ships,
+skipping uniformly, and the day a spec lands the activating task runs
+the full extension mechanics above (CI checkout widened, signoff
+extended, first-run red triaged per the protocol below).
+
+### nsx-9.0 (#2981, recorded 2026-08-18)
+
+- **Lane:** `backend/tests/test_connectors_nsx_spec_reconcile.py` — 11
+  hand-coded op_ids introspected live (ten `GET` typed-read paths +
+  the session-establish `POST`); dormant, skips with the harness's
+  uniform reason.
+- **Why no spec is pinnable** (evidence grounded 2026-04-29, per the
+  shelf's `nsx-9.0/MANIFEST.md`): no public NSX 9 OpenAPI artifact
+  exists in any checked location — `vmware/vcf-api-specs` covers the
+  sibling VCF components (SDDC Manager, vSphere, VCF Installer, VCF
+  Operations, vSAN DP) but **not NSX**; the `vmware-nsx` GitHub org
+  publishes no 9.x spec; `vmware/go-vmware-nsxt` is Go bindings, not a
+  spec; `vmware-archive/nsxraml` predates NSX-T. Live-manager fetch is
+  also closed: 30 candidate spec endpoints
+  (`/api/v1/spec/openapi.json`, `/policy/api/v1/openapi.json`,
+  `/v3/api-docs`, `/swagger`, …) probed against a live NSX 9.0.2
+  manager returned 404 or 302-to-UI under **both** HTTP Basic and the
+  session-cookie + `X-XSRF-TOKEN` flow (per-path table in the shelf's
+  `kb/nsx-9.0-overview.md` and `kb/vcf-9.0-in-ui-explorer-survey.md`).
+  The vendor's NSX REST API reference exists only as a documentation
+  portal (`developer.broadcom.com/xapis/nsx-t-data-center-rest-api/`),
+  with no downloadable machine-readable spec.
+- **Deliberately not done while dormant:** no `ci.yml`
+  sparse-checkout/verify widening (the shelf dir carries only the
+  manifest — fetching it adds CI surface for zero guard value) and no
+  `vendor-spec-ci-provisioning.md` signoff extension (that signoff
+  covers vendor content fetched in CI; none is fetched for nsx).
+- **Activation:** a spec landing at `nsx-9.0/nsx-openapi.json` on the
+  shelf (re-ground seeds in the shelf manifest: re-check
+  `vcf-api-specs`, the VCF 9 doc hub, PowerCLI's bundled
+  `VMware.Sdk.Nsx.*` spec files, and the live-manager endpoints on
+  maintenance releases) arms the lane automatically wherever
+  `MEHO_CONSUMER_DOCS_ROOT` resolves it. The activating task then
+  widens the CI checkout, extends the signoff, and triages any
+  first-run red — expect at least the `{id}` template segment of
+  `GET:/api/v1/transport-nodes/{id}/state` to need reconciling against
+  the vendor's parameter naming.
 
 ## Red lane = finding (the protocol)
 

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -226,6 +226,61 @@ OSS-licensed-spec form in
 [`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
 extension mechanics.
 
+### Signoff extension — NSX (nsx-9.0, 2026-08-18, #2981 / PR #3007)
+
+The nsx spec-reconcile lane
+(`backend/tests/test_connectors_nsx_spec_reconcile.py`) arms against
+two additional vendor-licensed artifacts, fetched by the **same**
+secret-gated sparse checkout (widened to `docs/nsx-9.0`; same
+`SPEC_SHELF_TOKEN`, no new secret) under the **same** ephemeral-use
+conditions recorded in "What CI does with the specs" above:
+
+- **What is fetched:** the shelf's `docs/nsx-9.0/` directory (~33 MB)
+  — `nsx_api.json` + `nsx_policy_api.json` (NSX Manager / Policy API
+  Swagger 2.0 documents, **served by the licensed NSX manager
+  appliance itself** at the vendor-documented
+  `GET /api/v1/spec/openapi/…` endpoints; fetched 2026-08-18 from the
+  operator's lab manager, NSX 9.1.0.0.25318225, session-auth) plus
+  their deterministic OpenAPI 3.0 conversions
+  (`*.openapi3.json`, the files the lane parses) and sidecars.
+  Provenance, sha256, and the conversion recipe: the shelf's
+  `nsx-9.0/MANIFEST.md`.
+- **Same conditions:** read-only pytest input on an ephemeral ARC
+  runner destroyed at job end; never committed to this public repo;
+  never in build artifacts or logs (the verify step prints file
+  presence only); secret withheld from fork PRs and the Dependabot
+  store; `persist-credentials: false`.
+- **Provenance difference vs vSphere, recorded for the reviewer:**
+  the vSphere specs are vendor-*published* (public
+  `vmware/vcf-api-specs`); the NSX specs are vendor-*served* — NSX
+  publishes no public artifact, and each licensed manager serves its
+  own spec to its authenticated operators. The shelf copy is the
+  operator's lawful fetch from the operator's own licensed appliance,
+  handled thereafter identically to the vSphere specs.
+
+**Attestation for the NSX extension:** completed (mirrors the #2949
+flow — attestation comment linked below).
+
+- **Reviewer:** Damir Topic (@damir-topic), maintainer/operator
+- **Date:** 2026-08-18
+- **Determination:** Attestation that fetching the pinned NSX
+  manager-served OpenAPI specs from the private spec-shelf into
+  ephemeral same-repo CI jobs, under the conditions above, is
+  acceptable under the operator's vendor license. The specs were
+  obtained from the operator's own lab NSX manager — same conditions
+  as the 2026-08-17 vSphere determination.
+- **Attestation link:**
+  <https://github.com/evoila/meho/issues/2981#issuecomment-5329188426>
+
+**Wave-3 blanket determination:** the attestation comment above also
+records a standing blanket for the remaining wave-3 vendor-spec pins
+(initiative #2979 — e.g. vcf-automation-9.0, vcf-operations-9.0,
+hetzner-robot-2026-04, and any further vendor spec pinned to the
+operator's shelf for reconcile lanes) under identical conditions.
+Future lane tasks record a reference to that comment here instead of
+obtaining a fresh attestation; OSS-licensed specs continue to use the
+provenance-note form and need no attestation.
+
 ## Consequences
 
 - The five real-spec lanes light up together the moment the secret exists;
@@ -237,7 +292,12 @@ extension mechanics.
 - The shelf's `docs/` also carries other vendor spec directories (`nsx-9.0/`,
   `sddc-manager-9.0/`, …). The same checkout could serve future sibling
   canaries by widening the `sparse-checkout` list — deliberately not done
-  here (#2949's DoD is the vCenter lanes). The G4.1 consumer-kb canary does
+  here (#2949's DoD is the vCenter lanes). *Update 2026-08-18:* the
+  first such widenings happened — `docs/sddc-manager-9.0` was added
+  for the sddc-manager reconcile lane (#2982 / PR #3008; see the
+  sddc-manager extension above) and `docs/nsx-9.0` for the nsx
+  reconcile lane (#2981 / PR #3007; see the "Signoff extension — NSX"
+  section above). The G4.1 consumer-kb canary does
   **not** light up: it resolves `<docs-root>/kb`, which does not exist under
   the shelf's `docs/` (the consumer's `kb/` is a repo-root sibling).
 - Rotation is a secret-value swap (runbook step 3); revocation (delete the


### PR DESCRIPTION
## Summary

- Ships the nsx real-spec reconcile lane on the #2980 harness (`backend/tests/test_connectors_nsx_spec_reconcile.py`): the connector's 11 hand-coded `METHOD:/path` literals are introspected live (ten `GET` typed-read `*_PATH` constants in `typed_reads.py` + the session-establish `POST` in `connector.py`; the fingerprint probe's inline `/api/v1/node` collapses into the same op_id) and asserted against a pinned `nsx-9.0/nsx-openapi.json` shelf spec.
- **The lane ships dormant** — the scope reality diverges from the ticket as filed: the shelf's `nsx-9.0/` directory contains only a `MANIFEST.md` recording that **no public NSX 9 OpenAPI spec exists to pin** (grounded 2026-04-29: `vmware/vcf-api-specs` covers the sibling VCF components but not NSX; the `vmware-nsx` org, `go-vmware-nsxt`, and `nsxraml` publish no usable spec; 30 candidate spec endpoints on a live NSX 9.0.2 manager returned 404/302 under both HTTP Basic and session auth; the vendor's NSX REST API reference at `developer.broadcom.com/xapis/nsx-t-data-center-rest-api/` is a documentation portal with no downloadable machine-readable artifact). The standard doc (#2980) prescribes exactly this branch: the lane still ships, skips uniformly, and arms itself the day a spec lands on the shelf — no code change needed here.
- Records the evidenced exclusion in a new "Evidenced exclusions (no pinnable spec today)" section of `docs/decisions/spec-reconcile-guards-standard.md` (the #2993 option-c contract): what was checked, why nothing is pinnable, what deliberately isn't done while dormant, and what activates the lane.
- An unconditional manifest-pin test asserts the swept set equals the expected 11 op_ids, so the enumeration wiring stays proven while the lane is dormant (a renamed constant or new hand-coded path fails loudly instead of silently shrinking the reconcile).
- `docs/codebase/connectors-nsx.md` gains the lane reference bullet.

## Scope divergence from the ticket (deliberate)

Ticket deliverables 2 (widen `ci.yml` sparse-checkout + verify) and 3 (extend the `vendor-spec-ci-provisioning.md` signoff) assume a pinned spec exists. It does not, so both are deliberately **not** done: the shelf dir carries only a manifest — fetching it would add CI surface for zero guard value, and the signoff covers vendor content fetched in CI, of which there is none for nsx. Deliverable 4 (fix red paths) is n/a — there is no spec to be red against. The activating task (the day a spec lands) runs the full extension mechanics; this is spelled out in the new exclusion entry.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` — one pre-existing darwin-only false positive in untouched `net/icmp.py` (`MSG_ERRQUEUE` is Linux-only); green in Linux CI
- [x] Lane skip-clean without env: `1 passed, 1 skipped` with the harness's uniform reason naming `nsx-9.0/nsx-openapi.json`
- [x] Lane skip-clean against the **real armed shelf** (`MEHO_CONSUMER_DOCS_ROOT=<shelf>/docs`): same uniform skip — the correct dormant behavior, since the shelf carries no nsx spec file
- [x] Light-up proof (synthetic shelf, not committed): a minimal `nsx-openapi.json` serving all 11 paths → lane runs and **passes**; renaming one template segment (`{id}` → `{transportnode-id}`) → lane **fails** with the actionable near-miss diff, proving the red-lane path works end to end
- [x] `pytest tests/test_spec_shelf_harness.py tests/test_spec_shelf_example_lane.py tests/test_connectors_nsx_spec_reconcile.py tests/test_connectors_nsx_typed_reads.py tests/test_connectors_nsx_auth.py` — 91 passed, 2 skipped (the two shelf-gated lanes)
- [x] code-quality diff gate — exit 0

## Out of scope

- Sibling lanes #2982–#2985 (own connectors, own files — no collisions; this PR touches no `ci.yml`).
- #2993 will append vcf-fleet / vcf-logs entries to the same "Evidenced exclusions" section this PR introduces (trivial rebase).
- Expected first-run finding when the spec eventually lands: the `{id}` template segment of `GET:/api/v1/transport-nodes/{id}/state` will likely need reconciling against the vendor's parameter naming — noted in the lane docstring and the exclusion entry.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2981

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-18)

Addressed review finding **B1** from [review iter 1](https://github.com/evoila/meho/pull/3007#issuecomment-5327145283) (inline: [discussion_r3803365004](https://github.com/evoila/meho/pull/3007#discussion_r3803365004)) in `d369b7bf`. **The probe flipped the PR from the dormant variant to the armed lane** — the summary above describes the pre-B1 dormant shape; this section is the shape of record.

### Probe evidence (B1 appendix)

Probed 2026-08-18, live lab manager `c2fs1-nsx` (`nsx-mgmt-01a`, NSX **9.1.0.0.25318225**, alias 10.5.52.43), NSX session-auth (`POST /api/session/create` → `JSESSIONID` + `X-XSRF-TOKEN`, the consumer repo's `scripts/nsx.sh` flow). No live NSX 9.0.2 manager remains in the lab (`vcf9-nsx` retired with its env 2026-07-13); the cluster-2 fleet (c2fs1/c2fs2/c2fs3) is 9.1.0 — inside the connector's `supported_version_range >=4.0,<10.0`.

| URL probed | HTTP status | Body size |
|---|---|---|
| `https://<c2fs1-nsx>/api/v1/spec/openapi/nsx_api.json` | **200** | 4,417,173 B |
| `https://<c2fs1-nsx>/api/v1/spec/openapi/nsx_api.yaml` | **200** | 5,429,995 B |
| `https://<c2fs1-nsx>/api/v1/spec/openapi/nsx_policy_api.json` | **200** | 12,195,576 B |
| `https://<c2fs1-nsx>/api/v1/spec/openapi/nsx_policy_api.yaml` | **200** | 14,683,229 B |

Controls for the session-endpoint quirk (same manager, same session): `POST /api/v1/api/session/create` → **400** (route exists; empty body rejected) vs `POST /api/v1/api/session/nonexistent-zz` → **404** and `POST /api/v1/zzz-nonexistent` → **404**.

### What landed (`d369b7bf`)

- **Shelf pin (consumer repo, Track A):** [claude-rdc-hetzner-dc#2514](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/pull/2514) (ticket [#2512](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/2512)) — raw `nsx_api.json` + `nsx_policy_api.json` as fetched, OpenAPI 3.0 conversions (`*.openapi3.json`; `parse_openapi` accepts 3.0/3.1 only — recipe + sha256 in the shelf MANIFEST), sidecars, MANIFEST rewrite, dated kb corrections. **Not merged by automation.**
- **Lane armed:** two-spec contract (`nsx_api.openapi3.json` + `nsx_policy_api.openapi3.json`), served sets unioned; `_SPEC_MODELED_OP_IDS` maps the session-create op to the spec's under-basePath modeling (documented quirk, not a repoint).
- **Reconcile findings fixed (per-op decisions, #2970 shape):** (1) `{id}` → `{transport-node-id}` in `_TRANSPORT_NODE_STATE_PATH`; (2) `_TRANSPORT_ZONES_PATH` now carries the vendor template `…/sites/{site-id}/enforcement-points/{enforcementpoint-id}/transport-zones`, call site instantiates `default`/`default` (runtime path byte-identical); (3) session-create mapped, not repointed — live probe shows both concatenations served, and the canonical documented endpoint stays the production auth path.
- **Extension mechanics:** `ci.yml` sparse-checkout + fail-loud verify widened to `docs/nsx-9.0` (both Python jobs, alphabetical); vendor-licensed signoff extension appended to `vendor-spec-ci-provisioning.md` (**attestation left to the maintainer** — mirror of the #2949 flow); the evidenced-exclusion entry rewritten into an activation record (exclusion withdrawn, history retained).

### Verification

- No-env: `100 passed, 2 skipped` (uniform skip naming `nsx-9.0/nsx_api.openapi3.json`) across the nsx + shelf modules.
- Armed vs full local shelf (`MEHO_CONSUMER_DOCS_ROOT=<shelf-worktree>/docs`): lane `2 passed`, vcenter example lane still green.
- `ruff check` / `ruff format --check` clean (`src/ tests/`); `mypy src/` clean except the pre-existing darwin-only `net/icmp.py` `MSG_ERRQUEUE` false positive; g35 nsx acceptance modules `9 passed` (exercise both `.format` call sites).

### Sequencing (merge order)

**claude-rdc-hetzner-dc#2514 must merge before this PR's CI can go green:** the widened verify step fail-louds on the shelf's default branch until the nsx files land there. Until then, expect `Spec-shelf layout drift` failures on both Python jobs — by design, not a regression.

<!-- auto-implement-issue: continue, iteration 1 -->


---

## Follow-up (auto-implement-issue, iteration 2, 2026-08-18)

Addressed review iteration 2's blocker ([B2](https://github.com/evoila/meho/pull/3007#discussion_r3803694605); B1 was resolved in iteration 1):

- **B2** `30c9870b` — rebased onto `origin/main` @ `2257c992` (sibling #3008 / sddc-manager lane had merged, conflicting on the same `ci.yml` hunks + `vendor-spec-ci-provisioning.md`). Resolution: both Python jobs now sparse-checkout the three-directory union (`docs/nsx-9.0`, `docs/sddc-manager-9.0`, `docs/vcenter-9.0`, alphabetical) and fail-loud verify the five-file union (`nsx_api.openapi3.json`, `nsx_policy_api.openapi3.json`, `sddc-manager-openapi.json`, `vcenter.yaml`, `vi-json.yaml`), OK-echo naming all five; the decision doc keeps both signoff extensions and merges the Consequences "first such widening" sentence to name both widenings.
- **NSX attestation completed:** the maintainer attested on 2026-08-18 ([#2981 comment](https://github.com/evoila/meho/issues/2981#issuecomment-5329188426)) — the signoff extension now records Reviewer / Date / Determination / link, plus the wave-3 blanket-determination note (future wave-3 lane tasks reference that comment instead of fresh attestations). This clears the reviewer's merge-gate note.

Post-rebase local verification: armed nsx lane `2 passed`, no-env `1 passed, 1 skipped` (uniform skip reason), sddc lane (from main) `3 passed` armed, `ruff check src/ tests/` + `ruff format --check` clean, code-quality gate exit 0. `pull_request` CI run [32145762426](https://github.com/evoila/meho/actions/runs/32145762426) started on the new head (the PR was `CONFLICTING` before, so no CI could run on `d369b7bf`).

<!-- auto-implement-issue: continue, iteration 2 -->
