### PR TITLE
feat(tests): sddc-manager real-spec reconcile lane — assert hand-coded paths against the pinned sddc-manager-9.0 spec (#2982)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,14 +293,16 @@ jobs:
           repository: evoila-bosnia/claude-rdc-hetzner-dc
           token: ${{ secrets.SPEC_SHELF_TOKEN }}
           path: spec-shelf
-          # Cone-mode sparse checkout of the shelf directory only +
-          # lazy blob filter: the runner materialises just the
-          # vcenter-9.0 spec files (~18 MB), not the whole consumer
-          # repo. No `ref:` pin — the shelf's default branch IS the
-          # operator-curated pin (the directory is version-named
-          # vcenter-9.0/), matching the local-dev contract documented
-          # in tests/acceptance/_vcenter_spec.py.
-          sparse-checkout: docs/vcenter-9.0
+          # Cone-mode sparse checkout of the shelf directories only +
+          # lazy blob filter: the runner materialises just the pinned
+          # spec files (~20 MB), not the whole consumer repo. No `ref:`
+          # pin — the shelf's default branch IS the operator-curated
+          # pin (the directories are version-named, e.g. vcenter-9.0/),
+          # matching the local-dev contract documented in
+          # tests/acceptance/_vcenter_spec.py. Keep the list sorted.
+          sparse-checkout: |
+            docs/sddc-manager-9.0
+            docs/vcenter-9.0
           filter: blob:none
           # Read-only consumer; never pushes. Don't leave the token in
           # the shelf clone's local git config after checkout.
@@ -318,13 +320,13 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          for f in spec-shelf/docs/vcenter-9.0/vcenter.yaml spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
+          for f in spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json spec-shelf/docs/vcenter-9.0/vcenter.yaml spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
             if [ ! -f "$f" ]; then
-              echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the vCenter real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
+              echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
               exit 1
             fi
           done
-          echo "spec-shelf OK: vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/"
+          echo "spec-shelf OK: sddc-manager-openapi.json + vcenter.yaml + vi-json.yaml present under spec-shelf/docs/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -942,7 +944,9 @@ jobs:
           repository: evoila-bosnia/claude-rdc-hetzner-dc
           token: ${{ secrets.SPEC_SHELF_TOKEN }}
           path: spec-shelf
-          sparse-checkout: docs/vcenter-9.0
+          sparse-checkout: |
+            docs/sddc-manager-9.0
+            docs/vcenter-9.0
           filter: blob:none
           persist-credentials: false
 
@@ -953,13 +957,13 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          for f in spec-shelf/docs/vcenter-9.0/vcenter.yaml spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
+          for f in spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json spec-shelf/docs/vcenter-9.0/vcenter.yaml spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
             if [ ! -f "$f" ]; then
-              echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the vCenter real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
+              echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
               exit 1
             fi
           done
-          echo "spec-shelf OK: vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/"
+          echo "spec-shelf OK: sddc-manager-openapi.json + vcenter.yaml + vi-json.yaml present under spec-shelf/docs/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-lint-test's login step — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — sddc-manager real-spec reconcile lane (#2982)
+
+- Every hand-coded `METHOD:/path` the sddc-manager connector dispatches
+  (the 14 typed-read paths, the `POST /v1/tokens` session mint, the
+  profile fingerprint's `GET /v1/releases/system`) is now asserted
+  against the pinned `sddc-manager-9.0` spec on every PR via the #2980
+  harness (`backend/tests/test_connectors_sddc_manager_spec_reconcile.py`
+  — parse-only, required unit sweep, uniform skip when the shelf is
+  unconfigured). CI's secret-gated spec-shelf checkout is widened to
+  `docs/sddc-manager-9.0` in both Python jobs. First armed run surfaced
+  one real finding, fixed in the same PR per the #2970 protocol:
+  `sddc.domain.status` targeted `GET /v1/domains/{id}/status`, which the
+  pinned 9.0 spec does not serve — repointed to `GET /v1/domains/{id}`,
+  whose domain object carries the top-level `status` lifecycle field the
+  op documents (the op now returns the full domain object; `status`
+  stays top-level).
+
 ### Added — holodeck deploy-lifecycle typed ops: `config.apply` / `instance.start` / `instance.status` / `router.patch` (#2908)
 
 - The `holodeck` connector gains four typed ops that make the consumer's

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_ops.py
@@ -235,11 +235,13 @@ _DOMAIN_STATUS = SddcTypedOp(
     summary="Lifecycle status of one VCF domain.",
     description=(
         "Reads the lifecycle status of one VCF domain via "
-        "GET /v1/domains/{id}/status -- its ACTIVE / ACTIVATING / ERROR "
-        "state and the last status transition. Requires a domain id from "
-        "sddc.domain.list. The read an operator runs when a domain-create "
-        "or expand workflow is in flight or a domain is reported unhealthy. "
-        "Works with zero catalog ingest. safety_level=safe, read-only."
+        "GET /v1/domains/{id} -- the domain object's top-level status "
+        "field carries the ACTIVE / ACTIVATING / UPGRADING / ERROR state "
+        "(SDDC Manager 9.0 serves no dedicated /status sub-resource). "
+        "Requires a domain id from sddc.domain.list. The read an operator "
+        "runs when a domain-create or expand workflow is in flight or a "
+        "domain is reported unhealthy. Works with zero catalog ingest. "
+        "safety_level=safe, read-only."
     ),
     parameter_schema={
         "type": "object",
@@ -264,7 +266,10 @@ _DOMAIN_STATUS = SddcTypedOp(
             "still activating / errored -- e.g. while a domain-expand "
             "workflow runs."
         ),
-        output_shape="{status, ...}. Surface the state and any error detail.",
+        output_shape=(
+            "{id, name, status, upgradeState, ...} -- the full domain "
+            "object. Surface the top-level status and any error detail."
+        ),
         parameter_hints={"id": "The VCF domain id from sddc.domain.list."},
     ),
 )

--- a/backend/src/meho_backplane/connectors/sddc_manager/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/typed_reads.py
@@ -31,8 +31,10 @@ https://developer.broadcom.com/xapis/vmware-cloud-foundation-api/latest/:
 
 * ``sddc.domain.list`` -- ``GET /v1/domains`` (management + workload
   domain inventory).
-* ``sddc.domain.status`` -- ``GET /v1/domains/{id}/status`` (per-domain
-  status: the READY / ACTIVATING / ERROR lifecycle state).
+* ``sddc.domain.status`` -- ``GET /v1/domains/{id}`` (the domain object,
+  whose top-level ``status`` field carries the ACTIVE / ACTIVATING /
+  ERROR lifecycle state; the pinned 9.0 spec serves no dedicated
+  ``/status`` sub-resource -- the #2982 spec-reconcile finding).
 * ``sddc.cluster.list`` -- ``GET /v1/clusters`` (vSphere cluster
   inventory; optional ``domainId`` filter).
 * ``sddc.host.list`` -- ``GET /v1/hosts`` (ESXi host inventory; optional
@@ -102,7 +104,7 @@ _log = structlog.get_logger(__name__)
 # the ``Authorization: Bearer <accessToken>`` header the token session
 # primed (#2290).
 _DOMAINS_PATH = "/v1/domains"
-_DOMAIN_STATUS_PATH = "/v1/domains/{id}/status"
+_DOMAIN_STATUS_PATH = "/v1/domains/{id}"
 _CLUSTERS_PATH = "/v1/clusters"
 _HOSTS_PATH = "/v1/hosts"
 _VCENTERS_PATH = "/v1/vcenters"
@@ -211,13 +213,17 @@ async def sddc_domain_status_impl(
     target: SddcTargetLike,
     params: dict[str, Any],
 ) -> dict[str, Any]:
-    """``sddc.domain.status`` -- ``GET /v1/domains/{id}/status``.
+    """``sddc.domain.status`` -- ``GET /v1/domains/{id}``.
 
-    Reads the lifecycle status of one VCF domain (its ACTIVE / ACTIVATING
-    / ERROR state and the last status transition). Requires a domain
-    ``id`` from ``sddc.domain.list``; the read an operator runs when a
-    domain-create or expand workflow is in flight or a domain is reported
-    unhealthy.
+    Reads one VCF domain by id and surfaces its lifecycle state: the
+    returned domain object carries a top-level ``status`` (ACTIVE /
+    ACTIVATING / UPGRADING / ERROR / ...) plus ``upgradeState`` /
+    ``upgradeStatus``. The pinned SDDC Manager 9.0 spec serves no
+    dedicated ``/v1/domains/{id}/status`` sub-resource (the #2982
+    spec-reconcile finding), so the domain read *is* the status read.
+    Requires a domain ``id`` from ``sddc.domain.list``; the read an
+    operator runs when a domain-create or expand workflow is in flight
+    or a domain is reported unhealthy.
     """
     domain_id = params["id"]
     path = _DOMAIN_STATUS_PATH.format(id=domain_id)

--- a/backend/tests/test_connectors_sddc_manager_spec_reconcile.py
+++ b/backend/tests/test_connectors_sddc_manager_spec_reconcile.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""sddc-manager real-spec reconcile lane (#2982) — the #2980 harness.
+
+Asserts every hand-coded ``METHOD:/path`` the sddc-manager connector
+dispatches is served by the pinned ``sddc-manager-9.0`` spec on the
+shelf (``vmware/vcf-api-specs``' OpenAPI 3.0.1 document — Apache-2.0,
+provenance in the shelf's ``MANIFEST.md``). Parse-only set compare —
+no DB, no embeddings, no containers — so it lives in the required unit
+sweep per the lane-placement rule in
+``docs/decisions/spec-reconcile-guards-standard.md``. Uniform skip when
+the shelf is unconfigured (``tests/_spec_shelf.py`` contract).
+
+The declared set is introspected from the connector's live constants
+(the #2944 pattern — never a hardcoded mirror), across the three
+surfaces that hand-code a path:
+
+* :mod:`~meho_backplane.connectors.sddc_manager.typed_reads` — the 14
+  ``_*_PATH`` module constants. Every typed read dispatches through
+  :meth:`HttpConnector._get_json` (a GET-only seam that delegates to
+  ``_request_json(target, "GET", ...)``), so each declares ``GET:``.
+* :mod:`~meho_backplane.connectors.sddc_manager.connector` — the token
+  mint ``_SESSION_CREATE_PATH`` (``POST /v1/tokens``, sourced from the
+  ``session_login_token`` scheme spec). The connector's bespoke
+  fingerprint probe GETs the literal ``"/v1/sddc-managers"`` inline; the
+  same string is declared here via ``_SDDC_MANAGERS_PATH``, so the probe
+  path is covered by value.
+* :mod:`~meho_backplane.connectors.sddc_manager.profile` — the
+  declarative fingerprint recipe's ``GET /v1/releases/system``.
+
+A red lane here is the guard surfacing a real finding, not harness
+noise — first run against the real shelf caught exactly one:
+``GET:/v1/domains/{id}/status`` (repointed to ``GET:/v1/domains/{id}``
+in the same PR; the 9.0 spec serves no ``/status`` sub-resource).
+Protocol: docs/decisions/spec-reconcile-guards-standard.md.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.sddc_manager import connector as _connector
+from meho_backplane.connectors.sddc_manager import typed_reads as _typed_reads
+from meho_backplane.connectors.sddc_manager.profile import SDDC_EXECUTION_PROFILE
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+_SPEC_DIR = "sddc-manager-9.0"
+_SPEC_FILE = "sddc-manager-openapi.json"
+_SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
+
+
+def _typed_read_paths() -> dict[str, str]:
+    """The live ``_*_PATH`` constants of ``typed_reads``, by constant name."""
+    return {
+        name: value
+        for name, value in vars(_typed_reads).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the sddc-manager connector dispatches."""
+    declared = {f"GET:{path}" for path in _typed_read_paths().values()}
+    declared.add(f"POST:{_connector._SESSION_CREATE_PATH}")
+    declared.add(f"GET:{SDDC_EXECUTION_PROFILE.fingerprint.path}")
+    return declared
+
+
+def test_typed_read_path_constants_are_all_discovered() -> None:
+    """Guard: the introspection finds every typed-read path constant.
+
+    Pinning the exact constant-name set (the #2944 guard shape) means a
+    renamed or dropped ``_*_PATH`` constant — or a new one that skips
+    the ``_PATH`` suffix convention — can't silently shrink the
+    reconciled set to a vacuous pass.
+    """
+    assert sorted(_typed_read_paths()) == [
+        "_CLUSTERS_PATH",
+        "_CREDENTIALS_PATH",
+        "_DOMAINS_PATH",
+        "_DOMAIN_STATUS_PATH",
+        "_HOSTS_PATH",
+        "_LICENSE_KEYS_PATH",
+        "_NETWORK_POOLS_PATH",
+        "_NETWORK_POOL_GET_PATH",
+        "_NSXT_CLUSTERS_PATH",
+        "_SDDC_MANAGERS_PATH",
+        "_SYSTEM_PATH",
+        "_TASKS_PATH",
+        "_VCENTERS_PATH",
+        "_VCF_SERVICES_PATH",
+    ]
+
+
+def test_fingerprint_probe_literal_is_covered_by_the_typed_constant() -> None:
+    """Guard: the connector's inline fingerprint literal can't drift uncovered.
+
+    ``SddcManagerConnector.fingerprint`` GETs ``"/v1/sddc-managers"`` as
+    an inline literal (not introspectable), relying on the typed
+    ``_SDDC_MANAGERS_PATH`` declaring the same string. This pins that
+    value equality so an edit to either side surfaces here instead of
+    silently dropping the probe path from the reconcile.
+    """
+    assert _typed_reads._SDDC_MANAGERS_PATH == "/v1/sddc-managers"
+
+
+def test_declared_op_ids_are_served_by_the_pinned_spec() -> None:
+    """Every hand-coded op_id is served by the pinned sddc-manager-9.0 spec."""
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = openapi_served_op_ids(spec_path)
+    assert_op_ids_served(_declared_op_ids(), served, spec_label=_SPEC_LABEL)

--- a/backend/tests/test_connectors_sddc_manager_typed_reads.py
+++ b/backend/tests/test_connectors_sddc_manager_typed_reads.py
@@ -242,12 +242,19 @@ async def test_domain_status_builds_path_from_id(
     _stub_embedding: AsyncMock,
     session: AsyncSession,
 ) -> None:
-    """AC #1: sddc.domain.status interpolates the domain id into the path."""
+    """AC #1: sddc.domain.status interpolates the domain id into the path.
+
+    The op reads ``GET /v1/domains/{id}`` -- the domain object whose
+    top-level ``status`` carries the lifecycle state; the pinned 9.0 spec
+    serves no dedicated ``/status`` sub-resource (the #2982 reconcile
+    finding).
+    """
     await _register_and_resolve(_stub_embedding)
 
+    domain_payload = {"id": "domain-mgmt", "name": "sfo-m01", "status": "ACTIVE"}
     async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
         mock.post(_TOKEN_PATH).respond(200, json={"accessToken": _ACCESS_TOKEN})
-        route = mock.get("/v1/domains/domain-mgmt/status").respond(200, json={"status": "ACTIVE"})
+        route = mock.get("/v1/domains/domain-mgmt").respond(200, json=domain_payload)
         result = await dispatch(
             operator=_make_operator(),
             connector_id=SDDC_CONNECTOR_ID,
@@ -257,7 +264,7 @@ async def test_domain_status_builds_path_from_id(
         )
 
     assert result.status == "ok", result.error
-    assert result.result == {"status": "ACTIVE"}
+    assert result.result == domain_payload
     assert route.called and route.call_count == 1
 
 

--- a/docs/codebase/connectors-sddc-manager.md
+++ b/docs/codebase/connectors-sddc-manager.md
@@ -163,7 +163,7 @@ dispatcher's #2067 recovery arm, which calls the connector's public
 | op_id | group | path |
 |---|---|---|
 | `sddc.domain.list` | `sddc-inventory` | `GET /v1/domains` |
-| `sddc.domain.status` | `sddc-inventory` | `GET /v1/domains/{id}/status` |
+| `sddc.domain.status` | `sddc-inventory` | `GET /v1/domains/{id}` |
 | `sddc.cluster.list` | `sddc-inventory` | `GET /v1/clusters` |
 | `sddc.host.list` | `sddc-inventory` | `GET /v1/hosts` |
 | `sddc.vcenter.list` | `sddc-inventory` | `GET /v1/vcenters` |
@@ -176,6 +176,24 @@ dispatcher's #2067 recovery arm, which calls the connector's public
 | `sddc.vcf_service.list` | `sddc-platform` | `GET /v1/vcf-services` |
 | `sddc.manager.list` | `sddc-platform` | `GET /v1/sddc-managers` |
 | `sddc.license.list` | `sddc-platform` | `GET /v1/license-keys` |
+
+`sddc.domain.status` reads the domain object itself: the pinned SDDC Manager
+9.0 spec serves no `/v1/domains/{id}/status` sub-resource (the #2982
+spec-reconcile finding — the original path 404s on a live 9.0 appliance), and
+the domain object's top-level `status` field carries the ACTIVE / ACTIVATING /
+UPGRADING / ERROR lifecycle state the op documents. The typed op therefore
+rides the same vendor path as the ingested `GET:/v1/domains/{id}` browse row;
+no resolver collision — typed op_ids are dotted (`sddc.domain.status`) and
+never shadow `METHOD:path` ingested rows (#1750/#1798).
+
+**Spec-reconcile lane (#2982).** Every hand-coded `METHOD:/path` above — plus
+the token mint (`POST /v1/tokens`), the profile fingerprint recipe
+(`GET /v1/releases/system`), and the probe path (`GET /v1/sddc-managers`) — is
+asserted against the pinned `sddc-manager-9.0` shelf spec by
+[`backend/tests/test_connectors_sddc_manager_spec_reconcile.py`](../../backend/tests/test_connectors_sddc_manager_spec_reconcile.py)
+(the #2980 harness; parse-only, runs in the required unit sweep, uniform skip
+when the shelf is unconfigured). Standard:
+[`docs/decisions/spec-reconcile-guards-standard.md`](../decisions/spec-reconcile-guards-standard.md).
 
 **Credential-read gating (`sddc.credential.list`).** SDDC Manager is the system
 of record for nested-infra credentials; its `GET /v1/credentials` read returns

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -208,6 +208,24 @@ Until this section is completed, the question stands as **recorded and
 routed**, not resolved — and the `SPEC_SHELF_TOKEN` secret must not be
 provisioned.
 
+### Extension: sddc-manager / sddc-manager-9.0 (#2982)
+
+The same secret-gated checkout additionally fetches the shelf's
+`docs/sddc-manager-9.0/` directory (`sddc-manager-openapi.json`, OpenAPI
+3.0.1, ~1.6 MB, 280 paths) for the sddc-manager reconcile lane
+(`backend/tests/test_connectors_sddc_manager_spec_reconcile.py`), under
+the identical ephemeral-use conditions recorded above (sparse read-only
+checkout, workspace destroyed at job end, never committed, never in
+artifacts or logs, secret withheld from fork PRs and the Dependabot
+store). No vendor-license attestation is needed for this extension: the
+spec is published by VMware in the **public, Apache-2.0**
+[`vmware/vcf-api-specs`](https://github.com/vmware/vcf-api-specs) repo
+(pinned at `85151f6b`, retrieved 2026-04-29) — the provenance note of
+record is the shelf's `sddc-manager-9.0/MANIFEST.md`, per the
+OSS-licensed-spec form in
+[`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
+extension mechanics.
+
 ## Consequences
 
 - The five real-spec lanes light up together the moment the secret exists;


### PR DESCRIPTION
## Summary

- Adds the sddc-manager real-spec reconcile lane (#2979 wave 3, on the #2980 harness): every hand-coded `METHOD:/path` the connector dispatches is introspected from the live constants and asserted against the pinned `sddc-manager-9.0/sddc-manager-openapi.json` shelf spec. Parse-only (no DB / embeddings / containers), so it lives in the required unit sweep per `docs/decisions/spec-reconcile-guards-standard.md`; uniform skip-with-reason when the shelf is unconfigured.
- Declared set (16 op_ids, three introspection sources — never a hardcoded mirror): the 14 `_*_PATH` constants in `typed_reads.py` (all dispatch through the GET-only `HttpConnector._get_json` seam), `POST:{_SESSION_CREATE_PATH}` (`/v1/tokens`, sourced from the `session_login_token` scheme spec), and `GET:{SDDC_EXECUTION_PROFILE.fingerprint.path}` (`/v1/releases/system`). Two guards pin the constant-name set and the fingerprint probe's inline `"/v1/sddc-managers"` literal (value-covered by `_SDDC_MANAGERS_PATH`) so the enumeration can't silently shrink to a vacuous pass.
- Widens CI's secret-gated spec-shelf sparse checkout + fail-loud verify step to `docs/sddc-manager-9.0` in **both** Python jobs (alphabetical insertion, mirrors the #2966 step shape; same `SPEC_SHELF_TOKEN`, no new secret).
- Extends `docs/decisions/vendor-spec-ci-provisioning.md`'s signoff with the sddc-manager-9.0 paragraph — the OSS-licensed form: the spec is VMware's **public Apache-2.0** [`vmware/vcf-api-specs`](https://github.com/vmware/vcf-api-specs) (pinned `85151f6b`, provenance of record in the shelf's `sddc-manager-9.0/MANIFEST.md`), so no vendor-license attestation is needed.

## Red-lane finding + per-op decision (the #2970 protocol)

First armed run: **15 of 16 op_ids served, 1 unserved**. Decision table:

| op_id | declared path | pinned-spec verdict | decision |
|---|---|---|---|
| `sddc.domain.status` | `GET:/v1/domains/{id}/status` | **NOT served** — the 9.0 spec has no `/status` sub-resource under `/v1/domains/{id}` (the only `status`-named path in the whole 280-path spec is `GET /v1/bundles/download-status`); the call 404s on a live appliance | **Repoint (mechanical, this PR)** → `GET:/v1/domains/{id}`. The served path's `Domain` response schema carries a top-level `status` field whose documented values ("One among: ACTIVE, ACTIVATING, UPGRADING, DISABLED, ERROR, …") are exactly the lifecycle state the op documents, plus `upgradeState`/`upgradeStatus`. Same resource, same read-only GET, same auth — not a design-level repoint. The op keeps its `sddc.domain.status` id and now returns the full domain object (`status` stays top-level); `response_schema` was already `{type: object, additionalProperties: true}`. No resolver collision with the ingested `GET:/v1/domains/{id}` browse row — typed op_ids are dotted and never shadow `METHOD:path` rows (#1750/#1798). |
| all 15 others | `GET:/v1/{domains,clusters,hosts,vcenters,nsxt-clusters,network-pools,network-pools/{id},credentials,tasks,system,vcf-services,sddc-managers,license-keys,releases/system}`, `POST:/v1/tokens` | served | none needed |

No path was invented: the repoint target was grepped out of the shelf's `sddc-manager-openapi.json.paths.txt` and field-verified in the spec's `Domain` schema.

## Test plan

- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy src/` — 1 pre-existing platform error in untouched `net/icmp.py` (`socket.MSG_ERRQUEUE` is Linux-only, absent on the macOS dev sandbox; green on CI's Linux runners); touched files clean
- [x] Lane armed against the local shelf (`MEHO_CONSUMER_DOCS_ROOT=<shelf>/docs`) — 3 passed
- [x] Lane unarmed — 2 passed (guards), 1 skipped with the uniform `tests/_spec_shelf.py` reason
- [x] Full sddc + spec-shelf sweep armed (`test_connectors_sddc_manager_*` × 5 + `test_spec_shelf_harness` + `test_spec_shelf_example_lane`) — 121 passed; `test_connectors_sddc_manager_e2e.py` — 7 passed
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (2 pre-existing size warnings in touched files, not introduced here)
- [x] Workflow YAML parses; `docs/sddc-manager-9.0` present in both sparse-checkout lists and both verify loops
- [ ] CI (armed repo): verify step passes with the widened checkout and the lane **runs, not skips**, in `python-lint-test` — observable on this PR's checks

## Out of scope

- Sibling wave-3 lanes (#2981, #2983–#2993) — expect trivial `ci.yml` adjacency conflicts; rebase, don't battle.
- Adjacent findings (recorded, untouched): `typed_reads.py` at 465 lines (warn >400) and `register_sddc_typed_operations` at 71 lines (warn >60) — pre-existing size debt; `net/icmp.py` mypy platform error above.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2982
