### PR TITLE
feat(tests): vcf-automation real-spec reconcile lane — tenant plane armed, provider plane evidenced-excluded, region-list repoint (#2983)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,8 @@ jobs:
           # Cone-mode sparse checkout of the shelf directories only +
           # lazy blob filter: the runner materialises just the pinned
           # spec files (~33 MB nsx-9.0 + ~2 MB sddc-manager-9.0 +
-          # ~18 MB vcenter-9.0), not the whole consumer repo. No
+          # ~18 MB vcenter-9.0 + ~3 MB vcf-automation-9.0), not the
+          # whole consumer repo. No
           # `ref:` pin — the shelf's default branch IS the
           # operator-curated pin (the directories are version-named),
           # matching the local-dev contract documented in
@@ -307,6 +308,7 @@ jobs:
             docs/nsx-9.0
             docs/sddc-manager-9.0
             docs/vcenter-9.0
+            docs/vcf-automation-9.0
           filter: blob:none
           # Read-only consumer; never pushes. Don't leave the token in
           # the shelf clone's local git config after checkout.
@@ -329,13 +331,14 @@ jobs:
             spec-shelf/docs/nsx-9.0/nsx_policy_api.openapi3.json \
             spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json \
             spec-shelf/docs/vcenter-9.0/vcenter.yaml \
-            spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
+            spec-shelf/docs/vcenter-9.0/vi-json.yaml \
+            spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json; do
             if [ ! -f "$f" ]; then
               echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
               exit 1
             fi
           done
-          echo "spec-shelf OK: nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/"
+          echo "spec-shelf OK: nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -957,6 +960,7 @@ jobs:
             docs/nsx-9.0
             docs/sddc-manager-9.0
             docs/vcenter-9.0
+            docs/vcf-automation-9.0
           filter: blob:none
           persist-credentials: false
 
@@ -972,13 +976,14 @@ jobs:
             spec-shelf/docs/nsx-9.0/nsx_policy_api.openapi3.json \
             spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json \
             spec-shelf/docs/vcenter-9.0/vcenter.yaml \
-            spec-shelf/docs/vcenter-9.0/vi-json.yaml; do
+            spec-shelf/docs/vcenter-9.0/vi-json.yaml \
+            spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json; do
             if [ ! -f "$f" ]; then
               echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
               exit 1
             fi
           done
-          echo "spec-shelf OK: nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/"
+          echo "spec-shelf OK: nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-lint-test's login step — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — vcf-automation real-spec reconcile lane + region-list repoint (#2983)
+
+- Every hand-coded `METHOD:/path` the vcf-automation connector
+  dispatches (the seven typed-op paths, the two per-plane login POSTs,
+  the two fingerprint probes) is now swept by the #2980-harness lane
+  (`backend/tests/test_connectors_vcf_automation_spec_reconcile.py` —
+  parse-only, required unit sweep, uniform skip when the shelf is
+  unconfigured). VCFA's shelf is a mosaic, so the lane splits by
+  plane: the tenant half asserts against the pinned Apache-2.0
+  `vra-iaas.json` (Swagger 2.0; lane-supplied extraction per the
+  standard's non-OpenAPI clause), the provider half is an evidenced
+  exclusion (no pinnable wire spec exists — recorded in
+  `docs/decisions/spec-reconcile-guards-standard.md`). CI's
+  secret-gated spec-shelf checkout is widened to
+  `docs/vcf-automation-9.0` in both Python jobs. First run surfaced
+  one real finding, fixed per the #2970 protocol:
+  `vcfa.provider.region.list` targeted `GET /cloudapi/1.0.0/regions`,
+  which VCFA 9.0 404s (Region moved to the `vcf/` cloudapi prefix) —
+  repointed to `GET /cloudapi/vcf/regions` per the pinned
+  go-vcloud-director v3.0.0 endpoint map and the shelf's live-probe
+  record.
+
 ### Added — sddc-manager real-spec reconcile lane (#2982)
 
 - Every hand-coded `METHOD:/path` the sddc-manager connector dispatches

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -753,7 +753,7 @@ class VcfAutomationConnector(HttpConnector):
         target: VcfAutomationTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """``vcfa.provider.region.list`` — ``GET /cloudapi/1.0.0/regions`` (provider plane)."""
+        """``vcfa.provider.region.list`` — ``GET /cloudapi/vcf/regions`` (provider plane)."""
         return await self._request_json(
             target,
             "GET",

--- a/backend/src/meho_backplane/connectors/vcf_automation/typed_ops.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/typed_ops.py
@@ -24,7 +24,7 @@ Provider plane (``/cloudapi/1.0.0/*`` — Basic-auth →
 ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` JWT session):
 
 * ``vcfa.provider.org.list`` — ``GET /cloudapi/1.0.0/orgs``
-* ``vcfa.provider.region.list`` — ``GET /cloudapi/1.0.0/regions``
+* ``vcfa.provider.region.list`` — ``GET /cloudapi/vcf/regions``
 * ``vcfa.provider.health`` — ``GET /cloudapi/1.0.0/site`` (appliance
   site identity + product version; the provider-plane health/probe
   surface ``fingerprint`` and the operator use to confirm which VCFA
@@ -91,7 +91,15 @@ __all__ = [
 # connector handler bodies so the two never drift. plane_for_path()
 # reads these to pick the auth plane at transport time.
 PROVIDER_ORGS_PATH: Final[str] = "/cloudapi/1.0.0/orgs"
-PROVIDER_REGIONS_PATH: Final[str] = "/cloudapi/1.0.0/regions"
+#: VCFA 9.0 serves Region under the ``vcf/`` cloudapi prefix, not the
+#: classic ``1.0.0/`` one (#2983 reconcile finding): the SDK the vendor's
+#: own terraform provider pins for VCFA 9.0 maps regions as
+#: ``OpenApiPathVcf`` (``go-vcloud-director@v3.0.0``
+#: ``govcd/openapi_endpoints.go``), and the shelf's live-probe record
+#: has ``GET /cloudapi/1.0.0/regions`` → 404 with ``/cloudapi/vcf/regions``
+#: serving (consumer kb ``vcf-automation-9.0-provider-object-model.md``,
+#: probes 2026-05-16 / 2026-07-21).
+PROVIDER_REGIONS_PATH: Final[str] = "/cloudapi/vcf/regions"
 PROVIDER_SITE_PATH: Final[str] = "/cloudapi/1.0.0/site"
 TENANT_PROJECTS_PATH: Final[str] = "/iaas/api/projects"
 TENANT_DEPLOYMENTS_PATH: Final[str] = "/iaas/api/deployments"
@@ -263,7 +271,7 @@ _PROVIDER_REGION_LIST = VcfaTypedOp(
     path=PROVIDER_REGIONS_PATH,
     summary="List VCFA regions on the appliance (provider plane).",
     description=(
-        "Lists VCFA regions via GET /cloudapi/1.0.0/regions on the provider "
+        "Lists VCFA regions via GET /cloudapi/vcf/regions on the provider "
         "plane — the VCFA 9 evolution of the vCloud-Director provider VDC. "
         "Each region groups compute/memory/networking under one NSX domain, "
         "typically backed by one or more VCF workload domains. Supports "

--- a/backend/tests/test_connectors_vcf_automation_spec_reconcile.py
+++ b/backend/tests/test_connectors_vcf_automation_spec_reconcile.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vcf-automation real-spec reconcile lane (#2983) — the #2980 harness.
+
+Asserts the hand-coded ``METHOD:/path`` literals the vcf-automation
+connector dispatches against the pinned ``vcf-automation-9.0`` shelf.
+Parse-only set compare — no DB, no embeddings, no containers — so it
+lives in the required unit sweep per the lane-placement rule in
+``docs/decisions/spec-reconcile-guards-standard.md``. Uniform skip when
+the shelf is unconfigured (``tests/_spec_shelf.py`` contract).
+
+VCFA is dual-plane and its shelf is a **mosaic** (the shelf's
+``vcf-automation-9.0/MANIFEST.md`` is the provenance record), so the
+lane splits by plane:
+
+* **Tenant plane — armed.** Every ``/iaas/api/*`` op_id asserts against
+  the pinned ``swagger-vra-sdk-go-v0.6.5/vra-iaas.json`` — the IaaS API
+  Swagger 2.0 document vendored in the **Apache-2.0**
+  `vmware/vra-sdk-go <https://github.com/vmware/vra-sdk-go>`_ repo at
+  tag ``v0.6.5``, the closest published surface to the VCFA 9.x
+  consumption plane (the on-prem appliance serves the same path
+  shapes). ``parse_openapi`` accepts OpenAPI 3.0/3.1 only (#2090), so
+  the lane supplies its own served-set extraction from the Swagger 2.0
+  document — the standard's non-OpenAPI-artifact clause. No OpenAPI 3
+  conversion is pinned (unlike nsx-9.0's): these fragments are never
+  operator-ingested — the typed ops exist precisely because ingest
+  rejects them — so a converted artifact would be a test-only
+  fabrication with no dispatch-fidelity value.
+* **Provider plane — evidenced exclusion.** No wire-level provider
+  (cloudapi / classic ``/api/*``) spec exists or can be pinned: the
+  vendor publishes no artifact (no ``automation/`` directory in
+  ``vmware/vcf-api-specs``; go-vcloud-director and
+  terraform-provider-vcfa vendor no swagger — the SDK's hand-written
+  endpoint map is the machine-readable surface) and the appliance
+  serves none (``/cloudapi/1.0.0/openapi*`` → 404, probed 2026-05-16).
+  Evidence, coverage, and the activation trigger live in the
+  ``vcf-automation-9.0`` entry of the standard doc's
+  Evidenced-exclusions section. The manifest pin below still sweeps
+  the provider op_ids so the enumeration stays complete and a future
+  spec activates against the full set.
+
+The declared set is introspected from the connector's live constants
+(the #2944 pattern — never a hardcoded mirror), across the two modules
+that hand-code a path:
+
+* :mod:`~meho_backplane.connectors.vcf_automation.typed_ops` — the
+  seven ``*_PATH`` op constants. Every typed handler dispatches through
+  the connector's ``_request_json(target, "GET", ...)``, so each
+  declares ``GET:``.
+* :mod:`~meho_backplane.connectors.vcf_automation._routing` — the two
+  ``*_SESSION_PATH`` login endpoints (both POSTed by ``._auth``) and
+  the two ``*_VERSION_PATH`` unauthenticated fingerprint probes (both
+  GET). ``TENANT_VERSION_PATH`` collapses onto the typed
+  ``GET:/iaas/api/about`` op_id by value.
+
+First run against the real shelf surfaced one finding — caught by the
+shelf's provenance record rather than a spec parse, since the affected
+path is provider-plane: ``vcfa.provider.region.list`` targeted
+``GET:/cloudapi/1.0.0/regions``, which the live product 404s (Region
+moved to the ``vcf/`` cloudapi prefix on VCFA 9.0); repointed to
+``GET:/cloudapi/vcf/regions`` in the same PR per the #2970 protocol.
+Rationale on the constant; protocol:
+docs/decisions/spec-reconcile-guards-standard.md.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from meho_backplane.connectors.vcf_automation import _routing as _routing_module
+from meho_backplane.connectors.vcf_automation import typed_ops as _typed_ops_module
+from meho_backplane.connectors.vcf_automation._routing import plane_for_path
+from meho_backplane.connectors.vcf_automation.typed_ops import VCFA_TYPED_OPS
+from tests._spec_shelf import assert_op_ids_served, require_shelf_spec
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SPEC_DIR = "vcf-automation-9.0"
+_TENANT_SPEC_FILE = "swagger-vra-sdk-go-v0.6.5/vra-iaas.json"
+_TENANT_SPEC_LABEL = f"{_SPEC_DIR}/{_TENANT_SPEC_FILE}"
+
+#: The Swagger 2.0 path-item keys that are HTTP operations (its fixed
+#: verb vocabulary); everything else on a path item (``parameters``,
+#: vendor extensions) is not a served operation.
+_SWAGGER2_METHODS = frozenset({"get", "put", "post", "delete", "options", "head", "patch"})
+
+#: HTTP method per ``_routing`` constant-name suffix. The two
+#: ``*_SESSION_PATH`` login endpoints are POSTed (``._auth``'s
+#: ``vcfa_provider_login`` / ``tenant_login``); the two
+#: ``*_VERSION_PATH`` probes are GET (``connector.fingerprint`` via
+#: ``_try_probe``). A new ``*_PATH`` constant matching neither suffix
+#: fails the sweep loudly so its method is mapped consciously.
+_ROUTING_METHOD_BY_SUFFIX = {
+    "_SESSION_PATH": "POST",
+    "_VERSION_PATH": "GET",
+}
+
+
+def _path_constants(module: object) -> dict[str, str]:
+    """The live ``*_PATH`` string constants of *module*, by constant name."""
+    return {
+        name: value
+        for name, value in vars(module).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the vcf-automation connector dispatches.
+
+    Sweeps the live module constants (never a hardcoded mirror): all
+    typed-op paths dispatch as ``GET`` (each handler is a
+    ``_request_json(target, "GET", ...)`` call); the ``_routing``
+    constants map to their method by name suffix
+    (:data:`_ROUTING_METHOD_BY_SUFFIX`).
+    """
+    declared = {f"GET:{path}" for path in _path_constants(_typed_ops_module).values()}
+    for name, path in _path_constants(_routing_module).items():
+        for suffix, method in _ROUTING_METHOD_BY_SUFFIX.items():
+            if name.endswith(suffix):
+                declared.add(f"{method}:{path}")
+                break
+        else:
+            raise AssertionError(
+                f"_routing.{name} matches no suffix in _ROUTING_METHOD_BY_SUFFIX — "
+                "map the new constant's HTTP method there consciously so the "
+                "reconcile keeps covering it."
+            )
+    return declared
+
+
+def test_path_constant_names_are_pinned() -> None:
+    """Guard: the introspection finds every hand-coded path constant.
+
+    Pinning the exact constant-name sets (the #2944 guard shape) means a
+    renamed or dropped ``*_PATH`` constant — or a new one that skips the
+    ``_PATH`` suffix convention — can't silently shrink the reconciled
+    set to a vacuous pass.
+    """
+    assert sorted(_path_constants(_typed_ops_module)) == [
+        "PROVIDER_ORGS_PATH",
+        "PROVIDER_REGIONS_PATH",
+        "PROVIDER_SITE_PATH",
+        "TENANT_ABOUT_PATH",
+        "TENANT_DEPLOYMENTS_PATH",
+        "TENANT_DEPLOYMENT_DETAIL_PATH",
+        "TENANT_PROJECTS_PATH",
+    ]
+    assert sorted(_path_constants(_routing_module)) == [
+        "PROVIDER_SESSION_PATH",
+        "PROVIDER_VERSION_PATH",
+        "TENANT_SESSION_PATH",
+        "TENANT_VERSION_PATH",
+    ]
+
+
+def test_typed_op_paths_are_covered_by_the_swept_constants() -> None:
+    """Guard: no typed op can carry an inline path the sweep misses.
+
+    Every :data:`VCFA_TYPED_OPS` entry's ``path`` must be one of the
+    swept ``typed_ops`` module constants — an op added with an inline
+    literal (skipping the shared-constant convention the module
+    documents) would otherwise dodge the reconcile.
+    """
+    swept = set(_path_constants(_typed_ops_module).values())
+    unswept = {op.op_id: op.path for op in VCFA_TYPED_OPS if op.path not in swept}
+    assert not unswept, (
+        f"typed ops with paths outside the swept *_PATH constants: {unswept} — "
+        "route the path through a module-level *_PATH constant so the "
+        "reconcile lane covers it."
+    )
+
+
+def test_vcfa_hand_coded_op_id_manifest_is_pinned() -> None:
+    """Pin the swept op_id set so drift can't silently shrink the reconcile.
+
+    Runs unconditionally (no shelf needed), so the enumeration is proven
+    on every sweep — both planes, including the provider op_ids whose
+    spec-assert is an evidenced exclusion today. A new hand-coded path,
+    a renamed constant, or a method change must update this manifest
+    consciously — and the lane's declared set moves with it.
+    """
+    assert _declared_op_ids() == {
+        "GET:/api/versions",
+        "GET:/cloudapi/1.0.0/orgs",
+        "GET:/cloudapi/1.0.0/site",
+        "GET:/cloudapi/vcf/regions",
+        "GET:/iaas/api/about",
+        "GET:/iaas/api/deployments",
+        "GET:/iaas/api/deployments/{id}",
+        "GET:/iaas/api/projects",
+        "POST:/cloudapi/1.0.0/sessions/provider",
+        "POST:/iaas/api/login",
+    }
+
+
+def _swagger2_served_op_ids(spec_path: Path) -> set[str]:
+    """Extract the served ``METHOD:/path`` set from a Swagger 2.0 document.
+
+    The pinned tenant spec is Swagger 2.0, which the ingest parser
+    rejects by decision (#2090) — so this lane extracts directly instead
+    of routing through :func:`tests._spec_shelf.openapi_served_op_ids`
+    (the standard's non-OpenAPI-artifact clause). Served op_ids are the
+    ``basePath``-folded path keys crossed with their operation-verb
+    keys; ``vra-iaas.json`` pins ``basePath: /``, so its paths fold
+    unchanged. Format drift on the shelf (a re-pin that is no longer
+    Swagger 2.0, or an empty path map) fails loudly rather than
+    regressing the lane to a vacuous compare.
+    """
+    document = json.loads(spec_path.read_text(encoding="utf-8"))
+    if document.get("swagger") != "2.0":
+        pytest.fail(
+            f"{_TENANT_SPEC_LABEL}: expected a Swagger 2.0 document "
+            f"(got swagger={document.get('swagger')!r} / "
+            f"openapi={document.get('openapi')!r}) — the shelf artifact "
+            "format moved; update this lane's extraction."
+        )
+    base = str(document.get("basePath") or "").rstrip("/")
+    served = {
+        f"{method.upper()}:{base}{path}"
+        for path, item in document.get("paths", {}).items()
+        for method in item
+        if method.lower() in _SWAGGER2_METHODS
+    }
+    if not served:
+        pytest.fail(
+            f"{_TENANT_SPEC_LABEL}: extracted zero served operations — the "
+            "shelf artifact layout moved; update this lane's extraction."
+        )
+    return served
+
+
+def test_tenant_hand_coded_paths_are_served_by_the_pinned_iaas_spec() -> None:
+    """Every tenant-plane op_id is served by the pinned vra-iaas.json spec.
+
+    The tenant subset is selected with the connector's own
+    :func:`~meho_backplane.connectors.vcf_automation._routing.plane_for_path`
+    — the same classifier the transport uses to pick the auth plane —
+    so the lane's plane split can never drift from dispatch reality.
+    A red run here is the guard surfacing a finding; triage per
+    docs/decisions/spec-reconcile-guards-standard.md.
+    """
+    spec_path = require_shelf_spec(_SPEC_DIR, _TENANT_SPEC_FILE)
+    served = _swagger2_served_op_ids(spec_path)
+    declared = {
+        op_id for op_id in _declared_op_ids() if plane_for_path(op_id.partition(":")[2]) == "tenant"
+    }
+    assert_op_ids_served(declared, served, spec_label=_TENANT_SPEC_LABEL)

--- a/docs/codebase/connectors-vcf-automation.md
+++ b/docs/codebase/connectors-vcf-automation.md
@@ -30,12 +30,24 @@ session with **zero catalog state**. Seven ops:
 | op_id | plane | path |
 |---|---|---|
 | `vcfa.provider.org.list` | provider | `GET /cloudapi/1.0.0/orgs` |
-| `vcfa.provider.region.list` | provider | `GET /cloudapi/1.0.0/regions` |
+| `vcfa.provider.region.list` | provider | `GET /cloudapi/vcf/regions` |
 | `vcfa.provider.health` | provider | `GET /cloudapi/1.0.0/site` |
 | `vcfa.tenant.project.list` | tenant | `GET /iaas/api/projects` |
 | `vcfa.tenant.deployment.list` | tenant | `GET /iaas/api/deployments` |
 | `vcfa.tenant.deployment.get` | tenant | `GET /iaas/api/deployments/{id}` |
 | `vcfa.tenant.about` | tenant | `GET /iaas/api/about` |
+
+The region list rides the `vcf/` cloudapi prefix, not the classic
+`1.0.0/` one — VCFA 9.0 moved Region there and 404s the classic form
+(repointed by the #2983 reconcile; rationale on the
+`PROVIDER_REGIONS_PATH` constant). Every hand-coded `METHOD:/path` in
+the connector is swept by the spec-reconcile lane
+(`backend/tests/test_connectors_vcf_automation_spec_reconcile.py`,
+#2983): the tenant-plane half asserts against the pinned Apache-2.0
+`vra-iaas.json` on the spec shelf; the provider-plane half is an
+evidenced exclusion (no pinnable wire spec exists — see the
+`vcf-automation-9.0` entry in
+`docs/decisions/spec-reconcile-guards-standard.md`).
 
 Each op **declares the plane it rides**; `typed_ops._validate_typed_op_planes`
 asserts at import time that the declared `plane` matches

--- a/docs/decisions/spec-reconcile-guards-standard.md
+++ b/docs/decisions/spec-reconcile-guards-standard.md
@@ -269,6 +269,82 @@ pinnable. The record below replaces the exclusion; the lane is armed.
   (`claude-rdc-hetzner-dc#2514`) which must merge before this repo's
   widened verify step can pass.
 
+### vcf-automation-9.0 — tenant plane ARMED, provider plane excluded (#2983)
+
+VCFA is dual-plane and its shelf is a **mosaic** (the shelf's
+`vcf-automation-9.0/MANIFEST.md`, grounded 2026-04-30, is the
+provenance record): the tenant/consumption plane has a pinnable
+published spec; the provider (cloudapi / classic `/api/*`) plane has
+none. The lane
+(`backend/tests/test_connectors_vcf_automation_spec_reconcile.py`)
+splits accordingly — its manifest pin sweeps **all ten** hand-coded
+op_ids unconditionally, so the enumeration stays whole across the
+split.
+
+- **Armed (tenant plane, 5 op_ids under `/iaas/api/*`):** asserted
+  against the pinned
+  `swagger-vra-sdk-go-v0.6.5/vra-iaas.json` (IaaS API, Swagger 2.0,
+  143 paths) — vendored in the **public Apache-2.0**
+  [`vmware/vra-sdk-go`](https://github.com/vmware/vra-sdk-go) repo at
+  tag `v0.6.5`; the on-prem VCFA appliance serves the same path shapes
+  (MANIFEST caveat). `parse_openapi` rejects Swagger 2.0 by decision
+  (#2090), so the lane supplies its own served-set extraction per this
+  standard's non-OpenAPI-artifact clause. Deliberately **no** OpenAPI 3
+  conversion is pinned (contrast nsx-9.0): unlike the nsx conversions
+  — which are byte-for-byte what an operator ingest consumes — nothing
+  VCFA-tenant is ever ingested (the typed ops exist precisely because
+  ingest rejects these fragments), so a conversion would be a
+  test-only artifact with no dispatch-fidelity value.
+- **Excluded (provider plane, 5 op_ids: `GET:/cloudapi/1.0.0/orgs`,
+  `GET:/cloudapi/vcf/regions`, `GET:/cloudapi/1.0.0/site`,
+  `POST:/cloudapi/1.0.0/sessions/provider`, `GET:/api/versions`).**
+  What was checked, per family: (1) **vendor-published artifacts** —
+  no `automation/` directory in
+  [`vmware/vcf-api-specs`](https://github.com/vmware/vcf-api-specs)
+  (checked 2026-04-30; re-checked at filing); no swagger/openapi
+  artifact vendored in `go-vcloud-director@v3.0.0` (the exact SDK tag
+  the vendor's own `terraform-provider-vcfa@v1.0.0` pins for VCFA 9.0)
+  or in the provider repo itself — a `find` for `*swagger*` /
+  `*openapi*.{json,yaml}` is empty in both; the hand-written
+  `govcd/openapi_endpoints.go` endpoint→version map is the only
+  machine-readable surface (consumer kb
+  `vcf-automation-9.0-provider-object-model.md`, #501). That map
+  covers only the cloudapi object families — not the classic `/api/*`
+  surface, not the session endpoints, not `/site` — so pinning it
+  cannot serve a reconcile authority for the five paths above without
+  false reds. (2) **Appliance-served spec** —
+  `/cloudapi/1.0.0/openapi*` → 404 with a correctly-versioned
+  `Accept` (live Holodeck VCFA 9.0.2, 2026-05-16, #501). (3)
+  **Broadcom dev-portal (xapis)** — the VCFA pages there cover the
+  consumption/tenant surface already vendored in `vra-sdk-go`
+  (MANIFEST survey note). **Residual risk, named** (the nsx lesson —
+  an exclusion must cover every vendor-documented family): no probe
+  has surveyed appliance spec-serving locations beyond
+  `/cloudapi/1.0.0/openapi*`; if a vendor-documented spec-serving
+  family emerges, that falsifies this exclusion and is the activation
+  trigger.
+- **Activation:** `vmware/vcf-api-specs` gaining an automation spec
+  (the MANIFEST's re-grounding trigger) or an appliance-served spec
+  being evidenced. The activating task runs the full extension
+  mechanics and reconciles the five provider op_ids on first run.
+- **First-run findings (1), dispositioned in the lane PR:**
+  `vcfa.provider.region.list` targeted `GET:/cloudapi/1.0.0/regions`
+  — surfaced by the shelf's provenance record rather than a spec
+  parse (the path is provider-plane): the pinned SDK map places
+  Region under the `vcf/` cloudapi prefix, and the shelf's live-probe
+  record has the `1.0.0/` form → 404 with `/cloudapi/vcf/regions`
+  serving (2026-05-16 #505 build run; re-confirmed by later probes,
+  #499/#2006). **Mechanical repoint** to `GET:/cloudapi/vcf/regions`
+  — same resource, same paged `values[]`/`resultTotal` envelope, same
+  `Accept` (the cloudapi form; `provider_accept_for_path` keys on the
+  `/api/` prefix only), plane classification unchanged. One residual
+  the exclusion cannot discharge: `GET:/cloudapi/1.0.0/site`
+  (`vcfa.provider.health`) is unverifiable today — no spec serves it,
+  no live probe of the singular `/site` form is recorded (the plural
+  `/sites` 404s live, 2026-05-05), and vCD 10.5 serves the singular
+  form. Left as-is per "never invent a path"; the activation run
+  reconciles it.
+
 ## Red lane = finding (the protocol)
 
 A red lane on first run against the real shelf is **the guard working**,

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -281,6 +281,28 @@ Future lane tasks record a reference to that comment here instead of
 obtaining a fresh attestation; OSS-licensed specs continue to use the
 provenance-note form and need no attestation.
 
+### Extension: vcf-automation / vcf-automation-9.0 (#2983)
+
+The same secret-gated checkout additionally fetches the shelf's
+`docs/vcf-automation-9.0/` directory (~3 MB; the lane parses
+`swagger-vra-sdk-go-v0.6.5/vra-iaas.json`, the tenant-plane IaaS API
+Swagger 2.0 document, 143 paths) for the vcf-automation reconcile lane
+(`backend/tests/test_connectors_vcf_automation_spec_reconcile.py`),
+under the identical ephemeral-use conditions recorded above (sparse
+read-only checkout, workspace destroyed at job end, never committed,
+never in artifacts or logs, secret withheld from fork PRs and the
+Dependabot store). No vendor-license attestation is needed for this
+extension: the spec is vendored by VMware in the **public, Apache-2.0**
+[`vmware/vra-sdk-go`](https://github.com/vmware/vra-sdk-go) repo
+(pinned at tag `v0.6.5`, commit `a886fc67`, retrieved 2026-04-30) — the
+provenance note of record is the shelf's
+`vcf-automation-9.0/MANIFEST.md`, per the OSS-licensed-spec form in
+[`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
+extension mechanics. The provider (cloudapi / classic `/api/*`) plane
+pins nothing because nothing pinnable exists — that half of the lane is
+the evidenced exclusion recorded in the standard doc's
+`vcf-automation-9.0` entry.
+
 ## Consequences
 
 - The five real-spec lanes light up together the moment the secret exists;


### PR DESCRIPTION
## Summary

- Ships the vcf-automation spec-reconcile lane (#2980 harness): `backend/tests/test_connectors_vcf_automation_spec_reconcile.py` sweeps every hand-coded `METHOD:/path` the connector dispatches — introspected from the live `*_PATH` constants of `typed_ops` (all GET) and `_routing` (`*_SESSION_PATH` → POST, `*_VERSION_PATH` → GET), never a hardcoded mirror. Parse-only, required unit sweep, uniform skip without the shelf.
- **VCFA's shelf is a mosaic, so the lane splits by plane** (verified against the shelf before designing, per the wave-3 protocol). Tenant plane (5 op_ids under `/iaas/api/*`) **arms** against the pinned `swagger-vra-sdk-go-v0.6.5/vra-iaas.json` — Swagger 2.0 from the public **Apache-2.0** [`vmware/vra-sdk-go`](https://github.com/vmware/vra-sdk-go) at tag `v0.6.5`. `parse_openapi` rejects Swagger 2.0 by decision (#2090), so the lane supplies its own served-set extraction (the standard's non-OpenAPI-artifact clause; the hetzner-robot shape). Deliberately no OpenAPI 3 conversion is pinned (contrast nsx-9.0): nothing VCFA-tenant is ever ingested — the typed ops exist precisely because ingest rejects these fragments — so a conversion would be a test-only artifact with no dispatch-fidelity value.
- Provider plane (5 op_ids) is an **evidenced exclusion** recorded in `spec-reconcile-guards-standard.md`: no wire-level spec exists or can be pinned (no `automation/` dir in `vmware/vcf-api-specs`; no vendored swagger in `go-vcloud-director@v3.0.0` / `terraform-provider-vcfa@v1.0.0`; appliance-served `/cloudapi/1.0.0/openapi*` → 404, probed 2026-05-16). The residual-risk family (unprobed spec-serving locations — the nsx lesson) is named explicitly, with the activation trigger. The lane's unconditional manifest pin still sweeps **all ten** op_ids so the enumeration stays whole.
- **First-run finding, fixed in this PR (the #2970 protocol):** `vcfa.provider.region.list` targeted `GET /cloudapi/1.0.0/regions`, which VCFA 9.0 404s — repointed to `GET /cloudapi/vcf/regions` (decision table below).
- CI: spec-shelf sparse-checkout + fail-loud verify widened to `docs/vcf-automation-9.0` in **both** Python jobs (alphabetical insertion; trivial rebase expected against the sibling wave-3 lanes). ADR extension added to `vendor-spec-ci-provisioning.md` in the **OSS provenance-note form** (Apache-2.0 spec — no attestation needed per the wave-3 rules; the vendor-licensed blanket is not invoked).

## Per-op decisions (all 10 swept op_ids)

| op_id | plane | disposition | grounds |
|---|---|---|---|
| `GET:/iaas/api/about` | tenant | **served** | `vra-iaas.json` `GET /iaas/api/about` |
| `GET:/iaas/api/projects` | tenant | **served** | `vra-iaas.json` `GET /iaas/api/projects` |
| `GET:/iaas/api/deployments` | tenant | **served** | `vra-iaas.json` `GET /iaas/api/deployments` |
| `GET:/iaas/api/deployments/{id}` | tenant | **served** (template byte-equal) | `vra-iaas.json` `GET /iaas/api/deployments/{id}` |
| `POST:/iaas/api/login` | tenant | **served** | `vra-iaas.json` `POST /iaas/api/login` |
| `GET:/cloudapi/1.0.0/orgs` | provider | excluded — kept | live-proven repeatedly (shelf kb #501/#505/#1877: 200s); the one classic-looking path that survived on VCFA 9.0 |
| `GET:/cloudapi/1.0.0/regions` → `GET:/cloudapi/vcf/regions` | provider | **mechanical repoint (this PR)** | pinned `go-vcloud-director@v3.0.0` `govcd/openapi_endpoints.go` maps Region as `OpenApiPathVcf` (`vcf/` prefix); shelf live-probe record: `1.0.0/regions` → **404** with `/cloudapi/vcf/regions` serving (Holodeck VCFA 9.0.2, 2026-05-16 #505 build run; re-confirmed #499 / #2006). Same resource, same paged `values[]`/`resultTotal` envelope, same `Accept` (`provider_accept_for_path` keys on the `/api/` prefix only), `plane_for_path` unchanged (provider). Not invented: the target path is live-proven 200 and SDK-pinned. |
| `GET:/cloudapi/1.0.0/site` | provider | excluded — kept, residual named | no spec serves it; no live probe of the singular `/site` form recorded (the plural `/sites` 404s live, 2026-05-05); vCD 10.5 serves the singular form. "Never invent a path" cuts both ways — no grounded repoint target exists, so the constant stands and the exclusion entry names it for the activation run. |
| `POST:/cloudapi/1.0.0/sessions/provider` | provider | excluded — kept | live-proven login flow (shelf kb, consumer wrapper `scripts/vcf-automation.sh`) |
| `GET:/api/versions` | provider | excluded — kept | live-proven unauthenticated probe (shelf kb #517: advertises 38.0–40.0 + 9.0.0) |

## Test plan

- [x] Lane armed (`MEHO_CONSUMER_DOCS_ROOT=<shelf>/docs`): `pytest tests/test_connectors_vcf_automation_spec_reconcile.py` — **4 passed** (tenant reconcile green against the real shelf)
- [x] Lane without env: **3 passed, 1 skipped** with the harness's uniform reason naming `vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json`
- [x] Repoint blast radius + siblings: vcfa auth/credread/e2e/typed_reads + registry/resolver/probe + `_spec_shelf` harness tests + example lane + sddc + nsx lanes — **199 passed** (the typed-reads dispatch test derives its respx routes from `op.path`, so the repoint is exercised there against the new path)
- [x] `ruff check src/ tests/` — clean; `ruff format --check` — clean
- [x] `mypy src/` — 1 pre-existing darwin-only error in untouched `connectors/net/icmp.py` (`socket.MSG_ERRQUEUE` doesn't exist on macOS; CI runs Linux)
- [x] `code-quality.py --diff` — 0 blockers (warnings are pre-existing file-size debt)
- [x] `ci.yml` parses (yaml.safe_load); insertion strictly alphabetical in all four lists
- [ ] CI armed run: verify step passes with the widened checkout; lane runs (not skips) in `python-lint-test`

## Out of scope / adjacent findings

- Sibling wave-3 lanes #2984 (vcf-operations) / #2985 (hetzner-robot) edit the same `ci.yml` lists — trivial rebase expected, insertion kept alphabetical to minimize it.
- Vestigial respx routes in `test_connectors_vcf_automation_e2e.py` (`/cloudapi/1.0.0/site|orgs|regions` list mocks, lines 575–578): no e2e test dispatches the typed ops since the T5 #2305 move (typed surface covered by `typed_reads`); the routes are inert. Left untouched — cleanup would be scope creep here.
- `test_connectors_vcf_automation_auth.py` uses `"/cloudapi/1.0.0/regions"` as an arbitrary provider-plane path in a token-cache test — plane classification is prefix-based, so the test stays valid; left untouched.
- The retired-canary docs (`docs/cross-repo/g36-vcfa-canary.md`, `vcf-automation-onboarding.md`) still narrate `1.0.0/regions` ingested op_ids of the retired G3.6 flow — historical record of a retired apparatus, not current-path documentation; left untouched.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2983
