### PR TITLE
feat(tests): keycloak real-spec reconcile lane — assert hand-coded paths against the pinned keycloak-26.3 spec (#2988)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,7 @@ jobs:
           # Keep the list sorted.
           sparse-checkout: |
             docs/hetzner-robot-2026-04
+            docs/keycloak-26.3
             docs/nsx-9.0
             docs/sddc-manager-9.0
             docs/vcenter-9.0
@@ -331,6 +332,7 @@ jobs:
           set -euo pipefail
           for f in \
             spec-shelf/docs/hetzner-robot-2026-04/webservice-en.md \
+            spec-shelf/docs/keycloak-26.3/keycloak-admin-openapi.json \
             spec-shelf/docs/nsx-9.0/nsx_api.openapi3.json \
             spec-shelf/docs/nsx-9.0/nsx_policy_api.openapi3.json \
             spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json \
@@ -343,7 +345,7 @@ jobs:
               exit 1
             fi
           done
-          echo "spec-shelf OK: webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -963,6 +965,7 @@ jobs:
           path: spec-shelf
           sparse-checkout: |
             docs/hetzner-robot-2026-04
+            docs/keycloak-26.3
             docs/nsx-9.0
             docs/sddc-manager-9.0
             docs/vcenter-9.0
@@ -980,6 +983,7 @@ jobs:
           set -euo pipefail
           for f in \
             spec-shelf/docs/hetzner-robot-2026-04/webservice-en.md \
+            spec-shelf/docs/keycloak-26.3/keycloak-admin-openapi.json \
             spec-shelf/docs/nsx-9.0/nsx_api.openapi3.json \
             spec-shelf/docs/nsx-9.0/nsx_policy_api.openapi3.json \
             spec-shelf/docs/sddc-manager-9.0/sddc-manager-openapi.json \
@@ -992,7 +996,7 @@ jobs:
               exit 1
             fi
           done
-          echo "spec-shelf OK: webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-lint-test's login step — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,30 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added — keycloak real-spec reconcile lane (#2988)
+
+- Every hand-coded `METHOD:/path` the keycloak connector dispatches —
+  18 reconciled op_ids across the 8 read ops, 9 write ops, the
+  fingerprint probe, and the name→UUID resolver reads — is now
+  asserted against the pinned `keycloak-26.3` shelf spec
+  (`keycloak-admin-openapi.json`, the vendor's Admin REST API OpenAPI
+  at the lab's deployed Keycloak 26.3.3; Apache-2.0, from Maven
+  Central `org.keycloak:keycloak-api-docs-dist:26.3.3`) on every PR
+  via the #2980 harness
+  (`backend/tests/test_connectors_keycloak_spec_reconcile.py` —
+  parse-only, required unit sweep, uniform skip when the shelf is
+  unconfigured). To make the enumeration introspectable, every request
+  path moved out of inline f-strings into the `_*_PATH` template
+  constants of `connectors/keycloak/_paths.py` (placeholders carry the
+  spec's own parameter names; handlers fill them via the fail-loud
+  `fill_path`) — wire requests are byte-identical. Two dispatched
+  paths are pinned as evidenced exclusions (the OIDC token mint and
+  `GET /admin/serverinfo` — both outside the Admin REST OpenAPI's
+  scope by construction), with an armed tripwire that forces their
+  promotion the day a newer pinned spec serves them. First armed run:
+  all 18 served, no repoints needed. CI's secret-gated spec-shelf
+  checkout is widened to `docs/keycloak-26.3` in both Python jobs.
+
 ### Breaking changes — hetzner-robot `about` op + CLI verb removed (#2985 / #3014)
 
 - `hetzner-robot.about` (`GET:/query`) and the `meho hetzner-robot

--- a/backend/src/meho_backplane/connectors/keycloak/_paths.py
+++ b/backend/src/meho_backplane/connectors/keycloak/_paths.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Hand-coded Keycloak Admin REST path templates — the reconcile-lane surface.
+
+Every request path the keycloak connector dispatches is declared here as
+a module-level ``_*_PATH`` template constant, and every handler builds
+its concrete path from one of these templates via :func:`fill_path` —
+never from an inline f-string. Placeholder names are byte-for-byte the
+pinned spec's own path-parameter names (``{realm}``, ``{client-uuid}``,
+``{user-id}``, ``{role-name}`` — ``docs/keycloak-26.3/`` on the
+operator's spec shelf), so the spec-reconcile lane
+(:mod:`tests.test_connectors_keycloak_spec_reconcile`, #2988) can
+introspect these live constants and assert each declared
+``METHOD:/path`` is served by the pinned spec verbatim — the #2944
+introspect-live-constants pattern (never a hardcoded mirror that can
+drift). Before #2988 the paths lived as inline f-strings across four
+modules; hoisting them here is what makes the lane's enumeration
+introspectable.
+
+Two constants are dispatched but deliberately **outside** the pinned
+Admin REST spec's scope (the spec's only top-level path family is
+``/admin/realms``); the lane pins them as evidenced exclusions rather
+than reconciling them:
+
+* :data:`_TOKEN_PATH` — the OIDC token endpoint the admin-token mint
+  POSTs. Specified by OAuth 2.0 (RFC 6749 §3.2) / OIDC discovery
+  (``/realms/{realm}/.well-known/openid-configuration``), not by the
+  Admin REST OpenAPI document.
+* :data:`_SERVERINFO_PATH` — the admin console's server-info endpoint
+  (best-effort version read in
+  :meth:`~meho_backplane.connectors.keycloak.connector.KeycloakConnector._server_version`).
+  Stable in practice but not modeled by the published Admin REST
+  OpenAPI document.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ["fill_path"]
+
+# -- templates reconciled against the pinned Admin REST spec ----------------
+
+_ADMIN_REALMS_PATH = "/admin/realms"
+_ADMIN_REALM_PATH = "/admin/realms/{realm}"
+_CLIENTS_PATH = "/admin/realms/{realm}/clients"
+_CLIENT_PATH = "/admin/realms/{realm}/clients/{client-uuid}"
+_CLIENT_PROTOCOL_MAPPERS_PATH = (
+    "/admin/realms/{realm}/clients/{client-uuid}/protocol-mappers/models"
+)
+_CLIENT_SCOPES_PATH = "/admin/realms/{realm}/client-scopes"
+_USERS_PATH = "/admin/realms/{realm}/users"
+_USER_ROLE_MAPPINGS_PATH = "/admin/realms/{realm}/users/{user-id}/role-mappings"
+_USER_ROLE_MAPPINGS_REALM_PATH = "/admin/realms/{realm}/users/{user-id}/role-mappings/realm"
+_USER_RESET_PASSWORD_PATH = "/admin/realms/{realm}/users/{user-id}/reset-password"
+_ROLES_PATH = "/admin/realms/{realm}/roles"
+_ROLE_PATH = "/admin/realms/{realm}/roles/{role-name}"
+_ROLE_USERS_PATH = "/admin/realms/{realm}/roles/{role-name}/users"
+
+# -- dispatched, but outside the Admin REST spec's scope (see docstring) ----
+
+_TOKEN_PATH = "/realms/{realm}/protocol/openid-connect/token"
+_SERVERINFO_PATH = "/admin/serverinfo"
+
+
+_PLACEHOLDER_RE = re.compile(r"\{([^{}]+)\}")
+
+
+def fill_path(template: str, values: Mapping[str, str]) -> str:
+    """Substitute *values* into *template*'s ``{placeholder}`` segments.
+
+    Fail-loud contract, both directions: every placeholder in *template*
+    must have a value and every provided key must name a placeholder — a
+    typo'd key or a missing segment raises :exc:`ValueError` at the call
+    site instead of dispatching a malformed URL. Values are inserted
+    verbatim; callers pre-encode caller-controlled segments with
+    :func:`~meho_backplane.connectors.keycloak.session.quote_segment`
+    exactly as the pre-#2988 f-strings did.
+    """
+    placeholders = set(_PLACEHOLDER_RE.findall(template))
+    provided = set(values)
+    if placeholders != provided:
+        raise ValueError(
+            f"fill_path template {template!r} declares placeholders "
+            f"{sorted(placeholders)} but got values for {sorted(provided)}"
+        )
+    return _PLACEHOLDER_RE.sub(lambda match: values[match.group(1)], template)

--- a/backend/src/meho_backplane/connectors/keycloak/connector.py
+++ b/backend/src/meho_backplane/connectors/keycloak/connector.py
@@ -99,6 +99,15 @@ from meho_backplane.connectors._shared.vault_creds import (
 )
 from meho_backplane.connectors._shared.vcf_auth import is_acceptable_auth_model
 from meho_backplane.connectors.adapters.http import HttpConnector, _retryable
+from meho_backplane.connectors.keycloak._paths import (
+    _ADMIN_REALM_PATH,
+    _CLIENTS_PATH,
+    _ROLE_PATH,
+    _SERVERINFO_PATH,
+    _TOKEN_PATH,
+    _USERS_PATH,
+    fill_path,
+)
 from meho_backplane.connectors.keycloak.session import (
     KeycloakAdminCredentials,
     KeycloakAdminCredentialsLoader,
@@ -426,7 +435,7 @@ class KeycloakConnector(HttpConnector):
         realms = resolve_realm_config(target)
         creds = await self._credentials_loader(target, operator)
         client = await self._http_client(target)
-        token_path = f"/realms/{realms.admin_realm}/protocol/openid-connect/token"
+        token_path = fill_path(_TOKEN_PATH, {"realm": realms.admin_realm})
         try:
             resp = await client.post(
                 token_path,
@@ -509,13 +518,14 @@ class KeycloakConnector(HttpConnector):
 
         probed_at = datetime.now(UTC)
         realms = resolve_realm_config(target)
-        probe_method = f"GET /admin/realms/{realms.managed_realm}"
+        realm_path = fill_path(_ADMIN_REALM_PATH, {"realm": realms.managed_realm})
+        probe_method = f"GET {realm_path}"
         effective_operator = operator if operator is not None else synthesise_system_operator()
 
         try:
             realm_repr = await self._get_json(
                 target,
-                f"/admin/realms/{realms.managed_realm}",
+                realm_path,
                 operator=effective_operator,
             )
         except (
@@ -559,7 +569,7 @@ class KeycloakConnector(HttpConnector):
         canonical reachability signal, the version is a nice-to-have.
         """
         try:
-            info = await self._get_json(target, "/admin/serverinfo", operator=operator)
+            info = await self._get_json(target, _SERVERINFO_PATH, operator=operator)
         except (
             httpx.HTTPError,
             OSError,
@@ -717,7 +727,7 @@ class KeycloakConnector(HttpConnector):
         """
         rows = await self._get_admin_list(
             target,
-            f"/admin/realms/{managed_realm}/clients",
+            fill_path(_CLIENTS_PATH, {"realm": managed_realm}),
             operator=operator,
             params={"clientId": client_id},
         )
@@ -746,7 +756,7 @@ class KeycloakConnector(HttpConnector):
         """
         rows = await self._get_admin_list(
             target,
-            f"/admin/realms/{managed_realm}/users",
+            fill_path(_USERS_PATH, {"realm": managed_realm}),
             operator=operator,
             params={"username": username, "exact": "true"},
         )
@@ -777,7 +787,7 @@ class KeycloakConnector(HttpConnector):
         try:
             role = await self._get_admin_json(
                 target,
-                f"/admin/realms/{managed_realm}/roles/{role_name}",
+                fill_path(_ROLE_PATH, {"realm": managed_realm, "role-name": role_name}),
                 operator=operator,
             )
         except httpx.HTTPStatusError as exc:

--- a/backend/src/meho_backplane/connectors/keycloak/ops_read.py
+++ b/backend/src/meho_backplane/connectors/keycloak/ops_read.py
@@ -78,6 +78,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
+from meho_backplane.connectors.keycloak._paths import (
+    _ADMIN_REALM_PATH,
+    _CLIENT_PATH,
+    _CLIENT_SCOPES_PATH,
+    _CLIENTS_PATH,
+    _ROLE_USERS_PATH,
+    _ROLES_PATH,
+    _USER_ROLE_MAPPINGS_PATH,
+    _USERS_PATH,
+    fill_path,
+)
 from meho_backplane.connectors.keycloak.redaction import redact_secret_fields
 from meho_backplane.connectors.keycloak.session import quote_segment, resolve_realm_config
 
@@ -152,7 +163,7 @@ async def keycloak_realm_get(
     del params  # declared empty; intentionally ignored
     realms = resolve_realm_config(target)
     realm = await self._get_admin_json(
-        target, f"/admin/realms/{realms.managed_realm}", operator=operator
+        target, fill_path(_ADMIN_REALM_PATH, {"realm": realms.managed_realm}), operator=operator
     )
     return {"realm": redact_secret_fields(realm)}
 
@@ -180,7 +191,7 @@ async def keycloak_client_list(
         query["max"] = max_results
     rows = await self._get_admin_list(
         target,
-        f"/admin/realms/{realms.managed_realm}/clients",
+        fill_path(_CLIENTS_PATH, {"realm": realms.managed_realm}),
         operator=operator,
         params=query or None,
     )
@@ -208,7 +219,7 @@ async def keycloak_client_get(
     client_uuid = quote_segment(params["id"])
     client = await self._get_admin_json(
         target,
-        f"/admin/realms/{realms.managed_realm}/clients/{client_uuid}",
+        fill_path(_CLIENT_PATH, {"realm": realms.managed_realm, "client-uuid": client_uuid}),
         operator=operator,
     )
     return {"client": redact_secret_fields(client)}
@@ -230,7 +241,7 @@ async def keycloak_client_scope_list(
     realms = resolve_realm_config(target)
     rows = await self._get_admin_list(
         target,
-        f"/admin/realms/{realms.managed_realm}/client-scopes",
+        fill_path(_CLIENT_SCOPES_PATH, {"realm": realms.managed_realm}),
         operator=operator,
     )
     scrubbed = [redact_secret_fields(row) for row in rows]
@@ -261,7 +272,7 @@ async def keycloak_user_list(
         query["max"] = max_results
     rows = await self._get_admin_list(
         target,
-        f"/admin/realms/{realms.managed_realm}/users",
+        fill_path(_USERS_PATH, {"realm": realms.managed_realm}),
         operator=operator,
         params=query or None,
     )
@@ -287,7 +298,10 @@ async def keycloak_role_mapping_get(
     user_uuid = quote_segment(params["id"])
     mappings = await self._get_admin_json(
         target,
-        f"/admin/realms/{realms.managed_realm}/users/{user_uuid}/role-mappings",
+        fill_path(
+            _USER_ROLE_MAPPINGS_PATH,
+            {"realm": realms.managed_realm, "user-id": user_uuid},
+        ),
         operator=operator,
     )
     return {"role_mappings": redact_secret_fields(mappings)}
@@ -315,7 +329,7 @@ async def keycloak_role_list(
     realms = resolve_realm_config(target)
     rows = await self._get_admin_list(
         target,
-        f"/admin/realms/{realms.managed_realm}/roles",
+        fill_path(_ROLES_PATH, {"realm": realms.managed_realm}),
         operator=operator,
     )
     scrubbed = [redact_secret_fields(row) for row in rows]
@@ -344,7 +358,7 @@ async def keycloak_role_users(
     role_name = quote_segment(params["name"])
     rows = await self._get_admin_list(
         target,
-        f"/admin/realms/{realms.managed_realm}/roles/{role_name}/users",
+        fill_path(_ROLE_USERS_PATH, {"realm": realms.managed_realm, "role-name": role_name}),
         operator=operator,
     )
     scrubbed = [redact_secret_fields(row) for row in rows]

--- a/backend/src/meho_backplane/connectors/keycloak/ops_write.py
+++ b/backend/src/meho_backplane/connectors/keycloak/ops_write.py
@@ -102,6 +102,18 @@ from meho_backplane.connectors._shared.vault_creds import (
     load_vault_secret_data,
     strip_credential_value,
 )
+from meho_backplane.connectors.keycloak._paths import (
+    _ADMIN_REALM_PATH,
+    _ADMIN_REALMS_PATH,
+    _CLIENT_PATH,
+    _CLIENT_PROTOCOL_MAPPERS_PATH,
+    _CLIENT_SCOPES_PATH,
+    _CLIENTS_PATH,
+    _USER_RESET_PASSWORD_PATH,
+    _USER_ROLE_MAPPINGS_REALM_PATH,
+    _USERS_PATH,
+    fill_path,
+)
 from meho_backplane.connectors.keycloak.session import quote_segment, resolve_realm_config
 
 if TYPE_CHECKING:
@@ -262,7 +274,7 @@ async def keycloak_realm_create(
     realm_name = str(representation.get("realm") or params.get("realm") or "").strip()
     representation.setdefault("realm", realm_name)
     result = await self._write_admin(
-        target, "POST", "/admin/realms", operator=operator, json=representation
+        target, "POST", _ADMIN_REALMS_PATH, operator=operator, json=representation
     )
     return {
         "realm": realm_name,
@@ -290,7 +302,7 @@ async def keycloak_realm_update(
     await self._write_admin(
         target,
         "PUT",
-        f"/admin/realms/{realm_name}",
+        fill_path(_ADMIN_REALM_PATH, {"realm": realm_name}),
         operator=operator,
         json=representation,
         idempotent_conflict=False,
@@ -325,7 +337,7 @@ async def keycloak_client_create(
     result = await self._write_admin(
         target,
         "POST",
-        f"/admin/realms/{realms.managed_realm}/clients",
+        fill_path(_CLIENTS_PATH, {"realm": realms.managed_realm}),
         operator=operator,
         json=representation,
     )
@@ -378,7 +390,10 @@ async def keycloak_client_update(
     await self._write_admin(
         target,
         "PUT",
-        f"/admin/realms/{realms.managed_realm}/clients/{quote_segment(uuid)}",
+        fill_path(
+            _CLIENT_PATH,
+            {"realm": realms.managed_realm, "client-uuid": quote_segment(uuid)},
+        ),
         operator=operator,
         json=representation,
         idempotent_conflict=False,
@@ -406,7 +421,7 @@ async def keycloak_client_scope_create(
     result = await self._write_admin(
         target,
         "POST",
-        f"/admin/realms/{realms.managed_realm}/client-scopes",
+        fill_path(_CLIENT_SCOPES_PATH, {"realm": realms.managed_realm}),
         operator=operator,
         json=representation,
     )
@@ -454,7 +469,10 @@ async def keycloak_protocol_mapper_create(
     result = await self._write_admin(
         target,
         "POST",
-        f"/admin/realms/{realms.managed_realm}/clients/{quote_segment(uuid)}/protocol-mappers/models",
+        fill_path(
+            _CLIENT_PROTOCOL_MAPPERS_PATH,
+            {"realm": realms.managed_realm, "client-uuid": quote_segment(uuid)},
+        ),
         operator=operator,
         json=representation,
     )
@@ -503,7 +521,7 @@ async def keycloak_user_create(
     result = await self._write_admin(
         target,
         "POST",
-        f"/admin/realms/{realms.managed_realm}/users",
+        fill_path(_USERS_PATH, {"realm": realms.managed_realm}),
         operator=operator,
         json=representation,
     )
@@ -551,7 +569,10 @@ async def keycloak_user_reset_password(
     await self._write_admin(
         target,
         "PUT",
-        f"/admin/realms/{realms.managed_realm}/users/{quote_segment(uuid)}/reset-password",
+        fill_path(
+            _USER_RESET_PASSWORD_PATH,
+            {"realm": realms.managed_realm, "user-id": quote_segment(uuid)},
+        ),
         operator=operator,
         json=credential,
         idempotent_conflict=False,
@@ -608,7 +629,10 @@ async def keycloak_role_mapping_assign(
     await self._write_admin(
         target,
         "POST",
-        f"/admin/realms/{realms.managed_realm}/users/{quote_segment(uuid)}/role-mappings/realm",
+        fill_path(
+            _USER_ROLE_MAPPINGS_REALM_PATH,
+            {"realm": realms.managed_realm, "user-id": quote_segment(uuid)},
+        ),
         operator=operator,
         json=role_reprs,  # type: ignore[arg-type]  # KC accepts a JSON array body here
         idempotent_conflict=False,

--- a/backend/src/meho_backplane/connectors/keycloak/secret_endpoint.py
+++ b/backend/src/meho_backplane/connectors/keycloak/secret_endpoint.py
@@ -79,6 +79,7 @@ from typing import TYPE_CHECKING, cast
 import structlog
 
 from meho_backplane.connectors._shared.vault_creds import strip_credential_value
+from meho_backplane.connectors.keycloak._paths import _USER_RESET_PASSWORD_PATH, fill_path
 from meho_backplane.connectors.keycloak.connector import KeycloakConnector
 from meho_backplane.connectors.keycloak.ops_write import KeycloakUserNotFoundError
 from meho_backplane.connectors.keycloak.session import KeycloakTargetLike, quote_segment
@@ -235,8 +236,10 @@ class KeycloakCredentialSecretEndpoint:
         await connector._write_admin(
             target,
             "PUT",
-            f"/admin/realms/{quote_segment(self._realm)}/users/"
-            f"{quote_segment(uuid)}/reset-password",
+            fill_path(
+                _USER_RESET_PASSWORD_PATH,
+                {"realm": quote_segment(self._realm), "user-id": quote_segment(uuid)},
+            ),
             operator=operator,
             json=credential,
             idempotent_conflict=False,

--- a/backend/tests/test_connectors_keycloak_spec_reconcile.py
+++ b/backend/tests/test_connectors_keycloak_spec_reconcile.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""keycloak real-spec reconcile lane (#2988) — the #2980 harness.
+
+Asserts every hand-coded ``METHOD:/path`` the keycloak connector
+dispatches is served by the pinned ``keycloak-26.3`` spec on the shelf
+(``keycloak-admin-openapi.json`` — the vendor's Admin REST API OpenAPI
+3.0.3 document from Maven Central
+``org.keycloak:keycloak-api-docs-dist:26.3.3``, Apache-2.0, provenance
+in the shelf's ``MANIFEST.md``; version matches the lab's deployed
+Keycloak 26.3.3). Parse-only set compare — no DB, no embeddings, no
+containers — so it lives in the required unit sweep per the
+lane-placement rule in
+``docs/decisions/spec-reconcile-guards-standard.md``. Uniform skip when
+the shelf is unconfigured (``tests/_spec_shelf.py`` contract).
+
+The declared set is introspected from the connector's live constants
+(the #2944 pattern — never a hardcoded mirror): #2988 hoisted every
+request path out of inline f-strings (previously spread across
+``connector.py`` / ``ops_read.py`` / ``ops_write.py`` /
+``secret_endpoint.py``) into the ``_*_PATH`` template constants of
+:mod:`~meho_backplane.connectors.keycloak._paths`, which every handler
+now fills via ``fill_path`` — so these constants ARE the dispatched
+surface. Template placeholders carry the pinned spec's own parameter
+names (``{realm}``, ``{client-uuid}``, ``{user-id}``, ``{role-name}``),
+making the reconcile byte-for-byte against
+:func:`~meho_backplane.operations.ingest.parse_openapi`'s op_ids. The
+HTTP method cannot be introspected from a bare path string, so
+:data:`_METHODS_BY_CONSTANT` declares it per constant (several
+templates dispatch under two methods — list/create, get/update) and a
+guard test pins the constant-name set; the method claims come from the
+dispatch seams: ``_get_json`` / ``_get_admin_json`` / ``_get_admin_list``
+are GET-only, every ``_write_admin`` call site names its verb
+explicitly, and the token mint is a ``client.post``.
+
+Sweep note (f-strings / concatenations): after the #2988 hoist the
+keycloak package contains no other composed request path (verified by
+grep for ``/admin`` / ``/realms`` string literals). The
+``probe_method = f"GET {realm_path}"`` string in ``fingerprint`` is
+display metadata derived from the same filled constant, never
+dispatched (the vcf-operations lane's display-metadata precedent).
+
+Two hand-coded paths are dispatched but deliberately **excluded** from
+the reconcile — the #2970 decision-table class "surface lives outside
+the pinned spec", evidenced rather than repointed (the pinned spec's
+only top-level path family is ``/admin/realms``; verified 2026-08-18,
+first armed run):
+
+* ``POST:/realms/{realm}/protocol/openid-connect/token`` — the OIDC
+  token endpoint the admin-token mint POSTs. Specified by OAuth 2.0
+  (RFC 6749 §3.2) / per-realm OIDC discovery
+  (``/realms/{realm}/.well-known/openid-configuration``), not by the
+  Admin REST OpenAPI document. No served alternative exists.
+* ``GET:/admin/serverinfo`` — the admin console's server-info endpoint
+  (best-effort version read; the connector already treats any failure
+  as non-fatal ``version=None``). Stable in practice but not modeled by
+  the published Admin REST OpenAPI document. No served alternative
+  exists.
+
+Both exclusions are pinned by value below, and an armed test asserts
+they stay **unserved** — the day a newer pinned spec starts serving
+one, that test fails and the constant must be promoted into
+:data:`_METHODS_BY_CONSTANT`. All 18 reconciled op_ids were served on
+the first armed run; no path repoints were needed. Protocol:
+docs/decisions/spec-reconcile-guards-standard.md.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.keycloak import _paths
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+_SPEC_DIR = "keycloak-26.3"
+_SPEC_FILE = "keycloak-admin-openapi.json"
+_SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
+
+#: HTTP method(s) per hand-coded path constant reconciled against the
+#: pinned spec. Declared (not introspected) because a module-level path
+#: string carries no method; the guard test below pins this mapping's
+#: key set against the live constants so the two can never drift apart
+#: silently. Constants serving both a collection read and a create (or
+#: a get and an update) declare both verbs.
+_METHODS_BY_CONSTANT: dict[str, tuple[str, ...]] = {
+    "_ADMIN_REALMS_PATH": ("POST",),
+    "_ADMIN_REALM_PATH": ("GET", "PUT"),
+    "_CLIENTS_PATH": ("GET", "POST"),
+    "_CLIENT_PATH": ("GET", "PUT"),
+    "_CLIENT_PROTOCOL_MAPPERS_PATH": ("POST",),
+    "_CLIENT_SCOPES_PATH": ("GET", "POST"),
+    "_USERS_PATH": ("GET", "POST"),
+    "_USER_ROLE_MAPPINGS_PATH": ("GET",),
+    "_USER_ROLE_MAPPINGS_REALM_PATH": ("POST",),
+    "_USER_RESET_PASSWORD_PATH": ("PUT",),
+    "_ROLES_PATH": ("GET",),
+    "_ROLE_PATH": ("GET",),
+    "_ROLE_USERS_PATH": ("GET",),
+}
+
+#: Dispatched constants deliberately outside the pinned Admin REST
+#: spec's scope (module docstring: OIDC protocol endpoint; unmodeled
+#: serverinfo). Method per constant, mirroring the dispatch seams.
+_EXCLUDED_METHODS_BY_CONSTANT: dict[str, tuple[str, ...]] = {
+    "_TOKEN_PATH": ("POST",),
+    "_SERVERINFO_PATH": ("GET",),
+}
+
+
+def _path_constants() -> dict[str, str]:
+    """The live ``_*_PATH`` constants of ``keycloak._paths``, by constant name."""
+    return {
+        name: value
+        for name, value in vars(_paths).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _op_ids(methods_by_constant: dict[str, tuple[str, ...]]) -> set[str]:
+    """``METHOD:/path`` op_ids for *methods_by_constant* from the live constants."""
+    constants = _path_constants()
+    return {
+        f"{method}:{constants[name]}"
+        for name, methods in methods_by_constant.items()
+        for method in methods
+    }
+
+
+def test_path_constants_are_all_discovered_and_method_mapped() -> None:
+    """Guard: the introspection finds every path constant, each with a method.
+
+    Pinning the exact constant-name set (the #2944 guard shape) means a
+    renamed or dropped ``_*_PATH`` constant — or a new one that skips
+    the ``_PATH`` suffix convention or lacks a method mapping — can't
+    silently shrink the reconciled set to a vacuous pass.
+    """
+    assert sorted(_path_constants()) == sorted(
+        [*_METHODS_BY_CONSTANT, *_EXCLUDED_METHODS_BY_CONSTANT]
+    )
+
+
+def test_hand_coded_op_id_manifest_is_pinned() -> None:
+    """Pin the swept op_id set so drift can't silently shrink the reconcile.
+
+    Runs unconditionally (no shelf needed), so the enumeration wiring is
+    proven on every sweep — the nsx-lane manifest precedent. A new
+    hand-coded path, a renamed constant, or a changed method must update
+    this manifest consciously, and the lane's declared set moves with
+    it. Template segments carry the vendor's own parameter names
+    (reconciled against the pinned spec in the armed test below).
+    """
+    assert sorted(_op_ids(_METHODS_BY_CONSTANT)) == [
+        "GET:/admin/realms/{realm}",
+        "GET:/admin/realms/{realm}/client-scopes",
+        "GET:/admin/realms/{realm}/clients",
+        "GET:/admin/realms/{realm}/clients/{client-uuid}",
+        "GET:/admin/realms/{realm}/roles",
+        "GET:/admin/realms/{realm}/roles/{role-name}",
+        "GET:/admin/realms/{realm}/roles/{role-name}/users",
+        "GET:/admin/realms/{realm}/users",
+        "GET:/admin/realms/{realm}/users/{user-id}/role-mappings",
+        "POST:/admin/realms",
+        "POST:/admin/realms/{realm}/client-scopes",
+        "POST:/admin/realms/{realm}/clients",
+        "POST:/admin/realms/{realm}/clients/{client-uuid}/protocol-mappers/models",
+        "POST:/admin/realms/{realm}/users",
+        "POST:/admin/realms/{realm}/users/{user-id}/role-mappings/realm",
+        "PUT:/admin/realms/{realm}",
+        "PUT:/admin/realms/{realm}/clients/{client-uuid}",
+        "PUT:/admin/realms/{realm}/users/{user-id}/reset-password",
+    ]
+    assert sorted(_op_ids(_EXCLUDED_METHODS_BY_CONSTANT)) == [
+        "GET:/admin/serverinfo",
+        "POST:/realms/{realm}/protocol/openid-connect/token",
+    ]
+
+
+def test_declared_op_ids_are_served_by_the_pinned_spec() -> None:
+    """Every reconciled hand-coded op_id is served by the pinned keycloak-26.3 spec."""
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = openapi_served_op_ids(spec_path)
+    assert_op_ids_served(_op_ids(_METHODS_BY_CONSTANT), served, spec_label=_SPEC_LABEL)
+
+
+def test_excluded_op_ids_stay_unserved_by_the_pinned_spec() -> None:
+    """The evidenced exclusions remain genuinely outside the pinned spec.
+
+    Keeps the exclusion list honest: the day a newer pinned spec version
+    starts serving one of these surfaces, this fails and the constant
+    must move from ``_EXCLUDED_METHODS_BY_CONSTANT`` into
+    ``_METHODS_BY_CONSTANT`` (reconciled) instead of staying silently
+    excluded.
+    """
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = openapi_served_op_ids(spec_path)
+    wrongly_served = _op_ids(_EXCLUDED_METHODS_BY_CONSTANT) & served
+    assert not wrongly_served, (
+        f"excluded op_id(s) are now served by the pinned {_SPEC_LABEL}: "
+        f"{sorted(wrongly_served)} — promote them into _METHODS_BY_CONSTANT "
+        "(the exclusion's premise no longer holds)."
+    )

--- a/docs/codebase/connectors-keycloak.md
+++ b/docs/codebase/connectors-keycloak.md
@@ -274,6 +274,28 @@ default. The builders are pure (no connector I/O) and so fail-soft by
 construction; see [`approvals.md`](approvals.md) "`proposed_effect` builder
 hook" for the registry contract.
 
+**Spec-reconcile lane (#2988).** Every request path the connector dispatches
+lives as a `_*_PATH` template constant in
+`backend/src/meho_backplane/connectors/keycloak/_paths.py` (hoisted out of
+inline f-strings by #2988); handlers fill a template via `fill_path`, whose
+placeholder names are byte-for-byte the pinned spec's own parameter names
+(`{realm}`, `{client-uuid}`, `{user-id}`, `{role-name}`). The lane
+[`backend/tests/test_connectors_keycloak_spec_reconcile.py`](../../backend/tests/test_connectors_keycloak_spec_reconcile.py)
+(the #2980 harness; parse-only, runs in the required unit sweep, uniform
+skip when the shelf is unconfigured) introspects those live constants and
+asserts all 18 reconciled `METHOD:/path` op_ids are served by the pinned
+`keycloak-26.3` shelf spec (`keycloak-admin-openapi.json` — the vendor's
+Admin REST API OpenAPI at the lab's deployed 26.3.3, from Maven Central
+`org.keycloak:keycloak-api-docs-dist:26.3.3`, Apache-2.0). Two dispatched
+paths are pinned as evidenced exclusions rather than reconciled — the OIDC
+token mint (`POST /realms/{realm}/protocol/openid-connect/token`; specified
+by OAuth 2.0 / OIDC discovery, not the Admin REST OpenAPI) and
+`GET /admin/serverinfo` (unmodeled by the published spec; already
+best-effort in `fingerprint`) — and an armed test asserts they stay
+unserved, so a future spec pin that begins serving one forces its promotion
+into the reconciled set. Standard:
+[`docs/decisions/spec-reconcile-guards-standard.md`](../decisions/spec-reconcile-guards-standard.md).
+
 ## Target configuration
 
 Base URL is `https://{host}[:{port}]` from `HttpConnector._base_url`. The

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -346,6 +346,27 @@ no explicit open license, so this extension records a reference to the
 which names hetzner-robot-2026-04 explicitly) instead of a fresh
 attestation.
 
+### Extension: keycloak / keycloak-26.3 (#2988)
+
+The same secret-gated checkout additionally fetches the shelf's
+`docs/keycloak-26.3/` directory (`keycloak-admin-openapi.json`, OpenAPI
+3.0.3, ~0.5 MB, 247 paths — the Keycloak Admin REST API at the lab's
+deployed 26.3.3) for the keycloak reconcile lane
+(`backend/tests/test_connectors_keycloak_spec_reconcile.py`), under the
+identical ephemeral-use conditions recorded above (sparse read-only
+checkout, workspace destroyed at job end, never committed, never in
+artifacts or logs, secret withheld from fork PRs and the Dependabot
+store). No vendor-license attestation is needed for this extension: the
+spec is a build artifact of the **public, Apache-2.0**
+[`keycloak/keycloak`](https://github.com/keycloak/keycloak) project,
+distributed on Maven Central as
+`org.keycloak:keycloak-api-docs-dist:26.3.3` (zip sha256 verified
+against Maven Central's published checksum, retrieved 2026-08-18) — the
+provenance note of record is the shelf's `keycloak-26.3/MANIFEST.md`,
+per the OSS-licensed-spec form in
+[`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
+extension mechanics.
+
 ## Consequences
 
 - The five real-spec lanes light up together the moment the secret exists;


### PR DESCRIPTION
## Summary

- Adds the keycloak real-spec reconcile lane (`backend/tests/test_connectors_keycloak_spec_reconcile.py`) on the #2980 harness: every hand-coded `METHOD:/path` the connector dispatches — **18 reconciled op_ids** across the 8 read ops, 9 write ops, the fingerprint probe, and the name→UUID resolver reads — introspected from live `_*_PATH` constants and asserted served by the pinned `keycloak-26.3` shelf spec. Parse-only, required unit sweep, uniform skip when the shelf is unconfigured.
- **Makes the enumeration introspectable** (the #2944 live-constants rule — never a hardcoded mirror): the keycloak package had no path constants; all ~20 literals were inline f-strings across four modules. This PR hoists them into `connectors/keycloak/_paths.py` as template constants whose placeholders are byte-for-byte the pinned spec's own parameter names (`{realm}`, `{client-uuid}`, `{user-id}`, `{role-name}`), filled at call sites via the fail-loud `fill_path` helper. Wire requests are byte-identical (same `quote_segment` discipline at the same sites); all 110 existing keycloak backend tests + 34 UI keycloak tests pass unchanged.
- Widens CI's secret-gated spec-shelf sparse-checkout + fail-loud verify step to `docs/keycloak-26.3` in both Python jobs (strictly alphabetical: between `hetzner-robot-2026-04` and `nsx-9.0`; trivial rebase expected against sibling wave-4 lanes #2987/#2989).
- Extends `vendor-spec-ci-provisioning.md` with the keycloak entry (OSS provenance-note form — Apache-2.0 `keycloak/keycloak` build artifact from Maven Central; no attestation needed).
- Records the lane in `docs/codebase/connectors-keycloak.md` and `CHANGELOG.md`.

## Spec version pinned + why

The lab runs **Keycloak 26.3.3** (consumer INVENTORY fingerprint `keycloak:26.3.3` + `targets.yaml`), so the shelf pins the Admin REST API OpenAPI at exactly that release: Maven Central `org.keycloak:keycloak-api-docs-dist:26.3.3`, zip entry `rest-api/openapi.json`, byte-identical (zip sha256 verified against Maven Central's published checksum). Maven Central is the only version-pinned vendor source — the spec is a release build artifact (not in the `keycloak/keycloak` source tree) and keycloak.org hosts only `docs-api/latest/` (versioned URLs 404). The vendor document parses **clean** through `parse_openapi` (374 op_ids, OpenAPI 3.0.3) — no ingestable derivative needed, unlike vcf-operations. The spec declares **no `servers` entry**, so no #1796 server-base folding applies: path keys carry `/admin/...` directly, exactly the relative-path shape the connector dispatches against its root base URL.

## First-run findings + per-op decisions (the #2970 protocol)

First armed run: **all 18 reconciled op_ids served — no repoints needed.** Two hand-coded paths are not served, both of the "surface lives outside the pinned spec" class (evidence: the spec's only top-level path family is `/admin/realms`); per the decision table they are **evidenced exclusions**, never repoints (no served alternative exists):

| surface | declared | decision |
|---|---|---|
| admin-token mint (`_mint_admin_token`) | `POST:/realms/{realm}/protocol/openid-connect/token` | **exclude, evidenced** — OIDC protocol endpoint (RFC 6749 §3.2; per-realm `.well-known/openid-configuration`), definitionally outside the Admin REST OpenAPI |
| best-effort version read (`_server_version`) | `GET:/admin/serverinfo` | **exclude, evidenced** — unmodeled by the published Admin REST OpenAPI (connector already treats failure as non-fatal `version=None`) |

Both exclusions are pinned by value in an unconditional manifest test, and an armed tripwire (`test_excluded_op_ids_stay_unserved_by_the_pinned_spec`) asserts they stay unserved — the day a newer pinned spec serves one, the lane forces its promotion into the reconciled set.

Sweep notes (f-strings / concatenations, exhaustive): after the hoist, `grep -rn 'f?"/(admin|realms)'` over the package matches only `_paths.py`. The `probe_method = f"GET {realm_path}"` string in `fingerprint` is display metadata derived from the same filled constant, never dispatched (the vcf-operations display-metadata precedent). The `secret_endpoint.py` reset-password write (previously a two-line f-string concatenation) now fills the same `_USER_RESET_PASSWORD_PATH` constant the ops_write handler uses.

## Sequencing

Consumer PR [claude-rdc-hetzner-dc#2536](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/pull/2536) (ticket [#2535](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/issues/2535)) must merge **before** this PR's widened verify step can pass on armed CI (the nsx #2512 → #3007 and vcf-operations #2534 → #3012 sequencing). Until then the spec-shelf verify step fails by design.

## Test plan

- [x] Lane armed (`MEHO_CONSUMER_DOCS_ROOT=<shelf worktree with #2536>/docs`) — 4 passed; full reconcile-lane family (keycloak + sddc-manager + nsx + vcf-operations + vcf-automation + hetzner-robot + harness + example lane) — 34 passed
- [x] Lane without env — 2 passed (guards run unconditionally), 2 skipped with the uniform `tests/_spec_shelf.py` reason naming `keycloak-26.3/keycloak-admin-openapi.json`
- [x] Full keycloak backend family (auth / e2e / path_encoding / redaction / write_e2e / write_preview / admin / secret-broker sink) — 110 passed; UI keycloak routes — 34 passed
- [x] `ruff check src/ tests/` — clean; `ruff format --check` — clean
- [x] `mypy src/` — no new errors (pre-existing macOS-only `net/icmp.py` `MSG_ERRQUEUE` finding untouched; passes on Linux CI)
- [x] `ci.yml` YAML-parses; code-quality gate exit 0 (4 pre-existing warnings, see below)
- [ ] CI verify step green once claude-rdc-hetzner-dc#2536 merges (armed repo)

## Out of scope

- Sibling wave-4 lanes: #2987 (argocd), #2989 (rabbitmq) — same `ci.yml` lists, rebase-not-battle per the initiative.
- Adjacent findings (recorded, not edited): `_find_realm_role` interpolates `role_name` without `quote_segment` (pre-existing; unlike `keycloak_role_users`, which quotes) — behavior preserved verbatim by the hoist; OIDC token-URL literals outside the connector package (`auth/keycloak_admin.py`, `auth/agent_token.py`, `_shared/profile_auth.py`) are backplane-auth surfaces outside this lane's declared scope and OIDC-protocol (out of Admin-REST-spec scope) besides; code-quality pre-existing warnings (3 function-size in `connector.py`, file-size in `ops_write.py`).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2988
