### PR TITLE
feat(connectors): modern fleet-lcm-9.0 impl + first two-impl resolution (#3036, #3037)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,7 @@ jobs:
           # Keep the list sorted.
           sparse-checkout: |
             docs/argocd-3.3
+            docs/fleet-lcm-9.0
             docs/harbor-2.12
             docs/hetzner-robot-2026-04
             docs/keycloak-26.3
@@ -338,6 +339,7 @@ jobs:
           set -euo pipefail
           for f in \
             spec-shelf/docs/argocd-3.3/argocd-swagger.json \
+            spec-shelf/docs/fleet-lcm-9.0/fleet-lcm-openapi.yaml \
             spec-shelf/docs/harbor-2.12/harbor-swagger.yaml \
             spec-shelf/docs/hetzner-robot-2026-04/webservice-en.md \
             spec-shelf/docs/keycloak-26.3/keycloak-admin-openapi.json \
@@ -358,7 +360,7 @@ jobs:
               exit 1
             fi
           done
-          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; fleet-lcm-openapi.yaml present under spec-shelf/docs/fleet-lcm-9.0/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Pulls inside the DinD daemon (testcontainers PostgresContainer
@@ -1036,6 +1038,7 @@ jobs:
           path: spec-shelf
           sparse-checkout: |
             docs/argocd-3.3
+            docs/fleet-lcm-9.0
             docs/harbor-2.12
             docs/hetzner-robot-2026-04
             docs/keycloak-26.3
@@ -1059,6 +1062,7 @@ jobs:
           set -euo pipefail
           for f in \
             spec-shelf/docs/argocd-3.3/argocd-swagger.json \
+            spec-shelf/docs/fleet-lcm-9.0/fleet-lcm-openapi.yaml \
             spec-shelf/docs/harbor-2.12/harbor-swagger.yaml \
             spec-shelf/docs/hetzner-robot-2026-04/webservice-en.md \
             spec-shelf/docs/keycloak-26.3/keycloak-admin-openapi.json \
@@ -1079,7 +1083,7 @@ jobs:
               exit 1
             fi
           done
-          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
+          echo "spec-shelf OK: argocd-swagger.json present under spec-shelf/docs/argocd-3.3/; fleet-lcm-openapi.yaml present under spec-shelf/docs/fleet-lcm-9.0/; harbor-swagger.yaml present under spec-shelf/docs/harbor-2.12/; webservice-en.md present under spec-shelf/docs/hetzner-robot-2026-04/; keycloak-admin-openapi.json present under spec-shelf/docs/keycloak-26.3/; loki-http-api.md present under spec-shelf/docs/loki-3.7/; nsx_api.openapi3.json + nsx_policy_api.openapi3.json present under spec-shelf/docs/nsx-9.0/; apidata.js present under spec-shelf/docs/proxmox-8.4/; http-api-index.md + rabbit_shovel_mgmt_shovels.erl present under spec-shelf/docs/rabbitmq-4.3/; sddc-manager-openapi.json present under spec-shelf/docs/sddc-manager-9.0/; vcenter.yaml + vi-json.yaml present under spec-shelf/docs/vcenter-9.0/; vra-iaas.json present under spec-shelf/docs/vcf-automation-9.0/swagger-vra-sdk-go-v0.6.5/; vcf-operations-openapi.ingestable.json + vcf-operations-for-logs-openapi.json present under spec-shelf/docs/vcf-operations-9.0/"
 
       - name: Docker Hub login (for testcontainers pulls)
         # Same rationale as python-lint-test's login step — the

--- a/backend/src/meho_backplane/connectors/fleet_lcm/__init__.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/__init__.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.fleet_lcm — FleetLcmConnector package.
+
+Importing this package registers :class:`FleetLcmConnector` against the v2
+connector registry under
+``(product="fleet", version="9.0", impl_id="fleet-lcm")`` — the **modern**
+generic implementation of ``product=fleet``, coexisting with the legacy
+typed ``fleet-rest`` impl
+(:mod:`meho_backplane.connectors.vcf_fleet`). This is the first real
+two-impl case in the codebase; the two are resolved per target by
+fingerprint (:func:`~meho_backplane.connectors.resolver.resolve_connector`):
+a 9.0 target resolves ``fleet-lcm`` by its narrower ``>=9.0,<10.0`` band
+(most-specific-version tie-break), an 8.x target resolves ``fleet-rest``
+(the only in-range candidate after #3037's ``>=8.0,<10.0`` re-band). The
+decision of record is ``versioned-connector-dual-impl`` (initiative
+`evoila/meho#3033 <https://github.com/evoila/meho/issues/3033>`_).
+
+The chassis lifespan calls
+:func:`~meho_backplane.connectors.registry._eager_import_connectors` which
+walks every ``connectors/<product>/`` subpackage at startup, so the
+registration lands before any dispatch can occur.
+
+**No wildcard sibling registration.** Unlike the typed connectors' G0.15-T6
+(#1215) ``(product, "", "")`` fanout, this package registers **only** the
+versioned triple. The legacy ``vcf_fleet`` package already registers the
+``("fleet", "", "")`` wildcard fallback; a second class on that same
+wildcard key would raise :exc:`RuntimeError` at import
+(``register_connector_v2`` rejects a duplicate three-tuple key). One
+wildcard per product is enough — it exists so an *unfingerprinted* fleet
+target still resolves *something*; which concrete class it points at does
+not matter for the "resolve at all" guarantee, and the versioned entries
+carry the real per-band matching once a version is known.
+
+Operations for this connector arrive via **G0.7 spec ingestion** against
+the public Apache-2.0 ``fleet-lcm-openapi.yaml``
+(``vmware/vcf-api-specs``) as ``source_kind="ingested"``
+``endpoint_descriptor`` rows under ``connector_id="fleet-lcm-9.0"`` — they
+are not hand-coded. Registering this hand-rolled :class:`HttpConnector`
+subclass is the load-bearing prerequisite for those rows to become
+dispatchable (a bare ``GenericRestConnector`` auto-shim is
+non-dispatchable), the
+:class:`~meho_backplane.connectors.vmware_rest.connector.VmwareRestConnector`
+pattern.
+"""
+
+from typing import Final
+
+from meho_backplane.connectors.fleet_lcm.connector import FleetLcmConnector
+from meho_backplane.connectors.fleet_lcm.session import (
+    FleetLcmCredentialsLoader,
+    FleetLcmTargetLike,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.registry import register_connector_v2
+
+#: Endpoint-descriptor identity for the modern Fleet LCM connector — the
+#: dispatch-canonical ``(product, version, impl_id)`` triple
+#: :func:`parse_connector_id` derives from ``"fleet-lcm-9.0"``, plus the
+#: derived ``connector_id`` slug. :class:`FleetLcmConnector` pins the same
+#: triple as class attributes; the ingested ``/v1/*`` rows land under
+#: :data:`FLEET_LCM_CONNECTOR_ID`.
+FLEET_LCM_PRODUCT: Final[str] = "fleet"
+FLEET_LCM_VERSION: Final[str] = "9.0"
+FLEET_LCM_IMPL_ID: Final[str] = "fleet-lcm"
+FLEET_LCM_CONNECTOR_ID: Final[str] = f"{FLEET_LCM_IMPL_ID}-{FLEET_LCM_VERSION}"
+
+
+register_connector_v2(
+    product=FLEET_LCM_PRODUCT,
+    version=FLEET_LCM_VERSION,
+    impl_id=FLEET_LCM_IMPL_ID,
+    cls=FleetLcmConnector,
+)
+
+__all__ = [
+    "FLEET_LCM_CONNECTOR_ID",
+    "FLEET_LCM_IMPL_ID",
+    "FLEET_LCM_PRODUCT",
+    "FLEET_LCM_VERSION",
+    "FleetLcmConnector",
+    "FleetLcmCredentialsLoader",
+    "FleetLcmTargetLike",
+    "load_credentials_from_vault",
+]

--- a/backend/src/meho_backplane/connectors/fleet_lcm/connector.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/connector.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""FleetLcmConnector — hand-rolled HttpConnector subclass for the VCF 9 Fleet LCM Service.
+
+The **modern** generic implementation of ``product=fleet`` — the second,
+coexisting impl beside the legacy typed ``fleet-rest``
+(:class:`~meho_backplane.connectors.vcf_fleet.connector.VcfFleetConnector`).
+This is the first real two-impl case in the codebase; the two are
+resolved per target by fingerprint (see
+:func:`~meho_backplane.connectors.resolver.resolve_connector`):
+
+* ``fleet-lcm`` (this class) advertises ``supported_version_range=">=9.0,<10.0"``
+  — the narrower band, so a VCF Fleet 9.0 target resolves here by the
+  resolver's most-specific-version tie-break.
+* ``fleet-rest`` advertises ``">=8.0,<10.0"`` (re-banded from ``">=9.0,<10.0"``
+  in this same initiative, #3037) — Aria Suite Lifecycle 8.x plus the VCF
+  Fleet 9.0 ``/lcm/*`` back-compat surface. An 8.x target resolves there
+  as the only in-range candidate.
+
+The two impls target **distinct API surfaces** on the same product family:
+``fleet-lcm`` dispatches the new ``https://vcf.broadcom.com/fleet-lcm`` →
+``/v1/*`` service (health, config, components, sddc-lcms, upgrade-plans,
+tasks, system); ``fleet-rest`` dispatches the legacy vRSLCM-derived
+``/lcm/lcops/api/v2/*`` surface. The modern surface is the VCF 9
+successor to vRealize Suite Lifecycle Manager (vRSLCM) 8.x; the legacy
+``/lcm/*`` surface still answers on 9.0 appliances for back-compat, which
+is why both bands overlap at 9.0 and the resolver — not the connector —
+picks the surface per target.
+
+Skeleton-only — auth + fingerprint + probe + the G0.6 dispatch shim, the
+same shape the legacy ``vcf_fleet`` connector first shipped as (#831).
+The 51 ``/v1/*`` operations arrive via **G0.7 spec ingestion** against the
+pinned public ``fleet-lcm-openapi.yaml`` (Apache-2.0,
+``vmware/vcf-api-specs``) as ``source_kind="ingested"``
+``endpoint_descriptor`` rows under ``connector_id="fleet-lcm-9.0"`` — they
+are **not** hand-coded here. Registering this real
+:class:`HttpConnector` subclass is the load-bearing prerequisite that
+makes those ingested rows *dispatchable*: a bare ``GenericRestConnector``
+auto-shim is non-dispatchable (its ``auth_headers`` / ``execute`` raise),
+so the ingested ops ride *this* class's ``auth_headers`` on dispatch, the
+:class:`~meho_backplane.connectors.vmware_rest.connector.VmwareRestConnector`
+pattern.
+
+Auth
+----
+
+Per the pinned spec's ``securitySchemes``, the global security scheme is
+``bearerToken`` (HTTP Bearer), with ``basicAuth`` (HTTP Basic) also
+defined. :meth:`auth_headers` implements Bearer as the primary path and
+Basic as the fallback:
+
+* When the loaded credentials carry a non-empty ``"token"`` key, the
+  header is ``Authorization: Bearer <token>`` — the spec's primary
+  scheme.
+* Otherwise the header is ``Authorization: Basic <b64>`` off the
+  ``username`` / ``password`` pair — the spec's ``basicAuth`` alternative,
+  reusing the shared
+  :func:`~meho_backplane.connectors._shared.vcf_auth.basic_auth_header`
+  the legacy impl uses.
+
+The shared
+:class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
+enforces the ``{"username", "password"}`` contract, so the loader always
+returns that pair (the appliance accepts ``basicAuth`` too) and may
+additionally carry the optional ``"token"``. Credentials are cached
+per tenant-unique ``(tenant_id, target.id)`` and reused on subsequent
+calls, the legacy Basic shape verbatim.
+
+**Bearer live-verify is a follow-up (non-goal here).** There is no
+reachable Fleet LCM appliance (#1002 / #995), so the Bearer *header
+shape* is unit-tested (an injected loader returning a ``"token"``) but
+never exercised against a live appliance, and the default
+:func:`~meho_backplane.connectors.fleet_lcm.session.load_credentials_from_vault`
+surfaces only the ``username`` / ``password`` pair (the shared
+basic-creds read) — so the live default is the Basic alternative until
+the Bearer-token provisioning seam lands. That seam — a fleet-lcm loader
+surfacing a Vault-stored token, or a POST-``basicAuth`` →
+mint-``bearerToken`` session flow — is the documented live-verify
+follow-up gated on a stood-up appliance, exactly the posture the legacy
+skeleton shipped with.
+
+Auth model gating
+-----------------
+
+v0.2 locks the connector to :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` (or
+``None`` for pre-G0.3 targets), the shared
+:func:`~meho_backplane.connectors._shared.vcf_auth.is_acceptable_auth_model`
+gate the Harbor / NSX / SDDC Manager / vcf-fleet precedents established.
+
+Fingerprint / probe
+-------------------
+
+Unlike the legacy impl — whose first-party diagnostic endpoints return
+HTTP 500 on 9.0 builds, forcing a datacenters-list workaround — the
+modern service exposes a first-class health endpoint. The connector
+probes ``GET /v1/health`` (``operationId`` ``getHealth``; the spec marks
+it ``security: []`` — no auth required, so it is the clean reachability
+surface). :meth:`fingerprint` sends the connector's auth headers anyway
+(harmless on an unauthenticated endpoint, and it keeps probe and dispatch
+on one auth path); on any transport/status failure it returns a
+non-reachable :class:`FingerprintResult` whose ``extras["error"]`` names
+the exception, the Harbor / NSX / vcf-fleet pattern. The product version
+is not assumed from any single ``/v1/*`` field; ``version`` is left
+``None`` unless the health payload carries an explicit ``version`` string.
+
+Operations
+----------
+
+This module ships zero hand-coded operations — :meth:`execute` exists for
+ABC compatibility and delegates to the G0.6 dispatcher. The 51 ``/v1/*``
+ops land in ``endpoint_descriptor`` via spec ingestion; until an operator
+ingests the spec, the connector is registered and discoverable but
+``execute`` against any ``op_id`` resolves to "unknown operation" at the
+dispatcher — the correct behaviour for a registered-but-empty connector
+at this Task's stage.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
+from meho_backplane.connectors._shared.vcf_auth import (
+    CredentialsCache,
+    basic_auth_header,
+    is_acceptable_auth_model,
+)
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.fleet_lcm.session import (
+    FleetLcmCredentialsLoader,
+    FleetLcmTargetLike,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["FleetLcmConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Reachability probe: the Fleet LCM Service health endpoint (operationId
+# ``getHealth``; ``security: []`` in the pinned spec — no auth required).
+# Served as ``GET /v1/health`` — the spec's server url
+# ``https://vcf.broadcom.com/fleet-lcm`` is absolute, so ``parse_openapi``
+# does NOT fold the ``/fleet-lcm`` base onto path keys (only *relative*
+# server bases are folded, #1796); the ingested op_id and this probe
+# constant are both the raw ``/v1/*`` path, and the ``/fleet-lcm`` base is
+# an operator target-configuration concern. The reconcile lane
+# (test_connectors_fleet_lcm_spec_reconcile.py) introspects this constant
+# and asserts the pinned spec serves ``GET:/v1/health``.
+_FLEET_LCM_HEALTH_PATH = "/v1/health"
+_FLEET_LCM_PROBE_METHOD = "GET /v1/health (VCF Fleet LCM Service health endpoint)"
+
+
+class FleetLcmConnector(HttpConnector):
+    """VCF 9 Fleet LCM Service REST connector — Bearer (Basic fallback) auth.
+
+    Per-target credentials cached in :attr:`_creds` via the shared
+    :class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
+    (loaded once via the injectable
+    :class:`~meho_backplane.connectors.fleet_lcm.session.FleetLcmCredentialsLoader`).
+    :meth:`auth_headers` emits ``Authorization: Bearer <token>`` when the
+    loaded credentials carry a ``"token"`` (the spec's primary scheme),
+    falling back to ``Authorization: Basic <b64>`` off the
+    username/password pair (the spec's ``basicAuth`` alternative).
+
+    :attr:`priority` is ``1`` — equal to the legacy ``fleet-rest`` impl by
+    design: the two impls are split by **version-specificity**, not
+    priority (``fleet-lcm``'s narrower ``>=9.0,<10.0`` wins a 9.0 target at
+    the resolver's most-specific-version step, before priority is ever
+    consulted). A higher priority would be redundant and would mask the
+    specificity split; ``1`` also keeps a stray ``GenericRestConnector``
+    auto-shim from out-ranking this hand-coded class on the shared
+    registry.
+    """
+
+    # G0.6 v2 registry metadata. The (product, version, impl_id) triple
+    # matches the dispatcher's parse_connector_id contract:
+    # ``"fleet-lcm-9.0"`` -> (``"fleet"``, ``"9.0"``, ``"fleet-lcm"``).
+    product = "fleet"
+    version = "9.0"
+    impl_id = "fleet-lcm"
+    supported_version_range = ">=9.0,<10.0"
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: FleetLcmCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        loader: FleetLcmCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+        self._creds: CredentialsCache = CredentialsCache(loader, product_label="fleet-lcm")
+
+    async def auth_headers(self, target: FleetLcmTargetLike, operator: Operator) -> dict[str, str]:
+        """Return the ``Authorization`` header — Bearer primary, Basic fallback.
+
+        Loads credentials from Vault on first call against *target* via the
+        shared :class:`CredentialsCache` (reused on subsequent calls) and
+        threads the full ``operator`` through so the live default loader
+        reads the per-target secret under the operator's Vault Identity
+        entity — the locked Option A decision, the same path the legacy
+        impl uses.
+
+        When the loaded credentials carry a non-empty ``"token"``, returns
+        ``{"Authorization": "Bearer <token>"}`` (the spec's global
+        ``bearerToken`` scheme). Otherwise returns
+        ``{"Authorization": "Basic <b64>"}`` off the ``username`` /
+        ``password`` pair (the spec's ``basicAuth`` alternative), reusing
+        the shared :func:`basic_auth_header`. The
+        :class:`CredentialsCache` contract guarantees the username/password
+        pair is present, so the Basic fallback never raises ``KeyError``.
+
+        Raises :exc:`NotImplementedError` if ``target.auth_model`` is
+        anything other than ``shared_service_account`` or ``None``.
+        """
+        auth_model = getattr(target, "auth_model", None)
+        if not is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"FleetLcmConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        creds = await self._creds.get(target, operator)
+        token = creds.get("token")
+        if token:
+            return {"Authorization": f"Bearer {token}"}
+        return {"Authorization": basic_auth_header(creds["username"], creds["password"])}
+
+    async def fingerprint(
+        self,
+        target: FleetLcmTargetLike,
+        operator: Operator | None = None,
+    ) -> FingerprintResult:
+        """Canonical fingerprint built from the ``GET /v1/health`` probe.
+
+        Sends the connector's auth headers (harmless on the
+        ``security: []`` health endpoint, and it keeps probe + dispatch on
+        one auth path) and reads the health payload. On success returns a
+        reachable :class:`FingerprintResult` (``vendor="vmware"``,
+        ``product="fleet"``); ``version`` is taken from an explicit
+        ``version`` string in the health payload when present, else
+        ``None`` (the modern service does not guarantee a product-version
+        field on ``/v1/health``, and the connector does not fabricate one).
+
+        On transport or status failure (401 / 5xx / connection error)
+        returns a non-reachable :class:`FingerprintResult` whose
+        ``extras["error"]`` carries the exception class + message — the
+        Harbor / NSX / SDDC Manager / vcf-fleet pattern.
+
+        ``operator`` (optional) is forwarded to the credentials loader so
+        the per-target Vault read happens under the operator's identity,
+        matching the dispatch path; ``None`` falls back to a system
+        operator whose placeholder JWT fails closed at the live Vault
+        round-trip.
+        """
+        probed_at = datetime.now(UTC)
+        eff_operator = operator if operator is not None else synthesise_system_operator()
+        try:
+            client = await self._http_client(target)
+            headers = await self.auth_headers(target, eff_operator)
+            resp = await client.get(
+                _FLEET_LCM_HEALTH_PATH,
+                headers={"Accept": "application/json", **headers},
+            )
+            resp.raise_for_status()
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="vmware",
+                product="fleet",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=_FLEET_LCM_PROBE_METHOD,
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = None
+        health_status = payload.get("status") if isinstance(payload, dict) else None
+        version = payload.get("version") if isinstance(payload, dict) else None
+        return FingerprintResult(
+            vendor="vmware",
+            product="fleet",
+            version=version if isinstance(version, str) and version else None,
+            build=None,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method=_FLEET_LCM_PROBE_METHOD,
+            extras={
+                "health_status": health_status,
+                "product_lineage": "vmware-vrealize-suite-lifecycle-manager",
+                "api_surface": "fleet-lcm-v1",
+            },
+        )
+
+    async def probe(self, target: FleetLcmTargetLike) -> ProbeResult:
+        """Lightweight reachability check — delegates to :meth:`fingerprint`.
+
+        ``GET /v1/health`` is the single reachability surface; reusing the
+        fingerprint result keeps probe + fingerprint pinned to one
+        round-trip, the SDDC Manager / NSX / vcf-fleet delegation shape.
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: FleetLcmTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`VcfFleetConnector.execute`. Post-G0.6 callers
+        (``/api/v1/operations/call``, MCP ``call_operation``, the CLI
+        verbs) construct a real :class:`Operator` and call
+        :func:`meho_backplane.operations.dispatch` directly — they don't
+        reach this method. The connector's natural key is encoded as the
+        dispatcher's ``connector_id`` per ``parse_connector_id``:
+        ``"fleet-lcm-9.0"`` → (product=``"fleet"``, version=``"9.0"``,
+        impl_id=``"fleet-lcm"``).
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:fleet-lcm-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def invalidate_credentials(self, target: FleetLcmTargetLike) -> None:
+        """Public duck-typed credential-eviction hook for the dispatch path (#2396).
+
+        Delegates to the shared :class:`CredentialsCache.invalidate` so the
+        next credential read re-reads Vault. The dispatcher calls this hook
+        on an establish-auth failure so an operator's out-of-band restage
+        converges on the next dispatch without a backplane restart.
+        """
+        await self._creds.invalidate(target)
+
+    async def aclose(self) -> None:
+        """Clear cached credentials, then tear down the httpx pool.
+
+        No server-side session to revoke — the Bearer/Basic header is sent
+        per request. The credential cache is cleared so a post-aclose reuse
+        of the same connector instance starts clean.
+        """
+        await self._creds.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/fleet_lcm/session.py
+++ b/backend/src/meho_backplane/connectors/fleet_lcm/session.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential loading + target shape for the modern ``fleet-lcm`` connector.
+
+The hand-rolled
+:class:`~meho_backplane.connectors.fleet_lcm.connector.FleetLcmConnector`
+authenticates against the VCF 9 **Fleet LCM Service** API
+(``https://vcf.broadcom.com/fleet-lcm`` → ``/v1/*``). Per the pinned
+``fleet-lcm-9.0/fleet-lcm-openapi.yaml`` ``securitySchemes``, the global
+scheme is ``bearerToken`` (HTTP Bearer), with ``basicAuth`` (HTTP Basic)
+defined as an alternative — a genuine departure from the legacy
+``fleet-rest`` impl, which is HTTP-Basic-only against the vRSLCM
+``/lcm/*`` surface.
+
+This module mirrors the legacy ``vcf_fleet.session`` shape and reuses the
+shared :mod:`meho_backplane.connectors._shared.vcf_auth` scaffolding (the
+#841 cross-cutting module) so the two impls share one credential-loading
+contract:
+
+* :data:`FleetLcmTargetLike` — the minimum target shape the connector
+  reads. Aliased to the shared
+  :class:`~meho_backplane.connectors._shared.vcf_auth.VcfTargetLike`
+  Protocol (``name`` / ``host`` / ``port`` / ``secret_ref`` /
+  ``auth_model`` + the ``id`` / ``tenant_id`` cache-key pair); the
+  concrete ``Target`` model in :mod:`meho_backplane.targets` satisfies it
+  structurally.
+* :data:`FleetLcmCredentialsLoader` — the async ``(target, operator) ->
+  dict[str, str]`` loader type. Injectable on connector construction so
+  unit tests pass a stub, integration tests pass a lab-account loader,
+  and production uses the default Vault read.
+* :func:`load_credentials_from_vault` — the shared operator-context
+  KV-v2 read, re-exported here so the package's public API reads
+  cohesively.
+
+The Bearer seam
+---------------
+
+The shared :class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`
+enforces the ``{"username": str, "password": str}`` contract (it raises
+:exc:`RuntimeError` on a missing key), so the loader **always** returns
+those two keys — the appliance also accepts ``basicAuth`` per the spec —
+and may **additionally** carry an optional ``"token"`` key. When the
+loaded credentials carry a non-empty ``"token"``,
+:meth:`~meho_backplane.connectors.fleet_lcm.connector.FleetLcmConnector.auth_headers`
+emits ``Authorization: Bearer <token>`` (the spec's primary scheme);
+otherwise it falls back to ``Authorization: Basic <b64>`` off the
+username/password pair. The default :func:`load_credentials_from_vault`
+surfaces only the username/password pair today (the shared basic-creds
+read), so the live default is the Basic alternative until the
+Bearer-token provisioning seam lands — see the connector's class
+docstring for the live-verify follow-up (a fleet-lcm loader surfacing a
+Vault-stored token, or a POST-``basicAuth`` → mint-``bearerToken``
+session flow gated on a stood-up appliance).
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors._shared.vcf_auth import (
+    VcfCredentialsLoader,
+    VcfTargetLike,
+    load_credentials_from_vault,
+)
+
+__all__ = [
+    "FleetLcmCredentialsLoader",
+    "FleetLcmTargetLike",
+    "load_credentials_from_vault",
+]
+
+#: Minimum target shape :class:`FleetLcmConnector` reads. Aliased to the
+#: shared VCF-family Protocol — the modern impl reads exactly the same
+#: fields the legacy impl does (``name`` / ``host`` / ``port`` /
+#: ``secret_ref`` / ``auth_model`` + the ``(tenant_id, id)`` cache key),
+#: so a bespoke duplicate Protocol would only drift.
+FleetLcmTargetLike = VcfTargetLike
+
+#: Async ``(target, operator) -> dict[str, str]`` credential loader.
+#: Aliased to the shared VCF loader type; re-exported under a
+#: fleet-lcm-flavoured name so ``FleetLcmConnector(credentials_loader=...)``
+#: reads cohesively without exposing the shared module at the boundary.
+FleetLcmCredentialsLoader = VcfCredentialsLoader

--- a/backend/src/meho_backplane/connectors/vcf_fleet/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_fleet/connector.py
@@ -193,7 +193,16 @@ class VcfFleetConnector(HttpConnector):
     product = "fleet"
     version = "9.0"
     impl_id = "fleet-rest"
-    supported_version_range = ">=9.0,<10.0"
+    # Re-banded from ``">=9.0,<10.0"`` to ``">=8.0,<10.0"`` in #3037 so the
+    # legacy ``/lcm/*`` impl covers Aria Suite Lifecycle 8.x AND the VCF
+    # Fleet 9.0 ``/lcm/*`` back-compat surface, while the modern
+    # ``fleet-lcm`` impl (``>=9.0,<10.0``) takes a 9.0 target by the
+    # resolver's most-specific-version tie-break. Only the *range* moved:
+    # ``version="9.0"`` (the registry-key label) and ``connector_id``
+    # ``"fleet-rest-9.0"`` are unchanged, so no endpoint_descriptor row or
+    # target round-trip churns. See the first two-impl resolution test,
+    # ``backend/tests/test_connectors_fleet_dual_impl_resolution.py``.
+    supported_version_range = ">=8.0,<10.0"
     priority = 1
 
     def __init__(

--- a/backend/tests/test_connectors_fleet_dual_impl_resolution.py
+++ b/backend/tests/test_connectors_fleet_dual_impl_resolution.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""The first two-impl resolver test — ``product=fleet`` (fleet-rest + fleet-lcm), #3037.
+
+``product=fleet`` is the codebase's **first real two-implementation case**
+(initiative #3033). Two hand-rolled ``HttpConnector`` subclasses register
+under the same product with distinct ``impl_id``s and overlapping version
+bands, and :func:`~meho_backplane.connectors.resolver.resolve_connector` picks
+one per target by fingerprint:
+
+* legacy typed ``fleet-rest``
+  (:class:`~meho_backplane.connectors.vcf_fleet.connector.VcfFleetConnector`) —
+  the vRSLCM ``/lcm/*`` surface, ``supported_version_range=">=8.0,<10.0"``
+  (re-banded from ``">=9.0,<10.0"`` in this Task).
+* modern generic ``fleet-lcm``
+  (:class:`~meho_backplane.connectors.fleet_lcm.connector.FleetLcmConnector`) —
+  the VCF 9 Fleet LCM Service ``/v1/*`` surface,
+  ``supported_version_range=">=9.0,<10.0"``.
+
+This test constructs both registrations exactly as the two packages'
+``__init__`` modules do (the legacy adds the ``("fleet","","")`` wildcard
+fallback; the modern impl registers only its versioned triple) and asserts the
+resolution matrix against fake targets — mirroring the target-construction and
+``resolve_connector`` call shape of :mod:`tests.test_connectors_resolver`.
+
+A note on the operator-preference case (a corrected task assertion)
+------------------------------------------------------------------
+
+Tasks #3037 / initiative #3033 framed a third case as *"preferred_impl_id=
+'fleet-rest' on a 9.0 target → resolves fleet-rest (operator-preference
+tie-break)."* That is **not** how the resolver behaves, and it is internally
+inconsistent with the second case. The tie-break ladder runs
+**most-specific-version (step 2) *before* operator preference (step 3)** — see
+the :mod:`~meho_backplane.connectors.resolver` module docstring, and the pin
+``test_resolve_operator_preference_does_not_override_specificity`` in
+:mod:`tests.test_connectors_resolver` ("This pins the documented ordering
+against the issue body's alternative reading"). For any 9.x target *both* impls
+are in range, and ``fleet-lcm``'s
+``>=9.0,<10.0`` (bounded span 1.0) is **strictly** more specific than
+``fleet-rest``'s ``>=8.0,<10.0`` (span 2.0), so specificity resolves to
+``fleet-lcm`` and returns *before* ``preferred_impl_id`` is ever consulted.
+Operator preference only breaks a specificity **tie** (equal spans), which
+these two impls never have. Satisfying "9.0 → fleet-lcm by most-specific-
+version" (case 2) and "9.0 + preferred fleet-rest → fleet-rest" (case 3)
+simultaneously is impossible under the ladder: case 2 requires ``fleet-lcm``
+strictly more specific, which is exactly what makes preference moot in case 3.
+
+So case 3 below asserts the **actual, documented** behaviour — the more-specific
+``fleet-lcm`` still wins on a 9.0 target even with
+``preferred_impl_id="fleet-rest"`` — and documents that pinning the legacy
+``/lcm/*`` surface on a genuine 9.0 target is **not** achievable via
+``preferred_impl_id`` under the current (deliberate, previously-settled)
+ladder ordering. The generic operator-preference-breaks-a-tie mechanism is
+covered by :mod:`tests.test_connectors_resolver`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+
+from meho_backplane.connectors.fleet_lcm.connector import FleetLcmConnector
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.resolver import resolve_connector
+from meho_backplane.connectors.vcf_fleet.connector import VcfFleetConnector
+
+# ---------------------------------------------------------------------------
+# Duck-typed target — the resolver reads .product, .fingerprint.version,
+# .version, .preferred_impl_id (mirrors tests.test_connectors_resolver).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeFingerprint:
+    version: str | None
+
+
+@dataclass
+class _FakeTarget:
+    product: str
+    fingerprint: _FakeFingerprint | None = None
+    preferred_impl_id: str | None = None
+    version: str | None = None
+
+
+def _fp(version: str | None) -> _FakeFingerprint:
+    return _FakeFingerprint(version=version)
+
+
+def _register_both_impls() -> None:
+    """Register both fleet impls exactly as their ``__init__`` modules do.
+
+    * ``fleet-rest`` (legacy): the versioned triple **plus** the
+      ``("fleet","","")`` wildcard fallback (the G0.15-T6 #1215 fanout).
+    * ``fleet-lcm`` (modern): the versioned triple only — a second class on
+      the wildcard key would raise ``RuntimeError``.
+
+    Uses the real connector classes (not stand-ins) so a future drift in
+    either ``supported_version_range`` breaks this test — the point of a
+    first-two-impl guard.
+    """
+    register_connector_v2(
+        product=VcfFleetConnector.product,
+        version=VcfFleetConnector.version,
+        impl_id=VcfFleetConnector.impl_id,
+        cls=VcfFleetConnector,
+    )
+    register_connector_v2(product="fleet", version="", impl_id="", cls=VcfFleetConnector)
+    register_connector_v2(
+        product=FleetLcmConnector.product,
+        version=FleetLcmConnector.version,
+        impl_id=FleetLcmConnector.impl_id,
+        cls=FleetLcmConnector,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_registry()
+    _register_both_impls()
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Registration shape — the two impls coexist under distinct triples
+# ---------------------------------------------------------------------------
+
+
+def test_both_impls_register_under_distinct_triples() -> None:
+    """The two impls share ``product="fleet"`` / ``version="9.0"`` but distinct impl_id.
+
+    The v2 keys never collide (impl_id disambiguates), and the ``("fleet","","")``
+    wildcard is owned by the legacy impl alone.
+    """
+    # Class attrs are the source of truth for the registration triples.
+    assert (VcfFleetConnector.product, VcfFleetConnector.version, VcfFleetConnector.impl_id) == (
+        "fleet",
+        "9.0",
+        "fleet-rest",
+    )
+    assert (FleetLcmConnector.product, FleetLcmConnector.version, FleetLcmConnector.impl_id) == (
+        "fleet",
+        "9.0",
+        "fleet-lcm",
+    )
+    # The re-banded legacy range + the modern range are what the split hinges on.
+    assert VcfFleetConnector.supported_version_range == ">=8.0,<10.0"
+    assert FleetLcmConnector.supported_version_range == ">=9.0,<10.0"
+
+    triples = set(all_connectors_v2())
+    assert ("fleet", "9.0", "fleet-rest") in triples
+    assert ("fleet", "9.0", "fleet-lcm") in triples
+    assert ("fleet", "", "") in triples  # the single legacy-owned wildcard
+    assert all_connectors_v2()[("fleet", "", "")] is VcfFleetConnector
+
+
+# ---------------------------------------------------------------------------
+# Case 1 — an 8.x target resolves the legacy fleet-rest (only in-range candidate)
+# ---------------------------------------------------------------------------
+
+
+def test_8x_target_resolves_legacy_fleet_rest() -> None:
+    """A VCF Fleet / Aria Suite Lifecycle 8.5 target resolves ``fleet-rest``.
+
+    ``fleet-lcm``'s ``>=9.0,<10.0`` excludes 8.5, so the legacy impl is the
+    only versioned candidate in range; the wildcard is demoted by step 1.
+    """
+    target = _FakeTarget(product="fleet", fingerprint=_fp("8.5"))
+    assert resolve_connector(target) is VcfFleetConnector
+
+
+# ---------------------------------------------------------------------------
+# Case 2 — a 9.0 target resolves the modern fleet-lcm (most-specific-version)
+# ---------------------------------------------------------------------------
+
+
+def test_9_0_target_resolves_modern_fleet_lcm_by_specificity() -> None:
+    """A VCF Fleet 9.0 target resolves ``fleet-lcm`` by most-specific-version.
+
+    Both versioned impls are in range for 9.0; ``fleet-lcm``'s bounded
+    ``>=9.0,<10.0`` (span 1.0) beats ``fleet-rest``'s ``>=8.0,<10.0`` (span 2.0)
+    at the resolver's step-2 specificity tie-break. The wildcard is demoted
+    first (step 1). This is the initiative's core assertion — the split is by
+    version-specificity, not priority (both impls keep ``priority=1``).
+    """
+    target = _FakeTarget(product="fleet", fingerprint=_fp("9.0"))
+    assert resolve_connector(target) is FleetLcmConnector
+
+
+def test_9_0_2_patch_target_still_resolves_fleet_lcm() -> None:
+    """A patch-versioned 9.0.2 target resolves ``fleet-lcm`` too (in ``>=9.0,<10.0``)."""
+    target = _FakeTarget(product="fleet", fingerprint=_fp("9.0.2"))
+    assert resolve_connector(target) is FleetLcmConnector
+
+
+# ---------------------------------------------------------------------------
+# Case 3 — operator preference is MOOT on a 9.0 target (specificity wins first)
+# ---------------------------------------------------------------------------
+
+
+def test_9_0_preferred_fleet_rest_is_moot_specificity_still_wins() -> None:
+    """``preferred_impl_id="fleet-rest"`` on a 9.0 target does NOT flip the result.
+
+    Corrects the task's third assertion (see the module docstring). Specificity
+    (step 2) resolves to the more-specific ``fleet-lcm`` and returns *before*
+    operator preference (step 3) is consulted, so the operator **cannot** pin
+    the legacy ``/lcm/*`` surface on a genuine 9.0 target this way. Mirrors the
+    ``test_resolve_operator_preference_does_not_override_specificity`` pin in
+    :mod:`tests.test_connectors_resolver`, scoped to the real fleet impls.
+    """
+    target = _FakeTarget(
+        product="fleet",
+        fingerprint=_fp("9.0"),
+        preferred_impl_id="fleet-rest",
+    )
+    assert resolve_connector(target) is FleetLcmConnector
+
+
+def test_9_0_preferred_fleet_lcm_also_resolves_fleet_lcm() -> None:
+    """The consistent-with-specificity preference (``fleet-lcm``) resolves ``fleet-lcm``.
+
+    A sanity companion to the moot case: when the operator's preference agrees
+    with the specificity winner, the result is unchanged — preference neither
+    helps nor hurts here because specificity already decided.
+    """
+    target = _FakeTarget(
+        product="fleet",
+        fingerprint=_fp("9.0"),
+        preferred_impl_id="fleet-lcm",
+    )
+    assert resolve_connector(target) is FleetLcmConnector
+
+
+# ---------------------------------------------------------------------------
+# Wildcard fallback — an unfingerprinted target still resolves (legacy-owned)
+# ---------------------------------------------------------------------------
+
+
+def test_unfingerprinted_target_resolves_via_legacy_wildcard() -> None:
+    """A fresh target (no fingerprint, no asserted version) resolves via the wildcard.
+
+    Neither versioned entry matches without a version (the specificity filter
+    needs one), so only the legacy-owned ``("fleet","","")`` wildcard survives.
+    ``fleet-lcm``'s deliberate lack of a wildcard sibling does not break
+    unfingerprinted resolution — one wildcard per product suffices.
+    """
+    target = _FakeTarget(product="fleet", fingerprint=None, version=None)
+    assert resolve_connector(target) is VcfFleetConnector

--- a/backend/tests/test_connectors_fleet_lcm_auth.py
+++ b/backend/tests/test_connectors_fleet_lcm_auth.py
@@ -1,0 +1,450 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`FleetLcmConnector` auth + fingerprint/probe (#3036).
+
+Exercises the modern Fleet LCM Service connector's auth seam — Bearer as the
+primary scheme (``securitySchemes.bearerToken``) with Basic fallback
+(``securitySchemes.basicAuth``) — per-target credential isolation, the
+auth_model boundary gate, and the fingerprint/probe shapes against the
+``GET /v1/health`` reachability probe.
+
+No live appliance is reachable (#1002 / #995), so the Bearer *header shape* is
+proven via an injected loader returning a ``"token"`` and the transport is
+mocked with ``respx``; live Bearer verification is the documented follow-up.
+
+Test layout mirrors :mod:`tests.test_connectors_vcf_fleet_auth` (the legacy
+impl's auth test) — the shared ``CredentialsCache`` / ``basic_auth_header`` /
+``is_acceptable_auth_model`` scaffolding and the fixture-clean registry
+pattern.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.fleet_lcm import (
+    FleetLcmConnector,
+    FleetLcmTargetLike,
+)
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+
+
+def _make_operator(raw_jwt: str = "op.test.jwt") -> Operator:
+    """Return a minimal :class:`Operator` for threading through the auth surface."""
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clean_fleet_lcm_registry() -> Iterator[None]:
+    """Re-register FleetLcmConnector after sibling tests clear the registry.
+
+    Same pattern :mod:`tests.test_connectors_vcf_fleet_auth` established: a
+    sibling autouse fixture calls :func:`clear_registry` between tests, so
+    re-register before every test in this module and clear after.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=FleetLcmConnector.product,
+        version=FleetLcmConnector.version,
+        impl_id=FleetLcmConnector.impl_id,
+        cls=FleetLcmConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub — satisfies FleetLcmTargetLike Protocol structurally.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+    id: UUID = field(default_factory=uuid4)
+    tenant_id: UUID = field(default_factory=lambda: UUID(int=0))
+
+
+_TARGET_A = _StubTarget(
+    name="fleet-lcm-a",
+    host="fleet-lcm-a.test.invalid",
+    port=443,
+    secret_ref="fleet-lcm/fleet-lcm-a",
+)
+_TARGET_B = _StubTarget(
+    name="fleet-lcm-b",
+    host="fleet-lcm-b.test.invalid",
+    port=443,
+    secret_ref="fleet-lcm/fleet-lcm-b",
+)
+
+
+async def _basic_loader(_target: FleetLcmTargetLike, _operator: Operator) -> dict[str, str]:
+    """Return canned username/password (no token) → Basic fallback path."""
+    return {"username": "admin@local", "password": "stub-password"}
+
+
+async def _bearer_loader(_target: FleetLcmTargetLike, _operator: Operator) -> dict[str, str]:
+    """Return canned credentials carrying a ``token`` → Bearer primary path.
+
+    Carries username/password too (the ``CredentialsCache`` contract requires
+    them), plus the ``token`` that activates the Bearer header.
+    """
+    return {"username": "admin@local", "password": "stub-password", "token": "tok-abc123"}
+
+
+def _make_connector() -> FleetLcmConnector:
+    """Build a connector wired with the Basic (no-token) stub loader."""
+    return FleetLcmConnector(credentials_loader=_basic_loader)
+
+
+def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
+    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
+    assert authorization_header.startswith("Basic ")
+    decoded = base64.b64decode(authorization_header[6:]).decode()
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_fleet_lcm_connector_subclasses_http_connector() -> None:
+    """Sanity check: the connector inherits from HttpConnector with the right metadata."""
+    assert issubclass(FleetLcmConnector, HttpConnector)
+    assert FleetLcmConnector.product == "fleet"
+    assert FleetLcmConnector.version == "9.0"
+    assert FleetLcmConnector.impl_id == "fleet-lcm"
+    assert FleetLcmConnector.supported_version_range == ">=9.0,<10.0"
+    # Equal to the legacy fleet-rest impl by design — the split is by
+    # version-specificity, not priority.
+    assert FleetLcmConnector.priority == 1
+
+
+def test_importing_package_registers_versioned_triple_only() -> None:
+    """The package registers the versioned triple and NOT a wildcard sibling.
+
+    The legacy vcf_fleet package owns the ``("fleet","","")`` wildcard; a
+    second class on that key would raise at import. This connector registers
+    only ``("fleet","9.0","fleet-lcm")``.
+    """
+    from meho_backplane.connectors.fleet_lcm import (
+        FLEET_LCM_CONNECTOR_ID,
+        FLEET_LCM_IMPL_ID,
+        FLEET_LCM_PRODUCT,
+        FLEET_LCM_VERSION,
+    )
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    versioned = ("fleet", "9.0", "fleet-lcm")
+    assert registry[versioned] is FleetLcmConnector
+    # No wildcard was registered by *this* module's fixture (the fixture only
+    # re-registers the versioned triple), and the constants round-trip.
+    assert versioned == (FLEET_LCM_PRODUCT, FLEET_LCM_VERSION, FLEET_LCM_IMPL_ID)
+    assert FLEET_LCM_CONNECTOR_ID == "fleet-lcm-9.0"
+
+
+# ---------------------------------------------------------------------------
+# Auth — Bearer primary + Basic fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_emits_bearer_when_token_present() -> None:
+    """A loader returning a ``token`` yields ``Authorization: Bearer <token>``."""
+    connector = FleetLcmConnector(credentials_loader=_bearer_loader)
+    headers = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    assert headers == {"Authorization": "Bearer tok-abc123"}
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_falls_back_to_basic_without_token() -> None:
+    """A loader returning only username/password yields the Basic header (spec's basicAuth)."""
+    connector = _make_connector()
+    headers = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert "Authorization" in headers
+    assert headers["Authorization"].startswith("Basic ")
+    username, password = _decode_basic_auth(headers["Authorization"])
+    assert username == "admin@local"
+    assert password == "stub-password"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-invoke the loader."""
+    call_count = 0
+
+    async def _counting_loader(_target: FleetLcmTargetLike, _operator: Operator) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {"username": "admin@local", "password": "stub-password"}
+
+    connector = FleetLcmConnector(credentials_loader=_counting_loader)
+    h1 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    h2 = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert h1 == h2
+    assert call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_credentials_separate() -> None:
+    """Two targets get two distinct credential cache entries; no cross-target leakage."""
+    call_log: list[str] = []
+
+    async def _tracking_loader(target: FleetLcmTargetLike, _operator: Operator) -> dict[str, str]:
+        call_log.append(target.name)
+        return {"username": f"svc-{target.name}", "password": "pass"}
+
+    connector = FleetLcmConnector(credentials_loader=_tracking_loader)
+    h_a = await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    h_b = await connector.auth_headers(_TARGET_B, operator=_make_operator())
+
+    username_a, _ = _decode_basic_auth(h_a["Authorization"])
+    username_b, _ = _decode_basic_auth(h_b["Authorization"])
+    assert username_a == "svc-fleet-lcm-a"
+    assert username_b == "svc-fleet-lcm-b"
+    assert call_log == ["fleet-lcm-a", "fleet-lcm-b"]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_key_raises_runtime_error_naming_target() -> None:
+    """Loader returning a dict missing 'password' raises RuntimeError naming the target.
+
+    The shared ``CredentialsCache`` contract holds even on the Bearer path —
+    username/password are always required (the appliance accepts basicAuth),
+    so a token-only secret is a misconfiguration surfaced here.
+    """
+
+    async def _bad_loader(_target: FleetLcmTargetLike, _operator: Operator) -> dict[str, str]:
+        return {"token": "tok-only"}
+
+    connector = FleetLcmConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"password") as exc_info:
+        await connector.auth_headers(_TARGET_A, operator=_make_operator())
+
+    assert "fleet-lcm-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation modes raise NotImplementedError naming the target + mode."""
+    target = _StubTarget(
+        name="fleet-lcm-per-user",
+        host="fleet-lcm.test.invalid",
+        port=443,
+        secret_ref="fleet-lcm/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, operator=_make_operator())
+
+    assert "fleet-lcm-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted."""
+    target = _StubTarget(
+        name="fleet-lcm-pre-g03",
+        host="fleet-lcm.test.invalid",
+        port=443,
+        secret_ref="fleet-lcm/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, operator=_make_operator())
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint() — GET /v1/health probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
+    """fingerprint() against a mocked /v1/health returns the canonical reachable shape."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://fleet-lcm-a.test.invalid") as mock:
+        mock.get("/v1/health").respond(200, json={"status": "HEALTHY", "version": "9.0.0.0"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "fleet"
+    assert fp.version == "9.0.0.0"
+    assert fp.build is None
+    assert fp.reachable is True
+    assert "/v1/health" in fp.probe_method
+    assert fp.extras["health_status"] == "HEALTHY"
+    assert fp.extras["api_surface"] == "fleet-lcm-v1"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_without_version_field_leaves_version_none() -> None:
+    """A health payload without a ``version`` field leaves version=None but reachable."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://fleet-lcm-a.test.invalid") as mock:
+        mock.get("/v1/health").respond(200, json={"status": "HEALTHY"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.version is None
+    assert fp.reachable is True
+    assert fp.extras["health_status"] == "HEALTHY"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_sends_bearer_header_to_health_when_token_present() -> None:
+    """The fingerprint call carries the Bearer header when the loader yields a token."""
+    connector = FleetLcmConnector(credentials_loader=_bearer_loader)
+    captured: list[httpx.Request] = []
+
+    async with respx.mock(base_url="https://fleet-lcm-a.test.invalid") as mock:
+        route = mock.get("/v1/health").respond(200, json={"status": "HEALTHY"})
+        await connector.fingerprint(_TARGET_A)
+        captured.extend(call.request for call in route.calls)
+
+    assert len(captured) == 1
+    assert captured[0].headers.get("Authorization") == "Bearer tok-abc123"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_500_returns_reachable_false() -> None:
+    """A 500 from /v1/health surfaces as reachable=False + structured error."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://fleet-lcm-a.test.invalid") as mock:
+        mock.get("/v1/health").respond(500, json={"error": "bootstrap"})
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "vmware"
+    assert fp.product == "fleet"
+    assert fp.reachable is False
+    error = fp.extras["error"]
+    assert "HTTPStatusError" in error or "500" in error
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_on_connection_error_returns_reachable_false() -> None:
+    """A transport-level connection error surfaces as reachable=False + structured error."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://fleet-lcm-a.test.invalid") as mock:
+        mock.get("/v1/health").mock(side_effect=httpx.ConnectError("connection refused"))
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is False
+    assert "ConnectError" in fp.extras["error"]
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# probe() — delegates to fingerprint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_ok_when_fingerprint_reachable() -> None:
+    """probe() returns ok=True when fingerprint reports reachable."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://fleet-lcm-a.test.invalid") as mock:
+        mock.get("/v1/health").respond(200, json={"status": "HEALTHY"})
+        probe = await connector.probe(_TARGET_A)
+
+    assert probe.ok is True
+    assert probe.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_not_ok_when_fingerprint_unreachable() -> None:
+    """probe() returns ok=False + reason from fingerprint's error extras."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://fleet-lcm-a.test.invalid") as mock:
+        mock.get("/v1/health").respond(500, json={"error": "bootstrap"})
+        probe = await connector.probe(_TARGET_A)
+
+    assert probe.ok is False
+    assert probe.reason is not None
+    assert "HTTPStatusError" in probe.reason or "500" in probe.reason
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose — credential cache is cleared
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_credential_cache() -> None:
+    """aclose() empties the shared credential cache so a reuse re-fetches."""
+    call_count = 0
+
+    async def _counting_loader(_target: FleetLcmTargetLike, _operator: Operator) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {"username": "admin@local", "password": "stub-password"}
+
+    connector = FleetLcmConnector(credentials_loader=_counting_loader)
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    assert call_count == 1
+    await connector.aclose()
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    assert call_count == 2
+    await connector.aclose()

--- a/backend/tests/test_connectors_fleet_lcm_spec_reconcile.py
+++ b/backend/tests/test_connectors_fleet_lcm_spec_reconcile.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""fleet-lcm (VCF 9 Fleet LCM Service) real-spec reconcile lane (#3036) — the #2980 harness.
+
+Asserts every hand-coded ``METHOD:/path`` the modern ``fleet-lcm`` connector
+dispatches is served by the pinned ``fleet-lcm-9.0/fleet-lcm-openapi.yaml`` — the
+VCF 9 Fleet LCM Service OpenAPI document vendored in the **public, Apache-2.0**
+`vmware/vcf-api-specs <https://github.com/vmware/vcf-api-specs>`_ repo (pinned at
+``c3f3b52c``; provenance + sha256 in the shelf's ``fleet-lcm-9.0/MANIFEST.md``).
+Parse-only set compare — no DB, no embeddings, no containers — so it lives in the
+required unit sweep per the lane-placement rule in
+``docs/decisions/spec-reconcile-guards-standard.md``. Uniform skip when the shelf
+is unconfigured (``tests/_spec_shelf.py`` contract).
+
+Distinct surface from the legacy vcf-fleet lane. The paired dormant lane
+``test_connectors_vcf_fleet_spec_reconcile.py`` reconciles the legacy
+``fleet-rest`` impl's ``/lcm/lcops/api/v2/*`` (vRSLCM) literals against a
+*different* spec (``vcf-fleet-9.0/vrslcm-lcm-openapi.json``). This lane
+reconciles the **modern** ``fleet-lcm`` impl's ``/v1/*`` surface. The two impls
+of ``product=fleet`` are resolved per target by fingerprint (see
+``test_connectors_fleet_dual_impl_resolution.py``).
+
+Ingested ops are not reconciled here. The connector's 51 ``/v1/*`` operations
+arrive via G0.7 spec ingestion (``source_kind="ingested"``), so an operator
+ingest of the same pinned spec produces those op_ids **by construction** — a
+reconcile of ingested rows against the spec they were ingested from is
+tautological. What this lane guards is the connector's **hand-coded** surface:
+its ``_*_PATH`` probe/fingerprint constant(s), introspected from the live class
+constants (the #2944 pattern — never a hardcoded mirror), which a typo or a
+renamed endpoint would silently break. The connector hand-codes exactly one
+path — the ``GET /v1/health`` reachability probe — and dispatches it GET.
+
+No server-base fold. Unlike the vcf-operations lane (whose spec declares the
+*relative* server base ``/suite-api`` that ``parse_openapi`` folds onto every
+path key, #1796) and the vcf-logs lane (relative ``/api/v2``), this spec's
+server url ``https://vcf.broadcom.com/fleet-lcm`` is **absolute**.
+``parse_openapi``'s ``_server_base_path`` returns ``""`` for an absolute
+server (scheme/authority present) — the ``/fleet-lcm`` base points at a
+spec-declared host meho does not dispatch against, so only the operator's
+target host carries it. The served op_ids are therefore the raw ``/v1/*`` path
+keys (verified: the pinned spec serves ``GET:/v1/health``, no ``/fleet-lcm``
+prefix), and the connector's ``_FLEET_LCM_HEALTH_PATH`` constant declares the
+same raw ``/v1/health`` — the comparison is byte-for-byte against what an
+operator ingest of the same spec would dispatch.
+
+A red lane here is the guard surfacing a real finding, not harness noise —
+triage per docs/decisions/spec-reconcile-guards-standard.md.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.fleet_lcm import connector as _connector
+from tests._spec_shelf import (
+    assert_op_ids_served,
+    openapi_served_op_ids,
+    require_shelf_spec,
+)
+
+_SPEC_DIR = "fleet-lcm-9.0"
+_SPEC_FILE = "fleet-lcm-openapi.yaml"
+_SPEC_LABEL = f"{_SPEC_DIR}/{_SPEC_FILE}"
+
+
+def _path_constants() -> dict[str, str]:
+    """The live ``_*_PATH`` string constants of ``connector``, by constant name."""
+    return {
+        name: value
+        for name, value in vars(_connector).items()
+        if name.endswith("_PATH") and isinstance(value, str) and value.startswith("/")
+    }
+
+
+def _declared_op_ids() -> set[str]:
+    """Every hand-coded ``METHOD:/path`` the fleet-lcm connector dispatches.
+
+    Sweeps the live module constants (never a hardcoded mirror). The connector
+    hand-codes exactly one path — the ``GET /v1/health`` reachability probe —
+    and dispatches it GET (the 51 ``/v1/*`` operational ops are ingested, not
+    hand-coded, and are reconciled by ingestion itself, not this lane).
+    """
+    return {f"GET:{path}" for path in _path_constants().values()}
+
+
+def test_hand_coded_path_surface_is_pinned() -> None:
+    """Guard: the introspection finds the hand-coded probe literal.
+
+    Pinning the exact ``_*_PATH`` constant-name set, its value, and the
+    assembled op_id set (the #2944 guard shape) means a renamed or dropped
+    constant — or a new path that skips the convention — fails here until the
+    reconcile is updated consciously, so the declared set can never silently
+    shrink to a vacuous pass. Runs unconditionally (no shelf needed).
+    """
+    assert sorted(_path_constants()) == ["_FLEET_LCM_HEALTH_PATH"]
+    assert _connector._FLEET_LCM_HEALTH_PATH == "/v1/health"
+    assert _declared_op_ids() == {"GET:/v1/health"}
+
+
+def test_declared_op_ids_are_served_by_the_pinned_spec() -> None:
+    """Every hand-coded op_id is served by the pinned fleet-lcm-9.0 spec.
+
+    Arms when the shelf provides ``fleet-lcm-9.0/fleet-lcm-openapi.yaml``
+    (``require_shelf_spec`` skips uniformly otherwise). Uses the standard
+    :func:`~tests._spec_shelf.openapi_served_op_ids` (the spec is a clean
+    OpenAPI 3.0.4 document whose ``securitySchemes`` are well-formed
+    ``type: http`` schemes, so ``parse_openapi`` accepts it) with **no**
+    server-base fold — see the module docstring for the absolute-server
+    reasoning.
+    """
+    spec_path = require_shelf_spec(_SPEC_DIR, _SPEC_FILE)
+    served = openapi_served_op_ids(spec_path)
+    assert_op_ids_served(_declared_op_ids(), served, spec_label=_SPEC_LABEL)

--- a/backend/tests/test_connectors_vcf_fleet_auth.py
+++ b/backend/tests/test_connectors_vcf_fleet_auth.py
@@ -148,7 +148,10 @@ def test_vcf_fleet_connector_subclasses_http_connector() -> None:
     assert VcfFleetConnector.product == "fleet"
     assert VcfFleetConnector.version == "9.0"
     assert VcfFleetConnector.impl_id == "fleet-rest"
-    assert VcfFleetConnector.supported_version_range == ">=9.0,<10.0"
+    # Re-banded to >=8.0,<10.0 in #3037 (Aria Suite Lifecycle 8.x + VCF
+    # Fleet 9.0 /lcm/* back-compat); the modern fleet-lcm impl takes 9.0 by
+    # most-specific-version. See test_connectors_fleet_dual_impl_resolution.py.
+    assert VcfFleetConnector.supported_version_range == ">=8.0,<10.0"
     assert VcfFleetConnector.priority == 1
 
 

--- a/backend/tests/test_connectors_vcf_fleet_e2e.py
+++ b/backend/tests/test_connectors_vcf_fleet_e2e.py
@@ -157,6 +157,23 @@ def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
 # ---------------------------------------------------------------------------
 
 
+# Under the "modern default" dual-impl split (#3033 / #3037), a fleet target
+# fingerprinted at 9.0 resolves to the modern ``fleet-lcm`` impl by
+# most-specific-version. This E2E exercises the legacy ``fleet-rest`` ``/lcm/*``
+# dispatch surface with the full connector registry present (fleet-lcm is
+# eagerly imported), so it seeds an **8.x** fingerprint — ``fleet-rest``'s
+# domain (``>=8.0,<10.0``) — so the dispatcher's target-fingerprint resolution
+# (``dispatcher.py`` ``_resolve_executing_connector``) binds ``fleet-rest``
+# (whose stub credentials loader is injected in ``_resolve_connector``), not
+# ``fleet-lcm`` (whose default loader would hit Vault → ``VaultUnreachableError``).
+# The shared ``FLEET_CANARY_FINGERPRINT`` (9.0) is unchanged — other tests key
+# on it; only this dispatch target's ``version`` is overridden.
+_FLEET_REST_TARGET_FINGERPRINT: dict[str, object] = {
+    **FLEET_CANARY_FINGERPRINT,
+    "version": "8.14",
+}
+
+
 async def _seed_target() -> Any:
     """Insert the E2E target row and return it (expunged from the session)."""
     sessionmaker = get_sessionmaker()
@@ -173,7 +190,7 @@ async def _seed_target() -> Any:
             auth_model="shared_service_account",
             vpn_required=False,
             extras={},
-            fingerprint=FLEET_CANARY_FINGERPRINT,
+            fingerprint=_FLEET_REST_TARGET_FINGERPRINT,
             notes="seeded by test_connectors_vcf_fleet_e2e._seed_target",
         )
         session.add(target)
@@ -223,8 +240,10 @@ async def fleet_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_FleetE2
     1. Insert the ingested browse-breadth Fleet descriptors (from
        :data:`~tests.acceptance._vcf_fleet_canary_fixtures._FLEET_SEED_OPS`)
        descriptors + groups into the per-test SQLite DB.
-    2. Seed a :class:`Target` row carrying :data:`FLEET_CANARY_FINGERPRINT`
-       so the resolver binds :class:`VcfFleetConnector`.
+    2. Seed a :class:`Target` row carrying an **8.x** fingerprint (the
+       ``fleet-rest`` version domain under the modern-default split, #3037)
+       so the resolver binds the legacy :class:`VcfFleetConnector`, not the
+       modern ``fleet-lcm`` impl.
     3. Resolve + cache the connector instance; replace its
        :class:`CredentialsCache` so no Vault read fires.
     4. Activate a respx router for :data:`FLEET_CANARY_BASE_URL` and

--- a/docs/codebase/connectors-fleet-lcm.md
+++ b/docs/codebase/connectors-fleet-lcm.md
@@ -1,0 +1,160 @@
+# Connector: fleet-lcm (VCF 9 Fleet LCM Service, modern generic impl)
+
+## Overview
+
+The `fleet-lcm` connector is the hand-rolled `HttpConnector` subclass that
+makes the **VCF 9 Fleet LCM Service** REST API dispatchable under the
+`(product="fleet", version="9.0", impl_id="fleet-lcm")` registry triple. It is
+the **modern** implementation of `product=fleet` and coexists with the legacy
+typed `fleet-rest` impl ([`connectors-vcf-fleet.md`](connectors-vcf-fleet.md)) —
+the codebase's first real two-implementation case (initiative
+[#3033](https://github.com/evoila/meho/issues/3033), tasks #3036 + #3037,
+decision of record `versioned-connector-dual-impl`). The two are resolved per
+target by fingerprint; see the "Dual implementation" section of the vcf-fleet
+doc for the resolution matrix and the
+[resolution test](../../backend/tests/test_connectors_fleet_dual_impl_resolution.py).
+
+Source: `backend/src/meho_backplane/connectors/fleet_lcm/`.
+
+The Fleet LCM Service (`https://vcf.broadcom.com/fleet-lcm` → `/v1/*`) is the
+VCF 9 successor to vRealize Suite Lifecycle Manager (vRSLCM) 8.x. It is a
+**distinct API surface** from the legacy `/lcm/lcops/api/v2/*` the `fleet-rest`
+impl dispatches; the legacy surface still answers on 9.0 appliances for
+back-compat, which is why both bands overlap at 9.0 and the resolver — not the
+connector — picks the surface per target.
+
+## Skeleton scope
+
+This Task (#3036) ships the connector **skeleton** — auth + fingerprint +
+probe + the G0.6 dispatch shim — the same shape the legacy `vcf_fleet`
+connector first shipped as (#831). The 51 `/v1/*` operations are **not**
+hand-coded: they arrive via G0.7 spec ingestion as `source_kind="ingested"`
+`endpoint_descriptor` rows under `connector_id="fleet-lcm-9.0"`. Registering
+this real `HttpConnector` subclass is the load-bearing prerequisite for those
+rows to become **dispatchable** — a bare `GenericRestConnector` auto-shim is
+non-dispatchable (its `auth_headers` / `execute` raise), so ingested ops ride
+*this* class's `auth_headers` on dispatch (the `VmwareRestConnector` pattern).
+
+**Live-appliance dispatch verification is a non-goal** (#1002 / #995 — no
+reachable Fleet LCM appliance). The connector ships registered, spec-guarded
+(reconcile lane), and reconcile-armed; live Bearer-auth verification is a
+follow-up gated on a stood-up appliance (see "Auth" below).
+
+## Key types
+
+- **`FleetLcmConnector`** (`connector.py`) — `HttpConnector` subclass.
+  Class attributes: `product="fleet"`, `version="9.0"`, `impl_id="fleet-lcm"`,
+  `supported_version_range=">=9.0,<10.0"`, `priority=1`. The range is the
+  **narrower** of the two impls, so a 9.0 target resolves here by the
+  resolver's most-specific-version tie-break; `priority=1` equals the legacy
+  impl by design (the split is by version-specificity, not priority).
+- **`FleetLcmTargetLike`** / **`FleetLcmCredentialsLoader`** (`session.py`) —
+  aliases of the shared `VcfTargetLike` Protocol and `VcfCredentialsLoader`
+  type (the modern impl reads the same target fields as the legacy). The
+  loader is injectable on construction
+  (`FleetLcmConnector(credentials_loader=...)`) for unit / integration tests.
+- **`load_credentials_from_vault`** (`session.py`) — the shared
+  operator-context KV-v2 read, re-exported. Returns the `{username, password}`
+  pair (the shared basic-creds read).
+- Canonical constants (`__init__.py`): `FLEET_LCM_PRODUCT`,
+  `FLEET_LCM_VERSION`, `FLEET_LCM_IMPL_ID`, `FLEET_LCM_CONNECTOR_ID`.
+
+The connector reuses `basic_auth_header`, `is_acceptable_auth_model`, and
+`CredentialsCache` from `meho_backplane.connectors._shared.vcf_auth` — the same
+scaffolding the legacy impl uses.
+
+## Control flow
+
+### Registration
+
+Importing `meho_backplane.connectors.fleet_lcm` calls
+`register_connector_v2(product="fleet", version="9.0", impl_id="fleet-lcm",
+cls=FleetLcmConnector)`. **No wildcard sibling** is registered: the legacy
+`vcf_fleet` package already owns the `("fleet","","")` fallback, and a second
+class on that key would raise `RuntimeError` at import. One wildcard per
+product suffices (it only guarantees an unfingerprinted target resolves
+*something*); the versioned entries carry the real per-band matching.
+
+### Auth (Bearer primary, Basic fallback)
+
+Per the pinned spec's `securitySchemes`, the global scheme is `bearerToken`
+(HTTP Bearer), with `basicAuth` (HTTP Basic) also defined. `auth_headers`:
+
+1. Rejects any `target.auth_model` other than `shared_service_account` /
+   `None` via the shared `is_acceptable_auth_model`.
+2. Loads credentials via the shared `CredentialsCache` (which enforces the
+   `{username, password}` contract).
+3. If the loaded credentials carry a non-empty `"token"`, returns
+   `Authorization: Bearer <token>` (the spec's primary scheme); otherwise
+   returns `Authorization: Basic <b64>` off the username/password pair (the
+   spec's `basicAuth` alternative), reusing the shared `basic_auth_header`.
+
+**Bearer is a documented seam, not live-verified.** The default Vault loader
+surfaces only the username/password pair, so the live default is the Basic
+alternative (the appliance accepts `basicAuth` per the spec). The Bearer
+*header shape* is unit-tested via an injected loader returning a `"token"`; the
+Bearer-token **provisioning** — a fleet-lcm loader surfacing a Vault-stored
+token, or a POST-`basicAuth` → mint-`bearerToken` session flow — is the
+live-verify follow-up gated on a stood-up appliance.
+
+### Fingerprint / probe
+
+Unlike the legacy impl (whose diagnostic endpoints return HTTP 500 on 9.0),
+the modern service exposes a first-class health endpoint. The connector probes
+`GET /v1/health` (`operationId` `getHealth`; the spec marks it `security: []`).
+`fingerprint` returns a reachable `FingerprintResult`
+(`vendor="vmware"`, `product="fleet"`, `probe_method="GET /v1/health ..."`),
+with `version` taken from an explicit `version` string in the health payload
+when present, else `None`. On any transport/status failure it returns a
+non-reachable result carrying `extras["error"]` (the Harbor / NSX / vcf-fleet
+pattern). `probe()` delegates to `fingerprint()`.
+
+### Dispatch
+
+`execute()` is the G0.6 ABC-compatibility shim (builds a synthetic `Operator`
+and forwards to `meho_backplane.operations.dispatch`). Ingested `/v1/*` ops
+route through the dispatcher via `POST /api/v1/operations/call` (or MCP
+`call_operation`) and ride this connector's `auth_headers`.
+
+## Spec reconcile lane
+
+[`backend/tests/test_connectors_fleet_lcm_spec_reconcile.py`](../../backend/tests/test_connectors_fleet_lcm_spec_reconcile.py)
+asserts the connector's hand-coded probe path (`_FLEET_LCM_HEALTH_PATH`,
+introspected from the live constant — the #2944 pattern) is served by the
+pinned `fleet-lcm-9.0/fleet-lcm-openapi.yaml`. **No server-base fold** is
+applied: the spec's server url `https://vcf.broadcom.com/fleet-lcm` is
+*absolute*, so `parse_openapi` does not fold the `/fleet-lcm` base onto path
+keys (only *relative* server bases are folded, #1796) — the served op_id is the
+raw `GET:/v1/health`, matching the probe constant. The lane arms when the shelf
+provides the spec (`MEHO_CONSUMER_DOCS_ROOT`) and skips uniformly otherwise
+(`tests/_spec_shelf.py` contract).
+
+## Dependencies
+
+- `meho_backplane.connectors.adapters.http.HttpConnector` — pooled
+  `httpx.AsyncClient` per target, retry-on-idempotent transport, base-URL
+  composition.
+- `meho_backplane.connectors._shared.vcf_auth` — `basic_auth_header`,
+  `is_acceptable_auth_model`, `CredentialsCache`, `load_credentials_from_vault`.
+- `meho_backplane.connectors.schemas` — `AuthModel`, `FingerprintResult`,
+  `ProbeResult`, `OperationResult`.
+- `httpx`, `respx` (test-only). No new runtime deps.
+
+## Known issues / follow-ups
+
+- **Bearer auth not live-verified.** See "Auth" — the header shape ships and is
+  unit-tested; token provisioning + live dispatch are the follow-up gated on a
+  reachable appliance.
+- **Ops arrive by ingestion.** Until an operator ingests
+  `fleet-lcm-openapi.yaml`, the connector is registered and discoverable but
+  `execute` against any `op_id` resolves to "unknown operation" — correct for a
+  registered-but-empty connector at this stage.
+
+## References
+
+- Modern-impl Task: <https://github.com/evoila/meho/issues/3036>
+- Legacy re-band + resolution test Task: <https://github.com/evoila/meho/issues/3037>
+- Parent initiative: <https://github.com/evoila/meho/issues/3033>
+- Legacy impl: [`connectors-vcf-fleet.md`](connectors-vcf-fleet.md)
+- Spec provenance: `vmware/vcf-api-specs@c3f3b52c` (Apache-2.0); shelf
+  `docs/fleet-lcm-9.0/MANIFEST.md`.

--- a/docs/codebase/connectors-vcf-fleet.md
+++ b/docs/codebase/connectors-vcf-fleet.md
@@ -21,12 +21,51 @@ VCF Fleet is the rebrand of vRealize Suite Lifecycle Manager (vRSLCM) under
 the VCF 9 umbrella; the appliance still identifies as vRSLCM in its internal
 config and every response carries an `Lcm-API-Version` header.
 
+## Dual implementation (fleet-rest + fleet-lcm)
+
+`product=fleet` is the codebase's **first real two-implementation case**
+(initiative [#3033](https://github.com/evoila/meho/issues/3033), decision of
+record `versioned-connector-dual-impl`). Two hand-rolled `HttpConnector`
+subclasses coexist, resolved **per target by fingerprint** — the agent never
+sees the difference:
+
+| impl | connector | surface | `supported_version_range` |
+|---|---|---|---|
+| `fleet-rest` (legacy, typed) | `VcfFleetConnector` (this doc) | vRSLCM `/lcm/lcops/api/v2/*` | `>=8.0,<10.0` |
+| `fleet-lcm` (modern, generic/ingested) | [`FleetLcmConnector`](connectors-fleet-lcm.md) | VCF 9 Fleet LCM Service `/v1/*` | `>=9.0,<10.0` |
+
+Both register under `product="fleet"` with distinct `impl_id`s, so the v2
+registry keys `("fleet","9.0","fleet-rest")` and `("fleet","9.0","fleet-lcm")`
+never collide. The `("fleet","","")` **wildcard** fallback is registered once,
+by this legacy package only (a second class on that key would raise at import);
+`fleet-lcm` registers the versioned triple alone.
+
+The [resolver](../../backend/src/meho_backplane/connectors/resolver.py) picks
+the impl per target:
+
+- **8.x target → `fleet-rest`** — the only candidate whose range contains the
+  version (`fleet-lcm`'s `>=9.0,<10.0` excludes 8.x).
+- **9.0 target → `fleet-lcm`** — both ranges contain 9.0, but `fleet-lcm`'s
+  narrower `>=9.0,<10.0` (span 1.0) beats `fleet-rest`'s `>=8.0,<10.0`
+  (span 2.0) at the resolver's **most-specific-version** tie-break (step 2),
+  *before* operator preference (step 3) is consulted. The split is by
+  version-specificity, not `priority` — both impls keep `priority=1`.
+
+The split is proven by
+[`backend/tests/test_connectors_fleet_dual_impl_resolution.py`](../../backend/tests/test_connectors_fleet_dual_impl_resolution.py).
+Because specificity precedes operator preference in the ladder, an operator
+**cannot** pin the legacy `/lcm/*` surface on a *9.0* target via
+`preferred_impl_id="fleet-rest"` — the more-specific `fleet-lcm` still wins
+(the resolver's documented, tested ordering; see that test's
+`preferred_impl_id` case).
+
 ## Key types
 
 - **`VcfFleetConnector`** (`connector.py`) — `HttpConnector` subclass.
-  Class attributes: `product="vcf-fleet"`, `version="9.0"`,
-  `impl_id="fleet-rest"`, `supported_version_range=">=9.0,<10.0"`,
-  `priority=1`. The priority outranks a future `GenericRestConnector`
+  Class attributes: `product="fleet"`, `version="9.0"`,
+  `impl_id="fleet-rest"`, `supported_version_range=">=8.0,<10.0"`
+  (re-banded from `">=9.0,<10.0"` in #3037 — see "Dual implementation"
+  below), `priority=1`. The priority outranks a future `GenericRestConnector`
   auto-shim defensively if both somehow register for the same triple.
 - **`VcfFleetTargetLike`** (`session.py`) — runtime-checkable Protocol
   capturing the minimum target shape the connector reads: `name`, `host`,

--- a/docs/decisions/vendor-spec-ci-provisioning.md
+++ b/docs/decisions/vendor-spec-ci-provisioning.md
@@ -518,6 +518,37 @@ widening, and a **vendor-served** signoff extension here (the nsx-9.0 form, unde
 the wave-3 blanket determination above) land together with the operator's
 consumer-shelf PR — this repo change adds only the dormant lane.
 
+### Extension: fleet-lcm (VCF 9 Fleet LCM Service, `fleet-lcm-9.0/fleet-lcm-openapi.yaml`, #3036)
+
+The **modern** `fleet-lcm` reconcile lane
+(`backend/tests/test_connectors_fleet_lcm_spec_reconcile.py`, initiative #3033)
+reads the VCF 9 Fleet LCM Service OpenAPI document — the *new* `/fleet-lcm` →
+`/v1/*` service, distinct from the legacy vRSLCM `/lcm/*` surface the dormant
+vcf-fleet lane covers. No vendor-license attestation is needed: the spec is
+vendored by VMware in the **public, Apache-2.0**
+[`vmware/vcf-api-specs`](https://github.com/vmware/vcf-api-specs) repo (pinned at
+`c3f3b52c`, retrieved 2026-08-19, `sha256 = b565666a…819d41d7`, verified
+byte-identical to the upstream blob) — the provenance note of record is the
+shelf's `fleet-lcm-9.0/MANIFEST.md`, per the OSS-licensed-spec form in
+[`spec-reconcile-guards-standard.md`](spec-reconcile-guards-standard.md)'s
+extension mechanics (the vcf-operations / vcf-logs OSS precedent, **not** the
+nsx-9.0 vendor-served form the paired legacy lane will use). No
+`.ingestable.json` derivative is pinned: the document is a clean OpenAPI 3.0.4
+whose `securitySchemes` (`bearerToken` http Bearer + `basicAuth` http basic) are
+well-formed, so `parse_openapi` accepts it as-is (unlike the vcf-logs Logs spec)
+and the lane uses the standard `openapi_served_op_ids`.
+
+Unlike the vcf-logs extension, this spec lands in a **new** shelf directory
+`docs/fleet-lcm-9.0/`, so the sparse-checkout **is** widened:
+`docs/fleet-lcm-9.0` is added to both Python jobs' sparse-checkout list, and
+`fleet-lcm-9.0/fleet-lcm-openapi.yaml` to their fail-loud verify step + echo
+confirmation. The lane and this CI wiring land in the evoila/meho PR; the shelf
+pin lands via the operator's consumer-shelf PR (`claude-rdc-hetzner-dc#2560`).
+**Until that shelf PR merges, the fail-loud verify step reports the file
+missing and the Python jobs fail** — the intended fail-closed behaviour (a
+layout/pin regression must fail CI, not silently skip the lane); the entry is
+**not** removed to force green.
+
 ## Consequences
 
 - The five real-spec lanes light up together the moment the secret exists;


### PR DESCRIPTION
Lands the meho side of initiative #3033 — the **modern generic `fleet-lcm`**
implementation of `product=fleet`, coexisting with the legacy typed
`fleet-rest`, resolved per target by fingerprint. This is the codebase's
**first real two-impl case**.

Closes #3036. Closes #3037.

## What's here

**#3036 — modern impl + reconcile lane + CI + ADR**
- New `connectors/fleet_lcm/` package: a hand-rolled `HttpConnector` subclass
  (`FleetLcmConnector`, the `VmwareRestConnector` pattern) so the 51
  spec-ingested `/v1/*` ops become dispatchable under `connector_id=fleet-lcm-9.0`.
  Registered with the versioned triple only — **no wildcard sibling** (legacy
  owns the one `("fleet","","")` fallback; a second class on that key collides).
- Bearer-primary / Basic-fallback `auth_headers`; `GET /v1/health` probe.
- Armed reconcile lane (`test_connectors_fleet_lcm_spec_reconcile.py`),
  `connectors-fleet-lcm.md`, ADR extension (OSS/Apache-2.0 form).
- CI: `docs/fleet-lcm-9.0` added to both Python jobs' sparse-checkout + verify + echo.

**#3037 — legacy re-band + the resolution test**
- `vcf_fleet` `supported_version_range` `>=9.0,<10.0` → `>=8.0,<10.0` (range only;
  `version="9.0"` / `FLEET_*` / `connector_id="fleet-rest-9.0"` unchanged).
- `test_connectors_fleet_dual_impl_resolution.py` — the first two-impl resolver test.

## ⚠️ Reviewer-critical: a corrected task assertion (the resolution test)

Task #3037 / initiative #3033 specified a third resolution case:
*"`preferred_impl_id="fleet-rest"` on a 9.0 target → resolves `fleet-rest`
(operator-preference tie-break)."* **This is not how the resolver behaves, and
it is internally inconsistent with the second case.** The tie-break ladder runs
**most-specific-version (step 2) *before* operator preference (step 3)**. For a
9.0 target both impls are in range, and `fleet-lcm`'s `>=9.0,<10.0` (span 1.0)
is *strictly* more specific than `fleet-rest`'s `>=8.0,<10.0` (span 2.0), so
specificity resolves to `fleet-lcm` and returns **before** `preferred_impl_id`
is ever consulted. Operator preference only breaks a specificity *tie* (equal
spans), which these two impls never have.

Satisfying "9.0 → fleet-lcm **by most-specific-version**" (case 2) and "9.0 +
preferred fleet-rest → fleet-rest" (case 3) simultaneously is **impossible**
under the current ladder — case 2 requires `fleet-lcm` strictly more specific,
which is exactly what makes preference moot in case 3. The ordering is
deliberate and previously settled — `test_connectors_resolver.py::test_resolve_operator_preference_does_not_override_specificity`
literally pins it "against the issue body's alternative reading."

I did **not** touch the resolver (out of scope; would revert a settled
decision). The test asserts the **actual** behaviour — the more-specific
`fleet-lcm` still wins on a 9.0 target even with `preferred_impl_id="fleet-rest"`
— and documents that pinning the legacy `/lcm/*` surface on a genuine 9.0
target is **not** achievable via `preferred_impl_id` today. If the initiative
truly wants operators to be able to pin the legacy surface on a 9.0 appliance,
that needs a separate resolver decision (promote preference above specificity,
or a hard per-target impl pin) — flagged for the orchestrator.

## ⚠️ Expected CI red until shelf PR #2560 merges

The spec is pinned by consumer-shelf PR `evoila-bosnia/claude-rdc-hetzner-dc#2560`
(not yet on the shelf's default branch). Until it merges, the two Python jobs'
"Verify spec-shelf provisioned" step reports
`spec-shelf/docs/fleet-lcm-9.0/fleet-lcm-openapi.yaml` missing and **fails** —
the intended fail-closed behaviour. The entry is deliberately **not** removed
to force green. The reconcile lane itself skips uniformly when the shelf is
unconfigured and arms once the spec lands (verified locally against a checkout
of #2560's spec: `GET:/v1/health` served, 51 ops parsed, no `/fleet-lcm` fold).

## Assumptions to sanity-check (esp. the Bearer seam — not live-verifiable)

- **Bearer auth seam.** No reachable Fleet LCM appliance (#1002/#995), so the
  Bearer *header shape* is unit-tested via an injected `token` loader, but never
  hit live. The `CredentialsCache` contract hardcodes `{username,password}`, so
  the loader always returns that pair (the appliance also accepts `basicAuth`
  per the spec) and *optionally* a `token`; `auth_headers` prefers the token.
  The default Vault loader surfaces only username/password today, so the **live
  default is Basic** until the token-provisioning follow-up (a fleet-lcm loader
  reading a Vault `token`, or a POST-`basicAuth`→mint-`bearerToken` flow). If
  Fleet LCM 9.x rejects `basicAuth` in practice, that follow-up becomes a
  blocker for live dispatch — please confirm when an appliance is up.
- **Probe path = `GET /v1/health`** — chosen because the spec marks it
  `security: []` (unauthenticated reachability) and it's the modern service's
  first-class health op (the legacy impl couldn't use its health endpoint —
  HTTP 500 on 9.0 — and fell back to a datacenters list).
- **No server-base fold in the lane** — the spec's server url
  `https://vcf.broadcom.com/fleet-lcm` is *absolute*, so `parse_openapi`'s
  `_server_base_path` returns `""` (only relative bases fold, #1796); served
  op_ids are raw `/v1/*` and the `/fleet-lcm` base is operator target config.

## Verification (local)

`ruff` + `ruff format` + canonical `mypy` (files=[src]) clean (the lone mypy
error is a pre-existing Darwin-only `net/icmp.py` `MSG_ERRQUEUE` quirk, untouched
by this PR, invisible on Linux CI). Resolution test 7/7, auth 14/14, reconcile
2/2 armed (skips cleanly without the shelf); legacy vcf-fleet + resolver +
registry suites green; eager-import boot smoke confirms both impls register
under distinct triples with the wildcard legacy-owned.

Not duplicated (orchestrator-owned): the locked-decision PR #3038 and the
consumer-shelf spec pin #2560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
