### PR TITLE
feat(deploy): netpol knob + deploy docs for in-cluster webhook senders

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -392,6 +392,55 @@ jobs:
             || { echo "::error title=CHART_VERSION env missing::Deployment must inject CHART_VERSION=${CHART_VER} from .Chart.Version (#631)" >&2; exit 1; }
           echo ">> CHART_VERSION env present with value ${CHART_VER}"
 
+      - name: Assert in-cluster ingest-sender netpol rule renders on opt-in (#2883)
+        # #2883: under the default-deny NetworkPolicy, tcp/8000 ingress is
+        # admitted ONLY from the ingress-controller namespace, so an
+        # in-cluster webhook sender (Alertmanager, Grafana, Harbor, VCF
+        # Operations) in another namespace can't reach the inbound
+        # event-ingest endpoint (#2881) without hair-pinning through the
+        # ingress hostname. `networkPolicy.ingestAllowedNamespaces` renders
+        # an ADDITIONAL ingress rule admitting the listed namespaces (one
+        # OR-ed `kubernetes.io/metadata.name` peer each) on tcp/8000. This
+        # golden test proves BOTH directions the schema can't see: the
+        # opt-in render emits a peer per listed namespace, and the default
+        # render (from the "Helm template + kubeconform" step, which sets no
+        # ingestAllowedNamespaces) carries NO sender namespace — the
+        # backplane stays default-deny unless an operator opts a namespace in.
+        run: |
+          set -euo pipefail
+          helm template test deploy/charts/meho/ \
+            --set image.tag=test \
+            --set ingress.host=meho.test \
+            --set ingress.tls.secretName=meho-tls \
+            --set postgres.credentialsSecret=meho-postgres \
+            --set vault.address=https://vault.test \
+            --set keycloak.issuer=https://keycloak.test/realms/meho \
+            --set config.keycloakIssuerUrl=https://keycloak.test/realms/meho \
+            --set config.keycloakAudience=meho-backplane \
+            --set config.vaultAddr=https://vault.test \
+            --set networkPolicy.postgresCIDR=10.0.1.0/24 \
+            --set networkPolicy.vaultCIDR=10.0.2.0/24 \
+            --set networkPolicy.keycloakCIDR=10.0.3.0/24 \
+            --set 'networkPolicy.ingestAllowedNamespaces={monitoring,harbor}' \
+            --show-only templates/networkpolicy.yaml \
+            > /tmp/rendered-ingest-netpol.yaml
+
+          # Opt-in: each listed namespace renders as its own namespaceSelector
+          # peer, matched on the kube-apiserver-stamped metadata.name label.
+          grep -Eq '^[[:space:]]*kubernetes\.io/metadata\.name:[[:space:]]*monitoring[[:space:]]*$' /tmp/rendered-ingest-netpol.yaml \
+            || { echo "::error::networkPolicy.ingestAllowedNamespaces did not render the 'monitoring' peer (#2883 regression)"; exit 1; }
+          grep -Eq '^[[:space:]]*kubernetes\.io/metadata\.name:[[:space:]]*harbor[[:space:]]*$' /tmp/rendered-ingest-netpol.yaml \
+            || { echo "::error::networkPolicy.ingestAllowedNamespaces did not render the 'harbor' peer (#2883 regression)"; exit 1; }
+
+          # Opt-out: the default-overrides render (no ingestAllowedNamespaces)
+          # must carry ONLY the ingress-controller peer — no sender namespace
+          # leaks into a default install.
+          if grep -Eq '^[[:space:]]*kubernetes\.io/metadata\.name:[[:space:]]*(monitoring|harbor)[[:space:]]*$' /tmp/rendered.yaml; then
+            echo "::error::default render leaked an ingest-sender netpol rule without opt-in (#2883 regression)"
+            exit 1
+          fi
+          echo ">> ingest-sender netpol rule verified: renders on opt-in, absent by default"
+
   helm-test:
     # Internal "run" job — the REQUIRED branch-protection context lives on the
     # `helm-test-gate` aggregator below, not here. A required job that is gated

--- a/deploy/charts/meho/templates/networkpolicy.yaml
+++ b/deploy/charts/meho/templates/networkpolicy.yaml
@@ -23,6 +23,29 @@ spec:
       ports:
         - port: 8000
           protocol: TCP
+    {{- with .Values.networkPolicy.ingestAllowedNamespaces }}
+    # In-cluster webhook senders (Alertmanager, Grafana, Harbor, VCF
+    # Operations, ...) delivering to the inbound event-ingest endpoint
+    # (`POST /api/v1/events/ingest/{source_slug}`, #2881) from another
+    # namespace of the same cluster. Default empty → this rule is omitted
+    # and the backplane stays default-deny; only namespaces listed in
+    # `networkPolicy.ingestAllowedNamespaces` are admitted to tcp/8000.
+    # Each entry matches a namespace by the `kubernetes.io/metadata.name`
+    # label kube-apiserver stamps on every namespace (Kubernetes ≥ 1.22),
+    # the same label the ingress-controller rule above matches on. The
+    # peers are OR-ed, so any listed namespace is admitted. SaaS-origin
+    # senders and the satellite-runner inbound listener are out of scope —
+    # they reach the endpoint through the ingress hostname.
+    - from:
+        {{- range . }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . }}
+        {{- end }}
+      ports:
+        - port: 8000
+          protocol: TCP
+    {{- end }}
   egress:
     # PostgreSQL — locked to the operator-supplied CIDR. Defaults to a /32
     # placeholder so the chart fails-closed on a misconfigured value rather

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -892,6 +892,15 @@
         "keycloakCIDR": {
           "type": "string",
           "description": "Keycloak egress CIDR (IPv4). Same conditional shape rules as postgresCIDR."
+        },
+        "ingestAllowedNamespaces": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          "description": "Namespaces whose Pods are admitted to the inbound event-ingest endpoint on tcp/8000, for in-cluster webhook senders (Alertmanager, Grafana, Harbor, VCF Operations) in another namespace of the same cluster. Each entry is an RFC 1123 namespace name matched by its kubernetes.io/metadata.name label; the rendered ingress rule OR-s them. Default empty — the backplane stays default-deny and senders reach it via the ingress hostname. SaaS-origin senders and the satellite-runner inbound listener are out of scope."
         }
       },
       "allOf": [

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -1064,6 +1064,20 @@ networkPolicy:
   vaultCIDR: ""
   # -- Keycloak egress CIDR. Same conditional rules as postgresCIDR.
   keycloakCIDR: ""
+  # -- Namespaces whose Pods may reach the inbound event-ingest endpoint
+  # (`POST /api/v1/events/ingest/{source_slug}`, #2881) on tcp/8000
+  # directly, for **in-cluster** webhook senders (Alertmanager, Grafana,
+  # Harbor, VCF Operations, ...) running in another namespace of the same
+  # cluster. Each entry is a namespace name matched by its
+  # `kubernetes.io/metadata.name` label; the rendered ingress rule OR-s
+  # them. Default empty — the backplane stays default-deny and every
+  # sender reaches it through the ingress hostname instead. Add a
+  # namespace here only after registering the matching event source
+  # (`meho event-source add`); see the "In-cluster webhook senders"
+  # section of docs/deploying.md. SaaS-origin senders and the
+  # satellite-runner inbound listener are out of scope — they use the
+  # ingress hostname, not this rule.
+  ingestAllowedNamespaces: []
 
 # -- Node selector applied to the Pod template.
 nodeSelector: {}

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -195,6 +195,22 @@ Ingress is permitted only from the namespace whose
 `networkPolicy.ingressControllerNamespace` (default `ingress-nginx`,
 RKE2's bundled controller).
 
+`networkPolicy.ingestAllowedNamespaces` (default `[]`) renders a
+**second** ingress rule for **in-cluster webhook senders** delivering to
+the inbound event-ingest endpoint (`POST
+/api/v1/events/ingest/{source_slug}`, #2881): each listed namespace
+becomes an OR-ed `kubernetes.io/metadata.name` peer admitted to
+`tcp/8000`, matched on the label kube-apiserver stamps on every namespace
+(Kubernetes ≥ 1.22). Empty by default, so the rule is omitted and the
+backplane stays default-deny — a sender in another namespace otherwise
+has to hair-pin through the ingress hostname. The full operator flow
+(enable the knob, register the `event_source`, custody its per-source
+secret, point the sender's webhook at the in-cluster Service URL) is the
+[In-cluster webhook senders](../deploying.md#in-cluster-webhook-senders)
+section of the deploy guide. SaaS-origin senders and the satellite-runner
+inbound listener are out of scope — they reach the endpoint through the
+ingress hostname, not this rule.
+
 The three egress CIDR fields ship **empty** in `values.yaml` and are
 required-with-shape-validation in the schema **when
 `networkPolicy.enabled: true`**. The chart will not render with the

--- a/docs/deploying.md
+++ b/docs/deploying.md
@@ -353,6 +353,113 @@ each lives inline in
   Applied to **both** the backplane container and the migration Job
   container.
 
+## In-cluster webhook senders
+
+MEHO accepts inbound events from external producers — Alertmanager,
+Grafana, Harbor, VCF Operations, or any `generic-json` webhook — at the
+JWT-less ingest endpoint `POST /api/v1/events/ingest/{source_slug}`
+(#2881). Each producer is a registered `event_source` (#2880),
+authenticated per-source against a Vault-custodied shared secret. This
+section wires an **in-cluster** sender (one running in another namespace
+of the same cluster) end to end. SaaS-origin senders and the
+satellite-runner inbound listener are out of scope here — both reach the
+endpoint through the ingress hostname of step 1.
+
+### 1. Reach the endpoint — two paths
+
+The backplane is internal-only; it is never publicly exposed. A sender
+reaches the ingest endpoint one of two ways:
+
+- **Ingress hostname (default).** Point the sender's webhook at
+  `https://<ingress.host>/api/v1/events/ingest/<slug>` on the cluster's
+  internal DNS. This needs **no** NetworkPolicy change — the chart's
+  default-deny policy already admits the ingress-controller namespace,
+  and the request arrives through the ingress like any other. Prefer this
+  unless you have a reason not to round-trip through the ingress.
+- **Direct to the Service (opt-in NetworkPolicy).** With
+  `networkPolicy.enabled: true` (the default), tcp/8000 ingress is
+  admitted **only** from the ingress-controller namespace, so a sender in
+  another namespace cannot dial the Service directly. List its namespace
+  in `networkPolicy.ingestAllowedNamespaces` to render an additional
+  ingress rule admitting it, then point the webhook at the in-cluster
+  Service URL
+  `http://<release>.<meho-namespace>.svc.cluster.local:8000/api/v1/events/ingest/<slug>`
+  (the `ClusterIP` Service is named after the Helm release and listens on
+  `service.port`, default 8000). The knob is a list of namespace names;
+  the rendered rule OR-s them:
+
+  ```yaml
+  networkPolicy:
+    ingestAllowedNamespaces:
+      - monitoring   # e.g. Alertmanager / Grafana
+      - harbor
+  ```
+
+  Default empty — the backplane stays default-deny until you opt a
+  namespace in. When `networkPolicy.enabled: false` (a mesh-level policy
+  is enforced upstream) the knob is a no-op; add the equivalent admit
+  rule to that policy instead. See
+  [`codebase/devops.md`](codebase/devops.md#networkpolicy) for the
+  rendered-rule detail.
+
+### 2. Register the source + custody its secret
+
+Register the source once with the CLI. The backplane writes the auth
+secret to Vault under **your** operator identity and persists only the
+derived path (`tenants/<tenant_id>/event-sources/<slug>`, KV-v2 field
+`secret`) on the row — the value never lands in the database, a log line,
+or an audit row.
+
+```bash
+# The secret is NEVER a flag — pipe it via stdin (or MEHO_EVENT_SOURCE_SECRET).
+printf '%s' "$SIGNING_KEY" | meho event-source add alertmanager-prod \
+  --name "Alertmanager (prod)" \
+  --kind alertmanager \
+  --auth-strategy hmac-sha256 \
+  --secret-stdin
+```
+
+- `--kind` selects the producer family: `alertmanager` | `grafana` |
+  `vcf-operations` | `harbor` | `generic-json`.
+- `--auth-strategy` picks how the sender is authenticated — all three
+  verify against the Vault secret:
+  - `hmac-sha256` — the sender signs the raw body with the shared key.
+    The generic scheme sends the hex signature in `X-Meho-Signature` and
+    a unix timestamp in `X-Meho-Timestamp` (bound into the signature and
+    gated by a 300 s replay window). A vendor with different header names
+    (Grafana's `X-Grafana-Alerting-Signature`) overrides them via
+    `--extras`, not a code change.
+  - `static-header` — a fixed header (default `Authorization`) carries a
+    shared token compared against the secret (Harbor).
+  - `basic` — HTTP Basic; the non-secret username goes in
+    `--extras '{"basic_username":"…"}'` and the password is the Vault
+    secret (Alertmanager `http_config`).
+- **Rotate** with `meho event-source update <slug> --secret-stdin` — a
+  new KV-v2 version at the same path, read on the ingest path's next
+  lookup, zero downtime. **Pause** with `--status paused` (rejected on
+  the next request; a paused *or* missing source both return a uniform
+  `404`).
+- Per-source tuning rides on `--extras` (a JSON object): `max_body_bytes`
+  (clamped ≤ 256 KiB), `rate_per_minute`, `replay_window_seconds`
+  (≤ 3600), `require_timestamp`, and the `*_header` / `basic_username`
+  names above.
+
+Reading the secret on the ingest path needs a Vault client identity — the
+same background-dispatch service principal the sensor check-runner uses
+([`checkRunner.*`](#per-operator-wif-and-background-dispatch-2642)). With
+none configured the Vault read fails and ingest fails closed (`503`).
+
+### 3. Point the sender at the webhook
+
+Configure the sender's webhook receiver at the URL from step 1 and its
+auth material to match the strategy from step 2 (the same signing key /
+token / password you custodied). On success the endpoint returns `202`
+(accepted) or `200` (idempotent duplicate); a bad signature is `401`, an
+oversize body `413`, a throttled burst `429`. The event lands one
+`event_outbox` row that the drain + subscription matcher route to
+`kind=event` scheduler triggers — see [`codebase/events.md`](codebase/events.md)
+for the internal path.
+
 ## See also
 
 - [`codebase/devops.md`](codebase/devops.md) — chart internals, migration


### PR DESCRIPTION
## Summary

- Add `networkPolicy.ingestAllowedNamespaces` (default `[]`) to the MEHO Helm chart: a list of namespace names that renders an **additional** NetworkPolicy ingress rule admitting **in-cluster** webhook senders (Alertmanager, Grafana, Harbor, VCF Operations) to the inbound event-ingest endpoint (`POST /api/v1/events/ingest/{source_slug}`, #2881) on tcp/8000. Each entry becomes an OR-ed `kubernetes.io/metadata.name` peer, mirroring the chart's existing single-namespace ingress-controller rule.
- **Least-open by default:** empty list → the `{{- with }}` block renders nothing → the backplane stays default-deny. The knob is opt-in; a sender only reaches the Service directly once its namespace is listed.
- **Design note:** the knob lives under `networkPolicy.*` (not a new top-level `ingest.*` section) so all NetworkPolicy config stays where the template reads it (`.Values.networkPolicy.*`) — the "or equivalent" placement the issue invites. `values.schema.json` gains an array + RFC 1123 item pattern (its `additionalProperties: false` requires the new key be declared, else `helm lint` rejects it).
- **Deploy docs:** a new `docs/deploying.md` "In-cluster webhook senders" section documents the end-to-end operator flow — sender reachability (ingress hostname default vs. the netpol opt-in), registering the `event_source` (#2880), custodying the per-source HMAC/bearer/Basic secret in Vault (`meho event-source add`), and pointing the webhook at the in-cluster Service URL. `docs/codebase/devops.md` gets the matching rendered-rule note.
- Honours the non-goal: **in-cluster senders only.** SaaS-origin senders and the satellite-runner inbound listener stay on the ingress hostname and are explicitly out of scope.

## Test plan

- [x] `helm lint` (with `--set 'networkPolicy.ingestAllowedNamespaces={monitoring,harbor}'`) — clean; schema accepts the array.
- [x] `helm template` opt-in render — emits one `namespaceSelector` peer per listed namespace on tcp/8000.
- [x] `helm template` opt-out default render — only the ingress-controller peer; no sender namespace leaks in (default-deny preserved).
- [x] `kubeconform -strict -kubernetes-version 1.28.0` on the opt-in render — 11/11 resources valid.
- [x] Negative schema test — an invalid namespace name (`Bad_NS`) is rejected by `helm template`.
- [x] New chart-CI golden test (`chart.yml` → `validate`) asserting the opt-in render **and** the opt-out default — runs green end-to-end locally.
- [x] `values.schema.json` valid JSON; `values.yaml` valid YAML; no trailing whitespace.

No backend code, no migration — chart + docs only (effort:small). NetworkPolicy multi-peer OR semantics confirmed against the [upstream Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/network-policies/); `kubernetes.io/metadata.name` is control-plane-stamped since k8s 1.22 (chart floor is 1.28, and the existing ingress-controller rule already relies on it).

## Out of scope

- SaaS-origin senders + satellite-runner inbound listener (per Initiative #2877 non-goal).
- Richer per-vendor payload normalisation (#2882).

Closes #2883
