### PR TITLE
test(connectors): argocd real-spec reconcile lane against the pinned argocd-3.3 shelf (#2987)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,8 @@ jobs:
           path: spec-shelf
           # Cone-mode sparse checkout of the shelf directories only +
           # lazy blob filter: the runner materialises just the pinned
-          # spec files (~0.2 MB hetzner-robot-2026-04 + ~33 MB nsx-9.0 +
+          # spec files (~0.4 MB argocd-3.3 + ~0.2 MB
+          # hetzner-robot-2026-04 + ~33 MB nsx-9.0 +
           # ~2 MB sddc-manager-9.0 + ~18 MB vcenter-9.0 + ~3 MB
           # vcf-automation-9.0 + ~5 MB vcf-operations-9.0), not the
           # whole consumer repo. No
@@ -306,6 +307,7 @@ jobs:
           # tests/acceptance/_vcenter_spec.py + tests/_spec_shelf.py.
           # Keep the list sorted.
           sparse-checkout: |
+            docs/argocd-3.3
             docs/hetzner-robot-2026-04
             docs/keycloak-26.3
             docs/nsx-9.0
@@ -332,6 +334,7 @@ jobs:
         run: |
           set -euo pipefail
           for f in \
+            spec-shelf/docs/argocd-3.3/argocd-swagger.json \
             spec-shelf/docs/hetzner-robot-2026-04/webservice-en.md \
             spec-shelf/docs/keycloak-26.3/keycloak-admin-openapi.json \
             spec-shelf/docs/nsx-9.0/nsx_api.openapi3.json \
@@ -348,7 +351,7 @@ jobs:
               exit 1
             fi
           done
-          echo "spec-shelf OK: webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -967,6 +970,7 @@ jobs:
           token: ${{ secrets.SPEC_SHELF_TOKEN }}
           path: spec-shelf
           sparse-checkout: |
+            docs/argocd-3.3
             docs/hetzner-robot-2026-04
             docs/keycloak-26.3
             docs/nsx-9.0
@@ -986,6 +990,7 @@ jobs:
         run: |
           set -euo pipefail
           for f in \
+            spec-shelf/docs/argocd-3.3/argocd-swagger.json \
             spec-shelf/docs/hetzner-robot-2026-04/webservice-en.md \
             spec-shelf/docs/keycloak-26.3/keycloak-admin-openapi.json \
             spec-shelf/docs/nsx-9.0/nsx_api.openapi3.json \
@@ -1002,7 +1007,7 @@ jobs:
               exit 1
             fi
           done
-          echo "spec-shelf OK: webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-lint-test's login step — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,30 @@ connector-related release-notes line.
   templates — wire requests are byte-identical, only the op_id
   strings agents and operators reference change.
 
+### Added — argocd real-spec reconcile lane (#2987)
+
+- Every hand-coded `METHOD:/path` the argocd connector dispatches (the
+  seven curated reads, the seven approval-gated writes, the
+  unauthenticated `GET /api/version` fingerprint/probe) is now asserted
+  against the pinned `argocd-3.3` spec on every PR via the #2980
+  harness (`backend/tests/test_connectors_argocd_spec_reconcile.py` —
+  parse-only, required unit sweep, uniform skip when the shelf is
+  unconfigured). The connector's path literals are hoisted into a
+  single route table (`connectors/argocd/routes.py`, fourteen
+  `"METHOD:/path"` constants) that both dispatch and the lane derive
+  from, so the reconcile introspects live constants rather than a
+  mirror. The pinned spec is ArgoCD's own `assets/swagger.json`
+  (Apache-2.0, tag `v3.3.9` — the newer of the lab's two deployed
+  3.3.x instances); it is Swagger 2.0, so the lane supplies its own
+  extraction per the standard's non-OpenAPI clause (ingest rejects
+  Swagger 2.0 by decision #2090). CI's secret-gated spec-shelf
+  checkout is widened to `docs/argocd-3.3` in both Python jobs. First
+  reconcile surfaced three findings, all vendor template-segment
+  renames adopted in the same PR per the #2970 protocol
+  (`{applicationName}` on `managed-resources` / `resource-tree`,
+  `{project.metadata.name}` on the project-update PUT) — wire requests
+  are byte-identical; no endpoint fictions, no repoints.
+
 ### Added — hetzner-robot real-spec reconcile lane (#2985 / #3014)
 
 - Every hand-coded `METHOD:/path` the hetzner-robot connector

--- a/backend/src/meho_backplane/connectors/argocd/connector.py
+++ b/backend/src/meho_backplane/connectors/argocd/connector.py
@@ -80,7 +80,6 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 from typing import Any
-from urllib.parse import quote
 
 import httpx
 import structlog
@@ -90,6 +89,17 @@ from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors._shared.cache_key import target_cache_key
 from meho_backplane.connectors._shared.system_operator import is_system_operator
 from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.argocd.routes import (
+    APP_GET_ROUTE,
+    APP_LIST_ROUTE,
+    APP_MANAGED_RESOURCES_ROUTE,
+    APP_RESOURCE_TREE_ROUTE,
+    CLUSTER_LIST_ROUTE,
+    PROJECT_LIST_ROUTE,
+    REPO_LIST_ROUTE,
+    VERSION_ROUTE,
+    route_path,
+)
 from meho_backplane.connectors.argocd.session import (
     ARGOCD_TOKEN_FIELD,
     ArgoCdCredentialsLoader,
@@ -109,7 +119,9 @@ _log = structlog.get_logger(__name__)
 
 #: The ArgoCD server version endpoint. Unauthenticated; returns the
 #: ``VersionMessage`` payload. Used by both fingerprint() and probe().
-_VERSION_PATH = "/api/version"
+#: Sourced from the connector's route table (#2987) so the reconcile
+#: lane's declared set covers the probe path by construction.
+_VERSION_PATH = route_path(VERSION_ROUTE)
 _PROBE_METHOD = f"GET {_VERSION_PATH}"
 
 
@@ -433,7 +445,7 @@ class ArgoCdConnector(HttpConnector):
         if selector:
             query["selector"] = selector
         return await self._get_json(
-            target, "/api/v1/applications", operator=operator, params=query or None
+            target, route_path(APP_LIST_ROUTE), operator=operator, params=query or None
         )
 
     async def app_get(
@@ -448,14 +460,12 @@ class ArgoCdConnector(HttpConnector):
         optional ``project`` query param scopes the lookup (ArgoCD returns
         404 rather than the app if it is not in that project).
         """
-        name = quote(str(params["name"]), safe="")
+        path = route_path(APP_GET_ROUTE, name=params["name"])
         query: dict[str, Any] = {}
         project = params.get("project")
         if project:
             query["project"] = project
-        return await self._get_json(
-            target, f"/api/v1/applications/{name}", operator=operator, params=query or None
-        )
+        return await self._get_json(target, path, operator=operator, params=query or None)
 
     async def app_diff(
         self,
@@ -470,17 +480,12 @@ class ArgoCdConnector(HttpConnector):
         ``liveState`` / ``targetState`` (and the normalized / predicted pair
         the controller compares) for one managed resource.
         """
-        name = quote(str(params["name"]), safe="")
+        path = route_path(APP_MANAGED_RESOURCES_ROUTE, name=params["name"])
         query: dict[str, Any] = {}
         project = params.get("project")
         if project:
             query["project"] = project
-        return await self._get_json(
-            target,
-            f"/api/v1/applications/{name}/managed-resources",
-            operator=operator,
-            params=query or None,
-        )
+        return await self._get_json(target, path, operator=operator, params=query or None)
 
     async def app_resource_tree(
         self,
@@ -494,17 +499,12 @@ class ArgoCdConnector(HttpConnector):
         ``hosts`` / ``shardsCount``); each node carries per-resource health
         and sync status plus ``parentRefs`` linking it into the hierarchy.
         """
-        name = quote(str(params["name"]), safe="")
+        path = route_path(APP_RESOURCE_TREE_ROUTE, name=params["name"])
         query: dict[str, Any] = {}
         project = params.get("project")
         if project:
             query["project"] = project
-        return await self._get_json(
-            target,
-            f"/api/v1/applications/{name}/resource-tree",
-            operator=operator,
-            params=query or None,
-        )
+        return await self._get_json(target, path, operator=operator, params=query or None)
 
     async def appproject_list(
         self,
@@ -519,7 +519,7 @@ class ArgoCdConnector(HttpConnector):
         ``destinations`` / resource allow- and deny-lists).
         """
         del params  # schema declares the param object empty
-        return await self._get_json(target, "/api/v1/projects", operator=operator)
+        return await self._get_json(target, route_path(PROJECT_LIST_ROUTE), operator=operator)
 
     async def repo_list(
         self,
@@ -534,7 +534,7 @@ class ArgoCdConnector(HttpConnector):
         ArgoCD can currently reach and authenticate to the repo).
         """
         del params  # schema declares the param object empty
-        return await self._get_json(target, "/api/v1/repositories", operator=operator)
+        return await self._get_json(target, route_path(REPO_LIST_ROUTE), operator=operator)
 
     async def cluster_list(
         self,
@@ -558,7 +558,7 @@ class ArgoCdConnector(HttpConnector):
         broad-RBAC token makes ``argocd-server`` include it.
         """
         del params  # schema declares the param object empty
-        payload = await self._get_json(target, "/api/v1/clusters", operator=operator)
+        payload = await self._get_json(target, route_path(CLUSTER_LIST_ROUTE), operator=operator)
         items = payload.get("items")
         if isinstance(items, list):
             for item in items:

--- a/backend/src/meho_backplane/connectors/argocd/ops_write.py
+++ b/backend/src/meho_backplane/connectors/argocd/ops_write.py
@@ -93,7 +93,20 @@ from __future__ import annotations
 import asyncio
 import time
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote
+
+from meho_backplane.connectors.argocd.routes import (
+    APP_DELETE_ROUTE,
+    APP_GET_ROUTE,
+    APP_RESOURCE_TREE_ROUTE,
+    APP_ROLLBACK_ROUTE,
+    APP_SPEC_UPDATE_ROUTE,
+    APP_SYNC_ROUTE,
+    PROJECT_CREATE_ROUTE,
+    PROJECT_LIST_ROUTE,
+    PROJECT_UPDATE_ROUTE,
+    route_method,
+    route_path,
+)
 
 if TYPE_CHECKING:
     from meho_backplane.auth.operator import Operator
@@ -125,11 +138,6 @@ _DEFAULT_POLL_TIMEOUT = 300
 
 #: Seconds between operationState polls.
 _POLL_INTERVAL = 2.0
-
-
-def _quote_name(name: Any) -> str:
-    """URL-encode an Application / project name for a path segment."""
-    return quote(str(name), safe="")
 
 
 def _project_query(params: dict[str, Any]) -> dict[str, Any]:
@@ -173,8 +181,7 @@ async def _poll_operation_state(
     on timeout — the last-observed phase with ``timed_out=True``. Mirrors
     ``vmware.composite.vm.clone``'s ``_poll_clone_task`` bound-deadline loop.
     """
-    encoded = _quote_name(name)
-    path = f"/api/v1/applications/{encoded}"
+    path = route_path(APP_GET_ROUTE, name=name)
     deadline = time.monotonic() + timeout_seconds
     last_phase: str | None = None
     last_message: str | None = None
@@ -221,7 +228,6 @@ async def argocd_app_sync(
     the final phase + message + synced revision.
     """
     name = str(params["name"])
-    encoded = _quote_name(name)
     body: dict[str, Any] = {"name": name}
     if params.get("revision"):
         body["revision"] = params["revision"]
@@ -232,7 +238,11 @@ async def argocd_app_sync(
     if params.get("project"):
         body["project"] = params["project"]
     await self._write_json(
-        target, "POST", f"/api/v1/applications/{encoded}/sync", operator=operator, json=body
+        target,
+        route_method(APP_SYNC_ROUTE),
+        route_path(APP_SYNC_ROUTE, name=name),
+        operator=operator,
+        json=body,
     )
     timeout = int(params.get("poll_timeout_seconds") or _DEFAULT_POLL_TIMEOUT)
     outcome = await _poll_operation_state(
@@ -259,7 +269,6 @@ async def argocd_app_rollback(
     terminal phase. Returns the final phase + message.
     """
     name = str(params["name"])
-    encoded = _quote_name(name)
     rollback_id = int(params["id"])
     body: dict[str, Any] = {"name": name, "id": rollback_id}
     if params.get("prune") is not None:
@@ -269,7 +278,11 @@ async def argocd_app_rollback(
     if params.get("project"):
         body["project"] = params["project"]
     await self._write_json(
-        target, "POST", f"/api/v1/applications/{encoded}/rollback", operator=operator, json=body
+        target,
+        route_method(APP_ROLLBACK_ROUTE),
+        route_path(APP_ROLLBACK_ROUTE, name=name),
+        operator=operator,
+        json=body,
     )
     timeout = int(params.get("poll_timeout_seconds") or _DEFAULT_POLL_TIMEOUT)
     outcome = await _poll_operation_state(
@@ -298,9 +311,8 @@ async def _read_app_spec(
     preview builder. Issues only ``GET /api/v1/applications/{name}`` — never
     a mutating verb.
     """
-    encoded = _quote_name(name)
     before = await self._get_json(
-        target, f"/api/v1/applications/{encoded}", operator=operator, params=query or None
+        target, route_path(APP_GET_ROUTE, name=name), operator=operator, params=query or None
     )
     return before.get("spec") if isinstance(before, dict) else None
 
@@ -318,7 +330,6 @@ async def argocd_app_set(
     ``proposed_effect`` so the reviewer sees what changed.
     """
     name = str(params["name"])
-    encoded = _quote_name(name)
     query = _project_query(params)
     before_spec = await _read_app_spec(self, operator, target, name=name, query=query)
     put_query: dict[str, Any] = dict(query)
@@ -326,8 +337,8 @@ async def argocd_app_set(
         put_query["validate"] = bool(params["validate"])
     after_spec = await self._write_json(
         target,
-        "PUT",
-        f"/api/v1/applications/{encoded}/spec",
+        route_method(APP_SPEC_UPDATE_ROUTE),
+        route_path(APP_SPEC_UPDATE_ROUTE, name=name),
         operator=operator,
         json=dict(params["spec"]),
         params=put_query or None,
@@ -352,13 +363,12 @@ async def argocd_app_refresh(
     in the op's llm_instructions). Returns the refreshed sync + health status.
     """
     name = str(params["name"])
-    encoded = _quote_name(name)
     hard = params.get("hard")
     refresh = "normal" if hard is False else "hard"
     query = _project_query(params)
     query["refresh"] = refresh
     app = await self._get_json(
-        target, f"/api/v1/applications/{encoded}", operator=operator, params=query
+        target, route_path(APP_GET_ROUTE, name=name), operator=operator, params=query
     )
     raw_status = app.get("status") if isinstance(app, dict) else None
     status: dict[str, Any] = raw_status if isinstance(raw_status, dict) else {}
@@ -413,10 +423,9 @@ async def _read_cascade_resources(
     """
     if not cascade:
         return []
-    encoded = _quote_name(name)
     tree = await self._get_json(
         target,
-        f"/api/v1/applications/{encoded}/resource-tree",
+        route_path(APP_RESOURCE_TREE_ROUTE, name=name),
         operator=operator,
         params=query or None,
     )
@@ -443,7 +452,6 @@ async def argocd_app_delete(
     app.
     """
     name = str(params["name"])
-    encoded = _quote_name(name)
     cascade = _delete_cascade_flag(params)
     query = _project_query(params)
 
@@ -458,8 +466,8 @@ async def argocd_app_delete(
         delete_query["propagationPolicy"] = propagation
     await self._write_json(
         target,
-        "DELETE",
-        f"/api/v1/applications/{encoded}",
+        route_method(APP_DELETE_ROUTE),
+        route_path(APP_DELETE_ROUTE, name=name),
         operator=operator,
         params=delete_query,
     )
@@ -500,7 +508,13 @@ async def argocd_appproject_create(
     project = dict(params["project"])
     name = _project_name(project)
     body: dict[str, Any] = {"project": project, "upsert": bool(params.get("upsert", False))}
-    await self._write_json(target, "POST", "/api/v1/projects", operator=operator, json=body)
+    await self._write_json(
+        target,
+        route_method(PROJECT_CREATE_ROUTE),
+        route_path(PROJECT_CREATE_ROUTE),
+        operator=operator,
+        json=body,
+    )
     return {"name": name, "created": True}
 
 
@@ -518,7 +532,7 @@ async def _read_project_spec(
     use to capture ``before_spec``. Issues only ``GET /api/v1/projects``;
     returns ``None`` when the project is not (yet) present.
     """
-    projects = await self._get_json(target, "/api/v1/projects", operator=operator)
+    projects = await self._get_json(target, route_path(PROJECT_LIST_ROUTE), operator=operator)
     items = projects.get("items") if isinstance(projects, dict) else None
     if isinstance(items, list):
         for item in items:
@@ -541,13 +555,16 @@ async def argocd_appproject_update(
     """
     project = dict(params["project"])
     name = _project_name(project)
-    encoded = _quote_name(name)
 
     before_spec = await _read_project_spec(self, operator, target, name=name)
 
     body: dict[str, Any] = {"project": project}
     updated = await self._write_json(
-        target, "PUT", f"/api/v1/projects/{encoded}", operator=operator, json=body
+        target,
+        route_method(PROJECT_UPDATE_ROUTE),
+        route_path(PROJECT_UPDATE_ROUTE, name=name),
+        operator=operator,
+        json=body,
     )
     after_spec = updated.get("spec") if isinstance(updated, dict) else None
     return {

--- a/backend/src/meho_backplane/connectors/argocd/routes.py
+++ b/backend/src/meho_backplane/connectors/argocd/routes.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The argocd connector's hand-coded route table — its full REST surface (#2987).
+
+Every ``argocd-server`` endpoint the connector dispatches is declared
+here exactly once as a ``"METHOD:/path"`` route constant, and every
+handler derives both its HTTP verb (:func:`route_method`) and its
+concrete request path (:func:`route_path`) from the same constant. That
+single-sourcing is what makes the spec-reconcile lane
+(``backend/tests/test_connectors_argocd_spec_reconcile.py``) a live
+introspection instead of a hardcoded mirror (the #2944 pattern, per
+``docs/decisions/spec-reconcile-guards-standard.md``): the declared set
+the lane asserts against the pinned ``argocd-3.3`` shelf spec *is* the
+set dispatch executes, so a path edit here flows into the reconcile
+automatically — and a new inline path literal in a handler is the drift
+the lane's pinned-manifest guard exists to catch in review.
+
+Template segments carry the **vendor's own parameter names** from the
+pinned ``argocd-server`` Swagger 2.0 document (``argoproj/argo-cd``
+``assets/swagger.json``), because the reconcile compares op_ids
+byte-for-byte: the gRPC-gateway names the Application segment ``{name}``
+on most application routes but ``{applicationName}`` on
+``managed-resources`` / ``resource-tree``, and the project-update
+segment is ``{project.metadata.name}`` (the proto field path). The
+runtime request is unaffected — :func:`route_path` substitutes whatever
+single placeholder the template carries with the URL-encoded resource
+name.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import quote
+
+__all__ = [
+    "APP_DELETE_ROUTE",
+    "APP_GET_ROUTE",
+    "APP_LIST_ROUTE",
+    "APP_MANAGED_RESOURCES_ROUTE",
+    "APP_RESOURCE_TREE_ROUTE",
+    "APP_ROLLBACK_ROUTE",
+    "APP_SPEC_UPDATE_ROUTE",
+    "APP_SYNC_ROUTE",
+    "CLUSTER_LIST_ROUTE",
+    "PROJECT_CREATE_ROUTE",
+    "PROJECT_LIST_ROUTE",
+    "PROJECT_UPDATE_ROUTE",
+    "REPO_LIST_ROUTE",
+    "VERSION_ROUTE",
+    "route_method",
+    "route_path",
+]
+
+# --- Unauthenticated fingerprint/probe surface -----------------------------
+
+#: ArgoCD's ``VersionMessage`` endpoint; unauthenticated on argocd-server.
+VERSION_ROUTE = "GET:/api/version"
+
+# --- Application reads (G3.12-T2 #1391) ------------------------------------
+
+APP_LIST_ROUTE = "GET:/api/v1/applications"
+APP_GET_ROUTE = "GET:/api/v1/applications/{name}"
+APP_MANAGED_RESOURCES_ROUTE = "GET:/api/v1/applications/{applicationName}/managed-resources"
+APP_RESOURCE_TREE_ROUTE = "GET:/api/v1/applications/{applicationName}/resource-tree"
+
+# --- Application writes (G3.12-T4 #1405) -----------------------------------
+
+APP_SYNC_ROUTE = "POST:/api/v1/applications/{name}/sync"
+APP_ROLLBACK_ROUTE = "POST:/api/v1/applications/{name}/rollback"
+APP_SPEC_UPDATE_ROUTE = "PUT:/api/v1/applications/{name}/spec"
+APP_DELETE_ROUTE = "DELETE:/api/v1/applications/{name}"
+
+# --- AppProject / repository / cluster surfaces ----------------------------
+
+PROJECT_LIST_ROUTE = "GET:/api/v1/projects"
+PROJECT_CREATE_ROUTE = "POST:/api/v1/projects"
+PROJECT_UPDATE_ROUTE = "PUT:/api/v1/projects/{project.metadata.name}"
+REPO_LIST_ROUTE = "GET:/api/v1/repositories"
+CLUSTER_LIST_ROUTE = "GET:/api/v1/clusters"
+
+#: One ``{segment}`` placeholder in a route template. Vendor segment
+#: names may carry dots (``{project.metadata.name}``), so the match is
+#: any non-brace run.
+_PLACEHOLDER_RE = re.compile(r"\{[^{}]+\}")
+
+
+def route_method(route: str) -> str:
+    """The HTTP verb a route constant declares (``"POST:/x"`` → ``"POST"``)."""
+    return route.partition(":")[0]
+
+
+def route_path(route: str, *, name: str | None = None) -> str:
+    """The dispatchable URL path of *route*, with its placeholder filled.
+
+    *name* is the resource name (Application ``metadata.name`` /
+    AppProject name) substituted — URL-encoded, ``safe=""`` so an
+    embedded ``/`` cannot splice path segments — into the template's
+    single ``{segment}`` placeholder. Passing *name* against a
+    placeholder-less template (or omitting it when the template has
+    one) raises :exc:`ValueError`: every call site states exactly the
+    shape its route carries, so a route edit that changes the template
+    arity fails loudly at dispatch instead of issuing a wrong path.
+    """
+    template = route.partition(":")[2]
+    if name is None:
+        if _PLACEHOLDER_RE.search(template):
+            raise ValueError(f"route {route!r} has a placeholder but no name was given")
+        return template
+    filled, substitutions = _PLACEHOLDER_RE.subn(quote(str(name), safe=""), template)
+    if substitutions != 1:
+        raise ValueError(
+            f"route {route!r} has {substitutions} placeholders; route_path(name=...) "
+            "fills exactly one"
+        )
+    return filled

--- a/backend/tests/test_connectors_argocd_spec_reconcile.py
+++ b/backend/tests/test_connectors_argocd_spec_reconcile.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""argocd real-spec reconcile lane (#2987) — the #2980 harness.
+
+Asserts every hand-coded ``METHOD:/path`` the argocd connector
+dispatches is served by the pinned ``argocd-3.3`` spec on the shelf —
+the ``argocd-server`` Swagger 2.0 document (``argoproj/argo-cd``
+``assets/swagger.json`` at tag ``v3.3.9``, **Apache-2.0**; provenance
+in the shelf's ``MANIFEST.md``). Parse-only set compare — no DB, no
+embeddings, no containers — so it lives in the required unit sweep per
+the lane-placement rule in
+``docs/decisions/spec-reconcile-guards-standard.md``. Uniform skip when
+the shelf is unconfigured (``tests/_spec_shelf.py`` contract).
+
+The pinned artifact is Swagger 2.0, which the ingest parser rejects by
+decision (#2090), so the lane supplies its own served-set extraction
+instead of routing through
+:func:`tests._spec_shelf.openapi_served_op_ids` — the standard's
+non-OpenAPI-artifact clause, following the vcf-automation lane's
+sanctioned Swagger 2.0 extraction shape. No OpenAPI 3 conversion is
+pinned: the typed ops exist precisely because ingest rejects the
+document, so a converted artifact would be a test-only fabrication with
+no dispatch-fidelity value.
+
+The declared set is introspected from the connector's live constants
+(the #2944 pattern — never a hardcoded mirror):
+:mod:`meho_backplane.connectors.argocd.routes` declares every dispatched
+endpoint exactly once as a ``"METHOD:/path"`` ``*_ROUTE`` constant, and
+every handler derives both its verb and its request path from the same
+constant (``route_method`` / ``route_path``) — the seven curated reads
+and the fingerprint/probe ``GET /api/version`` in ``connector.py``, and
+the seven approval-gated writes plus their read-only snapshot helpers in
+``ops_write.py``. A path edit in the connector therefore flows into the
+reconcile automatically, and a handler regressing to an inline literal
+is exactly the drift the pinned-manifest guard below surfaces in review.
+
+First reconcile of the enumerated routes against the real spec surfaced
+three findings, all template-segment renames (the vendor's
+gRPC-gateway parameter names differ per route family; the runtime
+request path — placeholder filled with the URL-encoded resource name —
+is unchanged): ``app.diff``'s ``managed-resources`` and
+``app.resource_tree``'s ``resource-tree`` use ``{applicationName}``
+(not ``{name}``), and the ``appproject.update`` PUT uses
+``{project.metadata.name}``. All three were adopted into the route
+table in the same PR per the #2970 protocol (the hetzner-robot
+``{vswitch-id}`` precedent). Protocol:
+docs/decisions/spec-reconcile-guards-standard.md.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from meho_backplane.connectors.argocd import routes as _routes_module
+from tests._spec_shelf import assert_op_ids_served, require_shelf_spec
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SPEC_DIR = "argocd-3.3"
+_SPEC_FILE = "argocd-swagger.json"
+_SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
+
+#: The Swagger 2.0 path-item keys that are HTTP operations (its fixed
+#: verb vocabulary); everything else on a path item (``parameters``,
+#: vendor extensions) is not a served operation.
+_SWAGGER2_METHODS = frozenset({"get", "put", "post", "delete", "options", "head", "patch"})
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the argocd connector dispatches.
+
+    Sweeps the live ``*_ROUTE`` constants of the connector's route table
+    (:mod:`~meho_backplane.connectors.argocd.routes`) — each value is
+    already the ``METHOD:/path`` op_id shape the harness compares, and
+    is the same string dispatch derives its verb and request path from.
+    """
+    return {
+        value
+        for name, value in vars(_routes_module).items()
+        if name.endswith("_ROUTE") and isinstance(value, str)
+    }
+
+
+def test_route_constant_names_are_pinned() -> None:
+    """Guard: the introspection finds every hand-coded route constant.
+
+    Pinning the exact constant-name set (the #2944 guard shape) means a
+    renamed or dropped ``*_ROUTE`` constant — or a new one that skips
+    the ``_ROUTE`` suffix convention — can't silently shrink the
+    reconciled set to a vacuous pass.
+    """
+    assert sorted(
+        name
+        for name, value in vars(_routes_module).items()
+        if name.endswith("_ROUTE") and isinstance(value, str)
+    ) == [
+        "APP_DELETE_ROUTE",
+        "APP_GET_ROUTE",
+        "APP_LIST_ROUTE",
+        "APP_MANAGED_RESOURCES_ROUTE",
+        "APP_RESOURCE_TREE_ROUTE",
+        "APP_ROLLBACK_ROUTE",
+        "APP_SPEC_UPDATE_ROUTE",
+        "APP_SYNC_ROUTE",
+        "CLUSTER_LIST_ROUTE",
+        "PROJECT_CREATE_ROUTE",
+        "PROJECT_LIST_ROUTE",
+        "PROJECT_UPDATE_ROUTE",
+        "REPO_LIST_ROUTE",
+        "VERSION_ROUTE",
+    ]
+
+
+def test_argocd_hand_coded_op_id_manifest_is_pinned() -> None:
+    """Pin the swept op_id set so drift can't silently shrink the reconcile.
+
+    Runs unconditionally (no shelf needed), so the enumeration is proven
+    on every sweep. A new hand-coded path, a renamed constant, or a
+    method change must update this manifest consciously — and the lane's
+    declared set moves with it. Template segments carry the vendor's own
+    parameter names (reconciled against the pinned spec below).
+    """
+    assert _declared_op_ids() == {
+        "DELETE:/api/v1/applications/{name}",
+        "GET:/api/v1/applications",
+        "GET:/api/v1/applications/{applicationName}/managed-resources",
+        "GET:/api/v1/applications/{applicationName}/resource-tree",
+        "GET:/api/v1/applications/{name}",
+        "GET:/api/v1/clusters",
+        "GET:/api/v1/projects",
+        "GET:/api/v1/repositories",
+        "GET:/api/version",
+        "POST:/api/v1/applications/{name}/rollback",
+        "POST:/api/v1/applications/{name}/sync",
+        "POST:/api/v1/projects",
+        "PUT:/api/v1/applications/{name}/spec",
+        "PUT:/api/v1/projects/{project.metadata.name}",
+    }
+
+
+def _swagger2_served_op_ids(spec_path: Path) -> set[str]:
+    """Extract the served ``METHOD:/path`` set from a Swagger 2.0 document.
+
+    The pinned spec is Swagger 2.0, which the ingest parser rejects by
+    decision (#2090) — so this lane extracts directly instead of routing
+    through :func:`tests._spec_shelf.openapi_served_op_ids` (the
+    standard's non-OpenAPI-artifact clause; same shape as the
+    vcf-automation lane). Served op_ids are the ``basePath``-folded path
+    keys crossed with their operation-verb keys; the argocd document
+    declares no ``basePath``, so its paths fold unchanged. Format drift
+    on the shelf (a re-pin that is no longer Swagger 2.0, or an empty
+    path map) fails loudly rather than regressing the lane to a vacuous
+    compare.
+    """
+    document = json.loads(spec_path.read_text(encoding="utf-8"))
+    if document.get("swagger") != "2.0":
+        pytest.fail(
+            f"{_SPEC_LABEL}: expected a Swagger 2.0 document "
+            f"(got swagger={document.get('swagger')!r} / "
+            f"openapi={document.get('openapi')!r}) — the shelf artifact "
+            "format moved; update this lane's extraction."
+        )
+    base = str(document.get("basePath") or "").rstrip("/")
+    served = {
+        f"{method.upper()}:{base}{path}"
+        for path, item in document.get("paths", {}).items()
+        for method in item
+        if method.lower() in _SWAGGER2_METHODS
+    }
+    if not served:
+        pytest.fail(
+            f"{_SPEC_LABEL}: extracted zero served operations — the "
+            "shelf artifact layout moved; update this lane's extraction."
+        )
+    return served
+
+
+def test_declared_op_ids_are_served_by_the_pinned_spec() -> None:
+    """Every hand-coded argocd op_id is served by the pinned argocd-3.3 spec.
+
+    A red run here is the guard surfacing a finding; triage per
+    docs/decisions/spec-reconcile-guards-standard.md.
+    """
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = _swagger2_served_op_ids(spec_path)
+    assert_op_ids_served(_declared_op_ids(), served, spec_label=_SPEC_LABEL)

--- a/docs/codebase/connectors-argocd.md
+++ b/docs/codebase/connectors-argocd.md
@@ -59,6 +59,22 @@ Source: `backend/src/meho_backplane/connectors/argocd/`.
 - **`register_argocd_typed_operations`** (`__init__.py`) — the lifespan-driven
   registrar (queued via `register_typed_op_registrar`) that delegates to
   `ArgoCdConnector.register_operations()`.
+- **`*_ROUTE` constants + `route_method` / `route_path`** (`routes.py`,
+  #2987) — the connector's full hand-coded REST surface as fourteen
+  `"METHOD:/path"` constants; every handler in `connector.py` /
+  `ops_write.py` derives its verb and its concrete request path
+  (placeholder filled with the URL-encoded resource name) from the same
+  constant. Template segments carry the vendor's own gRPC-gateway
+  parameter names (`{name}` on most application routes,
+  `{applicationName}` on `managed-resources` / `resource-tree`,
+  `{project.metadata.name}` on the project-update PUT) because the
+  spec-reconcile lane
+  ([`tests/test_connectors_argocd_spec_reconcile.py`](../../backend/tests/test_connectors_argocd_spec_reconcile.py))
+  compares these values byte-for-byte against the pinned `argocd-3.3`
+  shelf spec (`docs/decisions/spec-reconcile-guards-standard.md`). New
+  endpoints must land here as a `*_ROUTE` constant — an inline path
+  literal in a handler dodges the reconcile and fails the lane's
+  pinned-manifest guard in review.
 
 ## Control flow
 
@@ -296,6 +312,14 @@ shim.
   (`awaiting_approval`, handler never fires), the `app.sync`/`rollback`
   operationState poll to a terminal phase, the `app.set`/`delete`/`appproject.update`
   `proposed_effect` snapshots, and the bearer-rides-never-leaks guarantee.
+- `tests/test_connectors_argocd_spec_reconcile.py` — the real-spec
+  reconcile lane (#2987, the #2980 harness): sweeps the live `*_ROUTE`
+  constants of `routes.py` and asserts every hand-coded `METHOD:/path`
+  is served by the pinned `argocd-3.3` shelf spec (`argocd-swagger.json`,
+  Swagger 2.0 — the lane supplies its own extraction since ingest
+  rejects Swagger 2.0 by decision #2090). Skips uniformly when
+  `MEHO_CONSUMER_DOCS_ROOT` is unset; the constant-name and op_id
+  manifest pins run unconditionally.
 
 ## Known issues
 

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -353,6 +353,13 @@ The same secret-gated checkout additionally fetches the shelf's
 3.0.3, ~0.5 MB, 247 paths — the Keycloak Admin REST API at the lab's
 deployed 26.3.3) for the keycloak reconcile lane
 (`backend/tests/test_connectors_keycloak_spec_reconcile.py`), under the
+### Extension: argocd / argocd-3.3 (#2987)
+
+The same secret-gated checkout additionally fetches the shelf's
+`docs/argocd-3.3/` directory (~0.4 MB; the lane parses
+`argocd-swagger.json`, the `argocd-server` Swagger 2.0 document, 80
+paths) for the argocd reconcile lane
+(`backend/tests/test_connectors_argocd_spec_reconcile.py`), under the
 identical ephemeral-use conditions recorded above (sparse read-only
 checkout, workspace destroyed at job end, never committed, never in
 artifacts or logs, secret withheld from fork PRs and the Dependabot
@@ -387,6 +394,19 @@ note of record is the shelf's `rabbitmq-4.3/MANIFEST.md`, per the
 OSS-licensed-spec form in
 [`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
 extension mechanics.
+spec is vendored at `assets/swagger.json` in the **public, Apache-2.0**
+[`argoproj/argo-cd`](https://github.com/argoproj/argo-cd) repo (pinned
+at tag `v3.3.9`, commit `1b1bb48f`, retrieved 2026-08-18 — matching the
+newer of the lab's two deployed 3.3.x instances) — the provenance note
+of record is the shelf's `argocd-3.3/MANIFEST.md`, per the
+OSS-licensed-spec form in
+[`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
+extension mechanics. The artifact stays Swagger 2.0 (no OpenAPI 3
+derivative): ingest rejects Swagger 2.0 by decision (#2090), so the
+lane supplies its own extraction — the vcf-automation `vra-iaas.json`
+precedent. **Sequencing:** the pin lands via consumer-repo PR
+(`claude-rdc-hetzner-dc#2540`) which must merge before this repo's
+widened verify step can pass.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

- **Route table (`connectors/argocd/routes.py`):** the argocd connector's fourteen hand-coded `METHOD:/path` literals move out of handler-body f-strings into one module of `"METHOD:/path"` `*_ROUTE` constants; every handler (7 curated reads + 7 approval-gated writes + the snapshot helpers + the `GET /api/version` fingerprint/probe) derives its verb (`route_method`) and its concrete request path (`route_path`, URL-encoded fill) from the same constant. Single-sourcing is what lets the lane introspect live constants instead of a hardcoded mirror (the #2944 pattern).
- **Reconcile lane (`backend/tests/test_connectors_argocd_spec_reconcile.py`):** asserts the full declared set against the pinned `argocd-3.3` shelf spec via the #2980 harness. The pinned artifact (ArgoCD's own `assets/swagger.json` at tag `v3.3.9`, Apache-2.0) is **Swagger 2.0**, which ingest rejects by decision (#2090) — the lane supplies its own served-set extraction, the sanctioned vcf-automation shape for the standard's non-OpenAPI clause. Constant-name + op_id manifest pins run unconditionally; the spec assert skips uniformly without `MEHO_CONSUMER_DOCS_ROOT`.
- **CI:** both Python jobs' spec-shelf `sparse-checkout` + verify lists widen to `docs/argocd-3.3` (`argocd-3.3` sorts first — strictly alphabetical).
- **ADR:** OSS provenance-note extension in `docs/decisions/vendor-spec-ci-provisioning.md` (no attestation needed — Apache-2.0); `docs/codebase/connectors-argocd.md` + CHANGELOG updated.

## Red-lane findings + per-op decisions (#2970 protocol)

First reconcile of the enumerated routes against the real spec: **3 unserved of 14** — all vendor **template-segment renames**, zero endpoint fictions. The gRPC-gateway names its path parameters inconsistently per route family; runtime request paths (placeholder filled with the resource name) are byte-identical before and after.

| op | was declared | spec serves | decision |
|---|---|---|---|
| `argocd.app.diff` | `GET:/api/v1/applications/{name}/managed-resources` | `GET:/api/v1/applications/{applicationName}/managed-resources` | adopt vendor segment name (mechanical; the hetzner `{vswitch-id}` precedent, PR #3014) |
| `argocd.app.resource_tree` (+ delete-cascade snapshot helper) | `GET:/api/v1/applications/{name}/resource-tree` | `GET:/api/v1/applications/{applicationName}/resource-tree` | adopt vendor segment name (mechanical) |
| `argocd.appproject.update` | `PUT:/api/v1/projects/{name}` | `PUT:/api/v1/projects/{project.metadata.name}` | adopt vendor segment name (mechanical; proto field path) |

The other 11 op_ids are served verbatim. No removals (#3014-style) and no design-level repoints needed.

## Spec pin (consumer-repo sequencing)

`evoila-bosnia/claude-rdc-hetzner-dc#2540` pins `docs/argocd-3.3/argocd-swagger.json` (byte-identical fetch from `argoproj/argo-cd@v3.3.9`, commit `1b1bb48f`, sha256 in the shelf MANIFEST) + sidecars + MANIFEST provenance/license note. **That PR must merge before this PR's spec-shelf verify step can pass** (the nsx #2512 → #3007 sequencing). Version choice: the lab runs two 3.3.x instances, both registered meho targets — `rdc-argocd` v3.3.9 and `rke2-meho-argocd` v3.3.4 — so the shelf dir is `argocd-3.3` (major.minor convention) pinning the newer deployed patch.

## Test plan

- [x] `ruff check src/ tests/` — clean; `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/argocd/` — clean (repo-wide mypy carries one pre-existing Linux-only `socket.MSG_ERRQUEUE` artifact in untouched `net/icmp.py` on macOS; CI runs Linux)
- [x] Affected sweep (`argocd_*` suites + `test_operations_preview` + `test_spec_shelf_harness`) — 120 passed, 1 skipped (the lane's uniform no-env skip)
- [x] Lane **armed** against the local consumer worktree's `docs/argocd-3.3` (unmerged #2540 content): 3 passed — all 14 op_ids served
- [x] Lane **without env**: skip-clean with the harness's uniform reason
- [x] `code-quality.py --diff` — 0 blockers (3 pre-existing size warnings in legacy files)

## Out of scope

- Siblings #2988 (keycloak) / #2989 (rabbitmq) edit the same `ci.yml` lists concurrently — trivial rebase expected at merge time.
- The Swagger 2.0 extraction is deliberately lane-local (duplicated from the vcf-automation lane) per the standard's "the lane supplies its own served-set extraction" clause; hoisting it into `_spec_shelf.py` would touch the shipped #2980 harness and collide with the concurrent sibling lanes — left as an adjacent finding.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2987

🤖 Generated with [Claude Code](https://claude.com/claude-code)
