### PR TITLE
fix(connectors): assert + vim-switch the vmware cluster DRS read; exhaustive read-composite spec lane (#2986)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_read.py
@@ -151,7 +151,14 @@ __all__ = [
 # guard can assert the composite hits the same canonical paths the vCenter
 # catalog would emit.
 _OP_GET_CLUSTER = "GET:/vcenter/cluster/{cluster}"
-_OP_GET_CLUSTER_DRS = "GET:/vcenter/cluster/{cluster}/drs"
+# The pinned vcenter.yaml serves NO cluster DRS REST resource at all: the
+# ``GET:/vcenter/cluster/{cluster}/drs`` path #508 declared was unserved
+# (the #2970 adjacent finding, fixed in #2986). DRS state is a vim-only
+# surface, so the composite reads it through the PropertyCollector
+# singleton (``configurationEx.drsConfig`` + optional
+# ``drsRecommendation``) -- the same vim seam the vm.migrate DRS lookup
+# uses (#2970).
+_OP_RETRIEVE_PROPERTIES = "POST:/PropertyCollector/{moId}/RetrievePropertiesEx"
 _OP_POST_QUERY_EVENTS = "POST:/EventManager/{moId}/QueryEvents"
 _OP_POST_QUERY_AVAILABLE_PERF_METRIC = "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric"
 _OP_POST_QUERY_PERF = "POST:/PerformanceManager/{moId}/QueryPerf"
@@ -175,18 +182,39 @@ _OP_LIST_VMS = "GET:/vcenter/vm"
 _OP_LIST_NETWORK = "GET:/vcenter/network"
 _NETWORK_TYPE_DISTRIBUTED_PORTGROUP = "DISTRIBUTED_PORTGROUP"
 
+# vim constants for the cluster DRS read. The PropertyCollector is a vim
+# singleton whose moId is the literal ``propertyCollector`` -- the
+# concrete value the ``{moId}`` path template takes at call time (the
+# same convention the typed reads and write composites use).
+_PROPERTY_COLLECTOR_MOID = "propertyCollector"
+_CLUSTER_COMPUTE_RESOURCE_MO_TYPE = "ClusterComputeResource"
+# Nested vim property path for the cluster's DRS configuration:
+# ``ClusterConfigInfoEx.drsConfig`` is a ``ClusterDrsConfigInfo``
+# (``enabled`` / ``defaultVmBehavior`` / ``vmotionRate`` / ...),
+# spec-verified against the pinned vi-json.yaml.
+_PROP_DRS_CONFIG = "configurationEx.drsConfig"
+# The cluster's current DRS recommendation list
+# (``ClusterDrsRecommendation[]``). Deprecated in the vim API since
+# VI 2.5 but served by the pinned spec and the only surface carrying the
+# vm -> destination migration pairs -- the #2970 / PR #2974 decision the
+# vm.migrate DRS lookup already relies on.
+_PROP_DRS_RECOMMENDATION = "drsRecommendation"
+
 # Per-composite sub-op-id tuples. Each tuple lists the raw-REST /
 # vi-json sub-ops the composite issues directly on the connector
 # session. Pre-#2253 these fed the L2 pre-flight check that guarded a
 # missing catalog ingest; the direct-session migration removed that
 # coupling (the composites no longer need ingested descriptor rows), so
 # the tuples now serve as the canonical sub-op-path manifest the
-# ingest-reconcile acceptance guard
-# (``tests/acceptance/test_portgroup_audit_op_id_reconcile.py``) checks
-# against the vCenter spec.
+# spec-reconcile lanes check against the pinned specs: the exhaustive
+# read lane
+# (``tests/test_connectors_vmware_rest_composites_read_reconcile.py``,
+# #2986 -- every ``_OP_*`` constant, GET legs vs vcenter.yaml, POST legs
+# vs vi-json.yaml) plus the portgroup-audit acceptance guard
+# (``tests/acceptance/test_portgroup_audit_op_id_reconcile.py``).
 _SUB_OPS_CLUSTER_DRS_RECS: tuple[str, ...] = (
     _OP_GET_CLUSTER,
-    _OP_GET_CLUSTER_DRS,
+    _OP_RETRIEVE_PROPERTIES,
 )
 _SUB_OPS_EVENT_TAIL: tuple[str, ...] = (_OP_POST_QUERY_EVENTS,)
 _SUB_OPS_PERFORMANCE_SUMMARY: tuple[str, ...] = (
@@ -258,7 +286,8 @@ async def _read_sub_op(
     ``GET`` legs are vSphere Automation ``/vcenter/*`` paths, mounted on
     ``/api`` / ``/rest`` via :meth:`VmwareRestConnector.mount_op_path`.
     ``POST`` legs are vmomi (VI-JSON) methods (``QueryEvents`` /
-    ``QueryAvailablePerfMetric`` / ``QueryPerf``); they route through
+    ``QueryAvailablePerfMetric`` / ``QueryPerf`` /
+    ``RetrievePropertiesEx``); they route through
     :meth:`VmwareRestConnector._post_vmomi_json`, which mounts them on the
     documented VI-JSON base ``/sdk/vim25/{release}`` (single ``/api``
     fallback) so they resolve on vCenter 8.0.x instead of 404ing (#2466) —
@@ -280,6 +309,49 @@ async def _read_sub_op(
     return await connector._post_vmomi_json(target, path, operator=operator, json=body)
 
 
+def _build_cluster_props_retrieve_body(cluster_moid: str, path_set: list[str]) -> dict[str, Any]:
+    """Build a ``RetrievePropertiesEx`` body reading cluster properties.
+
+    One ``PropertyFilterSpec`` scoped directly to the cluster's MoRef;
+    the singleton ``propertyCollector`` moId rides the path, so the body
+    is only the method args -- the same shape the write composites'
+    config reads send.
+    """
+    return {
+        "specSet": [
+            {
+                "propSet": [{"type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, "pathSet": path_set}],
+                "objectSet": [
+                    {"obj": {"type": _CLUSTER_COMPUTE_RESOURCE_MO_TYPE, "value": cluster_moid}}
+                ],
+            }
+        ],
+        "options": {},
+    }
+
+
+def _extract_object_props(retrieve_result: Any) -> dict[str, Any]:
+    """Flatten a single-object ``RetrievePropertiesEx`` result to ``{name: val}``.
+
+    vim omits unset properties from ``propSet`` (they surface in
+    ``missingSet`` instead), so callers treat an absent key as "property
+    not set on this object" and fall back to their documented defaults.
+    """
+    payload = _unwrap_value(retrieve_result)
+    objects = payload.get("objects", []) if isinstance(payload, dict) else payload
+    props: dict[str, Any] = {}
+    if not isinstance(objects, list):
+        return props
+    for obj in objects:
+        if not isinstance(obj, dict):
+            continue
+        for entry in obj.get("propSet", []) or []:
+            name = entry.get("name") if isinstance(entry, dict) else None
+            if isinstance(name, str):
+                props[name] = entry.get("val")
+    return props
+
+
 async def cluster_drs_recommendations_composite(
     *,
     operator: Operator,
@@ -294,26 +366,31 @@ async def cluster_drs_recommendations_composite(
     Sub-ops read directly on the connector session (sequential):
 
     1. ``GET:/vcenter/cluster/{cluster}`` -- cluster summary (name,
-       resource pool, default host, DRS-enabled flag).
-    2. ``GET:/vcenter/cluster/{cluster}/drs`` -- DRS configuration
-       (enabled, automation level, migration threshold).
+       resource pool, HA/DRS-enabled flags).
+    2. ``POST:/PropertyCollector/{moId}/RetrievePropertiesEx`` (vi-json)
+       -- the cluster's DRS configuration
+       (``ClusterComputeResource.configurationEx.drsConfig``, a
+       ``ClusterDrsConfigInfo``: ``enabled``, ``defaultVmBehavior``,
+       ``vmotionRate``, ...) plus, when
+       ``include_recommendations_history=True``, the cluster's current
+       ``drsRecommendation`` list in the same read. The pinned
+       ``vcenter.yaml`` serves no cluster DRS REST resource at all (the
+       ``GET:/vcenter/cluster/{cluster}/drs`` path #508 declared was
+       unserved -- the #2970 adjacent finding, fixed here per #2986);
+       vim is the only DRS surface, mirroring the vm.migrate DRS
+       lookup.
 
     Returns
     -------
     dict[str, Any]
-        ``{"cluster": <summary dict>, "drs": <drs config dict>,
-        "recommendations_history": <optional list>}``. The
+        ``{"cluster": <summary dict>, "drs": <ClusterDrsConfigInfo
+        dict>, "recommendations_history": <optional list>}``. ``drs``
+        is ``{}`` when the property is unset on the target. The
         ``recommendations_history`` key appears only when the operator
-        sets ``include_recommendations_history=True``; otherwise it is
-        omitted.
-
-    The ``include_recommendations_history`` flag is a placeholder for
-    a future Task that adds a third sub-op (DRS recommendations list).
-    The vSphere REST surface does not expose a stable
-    "recommendations" endpoint in 9.0; the issue body's "DRS state read
-    + performance read + format" hint is satisfied by reading the
-    cluster summary plus the DRS config -- the format/aggregation is
-    what differentiates the composite from a raw GET.
+        sets ``include_recommendations_history=True``; it carries the
+        cluster's current ``ClusterDrsRecommendation`` rows (empty list
+        when DRS has none pending) -- the key name predates the vim
+        switch and is retained for envelope stability.
     """
     cluster_moid = params["cluster"]
     include_history = bool(params.get("include_recommendations_history", False))
@@ -321,26 +398,28 @@ async def cluster_drs_recommendations_composite(
     cluster_result = await _read_sub_op(
         connector, target, operator, _OP_GET_CLUSTER, path_params={"cluster": cluster_moid}
     )
-    drs_result = await _read_sub_op(
-        connector, target, operator, _OP_GET_CLUSTER_DRS, path_params={"cluster": cluster_moid}
+    path_set = [_PROP_DRS_CONFIG]
+    if include_history:
+        path_set.append(_PROP_DRS_RECOMMENDATION)
+    retrieve_result = await _read_sub_op(
+        connector,
+        target,
+        operator,
+        _OP_RETRIEVE_PROPERTIES,
+        path_params={"moId": _PROPERTY_COLLECTOR_MOID},
+        body=_build_cluster_props_retrieve_body(cluster_moid, path_set),
     )
+    props = _extract_object_props(retrieve_result)
+    drs_config = props.get(_PROP_DRS_CONFIG)
     out: dict[str, Any] = {
         "cluster": _unwrap_value(cluster_result),
-        "drs": _unwrap_value(drs_result),
+        "drs": drs_config if isinstance(drs_config, dict) else {},
     }
     if include_history:
-        # Surface the history slice from the DRS payload when present.
-        # vSphere 9.0 returns ``{"drs_config": ..., "history": [...]}``;
-        # the key is absent on legacy targets. Empty list rather than
-        # None keeps the operator-visible shape stable.
-        drs_payload = out["drs"]
-        history = drs_payload.get("history", []) if isinstance(drs_payload, dict) else []
-        # Guard against non-list ``history`` values (e.g. a target that
-        # returns the field as a scalar / dict). ``list(history)`` would
-        # iterate keys on a dict or fail on a scalar; the contract is
-        # "always a list when surfaced", so coerce to an empty list when
-        # the payload disagrees.
-        out["recommendations_history"] = history if isinstance(history, list) else []
+        recommendations = props.get(_PROP_DRS_RECOMMENDATION)
+        out["recommendations_history"] = (
+            recommendations if isinstance(recommendations, list) else []
+        )
     return out
 
 

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_register.py
@@ -294,10 +294,9 @@ _COMPOSITES: tuple[_CompositeSpec, ...] = (
             "Orchestrates a cluster summary read plus a DRS-config read, "
             "returning a single aggregated payload. Equivalent of "
             "'govc cluster.recommendations' for the operator-facing "
-            "workflow: one composite call replaces two raw vCenter REST "
-            "GETs while preserving the audit-tree linkage between the "
-            "parent composite row and each sub-op row. Read-only -- "
-            "never mutates cluster state."
+            "workflow: one composite call replaces a raw vCenter REST "
+            "GET plus a vim property read (DRS state is vim-only in "
+            "vSphere 9.0). Read-only -- never mutates cluster state."
         ),
         parameter_schema=CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA,
         response_schema=CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA,

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -96,10 +96,13 @@ __all__ = [
 
 #: ``vmware.composite.cluster.drs_recommendations`` parameter schema.
 #:
-#: Reads cluster summary + DRS state (optionally surfacing
-#: ``recommendations_history`` from the DRS payload when present). The
-#: composite dispatches one ``GET:/vcenter/cluster/{cluster}`` and one
-#: ``GET:/vcenter/cluster/{cluster}/drs`` to a single target.
+#: Reads cluster summary + DRS state (optionally surfacing the cluster's
+#: current DRS recommendation list). The composite dispatches one
+#: ``GET:/vcenter/cluster/{cluster}`` plus one vi-json
+#: ``POST:/PropertyCollector/{moId}/RetrievePropertiesEx`` (reading
+#: ``ClusterComputeResource.configurationEx.drsConfig`` and, on request,
+#: ``drsRecommendation``) to a single target -- the pinned vcenter.yaml
+#: serves no cluster DRS REST resource (#2986).
 CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -116,10 +119,12 @@ CLUSTER_DRS_RECOMMENDATIONS_PARAMETER_SCHEMA: dict[str, Any] = {
             "type": "boolean",
             "default": False,
             "description": (
-                "When true, the handler will also surface the historical "
-                "recommendation summary from the DRS sub-op response. "
-                "Read-only on either setting; the flag toggles aggregation "
-                "shape, not the underlying calls."
+                "When true, the handler also reads the cluster's current "
+                "DRS recommendation list (the vim ``drsRecommendation`` "
+                "property) in the same RetrievePropertiesEx call and "
+                "surfaces it as ``recommendations_history``. Read-only "
+                "on either setting; the flag widens the property read, "
+                "never adds a mutating call."
             ),
         },
     },
@@ -339,18 +344,21 @@ CLUSTER_DRS_RECOMMENDATIONS_RESPONSE_SCHEMA: dict[str, Any] = {
         "drs": {
             "type": "object",
             "description": (
-                "DRS configuration payload from "
-                "``GET:/vcenter/cluster/{cluster}/drs`` (vSphere REST "
-                "owns the inner shape)."
+                "DRS configuration payload: the cluster's vim "
+                "``configurationEx.drsConfig`` (``ClusterDrsConfigInfo`` "
+                "-- the vim API owns the inner shape) read via "
+                "``RetrievePropertiesEx``; ``{}`` when the property is "
+                "unset on the target."
             ),
         },
         "recommendations_history": {
             "type": "array",
             "items": {"type": "object"},
             "description": (
-                "Optional history slice surfaced from the DRS payload "
-                "when ``include_recommendations_history=True``. Always "
-                "a list when present; absent otherwise."
+                "Optional list of the cluster's current DRS "
+                "recommendations (vim ``drsRecommendation`` rows) when "
+                "``include_recommendations_history=True``. Always a "
+                "list when present; absent otherwise."
             ),
         },
     },

--- a/backend/tests/test_connectors_vmware_rest_composites_read.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read.py
@@ -194,15 +194,36 @@ def _http_error(status: int, url: str) -> httpx.HTTPStatusError:
 # ---------------------------------------------------------------------------
 
 
+_RETRIEVE_PROPERTIES_PATH = "/api/PropertyCollector/propertyCollector/RetrievePropertiesEx"
+
+
+def _retrieve_result(prop_sets: dict[str, Any]) -> dict[str, Any]:
+    """Build a single-object ``RetrievePropertiesEx`` result payload."""
+    return {
+        "objects": [
+            {
+                "obj": {"type": "ClusterComputeResource", "value": "domain-c123"},
+                "propSet": [{"name": name, "val": val} for name, val in prop_sets.items()],
+            }
+        ]
+    }
+
+
 @pytest.mark.asyncio
-async def test_cluster_drs_recommendations_reads_summary_and_drs_in_order() -> None:
-    """Two GETs fire: cluster summary then DRS config, both mounted, cluster in path."""
+async def test_cluster_drs_recommendations_reads_summary_then_vim_drs_config() -> None:
+    """Cluster summary GET then a vmomi RetrievePropertiesEx read of drsConfig.
+
+    The pinned vcenter.yaml serves no cluster DRS REST resource (#2986),
+    so the second leg is a vi-json property read on the PropertyCollector
+    singleton -- routed through ``_post_vmomi_json``, never the Automation
+    mount.
+    """
     cluster_payload = {"name": "Cluster-A", "drs_enabled": True}
-    drs_payload = {"enabled": True, "automation_level": "FULLY_AUTOMATED"}
+    drs_config = {"enabled": True, "defaultVmBehavior": "fullyAutomated", "vmotionRate": 3}
     conn = _RecordingConnector(
         {
             "/api/vcenter/cluster/domain-c123": cluster_payload,
-            "/api/vcenter/cluster/domain-c123/drs": drs_payload,
+            _RETRIEVE_PROPERTIES_PATH: _retrieve_result({"configurationEx.drsConfig": drs_config}),
         }
     )
 
@@ -215,55 +236,103 @@ async def test_cluster_drs_recommendations_reads_summary_and_drs_in_order() -> N
 
     assert [(c["method"], c["path"]) for c in conn.calls] == [
         ("GET", "/api/vcenter/cluster/domain-c123"),
-        ("GET", "/api/vcenter/cluster/domain-c123/drs"),
+        ("POST", _RETRIEVE_PROPERTIES_PATH),
     ]
-    # Both paths were mounted (spec-relative -> live prefix).
-    assert conn.mount_calls == [
-        "/vcenter/cluster/domain-c123",
-        "/vcenter/cluster/domain-c123/drs",
-    ]
-    assert out == {"cluster": cluster_payload, "drs": drs_payload}
+    # Only the Automation GET resolves through mount_op_path; the vmomi
+    # leg rides the VI-JSON seam (#2466).
+    assert conn.mount_calls == ["/vcenter/cluster/domain-c123"]
+    assert conn.calls[1]["vmomi"] is True
+    # The filter spec scopes one PropertyFilterSpec to the cluster MoRef
+    # and reads only the DRS config (no history requested).
+    body = conn.calls[1]["body"]
+    assert body == {
+        "specSet": [
+            {
+                "propSet": [
+                    {
+                        "type": "ClusterComputeResource",
+                        "pathSet": ["configurationEx.drsConfig"],
+                    }
+                ],
+                "objectSet": [{"obj": {"type": "ClusterComputeResource", "value": "domain-c123"}}],
+            }
+        ],
+        "options": {},
+    }
+    assert out == {"cluster": cluster_payload, "drs": drs_config}
 
 
 @pytest.mark.asyncio
-async def test_cluster_drs_recommendations_history_flag_surfaces_history_slice() -> None:
-    """``include_recommendations_history=True`` surfaces ``history`` from the DRS payload."""
+async def test_cluster_drs_recommendations_history_flag_widens_read_and_surfaces_recs() -> None:
+    """``include_recommendations_history=True`` reads ``drsRecommendation`` too."""
+    recs = [{"key": "1", "rating": 5, "migrationList": []}]
     conn = _RecordingConnector(
         {
-            "/api/vcenter/cluster/domain-c1": {"name": "Cluster-A"},
-            "/api/vcenter/cluster/domain-c1/drs": {
-                "enabled": True,
-                "history": [{"recommendation_id": "rec-1", "reason": "load balance"}],
-            },
+            "/api/vcenter/cluster/domain-c123": {"name": "Cluster-A"},
+            _RETRIEVE_PROPERTIES_PATH: _retrieve_result(
+                {"configurationEx.drsConfig": {"enabled": True}, "drsRecommendation": recs}
+            ),
         }
     )
     out = await cluster_drs_recommendations_composite(
         operator=_make_operator(),
         target=object(),
-        params={"cluster": "domain-c1", "include_recommendations_history": True},
+        params={"cluster": "domain-c123", "include_recommendations_history": True},
         connector=conn,  # type: ignore[arg-type]
     )
-    assert out["recommendations_history"] == [
-        {"recommendation_id": "rec-1", "reason": "load balance"}
-    ]
+    # The flag widens the same RetrievePropertiesEx read -- no extra call.
+    assert len(conn.calls) == 2
+    path_set = conn.calls[1]["body"]["specSet"][0]["propSet"][0]["pathSet"]
+    assert path_set == ["configurationEx.drsConfig", "drsRecommendation"]
+    assert out["drs"] == {"enabled": True}
+    assert out["recommendations_history"] == recs
 
 
 @pytest.mark.asyncio
 async def test_cluster_drs_recommendations_history_flag_default_omits_key() -> None:
-    """Default ``include_recommendations_history=False`` omits the key."""
+    """Default ``include_recommendations_history=False`` omits the key and the prop."""
     conn = _RecordingConnector(
         {
-            "/api/vcenter/cluster/domain-c1": {"name": "Cluster-A"},
-            "/api/vcenter/cluster/domain-c1/drs": {"enabled": False, "history": [1, 2]},
+            "/api/vcenter/cluster/domain-c123": {"name": "Cluster-A"},
+            _RETRIEVE_PROPERTIES_PATH: _retrieve_result(
+                {"configurationEx.drsConfig": {"enabled": False}}
+            ),
         }
     )
     out = await cluster_drs_recommendations_composite(
         operator=_make_operator(),
         target=object(),
-        params={"cluster": "domain-c1"},
+        params={"cluster": "domain-c123"},
         connector=conn,  # type: ignore[arg-type]
     )
     assert "recommendations_history" not in out
+    path_set = conn.calls[1]["body"]["specSet"][0]["propSet"][0]["pathSet"]
+    assert "drsRecommendation" not in path_set
+
+
+@pytest.mark.asyncio
+async def test_cluster_drs_recommendations_tolerates_missing_props_and_envelope() -> None:
+    """Unset vim properties degrade to the documented defaults.
+
+    vim omits unset properties from ``propSet`` (they land in
+    ``missingSet``), and a legacy target may wrap the RetrieveResult in
+    the pre-7 ``{"value": ...}`` envelope: ``drs`` degrades to ``{}``
+    and ``recommendations_history`` to ``[]``.
+    """
+    conn = _RecordingConnector(
+        {
+            "/api/vcenter/cluster/domain-c123": {"name": "Cluster-A"},
+            _RETRIEVE_PROPERTIES_PATH: {"value": _retrieve_result({})},
+        }
+    )
+    out = await cluster_drs_recommendations_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"cluster": "domain-c123", "include_recommendations_history": True},
+        connector=conn,  # type: ignore[arg-type]
+    )
+    assert out["drs"] == {}
+    assert out["recommendations_history"] == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_connectors_vmware_rest_composites_read_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_read_reconcile.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Real-spec reconcile lane for every read-composite sub-op path (#2986).
+
+#2970's real-spec sweep covered the write composites' hand-coded paths
+but left ``composites/_read.py`` guarded only piecemeal: the
+portgroup-audit lane (``tests/acceptance/test_portgroup_audit_op_id_reconcile.py``)
+asserted its own two op_ids and nothing asserted the rest -- which is
+exactly how ``_OP_GET_CLUSTER_DRS = "GET:/vcenter/cluster/{cluster}/drs"``
+(a path the pinned ``vcenter.yaml`` does not serve) survived the 11-op
+fix as a recorded adjacent finding (PR #2974). This lane closes the gap
+per the spec-reconcile standard
+(``docs/decisions/spec-reconcile-guards-standard.md``): **every**
+``_OP_*`` constant in ``_read.py`` is introspected live (never a
+hardcoded mirror that can drift) and asserted against the pinned spec
+that actually serves its dispatch leg.
+
+The partition mirrors :func:`~...composites._read._read_sub_op`'s
+dispatch branch byte-for-byte: ``GET`` legs are vSphere Automation
+``/vcenter/*`` paths (mounted on ``/api`` / ``/rest``) and must be
+served by ``vcenter-9.0/vcenter.yaml``; ``POST`` legs are vmomi
+(VI-JSON) methods (routed through ``_post_vmomi_json`` onto the
+``/sdk/vim25`` mount, #2466) and must be served by
+``vcenter-9.0/vi-json.yaml``.
+
+Both shelf-backed tests skip uniformly when the spec shelf is
+unconfigured (the #2980 harness contract) and run for real in CI, where
+the ``vcenter-9.0`` checkout is armed. The always-on pin test freezes
+the corrected constant strings so a regression to the unserved DRS path
+is caught even without the shelf (the portgroup lane's convention).
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vmware_rest.composites import _read
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+
+def _swept_op_ids() -> dict[str, str]:
+    """Every ``_OP_*`` op_id constant in ``_read``, introspected live."""
+    ops: dict[str, str] = {}
+    for name in dir(_read):
+        if not name.startswith("_OP_"):
+            continue
+        value = getattr(_read, name)
+        if isinstance(value, str):
+            ops[name] = value
+    return ops
+
+
+def _manifest_union() -> set[str]:
+    """Union of every ``_SUB_OPS_*`` tuple in ``_read``, introspected live."""
+    union: set[str] = set()
+    for name in dir(_read):
+        if name.startswith("_SUB_OPS_"):
+            union.update(getattr(_read, name))
+    return union
+
+
+def _partition_by_dispatch_leg() -> tuple[set[str], set[str]]:
+    """Split the swept op_ids by ``_read_sub_op``'s dispatch branch.
+
+    Returns ``(rest, vim)``: ``GET`` legs dispatch on the Automation
+    mount and reconcile against ``vcenter.yaml``; every other method is
+    a vmomi POST on the VI-JSON mount and reconciles against
+    ``vi-json.yaml``.
+    """
+    rest: set[str] = set()
+    vim: set[str] = set()
+    for op_id in _swept_op_ids().values():
+        method, _, _ = op_id.partition(":")
+        (rest if method == "GET" else vim).add(op_id)
+    return rest, vim
+
+
+def test_every_op_constant_is_manifested_and_every_manifest_entry_is_a_constant() -> None:
+    """The ``_OP_*`` sweep and the ``_SUB_OPS_*`` manifests agree exactly.
+
+    The exhaustiveness contract behind #2986's "every op_id constant is
+    asserted by a lane": a new ``_OP_*`` constant that never lands in a
+    composite manifest, or a raw path literal smuggled into a
+    ``_SUB_OPS_*`` tuple without a swept constant, both fail here -- so
+    the shelf-backed lanes below always cover the full live surface.
+    """
+    swept = set(_swept_op_ids().values())
+    manifested = _manifest_union()
+    assert swept, "introspection found no _OP_* constants -- wiring broke"
+    assert swept == manifested, (
+        f"_OP_* constants not in any _SUB_OPS_* manifest: {sorted(swept - manifested)}; "
+        f"manifest entries with no _OP_* constant: {sorted(manifested - swept)}"
+    )
+
+
+def test_read_sub_op_constants_are_the_reconciled_keys() -> None:
+    """Pin the corrected op_id strings (sandbox-safe, always runs).
+
+    The shelf-backed lanes below skip without the spec shelf; this pin
+    runs everywhere and freezes the reconciled keys, so a regression to
+    the unserved ``GET:/vcenter/cluster/{cluster}/drs`` path (the #2970
+    adjacent finding this task fixed) is caught even in the sandbox.
+    """
+    rest, vim = _partition_by_dispatch_leg()
+    assert rest == {
+        "GET:/vcenter/cluster/{cluster}",
+        "GET:/vcenter/datastore",
+        "GET:/vcenter/datastore/{datastore}",
+        "GET:/vcenter/network",
+        "GET:/vcenter/vm",
+    }
+    assert vim == {
+        "POST:/EventManager/{moId}/QueryEvents",
+        "POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric",
+        "POST:/PerformanceManager/{moId}/QueryPerf",
+        "POST:/PropertyCollector/{moId}/RetrievePropertiesEx",
+    }
+    # #2986: the DRS config read rides vim now -- no REST DRS constant
+    # may reappear (the pinned vcenter.yaml serves no cluster DRS
+    # resource at all).
+    assert not hasattr(_read, "_OP_GET_CLUSTER_DRS")
+
+
+def test_rest_read_sub_ops_are_served_by_the_pinned_vcenter_spec() -> None:
+    """Every GET (Automation) sub-op is served by the pinned vcenter.yaml."""
+    spec_path = require_shelf_spec("vcenter-9.0", "vcenter.yaml")
+    served = openapi_served_op_ids(spec_path)
+    rest, _ = _partition_by_dispatch_leg()
+    assert_op_ids_served(rest, served, spec_label="vcenter-9.0/vcenter.yaml")
+
+
+def test_vim_read_sub_ops_are_served_by_the_pinned_vi_json_spec() -> None:
+    """Every POST (vmomi VI-JSON) sub-op is served by the pinned vi-json.yaml."""
+    spec_path = require_shelf_spec("vcenter-9.0", "vi-json.yaml")
+    served = openapi_served_op_ids(spec_path)
+    _, vim = _partition_by_dispatch_leg()
+    assert_op_ids_served(vim, served, spec_label="vcenter-9.0/vi-json.yaml")

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -488,10 +488,12 @@ failure-coping apparatus is gone (Task #2259): the dispatch-time
 exceptions, and the `composite_l2_missing` / `composite_l2_disabled`
 structured errors are deleted, not guarded. The `_SUB_OPS_*` tuples in
 `_read.py` / `_write.py` are retained purely as the canonical
-sub-op-path manifest the ingest-reconcile acceptance guard
-(`tests/acceptance/test_portgroup_audit_op_id_reconcile.py` and
-`tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py`)
-checks against the vCenter spec.
+sub-op-path manifest the spec-reconcile lanes
+(`tests/test_connectors_vmware_rest_composites_read_reconcile.py` — the
+exhaustive read lane, #2986 —
+`tests/test_connectors_vmware_rest_composites_l2_ingest_reconcile.py`,
+and `tests/acceptance/test_portgroup_audit_op_id_reconcile.py`) check
+against the pinned vCenter specs.
 
 The sole remaining safety net is the platform-wide registration-time
 invariant (`operations.composite_invariant`, `#2252`): if any future
@@ -1147,6 +1149,27 @@ they never park.
   DVS host removal (`DistributedVirtualSwitch.ReconfigureDvs_Task` with
   the `config.configVersion` read). The audit's DVS listing was dropped
   (degradation note above).
+- **#2986 read-composite residual + exhaustive read lane** — #2970's
+  sweep covered the write composites; the read side's
+  `_OP_GET_CLUSTER_DRS = "GET:/vcenter/cluster/{cluster}/drs"` was
+  recorded as an adjacent finding (unserved by the pinned
+  `vcenter.yaml`, which has **no** cluster DRS REST resource — the
+  `/vcenter/cluster` family is list/get/evc-mode only). #2986 switched
+  the `cluster.drs_recommendations` DRS leg to vim: one
+  `RetrievePropertiesEx` on the `propertyCollector` singleton reading
+  `ClusterComputeResource.configurationEx.drsConfig`
+  (`ClusterDrsConfigInfo`) and — when
+  `include_recommendations_history=True` — `drsRecommendation` in the
+  same call (the surface `vm.migrate`'s DRS lookup already uses; the
+  response envelope keys are unchanged, `drs` now carries the vim
+  config object). The same task added the exhaustive read lane
+  (`tests/test_connectors_vmware_rest_composites_read_reconcile.py`,
+  #2980 harness): every `_OP_*` constant in `_read.py` is introspected
+  live, cross-checked against the `_SUB_OPS_*` manifests, and asserted
+  against the spec serving its dispatch leg — GET legs vs
+  `vcenter-9.0/vcenter.yaml`, vmomi POST legs vs
+  `vcenter-9.0/vi-json.yaml` — skipping uniformly without the shelf,
+  running for real in CI.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Fixes the #2970 adjacent finding recorded in PR #2974: `_read._OP_GET_CLUSTER_DRS = "GET:/vcenter/cluster/{cluster}/drs"` is not served by the pinned `vcenter.yaml` (the `/vcenter/cluster` REST family is list/get/evc-mode only — **no** cluster DRS resource exists). The `cluster.drs_recommendations` DRS leg switches to the governed vim seam, per the #2970/#2974 pattern; no path was invented — every new surface is spec-verified against the pinned `vi-json.yaml`.
- Completes read-composite lane coverage per the #2980 standard (`docs/decisions/spec-reconcile-guards-standard.md`): a new seconds-cheap reconcile lane (`backend/tests/test_connectors_vmware_rest_composites_read_reconcile.py`) introspects **every** `_OP_*` constant in `composites/_read.py` live, cross-checks the `_SUB_OPS_*` manifests for exhaustiveness, and asserts each op_id against the spec serving its dispatch leg — GET legs vs `vcenter-9.0/vcenter.yaml`, vmomi POST legs vs `vcenter-9.0/vi-json.yaml`. Parse-only, unit-sweep placement, uniform skip without the shelf. No `ci.yml` change — `vcenter-9.0` is already in the armed spec-shelf checkout.

## Per-op decision table

| # | Old op_id (not served) | Decision | New surface (serving spec section) |
|---|---|---|---|
| 1 | `GET:/vcenter/cluster/{cluster}/drs` (`_read._OP_GET_CLUSTER_DRS`, `cluster.drs_recommendations`) | **vim switch** | One `POST:/PropertyCollector/{moId}/RetrievePropertiesEx` (singleton `propertyCollector`) reading `ClusterComputeResource.configurationEx.drsConfig` (`ClusterConfigInfoEx.drsConfig` is required in the pinned schema; `ClusterDrsConfigInfo`: `enabled` / `defaultVmBehavior` / `vmotionRate` / ...). When `include_recommendations_history=True`, the same call's `pathSet` widens with `drsRecommendation` (`ClusterDrsRecommendation[]` — deprecated since VI 2.5 but served by the pinned spec; the exact surface and tradeoff PR #2974 already recorded for `vm.migrate`'s DRS lookup). Response envelope keys unchanged (`cluster` / `drs` / optional `recommendations_history`); `drs` now carries the vim config object, `{}` when unset. |

All other `_read.py` op_ids verified served: `GET:/vcenter/cluster/{cluster}`, `GET:/vcenter/datastore`, `GET:/vcenter/datastore/{datastore}`, `GET:/vcenter/vm`, `GET:/vcenter/network` (vcenter.yaml); `POST:/EventManager/{moId}/QueryEvents`, `POST:/PerformanceManager/{moId}/QueryAvailablePerfMetric`, `POST:/PerformanceManager/{moId}/QueryPerf` (vi-json.yaml) — no other repoint needed.

## Lane design

- Declared set is introspected from the live constants (never a hardcoded mirror): all `_OP_*` strings, partitioned by `_read_sub_op`'s actual dispatch branch (GET → Automation mount → vcenter.yaml; POST → `_post_vmomi_json` → vi-json.yaml).
- An always-on exhaustiveness test pins `set(_OP_*) == union(_SUB_OPS_*)` so a constant outside every manifest, or a raw literal smuggled into a manifest, fails sandbox-side.
- An always-on pin test freezes the corrected keys (and `assert not hasattr(_read, "_OP_GET_CLUSTER_DRS")`) — the portgroup lane's convention.
- Both shelf-backed tests use the #2980 harness (`require_shelf_spec` / `openapi_served_op_ids` / `assert_op_ids_served`); measured cost armed: ~1.3 s (vcenter.yaml) + ~2.6 s (vi-json.yaml) parse — inside the reconcile-lane placement rule (unit sweep, no gating).

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/` — no new errors (one pre-existing darwin-only `net/icmp.py` `MSG_ERRQUEUE` artifact; Linux CI unaffected)
- [x] Acceptance criterion 1 — every `_read.py` op_id constant asserted by a lane: new module's 4 tests green armed (`MEHO_CONSUMER_DOCS_ROOT` → pinned shelf)
- [x] Acceptance criterion 2 — all vmware spec lanes green against the real shelf: `test_spec_shelf_example_lane` + `test_spec_shelf_harness` + `composites_l2_ingest_reconcile` + `portgroup_audit_op_id_reconcile` (acceptance) + new read lane = **53 passed / 0 failed** armed; **38 passed / 15 skipped** (skip-clean, 0.83 s) without env
- [x] Composite behavior tests updated + green, incl. reworked DRS tests (call order, vmomi routing via `_post_vmomi_json` — never the Automation mount, filter-spec body shape, history-flag pathSet widening, unset-prop + legacy-envelope degradation, load-bearing error propagation)
- [x] Full unit sweep as CI runs it (`pytest -n 3 --dist loadscope --ignore=tests/integration --ignore=tests/migrations`) — **11795 passed / 69 skipped / 0 failed**. Three tests deselected as proven-pre-existing darwin-sandbox artifacts (each fails identically on clean `origin/main` with my diff stashed; all outside this change's blast radius; Linux CI unaffected): `test_connectors_net_icmp.py::test_trace_reaches_loopback` (raw-socket loopback trace), `test_connectors_net_dns_lookup.py::test_chosen_resolver_queries_that_nameserver` (real resolver egress), `test_chart_mcp_resource_uri.py::test_no_mcp_env_keys_when_ingress_disabled_and_nothing_set` (local helm v4.2.3 vs CI's v3 renderer)
- [x] `code-quality.py --diff` — 0 blockers (5 warnings, all pre-existing legacy debt in touched files)

## Out of scope / adjacent findings

- `docs/codebase/connectors-vmware-rest.md` still says "seven module-level read handlers" (five since #2258) and describes the spec-shelf as "not provisioned in public-repo CI" (armed since #2949/#2966) — pre-existing drift beyond this task's sections; my edits touch only the manifest-guard sentence and add the #2986 bullet.
- `docs/cross-repo/g316-vmware-write-activation.md` still shows pre-#2970 paths in narrative examples (the #2971 docs sweep owns that surface).
- The l2 write lane's `_vi_json_path_item_has_post` line-scan predates the #2980 harness; vi-json.yaml parses in ~2.6 s now, so it could migrate to `openapi_served_op_ids` for byte-for-byte op_id equality — deliberate non-change here (out of scope).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2986
