### PR TITLE
feat(tests): vcf-operations real-spec reconcile lane — assert hand-coded paths against the pinned vcf-operations-9.0 spec (#2984)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,8 @@ jobs:
           # lazy blob filter: the runner materialises just the pinned
           # spec files (~0.2 MB hetzner-robot-2026-04 + ~33 MB nsx-9.0 +
           # ~2 MB sddc-manager-9.0 + ~18 MB vcenter-9.0 + ~3 MB
-          # vcf-automation-9.0), not the whole consumer repo. No
+          # vcf-automation-9.0 + ~5 MB vcf-operations-9.0), not the
+          # whole consumer repo. No
           # `ref:` pin — the shelf's default branch IS the
           # operator-curated pin (the directories are version-named),
           # matching the local-dev contract documented in
@@ -310,6 +311,7 @@ jobs:
             docs/sddc-manager-9.0
             docs/vcenter-9.0
             docs/vcf-automation-9.0
+            docs/vcf-operations-9.0
           filter: blob:none
           # Read-only consumer; never pushes. Don't leave the token in
           # the shelf clone's local git config after checkout.
@@ -334,13 +336,14 @@ jobs:
             spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json \
             spec-shelf/docs/vcenter-9.0/vcenter.yaml \
             spec-shelf/docs/vcenter-9.0/vi-json.yaml \
-            spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json; do
+            spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json \
+            spec-shelf/docs/vcf-operations-9.0/vcf-operations-openapi.ingestable.json; do
             if [ ! -f "$f" ]; then
               echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
               exit 1
             fi
           done
-          echo "spec-shelf OK: webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/"
+          echo "spec-shelf OK: webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -964,6 +967,7 @@ jobs:
             docs/sddc-manager-9.0
             docs/vcenter-9.0
             docs/vcf-automation-9.0
+            docs/vcf-operations-9.0
           filter: blob:none
           persist-credentials: false
 
@@ -981,13 +985,14 @@ jobs:
             spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json \
             spec-shelf/docs/vcenter-9.0/vcenter.yaml \
             spec-shelf/docs/vcenter-9.0/vi-json.yaml \
-            spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json; do
+            spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json \
+            spec-shelf/docs/vcf-operations-9.0/vcf-operations-openapi.ingestable.json; do
             if [ ! -f "$f" ]; then
               echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
               exit 1
             fi
           done
-          echo "spec-shelf OK: webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/"
+          echo "spec-shelf OK: webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-lint-test's login step — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,23 @@ connector-related release-notes line.
   repointed to `GET /cloudapi/vcf/regions` per the pinned
   go-vcloud-director v3.0.0 endpoint map and the shelf's live-probe
   record.
+### Added — vcf-operations real-spec reconcile lane (#2984)
+
+- Every hand-coded `METHOD:/path` the vcf-operations connector dispatches
+  (the four typed-read paths from #2303/#2838 and the
+  `POST /suite-api/api/auth/token/acquire` session mint) is now asserted
+  against the pinned `vcf-operations-9.0` spec on every PR via the #2980
+  harness (`backend/tests/test_connectors_vcf_operations_spec_reconcile.py`
+  — parse-only, required unit sweep, uniform skip when the shelf is
+  unconfigured). CI's secret-gated spec-shelf checkout is widened to
+  `docs/vcf-operations-9.0` in both Python jobs. First armed run surfaced
+  one real finding — the vendor-published core spec itself fails the ingest
+  metaschema gate (three `"required": []` schema entries, illegal per
+  OpenAPI 3.0), so an operator ingest fails identically; the shelf now pins
+  a deterministic ingest-consumable derivative
+  (`vcf-operations-openapi.ingestable.json`, recipe + sha256 in the shelf
+  MANIFEST) that the lane parses. All five op_ids are served; no path
+  repoints were needed.
 
 ### Added — sddc-manager real-spec reconcile lane (#2982)
 

--- a/backend/tests/test_connectors_vcf_operations_spec_reconcile.py
+++ b/backend/tests/test_connectors_vcf_operations_spec_reconcile.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vcf-operations real-spec reconcile lane (#2984) — the #2980 harness.
+
+Asserts every hand-coded ``METHOD:/path`` the vcf-operations connector
+dispatches is served by the pinned ``vcf-operations-9.0`` core (vROps
+Suite API) spec on the shelf (``vmware/vcf-api-specs``' OpenAPI 3.0.1
+document — Apache-2.0, provenance in the shelf's ``MANIFEST.md``).
+Parse-only set compare — no DB, no embeddings, no containers — so it
+lives in the required unit sweep per the lane-placement rule in
+``docs/decisions/spec-reconcile-guards-standard.md``. Uniform skip when
+the shelf is unconfigured (``tests/_spec_shelf.py`` contract).
+
+The declared set is introspected from the connector's live constants
+(the #2944 pattern — never a hardcoded mirror): the five ``_*_PATH``
+module constants of
+:mod:`~meho_backplane.connectors.vcf_operations.connector` — the
+session mint (``POST /suite-api/api/auth/token/acquire``, issued by the
+shared ``vcf_session_login`` helper's ``client.post``), the
+version/liveness surface ``fingerprint`` / ``probe`` / ``vrops.liveness``
+all read, and the three remaining typed reads (#2303 / #2838). The HTTP
+method cannot be introspected from a bare path string, so
+:data:`_METHOD_BY_CONSTANT` declares it per constant and a guard test
+pins the constant-name set — a new or renamed ``_*_PATH`` constant
+fails the guard until its method mapping is added, so the reconciled
+set can never silently shrink.
+
+Sweep note (f-strings / concatenations): the only composed request path
+in the package is ``resource_query``'s query-string append onto
+``_RESOURCES_QUERY_PATH`` (``f"{path}?{urlencode(...)}"``) — no second
+path literal. The ``probe_method="GET /suite-api/api/versions/current"``
+strings in ``fingerprint`` are display metadata on the result object,
+never dispatched; the dispatched path is ``_VERSIONS_CURRENT_PATH``
+itself.
+
+Spec-shape note: the pinned spec's path keys are ``/api/...`` under the
+server template ``/suite-api``; the ingest parser folds a relative
+``servers[0].url`` base onto every op path (#1796), so the served
+op_ids carry the full ``/suite-api/api/...`` shape the connector's
+constants declare — the comparison is byte-for-byte against what an
+operator ingest of the same spec would dispatch.
+
+A red lane here is the guard surfacing a real finding, not harness
+noise — first run against the real shelf caught exactly one, of a
+different class than an unserved path: the vendor-published
+``vcf-operations-openapi.json`` itself fails ``parse_openapi``'s
+OpenAPI 3.0 metaschema gate (three ``components.schemas`` entries carry
+``"required": []``, illegal per JSON Schema draft-04), so an operator
+ingest fails identically. The shelf therefore pins
+``vcf-operations-openapi.ingestable.json`` — the vendor document with
+the three empty arrays dropped (a semantic no-op), deterministic recipe
++ sha256 in the shelf's ``MANIFEST.md`` — and this lane parses that
+file, byte-for-byte what an operator ingest consumes (the nsx-9.0
+derived-artifact precedent). All five op_ids are served; no path
+repoints were needed. Protocol:
+docs/decisions/spec-reconcile-guards-standard.md.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vcf_operations import connector as _connector
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+_SPEC_DIR = "vcf-operations-9.0"
+_SPEC_FILE = "vcf-operations-openapi.ingestable.json"
+_SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
+
+#: HTTP method per hand-coded path constant. Declared (not introspected)
+#: because a module-level path string carries no method; the guard test
+#: below pins this mapping's key set against the live constants so the
+#: two can never drift apart silently.
+_METHOD_BY_CONSTANT: dict[str, str] = {
+    "_SESSION_ACQUIRE_PATH": "POST",
+    "_VERSIONS_CURRENT_PATH": "GET",
+    "_ALERTS_PATH": "GET",
+    "_RESOURCES_QUERY_PATH": "POST",
+    "_RESOURCES_STATS_LATEST_PATH": "GET",
+}
+
+
+def _path_constants() -> dict[str, str]:
+    """The live ``_*_PATH`` constants of ``connector``, by constant name."""
+    return {
+        name: value
+        for name, value in vars(_connector).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the vcf-operations connector dispatches."""
+    return {f"{_METHOD_BY_CONSTANT[name]}:{path}" for name, path in _path_constants().items()}
+
+
+def test_path_constants_are_all_discovered_and_method_mapped() -> None:
+    """Guard: the introspection finds every path constant, each with a method.
+
+    Pinning the exact constant-name set (the #2944 guard shape) means a
+    renamed or dropped ``_*_PATH`` constant — or a new one that skips
+    the ``_PATH`` suffix convention or lacks a ``_METHOD_BY_CONSTANT``
+    entry — can't silently shrink the reconciled set to a vacuous pass.
+    """
+    assert (
+        sorted(_path_constants())
+        == sorted(_METHOD_BY_CONSTANT)
+        == [
+            "_ALERTS_PATH",
+            "_RESOURCES_QUERY_PATH",
+            "_RESOURCES_STATS_LATEST_PATH",
+            "_SESSION_ACQUIRE_PATH",
+            "_VERSIONS_CURRENT_PATH",
+        ]
+    )
+
+
+def test_declared_op_ids_are_served_by_the_pinned_spec() -> None:
+    """Every hand-coded op_id is served by the pinned vcf-operations-9.0 spec."""
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = openapi_served_op_ids(spec_path)
+    assert_op_ids_served(_declared_op_ids(), served, spec_label=_SPEC_LABEL)

--- a/docs/codebase/connectors-vcf-operations.md
+++ b/docs/codebase/connectors-vcf-operations.md
@@ -240,6 +240,21 @@ The remaining 6 ingested-browse ops (resource list/get, alert definitions,
 symptoms, recommendations, super metrics) stay browsable until Initiative
 #2266 T7 retires the apparatus.
 
+**Spec-reconcile lane (#2984).** Every hand-coded `METHOD:/path` above — the
+four typed-read paths plus the session mint
+(`POST /suite-api/api/auth/token/acquire`) — is asserted against the pinned
+`vcf-operations-9.0` shelf spec by
+[`backend/tests/test_connectors_vcf_operations_spec_reconcile.py`](../../backend/tests/test_connectors_vcf_operations_spec_reconcile.py)
+(the #2980 harness; parse-only, runs in the required unit sweep, uniform skip
+when the shelf is unconfigured). The lane parses
+`vcf-operations-openapi.ingestable.json` — a deterministic derivative of the
+vendor core spec pinned on the shelf, because the vendor document itself
+fails `parse_openapi`'s OpenAPI 3.0 metaschema gate (three
+`components.schemas` entries carry `"required": []`; the derivative drops
+them, a semantic no-op — recipe + sha256 in the shelf's `MANIFEST.md`). An
+operator ingesting the core spec needs the same remediation. Standard:
+[`docs/decisions/spec-reconcile-guards-standard.md`](../decisions/spec-reconcile-guards-standard.md).
+
 ### Shutdown
 
 `aclose()` clears the in-memory session-token cache and the shared

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -288,6 +288,12 @@ The same secret-gated checkout additionally fetches the shelf's
 `swagger-vra-sdk-go-v0.6.5/vra-iaas.json`, the tenant-plane IaaS API
 Swagger 2.0 document, 143 paths) for the vcf-automation reconcile lane
 (`backend/tests/test_connectors_vcf_automation_spec_reconcile.py`),
+### Extension: vcf-operations / vcf-operations-9.0 (#2984)
+
+The same secret-gated checkout additionally fetches the shelf's
+`docs/vcf-operations-9.0/` directory (~5 MB) for the vcf-operations
+reconcile lane
+(`backend/tests/test_connectors_vcf_operations_spec_reconcile.py`),
 under the identical ephemeral-use conditions recorded above (sparse
 read-only checkout, workspace destroyed at job end, never committed,
 never in artifacts or logs, secret withheld from fork PRs and the
@@ -302,6 +308,22 @@ extension mechanics. The provider (cloudapi / classic `/api/*`) plane
 pins nothing because nothing pinnable exists — that half of the lane is
 the evidenced exclusion recorded in the standard doc's
 `vcf-automation-9.0` entry.
+extension: the core (vROps Suite API) spec is published by VMware in
+the **public, Apache-2.0**
+[`vmware/vcf-api-specs`](https://github.com/vmware/vcf-api-specs) repo
+(pinned at `85151f6b`, retrieved 2026-04-29) — the provenance note of
+record is the shelf's `vcf-operations-9.0/MANIFEST.md`, per the
+OSS-licensed-spec form in
+[`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
+extension mechanics; the wave-3 blanket above is not needed here. The
+file the lane parses is `vcf-operations-openapi.ingestable.json` — a
+deterministic derivative pinned next to the byte-identical vendor fetch
+(the vendor document carries three empty `required` arrays, illegal per
+the OpenAPI 3.0 metaschema, so `parse_openapi` refuses it; recipe +
+sha256 in the shelf MANIFEST — the nsx-9.0 derived-artifact shape).
+**Sequencing:** the derivative lands via consumer-repo PR
+(`claude-rdc-hetzner-dc#2534`) which must merge before this repo's
+widened verify step can pass.
 
 ### Signoff extension — Hetzner Robot (hetzner-robot-2026-04, 2026-08-18, #2985)
 


### PR DESCRIPTION
## Summary

- Adds the vcf-operations real-spec reconcile lane (`backend/tests/test_connectors_vcf_operations_spec_reconcile.py`) on the #2980 harness: every hand-coded `METHOD:/path` the connector dispatches — the four typed-read paths (#2303/#2838) plus the `POST /suite-api/api/auth/token/acquire` session mint — introspected from the live `_*_PATH` constants and asserted served by the pinned `vcf-operations-9.0` core (vROps Suite API) spec. Parse-only, required unit sweep, uniform skip when the shelf is unconfigured.
- Widens CI's secret-gated spec-shelf sparse-checkout + fail-loud verify step to `docs/vcf-operations-9.0` in both Python jobs (alphabetical insertion; trivial rebase expected against sibling wave-3 lanes #2983/#2985).
- Extends the `vendor-spec-ci-provisioning.md` signoff with the vcf-operations entry (OSS-provenance form — the spec is from the public, Apache-2.0 `vmware/vcf-api-specs@85151f6b`, same source as sddc-manager; no attestation needed, wave-3 blanket not required).
- Records the lane in `docs/codebase/connectors-vcf-operations.md` and `CHANGELOG.md`.

## First-run finding + per-op decisions (the #2970 protocol)

The first armed run went red — but not on an unserved path. The vendor-published `vcf-operations-openapi.json` itself fails `parse_openapi`'s OpenAPI 3.0 metaschema gate:

- `$.components.schemas.VCFIntegration.required: []`
- `$.components.schemas.VCFDomainVcenter.required: []`
- `$.components.schemas.VcenterIntegration.required: []`

Empty `required` is illegal per the OpenAPI 3.0 metaschema (JSON Schema draft-04), so an **operator ingest of this spec fails identically** (`invalid_spec`). Disposition: remediate the artifact, not the gate — meho's documented posture is fix-the-document, and the nsx-9.0 precedent pins a deterministic ingest-consumable derivative next to the byte-identical vendor fetch. The shelf now pins `vcf-operations-openapi.ingestable.json` (the vendor document with the three empty arrays dropped — a semantic no-op; minified; recipe + sha256 in the shelf MANIFEST) via consumer PR [claude-rdc-hetzner-dc#2534](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/pull/2534). The lane parses that file — byte-for-byte what an operator ingest consumes.

Per-op path decisions — all five served, **no repoints needed** (verified against the pinned spec after the `/suite-api` server-base fold, #1796):

| op / surface | declared | spec (folded) | decision |
|---|---|---|---|
| session mint (`vcf_session_login`) | `POST:/suite-api/api/auth/token/acquire` | served | keep |
| `fingerprint` / `probe` / `vrops.liveness` | `GET:/suite-api/api/versions/current` | served | keep |
| `vrops.alert.list` | `GET:/suite-api/api/alerts` | served | keep |
| `vrops.resource.query` | `POST:/suite-api/api/resources/query` | served | keep |
| `vrops.resource.stats` | `GET:/suite-api/api/resources/stats/latest` | served | keep |

Sweep notes: the only composed path in the package is `resource_query`'s query-string append onto the introspected constant (no second literal); the `probe_method="GET /suite-api/api/versions/current"` strings are display metadata, never dispatched.

## Sequencing

Consumer PR [claude-rdc-hetzner-dc#2534](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/pull/2534) must merge **before** this PR's widened verify step can pass on armed CI (the nsx #2512 → #3007 sequencing). Until then the verify step fails by design.

## Test plan

- [x] Lane armed (`MEHO_CONSUMER_DOCS_ROOT=<shelf-with-#2534>/docs`) — 2 passed; full reconcile-lane family (vcf-operations + sddc-manager + nsx + harness + example lane) — 21 passed
- [x] Lane without env — 1 passed (guard), 1 skipped with the uniform `tests/_spec_shelf.py` reason
- [x] `ruff check src/ tests/` — clean; `ruff format --check` — clean
- [x] `mypy src/` — no new errors (pre-existing macOS-only `net/icmp.py` `MSG_ERRQUEUE` finding untouched; passes on Linux CI)
- [x] Existing vcf_operations test modules (auth / credread / e2e / typed_reads) — 55 passed
- [x] `ci.yml` YAML-parses; code-quality gate exit 0
- [ ] CI verify step green once claude-rdc-hetzner-dc#2534 merges (armed repo)

## Out of scope

- Sibling wave-3 lanes: #2983 (vcf-automation), #2985 (hetzner-robot) — same `ci.yml` lists, rebase-not-battle per the initiative.
- The shelf's Logs / Networks sub-product specs (no meho consumer parses them today; the MANIFEST notes re-checking the metaschema before wiring one).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2984
