### PR TITLE
test(connectors): harbor real-spec reconcile lane vs the pinned harbor-2.12 shelf (#2990)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,7 @@ jobs:
           # Keep the list sorted.
           sparse-checkout: |
             docs/argocd-3.3
+            docs/harbor-2.12
             docs/hetzner-robot-2026-04
             docs/keycloak-26.3
             docs/loki-3.7
@@ -337,6 +338,7 @@ jobs:
           set -euo pipefail
           for f in \
             spec-shelf/docs/argocd-3.3/argocd-swagger.json \
+            spec-shelf/docs/harbor-2.12/harbor-swagger.yaml \
             spec-shelf/docs/hetzner-robot-2026-04/webservice-en.md \
             spec-shelf/docs/keycloak-26.3/keycloak-admin-openapi.json \
             spec-shelf/docs/loki-3.7/loki-http-api.md \
@@ -355,7 +357,7 @@ jobs:
               exit 1
             fi
           done
-          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -975,6 +977,7 @@ jobs:
           path: spec-shelf
           sparse-checkout: |
             docs/argocd-3.3
+            docs/harbor-2.12
             docs/hetzner-robot-2026-04
             docs/keycloak-26.3
             docs/loki-3.7
@@ -997,6 +1000,7 @@ jobs:
           set -euo pipefail
           for f in \
             spec-shelf/docs/argocd-3.3/argocd-swagger.json \
+            spec-shelf/docs/harbor-2.12/harbor-swagger.yaml \
             spec-shelf/docs/hetzner-robot-2026-04/webservice-en.md \
             spec-shelf/docs/keycloak-26.3/keycloak-admin-openapi.json \
             spec-shelf/docs/loki-3.7/loki-http-api.md \
@@ -1015,7 +1019,7 @@ jobs:
               exit 1
             fi
           done
-          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-lint-test's login step — the

--- a/backend/src/meho_backplane/connectors/harbor/_paths.py
+++ b/backend/src/meho_backplane/connectors/harbor/_paths.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Hand-coded Harbor REST path templates — the reconcile-lane surface.
+
+Every request path the harbor connector dispatches is declared here as a
+module-level ``_*_PATH`` template constant, and every handler builds its
+concrete path from one of these templates via :func:`fill_path` (or uses
+a placeholder-free constant directly) — never from an inline f-string.
+Placeholder names are byte-for-byte the pinned spec's own path-parameter
+names (``docs/harbor-2.12/`` on the operator's spec shelf): the
+project-detail and ``/summary`` endpoints take Harbor's name-or-id
+segment ``{project_name_or_id}``, while the repository sub-tree uses
+``{project_name}`` / ``{repository_name}`` / ``{reference}`` and the
+robot-delete uses ``{robot_id}``. This lets the spec-reconcile lane
+(:mod:`tests.test_connectors_harbor_spec_reconcile`, #2990) introspect
+these live constants and assert each declared ``METHOD:/path`` is served
+by the pinned spec — the #2944 introspect-live-constants pattern (never a
+hardcoded mirror that can drift). Before #2990 the paths lived as inline
+f-strings across :mod:`~meho_backplane.connectors.harbor.connector` and
+:mod:`~meho_backplane.connectors.harbor.typed_reads`; hoisting them here
+is what makes the lane's enumeration introspectable.
+
+All templates are the folded ``/api/v2.0`` form the connector's pooled
+per-target client dispatches. The pinned Swagger 2.0 document declares
+its path keys relative to ``basePath: /api/v2.0``, which the lane
+prepends before comparing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+from urllib.parse import quote
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ["encode_segment", "fill_path"]
+
+# -- templates reconciled against the pinned Harbor 2.12 spec ---------------
+
+_SYSTEMINFO_PATH = "/api/v2.0/systeminfo"
+_HEALTH_PATH = "/api/v2.0/health"
+_PROJECTS_PATH = "/api/v2.0/projects"
+_PROJECT_PATH = "/api/v2.0/projects/{project_name_or_id}"
+_PROJECT_SUMMARY_PATH = "/api/v2.0/projects/{project_name_or_id}/summary"
+_PROJECT_REPOSITORIES_PATH = "/api/v2.0/projects/{project_name}/repositories"
+_REPOSITORY_PATH = "/api/v2.0/projects/{project_name}/repositories/{repository_name}"
+_ARTIFACTS_PATH = "/api/v2.0/projects/{project_name}/repositories/{repository_name}/artifacts"
+_ARTIFACT_PATH = (
+    "/api/v2.0/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}"
+)
+_ARTIFACT_VULNERABILITIES_PATH = (
+    "/api/v2.0/projects/{project_name}/repositories/{repository_name}"
+    "/artifacts/{reference}/additions/vulnerabilities"
+)
+_ROBOTS_PATH = "/api/v2.0/robots"
+_ROBOT_PATH = "/api/v2.0/robots/{robot_id}"
+_QUOTAS_PATH = "/api/v2.0/quotas"
+
+
+_PLACEHOLDER_RE = re.compile(r"\{([^{}]+)\}")
+
+
+def encode_segment(value: object) -> str:
+    """Percent-encode one URL path segment (OpenAPI ``style: simple``).
+
+    Empty safe set, so a reserved char in a caller-controlled value can
+    never leak path structure: a nested ``repository_name``
+    (``team/nginx`` -> ``team%2Fnginx``) keeps its separator encoded and a
+    ``sha256:`` digest ``reference`` has its ``:`` encoded to ``%3A``. The
+    single encoder both :mod:`~meho_backplane.connectors.harbor.connector`
+    and :mod:`~meho_backplane.connectors.harbor.typed_reads` share (was the
+    duplicated ``_encode_segment`` / ``_seg`` before #2990); matches the
+    retired generic dispatcher's ``_substitute_path`` RFC6570 expansion.
+    """
+    return quote(str(value), safe="")
+
+
+def fill_path(template: str, values: Mapping[str, str]) -> str:
+    """Substitute *values* into *template*'s ``{placeholder}`` segments.
+
+    Fail-loud contract, both directions: every placeholder in *template*
+    must have a value and every provided key must name a placeholder — a
+    typo'd key or a missing segment raises :exc:`ValueError` at the call
+    site instead of dispatching a malformed URL. Values are inserted
+    verbatim; callers pre-encode caller-controlled segments with
+    :func:`encode_segment` exactly as the pre-#2990 f-strings did.
+    """
+    placeholders = set(_PLACEHOLDER_RE.findall(template))
+    provided = set(values)
+    if placeholders != provided:
+        raise ValueError(
+            f"fill_path template {template!r} declares placeholders "
+            f"{sorted(placeholders)} but got values for {sorted(provided)}"
+        )
+    return _PLACEHOLDER_RE.sub(lambda match: values[match.group(1)], template)

--- a/backend/src/meho_backplane/connectors/harbor/connector.py
+++ b/backend/src/meho_backplane/connectors/harbor/connector.py
@@ -62,7 +62,6 @@ import asyncio
 import base64
 from datetime import UTC, datetime
 from typing import Any
-from urllib.parse import quote
 
 import httpx
 import structlog
@@ -74,6 +73,17 @@ from meho_backplane.connectors._shared.system_operator import (
     synthesise_system_operator,
 )
 from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.harbor._paths import (
+    _ARTIFACT_VULNERABILITIES_PATH,
+    _HEALTH_PATH,
+    _PROJECT_SUMMARY_PATH,
+    _QUOTAS_PATH,
+    _ROBOT_PATH,
+    _ROBOTS_PATH,
+    _SYSTEMINFO_PATH,
+    encode_segment,
+    fill_path,
+)
 from meho_backplane.connectors.harbor.session import (
     HarborCredentialsLoader,
     HarborTargetLike,
@@ -138,19 +148,6 @@ def _parse_harbor_version(harbor_version: str) -> tuple[str | None, str | None]:
 #: wins); pinning the current type alone keeps the projected field names
 #: stable instead of depending on which format Harbor falls back to.
 _VULN_REPORT_MIME = "application/vnd.security.vulnerability.report; version=1.1"
-
-
-def _encode_segment(value: Any) -> str:
-    """Percent-encode one URL path segment (OpenAPI ``style: simple``).
-
-    Matches how the generic dispatcher expands a ``{var}`` path template
-    (:func:`meho_backplane.operations._branches._substitute_path`): every
-    reserved char is encoded (empty safe set), so a nested ``repository_name``
-    (``team/nginx`` -> ``team%2Fnginx``) cannot leak a path separator and a
-    ``sha256:`` digest reference has its ``:`` encoded to ``%3A``. This is the
-    same resolution ``harbor.artifact.info`` uses, one segment shallower.
-    """
-    return quote(str(value), safe="")
 
 
 def _project_vulnerability(item: dict[str, Any]) -> dict[str, Any]:
@@ -358,7 +355,7 @@ class HarborConnector(HttpConnector):
         probed_at = datetime.now(UTC)
         try:
             payload = await self._get_json(
-                target, "/api/v2.0/systeminfo", operator=synthesise_system_operator()
+                target, _SYSTEMINFO_PATH, operator=synthesise_system_operator()
             )
         except (httpx.HTTPError, OSError, RuntimeError) as exc:
             return FingerprintResult(
@@ -366,7 +363,7 @@ class HarborConnector(HttpConnector):
                 product="harbor",
                 reachable=False,
                 probed_at=probed_at,
-                probe_method="GET /api/v2.0/systeminfo",
+                probe_method=f"GET {_SYSTEMINFO_PATH}",
                 extras={"error": f"{type(exc).__name__}: {exc}"},
             )
         harbor_version = payload.get("harbor_version") or ""
@@ -378,7 +375,7 @@ class HarborConnector(HttpConnector):
             build=build_str,
             reachable=True,
             probed_at=probed_at,
-            probe_method="GET /api/v2.0/systeminfo",
+            probe_method=f"GET {_SYSTEMINFO_PATH}",
             extras={
                 "auth_mode": payload.get("auth_mode"),
                 "registry_url": payload.get("registry_url"),
@@ -402,7 +399,7 @@ class HarborConnector(HttpConnector):
         probed_at = datetime.now(UTC)
         try:
             payload = await self._get_json(
-                target, "/api/v2.0/health", operator=synthesise_system_operator()
+                target, _HEALTH_PATH, operator=synthesise_system_operator()
             )
         except (httpx.HTTPError, OSError, RuntimeError) as exc:
             return ProbeResult(
@@ -538,8 +535,7 @@ class HarborConnector(HttpConnector):
                 }
             ],
         }
-        path = "/api/v2.0/robots"
-        result = await self._post_json(target, path, operator=operator, json=body)
+        result = await self._post_json(target, _ROBOTS_PATH, operator=operator, json=body)
         return {
             "id": result["id"],
             "name": result["name"],
@@ -596,7 +592,7 @@ class HarborConnector(HttpConnector):
         """
         robot_id = int(params["id"])
 
-        path = f"/api/v2.0/robots/{robot_id}"
+        path = fill_path(_ROBOT_PATH, {"robot_id": str(robot_id)})
         client = await self._http_client(target)
         headers = await self.auth_headers(target, operator)
         resp = await client.request("DELETE", path, headers=headers)
@@ -742,12 +738,13 @@ class HarborConnector(HttpConnector):
             been scanned). The dispatcher wraps it as a ``connector_error``
             OperationResult.
         """
-        project = _encode_segment(params["project_name"])
-        repository = _encode_segment(params["repository_name"])
-        reference = _encode_segment(params["reference"])
-        path = (
-            f"/api/v2.0/projects/{project}/repositories/{repository}"
-            f"/artifacts/{reference}/additions/vulnerabilities"
+        path = fill_path(
+            _ARTIFACT_VULNERABILITIES_PATH,
+            {
+                "project_name": encode_segment(params["project_name"]),
+                "repository_name": encode_segment(params["repository_name"]),
+                "reference": encode_segment(params["reference"]),
+            },
         )
         payload = await self._request_json(
             target,
@@ -826,8 +823,10 @@ class HarborConnector(HttpConnector):
             On any 4xx/5xx from Harbor (e.g. 404 for an unknown project).
             The dispatcher wraps it as a ``connector_error`` OperationResult.
         """
-        project = quote(str(params["project_name"]), safe="")
-        path = f"/api/v2.0/projects/{project}/summary"
+        path = fill_path(
+            _PROJECT_SUMMARY_PATH,
+            {"project_name_or_id": encode_segment(params["project_name"])},
+        )
         payload = await self._request_json(
             target,
             "GET",
@@ -916,9 +915,7 @@ class HarborConnector(HttpConnector):
             "page": int(params.get("page") or 1),
             "page_size": int(params.get("page_size") or 50),
         }
-        payload: Any = await self._get_json(
-            target, "/api/v2.0/quotas", operator=operator, params=query
-        )
+        payload: Any = await self._get_json(target, _QUOTAS_PATH, operator=operator, params=query)
         quotas = payload if isinstance(payload, list) else []
         return {
             "quotas": [

--- a/backend/src/meho_backplane/connectors/harbor/typed_reads.py
+++ b/backend/src/meho_backplane/connectors/harbor/typed_reads.py
@@ -27,9 +27,10 @@ arm, which evicts the cached credentials via the connector's public
 :meth:`HarborConnector.invalidate_credentials` hook (#2396) and
 re-dispatches once.
 
-The audited 9-read set (paths confirmed against the pinned Harbor
-2.11.0 OpenAPI spec, ``goharbor/harbor`` tag ``v2.11.0``,
-``api/v2.0/swagger.yaml``):
+The audited 9-read set (each ``METHOD:/path`` reconciled against the
+pinned Harbor 2.12 spec on the operator's shelf by
+:mod:`tests.test_connectors_harbor_spec_reconcile` (#2990); the path
+templates live in :mod:`~meho_backplane.connectors.harbor._paths`):
 
 * ``harbor.about`` -- ``GET /api/v2.0/systeminfo`` (appliance version,
   auth mode, registry URL).
@@ -63,9 +64,21 @@ The audited 9-read set (paths confirmed against the pinned Harbor
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, cast
-from urllib.parse import quote
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.harbor._paths import (
+    _ARTIFACT_PATH,
+    _ARTIFACTS_PATH,
+    _HEALTH_PATH,
+    _PROJECT_PATH,
+    _PROJECT_REPOSITORIES_PATH,
+    _PROJECTS_PATH,
+    _REPOSITORY_PATH,
+    _ROBOTS_PATH,
+    _SYSTEMINFO_PATH,
+    encode_segment,
+    fill_path,
+)
 from meho_backplane.connectors.harbor.session import HarborTargetLike
 
 if TYPE_CHECKING:
@@ -83,28 +96,6 @@ __all__ = [
     "harbor_repository_list_impl",
     "harbor_robot_list_impl",
 ]
-
-# Spec-relative Harbor endpoints. Every path lives under the ``/api/v2.0``
-# base the connector's pooled per-target client targets; HTTP Basic auth
-# rides every request.
-_SYSTEMINFO_PATH = "/api/v2.0/systeminfo"
-_HEALTH_PATH = "/api/v2.0/health"
-_PROJECTS_PATH = "/api/v2.0/projects"
-_ROBOTS_PATH = "/api/v2.0/robots"
-
-
-def _seg(value: object) -> str:
-    """Percent-encode one path segment with an empty safe set.
-
-    Reproduces the encoding the retired generic-ingested dispatch applied
-    to ``{var}`` placeholders (``_substitute_path``'s RFC6570 simple
-    expansion, ``quote(value, safe="")``): a reserved char like ``/`` in a
-    value becomes ``%2F`` so a value can never leak a path separator, and a
-    ``sha256:`` digest reference has its ``:`` encoded to ``%3A``. Behaviour
-    for the common bare names (``library`` / ``ubuntu`` / ``latest``) is a
-    no-op.
-    """
-    return quote(str(value), safe="")
 
 
 def _query(params: dict[str, Any], keys: tuple[str, ...]) -> dict[str, Any] | None:
@@ -189,7 +180,7 @@ async def harbor_project_info_impl(
     the summary endpoint (``harbor.project.summary``, #2858). Requires
     ``project_name`` from ``harbor.project.list``.
     """
-    path = f"{_PROJECTS_PATH}/{_seg(params['project_name'])}"
+    path = fill_path(_PROJECT_PATH, {"project_name_or_id": encode_segment(params["project_name"])})
     return await connector._get_json(target, path, operator=operator)
 
 
@@ -205,7 +196,10 @@ async def harbor_repository_list_impl(
     names within a project. Requires ``project_name``; optional ``q`` /
     ``sort`` / ``page`` / ``page_size``. Returns a bare JSON array.
     """
-    path = f"{_PROJECTS_PATH}/{_seg(params['project_name'])}/repositories"
+    path = fill_path(
+        _PROJECT_REPOSITORIES_PATH,
+        {"project_name": encode_segment(params["project_name"])},
+    )
     query = _query(params, ("q", "sort", "page", "page_size"))
     raw = await connector._get_json(target, path, operator=operator, params=query)
     return cast("list[dict[str, Any]]", raw)
@@ -224,9 +218,13 @@ async def harbor_repository_info_impl(
     repository. ``repository_name`` is the bare image name (without the
     project prefix).
     """
-    project = _seg(params["project_name"])
-    repository = _seg(params["repository_name"])
-    path = f"{_PROJECTS_PATH}/{project}/repositories/{repository}"
+    path = fill_path(
+        _REPOSITORY_PATH,
+        {
+            "project_name": encode_segment(params["project_name"]),
+            "repository_name": encode_segment(params["repository_name"]),
+        },
+    )
     return await connector._get_json(target, path, operator=operator)
 
 
@@ -245,9 +243,13 @@ async def harbor_artifact_list_impl(
     optional ``q`` / ``sort`` / ``page`` / ``page_size`` and the ``with_*``
     flags. Returns a bare JSON array.
     """
-    project = _seg(params["project_name"])
-    repository = _seg(params["repository_name"])
-    path = f"{_PROJECTS_PATH}/{project}/repositories/{repository}/artifacts"
+    path = fill_path(
+        _ARTIFACTS_PATH,
+        {
+            "project_name": encode_segment(params["project_name"]),
+            "repository_name": encode_segment(params["repository_name"]),
+        },
+    )
     query = _query(
         params,
         (
@@ -280,10 +282,14 @@ async def harbor_artifact_info_impl(
     ``with_*`` include flag is passed) the vulnerability scan overview,
     SBOM accessors, and signature status.
     """
-    project = _seg(params["project_name"])
-    repository = _seg(params["repository_name"])
-    reference = _seg(params["reference"])
-    path = f"{_PROJECTS_PATH}/{project}/repositories/{repository}/artifacts/{reference}"
+    path = fill_path(
+        _ARTIFACT_PATH,
+        {
+            "project_name": encode_segment(params["project_name"]),
+            "repository_name": encode_segment(params["repository_name"]),
+            "reference": encode_segment(params["reference"]),
+        },
+    )
     query = _query(
         params,
         (

--- a/backend/tests/test_connectors_harbor_spec_reconcile.py
+++ b/backend/tests/test_connectors_harbor_spec_reconcile.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""harbor real-spec reconcile lane (#2990) — the #2980 harness.
+
+Asserts every hand-coded ``METHOD:/path`` the harbor connector dispatches
+is served by the pinned ``harbor-2.12`` spec on the shelf (``goharbor/harbor``
+``api/v2.0/swagger.yaml`` at tag ``v2.12.2``, **Apache-2.0**; provenance in
+the shelf's ``MANIFEST.md``, version matching the lab's deployed Harbor
+``v2.12.2``). Parse-only set compare — no DB, no embeddings, no containers —
+so it lives in the required unit sweep per the lane-placement rule in
+``docs/decisions/spec-reconcile-guards-standard.md``. Uniform skip when the
+shelf is unconfigured (``tests/_spec_shelf.py`` contract).
+
+The pinned artifact is **Swagger 2.0**, which the ingest parser rejects by
+decision (#2090), so the lane supplies its own served-set extraction instead
+of routing through :func:`tests._spec_shelf.openapi_served_op_ids` — the
+standard's non-OpenAPI-artifact clause, following the ``argocd-3.3`` lane's
+sanctioned Swagger 2.0 extraction shape. The document declares
+``basePath: /api/v2.0``, so the extractor folds that prefix onto every path
+key before comparing against the connector's hand-coded ``/api/v2.0/…`` form
+(the #1796 server-base fold). No OpenAPI 3 conversion is pinned: the typed
+ops exist precisely because ingest rejects the document, so a converted
+artifact would be a test-only fabrication with no dispatch-fidelity value.
+
+The declared set is introspected from the connector's live constants (the
+#2944 pattern — never a hardcoded mirror): #2990 hoisted every request path
+out of inline f-strings (previously spread across ``connector.py`` /
+``typed_reads.py``) into the ``_*_PATH`` template constants of
+:mod:`~meho_backplane.connectors.harbor._paths`, which every handler now fills
+via ``fill_path`` (or uses directly) — so these constants ARE the dispatched
+surface. Template placeholders carry the pinned spec's own path-parameter
+names: the project detail / ``/summary`` endpoints take Harbor's name-or-id
+segment ``{project_name_or_id}`` while the repository sub-tree uses
+``{project_name}`` / ``{repository_name}`` / ``{reference}`` and the
+robot-delete uses ``{robot_id}`` — making the reconcile byte-for-byte against
+the ``basePath``-folded path keys. The HTTP method cannot be introspected
+from a bare path string, so :data:`_METHODS_BY_CONSTANT` declares it per
+constant (``_ROBOTS_PATH`` dispatches under two methods — list ``GET`` and
+create ``POST``) and a guard test pins the constant-name set; the method
+claims come from the dispatch seams: the nine typed reads and the
+``project_summary`` / ``quota_list`` / ``artifact_vulnerabilities`` reads are
+``GET``, ``robot_create`` is a ``POST``, and ``robot_delete`` is a ``DELETE``.
+
+All 14 reconciled op_ids were served on the first armed run; no path repoints
+and no evidenced exclusions were needed (the connector's fingerprint /
+``systeminfo`` and probe / ``health`` reads are both modeled by the pinned
+spec, unlike keycloak's OIDC-token / serverinfo exclusions). A red run here
+is the guard surfacing a finding; triage per
+docs/decisions/spec-reconcile-guards-standard.md.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from meho_backplane.connectors.harbor import _paths
+from tests._spec_shelf import assert_op_ids_served, require_shelf_spec
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SPEC_DIR = "harbor-2.12"
+_SPEC_FILE = "harbor-swagger.yaml"
+_SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
+
+#: The Swagger 2.0 path-item keys that are HTTP operations (its fixed verb
+#: vocabulary); everything else on a path item (``parameters``, vendor
+#: extensions) is not a served operation.
+_SWAGGER2_METHODS = frozenset({"get", "put", "post", "delete", "options", "head", "patch"})
+
+#: HTTP method(s) per hand-coded path constant reconciled against the pinned
+#: spec. Declared (not introspected) because a module-level path string
+#: carries no method; the guard test below pins this mapping's key set against
+#: the live constants so the two can never drift apart silently.
+#: ``_ROBOTS_PATH`` serves both a collection read (``GET``) and a create
+#: (``POST``).
+_METHODS_BY_CONSTANT: dict[str, tuple[str, ...]] = {
+    "_SYSTEMINFO_PATH": ("GET",),
+    "_HEALTH_PATH": ("GET",),
+    "_PROJECTS_PATH": ("GET",),
+    "_PROJECT_PATH": ("GET",),
+    "_PROJECT_SUMMARY_PATH": ("GET",),
+    "_PROJECT_REPOSITORIES_PATH": ("GET",),
+    "_REPOSITORY_PATH": ("GET",),
+    "_ARTIFACTS_PATH": ("GET",),
+    "_ARTIFACT_PATH": ("GET",),
+    "_ARTIFACT_VULNERABILITIES_PATH": ("GET",),
+    "_ROBOTS_PATH": ("GET", "POST"),
+    "_ROBOT_PATH": ("DELETE",),
+    "_QUOTAS_PATH": ("GET",),
+}
+
+
+def _path_constants() -> dict[str, str]:
+    """The live ``_*_PATH`` constants of ``harbor._paths``, by constant name."""
+    return {
+        name: value
+        for name, value in vars(_paths).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the harbor connector dispatches."""
+    constants = _path_constants()
+    return {
+        f"{method}:{constants[name]}"
+        for name, methods in _METHODS_BY_CONSTANT.items()
+        for method in methods
+    }
+
+
+def test_path_constants_are_all_discovered_and_method_mapped() -> None:
+    """Guard: the introspection finds every path constant, each with a method.
+
+    Pinning the exact constant-name set (the #2944 guard shape) means a
+    renamed or dropped ``_*_PATH`` constant — or a new one that skips the
+    ``_PATH`` suffix convention or lacks a method mapping — can't silently
+    shrink the reconciled set to a vacuous pass.
+    """
+    assert sorted(_path_constants()) == sorted(_METHODS_BY_CONSTANT)
+
+
+def test_hand_coded_op_id_manifest_is_pinned() -> None:
+    """Pin the swept op_id set so drift can't silently shrink the reconcile.
+
+    Runs unconditionally (no shelf needed), so the enumeration wiring is
+    proven on every sweep — the nsx-lane manifest precedent. A new hand-coded
+    path, a renamed constant, or a changed method must update this manifest
+    consciously, and the lane's declared set moves with it. Template segments
+    carry the vendor's own parameter names (reconciled against the pinned spec
+    in the armed test below).
+    """
+    assert sorted(_declared_op_ids()) == [
+        "DELETE:/api/v2.0/robots/{robot_id}",
+        "GET:/api/v2.0/health",
+        "GET:/api/v2.0/projects",
+        "GET:/api/v2.0/projects/{project_name_or_id}",
+        "GET:/api/v2.0/projects/{project_name_or_id}/summary",
+        "GET:/api/v2.0/projects/{project_name}/repositories",
+        "GET:/api/v2.0/projects/{project_name}/repositories/{repository_name}",
+        "GET:/api/v2.0/projects/{project_name}/repositories/{repository_name}/artifacts",
+        "GET:/api/v2.0/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}",
+        "GET:/api/v2.0/projects/{project_name}/repositories/{repository_name}"
+        "/artifacts/{reference}/additions/vulnerabilities",
+        "GET:/api/v2.0/quotas",
+        "GET:/api/v2.0/robots",
+        "GET:/api/v2.0/systeminfo",
+        "POST:/api/v2.0/robots",
+    ]
+
+
+def _swagger2_served_op_ids(spec_path: Path) -> set[str]:
+    """Extract the served ``METHOD:/path`` set from the pinned Swagger 2.0 YAML.
+
+    The pinned spec is Swagger 2.0, which the ingest parser rejects by
+    decision (#2090) — so this lane extracts directly instead of routing
+    through :func:`tests._spec_shelf.openapi_served_op_ids` (the standard's
+    non-OpenAPI-artifact clause; same shape as the argocd lane, reading YAML
+    rather than JSON). Served op_ids are the ``basePath``-folded path keys
+    crossed with their operation-verb keys; the harbor document declares
+    ``basePath: /api/v2.0``, so every key folds onto the ``/api/v2.0/…`` form
+    the connector hand-codes. Format drift on the shelf (a re-pin that is no
+    longer Swagger 2.0, or an empty path map) fails loudly rather than
+    regressing the lane to a vacuous compare.
+    """
+    document = yaml.safe_load(spec_path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict) or str(document.get("swagger")) != "2.0":
+        got = document.get("swagger") if isinstance(document, dict) else type(document).__name__
+        raise AssertionError(
+            f"{_SPEC_LABEL}: expected a Swagger 2.0 document (got swagger={got!r}) — "
+            "the shelf artifact format moved; update this lane's extraction."
+        )
+    base = str(document.get("basePath") or "").rstrip("/")
+    served = {
+        f"{method.upper()}:{base}{path}"
+        for path, item in (document.get("paths") or {}).items()
+        for method in item
+        if method.lower() in _SWAGGER2_METHODS
+    }
+    if not served:
+        raise AssertionError(
+            f"{_SPEC_LABEL}: extracted zero served operations — the shelf "
+            "artifact layout moved; update this lane's extraction."
+        )
+    return served
+
+
+def test_declared_op_ids_are_served_by_the_pinned_spec() -> None:
+    """Every hand-coded harbor op_id is served by the pinned harbor-2.12 spec.
+
+    A red run here is the guard surfacing a finding; triage per
+    docs/decisions/spec-reconcile-guards-standard.md.
+    """
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = _swagger2_served_op_ids(spec_path)
+    assert_op_ids_served(_declared_op_ids(), served, spec_label=_SPEC_LABEL)

--- a/docs/codebase/connectors-harbor.md
+++ b/docs/codebase/connectors-harbor.md
@@ -321,14 +321,14 @@ not one of the 9.
 | `harbor.about` | `harbor-system` | `GET /api/v2.0/systeminfo` |
 | `harbor.health` | `harbor-system` | `GET /api/v2.0/health` |
 | `harbor.project.list` | `harbor-projects` | `GET /api/v2.0/projects` |
-| `harbor.project.info` | `harbor-projects` | `GET /api/v2.0/projects/{project_name}` |
+| `harbor.project.info` | `harbor-projects` | `GET /api/v2.0/projects/{project_name_or_id}` |
 | `harbor.repository.list` | `harbor-repositories` | `GET /api/v2.0/projects/{project_name}/repositories` |
 | `harbor.repository.info` | `harbor-repositories` | `GET /api/v2.0/projects/{project_name}/repositories/{repository_name}` |
 | `harbor.artifact.list` | `harbor-artifacts` | `GET …/repositories/{repository_name}/artifacts` |
 | `harbor.artifact.info` | `harbor-artifacts` | `GET …/artifacts/{reference}` |
 | `harbor.robot.list` | `harbor-robots` | `GET /api/v2.0/robots` |
 | `harbor.artifact.vulnerabilities` *(standalone typed read, #2857)* | `harbor-artifacts` | `GET …/artifacts/{reference}/additions/vulnerabilities` |
-| `harbor.project.summary` *(standalone typed read, #2858)* | `harbor-projects` | `GET /api/v2.0/projects/{project_name}/summary` |
+| `harbor.project.summary` *(standalone typed read, #2858)* | `harbor-projects` | `GET /api/v2.0/projects/{project_name_or_id}/summary` |
 | `harbor.quota.list` *(standalone typed read, #2858)* | `harbor-projects` | `GET /api/v2.0/quotas?reference=project` |
 
 **Quota lives on the summary endpoint, not on `Project`**: `harbor.project.info`
@@ -344,6 +344,27 @@ only exposes secrets in the `POST` create response, and the read handler
 returns Harbor's list payload verbatim. The unit and acceptance tests assert
 this invariant explicitly.
 
+**Spec-reconcile lane (#2990).** Every request path the connector dispatches
+is declared once as a `_*_PATH` template constant in
+[`_paths.py`](../../backend/src/meho_backplane/connectors/harbor/_paths.py)
+(hoisted out of inline f-strings by #2990); each handler builds its concrete
+path via `fill_path` (or uses a placeholder-free constant directly), and the
+single `encode_segment` helper percent-encodes caller-controlled segments — so
+these constants ARE the dispatched surface. The lane
+[`test_connectors_harbor_spec_reconcile.py`](../../backend/tests/test_connectors_harbor_spec_reconcile.py)
+(parse-only, in the required unit sweep; uniform skip when the shelf is
+unconfigured) introspects those live constants and asserts all 14 hand-coded
+`METHOD:/path` op_ids are served by the pinned `harbor-2.12` shelf spec
+(`harbor-swagger.yaml` — `goharbor/harbor@v2.12.2` `api/v2.0/swagger.yaml`,
+Apache-2.0). The spec is Swagger 2.0 (ingest rejects it, #2090), so the lane
+extracts its own served set and folds the document's `basePath: /api/v2.0`
+onto every path key; template placeholders carry the vendor's own parameter
+names (`{project_name_or_id}` on the project detail / `/summary` routes,
+`{project_name}` / `{repository_name}` / `{reference}` on the repository
+sub-tree, `{robot_id}` on robot-delete). All 14 were served on the first armed
+run — no repoints, no exclusions. Standard:
+[`docs/decisions/spec-reconcile-guards-standard.md`](../decisions/spec-reconcile-guards-standard.md).
+
 ## Tests
 
 - `tests/test_connectors_harbor_typed_reads.py` — unit tests (SQLite): each read
@@ -351,6 +372,11 @@ this invariant explicitly.
   forwarding, `source_kind="typed"`, the robot id/secret invariant,
   `classify_op == "read"`, and the registration-shape invariants (safe,
   no-approval, read-only tag, `llm_instructions` canonical keys, no write op).
+- `tests/test_connectors_harbor_spec_reconcile.py` — the #2990 real-spec
+  reconcile lane: introspects the `_paths` template constants and asserts every
+  hand-coded `METHOD:/path` is served by the pinned `harbor-2.12` Swagger 2.0
+  spec (basePath-folded); the two offline guards (constant-set + op_id manifest)
+  run unconditionally, the armed assertion skips clean without the shelf.
 - `tests/acceptance/_harbor_canary_fixtures.py` — shared fixtures: runs the
   typed registrar, seeds a `Target`, respx-mocks the Harbor REST surface, and
   stubs the credentials loader.

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -455,6 +455,31 @@ pins latest stable 8.x (PVE 8.4); meho's `proxmox-api` connector
 advertises `>=7.0,<9.0`. **Sequencing:** the pin lands via consumer-repo
 PR (`claude-rdc-hetzner-dc#2546`) which must merge before this repo's
 widened verify step can pass.
+### Extension: harbor / harbor-2.12 (#2990)
+
+The same secret-gated checkout additionally fetches the shelf's
+`docs/harbor-2.12/` directory (~0.3 MB; the lane parses
+`harbor-swagger.yaml`, the `harbor-core` Swagger 2.0 document, 134
+paths) for the harbor reconcile lane
+(`backend/tests/test_connectors_harbor_spec_reconcile.py`), under the
+identical ephemeral-use conditions recorded above (sparse read-only
+checkout, workspace destroyed at job end, never committed, never in
+artifacts or logs, secret withheld from fork PRs and the Dependabot
+store). No vendor-license attestation is needed for this extension: the
+spec is vendored at `api/v2.0/swagger.yaml` in the **public, Apache-2.0**
+[`goharbor/harbor`](https://github.com/goharbor/harbor) repo (pinned at
+tag `v2.12.2`, commit `73072d0d`, retrieved 2026-08-18 — matching the
+lab's deployed Harbor `v2.12.2-73072d0d`) — the provenance note of
+record is the shelf's `harbor-2.12/MANIFEST.md`, per the
+OSS-licensed-spec form in
+[`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
+extension mechanics. The artifact stays Swagger 2.0 (no OpenAPI 3
+derivative): ingest rejects Swagger 2.0 by decision (#2090), so the
+lane supplies its own extraction — folding the document's
+`basePath: /api/v2.0` onto every path key (the argocd `argocd-swagger.json`
+precedent, reading YAML rather than JSON). **Sequencing:** the pin lands
+via consumer-repo PR (`claude-rdc-hetzner-dc#2549`) which must merge
+before this repo's widened verify step can pass.
 
 ## Consequences
 


### PR DESCRIPTION
## Summary

- **harbor real-spec reconcile lane** (`backend/tests/test_connectors_harbor_spec_reconcile.py`) — the #2980 harness applied to the harbor connector: asserts every hand-coded `METHOD:/path` it dispatches is served by the pinned `harbor-2.12` Swagger 2.0 spec (`goharbor/harbor@v2.12.2` `api/v2.0/swagger.yaml`, Apache-2.0), pinned to the **lab's deployed Harbor v2.12.2** (INVENTORY § Harbor).
- **Path hoist** — every request path moved out of inline f-strings (`connector.py` / `typed_reads.py`) into `_paths.py` template constants filled via `fill_path`, with a single `encode_segment` helper (the keycloak #2988 precedent). Behaviour-preserving: runtime URLs are byte-identical (226 harbor tests green). This is what makes the lane introspect the live dispatched surface, never a hardcoded mirror.
- The spec is **Swagger 2.0** (ingest rejects it, #2090), so the lane supplies its own served-set extraction and **folds `basePath: /api/v2.0`** onto every path key — the argocd lane's shape, reading YAML.
- **CI + provenance** — both Python jobs' spec-shelf `sparse-checkout` + verify step widened for `docs/harbor-2.12`; OSS provenance note appended to `vendor-spec-ci-provisioning.md`; lane documented in `docs/codebase/connectors-harbor.md`.

## Findings (red-lane protocol)

All **14** hand-coded op_ids were **served on the first armed run — no repoints, no evidenced exclusions**. Template placeholders were named to the vendor's own path-parameter names during the hoist: `{project_name_or_id}` on the project detail / `/summary` routes (Harbor's name-or-id segment), `{project_name}` / `{repository_name}` / `{reference}` on the repository sub-tree, `{robot_id}` on robot-delete. The fingerprint/`systeminfo` and probe/`health` reads are both modeled by the spec (unlike keycloak's OIDC-token / serverinfo exclusions).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean for the changed files (pre-existing macOS-only `net/icmp.py` `MSG_ERRQUEUE` unrelated; resolves on CI Linux)
- [x] Lane **armed** against a local `harbor-2.12` shelf — 3 passed (all 14 op_ids served)
- [x] Lane **unarmed** (no `MEHO_CONSUMER_DOCS_ROOT`) — 2 offline guards pass, armed assertion skips clean with the uniform reason
- [x] Behaviour-preservation — 226 harbor + blast-radius tests green (typed_reads / auth / robot / quota / cve / credread / registry_v2 / broadcast credential-mint / execution_profile / g35 dispatch + jsonflux)
- [x] `code-quality.py --diff` — 0 blockers (5 pre-existing size warnings on touched functions/file)

## Sequencing / out of scope

- The pinned spec lands via consumer-repo PR **evoila-bosnia/claude-rdc-hetzner-dc#2549** (paired work-ticket #2545). That PR must merge before this repo's widened `ci.yml` verify step passes and the lane arms in CI; until then the lane skips clean. Verified locally against the consumer PR's shelf branch files (CI cannot see them until that PR merges).
- Siblings #2991 (loki) / #2992 (proxmox) edit the same `ci.yml` lists — a trivial rebase collision the orchestrator serializes.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2990
