### PR TITLE
fix(checks): advisory locks pinned to one connection — end the silent zero-claim ticks (#3010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,31 @@ connector-related release-notes line.
   MANIFEST) that the lane parses. All five op_ids are served; no path
   repoints were needed.
 
+### Fixed — sensor-runner advisory lock leaked onto idle pooled connections, silently starving evaluations (#3010)
+
+- Every background tick loop (sensor runner, agent scheduler, event
+  drain, agent-run reaper, gateway dead-man sweeper) took its
+  `pg_try_advisory_lock` on the tick's pooled work session and committed
+  inside the locked region — each commit returns the session's
+  connection, so the `finally` unlock landed on a *different* connection
+  (PG warns `you don't own a lock`, returns `false`, nothing raises) and
+  the lock stranded on an idle pooled connection. Every later tick that
+  drew any other connection silently claimed nothing: a 300 s sensor
+  recorded 75–118 evaluations/day (expected 288) while the #2763
+  watchdog read healthy. Locks now live on a dedicated pinned connection
+  (`meho_backplane/db/advisory.py::advisory_lock`) so work-session
+  commits can never move them; the invariant — advisory lock and unlock
+  must run on the same connection — is documented on the runner and
+  scheduler pages and regression-tested against real PG (`pg_locks`
+  probes, cross-connection-commit shape).
+- Lock-miss ticks are visible: structured skip logs per subsystem
+  (`sensor_tick_lock_busy`, `scheduler_tick_lock_busy`, …), a new
+  `advisory_lock_busy_total{subsystem}` Prometheus counter, and the
+  `sensor_runner` health facet gains `seconds_since_last_claim` — a
+  claim-based liveness number that keeps growing when the loop ticks
+  without ever winning the lock, the signature `seconds_since_last_tick`
+  was structurally blind to.
+
 ### Added — sddc-manager real-spec reconcile lane (#2982)
 
 - Every hand-coded `METHOD:/path` the sddc-manager connector dispatches

--- a/backend/src/meho_backplane/agent/reaper.py
+++ b/backend/src/meho_backplane/agent/reaper.py
@@ -48,6 +48,13 @@ session-level advisory lock on a fixed key, acquired non-blocking,
 elects one replica per tick. The replica that loses the race skips
 the sweep entirely; the next cadence is its chance to re-elect.
 
+The lock is hosted on a dedicated pinned connection
+(:func:`meho_backplane.db.advisory.advisory_lock`, #3010) -- **advisory
+lock and unlock must run on the same connection**. The tick commits its
+transitions before unlocking; a lock taken on the work session would
+strand on the pooled connection that commit releases, and every later
+tick drawing a different connection would skip the sweep silently.
+
 On SQLite (the dev / test path) the lock is a no-op: the test process
 is single-replica so there is nothing to elect.
 
@@ -103,9 +110,10 @@ from datetime import UTC, datetime
 from decimal import Decimal
 
 import structlog
-from sqlalchemy import select, text
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from meho_backplane.db.advisory import advisory_lock
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
     AgentRun,
@@ -166,41 +174,6 @@ _AUDIT_PATH_RESUME = "internal/agent-run/reaper/clear-for-resume"
 AGENT_RUN_REAPER_INTERRUPTION_REASON = (
     "interrupted: lease expired -- worker died mid-flight (reaped by agent_run_reaper)"
 )
-
-
-async def _try_advisory_lock(session: AsyncSession, key: int) -> bool:
-    """Acquire a session-level PG advisory lock; ``True`` on non-PG.
-
-    Returns ``True`` when the lock is held (or the dialect has no
-    advisory locks, i.e. the single-replica SQLite test path) and the
-    caller should proceed with the sweep; ``False`` when another
-    replica holds it and this tick should be skipped.
-
-    Same shape as
-    :func:`meho_backplane.topology.scheduler._try_advisory_lock` --
-    duplicated rather than imported so the reaper does not pull in
-    the topology package (different feature surface, different
-    lifespan ordering).
-    """
-    conn = await session.connection()
-    if conn.dialect.name != "postgresql":
-        return True
-    locked = await session.scalar(text("SELECT pg_try_advisory_lock(:k)"), {"k": key})
-    return bool(locked)
-
-
-async def _release_advisory_lock(session: AsyncSession, key: int) -> None:
-    """Release the session-level PG advisory lock; no-op on non-PG.
-
-    The advisory lock is released explicitly at the end of every tick
-    so the connection can be returned to the pool clean. PG would
-    release it on session close anyway, but the asyncpg pool may
-    reuse the connection before close.
-    """
-    conn = await session.connection()
-    if conn.dialect.name != "postgresql":
-        return
-    await session.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": key})
 
 
 def _stage_audit_row(
@@ -360,11 +333,13 @@ async def _run_one_tick() -> None:
     now = datetime.now(UTC)
     settings = get_settings()
     sessionmaker = get_sessionmaker()
-    async with sessionmaker() as session:
-        if not await _try_advisory_lock(session, _REAPER_ADVISORY_LOCK_KEY):
+    # #3010: the lock rides a dedicated pinned connection — the tick's
+    # commit would strand a lock taken on the work session.
+    async with advisory_lock(_REAPER_ADVISORY_LOCK_KEY, subsystem="agent_run_reaper") as locked:
+        if not locked:
             _log.debug("agent_run_reaper_tick_skipped_lock_held")
             return
-        try:
+        async with sessionmaker() as session:
             # ``select ... where status='running' AND lease_expires_at < now``
             # -- the partial index drives this on PG. The LIMIT bounds
             # the per-tick work; a backlog is drained across multiple
@@ -438,8 +413,6 @@ async def _run_one_tick() -> None:
                 cleared_for_resume=outcomes.get("cleared", 0),
                 duration_ms=duration_ms,
             )
-        finally:
-            await _release_advisory_lock(session, _REAPER_ADVISORY_LOCK_KEY)
 
 
 async def _reaper_loop() -> None:

--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -221,11 +221,21 @@ class SensorRunnerStatus(BaseModel):
     always a number. The value is per-process: each replica reports its
     own loop, which is exactly the failure mode observed (one process's
     loop coroutine going quiet).
+
+    ``seconds_since_last_claim`` (#3010) measures from the last tick
+    that actually **held** the runner's advisory lock. It diverges from
+    ``seconds_since_last_tick`` when the loop is alive but never winning
+    the lock — the stranded-lock starvation ``stalled`` is structurally
+    blind to (every tick completes; nothing is ever claimed). Per-process
+    and informational: on a multi-replica deploy only the lock-winning
+    replica's claim stamp advances, so alert on the minimum across
+    replicas, not per pod.
     """
 
     model_config = ConfigDict(frozen=True)
 
     seconds_since_last_tick: float | None
+    seconds_since_last_claim: float | None
     stalled: bool
     stall_threshold_seconds: float
 
@@ -545,6 +555,7 @@ def _sensor_runner_status() -> SensorRunnerStatus | None:
     liveness = sensor_runner_liveness()
     return SensorRunnerStatus(
         seconds_since_last_tick=liveness.seconds_since_last_tick,
+        seconds_since_last_claim=liveness.seconds_since_last_claim,
         stalled=liveness.stalled,
         stall_threshold_seconds=liveness.stall_threshold_seconds,
     )

--- a/backend/src/meho_backplane/checks/runner.py
+++ b/backend/src/meho_backplane/checks/runner.py
@@ -32,7 +32,15 @@ Replica-safety (copied from ``scheduler/loop.py``'s belt-and-braces)
 Each tick acquires a process-wide ``pg_try_advisory_lock`` under
 :data:`_SENSOR_RUNNER_ADVISORY_LOCK_KEY` (a fixed 63-bit key distinct from the
 scheduler's ``_SCHEDULER_ADVISORY_LOCK_KEY`` and the topology per-target
-keyspace) so only one replica runs the tick body at a time. Due rows are
+keyspace) so only one replica runs the tick body at a time. The lock is
+hosted on a dedicated pinned connection via
+:func:`meho_backplane.db.advisory.advisory_lock` — **advisory lock and
+unlock must run on the same connection** (#3010): the tick body commits
+per claimed row, and a lock taken on the work session would strand on
+the pooled connection the first commit releases, silently starving every
+later tick that draws a different connection. A lock-miss tick logs
+``sensor_tick_lock_busy`` and counts on ``advisory_lock_busy_total``;
+it stamps the watchdog's tick facet but not its claim facet. Due rows are
 claimed with ``FOR UPDATE SKIP LOCKED`` and each claimed row's ``next_fire_at``
 is advanced by a conditional ``UPDATE ... WHERE next_fire_at=:previous`` that
 commits *before* dispatch. The advisory lock alone leaves the SQLite test path
@@ -120,8 +128,6 @@ from datetime import UTC, datetime, timedelta
 from typing import cast
 
 import structlog
-from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.runner_identity import (
@@ -139,6 +145,7 @@ from meho_backplane.checks.repository import (
     record_sensor_result,
 )
 from meho_backplane.checks.watchdog import note_tick_completed, reset_watchdog_state
+from meho_backplane.db.advisory import advisory_lock
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Sensor
 from meho_backplane.operations.dispatcher import dispatch
@@ -271,29 +278,6 @@ class _SensorSnapshot:
             assertion=row.assertion,
             identity_sub=row.identity_sub,
         )
-
-
-async def _try_advisory_lock(session: AsyncSession, key: int) -> bool:
-    """Acquire the process-wide PG advisory lock; ``True`` on non-PG.
-
-    Returns ``True`` when the lock is held (or the dialect has no advisory
-    locks -- the SQLite single-replica test path) and the caller should
-    proceed; ``False`` when another replica holds it and this tick is skipped.
-    Mirrors :func:`meho_backplane.scheduler.loop._try_advisory_lock`.
-    """
-    conn = await session.connection()
-    if conn.dialect.name != "postgresql":
-        return True
-    locked = await session.scalar(text("SELECT pg_try_advisory_lock(:k)"), {"k": key})
-    return bool(locked)
-
-
-async def _advisory_unlock(session: AsyncSession, key: int) -> None:
-    """Release the advisory lock; no-op on non-PG dialects."""
-    conn = await session.connection()
-    if conn.dialect.name != "postgresql":
-        return
-    await session.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": key})
 
 
 async def _sensor_operator(snap: _SensorSnapshot) -> Operator:
@@ -566,24 +550,44 @@ async def run_one_sensor_tick() -> int:
     Every *completed* tick -- including the lock-not-acquired no-op -- stamps
     the #2763 watchdog via :func:`~meho_backplane.checks.watchdog.note_tick_completed`
     (which also emits the recovery event when a stall was flagged, and never
-    raises). A tick that raises deliberately does not stamp: a loop that fails
-    every tick is a stalled evaluation plane and must trip the watchdog.
+    raises); only a lock-acquired tick also stamps the claim facet
+    (``lock_acquired``, #3010), so a runner starved by a stranded or
+    contended lock stays visible on ``seconds_since_last_claim`` while its
+    loop still reads alive. A tick that raises deliberately does not stamp: a
+    loop that fails every tick is a stalled evaluation plane and must trip the
+    watchdog.
     """
-    dispatched = await _claim_and_spawn_due()
-    await note_tick_completed()
+    lock_acquired, dispatched = await _claim_and_spawn_due()
+    await note_tick_completed(lock_acquired=lock_acquired)
     return dispatched
 
 
-async def _claim_and_spawn_due() -> int:
-    """The tick body: claim + advance under the lock, then spawn evaluations."""
+async def _claim_and_spawn_due() -> tuple[bool, int]:
+    """The tick body: claim + advance under the lock, then spawn evaluations.
+
+    Returns ``(lock_acquired, dispatched)`` so the caller can stamp the
+    watchdog's claim facet only for ticks that actually held the lock.
+
+    The advisory lock lives on its own pinned connection
+    (:func:`~meho_backplane.db.advisory.advisory_lock`, #3010) while the
+    claim/advance work runs on a separate session that commits per row.
+    Lock and unlock must run on the same connection: taken on the work
+    session, the first per-row commit would return that connection to the
+    pool, the ``finally`` unlock would land on a different one, and the
+    lock would strand on an idle pooled connection -- every later tick
+    drawing any other connection would skip silently (#3010's observed
+    ~35-50 % cadence).
+    """
     now = datetime.now(UTC)
     to_dispatch: list[_SensorSnapshot] = []
-    sessionmaker = get_sessionmaker()
-    async with sessionmaker() as session:
-        locked = await _try_advisory_lock(session, _SENSOR_RUNNER_ADVISORY_LOCK_KEY)
+    async with advisory_lock(_SENSOR_RUNNER_ADVISORY_LOCK_KEY, subsystem="sensor_runner") as locked:
         if not locked:
-            return 0
-        try:
+            # #3010: the silent zero-claim tick made the stranded-lock class
+            # invisible; the log + the helper's counter make it observable.
+            _log().info("sensor_tick_lock_busy")
+            return (False, 0)
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
             rows = await claim_due_sensors(session, now=now, limit=_CLAIM_BATCH_LIMIT)
             for row in rows:
                 try:
@@ -617,9 +621,6 @@ async def _claim_and_spawn_due() -> int:
                     # Per-row isolation: one bad row never stalls the tick.
                     _log().exception("sensor_tick_row_failed", sensor_id=str(row.id))
                     await session.rollback()
-        finally:
-            await _advisory_unlock(session, _SENSOR_RUNNER_ADVISORY_LOCK_KEY)
-            await session.commit()
 
     # Advisory lock released, advances committed. Spawn the evaluations as
     # background tasks -- never awaited here (the #1502 lock-wedge class).
@@ -627,7 +628,7 @@ async def _claim_and_spawn_due() -> int:
     for snap in to_dispatch:
         if _spawn_evaluation(snap):
             dispatched += 1
-    return dispatched
+    return (True, dispatched)
 
 
 async def _runner_loop() -> None:

--- a/backend/src/meho_backplane/checks/watchdog.py
+++ b/backend/src/meho_backplane/checks/watchdog.py
@@ -125,6 +125,18 @@ __all__ = [
 #: lock-not-acquired no-op ticks — see the module docstring).
 _LAST_TICK_COMPLETED_AT: datetime | None = None
 
+#: When the last tick that actually **held the advisory lock** finished,
+#: per process (#3010). A lock-miss tick proves the loop coroutine is
+#: alive but not that this process is evaluating anything — the observed
+#: failure mode was a lock stranded on an idle pooled connection: every
+#: tick completed, ``seconds_since_last_tick`` stayed green, and zero
+#: sensors were claimed for hours. This stamp feeds the
+#: ``seconds_since_last_claim`` facet so that class is visible. On a
+#: multi-replica deploy only the lock-winning replica's claim stamp
+#: advances — which is why ``stalled`` deliberately stays keyed on the
+#: tick stamp, not this one.
+_LAST_CLAIM_AT: datetime | None = None
+
 #: Watchdog start instant — the staleness reference until the first tick
 #: completes, so a runner that never manages a single tick still trips
 #: the detector instead of hiding behind a ``None`` stamp.
@@ -161,9 +173,21 @@ class SensorRunnerLiveness:
     directly). ``stalled`` is derived live from the stamp against the
     threshold on every read, deliberately **not** from the watchdog's
     emission latch, so a dead watchdog task cannot blind the health facet.
+
+    ``seconds_since_last_claim`` (#3010) measures from the last tick that
+    actually **held** the advisory lock (falling back to the watchdog
+    start, like the tick reference). It diverges from
+    ``seconds_since_last_tick`` exactly when the loop is alive but never
+    winning the lock — the stranded-lock starvation the tick facet is
+    structurally blind to. It is per-process and informational: on a
+    multi-replica deploy the non-leader replicas' claim staleness grows
+    legitimately, so ``stalled`` stays keyed on the tick stamp and an
+    external prober alerts on claim staleness fleet-wide (min across
+    replicas), not per pod.
     """
 
     seconds_since_last_tick: float | None
+    seconds_since_last_claim: float | None
     stalled: bool
     stall_threshold_seconds: float
 
@@ -174,8 +198,9 @@ def reset_watchdog_state() -> None:
     Called from :func:`meho_backplane.checks.runner.reset_sensor_runner_state`
     so the runner test fixtures reset both modules in one place.
     """
-    global _LAST_TICK_COMPLETED_AT, _BASELINE, _STALLED_SINCE, _STALL_TENANTS
+    global _LAST_TICK_COMPLETED_AT, _LAST_CLAIM_AT, _BASELINE, _STALLED_SINCE, _STALL_TENANTS
     _LAST_TICK_COMPLETED_AT = None
+    _LAST_CLAIM_AT = None
     _BASELINE = None
     _STALLED_SINCE = None
     _STALL_TENANTS = ()
@@ -213,15 +238,21 @@ def sensor_runner_liveness(now: datetime | None = None) -> SensorRunnerLiveness:
     check_at = now if now is not None else datetime.now(UTC)
     threshold = _stall_threshold_seconds()
     reference = _staleness_reference()
+    claim_reference = _LAST_CLAIM_AT if _LAST_CLAIM_AT is not None else _BASELINE
+    claim_seconds = (
+        (check_at - claim_reference).total_seconds() if claim_reference is not None else None
+    )
     if reference is None:
         return SensorRunnerLiveness(
             seconds_since_last_tick=None,
+            seconds_since_last_claim=claim_seconds,
             stalled=False,
             stall_threshold_seconds=threshold,
         )
     quiet_seconds = (check_at - reference).total_seconds()
     return SensorRunnerLiveness(
         seconds_since_last_tick=quiet_seconds,
+        seconds_since_last_claim=claim_seconds,
         stalled=quiet_seconds > threshold,
         stall_threshold_seconds=threshold,
     )
@@ -237,20 +268,30 @@ async def _active_sensor_tenant_ids() -> list[uuid.UUID]:
         return list(rows)
 
 
-async def note_tick_completed(now: datetime | None = None) -> None:
+async def note_tick_completed(now: datetime | None = None, *, lock_acquired: bool = True) -> None:
     """Stamp a completed runner tick; emit recovery if a stall was flagged.
 
     Called by :func:`~meho_backplane.checks.runner.run_one_sensor_tick` on
-    every completed tick. **Never raises**: the stamp and the stall-latch
-    clear commit before any emission, and the emission block is guarded,
-    so a broadcast or logging failure cannot fail the tick that proved
-    the loop alive. *now* is injectable for deterministic tests.
+    every completed tick. *lock_acquired* (#3010) says whether the tick
+    actually held the advisory lock: only those ticks stamp the claim
+    facet, so a loop that completes every tick but never wins the lock (a
+    stranded lock on an idle pooled connection, or genuine multi-replica
+    contention) shows a growing ``seconds_since_last_claim`` instead of
+    reading fully healthy. The tick stamp itself is unconditional — a
+    lock-miss tick still proves the loop coroutine alive, which is the
+    stall class the tick facet exists for. **Never raises**: the stamp and
+    the stall-latch clear commit before any emission, and the emission
+    block is guarded, so a broadcast or logging failure cannot fail the
+    tick that proved the loop alive. *now* is injectable for
+    deterministic tests.
     """
-    global _LAST_TICK_COMPLETED_AT, _STALLED_SINCE, _STALL_TENANTS
+    global _LAST_TICK_COMPLETED_AT, _LAST_CLAIM_AT, _STALLED_SINCE, _STALL_TENANTS
     stamp = now if now is not None else datetime.now(UTC)
     stalled_since = _STALLED_SINCE
     notified = _STALL_TENANTS
     _LAST_TICK_COMPLETED_AT = stamp
+    if lock_acquired:
+        _LAST_CLAIM_AT = stamp
     if stalled_since is None:
         return
     _STALLED_SINCE = None

--- a/backend/src/meho_backplane/db/advisory.py
+++ b/backend/src/meho_backplane/db/advisory.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Session-level PG advisory locks pinned to one connection (#3010).
+
+Invariant: **the advisory lock and unlock must run on the same DBAPI
+connection.** ``pg_try_advisory_lock`` takes a *session-level* lock owned
+by the connection it executes on; only ``pg_advisory_unlock`` issued on
+that same connection (or the connection actually closing) releases it.
+A transaction commit or rollback does not.
+
+Why a dedicated connection
+==========================
+
+An :class:`~sqlalchemy.ext.asyncio.AsyncSession` releases its pooled
+connection on every ``commit()``; the next statement autobegins on
+whatever connection the pool hands out next. A tick body that locks on
+its work session and then commits mid-lock therefore unlocks on a
+*different* connection: PostgreSQL answers ``WARNING: you don't own a
+lock of type ExclusiveLock``, returns ``false``, nothing raises, and the
+lock strands on the original connection — now idle in the pool. Every
+later tick that draws any other connection reads the key as held and
+skips silently. That was #3010: the sensor runner delivered ~35-50 % of
+its expected evaluations while ``pg_locks`` showed an *idle* holder of
+the runner key, and the #2763 watchdog stamped every lock-miss tick as
+healthy.
+
+:func:`advisory_lock` closes the hole by hosting the lock on a dedicated
+:meth:`~sqlalchemy.ext.asyncio.AsyncEngine.connect` connection that
+carries **only** the lock/unlock statements. The caller's own sessions
+commit freely inside the block without ever migrating the lock's
+ownership, and the ``finally`` unlock provably lands on the connection
+that acquired the key. The same shape has run correctly in
+:mod:`meho_backplane.topology.scheduler` (its ``lock_session`` never
+commits) since G9.1.
+
+Why not ``pg_try_advisory_xact_lock``
+=====================================
+
+A transaction-scoped lock dies at the first ``COMMIT``. Every consumer
+of this helper must commit *inside* the locked region (the
+claim/advance-before-dispatch durability discipline), so an xact lock
+would silently evaporate mid-batch. The session-level lock on a pinned
+connection keeps the whole tick body covered.
+
+Cost: one extra pooled connection is checked out per subsystem for the
+duration of its tick. With five lock-holding loops and the default pool
+size of 10 that is well inside budget; the lock connection runs two
+trivial ``SELECT``\\ s and is returned on block exit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import cast
+
+import structlog
+from sqlalchemy import text
+
+from meho_backplane.db.engine import get_engine
+from meho_backplane.metrics import ADVISORY_LOCK_BUSY_TOTAL
+
+__all__ = ["advisory_lock"]
+
+
+def _log() -> structlog.typing.FilteringBoundLogger:
+    """Resolve the structlog logger per call (not a module-level proxy).
+
+    Same discipline as :mod:`meho_backplane.checks.runner`: a module-level
+    proxy caches its bound methods on first use under the production
+    ``cache_logger_on_first_use=True`` config, orphaning them from a later
+    :func:`structlog.testing.capture_logs`.
+    """
+    return cast("structlog.typing.FilteringBoundLogger", structlog.get_logger(__name__))
+
+
+@asynccontextmanager
+async def advisory_lock(key: int, *, subsystem: str) -> AsyncIterator[bool]:
+    """Hold the session-level PG advisory lock *key* on a pinned connection.
+
+    Yields ``True`` when the lock was acquired (or the engine dialect has
+    no advisory locks — the SQLite single-replica test path) and the
+    caller should run its tick body; yields ``False`` when another holder
+    owns *key* and the caller should skip. On acquisition the lock is
+    hosted on a dedicated connection checked out for the whole ``async
+    with`` block, so the caller's work sessions may commit freely without
+    ever moving the lock, and the unlock in the ``finally`` runs on the
+    very connection that acquired it (the #3010 invariant).
+
+    *subsystem* labels the ``advisory_lock_busy_total`` counter
+    incremented on a miss and the ``advisory_unlock_failed`` tripwire
+    log. Callers add their own subsystem-vocabulary skip log next to the
+    ``False`` branch; the counter here is the uniform cross-subsystem
+    surface.
+    """
+    engine = get_engine()
+    if engine.dialect.name != "postgresql":
+        yield True
+        return
+    async with engine.connect() as conn:
+        locked = bool(await conn.scalar(text("SELECT pg_try_advisory_lock(:k)"), {"k": key}))
+        if not locked:
+            ADVISORY_LOCK_BUSY_TOTAL.labels(subsystem=subsystem).inc()
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            try:
+                released = bool(
+                    await conn.scalar(text("SELECT pg_advisory_unlock(:k)"), {"k": key})
+                )
+            except BaseException:
+                # The unlock could not run (cancellation delivered during
+                # cleanup, connection died mid-tick). Invalidate so the raw
+                # connection is closed instead of returning to the pool
+                # still owning the lock — closing the connection is what
+                # releases a session-level advisory lock server-side.
+                await conn.invalidate()
+                raise
+            if not released:
+                # Tripwire: with lock + unlock pinned to one connection
+                # this cannot fire; if it does, the #3010 invariant has
+                # regressed somewhere between acquire and here.
+                _log().warning("advisory_unlock_failed", subsystem=subsystem, key=key)

--- a/backend/src/meho_backplane/events/drain.py
+++ b/backend/src/meho_backplane/events/drain.py
@@ -10,7 +10,14 @@ event-subscription trigger. On each cadence (default 10s, settable via
 1. **Claim the process-wide advisory lock**
    (``pg_try_advisory_lock``) so only one replica's drain is running
    the tick body at a time. Mirrors the scheduler-loop precedent
-   (:mod:`meho_backplane.scheduler.loop`).
+   (:mod:`meho_backplane.scheduler.loop`). The lock lives on a
+   dedicated pinned connection
+   (:func:`meho_backplane.db.advisory.advisory_lock`, #3010) —
+   **advisory lock and unlock must run on the same connection**: the
+   tick commits mid-lock (the claim stamp, each processed stamp), and a
+   lock taken on the work session would strand on the pooled connection
+   the first commit releases, silently skipping every later drain tick
+   that draws a different connection.
 
 2. **Scan + claim unprocessed rows** via
    ``SELECT ... WHERE processed_at IS NULL ORDER BY event_id LIMIT N
@@ -26,8 +33,9 @@ event-subscription trigger. On each cadence (default 10s, settable via
    no subscriber is still durably consumed (stamped, no fire, no log
    noise).
 
-4. **Release the advisory lock** in a ``finally`` so a crash mid-tick
-   never strands the lock for the rest of the connection's life.
+4. **Release the advisory lock** on the same pinned connection that
+   acquired it (the helper's ``finally``) so a crash mid-tick never
+   strands the lock for the rest of the connection's life.
 
 LISTEN/NOTIFY wake hint
 =======================
@@ -93,9 +101,10 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import structlog
-from sqlalchemy import select, text, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from meho_backplane.db.advisory import advisory_lock
 from meho_backplane.db.engine import get_engine, get_sessionmaker
 from meho_backplane.db.models import EVENT_OUTBOX_NOTIFY_CHANNEL, EventOutbox
 from meho_backplane.settings import get_settings
@@ -138,29 +147,6 @@ def _claimer_identity() -> str:
     the offending pod / process from this stamp.
     """
     return f"{socket.gethostname()}:{os.getpid()}"
-
-
-async def _try_advisory_lock(session: AsyncSession, key: int) -> bool:
-    """Acquire the process-wide PG advisory lock; ``True`` on non-PG."""
-    conn = await session.connection()
-    if conn.dialect.name != "postgresql":
-        return True
-    locked = await session.scalar(
-        text("SELECT pg_try_advisory_lock(:k)"),
-        {"k": key},
-    )
-    return bool(locked)
-
-
-async def _advisory_unlock(session: AsyncSession, key: int) -> None:
-    """Release the advisory lock; no-op on non-PG dialects."""
-    conn = await session.connection()
-    if conn.dialect.name != "postgresql":
-        return
-    await session.execute(
-        text("SELECT pg_advisory_unlock(:k)"),
-        {"k": key},
-    )
 
 
 async def _claim_unprocessed(
@@ -304,16 +290,19 @@ async def run_one_drain_tick(invoker: AgentInvoker | None = None) -> int:
         from meho_backplane.agent.invocation import get_agent_invoker
 
         invoker = get_agent_invoker()
-    sessionmaker = get_sessionmaker()
     processed = 0
-    async with sessionmaker() as session:
-        locked = await _try_advisory_lock(
-            session,
-            _EVENT_DRAIN_ADVISORY_LOCK_KEY,
-        )
+    # The advisory lock lives on its own pinned connection (#3010): the
+    # mid-tick commits below (claim stamps, per-row processed stamps)
+    # each return the work session's connection to the pool, so a lock
+    # taken on that session would migrate off it at the first commit and
+    # strand -- silently skipping every later drain tick that draws a
+    # different connection.
+    async with advisory_lock(_EVENT_DRAIN_ADVISORY_LOCK_KEY, subsystem="event_drain") as locked:
         if not locked:
+            _log.debug("event_drain_tick_skipped_lock_held")
             return 0
-        try:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
             now = datetime.now(UTC)
             rows = await _claim_unprocessed(session, limit=_DRAIN_BATCH_LIMIT)
             if not rows:
@@ -328,10 +317,11 @@ async def run_one_drain_tick(invoker: AgentInvoker | None = None) -> int:
             # subscription fires an agent run that commits in its own session,
             # and the drain must hold no open write across that commit (the
             # scheduler-fire precedent -- loop.py commits the trigger-state
-            # write before dispatching). The advisory lock (session-scoped, so
-            # a mid-tick commit does not release it) plus the ``processed_at IS
-            # NULL`` conditional in `_mark_processed` remain the single-
-            # processing guards once the claim's row locks release here.
+            # write before dispatching). The advisory lock (pinned to its own
+            # dedicated connection, which a work-session commit cannot touch)
+            # plus the ``processed_at IS NULL`` conditional in
+            # `_mark_processed` remain the single-processing guards once the
+            # claim's row locks release here.
             await session.commit()
             for row in rows:
                 try:
@@ -351,9 +341,6 @@ async def run_one_drain_tick(invoker: AgentInvoker | None = None) -> int:
                         "event_drain_dispatch_failed",
                         event_id=row.event_id,
                     )
-        finally:
-            await _advisory_unlock(session, _EVENT_DRAIN_ADVISORY_LOCK_KEY)
-            await session.commit()
     return processed
 
 

--- a/backend/src/meho_backplane/gateway/deadman.py
+++ b/backend/src/meho_backplane/gateway/deadman.py
@@ -29,8 +29,11 @@ Design moulds
   scheduler trigger loop.
 * Lapse-then-flip tick body + advisory lock: moulded on the agent-run
   reaper (:mod:`meho_backplane.agent.reaper`) — a fixed non-blocking PG
-  advisory lock elects one replica per tick (no-op on SQLite), the flip
-  is per-row isolated, one internal audit row per flipped runner.
+  advisory lock elects one replica per tick (no-op on SQLite; hosted on
+  a dedicated pinned connection via
+  :func:`meho_backplane.db.advisory.advisory_lock` because the tick
+  commits mid-lock, #3010), the flip is per-row isolated, one internal
+  audit row per flipped runner.
 * Internal audit row: :func:`~meho_backplane.memory.audit.write_internal_audit_row`
   (opens its own session, commits) — mould parity with the memory sweeper.
 
@@ -72,9 +75,10 @@ from datetime import UTC, datetime, timedelta
 
 import sqlalchemy as sa
 import structlog
-from sqlalchemy import select, text, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from meho_backplane.db.advisory import advisory_lock
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import RunnerAssignmentRow, RunnerPrincipal
 from meho_backplane.gateway.queue import GATEWAY_LONGPOLL_MAX_WAIT_SECONDS
@@ -144,29 +148,6 @@ def _as_utc(value: datetime) -> datetime:
     return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
 
 
-async def _try_advisory_lock(session: AsyncSession, key: int) -> bool:
-    """Acquire a session-level PG advisory lock; ``True`` on non-PG.
-
-    Returns ``True`` when the lock is held (or the dialect has no advisory
-    locks, i.e. the single-replica SQLite test path) and the caller should
-    proceed; ``False`` when another replica holds it and this tick should
-    be skipped. Mould: :func:`meho_backplane.agent.reaper._try_advisory_lock`.
-    """
-    conn = await session.connection()
-    if conn.dialect.name != "postgresql":
-        return True
-    locked = await session.scalar(text("SELECT pg_try_advisory_lock(:k)"), {"k": key})
-    return bool(locked)
-
-
-async def _release_advisory_lock(session: AsyncSession, key: int) -> None:
-    """Release the session-level PG advisory lock; no-op on non-PG."""
-    conn = await session.connection()
-    if conn.dialect.name != "postgresql":
-        return
-    await session.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": key})
-
-
 async def _run_one_tick() -> None:
     """One sweep: flip lapsed runners' assignment rows, audit each flip.
 
@@ -189,11 +170,13 @@ async def _run_one_tick() -> None:
     sessionmaker = get_sessionmaker()
     # (tenant_id, runner_name, lapse_seconds) for each flip this tick won.
     flipped: list[tuple[uuid.UUID, str, float]] = []
-    async with sessionmaker() as session:
-        if not await _try_advisory_lock(session, _DEADMAN_ADVISORY_LOCK_KEY):
+    # #3010: the lock rides a dedicated pinned connection — the tick's
+    # commit would strand a lock taken on the work session.
+    async with advisory_lock(_DEADMAN_ADVISORY_LOCK_KEY, subsystem="gateway_deadman") as locked:
+        if not locked:
             _log.debug("gateway_deadman_tick_skipped_lock_held")
             return
-        try:
+        async with sessionmaker() as session:
             candidate_stmt = (
                 select(
                     RunnerAssignmentRow.id,
@@ -237,14 +220,33 @@ async def _run_one_tick() -> None:
                     lapse_seconds = (now - _as_utc(last_seen_at)).total_seconds()
                     flipped.append((tenant_id, runner_name, lapse_seconds))
             await session.commit()
-        finally:
-            await _release_advisory_lock(session, _DEADMAN_ADVISORY_LOCK_KEY)
 
     if not flipped:
         _log.debug("gateway_deadman_tick_clean")
         return
 
     duration_ms = (time.perf_counter() - tick_started) * 1000.0
+    await _audit_flips(flipped, duration_ms=duration_ms)
+    _log.info(
+        "gateway_deadman_tick_done",
+        flipped=len(flipped),
+        threshold_seconds=_threshold_seconds(),
+        duration_ms=duration_ms,
+    )
+
+
+async def _audit_flips(
+    flipped: list[tuple[uuid.UUID, str, float]],
+    *,
+    duration_ms: float,
+) -> None:
+    """Write one internal audit row per won flip, isolating failures.
+
+    Runs after the flips committed (the memory-sweeper ordering: mutate +
+    commit, then audit) and outside the advisory lock — the audit helper
+    opens its own session, and holding a lock across a foreign commit is
+    the #3010 shape this module just shed.
+    """
     for tenant_id, runner_name, lapse_seconds in flipped:
         try:
             await write_internal_audit_row(
@@ -265,12 +267,6 @@ async def _run_one_tick() -> None:
                 tenant_id=str(tenant_id),
                 runner=runner_name,
             )
-    _log.info(
-        "gateway_deadman_tick_done",
-        flipped=len(flipped),
-        threshold_seconds=_threshold_seconds(),
-        duration_ms=duration_ms,
-    )
 
 
 async def clear_runner_stale(

--- a/backend/src/meho_backplane/metrics.py
+++ b/backend/src/meho_backplane/metrics.py
@@ -62,6 +62,22 @@ TOPOLOGY_REFRESH_TOTAL: Counter = Counter(
     labelnames=("outcome",),
 )
 
+#: Counter for background-loop ticks skipped because the subsystem's
+#: process-wide PG advisory lock was already held, partitioned by
+#: ``subsystem`` (``sensor_runner`` / ``scheduler`` / ``event_drain`` /
+#: ``agent_run_reaper`` / ``gateway_deadman``). #3010: a lock-miss tick
+#: used to be a silent ``return 0`` — a stranded lock (the
+#: cross-connection unlock leak) starved the sensor runner to ~35-50 %
+#: cadence with no signal anywhere. Incremented by
+#: :func:`meho_backplane.db.advisory.advisory_lock` so a sustained
+#: non-zero rate on a single-replica deploy is directly alertable.
+#: Same module-level-singleton rationale as ``HTTP_REQUESTS_TOTAL``.
+ADVISORY_LOCK_BUSY_TOTAL: Counter = Counter(
+    "advisory_lock_busy_total",
+    "Background-loop ticks skipped because the advisory lock was held.",
+    labelnames=("subsystem",),
+)
+
 
 def render_metrics() -> tuple[bytes, str]:
     """Render the default registry as Prometheus exposition bytes.

--- a/backend/src/meho_backplane/scheduler/loop.py
+++ b/backend/src/meho_backplane/scheduler/loop.py
@@ -10,8 +10,13 @@ scheduler. On each cadence (default 30s, settable via
 1. **Claim the process-wide advisory lock**
    (``pg_try_advisory_lock``) so only one replica's loop is running the
    tick body at a time. Non-blocking: a replica that loses the race
-   sleeps and tries the next cadence. Mirrors the
-   :mod:`meho_backplane.topology.scheduler` precedent.
+   sleeps and tries the next cadence. The lock lives on a dedicated
+   pinned connection (:func:`meho_backplane.db.advisory.advisory_lock`,
+   #3010) — **advisory lock and unlock must run on the same
+   connection**. The tick body commits per fired row; a lock taken on
+   the work session would strand on the pooled connection the first
+   commit releases, and every later tick drawing a different connection
+   would skip silently (#2245-shaped stalls).
 
 2. **Scan for due rows**
    (:func:`~meho_backplane.scheduler.repository.claim_due_triggers`)
@@ -44,8 +49,9 @@ scheduler. On each cadence (default 30s, settable via
    The ``agent_run`` row's ``trigger`` column is set to
    ``AgentRunTrigger.SCHEDULED`` for provenance.
 
-5. **Release the advisory lock** in a ``finally`` so a crash mid-tick
-   never strands the lock for the rest of the connection's life.
+5. **Release the advisory lock** on the same pinned connection that
+   acquired it (the helper's ``finally``) so a crash mid-tick never
+   strands the lock for the rest of the connection's life.
 
 Per-row failure isolation
 =========================
@@ -127,7 +133,7 @@ from datetime import UTC, datetime
 
 import structlog
 from pydantic import SecretStr
-from sqlalchemy import select, text, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.agent.invocation import (
@@ -139,6 +145,7 @@ from meho_backplane.agent.invocation import (
     get_agent_invoker,
 )
 from meho_backplane.auth.agent_token import AgentTokenError
+from meho_backplane.db.advisory import advisory_lock
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
     AgentDefinition,
@@ -268,35 +275,6 @@ class _ResolvedDefinition:
     name: str
     enabled: bool
     identity_ref: str
-
-
-async def _try_advisory_lock(session: AsyncSession, key: int) -> bool:
-    """Acquire the process-wide PG advisory lock; ``True`` on non-PG.
-
-    Returns ``True`` when the lock is held (or the dialect has no
-    advisory locks -- the SQLite single-replica test path) and the
-    caller should proceed; ``False`` when another replica holds it
-    and this tick is skipped.
-    """
-    conn = await session.connection()
-    if conn.dialect.name != "postgresql":
-        return True
-    locked = await session.scalar(
-        text("SELECT pg_try_advisory_lock(:k)"),
-        {"k": key},
-    )
-    return bool(locked)
-
-
-async def _advisory_unlock(session: AsyncSession, key: int) -> None:
-    """Release the advisory lock; no-op on non-PG dialects."""
-    conn = await session.connection()
-    if conn.dialect.name != "postgresql":
-        return
-    await session.execute(
-        text("SELECT pg_advisory_unlock(:k)"),
-        {"k": key},
-    )
 
 
 async def _resolve_definition(
@@ -837,13 +815,18 @@ async def run_one_tick(invoker: AgentInvoker | None = None) -> int:
     """
     if invoker is None:
         invoker = get_agent_invoker()
-    sessionmaker = get_sessionmaker()
     fires = 0
-    async with sessionmaker() as session:
-        locked = await _try_advisory_lock(session, _SCHEDULER_ADVISORY_LOCK_KEY)
+    # The advisory lock lives on its own pinned connection (#3010): the
+    # per-row fire paths commit on the work session below, and a lock
+    # taken on that session would strand on the pooled connection the
+    # first commit releases -- silently starving every later tick that
+    # draws a different connection.
+    async with advisory_lock(_SCHEDULER_ADVISORY_LOCK_KEY, subsystem="scheduler") as locked:
         if not locked:
+            _log.debug("scheduler_tick_lock_busy")
             return 0
-        try:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
             now = datetime.now(UTC)
             rows = await claim_due_triggers(
                 session,
@@ -888,12 +871,6 @@ async def run_one_tick(invoker: AgentInvoker | None = None) -> int:
                     # Roll back any partial work on this row so the
                     # next row's claim sees a clean session.
                     await session.rollback()
-        finally:
-            await _advisory_unlock(session, _SCHEDULER_ADVISORY_LOCK_KEY)
-            # Commit the unlock (PG sessions hold no transaction across
-            # the advisory-unlock call but flush + commit is the
-            # mirror-image of the topology scheduler's discipline).
-            await session.commit()
     return fires
 
 

--- a/backend/tests/integration/test_advisory_lock_pg.py
+++ b/backend/tests/integration/test_advisory_lock_pg.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Real-Postgres regression tests for the #3010 advisory-lock invariant.
+
+The bug: every tick loop took ``pg_try_advisory_lock`` (a session-level,
+connection-owned lock) on its work :class:`AsyncSession` and then
+committed inside the locked region. Each commit returns the session's
+pooled connection; the ``finally`` unlock then ran on a *different*
+connection — PG answered ``WARNING: you don't own a lock of type
+ExclusiveLock``, returned ``false``, nothing raised, and the lock
+stranded on an idle pooled connection. Every later tick drawing any
+other connection silently claimed nothing (~35-50 % sensor cadence,
+watchdog blind).
+
+These tests run the fixed shape — the lock pinned to a dedicated
+connection via :func:`meho_backplane.db.advisory.advisory_lock` — on the
+production dialect and assert the issue's acceptance criteria directly:
+
+* mid-lock commits on pool sessions never move or strand the lock, and
+  ``pg_locks`` shows **no** advisory holder once the block exits;
+* a second would-be holder reads busy while the block is open;
+* a sensor-runner tick that claims (and therefore commits) leaves no
+  lock behind, and a **subsequent tick claims due rows again**;
+* every other converted subsystem tick (scheduler, drain, reaper,
+  deadman — the deadman committed mid-lock even on an empty sweep, so
+  the old shape stranded its key on every single tick) exits with a
+  clean ``pg_locks``.
+
+The ``pg_engine`` fixture from :mod:`tests.integration.conftest` points
+the process-wide engine at a ``pgvector/pgvector:pg16`` container and
+skips the module when Docker is unavailable (agent sandboxes); CI
+provisions containers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import text
+
+from meho_backplane.agent.invocation import AgentInvoker
+from meho_backplane.agent.reaper import _run_one_tick as reaper_tick
+from meho_backplane.checks.assertions import AssertionOutcome
+from meho_backplane.checks.runner import (
+    _SENSOR_RUNNER_ADVISORY_LOCK_KEY,
+    reset_sensor_runner_state,
+    run_one_sensor_tick,
+)
+from meho_backplane.db.advisory import advisory_lock
+from meho_backplane.db.engine import get_engine, get_sessionmaker
+from meho_backplane.events.drain import run_one_drain_tick
+from meho_backplane.gateway.deadman import _run_one_tick as deadman_tick
+from meho_backplane.scheduler.loop import run_one_tick as scheduler_tick
+from tests.test_sensor_runner import (
+    _create_interval_sensor,
+    _drain_in_flight,
+    _force_due,
+)
+
+_TEST_KEY = 0x4D45_484F_5445_5354  # "MEHOTEST" — collides with no subsystem key
+
+
+@pytest.fixture(autouse=True)
+async def _runner_state() -> AsyncIterator[None]:
+    """Reset the sensor runner's per-process state around every test."""
+    reset_sensor_runner_state()
+    yield
+    reset_sensor_runner_state()
+
+
+async def _advisory_lock_rows() -> list[tuple[int, int, bool]]:
+    """Every advisory lock currently held in the container, as pg_locks rows."""
+    engine = get_engine()
+    async with engine.connect() as conn:
+        result = await conn.execute(
+            text("SELECT classid, objid, granted FROM pg_locks WHERE locktype = 'advisory'")
+        )
+        return [(row.classid, row.objid, row.granted) for row in result]
+
+
+def _low32(key: int) -> int:
+    """The ``objid`` half PG reports for a 64-bit advisory key."""
+    return key & 0xFFFF_FFFF
+
+
+async def test_lock_survives_mid_lock_commits_and_is_released(pg_engine: None) -> None:
+    """Pool-session commits inside the block never strand the lock (#3010 AC).
+
+    The exact bug shape: lock, then commit on a pooled session (which
+    returns that session's connection), then unlock. With the lock pinned
+    to its own connection the unlock lands where the lock lives, and
+    ``pg_locks`` reads clean after the block.
+    """
+    sessionmaker = get_sessionmaker()
+    async with advisory_lock(_TEST_KEY, subsystem="test") as locked:
+        assert locked is True
+        # Two mid-lock commit cycles on pool sessions — each returns its
+        # connection to the pool, exactly what used to migrate the unlock.
+        for _ in range(2):
+            async with sessionmaker() as session:
+                await session.execute(text("SELECT 1"))
+                await session.commit()
+        # While the block is open the lock is visibly granted.
+        held = await _advisory_lock_rows()
+        assert any(objid == _low32(_TEST_KEY) and granted for _, objid, granted in held)
+
+    # The AC's pg_locks probe: no idle holder left behind.
+    assert await _advisory_lock_rows() == []
+
+
+async def test_second_holder_reads_busy_while_block_open(pg_engine: None) -> None:
+    """A concurrent would-be holder gets ``False``; after release it acquires."""
+    async with advisory_lock(_TEST_KEY, subsystem="test") as first:
+        assert first is True
+        async with advisory_lock(_TEST_KEY, subsystem="test") as second:
+            assert second is False
+
+    async with advisory_lock(_TEST_KEY, subsystem="test") as again:
+        assert again is True
+    assert await _advisory_lock_rows() == []
+
+
+async def test_sensor_tick_claims_commits_and_next_tick_claims_again(
+    pg_engine: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The runner's real tick on PG: claim → advance-commit → unlock → re-claim.
+
+    Encodes the issue's headline acceptance criterion: after the change a
+    subsequent tick claims due rows — under the old shape the first
+    claiming tick (whose advance committed mid-lock) stranded the key and
+    later ticks silently returned 0.
+    """
+    monkeypatch.setattr(
+        "meho_backplane.checks.runner._run_evaluation",
+        AsyncMock(return_value=AssertionOutcome(state="ok", value=1, evidence={})),
+    )
+    sensor_id = await _create_interval_sensor()
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    first = await run_one_sensor_tick()
+    assert first == 1
+    await _drain_in_flight()
+    # No idle holder of the runner key (or any advisory key) between ticks.
+    locks = await _advisory_lock_rows()
+    assert not any(objid == _low32(_SENSOR_RUNNER_ADVISORY_LOCK_KEY) for _, objid, _g in locks)
+
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+    second = await run_one_sensor_tick()
+    assert second == 1
+    await _drain_in_flight()
+    assert await _advisory_lock_rows() == []
+
+
+async def test_all_converted_subsystem_ticks_leave_pg_locks_clean(pg_engine: None) -> None:
+    """Scheduler / drain / reaper / deadman ticks strand no advisory lock.
+
+    The deadman is the sharpest probe: its old shape committed before the
+    unlock even on an empty sweep, so *every* tick stranded its key. The
+    invoker sentinels are never touched — the tables are empty, so each
+    tick runs lock → scan → (commit) → unlock only.
+    """
+    unused_invoker = cast("AgentInvoker", object())
+
+    assert await scheduler_tick(invoker=unused_invoker) == 0
+    assert await _advisory_lock_rows() == []
+
+    assert await run_one_drain_tick(invoker=unused_invoker) == 0
+    assert await _advisory_lock_rows() == []
+
+    await reaper_tick()
+    assert await _advisory_lock_rows() == []
+
+    await deadman_tick()
+    assert await _advisory_lock_rows() == []

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -381,6 +381,7 @@ def test_happy_path_returns_full_federation_response(
         # shape; the conftest autouse reset guarantees a clean slate).
         "sensor_runner": {
             "seconds_since_last_tick": None,
+            "seconds_since_last_claim": None,
             "stalled": False,
             "stall_threshold_seconds": 60.0,
         },
@@ -814,6 +815,52 @@ def test_sensor_runner_facet_stalled_when_stamp_is_stale(
     facet = response.json()["sensor_runner"]
     assert facet["stalled"] is True
     assert facet["seconds_since_last_tick"] >= 120.0
+
+
+def test_sensor_runner_facet_exposes_claim_staleness(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The facet carries ``seconds_since_last_claim`` from the claim stamp.
+
+    #3010: a fresh tick stamp with a stale claim stamp is the
+    stranded-advisory-lock signature — the loop completes every tick but
+    never actually claims. The route must surface both numbers so an
+    external prober can alert on the divergence the tick-only facet was
+    structurally blind to.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    import meho_backplane.checks.watchdog as watchdog
+
+    monkeypatch.setattr(
+        watchdog,
+        "_LAST_TICK_COMPLETED_AT",
+        datetime.now(UTC) - timedelta(seconds=1),
+    )
+    monkeypatch.setattr(
+        watchdog,
+        "_LAST_CLAIM_AT",
+        datetime.now(UTC) - timedelta(seconds=300),
+    )
+    key = _make_rsa_keypair("kid-runner-claim")
+    token = _mint_token(key, sub="op-runner-claim")
+    _install_fake_vault(monkeypatch, version=1)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    facet = response.json()["sensor_runner"]
+    # Loop reads alive on the tick facet while the claim facet exposes
+    # the starvation.
+    assert facet["stalled"] is False
+    assert 0.0 <= facet["seconds_since_last_tick"] < 30.0
+    assert facet["seconds_since_last_claim"] >= 300.0
 
 
 def test_sensor_runner_facet_absent_when_runner_disabled(

--- a/backend/tests/test_api_v1_health_split.py
+++ b/backend/tests/test_api_v1_health_split.py
@@ -229,6 +229,7 @@ def test_read_only_liveness_returns_200_without_vault_touch(
         # reads the enabled-but-not-started shape.
         "sensor_runner": {
             "seconds_since_last_tick": None,
+            "seconds_since_last_claim": None,
             "stalled": False,
             "stall_threshold_seconds": 60.0,
         },

--- a/backend/tests/test_checks_watchdog.py
+++ b/backend/tests/test_checks_watchdog.py
@@ -468,6 +468,76 @@ async def test_run_one_sensor_tick_stamps_the_liveness_view() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Claim facet (#3010) — lock-miss ticks must not read fully healthy
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_lock_acquired_tick_stamps_both_facets() -> None:
+    """The default (lock held) stamps the tick and the claim together."""
+    await note_tick_completed(now=_T0)
+    liveness = sensor_runner_liveness(now=_T0 + timedelta(seconds=30))
+    assert liveness.seconds_since_last_tick == pytest.approx(30.0)
+    assert liveness.seconds_since_last_claim == pytest.approx(30.0)
+
+
+@pytest.mark.asyncio
+async def test_lock_miss_tick_stamps_tick_but_not_claim() -> None:
+    """A ``lock_acquired=False`` tick keeps the loop alive without faking a claim.
+
+    #3010: a lock stranded on an idle pooled connection made every tick
+    complete (fresh tick stamp, ``stalled=False``) while zero sensors were
+    claimed for hours. The claim facet must keep measuring from the last
+    tick that actually held the lock, so the divergence is visible.
+    """
+    await note_tick_completed(now=_T0)
+    await note_tick_completed(now=_T0 + timedelta(seconds=10), lock_acquired=False)
+    await note_tick_completed(now=_T0 + timedelta(seconds=20), lock_acquired=False)
+
+    liveness = sensor_runner_liveness(now=_T0 + timedelta(seconds=25))
+    # The loop is alive: the tick stamp advanced on every completed tick.
+    assert liveness.seconds_since_last_tick == pytest.approx(5.0)
+    assert liveness.stalled is False
+    # But nothing was claimed since _T0 — the claim facet says so.
+    assert liveness.seconds_since_last_claim == pytest.approx(25.0)
+
+
+@pytest.mark.asyncio
+async def test_claim_facet_falls_back_to_watchdog_baseline() -> None:
+    """Before any lock-acquired tick, claim staleness measures from start.
+
+    Mirrors the tick facet's baseline discipline: a runner that never
+    wins the lock after process start must not hide behind a ``None``.
+    """
+    task = start_checks_watchdog()
+    try:
+        assert watchdog._BASELINE is not None
+        await note_tick_completed(
+            now=watchdog._BASELINE + timedelta(seconds=10), lock_acquired=False
+        )
+        liveness = sensor_runner_liveness(now=watchdog._BASELINE + timedelta(seconds=30))
+        assert liveness.seconds_since_last_claim == pytest.approx(30.0)
+        assert liveness.seconds_since_last_tick == pytest.approx(20.0)
+    finally:
+        await stop_checks_watchdog(task)
+
+
+def test_claim_facet_is_none_with_no_reference_at_all() -> None:
+    liveness = sensor_runner_liveness(now=_T0)
+    assert liveness.seconds_since_last_claim is None
+
+
+@pytest.mark.asyncio
+async def test_run_one_sensor_tick_stamps_the_claim_facet() -> None:
+    """The real tick seam holds the (SQLite no-op) lock and stamps the claim."""
+    assert sensor_runner_liveness().seconds_since_last_claim is None
+    await run_one_sensor_tick()
+    liveness = sensor_runner_liveness()
+    assert liveness.seconds_since_last_claim is not None
+    assert liveness.seconds_since_last_claim < 5.0
+
+
+# --------------------------------------------------------------------------- #
 # Lifecycle
 # --------------------------------------------------------------------------- #
 

--- a/backend/tests/test_db_advisory.py
+++ b/backend/tests/test_db_advisory.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the pinned-connection advisory-lock helper (#3010).
+
+The SQLite path only: on a dialect without advisory locks the helper
+must yield ``True`` unconditionally (the single-replica test path every
+tick-loop suite rides) and must not open a dedicated connection. The PG
+semantics — same-connection lock/unlock across mid-lock commits, busy
+second holder, no stranded lock in ``pg_locks`` — are exercised against
+a real container in :mod:`tests.integration.test_advisory_lock_pg`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from meho_backplane.db.advisory import advisory_lock
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env vars :class:`Settings` requires at construction time."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_dialect_always_yields_true() -> None:
+    """No advisory locks on SQLite: the helper is a transparent no-op."""
+    async with advisory_lock(0x1234, subsystem="test") as locked:
+        assert locked is True
+
+
+@pytest.mark.asyncio
+async def test_sqlite_dialect_is_reentrant_across_keys() -> None:
+    """Two nested holds (any keys) both proceed on the lockless dialect."""
+    async with (
+        advisory_lock(1, subsystem="test") as outer,
+        advisory_lock(1, subsystem="test") as inner,
+    ):
+        assert outer is True
+        assert inner is True

--- a/backend/tests/test_sensor_runner.py
+++ b/backend/tests/test_sensor_runner.py
@@ -330,6 +330,50 @@ def test_advisory_lock_key_differs_from_scheduler() -> None:
     assert 0 <= _SENSOR_RUNNER_ADVISORY_LOCK_KEY <= 0x7FFF_FFFF_FFFF_FFFF
 
 
+@pytest.mark.asyncio
+async def test_lock_miss_tick_logs_and_skips_claim_stamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lock-miss tick is visible and never stamps the claim facet (#3010).
+
+    The stranded-lock incident was invisible precisely because the miss
+    path was a silent ``return 0`` and ``note_tick_completed`` stamped it
+    healthy. The tick must log ``sensor_tick_lock_busy``, dispatch
+    nothing, keep the tick stamp advancing (loop liveness), and leave the
+    claim stamp untouched.
+    """
+    from contextlib import asynccontextmanager
+
+    from meho_backplane.checks.watchdog import sensor_runner_liveness
+
+    sensor_id = await _create_interval_sensor()
+    await _force_due(sensor_id, datetime.now(UTC) - timedelta(seconds=1))
+
+    @asynccontextmanager
+    async def _held_elsewhere(key: int, *, subsystem: str) -> Any:
+        assert key == _SENSOR_RUNNER_ADVISORY_LOCK_KEY
+        assert subsystem == "sensor_runner"
+        yield False
+
+    monkeypatch.setattr("meho_backplane.checks.runner.advisory_lock", _held_elsewhere)
+
+    with structlog.testing.capture_logs() as logs:
+        dispatched = await run_one_sensor_tick()
+
+    assert dispatched == 0
+    assert [e for e in logs if e["event"] == "sensor_tick_lock_busy"]
+    liveness = sensor_runner_liveness()
+    # Loop liveness still stamps (the multi-replica contract) …
+    assert liveness.seconds_since_last_tick is not None
+    # … but the claim facet does not pretend anything was claimed.
+    assert liveness.seconds_since_last_claim is None
+    # The due row was untouched — the next lock-winning tick claims it.
+    row = await _get_sensor(sensor_id)
+    fire_at = _aware(row.next_fire_at)
+    assert fire_at is not None
+    assert fire_at <= datetime.now(UTC)
+
+
 # --------------------------------------------------------------------------- #
 # Cadence advance (value-assert, deterministic fire_instant)
 # --------------------------------------------------------------------------- #

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -29169,6 +29169,11 @@
             "nullable": true,
             "title": "Seconds Since Last Tick"
           },
+          "seconds_since_last_claim": {
+            "type": "number",
+            "nullable": true,
+            "title": "Seconds Since Last Claim"
+          },
           "stalled": {
             "type": "boolean",
             "title": "Stalled"
@@ -29181,11 +29186,12 @@
         "type": "object",
         "required": [
           "seconds_since_last_tick",
+          "seconds_since_last_claim",
           "stalled",
           "stall_threshold_seconds"
         ],
         "title": "SensorRunnerStatus",
-        "description": "Liveness of this process's sensor evaluation loop (#2763).\n\nThe queryable half of the checks-runner watchdog: an external prober\n(\"how we monitor the monitoring\") alerts when\n``seconds_since_last_tick`` exceeds ``stall_threshold_seconds`` \u2014 or\nsimply on ``stalled``, which is that comparison server-side.\n``stalled`` is derived live from the in-process tick stamp on every\nread (never from the watchdog task's emission latch), so it stays\ntruthful even if the watchdog task itself has died.\n\n``seconds_since_last_tick`` is ``None`` only in the window between\nprocess start and runner start \u2014 once the lifespan is up it is\nalways a number. The value is per-process: each replica reports its\nown loop, which is exactly the failure mode observed (one process's\nloop coroutine going quiet)."
+        "description": "Liveness of this process's sensor evaluation loop (#2763).\n\nThe queryable half of the checks-runner watchdog: an external prober\n(\"how we monitor the monitoring\") alerts when\n``seconds_since_last_tick`` exceeds ``stall_threshold_seconds`` \u2014 or\nsimply on ``stalled``, which is that comparison server-side.\n``stalled`` is derived live from the in-process tick stamp on every\nread (never from the watchdog task's emission latch), so it stays\ntruthful even if the watchdog task itself has died.\n\n``seconds_since_last_tick`` is ``None`` only in the window between\nprocess start and runner start \u2014 once the lifespan is up it is\nalways a number. The value is per-process: each replica reports its\nown loop, which is exactly the failure mode observed (one process's\nloop coroutine going quiet).\n\n``seconds_since_last_claim`` (#3010) measures from the last tick\nthat actually **held** the runner's advisory lock. It diverges from\n``seconds_since_last_tick`` when the loop is alive but never winning\nthe lock \u2014 the stranded-lock starvation ``stalled`` is structurally\nblind to (every tick completes; nothing is ever claimed). Per-process\nand informational: on a multi-replica deploy only the lock-winning\nreplica's claim stamp advances, so alert on the minimum across\nreplicas, not per pod."
       },
       "SensorSeverity": {
         "type": "string",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4568,6 +4568,15 @@ type HealthResponse struct {
 	// always a number. The value is per-process: each replica reports its
 	// own loop, which is exactly the failure mode observed (one process's
 	// loop coroutine going quiet).
+	//
+	// ``seconds_since_last_claim`` (#3010) measures from the last tick
+	// that actually **held** the runner's advisory lock. It diverges from
+	// ``seconds_since_last_tick`` when the loop is alive but never winning
+	// the lock — the stranded-lock starvation ``stalled`` is structurally
+	// blind to (every tick completes; nothing is ever claimed). Per-process
+	// and informational: on a multi-replica deploy only the lock-winning
+	// replica's claim stamp advances, so alert on the minimum across
+	// replicas, not per pod.
 	SensorRunner *SensorRunnerStatus `json:"sensor_runner,omitempty"`
 
 	// Vault Federation-chain status for the deployment's credential backend.
@@ -5042,6 +5051,15 @@ type LivenessResponse struct {
 	// always a number. The value is per-process: each replica reports its
 	// own loop, which is exactly the failure mode observed (one process's
 	// loop coroutine going quiet).
+	//
+	// ``seconds_since_last_claim`` (#3010) measures from the last tick
+	// that actually **held** the runner's advisory lock. It diverges from
+	// ``seconds_since_last_tick`` when the loop is alive but never winning
+	// the lock — the stranded-lock starvation ``stalled`` is structurally
+	// blind to (every tick completes; nothing is ever claimed). Per-process
+	// and informational: on a multi-replica deploy only the lock-winning
+	// replica's claim stamp advances, so alert on the minimum across
+	// replicas, not per pod.
 	SensorRunner *SensorRunnerStatus `json:"sensor_runner,omitempty"`
 }
 
@@ -6840,7 +6858,17 @@ type SensorResultReadState string
 // always a number. The value is per-process: each replica reports its
 // own loop, which is exactly the failure mode observed (one process's
 // loop coroutine going quiet).
+//
+// “seconds_since_last_claim“ (#3010) measures from the last tick
+// that actually **held** the runner's advisory lock. It diverges from
+// “seconds_since_last_tick“ when the loop is alive but never winning
+// the lock — the stranded-lock starvation “stalled“ is structurally
+// blind to (every tick completes; nothing is ever claimed). Per-process
+// and informational: on a multi-replica deploy only the lock-winning
+// replica's claim stamp advances, so alert on the minimum across
+// replicas, not per pod.
 type SensorRunnerStatus struct {
+	SecondsSinceLastClaim *float32 `json:"seconds_since_last_claim"`
 	SecondsSinceLastTick  *float32 `json:"seconds_since_last_tick"`
 	StallThresholdSeconds float32  `json:"stall_threshold_seconds"`
 	Stalled               bool     `json:"stalled"`

--- a/docs/codebase/checks-runner.md
+++ b/docs/codebase/checks-runner.md
@@ -26,18 +26,22 @@ watchdog deliberately has no enable flag of its own.
   public test seam. Every *completed* tick (including the
   advisory-lock-not-acquired no-op) calls `note_tick_completed()`; a
   tick that raises does not — a loop failing every tick must read as
-  stalled.
-- `note_tick_completed(now=None)` (`checks/watchdog.py`) — stamps the
-  per-process "last tick completed at"; when a stall was flagged, emits
-  the recovery log + events and re-arms the detector. Never raises.
+  stalled. A lock-miss tick logs `sensor_tick_lock_busy`, counts on
+  `advisory_lock_busy_total{subsystem="sensor_runner"}`, and passes
+  `lock_acquired=False` so it never stamps the claim facet (#3010).
+- `note_tick_completed(now=None, *, lock_acquired=True)`
+  (`checks/watchdog.py`) — stamps the per-process "last tick completed
+  at" unconditionally and "last claim at" only when the tick held the
+  lock; when a stall was flagged, emits the recovery log + events and
+  re-arms the detector. Never raises.
 - `evaluate_stall_watchdog(now=None)` — one watchdog check: quiet time
   past the threshold trips the stall edge (log + events, once per
   continuous stall) and returns `True` while stalled. Clock-injectable.
 - `sensor_runner_liveness(now=None)` → `SensorRunnerLiveness` — the
   read-only view the health surface renders: `seconds_since_last_tick`,
-  `stalled`, `stall_threshold_seconds`. `stalled` is derived live from
-  the stamp, **not** from the watchdog's emission latch, so a dead
-  watchdog task cannot blind the facet.
+  `seconds_since_last_claim`, `stalled`, `stall_threshold_seconds`.
+  `stalled` is derived live from the stamp, **not** from the watchdog's
+  emission latch, so a dead watchdog task cannot blind the facet.
 - `start_checks_watchdog()` / `stop_checks_watchdog()` — lifespan pair
   (`main.py`, gated with the runner). Start sets the staleness baseline
   so a runner that never completes a single tick still trips.
@@ -77,6 +81,31 @@ health read:   GET /api/v1/health · GET /api/v1/health/live
 Detection latency is bounded by `threshold + one tick interval` (the
 watchdog rides the runner's own cadence; a finer grid would not tighten
 that bound).
+
+### The advisory-lock invariant (#3010)
+
+**Advisory lock and unlock must run on the same connection.**
+`pg_try_advisory_lock` is session-level — owned by the DBAPI connection
+it executes on, released only by `pg_advisory_unlock` *on that
+connection* or by the connection closing; a transaction commit does not
+release it. The tick body commits per claimed row, and an
+`AsyncSession` returns its pooled connection on every commit — so a
+lock taken on the work session strands on an idle pooled connection the
+moment the first advance commits, the `finally` unlock lands on a
+different connection (PG warns `you don't own a lock`, returns `false`,
+nothing raises), and every later tick that draws any other connection
+silently claims nothing. That was #3010: 75–118 evaluations/day from a
+300 s sensor (expected 288) with the watchdog reading healthy.
+
+The tick therefore hosts the lock on a dedicated pinned connection via
+`meho_backplane/db/advisory.py::advisory_lock(key, subsystem=...)`
+(one `engine.connect()` checked out for the whole locked region, work
+session commits freely, unlock provably on the acquiring connection).
+The same helper backs `scheduler/loop.py`, `events/drain.py`,
+`agent/reaper.py`, and `gateway/deadman.py`; the topology scheduler
+already had the correct dedicated-lock-session shape. Regression tests:
+`backend/tests/integration/test_advisory_lock_pg.py` (real PG,
+`pg_locks` probes, cross-connection-commit shape).
 
 ### Confirmation retries (#2799)
 
@@ -127,6 +156,8 @@ by that cadence instead of `retry_backoff_seconds`).
 | structlog `error` | `checks_scheduler_stalled` | stall detection edge |
 | structlog `warning` | `checks_scheduler_recovered` | first completed tick after a stall (carries `stalled_for_seconds`) |
 | structlog `warning` | `checks_watchdog_emit_failed` | fan-out query/publish block failed (fail-open) |
+| structlog `info` | `sensor_tick_lock_busy` | tick skipped: advisory lock held elsewhere (#3010; also counts on `advisory_lock_busy_total{subsystem="sensor_runner"}`) |
+| structlog `warning` | `advisory_unlock_failed` | unlock returned `false` — the #3010 same-connection invariant regressed (tripwire, should never fire) |
 | broadcast event | `checks.scheduler_stalled` | detection edge, per affected tenant |
 | broadcast event | `checks.scheduler_recovered` | recovery, to the same tenants |
 
@@ -144,18 +175,29 @@ audit row to point at), fail-open publish
 
 `GET /api/v1/health` and `GET /api/v1/health/live` both carry
 `sensor_runner` (`SensorRunnerStatus`): `seconds_since_last_tick`,
-`stalled`, `stall_threshold_seconds`; the whole field is `null` exactly
-when `SENSOR_RUNNER_ENABLED=false` (a deliberately disabled runner must
-not read as stalled). The liveness route carries it because the
-external prober ("how we monitor the monitoring") is a `read_only`
-monitoring principal, and polling the deep check instead would federate
-a Vault credential and write an audit row per poll; the facet is an
-in-memory clock read, honouring that route's no-connector constraint.
+`seconds_since_last_claim`, `stalled`, `stall_threshold_seconds`; the
+whole field is `null` exactly when `SENSOR_RUNNER_ENABLED=false` (a
+deliberately disabled runner must not read as stalled). The liveness
+route carries it because the external prober ("how we monitor the
+monitoring") is a `read_only` monitoring principal, and polling the
+deep check instead would federate a Vault credential and write an audit
+row per poll; the facet is an in-memory clock read, honouring that
+route's no-connector constraint.
+
+`seconds_since_last_claim` (#3010) measures from the last tick that
+actually held the advisory lock (falling back to the watchdog-start
+baseline). A fresh tick stamp with stale claim staleness is the
+stranded-lock / permanent-contention signature the tick facet alone
+cannot see. It is per-process: on a multi-replica deploy only the
+lock-winning replica's claim advances, so `stalled` deliberately stays
+keyed on the tick stamp and the prober alerts on the *minimum* claim
+staleness across replicas.
 
 The division of labour is the Prometheus `Watchdog` /
 dead-man's-switch pattern: MEHO surfaces the liveness signal; the
-external prober alerts on it (`stalled == true`, or
-`seconds_since_last_tick > stall_threshold_seconds`).
+external prober alerts on it (`stalled == true`,
+`seconds_since_last_tick > stall_threshold_seconds`, or fleet-min
+`seconds_since_last_claim` growing while ticks stay fresh).
 
 ## Known issues / boundaries
 
@@ -187,12 +229,16 @@ external prober alerts on it (`stalled == true`, or
 - `backend/src/meho_backplane/checks/runner.py`,
   `backend/src/meho_backplane/checks/watchdog.py`,
   `backend/src/meho_backplane/checks/broadcast.py`
+- `backend/src/meho_backplane/db/advisory.py` (#3010 pinned-connection
+  advisory-lock helper)
 - `backend/src/meho_backplane/api/v1/health.py` (`SensorRunnerStatus`)
 - `backend/src/meho_backplane/main.py` (lifespan wiring)
 - `backend/tests/test_checks_watchdog.py`, `test_sensor_runner.py`,
-  `test_api_v1_health.py`
+  `test_api_v1_health.py`, `test_db_advisory.py`,
+  `tests/integration/test_advisory_lock_pg.py`
 - #2763 (watchdog), #2505 (runner), #2799 (confirmation retries),
-  Initiative #2780, parent goal #221
+  #3010 (advisory-lock leak root cause), Initiative #2780, parent
+  goal #221
 - Moulds: `gateway/deadman.py` (#2501 — the satellite-runner dead-man
   switch, same lapse-detection shape at a different altitude),
   `memory/expiry.py` (loop lifecycle)

--- a/docs/codebase/events.md
+++ b/docs/codebase/events.md
@@ -152,7 +152,11 @@ On each tick (default 10s, settable via
    `pg_try_advisory_lock(0x4D45_484F_4556_5442)` — see
    [Advisory-lock keys](#advisory-lock-keys) below. Only one
    replica's drain runs the tick body at a time. A second replica's
-   tick is a no-op until the holder releases.
+   tick is a no-op until the holder releases. The lock is hosted on a
+   dedicated pinned connection
+   (`meho_backplane/db/advisory.py::advisory_lock`, #3010 — advisory
+   lock and unlock must run on the same connection, and the drain's
+   mid-tick commits would strand a lock taken on the work session).
 
 2. **Scan + claim unprocessed rows** via:
 

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -96,14 +96,17 @@ DBOS rebase swaps only the loop module.
                   +------------------------------------------+
                   | run_one_tick()                           |
                   | 1. pg_try_advisory_lock(MEHOSCHD)        |
-                  |    (no-op on SQLite test path)           |
+                  |    on a dedicated pinned connection      |
+                  |    (db/advisory.py; no-op on SQLite)     |
                   | 2. claim_due_triggers(now=now(UTC),      |
-                  |       limit=50)                          |
+                  |       limit=50)  -- separate work        |
+                  |    session, commits per row              |
                   |    -- SELECT ... FOR UPDATE SKIP LOCKED  |
                   | 3. for each row:                         |
                   |      kind==cron: advance + invoke        |
                   |      kind==one_off: mark fired + invoke  |
-                  | 4. pg_advisory_unlock                    |
+                  | 4. pg_advisory_unlock on the SAME        |
+                  |    pinned connection                     |
                   +------------------------------------------+
                                                  |
                                                  v
@@ -380,8 +383,21 @@ Two backplane pods sharing one Postgres are coordinated by two layers:
 
 1. **Process-wide advisory lock** (`pg_try_advisory_lock(MEHOSCHD)`):
    only one replica's loop runs the tick body at a time. The losing
-   replica's `try_advisory_lock` returns `False` and the tick is skipped.
-   Non-blocking.
+   replica reads `False`, debug-logs `scheduler_tick_lock_busy`, counts
+   on `advisory_lock_busy_total{subsystem="scheduler"}`, and skips the
+   tick. Non-blocking.
+
+   **Advisory lock and unlock must run on the same connection**
+   (#3010). The lock is session-level — owned by the DBAPI connection,
+   unaffected by commit/rollback — and the tick body commits per fired
+   row, which returns the work session's pooled connection. The lock is
+   therefore hosted on a dedicated pinned connection
+   (`meho_backplane/db/advisory.py::advisory_lock`), never on the work
+   session: taken there, the first commit would strand it on an idle
+   pooled connection, the unlock would land on a different connection
+   (PG warns and returns `false`, nothing raises), and every later tick
+   drawing another connection would skip silently — the sensor runner's
+   #3010 starvation, same shape here.
 2. **Per-row claim under `FOR UPDATE SKIP LOCKED`** plus the conditional
    `UPDATE` in the advance/mark-fired step. Belt-and-braces — even if the
    advisory lock were removed, single-fire would still hold across
@@ -427,7 +443,10 @@ lock — see "Known issues / limitations" (#1502).
   so the durable `agent_run` row's provenance column reflects the
   scheduler vs. a direct REST/MCP/CLI invocation.
 - **`pg_try_advisory_lock` / `pg_advisory_unlock`** — Postgres
-  session-level advisory locks. No-op on SQLite via dialect gate.
+  session-level advisory locks, held via the shared pinned-connection
+  helper `meho_backplane/db/advisory.py::advisory_lock` (#3010: lock and
+  unlock must run on the same connection). No-op on SQLite via dialect
+  gate.
 - **`SELECT ... FOR UPDATE SKIP LOCKED`** — SQLAlchemy 2.0
   `with_for_update(skip_locked=True)`; emitted only on PG.
 


### PR DESCRIPTION
## Summary

- **Root cause fix for the #2763 stall class (#3010):** every background tick loop took its session-level `pg_try_advisory_lock` on the tick's pooled work session and then committed inside the locked region. Each commit returns the session's connection to the pool, so the `finally` unlock ran on a *different* connection — PG answers `WARNING: you don't own a lock`, returns `false`, nothing raises — and the lock stranded on an idle pooled connection. Every later tick drawing any other connection silently claimed nothing (~35–50 % sensor cadence, watchdog blind).
- **Fix shape (issue's Desired state, option 1):** a new shared helper `meho_backplane/db/advisory.py::advisory_lock(key, subsystem=...)` hosts the lock on a dedicated `engine.connect()` connection pinned for the whole locked region; work sessions commit freely, and the unlock provably lands on the connection that acquired the key. `pg_try_advisory_xact_lock` was rejected because every consumer must commit *inside* the locked region (claim/advance-before-dispatch durability) — an xact lock would evaporate at the first commit. All five commit-mid-lock users converted: `checks/runner.py`, `scheduler/loop.py`, `events/drain.py` (whose comment claiming mid-tick commits don't release the lock was wrong — fixed), `agent/reaper.py`, `gateway/deadman.py` (which stranded its key on *every* tick, empty or not). The topology scheduler already had the correct dedicated-lock-session shape and is untouched.
- **Lock-miss visibility:** miss ticks log per-subsystem (`sensor_tick_lock_busy`, `scheduler_tick_lock_busy`, `event_drain_tick_skipped_lock_held`, existing reaper/deadman lines) and count on a new `advisory_lock_busy_total{subsystem}` Prometheus counter; a failed unlock warn-logs `advisory_unlock_failed` as an invariant tripwire.
- **Watchdog no longer stamps lock-miss ticks as claim-healthy:** `note_tick_completed(lock_acquired=...)` stamps the tick facet unconditionally (loop liveness — the multi-replica contract) but the new claim stamp only on lock-acquired ticks. `SensorRunnerStatus` on `GET /api/v1/health` + `/health/live` gains `seconds_since_last_claim`, the claim-based facet the issue asked for; `stalled` deliberately stays tick-keyed so non-leader replicas don't false-positive.
- **Docs:** `docs/codebase/checks-runner.md` and `docs/codebase/scheduler.md` state the invariant verbatim — "advisory lock and unlock must run on the same connection" — with the failure mechanics; `events.md` drain section updated; CHANGELOG bullet added.

## Test plan

- [x] `ruff check src/ tests/` — clean; `ruff format --check` — clean
- [x] `mypy src/` — clean apart from the pre-existing darwin-only `connectors/net/icmp.py` `MSG_ERRQUEUE` artifact (present on `main`; Linux CI unaffected)
- [x] `pytest -n 3 --dist loadscope --maxfail=1 --ignore=tests/integration --ignore=tests/migrations tests/` (the CI unit lane) — all passed locally
- [x] **AC "pg_locks shows no idle holder between ticks" + "test covering the cross-connection unlock case":** new `tests/integration/test_advisory_lock_pg.py` ran against a real `pgvector/pgvector:pg16` container locally — 4 passed. Covers: mid-lock commits on pool sessions with a `pg_locks` clean probe after release; busy second holder; the sensor runner's real tick claiming, committing, and **claiming again on the next tick**; scheduler/drain/reaper/deadman ticks leaving `pg_locks` clean (the deadman is the sharpest probe — its old shape leaked on every tick).
- [x] **AC "lock-miss ticks are logged/counted and do not satisfy the liveness stamp (claim-based facet added)":** `tests/test_sensor_runner.py::test_lock_miss_tick_logs_and_skips_claim_stamp`, new claim-facet tests in `tests/test_checks_watchdog.py`, route-level `tests/test_api_v1_health.py::test_sensor_runner_facet_exposes_claim_staleness` — all passing.
- [x] **AC "docs/codebase/ runner + scheduler pages state the invariant":** both pages carry the sentence and the mechanics.
- [ ] **AC "a 300 s sensor records ≥ 260 evaluations/day on the same deploy shape":** deploy-observable; the mechanism (no stranded lock, subsequent ticks claim) is proven by the PG integration tests above — the cadence number verifies on the next release's dogfood cycle.
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (18 pre-existing legacy-size warnings in touched files, unchanged by this PR beyond two functions shortened back under the cap).

## Out of scope

- `topology/scheduler.py` — already correct (dedicated lock session, no mid-lock commits); left untouched rather than converted for uniformity.
- Fleet-level claim aggregation / alert rules for `seconds_since_last_claim` — external-prober territory per the #2763 division of labour.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #3010

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up (auto-implement-issue, iteration 1, 2026-08-18)

Addressed review findings from the iteration-1 review (degraded-mode comment; machine review identity unavailable):

- **B1** `567afd6a` — regenerated `cli/api/openapi.json` + `cli/internal/api/client.gen.go` for the `SensorRunnerStatus.seconds_since_last_claim` schema change (`make snapshot-openapi && make generate`; `make build` + `make test` verified green).

<!-- auto-implement-issue: continue, iteration 1 -->
