### PR TITLE
test(connectors): vcf-logs armed + vcf-fleet dormant spec-reconcile lanes (#2993)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,13 +351,14 @@ jobs:
             spec-shelf/docs/vcenter-9.0/vcenter.yaml \
             spec-shelf/docs/vcenter-9.0/vi-json.yaml \
             spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json \
+            spec-shelf/docs/vcf-operations-9.0/vcf-operations-for-logs-openapi.json \
             spec-shelf/docs/vcf-operations-9.0/vcf-operations-openapi.ingestable.json; do
             if [ ! -f "$f" ]; then
               echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
               exit 1
             fi
           done
-          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -1013,13 +1014,14 @@ jobs:
             spec-shelf/docs/vcenter-9.0/vcenter.yaml \
             spec-shelf/docs/vcenter-9.0/vi-json.yaml \
             spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/vra-iaas.json \
+            spec-shelf/docs/vcf-operations-9.0/vcf-operations-for-logs-openapi.json \
             spec-shelf/docs/vcf-operations-9.0/vcf-operations-openapi.ingestable.json; do
             if [ ! -f "$f" ]; then
               echo "::error title=Spec-shelf layout drift::${f} missing after the spec-shelf checkout — the real-spec lanes would silently skip. Fix the shelf layout or this workflow's sparse-checkout path."
               exit 1
             fi
           done
-          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-lint-test's login step — the

--- a/backend/tests/test_connectors_vcf_fleet_spec_reconcile.py
+++ b/backend/tests/test_connectors_vcf_fleet_spec_reconcile.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vcf-fleet (vRSLCM) real-spec reconcile lane (#2993) — the #2980 harness.
+
+Asserts every hand-coded ``/lcm/*`` literal the vcf-fleet connector dispatches
+against a pinned ``vcf-fleet-9.0`` shelf spec. Parse-only set compare — no DB,
+no embeddings, no containers — so it lives in the required unit sweep per the
+lane-placement rule in ``docs/decisions/spec-reconcile-guards-standard.md``.
+Uniform skip when the shelf is unconfigured (``tests/_spec_shelf.py`` contract).
+
+Outcome (b) — a vendor spec EXISTS but is not yet pinned (#2993), so this lane
+ships **dormant**: it skips uniformly until the spec lands on the shelf, then
+arms (the standard's "the lane still ships and skips uniformly; it arms itself
+the day the spec lands on the shelf"). The declared-set enumeration guard below
+runs unconditionally regardless.
+
+Where the spec comes from (the #2993 hunt, evidenced 2026-08-18):
+
+* VCF Fleet 9.0 is a **rebrand of vRealize Suite Lifecycle Manager (vRSLCM)
+  8.x / VMware Aria Suite Lifecycle** — same Spring codebase, same
+  ``/lcm/<area>/api/...`` surface, same ``Lcm-API-Version: 8.0`` header (shelf
+  ``kb/vcf-fleet-9.0-overview.md``). Its **vRSLCM 1.3.0 LCM REST API** — the
+  ``/lcm/lcops/api/v2/*`` surface this connector dispatches — is served by the
+  appliance's own Swagger UI (``/api/swagger-ui.html``) and documented on the
+  Broadcom developer portal (``developer.broadcom.com/xapis/
+  vrealize-suite-lifecycle-manager/latest/`` — "vRealize Suite Lifecycle
+  Manager API - 1.3.0"; also ``developer.vmware.com/apis/1190``). MEHO's G3.6
+  canary ingested exactly this surface (``docs/cross-repo/g36-fleet-canary.md``
+  — "the vRSLCM LCM REST OpenAPI surface; vRSLCM 1.3.0"), so a machine-readable
+  spec demonstrably exists and covers ``/about`` + ``/environments`` +
+  ``/datacenters``. An evidenced *exclusion* would repeat the nsx-9.0
+  falsification (an appliance-served spec the exclusion's probe never checked),
+  so this is a pin-and-arm (b), not an exclusion (c).
+* It is **not** the public ``vmware/vcf-api-specs`` ``fleet-lcm-openapi.yaml``:
+  that document is the **new VCF 9 "Fleet LCM Service" API** at
+  ``https://vcf.broadcom.com/fleet-lcm`` → ``/v1/*`` (health, config, components,
+  tasks, upgrade-plans, release-versions, system), a distinct surface that
+  serves **zero** ``/lcm/lcops/*`` / ``/lcm/common/*`` / ``/lcm/locker/*`` path
+  (grep-confirmed). Pinning it would red-line all eight literals for the wrong
+  reason.
+
+Pinning is the orchestrator's licensed-spec choreography (consumer-shelf PR +
+``ci.yml`` sparse-checkout/verify widening for ``docs/vcf-fleet-9.0`` + the
+``vendor-spec-ci-provisioning.md`` signoff extension — vendor-served form, like
+nsx-9.0, referencing the wave-3 blanket determination). Per the #2993 handoff:
+
+* dir ``vcf-fleet-9.0``; file :data:`_SPEC_FILE`;
+* source: fetch the vRSLCM 1.3.0 LCM REST OpenAPI from the operator's own lab
+  Fleet / Aria Suite Lifecycle appliance's Swagger backend (behind
+  ``/api/swagger-ui.html``) — the nsx-9.0 appliance-served pattern.
+
+Served-set extraction is finalized at pin time against the actual artifact:
+this lane uses :func:`~tests._spec_shelf.openapi_served_op_ids` (OpenAPI 3.x);
+if the appliance emits Swagger 2.0 (springfox ``/v2/api-docs``), swap to a
+Swagger-2.0 extractor per the vcf-automation / argocd precedent — the standard's
+non-OpenAPI-artifact clause. First armed run triages any unserved literal per
+the red-lane protocol; note six of the eight are the diagnostic endpoints that
+return **HTTP 500 across the vRSLCM 8.x family** (they are hand-coded in
+``_FLEET_BROKEN_DIAGNOSTIC_ENDPOINTS`` as a known-issue inventory), so whether
+the vendor spec documents them is exactly what the first arm decides.
+
+The declared set is introspected from the connector's live constants (the #2944
+pattern — never a hardcoded mirror): the three ``_FLEET_*_PATH`` module
+constants (probe / about / environments) plus the
+``_FLEET_BROKEN_DIAGNOSTIC_ENDPOINTS`` tuple. The connector dispatches
+**GET-only** — HTTP Basic on every request, no session-establish POST — so every
+literal declares ``GET:``.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vcf_fleet import connector as _connector
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+_SPEC_DIR = "vcf-fleet-9.0"
+#: Handoff filename the shelf pin must land under (or adjust here to match). The
+#: vRSLCM 1.3.0 LCM REST OpenAPI, fetched from the appliance Swagger backend.
+_SPEC_FILE = "vrslcm-lcm-openapi.json"
+_SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
+
+
+def _path_constants() -> dict[str, str]:
+    """The live ``_*_PATH`` string constants of ``connector``, by constant name."""
+    return {
+        name: value
+        for name, value in vars(_connector).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the vcf-fleet connector dispatches.
+
+    Sweeps the live module constants (never a hardcoded mirror): the
+    ``_FLEET_*_PATH`` op/probe constants and the
+    ``_FLEET_BROKEN_DIAGNOSTIC_ENDPOINTS`` known-issue tuple. All dispatch as
+    ``GET`` — the Fleet connector sends HTTP Basic per request with no
+    session-establish POST.
+    """
+    paths = set(_path_constants().values())
+    paths |= set(_connector._FLEET_BROKEN_DIAGNOSTIC_ENDPOINTS)
+    return {f"GET:{path}" for path in paths}
+
+
+def test_hand_coded_path_surface_is_pinned() -> None:
+    """Guard: the introspection finds every hand-coded ``/lcm/*`` literal.
+
+    Pinning the exact ``_*_PATH`` constant-name set, the broken-diagnostic
+    tuple, and the assembled op_id set (the #2944 guard shape) means a renamed
+    or dropped constant — or a new path that skips the convention — fails here
+    until the reconcile is updated consciously, so the declared set can never
+    silently shrink to a vacuous pass. Runs unconditionally (no shelf needed),
+    so the eight-literal enumeration is proven on every sweep even while the
+    spec-assert below is dormant.
+    """
+    assert sorted(_path_constants()) == [
+        "_FLEET_ABOUT_PATH",
+        "_FLEET_ENVIRONMENTS_PATH",
+        "_FLEET_PROBE_PATH",
+    ]
+    assert _connector._FLEET_BROKEN_DIAGNOSTIC_ENDPOINTS == (
+        "/lcm/lcops/api/v2/about",
+        "/lcm/lcops/api/v2/health",
+        "/lcm/lcops/api/v2/version",
+        "/lcm/lcops/api/v2/system-details",
+        "/lcm/common/api/about",
+        "/lcm/locker/api/v2/about",
+    )
+    assert _declared_op_ids() == {
+        "GET:/lcm/common/api/about",
+        "GET:/lcm/lcops/api/v2/about",
+        "GET:/lcm/lcops/api/v2/datacenters",
+        "GET:/lcm/lcops/api/v2/environments",
+        "GET:/lcm/lcops/api/v2/health",
+        "GET:/lcm/lcops/api/v2/system-details",
+        "GET:/lcm/lcops/api/v2/version",
+        "GET:/lcm/locker/api/v2/about",
+    }
+
+
+def test_declared_op_ids_are_served_by_the_pinned_vrslcm_spec() -> None:
+    """Every hand-coded op_id is served by the pinned vRSLCM LCM REST spec.
+
+    Dormant until the spec lands on the shelf (``require_shelf_spec`` skips
+    uniformly). See the module docstring for the pin handoff and the first-arm
+    triage note.
+    """
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = openapi_served_op_ids(spec_path)
+    assert_op_ids_served(_declared_op_ids(), served, spec_label=_SPEC_LABEL)

--- a/backend/tests/test_connectors_vcf_logs_spec_reconcile.py
+++ b/backend/tests/test_connectors_vcf_logs_spec_reconcile.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""vcf-logs (vRLI) real-spec reconcile lane (#2993) — the #2980 harness.
+
+Asserts every hand-coded ``METHOD:/path`` the vcf-logs (VCF Operations for
+Logs / vRealize Log Insight) connector dispatches is served by the pinned
+``vcf-operations-9.0`` shelf's ``vcf-operations-for-logs-openapi.json`` — the
+Logs (vRLI) OpenAPI document vendored in the **public, Apache-2.0**
+`vmware/vcf-api-specs <https://github.com/vmware/vcf-api-specs>`_ repo (pinned
+at ``85151f6b``; provenance in the shelf's ``vcf-operations-9.0/MANIFEST.md``).
+Parse-only set compare — no DB, no embeddings, no containers — so it lives in
+the required unit sweep per the lane-placement rule in
+``docs/decisions/spec-reconcile-guards-standard.md``. Uniform skip when the
+shelf is unconfigured (``tests/_spec_shelf.py`` contract).
+
+Outcome (a) — an **already-pinned** shelf spec serves these paths (#2993).
+The Logs spec shares the ``vcf-operations-9.0`` directory the vcf-operations
+lane (#2984) already provisions in CI, so no new shelf dir and no
+sparse-checkout widening is needed; the file is added to the fail-loud verify
+step so a shelf-layout move can't silently regress this lane to skip.
+
+Own served-set extraction (the standard's non-OpenAPI-artifact clause).
+The vendor document is OpenAPI 3.0.1, but ``parse_openapi`` refuses it at the
+metaschema gate: ``components.securitySchemes.Bearer`` is a ``type: http``
+scheme carrying the apiKey-only ``name`` / ``in`` keys, illegal for an
+``http`` scheme under the OpenAPI 3.0 metaschema — so an operator ingest of
+the raw document fails identically. Rather than pin a repaired
+``.ingestable.json`` derivative (the vcf-operations precedent), this lane
+extracts the served set directly: the vcf-logs reconciled paths are all
+**typed** — the fingerprint version read, the events query, and the
+session-login POST — never operator-ingested, so a repaired derivative would
+be a test-only artifact with no dispatch-fidelity value (the vcf-automation
+``vra-iaas.json`` reasoning). The extractor folds the relative
+``servers[0].url`` (``/api/v2``) base onto each path key exactly as
+``parse_openapi`` (#1796) does — verified byte-for-byte against the three
+declared op_ids.
+
+The declared set is introspected from the connector's live constants (the
+#2944 pattern — never a hardcoded mirror), across the three modules that
+hand-code a vRLI path:
+
+* :mod:`~meho_backplane.connectors.vcf_logs.profile` —
+  ``VRLI_EXECUTION_PROFILE.fingerprint.path`` (``GET /api/v2/version``, the
+  unauthenticated version probe).
+* :mod:`~meho_backplane.connectors.vcf_logs.typed_ops` —
+  ``_EVENTS_PATH_PREFIX`` (``GET /api/v2/events/``). The ``vrli.event.query``
+  op appends an RFC6570 ``{+constraints}`` reserved-expansion sub-path onto
+  this prefix; the vendor spec models that exact endpoint as the reserved
+  template ``/events/{+path}``, so the reconcile declares
+  ``GET:/api/v2/events/{+path}`` — the op_id ``parse_openapi`` emits for that
+  path key.
+* :mod:`~meho_backplane.connectors._shared.profile_auth` —
+  ``_VRLI_SESSION_PATH`` (``POST /api/v2/sessions``), the ``session_login``
+  scheme's vRLI login endpoint the profiled connector POSTs. Hand-coded as a
+  vRLI-specific literal even though it lives in the shared scheme module.
+
+A red lane here is the guard surfacing a real finding, not harness noise —
+triage per docs/decisions/spec-reconcile-guards-standard.md.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from meho_backplane.connectors._shared.profile_auth import _VRLI_SESSION_PATH
+from meho_backplane.connectors.vcf_logs.profile import VRLI_EXECUTION_PROFILE
+from meho_backplane.connectors.vcf_logs.typed_ops import _EVENTS_PATH_PREFIX
+from tests._spec_shelf import assert_op_ids_served, require_shelf_spec
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SPEC_DIR = "vcf-operations-9.0"
+_SPEC_FILE = "vcf-operations-for-logs-openapi.json"
+_SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
+
+#: OpenAPI 3.x path-item keys that are HTTP operations (its fixed verb
+#: vocabulary); everything else on a path item (``parameters``, ``summary``,
+#: ``$ref``, vendor extensions) is not a served operation.
+_OPENAPI3_METHODS = frozenset({"get", "put", "post", "delete", "options", "head", "patch", "trace"})
+
+#: The reserved-expansion template segment the vendor spec models the events
+#: query with. ``vrli.event.query`` builds its request path by appending an
+#: RFC6570 ``{+constraints}`` chain onto ``_EVENTS_PATH_PREFIX``
+#: (:func:`~meho_backplane.connectors.vcf_logs.typed_ops.build_event_query_path`);
+#: the spec's ``/events/{+path}`` key is that same reserved-expansion endpoint,
+#: so the declared op_id folds this segment onto the live prefix constant.
+_EVENTS_RESERVED_TEMPLATE = "{+path}"
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the vcf-logs connector dispatches.
+
+    Built from the live constants (never a hardcoded mirror): the profile's
+    fingerprint path (GET), the events-query prefix folded with the spec's
+    reserved-expansion template segment (GET), and the shared ``session_login``
+    scheme's vRLI login path (POST).
+    """
+    return {
+        f"GET:{VRLI_EXECUTION_PROFILE.fingerprint.path}",
+        f"GET:{_EVENTS_PATH_PREFIX}{_EVENTS_RESERVED_TEMPLATE}",
+        f"POST:{_VRLI_SESSION_PATH}",
+    }
+
+
+def test_hand_coded_path_surface_is_pinned() -> None:
+    """Guard: the introspected constants and declared set can't silently drift.
+
+    Pinning the exact live-constant values plus the assembled op_id set (the
+    #2944 guard shape) means a renamed/moved constant — or a change to the
+    events reserved-expansion shape — fails here until the reconcile is updated
+    consciously, so the declared set can never shrink to a vacuous pass.
+    """
+    assert VRLI_EXECUTION_PROFILE.fingerprint.path == "/api/v2/version"
+    assert _EVENTS_PATH_PREFIX == "/api/v2/events/"
+    assert _VRLI_SESSION_PATH == "/api/v2/sessions"
+    assert _declared_op_ids() == {
+        "GET:/api/v2/version",
+        "GET:/api/v2/events/{+path}",
+        "POST:/api/v2/sessions",
+    }
+
+
+def _openapi3_served_op_ids(spec_path: Path) -> set[str]:
+    """Extract the served ``METHOD:/path`` set from an OpenAPI 3.x document.
+
+    Used instead of :func:`tests._spec_shelf.openapi_served_op_ids` because the
+    pinned Logs document fails ``parse_openapi``'s metaschema gate on a
+    malformed ``securitySchemes.Bearer`` (see the module docstring) — the
+    standard's non-OpenAPI-artifact clause. Served op_ids are the path keys
+    crossed with their operation-verb keys, with the relative ``servers[0].url``
+    base folded on (``/api/v2`` → every path folds under it), byte-identical to
+    ``parse_openapi``'s #1796 relative-server fold for the declared paths.
+    Format drift on the shelf (no longer OpenAPI 3, no server to fold, or an
+    empty path map) fails loudly rather than regressing the lane to a vacuous
+    compare.
+    """
+    document = json.loads(spec_path.read_text(encoding="utf-8"))
+    if not str(document.get("openapi", "")).startswith("3."):
+        pytest.fail(
+            f"{_SPEC_LABEL}: expected an OpenAPI 3.x document (got "
+            f"openapi={document.get('openapi')!r} / swagger={document.get('swagger')!r}) "
+            "— the shelf artifact format moved; update this lane's extraction."
+        )
+    servers = document.get("servers")
+    if not isinstance(servers, list) or not servers:
+        pytest.fail(
+            f"{_SPEC_LABEL}: no servers[] to fold the relative base from — the "
+            "shelf artifact layout moved; update this lane's extraction."
+        )
+    base = str((servers[0] or {}).get("url") or "").rstrip("/")
+    served = {
+        f"{method.upper()}:{base}{path}"
+        for path, item in (document.get("paths") or {}).items()
+        if isinstance(item, dict)
+        for method in item
+        if method.lower() in _OPENAPI3_METHODS
+    }
+    if not served:
+        pytest.fail(
+            f"{_SPEC_LABEL}: extracted zero served operations — the shelf "
+            "artifact layout moved; update this lane's extraction."
+        )
+    return served
+
+
+def test_declared_op_ids_are_served_by_the_pinned_logs_spec() -> None:
+    """Every hand-coded op_id is served by the pinned vcf-operations-for-logs spec."""
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = _openapi3_served_op_ids(spec_path)
+    assert_op_ids_served(_declared_op_ids(), served, spec_label=_SPEC_LABEL)

--- a/docs/codebase/connectors-vcf-fleet.md
+++ b/docs/codebase/connectors-vcf-fleet.md
@@ -229,3 +229,13 @@ The runbook for end-to-end ingest + enable + verify is
   <https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-fleet.sh>
 - VCF Fleet / vRSLCM API:
   <https://developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager-api/latest/>
+- Spec-reconcile guard (#2993):
+  [`backend/tests/test_connectors_vcf_fleet_spec_reconcile.py`](../../backend/tests/test_connectors_vcf_fleet_spec_reconcile.py)
+  asserts every hand-coded `/lcm/*` literal against a pinned vRSLCM 1.3.0 LCM
+  REST OpenAPI. Ships **dormant** (skips until the spec is pinned): the spec
+  exists — appliance-served (`/api/swagger-ui.html`), Broadcom-portal-documented,
+  and ingested by the G3.6 canary — but is **not** the public
+  `vmware/vcf-api-specs` `fleet-lcm-openapi.yaml` (that is the new
+  `/fleet-lcm/v1/*` service, a different surface serving none of these paths).
+  Determination + pin handoff: the lane docstring and the vcf-fleet note in
+  [`docs/decisions/vendor-spec-ci-provisioning.md`](../decisions/vendor-spec-ci-provisioning.md).

--- a/docs/codebase/connectors-vcf-logs.md
+++ b/docs/codebase/connectors-vcf-logs.md
@@ -329,6 +329,15 @@ External: `httpx>=0.27` (Bearer header + `AsyncClient`), `structlog`
   second-expiry-fails paths via `_get_json_with_session_retry`, the
   audit-row contract, and the JSONFlux handle path on the typed
   `vrli.event.query`.
+- Spec-reconcile guard (#2993):
+  [`backend/tests/test_connectors_vcf_logs_spec_reconcile.py`](../../backend/tests/test_connectors_vcf_logs_spec_reconcile.py)
+  asserts the hand-coded version / events / session-login paths against the
+  already-pinned `vcf-operations-9.0/vcf-operations-for-logs-openapi.json`
+  (public Apache-2.0, `vmware/vcf-api-specs`). Armed on every unit sweep; the
+  lane extracts the served set directly because the vendor doc trips
+  `parse_openapi`'s metaschema gate on a malformed `Bearer` scheme (see the
+  vcf-logs extension in
+  [`docs/decisions/vendor-spec-ci-provisioning.md`](../decisions/vendor-spec-ci-provisioning.md)).
 - Typed events-query coverage (#2295):
   [`backend/tests/test_connectors_vcf_logs_typed_event_query.py`](../../backend/tests/test_connectors_vcf_logs_typed_event_query.py)
   — dispatch-level `source_kind="typed"` dispatch on a fresh boot, the

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -481,6 +481,43 @@ precedent, reading YAML rather than JSON). **Sequencing:** the pin lands
 via consumer-repo PR (`claude-rdc-hetzner-dc#2549`) which must merge
 before this repo's widened verify step can pass.
 
+### Extension: vcf-logs (vRLI, `vcf-operations-9.0/vcf-operations-for-logs-openapi.json`, #2993)
+
+The vcf-logs (VCF Operations for Logs / vRealize Log Insight) reconcile lane
+(`backend/tests/test_connectors_vcf_logs_spec_reconcile.py`) reads the Logs
+(vRLI) OpenAPI document that **already ships** in the shelf's
+`docs/vcf-operations-9.0/` directory — the same directory the vcf-operations
+core lane (#2984) already provisions — so **no sparse-checkout widening** is
+needed; `vcf-operations-for-logs-openapi.json` is added to the fail-loud verify
+step of both Python jobs so a shelf-layout move can't silently regress the lane
+to skip. No vendor-license attestation is needed: the spec is vendored by VMware
+in the **public, Apache-2.0**
+[`vmware/vcf-api-specs`](https://github.com/vmware/vcf-api-specs) repo (pinned at
+`85151f6b`, retrieved 2026-04-29) — the provenance note of record is the shelf's
+`vcf-operations-9.0/MANIFEST.md`, per the OSS-licensed-spec form in
+[`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
+extension mechanics. Unlike the vcf-operations core spec, **no `.ingestable.json`
+derivative is pinned**: the vendor document fails `parse_openapi`'s OpenAPI 3.0
+metaschema gate on a malformed `securitySchemes.Bearer` (a `type: http` scheme
+carrying the apiKey-only `name`/`in` keys), but the vcf-logs reconciled paths are
+all **typed** (the version probe, the events query, the session-login POST) —
+never operator-ingested — so a repaired derivative would be a test-only artifact
+(the vcf-automation `vra-iaas.json` reasoning); the lane extracts the served set
+directly per the standard's non-OpenAPI-artifact clause. The file already being
+on the shelf, this extension arms with **no consumer-repo PR** (outcome (a) of
+#2993).
+
+**vcf-fleet (vRSLCM, #2993) — pin pending.** The paired vcf-fleet reconcile lane
+(`backend/tests/test_connectors_vcf_fleet_spec_reconcile.py`) ships **dormant**
+(outcome (b) of #2993): its vRSLCM 1.3.0 LCM REST OpenAPI (the
+`/lcm/lcops/api/v2/*` appliance-served Swagger surface — distinct from the public
+`vmware/vcf-api-specs` `fleet-lcm-openapi.yaml`, which documents the *new* VCF 9
+`/fleet-lcm/v1/*` service and serves none of the connector's paths) is not yet on
+the shelf. Its shelf pin, the `docs/vcf-fleet-9.0` sparse-checkout + verify
+widening, and a **vendor-served** signoff extension here (the nsx-9.0 form, under
+the wave-3 blanket determination above) land together with the operator's
+consumer-shelf PR — this repo change adds only the dormant lane.
+
 ## Consequences
 
 - The five real-spec lanes light up together the moment the secret exists;


### PR DESCRIPTION
## Summary

Final task of Initiative #2979 (spec-reconcile guards as standard, wave 3):
the two typed connectors with **unknown** spec availability — `vcf_fleet`
(vRSLCM, 8 `/lcm/*` literals) and `vcf_logs` (vRLI, version/events/session) —
are resolved to reconcile lanes **with evidence**, not exclusions. The
spec-availability hunt (Broadcom/VMware developer docs + `vmware/vcf-api-specs`
+ the operator shelf) flipped the anticipated "at least fleet → exclusion":
both products **do** publish a machine-readable spec, so an exclusion would
have repeated the nsx-9.0 falsification.

- **`vcf_logs` (vRLI) → outcome (a), armed & green.** The Logs OpenAPI already
  ships on the shelf (`vcf-operations-9.0/vcf-operations-for-logs-openapi.json`,
  public **Apache-2.0** `vmware/vcf-api-specs@85151f6b`) and its dir is already
  CI-provisioned. The lane asserts the hand-coded `GET:/api/v2/version`,
  `GET:/api/v2/events/{+path}`, and `POST:/api/v2/sessions` against it. The raw
  doc trips `parse_openapi`'s OpenAPI-3.0 metaschema gate on a malformed
  `securitySchemes.Bearer` (a `type: http` scheme carrying the apiKey-only
  `name`/`in`); because the reconciled paths are all **typed** (never
  operator-ingested), the lane extracts the served set directly (the standard's
  non-OpenAPI-artifact clause; the vcf-automation `vra-iaas.json` precedent)
  instead of pinning a test-only `.ingestable` derivative. **No shelf PR.**
- **`vcf_fleet` (vRSLCM) → outcome (b), dormant lane + handoff below.** The
  connector's `/lcm/lcops/api/v2/*` surface is the **vRSLCM 1.3.0 LCM REST API**
  — appliance-served (Swagger UI `/api/swagger-ui.html`), Broadcom-portal
  documented, and previously ingested by the G3.6 canary — so a spec exists but
  is not pinned. The lane ships dormant (skips until the spec lands). It is
  **not** the public `vmware/vcf-api-specs` `fleet-lcm-openapi.yaml`: that
  documents the *new* VCF 9 `/fleet-lcm/v1/*` service (absolute server
  `https://vcf.broadcom.com/fleet-lcm`) and serves **zero** `/lcm/lcops`,
  `/lcm/common`, or `/lcm/locker` paths (grep-confirmed).

Both lanes introspect the declared set from **live connector constants** (the
#2944 pattern — never a hardcoded mirror), pin the enumeration in an
unconditional guard test, and are parse-only unit-sweep lanes (no DB / no
embeddings / no ingest). Outcome (a) is ruled out for both against the pinned
`sddc-manager-9.0` / `vcf-operations-9.0` cores by product identity (vRSLCM and
Log Insight are distinct API surfaces).

## Handoff — `vcf_fleet` outcome (b) shelf pin (orchestrator's licensed-spec choreography)

The meho side is done (dormant lane). To arm it, the consumer-shelf pin +
CI/ADR wiring — deliberately **not** in this PR:

| Field | Value |
|---|---|
| Product-version dir | `vcf-fleet-9.0` |
| Filename (lane's `_SPEC_FILE`) | `vrslcm-lcm-openapi.json` (adjust the lane constant if you pin a different name/extension) |
| Spec | vRSLCM **1.3.0** LCM REST OpenAPI — the `/lcm/lcops/api/v2/*` + `/lcm/common/*` + `/lcm/locker/*` surface |
| Source (fetch) | The operator's own lab **Fleet / VMware Aria Suite Lifecycle** appliance, behind the Swagger UI at `https://<fleet>/api/swagger-ui.html` (springfox api-docs backend) — the **nsx-9.0 appliance-served** pattern. Public reference: `developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager/latest/` ("vRealize Suite Lifecycle Manager API - 1.3.0"), `developer.vmware.com/apis/1190`. |
| License form | **vendor-served** (like nsx-9.0) → the wave-3 blanket determination in `vendor-spec-ci-provisioning.md` covers it; add the signoff-extension paragraph. |
| CI wiring | add `docs/vcf-fleet-9.0` to the `sparse-checkout` list **and** the verify-step file list in **both** Python jobs (`ci.yml`). |

Two things to verify at pin time (why the lane ships dormant, not falsely
green):

1. **Format.** The lane uses `openapi_served_op_ids` (OpenAPI 3.x). vRSLCM
   springfox commonly emits **Swagger 2.0** (`/v2/api-docs`); if so, swap the
   served-set extraction for a Swagger-2.0 extractor (the vcf-automation /
   argocd precedent) — the lane docstring flags this.
2. **Coverage (the nsx lesson).** 6 of the 8 literals are the diagnostic
   endpoints that return **HTTP 500 across the vRSLCM 8.x family** and are
   hand-coded in `_FLEET_BROKEN_DIAGNOSTIC_ENDPOINTS` as a known-issue
   inventory; the canary confirms `/lcm/lcops/api/v2/about` is in the spec, but
   whether the spec documents `/health` / `/version` / `/system-details` and the
   `/lcm/common/*` + `/lcm/locker/*` `about` variants is exactly what the first
   armed run triages per the red-lane protocol.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] mypy scope is `src/` only (lanes not mypy-checked) — n/a
- [x] Local pre-verify against the full shelf
  (`MEHO_CONSUMER_DOCS_ROOT=<shelf>/docs`): `vcf_logs` armed lane **2 passed**;
  `vcf_fleet` enumeration guard **passed** + armed assert **skipped** (dormant,
  no `vcf-fleet-9.0` dir).
- [x] Degraded mode (no shelf env): both enumeration guards pass, both armed
  asserts skip.
- [x] Regression: sibling `vcf-operations` lane still green; 44 `spec_reconcile`
  tests collect cleanly.
- [x] `ci.yml` valid YAML; verify step adds the already-present logs file in
  both jobs (stays green).

## ci.yml scope

Touched **only** to widen the fail-loud verify step (both Python jobs) with the
already-provisioned `vcf-operations-for-logs-openapi.json` — no sparse-checkout
change (its dir is already fetched for the vcf-operations lane). **No** ci.yml
change for `vcf_fleet` — its checkout widening lands with the shelf pin
(handoff above).

## Out of scope

- The `vcf_fleet` shelf pin + its CI/ADR wiring (outcome (b) handoff above).
- The vRSLCM/Log-Insight connectors' behavior — unchanged; only test lanes +
  docs added.

Closes #2993
