### PR TITLE
feat(events): inbound ingest endpoint — per-source auth, body cap, rate limit, dedupe, __ingest__ audit

### DIFF
--- a/backend/src/meho_backplane/api/openapi_maturity.py
+++ b/backend/src/meho_backplane/api/openapi_maturity.py
@@ -76,6 +76,10 @@ TAG_FEATURE: Final[dict[str, str]] = {
     # event -> kind=event ScheduledTrigger substrate (Initiative #2877), so
     # it follows the scheduler feature it feeds.
     "event-sources": "scheduler",
+    # The inbound ingest endpoint (#2881) is the runtime that consumes the
+    # event_source registry and publishes to the event_outbox the scheduler
+    # drains -- same substrate, same feature.
+    "events": "scheduler",
     "feed": "broadcast",
     "gateway": "satellite_gateway",
     "knowledge": "memory_knowledge",

--- a/backend/src/meho_backplane/api/v1/events_ingest.py
+++ b/backend/src/meho_backplane/api/v1/events_ingest.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Inbound event ingest endpoint ``POST /api/v1/events/ingest/{source_slug}`` (#2881).
+
+The JWT-less webhook surface a registered ``event_source`` (#2880) delivers
+to. Unlike every other ``/api/v1`` route it carries **no** operator
+dependency: the sender is authenticated per-source against the source's
+Vault-custodied secret, not by a Keycloak JWT, so the chassis
+``AuditMiddleware`` (which keys on the JWT-bound ``operator_sub`` contextvar)
+writes no row for it -- the ingest service writes its own synchronous
+``__ingest__`` audit row instead.
+
+Request path (the order is load-bearing)
+=======================================
+
+1. **Resolve** the source by slug (global, tenant-less -- the webhook carries
+   no tenant). A missing *or* paused source returns the identical uniform
+   ``404`` so the two are indistinguishable (no paused-vs-missing oracle).
+2. **Body cap** (``413``) enforced *before* buffering the whole body -- a
+   ``Content-Length`` fast-reject plus a streaming running-total guard so a
+   lying/absent length header cannot bypass it (the ``ui/csrf.py`` DoS
+   lesson). The cap is the source's ``extras`` override clamped to 256 KiB.
+3-6. **Auth / rate-limit / dedupe / publish+audit / broadcast** run in
+   :func:`~meho_backplane.events.ingest.service.accept_ingest_event`.
+
+CSRF does not apply: ``/api/*`` is structurally outside the ``/ui/`` prefix
+the CSRF middleware guards.
+
+Reconciliation note (404 vs 401)
+================================
+
+The #2880 resolver's docstring suggests mapping a missing slug to the *same*
+response as an auth failure. This endpoint instead follows the #2881 issue
+contract: missing/paused -> ``404``, bad signature -> ``401``. The residual
+"a 404 vs 401 distinguishes a real slug" oracle is acceptable because a slug
+is a high-entropy routing token (not enumerable), and the uniform 404 still
+hides the operationally sensitive paused-vs-missing distinction.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_raw_session
+from meho_backplane.event_source.resolver import resolve_event_source_by_slug
+from meho_backplane.event_source.schemas import EventSourceAuthStrategy, EventSourceStatus
+from meho_backplane.events.ingest.auth import IngestAuthError
+from meho_backplane.events.ingest.config import resolve_ingest_config
+from meho_backplane.events.ingest.rate_limit import IngestRateLimitError
+from meho_backplane.events.ingest.service import (
+    IngestPayloadError,
+    IngestVaultError,
+    ResolvedSource,
+    accept_ingest_event,
+)
+
+__all__ = ["router"]
+
+_log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/events", tags=["events"])
+
+#: Uniform not-found detail. Missing and paused sources return this same
+#: body so the response leaks neither existence nor pause-state.
+_NOT_FOUND_DETAIL = {"error": "no_event_source"}
+
+
+class EventIngestResponse(BaseModel):
+    """Accepted (``202``) or deduplicated (``200``) acknowledgement.
+
+    ``event_id`` is the ``event_outbox`` row id the delivery landed on (the
+    original row's id on a duplicate); ``None`` only in the rare race where a
+    duplicate collided but the original row was concurrently removed.
+    """
+
+    event_id: int | None
+    deduplicated: bool
+
+
+class _IngestBodyTooLargeError(Exception):
+    """Raised by the capped reader when the body exceeds the source's cap."""
+
+
+async def _read_capped_body(request: Request, max_bytes: int) -> bytes:
+    """Read the request body, rejecting oversize input before full buffering.
+
+    A ``Content-Length`` over the cap is rejected up front; then the body is
+    streamed with a running byte total so an absent or understated length
+    header cannot smuggle an oversize body past the guard. At most
+    ``max_bytes`` (plus one final chunk) is ever held in memory.
+    """
+    declared = request.headers.get("content-length")
+    if declared is not None:
+        try:
+            if int(declared) > max_bytes:
+                raise _IngestBodyTooLargeError
+        except ValueError:
+            # A malformed Content-Length is ignored here; the streaming
+            # running-total below is the real guard.
+            pass
+
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > max_bytes:
+            raise _IngestBodyTooLargeError
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _snapshot_source(row: object) -> ResolvedSource:
+    """Snapshot the resolved ORM row's routing/auth fields off the read session."""
+    return ResolvedSource(
+        id=row.id,  # type: ignore[attr-defined]
+        tenant_id=row.tenant_id,  # type: ignore[attr-defined]
+        slug=row.slug,  # type: ignore[attr-defined]
+        kind=row.kind,  # type: ignore[attr-defined]
+        auth_strategy=EventSourceAuthStrategy(row.auth_strategy),  # type: ignore[attr-defined]
+        secret_ref=row.secret_ref,  # type: ignore[attr-defined]
+        extras=dict(row.extras),  # type: ignore[attr-defined]
+    )
+
+
+@router.post(
+    "/ingest/{source_slug}",
+    response_model=EventIngestResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def ingest_event(
+    source_slug: str,
+    request: Request,
+    response: Response,
+    session: AsyncSession = Depends(get_raw_session),
+) -> EventIngestResponse:
+    """Accept one external event for *source_slug*. See the module docstring."""
+    row = await resolve_event_source_by_slug(session, source_slug)
+    if row is None or row.status != EventSourceStatus.ACTIVE.value:
+        # Uniform 404 for both missing and paused -- no existence oracle.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND_DETAIL)
+
+    source = _snapshot_source(row)
+    config = resolve_ingest_config(source.extras)
+
+    try:
+        raw_body = await _read_capped_body(request, config.max_body_bytes)
+    except _IngestBodyTooLargeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail={"error": "payload_too_large", "max_bytes": config.max_body_bytes},
+        ) from exc
+
+    try:
+        outcome = await accept_ingest_event(
+            source=source, config=config, headers=request.headers, raw_body=raw_body
+        )
+    except IngestAuthError as exc:
+        # Uniform 401; the specific reason is logged, never returned.
+        _log.info("ingest_auth_rejected", slug=source.slug, reason=exc.reason)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail={"error": "unauthorized"}
+        ) from exc
+    except IngestRateLimitError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={"error": "rate_limited"},
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc
+    except IngestVaultError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"error": "secret_unavailable"},
+        ) from exc
+    except IngestPayloadError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail={"error": "invalid_payload"}
+        ) from exc
+
+    # A duplicate delivery is an idempotent 200, an accepted one a 202.
+    response.status_code = status.HTTP_200_OK if outcome.deduplicated else status.HTTP_202_ACCEPTED
+    return EventIngestResponse(event_id=outcome.event_id, deduplicated=outcome.deduplicated)

--- a/backend/src/meho_backplane/api/v1/events_ingest.py
+++ b/backend/src/meho_backplane/api/v1/events_ingest.py
@@ -32,10 +32,25 @@ Reconciliation note (404 vs 401)
 
 The #2880 resolver's docstring suggests mapping a missing slug to the *same*
 response as an auth failure. This endpoint instead follows the #2881 issue
-contract: missing/paused -> ``404``, bad signature -> ``401``. The residual
-"a 404 vs 401 distinguishes a real slug" oracle is acceptable because a slug
-is a high-entropy routing token (not enumerable), and the uniform 404 still
-hides the operationally sensitive paused-vs-missing distinction.
+contract: missing/paused -> ``404``, bad signature -> ``401``. That leaves a
+residual oracle -- a ``404`` vs ``401`` tells a prober whether a slug is
+registered, and because the ``404`` short-circuits *before* the Vault secret
+read the difference is observable in latency as well as in status.
+
+This is **not** defended by slug entropy: slugs are operator-named and
+guessable (``grafana``, ``harbor``, ...), so an attacker can enumerate the
+likely ones. The oracle is acceptable for two other, load-bearing reasons:
+
+1. The backplane is internal-only (never publicly exposed), so a prober must
+   already be inside the trust boundary to reach this route at all.
+2. Confirming a slug exists grants nothing by itself: forging any event still
+   requires that source's per-source secret, which is Vault-custodied and
+   never leaves the backplane.
+
+The uniform ``404`` still hides the operationally sensitive paused-vs-missing
+distinction. If this endpoint were ever exposed externally, the 404-vs-401
+(and the pre-Vault timing) split would have to be closed first -- e.g. by
+enforcing slug entropy or emitting a uniform response before the resolver read.
 """
 
 from __future__ import annotations

--- a/backend/src/meho_backplane/event_source/secrets.py
+++ b/backend/src/meho_backplane/event_source/secrets.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import structlog
+from pydantic import SecretStr
 
 from meho_backplane.connectors._shared.vault_creds import DEFAULT_KV_MOUNT
 from meho_backplane.connectors.secret.endpoints import SecretMaterial
@@ -37,13 +38,12 @@ from meho_backplane.connectors.secret.vault_endpoint import VaultKvSecretEndpoin
 from meho_backplane.connectors.vault.tenant_paths import TENANT_SECRET_PREFIX
 
 if TYPE_CHECKING:
-    from pydantic import SecretStr
-
     from meho_backplane.auth.operator import Operator
 
 __all__ = [
     "EVENT_SOURCE_SECRET_FIELD",
     "event_source_secret_ref",
+    "read_event_source_secret",
     "store_event_source_secret",
 ]
 
@@ -100,3 +100,34 @@ async def store_event_source_secret(
     )
     _log.info("event_source_secret_write", secret_ref=secret_ref)
     await endpoint.write_secret(operator, SecretMaterial(secret.get_secret_value()))
+
+
+async def read_event_source_secret(operator: Operator, secret_ref: str) -> SecretStr:
+    """Read the source's auth secret from Vault at *secret_ref* under *operator*.
+
+    The read counterpart to :func:`store_event_source_secret`, reusing the
+    same secret-broker vault-kv endpoint so custody is shared, not
+    re-implemented. The ingest path (#2881) calls this with its synthetic
+    ``__ingest__`` operator (a background-dispatch service principal, since
+    the JWT-less webhook carries no operator) to fetch the shared HMAC key /
+    static token / Basic password it verifies the sender against.
+
+    The value is carried by a :class:`~pydantic.SecretStr` from the KV-v2
+    read boundary onward -- it masks itself in every repr / log / traceback,
+    so a fail-closed auth-verification path that logs the rejection never
+    leaks the material. The value is reachable only through
+    :meth:`~pydantic.SecretStr.get_secret_value` at the constant-time
+    comparison site.
+
+    Raises whatever the vault-kv source raises on an I/O / auth failure (an
+    ``hvac`` error, or :class:`~meho_backplane.connectors.secret.vault_endpoint.VaultSecretRefError`
+    when the field is absent); the caller maps it to a fail-closed HTTP
+    status. The value never reaches the raised message -- the source names
+    only the path and field.
+    """
+    endpoint = VaultKvSecretEndpoint(
+        f"{secret_ref}#{EVENT_SOURCE_SECRET_FIELD}", mount=DEFAULT_KV_MOUNT
+    )
+    _log.info("event_source_secret_read", secret_ref=secret_ref)
+    material = await endpoint.read_secret(operator)
+    return SecretStr(material.value.decode("utf-8"))

--- a/backend/src/meho_backplane/events/ingest/__init__.py
+++ b/backend/src/meho_backplane/events/ingest/__init__.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Inbound external event ingest (#2881).
+
+The JWT-less webhook path a registered ``event_source`` (#2880) delivers to.
+The endpoint (:mod:`meho_backplane.api.v1.events_ingest`) resolves the source
+by slug and reads the capped body; this package owns everything that follows:
+
+* :mod:`~meho_backplane.events.ingest.config` -- per-source knobs off
+  ``event_source.extras`` (body cap, rate limit, replay window, header names).
+* :mod:`~meho_backplane.events.ingest.auth` -- constant-time per-strategy
+  sender authentication against the Vault-custodied secret.
+* :mod:`~meho_backplane.events.ingest.rate_limit` -- the per-source
+  fixed-window Valkey limiter.
+* :mod:`~meho_backplane.events.ingest.service` -- the orchestration:
+  publish to ``event_outbox`` in the same transaction as a synchronous
+  ``__ingest__`` audit row, then a fail-open broadcast.
+"""
+
+from meho_backplane.events.ingest.auth import IngestAuthError, verify_ingest_auth
+from meho_backplane.events.ingest.config import IngestConfig, resolve_ingest_config
+from meho_backplane.events.ingest.rate_limit import (
+    IngestRateLimitError,
+    enforce_ingest_rate_limit,
+)
+from meho_backplane.events.ingest.service import (
+    INGEST_OPERATOR_SUB,
+    IngestOutcome,
+    IngestPayloadError,
+    IngestVaultError,
+    ResolvedSource,
+    accept_ingest_event,
+)
+
+__all__ = [
+    "INGEST_OPERATOR_SUB",
+    "IngestAuthError",
+    "IngestConfig",
+    "IngestOutcome",
+    "IngestPayloadError",
+    "IngestRateLimitError",
+    "IngestVaultError",
+    "ResolvedSource",
+    "accept_ingest_event",
+    "enforce_ingest_rate_limit",
+    "resolve_ingest_config",
+    "verify_ingest_auth",
+]

--- a/backend/src/meho_backplane/events/ingest/auth.py
+++ b/backend/src/meho_backplane/events/ingest/auth.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-source sender authentication for the inbound ingest endpoint (#2881).
+
+The webhook is JWT-less: MEHO does not know the sender is who it claims until
+it verifies the request against the source's Vault-custodied shared secret.
+Three strategies (mirroring the ``ck_event_source_auth_strategy`` CHECK set):
+
+* ``hmac-sha256`` -- the sender signs the raw body (optionally prefixed with
+  a timestamp, which is then bound into the signature and gated by a replay
+  window) with the shared key. The generic sender uses ``X-Meho-Signature``
+  + ``X-Meho-Timestamp``; a vendor with different header names (Grafana's
+  ``X-Grafana-Alerting-Signature``) sets them per-source via ``extras``.
+* ``static-header`` -- a fixed header carries a shared token compared against
+  the secret (Harbor).
+* ``basic`` -- HTTP Basic; the non-secret username lives in ``extras``, the
+  password is the Vault secret (Alertmanager ``http_config``).
+
+Constant-time discipline (acceptance criterion 4)
+================================================
+
+**Every** comparison that touches secret material runs through
+:func:`hmac.compare_digest`, so a network attacker cannot recover the secret
+(or the expected signature) one byte at a time from response-timing. The
+Basic path computes both the username and password verdicts before combining
+them, so it leaks neither which half failed nor the username length through
+an early return. All comparisons are on ``bytes`` -- ``compare_digest`` on a
+``str`` carrying non-ASCII raises, and a secret is arbitrary bytes.
+
+Fail-closed: any missing header, malformed value, unparseable timestamp, or
+mismatch raises :class:`IngestAuthError`. The endpoint maps it to a uniform
+``401`` -- the reason is logged server-side, never returned, so the response
+is the same shape whatever failed (no oracle for *why* auth failed).
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+from collections.abc import Mapping
+
+from pydantic import SecretStr
+
+from meho_backplane.event_source.schemas import EventSourceAuthStrategy
+from meho_backplane.events.ingest.config import IngestConfig
+
+__all__ = ["IngestAuthError", "verify_ingest_auth"]
+
+
+class IngestAuthError(Exception):
+    """Sender authentication failed. Carries a server-side-only *reason*.
+
+    The reason is a stable machine token (``bad_signature``,
+    ``stale_timestamp``, ``missing_signature``, ...) logged for operator
+    debugging; it is **never** returned to the sender, so every failure
+    presents the same uniform ``401`` and reveals nothing about which check
+    tripped.
+    """
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+def _require_header(headers: Mapping[str, str], name: str, reason: str) -> str:
+    """Return the non-empty header *name* or raise :class:`IngestAuthError`."""
+    value = headers.get(name)
+    if not value or not value.strip():
+        raise IngestAuthError(reason)
+    return value.strip()
+
+
+def _verify_hmac_sha256(
+    secret: SecretStr,
+    headers: Mapping[str, str],
+    raw_body: bytes,
+    config: IngestConfig,
+    now: float,
+) -> None:
+    """Verify an HMAC-SHA256 signature over the (optionally timestamped) body.
+
+    When ``config.require_timestamp`` is set, the timestamp header is
+    mandatory, must parse as unix seconds, must fall inside the replay
+    window, and is bound into the signed message (``"<ts>." + body``) so an
+    attacker cannot swap a fresh timestamp onto a captured body. When it is
+    unset (a body-only vendor scheme), the signature covers the raw body
+    alone and no replay check applies.
+    """
+    provided = _require_header(headers, config.signature_header, "missing_signature")
+
+    signed = raw_body
+    if config.require_timestamp:
+        ts_raw = _require_header(headers, config.timestamp_header, "missing_timestamp")
+        try:
+            ts = float(ts_raw)
+        except ValueError as exc:
+            raise IngestAuthError("bad_timestamp") from exc
+        if abs(now - ts) > config.replay_window_seconds:
+            raise IngestAuthError("stale_timestamp")
+        signed = ts_raw.encode("utf-8") + b"." + raw_body
+
+    expected = hmac.new(
+        secret.get_secret_value().encode("utf-8"), signed, hashlib.sha256
+    ).hexdigest()
+    # Hex is case-insensitive; normalise both sides so a sender emitting
+    # upper-case hex is not spuriously rejected. compare_digest on unequal
+    # lengths returns False without leaking the length difference by timing.
+    if not hmac.compare_digest(expected.encode("ascii"), provided.lower().encode("ascii")):
+        raise IngestAuthError("bad_signature")
+
+
+def _verify_static_header(
+    secret: SecretStr,
+    headers: Mapping[str, str],
+    config: IngestConfig,
+) -> None:
+    """Constant-time compare a fixed header value against the shared token."""
+    provided = _require_header(headers, config.static_header, "missing_static_header")
+    if not hmac.compare_digest(provided.encode("utf-8"), secret.get_secret_value().encode("utf-8")):
+        raise IngestAuthError("bad_static_header")
+
+
+def _verify_basic(
+    secret: SecretStr,
+    headers: Mapping[str, str],
+    config: IngestConfig,
+) -> None:
+    """Verify HTTP Basic: username from ``extras``, password is the secret."""
+    header = _require_header(headers, "Authorization", "missing_authorization")
+    scheme, _, encoded = header.partition(" ")
+    if scheme.lower() != "basic" or not encoded:
+        raise IngestAuthError("bad_authorization_scheme")
+    try:
+        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+    except (binascii.Error, ValueError) as exc:
+        raise IngestAuthError("malformed_basic_credentials") from exc
+    username, sep, password = decoded.partition(":")
+    if not sep:
+        raise IngestAuthError("malformed_basic_credentials")
+    # Compute both verdicts before combining -- no early return that would
+    # leak which half failed or the username length through timing.
+    user_ok = hmac.compare_digest(username.encode("utf-8"), config.basic_username.encode("utf-8"))
+    pass_ok = hmac.compare_digest(
+        password.encode("utf-8"), secret.get_secret_value().encode("utf-8")
+    )
+    if not (user_ok and pass_ok):
+        raise IngestAuthError("bad_basic_credentials")
+
+
+def verify_ingest_auth(
+    *,
+    strategy: EventSourceAuthStrategy,
+    secret: SecretStr,
+    headers: Mapping[str, str],
+    raw_body: bytes,
+    config: IngestConfig,
+    now: float,
+) -> None:
+    """Verify the sender against the source's *strategy*. Raise on any failure.
+
+    ``headers`` is the request's case-insensitive header map, ``raw_body`` the
+    exact bytes the signature is computed over (never a re-serialised view),
+    ``now`` the current unix time for the replay window. Returns ``None`` on
+    success; raises :class:`IngestAuthError` (uniform ``401`` at the boundary)
+    otherwise.
+    """
+    if strategy is EventSourceAuthStrategy.HMAC_SHA256:
+        _verify_hmac_sha256(secret, headers, raw_body, config, now)
+    elif strategy is EventSourceAuthStrategy.STATIC_HEADER:
+        _verify_static_header(secret, headers, config)
+    elif strategy is EventSourceAuthStrategy.BASIC:
+        _verify_basic(secret, headers, config)
+    else:  # pragma: no cover -- exhaustive over the closed StrEnum
+        raise IngestAuthError("unsupported_strategy")

--- a/backend/src/meho_backplane/events/ingest/config.py
+++ b/backend/src/meho_backplane/events/ingest/config.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-source ingest configuration resolved from ``event_source.extras`` (#2881).
+
+The inbound ingest endpoint needs a handful of knobs per source -- the body
+cap, the rate limit, the replay window, and the header names each auth
+strategy reads. #2880 deliberately did not add dedicated columns for these:
+it shipped ``event_source.extras`` (a JSON object, ``NOT NULL DEFAULT '{}'``)
+as the escape hatch for exactly this kind of per-source tuning. This module
+reads those keys off ``extras`` with safe defaults and defensive coercion,
+so a malformed operator-authored value degrades to the default rather than
+crashing the ingest path.
+
+Body-cap ceiling
+================
+
+``max_body_bytes`` defaults to :data:`DEFAULT_MAX_BODY_BYTES` (256 KiB, the
+in-repo pre-parse-cap precedent -- ``ui/csrf.py``, the connector-import and
+topology caps). A per-source override can only *lower* it: the resolved cap
+is ``min(override, DEFAULT_MAX_BODY_BYTES)`` so no operator config can widen
+the endpoint's own DoS ceiling above 256 KiB.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = [
+    "DEFAULT_DELIVERY_ID_HEADER",
+    "DEFAULT_MAX_BODY_BYTES",
+    "DEFAULT_REPLAY_WINDOW_SECONDS",
+    "DEFAULT_SIGNATURE_HEADER",
+    "DEFAULT_STATIC_HEADER",
+    "DEFAULT_TIMESTAMP_HEADER",
+    "MAX_REPLAY_WINDOW_SECONDS",
+    "IngestConfig",
+    "resolve_ingest_config",
+]
+
+#: Pre-parse body cap (256 KiB). Matches the ``ui/csrf.py`` DoS-lesson cap
+#: and the connector-import / topology caps. Also the hard ceiling a
+#: per-source override may only lower, never raise.
+DEFAULT_MAX_BODY_BYTES: int = 256 * 1024
+
+#: Default replay tolerance for timestamp-bearing signatures, and the hard
+#: upper bound a per-source override is clamped to (a wider window weakens
+#: replay protection, so the endpoint caps how far an operator can open it).
+DEFAULT_REPLAY_WINDOW_SECONDS: int = 300
+MAX_REPLAY_WINDOW_SECONDS: int = 3600
+
+#: Generic-sender header defaults. A vendor whose header names differ
+#: (Grafana's ``X-Grafana-Alerting-Signature``) overrides these per-source
+#: via ``extras`` -- keeping the verification code generic and the
+#: vendor-specificity in config, not branches (#2882 owns richer vendor
+#: normalisation).
+DEFAULT_SIGNATURE_HEADER: str = "X-Meho-Signature"
+DEFAULT_TIMESTAMP_HEADER: str = "X-Meho-Timestamp"
+DEFAULT_STATIC_HEADER: str = "Authorization"
+DEFAULT_DELIVERY_ID_HEADER: str = "X-Meho-Delivery-Id"
+
+
+@dataclass(frozen=True)
+class IngestConfig:
+    """Resolved per-source ingest knobs. Frozen -- built once per request."""
+
+    max_body_bytes: int
+    replay_window_seconds: int
+    require_timestamp: bool
+    signature_header: str
+    timestamp_header: str
+    static_header: str
+    delivery_id_header: str
+    basic_username: str
+    rate_per_minute_override: int | None
+
+
+def _coerce_positive_int(value: Any, default: int, *, maximum: int | None = None) -> int:
+    """Coerce *value* to a positive ``int``, falling back to *default*.
+
+    A malformed operator-authored ``extras`` value (a string, a float, a
+    negative) degrades to *default* rather than raising on the ingest path.
+    When *maximum* is given the result is clamped so an override can only
+    tighten a security-relevant bound, never widen it past the ceiling.
+    """
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    if coerced <= 0:
+        return default
+    if maximum is not None:
+        return min(coerced, maximum)
+    return coerced
+
+
+def _coerce_str(value: Any, default: str) -> str:
+    """Return *value* as a non-empty stripped ``str`` or *default*."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return default
+
+
+def _coerce_rate_override(value: Any) -> int | None:
+    """Resolve the per-source rate override: ``None`` (use the global) or ``>=0``.
+
+    ``0`` is meaningful here (disable the limit for this one source), so this
+    accepts the whole non-negative range rather than reusing the
+    positive-only coercion. ``bool`` is a subclass of ``int`` but is never a
+    valid cap, so it is rejected to ``None``.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value >= 0 else None
+
+
+def resolve_ingest_config(extras: dict[str, Any]) -> IngestConfig:
+    """Build the :class:`IngestConfig` for a source from its ``extras`` dict.
+
+    Every key is optional; an absent or malformed value yields the default.
+    ``max_body_bytes`` is clamped to :data:`DEFAULT_MAX_BODY_BYTES` (the cap
+    can only be lowered) and ``replay_window_seconds`` to
+    :data:`MAX_REPLAY_WINDOW_SECONDS`.
+    """
+    return IngestConfig(
+        max_body_bytes=_coerce_positive_int(
+            extras.get("max_body_bytes"),
+            DEFAULT_MAX_BODY_BYTES,
+            maximum=DEFAULT_MAX_BODY_BYTES,
+        ),
+        replay_window_seconds=_coerce_positive_int(
+            extras.get("replay_window_seconds"),
+            DEFAULT_REPLAY_WINDOW_SECONDS,
+            maximum=MAX_REPLAY_WINDOW_SECONDS,
+        ),
+        require_timestamp=bool(extras.get("require_timestamp", True)),
+        signature_header=_coerce_str(extras.get("signature_header"), DEFAULT_SIGNATURE_HEADER),
+        timestamp_header=_coerce_str(extras.get("timestamp_header"), DEFAULT_TIMESTAMP_HEADER),
+        static_header=_coerce_str(extras.get("static_header"), DEFAULT_STATIC_HEADER),
+        delivery_id_header=_coerce_str(
+            extras.get("delivery_id_header"), DEFAULT_DELIVERY_ID_HEADER
+        ),
+        basic_username=_coerce_str(extras.get("basic_username"), ""),
+        rate_per_minute_override=_coerce_rate_override(extras.get("rate_per_minute")),
+    )

--- a/backend/src/meho_backplane/events/ingest/rate_limit.py
+++ b/backend/src/meho_backplane/events/ingest/rate_limit.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-source fixed-window rate limit for the inbound ingest endpoint (#2881).
+
+The broadcast-announce limiter (``broadcast/rate_limit.py``) proved out the
+fixed-window ``INCR`` + ``EXPIRE`` shape on the shared Valkey; this is the
+same mechanism under a distinct key namespace,
+``meho:ratelimit:ingest:{tenant}:{source}``, so the two limiters never
+collide and each source's counter is isolated from every other source (and
+every other tenant, structurally, via the key).
+
+The cap is passed in by the caller (resolved from
+``event_source.extras["rate_per_minute"]`` or the
+:attr:`~meho_backplane.settings.Settings.events_ingest_rate_per_minute`
+default) rather than read here, so this function stays a pure limiter over an
+explicit limit. A cap of ``0`` disables enforcement entirely -- no Valkey
+round-trip, keeping the ingest hot path a single insert when a source opts
+out.
+
+Fail-loud on a Valkey outage
+============================
+
+Any redis-py / Valkey failure propagates verbatim (the endpoint maps it to a
+``503``). A webhook sender is a well-behaved retrier by nature, so failing
+the delivery closed on an infrastructure blip -- rather than fail-open
+admitting unbounded traffic -- is the safe posture. This mirrors the
+broadcast limiter's fail-loud contract.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Final
+from uuid import UUID
+
+from meho_backplane.broadcast.client import get_broadcast_client
+
+__all__ = [
+    "INGEST_RATE_LIMIT_WINDOW_SECONDS",
+    "IngestRateLimitError",
+    "enforce_ingest_rate_limit",
+]
+
+#: Fixed window width. One minute, matching the ``*_per_minute`` cap unit.
+INGEST_RATE_LIMIT_WINDOW_SECONDS: Final[int] = 60
+
+
+class IngestRateLimitError(Exception):
+    """The source is over its per-window cap. Carries a ``Retry-After`` hint."""
+
+    def __init__(self, *, limit: int, window_seconds: int, retry_after_seconds: int) -> None:
+        super().__init__(
+            f"ingest rate limit exceeded: {limit} per {window_seconds}s window "
+            f"for this source; retry after {retry_after_seconds}s",
+        )
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self.retry_after_seconds = retry_after_seconds
+
+
+def _window_key(tenant_id: UUID, source_slug: str, bucket: int) -> str:
+    """Build the per-``(tenant, source, window)`` counter key.
+
+    The bucket (``floor(now / window)``) is embedded so each window gets its
+    own key: a new window starts from zero and the ``EXPIRE`` on the old key
+    reclaims it. The ``ingest`` segment keeps this namespace clear of the
+    broadcast limiter's ``meho:ratelimit:announce:`` keys.
+    """
+    return f"meho:ratelimit:ingest:{tenant_id}:{source_slug}:{bucket}"
+
+
+async def enforce_ingest_rate_limit(
+    tenant_id: UUID,
+    source_slug: str,
+    limit: int,
+) -> None:
+    """Reject the delivery if this source is over *limit* in the current window.
+
+    A *limit* of ``0`` (or negative) disables enforcement with no Valkey
+    round-trip. Otherwise increments the current window's per-source counter
+    and raises :class:`IngestRateLimitError` once the count exceeds *limit*.
+
+    Raises:
+        IngestRateLimitError: The source has already made *limit* deliveries
+            in the current window.
+        Exception: Any Valkey failure propagates verbatim (fail-loud; the
+            endpoint maps it to a ``503``).
+    """
+    if limit <= 0:
+        return
+
+    window = INGEST_RATE_LIMIT_WINDOW_SECONDS
+    now = int(time.time())
+    bucket = now // window
+    key = _window_key(tenant_id, source_slug, bucket)
+
+    client = get_broadcast_client()
+    # INCR + EXPIRE atomically so a counter can never outlive its window: the
+    # EXPIRE re-arms on every call within the window, extending the key's life
+    # to at most one window past its last write -- harmless, since the next
+    # window uses a different key.
+    async with client.pipeline(transaction=True) as pipe:
+        pipe.incr(key)
+        pipe.expire(key, window)
+        count, _ = await pipe.execute()
+
+    if count > limit:
+        retry_after = window - (now % window)
+        raise IngestRateLimitError(
+            limit=limit,
+            window_seconds=window,
+            retry_after_seconds=retry_after,
+        )

--- a/backend/src/meho_backplane/events/ingest/service.py
+++ b/backend/src/meho_backplane/events/ingest/service.py
@@ -74,6 +74,7 @@ from meho_backplane.events.ingest.auth import IngestAuthError, verify_ingest_aut
 from meho_backplane.events.ingest.config import IngestConfig
 from meho_backplane.events.ingest.rate_limit import enforce_ingest_rate_limit
 from meho_backplane.events.outbox import publish
+from meho_backplane.operations._audit import resolve_broadcast_lineage
 from meho_backplane.settings import get_settings
 
 __all__ = [
@@ -305,6 +306,7 @@ async def _publish_ingest_broadcast(
     Aggregate/attribution metadata only -- no external body content -- so the
     read-class default holds without a redactor pass.
     """
+    lineage = resolve_broadcast_lineage()
     event = BroadcastEvent(
         event_id=uuid.uuid4(),
         ts=now,
@@ -316,6 +318,9 @@ async def _publish_ingest_broadcast(
         op_class=_INGEST_OP_CLASS,
         result_status="ok",
         audit_id=audit_id,
+        actor_sub=lineage.actor_sub,
+        agent_session_id=lineage.agent_session_id,
+        work_ref=lineage.work_ref,
         payload={
             "op_class": _INGEST_OP_CLASS,
             "result_status": "ok",

--- a/backend/src/meho_backplane/events/ingest/service.py
+++ b/backend/src/meho_backplane/events/ingest/service.py
@@ -195,7 +195,12 @@ def _dedupe_key(source: ResolvedSource, headers: Any, raw_body: bytes, config: I
 
 
 def _parse_json_or_fail(raw_body: bytes) -> object:
-    """Parse the raw body as JSON (normalise-lite). Raise on invalid JSON.
+    """Parse the raw body as JSON (normalise-lite). Raise on unparseable input.
+
+    ``json.loads`` raises ``RecursionError`` -- not ``JSONDecodeError`` -- on a
+    deeply-nested body that still fits under the 256 KiB cap (e.g. a 120 KB
+    ``[[[...]]]``). It is caught here alongside the malformed-JSON errors so a
+    hostile-nesting body fails closed as a clean 400, never a 500.
 
     Runs only after auth + rate-limit have passed, so an unauthenticated
     sender never learns whether its body parsed -- the pre-parse failure it
@@ -203,7 +208,7 @@ def _parse_json_or_fail(raw_body: bytes) -> object:
     """
     try:
         return json.loads(raw_body)
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+    except (json.JSONDecodeError, UnicodeDecodeError, RecursionError) as exc:
         raise IngestPayloadError(f"body is not valid JSON: {type(exc).__name__}") from exc
 
 

--- a/backend/src/meho_backplane/events/ingest/service.py
+++ b/backend/src/meho_backplane/events/ingest/service.py
@@ -1,0 +1,454 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Inbound ingest orchestration: resolve-secret -> auth -> guard -> publish (#2881).
+
+The endpoint (:mod:`meho_backplane.api.v1.events_ingest`) resolves the source
+and reads the capped body; this module runs everything that follows, in the
+order the issue fixes:
+
+1. Read the source's shared secret from Vault under the synthetic
+   ``__ingest__`` identity (a background-dispatch service principal, since
+   the webhook is JWT-less).
+2. Verify the sender against the source's auth strategy (constant-time).
+3. Enforce the per-source rate limit.
+4. Compute the dedupe key (sender delivery id, else body hash).
+5. Normalise-lite (parse the JSON body into an envelope) and
+   :func:`~meho_backplane.events.outbox.publish` it to ``event_outbox`` **in
+   the same transaction** as a synchronous ``__ingest__`` audit row -- the
+   spec's "no success without a committed audit row" invariant (CLAUDE.md
+   postulate 7). A ``dedupe_key`` collision is mapped to an idempotent
+   acknowledgement, never a second outbox row.
+6. Publish a fail-open broadcast event after the transaction commits.
+
+The ``__ingest__`` audit identity
+=================================
+
+Ingest is authenticated per-source, not per-operator, so there is no JWT to
+derive an ``operator_sub`` from. The audit row is written under the synthetic
+sentinel ``__ingest__`` (the ``__sensor__`` / ``__scheduler__`` precedent;
+``audit_log.operator_sub`` is plain ``Text`` and accepts it), with the source
+id recorded as ``origin`` on both the outbox row and the audit payload.
+
+The Vault-read identity
+=======================
+
+Reading the secret needs a Vault client, which needs an operator. The webhook
+carries none, so the ``__ingest__`` operator reuses the backplane's existing
+background-dispatch service-principal token
+(:func:`~meho_backplane.auth.runner_identity.check_runner_jwt`) -- the same
+"MEHO's own in-process dispatch, outward" identity the sensor check-runner
+uses. It carries ``check_runner_dispatch=False`` so the Vault login uses the
+standard ``vault_oidc_role`` (the check-runner's bounded role is scoped to
+target secrets, not event-source secrets). When that principal is
+unconfigured the token is empty, the Vault read fails, and ingest fails
+closed -- the correct posture.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import structlog
+from pydantic import SecretStr
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.auth.runner_identity import check_runner_jwt
+from meho_backplane.auth.vault import VaultClientError
+from meho_backplane.broadcast.events import BroadcastEvent
+from meho_backplane.broadcast.publisher import publish_event
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EventOutbox
+from meho_backplane.event_source.schemas import EventSourceAuthStrategy
+from meho_backplane.event_source.secrets import read_event_source_secret
+from meho_backplane.events.ingest.auth import IngestAuthError, verify_ingest_auth
+from meho_backplane.events.ingest.config import IngestConfig
+from meho_backplane.events.ingest.rate_limit import enforce_ingest_rate_limit
+from meho_backplane.events.outbox import publish
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "INGEST_AUDIT_METHOD",
+    "INGEST_AUDIT_PATH",
+    "INGEST_OPERATOR_SUB",
+    "IngestOutcome",
+    "IngestPayloadError",
+    "IngestVaultError",
+    "ResolvedSource",
+    "accept_ingest_event",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Synthetic ``operator_sub`` every ingest audit row is written under. The
+#: ``__sensor__`` / ``__scheduler__`` sentinel precedent -- a stable literal
+#: audit filters can partition JWT-less ingest traffic by.
+INGEST_OPERATOR_SUB: str = "__ingest__"
+
+#: Audit channel + op-id for ingest rows (the ``method``-is-channel,
+#: ``path``-is-op-id convention the internal-audit writer documents).
+INGEST_AUDIT_METHOD: str = "INGEST"
+INGEST_AUDIT_PATH: str = "events.ingest"
+
+#: Broadcast op metadata. ``other`` is a valid ``op_class`` (avoids touching
+#: the classifier); ``events.ingest`` mirrors the audit op-id.
+_INGEST_OP_ID: str = "events.ingest"
+_INGEST_OP_CLASS: str = "other"
+
+#: Defensive cap on a sender-supplied delivery id used as the dedupe basis,
+#: so an attacker cannot bloat the ``dedupe_key`` column with a huge header.
+_MAX_DELIVERY_ID_LEN: int = 200
+
+#: Max length of the derived ``event_type`` token in ``external.{kind}.{type}``.
+_MAX_EVENT_TYPE_LEN: int = 64
+
+
+class IngestPayloadError(Exception):
+    """The request body is not a JSON object/array (400 at the boundary)."""
+
+
+class IngestVaultError(Exception):
+    """The source secret could not be read from Vault (503 -- transient)."""
+
+
+@dataclass(frozen=True)
+class ResolvedSource:
+    """Immutable snapshot of the resolved source's routing/auth fields.
+
+    Snapshotted off the ORM row by the endpoint so this service never
+    touches a possibly-detached ORM instance across its own transaction.
+    """
+
+    id: uuid.UUID
+    tenant_id: uuid.UUID
+    slug: str
+    kind: str
+    auth_strategy: EventSourceAuthStrategy
+    secret_ref: str | None
+    extras: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class IngestOutcome:
+    """Result of an accepted (or deduplicated) delivery."""
+
+    event_id: int | None
+    deduplicated: bool
+
+
+async def _build_ingest_operator(tenant_id: uuid.UUID) -> Operator:
+    """Build the synthetic ``__ingest__`` operator for the outward Vault read."""
+    return Operator(
+        sub=INGEST_OPERATOR_SUB,
+        name=None,
+        email=None,
+        raw_jwt=await check_runner_jwt(),
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _read_secret_or_fail(source: ResolvedSource) -> SecretStr:
+    """Read the source's Vault secret, mapping failures to fail-closed errors.
+
+    A source with no ``secret_ref`` cannot authenticate any sender, so it
+    fails closed as an auth error (uniform 401). A Vault I/O / auth failure
+    is transient and maps to :class:`IngestVaultError` (503); the sender
+    retries.
+    """
+    if source.secret_ref is None:
+        raise IngestAuthError("no_secret_configured")
+    operator = await _build_ingest_operator(source.tenant_id)
+    try:
+        return await read_event_source_secret(operator, source.secret_ref)
+    except VaultClientError as exc:
+        _log.warning(
+            "ingest_secret_read_failed",
+            slug=source.slug,
+            error_class=type(exc).__name__,
+        )
+        raise IngestVaultError(str(type(exc).__name__)) from exc
+
+
+def _dedupe_key(source: ResolvedSource, headers: Any, raw_body: bytes, config: IngestConfig) -> str:
+    """Derive the ``(tenant, dedupe_key)`` idempotency token for this delivery.
+
+    Prefers a sender-supplied delivery id (capped) and falls back to a
+    SHA-256 of the raw body. Namespaced by source id so two sources in one
+    tenant that happen to relay an identical body never false-collide.
+    """
+    delivery_id = headers.get(config.delivery_id_header)
+    if delivery_id and delivery_id.strip():
+        basis = delivery_id.strip()[:_MAX_DELIVERY_ID_LEN]
+    else:
+        basis = hashlib.sha256(raw_body).hexdigest()
+    return f"{source.id}:{basis}"
+
+
+def _parse_json_or_fail(raw_body: bytes) -> object:
+    """Parse the raw body as JSON (normalise-lite). Raise on invalid JSON.
+
+    Runs only after auth + rate-limit have passed, so an unauthenticated
+    sender never learns whether its body parsed -- the pre-parse failure it
+    could otherwise distinguish is behind the uniform auth wall.
+    """
+    try:
+        return json.loads(raw_body)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise IngestPayloadError(f"body is not valid JSON: {type(exc).__name__}") from exc
+
+
+def _sanitise_event_type(raw: object) -> str:
+    """Reduce a payload ``type`` hint to a safe ``[a-z0-9._-]`` token.
+
+    Untrusted external input, so a non-string / empty / all-stripped value
+    degrades to ``"event"`` and anything outside the allowed set is dropped.
+    """
+    if not isinstance(raw, str):
+        return "event"
+    kept = "".join(c for c in raw.lower() if c.isalnum() or c in "._-")
+    return kept[:_MAX_EVENT_TYPE_LEN] or "event"
+
+
+def _normalise_lite(
+    source: ResolvedSource, parsed_body: object, now: datetime
+) -> tuple[str, dict[str, object]]:
+    """Build ``(event_kind, envelope)`` from the parsed body (normalise-lite).
+
+    The external (untrusted) body is nested under ``data`` so it can never
+    collide with the envelope's own ``source`` / ``event_type`` keys, and the
+    outbox ``payload`` is always a JSON object regardless of the body's shape
+    (a top-level array/scalar body still yields a dict envelope). Richer
+    per-vendor normalisation is #2882.
+    """
+    event_type = _sanitise_event_type(
+        parsed_body.get("type") if isinstance(parsed_body, dict) else None
+    )
+    event_kind = f"external.{source.kind}.{event_type}"
+    envelope = {
+        "source": {"slug": source.slug, "kind": source.kind, "id": str(source.id)},
+        "event_type": event_type,
+        "received_at": now.isoformat(),
+        "data": parsed_body,
+    }
+    return event_kind, envelope
+
+
+def _build_audit_row(
+    *,
+    audit_id: uuid.UUID,
+    source: ResolvedSource,
+    event_id: int,
+    event_kind: str,
+    dedupe_key: str,
+    duration_ms: float,
+    now: datetime,
+) -> AuditLog:
+    """Construct the synchronous ``__ingest__`` audit row (same-txn insert).
+
+    The payload is metadata only -- source attribution, the event kind, the
+    outbox id, the dedupe key -- never the raw external body (that lives on
+    the outbox row; the audit row must not duplicate untrusted, possibly-PII
+    content).
+    """
+    return AuditLog(
+        id=audit_id,
+        occurred_at=now,
+        operator_sub=INGEST_OPERATOR_SUB,
+        tenant_id=source.tenant_id,
+        method=INGEST_AUDIT_METHOD,
+        path=INGEST_AUDIT_PATH,
+        status_code=202,
+        request_id=None,
+        duration_ms=Decimal(str(round(duration_ms, 2))),
+        payload={
+            "op_id": INGEST_AUDIT_PATH,
+            "origin": str(source.id),
+            "source_slug": source.slug,
+            "source_kind": source.kind,
+            "event_kind": event_kind,
+            "event_id": event_id,
+            "dedupe_key": dedupe_key,
+        },
+    )
+
+
+async def _lookup_existing_event_id(tenant_id: uuid.UUID, dedupe_key: str) -> int | None:
+    """Fetch the event_id of the row a duplicate delivery collided with."""
+    async with get_sessionmaker()() as session:
+        stmt = select(EventOutbox.event_id).where(
+            EventOutbox.tenant_id == tenant_id,
+            EventOutbox.dedupe_key == dedupe_key,
+        )
+        return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def _publish_ingest_broadcast(
+    *, audit_id: uuid.UUID, source: ResolvedSource, event_id: int, event_kind: str, now: datetime
+) -> None:
+    """Emit the per-ingest broadcast event. Fail-open by contract.
+
+    Aggregate/attribution metadata only -- no external body content -- so the
+    read-class default holds without a redactor pass.
+    """
+    event = BroadcastEvent(
+        event_id=uuid.uuid4(),
+        ts=now,
+        tenant_id=source.tenant_id,
+        principal_sub=INGEST_OPERATOR_SUB,
+        principal_name=None,
+        target_name=source.slug,
+        op_id=_INGEST_OP_ID,
+        op_class=_INGEST_OP_CLASS,
+        result_status="ok",
+        audit_id=audit_id,
+        payload={
+            "op_class": _INGEST_OP_CLASS,
+            "result_status": "ok",
+            "origin": str(source.id),
+            "source_slug": source.slug,
+            "source_kind": source.kind,
+            "event_kind": event_kind,
+            "event_id": event_id,
+        },
+    )
+    await publish_event(event)
+
+
+def _resolve_rate_limit(source: ResolvedSource, config: IngestConfig) -> int:
+    """Per-source override wins over the global default cap."""
+    if config.rate_per_minute_override is not None:
+        return config.rate_per_minute_override
+    return get_settings().events_ingest_rate_per_minute
+
+
+async def accept_ingest_event(
+    *,
+    source: ResolvedSource,
+    config: IngestConfig,
+    headers: Any,
+    raw_body: bytes,
+) -> IngestOutcome:
+    """Run auth -> rate-limit -> dedupe -> normalise -> publish+audit -> broadcast.
+
+    Raises the typed ingest errors on a fail-closed guard; returns an
+    :class:`IngestOutcome` on accept or on a duplicate delivery (no second
+    outbox/audit row). The JSON body is parsed only after auth + rate-limit
+    pass, so a parse failure (400) is never reachable unauthenticated.
+    """
+    started = time.perf_counter()
+    now = datetime.now(UTC)
+
+    secret = await _read_secret_or_fail(source)
+    verify_ingest_auth(
+        strategy=source.auth_strategy,
+        secret=secret,
+        headers=headers,
+        raw_body=raw_body,
+        config=config,
+        now=now.timestamp(),
+    )
+    await enforce_ingest_rate_limit(
+        source.tenant_id, source.slug, _resolve_rate_limit(source, config)
+    )
+
+    dedupe_key = _dedupe_key(source, headers, raw_body, config)
+    parsed_body = _parse_json_or_fail(raw_body)
+    event_kind, envelope = _normalise_lite(source, parsed_body, now)
+
+    audit_id = uuid.uuid4()
+    outcome = await _publish_with_audit(
+        source=source,
+        event_kind=event_kind,
+        envelope=envelope,
+        dedupe_key=dedupe_key,
+        audit_id=audit_id,
+        started=started,
+        now=now,
+    )
+    if outcome.deduplicated:
+        return outcome
+
+    assert outcome.event_id is not None  # non-dedup path always has an id
+    # Fail-open broadcast: the audit row has already committed (the canonical
+    # record of the accepted delivery), so a broadcast failure must never turn
+    # a successful ingest into an error. publish_event is itself fail-open;
+    # this guard makes that contract local and explicit at the ingest boundary.
+    try:
+        await _publish_ingest_broadcast(
+            audit_id=audit_id,
+            source=source,
+            event_id=outcome.event_id,
+            event_kind=event_kind,
+            now=now,
+        )
+    except Exception as exc:
+        _log.warning("ingest_broadcast_failed", slug=source.slug, error_class=type(exc).__name__)
+    return outcome
+
+
+async def _publish_with_audit(
+    *,
+    source: ResolvedSource,
+    event_kind: str,
+    envelope: dict[str, object],
+    dedupe_key: str,
+    audit_id: uuid.UUID,
+    started: float,
+    now: datetime,
+) -> IngestOutcome:
+    """Publish the outbox row + audit row in one transaction; dedupe -> 200.
+
+    The load-bearing invariant (postulate 7): the audit row is inserted in the
+    **same** ``session.begin()`` block as the outbox row, so a delivery that
+    cannot commit its audit row publishes nothing. A ``(tenant_id, dedupe_key)``
+    collision is caught and mapped to an idempotent ack carrying the original
+    event id -- never a second outbox/audit row.
+    """
+    event_id: int | None = None
+    try:
+        async with get_sessionmaker()() as session, session.begin():
+            outbox = await publish(
+                session,
+                tenant_id=source.tenant_id,
+                event_kind=event_kind,
+                payload=envelope,
+                origin=str(source.id),
+                dedupe_key=dedupe_key,
+            )
+            # Capture the flushed id before the commit expires the instance.
+            event_id = outbox.event_id
+            session.add(
+                _build_audit_row(
+                    audit_id=audit_id,
+                    source=source,
+                    event_id=event_id,
+                    event_kind=event_kind,
+                    dedupe_key=dedupe_key,
+                    duration_ms=(time.perf_counter() - started) * 1000.0,
+                    now=now,
+                )
+            )
+    except IntegrityError:
+        _log.info("ingest_duplicate", slug=source.slug, dedupe_key=dedupe_key)
+        existing = await _lookup_existing_event_id(source.tenant_id, dedupe_key)
+        return IngestOutcome(event_id=existing, deduplicated=True)
+
+    assert event_id is not None  # populated inside the committed block
+    _log.info(
+        "ingest_accepted",
+        slug=source.slug,
+        event_id=event_id,
+        event_kind=event_kind,
+        origin=str(source.id),
+    )
+    return IngestOutcome(event_id=event_id, deduplicated=False)

--- a/backend/src/meho_backplane/events/outbox.py
+++ b/backend/src/meho_backplane/events/outbox.py
@@ -146,6 +146,8 @@ async def publish(
     tenant_id: uuid.UUID,
     event_kind: str,
     payload: dict[str, object] | None = None,
+    origin: str | None = None,
+    dedupe_key: str | None = None,
 ) -> EventOutbox:
     """Append one ``event_outbox`` row in *session*'s open transaction.
 
@@ -169,14 +171,33 @@ async def publish(
         payload: Event-specific data the subscriber's filter matches
             against. ``None`` is normalised to ``{}`` so the
             ``NOT NULL`` column always carries a valid JSON object.
+        origin: Event provenance (migration ``0073``). ``None`` for the
+            internal MEHO producers (agent-run completion, ...); the
+            external event-source id for the #2881 inbound ingest path.
+            Gives audit / policy surfaces a column to key "external
+            input" on without parsing the free-text ``event_kind``.
+        dedupe_key: Producer-supplied idempotency token (migration
+            ``0073``). ``None`` for internal producers. When set, the
+            ``event_outbox_tenant_dedupe_idx`` partial unique index makes
+            a duplicate ``(tenant_id, dedupe_key)`` collide at flush with
+            an :class:`~sqlalchemy.exc.IntegrityError` instead of
+            double-firing a subscriber; the ingest endpoint maps that
+            collision to an idempotent ``200``.
 
     Returns:
         The inserted, flushed :class:`EventOutbox` row.
+
+    Raises:
+        IntegrityError: When *dedupe_key* collides with an existing
+            ``(tenant_id, dedupe_key)`` row. Propagates verbatim so the
+            caller can map it to an idempotent acknowledgement.
     """
     row = EventOutbox(
         tenant_id=tenant_id,
         event_kind=event_kind,
         payload=payload if payload is not None else {},
+        origin=origin,
+        dedupe_key=dedupe_key,
     )
     session.add(row)
     await session.flush()

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -87,6 +87,7 @@ from meho_backplane.api.v1.connectors_ingest import (
 from meho_backplane.api.v1.conventions import router as api_v1_conventions_router
 from meho_backplane.api.v1.doc_collections import router as api_v1_doc_collections_router
 from meho_backplane.api.v1.event_source import router as api_v1_event_source_router
+from meho_backplane.api.v1.events_ingest import router as api_v1_events_ingest_router
 from meho_backplane.api.v1.feed import router as api_v1_feed_router
 from meho_backplane.api.v1.gateway import router as api_v1_gateway_router
 from meho_backplane.api.v1.health import router as api_v1_health_router
@@ -813,6 +814,13 @@ app.include_router(api_v1_targets_router)
 # JWT-less sender against; secrets are custodied in Vault, the row keeps
 # only the derived secret_ref path.
 app.include_router(api_v1_event_source_router)
+# T4 (#2881) -- inbound event ingest at POST /api/v1/events/ingest/{slug}.
+# JWT-less: the sender is authenticated per-source against the source's
+# Vault-custodied secret (constant-time), body-capped / rate-limited /
+# replay-gated / deduped, then published to event_outbox in the same
+# transaction as a synchronous __ingest__ audit row (postulate 7). No
+# operator dependency, so the chassis AuditMiddleware writes no row for it.
+app.include_router(api_v1_events_ingest_router)
 # G9.1-T5 (#453) — topology REST surface at /api/v1/topology*. Three
 # query routes (dependents / dependencies / path) wrapping the T4
 # recursive-CTE verbs + POST /refresh/{target_name} wrapping the T3

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -1098,6 +1098,14 @@ class Settings(BaseModel):
     )
     broadcast_retention_hours: int = Field(default=24, gt=0)
     broadcast_announce_rate_per_minute: int = Field(default=10, ge=0)
+    #: Default per-source fixed-window cap for the inbound event-ingest
+    #: endpoint (#2881), keyed ``meho:ratelimit:ingest:{tenant}:{source}``
+    #: on the same Valkey the broadcast limiter uses. A well-behaved
+    #: webhook sender retries on the ``429`` this produces. ``0`` disables
+    #: the limit entirely (no Valkey round-trip on the ingest hot path);
+    #: a source may override the cap per-source via
+    #: ``event_source.extras["rate_per_minute"]``.
+    events_ingest_rate_per_minute: int = Field(default=60, ge=0)
     #: Look-back window (minutes) for the dispatch-time target-activity
     #: advisory (#2550). A write-class dispatch on a target with peer
     #: activity inside this window carries a compact
@@ -1826,6 +1834,9 @@ def get_settings() -> Settings:
         ),
         broadcast_announce_rate_per_minute=int(
             os.environ.get("BROADCAST_ANNOUNCE_RATE_PER_MINUTE", "10"),
+        ),
+        events_ingest_rate_per_minute=int(
+            os.environ.get("EVENTS_INGEST_RATE_PER_MINUTE", "60"),
         ),
         dispatch_activity_advisory_window_minutes=int(
             os.environ.get("DISPATCH_ACTIVITY_ADVISORY_WINDOW_MINUTES", "30"),

--- a/backend/tests/integration/test_events_ingest_pg.py
+++ b/backend/tests/integration/test_events_ingest_pg.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Real-Postgres coverage for the inbound ingest endpoint (#2881).
+
+The SQLite unit suite (:mod:`tests.test_api_v1_events_ingest`) proves the
+endpoint's logic; this module runs the two most dialect-sensitive paths --
+the same-transaction ``event_outbox`` + ``__ingest__`` ``audit_log`` commit,
+and the ``(tenant_id, dedupe_key)`` partial-unique dedupe collision -- against
+a real ``pgvector/pgvector:pg16`` container so the JSONB envelope round-trip,
+the real ``event_source`` / ``event_outbox`` FKs to ``tenant``, and the
+production dialect's ``IntegrityError`` on the partial unique index are all
+exercised on Postgres.
+
+The ``pg_engine`` fixture from :mod:`tests.integration.conftest` points the
+process-wide engine at the container, re-seeds the two pinned ``tenant`` rows
+(``tenant-a`` = ``1111...``), and skips the module when Docker is unavailable
+(agent sandboxes), so this runs in CI where containers are provisioned. The
+source is registered under the pinned ``tenant-a`` so its ``event_outbox`` /
+``event_source`` FKs resolve.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from httpx import ASGITransport
+from pydantic import SecretStr
+from sqlalchemy import func, select
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EventOutbox
+from tests._event_source_helpers import _insert_event_source
+from tests.test_api_v1_events_ingest import _build_app, _count, _signed
+
+#: The pinned ``tenant-a`` row the integration conftest re-seeds per test.
+_PINNED_TENANT = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_SECRET_REF = f"tenants/{_PINNED_TENANT}/event-sources/prod-am"
+
+
+@pytest.fixture(autouse=True)
+def _stub_service_seams(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Stub the Vault read / rate limiter / broadcast (no external sockets)."""
+
+    async def _read_secret(_operator: object, _ref: str) -> SecretStr:
+        return SecretStr("shared-hmac-key")
+
+    async def _no_op(*_a: object, **_k: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "meho_backplane.events.ingest.service.read_event_source_secret", _read_secret
+    )
+    monkeypatch.setattr("meho_backplane.events.ingest.service.enforce_ingest_rate_limit", _no_op)
+    monkeypatch.setattr("meho_backplane.events.ingest.service.publish_event", _no_op)
+    yield
+
+
+async def _seed_source() -> None:
+    """Register the source under the pre-seeded pinned ``tenant-a``."""
+    await _insert_event_source(
+        tenant_id=_PINNED_TENANT,
+        slug="prod-am",
+        name="prod-am",
+        kind="alertmanager",
+        auth_strategy="hmac-sha256",
+        secret_ref=_SECRET_REF,
+        status="active",
+    )
+
+
+def _async_client() -> httpx.AsyncClient:
+    """Drive the app in-process on the test's event loop.
+
+    ASGITransport keeps the request handler and the ``pg_engine``-bound
+    asyncpg pool on the same loop -- a threaded ``TestClient`` would run the
+    handler on its own loop and asyncpg rejects the cross-loop use.
+    """
+    return httpx.AsyncClient(transport=ASGITransport(app=_build_app()), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_accepted_event_commits_outbox_and_audit_on_pg(pg_engine: None) -> None:
+    await _seed_source()
+    body = json.dumps({"type": "alert", "severity": "critical"}).encode()
+
+    async with _async_client() as client:
+        resp = await client.post(
+            "/api/v1/events/ingest/prod-am", content=body, headers=_signed(body)
+        )
+    assert resp.status_code == 202
+
+    sm = get_sessionmaker()
+    async with sm() as session:
+        outbox = (await session.execute(select(EventOutbox))).scalars().all()
+        assert len(outbox) == 1
+        assert outbox[0].origin is not None
+        assert outbox[0].dedupe_key is not None
+        # JSONB envelope round-trips through the real dialect.
+        assert outbox[0].payload["data"] == {"type": "alert", "severity": "critical"}
+
+        audits = (
+            (await session.execute(select(AuditLog).where(AuditLog.method == "INGEST")))
+            .scalars()
+            .all()
+        )
+        assert len(audits) == 1
+        assert audits[0].operator_sub == "__ingest__"
+        assert audits[0].tenant_id == _PINNED_TENANT
+
+
+@pytest.mark.asyncio
+async def test_duplicate_delivery_dedupes_on_pg_partial_unique(pg_engine: None) -> None:
+    await _seed_source()
+    body = json.dumps({"type": "alert"}).encode()
+
+    async with _async_client() as client:
+        first = await client.post(
+            "/api/v1/events/ingest/prod-am", content=body, headers=_signed(body)
+        )
+        assert first.status_code == 202
+        # Same body -> same dedupe_key -> the PG partial unique index collides,
+        # the IntegrityError maps to an idempotent 200 with the original id.
+        second = await client.post(
+            "/api/v1/events/ingest/prod-am", content=body, headers=_signed(body)
+        )
+    assert second.status_code == 200
+    assert second.json()["deduplicated"] is True
+    assert second.json()["event_id"] == first.json()["event_id"]
+
+    assert await _count(EventOutbox) == 1
+    async with get_sessionmaker()() as session:
+        n_audit = (
+            await session.execute(
+                select(func.count()).select_from(AuditLog).where(AuditLog.method == "INGEST")
+            )
+        ).scalar_one()
+    assert n_audit == 1

--- a/backend/tests/test_api_v1_events_ingest.py
+++ b/backend/tests/test_api_v1_events_ingest.py
@@ -16,6 +16,7 @@ Acceptance-criteria coverage:
 * broadcast failure is fail-open (the 202 still lands)
 * rate-limit -> 429 with ``Retry-After``
 * authenticated invalid JSON -> 400
+* deeply-nested within-cap body -> parser fails closed (400, never a 500)
 """
 
 from __future__ import annotations
@@ -39,6 +40,7 @@ from meho_backplane.audit import AuditMiddleware
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog, EventOutbox, Tenant
 from meho_backplane.events.ingest.rate_limit import IngestRateLimitError
+from meho_backplane.events.ingest.service import IngestPayloadError, _parse_json_or_fail
 from meho_backplane.middleware import RequestContextMiddleware
 
 from ._event_source_helpers import (
@@ -310,3 +312,27 @@ async def test_authenticated_invalid_json_returns_400(client: TestClient) -> Non
     assert resp.json()["detail"]["error"] == "invalid_payload"
     # Nothing published on a rejected payload.
     assert await _count(EventOutbox) == 0
+
+
+def test_deeply_nested_body_fails_closed_not_500() -> None:
+    """A deeply-nested within-cap body fails closed as 400, never crashes to 500.
+
+    ``json.loads`` raises ``RecursionError`` -- not ``JSONDecodeError`` -- on a
+    120 KB ``[[[...]]]`` body that still fits under the 256 KiB cap.
+    ``_parse_json_or_fail`` must map it to :class:`IngestPayloadError`, which the
+    endpoint turns into its clean 400 (that mapping is covered by
+    :func:`test_authenticated_invalid_json_returns_400`); before the fix the
+    ``RecursionError`` propagated uncaught and the request 500'd.
+
+    Asserted at the parser, not end-to-end: the ``TestClient`` runs the route in
+    an anyio worker thread whose larger C stack does not reach the recursion
+    ceiling at a within-cap depth, so an end-to-end nested body would be
+    harness-dependent. The parser call here runs on the test thread and is
+    deterministic.
+    """
+    body = b"[" * 60_000 + b"]" * 60_000
+    assert len(body) < 256 * 1024  # within the endpoint's body cap
+    with pytest.raises(IngestPayloadError) as exc:
+        _parse_json_or_fail(body)
+    # It is specifically the recursion path that was caught and re-raised.
+    assert isinstance(exc.value.__cause__, RecursionError)

--- a/backend/tests/test_api_v1_events_ingest.py
+++ b/backend/tests/test_api_v1_events_ingest.py
@@ -314,25 +314,28 @@ async def test_authenticated_invalid_json_returns_400(client: TestClient) -> Non
     assert await _count(EventOutbox) == 0
 
 
-def test_deeply_nested_body_fails_closed_not_500() -> None:
-    """A deeply-nested within-cap body fails closed as 400, never crashes to 500.
+def test_deeply_nested_body_fails_closed_not_500(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A body that overflows the JSON parser's recursion guard fails closed (400, never 500).
 
-    ``json.loads`` raises ``RecursionError`` -- not ``JSONDecodeError`` -- on a
-    120 KB ``[[[...]]]`` body that still fits under the 256 KiB cap.
-    ``_parse_json_or_fail`` must map it to :class:`IngestPayloadError`, which the
-    endpoint turns into its clean 400 (that mapping is covered by
-    :func:`test_authenticated_invalid_json_returns_400`); before the fix the
+    ``json.loads`` can raise ``RecursionError`` -- not ``JSONDecodeError`` -- on a
+    deeply-nested body. The exact nesting depth that trips the C-stack ceiling is
+    environment-dependent (interpreter build, C-stack size, worker thread), so rather
+    than rely on a specific depth -- which is flaky across CPython builds -- we force
+    ``json.loads`` to raise ``RecursionError`` and assert ``_parse_json_or_fail`` maps
+    it to :class:`IngestPayloadError`. The endpoint turns that into its clean 400 -- the
+    ``IngestPayloadError`` -> 400 mapping is covered end-to-end by
+    :func:`test_authenticated_invalid_json_returns_400`. Before the fix the
     ``RecursionError`` propagated uncaught and the request 500'd.
-
-    Asserted at the parser, not end-to-end: the ``TestClient`` runs the route in
-    an anyio worker thread whose larger C stack does not reach the recursion
-    ceiling at a within-cap depth, so an end-to-end nested body would be
-    harness-dependent. The parser call here runs on the test thread and is
-    deterministic.
     """
-    body = b"[" * 60_000 + b"]" * 60_000
-    assert len(body) < 256 * 1024  # within the endpoint's body cap
+
+    def _raise_recursion(*_args: object, **_kwargs: object) -> object:
+        raise RecursionError("maximum recursion depth exceeded while decoding JSON")
+
+    # ``service`` calls the stdlib ``json.loads``; patch it to raise deterministically.
+    monkeypatch.setattr(json, "loads", _raise_recursion)
     with pytest.raises(IngestPayloadError) as exc:
-        _parse_json_or_fail(body)
+        _parse_json_or_fail(b"[]")
     # It is specifically the recursion path that was caught and re-raised.
     assert isinstance(exc.value.__cause__, RecursionError)

--- a/backend/tests/test_api_v1_events_ingest.py
+++ b/backend/tests/test_api_v1_events_ingest.py
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.api.v1.events_ingest` (#2881).
+
+Acceptance-criteria coverage:
+
+* oversize body -> 413 before the body is buffered (streaming-guard unit +
+  Content-Length endpoint path)
+* missing / paused source -> uniform 404 (no existence oracle)
+* bad signature -> 401
+* accepted delivery -> 202 ``{event_id}`` with one ``event_outbox`` row
+  (``origin`` = source id, ``dedupe_key`` set) and one synchronous
+  ``__ingest__`` audit row (criterion 2)
+* duplicate delivery -> 200 with no second outbox/audit row (criterion 1)
+* broadcast failure is fail-open (the 202 still lands)
+* rate-limit -> 429 with ``Retry-After``
+* authenticated invalid JSON -> 400
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+from sqlalchemy import func, select
+
+from meho_backplane.api.v1.events_ingest import _read_capped_body, router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EventOutbox, Tenant
+from meho_backplane.events.ingest.rate_limit import IngestRateLimitError
+from meho_backplane.middleware import RequestContextMiddleware
+
+from ._event_source_helpers import (
+    _insert_event_source,
+    _settings_env,  # noqa: F401  (autouse fixture)
+)
+from ._oidc_jwt_helpers import DEFAULT_TENANT_ID
+
+_SECRET_VALUE = "shared-hmac-key"
+_SECRET_REF = f"tenants/{DEFAULT_TENANT_ID}/event-sources/prod-am"
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(_build_app())
+
+
+@pytest.fixture(autouse=True)
+def _stub_service_seams(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Stub the Vault read, the rate limiter, and the broadcast for the endpoint.
+
+    The Vault read returns the known secret (no socket); the rate limiter is a
+    no-op (its own behaviour is unit-tested); the broadcast is a no-op AsyncMock
+    (no Valkey). Individual tests re-patch a seam to drive its failure path.
+    """
+
+    async def _read_secret(_operator: object, _ref: str) -> SecretStr:
+        return SecretStr(_SECRET_VALUE)
+
+    async def _no_rate_limit(*_a: object, **_k: object) -> None:
+        return None
+
+    async def _no_broadcast(_event: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "meho_backplane.events.ingest.service.read_event_source_secret", _read_secret
+    )
+    monkeypatch.setattr(
+        "meho_backplane.events.ingest.service.enforce_ingest_rate_limit", _no_rate_limit
+    )
+    monkeypatch.setattr("meho_backplane.events.ingest.service.publish_event", _no_broadcast)
+    yield
+
+
+async def _seed_tenant() -> None:
+    """Insert the default tenant so ``event_outbox.tenant_id`` FK is satisfied."""
+    sm = get_sessionmaker()
+    async with sm() as session:
+        tid = uuid.UUID(DEFAULT_TENANT_ID)
+        if await session.get(Tenant, tid) is None:
+            session.add(Tenant(id=tid, slug="tenant-a", name="Tenant A"))
+            await session.commit()
+
+
+async def _seed_source(**kwargs: object) -> None:
+    await _seed_tenant()
+    defaults: dict[str, object] = {
+        "slug": "prod-am",
+        "name": "prod-am",
+        "kind": "alertmanager",
+        "auth_strategy": "hmac-sha256",
+        "secret_ref": _SECRET_REF,
+        "status": "active",
+    }
+    defaults.update(kwargs)
+    await _insert_event_source(**defaults)
+
+
+def _signed(body: bytes, *, ts: float | None = None, secret: str = _SECRET_VALUE) -> dict[str, str]:
+    ts = time.time() if ts is None else ts
+    ts_str = f"{ts}"
+    sig = hmac.new(secret.encode(), ts_str.encode() + b"." + body, hashlib.sha256).hexdigest()
+    return {"X-Meho-Signature": sig, "X-Meho-Timestamp": ts_str}
+
+
+async def _count(model: object) -> int:
+    sm = get_sessionmaker()
+    async with sm() as session:
+        return (await session.execute(select(func.count()).select_from(model))).scalar_one()
+
+
+# --------------------------------------------------------------------------
+# resolution / 404
+# --------------------------------------------------------------------------
+
+
+def test_missing_source_returns_uniform_404(client: TestClient) -> None:
+    resp = client.post("/api/v1/events/ingest/nope", content=b"{}")
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == {"error": "no_event_source"}
+
+
+@pytest.mark.asyncio
+async def test_paused_source_returns_same_404(client: TestClient) -> None:
+    await _seed_source(status="paused")
+    body = b'{"x":1}'
+    resp = client.post("/api/v1/events/ingest/prod-am", content=body, headers=_signed(body))
+    # Paused is indistinguishable from missing -- same body, no oracle.
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == {"error": "no_event_source"}
+
+
+# --------------------------------------------------------------------------
+# body cap / 413
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_oversize_body_returns_413(client: TestClient) -> None:
+    await _seed_source()
+    huge = b"x" * (256 * 1024 + 1)
+    resp = client.post("/api/v1/events/ingest/prod-am", content=huge, headers=_signed(huge))
+    assert resp.status_code == 413
+    assert resp.json()["detail"]["error"] == "payload_too_large"
+
+
+@pytest.mark.asyncio
+async def test_capped_reader_streams_before_buffering() -> None:
+    """The streaming running-total guard rejects even without Content-Length."""
+
+    async def _stream():
+        # No content-length header; three chunks that together exceed the cap.
+        for _ in range(3):
+            yield b"a" * 100
+
+    request = SimpleNamespace(headers={}, stream=_stream)
+    with pytest.raises(Exception) as exc:  # _IngestBodyTooLargeError
+        await _read_capped_body(request, max_bytes=150)  # type: ignore[arg-type]
+    assert type(exc.value).__name__ == "_IngestBodyTooLargeError"
+
+
+# --------------------------------------------------------------------------
+# auth / 401
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bad_signature_returns_401(client: TestClient) -> None:
+    await _seed_source()
+    body = b'{"alert":"firing"}'
+    headers = _signed(body)
+    headers["X-Meho-Signature"] = "0" * 64
+    resp = client.post("/api/v1/events/ingest/prod-am", content=body, headers=headers)
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == {"error": "unauthorized"}
+
+
+@pytest.mark.asyncio
+async def test_source_without_secret_fails_closed_401(client: TestClient) -> None:
+    await _seed_source(slug="no-secret", name="no-secret", secret_ref=None)
+    body = b"{}"
+    resp = client.post("/api/v1/events/ingest/no-secret", content=body, headers=_signed(body))
+    assert resp.status_code == 401
+
+
+# --------------------------------------------------------------------------
+# accept / 202 + audit + outbox
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accepted_event_publishes_outbox_and_audit(client: TestClient) -> None:
+    await _seed_source()
+    body = json.dumps({"type": "alert", "severity": "critical"}).encode()
+    resp = client.post("/api/v1/events/ingest/prod-am", content=body, headers=_signed(body))
+    assert resp.status_code == 202
+    payload = resp.json()
+    assert payload["deduplicated"] is False
+    assert isinstance(payload["event_id"], int)
+
+    sm = get_sessionmaker()
+    async with sm() as session:
+        outbox = (await session.execute(select(EventOutbox))).scalars().all()
+        assert len(outbox) == 1
+        row = outbox[0]
+        assert row.origin is not None  # source id
+        assert row.dedupe_key is not None
+        assert row.event_kind == "external.alertmanager.alert"
+        assert row.payload["source"]["slug"] == "prod-am"
+        assert row.payload["data"] == {"type": "alert", "severity": "critical"}
+
+        audits = (
+            (await session.execute(select(AuditLog).where(AuditLog.method == "INGEST")))
+            .scalars()
+            .all()
+        )
+        assert len(audits) == 1
+        audit = audits[0]
+        assert audit.operator_sub == "__ingest__"
+        assert audit.path == "events.ingest"
+        assert audit.status_code == 202
+        assert audit.payload["origin"] == row.origin
+
+
+@pytest.mark.asyncio
+async def test_duplicate_delivery_is_idempotent_200(client: TestClient) -> None:
+    await _seed_source()
+    body = json.dumps({"type": "alert"}).encode()
+
+    first = client.post("/api/v1/events/ingest/prod-am", content=body, headers=_signed(body))
+    assert first.status_code == 202
+    # Same body -> same dedupe_key -> the retry is an idempotent ack.
+    second = client.post("/api/v1/events/ingest/prod-am", content=body, headers=_signed(body))
+    assert second.status_code == 200
+    assert second.json()["deduplicated"] is True
+    assert second.json()["event_id"] == first.json()["event_id"]
+
+    # No second outbox row, no second audit row.
+    assert await _count(EventOutbox) == 1
+    async with get_sessionmaker()() as session:
+        n_audit = (
+            await session.execute(
+                select(func.count()).select_from(AuditLog).where(AuditLog.method == "INGEST")
+            )
+        ).scalar_one()
+    assert n_audit == 1
+
+
+@pytest.mark.asyncio
+async def test_broadcast_failure_is_fail_open(client: TestClient, monkeypatch) -> None:
+    await _seed_source()
+
+    async def _boom(_event: object) -> None:
+        raise RuntimeError("valkey down")
+
+    monkeypatch.setattr("meho_backplane.events.ingest.service.publish_event", _boom)
+    body = json.dumps({"type": "alert"}).encode()
+    resp = client.post("/api/v1/events/ingest/prod-am", content=body, headers=_signed(body))
+    # The audit row committed before the broadcast, so the delivery still 202s.
+    assert resp.status_code == 202
+    assert await _count(EventOutbox) == 1
+
+
+# --------------------------------------------------------------------------
+# rate-limit / 429 mapping, invalid payload / 400
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rate_limited_returns_429_with_retry_after(client: TestClient, monkeypatch) -> None:
+    await _seed_source()
+
+    async def _limited(*_a: object, **_k: object) -> None:
+        raise IngestRateLimitError(limit=1, window_seconds=60, retry_after_seconds=42)
+
+    monkeypatch.setattr("meho_backplane.events.ingest.service.enforce_ingest_rate_limit", _limited)
+    body = b'{"type":"alert"}'
+    resp = client.post("/api/v1/events/ingest/prod-am", content=body, headers=_signed(body))
+    assert resp.status_code == 429
+    assert resp.headers["Retry-After"] == "42"
+    assert resp.json()["detail"]["error"] == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_authenticated_invalid_json_returns_400(client: TestClient) -> None:
+    await _seed_source()
+    body = b"this is not json"
+    resp = client.post("/api/v1/events/ingest/prod-am", content=body, headers=_signed(body))
+    assert resp.status_code == 400
+    assert resp.json()["detail"]["error"] == "invalid_payload"
+    # Nothing published on a rejected payload.
+    assert await _count(EventOutbox) == 0

--- a/backend/tests/test_event_outbox.py
+++ b/backend/tests/test_event_outbox.py
@@ -37,6 +37,7 @@ from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
@@ -484,3 +485,68 @@ async def test_drain_claim_stamps_claimed_at_and_by() -> None:
     assert claimed_at >= before
     assert row.claimed_by is not None
     assert ":" in row.claimed_by, "claimed_by should be 'hostname:pid'"
+
+
+# ---------------------------------------------------------------------------
+# origin + dedupe_key (#2879 substrate, consumed by the #2881 ingest path)
+# ---------------------------------------------------------------------------
+
+
+async def test_publish_sets_origin_and_dedupe_key() -> None:
+    """The two ingest columns round-trip when the producer supplies them."""
+    await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await publish(
+            session,
+            tenant_id=_TENANT_A,
+            event_kind="external.alertmanager.alert",
+            payload={"k": "v"},
+            origin="src-123",
+            dedupe_key="src-123:abc",
+        )
+        await session.commit()
+
+    rows = await _all_outbox_rows()
+    assert len(rows) == 1
+    assert rows[0].origin == "src-123"
+    assert rows[0].dedupe_key == "src-123:abc"
+
+
+async def test_publish_defaults_origin_and_dedupe_key_to_null() -> None:
+    """Internal producers leave both columns NULL (behaviour-preserving)."""
+    await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await publish(session, tenant_id=_TENANT_A, event_kind="agent_run.completed", payload={})
+        await session.commit()
+
+    rows = await _all_outbox_rows()
+    assert rows[0].origin is None
+    assert rows[0].dedupe_key is None
+
+
+async def test_duplicate_dedupe_key_raises_integrity_error() -> None:
+    """A second (tenant, dedupe_key) collides at flush -- the ingest 200 hook."""
+    await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await publish(
+            session,
+            tenant_id=_TENANT_A,
+            event_kind="external.x.y",
+            payload={},
+            dedupe_key="dupe-1",
+        )
+        await session.commit()
+
+    with pytest.raises(IntegrityError):
+        async with sessionmaker() as session:
+            await publish(
+                session,
+                tenant_id=_TENANT_A,
+                event_kind="external.x.y",
+                payload={},
+                dedupe_key="dupe-1",
+            )
+            await session.commit()

--- a/backend/tests/test_event_source_secrets.py
+++ b/backend/tests/test_event_source_secrets.py
@@ -23,6 +23,7 @@ from pydantic import SecretStr
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.event_source.secrets import (
     event_source_secret_ref,
+    read_event_source_secret,
     store_event_source_secret,
 )
 
@@ -76,3 +77,33 @@ async def test_store_writes_value_to_vault_kv(monkeypatch: pytest.MonkeyPatch) -
     assert calls[0]["path"] == f"tenants/{_TENANT}/event-sources/prod-am"
     assert calls[0]["secret"] == {"secret": "hmac-signing-key"}
     assert calls[0]["mount_point"] == "secret"
+
+
+@pytest.mark.asyncio
+async def test_read_returns_value_from_vault_kv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The read helper double-unwraps the KV-v2 payload to the ``secret`` field."""
+
+    def _read_secret_version(**_kwargs: Any) -> dict[str, Any]:
+        return {"data": {"data": {"secret": "hmac-signing-key"}, "metadata": {}}}
+
+    fake_client = SimpleNamespace(
+        secrets=SimpleNamespace(
+            kv=SimpleNamespace(v2=SimpleNamespace(read_secret_version=_read_secret_version))
+        )
+    )
+
+    @contextlib.asynccontextmanager
+    async def _fake_client_for_operator(_operator: Operator) -> AsyncIterator[Any]:
+        yield fake_client
+
+    monkeypatch.setattr(
+        "meho_backplane.auth.vault.vault_client_for_operator", _fake_client_for_operator
+    )
+
+    ref = event_source_secret_ref(_TENANT, "prod-am")
+    secret = await read_event_source_secret(_operator(), ref)
+
+    assert isinstance(secret, SecretStr)
+    assert secret.get_secret_value() == "hmac-signing-key"
+    # SecretStr masks the value in its repr -- no leakage through logging.
+    assert "hmac-signing-key" not in repr(secret)

--- a/backend/tests/test_events_ingest_auth.py
+++ b/backend/tests/test_events_ingest_auth.py
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-strategy sender-auth unit tests for the ingest endpoint (#2881).
+
+Drives :func:`meho_backplane.events.ingest.auth.verify_ingest_auth` directly
+(no DB, no app) over the three strategies. Acceptance-criteria coverage:
+
+* bad signature rejected (criterion 1)
+* replayed / stale timestamp rejected (criterion 1)
+* constant-time comparison for every secret check (criterion 4) -- asserted
+  structurally by patching :func:`hmac.compare_digest` and proving every
+  strategy routes its secret comparison through it, and behaviourally by a
+  one-byte tamper being rejected.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+
+import pytest
+from pydantic import SecretStr
+
+from meho_backplane.event_source.schemas import EventSourceAuthStrategy
+from meho_backplane.events.ingest.auth import IngestAuthError, verify_ingest_auth
+from meho_backplane.events.ingest.config import resolve_ingest_config
+
+_SECRET = SecretStr("super-shared-key")
+_BODY = b'{"alert":"firing","severity":"critical"}'
+_NOW = 1_700_000_000.0
+
+
+def _hmac_headers(*, secret: str = "super-shared-key", ts: float = _NOW, body: bytes = _BODY):
+    """Build valid ``X-Meho-Signature`` + ``X-Meho-Timestamp`` headers."""
+    signed = f"{ts}".encode() + b"." + body
+    sig = hmac.new(secret.encode(), signed, hashlib.sha256).hexdigest()
+    return {"X-Meho-Signature": sig, "X-Meho-Timestamp": f"{ts}"}
+
+
+def _verify_hmac(headers: dict[str, str], *, now: float = _NOW, extras: dict | None = None) -> None:
+    verify_ingest_auth(
+        strategy=EventSourceAuthStrategy.HMAC_SHA256,
+        secret=_SECRET,
+        headers=headers,
+        raw_body=_BODY,
+        config=resolve_ingest_config(extras or {}),
+        now=now,
+    )
+
+
+# --------------------------------------------------------------------------
+# hmac-sha256
+# --------------------------------------------------------------------------
+
+
+def test_hmac_valid_signature_passes() -> None:
+    _verify_hmac(_hmac_headers())  # no raise
+
+
+def test_hmac_bad_signature_rejected() -> None:
+    headers = _hmac_headers()
+    headers["X-Meho-Signature"] = "0" * 64
+    with pytest.raises(IngestAuthError) as exc:
+        _verify_hmac(headers)
+    assert exc.value.reason == "bad_signature"
+
+
+def test_hmac_one_byte_tamper_rejected() -> None:
+    """A single flipped body byte invalidates the signature (integrity)."""
+    headers = _hmac_headers()
+    verify = lambda body: verify_ingest_auth(  # noqa: E731
+        strategy=EventSourceAuthStrategy.HMAC_SHA256,
+        secret=_SECRET,
+        headers=headers,
+        raw_body=body,
+        config=resolve_ingest_config({}),
+        now=_NOW,
+    )
+    with pytest.raises(IngestAuthError):
+        verify(_BODY + b" ")
+
+
+def test_hmac_missing_signature_header_rejected() -> None:
+    with pytest.raises(IngestAuthError) as exc:
+        _verify_hmac({"X-Meho-Timestamp": f"{_NOW}"})
+    assert exc.value.reason == "missing_signature"
+
+
+def test_hmac_stale_timestamp_rejected() -> None:
+    """A timestamp outside the replay window is rejected even if signed."""
+    old_ts = _NOW - 10_000  # far outside the 300 s default window
+    headers = _hmac_headers(ts=old_ts)
+    with pytest.raises(IngestAuthError) as exc:
+        _verify_hmac(headers, now=_NOW)
+    assert exc.value.reason == "stale_timestamp"
+
+
+def test_hmac_missing_timestamp_rejected_when_required() -> None:
+    headers = _hmac_headers()
+    del headers["X-Meho-Timestamp"]
+    with pytest.raises(IngestAuthError) as exc:
+        _verify_hmac(headers)
+    assert exc.value.reason == "missing_timestamp"
+
+
+def test_hmac_non_numeric_timestamp_rejected() -> None:
+    headers = _hmac_headers()
+    headers["X-Meho-Timestamp"] = "not-a-number"
+    with pytest.raises(IngestAuthError) as exc:
+        _verify_hmac(headers)
+    assert exc.value.reason == "bad_timestamp"
+
+
+def test_hmac_body_only_scheme_ignores_timestamp() -> None:
+    """``require_timestamp=false`` signs the body alone (Grafana-style)."""
+    sig = hmac.new(b"super-shared-key", _BODY, hashlib.sha256).hexdigest()
+    headers = {"X-Grafana-Alerting-Signature": sig}
+    _verify_hmac(
+        headers,
+        extras={"require_timestamp": False, "signature_header": "X-Grafana-Alerting-Signature"},
+    )  # no raise
+
+
+def test_hmac_uppercase_hex_signature_accepted() -> None:
+    headers = _hmac_headers()
+    headers["X-Meho-Signature"] = headers["X-Meho-Signature"].upper()
+    _verify_hmac(headers)  # no raise
+
+
+# --------------------------------------------------------------------------
+# static-header
+# --------------------------------------------------------------------------
+
+
+def test_static_header_valid_passes() -> None:
+    verify_ingest_auth(
+        strategy=EventSourceAuthStrategy.STATIC_HEADER,
+        secret=SecretStr("harbor-token"),
+        headers={"Authorization": "harbor-token"},
+        raw_body=_BODY,
+        config=resolve_ingest_config({}),
+        now=_NOW,
+    )
+
+
+def test_static_header_bad_value_rejected() -> None:
+    with pytest.raises(IngestAuthError) as exc:
+        verify_ingest_auth(
+            strategy=EventSourceAuthStrategy.STATIC_HEADER,
+            secret=SecretStr("harbor-token"),
+            headers={"Authorization": "wrong"},
+            raw_body=_BODY,
+            config=resolve_ingest_config({}),
+            now=_NOW,
+        )
+    assert exc.value.reason == "bad_static_header"
+
+
+def test_static_header_custom_header_name() -> None:
+    verify_ingest_auth(
+        strategy=EventSourceAuthStrategy.STATIC_HEADER,
+        secret=SecretStr("tok"),
+        headers={"X-Harbor-Secret": "tok"},
+        raw_body=_BODY,
+        config=resolve_ingest_config({"static_header": "X-Harbor-Secret"}),
+        now=_NOW,
+    )
+
+
+# --------------------------------------------------------------------------
+# basic
+# --------------------------------------------------------------------------
+
+
+def _basic_header(user: str, password: str) -> dict[str, str]:
+    token = base64.b64encode(f"{user}:{password}".encode()).decode()
+    return {"Authorization": f"Basic {token}"}
+
+
+def _verify_basic(headers: dict[str, str], *, username: str = "alertmanager") -> None:
+    verify_ingest_auth(
+        strategy=EventSourceAuthStrategy.BASIC,
+        secret=SecretStr("am-password"),
+        headers=headers,
+        raw_body=_BODY,
+        config=resolve_ingest_config({"basic_username": username}),
+        now=_NOW,
+    )
+
+
+def test_basic_valid_passes() -> None:
+    _verify_basic(_basic_header("alertmanager", "am-password"))  # no raise
+
+
+def test_basic_wrong_password_rejected() -> None:
+    with pytest.raises(IngestAuthError) as exc:
+        _verify_basic(_basic_header("alertmanager", "nope"))
+    assert exc.value.reason == "bad_basic_credentials"
+
+
+def test_basic_wrong_username_rejected() -> None:
+    with pytest.raises(IngestAuthError) as exc:
+        _verify_basic(_basic_header("intruder", "am-password"))
+    assert exc.value.reason == "bad_basic_credentials"
+
+
+def test_basic_wrong_scheme_rejected() -> None:
+    with pytest.raises(IngestAuthError) as exc:
+        _verify_basic({"Authorization": "Bearer am-password"})
+    assert exc.value.reason == "bad_authorization_scheme"
+
+
+def test_basic_malformed_credentials_rejected() -> None:
+    with pytest.raises(IngestAuthError) as exc:
+        _verify_basic({"Authorization": "Basic !!!not-base64!!!"})
+    assert exc.value.reason == "malformed_basic_credentials"
+
+
+# --------------------------------------------------------------------------
+# constant-time discipline (criterion 4)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("strategy", "secret", "headers", "extras"),
+    [
+        (
+            EventSourceAuthStrategy.HMAC_SHA256,
+            _SECRET,
+            _hmac_headers(),
+            {},
+        ),
+        (
+            EventSourceAuthStrategy.STATIC_HEADER,
+            SecretStr("harbor-token"),
+            {"Authorization": "harbor-token"},
+            {},
+        ),
+        (
+            EventSourceAuthStrategy.BASIC,
+            SecretStr("am-password"),
+            _basic_header("am", "am-password"),
+            {"basic_username": "am"},
+        ),
+    ],
+)
+def test_every_strategy_uses_compare_digest(
+    monkeypatch: pytest.MonkeyPatch, strategy, secret, headers, extras
+) -> None:
+    """Every secret comparison routes through ``hmac.compare_digest``."""
+    calls: list[int] = []
+    real = hmac.compare_digest
+
+    def _spy(a: object, b: object) -> bool:
+        calls.append(1)
+        return real(a, b)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("meho_backplane.events.ingest.auth.hmac.compare_digest", _spy)
+    verify_ingest_auth(
+        strategy=strategy,
+        secret=secret,
+        headers=headers,
+        raw_body=_BODY,
+        config=resolve_ingest_config(extras),
+        now=_NOW,
+    )
+    assert calls, "secret comparison must go through hmac.compare_digest"

--- a/backend/tests/test_events_ingest_config.py
+++ b/backend/tests/test_events_ingest_config.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-source ingest-config resolution tests (#2881).
+
+Covers defaults, overrides, defensive coercion of malformed operator-authored
+``extras`` values, and the security-relevant clamps (body cap can only be
+lowered; replay window is bounded above).
+"""
+
+from __future__ import annotations
+
+from meho_backplane.events.ingest.config import (
+    DEFAULT_MAX_BODY_BYTES,
+    DEFAULT_REPLAY_WINDOW_SECONDS,
+    DEFAULT_SIGNATURE_HEADER,
+    MAX_REPLAY_WINDOW_SECONDS,
+    resolve_ingest_config,
+)
+
+
+def test_defaults_on_empty_extras() -> None:
+    cfg = resolve_ingest_config({})
+    assert cfg.max_body_bytes == DEFAULT_MAX_BODY_BYTES
+    assert cfg.replay_window_seconds == DEFAULT_REPLAY_WINDOW_SECONDS
+    assert cfg.require_timestamp is True
+    assert cfg.signature_header == DEFAULT_SIGNATURE_HEADER
+    assert cfg.basic_username == ""
+    assert cfg.rate_per_minute_override is None
+
+
+def test_body_cap_override_can_only_lower() -> None:
+    assert resolve_ingest_config({"max_body_bytes": 1024}).max_body_bytes == 1024
+    # An override above the 256 KiB ceiling is clamped down, never widened.
+    assert (
+        resolve_ingest_config({"max_body_bytes": 10 * 1024 * 1024}).max_body_bytes
+        == DEFAULT_MAX_BODY_BYTES
+    )
+
+
+def test_replay_window_clamped_to_max() -> None:
+    assert resolve_ingest_config({"replay_window_seconds": 60}).replay_window_seconds == 60
+    assert (
+        resolve_ingest_config({"replay_window_seconds": 999_999}).replay_window_seconds
+        == MAX_REPLAY_WINDOW_SECONDS
+    )
+
+
+def test_malformed_values_degrade_to_defaults() -> None:
+    cfg = resolve_ingest_config(
+        {"max_body_bytes": "huge", "replay_window_seconds": -5, "signature_header": ""}
+    )
+    assert cfg.max_body_bytes == DEFAULT_MAX_BODY_BYTES
+    assert cfg.replay_window_seconds == DEFAULT_REPLAY_WINDOW_SECONDS
+    assert cfg.signature_header == DEFAULT_SIGNATURE_HEADER
+
+
+def test_rate_override_zero_disables_for_source() -> None:
+    # 0 is a meaningful per-source "disable", distinct from an absent override.
+    assert resolve_ingest_config({"rate_per_minute": 0}).rate_per_minute_override == 0
+    assert resolve_ingest_config({"rate_per_minute": 5}).rate_per_minute_override == 5
+    # bool is a subclass of int but never a valid cap.
+    assert resolve_ingest_config({"rate_per_minute": True}).rate_per_minute_override is None
+    assert resolve_ingest_config({"rate_per_minute": "9"}).rate_per_minute_override is None
+
+
+def test_header_name_overrides() -> None:
+    cfg = resolve_ingest_config(
+        {
+            "signature_header": "X-Grafana-Alerting-Signature",
+            "timestamp_header": "X-When",
+            "static_header": "X-Harbor-Secret",
+            "delivery_id_header": "X-GitHub-Delivery",
+            "basic_username": "am",
+        }
+    )
+    assert cfg.signature_header == "X-Grafana-Alerting-Signature"
+    assert cfg.timestamp_header == "X-When"
+    assert cfg.static_header == "X-Harbor-Secret"
+    assert cfg.delivery_id_header == "X-GitHub-Delivery"
+    assert cfg.basic_username == "am"

--- a/backend/tests/test_events_ingest_e2e.py
+++ b/backend/tests/test_events_ingest_e2e.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end ingest -> drain -> matcher -> agent run (#2881, criterion 3).
+
+A signed external event POSTed to ``/api/v1/events/ingest/{slug}`` lands on
+``event_outbox``; one drain tick matches it against a ``kind=event`` trigger
+(#2878) whose ``event_filter`` the ingest envelope contains, and fires an
+agent run through the shared ``run_scheduled`` seam -- no real LLM (a
+``FunctionModel`` stands in), no real Keycloak (the token + verify seams are
+stubbed the same way the matcher's own tests stub them).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from collections.abc import Iterator
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from sqlalchemy import select
+
+from meho_backplane.agent.invocation import AgentInvoker
+from meho_backplane.agent.run import PydanticAgentRun
+from meho_backplane.agents.schemas import AgentDefinitionCreate, AgentModelTier
+from meho_backplane.agents.service import AgentDefinitionService
+from meho_backplane.api.v1.events_ingest import router
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AgentPrincipal, AgentRun, EventOutbox, Tenant
+from meho_backplane.events.drain import run_one_drain_tick
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.scheduler.repository import create_event_trigger
+from meho_backplane.settings import get_settings
+
+from ._event_source_helpers import (
+    _insert_event_source,
+    _settings_env,  # noqa: F401  (autouse fixture)
+)
+
+_TENANT = uuid.UUID("33333333-3333-3333-3333-333333333333")
+_SECRET_VALUE = "e2e-hmac-key"
+
+
+@pytest.fixture(autouse=True)
+def _agent_secret_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    # identity_ref ``agent:reactor`` -> ``AGENT_REACTOR`` client-credentials env.
+    monkeypatch.setenv("MEHO_AGENT_SECRET_AGENT_REACTOR", "test-secret")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _stub_autonomous_auth(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Stub ``run_scheduled``'s Keycloak token + JWT-verify seams (offline)."""
+    monkeypatch.setattr(
+        "meho_backplane.agent.invocation.get_client_credentials_token",
+        AsyncMock(return_value="agent-token"),
+    )
+    monkeypatch.setattr(
+        "meho_backplane.agent.invocation.verify_jwt_for_audience",
+        AsyncMock(
+            return_value=Operator(
+                sub="agent-reactor",
+                name=None,
+                email=None,
+                raw_jwt="agent-token",
+                tenant_id=_TENANT,
+                tenant_role=TenantRole.OPERATOR,
+            ),
+        ),
+    )
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _stub_ingest_seams(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    async def _read_secret(_operator: object, _ref: str) -> SecretStr:
+        return SecretStr(_SECRET_VALUE)
+
+    async def _no_op(*_a: object, **_k: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "meho_backplane.events.ingest.service.read_event_source_secret", _read_secret
+    )
+    monkeypatch.setattr("meho_backplane.events.ingest.service.enforce_ingest_rate_limit", _no_op)
+    monkeypatch.setattr("meho_backplane.events.ingest.service.publish_event", _no_op)
+    yield
+
+
+def _final_text(text: str) -> FunctionModel:
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(parts=[TextPart(text)])
+
+    return FunctionModel(fn)
+
+
+def _make_invoker() -> AgentInvoker:
+    return AgentInvoker(runtime=PydanticAgentRun(model_factory=lambda: _final_text("handled")))
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(router)
+    return app
+
+
+async def _seed_tenant_agent_trigger_source() -> None:
+    sm = get_sessionmaker()
+    async with sm() as session:
+        if await session.get(Tenant, _TENANT) is None:
+            session.add(Tenant(id=_TENANT, slug="tenant-e2e", name="Tenant E2E"))
+            await session.commit()
+        session.add(
+            AgentPrincipal(
+                id=uuid.uuid4(),
+                tenant_id=_TENANT,
+                name="reactor",
+                keycloak_client_id="agent:reactor",
+                keycloak_internal_id="kc-internal-reactor",
+                owner_sub="seed-admin",
+                revoked=False,
+                created_by_sub="seed-admin",
+            )
+        )
+        await session.commit()
+
+    entry = await AgentDefinitionService().create(
+        tenant_id=_TENANT,
+        created_by_sub="seed-admin",
+        payload=AgentDefinitionCreate(
+            name="reactor",
+            identity_ref="agent:reactor",
+            model_tier=AgentModelTier.STANDARD,
+            system_prompt="You react to ingested events.",
+            toolset={},
+            turn_budget=2,
+            enabled=True,
+        ),
+    )
+    async with sm() as session:
+        await create_event_trigger(
+            session,
+            tenant_id=_TENANT,
+            agent_definition_id=entry.id,
+            event_filter={"source": {"slug": "e2e-src"}},
+            inputs={"prompt": "react"},
+            identity_sub="__scheduler__",
+            created_by_sub="seed-admin",
+            in_flight_policy="fail_into_audit",
+        )
+        await session.commit()
+
+    await _insert_event_source(
+        tenant_id=_TENANT,
+        slug="e2e-src",
+        name="e2e-src",
+        kind="alertmanager",
+        auth_strategy="hmac-sha256",
+        secret_ref=f"tenants/{_TENANT}/event-sources/e2e-src",
+        status="active",
+    )
+
+
+def _signed(body: bytes) -> dict[str, str]:
+    ts = f"{time.time()}"
+    sig = hmac.new(_SECRET_VALUE.encode(), ts.encode() + b"." + body, hashlib.sha256).hexdigest()
+    return {"X-Meho-Signature": sig, "X-Meho-Timestamp": ts}
+
+
+async def _all_runs() -> list[AgentRun]:
+    async with get_sessionmaker()() as session:
+        return list((await session.execute(select(AgentRun))).scalars().all())
+
+
+async def _wait_for_runs(expected: int, *, timeout: float = 3.0) -> list[AgentRun]:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        runs = await _all_runs()
+        if len(runs) >= expected:
+            return runs
+        await asyncio.sleep(0.05)
+    return await _all_runs()
+
+
+@pytest.mark.asyncio
+async def test_posted_event_matches_trigger_and_fires_agent_run() -> None:
+    await _seed_tenant_agent_trigger_source()
+
+    body = json.dumps({"type": "deploy", "severity": "critical"}).encode()
+    client = TestClient(_build_app())
+    resp = client.post("/api/v1/events/ingest/e2e-src", content=body, headers=_signed(body))
+    assert resp.status_code == 202
+    event_id = resp.json()["event_id"]
+
+    # One drain tick routes the outbox row through the #2878 matcher.
+    processed = await run_one_drain_tick(invoker=_make_invoker())
+    assert processed == 1
+
+    async with get_sessionmaker()() as session:
+        outbox = await session.get(EventOutbox, event_id)
+        assert outbox is not None
+        assert outbox.processed_at is not None
+
+    runs = await _wait_for_runs(1)
+    assert len(runs) == 1
+    assert runs[0].tenant_id == _TENANT
+    assert runs[0].work_ref.startswith(f"event:{event_id}:")

--- a/backend/tests/test_events_ingest_rate_limit.py
+++ b/backend/tests/test_events_ingest_rate_limit.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-source ingest rate-limit unit tests (#2881).
+
+Drives :func:`meho_backplane.events.ingest.rate_limit.enforce_ingest_rate_limit`
+against an in-memory fake Valkey (no socket), mirroring
+``test_broadcast_announce_rate_limit.py``. Acceptance-criteria coverage:
+
+* the ``limit+1``-th delivery in one window is rejected with a
+  ``Retry-After`` (criterion 1 / rate-limit)
+* a second source in the same tenant is unaffected (per-``(tenant, source)``
+  counter)
+* ``limit == 0`` disables the limit with no Valkey round-trip
+* a Valkey outage propagates (fail-loud; the endpoint maps it to 503)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from meho_backplane.events.ingest.rate_limit import (
+    INGEST_RATE_LIMIT_WINDOW_SECONDS,
+    IngestRateLimitError,
+    enforce_ingest_rate_limit,
+)
+
+_TENANT = uuid.UUID("00000000-0000-0000-0000-0000000000c1")
+_FIXED_NOW = 1_700_000_030.0  # 30 s into a fixed window
+
+
+class _FakePipeline:
+    def __init__(self, store: dict[str, int]) -> None:
+        self._store = store
+        self._ops: list[tuple[str, str, int]] = []
+
+    async def __aenter__(self) -> _FakePipeline:
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    def incr(self, name: str, amount: int = 1) -> None:
+        self._ops.append(("incr", name, amount))
+
+    def expire(self, name: str, time: int, *args: object, **kwargs: object) -> None:
+        self._ops.append(("expire", name, time))
+
+    async def execute(self) -> list[Any]:
+        results: list[Any] = []
+        for op, name, arg in self._ops:
+            if op == "incr":
+                self._store[name] = self._store.get(name, 0) + arg
+                results.append(self._store[name])
+            else:
+                results.append(True)
+        return results
+
+
+class _FakeValkey:
+    def __init__(self) -> None:
+        self.store: dict[str, int] = {}
+        self.pipeline_calls = 0
+
+    def pipeline(self, transaction: bool = True) -> _FakePipeline:
+        self.pipeline_calls += 1
+        return _FakePipeline(self.store)
+
+
+@pytest.fixture
+def fake_valkey(monkeypatch: pytest.MonkeyPatch) -> _FakeValkey:
+    fake = _FakeValkey()
+    monkeypatch.setattr(
+        "meho_backplane.events.ingest.rate_limit.get_broadcast_client",
+        lambda: fake,
+    )
+    monkeypatch.setattr(
+        "meho_backplane.events.ingest.rate_limit.time.time",
+        lambda: _FIXED_NOW,
+    )
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_within_limit_passes(fake_valkey: _FakeValkey) -> None:
+    for _ in range(3):
+        await enforce_ingest_rate_limit(_TENANT, "prod-am", limit=3)  # no raise
+
+
+@pytest.mark.asyncio
+async def test_over_limit_rejected_with_retry_after(fake_valkey: _FakeValkey) -> None:
+    for _ in range(3):
+        await enforce_ingest_rate_limit(_TENANT, "prod-am", limit=3)
+    with pytest.raises(IngestRateLimitError) as exc:
+        await enforce_ingest_rate_limit(_TENANT, "prod-am", limit=3)
+    assert exc.value.limit == 3
+    assert exc.value.window_seconds == INGEST_RATE_LIMIT_WINDOW_SECONDS
+    # Retry-After counts the seconds until the current fixed window rolls.
+    expected_retry = INGEST_RATE_LIMIT_WINDOW_SECONDS - (
+        int(_FIXED_NOW) % INGEST_RATE_LIMIT_WINDOW_SECONDS
+    )
+    assert exc.value.retry_after_seconds == expected_retry
+    assert 0 < exc.value.retry_after_seconds <= INGEST_RATE_LIMIT_WINDOW_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_second_source_unaffected(fake_valkey: _FakeValkey) -> None:
+    for _ in range(3):
+        await enforce_ingest_rate_limit(_TENANT, "source-a", limit=3)
+    # source-b has its own counter; the first call is well within the cap.
+    await enforce_ingest_rate_limit(_TENANT, "source-b", limit=3)  # no raise
+
+
+@pytest.mark.asyncio
+async def test_zero_limit_disables_no_round_trip(fake_valkey: _FakeValkey) -> None:
+    for _ in range(1000):
+        await enforce_ingest_rate_limit(_TENANT, "prod-am", limit=0)
+    assert fake_valkey.pipeline_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_valkey_outage_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Valkey failure fails the delivery closed (raises, mapped to 503)."""
+
+    def _boom() -> object:
+        raise ConnectionError("valkey down")
+
+    monkeypatch.setattr("meho_backplane.events.ingest.rate_limit.get_broadcast_client", _boom)
+    with pytest.raises(ConnectionError):
+        await enforce_ingest_rate_limit(_TENANT, "prod-am", limit=10)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -1647,6 +1647,49 @@
         }
       }
     },
+    "/api/v1/events/ingest/{source_slug}": {
+      "post": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Ingest Event",
+        "description": "Accept one external event for *source_slug*. See the module docstring.",
+        "operationId": "ingest_event_api_v1_events_ingest__source_slug__post",
+        "parameters": [
+          {
+            "name": "source_slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Source Slug"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventIngestResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/topology/dependents/{name}": {
       "get": {
         "tags": [
@@ -25304,6 +25347,26 @@
         "title": "EvalResult",
         "description": "Top-level eval result \u2014 the shape the API + CLI return.\n\n``overall_verdict`` is the worst-of every surface (a red surface\nflips the whole result red); the CLI's exit-1-on-red CI-gate\nsemantics key off this field. ``ran_at`` is the UTC timestamp\nthe runner started; consumers comparing two saved baselines see\nwhen each was captured."
       },
+      "EventIngestResponse": {
+        "properties": {
+          "event_id": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Event Id"
+          },
+          "deduplicated": {
+            "type": "boolean",
+            "title": "Deduplicated"
+          }
+        },
+        "type": "object",
+        "required": [
+          "event_id",
+          "deduplicated"
+        ],
+        "title": "EventIngestResponse",
+        "description": "Accepted (``202``) or deduplicated (``200``) acknowledgement.\n\n``event_id`` is the ``event_outbox`` row id the delivery landed on (the\noriginal row's id on a duplicate); ``None`` only in the rare race where a\nduplicate collided but the original row was concurrently removed."
+      },
       "EventSource": {
         "properties": {
           "id": {
@@ -31166,6 +31229,10 @@
     },
     {
       "name": "event-sources",
+      "x-maturity": "beta"
+    },
+    {
+      "name": "events",
       "x-maturity": "beta"
     },
     {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4184,6 +4184,16 @@ type EvalResult struct {
 // EvalResultOverallVerdict defines model for EvalResult.OverallVerdict.
 type EvalResultOverallVerdict string
 
+// EventIngestResponse Accepted (“202“) or deduplicated (“200“) acknowledgement.
+//
+// “event_id“ is the “event_outbox“ row id the delivery landed on (the
+// original row's id on a duplicate); “None“ only in the rare race where a
+// duplicate collided but the original row was concurrently removed.
+type EventIngestResponse struct {
+	Deduplicated bool `json:"deduplicated"`
+	EventId      *int `json:"event_id"`
+}
+
 // EventSource Full read shape. Maps 1:1 to the live “event_source“ columns.
 //
 // Frozen. Carries “secret_ref“ (the Vault *path*) but never the secret
@@ -11361,6 +11371,9 @@ type ClientInterface interface {
 
 	UpdateEventSourceApiV1EventSourcesSlugPatch(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, body UpdateEventSourceApiV1EventSourcesSlugPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// IngestEventApiV1EventsIngestSourceSlugPost request
+	IngestEventApiV1EventsIngestSourceSlugPost(ctx context.Context, sourceSlug string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// FeedEndpointApiV1FeedGet request
 	FeedEndpointApiV1FeedGet(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -13639,6 +13652,18 @@ func (c *Client) UpdateEventSourceApiV1EventSourcesSlugPatchWithBody(ctx context
 
 func (c *Client) UpdateEventSourceApiV1EventSourcesSlugPatch(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, body UpdateEventSourceApiV1EventSourcesSlugPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUpdateEventSourceApiV1EventSourcesSlugPatchRequest(c.Server, slug, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) IngestEventApiV1EventsIngestSourceSlugPost(ctx context.Context, sourceSlug string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewIngestEventApiV1EventsIngestSourceSlugPostRequest(c.Server, sourceSlug)
 	if err != nil {
 		return nil, err
 	}
@@ -23163,6 +23188,40 @@ func NewUpdateEventSourceApiV1EventSourcesSlugPatchRequestWithBody(server string
 			req.Header.Set("authorization", headerParam0)
 		}
 
+	}
+
+	return req, nil
+}
+
+// NewIngestEventApiV1EventsIngestSourceSlugPostRequest generates requests for IngestEventApiV1EventsIngestSourceSlugPost
+func NewIngestEventApiV1EventsIngestSourceSlugPostRequest(server string, sourceSlug string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "source_slug", runtime.ParamLocationPath, sourceSlug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/events/ingest/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
 	}
 
 	return req, nil
@@ -39050,6 +39109,9 @@ type ClientWithResponsesInterface interface {
 
 	UpdateEventSourceApiV1EventSourcesSlugPatchWithResponse(ctx context.Context, slug string, params *UpdateEventSourceApiV1EventSourcesSlugPatchParams, body UpdateEventSourceApiV1EventSourcesSlugPatchJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateEventSourceApiV1EventSourcesSlugPatchResponse, error)
 
+	// IngestEventApiV1EventsIngestSourceSlugPostWithResponse request
+	IngestEventApiV1EventsIngestSourceSlugPostWithResponse(ctx context.Context, sourceSlug string, reqEditors ...RequestEditorFn) (*IngestEventApiV1EventsIngestSourceSlugPostResponse, error)
+
 	// FeedEndpointApiV1FeedGetWithResponse request
 	FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error)
 
@@ -41822,6 +41884,29 @@ func (r UpdateEventSourceApiV1EventSourcesSlugPatchResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UpdateEventSourceApiV1EventSourcesSlugPatchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type IngestEventApiV1EventsIngestSourceSlugPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON202      *EventIngestResponse
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r IngestEventApiV1EventsIngestSourceSlugPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r IngestEventApiV1EventsIngestSourceSlugPostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -48912,6 +48997,15 @@ func (c *ClientWithResponses) UpdateEventSourceApiV1EventSourcesSlugPatchWithRes
 	return ParseUpdateEventSourceApiV1EventSourcesSlugPatchResponse(rsp)
 }
 
+// IngestEventApiV1EventsIngestSourceSlugPostWithResponse request returning *IngestEventApiV1EventsIngestSourceSlugPostResponse
+func (c *ClientWithResponses) IngestEventApiV1EventsIngestSourceSlugPostWithResponse(ctx context.Context, sourceSlug string, reqEditors ...RequestEditorFn) (*IngestEventApiV1EventsIngestSourceSlugPostResponse, error) {
+	rsp, err := c.IngestEventApiV1EventsIngestSourceSlugPost(ctx, sourceSlug, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseIngestEventApiV1EventsIngestSourceSlugPostResponse(rsp)
+}
+
 // FeedEndpointApiV1FeedGetWithResponse request returning *FeedEndpointApiV1FeedGetResponse
 func (c *ClientWithResponses) FeedEndpointApiV1FeedGetWithResponse(ctx context.Context, params *FeedEndpointApiV1FeedGetParams, reqEditors ...RequestEditorFn) (*FeedEndpointApiV1FeedGetResponse, error) {
 	rsp, err := c.FeedEndpointApiV1FeedGet(ctx, params, reqEditors...)
@@ -54874,6 +54968,39 @@ func ParseUpdateEventSourceApiV1EventSourcesSlugPatchResponse(rsp *http.Response
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseIngestEventApiV1EventsIngestSourceSlugPostResponse parses an HTTP response from a IngestEventApiV1EventsIngestSourceSlugPostWithResponse call
+func ParseIngestEventApiV1EventsIngestSourceSlugPostResponse(rsp *http.Response) (*IngestEventApiV1EventsIngestSourceSlugPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &IngestEventApiV1EventsIngestSourceSlugPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
+		var dest EventIngestResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON202 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError

--- a/docs/codebase/events.md
+++ b/docs/codebase/events.md
@@ -345,6 +345,83 @@ bounded only by the manual kill switch. Two controls contain it:
 Work_ref dedupe does **not** help here — each distinct event has a
 distinct `event_id`, hence a distinct work_ref.
 
+## Inbound external event ingest (#2881)
+
+The producer side above is MEHO-internal (an agent run completing).
+`POST /api/v1/events/ingest/{source_slug}`
+(`api/v1/events_ingest.py` + `events/ingest/`) is the **external**
+producer: a JWT-less webhook a registered `event_source` (#2880)
+delivers to, which lands one `event_outbox` row the same drain + matcher
+route to `kind=event` triggers. It is the only `/api/v1` route with **no
+operator dependency** — the sender is authenticated per-source against
+the source's Vault-custodied secret, not by a Keycloak JWT.
+
+### Request path (the order is load-bearing)
+
+1. **Resolve** the source by slug via
+   `resolve_event_source_by_slug` (global — the webhook carries no
+   tenant). A missing *or* paused source returns the identical uniform
+   `404`, so the two are indistinguishable (no paused-vs-missing oracle).
+2. **Body cap** (`413`) is enforced *before* the whole body is buffered:
+   a `Content-Length` fast-reject plus a streaming running-total guard
+   (`_read_capped_body`) so an absent/understated length header cannot
+   smuggle an oversize body past it (the `ui/csrf.py` DoS lesson). The
+   cap defaults to 256 KiB; a source's `extras["max_body_bytes"]` can
+   only *lower* it, never raise it above the ceiling.
+3. **Auth** (`401`) per the source's `auth_strategy`, **constant-time**
+   (`events/ingest/auth.py`, every secret comparison through
+   `hmac.compare_digest`): `hmac-sha256` over the raw body (with an
+   optional timestamp bound into the signature and gated by a replay
+   window), `static-header`, or `basic` (username from `extras`,
+   password is the secret). Header names are `extras`-configurable, so a
+   vendor whose headers differ (Grafana's `X-Grafana-Alerting-Signature`)
+   is config, not a code branch — richer per-vendor normalisation is
+   #2882. The failure reason is logged server-side, never returned, so
+   every rejection is the same uniform `401`.
+4. **Rate limit** (`429` + `Retry-After`) — the broadcast fixed-window
+   `INCR`/`EXPIRE` pattern under a new key namespace
+   `meho:ratelimit:ingest:{tenant}:{source}` (`events/ingest/rate_limit.py`).
+   Fail-loud on a Valkey outage (`503`; a webhook sender retries).
+5. **Dedupe** — the sender's delivery id where one exists, else a SHA-256
+   of the raw body, namespaced by source id, written as `event_outbox.dedupe_key`
+   (#2879). A `(tenant_id, dedupe_key)` collision (the partial unique
+   index) is caught as an `IntegrityError` and mapped to an idempotent
+   `200` — never a second outbox row, never a second audit row, so a
+   retry-storming sender never double-fires a subscriber.
+6. **Publish + audit in one transaction.** `events.publish()` (now
+   carrying `origin` = source id and the `dedupe_key`) inserts the
+   outbox row in the **same** `session.begin()` block as a synchronous
+   audit row under the synthetic `__ingest__` identity (the `__sensor__`
+   / `__scheduler__` sentinel precedent; `audit_log.operator_sub` is
+   plain `Text`). No success without a committed audit row (postulate 7).
+   A **fail-open** broadcast follows the commit.
+
+### The `__ingest__` audit + Vault-read identities
+
+Ingest is authenticated per-source, not per-operator, so there is no JWT
+to derive an `operator_sub` from — the chassis `AuditMiddleware` (which
+keys on the JWT-bound contextvar) writes no row for it, and the ingest
+service writes its own `__ingest__` row instead. Reading the source's
+secret still needs a Vault client, which needs an operator: the
+`__ingest__` operator reuses the backplane's existing
+background-dispatch service-principal token (`check_runner_jwt`, the
+same "MEHO's own in-process dispatch, outward" identity the sensor
+check-runner uses) with `check_runner_dispatch=False` so the Vault login
+uses the standard `vault_oidc_role`. When that principal is unconfigured
+the token is empty, the Vault read fails, and ingest fails closed — the
+correct posture. A dedicated ingest principal (separately bounded Vault
+role) is a future refinement.
+
+### Reconciliation note (404 vs 401)
+
+The #2880 resolver docstring suggests mapping a missing slug to the
+*same* response as an auth failure. This endpoint instead follows the
+#2881 contract: missing/paused → `404`, bad signature → `401`. The
+residual "a 404 vs 401 distinguishes a real slug" oracle is acceptable
+because a slug is a high-entropy routing token (not enumerable), while
+the uniform 404 still hides the operationally sensitive paused-vs-missing
+distinction.
+
 ## Deferred work
 
 ### Reconnect-with-backoff for the `LISTEN` connection
@@ -376,6 +453,10 @@ Both gated via env vars (defaults shown in parens):
   the actual wake-up shorter than this interval; this bounds the
   *worst-case* poll latency when no producers fire and no listeners
   are connected.
+- `EVENTS_INGEST_RATE_PER_MINUTE` (`60`, `0` disables) — the default
+  per-source fixed-window cap for the inbound ingest endpoint (#2881). A
+  source overrides it via `event_source.extras["rate_per_minute"]`
+  (`0` there disables the limit for that one source).
 
 ## Test coverage
 
@@ -404,6 +485,21 @@ Both gated via env vars (defaults shown in parens):
   — `dedupe_key` / `origin` additive columns + partial unique dedupe
   index (per-tenant uniqueness, NULL-unconstrained, SQLite partial-index
   parity, downgrade round-trip)
+- Inbound ingest (#2881):
+  - [backend/tests/test_events_ingest_auth.py](backend/tests/test_events_ingest_auth.py)
+    — per-strategy constant-time auth: bad signature, replay window,
+    static-header, basic, and the `compare_digest`-for-every-secret guard
+  - [backend/tests/test_events_ingest_rate_limit.py](backend/tests/test_events_ingest_rate_limit.py)
+    — 429 + `Retry-After`, per-source isolation, `0` disables, Valkey
+    fail-loud
+  - [backend/tests/test_events_ingest_config.py](backend/tests/test_events_ingest_config.py)
+    — per-source `extras` config resolution + security clamps
+  - [backend/tests/test_api_v1_events_ingest.py](backend/tests/test_api_v1_events_ingest.py)
+    — endpoint: uniform 404, 413-before-buffer, 401, 202 + outbox
+    `origin`/`dedupe_key` + `__ingest__` audit row, idempotent 200,
+    broadcast fail-open, 429/400 mapping
+  - [backend/tests/test_events_ingest_e2e.py](backend/tests/test_events_ingest_e2e.py)
+    — POSTed event → drain tick → matched `kind=event` trigger → agent run
 
 ## References
 
@@ -415,6 +511,10 @@ Both gated via env vars (defaults shown in parens):
   one-off, merged), T4 #825 (in-flight resume), T5 #826 (admin surface)
 - Task #2878 — the subscription matcher + `kind=event` dispatch
   (`events/matcher.py`); Initiative #2877 (inbound event ingestion)
+- Task #2879 — `event_outbox.dedupe_key` / `origin` columns the ingest
+  path populates; Task #2880 — the `event_source` registry + Vault
+  secret custody the ingest path resolves against; Task #2881 — this
+  inbound ingest endpoint (`api/v1/events_ingest.py`, `events/ingest/`)
 - Companion: [scheduler.md](scheduler.md) — the cron + one-off
   substrate this layer joins on
 - PG `LISTEN`/`NOTIFY` durability:


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/events/ingest/{source_slug}` (`api/v1/events_ingest.py` + `events/ingest/`) — the **JWT-less** inbound webhook surface a registered `event_source` (#2880) delivers to. It publishes one `event_outbox` row that the #2878 matcher routes to `kind=event` triggers, closing the inbound half of Initiative #2877.
- Runs a **fail-closed** guard chain in the order the issue fixes: resolve (missing/paused → uniform `404`, no oracle) → pre-parse **256 KiB body cap** (`413` before buffering) → per-source **constant-time auth** (`401`) → per-source **rate limit** (`429` + `Retry-After`, fail-loud `503`) → **dedupe** (idempotent `200`) → publish + synchronous **`__ingest__` audit row in one transaction** (postulate 7) → **fail-open** broadcast (`202 {event_id}`).
- **Consumes all three prerequisites**: #2880's `resolve_event_source_by_slug` + Vault secret custody (a new `read_event_source_secret` helper is the read counterpart to the store helper, `SecretStr` end-to-end), #2879's `event_outbox.dedupe_key`/`origin` (a `(tenant_id, dedupe_key)` unique-violation → idempotent 200), and #2878's matcher for the E2E fire.
- **No migration** — the endpoint reuses the existing `event_source` registry, `event_outbox` (dedupe_key/origin), and `audit_log`; per-source knobs (body cap / rate limit / replay window / auth header names) live in the existing `event_source.extras` JSON escape hatch. One new setting `EVENTS_INGEST_RATE_PER_MINUTE` (default 60).

## Design notes (grounded against the shipped code of #2878/#2879/#2880)

- **Per-source auth strategies**, all constant-time via `hmac.compare_digest`: `hmac-sha256` over the raw body (optional timestamp bound into the signature + replay window), `static-header`, `basic` (username from `extras`, password is the secret). Header names are `extras`-configurable so a vendor whose headers differ (Grafana's `X-Grafana-Alerting-Signature`) is config, not a code branch — the vendor-specific normalizers are #2882 (out of scope).
- **`__ingest__` identity**: ingest is authenticated per-source, not per-operator, so the chassis `AuditMiddleware` writes no row (it keys on the JWT-bound contextvar); the service writes its own `__ingest__` row (the `__sensor__`/`__scheduler__` sentinel precedent). Reading the Vault secret needs an operator, so the `__ingest__` operator reuses the backplane's existing background-dispatch service principal (`check_runner_jwt`, `check_runner_dispatch=False`); it fails closed when that principal is unconfigured. A dedicated ingest principal is a future refinement.
- **404 vs 401 reconciliation**: the issue's step 1 says missing/paused → `404` and its acceptance says bad signature → `401`, whereas #2880's resolver docstring *suggested* collapsing a missing slug into the auth-failure response. Followed the issue (the task contract): the residual 404-vs-401 oracle is acceptable because a slug is a high-entropy routing token, while the uniform 404 still hides paused-vs-missing. Documented in `docs/codebase/events.md`.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (only pre-existing macOS-only `MSG_ERRQUEUE` in `connectors/net/icmp.py`, unrelated)
- [x] `code-quality.py --diff` — 0 blockers
- [x] Security (`test_events_ingest_auth.py`): bad signature `401`, replayed/stale timestamp rejected, missing headers rejected, static-header + basic good/bad, **constant-time comparison for every strategy** (criterion 4)
- [x] Rate limit (`test_events_ingest_rate_limit.py`): `429` + `Retry-After`, per-source isolation, `0` disables, Valkey outage fail-loud
- [x] Endpoint (`test_api_v1_events_ingest.py`): uniform `404` (missing + paused), `413` before buffer (+ streaming-guard unit), `401`, `202` + outbox `origin`/`dedupe_key` + `__ingest__` audit row, idempotent `200` (no second row), broadcast fail-open, `429`/`400` mapping
- [x] E2E (`test_events_ingest_e2e.py`): POSTed event → drain tick → matched `kind=event` trigger → agent run (criterion 3)
- [x] `publish()` origin/dedupe_key + `IntegrityError`-on-duplicate; `read_event_source_secret` custody
- [x] PostgreSQL lane (`tests/integration/test_events_ingest_pg.py`, Docker-gated): same-transaction outbox + `__ingest__` audit commit and the `(tenant_id, dedupe_key)` partial-unique dedupe on the real dialect — **verified passing against a live pg16 container**
- [x] `docs/codebase/events.md` updated with the ingest section; maturity drift guard + `test_app_starts` green

## Out of scope

- Per-vendor payload normalizers (#2882) — this ships the resolver-consuming ingest primitive + a generic/passthrough acceptance path; the envelope nests the untrusted external body under `data`.
- Netpol / deploy docs (#2883).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2881
