### PR TITLE
feat(events): event_source registry + admin CRUD with Vault secret custody

### DIFF
--- a/backend/alembic/versions/0074_create_event_source.py
+++ b/backend/alembic/versions/0074_create_event_source.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``event_source`` registry table (#2880).
+
+Revision ID: 0074
+Revises: 0073
+Create Date: 2026-08-18
+
+Task #2880 under Initiative #2877. The tenant-scoped registry the inbound
+webhook path (#2881, out of scope here) resolves a JWT-less sender
+against: the row supplies the tenant attribution ``events.publish()``
+needs a real tenant FK for, and its Vault-custodied secret is what the
+ingest endpoint verifies. Moulded on ``targets`` (per-tenant, ``name``
+unique via a partial index, ``secret_ref`` a nullable Vault path,
+``extras`` the escape hatch, ``deleted_at`` soft-delete) with three
+deliberate departures documented on the ORM model
+(:class:`meho_backplane.db.models.EventSource`):
+
+* ``tenant_id`` carries a **real** ``REFERENCES tenant(id)`` FK (the newer
+  ``sensor`` / ``event_outbox`` discipline).
+* ``slug`` is unique **globally**, not per-tenant -- it is the sole
+  routing key in the JWT-less ingest URL.
+* the admin surface writes the auth secret to Vault at ``secret_ref``
+  (``targets`` only ever references an externally provisioned path); the
+  row still stores only the path.
+
+Portability idioms (from ``0064_create_sensor``): the
+``is_postgres`` branch picks PG ``gen_random_uuid()`` / ``now()`` server
+defaults vs SQLite ORM-side defaults, and ``extras`` is
+``sa.JSON().with_variant(JSONB(), "postgresql")``. Both partial unique
+indexes emit their ``WHERE deleted_at IS NULL`` predicate on **both**
+dialects via the ``postgresql_where`` / ``sqlite_where`` pair (the
+``0072`` / ``0073`` pattern), so the SQLite unit-test path enforces the
+exact same partial-unique shape production does -- a soft-deleted
+tombstone frees the ``name`` / ``slug`` slot for re-use while a live
+duplicate still collides.
+
+Additive-only forward, reversible back
+--------------------------------------
+
+``upgrade()`` only creates a table + two indexes -- purely additive, so it
+clears ``scripts/ci/check_migration_compat.py`` and an older image reading
+the newer schema simply never references the table (the ``helm rollback``
+= image-revert + forward-compat-schema contract, ``docs/codebase/migrations.md``
+/ #1607, holds). ``downgrade()`` drops the indexes then the table; a plain
+``op.drop_table`` needs no ``batch_alter_table`` (SQLite drops whole
+tables natively), and it is dev-time symmetry only -- production never
+runs ``alembic downgrade``.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0074"
+down_revision: str | None = "0073"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_EVENT_SOURCE_KINDS: tuple[str, ...] = (
+    "alertmanager",
+    "grafana",
+    "vcf-operations",
+    "harbor",
+    "generic-json",
+)
+_EVENT_SOURCE_AUTH_STRATEGIES: tuple[str, ...] = (
+    "hmac-sha256",
+    "static-header",
+    "basic",
+)
+_EVENT_SOURCE_STATUSES: tuple[str, ...] = ("active", "paused")
+
+
+def _check_in(column: str, values: tuple[str, ...]) -> str:
+    """Render a portable ``column IN ('a', 'b', ...)`` CHECK body."""
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"{column} IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Create the ``event_source`` table + its two partial unique indexes."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    not_null_json = sa.JSON().with_variant(postgresql.JSONB(), "postgresql")
+
+    op.create_table(
+        "event_source",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        sa.Column(
+            "tenant_id",
+            sa.Uuid(),
+            sa.ForeignKey("tenant.id"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("auth_strategy", sa.Text(), nullable=False),
+        sa.Column("secret_ref", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False, server_default=sa.text("'active'")),
+        sa.Column("extras", not_null_json, nullable=False),
+        sa.Column("created_by_sub", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(_check_in("kind", _EVENT_SOURCE_KINDS), name="ck_event_source_kind"),
+        sa.CheckConstraint(
+            _check_in("auth_strategy", _EVENT_SOURCE_AUTH_STRATEGIES),
+            name="ck_event_source_auth_strategy",
+        ),
+        sa.CheckConstraint(
+            _check_in("status", _EVENT_SOURCE_STATUSES), name="ck_event_source_status"
+        ),
+    )
+
+    # Partial unique on live rows only: (tenant_id, name). A soft-deleted
+    # tombstone frees the name for re-use; a live duplicate still collides.
+    op.create_index(
+        "event_source_tenant_name_idx",
+        "event_source",
+        ["tenant_id", "name"],
+        unique=True,
+        postgresql_using="btree",
+        postgresql_where=sa.text("deleted_at IS NULL"),
+        sqlite_where=sa.text("deleted_at IS NULL"),
+    )
+    # Global partial unique on slug -- the JWT-less ingest routing key.
+    op.create_index(
+        "event_source_slug_idx",
+        "event_source",
+        ["slug"],
+        unique=True,
+        postgresql_using="btree",
+        postgresql_where=sa.text("deleted_at IS NULL"),
+        sqlite_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the indexes then the ``event_source`` table (dev-time symmetry)."""
+    op.drop_index("event_source_slug_idx", table_name="event_source")
+    op.drop_index("event_source_tenant_name_idx", table_name="event_source")
+    op.drop_table("event_source")

--- a/backend/src/meho_backplane/api/openapi_maturity.py
+++ b/backend/src/meho_backplane/api/openapi_maturity.py
@@ -72,6 +72,10 @@ TAG_FEATURE: Final[dict[str, str]] = {
     "conventions": "memory_knowledge",
     "discovery": "auth_tenancy",
     "docs": "doc_collections",
+    # The event_source registry (#2880) is the inbound producer side of the
+    # event -> kind=event ScheduledTrigger substrate (Initiative #2877), so
+    # it follows the scheduler feature it feeds.
+    "event-sources": "scheduler",
     "feed": "broadcast",
     "gateway": "satellite_gateway",
     "knowledge": "memory_knowledge",

--- a/backend/src/meho_backplane/api/v1/event_source.py
+++ b/backend/src/meho_backplane/api/v1/event_source.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""REST admin surface for the ``event_source`` registry (#2880).
+
+Tenant-scoped CRUD over ``/api/v1/event-sources`` -- the human/agent
+front the CLI (``meho event-source ...``) and the UI both dispatch
+through. Reads require ``operator``; writes require ``tenant_admin``
+(mirrors :mod:`meho_backplane.api.v1.targets`). ``tenant_id`` is always
+taken from the JWT; the body can never set it, and a source is addressed
+by its URL-safe ``slug`` (tenant-scoped -- a cross-tenant slug returns the
+same uniform 404 as a missing one, so the surface leaks no existence
+oracle).
+
+Secret custody is the one behaviour beyond a plain registry (#2880
+acceptance criterion 2): a create/update carrying a ``secret`` writes it
+to Vault at a derived per-tenant ``secret_ref`` and persists only the
+path. The value is a :class:`~pydantic.SecretStr` end to end and never
+enters the row, a log line, or the audit trail. A Vault write failure
+fails the request closed (502) so a source is never registered pointing
+at a secret that was not stored.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from pydantic import SecretStr
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.rbac import require_role
+from meho_backplane.db.engine import get_session
+from meho_backplane.db.models import EventSource as EventSourceORM
+from meho_backplane.event_source.resolver import resolve_event_source
+from meho_backplane.event_source.schemas import (
+    EventSource,
+    EventSourceCreate,
+    EventSourceListResponse,
+    EventSourceStatus,
+    EventSourceUpdate,
+    project_event_source_to_summary,
+)
+from meho_backplane.event_source.secrets import (
+    event_source_secret_ref,
+    store_event_source_secret,
+)
+
+__all__ = ["router"]
+
+_log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/event-sources", tags=["event-sources"])
+
+#: Module-level Depends closures -- required to satisfy ruff B008 (mutable
+#: calls in default argument positions). Mirrors :mod:`meho_backplane.api.v1.targets`.
+_require_operator = Depends(require_role(TenantRole.OPERATOR))
+_require_admin = Depends(require_role(TenantRole.TENANT_ADMIN))
+
+#: List page bounds (mirrors the targets list contract).
+_DEFAULT_LIMIT = 100
+_MAX_LIMIT = 500
+
+
+def _to_full(row: EventSourceORM) -> EventSource:
+    """Project an ``EventSource`` ORM row to the full read shape."""
+    return EventSource.model_validate(row, from_attributes=True)
+
+
+async def _store_secret_or_502(operator: Operator, secret_ref: str, secret: SecretStr) -> None:
+    """Write *secret* to Vault at *secret_ref*, failing the request closed.
+
+    Any Vault-side failure raises 502 ``secret_store_failed`` and leaves
+    the transaction to roll back, so the source is never persisted (create)
+    or the rotation is never acknowledged (update) while the secret sits
+    unstored. The secret value never reaches the response or the log: the
+    sink names only the path/field, and :class:`~pydantic.SecretStr` /
+    ``SecretMaterial`` redact the value in any traceback frame.
+    """
+    try:
+        await store_event_source_secret(operator, secret_ref, secret)
+    except Exception as exc:  # any Vault failure must fail the write closed
+        # Log a structured line, not the full traceback: the frame locals
+        # include the ``secret`` parameter, and even its redacted
+        # ``SecretStr('**********')`` rendering would trip the audit
+        # secret-leak sweep on the literal ``secret =`` substring. The
+        # error class + secret_ref is the operationally useful signal.
+        _log.error(
+            "event_source_secret_store_failed",
+            secret_ref=secret_ref,
+            error_class=type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail={
+                "error": "secret_store_failed",
+                "message": (
+                    "failed to store the event source secret in Vault; "
+                    "the registry write was rolled back"
+                ),
+            },
+        ) from exc
+
+
+@router.get("", response_model=EventSourceListResponse)
+async def list_event_sources(
+    operator: Operator = _require_operator,
+    session: AsyncSession = Depends(get_session),
+    status_filter: EventSourceStatus | None = Query(default=None, alias="status"),
+    limit: int = Query(default=_DEFAULT_LIMIT, ge=1, le=_MAX_LIMIT),
+    cursor: str | None = Query(default=None),
+) -> EventSourceListResponse:
+    """List the tenant's live event sources, keyset-paginated by ``name``.
+
+    Optional ``?status=active|paused`` filter. ``?cursor=<name>`` continues
+    after a previous page's ``next_cursor``. Soft-deleted sources are
+    excluded.
+    """
+    stmt = select(EventSourceORM).where(
+        EventSourceORM.tenant_id == operator.tenant_id,
+        EventSourceORM.deleted_at.is_(None),
+    )
+    if status_filter is not None:
+        stmt = stmt.where(EventSourceORM.status == status_filter.value)
+    if cursor is not None:
+        stmt = stmt.where(EventSourceORM.name > cursor)
+    stmt = stmt.order_by(EventSourceORM.name).limit(limit + 1)
+    rows = list((await session.execute(stmt)).scalars().all())
+    has_more = len(rows) > limit
+    page = rows[:limit]
+    next_cursor = page[-1].name if has_more else None
+    return EventSourceListResponse(
+        items=[project_event_source_to_summary(r) for r in page],
+        next_cursor=next_cursor,
+    )
+
+
+@router.get("/{slug}", response_model=EventSource)
+async def describe_event_source(
+    slug: str,
+    operator: Operator = _require_operator,
+    session: AsyncSession = Depends(get_session),
+) -> EventSource:
+    """Describe one event source by slug. 404 (uniform) when it does not
+    resolve in the tenant."""
+    row = await resolve_event_source(session, operator.tenant_id, slug)
+    return _to_full(row)
+
+
+@router.post("", response_model=EventSource, status_code=201)
+async def create_event_source(
+    body: EventSourceCreate,
+    operator: Operator = _require_admin,
+    session: AsyncSession = Depends(get_session),
+) -> EventSource:
+    """Register a new event source in the requesting tenant.
+
+    Returns 409 when the ``name`` (per tenant) or ``slug`` (global) is
+    already in use by a live source. When ``secret`` is supplied it is
+    written to Vault at the derived per-tenant ``secret_ref`` after the
+    row flushes (so a duplicate name/slug 409s before any Vault write) and
+    before the transaction commits (so a Vault failure rolls the row back).
+    Omitting ``secret`` registers the source with no credential
+    (``secret_ref`` NULL); the ingest path (#2881) fails closed until a
+    later PATCH sets one.
+    """
+    now = datetime.now(UTC)
+    secret_ref = (
+        event_source_secret_ref(operator.tenant_id, body.slug) if body.secret is not None else None
+    )
+    row = EventSourceORM(
+        id=uuid.uuid4(),
+        tenant_id=operator.tenant_id,
+        name=body.name,
+        slug=body.slug,
+        kind=body.kind.value,
+        auth_strategy=body.auth_strategy.value,
+        secret_ref=secret_ref,
+        status=body.status.value,
+        extras=body.extras,
+        created_by_sub=operator.sub,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add(row)
+    try:
+        await session.flush()
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=f"event source name {body.name!r} or slug {body.slug!r} is already in use",
+        ) from exc
+    if body.secret is not None:
+        assert secret_ref is not None  # derived in lockstep with body.secret
+        await _store_secret_or_502(operator, secret_ref, body.secret)
+    _log.info(
+        "event_source_created",
+        event_source_id=str(row.id),
+        slug=row.slug,
+        kind=row.kind,
+        tenant_id=str(operator.tenant_id),
+        has_secret=body.secret is not None,
+    )
+    return _to_full(row)
+
+
+@router.patch("/{slug}", response_model=EventSource)
+async def update_event_source(
+    slug: str,
+    body: EventSourceUpdate,
+    operator: Operator = _require_admin,
+    session: AsyncSession = Depends(get_session),
+) -> EventSource:
+    """Partially update an event source.
+
+    Only fields present in the body are changed; ``name`` and ``slug`` are
+    immutable (re-create to change them, since ``slug`` is a live routing
+    key). A PATCH to ``status='paused'`` takes effect on the ingest path's
+    next lookup -- nothing caches the row. Sending ``secret`` rotates the
+    Vault secret at the source's existing ``secret_ref`` (a new KV-v2
+    version at the same derived path, so no downtime); it is also how an
+    operator sets the first secret on a source created without one.
+    """
+    row = await resolve_event_source(session, operator.tenant_id, slug)
+    updates = body.model_dump(exclude_unset=True, exclude={"secret"})
+    for key, value in updates.items():
+        # StrEnum values persist as their plain string (Text column).
+        setattr(row, key, value.value if hasattr(value, "value") else value)
+    if body.secret is not None:
+        # slug is immutable, so the derived ref equals any existing one;
+        # this also (re)homes secret_ref when the source had none.
+        secret_ref = event_source_secret_ref(operator.tenant_id, row.slug)
+        await _store_secret_or_502(operator, secret_ref, body.secret)
+        row.secret_ref = secret_ref
+    row.updated_at = datetime.now(UTC)
+    _log.info(
+        "event_source_updated",
+        event_source_id=str(row.id),
+        slug=row.slug,
+        tenant_id=str(operator.tenant_id),
+        fields=list(updates.keys()),
+        secret_rotated=body.secret is not None,
+    )
+    return _to_full(row)
+
+
+@router.delete("/{slug}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
+async def delete_event_source(
+    slug: str,
+    operator: Operator = _require_admin,
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    """Soft-delete an event source by slug.
+
+    Stamps ``deleted_at`` so the row stays for audit history while every
+    read path (and the ingest resolver) filters it out; the partial unique
+    indexes free the ``name`` and ``slug`` for re-use immediately. The
+    Vault secret is intentionally left in place (RDC owns the Vault
+    lifecycle; a re-created source with the same slug derives the same ref
+    and overwrites it on its next secret write). A second DELETE collapses
+    to the uniform 404 -- the row no longer resolves.
+    """
+    row = await resolve_event_source(session, operator.tenant_id, slug)
+    row.deleted_at = datetime.now(UTC)
+    await session.flush()
+    _log.info(
+        "event_source_deleted",
+        event_source_id=str(row.id),
+        slug=row.slug,
+        tenant_id=str(operator.tenant_id),
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -5477,8 +5477,7 @@ class EventSource(Base):
             sqlite_where=sa.text("deleted_at IS NULL"),
         ),
         sa.CheckConstraint(
-            "kind IN ('alertmanager', 'grafana', 'vcf-operations', "
-            "'harbor', 'generic-json')",
+            "kind IN ('alertmanager', 'grafana', 'vcf-operations', 'harbor', 'generic-json')",
             name="ck_event_source_kind",
         ),
         sa.CheckConstraint(

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -5316,6 +5316,182 @@ class GatewayCommand(Base):
 # ---------------------------------------------------------------------------
 
 
+class EventSource(Base):
+    """A registered external event producer authorised to publish into a tenant.
+
+    Initiative #2877 (G11.3 inbound ingest), Task #2880 (T3). The
+    tenant-scoped registry the inbound webhook path
+    (``POST /api/v1/events/ingest/{source_slug}``, #2881 -- out of scope
+    here) resolves a sender against. Webhook senders (Alertmanager,
+    Grafana, VCF Operations, Harbor, generic JSON) carry no JWT, so this
+    row is the request's whole trust context: it supplies the
+    tenant attribution ``events.publish()`` needs a real tenant FK for,
+    and its Vault-custodied secret is what the ingest endpoint verifies
+    the sender's signature/token against.
+
+    Moulded on :class:`Target` (the per-tenant registry mould #2880 cites):
+    ``name`` unique-per-tenant via a partial unique index, ``secret_ref``
+    a nullable Vault path, ``extras`` the forward-compat escape hatch,
+    ``deleted_at`` soft-delete. It differs from :class:`Target` in three
+    deliberate ways:
+
+    * ``tenant_id`` carries a **real** ``REFERENCES tenant(id)`` FK (the
+      newer :class:`Sensor` / :class:`EventOutbox` discipline) rather than
+      the v0.2 soft-FK :class:`Target` kept -- #2880's rationale states
+      ``events.publish()`` requires a real tenant FK.
+    * ``slug`` is unique **globally**, not per-tenant. It is the sole
+      routing key in the JWT-less ingest URL, so slug -> tenant resolution
+      must be unambiguous across every tenant; a per-tenant slug could not
+      be resolved without the tenant the sender cannot supply.
+    * The admin surface **writes** the auth secret to Vault at
+      ``secret_ref`` (:class:`Target` only ever references an externally
+      provisioned path). The row still stores only the path, never the
+      value (secret-broker custody discipline,
+      ``docs/codebase/connectors-secret-broker.md``).
+
+    Column notes
+    ------------
+
+    * ``kind`` -- Text NOT NULL. The producer family, a closed set
+      (``ck_event_source_kind``): ``alertmanager``, ``grafana``,
+      ``vcf-operations``, ``harbor``, ``generic-json``. Selects the
+      payload normaliser #2882 applies. A closed enum (unlike
+      :attr:`EventOutbox.event_kind`'s free text) because each kind needs
+      hand-written normaliser code, so adding one is a code change anyway.
+    * ``auth_strategy`` -- Text NOT NULL. How the ingest endpoint
+      authenticates the sender, a closed set
+      (``ck_event_source_auth_strategy``): ``hmac-sha256`` (signed body),
+      ``static-header`` (fixed bearer/API-key header), ``basic`` (HTTP
+      Basic). All three verify against the Vault secret; #2881 owns the
+      verification.
+    * ``secret_ref`` -- Text, nullable. Logical Vault KV-v2 path the auth
+      secret lives at (``tenants/<tenant_id>/event-sources/<slug>``,
+      derived, not operator-supplied). NULL only transiently before the
+      first secret write.
+    * ``status`` -- Text NOT NULL DEFAULT ``'active'``, a closed set
+      (``ck_event_source_status``): ``active`` | ``paused``. ``paused``
+      makes the ingest path reject the sender; because nothing caches the
+      row, a PATCH to ``paused`` takes effect on the ingest path's very
+      next lookup.
+    * ``extras`` -- portable JSON NOT NULL DEFAULT ``{}``. Per-source
+      tuning the ingest reads: body-size cap, rate limit, replay window,
+      dedupe config, and (for ``basic``) the non-secret username. First-
+      class columns stay minimal per #2880's explicit column list.
+    * ``created_by_sub`` -- Text NOT NULL. JWT ``sub`` of the operator who
+      registered the source (:class:`Sensor` provenance discipline).
+
+    Indexes
+    -------
+
+    * ``event_source_tenant_name_idx`` -- partial **unique** b-tree on
+      ``(tenant_id, name)`` ``WHERE deleted_at IS NULL`` (live rows only,
+      so a soft-deleted tombstone frees the name for re-use, mirroring
+      ``targets_tenant_name_idx`` / #2874). Also serves the tenant-scoped
+      list query's ``WHERE tenant_id = ?`` prefix.
+    * ``event_source_slug_idx`` -- partial **unique** b-tree on ``(slug)``
+      ``WHERE deleted_at IS NULL``. Global slug uniqueness for JWT-less
+      ingest resolution; a tombstone frees the slug for re-use.
+    """
+
+    __tablename__ = "event_source"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    # Real REFERENCES tenant(id) FK (#2880): tenant attribution for a
+    # JWT-less webhook is taken from this row, and events.publish()
+    # requires a valid tenant, so the integrity is DB-enforced rather
+    # than left to the application layer as Target's soft-FK does.
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    # Globally unique URL token (not per-tenant): the sole routing key in
+    # the JWT-less ingest URL, so slug -> tenant must resolve unambiguously
+    # across all tenants. See event_source_slug_idx.
+    slug: Mapped[str] = mapped_column(Text, nullable=False)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    auth_strategy: Mapped[str] = mapped_column(Text, nullable=False)
+    # Logical Vault KV-v2 path (no mount, no ``/data/`` segment) the auth
+    # secret is written to; never the secret value itself. Derived as
+    # ``tenants/<tenant_id>/event-sources/<slug>`` at create time.
+    secret_ref: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="active",
+        server_default=sa.text("'active'"),
+    )
+    extras: Mapped[dict[str, object]] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=False,
+        default=dict,
+    )
+    created_by_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    # Soft-delete timestamp. NULL -> live row; non-NULL -> wall-clock time
+    # of the DELETE call. Every read path filters ``deleted_at IS NULL``
+    # so a soft-deleted source is invisible to the resolver while the
+    # tombstone keeps the name/slug slot free for re-use (partial indexes).
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+
+    __table_args__ = (
+        # Partial unique index on live rows only -- mirrors
+        # targets_tenant_name_idx (migration 0072 / #2874): a soft-deleted
+        # tombstone no longer occupies the name slot, so DELETE + POST of
+        # the same name succeeds while a live duplicate still collides.
+        # The postgresql_where / sqlite_where pair keeps the predicate
+        # matched on both dialects so Alembic autogenerate stays clean.
+        Index(
+            "event_source_tenant_name_idx",
+            "tenant_id",
+            "name",
+            unique=True,
+            postgresql_using="btree",
+            postgresql_where=sa.text("deleted_at IS NULL"),
+            sqlite_where=sa.text("deleted_at IS NULL"),
+        ),
+        Index(
+            "event_source_slug_idx",
+            "slug",
+            unique=True,
+            postgresql_using="btree",
+            postgresql_where=sa.text("deleted_at IS NULL"),
+            sqlite_where=sa.text("deleted_at IS NULL"),
+        ),
+        sa.CheckConstraint(
+            "kind IN ('alertmanager', 'grafana', 'vcf-operations', "
+            "'harbor', 'generic-json')",
+            name="ck_event_source_kind",
+        ),
+        sa.CheckConstraint(
+            "auth_strategy IN ('hmac-sha256', 'static-header', 'basic')",
+            name="ck_event_source_auth_strategy",
+        ),
+        sa.CheckConstraint(
+            "status IN ('active', 'paused')",
+            name="ck_event_source_status",
+        ),
+    )
+
+
 class EventOutbox(Base):
     """One durable MEHO-internal event ready for subscription dispatch.
 

--- a/backend/src/meho_backplane/event_source/__init__.py
+++ b/backend/src/meho_backplane/event_source/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The ``event_source`` registry: tenant-scoped external event producers.
+
+Initiative #2877 (G11.3 inbound ingest), Task #2880 (T3). This package
+owns the registry the inbound webhook path (#2881, out of scope here)
+resolves a JWT-less sender against: its Pydantic schemas, its name/slug
+resolvers, and the Vault secret-custody helpers that write a source's
+auth secret to Vault while the DB row keeps only the path.
+
+The ORM model lives in :mod:`meho_backplane.db.models` (``EventSource``);
+the REST admin surface in :mod:`meho_backplane.api.v1.event_source`.
+"""

--- a/backend/src/meho_backplane/event_source/resolver.py
+++ b/backend/src/meho_backplane/event_source/resolver.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Resolvers for the ``event_source`` registry (#2880).
+
+Two lookups, both filtering ``deleted_at IS NULL`` so a soft-deleted
+source is invisible:
+
+* :func:`resolve_event_source` -- the **admin** lookup, tenant-scoped by
+  ``slug``. Used by the REST / CLI / UI CRUD handlers. A slug that does
+  not exist *or* belongs to another tenant raises the identical
+  :class:`EventSourceNotFoundError` (404 ``no_event_source``): the two are
+  conflated so the admin surface reveals no cross-tenant existence oracle
+  (the :mod:`meho_backplane.auth.runner_guard` discipline). Unlike
+  :func:`~meho_backplane.targets.resolver.resolve_target` it surfaces **no**
+  near-miss ``matches`` list -- a slug is an opaque routing token, not a
+  human handle worth suggesting corrections for, and suggestions would
+  themselves be an oracle.
+
+* :func:`resolve_event_source_by_slug` -- the **ingest** primitive
+  (consumed by #2881), *not* tenant-scoped: a JWT-less webhook carries no
+  tenant, so slug is resolved globally against the unique
+  ``event_source_slug_idx``. Returns the live row (of any status) or
+  ``None``; the ingest endpoint reads ``status`` / ``auth_strategy`` /
+  ``secret_ref`` from it and MUST map a ``None`` result to the *same*
+  uniform response it returns for an authentication failure, so a missing
+  slug is indistinguishable from a bad signature to the sender. Returning
+  a bare ``None`` (no exception, no near-miss detail) keeps that discipline
+  at the primitive level.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import structlog
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.models import EventSource as EventSourceORM
+
+__all__ = [
+    "EventSourceNotFoundError",
+    "resolve_event_source",
+    "resolve_event_source_by_slug",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+class EventSourceNotFoundError(HTTPException):
+    """Raised when no live source matches the slug within the tenant.
+
+    The detail carries the queried slug but **no** ``matches`` list: the
+    admin surface must not distinguish "no such slug" from "slug owned by
+    another tenant" or leak near-miss suggestions (existence-oracle
+    discipline). A cross-tenant slug therefore returns exactly this 404.
+    """
+
+    def __init__(self, slug: str) -> None:
+        super().__init__(
+            status_code=404,
+            detail={"error": "no_event_source", "slug": slug},
+        )
+
+
+async def resolve_event_source(
+    session: AsyncSession,
+    tenant_id: UUID,
+    slug: str,
+) -> EventSourceORM:
+    """Resolve a live event source by slug, tenant-scoped.
+
+    Returns the :class:`~meho_backplane.db.models.EventSource` ORM row for
+    ``(tenant_id, slug)`` where ``deleted_at IS NULL``. Raises
+    :class:`EventSourceNotFoundError` (uniform 404) when the slug does not
+    resolve in this tenant -- whether it is truly absent or belongs to
+    another tenant.
+    """
+    stmt = select(EventSourceORM).where(
+        EventSourceORM.tenant_id == tenant_id,
+        EventSourceORM.slug == slug,
+        EventSourceORM.deleted_at.is_(None),
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        # Log the miss server-side with the distinguishing reason so an
+        # operator can debug, while the client sees only the uniform 404.
+        _log.info("event_source_not_found", tenant_id=str(tenant_id), slug=slug)
+        raise EventSourceNotFoundError(slug)
+    return row
+
+
+async def resolve_event_source_by_slug(
+    session: AsyncSession,
+    slug: str,
+) -> EventSourceORM | None:
+    """Resolve a live event source by slug globally (ingest primitive).
+
+    Not tenant-scoped: the caller (the #2881 ingest endpoint) has no
+    tenant context, so slug is matched globally against the unique
+    ``event_source_slug_idx``. Returns the live row (any ``status``) or
+    ``None`` -- never an exception, never near-miss detail. The caller is
+    responsible for mapping ``None`` to the same uniform response it uses
+    for an authentication failure so the lookup reveals no existence
+    oracle.
+    """
+    stmt = select(EventSourceORM).where(
+        EventSourceORM.slug == slug,
+        EventSourceORM.deleted_at.is_(None),
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()

--- a/backend/src/meho_backplane/event_source/schemas.py
+++ b/backend/src/meho_backplane/event_source/schemas.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pydantic schemas for the ``event_source`` registry (#2880).
+
+Moulded on :mod:`meho_backplane.targets.schemas`: a frozen full-read
+:class:`EventSource`, a narrow frozen :class:`EventSourceSummary` for
+lists, an ``extra='forbid'`` :class:`EventSourceCreate`, and an
+all-optional :class:`EventSourceUpdate`.
+
+The one shape that departs from targets is the **secret**. A target's
+``secret_ref`` is a Vault *path* an operator types and RDC provisions
+out of band, so it is a plain ``str``. An event source's admin surface
+*writes* the auth secret to Vault itself (#2880 acceptance criterion 2),
+so the write schemas carry a **write-only** :class:`~pydantic.SecretStr`
+``secret`` field that is never echoed back: it is absent from
+:class:`EventSource` / :class:`EventSourceSummary`, and ``SecretStr``
+masks it in every repr / log / traceback. The persisted row stores only
+the derived ``secret_ref`` path, never the value (secret-broker custody
+discipline, ``docs/codebase/connectors-secret-broker.md``).
+
+``kind`` / ``auth_strategy`` / ``status`` are closed :class:`~enum.StrEnum`
+sets whose values are mirrored by the ``ck_event_source_*`` CHECK
+constraints on the ORM model.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
+
+if TYPE_CHECKING:
+    from meho_backplane.db.models import EventSource as EventSourceORM
+
+__all__ = [
+    "EventSource",
+    "EventSourceAuthStrategy",
+    "EventSourceCreate",
+    "EventSourceKind",
+    "EventSourceListResponse",
+    "EventSourceStatus",
+    "EventSourceSummary",
+    "EventSourceUpdate",
+    "project_event_source_to_summary",
+]
+
+#: URL-token grammar for ``slug``: lowercase alphanumerics and internal
+#: hyphens, first/last char alphanumeric. The slug is the sole routing
+#: key in the JWT-less ingest URL (``/api/v1/events/ingest/{source_slug}``),
+#: so it must be path-safe with no percent-encoding surprises.
+_SLUG_PATTERN = r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+
+_NAME_MAX_LENGTH = 200
+_SLUG_MAX_LENGTH = 100
+
+
+class EventSourceKind(StrEnum):
+    """Producer family. Selects the payload normaliser (#2882) at ingest.
+
+    A closed set (unlike :attr:`~meho_backplane.db.models.EventOutbox.event_kind`'s
+    free text) because each kind needs hand-written normaliser code, so
+    adding one is a code change regardless. Values mirror the
+    ``ck_event_source_kind`` CHECK constraint.
+    """
+
+    ALERTMANAGER = "alertmanager"
+    GRAFANA = "grafana"
+    VCF_OPERATIONS = "vcf-operations"
+    HARBOR = "harbor"
+    GENERIC_JSON = "generic-json"
+
+
+class EventSourceAuthStrategy(StrEnum):
+    """How the ingest endpoint (#2881) authenticates the sender.
+
+    All three verify against the source's Vault secret. Values mirror the
+    ``ck_event_source_auth_strategy`` CHECK constraint.
+
+    * ``hmac-sha256`` -- the sender signs the body with a shared key.
+    * ``static-header`` -- a fixed bearer / API-key header value.
+    * ``basic`` -- HTTP Basic (the non-secret username lives in ``extras``;
+      the password is the Vault secret).
+    """
+
+    HMAC_SHA256 = "hmac-sha256"
+    STATIC_HEADER = "static-header"
+    BASIC = "basic"
+
+
+class EventSourceStatus(StrEnum):
+    """Registry status. Values mirror the ``ck_event_source_status`` CHECK.
+
+    ``paused`` makes the ingest path reject the sender; because nothing
+    caches the row, a PATCH to ``paused`` takes effect on the ingest
+    path's very next lookup (#2880 acceptance criterion 1).
+    """
+
+    ACTIVE = "active"
+    PAUSED = "paused"
+
+
+class EventSourceSummary(BaseModel):
+    """Narrow list-row shape. Frozen; omits ``extras`` to keep lists small."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID
+    tenant_id: UUID
+    name: str
+    slug: str
+    kind: EventSourceKind
+    auth_strategy: EventSourceAuthStrategy
+    status: EventSourceStatus
+    secret_ref: str | None
+    created_by_sub: str
+    created_at: datetime
+    updated_at: datetime
+    deleted_at: datetime | None = None
+
+
+class EventSourceListResponse(BaseModel):
+    """``{items, next_cursor}`` list envelope (api-shape-conventions §2).
+
+    ``next_cursor`` is the last row's ``name`` when a further page exists,
+    ``None`` when this page exhausted the tenant's live sources.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    items: list[EventSourceSummary]
+    next_cursor: str | None = None
+
+
+class EventSource(BaseModel):
+    """Full read shape. Maps 1:1 to the live ``event_source`` columns.
+
+    Frozen. Carries ``secret_ref`` (the Vault *path*) but never the secret
+    value -- there is no ``secret`` field on any read model.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: UUID
+    tenant_id: UUID
+    name: str
+    slug: str
+    kind: EventSourceKind
+    auth_strategy: EventSourceAuthStrategy
+    secret_ref: str | None
+    status: EventSourceStatus
+    extras: dict[str, Any]
+    created_by_sub: str
+    created_at: datetime
+    updated_at: datetime
+    deleted_at: datetime | None = None
+
+
+class EventSourceCreate(BaseModel):
+    """POST body. ``name`` and ``slug`` are immutable after creation.
+
+    ``secret`` is the optional auth secret to custody in Vault. When
+    present the create handler writes it to the derived per-tenant Vault
+    path and persists that path as ``secret_ref``; when absent the source
+    is registered with no secret (``secret_ref`` NULL) and the ingest path
+    (#2881) fails closed until a later PATCH sets one. The value is a
+    write-only :class:`~pydantic.SecretStr` -- it never appears on a read
+    model, in a log line, or in an audit row.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=_NAME_MAX_LENGTH)
+    slug: str = Field(min_length=1, max_length=_SLUG_MAX_LENGTH, pattern=_SLUG_PATTERN)
+    kind: EventSourceKind
+    auth_strategy: EventSourceAuthStrategy
+    status: EventSourceStatus = EventSourceStatus.ACTIVE
+    extras: dict[str, Any] = Field(default_factory=dict)
+    secret: SecretStr | None = None
+
+
+class EventSourceUpdate(BaseModel):
+    """PATCH body. Every field optional; ``name`` / ``slug`` are absent.
+
+    ``name`` and ``slug`` are immutable (rename or re-slug = delete +
+    re-create) because ``slug`` is a live routing key external senders are
+    already pointed at. Sending ``secret`` rotates the Vault secret in
+    place at the source's existing ``secret_ref`` -- a new KV-v2 version at
+    the same path, so the ingest path reads the new value on its next
+    lookup with no downtime (#2880 acceptance criterion 2). Omitting
+    ``secret`` leaves the stored secret untouched.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: EventSourceKind | None = None
+    auth_strategy: EventSourceAuthStrategy | None = None
+    status: EventSourceStatus | None = None
+    extras: dict[str, Any] | None = None
+    secret: SecretStr | None = None
+
+
+def project_event_source_to_summary(row: EventSourceORM) -> EventSourceSummary:
+    """Project an ``EventSource`` ORM row to the wire summary shape."""
+    return EventSourceSummary(
+        id=row.id,
+        tenant_id=row.tenant_id,
+        name=row.name,
+        slug=row.slug,
+        kind=EventSourceKind(row.kind),
+        auth_strategy=EventSourceAuthStrategy(row.auth_strategy),
+        status=EventSourceStatus(row.status),
+        secret_ref=row.secret_ref,
+        created_by_sub=row.created_by_sub,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        deleted_at=row.deleted_at,
+    )

--- a/backend/src/meho_backplane/event_source/secrets.py
+++ b/backend/src/meho_backplane/event_source/secrets.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault secret custody for the ``event_source`` registry (#2880).
+
+An event source's auth secret (HMAC signing key, static bearer token,
+Basic password) lives in Vault, never in the DB. The registry row stores
+only a logical ``secret_ref`` path; this module derives that path and
+writes the value to it, reusing the secret-broker's vault-kv **sink**
+(:class:`~meho_backplane.connectors.secret.vault_endpoint.VaultKvSecretEndpoint`)
+so the custody discipline is shared, not re-implemented:
+
+* the value is held as :class:`~pydantic.SecretStr` up to the write and
+  handed to a :class:`~meho_backplane.connectors.secret.endpoints.SecretMaterial`
+  at the boundary, both of which redact themselves in every repr / log;
+* the write runs under the operator's own Vault identity
+  (``vault_client_for_operator``), so it stays inside their authz envelope
+  and the Vault audit log attributes it to them;
+* only the *path* and the *field name* ever reach a log line -- never the
+  value.
+
+The derived path sits under the per-tenant Vault subtree the #1643 guard
+enforces (``tenants/<tenant_id>/...``), namespaced under ``event-sources/``
+so it never collides with a target's ``tenants/<tenant_id>/<name>`` secret.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import structlog
+
+from meho_backplane.connectors._shared.vault_creds import DEFAULT_KV_MOUNT
+from meho_backplane.connectors.secret.endpoints import SecretMaterial
+from meho_backplane.connectors.secret.vault_endpoint import VaultKvSecretEndpoint
+from meho_backplane.connectors.vault.tenant_paths import TENANT_SECRET_PREFIX
+
+if TYPE_CHECKING:
+    from pydantic import SecretStr
+
+    from meho_backplane.auth.operator import Operator
+
+__all__ = [
+    "EVENT_SOURCE_SECRET_FIELD",
+    "event_source_secret_ref",
+    "store_event_source_secret",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Logical-path segment separating an event source's secret from a
+#: target's secret under the same per-tenant Vault subtree.
+_EVENT_SOURCE_SECRET_LEAF = "event-sources"
+
+#: The single KV-v2 field an event source's secret is stored under. The
+#: ingest endpoint (#2881) reads this field to authenticate the sender,
+#: whatever the ``auth_strategy`` (the signing key / token / password all
+#: land here; a Basic username -- not a secret -- lives in ``extras``).
+EVENT_SOURCE_SECRET_FIELD = "secret"
+
+
+def event_source_secret_ref(tenant_id: UUID, slug: str) -> str:
+    """Derive the per-tenant logical ``secret_ref`` for a source's secret.
+
+    Returns ``"tenants/<tenant_id>/event-sources/<slug>"`` -- the logical
+    KV-v2 path relative to the mount (no mount segment, no ``/data/`` API
+    segment; hvac inserts both at read/write time). ``slug`` is already
+    validated URL-safe by :class:`~meho_backplane.event_source.schemas.EventSourceCreate`,
+    so it needs no further sanitising to key a path leaf.
+
+    The dashed lowercase ``tenant_id`` places the ref inside the per-tenant
+    prefix the #1643 Vault-scope guard enforces, and the ``event-sources/``
+    segment keeps it clear of a target's ``tenants/<tenant_id>/<name>``.
+    """
+    return f"{TENANT_SECRET_PREFIX}/{tenant_id}/{_EVENT_SOURCE_SECRET_LEAF}/{slug}"
+
+
+async def store_event_source_secret(
+    operator: Operator,
+    secret_ref: str,
+    secret: SecretStr,
+) -> None:
+    """Write *secret* to Vault at *secret_ref* under the operator's identity.
+
+    Reuses the secret-broker vault-kv sink so the value is carried only by
+    a :class:`SecretMaterial` (redacted repr) between :class:`SecretStr`
+    and the KV-v2 write. ``create_or_update_secret`` writes a new version
+    at the same path, so calling this again with a fresh value is a
+    zero-downtime rotation: the ingest path reads the latest version on its
+    next lookup.
+
+    Raises whatever the vault-kv sink raises on an I/O / auth failure
+    (an ``hvac`` error); the caller maps it to a fail-closed HTTP status.
+    The value never reaches the raised message -- the sink names only the
+    path and field.
+    """
+    endpoint = VaultKvSecretEndpoint(
+        f"{secret_ref}#{EVENT_SOURCE_SECRET_FIELD}", mount=DEFAULT_KV_MOUNT
+    )
+    _log.info("event_source_secret_write", secret_ref=secret_ref)
+    await endpoint.write_secret(operator, SecretMaterial(secret.get_secret_value()))

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -86,6 +86,7 @@ from meho_backplane.api.v1.connectors_ingest import (
 )
 from meho_backplane.api.v1.conventions import router as api_v1_conventions_router
 from meho_backplane.api.v1.doc_collections import router as api_v1_doc_collections_router
+from meho_backplane.api.v1.event_source import router as api_v1_event_source_router
 from meho_backplane.api.v1.feed import router as api_v1_feed_router
 from meho_backplane.api.v1.gateway import router as api_v1_gateway_router
 from meho_backplane.api.v1.health import router as api_v1_health_router
@@ -806,6 +807,12 @@ app.include_router(api_v1_doc_collections_router)
 # G9.1-T5 (#453) extends this router with GET /api/v1/targets/discover
 # (registered before GET /{name} so the literal path wins).
 app.include_router(api_v1_targets_router)
+# T3 (#2880) -- event_source registry admin surface at
+# /api/v1/event-sources*. Tenant-scoped CRUD (operator reads,
+# tenant_admin writes) the inbound webhook ingest (#2881) resolves a
+# JWT-less sender against; secrets are custodied in Vault, the row keeps
+# only the derived secret_ref path.
+app.include_router(api_v1_event_source_router)
 # G9.1-T5 (#453) — topology REST surface at /api/v1/topology*. Three
 # query routes (dependents / dependencies / path) wrapping the T4
 # recursive-CTE verbs + POST /refresh/{target_name} wrapping the T3

--- a/backend/src/meho_backplane/ui/maturity.py
+++ b/backend/src/meho_backplane/ui/maturity.py
@@ -81,6 +81,9 @@ SURFACE_FEATURE: dict[str, str] = {
     "checks": "sensors",
     "sensors": "sensors",
     "runners": "satellite_gateway",
+    # event_source registry (#2880): the inbound producer side of the
+    # event -> kind=event ScheduledTrigger substrate (#2877).
+    "event-source": "scheduler",
     "operations": "write_surfaces",
     "keycloak": "auth_tenancy",
     "vault": "write_surfaces",

--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -99,6 +99,7 @@ from meho_backplane.ui.routes.connectors import build_router as build_connectors
 from meho_backplane.ui.routes.conventions import build_conventions_router
 from meho_backplane.ui.routes.corpus import build_corpus_router
 from meho_backplane.ui.routes.dashboard import build_dashboard_router
+from meho_backplane.ui.routes.event_source import build_event_source_router
 from meho_backplane.ui.routes.kb import build_kb_router
 from meho_backplane.ui.routes.keycloak import build_keycloak_router
 from meho_backplane.ui.routes.memory import build_memory_router
@@ -194,6 +195,12 @@ def build_router() -> APIRouter:
     # without binding a literal as a slug; included before the stubs
     # aggregate so its concrete paths win the first-match-wins lookup.
     router.include_router(build_conventions_router())
+    # Event-source registry admin console (#2880): ``/ui/event-sources``
+    # list + create/edit forms + soft-delete. Static-prefix routes
+    # (``/new``) register before the ``{slug}`` routes inside the router so
+    # a literal is never bound as a slug; included before the stubs
+    # aggregate so its concrete paths win the first-match-wins lookup.
+    router.include_router(build_event_source_router())
     # Agent-grants surface ahead of the agents surface: the literal
     # ``/ui/agents/grants`` path must win the first-match-wins lookup
     # against the agents surface's ``/ui/agents/{name}`` (which would

--- a/backend/src/meho_backplane/ui/routes/event_source/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/event_source/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""UI surface for the ``event_source`` registry (#2880).
+
+Server-rendered tenant-scoped CRUD at ``/ui/event-sources``: a list page,
+create / edit forms, and a soft-delete action. Reads run at operator
+role; writes gate to ``tenant_admin`` (403 otherwise) and reuse the REST
+handler functions in :mod:`meho_backplane.api.v1.event_source` so the UI
+never re-implements persistence or Vault secret custody.
+"""
+
+from meho_backplane.ui.routes.event_source.routes import build_event_source_router
+
+__all__ = ["build_event_source_router"]

--- a/backend/src/meho_backplane/ui/routes/event_source/routes.py
+++ b/backend/src/meho_backplane/ui/routes/event_source/routes.py
@@ -1,0 +1,330 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Routes for the ``event_source`` admin UI (#2880).
+
+Classic server-rendered forms + POST/redirect-get, CSRF via the shared
+double-submit token. Every write reuses the REST handler in
+:mod:`meho_backplane.api.v1.event_source` (the ``meho_targets_register``
+-> ``create_target`` reuse pattern) so persistence, tenant scoping, and
+Vault secret custody are shared, not duplicated. Reads run at operator
+role; writes gate to ``tenant_admin`` via
+:func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`
+(403 otherwise).
+"""
+
+from __future__ import annotations
+
+import json
+
+import structlog
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import SecretStr, ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.api.v1.event_source import (
+    create_event_source,
+    delete_event_source,
+    list_event_sources,
+    update_event_source,
+)
+from meho_backplane.db.engine import get_raw_session, get_session
+from meho_backplane.event_source.resolver import resolve_event_source
+from meho_backplane.event_source.schemas import (
+    EventSourceAuthStrategy,
+    EventSourceCreate,
+    EventSourceKind,
+    EventSourceStatus,
+    EventSourceUpdate,
+)
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.connectors.operator import (
+    resolve_operator_or_403,
+    resolve_role_probe,
+)
+from meho_backplane.ui.routes.memory.operator import build_read_operator
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_event_source_router"]
+
+_log = structlog.get_logger(__name__)
+
+_LIST_LIMIT = 200
+_KIND_OPTIONS = [k.value for k in EventSourceKind]
+_AUTH_OPTIONS = [a.value for a in EventSourceAuthStrategy]
+_STATUS_OPTIONS = [s.value for s in EventSourceStatus]
+
+_require_session_dep = Depends(require_ui_session)
+_read_session_dep = Depends(get_session)
+_raw_session_dep = Depends(get_raw_session)
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _set_csrf_cookie(response: HTMLResponse, token: str) -> None:
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+
+
+def _form_context(
+    *,
+    mode: str,
+    csrf_token: str,
+    values: dict[str, str],
+    error: str | None = None,
+) -> dict[str, object]:
+    return {
+        "page_title": "Event Sources",
+        "active_surface": "event-source",
+        "mode": mode,
+        "csrf_token": csrf_token,
+        "values": values,
+        "error": error,
+        "kind_options": _KIND_OPTIONS,
+        "auth_options": _AUTH_OPTIONS,
+        "status_options": _STATUS_OPTIONS,
+    }
+
+
+def _form_error(
+    request: Request, *, mode: str, token: str, values: dict[str, str], error: str
+) -> HTMLResponse:
+    """Re-render the form with an inline error and refresh the CSRF cookie."""
+    response = get_templates().TemplateResponse(
+        request,
+        "event_source/form.html",
+        _form_context(mode=mode, csrf_token=token, values=values, error=error),
+    )
+    _set_csrf_cookie(response, token)
+    return response
+
+
+def _parse_extras(raw: str) -> dict[str, object]:
+    """Parse the extras textarea; empty is ``{}``. Raises ValueError on bad JSON."""
+    raw = raw.strip()
+    if not raw:
+        return {}
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError("extras must be a JSON object")
+    return parsed
+
+
+def _detail(exc: HTTPException) -> str:
+    """Flatten an HTTPException detail (str or structured dict) to one line."""
+    if isinstance(exc.detail, str):
+        return exc.detail
+    if isinstance(exc.detail, dict):
+        message = exc.detail.get("message") or exc.detail.get("error")
+        if message:
+            return str(message)
+    return f"request failed ({exc.status_code})"
+
+
+# --------------------------------------------------------------------------- handlers
+
+
+async def _list(
+    request: Request,
+    session_ctx: UISessionContext = _require_session_dep,
+    session: AsyncSession = _read_session_dep,
+) -> HTMLResponse:
+    operator = build_read_operator(session_ctx)
+    probe = await resolve_role_probe(request, session_ctx)
+    envelope = await list_event_sources(
+        operator=operator, session=session, status_filter=None, limit=_LIST_LIMIT, cursor=None
+    )
+    # Mint the session-stable CSRF token so the inline delete forms submit.
+    token = mint_csrf_token(str(session_ctx.session_id))
+    context = {
+        "page_title": "Event Sources",
+        "active_surface": "event-source",
+        "items": envelope.items,
+        "is_tenant_admin": probe.is_tenant_admin,
+        "csrf_token": token,
+    }
+    response = get_templates().TemplateResponse(request, "event_source/list.html", context)
+    _set_csrf_cookie(response, token)
+    return response
+
+
+async def _new_form(
+    request: Request,
+    session_ctx: UISessionContext = _require_session_dep,
+) -> HTMLResponse:
+    await resolve_operator_or_403(request, session_ctx)
+    token = mint_csrf_token(str(session_ctx.session_id))
+    response = get_templates().TemplateResponse(
+        request,
+        "event_source/form.html",
+        _form_context(mode="create", csrf_token=token, values={"status": "active"}),
+    )
+    _set_csrf_cookie(response, token)
+    return response
+
+
+async def _create(
+    request: Request,
+    name: str = Form(...),
+    slug: str = Form(...),
+    kind: str = Form(...),
+    auth_strategy: str = Form(...),
+    status_value: str = Form("active", alias="status"),
+    extras: str = Form(""),
+    secret: str = Form(""),
+    session_ctx: UISessionContext = _require_session_dep,
+    session: AsyncSession = _raw_session_dep,
+) -> HTMLResponse | RedirectResponse:
+    operator = await resolve_operator_or_403(request, session_ctx)
+    token = mint_csrf_token(str(session_ctx.session_id))
+    submitted = {
+        "name": name,
+        "slug": slug,
+        "kind": kind,
+        "auth_strategy": auth_strategy,
+        "status": status_value,
+        "extras": extras,
+    }
+    try:
+        body = EventSourceCreate(
+            name=name,
+            slug=slug,
+            kind=EventSourceKind(kind),
+            auth_strategy=EventSourceAuthStrategy(auth_strategy),
+            status=EventSourceStatus(status_value),
+            extras=_parse_extras(extras),
+            secret=SecretStr(secret) if secret else None,
+        )
+    except (ValidationError, ValueError) as exc:
+        await session.rollback()
+        return _form_error(request, mode="create", token=token, values=submitted, error=str(exc))
+    try:
+        await create_event_source(body=body, operator=operator, session=session)
+        await session.commit()
+    except HTTPException as exc:
+        await session.rollback()
+        return _form_error(
+            request, mode="create", token=token, values=submitted, error=_detail(exc)
+        )
+    _log.info("ui_event_source_create", tenant_id=str(operator.tenant_id), slug=slug)
+    return RedirectResponse("/ui/event-sources", status_code=303)
+
+
+async def _edit_form(
+    request: Request,
+    slug: str,
+    session_ctx: UISessionContext = _require_session_dep,
+    session: AsyncSession = _read_session_dep,
+) -> HTMLResponse:
+    operator = await resolve_operator_or_403(request, session_ctx)
+    row = await resolve_event_source(session, operator.tenant_id, slug)
+    token = mint_csrf_token(str(session_ctx.session_id))
+    values = {
+        "name": row.name,
+        "slug": row.slug,
+        "kind": row.kind,
+        "auth_strategy": row.auth_strategy,
+        "status": row.status,
+        "extras": json.dumps(row.extras, indent=2) if row.extras else "",
+        "has_secret": "yes" if row.secret_ref else "",
+    }
+    response = get_templates().TemplateResponse(
+        request,
+        "event_source/form.html",
+        _form_context(mode="edit", csrf_token=token, values=values),
+    )
+    _set_csrf_cookie(response, token)
+    return response
+
+
+async def _edit(
+    request: Request,
+    slug: str,
+    kind: str = Form(...),
+    auth_strategy: str = Form(...),
+    status_value: str = Form(..., alias="status"),
+    extras: str = Form(""),
+    secret: str = Form(""),
+    session_ctx: UISessionContext = _require_session_dep,
+    session: AsyncSession = _raw_session_dep,
+) -> HTMLResponse | RedirectResponse:
+    operator = await resolve_operator_or_403(request, session_ctx)
+    token = mint_csrf_token(str(session_ctx.session_id))
+    submitted = {
+        "slug": slug,
+        "kind": kind,
+        "auth_strategy": auth_strategy,
+        "status": status_value,
+        "extras": extras,
+    }
+    try:
+        body = EventSourceUpdate(
+            kind=EventSourceKind(kind),
+            auth_strategy=EventSourceAuthStrategy(auth_strategy),
+            status=EventSourceStatus(status_value),
+            extras=_parse_extras(extras),
+            secret=SecretStr(secret) if secret else None,
+        )
+    except (ValidationError, ValueError) as exc:
+        await session.rollback()
+        return _form_error(request, mode="edit", token=token, values=submitted, error=str(exc))
+    try:
+        await update_event_source(slug=slug, body=body, operator=operator, session=session)
+        await session.commit()
+    except HTTPException as exc:
+        await session.rollback()
+        return _form_error(request, mode="edit", token=token, values=submitted, error=_detail(exc))
+    _log.info("ui_event_source_update", tenant_id=str(operator.tenant_id), slug=slug)
+    return RedirectResponse("/ui/event-sources", status_code=303)
+
+
+async def _delete(
+    request: Request,
+    slug: str,
+    session_ctx: UISessionContext = _require_session_dep,
+    session: AsyncSession = _raw_session_dep,
+) -> RedirectResponse:
+    operator = await resolve_operator_or_403(request, session_ctx)
+    try:
+        await delete_event_source(slug=slug, operator=operator, session=session)
+        await session.commit()
+    except HTTPException:
+        # A double-fire (already gone) is benign; land back on the list.
+        await session.rollback()
+    _log.info("ui_event_source_delete", tenant_id=str(operator.tenant_id), slug=slug)
+    return RedirectResponse("/ui/event-sources", status_code=303)
+
+
+def build_event_source_router() -> APIRouter:
+    """Construct the event-source admin UI router.
+
+    Static-prefix routes (``/new``) register before the ``{slug}`` routes
+    so a literal is never bound as a slug. ``response_model=None`` on the
+    POST routes: they return ``HTMLResponse`` (inline error) |
+    ``RedirectResponse`` (PRG success), a union FastAPI cannot model.
+    """
+    router = APIRouter(tags=["ui-event-source"])
+    router.add_api_route("/ui/event-sources", _list, methods=["GET"], response_class=HTMLResponse)
+    router.add_api_route(
+        "/ui/event-sources/new", _new_form, methods=["GET"], response_class=HTMLResponse
+    )
+    router.add_api_route("/ui/event-sources", _create, methods=["POST"], response_model=None)
+    router.add_api_route(
+        "/ui/event-sources/{slug}/edit", _edit_form, methods=["GET"], response_class=HTMLResponse
+    )
+    router.add_api_route(
+        "/ui/event-sources/{slug}/edit", _edit, methods=["POST"], response_model=None
+    )
+    router.add_api_route(
+        "/ui/event-sources/{slug}/delete", _delete, methods=["POST"], response_model=None
+    )
+    return router

--- a/backend/src/meho_backplane/ui/templates/base.html
+++ b/backend/src/meho_backplane/ui/templates/base.html
@@ -49,6 +49,7 @@
   ("checks", "/ui/checks", "activity", "Checks"),
   ("sensors", "/ui/sensors", "zap", "Sensors"),
   ("runners", "/ui/runners", "radio-tower", "Runners"),
+  ("event-source", "/ui/event-sources", "radio-tower", "Event Sources"),
   ("operations", "/ui/operations", "terminal", "Operations"),
   ("keycloak", "/ui/keycloak", "key-round", "Keycloak"),
   ("vault", "/ui/vault", "lock", "Vault"),

--- a/backend/src/meho_backplane/ui/templates/event_source/form.html
+++ b/backend/src/meho_backplane/ui/templates/event_source/form.html
@@ -1,0 +1,98 @@
+{% extends "base.html" %}
+
+{% block page_title %}{{ "New" if mode == "create" else "Edit" }} Event Source &middot; MEHO{% endblock %}
+
+{% block content %}
+<section class="max-w-2xl space-y-4">
+  <h1 class="text-2xl font-semibold">
+    {{ "New event source" if mode == "create" else "Edit event source" }}
+  </h1>
+
+  {% if error %}
+    <div class="alert alert-error" role="alert" data-write-error><span>{{ error }}</span></div>
+  {% endif %}
+
+  <form method="post"
+        action="{{ '/ui/event-sources' if mode == 'create' else '/ui/event-sources/' + (values.get('slug', '') | urlencode) + '/edit' }}"
+        class="space-y-3">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+    <label class="form-control">
+      <span class="label-text">Name</span>
+      {% if mode == "create" %}
+        <input type="text" name="name" required maxlength="200"
+               value="{{ values.get('name', '') }}" class="input input-bordered input-sm"
+               placeholder="Prod Alertmanager" />
+      {% else %}
+        <input type="text" value="{{ values.get('name', '') }}"
+               class="input input-bordered input-sm" disabled />
+      {% endif %}
+    </label>
+
+    <label class="form-control">
+      <span class="label-text">Slug (URL routing token)</span>
+      {% if mode == "create" %}
+        <input type="text" name="slug" required maxlength="100"
+               pattern="[a-z0-9]([a-z0-9\-]*[a-z0-9])?"
+               value="{{ values.get('slug', '') }}"
+               class="input input-bordered input-sm font-mono" placeholder="prod-alertmanager" />
+        <span class="text-xs opacity-60 mt-1">Lowercase, digits, hyphen. Globally unique; immutable after creation.</span>
+      {% else %}
+        <input type="text" value="{{ values.get('slug', '') }}"
+               class="input input-bordered input-sm font-mono" disabled />
+      {% endif %}
+    </label>
+
+    <div class="grid gap-3 md:grid-cols-3">
+      <label class="form-control">
+        <span class="label-text">Kind</span>
+        <select name="kind" class="select select-bordered select-sm" required>
+          {% for k in kind_options %}
+            <option value="{{ k }}" {{ "selected" if values.get('kind') == k else "" }}>{{ k }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="form-control">
+        <span class="label-text">Auth strategy</span>
+        <select name="auth_strategy" class="select select-bordered select-sm" required>
+          {% for a in auth_options %}
+            <option value="{{ a }}" {{ "selected" if values.get('auth_strategy') == a else "" }}>{{ a }}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label class="form-control">
+        <span class="label-text">Status</span>
+        <select name="status" class="select select-bordered select-sm" required>
+          {% for s in status_options %}
+            <option value="{{ s }}" {{ "selected" if values.get('status') == s else "" }}>{{ s }}</option>
+          {% endfor %}
+        </select>
+      </label>
+    </div>
+
+    <label class="form-control">
+      <span class="label-text">Extras (JSON object, optional)</span>
+      <textarea name="extras" class="textarea textarea-bordered font-mono text-sm min-h-[6rem]"
+                placeholder='{"rate_limit": 60, "body_cap": 1048576}'>{{ values.get('extras', '') }}</textarea>
+      <span class="text-xs opacity-60 mt-1">Body cap, rate limit, replay window, dedupe config the ingest path reads.</span>
+    </label>
+
+    <label class="form-control">
+      <span class="label-text">
+        Auth secret
+        {% if mode == "edit" %}(leave blank to keep the current secret){% else %}(optional){% endif %}
+      </span>
+      <input type="password" name="secret" autocomplete="off" class="input input-bordered input-sm"
+             placeholder="written to Vault; never displayed" />
+      <span class="text-xs opacity-60 mt-1">Custodied in Vault — never stored in the database or shown again.</span>
+    </label>
+
+    <div class="flex gap-2 pt-2">
+      <button type="submit" class="btn btn-sm btn-primary" data-action="submit">
+        {{ "Create" if mode == "create" else "Save" }}
+      </button>
+      <a href="/ui/event-sources" class="btn btn-sm btn-ghost">Cancel</a>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/event_source/list.html
+++ b/backend/src/meho_backplane/ui/templates/event_source/list.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+
+{% block page_title %}Event Sources &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section class="space-y-4">
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Event Sources</h1>
+      <p class="text-sm opacity-70">
+        External producers authorised to publish inbound events into your tenant.
+      </p>
+    </div>
+    {% if is_tenant_admin %}
+      <a href="/ui/event-sources/new" class="btn btn-sm btn-primary" data-action="new-event-source">
+        New event source
+      </a>
+    {% endif %}
+  </header>
+
+  <div id="event-source-table">
+    {% if items %}
+      <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+        <table class="table table-zebra">
+          <thead>
+            <tr>
+              <th scope="col">Slug</th>
+              <th scope="col">Name</th>
+              <th scope="col">Kind</th>
+              <th scope="col">Auth</th>
+              <th scope="col">Status</th>
+              <th scope="col" class="text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for item in items %}
+              <tr>
+                <td class="font-mono break-all" data-slug="{{ item.slug }}">{{ item.slug }}</td>
+                <td>{{ item.name }}</td>
+                <td><span class="badge badge-outline badge-sm">{{ item.kind.value }}</span></td>
+                <td>{{ item.auth_strategy.value }}</td>
+                <td>
+                  <span class="badge badge-sm {{ 'badge-success' if item.status.value == 'active' else 'badge-warning' }}">
+                    {{ item.status.value }}
+                  </span>
+                </td>
+                <td class="text-right whitespace-nowrap">
+                  {% if is_tenant_admin %}
+                    <a href="/ui/event-sources/{{ item.slug | urlencode }}/edit" class="btn btn-ghost btn-xs">Edit</a>
+                    <form method="post" action="/ui/event-sources/{{ item.slug | urlencode }}/delete"
+                          class="inline" onsubmit="return confirm('Delete event source {{ item.slug }}?');">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                      <button type="submit" class="btn btn-ghost btn-xs text-error">Delete</button>
+                    </form>
+                  {% else %}
+                    <span class="opacity-50 text-xs">read-only</span>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <div class="rounded-box border border-base-300 bg-base-100 p-8 text-center opacity-70">
+        No event sources registered in this tenant.
+      </div>
+    {% endif %}
+  </div>
+</section>
+{% endblock %}

--- a/backend/tests/_event_source_helpers.py
+++ b/backend/tests/_event_source_helpers.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared pytest fixtures and helpers for event_source integration tests.
+
+Mirrors :mod:`tests._targets_helpers`. Import into test modules that
+exercise the /api/v1/event-sources router:
+
+    from ._event_source_helpers import (
+        _settings_env,          # noqa: F401  (autouse fixture)
+        _isolated_jwks_cache,   # noqa: F401  (autouse fixture)
+        _build_app,
+        _admin_token,
+        _operator_token,
+        _insert_event_source,
+    )
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+
+from meho_backplane.api.v1.event_source import router as event_source_router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EventSource as EventSourceORM
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import DEFAULT_TENANT_ID, mint_token
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_jwks_cache() -> Iterator[None]:
+    clear_jwks_cache()
+    yield
+    clear_jwks_cache()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(event_source_router)
+    return app
+
+
+def _admin_token(key: Any, tenant_id: str = DEFAULT_TENANT_ID) -> str:
+    return mint_token(
+        key, sub="admin-1", tenant_role=TenantRole.TENANT_ADMIN.value, tenant_id=tenant_id
+    )
+
+
+def _operator_token(key: Any, tenant_id: str = DEFAULT_TENANT_ID) -> str:
+    return mint_token(key, sub="op-1", tenant_role=TenantRole.OPERATOR.value, tenant_id=tenant_id)
+
+
+async def _insert_event_source(**kwargs: Any) -> EventSourceORM:
+    """Insert an EventSourceORM row directly via the test sessionmaker."""
+    defaults: dict[str, Any] = {
+        "id": uuid.uuid4(),
+        "tenant_id": uuid.UUID(DEFAULT_TENANT_ID),
+        "name": "default-source",
+        "slug": "default-source",
+        "kind": "alertmanager",
+        "auth_strategy": "hmac-sha256",
+        "secret_ref": None,
+        "status": "active",
+        "extras": {},
+        "created_by_sub": "admin-1",
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+    }
+    defaults.update(kwargs)
+    row = EventSourceORM(**defaults)
+    sm = get_sessionmaker()
+    async with sm() as session:
+        session.add(row)
+        await session.commit()
+    return row

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -211,6 +211,14 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     # errors at setup with ``cannot truncate a table referenced in a
     # foreign key constraint`` (the recurring fixture gotcha #1064 / #1065).
     "event_outbox",
+    # ``event_source.tenant_id`` is a real ``REFERENCES tenant(id)`` FK from
+    # migration ``0074`` (G11.3 inbound ingest, #2880). It follows the newer
+    # ``Sensor`` / ``EventOutbox`` real-FK discipline rather than ``Target``'s
+    # soft FK, so PG rejects truncating ``tenant`` unless ``event_source`` is
+    # listed in the same statement or every PG-backed acceptance test errors
+    # at setup with ``cannot truncate a table referenced in a foreign key
+    # constraint``.
+    "event_source",
     # ``gateway_command.tenant_id`` is a real ``REFERENCES tenant(id)`` FK
     # from migration ``0059`` (Initiative #2415 T2, #2498). Same rule: PG
     # rejects truncating ``tenant`` unless every referencing table is listed

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -432,13 +432,19 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
         #   a real ``REFERENCES sensor(id)`` FK, so truncating ``sensor`` in this
         #   same statement requires ``sensor_results`` be listed too or PG raises
         #   ``cannot truncate a table referenced in a foreign key constraint``.
+        # * ``event_source`` — migration 0074 (G11.3 inbound ingest, #2880)
+        #   carries a real ``REFERENCES tenant(id)`` FK (the newer ``Sensor`` /
+        #   ``EventOutbox`` discipline, not ``Target``'s soft FK); must be listed
+        #   here or PG rejects the per-test TRUNCATE with ``cannot truncate a
+        #   table referenced in a foreign key constraint``.
         await conn.execute(
             text(
                 "TRUNCATE TABLE agent_announcement, approval_request, agent_permission, "
                 "agent_principal, runner_principal, "
                 "runner_assignments, runner_check_results, "
                 "scheduled_trigger, sensor_results, sensor, "
-                "check_dashboard_sensors, check_dashboards, event_outbox, gateway_command, "
+                "check_dashboard_sensors, check_dashboards, "
+                "event_outbox, event_source, gateway_command, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "
@@ -506,7 +512,8 @@ async def pg_engine_empty_tenant(
                 "agent_principal, runner_principal, "
                 "runner_assignments, runner_check_results, "
                 "scheduled_trigger, sensor_results, sensor, "
-                "check_dashboard_sensors, check_dashboards, event_outbox, gateway_command, "
+                "check_dashboard_sensors, check_dashboards, "
+                "event_outbox, event_source, gateway_command, "
                 "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "

--- a/backend/tests/test_api_v1_event_source.py
+++ b/backend/tests/test_api_v1_event_source.py
@@ -1,0 +1,324 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.api.v1.event_source` (#2880).
+
+Coverage matrix (acceptance criteria):
+
+* **CRUD + tenant scoping** — create / list / describe / patch / delete,
+  tenant-scoped; operator role denied on writes; unauthenticated 401.
+* **Secret custody (criterion 2)** — a create/patch ``secret`` is written
+  to Vault at the derived ``secret_ref`` and never echoed in the response;
+  a Vault failure fails the request closed (502) with the row rolled back.
+* **Pause immediacy (criterion 1)** — a PATCH to ``paused`` is visible on
+  the ingest resolver's next lookup.
+* **No existence oracle (criterion 3)** — a cross-tenant slug returns the
+  same uniform 404 as an absent one.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.event_source.resolver import resolve_event_source_by_slug
+
+from ._event_source_helpers import (
+    _admin_token,
+    _build_app,
+    _insert_event_source,
+    _isolated_jwks_cache,  # noqa: F401  (autouse fixture)
+    _operator_token,
+    _settings_env,  # noqa: F401  (autouse fixture)
+)
+from ._oidc_jwt_helpers import (
+    DEFAULT_TENANT_ID,
+    make_rsa_keypair,
+    mock_discovery_and_jwks,
+    public_jwks,
+)
+
+_TENANT_B = "00000000-0000-0000-0000-0000000000b2"
+
+_MINIMAL = {
+    "name": "Prod Alertmanager",
+    "slug": "prod-am",
+    "kind": "alertmanager",
+    "auth_strategy": "hmac-sha256",
+}
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+@pytest.fixture
+def store_recorder(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    """Patch the Vault write seam; record (secret_ref, raw_value) per call."""
+    calls: list[tuple[str, str]] = []
+
+    async def _rec(operator: object, secret_ref: str, secret: object) -> None:
+        calls.append((secret_ref, secret.get_secret_value()))  # type: ignore[attr-defined]
+
+    monkeypatch.setattr("meho_backplane.api.v1.event_source.store_event_source_secret", _rec)
+    return calls
+
+
+def _req(
+    client: TestClient,
+    method: str,
+    path: str,
+    token: str,
+    key: object,
+    json: object | None = None,
+) -> object:
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        return client.request(method, path, headers={"Authorization": f"Bearer {token}"}, json=json)
+
+
+# --------------------------------------------------------------------------- create
+
+
+def test_create_without_secret_201(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    resp = _req(client, "POST", "/api/v1/event-sources", _admin_token(key), key, json=_MINIMAL)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["slug"] == "prod-am"
+    assert body["secret_ref"] is None
+    assert body["created_by_sub"] == "admin-1"
+    assert "secret" not in body  # read model never exposes the value field
+
+
+def test_create_with_secret_writes_to_vault(
+    client: TestClient, store_recorder: list[tuple[str, str]]
+) -> None:
+    key = make_rsa_keypair("kid-A")
+    payload = {**_MINIMAL, "secret": "hmac-signing-key"}
+    resp = _req(client, "POST", "/api/v1/event-sources", _admin_token(key), key, json=payload)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    # secret_ref is the derived per-tenant path; the value is never echoed.
+    assert body["secret_ref"] == f"tenants/{DEFAULT_TENANT_ID}/event-sources/prod-am"
+    assert "hmac-signing-key" not in resp.text
+    # The Vault write got the derived ref + the raw value exactly once.
+    assert store_recorder == [
+        (f"tenants/{DEFAULT_TENANT_ID}/event-sources/prod-am", "hmac-signing-key")
+    ]
+
+
+def test_create_duplicate_name_409(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    _req(client, "POST", "/api/v1/event-sources", _admin_token(key), key, json=_MINIMAL)
+    dup = {**_MINIMAL, "slug": "other-slug"}  # same name, different slug
+    resp = _req(client, "POST", "/api/v1/event-sources", _admin_token(key), key, json=dup)
+    assert resp.status_code == 409
+
+
+def test_create_duplicate_slug_409(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    _req(client, "POST", "/api/v1/event-sources", _admin_token(key), key, json=_MINIMAL)
+    dup = {**_MINIMAL, "name": "Different Name"}  # same slug, different name
+    resp = _req(client, "POST", "/api/v1/event-sources", _admin_token(key), key, json=dup)
+    assert resp.status_code == 409
+
+
+def test_create_as_operator_403(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    resp = _req(client, "POST", "/api/v1/event-sources", _operator_token(key), key, json=_MINIMAL)
+    assert resp.status_code == 403
+
+
+def test_create_unauthenticated_401(client: TestClient) -> None:
+    resp = client.post("/api/v1/event-sources", json=_MINIMAL)
+    assert resp.status_code == 401
+
+
+def test_create_vault_failure_502_and_no_row(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Vault write failure fails closed: 502 and the row is rolled back."""
+
+    async def _boom(operator: object, secret_ref: str, secret: object) -> None:
+        raise RuntimeError("vault unreachable")
+
+    monkeypatch.setattr("meho_backplane.api.v1.event_source.store_event_source_secret", _boom)
+    key = make_rsa_keypair("kid-A")
+    payload = {**_MINIMAL, "secret": "should-not-persist"}
+    resp = _req(client, "POST", "/api/v1/event-sources", _admin_token(key), key, json=payload)
+    assert resp.status_code == 502
+    assert "should-not-persist" not in resp.text
+    # The source was never persisted.
+    listed = _req(client, "GET", "/api/v1/event-sources", _admin_token(key), key)
+    assert listed.json()["items"] == []
+
+
+# --------------------------------------------------------------------------- list
+
+
+def test_list_empty(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    resp = _req(client, "GET", "/api/v1/event-sources", _operator_token(key), key)
+    assert resp.status_code == 200
+    assert resp.json() == {"items": [], "next_cursor": None}
+
+
+@pytest.mark.asyncio
+async def test_list_tenant_scoped(client: TestClient) -> None:
+    await _insert_event_source(tenant_id=uuid.UUID(DEFAULT_TENANT_ID), name="mine", slug="mine")
+    await _insert_event_source(tenant_id=uuid.UUID(_TENANT_B), name="theirs", slug="theirs")
+    key = make_rsa_keypair("kid-A")
+    resp = _req(client, "GET", "/api/v1/event-sources", _operator_token(key), key)
+    slugs = {i["slug"] for i in resp.json()["items"]}
+    assert slugs == {"mine"}
+
+
+@pytest.mark.asyncio
+async def test_list_status_filter(client: TestClient) -> None:
+    await _insert_event_source(name="a", slug="a", status="active")
+    await _insert_event_source(name="p", slug="p", status="paused")
+    key = make_rsa_keypair("kid-A")
+    resp = _req(client, "GET", "/api/v1/event-sources?status=paused", _operator_token(key), key)
+    slugs = {i["slug"] for i in resp.json()["items"]}
+    assert slugs == {"p"}
+
+
+@pytest.mark.asyncio
+async def test_list_pagination_cursor(client: TestClient) -> None:
+    for n in ("a", "b", "c"):
+        await _insert_event_source(name=n, slug=n)
+    key = make_rsa_keypair("kid-A")
+    first = _req(client, "GET", "/api/v1/event-sources?limit=2", _operator_token(key), key).json()
+    assert len(first["items"]) == 2
+    assert first["next_cursor"] == "b"
+    nxt = _req(
+        client, "GET", "/api/v1/event-sources?limit=2&cursor=b", _operator_token(key), key
+    ).json()
+    assert [i["name"] for i in nxt["items"]] == ["c"]
+    assert nxt["next_cursor"] is None
+
+
+# --------------------------------------------------------------------------- describe
+
+
+@pytest.mark.asyncio
+async def test_describe_found(client: TestClient) -> None:
+    await _insert_event_source(name="am", slug="am-prod")
+    key = make_rsa_keypair("kid-A")
+    resp = _req(client, "GET", "/api/v1/event-sources/am-prod", _operator_token(key), key)
+    assert resp.status_code == 200
+    assert resp.json()["slug"] == "am-prod"
+
+
+def test_describe_missing_404(client: TestClient) -> None:
+    key = make_rsa_keypair("kid-A")
+    resp = _req(client, "GET", "/api/v1/event-sources/nope", _operator_token(key), key)
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_describe_cross_tenant_is_uniform_404(client: TestClient) -> None:
+    """A slug owned by another tenant looks identical to an absent one."""
+    await _insert_event_source(tenant_id=uuid.UUID(_TENANT_B), name="am", slug="b-owned")
+    key = make_rsa_keypair("kid-A")
+    cross = _req(client, "GET", "/api/v1/event-sources/b-owned", _operator_token(key), key)
+    absent = _req(client, "GET", "/api/v1/event-sources/absent", _operator_token(key), key)
+    assert cross.status_code == absent.status_code == 404
+    assert cross.json() == {"detail": {"error": "no_event_source", "slug": "b-owned"}}
+
+
+# --------------------------------------------------------------------------- patch
+
+
+@pytest.mark.asyncio
+async def test_patch_pause_takes_effect_immediately(client: TestClient) -> None:
+    """PATCH status=paused is visible on the ingest resolver's next lookup."""
+    await _insert_event_source(name="am", slug="am-prod", status="active")
+    key = make_rsa_keypair("kid-A")
+    async with get_sessionmaker()() as session:
+        before = await resolve_event_source_by_slug(session, "am-prod")
+    assert before is not None and before.status == "active"
+
+    resp = _req(
+        client,
+        "PATCH",
+        "/api/v1/event-sources/am-prod",
+        _admin_token(key),
+        key,
+        json={"status": "paused"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "paused"
+
+    # No cache: the very next ingest-path lookup sees the pause.
+    async with get_sessionmaker()() as session:
+        after = await resolve_event_source_by_slug(session, "am-prod")
+    assert after is not None and after.status == "paused"
+
+
+@pytest.mark.asyncio
+async def test_patch_rotates_secret(
+    client: TestClient, store_recorder: list[tuple[str, str]]
+) -> None:
+    """PATCH ``secret`` rotates the value at the derived ref and homes secret_ref."""
+    await _insert_event_source(name="am", slug="am-prod", secret_ref=None)
+    key = make_rsa_keypair("kid-A")
+    resp = _req(
+        client,
+        "PATCH",
+        "/api/v1/event-sources/am-prod",
+        _admin_token(key),
+        key,
+        json={"secret": "rotated-key"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["secret_ref"] == f"tenants/{DEFAULT_TENANT_ID}/event-sources/am-prod"
+    assert store_recorder == [(f"tenants/{DEFAULT_TENANT_ID}/event-sources/am-prod", "rotated-key")]
+    assert "rotated-key" not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_patch_as_operator_403(client: TestClient) -> None:
+    await _insert_event_source(name="am", slug="am-prod")
+    key = make_rsa_keypair("kid-A")
+    resp = _req(
+        client,
+        "PATCH",
+        "/api/v1/event-sources/am-prod",
+        _operator_token(key),
+        key,
+        json={"status": "paused"},
+    )
+    assert resp.status_code == 403
+
+
+# --------------------------------------------------------------------------- delete
+
+
+@pytest.mark.asyncio
+async def test_delete_soft_and_slug_reusable(client: TestClient) -> None:
+    await _insert_event_source(name="am", slug="am-prod")
+    key = make_rsa_keypair("kid-A")
+    deleted = _req(client, "DELETE", "/api/v1/event-sources/am-prod", _admin_token(key), key)
+    assert deleted.status_code == 204
+    # Gone from reads.
+    gone = _req(client, "GET", "/api/v1/event-sources/am-prod", _operator_token(key), key)
+    assert gone.status_code == 404
+    # The slug + name free up for a fresh registration.
+    recreate = _req(client, "POST", "/api/v1/event-sources", _admin_token(key), key, json=_MINIMAL)
+    assert recreate.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_delete_as_operator_403(client: TestClient) -> None:
+    await _insert_event_source(name="am", slug="am-prod")
+    key = make_rsa_keypair("kid-A")
+    resp = _req(client, "DELETE", "/api/v1/event-sources/am-prod", _operator_token(key), key)
+    assert resp.status_code == 403

--- a/backend/tests/test_db_event_source.py
+++ b/backend/tests/test_db_event_source.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""DB-layer tests for the ``event_source`` model (#2880).
+
+Covers the columns, the two partial unique indexes (``name`` unique per
+tenant, ``slug`` unique globally -- both only among live rows), the
+soft-delete name/slug re-use property, and the CHECK constraints.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EventSource as EventSourceORM
+
+from ._event_source_helpers import (
+    _settings_env,  # noqa: F401  (autouse fixture)
+)
+
+_TENANT_A = uuid.UUID("00000000-0000-0000-0000-0000000000a1")
+_TENANT_B = uuid.UUID("00000000-0000-0000-0000-0000000000b2")
+
+
+async def _add(**kwargs: object) -> EventSourceORM:
+    defaults: dict[str, object] = {
+        "id": uuid.uuid4(),
+        "tenant_id": _TENANT_A,
+        "name": "am-prod",
+        "slug": "am-prod",
+        "kind": "alertmanager",
+        "auth_strategy": "hmac-sha256",
+        "secret_ref": None,
+        "status": "active",
+        "extras": {},
+        "created_by_sub": "admin-1",
+        "created_at": datetime.now(UTC),
+        "updated_at": datetime.now(UTC),
+    }
+    defaults.update(kwargs)
+    row = EventSourceORM(**defaults)
+    async with get_sessionmaker()() as session:
+        session.add(row)
+        await session.commit()
+    return row
+
+
+@pytest.mark.asyncio
+async def test_columns_round_trip() -> None:
+    """A row persists and reads back every column, extras included."""
+    row = await _add(extras={"rate_limit": 60, "body_cap": 1048576})
+    async with get_sessionmaker()() as session:
+        fetched = await session.get(EventSourceORM, row.id)
+    assert fetched is not None
+    assert fetched.name == "am-prod"
+    assert fetched.slug == "am-prod"
+    assert fetched.kind == "alertmanager"
+    assert fetched.auth_strategy == "hmac-sha256"
+    assert fetched.status == "active"
+    assert fetched.extras == {"rate_limit": 60, "body_cap": 1048576}
+    assert fetched.created_by_sub == "admin-1"
+    assert fetched.deleted_at is None
+
+
+@pytest.mark.asyncio
+async def test_name_unique_per_tenant_collides() -> None:
+    """Two live rows with the same (tenant_id, name) collide."""
+    await _add(name="dup", slug="slug-1")
+    with pytest.raises(IntegrityError):
+        await _add(name="dup", slug="slug-2")
+
+
+@pytest.mark.asyncio
+async def test_same_name_different_tenant_ok() -> None:
+    """The same name in a different tenant does not collide."""
+    await _add(name="shared", slug="slug-a", tenant_id=_TENANT_A)
+    # Different tenant, different slug -> both allowed.
+    await _add(name="shared", slug="slug-b", tenant_id=_TENANT_B)
+
+
+@pytest.mark.asyncio
+async def test_slug_unique_globally_collides_across_tenants() -> None:
+    """A slug is globally unique -- even across tenants it collides."""
+    await _add(name="n1", slug="global-slug", tenant_id=_TENANT_A)
+    with pytest.raises(IntegrityError):
+        await _add(name="n2", slug="global-slug", tenant_id=_TENANT_B)
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_frees_name_and_slug() -> None:
+    """A soft-deleted tombstone frees both name and slug for re-use."""
+    first = await _add(name="reuse", slug="reuse")
+    async with get_sessionmaker()() as session:
+        row = await session.get(EventSourceORM, first.id)
+        assert row is not None
+        row.deleted_at = datetime.now(UTC)
+        await session.commit()
+    # A live re-creation with the same name AND slug now succeeds.
+    await _add(name="reuse", slug="reuse")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("column", "bad_value"),
+    [
+        ("kind", "syslog"),
+        ("auth_strategy", "mtls"),
+        ("status", "archived"),
+    ],
+)
+async def test_check_constraints_reject_unknown_values(column: str, bad_value: str) -> None:
+    """The ck_event_source_* CHECK constraints reject out-of-set values."""
+    with pytest.raises(IntegrityError):
+        await _add(**{column: bad_value})

--- a/backend/tests/test_event_source_resolver.py
+++ b/backend/tests/test_event_source_resolver.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Resolver tests for the ``event_source`` registry (#2880).
+
+Asserts the tenant-scoped admin resolver conflates missing/cross-tenant
+into a uniform 404 with no near-miss oracle, and the global ingest
+primitive returns a bare ``None`` (any status) for a live-miss.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.event_source.resolver import (
+    EventSourceNotFoundError,
+    resolve_event_source,
+    resolve_event_source_by_slug,
+)
+
+from ._event_source_helpers import (
+    _insert_event_source,
+    _settings_env,  # noqa: F401  (autouse fixture)
+)
+
+_TENANT_A = uuid.UUID("00000000-0000-0000-0000-0000000000a1")
+_TENANT_B = uuid.UUID("00000000-0000-0000-0000-0000000000b2")
+
+
+@pytest.mark.asyncio
+async def test_resolve_event_source_found() -> None:
+    await _insert_event_source(tenant_id=_TENANT_A, name="am", slug="am-prod")
+    async with get_sessionmaker()() as session:
+        row = await resolve_event_source(session, _TENANT_A, "am-prod")
+    assert row.slug == "am-prod"
+
+
+@pytest.mark.asyncio
+async def test_resolve_missing_is_uniform_404_without_matches() -> None:
+    async with get_sessionmaker()() as session:
+        with pytest.raises(EventSourceNotFoundError) as exc:
+            await resolve_event_source(session, _TENANT_A, "nope")
+    assert exc.value.status_code == 404
+    # No existence-oracle: the detail carries no near-miss suggestions.
+    assert "matches" not in exc.value.detail
+    assert exc.value.detail == {"error": "no_event_source", "slug": "nope"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_cross_tenant_is_same_404_as_missing() -> None:
+    """A slug owned by another tenant returns the identical 404 as absent."""
+    await _insert_event_source(tenant_id=_TENANT_B, name="am", slug="b-owned")
+    async with get_sessionmaker()() as session:
+        with pytest.raises(EventSourceNotFoundError) as cross:
+            await resolve_event_source(session, _TENANT_A, "b-owned")
+        with pytest.raises(EventSourceNotFoundError) as missing:
+            await resolve_event_source(session, _TENANT_A, "b-owned")
+    # Byte-for-byte identical detail -> no way to tell "not yours" from "absent".
+    assert cross.value.detail == {"error": "no_event_source", "slug": "b-owned"}
+    assert missing.value.detail == cross.value.detail
+
+
+@pytest.mark.asyncio
+async def test_resolve_soft_deleted_not_found() -> None:
+    row = await _insert_event_source(tenant_id=_TENANT_A, name="am", slug="gone")
+    async with get_sessionmaker()() as session:
+        from meho_backplane.db.models import EventSource as EventSourceORM
+
+        live = await session.get(EventSourceORM, row.id)
+        assert live is not None
+        live.deleted_at = datetime.now(UTC)
+        await session.commit()
+    async with get_sessionmaker()() as session:
+        with pytest.raises(EventSourceNotFoundError):
+            await resolve_event_source(session, _TENANT_A, "gone")
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_slug_global_returns_row_any_status() -> None:
+    """The ingest primitive resolves globally and returns paused rows too."""
+    await _insert_event_source(tenant_id=_TENANT_B, name="am", slug="ingest-me", status="paused")
+    async with get_sessionmaker()() as session:
+        row = await resolve_event_source_by_slug(session, "ingest-me")
+    assert row is not None
+    assert row.status == "paused"
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_slug_missing_returns_none() -> None:
+    async with get_sessionmaker()() as session:
+        assert await resolve_event_source_by_slug(session, "no-such-slug") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_by_slug_soft_deleted_returns_none() -> None:
+    row = await _insert_event_source(tenant_id=_TENANT_A, name="am", slug="dead")
+    async with get_sessionmaker()() as session:
+        from meho_backplane.db.models import EventSource as EventSourceORM
+
+        live = await session.get(EventSourceORM, row.id)
+        assert live is not None
+        live.deleted_at = datetime.now(UTC)
+        await session.commit()
+    async with get_sessionmaker()() as session:
+        assert await resolve_event_source_by_slug(session, "dead") is None

--- a/backend/tests/test_event_source_schemas.py
+++ b/backend/tests/test_event_source_schemas.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Schema validation tests for the ``event_source`` registry (#2880)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from meho_backplane.db.models import EventSource as EventSourceORM
+from meho_backplane.event_source.schemas import (
+    EventSource,
+    EventSourceCreate,
+    EventSourceUpdate,
+    project_event_source_to_summary,
+)
+
+
+def test_create_valid_minimal() -> None:
+    body = EventSourceCreate(
+        name="Prod Alertmanager",
+        slug="prod-am",
+        kind="alertmanager",
+        auth_strategy="hmac-sha256",
+    )
+    assert body.slug == "prod-am"
+    assert body.status.value == "active"
+    assert body.secret is None
+
+
+@pytest.mark.parametrize("bad_slug", ["UPPER", "has space", "-leading", "trailing-", "under_score"])
+def test_create_rejects_bad_slug(bad_slug: str) -> None:
+    with pytest.raises(ValidationError):
+        EventSourceCreate(name="n", slug=bad_slug, kind="alertmanager", auth_strategy="hmac-sha256")
+
+
+def test_create_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        EventSourceCreate(
+            name="n",
+            slug="s",
+            kind="alertmanager",
+            auth_strategy="hmac-sha256",
+            tenant_id="00000000-0000-0000-0000-000000000000",  # forbidden extra
+        )
+
+
+def test_create_rejects_unknown_enum_values() -> None:
+    with pytest.raises(ValidationError):
+        EventSourceCreate(name="n", slug="s", kind="syslog", auth_strategy="hmac-sha256")
+
+
+def test_secret_is_masked_and_absent_from_read_model() -> None:
+    """``secret`` is a masked SecretStr on writes and absent from reads."""
+    body = EventSourceCreate(
+        name="n",
+        slug="s",
+        kind="grafana",
+        auth_strategy="static-header",
+        secret=SecretStr("super-secret-token"),
+    )
+    # Never exposes the raw value through repr / str.
+    assert "super-secret-token" not in repr(body)
+    assert "super-secret-token" not in str(body)
+    assert body.secret is not None
+    assert body.secret.get_secret_value() == "super-secret-token"
+    # The read model has no secret field at all.
+    assert "secret" not in EventSource.model_fields
+
+
+def test_update_all_optional_and_immutable_name_slug() -> None:
+    """Empty update is valid; ``name`` / ``slug`` are not patchable."""
+    assert EventSourceUpdate().model_dump(exclude_unset=True) == {}
+    with pytest.raises(ValidationError):
+        EventSourceUpdate(name="new")  # type: ignore[call-arg]
+    with pytest.raises(ValidationError):
+        EventSourceUpdate(slug="new")  # type: ignore[call-arg]
+
+
+def test_project_to_summary_maps_columns() -> None:
+    now = datetime.now(UTC)
+    row = EventSourceORM(
+        id=uuid.uuid4(),
+        tenant_id=uuid.uuid4(),
+        name="am",
+        slug="am",
+        kind="alertmanager",
+        auth_strategy="basic",
+        secret_ref="tenants/x/event-sources/am",
+        status="paused",
+        extras={"k": "v"},
+        created_by_sub="admin-1",
+        created_at=now,
+        updated_at=now,
+        deleted_at=None,
+    )
+    summary = project_event_source_to_summary(row)
+    assert summary.slug == "am"
+    assert summary.status.value == "paused"
+    assert summary.auth_strategy.value == "basic"
+    assert summary.secret_ref == "tenants/x/event-sources/am"
+    # The summary intentionally omits extras.
+    assert "extras" not in summary.model_fields

--- a/backend/tests/test_event_source_secrets.py
+++ b/backend/tests/test_event_source_secrets.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Vault secret-custody tests for the ``event_source`` registry (#2880).
+
+Asserts the derived path shape and that ``store_event_source_secret``
+carries the value through the secret-broker vault-kv sink to a KV-v2
+write -- with the raw value never touching a log line (the autouse
+secret-leak sweep in :mod:`tests.conftest` is the safety net).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import uuid
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from pydantic import SecretStr
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.event_source.secrets import (
+    event_source_secret_ref,
+    store_event_source_secret,
+)
+
+from ._event_source_helpers import (
+    _settings_env,  # noqa: F401  (autouse fixture)
+)
+
+_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000000a1")
+
+
+def _operator() -> Operator:
+    return Operator(
+        sub="admin-1",
+        raw_jwt="unused-in-mock",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+def test_secret_ref_derivation_shape() -> None:
+    ref = event_source_secret_ref(_TENANT, "prod-am")
+    assert ref == f"tenants/{_TENANT}/event-sources/prod-am"
+
+
+@pytest.mark.asyncio
+async def test_store_writes_value_to_vault_kv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The value round-trips to a KV-v2 write at the derived path/field."""
+    calls: list[dict[str, Any]] = []
+
+    def _create_or_update_secret(**kwargs: Any) -> None:
+        calls.append(kwargs)
+
+    fake_client = SimpleNamespace(
+        secrets=SimpleNamespace(
+            kv=SimpleNamespace(v2=SimpleNamespace(create_or_update_secret=_create_or_update_secret))
+        )
+    )
+
+    @contextlib.asynccontextmanager
+    async def _fake_client_for_operator(_operator: Operator) -> AsyncIterator[Any]:
+        yield fake_client
+
+    monkeypatch.setattr(
+        "meho_backplane.auth.vault.vault_client_for_operator", _fake_client_for_operator
+    )
+
+    ref = event_source_secret_ref(_TENANT, "prod-am")
+    await store_event_source_secret(_operator(), ref, SecretStr("hmac-signing-key"))
+
+    assert len(calls) == 1
+    assert calls[0]["path"] == f"tenants/{_TENANT}/event-sources/prod-am"
+    assert calls[0]["secret"] == {"secret": "hmac-signing-key"}
+    assert calls[0]["mount_point"] == "secret"

--- a/backend/tests/test_ui_event_source.py
+++ b/backend/tests/test_ui_event_source.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the event_source admin UI (#2880).
+
+Harness mirrors :mod:`tests.test_ui_conventions_write` (a real RSA-signed
+``tenant_admin`` JWT lifted through the BFF session so
+``resolve_operator_or_403`` passes). Covers the list render, the RBAC +
+CSRF gates on writes, create (incl. Vault secret custody through the
+reused REST handler), pause-via-edit, and soft-delete.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import EventSource as EventSourceORM
+from meho_backplane.db.models import Tenant
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import clear_discovery_cache, reset_verifier_store_for_testing
+from meho_backplane.ui.auth.session_store import create_session, reset_fernet_cache_for_testing
+from meho_backplane.ui.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRFMiddleware,
+    mint_csrf_token,
+)
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+
+from ._oidc_jwt_helpers import make_rsa_keypair, mint_token, mock_discovery_and_jwks, public_jwks
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_OPERATOR_SUB = "op-alice"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID = _TENANT_A) -> None:
+    async def _do() -> None:
+        async with get_sessionmaker()() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug="tenant-a", name="Tenant A"))
+
+    asyncio.run(_do())
+
+
+def _seed_event_source(
+    *, slug: str, status: str = "active", tenant_id: uuid.UUID = _TENANT_A
+) -> None:
+    now = datetime.now(UTC)
+
+    async def _do() -> None:
+        async with get_sessionmaker()() as session, session.begin():
+            session.add(
+                EventSourceORM(
+                    id=uuid.uuid4(),
+                    tenant_id=tenant_id,
+                    name=f"src {slug}",
+                    slug=slug,
+                    kind="alertmanager",
+                    auth_strategy="hmac-sha256",
+                    secret_ref=None,
+                    status=status,
+                    extras={},
+                    created_by_sub=_OPERATOR_SUB,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+
+    asyncio.run(_do())
+
+
+def _get_row(slug: str) -> EventSourceORM | None:
+    async def _do() -> EventSourceORM | None:
+        from sqlalchemy import select
+
+        async with get_sessionmaker()() as session:
+            stmt = select(EventSourceORM).where(EventSourceORM.slug == slug)
+            return (await session.execute(stmt)).scalar_one_or_none()
+
+    return asyncio.run(_do())
+
+
+def _seed_session(tenant_id: uuid.UUID, access_token: str) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        async with get_sessionmaker()() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=_OPERATOR_SUB,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _role_session(role: TenantRole) -> tuple[uuid.UUID, dict[str, Any]]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = make_rsa_keypair("ui-event-source-test-kid")
+    jwks = public_jwks(keypair)
+    token = mint_token(keypair, sub=_OPERATOR_SUB, tenant_id=str(_TENANT_A), tenant_role=role.value)
+    return _seed_session(_TENANT_A, token), jwks
+
+
+def _client(session_id: uuid.UUID, jwks: dict[str, Any]) -> tuple[TestClient, respx.MockRouter]:
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client, mock
+
+
+def _csrf(session_id: uuid.UUID) -> dict[str, Any]:
+    token = mint_csrf_token(str(session_id))
+    return {"headers": {CSRF_HEADER_NAME: token}, "cookies": {CSRF_COOKIE_NAME: token}}
+
+
+def test_list_page_renders_with_new_button_for_admin() -> None:
+    _seed_tenant()
+    _seed_event_source(slug="prod-am")
+    session_id, jwks = _role_session(TenantRole.TENANT_ADMIN)
+    client, mock = _client(session_id, jwks)
+    try:
+        resp = client.get("/ui/event-sources")
+    finally:
+        mock.stop()
+    assert resp.status_code == 200, resp.text
+    assert "Event Sources" in resp.text
+    assert "prod-am" in resp.text
+    assert "New event source" in resp.text
+
+
+def test_list_operator_hides_write_affordances() -> None:
+    _seed_tenant()
+    _seed_event_source(slug="prod-am")
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+    client, mock = _client(session_id, jwks)
+    try:
+        resp = client.get("/ui/event-sources")
+    finally:
+        mock.stop()
+    assert resp.status_code == 200
+    assert "New event source" not in resp.text
+
+
+def test_create_persists_and_redirects_with_secret_custody(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    async def _rec(operator: object, secret_ref: str, secret: object) -> None:
+        calls.append((secret_ref, secret.get_secret_value()))  # type: ignore[attr-defined]
+
+    monkeypatch.setattr("meho_backplane.api.v1.event_source.store_event_source_secret", _rec)
+    _seed_tenant()
+    session_id, jwks = _role_session(TenantRole.TENANT_ADMIN)
+    client, mock = _client(session_id, jwks)
+    try:
+        resp = client.post(
+            "/ui/event-sources",
+            data={
+                "name": "Prod Alertmanager",
+                "slug": "prod-am",
+                "kind": "alertmanager",
+                "auth_strategy": "hmac-sha256",
+                "status": "active",
+                "extras": "",
+                "secret": "hmac-signing-key",
+            },
+            **_csrf(session_id),
+        )
+    finally:
+        mock.stop()
+    assert resp.status_code == 303, resp.text
+    assert resp.headers["location"] == "/ui/event-sources"
+    row = _get_row("prod-am")
+    assert row is not None
+    assert row.secret_ref == f"tenants/{_TENANT_A}/event-sources/prod-am"
+    assert calls == [(f"tenants/{_TENANT_A}/event-sources/prod-am", "hmac-signing-key")]
+
+
+def test_create_duplicate_slug_rerenders_error_no_redirect() -> None:
+    _seed_tenant()
+    _seed_event_source(slug="prod-am")
+    session_id, jwks = _role_session(TenantRole.TENANT_ADMIN)
+    client, mock = _client(session_id, jwks)
+    try:
+        resp = client.post(
+            "/ui/event-sources",
+            data={
+                "name": "Another",
+                "slug": "prod-am",
+                "kind": "grafana",
+                "auth_strategy": "basic",
+                "status": "active",
+                "extras": "",
+                "secret": "",
+            },
+            **_csrf(session_id),
+        )
+    finally:
+        mock.stop()
+    assert resp.status_code == 200
+    assert "location" not in resp.headers
+    assert "data-write-error" in resp.text
+
+
+def test_create_non_admin_gets_403() -> None:
+    _seed_tenant()
+    session_id, jwks = _role_session(TenantRole.OPERATOR)
+    client, mock = _client(session_id, jwks)
+    try:
+        resp = client.post(
+            "/ui/event-sources",
+            data={
+                "name": "N",
+                "slug": "s",
+                "kind": "alertmanager",
+                "auth_strategy": "hmac-sha256",
+                "status": "active",
+                "extras": "",
+                "secret": "",
+            },
+            **_csrf(session_id),
+        )
+    finally:
+        mock.stop()
+    assert resp.status_code == 403
+    assert _get_row("s") is None
+
+
+def test_create_missing_csrf_blocked() -> None:
+    _seed_tenant()
+    session_id, jwks = _role_session(TenantRole.TENANT_ADMIN)
+    client, mock = _client(session_id, jwks)
+    try:
+        resp = client.post(
+            "/ui/event-sources",
+            data={
+                "name": "N",
+                "slug": "s",
+                "kind": "alertmanager",
+                "auth_strategy": "hmac-sha256",
+                "status": "active",
+                "extras": "",
+                "secret": "",
+            },
+        )
+    finally:
+        mock.stop()
+    assert resp.status_code == 403
+
+
+def test_edit_pauses_source() -> None:
+    _seed_tenant()
+    _seed_event_source(slug="prod-am", status="active")
+    session_id, jwks = _role_session(TenantRole.TENANT_ADMIN)
+    client, mock = _client(session_id, jwks)
+    try:
+        resp = client.post(
+            "/ui/event-sources/prod-am/edit",
+            data={
+                "kind": "alertmanager",
+                "auth_strategy": "hmac-sha256",
+                "status": "paused",
+                "extras": "",
+                "secret": "",
+            },
+            **_csrf(session_id),
+        )
+    finally:
+        mock.stop()
+    assert resp.status_code == 303
+    row = _get_row("prod-am")
+    assert row is not None and row.status == "paused"
+
+
+def test_delete_soft_removes_source() -> None:
+    _seed_tenant()
+    _seed_event_source(slug="prod-am")
+    session_id, jwks = _role_session(TenantRole.TENANT_ADMIN)
+    client, mock = _client(session_id, jwks)
+    try:
+        resp = client.post("/ui/event-sources/prod-am/delete", **_csrf(session_id))
+    finally:
+        mock.stop()
+    assert resp.status_code == 303
+    row = _get_row("prod-am")
+    assert row is not None and row.deleted_at is not None

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -1361,6 +1361,292 @@
         }
       }
     },
+    "/api/v1/event-sources": {
+      "get": {
+        "tags": [
+          "event-sources"
+        ],
+        "summary": "List Event Sources",
+        "description": "List the tenant's live event sources, keyset-paginated by ``name``.\n\nOptional ``?status=active|paused`` filter. ``?cursor=<name>`` continues\nafter a previous page's ``next_cursor``. Soft-deleted sources are\nexcluded.",
+        "operationId": "list_event_sources_api_v1_event_sources_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/EventSourceStatus",
+              "nullable": true,
+              "title": "Status"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Cursor"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventSourceListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "event-sources"
+        ],
+        "summary": "Create Event Source",
+        "description": "Register a new event source in the requesting tenant.\n\nReturns 409 when the ``name`` (per tenant) or ``slug`` (global) is\nalready in use by a live source. When ``secret`` is supplied it is\nwritten to Vault at the derived per-tenant ``secret_ref`` after the\nrow flushes (so a duplicate name/slug 409s before any Vault write) and\nbefore the transaction commits (so a Vault failure rolls the row back).\nOmitting ``secret`` registers the source with no credential\n(``secret_ref`` NULL); the ingest path (#2881) fails closed until a\nlater PATCH sets one.",
+        "operationId": "create_event_source_api_v1_event_sources_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventSourceCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventSource"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/event-sources/{slug}": {
+      "get": {
+        "tags": [
+          "event-sources"
+        ],
+        "summary": "Describe Event Source",
+        "description": "Describe one event source by slug. 404 (uniform) when it does not\nresolve in the tenant.",
+        "operationId": "describe_event_source_api_v1_event_sources__slug__get",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventSource"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "event-sources"
+        ],
+        "summary": "Update Event Source",
+        "description": "Partially update an event source.\n\nOnly fields present in the body are changed; ``name`` and ``slug`` are\nimmutable (re-create to change them, since ``slug`` is a live routing\nkey). A PATCH to ``status='paused'`` takes effect on the ingest path's\nnext lookup -- nothing caches the row. Sending ``secret`` rotates the\nVault secret at the source's existing ``secret_ref`` (a new KV-v2\nversion at the same derived path, so no downtime); it is also how an\noperator sets the first secret on a source created without one.",
+        "operationId": "update_event_source_api_v1_event_sources__slug__patch",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventSourceUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventSource"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "event-sources"
+        ],
+        "summary": "Delete Event Source",
+        "description": "Soft-delete an event source by slug.\n\nStamps ``deleted_at`` so the row stays for audit history while every\nread path (and the ingest resolver) filters it out; the partial unique\nindexes free the ``name`` and ``slug`` for re-use immediately. The\nVault secret is intentionally left in place (RDC owns the Vault\nlifecycle; a re-created source with the same slug derives the same ref\nand overwrites it on its next secret write). A second DELETE collapses\nto the uniform 404 -- the row no longer resolves.",
+        "operationId": "delete_event_source_api_v1_event_sources__slug__delete",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/topology/dependents/{name}": {
       "get": {
         "tags": [
@@ -13052,6 +13338,215 @@
         }
       }
     },
+    "/ui/event-sources": {
+      "get": {
+        "tags": [
+          "ui-event-source"
+        ],
+        "summary": " List",
+        "operationId": "_list_ui_event_sources_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-event-source"
+        ],
+        "summary": " Create",
+        "operationId": "_create_ui_event_sources_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body__create_ui_event_sources_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/event-sources/new": {
+      "get": {
+        "tags": [
+          "ui-event-source"
+        ],
+        "summary": " New Form",
+        "operationId": "_new_form_ui_event_sources_new_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/event-sources/{slug}/edit": {
+      "get": {
+        "tags": [
+          "ui-event-source"
+        ],
+        "summary": " Edit Form",
+        "operationId": "_edit_form_ui_event_sources__slug__edit_get",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-event-source"
+        ],
+        "summary": " Edit",
+        "operationId": "_edit_ui_event_sources__slug__edit_post",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body__edit_ui_event_sources__slug__edit_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/event-sources/{slug}/delete": {
+      "post": {
+        "tags": [
+          "ui-event-source"
+        ],
+        "summary": " Delete",
+        "operationId": "_delete_ui_event_sources__slug__delete_post",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/agents/grants": {
       "get": {
         "tags": [
@@ -20756,6 +21251,82 @@
         "title": "BaselineMetricsOverride",
         "description": "Per-surface baseline metrics supplied by the caller.\n\nCriterion 4 (MEHO \u2265 baseline) needs side-by-side numbers from a\nbaseline retrieval (``grep -r kb/`` for kb; ``grep paths.txt +\nyq`` for operations). The v0.2 backplane has no checked-in\ncorpus snapshot to evaluate the baseline against (see\n:mod:`meho_backplane.api.v1.retrieve_eval` \u2014 explicit\n``baseline=grep`` on that route is rejected with 501); the CLI\nruns the baseline locally against the operator's kb/ checkout and\ncan pass the resulting numbers here so the retire-checklist\nverdict honestly reflects criterion 4 instead of always reporting\nyellow (\"baseline did not run\") on the API path.\n\nWithout an override, criterion 4 stays yellow for v0.2 production\ncallers \u2014 the documented \"READY TO RETIRE\" path is unreachable\nvia the bare API alone, which is the honest v0.2 posture. T7\n(#446) / v0.2.next is expected to wire a server-side corpus\nsnapshot and remove the need for this override."
       },
+      "Body__create_ui_event_sources_post": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "auth_strategy": {
+            "type": "string",
+            "title": "Auth Strategy"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "default": "active"
+          },
+          "extras": {
+            "type": "string",
+            "title": "Extras",
+            "default": ""
+          },
+          "secret": {
+            "type": "string",
+            "title": "Secret",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "slug",
+          "kind",
+          "auth_strategy"
+        ],
+        "title": "Body__create_ui_event_sources_post"
+      },
+      "Body__edit_ui_event_sources__slug__edit_post": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "auth_strategy": {
+            "type": "string",
+            "title": "Auth Strategy"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "extras": {
+            "type": "string",
+            "title": "Extras",
+            "default": ""
+          },
+          "secret": {
+            "type": "string",
+            "title": "Secret",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": [
+          "kind",
+          "auth_strategy",
+          "status"
+        ],
+        "title": "Body__edit_ui_event_sources__slug__edit_post"
+      },
       "Body_annotate_ui_topology_edges_post": {
         "properties": {
           "from_name": {
@@ -24732,6 +25303,291 @@
         ],
         "title": "EvalResult",
         "description": "Top-level eval result \u2014 the shape the API + CLI return.\n\n``overall_verdict`` is the worst-of every surface (a red surface\nflips the whole result red); the CLI's exit-1-on-red CI-gate\nsemantics key off this field. ``ran_at`` is the UTC timestamp\nthe runner started; consumers comparing two saved baselines see\nwhen each was captured."
+      },
+      "EventSource": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/EventSourceKind"
+          },
+          "auth_strategy": {
+            "$ref": "#/components/schemas/EventSourceAuthStrategy"
+          },
+          "secret_ref": {
+            "type": "string",
+            "nullable": true,
+            "title": "Secret Ref"
+          },
+          "status": {
+            "$ref": "#/components/schemas/EventSourceStatus"
+          },
+          "extras": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Extras"
+          },
+          "created_by_sub": {
+            "type": "string",
+            "title": "Created By Sub"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "deleted_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Deleted At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "tenant_id",
+          "name",
+          "slug",
+          "kind",
+          "auth_strategy",
+          "secret_ref",
+          "status",
+          "extras",
+          "created_by_sub",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "EventSource",
+        "description": "Full read shape. Maps 1:1 to the live ``event_source`` columns.\n\nFrozen. Carries ``secret_ref`` (the Vault *path*) but never the secret\nvalue -- there is no ``secret`` field on any read model."
+      },
+      "EventSourceAuthStrategy": {
+        "type": "string",
+        "enum": [
+          "hmac-sha256",
+          "static-header",
+          "basic"
+        ],
+        "title": "EventSourceAuthStrategy",
+        "description": "How the ingest endpoint (#2881) authenticates the sender.\n\nAll three verify against the source's Vault secret. Values mirror the\n``ck_event_source_auth_strategy`` CHECK constraint.\n\n* ``hmac-sha256`` -- the sender signs the body with a shared key.\n* ``static-header`` -- a fixed bearer / API-key header value.\n* ``basic`` -- HTTP Basic (the non-secret username lives in ``extras``;\n  the password is the Vault secret)."
+      },
+      "EventSourceCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "slug": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+            "title": "Slug"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/EventSourceKind"
+          },
+          "auth_strategy": {
+            "$ref": "#/components/schemas/EventSourceAuthStrategy"
+          },
+          "status": {
+            "$ref": "#/components/schemas/EventSourceStatus",
+            "default": "active"
+          },
+          "extras": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Extras"
+          },
+          "secret": {
+            "type": "string",
+            "format": "password",
+            "writeOnly": true,
+            "nullable": true,
+            "title": "Secret"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "name",
+          "slug",
+          "kind",
+          "auth_strategy"
+        ],
+        "title": "EventSourceCreate",
+        "description": "POST body. ``name`` and ``slug`` are immutable after creation.\n\n``secret`` is the optional auth secret to custody in Vault. When\npresent the create handler writes it to the derived per-tenant Vault\npath and persists that path as ``secret_ref``; when absent the source\nis registered with no secret (``secret_ref`` NULL) and the ingest path\n(#2881) fails closed until a later PATCH sets one. The value is a\nwrite-only :class:`~pydantic.SecretStr` -- it never appears on a read\nmodel, in a log line, or in an audit row."
+      },
+      "EventSourceKind": {
+        "type": "string",
+        "enum": [
+          "alertmanager",
+          "grafana",
+          "vcf-operations",
+          "harbor",
+          "generic-json"
+        ],
+        "title": "EventSourceKind",
+        "description": "Producer family. Selects the payload normaliser (#2882) at ingest.\n\nA closed set (unlike :attr:`~meho_backplane.db.models.EventOutbox.event_kind`'s\nfree text) because each kind needs hand-written normaliser code, so\nadding one is a code change regardless. Values mirror the\n``ck_event_source_kind`` CHECK constraint."
+      },
+      "EventSourceListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/EventSourceSummary"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "next_cursor": {
+            "type": "string",
+            "nullable": true,
+            "title": "Next Cursor"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "title": "EventSourceListResponse",
+        "description": "``{items, next_cursor}`` list envelope (api-shape-conventions \u00a72).\n\n``next_cursor`` is the last row's ``name`` when a further page exists,\n``None`` when this page exhausted the tenant's live sources."
+      },
+      "EventSourceStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "paused"
+        ],
+        "title": "EventSourceStatus",
+        "description": "Registry status. Values mirror the ``ck_event_source_status`` CHECK.\n\n``paused`` makes the ingest path reject the sender; because nothing\ncaches the row, a PATCH to ``paused`` takes effect on the ingest\npath's very next lookup (#2880 acceptance criterion 1)."
+      },
+      "EventSourceSummary": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "slug": {
+            "type": "string",
+            "title": "Slug"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/EventSourceKind"
+          },
+          "auth_strategy": {
+            "$ref": "#/components/schemas/EventSourceAuthStrategy"
+          },
+          "status": {
+            "$ref": "#/components/schemas/EventSourceStatus"
+          },
+          "secret_ref": {
+            "type": "string",
+            "nullable": true,
+            "title": "Secret Ref"
+          },
+          "created_by_sub": {
+            "type": "string",
+            "title": "Created By Sub"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "deleted_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Deleted At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "tenant_id",
+          "name",
+          "slug",
+          "kind",
+          "auth_strategy",
+          "status",
+          "secret_ref",
+          "created_by_sub",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "EventSourceSummary",
+        "description": "Narrow list-row shape. Frozen; omits ``extras`` to keep lists small."
+      },
+      "EventSourceUpdate": {
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/EventSourceKind",
+            "nullable": true
+          },
+          "auth_strategy": {
+            "$ref": "#/components/schemas/EventSourceAuthStrategy",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/EventSourceStatus",
+            "nullable": true
+          },
+          "extras": {
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true,
+            "title": "Extras"
+          },
+          "secret": {
+            "type": "string",
+            "format": "password",
+            "writeOnly": true,
+            "nullable": true,
+            "title": "Secret"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "EventSourceUpdate",
+        "description": "PATCH body. Every field optional; ``name`` / ``slug`` are absent.\n\n``name`` and ``slug`` are immutable (rename or re-slug = delete +\nre-create) because ``slug`` is a live routing key external senders are\nalready pointed at. Sending ``secret`` rotates the Vault secret in\nplace at the source's existing ``secret_ref`` -- a new KV-v2 version at\nthe same path, so the ingest path reads the new value on its next\nlookup with no downtime (#2880 acceptance criterion 2). Omitting\n``secret`` leaves the stored secret untouched."
       },
       "FingerprintResult": {
         "properties": {

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -31165,6 +31165,10 @@
       "x-maturity": "experimental"
     },
     {
+      "name": "event-sources",
+      "x-maturity": "beta"
+    },
+    {
       "name": "feed",
       "x-maturity": "beta"
     },

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -248,6 +248,28 @@ const (
 	EvalResultOverallVerdictYellow EvalResultOverallVerdict = "yellow"
 )
 
+// Defines values for EventSourceAuthStrategy.
+const (
+	EventSourceAuthStrategyBasic        EventSourceAuthStrategy = "basic"
+	EventSourceAuthStrategyHmacSha256   EventSourceAuthStrategy = "hmac-sha256"
+	EventSourceAuthStrategyStaticHeader EventSourceAuthStrategy = "static-header"
+)
+
+// Defines values for EventSourceKind.
+const (
+	EventSourceKindAlertmanager  EventSourceKind = "alertmanager"
+	EventSourceKindGenericJson   EventSourceKind = "generic-json"
+	EventSourceKindGrafana       EventSourceKind = "grafana"
+	EventSourceKindHarbor        EventSourceKind = "harbor"
+	EventSourceKindVcfOperations EventSourceKind = "vcf-operations"
+)
+
+// Defines values for EventSourceStatus.
+const (
+	EventSourceStatusActive EventSourceStatus = "active"
+	EventSourceStatusPaused EventSourceStatus = "paused"
+)
+
 // Defines values for GatewayResultBodyOutcome.
 const (
 	GatewayResultBodyOutcomeFailed    GatewayResultBodyOutcome = "failed"
@@ -1517,6 +1539,26 @@ type BaselineMetricsOverride struct {
 	Kind         *string `json:"kind,omitempty"`
 	Mrr          float32 `json:"mrr"`
 	PrecisionAt5 float32 `json:"precision_at_5"`
+}
+
+// BodyCreateUiEventSourcesPost defines model for Body__create_ui_event_sources_post.
+type BodyCreateUiEventSourcesPost struct {
+	AuthStrategy string  `json:"auth_strategy"`
+	Extras       *string `json:"extras,omitempty"`
+	Kind         string  `json:"kind"`
+	Name         string  `json:"name"`
+	Secret       *string `json:"secret,omitempty"`
+	Slug         string  `json:"slug"`
+	Status       *string `json:"status,omitempty"`
+}
+
+// BodyEditUiEventSourcesSlugEditPost defines model for Body__edit_ui_event_sources__slug__edit_post.
+type BodyEditUiEventSourcesSlugEditPost struct {
+	AuthStrategy string  `json:"auth_strategy"`
+	Extras       *string `json:"extras,omitempty"`
+	Kind         string  `json:"kind"`
+	Secret       *string `json:"secret,omitempty"`
+	Status       string  `json:"status"`
 }
 
 // BodyAnnotateUiTopologyEdgesPost defines model for Body_annotate_ui_topology_edges_post.
@@ -4141,6 +4183,201 @@ type EvalResult struct {
 
 // EvalResultOverallVerdict defines model for EvalResult.OverallVerdict.
 type EvalResultOverallVerdict string
+
+// EventSource Full read shape. Maps 1:1 to the live “event_source“ columns.
+//
+// Frozen. Carries “secret_ref“ (the Vault *path*) but never the secret
+// value -- there is no “secret“ field on any read model.
+type EventSource struct {
+	// AuthStrategy How the ingest endpoint (#2881) authenticates the sender.
+	//
+	// All three verify against the source's Vault secret. Values mirror the
+	// ``ck_event_source_auth_strategy`` CHECK constraint.
+	//
+	// * ``hmac-sha256`` -- the sender signs the body with a shared key.
+	// * ``static-header`` -- a fixed bearer / API-key header value.
+	// * ``basic`` -- HTTP Basic (the non-secret username lives in ``extras``;
+	//   the password is the Vault secret).
+	AuthStrategy EventSourceAuthStrategy `json:"auth_strategy"`
+	CreatedAt    time.Time               `json:"created_at"`
+	CreatedBySub string                  `json:"created_by_sub"`
+	DeletedAt    *time.Time              `json:"deleted_at"`
+	Extras       map[string]interface{}  `json:"extras"`
+	Id           openapi_types.UUID      `json:"id"`
+
+	// Kind Producer family. Selects the payload normaliser (#2882) at ingest.
+	//
+	// A closed set (unlike :attr:`~meho_backplane.db.models.EventOutbox.event_kind`'s
+	// free text) because each kind needs hand-written normaliser code, so
+	// adding one is a code change regardless. Values mirror the
+	// ``ck_event_source_kind`` CHECK constraint.
+	Kind      EventSourceKind `json:"kind"`
+	Name      string          `json:"name"`
+	SecretRef *string         `json:"secret_ref"`
+	Slug      string          `json:"slug"`
+
+	// Status Registry status. Values mirror the ``ck_event_source_status`` CHECK.
+	//
+	// ``paused`` makes the ingest path reject the sender; because nothing
+	// caches the row, a PATCH to ``paused`` takes effect on the ingest
+	// path's very next lookup (#2880 acceptance criterion 1).
+	Status    EventSourceStatus  `json:"status"`
+	TenantId  openapi_types.UUID `json:"tenant_id"`
+	UpdatedAt time.Time          `json:"updated_at"`
+}
+
+// EventSourceAuthStrategy How the ingest endpoint (#2881) authenticates the sender.
+//
+// All three verify against the source's Vault secret. Values mirror the
+// “ck_event_source_auth_strategy“ CHECK constraint.
+//
+//   - “hmac-sha256“ -- the sender signs the body with a shared key.
+//   - “static-header“ -- a fixed bearer / API-key header value.
+//   - “basic“ -- HTTP Basic (the non-secret username lives in “extras“;
+//     the password is the Vault secret).
+type EventSourceAuthStrategy string
+
+// EventSourceCreate POST body. “name“ and “slug“ are immutable after creation.
+//
+// “secret“ is the optional auth secret to custody in Vault. When
+// present the create handler writes it to the derived per-tenant Vault
+// path and persists that path as “secret_ref“; when absent the source
+// is registered with no secret (“secret_ref“ NULL) and the ingest path
+// (#2881) fails closed until a later PATCH sets one. The value is a
+// write-only :class:`~pydantic.SecretStr` -- it never appears on a read
+// model, in a log line, or in an audit row.
+type EventSourceCreate struct {
+	// AuthStrategy How the ingest endpoint (#2881) authenticates the sender.
+	//
+	// All three verify against the source's Vault secret. Values mirror the
+	// ``ck_event_source_auth_strategy`` CHECK constraint.
+	//
+	// * ``hmac-sha256`` -- the sender signs the body with a shared key.
+	// * ``static-header`` -- a fixed bearer / API-key header value.
+	// * ``basic`` -- HTTP Basic (the non-secret username lives in ``extras``;
+	//   the password is the Vault secret).
+	AuthStrategy EventSourceAuthStrategy `json:"auth_strategy"`
+	Extras       *map[string]interface{} `json:"extras,omitempty"`
+
+	// Kind Producer family. Selects the payload normaliser (#2882) at ingest.
+	//
+	// A closed set (unlike :attr:`~meho_backplane.db.models.EventOutbox.event_kind`'s
+	// free text) because each kind needs hand-written normaliser code, so
+	// adding one is a code change regardless. Values mirror the
+	// ``ck_event_source_kind`` CHECK constraint.
+	Kind   EventSourceKind `json:"kind"`
+	Name   string          `json:"name"`
+	Secret *string         `json:"secret"`
+	Slug   string          `json:"slug"`
+
+	// Status Registry status. Values mirror the ``ck_event_source_status`` CHECK.
+	//
+	// ``paused`` makes the ingest path reject the sender; because nothing
+	// caches the row, a PATCH to ``paused`` takes effect on the ingest
+	// path's very next lookup (#2880 acceptance criterion 1).
+	Status *EventSourceStatus `json:"status,omitempty"`
+}
+
+// EventSourceKind Producer family. Selects the payload normaliser (#2882) at ingest.
+//
+// A closed set (unlike :attr:`~meho_backplane.db.models.EventOutbox.event_kind`'s
+// free text) because each kind needs hand-written normaliser code, so
+// adding one is a code change regardless. Values mirror the
+// “ck_event_source_kind“ CHECK constraint.
+type EventSourceKind string
+
+// EventSourceListResponse “{items, next_cursor}“ list envelope (api-shape-conventions §2).
+//
+// “next_cursor“ is the last row's “name“ when a further page exists,
+// “None“ when this page exhausted the tenant's live sources.
+type EventSourceListResponse struct {
+	Items      []EventSourceSummary `json:"items"`
+	NextCursor *string              `json:"next_cursor"`
+}
+
+// EventSourceStatus Registry status. Values mirror the “ck_event_source_status“ CHECK.
+//
+// “paused“ makes the ingest path reject the sender; because nothing
+// caches the row, a PATCH to “paused“ takes effect on the ingest
+// path's very next lookup (#2880 acceptance criterion 1).
+type EventSourceStatus string
+
+// EventSourceSummary Narrow list-row shape. Frozen; omits “extras“ to keep lists small.
+type EventSourceSummary struct {
+	// AuthStrategy How the ingest endpoint (#2881) authenticates the sender.
+	//
+	// All three verify against the source's Vault secret. Values mirror the
+	// ``ck_event_source_auth_strategy`` CHECK constraint.
+	//
+	// * ``hmac-sha256`` -- the sender signs the body with a shared key.
+	// * ``static-header`` -- a fixed bearer / API-key header value.
+	// * ``basic`` -- HTTP Basic (the non-secret username lives in ``extras``;
+	//   the password is the Vault secret).
+	AuthStrategy EventSourceAuthStrategy `json:"auth_strategy"`
+	CreatedAt    time.Time               `json:"created_at"`
+	CreatedBySub string                  `json:"created_by_sub"`
+	DeletedAt    *time.Time              `json:"deleted_at"`
+	Id           openapi_types.UUID      `json:"id"`
+
+	// Kind Producer family. Selects the payload normaliser (#2882) at ingest.
+	//
+	// A closed set (unlike :attr:`~meho_backplane.db.models.EventOutbox.event_kind`'s
+	// free text) because each kind needs hand-written normaliser code, so
+	// adding one is a code change regardless. Values mirror the
+	// ``ck_event_source_kind`` CHECK constraint.
+	Kind      EventSourceKind `json:"kind"`
+	Name      string          `json:"name"`
+	SecretRef *string         `json:"secret_ref"`
+	Slug      string          `json:"slug"`
+
+	// Status Registry status. Values mirror the ``ck_event_source_status`` CHECK.
+	//
+	// ``paused`` makes the ingest path reject the sender; because nothing
+	// caches the row, a PATCH to ``paused`` takes effect on the ingest
+	// path's very next lookup (#2880 acceptance criterion 1).
+	Status    EventSourceStatus  `json:"status"`
+	TenantId  openapi_types.UUID `json:"tenant_id"`
+	UpdatedAt time.Time          `json:"updated_at"`
+}
+
+// EventSourceUpdate PATCH body. Every field optional; “name“ / “slug“ are absent.
+//
+// “name“ and “slug“ are immutable (rename or re-slug = delete +
+// re-create) because “slug“ is a live routing key external senders are
+// already pointed at. Sending “secret“ rotates the Vault secret in
+// place at the source's existing “secret_ref“ -- a new KV-v2 version at
+// the same path, so the ingest path reads the new value on its next
+// lookup with no downtime (#2880 acceptance criterion 2). Omitting
+// “secret“ leaves the stored secret untouched.
+type EventSourceUpdate struct {
+	// AuthStrategy How the ingest endpoint (#2881) authenticates the sender.
+	//
+	// All three verify against the source's Vault secret. Values mirror the
+	// ``ck_event_source_auth_strategy`` CHECK constraint.
+	//
+	// * ``hmac-sha256`` -- the sender signs the body with a shared key.
+	// * ``static-header`` -- a fixed bearer / API-key header value.
+	// * ``basic`` -- HTTP Basic (the non-secret username lives in ``extras``;
+	//   the password is the Vault secret).
+	AuthStrategy *EventSourceAuthStrategy `json:"auth_strategy,omitempty"`
+	Extras       *map[string]interface{}  `json:"extras"`
+
+	// Kind Producer family. Selects the payload normaliser (#2882) at ingest.
+	//
+	// A closed set (unlike :attr:`~meho_backplane.db.models.EventOutbox.event_kind`'s
+	// free text) because each kind needs hand-written normaliser code, so
+	// adding one is a code change regardless. Values mirror the
+	// ``ck_event_source_kind`` CHECK constraint.
+	Kind   *EventSourceKind `json:"kind,omitempty"`
+	Secret *string          `json:"secret"`
+
+	// Status Registry status. Values mirror the ``ck_event_source_status`` CHECK.
+	//
+	// ``paused`` makes the ingest path reject the sender; because nothing
+	// caches the row, a PATCH to ``paused`` takes effect on the ingest
+	// path's very next lookup (#2880 acceptance criterion 1).
+	Status *EventSourceStatus `json:"status,omitempty"`
+}
 
 // FingerprintResult Connector fingerprint per consumer-needs L95.
 type FingerprintResult struct {
@@ -8208,6 +8445,34 @@ type ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams stru
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// ListEventSourcesApiV1EventSourcesGetParams defines parameters for ListEventSourcesApiV1EventSourcesGet.
+type ListEventSourcesApiV1EventSourcesGetParams struct {
+	Status        *EventSourceStatus `form:"status,omitempty" json:"status,omitempty"`
+	Limit         *int               `form:"limit,omitempty" json:"limit,omitempty"`
+	Cursor        *string            `form:"cursor,omitempty" json:"cursor,omitempty"`
+	Authorization *string            `json:"authorization,omitempty"`
+}
+
+// CreateEventSourceApiV1EventSourcesPostParams defines parameters for CreateEventSourceApiV1EventSourcesPost.
+type CreateEventSourceApiV1EventSourcesPostParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// DeleteEventSourceApiV1EventSourcesSlugDeleteParams defines parameters for DeleteEventSourceApiV1EventSourcesSlugDelete.
+type DeleteEventSourceApiV1EventSourcesSlugDeleteParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// DescribeEventSourceApiV1EventSourcesSlugGetParams defines parameters for DescribeEventSourceApiV1EventSourcesSlugGet.
+type DescribeEventSourceApiV1EventSourcesSlugGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
+// UpdateEventSourceApiV1EventSourcesSlugPatchParams defines parameters for UpdateEventSourceApiV1EventSourcesSlugPatch.
+type UpdateEventSourceApiV1EventSourcesSlugPatchParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // FeedEndpointApiV1FeedGetParams defines parameters for FeedEndpointApiV1FeedGet.
 type FeedEndpointApiV1FeedGetParams struct {
 	// OpClass Filter by event op_class.
@@ -9120,6 +9385,12 @@ type UpdateConventionApiV1ConventionsSlugPatchJSONRequestBody = ConventionUpdate
 // CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody defines body for CreateDocCollectionEndpointApiV1DocCollectionsPost for application/json ContentType.
 type CreateDocCollectionEndpointApiV1DocCollectionsPostJSONRequestBody = DocCollectionCreate
 
+// CreateEventSourceApiV1EventSourcesPostJSONRequestBody defines body for CreateEventSourceApiV1EventSourcesPost for application/json ContentType.
+type CreateEventSourceApiV1EventSourcesPostJSONRequestBody = EventSourceCreate
+
+// UpdateEventSourceApiV1EventSourcesSlugPatchJSONRequestBody defines body for UpdateEventSourceApiV1EventSourcesSlugPatch for application/json ContentType.
+type UpdateEventSourceApiV1EventSourcesSlugPatchJSONRequestBody = EventSourceUpdate
+
 // ReportCommandResultApiV1GatewayRunnerResultPostJSONRequestBody defines body for ReportCommandResultApiV1GatewayRunnerResultPost for application/json ContentType.
 type ReportCommandResultApiV1GatewayRunnerResultPostJSONRequestBody = GatewayResultBody
 
@@ -9425,6 +9696,12 @@ type UiCorpusCollectionProbeUiCorpusCollectionsCollectionKeyProbePostJSONRequest
 
 // CorpusSearchUiCorpusSearchPostFormdataRequestBody defines body for CorpusSearchUiCorpusSearchPost for application/x-www-form-urlencoded ContentType.
 type CorpusSearchUiCorpusSearchPostFormdataRequestBody = BodyCorpusSearchUiCorpusSearchPost
+
+// CreateUiEventSourcesPostFormdataRequestBody defines body for CreateUiEventSourcesPost for application/x-www-form-urlencoded ContentType.
+type CreateUiEventSourcesPostFormdataRequestBody = BodyCreateUiEventSourcesPost
+
+// EditUiEventSourcesSlugEditPostFormdataRequestBody defines body for EditUiEventSourcesSlugEditPost for application/x-www-form-urlencoded ContentType.
+type EditUiEventSourcesSlugEditPostFormdataRequestBody = BodyEditUiEventSourcesSlugEditPost
 
 // KbEditorPreviewUiKbEditorPreviewPostFormdataRequestBody defines body for KbEditorPreviewUiKbEditorPreviewPost for application/x-www-form-urlencoded ContentType.
 type KbEditorPreviewUiKbEditorPreviewPostFormdataRequestBody = BodyKbEditorPreviewUiKbEditorPreviewPost
@@ -11065,6 +11342,25 @@ type ClientInterface interface {
 	// ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePost request
 	ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePost(ctx context.Context, collectionKey string, params *ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListEventSourcesApiV1EventSourcesGet request
+	ListEventSourcesApiV1EventSourcesGet(ctx context.Context, params *ListEventSourcesApiV1EventSourcesGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateEventSourceApiV1EventSourcesPostWithBody request with any body
+	CreateEventSourceApiV1EventSourcesPostWithBody(ctx context.Context, params *CreateEventSourceApiV1EventSourcesPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateEventSourceApiV1EventSourcesPost(ctx context.Context, params *CreateEventSourceApiV1EventSourcesPostParams, body CreateEventSourceApiV1EventSourcesPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteEventSourceApiV1EventSourcesSlugDelete request
+	DeleteEventSourceApiV1EventSourcesSlugDelete(ctx context.Context, slug string, params *DeleteEventSourceApiV1EventSourcesSlugDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DescribeEventSourceApiV1EventSourcesSlugGet request
+	DescribeEventSourceApiV1EventSourcesSlugGet(ctx context.Context, slug string, params *DescribeEventSourceApiV1EventSourcesSlugGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateEventSourceApiV1EventSourcesSlugPatchWithBody request with any body
+	UpdateEventSourceApiV1EventSourcesSlugPatchWithBody(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UpdateEventSourceApiV1EventSourcesSlugPatch(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, body UpdateEventSourceApiV1EventSourcesSlugPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// FeedEndpointApiV1FeedGet request
 	FeedEndpointApiV1FeedGet(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -11789,6 +12085,28 @@ type ClientInterface interface {
 	CorpusSearchUiCorpusSearchPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	CorpusSearchUiCorpusSearchPostWithFormdataBody(ctx context.Context, body CorpusSearchUiCorpusSearchPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListUiEventSourcesGet request
+	ListUiEventSourcesGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateUiEventSourcesPostWithBody request with any body
+	CreateUiEventSourcesPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	CreateUiEventSourcesPostWithFormdataBody(ctx context.Context, body CreateUiEventSourcesPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// NewFormUiEventSourcesNewGet request
+	NewFormUiEventSourcesNewGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteUiEventSourcesSlugDeletePost request
+	DeleteUiEventSourcesSlugDeletePost(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EditFormUiEventSourcesSlugEditGet request
+	EditFormUiEventSourcesSlugEditGet(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// EditUiEventSourcesSlugEditPostWithBody request with any body
+	EditUiEventSourcesSlugEditPostWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	EditUiEventSourcesSlugEditPostWithFormdataBody(ctx context.Context, slug string, body EditUiEventSourcesSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// KbIndexUiKbGet request
 	KbIndexUiKbGet(ctx context.Context, params *KbIndexUiKbGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -13237,6 +13555,90 @@ func (c *Client) EnableCollectionEndpointApiV1DocCollectionsCollectionKeyEnableP
 
 func (c *Client) ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePost(ctx context.Context, collectionKey string, params *ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostRequest(c.Server, collectionKey, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListEventSourcesApiV1EventSourcesGet(ctx context.Context, params *ListEventSourcesApiV1EventSourcesGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListEventSourcesApiV1EventSourcesGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateEventSourceApiV1EventSourcesPostWithBody(ctx context.Context, params *CreateEventSourceApiV1EventSourcesPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateEventSourceApiV1EventSourcesPostRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateEventSourceApiV1EventSourcesPost(ctx context.Context, params *CreateEventSourceApiV1EventSourcesPostParams, body CreateEventSourceApiV1EventSourcesPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateEventSourceApiV1EventSourcesPostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteEventSourceApiV1EventSourcesSlugDelete(ctx context.Context, slug string, params *DeleteEventSourceApiV1EventSourcesSlugDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteEventSourceApiV1EventSourcesSlugDeleteRequest(c.Server, slug, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DescribeEventSourceApiV1EventSourcesSlugGet(ctx context.Context, slug string, params *DescribeEventSourceApiV1EventSourcesSlugGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDescribeEventSourceApiV1EventSourcesSlugGetRequest(c.Server, slug, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateEventSourceApiV1EventSourcesSlugPatchWithBody(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateEventSourceApiV1EventSourcesSlugPatchRequestWithBody(c.Server, slug, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UpdateEventSourceApiV1EventSourcesSlugPatch(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, body UpdateEventSourceApiV1EventSourcesSlugPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateEventSourceApiV1EventSourcesSlugPatchRequest(c.Server, slug, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -16537,6 +16939,102 @@ func (c *Client) CorpusSearchUiCorpusSearchPostWithBody(ctx context.Context, con
 
 func (c *Client) CorpusSearchUiCorpusSearchPostWithFormdataBody(ctx context.Context, body CorpusSearchUiCorpusSearchPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCorpusSearchUiCorpusSearchPostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListUiEventSourcesGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListUiEventSourcesGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateUiEventSourcesPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateUiEventSourcesPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateUiEventSourcesPostWithFormdataBody(ctx context.Context, body CreateUiEventSourcesPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateUiEventSourcesPostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) NewFormUiEventSourcesNewGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewNewFormUiEventSourcesNewGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteUiEventSourcesSlugDeletePost(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteUiEventSourcesSlugDeletePostRequest(c.Server, slug)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditFormUiEventSourcesSlugEditGet(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditFormUiEventSourcesSlugEditGetRequest(c.Server, slug)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditUiEventSourcesSlugEditPostWithBody(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditUiEventSourcesSlugEditPostRequestWithBody(c.Server, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) EditUiEventSourcesSlugEditPostWithFormdataBody(ctx context.Context, slug string, body EditUiEventSourcesSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewEditUiEventSourcesSlugEditPostRequestWithFormdataBody(c.Server, slug, body)
 	if err != nil {
 		return nil, err
 	}
@@ -22340,6 +22838,317 @@ func NewProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostRequest(
 	if err != nil {
 		return nil, err
 	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewListEventSourcesApiV1EventSourcesGetRequest generates requests for ListEventSourcesApiV1EventSourcesGet
+func NewListEventSourcesApiV1EventSourcesGetRequest(server string, params *ListEventSourcesApiV1EventSourcesGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/event-sources")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Cursor != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "cursor", runtime.ParamLocationQuery, *params.Cursor); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewCreateEventSourceApiV1EventSourcesPostRequest calls the generic CreateEventSourceApiV1EventSourcesPost builder with application/json body
+func NewCreateEventSourceApiV1EventSourcesPostRequest(server string, params *CreateEventSourceApiV1EventSourcesPostParams, body CreateEventSourceApiV1EventSourcesPostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateEventSourceApiV1EventSourcesPostRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewCreateEventSourceApiV1EventSourcesPostRequestWithBody generates requests for CreateEventSourceApiV1EventSourcesPost with any type of body
+func NewCreateEventSourceApiV1EventSourcesPostRequestWithBody(server string, params *CreateEventSourceApiV1EventSourcesPostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/event-sources")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewDeleteEventSourceApiV1EventSourcesSlugDeleteRequest generates requests for DeleteEventSourceApiV1EventSourcesSlugDelete
+func NewDeleteEventSourceApiV1EventSourcesSlugDeleteRequest(server string, slug string, params *DeleteEventSourceApiV1EventSourcesSlugDeleteParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/event-sources/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewDescribeEventSourceApiV1EventSourcesSlugGetRequest generates requests for DescribeEventSourceApiV1EventSourcesSlugGet
+func NewDescribeEventSourceApiV1EventSourcesSlugGetRequest(server string, slug string, params *DescribeEventSourceApiV1EventSourcesSlugGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/event-sources/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewUpdateEventSourceApiV1EventSourcesSlugPatchRequest calls the generic UpdateEventSourceApiV1EventSourcesSlugPatch builder with application/json body
+func NewUpdateEventSourceApiV1EventSourcesSlugPatchRequest(server string, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, body UpdateEventSourceApiV1EventSourcesSlugPatchJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateEventSourceApiV1EventSourcesSlugPatchRequestWithBody(server, slug, params, "application/json", bodyReader)
+}
+
+// NewUpdateEventSourceApiV1EventSourcesSlugPatchRequestWithBody generates requests for UpdateEventSourceApiV1EventSourcesSlugPatch with any type of body
+func NewUpdateEventSourceApiV1EventSourcesSlugPatchRequestWithBody(server string, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/event-sources/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	if params != nil {
 
@@ -32965,6 +33774,215 @@ func NewCorpusSearchUiCorpusSearchPostRequestWithBody(server string, contentType
 	return req, nil
 }
 
+// NewListUiEventSourcesGetRequest generates requests for ListUiEventSourcesGet
+func NewListUiEventSourcesGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/event-sources")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateUiEventSourcesPostRequestWithFormdataBody calls the generic CreateUiEventSourcesPost builder with application/x-www-form-urlencoded body
+func NewCreateUiEventSourcesPostRequestWithFormdataBody(server string, body CreateUiEventSourcesPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewCreateUiEventSourcesPostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewCreateUiEventSourcesPostRequestWithBody generates requests for CreateUiEventSourcesPost with any type of body
+func NewCreateUiEventSourcesPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/event-sources")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewNewFormUiEventSourcesNewGetRequest generates requests for NewFormUiEventSourcesNewGet
+func NewNewFormUiEventSourcesNewGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/event-sources/new")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewDeleteUiEventSourcesSlugDeletePostRequest generates requests for DeleteUiEventSourcesSlugDeletePost
+func NewDeleteUiEventSourcesSlugDeletePostRequest(server string, slug string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/event-sources/%s/delete", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewEditFormUiEventSourcesSlugEditGetRequest generates requests for EditFormUiEventSourcesSlugEditGet
+func NewEditFormUiEventSourcesSlugEditGetRequest(server string, slug string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/event-sources/%s/edit", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewEditUiEventSourcesSlugEditPostRequestWithFormdataBody calls the generic EditUiEventSourcesSlugEditPost builder with application/x-www-form-urlencoded body
+func NewEditUiEventSourcesSlugEditPostRequestWithFormdataBody(server string, slug string, body EditUiEventSourcesSlugEditPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewEditUiEventSourcesSlugEditPostRequestWithBody(server, slug, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewEditUiEventSourcesSlugEditPostRequestWithBody generates requests for EditUiEventSourcesSlugEditPost with any type of body
+func NewEditUiEventSourcesSlugEditPostRequestWithBody(server string, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/event-sources/%s/edit", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewKbIndexUiKbGetRequest generates requests for KbIndexUiKbGet
 func NewKbIndexUiKbGetRequest(server string, params *KbIndexUiKbGetParams) (*http.Request, error) {
 	var err error
@@ -38013,6 +39031,25 @@ type ClientWithResponsesInterface interface {
 	// ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostWithResponse request
 	ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostWithResponse(ctx context.Context, collectionKey string, params *ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostParams, reqEditors ...RequestEditorFn) (*ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse, error)
 
+	// ListEventSourcesApiV1EventSourcesGetWithResponse request
+	ListEventSourcesApiV1EventSourcesGetWithResponse(ctx context.Context, params *ListEventSourcesApiV1EventSourcesGetParams, reqEditors ...RequestEditorFn) (*ListEventSourcesApiV1EventSourcesGetResponse, error)
+
+	// CreateEventSourceApiV1EventSourcesPostWithBodyWithResponse request with any body
+	CreateEventSourceApiV1EventSourcesPostWithBodyWithResponse(ctx context.Context, params *CreateEventSourceApiV1EventSourcesPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEventSourceApiV1EventSourcesPostResponse, error)
+
+	CreateEventSourceApiV1EventSourcesPostWithResponse(ctx context.Context, params *CreateEventSourceApiV1EventSourcesPostParams, body CreateEventSourceApiV1EventSourcesPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEventSourceApiV1EventSourcesPostResponse, error)
+
+	// DeleteEventSourceApiV1EventSourcesSlugDeleteWithResponse request
+	DeleteEventSourceApiV1EventSourcesSlugDeleteWithResponse(ctx context.Context, slug string, params *DeleteEventSourceApiV1EventSourcesSlugDeleteParams, reqEditors ...RequestEditorFn) (*DeleteEventSourceApiV1EventSourcesSlugDeleteResponse, error)
+
+	// DescribeEventSourceApiV1EventSourcesSlugGetWithResponse request
+	DescribeEventSourceApiV1EventSourcesSlugGetWithResponse(ctx context.Context, slug string, params *DescribeEventSourceApiV1EventSourcesSlugGetParams, reqEditors ...RequestEditorFn) (*DescribeEventSourceApiV1EventSourcesSlugGetResponse, error)
+
+	// UpdateEventSourceApiV1EventSourcesSlugPatchWithBodyWithResponse request with any body
+	UpdateEventSourceApiV1EventSourcesSlugPatchWithBodyWithResponse(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateEventSourceApiV1EventSourcesSlugPatchResponse, error)
+
+	UpdateEventSourceApiV1EventSourcesSlugPatchWithResponse(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, body UpdateEventSourceApiV1EventSourcesSlugPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateEventSourceApiV1EventSourcesSlugPatchResponse, error)
+
 	// FeedEndpointApiV1FeedGetWithResponse request
 	FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error)
 
@@ -38737,6 +39774,28 @@ type ClientWithResponsesInterface interface {
 	CorpusSearchUiCorpusSearchPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CorpusSearchUiCorpusSearchPostResponse, error)
 
 	CorpusSearchUiCorpusSearchPostWithFormdataBodyWithResponse(ctx context.Context, body CorpusSearchUiCorpusSearchPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*CorpusSearchUiCorpusSearchPostResponse, error)
+
+	// ListUiEventSourcesGetWithResponse request
+	ListUiEventSourcesGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListUiEventSourcesGetResponse, error)
+
+	// CreateUiEventSourcesPostWithBodyWithResponse request with any body
+	CreateUiEventSourcesPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateUiEventSourcesPostResponse, error)
+
+	CreateUiEventSourcesPostWithFormdataBodyWithResponse(ctx context.Context, body CreateUiEventSourcesPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*CreateUiEventSourcesPostResponse, error)
+
+	// NewFormUiEventSourcesNewGetWithResponse request
+	NewFormUiEventSourcesNewGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*NewFormUiEventSourcesNewGetResponse, error)
+
+	// DeleteUiEventSourcesSlugDeletePostWithResponse request
+	DeleteUiEventSourcesSlugDeletePostWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*DeleteUiEventSourcesSlugDeletePostResponse, error)
+
+	// EditFormUiEventSourcesSlugEditGetWithResponse request
+	EditFormUiEventSourcesSlugEditGetWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*EditFormUiEventSourcesSlugEditGetResponse, error)
+
+	// EditUiEventSourcesSlugEditPostWithBodyWithResponse request with any body
+	EditUiEventSourcesSlugEditPostWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditUiEventSourcesSlugEditPostResponse, error)
+
+	EditUiEventSourcesSlugEditPostWithFormdataBodyWithResponse(ctx context.Context, slug string, body EditUiEventSourcesSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*EditUiEventSourcesSlugEditPostResponse, error)
 
 	// KbIndexUiKbGetWithResponse request
 	KbIndexUiKbGetWithResponse(ctx context.Context, params *KbIndexUiKbGetParams, reqEditors ...RequestEditorFn) (*KbIndexUiKbGetResponse, error)
@@ -40649,6 +41708,120 @@ func (r ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r ProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListEventSourcesApiV1EventSourcesGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *EventSourceListResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ListEventSourcesApiV1EventSourcesGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListEventSourcesApiV1EventSourcesGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateEventSourceApiV1EventSourcesPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *EventSource
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateEventSourceApiV1EventSourcesPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateEventSourceApiV1EventSourcesPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteEventSourceApiV1EventSourcesSlugDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteEventSourceApiV1EventSourcesSlugDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteEventSourceApiV1EventSourcesSlugDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DescribeEventSourceApiV1EventSourcesSlugGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *EventSource
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r DescribeEventSourceApiV1EventSourcesSlugGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DescribeEventSourceApiV1EventSourcesSlugGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UpdateEventSourceApiV1EventSourcesSlugPatchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *EventSource
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateEventSourceApiV1EventSourcesSlugPatchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateEventSourceApiV1EventSourcesSlugPatchResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -44667,6 +45840,139 @@ func (r CorpusSearchUiCorpusSearchPostResponse) StatusCode() int {
 	return 0
 }
 
+type ListUiEventSourcesGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r ListUiEventSourcesGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListUiEventSourcesGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateUiEventSourcesPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateUiEventSourcesPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateUiEventSourcesPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type NewFormUiEventSourcesNewGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r NewFormUiEventSourcesNewGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r NewFormUiEventSourcesNewGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteUiEventSourcesSlugDeletePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteUiEventSourcesSlugDeletePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteUiEventSourcesSlugDeletePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EditFormUiEventSourcesSlugEditGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r EditFormUiEventSourcesSlugEditGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EditFormUiEventSourcesSlugEditGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type EditUiEventSourcesSlugEditPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r EditUiEventSourcesSlugEditPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r EditUiEventSourcesSlugEditPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type KbIndexUiKbGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -47545,6 +48851,67 @@ func (c *ClientWithResponses) ProbeCollectionEndpointApiV1DocCollectionsCollecti
 	return ParseProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostResponse(rsp)
 }
 
+// ListEventSourcesApiV1EventSourcesGetWithResponse request returning *ListEventSourcesApiV1EventSourcesGetResponse
+func (c *ClientWithResponses) ListEventSourcesApiV1EventSourcesGetWithResponse(ctx context.Context, params *ListEventSourcesApiV1EventSourcesGetParams, reqEditors ...RequestEditorFn) (*ListEventSourcesApiV1EventSourcesGetResponse, error) {
+	rsp, err := c.ListEventSourcesApiV1EventSourcesGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListEventSourcesApiV1EventSourcesGetResponse(rsp)
+}
+
+// CreateEventSourceApiV1EventSourcesPostWithBodyWithResponse request with arbitrary body returning *CreateEventSourceApiV1EventSourcesPostResponse
+func (c *ClientWithResponses) CreateEventSourceApiV1EventSourcesPostWithBodyWithResponse(ctx context.Context, params *CreateEventSourceApiV1EventSourcesPostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateEventSourceApiV1EventSourcesPostResponse, error) {
+	rsp, err := c.CreateEventSourceApiV1EventSourcesPostWithBody(ctx, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateEventSourceApiV1EventSourcesPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateEventSourceApiV1EventSourcesPostWithResponse(ctx context.Context, params *CreateEventSourceApiV1EventSourcesPostParams, body CreateEventSourceApiV1EventSourcesPostJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateEventSourceApiV1EventSourcesPostResponse, error) {
+	rsp, err := c.CreateEventSourceApiV1EventSourcesPost(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateEventSourceApiV1EventSourcesPostResponse(rsp)
+}
+
+// DeleteEventSourceApiV1EventSourcesSlugDeleteWithResponse request returning *DeleteEventSourceApiV1EventSourcesSlugDeleteResponse
+func (c *ClientWithResponses) DeleteEventSourceApiV1EventSourcesSlugDeleteWithResponse(ctx context.Context, slug string, params *DeleteEventSourceApiV1EventSourcesSlugDeleteParams, reqEditors ...RequestEditorFn) (*DeleteEventSourceApiV1EventSourcesSlugDeleteResponse, error) {
+	rsp, err := c.DeleteEventSourceApiV1EventSourcesSlugDelete(ctx, slug, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteEventSourceApiV1EventSourcesSlugDeleteResponse(rsp)
+}
+
+// DescribeEventSourceApiV1EventSourcesSlugGetWithResponse request returning *DescribeEventSourceApiV1EventSourcesSlugGetResponse
+func (c *ClientWithResponses) DescribeEventSourceApiV1EventSourcesSlugGetWithResponse(ctx context.Context, slug string, params *DescribeEventSourceApiV1EventSourcesSlugGetParams, reqEditors ...RequestEditorFn) (*DescribeEventSourceApiV1EventSourcesSlugGetResponse, error) {
+	rsp, err := c.DescribeEventSourceApiV1EventSourcesSlugGet(ctx, slug, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDescribeEventSourceApiV1EventSourcesSlugGetResponse(rsp)
+}
+
+// UpdateEventSourceApiV1EventSourcesSlugPatchWithBodyWithResponse request with arbitrary body returning *UpdateEventSourceApiV1EventSourcesSlugPatchResponse
+func (c *ClientWithResponses) UpdateEventSourceApiV1EventSourcesSlugPatchWithBodyWithResponse(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateEventSourceApiV1EventSourcesSlugPatchResponse, error) {
+	rsp, err := c.UpdateEventSourceApiV1EventSourcesSlugPatchWithBody(ctx, slug, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateEventSourceApiV1EventSourcesSlugPatchResponse(rsp)
+}
+
+func (c *ClientWithResponses) UpdateEventSourceApiV1EventSourcesSlugPatchWithResponse(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, body UpdateEventSourceApiV1EventSourcesSlugPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateEventSourceApiV1EventSourcesSlugPatchResponse, error) {
+	rsp, err := c.UpdateEventSourceApiV1EventSourcesSlugPatch(ctx, slug, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateEventSourceApiV1EventSourcesSlugPatchResponse(rsp)
+}
+
 // FeedEndpointApiV1FeedGetWithResponse request returning *FeedEndpointApiV1FeedGetResponse
 func (c *ClientWithResponses) FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error) {
 	rsp, err := c.FeedEndpointApiV1FeedGet(ctx, params, reqEditors...)
@@ -49918,6 +51285,76 @@ func (c *ClientWithResponses) CorpusSearchUiCorpusSearchPostWithFormdataBodyWith
 		return nil, err
 	}
 	return ParseCorpusSearchUiCorpusSearchPostResponse(rsp)
+}
+
+// ListUiEventSourcesGetWithResponse request returning *ListUiEventSourcesGetResponse
+func (c *ClientWithResponses) ListUiEventSourcesGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListUiEventSourcesGetResponse, error) {
+	rsp, err := c.ListUiEventSourcesGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListUiEventSourcesGetResponse(rsp)
+}
+
+// CreateUiEventSourcesPostWithBodyWithResponse request with arbitrary body returning *CreateUiEventSourcesPostResponse
+func (c *ClientWithResponses) CreateUiEventSourcesPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateUiEventSourcesPostResponse, error) {
+	rsp, err := c.CreateUiEventSourcesPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateUiEventSourcesPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) CreateUiEventSourcesPostWithFormdataBodyWithResponse(ctx context.Context, body CreateUiEventSourcesPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*CreateUiEventSourcesPostResponse, error) {
+	rsp, err := c.CreateUiEventSourcesPostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateUiEventSourcesPostResponse(rsp)
+}
+
+// NewFormUiEventSourcesNewGetWithResponse request returning *NewFormUiEventSourcesNewGetResponse
+func (c *ClientWithResponses) NewFormUiEventSourcesNewGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*NewFormUiEventSourcesNewGetResponse, error) {
+	rsp, err := c.NewFormUiEventSourcesNewGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseNewFormUiEventSourcesNewGetResponse(rsp)
+}
+
+// DeleteUiEventSourcesSlugDeletePostWithResponse request returning *DeleteUiEventSourcesSlugDeletePostResponse
+func (c *ClientWithResponses) DeleteUiEventSourcesSlugDeletePostWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*DeleteUiEventSourcesSlugDeletePostResponse, error) {
+	rsp, err := c.DeleteUiEventSourcesSlugDeletePost(ctx, slug, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteUiEventSourcesSlugDeletePostResponse(rsp)
+}
+
+// EditFormUiEventSourcesSlugEditGetWithResponse request returning *EditFormUiEventSourcesSlugEditGetResponse
+func (c *ClientWithResponses) EditFormUiEventSourcesSlugEditGetWithResponse(ctx context.Context, slug string, reqEditors ...RequestEditorFn) (*EditFormUiEventSourcesSlugEditGetResponse, error) {
+	rsp, err := c.EditFormUiEventSourcesSlugEditGet(ctx, slug, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditFormUiEventSourcesSlugEditGetResponse(rsp)
+}
+
+// EditUiEventSourcesSlugEditPostWithBodyWithResponse request with arbitrary body returning *EditUiEventSourcesSlugEditPostResponse
+func (c *ClientWithResponses) EditUiEventSourcesSlugEditPostWithBodyWithResponse(ctx context.Context, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*EditUiEventSourcesSlugEditPostResponse, error) {
+	rsp, err := c.EditUiEventSourcesSlugEditPostWithBody(ctx, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditUiEventSourcesSlugEditPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) EditUiEventSourcesSlugEditPostWithFormdataBodyWithResponse(ctx context.Context, slug string, body EditUiEventSourcesSlugEditPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*EditUiEventSourcesSlugEditPostResponse, error) {
+	rsp, err := c.EditUiEventSourcesSlugEditPostWithFormdataBody(ctx, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseEditUiEventSourcesSlugEditPostResponse(rsp)
 }
 
 // KbIndexUiKbGetWithResponse request returning *KbIndexUiKbGetResponse
@@ -53275,6 +54712,164 @@ func ParseProbeCollectionEndpointApiV1DocCollectionsCollectionKeyProbePostRespon
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest BackendReadiness
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListEventSourcesApiV1EventSourcesGetResponse parses an HTTP response from a ListEventSourcesApiV1EventSourcesGetWithResponse call
+func ParseListEventSourcesApiV1EventSourcesGetResponse(rsp *http.Response) (*ListEventSourcesApiV1EventSourcesGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListEventSourcesApiV1EventSourcesGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest EventSourceListResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateEventSourceApiV1EventSourcesPostResponse parses an HTTP response from a CreateEventSourceApiV1EventSourcesPostWithResponse call
+func ParseCreateEventSourceApiV1EventSourcesPostResponse(rsp *http.Response) (*CreateEventSourceApiV1EventSourcesPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateEventSourceApiV1EventSourcesPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest EventSource
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteEventSourceApiV1EventSourcesSlugDeleteResponse parses an HTTP response from a DeleteEventSourceApiV1EventSourcesSlugDeleteWithResponse call
+func ParseDeleteEventSourceApiV1EventSourcesSlugDeleteResponse(rsp *http.Response) (*DeleteEventSourceApiV1EventSourcesSlugDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteEventSourceApiV1EventSourcesSlugDeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDescribeEventSourceApiV1EventSourcesSlugGetResponse parses an HTTP response from a DescribeEventSourceApiV1EventSourcesSlugGetWithResponse call
+func ParseDescribeEventSourceApiV1EventSourcesSlugGetResponse(rsp *http.Response) (*DescribeEventSourceApiV1EventSourcesSlugGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DescribeEventSourceApiV1EventSourcesSlugGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest EventSource
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateEventSourceApiV1EventSourcesSlugPatchResponse parses an HTTP response from a UpdateEventSourceApiV1EventSourcesSlugPatchWithResponse call
+func ParseUpdateEventSourceApiV1EventSourcesSlugPatchResponse(rsp *http.Response) (*UpdateEventSourceApiV1EventSourcesSlugPatchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateEventSourceApiV1EventSourcesSlugPatchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest EventSource
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -58337,6 +59932,163 @@ func ParseCorpusSearchUiCorpusSearchPostResponse(rsp *http.Response) (*CorpusSea
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListUiEventSourcesGetResponse parses an HTTP response from a ListUiEventSourcesGetWithResponse call
+func ParseListUiEventSourcesGetResponse(rsp *http.Response) (*ListUiEventSourcesGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListUiEventSourcesGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseCreateUiEventSourcesPostResponse parses an HTTP response from a CreateUiEventSourcesPostWithResponse call
+func ParseCreateUiEventSourcesPostResponse(rsp *http.Response) (*CreateUiEventSourcesPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateUiEventSourcesPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseNewFormUiEventSourcesNewGetResponse parses an HTTP response from a NewFormUiEventSourcesNewGetWithResponse call
+func ParseNewFormUiEventSourcesNewGetResponse(rsp *http.Response) (*NewFormUiEventSourcesNewGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &NewFormUiEventSourcesNewGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseDeleteUiEventSourcesSlugDeletePostResponse parses an HTTP response from a DeleteUiEventSourcesSlugDeletePostWithResponse call
+func ParseDeleteUiEventSourcesSlugDeletePostResponse(rsp *http.Response) (*DeleteUiEventSourcesSlugDeletePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteUiEventSourcesSlugDeletePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEditFormUiEventSourcesSlugEditGetResponse parses an HTTP response from a EditFormUiEventSourcesSlugEditGetWithResponse call
+func ParseEditFormUiEventSourcesSlugEditGetResponse(rsp *http.Response) (*EditFormUiEventSourcesSlugEditGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EditFormUiEventSourcesSlugEditGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseEditUiEventSourcesSlugEditPostResponse parses an HTTP response from a EditUiEventSourcesSlugEditPostWithResponse call
+func ParseEditUiEventSourcesSlugEditPostResponse(rsp *http.Response) (*EditUiEventSourcesSlugEditPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &EditUiEventSourcesSlugEditPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/cli/internal/cmd/event-source/add.go
+++ b/cli/internal/cmd/event-source/add.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package eventsource
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newAddCmd returns `meho event-source add <slug>` (alias `create`).
+func newAddCmd() *cobra.Command {
+	var (
+		name              string
+		kind              string
+		authStrategy      string
+		statusFlag        string
+		extrasJSON        string
+		secretStdin       bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:     "add <slug>",
+		Aliases: []string{"create"},
+		Short:   "Register a single event source (alias `create`)",
+		Long: "add registers one event source in the operator's tenant via " +
+			"POST /api/v1/event-sources. The <slug> is the URL routing token " +
+			"the ingest endpoint resolves; it is globally unique. The auth " +
+			"secret is never a flag: set " + SecretEnvVar + " or pass " +
+			"--secret-stdin to pipe it in.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body := map[string]any{
+				"slug":          args[0],
+				"name":          name,
+				"kind":          kind,
+				"auth_strategy": authStrategy,
+			}
+			fs := cmd.Flags()
+			if fs.Changed("status") {
+				body["status"] = statusFlag
+			}
+			if fs.Changed("extras") {
+				var extras map[string]any
+				if err := json.Unmarshal([]byte(extrasJSON), &extras); err != nil {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unexpected(fmt.Sprintf("invalid --extras JSON: %v", err)), jsonOut)
+				}
+				body["extras"] = extras
+			}
+			secret, hasSecret, err := resolveSecret(cmd, secretStdin)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+			}
+			if hasSecret {
+				body["secret"] = secret
+			}
+			return runCreate(cmd, body, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "human-readable name, unique within the tenant (required)")
+	cmd.Flags().StringVar(&kind, "kind", "",
+		"producer kind: alertmanager | grafana | vcf-operations | harbor | generic-json (required)")
+	cmd.Flags().StringVar(&authStrategy, "auth-strategy", "",
+		"auth strategy: hmac-sha256 | static-header | basic (required)")
+	cmd.Flags().StringVar(&statusFlag, "status", "active", "initial status: active | paused")
+	cmd.Flags().StringVar(&extrasJSON, "extras", "",
+		"per-source tuning as a JSON object (body cap, rate limit, replay window, dedupe)")
+	cmd.Flags().BoolVar(&secretStdin, "secret-stdin", false,
+		"read the auth secret from stdin (else "+SecretEnvVar+"); never a flag value")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the created event source as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by `meho login`)")
+	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("kind")
+	_ = cmd.MarkFlagRequired("auth-strategy")
+	return cmd
+}
+
+func runCreate(cmd *cobra.Command, body map[string]any, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("marshal request body: %v", err)), jsonOut)
+	}
+	raw, err := doAuthedRequest(cmd.Context(), backplaneURL, http.MethodPost, "/api/v1/event-sources", payload)
+	if err != nil {
+		return renderRequestErr(cmd, backplaneURL, err, jsonOut)
+	}
+	var es EventSource
+	if err := json.Unmarshal(raw, &es); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("decode created event source: %v", err)), jsonOut)
+	}
+	if jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), &es)
+	}
+	printEventSource(cmd.OutOrStdout(), &es)
+	return nil
+}
+
+// printEventSource renders one source as a stable key-value summary. It
+// prints secret_ref (the Vault path) but never a secret value -- the read
+// model does not carry one.
+func printEventSource(w io.Writer, es *EventSource) {
+	fmt.Fprintf(w, "%-16s %s\n", "slug:", es.Slug)
+	fmt.Fprintf(w, "%-16s %s\n", "name:", es.Name)
+	fmt.Fprintf(w, "%-16s %s\n", "kind:", es.Kind)
+	fmt.Fprintf(w, "%-16s %s\n", "auth_strategy:", es.AuthStrategy)
+	fmt.Fprintf(w, "%-16s %s\n", "status:", es.Status)
+	if ref := strDeref(es.SecretRef); ref != "" {
+		fmt.Fprintf(w, "%-16s %s\n", "secret_ref:", ref)
+	} else {
+		fmt.Fprintf(w, "%-16s <none>\n", "secret_ref:")
+	}
+	fmt.Fprintf(w, "%-16s %s\n", "created_by:", es.CreatedBySub)
+}

--- a/cli/internal/cmd/event-source/delete.go
+++ b/cli/internal/cmd/event-source/delete.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package eventsource
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// deleteResult is the --json success/decline envelope.
+type deleteResult struct {
+	Slug   string `json:"slug"`
+	Status string `json:"status"`
+}
+
+// newDeleteCmd returns `meho event-source delete <slug>`.
+func newDeleteCmd() *cobra.Command {
+	var (
+		confirm           bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           "delete <slug>",
+		Short:         "Soft-delete one event source by slug (tenant_admin)",
+		Long:          "delete calls DELETE /api/v1/event-sources/{slug}. Without --confirm it prompts for a y/N on stdin.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slug := args[0]
+			// Confirm before resolving the backplane so a decline exits 0
+			// regardless of login state.
+			if !confirm && !confirmPrompt(cmd, fmt.Sprintf("Delete event source %q. Continue?", slug)) {
+				result := deleteResult{Slug: slug, Status: "declined"}
+				if jsonOut {
+					return output.PrintJSON(cmd.OutOrStdout(), result)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "declined: event source %q not deleted\n", slug)
+				return nil
+			}
+			backplaneURL, err := backplane.Resolve(backplaneOverride)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
+			}
+			path := "/api/v1/event-sources/" + pathEscape(slug)
+			if _, err := doAuthedRequest(cmd.Context(), backplaneURL, http.MethodDelete, path, nil); err != nil {
+				return renderRequestErr(cmd, backplaneURL, err, jsonOut)
+			}
+			result := deleteResult{Slug: slug, Status: "deleted"}
+			if jsonOut {
+				return output.PrintJSON(cmd.OutOrStdout(), result)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "deleted event source %q\n", slug)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "skip the stdin confirmation prompt")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit a machine-readable envelope instead of the human line")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "", "backplane URL (defaults to `meho login`'s)")
+	return cmd
+}

--- a/cli/internal/cmd/event-source/describe.go
+++ b/cli/internal/cmd/event-source/describe.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package eventsource
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newDescribeCmd returns `meho event-source describe <slug>`.
+func newDescribeCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           "describe <slug>",
+		Short:         "Describe a single event source by slug",
+		Long:          "describe calls GET /api/v1/event-sources/{slug}. A slug absent or owned by another tenant returns the same 404.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			backplaneURL, err := backplane.Resolve(backplaneOverride)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
+			}
+			path := "/api/v1/event-sources/" + pathEscape(args[0])
+			raw, err := doAuthedRequest(cmd.Context(), backplaneURL, http.MethodGet, path, nil)
+			if err != nil {
+				return renderRequestErr(cmd, backplaneURL, err, jsonOut)
+			}
+			var es EventSource
+			if err := json.Unmarshal(raw, &es); err != nil {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf("decode event source: %v", err)), jsonOut)
+			}
+			if jsonOut {
+				return output.PrintJSON(cmd.OutOrStdout(), &es)
+			}
+			printEventSource(cmd.OutOrStdout(), &es)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "", "backplane URL (defaults to `meho login`'s)")
+	return cmd
+}

--- a/cli/internal/cmd/event-source/eventsource.go
+++ b/cli/internal/cmd/event-source/eventsource.go
@@ -81,8 +81,8 @@ type EventSource struct {
 	DeletedAt    *string        `json:"deleted_at"`
 }
 
-// EventSourceSummary mirrors the backend EventSourceSummary list row.
-type EventSourceSummary struct {
+// Summary mirrors the backend EventSourceSummary list row.
+type Summary struct {
 	Name         string  `json:"name"`
 	Slug         string  `json:"slug"`
 	Kind         string  `json:"kind"`
@@ -91,10 +91,10 @@ type EventSourceSummary struct {
 	SecretRef    *string `json:"secret_ref"`
 }
 
-// EventSourceListResponse mirrors the {items, next_cursor} envelope.
-type EventSourceListResponse struct {
-	Items      []EventSourceSummary `json:"items"`
-	NextCursor *string              `json:"next_cursor"`
+// ListResponse mirrors the {items, next_cursor} envelope.
+type ListResponse struct {
+	Items      []Summary `json:"items"`
+	NextCursor *string   `json:"next_cursor"`
 }
 
 // --------------------------------------------------------------------- secret input

--- a/cli/internal/cmd/event-source/eventsource.go
+++ b/cli/internal/cmd/event-source/eventsource.go
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package eventsource hosts the cobra commands under `meho event-source
+// ...` for the event_source registry (Initiative #2877, Task #2880). It
+// wraps the tenant-scoped admin CRUD surface at /api/v1/event-sources:
+//
+//   - `meho event-source add <slug>` (alias `create`) — POST, register a
+//     source. The auth secret is never a flag: it is read from the
+//     MEHO_EVENT_SOURCE_SECRET env var, or from stdin with --secret-stdin,
+//     so it never lands in shell history or `ps` output.
+//   - `meho event-source list [--status S]` — GET, keyset-paginated.
+//   - `meho event-source describe <slug>` — GET one source.
+//   - `meho event-source update <slug> [flags]` — PATCH; --secret-stdin /
+//     the env var rotates the Vault secret.
+//   - `meho event-source delete <slug> [--confirm]` — DELETE (soft).
+//
+// There is no generated typed client for event-source yet, so every verb
+// uses the package-local untyped `doAuthedRequest` plumbing (bearer
+// inject + one-shot 401-refresh), mirroring `meho targets add`. A copy of
+// the render helpers lives here rather than being shared to avoid the
+// cmd -> cmd/<x> -> cmd import cycle.
+package eventsource
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// SecretEnvVar is the environment variable an operator sets to supply an
+// event source's auth secret without it entering argv.
+const SecretEnvVar = "MEHO_EVENT_SOURCE_SECRET"
+
+// NewRootCmd returns the `meho event-source` parent command.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "event-source",
+		Aliases:      []string{"event-sources"},
+		Short:        "Operate the MEHO event_source registry (add / list / describe / update / delete)",
+		Long:         "Register, list, describe, update, and delete inbound event sources in the operator's tenant.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newAddCmd())
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newDescribeCmd())
+	cmd.AddCommand(newUpdateCmd())
+	cmd.AddCommand(newDeleteCmd())
+	return cmd
+}
+
+// --------------------------------------------------------------------- wire types
+
+// EventSource mirrors the backend EventSource read model.
+type EventSource struct {
+	ID           string         `json:"id"`
+	TenantID     string         `json:"tenant_id"`
+	Name         string         `json:"name"`
+	Slug         string         `json:"slug"`
+	Kind         string         `json:"kind"`
+	AuthStrategy string         `json:"auth_strategy"`
+	SecretRef    *string        `json:"secret_ref"`
+	Status       string         `json:"status"`
+	Extras       map[string]any `json:"extras"`
+	CreatedBySub string         `json:"created_by_sub"`
+	CreatedAt    string         `json:"created_at"`
+	UpdatedAt    string         `json:"updated_at"`
+	DeletedAt    *string        `json:"deleted_at"`
+}
+
+// EventSourceSummary mirrors the backend EventSourceSummary list row.
+type EventSourceSummary struct {
+	Name         string  `json:"name"`
+	Slug         string  `json:"slug"`
+	Kind         string  `json:"kind"`
+	AuthStrategy string  `json:"auth_strategy"`
+	Status       string  `json:"status"`
+	SecretRef    *string `json:"secret_ref"`
+}
+
+// EventSourceListResponse mirrors the {items, next_cursor} envelope.
+type EventSourceListResponse struct {
+	Items      []EventSourceSummary `json:"items"`
+	NextCursor *string              `json:"next_cursor"`
+}
+
+// --------------------------------------------------------------------- secret input
+
+// resolveSecret returns the auth secret and whether one was supplied. It
+// never accepts the value as a flag: the env var wins, else stdin is read
+// when --secret-stdin is set. Mirrors the admin/keycloak no-leak pattern.
+func resolveSecret(cmd *cobra.Command, useStdin bool) (string, bool, error) {
+	if v := os.Getenv(SecretEnvVar); v != "" {
+		return v, true, nil
+	}
+	if !useStdin {
+		return "", false, nil
+	}
+	if _, err := fmt.Fprint(cmd.ErrOrStderr(), "Enter event-source secret: "); err != nil {
+		return "", false, err
+	}
+	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", false, err
+	}
+	line = strings.TrimRight(line, "\r\n")
+	if line == "" {
+		return "", false, errors.New("empty secret on stdin")
+	}
+	return line, true, nil
+}
+
+// --------------------------------------------------------------------- HTTP plumbing
+
+var errMissingAccessToken = errors.New("meho: stored token has no access_token")
+
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// doAuthedRequest issues one request with bearer inject + one-shot
+// 401-refresh-retry, returning the 2xx body or an *httpError on non-2xx.
+// Copied from `meho targets` import.go for the import-cycle reason.
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errMissingAccessToken
+	}
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close() //nolint:errcheck
+			return nil, rerr
+		}
+		resp.Body.Close() //nolint:errcheck
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()                                      //nolint:errcheck
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, backplaneURL+path, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// renderRequestErr maps an error from doAuthedRequest to a StructuredError:
+// an *httpError routes through renderHTTPStatus; transport / auth-state
+// errors are categorised by the shared ladder.
+func renderRequestErr(cmd *cobra.Command, backplaneURL string, err error, jsonOut bool) error {
+	var he *httpError
+	if errors.As(err, &he) {
+		return renderHTTPStatus(cmd, backplaneURL, he.StatusCode, he.Body, jsonOut)
+	}
+	if errors.Is(err, errMissingAccessToken) || api.IsTokenNotFound(err) || api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf("run `meho login %s`", backplaneURL)), jsonOut)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)), jsonOut)
+}
+
+// renderHTTPStatus classifies a non-2xx (statusCode, body) into a
+// StructuredError. 404 conflates absent/cross-tenant per the backend's
+// uniform no-existence-oracle discipline.
+func renderHTTPStatus(cmd *cobra.Command, backplaneURL string, statusCode int, body string, jsonOut bool) error {
+	detail := decodeDetail(body)
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf("backplane rejected the stored token; run `meho login %s`", backplaneURL)),
+			jsonOut)
+	case http.StatusForbidden:
+		return output.RenderError(cmd.ErrOrStderr(), output.InsufficientRole(detail), jsonOut)
+	case http.StatusNotFound:
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected("event source not found"), jsonOut)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s", backplaneURL, statusCode, detail)), jsonOut)
+	}
+}
+
+// decodeDetail pulls a human string out of FastAPI's {"detail": ...}
+// envelope, whether detail is a plain string or a structured object
+// ({"error", "message", ...}); falls back to the raw body.
+func decodeDetail(body string) string {
+	var env struct {
+		Detail json.RawMessage `json:"detail"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil || len(env.Detail) == 0 {
+		return strings.TrimSpace(body)
+	}
+	var s string
+	if json.Unmarshal(env.Detail, &s) == nil && s != "" {
+		return s
+	}
+	var obj struct {
+		Message string `json:"message"`
+		Error   string `json:"error"`
+	}
+	if json.Unmarshal(env.Detail, &obj) == nil {
+		if obj.Message != "" {
+			return obj.Message
+		}
+		if obj.Error != "" {
+			return obj.Error
+		}
+	}
+	return strings.TrimSpace(body)
+}
+
+// pathEscape escapes a single path segment for a backend URL.
+func pathEscape(segment string) string {
+	return url.PathEscape(segment)
+}
+
+// strDeref returns *s or "" when s is nil.
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis on truncation.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}
+
+// confirmPrompt prints prompt to stderr and reads a y/N line from stdin;
+// a closed/EOF stdin reads as "no".
+func confirmPrompt(cmd *cobra.Command, prompt string) bool {
+	fmt.Fprintf(cmd.ErrOrStderr(), "%s [y/N]: ", prompt)
+	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false
+	}
+	line = strings.TrimSpace(line)
+	return line == "y" || line == "Y" || line == "yes" || line == "Yes"
+}

--- a/cli/internal/cmd/event-source/eventsource_test.go
+++ b/cli/internal/cmd/event-source/eventsource_test.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package eventsource
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+const createdJSON = `{
+  "id": "11111111-1111-1111-1111-111111111111",
+  "tenant_id": "22222222-2222-2222-2222-222222222222",
+  "name": "Prod Alertmanager",
+  "slug": "prod-am",
+  "kind": "alertmanager",
+  "auth_strategy": "hmac-sha256",
+  "secret_ref": "tenants/22222222-2222-2222-2222-222222222222/event-sources/prod-am",
+  "status": "active",
+  "extras": {},
+  "created_by_sub": "admin-1",
+  "created_at": "2026-08-18T12:00:00Z",
+  "updated_at": "2026-08-18T12:00:00Z",
+  "deleted_at": null
+}`
+
+// seedXDGAndToken seeds a fake token store + config pointed at backplaneURL.
+func seedXDGAndToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  "eyJ.test.token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+}
+
+func runCmd(t *testing.T, cmd *cobra.Command, stdin string, args ...string) (string, string, error) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if stdin != "" {
+		cmd.SetIn(strings.NewReader(stdin))
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cmd.SetContext(ctx)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func TestAddRegisteredWithCreateAlias(t *testing.T) {
+	t.Parallel()
+	root := NewRootCmd()
+	var add *cobra.Command
+	for _, c := range root.Commands() {
+		if c.Name() == "add" {
+			add = c
+		}
+	}
+	if add == nil {
+		t.Fatal("`event-source add` not registered")
+	}
+	found := false
+	for _, a := range add.Aliases {
+		if a == "create" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected `create` alias; got %v", add.Aliases)
+	}
+}
+
+func TestAddMissingRequiredFlags(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing name", []string{"prod-am", "--kind", "alertmanager", "--auth-strategy", "hmac-sha256"}, "name"},
+		{"missing kind", []string{"prod-am", "--name", "N", "--auth-strategy", "hmac-sha256"}, "kind"},
+		{"missing auth", []string{"prod-am", "--name", "N", "--kind", "alertmanager"}, "auth-strategy"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := runCmd(t, newAddCmd(), "", c.args...)
+			if err == nil || !strings.Contains(err.Error(), c.want) {
+				t.Errorf("expected error naming %q; got %v", c.want, err)
+			}
+		})
+	}
+}
+
+func TestAddSuccessSendsBodyWithSecretFromEnv(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/event-sources", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("want POST; got %s", r.Method)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(createdJSON))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+	t.Setenv(SecretEnvVar, "hmac-signing-key")
+
+	stdout, stderr, err := runCmd(t, newAddCmd(), "",
+		"prod-am", "--name", "Prod Alertmanager", "--kind", "alertmanager",
+		"--auth-strategy", "hmac-sha256", "--backplane", srv.URL)
+	if err != nil {
+		t.Fatalf("add: %v\nstderr=%s", err, stderr)
+	}
+	if gotBody["slug"] != "prod-am" || gotBody["name"] != "Prod Alertmanager" ||
+		gotBody["kind"] != "alertmanager" || gotBody["auth_strategy"] != "hmac-sha256" {
+		t.Errorf("body missing required fields: %v", gotBody)
+	}
+	if gotBody["secret"] != "hmac-signing-key" {
+		t.Errorf("secret should be carried in the body from the env var: %v", gotBody["secret"])
+	}
+	if _, leaked := gotBody["tenant_id"]; leaked {
+		t.Errorf("body must never carry tenant_id: %v", gotBody)
+	}
+	// Unset optionals are omitted.
+	for _, k := range []string{"status", "extras"} {
+		if _, present := gotBody[k]; present {
+			t.Errorf("unset optional %q should be omitted: %v", k, gotBody)
+		}
+	}
+	// The rendered output shows secret_ref (the path) but never the value.
+	if strings.Contains(stdout, "hmac-signing-key") {
+		t.Errorf("stdout must not echo the secret value:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "prod-am") {
+		t.Errorf("stdout should render the created source:\n%s", stdout)
+	}
+}
+
+func TestListRendersTable(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/event-sources", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"name":"AM","slug":"prod-am","kind":"alertmanager","auth_strategy":"hmac-sha256","status":"active","secret_ref":null}],"next_cursor":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	stdout, stderr, err := runCmd(t, newListCmd(), "", "--backplane", srv.URL)
+	if err != nil {
+		t.Fatalf("list: %v\nstderr=%s", err, stderr)
+	}
+	if !strings.Contains(stdout, "prod-am") || !strings.Contains(stdout, "SLUG") {
+		t.Errorf("list should render a table with the slug:\n%s", stdout)
+	}
+}
+
+func TestDeleteDeclineWithoutConfirm(t *testing.T) {
+	t.Parallel()
+	// Point --backplane at an unroutable URL; a decline must exit 0 before
+	// any HTTP call, so the URL is never dialed.
+	stdout, _, err := runCmd(t, newDeleteCmd(), "n\n", "prod-am", "--backplane", "http://127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("decline should exit 0; got %v", err)
+	}
+	if !strings.Contains(stdout, "declined") {
+		t.Errorf("expected a declined line; got:\n%s", stdout)
+	}
+}
+
+func TestDescribe404SurfacesError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/event-sources/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":{"error":"no_event_source","slug":"prod-am"}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	_, stderr, err := runCmd(t, newDescribeCmd(), "", "prod-am", "--backplane", srv.URL)
+	if err == nil {
+		t.Fatal("expected a non-nil error on 404")
+	}
+	if !strings.Contains(stderr, "not found") {
+		t.Errorf("stderr should surface a not-found message; got:\n%s", stderr)
+	}
+}

--- a/cli/internal/cmd/event-source/list.go
+++ b/cli/internal/cmd/event-source/list.go
@@ -55,7 +55,7 @@ func newListCmd() *cobra.Command {
 			if err != nil {
 				return renderRequestErr(cmd, backplaneURL, err, jsonOut)
 			}
-			var envelope EventSourceListResponse
+			var envelope ListResponse
 			if err := json.Unmarshal(raw, &envelope); err != nil {
 				return output.RenderError(cmd.ErrOrStderr(),
 					output.Unexpected(fmt.Sprintf("decode event source list: %v", err)), jsonOut)
@@ -75,7 +75,7 @@ func newListCmd() *cobra.Command {
 	return cmd
 }
 
-func printTable(w io.Writer, items []EventSourceSummary) {
+func printTable(w io.Writer, items []Summary) {
 	if len(items) == 0 {
 		fmt.Fprintln(w, "no event sources registered in this tenant")
 		return

--- a/cli/internal/cmd/event-source/list.go
+++ b/cli/internal/cmd/event-source/list.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package eventsource
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newListCmd returns `meho event-source list`.
+func newListCmd() *cobra.Command {
+	var (
+		statusFlag        string
+		limit             int
+		cursor            string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           "list",
+		Short:         "List event sources in your tenant",
+		Long:          "list calls GET /api/v1/event-sources, keyset-paginated by name, optionally filtered by status.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			backplaneURL, err := backplane.Resolve(backplaneOverride)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
+			}
+			q := url.Values{}
+			if cmd.Flags().Changed("status") {
+				q.Set("status", statusFlag)
+			}
+			if cmd.Flags().Changed("limit") {
+				q.Set("limit", fmt.Sprintf("%d", limit))
+			}
+			if cursor != "" {
+				q.Set("cursor", cursor)
+			}
+			path := "/api/v1/event-sources"
+			if len(q) > 0 {
+				path += "?" + q.Encode()
+			}
+			raw, err := doAuthedRequest(cmd.Context(), backplaneURL, http.MethodGet, path, nil)
+			if err != nil {
+				return renderRequestErr(cmd, backplaneURL, err, jsonOut)
+			}
+			var envelope EventSourceListResponse
+			if err := json.Unmarshal(raw, &envelope); err != nil {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf("decode event source list: %v", err)), jsonOut)
+			}
+			if jsonOut {
+				return output.PrintJSON(cmd.OutOrStdout(), envelope.Items)
+			}
+			printTable(cmd.OutOrStdout(), envelope.Items)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&statusFlag, "status", "", "filter by status: active | paused")
+	cmd.Flags().IntVar(&limit, "limit", 0, "max sources per page (1..500, server default 100)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "keyset cursor (the last name from the previous page)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON instead of the table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "", "backplane URL (defaults to `meho login`'s)")
+	return cmd
+}
+
+func printTable(w io.Writer, items []EventSourceSummary) {
+	if len(items) == 0 {
+		fmt.Fprintln(w, "no event sources registered in this tenant")
+		return
+	}
+	fmt.Fprintf(w, "%-24s %-18s %-16s %s\n", "SLUG", "KIND", "AUTH", "STATUS")
+	for _, s := range items {
+		fmt.Fprintf(w, "%-24s %-18s %-16s %s\n",
+			truncate(s.Slug, 24), truncate(s.Kind, 18), truncate(s.AuthStrategy, 16), s.Status)
+	}
+}

--- a/cli/internal/cmd/event-source/update.go
+++ b/cli/internal/cmd/event-source/update.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package eventsource
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newUpdateCmd returns `meho event-source update <slug>`.
+func newUpdateCmd() *cobra.Command {
+	var (
+		kind              string
+		authStrategy      string
+		statusFlag        string
+		extrasJSON        string
+		secretStdin       bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "update <slug>",
+		Short: "Apply a partial update to one event source (tenant_admin)",
+		Long: "update calls PATCH /api/v1/event-sources/{slug}. Only the flags " +
+			"you set are sent. name and slug are immutable. --status paused " +
+			"takes effect on the ingest path immediately. Rotate the secret " +
+			"with --secret-stdin or " + SecretEnvVar + ".",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body := map[string]any{}
+			fs := cmd.Flags()
+			if fs.Changed("kind") {
+				body["kind"] = kind
+			}
+			if fs.Changed("auth-strategy") {
+				body["auth_strategy"] = authStrategy
+			}
+			if fs.Changed("status") {
+				body["status"] = statusFlag
+			}
+			if fs.Changed("extras") {
+				var extras map[string]any
+				if err := json.Unmarshal([]byte(extrasJSON), &extras); err != nil {
+					return output.RenderError(cmd.ErrOrStderr(),
+						output.Unexpected(fmt.Sprintf("invalid --extras JSON: %v", err)), jsonOut)
+				}
+				body["extras"] = extras
+			}
+			secret, hasSecret, err := resolveSecret(cmd, secretStdin)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+			}
+			if hasSecret {
+				body["secret"] = secret
+			}
+			if len(body) == 0 {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected("update requires at least one field flag or a secret to rotate"), jsonOut)
+			}
+			backplaneURL, err := backplane.Resolve(backplaneOverride)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
+			}
+			payload, err := json.Marshal(body)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf("marshal request body: %v", err)), jsonOut)
+			}
+			path := "/api/v1/event-sources/" + pathEscape(args[0])
+			raw, err := doAuthedRequest(cmd.Context(), backplaneURL, http.MethodPatch, path, payload)
+			if err != nil {
+				return renderRequestErr(cmd, backplaneURL, err, jsonOut)
+			}
+			var es EventSource
+			if err := json.Unmarshal(raw, &es); err != nil {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf("decode updated event source: %v", err)), jsonOut)
+			}
+			if jsonOut {
+				return output.PrintJSON(cmd.OutOrStdout(), &es)
+			}
+			printEventSource(cmd.OutOrStdout(), &es)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&kind, "kind", "", "new producer kind")
+	cmd.Flags().StringVar(&authStrategy, "auth-strategy", "", "new auth strategy")
+	cmd.Flags().StringVar(&statusFlag, "status", "", "new status: active | paused")
+	cmd.Flags().StringVar(&extrasJSON, "extras", "", "replace per-source tuning with this JSON object")
+	cmd.Flags().BoolVar(&secretStdin, "secret-stdin", false,
+		"rotate the auth secret, reading it from stdin (else "+SecretEnvVar+")")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the updated event source as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "", "backplane URL (defaults to `meho login`'s)")
+	return cmd
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/conventions"
 	"github.com/evoila/meho/cli/internal/cmd/dashboard"
 	"github.com/evoila/meho/cli/internal/cmd/docs"
+	eventsource "github.com/evoila/meho/cli/internal/cmd/event-source"
 	"github.com/evoila/meho/cli/internal/cmd/gcloud"
 	"github.com/evoila/meho/cli/internal/cmd/harbor"
 	hetznerrobot "github.com/evoila/meho/cli/internal/cmd/hetzner-robot"
@@ -141,6 +142,9 @@ func newRootCmd() *cobra.Command {
 	// Registered before registerDynamicSubcommands so the backplane
 	// manifest cannot shadow the built-in `targets` parent.
 	root.AddCommand(targets.NewRootCmd())
+	// T3 (#2880) -- event_source registry admin verbs (add / list /
+	// describe / update / delete). Wraps /api/v1/event-sources/*.
+	root.AddCommand(eventsource.NewRootCmd())
 
 	// G8.1-T3 (#467) -- audit-query verbs (query / recent / show /
 	// who-touched / my-recent) for Initiative #334. Wraps the four

--- a/docs/codebase/event-source-registry.md
+++ b/docs/codebase/event-source-registry.md
@@ -1,0 +1,149 @@
+# Event source registry
+
+The `event_source` registry is the tenant-scoped list of external event
+producers (Alertmanager, Grafana, VCF Operations, Harbor, generic JSON
+senders) authorised to publish into a tenant's event → agent-trigger
+substrate. It is Task #2880 under Initiative #2877 (inbound event
+ingestion); the inbound webhook endpoint that *consumes* the registry is
+#2881 and is out of scope for this page.
+
+## Why it exists
+
+A webhook sender carries no JWT. The registry row is therefore the whole
+trust context of an inbound request:
+
+- **Tenant attribution.** `events.publish()` needs a real tenant. A
+  JWT-less sender cannot supply one, so it comes from the resolved row —
+  which is why `event_source.tenant_id` is a real `REFERENCES tenant(id)`
+  FK, not the soft-FK the older `targets` table kept.
+- **Authentication.** The row names an `auth_strategy` and points at a
+  Vault-custodied secret (`secret_ref`); the ingest endpoint verifies the
+  sender's signature / token against that secret.
+
+## Overview
+
+The registry is moulded on the `targets` registry (`db/models.py`,
+`targets/`, `api/v1/targets.py`): a per-tenant table with a partial unique
+index on `name`, a nullable `secret_ref` Vault path, an `extras` JSONB
+escape hatch, and a `deleted_at` soft-delete. Three things differ from
+`targets`, each deliberate:
+
+| Aspect | `targets` | `event_source` | Why |
+|---|---|---|---|
+| `tenant_id` | soft-FK (no constraint) | real `FK → tenant.id` | tenant attribution for a JWT-less sender must be integrity-checked |
+| `slug` uniqueness | n/a (addressed by `name`) | **global** partial unique | the slug is the sole routing key in the JWT-less ingest URL, so `slug → tenant` must resolve unambiguously across all tenants |
+| secret handling | references an externally provisioned Vault path | the admin surface **writes** the secret to Vault | criterion 2: rotation = write, no downtime |
+
+`name` is unique per tenant; `slug` is unique globally; both uniqueness
+rules apply only among live rows (`WHERE deleted_at IS NULL`), so a
+soft-deleted tombstone frees the `name`/`slug` for re-use (the `targets`
+#2874 pattern).
+
+## Key types
+
+- **`EventSource`** (`db/models.py`) — the ORM row. Columns: `id`,
+  `tenant_id` (FK), `name`, `slug`, `kind`, `auth_strategy`, `secret_ref`,
+  `status`, `extras` (JSONB), `created_by_sub`, `created_at`,
+  `updated_at`, `deleted_at`. `kind` / `auth_strategy` / `status` are
+  closed sets enforced by `ck_event_source_*` CHECK constraints. Two
+  partial unique indexes: `event_source_tenant_name_idx` on
+  `(tenant_id, name)` and `event_source_slug_idx` on `(slug)`.
+- **Schemas** (`event_source/schemas.py`) — `EventSourceCreate` /
+  `EventSourceUpdate` (write, `extra='forbid'`), `EventSource` /
+  `EventSourceSummary` (frozen reads), plus the `EventSourceKind`,
+  `EventSourceAuthStrategy`, `EventSourceStatus` StrEnums whose values
+  mirror the CHECK constraints. The write schemas carry a **write-only**
+  `secret: SecretStr`; no read model has a `secret` field.
+- **Resolvers** (`event_source/resolver.py`) —
+  `resolve_event_source(session, tenant_id, slug)` is the tenant-scoped
+  admin lookup (uniform 404 on miss or cross-tenant, no near-miss
+  oracle); `resolve_event_source_by_slug(session, slug)` is the global
+  ingest primitive (#2881 consumes it) returning the live row of any
+  status, or `None`.
+- **Secret custody** (`event_source/secrets.py`) —
+  `event_source_secret_ref(tenant_id, slug)` derives
+  `tenants/<tenant_id>/event-sources/<slug>`;
+  `store_event_source_secret(operator, secret_ref, secret)` writes the
+  value through the secret-broker vault-kv sink.
+- **REST surface** (`api/v1/event_source.py`) — the CRUD router at
+  `/api/v1/event-sources`, wired in `main.py`.
+
+## Control flow
+
+- **Create** (`POST /api/v1/event-sources`, tenant_admin) — build the
+  row (`tenant_id` and `created_by_sub` from the JWT, never the body);
+  `flush()` so a duplicate `name`/`slug` 409s *before* any Vault write;
+  if a `secret` was supplied, derive `secret_ref` and write the value to
+  Vault *before* the transaction commits, so a Vault failure rolls the row
+  back (fail-closed 502). Omitting `secret` registers the source with no
+  credential (`secret_ref` NULL); the ingest path fails closed until a
+  later PATCH sets one.
+- **Read** (`GET` list + `GET /{slug}`, operator) — tenant-scoped,
+  keyset-paginated by `name`, optional `?status=` filter. A slug that
+  does not resolve in the tenant (absent or cross-tenant) returns the
+  identical uniform 404.
+- **Update** (`PATCH /{slug}`, tenant_admin) — applies only sent fields;
+  `name`/`slug` are immutable (the slug is a live routing key). A
+  `status='paused'` PATCH takes effect on the ingest resolver's next
+  lookup because nothing caches the row. A `secret` rotates the Vault
+  value at the derived path (a new KV-v2 version — no downtime) and homes
+  `secret_ref` if the source had none.
+- **Delete** (`DELETE /{slug}`, tenant_admin) — soft-delete (stamps
+  `deleted_at`); the row stays for audit history, the partial indexes free
+  the `name`/`slug`, and a second DELETE collapses to the uniform 404.
+
+## Secret-custody discipline
+
+The auth secret lives in Vault, never in the DB. The registry row stores
+only the derived logical path. `store_event_source_secret` holds the value
+as `SecretStr` up to the write and hands it to the secret-broker's
+`SecretMaterial` (redacted repr) at the KV-v2 write boundary, reusing
+`VaultKvSecretEndpoint` so the "status + SHA-256 + length only, never the
+value" discipline (`docs/codebase/connectors-secret-broker.md`) is shared,
+not re-implemented. The value never enters params, the row, a log line,
+the audit row, or a broadcast. The write runs under the operator's own
+Vault identity (`vault_client_for_operator`), so it stays inside their
+authz envelope. The always-on secret-leak sweep in `tests/conftest.py`
+guards the log surface across the whole suite; the store path logs only
+`secret_ref` and never the traceback locals that would render the
+`secret` parameter name.
+
+## Extras (forward config for the ingest path)
+
+Per-source tuning the #2881 ingest reads — body-size cap, rate limit,
+replay window, dedupe config, and (for `basic` auth) the non-secret
+username — lives in the `extras` JSONB blob rather than first-class
+columns, keeping the schema to #2880's explicit column set.
+
+## Dependencies
+
+- `meho_backplane.connectors.secret.vault_endpoint.VaultKvSecretEndpoint`
+  + `SecretMaterial` — the vault-kv sink the secret write reuses.
+- `meho_backplane.connectors.vault.tenant_paths.TENANT_SECRET_PREFIX` —
+  the per-tenant Vault subtree the derived ref sits inside (the #1643
+  scope guard enforces it).
+- `meho_backplane.auth.rbac.require_role` / `auth.operator.Operator` —
+  RBAC (operator reads, tenant_admin writes) and JWT-bound tenant scope.
+- Alembic migration `0074_create_event_source.py`.
+
+## Known issues / non-goals
+
+- The inbound ingest endpoint, per-source auth enforcement (HMAC / bearer
+  / basic verification), rate limiting, replay windows, and payload
+  normalisers are #2881 / #2882 — not built here. This task ships the
+  registry, its migration, Vault secret custody, and the REST/CLI/UI admin
+  CRUD.
+- Soft-delete leaves the Vault secret in place (RDC owns the Vault
+  lifecycle). A re-created source re-using the slug derives the same ref
+  and overwrites it on its next secret write.
+- There is no MCP admin tool for `event_source` (unlike `targets`'
+  `meho_targets_register`). #2880's surface set is REST + CLI + UI; an MCP
+  admin tool would be a separate follow-up if agent-driven registration is
+  wanted.
+
+## References
+
+- Initiative #2877 (inbound event ingestion), Task #2880.
+- `docs/codebase/connectors-secret-broker.md` — the custody discipline.
+- `docs/codebase/migrations.md` — the additive-only migration contract.
+- `db/models.py` `Target` / `EventSource`; `api/v1/targets.py` — the mould.


### PR DESCRIPTION
## Summary

- Adds the tenant-scoped **`event_source` registry** (Initiative #2877, T3) — the trust context the JWT-less inbound webhook ingest path (#2881) resolves a sender against: the row supplies the tenant attribution `events.publish()` needs a real tenant FK for, and its Vault-custodied secret is what the ingest verifies.
- Moulded on the `targets` registry (partial-unique `name` index, nullable `secret_ref`, `extras` escape hatch, soft-delete) with three deliberate departures: **real FK** to `tenant.id` (the sensor/event_outbox discipline, per the issue's "real tenant FK"); **globally-unique `slug`** (the sole routing key in the JWT-less ingest URL, so `slug → tenant` must resolve unambiguously — per-tenant uniqueness is architecturally impossible here); and the admin surface **writes** the auth secret to Vault (targets only references an externally provisioned path).
- **Vault secret custody**: create/update accept a write-only `SecretStr` held end-to-end and written to a derived per-tenant path (`tenants/<tenant_id>/event-sources/<slug>`) via the secret-broker vault-kv sink; the DB row stores only the path, never the value; a Vault write failure fails the request closed (502, row rolled back).
- Three surfaces: **REST** CRUD at `/api/v1/event-sources` (operator reads, tenant_admin writes), a **`meho event-source`** Go CLI group (secret via env var / stdin, never a flag), and a **`/ui/event-sources`** admin console reusing the REST handlers. Migration **0074** (additive, reversible, PG + SQLite partial-unique parity).

## Test plan

- [x] `ruff check` + `ruff format --check` — clean across all changed files
- [x] `mypy` — clean
- [x] `pytest` — 55 new tests green (`test_db_event_source`, `test_event_source_schemas`, `test_event_source_resolver`, `test_event_source_secrets`, `test_api_v1_event_source`, `test_ui_event_source`); 88 passed incl. touched surfaces (maturity drift, UI aggregator, OpenAPI build)
- [x] `go build ./...` + `go vet` + `go test ./internal/cmd/event-source/` — green
- [x] Migration 0074 upgrade→downgrade smoke on SQLite: table + both partial-unique indexes + CHECK constraints verified
- [x] `make snapshot-openapi` + `make generate` — CLI `openapi.json` + client regenerated (freshness gate)
- **Acceptance criteria:**
  - [x] CRUD on REST + CLI + UI with tenant scoping; pause takes effect immediately on the ingest resolver's next lookup (`test_patch_pause_takes_effect_immediately`)
  - [x] Secret write path stores to Vault via `secret_ref`; rotation = write + no downtime (`test_create_with_secret_writes_to_vault`, `test_patch_rotates_secret`, `test_store_writes_value_to_vault_kv`)
  - [x] Slug lookups reveal no existence oracle — cross-tenant == absent, uniform 404 (`test_resolve_cross_tenant_is_same_404_as_missing`, `test_describe_cross_tenant_is_uniform_404`)
  - [x] `docs/codebase/event-source-registry.md`

## Out of scope

- The inbound ingest endpoint, per-source auth enforcement (HMAC / bearer / basic verification), rate limiting, replay windows, and payload normalizers are **#2881 / #2882**.
- No MCP admin tool for `event_source` (unlike `targets`' `meho_targets_register`) — #2880's surface set is REST + CLI + UI; the resolver primitive (`resolve_event_source_by_slug`) that #2881 consumes ships here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2880
