### PR TITLE
feat(deploy): ServiceMonitor + starter PrometheusRule scrape wiring

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -441,6 +441,74 @@ jobs:
           fi
           echo ">> ingest-sender netpol rule verified: renders on opt-in, absent by default"
 
+      - name: Assert observability scrape wiring renders on opt-in (#2885)
+        # #2885: the Prometheus Operator ServiceMonitor + starter
+        # PrometheusRule are OPTIONAL and disabled by default, so the
+        # kubeconform render above (which sets neither) never exercises
+        # them — and their CRDs (monitoring.coreos.com/v1) aren't in the
+        # upstream schema set kubeconform validates against anyway. This
+        # step is therefore the authoritative CI gate for the feature (the
+        # backend/tests/test_chart_observability_scrape.py mirror skips in
+        # the unit lane, which ships no helm). It renders with both opt-ins
+        # on and greps the load-bearing fields: the ServiceMonitor scrapes
+        # /metrics and carries the discovery label a Prometheus
+        # serviceMonitorSelector needs; the PrometheusRule ships both
+        # release-scoped starter alerts. The default render from the
+        # "Helm template + kubeconform" step proves the opt-out path (no
+        # ServiceMonitor / PrometheusRule without the flags).
+        run: |
+          set -euo pipefail
+          helm template test deploy/charts/meho/ \
+            --set image.tag=test \
+            --set ingress.host=meho.test \
+            --set ingress.tls.secretName=meho-tls \
+            --set postgres.credentialsSecret=meho-postgres \
+            --set vault.address=https://vault.test \
+            --set keycloak.issuer=https://keycloak.test/realms/meho \
+            --set config.keycloakIssuerUrl=https://keycloak.test/realms/meho \
+            --set config.keycloakAudience=meho-backplane \
+            --set config.vaultAddr=https://vault.test \
+            --set networkPolicy.postgresCIDR=10.0.1.0/24 \
+            --set networkPolicy.vaultCIDR=10.0.2.0/24 \
+            --set networkPolicy.keycloakCIDR=10.0.3.0/24 \
+            --set serviceMonitor.enabled=true \
+            --set serviceMonitor.labels.release=kube-prometheus-stack \
+            --set prometheusRule.enabled=true \
+            --set prometheusRule.labels.release=kube-prometheus-stack \
+            > /tmp/rendered-obs.yaml
+
+          grep -Eq '^kind: ServiceMonitor$' /tmp/rendered-obs.yaml \
+            || { echo "::error::serviceMonitor.enabled=true did not render a ServiceMonitor (#2885 regression)"; exit 1; }
+          grep -Eq '^kind: PrometheusRule$' /tmp/rendered-obs.yaml \
+            || { echo "::error::prometheusRule.enabled=true did not render a PrometheusRule (#2885 regression)"; exit 1; }
+
+          # ServiceMonitor scrapes the backplane /metrics route (the path
+          # is unique to the ServiceMonitor endpoint — probes use
+          # /healthz + /ready).
+          grep -Eq '^[[:space:]]*path: /metrics$' /tmp/rendered-obs.yaml \
+            || { echo "::error::ServiceMonitor did not scrape /metrics (#2885 regression)"; exit 1; }
+
+          # Both starter alerts, release-scoped.
+          grep -Fq 'absent(up{job="test-meho"' /tmp/rendered-obs.yaml \
+            || { echo "::error::PrometheusRule missing the release-scoped absent(up) scrape alert (#2885 regression)"; exit 1; }
+          grep -Fq 'rate(broadcast_publish_errors_total[5m])' /tmp/rendered-obs.yaml \
+            || { echo "::error::PrometheusRule missing the broadcast_publish_errors_total rate alert (#2885 regression)"; exit 1; }
+
+          # Discovery label present on BOTH resources — a Prometheus
+          # serviceMonitorSelector / ruleSelector only picks them up when
+          # this label matches (the #1 pickup gotcha).
+          if [ "$(grep -c '^[[:space:]]*release: kube-prometheus-stack$' /tmp/rendered-obs.yaml)" -lt 2 ]; then
+            echo "::error::discovery 'release' label missing on ServiceMonitor/PrometheusRule (#2885 regression)"
+            exit 1
+          fi
+
+          # Opt-out path: the default-overrides render carries neither.
+          if grep -Eq '^kind: (ServiceMonitor|PrometheusRule)$' /tmp/rendered.yaml; then
+            echo "::error::default render leaked a ServiceMonitor/PrometheusRule without opt-in (#2885 regression)"
+            exit 1
+          fi
+          echo ">> observability scrape wiring verified: renders on opt-in, absent by default"
+
   helm-test:
     # Internal "run" job — the REQUIRED branch-protection context lives on the
     # `helm-test-gate` aggregator below, not here. A required job that is gated

--- a/backend/tests/test_chart_observability_scrape.py
+++ b/backend/tests/test_chart_observability_scrape.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Chart-render assertions for the observability scrape wiring (#2885).
+
+Initiative #2884 ships the first Prometheus Operator resources in the
+chart: an optional ``ServiceMonitor`` that scrapes the backplane
+``/metrics`` endpoint and an optional starter ``PrometheusRule`` with two
+alerts. Both are **disabled by default** — a default install carries
+neither, so a cluster without the Prometheus Operator CRDs
+(``monitoring.coreos.com/v1``) is unaffected — and each is gated on its
+own ``enabled`` knob.
+
+These tests pin:
+
+* the safe-by-default posture (neither resource renders without opt-in);
+* the ServiceMonitor opt-in shape (selects this release's Service by the
+  name+instance selector labels, scrapes the named service port at
+  ``/metrics``, same-namespace discovery);
+* the discovery-``labels`` merge both resources need so a Prometheus
+  ``serviceMonitorSelector`` / ``ruleSelector`` actually picks them up;
+* the starter-alert contract (both alert names, the release-scoped
+  ``absent(up)`` scrape alert, the ``broadcast_publish_errors_total``
+  rate alert, the by-concern group split #2888 extends, and the tunable
+  ``for`` / ``severity`` knobs).
+
+The authoritative chart gate is ``.github/workflows/chart.yml`` (lint +
+``helm template`` + kubeconform + these render assertions). This test
+mirrors the assertions at the unit layer so the regression is catchable
+from ``pytest`` on any machine with ``helm`` installed; it skips cleanly
+where ``helm`` is absent (the backend unit-test sandbox does not ship it
+— the workflow gate covers that environment).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+import yaml
+
+# backend/tests/<this> → parents[2] == repo root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHART_DIR = _REPO_ROOT / "deploy" / "charts" / "meho"
+
+# Minimal chassis-required overrides that satisfy values.schema.json.
+_BASE_OVERRIDES = [
+    "--set",
+    "image.tag=test",
+    "--set",
+    "ingress.host=meho.test",
+    "--set",
+    "ingress.tls.secretName=meho-tls",
+    "--set",
+    "postgres.credentialsSecret=meho-postgres",
+    "--set",
+    "vault.address=https://vault.test",
+    "--set",
+    "keycloak.issuer=https://keycloak.test/realms/meho",
+    "--set",
+    "config.keycloakIssuerUrl=https://keycloak.test/realms/meho",
+    "--set",
+    "config.keycloakAudience=meho-backplane",
+    "--set",
+    "config.vaultAddr=https://vault.test",
+    "--set",
+    "networkPolicy.postgresCIDR=10.0.1.0/24",
+    "--set",
+    "networkPolicy.vaultCIDR=10.0.2.0/24",
+    "--set",
+    "networkPolicy.keycloakCIDR=10.0.3.0/24",
+]
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("helm") is None,
+    reason="helm not installed in this sandbox; chart.yml workflow gate covers CI",
+)
+
+
+def _render_show_only(template: str, *extra: str) -> dict[str, Any]:
+    """Return the parsed single manifest for ``--show-only <template>``."""
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "test",
+            str(_CHART_DIR),
+            *_BASE_OVERRIDES,
+            *extra,
+            "--show-only",
+            template,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return cast("dict[str, Any]", yaml.safe_load(result.stdout))
+
+
+def _render_full(*extra: str) -> str:
+    """Return the full multi-document render (no ``--show-only``)."""
+    result = subprocess.run(
+        ["helm", "template", "test", str(_CHART_DIR), *_BASE_OVERRIDES, *extra],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _alerts(rule: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Flatten a PrometheusRule's groups into ``{alert_name: rule}``."""
+    return {
+        r["alert"]: r for group in rule["spec"]["groups"] for r in group["rules"] if "alert" in r
+    }
+
+
+def test_service_monitor_absent_by_default() -> None:
+    """A default install renders NO ServiceMonitor (no operator dependency)."""
+    assert "kind: ServiceMonitor" not in _render_full()
+
+
+def test_prometheus_rule_absent_by_default() -> None:
+    """A default install renders NO PrometheusRule."""
+    assert "kind: PrometheusRule" not in _render_full()
+
+
+def test_service_monitor_renders_when_enabled() -> None:
+    """Opt-in renders a ServiceMonitor targeting this release's Service."""
+    sm = _render_show_only("templates/servicemonitor.yaml", "--set", "serviceMonitor.enabled=true")
+    assert sm["apiVersion"] == "monitoring.coreos.com/v1"
+    assert sm["kind"] == "ServiceMonitor"
+    # Selects THIS release's backplane Service by name + instance.
+    match = sm["spec"]["selector"]["matchLabels"]
+    assert match["app.kubernetes.io/name"] == "meho"
+    assert match["app.kubernetes.io/instance"] == "test"
+    # Same-namespace discovery.
+    assert sm["spec"]["namespaceSelector"]["matchNames"] == ["default"]
+    # Scrapes the named service port at /metrics.
+    endpoint = sm["spec"]["endpoints"][0]
+    assert endpoint["port"] == "http"
+    assert endpoint["path"] == "/metrics"
+
+
+def test_service_monitor_merges_discovery_labels() -> None:
+    """The label a Prometheus serviceMonitorSelector matches must survive.
+
+    Without this label a kube-prometheus-stack Prometheus silently never
+    generates the scrape config — the #1 ServiceMonitor pickup gotcha.
+    """
+    sm = _render_show_only(
+        "templates/servicemonitor.yaml",
+        "--set",
+        "serviceMonitor.enabled=true",
+        "--set",
+        "serviceMonitor.labels.release=kube-prometheus-stack",
+    )
+    assert sm["metadata"]["labels"]["release"] == "kube-prometheus-stack"
+
+
+def test_prometheus_rule_renders_starter_alerts() -> None:
+    """Opt-in renders both starter alerts under by-concern groups."""
+    pr = _render_show_only("templates/prometheusrule.yaml", "--set", "prometheusRule.enabled=true")
+    assert pr["apiVersion"] == "monitoring.coreos.com/v1"
+    assert pr["kind"] == "PrometheusRule"
+    # By-concern group split — #2888 adds a NEW group here, it does not
+    # append a rule to an existing group.
+    group_names = {g["name"] for g in pr["spec"]["groups"]}
+    assert {"meho.scrape", "meho.broadcast"} <= group_names
+
+    alerts = _alerts(pr)
+    # Scrape-absent alert is release-scoped absent(up).
+    assert (
+        alerts["MehoMetricsScrapeAbsent"]["expr"]
+        == 'absent(up{job="test-meho", namespace="default"})'
+    )
+    # Broadcast publish-error alert keys off the fail-open counter's rate.
+    assert (
+        "rate(broadcast_publish_errors_total[5m])" in alerts["MehoBroadcastPublishErrors"]["expr"]
+    )
+
+
+def test_prometheus_rule_merges_discovery_labels() -> None:
+    """The label a Prometheus ruleSelector matches must survive."""
+    pr = _render_show_only(
+        "templates/prometheusrule.yaml",
+        "--set",
+        "prometheusRule.enabled=true",
+        "--set",
+        "prometheusRule.labels.release=kube-prometheus-stack",
+    )
+    assert pr["metadata"]["labels"]["release"] == "kube-prometheus-stack"
+
+
+def test_alert_for_and_severity_are_tunable() -> None:
+    """Alert `for` windows and severities are operator-tunable via values."""
+    pr = _render_show_only(
+        "templates/prometheusrule.yaml",
+        "--set",
+        "prometheusRule.enabled=true",
+        "--set",
+        "prometheusRule.scrapeAbsent.severity=warning",
+        "--set",
+        "prometheusRule.broadcastPublishErrors.for=30m",
+    )
+    alerts = _alerts(pr)
+    assert alerts["MehoMetricsScrapeAbsent"]["labels"]["severity"] == "warning"
+    assert alerts["MehoBroadcastPublishErrors"]["for"] == "30m"
+
+
+def test_service_monitor_and_prometheus_rule_are_independent() -> None:
+    """Each resource is gated on its own knob — enabling one is not both."""
+    only_sm = _render_full("--set", "serviceMonitor.enabled=true")
+    assert "kind: ServiceMonitor" in only_sm
+    assert "kind: PrometheusRule" not in only_sm
+
+    only_pr = _render_full("--set", "prometheusRule.enabled=true")
+    assert "kind: PrometheusRule" in only_pr
+    assert "kind: ServiceMonitor" not in only_pr

--- a/deploy/charts/meho/templates/NOTES.txt
+++ b/deploy/charts/meho/templates/NOTES.txt
@@ -13,6 +13,12 @@ Resources deployed:
 {{- if .Values.networkPolicy.enabled }}
   - NetworkPolicy / {{ include "meho.fullname" . }} (default-deny + explicit egress)
 {{- end }}
+{{- if .Values.serviceMonitor.enabled }}
+  - ServiceMonitor / {{ include "meho.fullname" . }} (scrapes {{ .Values.serviceMonitor.path }} on port {{ .Values.service.portName }})
+{{- end }}
+{{- if .Values.prometheusRule.enabled }}
+  - PrometheusRule / {{ include "meho.fullname" . }} (starter alerts)
+{{- end }}
 
 Next steps:
   1. Watch the rollout:

--- a/deploy/charts/meho/templates/prometheusrule.yaml
+++ b/deploy/charts/meho/templates/prometheusrule.yaml
@@ -1,0 +1,67 @@
+{{- /*
+Prometheus Operator PrometheusRule — starter alerting rules
+(Initiative #2884, #2885).
+
+Optional and disabled by default: rendered only when
+`prometheusRule.enabled` is true, and requires the Prometheus Operator
+CRDs (`monitoring.coreos.com/v1`).
+
+Rules are split into groups BY CONCERN (`meho.scrape`, `meho.broadcast`)
+so sibling tasks can extend the rule without restructuring: the
+background-loop liveness alert lands with #2888 as a new `meho.loops`
+group rather than an edit to an existing group. Keep this shape.
+*/ -}}
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "meho.fullname" . }}
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+    {{- with .Values.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: meho.scrape
+      rules:
+        - alert: MehoMetricsScrapeAbsent
+          # Fires when Prometheus has NO target series for this release at
+          # all — the ServiceMonitor was never picked up (ruleSelector /
+          # serviceMonitorSelector label mismatch), the selector drifted,
+          # or the Service was removed. A target that is known-but-failing
+          # surfaces as `up == 0`, a separate signal the starter set does
+          # not cover. `job` defaults to the Service name (= fullname) and
+          # `namespace` is stamped by the operator's target relabeling.
+          expr: 'absent(up{job="{{ include "meho.fullname" . }}", namespace="{{ .Release.Namespace }}"})'
+          for: {{ .Values.prometheusRule.scrapeAbsent.for }}
+          labels:
+            severity: {{ .Values.prometheusRule.scrapeAbsent.severity }}
+          annotations:
+            summary: MEHO backplane metrics are not being scraped
+            description: >-
+              Prometheus has no scrape target for the MEHO backplane
+              (job {{ include "meho.fullname" . }}, namespace
+              {{ .Release.Namespace }}); every application counter is dark.
+              Check that the ServiceMonitor exists and its labels match the
+              Prometheus serviceMonitorSelector.
+    - name: meho.broadcast
+      rules:
+        - alert: MehoBroadcastPublishErrors
+          # broadcast_publish_errors_total is the fail-open activity
+          # publisher's only operational signal: a dropped event is
+          # swallowed by design (backend/src/meho_backplane/broadcast/publisher.py),
+          # so a sustained nonzero rate means the activity feed is silently
+          # losing events.
+          expr: 'rate(broadcast_publish_errors_total[5m]) > 0'
+          for: {{ .Values.prometheusRule.broadcastPublishErrors.for }}
+          labels:
+            severity: {{ .Values.prometheusRule.broadcastPublishErrors.severity }}
+          annotations:
+            summary: MEHO broadcast publisher is dropping events
+            description: >-
+              broadcast_publish_errors_total has a sustained nonzero rate:
+              the activity-broadcast publisher is failing to XADD events to
+              Valkey (unreachable / XADD error / teardown race) and events
+              are being lost. Check the broadcast subchart (Valkey) health.
+{{- end }}

--- a/deploy/charts/meho/templates/servicemonitor.yaml
+++ b/deploy/charts/meho/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- /*
+Prometheus Operator ServiceMonitor (Initiative #2884, #2885).
+
+Optional and disabled by default: rendered only when
+`serviceMonitor.enabled` is true, and requires the Prometheus Operator
+CRDs (`monitoring.coreos.com/v1`) to be installed in the cluster. A
+default install ships neither this resource nor the CRDs, so a cluster
+without the operator is unaffected.
+
+Selects THIS release's backplane Service via the name+instance selector
+labels (the broadcast subchart's Service carries a different
+`app.kubernetes.io/name`, so it is not matched) and scrapes the named
+`service.portName` port at `serviceMonitor.path`. The `/metrics`
+exposition is unauthenticated (see backend/src/meho_backplane/metrics.py),
+so no scrape credentials are wired.
+*/ -}}
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "meho.fullname" . }}
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "meho.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: {{ .Values.service.portName }}
+      path: {{ .Values.serviceMonitor.path }}
+      scheme: http
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -105,6 +105,84 @@
         "portName": { "type": "string", "minLength": 1, "maxLength": 15 }
       }
     },
+    "serviceMonitor": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Prometheus Operator ServiceMonitor scrape wiring (Initiative #2884, #2885). Optional and disabled by default; requires the Prometheus Operator CRDs (monitoring.coreos.com/v1) in the cluster. When `enabled: true` the chart renders a ServiceMonitor selecting this release's Service (app.kubernetes.io/name + app.kubernetes.io/instance) and scraping the named `service.portName` port at `path`. `labels` is the discovery contract: a Prometheus CR only picks up ServiceMonitors whose labels match its `serviceMonitorSelector` (kube-prometheus-stack default `release: <prometheus-release>`), so the scrape config is silently never generated unless `labels` carries the matching label. Default `enabled: false` renders nothing — a default install (no Prometheus Operator) is unaffected.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "labels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Extra labels on the ServiceMonitor metadata. Set the label your Prometheus CR's serviceMonitorSelector matches (commonly `release: kube-prometheus-stack`) or the ServiceMonitor is ignored."
+        },
+        "interval": {
+          "type": "string",
+          "pattern": "^([0-9]+(ms|s|m|h|d|w|y))+$",
+          "description": "Scrape interval as a Prometheus duration (e.g. `30s`, `1m`)."
+        },
+        "scrapeTimeout": {
+          "type": "string",
+          "pattern": "^([0-9]+(ms|s|m|h|d|w|y))+$",
+          "description": "Per-scrape timeout as a Prometheus duration. Must be <= `interval` (the Prometheus Operator rejects a larger value)."
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^/",
+          "description": "HTTP path scraped on the Service port. Default `/metrics` matches the backplane exposition route."
+        }
+      }
+    },
+    "prometheusRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Optional starter Prometheus Operator PrometheusRule (Initiative #2884, #2885). Disabled by default; requires the Prometheus Operator CRDs (monitoring.coreos.com/v1). When `enabled: true` the chart renders two conservative alerts — `MehoMetricsScrapeAbsent` (absent(up) for this release's target) and `MehoBroadcastPublishErrors` (sustained nonzero rate of broadcast_publish_errors_total) — grouped by concern (`meho.scrape`, `meho.broadcast`) so sibling tasks can extend the rule (the #2888 background-loop liveness alert lands as a new group). Independent of `serviceMonitor.enabled`. `labels` is the same discovery contract as `serviceMonitor.labels`: a Prometheus CR only evaluates PrometheusRules whose labels match its `ruleSelector`. Default `enabled: false` renders nothing.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "labels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Extra labels on the PrometheusRule metadata. Set the label your Prometheus CR's ruleSelector matches (commonly `release: kube-prometheus-stack`) or the rules are never loaded."
+        },
+        "scrapeAbsent": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Tuning for the `MehoMetricsScrapeAbsent` alert (fires when Prometheus has no scrape target for this release at all).",
+          "properties": {
+            "for": {
+              "type": "string",
+              "pattern": "^([0-9]+(ms|s|m|h|d|w|y))+$",
+              "description": "How long the target must be absent before firing (Prometheus duration)."
+            },
+            "severity": {
+              "type": "string",
+              "minLength": 1,
+              "description": "`severity` label attached to the alert (Alertmanager routing key). Free-form to allow site-specific severities."
+            }
+          }
+        },
+        "broadcastPublishErrors": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Tuning for the `MehoBroadcastPublishErrors` alert (sustained nonzero rate of broadcast_publish_errors_total).",
+          "properties": {
+            "for": {
+              "type": "string",
+              "pattern": "^([0-9]+(ms|s|m|h|d|w|y))+$",
+              "description": "How long the error rate must stay nonzero before firing (Prometheus duration)."
+            },
+            "severity": {
+              "type": "string",
+              "minLength": 1,
+              "description": "`severity` label attached to the alert."
+            }
+          }
+        }
+      }
+    },
     "ingress": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -139,6 +139,77 @@ service:
   # -- Name of the service port (consumed by the Ingress backend reference).
   portName: http
 
+# Prometheus Operator scrape wiring (Initiative #2884, #2885). Both
+# resources below are OPTIONAL and disabled by default: the chart renders
+# them only on opt-in, and they require the Prometheus Operator CRDs
+# (`monitoring.coreos.com/v1`) to be present in the cluster. A default
+# install ships neither, so a cluster without the operator is unaffected.
+serviceMonitor:
+  # -- Render a ServiceMonitor that scrapes the backplane `/metrics`
+  # endpoint (unauthenticated legacy-0.0.4 exposition — see
+  # `backend/src/meho_backplane/metrics.py`). Default `false`: `/metrics`
+  # stays dark until an operator running the Prometheus Operator flips
+  # this on. The ServiceMonitor selects THIS release's Service via the
+  # `app.kubernetes.io/name` + `app.kubernetes.io/instance` selector
+  # labels and scrapes the named `service.portName` port.
+  enabled: false
+  # -- Extra labels applied to the ServiceMonitor metadata. REQUIRED in
+  # most clusters: a Prometheus CR only discovers ServiceMonitors whose
+  # labels match its `serviceMonitorSelector`. kube-prometheus-stack's
+  # default selector is `release: <prometheus-release>` (e.g.
+  # `release: kube-prometheus-stack`), so set that here or the scrape
+  # config is silently never generated. Empty by default because the
+  # correct value is cluster-specific.
+  labels: {}
+  # -- Scrape interval (Prometheus duration, e.g. `30s`, `1m`).
+  interval: 30s
+  # -- Per-scrape timeout (Prometheus duration). Must be <= `interval`.
+  scrapeTimeout: 10s
+  # -- HTTP path scraped on the backplane Service port. `/metrics` matches
+  # the backplane exposition route (main.py).
+  path: /metrics
+
+# Optional starter alerting rules (Initiative #2884, #2885). Renders a
+# PrometheusRule with two conservative alerts so a fresh install has a
+# baseline safety net without hand-authoring PromQL. Sibling tasks extend
+# it (the background-loop liveness alert lands with #2888 as a new rule
+# group). Independent of `serviceMonitor.enabled` — an operator scraping
+# via their own ServiceMonitor can still adopt these rules, and vice
+# versa. Requires the Prometheus Operator CRDs; disabled by default.
+prometheusRule:
+  # -- Render the starter PrometheusRule. Default `false`.
+  enabled: false
+  # -- Extra labels applied to the PrometheusRule metadata. Same discovery
+  # contract as `serviceMonitor.labels`: a Prometheus CR only evaluates
+  # PrometheusRules whose labels match its `ruleSelector`
+  # (kube-prometheus-stack default `release: <prometheus-release>`). Set
+  # it or the rules are silently never loaded.
+  labels: {}
+  # `MehoMetricsScrapeAbsent`: fires when Prometheus has NO scrape target
+  # for this release at all — the ServiceMonitor was never picked up, the
+  # label selector drifted, or the Service was removed (i.e. `absent(up)`
+  # for this release's target). The "is anyone even scraping me" backstop;
+  # a target that is up-but-failing surfaces as `up == 0`, a separate
+  # signal not covered by the starter set.
+  scrapeAbsent:
+    # -- How long the target must be absent before the alert fires
+    # (Prometheus duration).
+    for: 10m
+    # -- `severity` label attached to the alert (Alertmanager routing).
+    severity: critical
+  # `MehoBroadcastPublishErrors`: fires on a sustained nonzero rate of
+  # `broadcast_publish_errors_total`. That counter is the fail-open
+  # broadcast publisher's only operational signal (a dropped event is
+  # swallowed by design —
+  # `backend/src/meho_backplane/broadcast/publisher.py`), so a persistent
+  # error rate means the activity feed is silently losing events.
+  broadcastPublishErrors:
+    # -- How long the error rate must stay nonzero before firing
+    # (Prometheus duration).
+    for: 15m
+    # -- `severity` label attached to the alert.
+    severity: warning
+
 ingress:
   enabled: true
   # -- IngressClass name. Empty = let the cluster's default IngressClass apply.

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -367,6 +367,57 @@ kubectl create secret generic meho-postgres \
   --namespace meho
 ```
 
+### Metrics scrape wiring (`templates/servicemonitor.yaml`, `templates/prometheusrule.yaml`)
+
+The backplane serves Prometheus exposition at an unauthenticated
+`/metrics` route (`backend/src/meho_backplane/metrics.py`, legacy
+`0.0.4` content type for universal scraper support), but nothing scrapes
+it out of the box. Two **optional, disabled-by-default** Prometheus
+Operator resources close that gap (Initiative #2884, #2885):
+
+- `serviceMonitor` (`serviceMonitor.enabled`, default `false`) renders a
+  `ServiceMonitor` (`monitoring.coreos.com/v1`) that selects **this
+  release's** backplane `Service` by its `app.kubernetes.io/name` +
+  `app.kubernetes.io/instance` labels and scrapes the named
+  `service.portName` port at `serviceMonitor.path` (default `/metrics`).
+  The broadcast subchart's Service carries a different
+  `app.kubernetes.io/name`, so it is not matched.
+- `prometheusRule` (`prometheusRule.enabled`, default `false`) renders a
+  starter `PrometheusRule` with two conservative alerts:
+  - `MehoMetricsScrapeAbsent` — `absent(up{job=<fullname>, namespace=<ns>})`;
+    fires when Prometheus has **no** target series for this release at
+    all (the ServiceMonitor was never picked up, the selector drifted, or
+    the Service was removed). A known-but-failing target surfaces as
+    `up == 0`, a separate signal the starter set does not cover.
+  - `MehoBroadcastPublishErrors` — `rate(broadcast_publish_errors_total[5m]) > 0`;
+    the fail-open broadcast publisher swallows dropped events by design
+    (`broadcast/publisher.py`), so a sustained nonzero rate is the only
+    signal that the activity feed is silently losing events.
+
+  The rules are split into groups **by concern** (`meho.scrape`,
+  `meho.broadcast`) so follow-up tasks extend them cleanly — the
+  background-loop liveness alert (#2888) lands as a new `meho.loops`
+  group, not an edit to an existing group.
+
+Both resources require the Prometheus Operator CRDs
+(`monitoring.coreos.com/v1`) to be installed in the cluster; a default
+install renders neither and is unaffected. **The `labels` knob on each is
+the discovery contract, not cosmetic**: a Prometheus custom resource only
+picks up ServiceMonitors / PrometheusRules whose labels match its
+`serviceMonitorSelector` / `ruleSelector`. On a kube-prometheus-stack
+install that selector defaults to `release: <prometheus-release>`, so
+`serviceMonitor.labels` / `prometheusRule.labels` must carry
+`release: kube-prometheus-stack` (or the site's equivalent) or the scrape
+config / rules are silently never generated. The alert `for` durations
+and `severity` labels are operator-tunable under
+`prometheusRule.scrapeAbsent` / `prometheusRule.broadcastPublishErrors`.
+
+Render assertions live in `backend/tests/test_chart_observability_scrape.py`
+(unit layer, skips where `helm` is absent) and in the `chart.yml`
+`validate` job (the authoritative CI gate: renders with both opt-ins on
+and greps the load-bearing fields, and re-checks the default render
+carries neither resource).
+
 ### Safe-by-default values
 
 `values.yaml` deliberately ships **blank** for every field the backplane
@@ -1264,8 +1315,9 @@ when application code is the only delta.
 
 ## Known gaps (filled by sibling tasks)
 
-- HPA / PDB / topologySpreadConstraints / ServiceMonitor / PrometheusRule
-  — deferred to v0.2. v0.1 is single-replica per Goal #11 scope.
+- HPA / PDB / topologySpreadConstraints — deferred to v0.2. v0.1 is
+  single-replica per Goal #11 scope. (ServiceMonitor + PrometheusRule
+  shipped in #2885 — see "Metrics scrape wiring" under Chart contract.)
 - Broadcast subchart HA (Sentinel/Cluster), persistence, auth —
   deferred to v0.2 per ADR 0005.
 - `broadcast.externalEndpoint` opt-out for operators with a managed


### PR DESCRIPTION
## Summary

- Chart shipped **no** ServiceMonitor/PodMonitor and no scrape annotations, so the backplane `/metrics` endpoint was dark unless a consumer hand-wired Prometheus — and `broadcast_publish_errors_total` (whose whole design is "alert on a sustained nonzero rate") was unobservable. This adds the scrape wiring as two **optional, disabled-by-default** Prometheus Operator resources.
- `templates/servicemonitor.yaml` (`serviceMonitor.enabled`, default `false`) selects **this release's** backplane Service by its `app.kubernetes.io/name` + `app.kubernetes.io/instance` labels and scrapes the named `service.portName` port at `serviceMonitor.path` (default `/metrics`).
- `templates/prometheusrule.yaml` (`prometheusRule.enabled`, default `false`) ships two starter alerts — `MehoMetricsScrapeAbsent` (release-scoped `absent(up{job,namespace})`) and `MehoBroadcastPublishErrors` (`rate(broadcast_publish_errors_total[5m]) > 0`). Rules are split into **by-concern groups** (`meho.scrape`, `meho.broadcast`) so the #2888 background-loop liveness alert lands as a new group, not a restructure.
- Both require the Prometheus Operator CRDs (`monitoring.coreos.com/v1`) and render nothing by default → a cluster without the operator is unaffected. The `labels` knob on each is the **discovery contract**: a Prometheus CR only picks up ServiceMonitors/PrometheusRules whose labels match its `serviceMonitorSelector`/`ruleSelector` (kube-prometheus-stack default `release: <name>`).

## Framework research

- Prometheus Operator API reference — `monitoring.coreos.com/v1` `ServiceMonitor` (`spec.selector` required; `endpoints[].{port,path,interval,scrapeTimeout,scheme}`; `namespaceSelector`) and `PrometheusRule` (`spec.groups[].{name,rules[]}`, rule `{alert,expr,for,labels,annotations}`).
- Operator design doc — `serviceMonitorSelector`/`ruleSelector` label-match semantics (the #1 pickup gotcha → the `labels` knob).
- Operator running-exporters guide — target labels stamped on scraped series (`namespace`, `service`, `pod`, `endpoint`, `job`; `job` defaults to the Service name), which pins the release-scoped `absent(up)` expression.

## Test plan

- [x] `helm lint` (schema + templates) — clean
- [x] Default render → `kubeconform -strict`: 11 valid, **no** ServiceMonitor/PrometheusRule rendered (opt-out proven)
- [x] Opt-in render → `kubeconform`: 11 valid, 2 CRDs skipped cleanly (`-ignore-missing-schemas`, no `-strict` failure)
- [x] `backend/tests/test_chart_observability_scrape.py` — 8 passed (default-absent, opt-in shape, discovery-label merge, both alerts, by-concern groups, tunable `for`/`severity`, independence)
- [x] New `chart.yml` render-assertion step greps the load-bearing fields (authoritative CI gate — the golden tests skip where `helm` is absent)
- [x] `ruff check` / `ruff format --check` / `mypy` / code-quality gate — clean

## Out of scope

- `http_request_duration_seconds` histogram + 404 cardinality fix — sibling **#2886**.
- stdlib→structlog logging bridge — sibling **#2887**.
- `background_loop_last_tick` liveness gauge + its staleness alert (extends this PR's PrometheusRule) — sibling **#2888**.
- Pre-existing, unrelated: `test_chart_mcp_resource_uri.py::test_no_mcp_env_keys_when_ingress_disabled_and_nothing_set` errors under **local helm v4** (deployment.yaml's #2394 MCP `fail`-guard fires on `ingress.enabled=false`). Reproduces identically on untouched `origin/main`; invisible in CI (chart golden tests skip where helm is absent; `chart.yml` renders with ingress enabled). Not touched by this PR.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2885
