### PR TITLE
fix(connectors): vmware-rest /api write bodies send top-level *Spec, not the /rest {spec} envelope

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/_write.py
@@ -473,10 +473,12 @@ _VIM_SUB_OPS_HOST_DETACH_FROM_VDS: tuple[str, ...] = (
 
 # Hardware write ops (#2891). Post-clone reconfigure of a VM's virtual
 # hardware, straight vSphere Automation REST. CPU/memory update and the
-# ethernet/cdrom device sub-resources take the update spec wrapped in the
-# ``{"spec": {...}}`` envelope this connector's write sub-ops author (see
-# ``_write_sub_op``); the CD-ROM ``disconnect`` rides an ``?action=``
-# suffix like the other action endpoints (power / relocate / maintenance).
+# ethernet/cdrom device sub-resources send the update spec's fields at the
+# **top level** of the request body -- the modern ``/api`` surface takes the
+# ``*Spec`` directly (``Cpu.UpdateSpec`` / ``Ethernet.UpdateSpec`` / ...),
+# not the legacy ``/rest`` ``{"spec": {...}}`` envelope (#2973); the CD-ROM
+# ``disconnect`` rides an ``?action=`` suffix like the other action
+# endpoints (power / relocate / maintenance).
 _OP_UPDATE_VM_CPU = "PATCH:/vcenter/vm/{vm}/hardware/cpu"
 _OP_UPDATE_VM_MEMORY = "PATCH:/vcenter/vm/{vm}/hardware/memory"
 _OP_GET_VM_NIC = "GET:/vcenter/vm/{vm}/hardware/ethernet/{nic}"
@@ -968,13 +970,11 @@ async def vm_create_composite(
     steps.append("folder_lookup")
 
     create_spec = {
-        "spec": {
-            "name": name,
-            "guest_OS": guest_os,
-            "placement": {"folder": folder_moid},
-            "cpu": {"count": cpu_count},
-            "memory": {"size_MiB": memory_mib},
-        },
+        "name": name,
+        "guest_OS": guest_os,
+        "placement": {"folder": folder_moid},
+        "cpu": {"count": cpu_count},
+        "memory": {"size_MiB": memory_mib},
     }
     try:
         gate, create_payload = await _write_sub_op(
@@ -1006,7 +1006,7 @@ async def vm_create_composite(
         }
         try:
             gate, _ = await _write_sub_op(
-                connector, target, operator, _OP_CREATE_VM_NIC, {"vm": vm_id, "spec": nic_spec}
+                connector, target, operator, _OP_CREATE_VM_NIC, {"vm": vm_id, **nic_spec}
             )
         except httpx.HTTPError as exc:
             await _rollback_created_vm(
@@ -1759,7 +1759,7 @@ async def vm_migrate_composite(
         target,
         operator,
         _OP_RELOCATE_VM,
-        {"vm": vm_moid, "spec": {"placement": {"host": target_host}}},
+        {"vm": vm_moid, "placement": {"host": target_host}},
     )
     if gate is not None:
         return gate
@@ -2131,11 +2131,9 @@ async def _repoint_vm_nics_to_fallback(
             {
                 "vm": vm_moid,
                 "nic": nic_id,
-                "spec": {
-                    "backing": {
-                        "type": _NIC_BACKING_STANDARD_PORTGROUP,
-                        "network": fallback_network,
-                    }
+                "backing": {
+                    "type": _NIC_BACKING_STANDARD_PORTGROUP,
+                    "network": fallback_network,
                 },
             },
         )
@@ -3723,7 +3721,7 @@ async def vm_resize_composite(
         if req_cores is not None:
             cpu_spec["cores_per_socket"] = req_cores
         gate, _ = await _write_sub_op(
-            connector, target, operator, _OP_UPDATE_VM_CPU, {"vm": vm_moid, "spec": cpu_spec}
+            connector, target, operator, _OP_UPDATE_VM_CPU, {"vm": vm_moid, **cpu_spec}
         )
         if gate is not None:
             return gate
@@ -3736,7 +3734,7 @@ async def vm_resize_composite(
                 target,
                 operator,
                 _OP_UPDATE_VM_MEMORY,
-                {"vm": vm_moid, "spec": {"size_MiB": req_mem}},
+                {"vm": vm_moid, "size_MiB": req_mem},
             )
         except httpx.HTTPError as exc:
             if applied_cpu:
@@ -3824,9 +3822,7 @@ async def vm_nic_repoint_composite(
         {
             "vm": vm_moid,
             "nic": nic_id,
-            "spec": {
-                "backing": {"type": _NETWORK_TYPE_DISTRIBUTED_PORTGROUP, "network": network_moid}
-            },
+            "backing": {"type": _NETWORK_TYPE_DISTRIBUTED_PORTGROUP, "network": network_moid},
         },
     )
     if gate is not None:
@@ -3896,7 +3892,7 @@ async def vm_device_cdrom_composite(
         target,
         operator,
         _OP_UPDATE_VM_CDROM,
-        {"vm": vm_moid, "cdrom": cdrom_id, "spec": {"backing": backing}},
+        {"vm": vm_moid, "cdrom": cdrom_id, "backing": backing},
     )
     if gate is not None:
         return gate
@@ -4030,10 +4026,12 @@ def _build_customization_create_body(params: dict[str, Any]) -> dict[str, Any]:
     """Assemble the ``POST:/vcenter/guest/customization-specs`` request body.
 
     Maps the agent-facing GOSC subset onto the vCenter ``CreateSpec``
-    (``{name, description, spec}``) whose ``spec`` is a
+    (``{name, description, spec}``) whose ``spec`` field is a
     ``CustomizationSpec`` (``{configuration_spec, interfaces,
-    global_dns_settings}``), wrapped in the operation's ``spec``
-    parameter per the connector's REST convention.
+    global_dns_settings}``). The ``CreateSpec`` fields sit at the **top
+    level** of the ``/api`` request body -- the modern surface takes the
+    ``CreateSpec`` directly (#2973), so the only ``spec`` key here is the
+    legitimate ``CustomizationSpec`` field, not a ``/rest``-style envelope.
     """
     if params["os_type"] == "linux":
         configuration_spec = {"linux_config": _build_linux_config(params)}
@@ -4062,7 +4060,7 @@ def _build_customization_create_body(params: dict[str, Any]) -> dict[str, Any]:
         "description": params.get("description") or "",
         "spec": customization_spec,
     }
-    return {"spec": create_spec}
+    return create_spec
 
 
 async def guest_customization_spec_create_composite(
@@ -4201,7 +4199,7 @@ async def vm_customize_composite(
         target,
         operator,
         _OP_SET_VM_CUSTOMIZATION,
-        {"vm": vm_moid, "spec": {"name": spec_name}},
+        {"vm": vm_moid, "name": spec_name},
     )
     if gate is not None:
         return gate

--- a/backend/tests/_spec_shelf.py
+++ b/backend/tests/_spec_shelf.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
 __all__ = [
     "SHELF_ENV_VAR",
     "assert_op_ids_served",
+    "openapi_request_body_props",
     "openapi_served_op_ids",
     "require_shelf_spec",
     "resolve_shelf_file",
@@ -112,6 +113,44 @@ def openapi_served_op_ids(spec_path: Path, *, spec_source: str | None = None) ->
         content=spec_text,
     )
     return {row.op_id for row in rows}
+
+
+def openapi_request_body_props(
+    spec_path: Path, *, spec_source: str | None = None
+) -> dict[str, set[str]]:
+    """Map every op_id with a JSON request body to its top-level body properties.
+
+    Runs the same ingest parser as :func:`openapi_served_op_ids`, then reads
+    each row's request body off the flattened parameter schema the parser
+    emits: :func:`~meho_backplane.operations.ingest.parse_openapi` folds the
+    resolved ``requestBody`` schema in under
+    ``parameter_schema["properties"]["body"]`` (tagged
+    ``x-meho-param-loc: "body"``), so ``…["body"]["properties"]`` holds the
+    request body's **top-level** property names -- the ``*Spec`` fields the
+    ``/api`` surface expects at the top of the JSON body. Rows without a
+    structured body (``GET`` reads, bodyless ``?action=`` verbs) are omitted.
+
+    A body-shape reconcile lane uses this to assert an ``/api`` write op's
+    request body is the flat ``*Spec`` the pinned spec declares, never the
+    legacy ``/rest``-style single-``spec`` wrapper -- the envelope regression
+    the path-only lanes (:func:`openapi_served_op_ids`) cannot see (#2973).
+    """
+    spec_text = spec_path.read_text(encoding="utf-8")
+    rows = parse_openapi(
+        f"file://{spec_path}",
+        spec_source=spec_source or f"spec:{spec_path.name}",
+        content=spec_text,
+    )
+    result: dict[str, set[str]] = {}
+    for row in rows:
+        param_schema = row.parameter_schema if isinstance(row.parameter_schema, dict) else {}
+        body = param_schema.get("properties", {}).get("body")
+        if not isinstance(body, dict):
+            continue
+        props = body.get("properties")
+        if isinstance(props, dict) and props:
+            result[row.op_id] = set(props)
+    return result
 
 
 def _near_misses(op_id: str, served: Collection[str]) -> list[str]:

--- a/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_vcsim.py
@@ -769,13 +769,13 @@ async def test_vm_create_composite_over_modern_mount(
     assert create_route.called
     assert nic_route.called
     assert power_route.called
-    # The create body carries the spec wrapper the vCenter POST expects.
+    # The create body is the VM.CreateSpec at the top level of the /api body (#2973).
     create_body = json.loads(create_route.calls.last.request.content)
-    assert create_body["spec"]["name"] == "web-01"
-    assert create_body["spec"]["placement"]["folder"] == "group-1"
-    # The NIC create body is the Ethernet.CreateSpec backing shape (#2970).
+    assert create_body["name"] == "web-01"
+    assert create_body["placement"]["folder"] == "group-1"
+    # The NIC create body is the Ethernet.CreateSpec backing shape (#2970), top-level (#2973).
     nic_body = json.loads(nic_route.calls.last.request.content)
-    assert nic_body["spec"]["backing"] == {"type": "STANDARD_PORTGROUP", "network": "net-1"}
+    assert nic_body["backing"] == {"type": "STANDARD_PORTGROUP", "network": "net-1"}
 
 
 @pytest.mark.asyncio
@@ -965,7 +965,7 @@ async def test_host_evacuate_recursion_over_modern_mount(
     assert relocate_route.called
     assert maintenance_route.called
     relocate_body = json.loads(relocate_route.calls.last.request.content)
-    assert relocate_body["spec"]["placement"]["host"] == "host-target"
+    assert relocate_body["placement"]["host"] == "host-target"
     enter_body = json.loads(maintenance_route.calls.last.request.content)
     assert enter_body == {"timeout": 0}
 
@@ -1196,8 +1196,8 @@ async def test_vm_customize_puts_named_spec_over_respx(
 
     Exercises the real connector transport (respx-intercepted): the resolve
     listing mounts onto ``/api/vcenter/vm``, and the customization set mounts
-    onto ``PUT /api/vcenter/vm/{vm}/guest/customization`` with the
-    ``{"spec": {"name": <spec>}}`` body. The #2254 governance seam is stubbed
+    onto ``PUT /api/vcenter/vm/{vm}/guest/customization`` with the top-level
+    ``{"name": <spec>}`` SetSpec body (#2973). The #2254 governance seam is stubbed
     to auto-execute so the write reaches the wire (the seam itself is proven
     end-to-end in the write-gate lane).
     """
@@ -1238,4 +1238,4 @@ async def test_vm_customize_puts_named_spec_over_respx(
     assert result["status"] == "customization_set"
     assert put_route.called
     sent_body = json.loads(put_route.calls.last.request.content)
-    assert sent_body == {"spec": {"name": "gosc-lin"}}
+    assert sent_body == {"name": "gosc-lin"}

--- a/backend/tests/test_connectors_vmware_rest_composites_write.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write.py
@@ -350,13 +350,11 @@ async def test_vm_create_happy_path_direct_session(gate: _GateRecorder) -> None:
     ]
     # Folder GET forwards the name filter as a query param; bare on /api (#2298).
     assert conn.calls[0]["query"] == {"names": ["Prod"]}
-    # Create body carries the spec; folder moid resolved in.
-    assert conn.calls[1]["body"]["spec"]["placement"]["folder"] == "folder-7"
-    # NIC create body is the Ethernet.CreateSpec: the network rides the
-    # backing spec (#2970); vm rides the path, not the body.
-    assert conn.calls[2]["body"] == {
-        "spec": {"backing": {"type": "STANDARD_PORTGROUP", "network": "net-3"}}
-    }
+    # Create body is the VM.CreateSpec at the top level (#2973); folder moid resolved in.
+    assert conn.calls[1]["body"]["placement"]["folder"] == "folder-7"
+    # NIC create body is the Ethernet.CreateSpec at the top level (#2973): the
+    # network rides the backing spec (#2970); vm rides the path, not the body.
+    assert conn.calls[2]["body"] == {"backing": {"type": "STANDARD_PORTGROUP", "network": "net-3"}}
     # Power POST carries no body (action rides the path).
     assert conn.calls[3]["body"] is None
 
@@ -1025,7 +1023,7 @@ async def test_vm_migrate_drs_recommendation_dispatches_relocate(gate: _GateReco
         "/PropertyCollector/propertyCollector/RetrievePropertiesEx"
     ]
     assert conn.calls[0]["path"] == "/api/vcenter/vm/vm-1?action=relocate"
-    assert conn.calls[0]["body"] == {"spec": {"placement": {"host": "host-A"}}}
+    assert conn.calls[0]["body"] == {"placement": {"host": "host-A"}}
     assert gate.gated_op_ids == ["POST:/vcenter/vm/{vm}?action=relocate"]
 
 
@@ -1478,7 +1476,7 @@ async def test_host_detach_from_vds_happy_path(gate: _GateRecorder) -> None:
         "/api/vcenter/vm/vm-2/hardware/ethernet/4001",
     ]
     assert nic_patches[0]["body"] == {
-        "spec": {"backing": {"type": "STANDARD_PORTGROUP", "network": "standard-net"}}
+        "backing": {"type": "STANDARD_PORTGROUP", "network": "standard-net"}
     }
     # The DVS detach is the vim ReconfigureDvs_Task: configVersion echoed,
     # host member spec with operation=remove.
@@ -3050,8 +3048,8 @@ async def test_vm_resize_powered_off_patches_cpu_and_memory(gate: _GateRecorder)
     cpu_call = next(c for c in conn.calls if c["path"].endswith("/hardware/cpu"))
     mem_call = next(c for c in conn.calls if c["path"].endswith("/hardware/memory"))
     assert cpu_call["method"] == "PATCH"
-    assert cpu_call["body"] == {"spec": {"count": 4, "cores_per_socket": 2}}
-    assert mem_call["body"] == {"spec": {"size_MiB": 8192}}
+    assert cpu_call["body"] == {"count": 4, "cores_per_socket": 2}
+    assert mem_call["body"] == {"size_MiB": 8192}
 
 
 @pytest.mark.asyncio
@@ -3209,7 +3207,7 @@ async def test_vm_nic_repoint_happy_path(gate: _GateRecorder) -> None:
     assert gate.gated_op_ids == ["PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}"]
     patch_call = next(c for c in conn.calls if c["method"] == "PATCH")
     assert patch_call["body"] == {
-        "spec": {"backing": {"type": "DISTRIBUTED_PORTGROUP", "network": "dvportgroup-9"}}
+        "backing": {"type": "DISTRIBUTED_PORTGROUP", "network": "dvportgroup-9"}
     }
     # The portgroup resolve used the corrected /vcenter/network path (#1602 fix).
     net_read = next(c for c in conn.calls if c["path"] == "/api/vcenter/network")
@@ -3343,7 +3341,7 @@ async def test_vm_device_cdrom_update_patches_backing(gate: _GateRecorder) -> No
     assert out["requested_backing"] == {"type": "CLIENT_DEVICE"}
     assert gate.gated_op_ids == ["PATCH:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}"]
     patch_call = next(c for c in conn.calls if c["method"] == "PATCH")
-    assert patch_call["body"] == {"spec": {"backing": {"type": "CLIENT_DEVICE"}}}
+    assert patch_call["body"] == {"backing": {"type": "CLIENT_DEVICE"}}
 
 
 @pytest.mark.asyncio
@@ -3402,7 +3400,7 @@ async def test_guest_customization_spec_create_linux_body(gate: _GateRecorder) -
     assert [(c["method"], c["path"]) for c in conn.calls] == [
         ("POST", "/api/vcenter/guest/customization-specs"),
     ]
-    body = conn.calls[0]["body"]["spec"]
+    body = conn.calls[0]["body"]
     assert body["name"] == "gosc-lin"
     assert body["description"] == "web tier"
     linux = body["spec"]["configuration_spec"]["linux_config"]
@@ -3460,9 +3458,7 @@ async def test_guest_customization_spec_create_windows_sysprep_body(gate: _GateR
         },
         connector=conn,  # type: ignore[arg-type]
     )
-    sysprep = conn.calls[0]["body"]["spec"]["spec"]["configuration_spec"]["windows_config"][
-        "sysprep"
-    ]
+    sysprep = conn.calls[0]["body"]["spec"]["configuration_spec"]["windows_config"]["sysprep"]
     assert sysprep["user_data"]["computer_name"] == {"type": "FIXED", "fixed_name": "win-01"}
     assert sysprep["user_data"]["product_key"] == "KEY-123"
     assert sysprep["user_data"]["organization"] == "evoila"
@@ -3716,8 +3712,9 @@ def test_gosc_create_body_conforms_to_pinned_customization_spec_schema(
     ``GuiUnattended``) that ``_put_if_str`` used to drop.
     """
     body = _write._build_customization_create_body(params)
-    # The connector wraps the CreateSpec under the request-body ``spec`` key.
-    Draft202012Validator(_PINNED_CREATE_SPEC_SCHEMA).validate(body["spec"])
+    # The builder returns the CreateSpec at the top level of the request body (#2973);
+    # the only ``spec`` key is the inner CustomizationSpec field, not a /rest envelope.
+    Draft202012Validator(_PINNED_CREATE_SPEC_SCHEMA).validate(body)
 
 
 def test_gosc_create_body_schema_rejects_pyvmomi_shape_and_missing_required() -> None:
@@ -3730,12 +3727,12 @@ def test_gosc_create_body_schema_rejects_pyvmomi_shape_and_missing_required() ->
     """
     validator = Draft202012Validator(_PINNED_CREATE_SPEC_SCHEMA)
     good = _write._build_customization_create_body(_GOSC_WINDOWS_DOMAIN_JOIN)
-    validator.validate(good["spec"])  # sanity: the corrected body is valid.
+    validator.validate(good)  # sanity: the corrected body is valid.
 
     # B1 regression: the pyvmomi ``identification`` block is not a
     # WindowsSysprep property -> additionalProperties rejects it.
     b1 = copy.deepcopy(good)
-    b1_sysprep = b1["spec"]["spec"]["configuration_spec"]["windows_config"]["sysprep"]
+    b1_sysprep = b1["spec"]["configuration_spec"]["windows_config"]["sysprep"]
     b1_sysprep.pop("domain", None)
     b1_sysprep["identification"] = {
         "joined_domain": "corp.test",
@@ -3743,22 +3740,22 @@ def test_gosc_create_body_schema_rejects_pyvmomi_shape_and_missing_required() ->
         "domain_admin_password": "pw-join",
     }
     with pytest.raises(ValidationError):
-        validator.validate(b1["spec"])
+        validator.validate(b1)
 
     # B2 regression: GuiUnattended.auto_logon_count is required -> dropping it
     # (as the old _put_if_str-built body did) fails.
     b2 = copy.deepcopy(good)
-    del b2["spec"]["spec"]["configuration_spec"]["windows_config"]["sysprep"]["gui_unattended"][
+    del b2["spec"]["configuration_spec"]["windows_config"]["sysprep"]["gui_unattended"][
         "auto_logon_count"
     ]
     with pytest.raises(ValidationError):
-        validator.validate(b2["spec"])
+        validator.validate(b2)
 
     # B2 regression: CreateSpec.description is required -> dropping it fails.
     b3 = copy.deepcopy(good)
-    del b3["spec"]["description"]
+    del b3["description"]
     with pytest.raises(ValidationError):
-        validator.validate(b3["spec"])
+        validator.validate(b3)
 
 
 @pytest.mark.asyncio
@@ -3816,7 +3813,7 @@ async def test_vm_customize_powered_off_sets_customization(gate: _GateRecorder) 
     ]
     # The resolve read forwards the name filter; PUT body is the named spec ref.
     assert conn.calls[0]["query"] == {"names": ["app"]}
-    assert conn.calls[1]["body"] == {"spec": {"name": "gosc-lin"}}
+    assert conn.calls[1]["body"] == {"name": "gosc-lin"}
     # Only the PUT was gated (the resolve GET is never gated).
     assert gate.gated_op_ids == ["PUT:/vcenter/vm/{vm}/guest/customization"]
     assert out["status"] == "customization_set"

--- a/backend/tests/test_connectors_vmware_rest_composites_write_body_reconcile.py
+++ b/backend/tests/test_connectors_vmware_rest_composites_write_body_reconcile.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Real-spec body-shape reconcile lane for the write-composite request bodies (#2973).
+
+The path-only reconcile lanes (``test_connectors_vmware_rest_composites_read_reconcile.py``,
+``test_connectors_vmware_rest_composites_l2_ingest_reconcile.py``) assert every
+hand-coded sub-op **path** is served by the pinned spec, but nothing asserted the
+request-**body** shape. That gap is how the legacy ``/rest``-style
+``{"spec": {...}}`` envelope survived on the modern ``/api`` write bodies:
+``vmware.composite.vm.migrate``'s relocate 400ed ``INVALID_ARGUMENT`` because the
+``/api`` surface takes the ``RelocateSpec`` at the **top level** of the body, not
+under a ``spec`` wrapper (#2973). The vm.create / NIC / CPU / memory / CD-ROM
+PATCH and guest-customization bodies shared the divergent envelope.
+
+This lane closes the gap per the spec-reconcile standard
+(``docs/decisions/spec-reconcile-guards-standard.md``): for every ``/api`` write
+sub-op the connector POSTs / PATCHes / PUTs a JSON body to, the pinned
+``vcenter.yaml`` must declare that ``requestBody`` as a **flat ``*Spec``** (its
+top-level properties are the Spec's own fields), never a single-``spec`` wrapper.
+The ingest parser folds the resolved body schema onto
+``parameter_schema["properties"]["body"]["properties"]``, so a ``/rest``-style
+``{"spec": ...}`` body would parse to the single top-level key ``spec`` -- the
+exact signal this lane bans.
+
+Division of labour (mirrors the read lane): this lane grounds the flat body
+**contract** against the pinned vendor spec and skips uniformly when the spec
+shelf is unprovisioned (the #2980 harness contract). The **connector-side** proof
+-- that the composites now emit those flat bodies with no ``{"spec": ...}``
+envelope -- is the byte-for-byte body assertion set in
+``test_connectors_vmware_rest_composites_write.py``, which runs everywhere
+(including public CI, where the shelf is absent) and fails the moment a body is
+re-wrapped.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.vmware_rest.composites import _write
+from tests._spec_shelf import openapi_request_body_props, require_shelf_spec
+
+# The full REST-Automation write surface: every ``/api`` op the connector sends a
+# POST / PATCH / PUT to (introspected live in :func:`_rest_write_op_ids`). Frozen
+# here as the always-on deliberate-change gate -- a new REST write op that lands
+# without being added forces a body-shape review (the shelf-backed lanes below
+# skip where the shelf is unprovisioned, so this pin is the sandbox backstop).
+_EXPECTED_REST_WRITE_OP_IDS = {
+    "POST:/vcenter/vm",
+    "POST:/vcenter/vm/{vm}/hardware/ethernet",
+    "POST:/vcenter/vm/{vm}?action=relocate",
+    "POST:/vcenter/vm-template/library-items/{templateLibraryItem}?action=deploy",
+    "POST:/vcenter/ovf/library-item/{ovfLibraryItemId}?action=deploy",
+    "POST:/content/library?action=find",
+    "POST:/content/library/item?action=find",
+    "POST:/esx/settings/hosts/{host}/software?action=apply&vmw-task=true",
+    "POST:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}?action=disconnect",
+    "PATCH:/vcenter/vm/{vm}/hardware/cpu",
+    "PATCH:/vcenter/vm/{vm}/hardware/memory",
+    "PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}",
+    "PATCH:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}",
+    "POST:/vcenter/guest/customization-specs",
+    "PUT:/vcenter/vm/{vm}/guest/customization",
+}
+
+# The bodies #2973 flattened from the ``/rest`` ``{"spec": {...}}`` envelope to
+# the flat ``/api`` ``*Spec``. Each must be served by the pinned spec with a flat
+# request body -- this set is the non-vacuous floor for the core lane (a parser
+# regression that dropped one would make the sweep silently green). The two NIC
+# PATCH call sites (repoint + detach fallback) share one op_id.
+_FLATTENED_WRITE_OP_IDS = {
+    "POST:/vcenter/vm",
+    "POST:/vcenter/vm/{vm}/hardware/ethernet",
+    "POST:/vcenter/vm/{vm}?action=relocate",
+    "PATCH:/vcenter/vm/{vm}/hardware/cpu",
+    "PATCH:/vcenter/vm/{vm}/hardware/memory",
+    "PATCH:/vcenter/vm/{vm}/hardware/ethernet/{nic}",
+    "PATCH:/vcenter/vm/{vm}/hardware/cdrom/{cdrom}",
+    "POST:/vcenter/guest/customization-specs",
+    "PUT:/vcenter/vm/{vm}/guest/customization",
+}
+
+
+def _rest_write_op_ids() -> set[str]:
+    """Every REST-Automation write op_id in ``_write``, introspected live.
+
+    A REST write op is a ``POST`` / ``PATCH`` / ``PUT`` ``_OP_*`` constant whose
+    path root is a lowercase Automation family (``/vcenter``, ``/esx``,
+    ``/content``, ...). The vmomi VI-JSON methods (``ReconfigVM_Task``,
+    ``CloneVM_Task``, ...) dispatch through ``_post_vmomi_json`` onto the
+    ``/sdk/vim25`` mount and are keyed by an **uppercase** managed-object type
+    (``/VirtualMachine/{moId}/...``); their request types genuinely carry a
+    ``spec`` field, so they are correctly excluded from the flat-body contract.
+    """
+    ops: set[str] = set()
+    for name in dir(_write):
+        if not name.startswith("_OP_"):
+            continue
+        value = getattr(_write, name)
+        if not isinstance(value, str) or ":" not in value:
+            continue
+        method, _, path = value.partition(":")
+        if method not in {"POST", "PATCH", "PUT"}:
+            continue
+        first = path.lstrip("/").split("/", 1)[0].split("?", 1)[0]
+        if not first or first[0].isupper():  # vmomi VI-JSON method, not the /api surface
+            continue
+        ops.add(value)
+    return ops
+
+
+def test_rest_write_op_ids_match_the_frozen_set() -> None:
+    """Introspection agrees with the frozen surface (always runs, no shelf).
+
+    A REST-Automation write op that lands without being added to
+    ``_EXPECTED_REST_WRITE_OP_IDS`` fails here, forcing a body-shape review of
+    the new op -- the deliberate-change gate the shelf-backed lanes need (they
+    skip where the shelf is unprovisioned).
+    """
+    live = _rest_write_op_ids()
+    assert live, "introspection found no REST write _OP_* constants -- wiring broke"
+    assert live == _EXPECTED_REST_WRITE_OP_IDS, (
+        f"unexpected REST write op_ids: {sorted(live - _EXPECTED_REST_WRITE_OP_IDS)}; "
+        f"missing from the frozen surface: {sorted(_EXPECTED_REST_WRITE_OP_IDS - live)}"
+    )
+    assert _FLATTENED_WRITE_OP_IDS <= _EXPECTED_REST_WRITE_OP_IDS
+
+
+def test_api_write_bodies_are_flat_specs_not_rest_spec_envelopes() -> None:
+    """No ``/api`` write op declares a single-``spec`` request-body wrapper.
+
+    The core body-shape reconcile: for every REST write sub-op the pinned
+    ``vcenter.yaml`` serves with a JSON body, the ``requestBody`` must be a flat
+    ``*Spec`` (top-level Spec fields), never the ``/rest``-style
+    ``{"spec": {...}}`` envelope -- whose parsed body has the single top-level key
+    ``spec``. Ops served without a body (the bodyless ``?action=disconnect``
+    verb) are not the body lane's concern; ops not served at all are the path
+    lane's. Skips uniformly without the spec shelf.
+    """
+    spec_path = require_shelf_spec("vcenter-9.0", "vcenter.yaml")
+    body_props = openapi_request_body_props(spec_path)
+    checked = 0
+    for op_id in sorted(_rest_write_op_ids()):
+        props = body_props.get(op_id)
+        if props is None:
+            continue  # bodyless action verb, or not served -- out of the body lane's scope
+        assert props != {"spec"}, (
+            f"{op_id}: the pinned vcenter.yaml declares a single-`spec` request-body "
+            f"wrapper ({sorted(props)}). The /api surface takes the *Spec at the top "
+            "level, so the connector must send the Spec's fields directly, never a "
+            "/rest-style {'spec': ...} envelope (#2973). "
+            "Protocol: docs/decisions/spec-reconcile-guards-standard.md."
+        )
+        checked += 1
+    assert checked, "no write-op request bodies were checked -- shelf or parser wiring broke"
+
+
+def test_flattened_2973_bodies_are_served_flat_by_the_pinned_spec() -> None:
+    """Every body #2973 flattened is served by the pinned spec as a flat ``*Spec``.
+
+    The non-vacuous floor: each op the fix unwrapped must appear in the pinned
+    spec's request-body map with top-level Spec fields (not a ``spec`` wrapper),
+    so a parser/introspection regression that silently dropped the ops cannot
+    leave the core lane vacuously green. Skips without the shelf.
+    """
+    spec_path = require_shelf_spec("vcenter-9.0", "vcenter.yaml")
+    body_props = openapi_request_body_props(spec_path)
+    for op_id in sorted(_FLATTENED_WRITE_OP_IDS):
+        assert op_id in body_props, (
+            f"{op_id}: not served with a request body by the pinned vcenter.yaml -- the "
+            "flatten target moved (the path reconcile lane localises a moved path)."
+        )
+        assert body_props[op_id] != {"spec"}, (
+            f"{op_id}: still a single-`spec` wrapper in the pinned spec -- the flat-body "
+            "contract this task relies on does not hold for it."
+        )

--- a/backend/tests/test_operations_subop_policy_gate.py
+++ b/backend/tests/test_operations_subop_policy_gate.py
@@ -46,7 +46,10 @@ from meho_backplane.settings import get_settings
 _TENANT_ID = uuid.UUID("00000000-0000-0000-0000-0000000024a4")
 _CONNECTOR_ID = "vmware-rest-9.0"
 _SUB_OP_ID = "POST:/vcenter/vm"
-_SUB_PARAMS = {"spec": {"name": "vm-under-test", "guest_OS": "OTHER"}}
+# Flat VM.CreateSpec params, as the write composite now passes them to the gate
+# (top-level /api body shape, #2973) -- the gate records these verbatim onto the
+# ApprovalRequest, so the sample mirrors a real dispatch.
+_SUB_PARAMS = {"name": "vm-under-test", "guest_OS": "OTHER"}
 
 
 @pytest.fixture(autouse=True)

--- a/docs/codebase/connectors-vmware-rest.md
+++ b/docs/codebase/connectors-vmware-rest.md
@@ -145,8 +145,11 @@ Source: `backend/src/meho_backplane/connectors/vmware_rest/`.
   `CloneSpec.guest_customization_spec` (consumed by the Task-D clone op) —
   reference. The body builders map the agent subset onto the vCenter
   `CreateSpec {name, description, spec:CustomizationSpec}` /
-  `SetSpec {name}`, wrapped in the operation's `spec` parameter per the
-  connector's REST convention.
+  `SetSpec {name}`, sent at the **top level** of the `/api` request body
+  (#2973). The `CreateSpec`'s own `spec` field (the `CustomizationSpec`) is
+  a legitimate top-level property here — not a `/rest`-style envelope, which
+  the modern `/api` surface rejects (see the request-body envelope note
+  under Control flow).
 
   **GOSC secret hygiene (`#1503`) — the load-bearing property.** A
   customization spec can carry Windows admin passwords, sysprep product
@@ -507,6 +510,69 @@ sub-ops resolve to registrar-guaranteed `source_kind='composite'` rows,
 not ingested primitives, and the invariant skips `*.composite.*` sub-ops
 for that reason.
 
+### Request-body envelope: top-level `*Spec`, not `{"spec": {...}}` (#2973)
+
+The write composites build their `/api` request bodies as the vSphere
+Automation `*Spec` **at the top level** of the JSON body —
+`{"placement": {…}}` for relocate, `{"count": …, "cores_per_socket": …}`
+for the CPU PATCH, and so on. `_split_sub_op` substitutes the
+`{vm}` / `{nic}` / `{cdrom}` path variables into the URL and posts every
+remaining key verbatim as the body, so a handler passes the `*Spec` fields
+alongside the path vars (e.g. `{"vm": vm_moid, "placement": {"host": …}}`).
+
+This is a behavioural contract of the modern `/api` surface, not a style
+choice. The legacy `/rest` surface wrapped each operation's structured
+input under a `{"spec": {...}}` envelope; the `/api` surface flattened it
+and **rejects the envelope** with `400 INVALID_ARGUMENT`
+(`vapi.invoke.invalid.input`). `vmware.composite.vm.migrate`'s first
+real-world dispatch hit exactly this (#2973) — the relocate body still
+carried the `/rest` `{"spec": {"placement": …}}` shape — which also wedged
+`host.evacuate` (it recurses into `vm.migrate` per VM). The same divergent
+envelope was swept off `vm.create`, the NIC create/repoint bodies, the
+CPU / memory / CD-ROM PATCH bodies, and the two guest-customization bodies
+(`guest.customization_spec.create` / `vm.customize`). The pinned
+`vcenter.yaml` declares each of these request bodies as the `*Spec`
+directly (`VM.RelocateSpec` / `VM.CreateSpec` / `Cpu.UpdateSpec` / …), with
+no `spec` property.
+
+Two `spec` shapes are **kept** and must not be confused with the legacy
+envelope:
+
+- The **vmomi (VI-JSON) write bodies** (`ReconfigVM_Task`, `CloneVM_Task`,
+  `ReconfigureDvs_Task`, `ReconfigureComputeResource_Task`) dispatch through
+  `_write_vmomi_sub_op` onto the `/sdk/vim25` mount, where the vim request
+  types genuinely take a `spec` parameter — a real field, not the `/rest`
+  envelope.
+- The **GOSC `CreateSpec`'s own `spec` field** (the inline
+  `CustomizationSpec`): the flattened create body is
+  `{name, description, spec: <CustomizationSpec>}` at the top level, so the
+  only `spec` key is the legitimate `CreateSpec.spec` property, not an outer
+  wrapper.
+
+A body-shape reconcile lane
+(`tests/test_connectors_vmware_rest_composites_write_body_reconcile.py`)
+grounds the flat-body contract against the pinned spec: for every REST write
+sub-op the pinned `vcenter.yaml` serves with a body, the `requestBody` must
+be a flat `*Spec`, never a single-`spec` wrapper. It follows the
+spec-reconcile standard (skips without the shelf, runs where it is wired).
+The byte-for-byte connector-side proof — that the composites emit the flat
+bodies with no envelope — lives in
+`tests/test_connectors_vmware_rest_composites_write.py`, which runs
+everywhere. The path-only reconcile lanes assert *which* endpoints exist;
+this pair asserts *what shape* their bodies take.
+
+**Not-yet-swept (adjacent findings).** The same envelope still rides three
+non-VM write bodies that the pinned spec likewise declares flat, left for a
+follow-up because each carries a wrinkle beyond the mechanical flatten:
+`vm.clone`'s library-item deploy (`DeploySpec`), the content-library `find`
+reads (`FindSpec`, a distinct `_post_json` helper, not `_write_sub_op`), and
+`cluster.patch`'s vLCM software apply (`ApplySpec` — an all-optional spec
+whose empty body raises the `json=body or None` "send `{}` vs no body"
+question). Separately, the create/memory bodies still use vSphere's
+documented mixed-case field names (`guest_OS`, `size_MiB`) while the pinned
+spec keys them lowercase (`guest_os`, `size_mib`); that field-casing gap is
+independent of the envelope and untouched here.
+
 ### Write-composite partial-failure conventions
 
 Write composites return a structured `{"status": ...}` envelope so
@@ -579,9 +645,11 @@ a host-pinning ISO:
 All three register a live-read **from->to** preview builder in
 `_write_preview.py`, so the parked approval row names the current state
 alongside the requested change (the delta is the decision the four-eyes
-reviewer signs off). Update PATCH bodies are wrapped in the
-`{"spec": {...}}` envelope the connector's `_write_sub_op` authors,
-matching the other write composites.
+reviewer signs off). Update PATCH bodies send the `*Spec`'s fields at the
+**top level** of the request body — the modern `/api` surface takes the
+`Cpu.UpdateSpec` / `Ethernet.UpdateSpec` / `Cdrom.UpdateSpec` directly, not
+the legacy `/rest` `{"spec": {...}}` envelope (#2973; see the request-body
+envelope note under Control flow).
 
 **Portgroup resolution — the #1602 lesson.** There is no dedicated
 `distributed-portgroup` list resource in the REST Automation API;


### PR DESCRIPTION
## Summary

- `vmware.composite.vm.migrate`'s first real-world dispatch against an `/api` vCenter `400`'d `INVALID_ARGUMENT`: the relocate sub-op sent the legacy `/rest`-style `{"spec": {"placement": …}}` envelope, but the modern `/api` surface takes the `RelocateSpec` at the **top level** of the request body. `host.evacuate` inherited the wedge (it recurses into `vm.migrate` per VM).
- The same divergent envelope rode every VM-write / guest-customization body on that surface. **Verified against the pinned `vcenter-9.0/vcenter.yaml`** (each `requestBody` is the `*Spec` directly, with no `spec` property), this flattens **10** bodies to top-level: relocate, `vm.create`, NIC create, the two NIC-repoint PATCH sites, the CPU / memory / CD-ROM PATCH bodies, `guest.customization_spec.create`, and `vm.customize`. Path-variable keys (`vm`/`nic`/`cdrom`) are consumed into the URL by `_split_sub_op` and are kept.
- **Two `spec` shapes are deliberately kept** (not the envelope): the vmomi (VI-JSON) write bodies (`ReconfigVM_Task`, `CloneVM_Task`, …) whose request types genuinely take a `spec` parameter, and the GOSC `CreateSpec`'s own inline `spec` field (the `CustomizationSpec`) — for GOSC only the **outer** wrapper is removed.
- **New body-shape reconcile lane** (`test_connectors_vmware_rest_composites_write_body_reconcile.py` + `_spec_shelf.openapi_request_body_props`): for every REST write sub-op the pinned `vcenter.yaml` serves with a body, the `requestBody` must be a flat `*Spec`, never a single-`spec` wrapper — the envelope regression the path-only reconcile lanes cannot see. Skips without the spec shelf, runs where it is wired (per the spec-reconcile-guards standard).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (1488 files formatted)
- [x] `mypy src/…/composites/_write.py` — no issues (the only `mypy src/` error is a pre-existing macOS-only `socket.MSG_ERRQUEUE` in untouched `net/icmp.py`; present on Linux CI)
- [x] Body-shape lane green **without** the shelf (1 passed / 2 skipped — public-CI path) and **with** the shelf (3 passed — asserts the flat contract against the real pinned `vcenter.yaml`)
- [x] `test_connectors_vmware_rest_composites_write.py` — 102 passed (corrected 10 assertions + the GOSC `CreateSpec` schema-validation unwrap shift)
- [x] `tests/integration/test_connectors_vmware_rest_vcsim.py` — 17 passed (respx transport parity: create/NIC/relocate/customize bodies now flat on the wire)
- [x] Broad `-k "vmware or spec_shelf"` with shelf armed — **555 passed, 2 skipped**; full-tree `--co` — 12738/12739 collected (no import breakage)

## Connector-side vs spec-side proof

The **connector emits flat bodies** — the byte-for-byte body assertions in the write unit + vcsim integration tests (run everywhere, including public CI where the shelf is absent). The **flat shape is spec-correct** — the new shelf-gated reconcile lane, grounded on the pinned spec. The path-only lanes assert *which* endpoints exist; this pair asserts *what shape* their bodies take. The issue's "live `/api` canary" is a deploy-time acceptance check (needs a real vCenter, like the g0.7 canary) rather than a CI gate; the pinned-spec lane + respx wire assertions are the CI-viable equivalent.

## Out of scope (adjacent findings — spec-proven same bug, filed for follow-up)

The same envelope still rides three **non-VM** write bodies the pinned spec likewise declares flat, left for a follow-up because each carries a wrinkle beyond the mechanical flatten (and all sit outside the `vm.create`/NIC/PATCH named scope):

- `vm.clone`'s library-item deploy (`DeploySpec`).
- The content-library `find` reads (`FindSpec`) — a distinct `_post_json` helper, not `_write_sub_op`.
- `cluster.patch`'s vLCM software apply (`ApplySpec`) — an all-optional spec whose empty body raises the `json=body or None` "send `{}` vs no body" question, which needs a live-host decision.

Separately, the create/memory bodies still use vSphere's documented mixed-case field names (`guest_OS`, `size_MiB`) while the pinned spec keys them lowercase (`guest_os`, `size_mib`); that field-casing gap is independent of the envelope and untouched here.

## Docs

`docs/codebase/connectors-vmware-rest.md` documented the buggy convention as correct (the "Hardware write composites" PATCH note and the GOSC body note). Both corrected, plus a new **"Request-body envelope: top-level `*Spec`"** subsection under Control flow covering the `/api` contract, the kept `spec` shapes, the reconcile lane, and the adjacent findings.

Closes #2973
