### PR TITLE
feat(checks): sample offending rows into breaching aggregate evidence (#2976)

### DIFF
--- a/backend/src/meho_backplane/checks/assertions.py
+++ b/backend/src/meho_backplane/checks/assertions.py
@@ -305,8 +305,11 @@ class AssertionOutcome(BaseModel):
     result when an aggregate was applied), or ``None`` when the outcome is
     ``unknown``. :attr:`evidence` is a JSON-serializable dict carrying at least
     ``path``, ``aggregate``, ``comparator``, ``observed``, the comparator's
-    expected bounds/values, and ``reason`` when ``state == "unknown"``. #2505
-    persists the evidence; #2506 renders it.
+    expected bounds/values, and ``reason`` when ``state == "unknown"``. A
+    breaching aggregate outcome additionally carries a bounded ``sample`` of the
+    selected rows (plus ``sample_truncated`` when clipped) so the offending
+    series' identity survives on the retained tick (#2976). #2505 persists the
+    evidence; #2506 renders it.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/backend/src/meho_backplane/checks/evaluate.py
+++ b/backend/src/meho_backplane/checks/evaluate.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import math
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Final
 
 from meho_backplane.checks.assertions import (
     AssertionOutcome,
@@ -52,6 +52,12 @@ __all__ = ["evaluate_assertion"]
 #: in :func:`_unknown`.
 _UNSET: Any = object()
 
+#: Upper bound on selected rows sampled into a *breaching* aggregate's evidence
+#: (#2976). Deliberately small: the sample names the offenders for triage yet
+#: must ride every retained per-tick ``sensor_results`` row without bloating it.
+#: ``observed`` keeps the true aggregate; ``sample_truncated`` flags a clip.
+_EVIDENCE_SAMPLE_LIMIT: Final[int] = 5
+
 
 def evaluate_assertion(spec: AssertionSpec, payload: object, *, now: datetime) -> AssertionOutcome:
     """Evaluate *spec* against *payload* at instant *now*.
@@ -67,7 +73,8 @@ def evaluate_assertion(spec: AssertionSpec, payload: object, *, now: datetime) -
     Returns:
         An :class:`AssertionOutcome` with ``state`` in
         ``{ok, degraded, critical, unknown}`` (never ``skip``), the observed
-        ``value``, and JSON-serializable ``evidence``.
+        ``value``, and JSON-serializable ``evidence`` (a breaching aggregate
+        also samples the offending rows -- see :func:`_with_offender_sample`).
 
     Raises:
         ValueError: *now* is naive (missing timezone). This is the only
@@ -109,7 +116,8 @@ def evaluate_assertion(spec: AssertionSpec, payload: object, *, now: datetime) -
             return _unknown(evidence, agg_err)
 
     evidence["observed"] = value
-    return _compare(compare, value, now, evidence)
+    outcome = _compare(compare, value, now, evidence)
+    return _with_offender_sample(outcome, spec.select.aggregate, selected)
 
 
 # --------------------------------------------------------------------------- #
@@ -344,6 +352,32 @@ def _expected_evidence(compare: Compare) -> dict[str, Any]:
         "max_age_seconds": compare.max_age_seconds,
         "degraded_age_seconds": compare.degraded_age_seconds,
     }
+
+
+def _with_offender_sample(
+    outcome: AssertionOutcome, aggregate: str | None, selected: Any
+) -> AssertionOutcome:
+    """Attach a bounded sample of the selected rows to a breaching aggregate.
+
+    An aggregate collapses the selected rows to one ``observed`` number, losing
+    *which* series breached; the identity is then unrecoverable once the
+    condition clears (#2976). On a ``degraded`` / ``critical`` aggregate tick
+    this adds ``sample`` (at most :data:`_EVIDENCE_SAMPLE_LIMIT` selected rows
+    verbatim -- prometheus series labels+value, or the selected objects/keys of
+    a JSON select) plus ``sample_truncated`` when rows were dropped. For
+    ``gt`` / ``gte`` the sample *is* the offending set; for ``lt`` / ``lte`` it is
+    the rows present. A no-op for scalar assertions, ``ok`` / ``unknown`` ticks,
+    or an empty selection, so a healthy tick's evidence is unchanged.
+    """
+    if aggregate is None or outcome.state not in ("degraded", "critical"):
+        return outcome
+    if not isinstance(selected, list) or not selected:
+        return outcome
+    evidence = dict(outcome.evidence)
+    evidence["sample"] = selected[:_EVIDENCE_SAMPLE_LIMIT]
+    if len(selected) > _EVIDENCE_SAMPLE_LIMIT:
+        evidence["sample_truncated"] = True
+    return outcome.model_copy(update={"evidence": evidence})
 
 
 def _unknown(evidence: dict[str, Any], reason: str, observed: Any = _UNSET) -> AssertionOutcome:

--- a/backend/tests/test_checks_assertions.py
+++ b/backend/tests/test_checks_assertions.py
@@ -36,6 +36,7 @@ from meho_backplane.checks import (
     evaluate_assertion,
 )
 from meho_backplane.checks.assertions import PathSegment, parse_path
+from meho_backplane.checks.evaluate import _EVIDENCE_SAMPLE_LIMIT
 
 #: A fixed, timezone-aware instant so freshness cases are deterministic.
 NOW = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
@@ -268,6 +269,133 @@ def test_boolean_aggregate_rejects_non_bool() -> None:
     out = _eval({"path": "$.xs[*]", "aggregate": "all"}, {"type": "bool"}, {"xs": [True, 1]})
     assert out.state == "unknown"
     assert "requires booleans" in out.evidence["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# Aggregate offender sample (#2976)
+# --------------------------------------------------------------------------- #
+
+
+#: A prometheus-shaped instant-vector result: two datastores over threshold. The
+#: motivating shape from the issue -- ``count($.data.result) gt 0`` fires, but
+#: the aggregate alone cannot say which two datastores breached.
+_PROM_TWO_SERIES: dict[str, Any] = {
+    "status": "success",
+    "data": {
+        "resultType": "vector",
+        "result": [
+            {"metric": {"__name__": "ds_used_pct", "datastore": "ds-01"}, "value": [1.7e9, "91.2"]},
+            {"metric": {"__name__": "ds_used_pct", "datastore": "ds-02"}, "value": [1.7e9, "94.5"]},
+        ],
+    },
+}
+
+
+def test_count_breach_samples_offending_series() -> None:
+    # The evidence now names WHICH series breached, not merely that two did.
+    out = _eval(
+        {"path": "$.data.result", "aggregate": "count"},
+        {"type": "threshold", "op": "gt", "critical": 0},
+        _PROM_TWO_SERIES,
+    )
+    assert out.state == "critical"
+    assert out.evidence["observed"] == 2
+    assert out.evidence["sample"] == _PROM_TWO_SERIES["data"]["result"]
+    assert "sample_truncated" not in out.evidence
+    json.dumps(out.evidence)  # evidence stays JSON-serializable end to end
+
+
+def test_sample_is_bounded_and_flags_truncation() -> None:
+    rows = [{"id": i} for i in range(_EVIDENCE_SAMPLE_LIMIT + 2)]
+    out = _eval(
+        {"path": "$.xs", "aggregate": "count"},
+        {"type": "threshold", "op": "gt", "critical": 0},
+        {"xs": rows},
+    )
+    assert out.state == "critical"
+    assert out.evidence["observed"] == len(rows)  # the true count survives
+    assert out.evidence["sample"] == rows[:_EVIDENCE_SAMPLE_LIMIT]
+    assert out.evidence["sample_truncated"] is True
+
+
+def test_healthy_tick_carries_no_sample() -> None:
+    # count gt 0 over an empty result -> ok, evidence byte-for-byte as before.
+    ok_empty = _eval(
+        {"path": "$.data.result", "aggregate": "count"},
+        {"type": "threshold", "op": "gt", "critical": 0},
+        {"data": {"result": []}},
+    )
+    assert ok_empty.state == "ok"
+    assert "sample" not in ok_empty.evidence
+    # A non-empty but healthy aggregate (count lt 3, five present) stays clean.
+    ok_full = _eval(
+        {"path": "$.xs", "aggregate": "count"},
+        {"type": "threshold", "op": "lt", "critical": 3},
+        {"xs": [{"id": i} for i in range(5)]},
+    )
+    assert ok_full.state == "ok"
+    assert "sample" not in ok_full.evidence
+
+
+def test_degraded_tick_samples_too() -> None:
+    out = _eval(
+        {"path": "$.xs", "aggregate": "count"},
+        {"type": "threshold", "op": "gt", "degraded": 1, "critical": 10},
+        {"xs": [{"id": 1}, {"id": 2}]},
+    )
+    assert out.state == "degraded"
+    assert out.evidence["sample"] == [{"id": 1}, {"id": 2}]
+
+
+def test_lt_breach_samples_rows_present() -> None:
+    # For lt the breach is what is *missing*; the sample is the rows present, so
+    # triage can diff against the expected set.
+    out = _eval(
+        {"path": "$.ready", "aggregate": "count"},
+        {"type": "threshold", "op": "lt", "critical": 3},
+        {"ready": [{"pod": "web-0"}]},
+    )
+    assert out.state == "critical"
+    assert out.evidence["sample"] == [{"pod": "web-0"}]
+
+
+def test_wildcard_projection_samples_projected_identities() -> None:
+    out = _eval(
+        {"path": "$.data.result[*].metric.datastore", "aggregate": "count"},
+        {"type": "threshold", "op": "gt", "critical": 0},
+        _PROM_TWO_SERIES,
+    )
+    assert out.state == "critical"
+    assert out.evidence["sample"] == ["ds-01", "ds-02"]
+
+
+@pytest.mark.parametrize("aggregate", ["sum", "max", "min"])
+def test_numeric_aggregate_breach_samples_rows(aggregate: str) -> None:
+    # The sample is attached uniformly across aggregates, not only count.
+    out = _eval(
+        {"path": "$.xs", "aggregate": aggregate},
+        {"type": "threshold", "op": "gt", "critical": 100},
+        {"xs": [150.0, 200.0]},
+    )
+    assert out.state == "critical"
+    assert out.evidence["sample"] == [150.0, 200.0]
+
+
+def test_scalar_assertion_never_samples() -> None:
+    out = _eval({"path": "$.v"}, {"type": "threshold", "op": "gt", "critical": 0}, {"v": 5})
+    assert out.state == "critical"
+    assert "sample" not in out.evidence
+
+
+def test_unknown_aggregate_tick_never_samples() -> None:
+    # A non-list under an aggregate is unknown -> no sample (there is no set).
+    out = _eval(
+        {"path": "$.n", "aggregate": "count"},
+        {"type": "threshold", "op": "gt", "critical": 0},
+        {"n": 7},
+    )
+    assert out.state == "unknown"
+    assert "sample" not in out.evidence
 
 
 # --------------------------------------------------------------------------- #

--- a/docs/codebase/sensor.md
+++ b/docs/codebase/sensor.md
@@ -155,6 +155,28 @@ history and projection can never diverge. The row records the *observed*
 outcome of each evaluation (committed, soft/pending, or re-confirmed), so a
 flapping reading that never commits still lands in history.
 
+### Aggregate offender sample (#2976)
+
+An aggregate assertion (`count` / `sum` / `max` / `min` / `any` / `all`)
+collapses the selected rows to one number, so the evidence records only
+`observed` — e.g. `{"aggregate":"count","observed":2,...}` says *two* series
+breached but not *which* two. Once the condition clears that identity is
+unrecoverable from the retained per-tick rows (the raw payload survives in
+`audit_log.raw_payload`, but no operator/agent read surface exposes it). On a
+**breaching** tick (`degraded` / `critical`) of an aggregate assertion the
+evaluator (`checks.evaluate._with_offender_sample`) now attaches a bounded
+`sample` of the selected rows to the evidence — at most
+`_EVIDENCE_SAMPLE_LIMIT` (5) rows verbatim (prometheus series labels+value, or
+the selected objects/keys for a JSON select), plus `sample_truncated: true`
+when more were dropped. `observed` still carries the true aggregate. For
+`gt` / `gte` the sample *is* the offending set; for `lt` / `lte` it is the rows
+present (the breach being what is missing). `ok` / `unknown` ticks, scalar
+(non-aggregate) assertions, and empty selections are untouched, so the common
+healthy tick's evidence is byte-for-byte unchanged. The sample rides the same
+evidence dict every surface already renders — the latest-result projection, the
+per-tick `sensor_results` rows, the sensor detail view, notification mails
+(clipped), and the investigator briefing — so no consumer needed a change.
+
 ### Per-tick evidence history (#2756)
 
 `meho_backplane.db.models.SensorResult` (`sensor_results` table, migration
@@ -239,9 +261,11 @@ Each surface carries the four verbs — `list` / `create` / `delete` plus the
   #2784 (the refusal is now the `connector_probe_refused` dispatch
   error, which lands here as `unknown` / `reason: dispatch_not_ok`), but
   the general hazard is a **connector contract** the checks layer cannot
-  detect: assertion evidence is `{path, aggregate, comparator, expect,
-  observed}` and carries no sibling fields from the payload, so a
-  reading-shaped refusal has no in-band way to announce itself. See
+  detect: a scalar assertion's evidence is `{path, aggregate, comparator,
+  expect, observed}` and carries no sibling fields from the payload (only a
+  breaching *aggregate* pulls a bounded `sample` in, #2976), so a
+  reading-shaped refusal on a scalar probe has no in-band way to announce
+  itself. See
   `docs/codebase/connectors-net-diagnostics.md` § *Refusal is a dispatch
   error, not a reading*.
 - The safe-only guard's descriptor read and the insert are in separate


### PR DESCRIPTION
## Summary

- A count/sum/… **aggregate** assertion collapses the selected rows to one `observed` number, so a fired sensor's evidence records *that* (e.g.) two datastores breached but not **which** two — and once the condition clears that identity is unrecoverable from the retained per-tick rows (the raw payload lives in `audit_log.raw_payload` but no read surface exposes it). Mid-incident triage had to re-run the query by hand via `call_operation`.
- The evaluator now attaches a **bounded `sample`** of the selected rows to the evidence of a **breaching** (`degraded`/`critical`) aggregate tick — at most `_EVIDENCE_SAMPLE_LIMIT` (5) rows verbatim, plus `sample_truncated: true` when clipped. `observed` still carries the true aggregate. For `gt`/`gte` the sample *is* the offending set; for `lt`/`lte` it is the rows present (the breach being what's missing).
- The sample rides the **existing** evidence dict that `record_sensor_result` persists verbatim, so every surface that already renders evidence — the latest-result projection, per-tick `sensor_results` rows, the sensor detail view, notify mails (clipped), and the investigator briefing — gains the offender identity with **no consumer change**.
- Healthy (`ok`/`unknown`) ticks, scalar (non-aggregate) assertions, and empty selections are **byte-for-byte unchanged**, so the retained history stays lean (the flagship `count gt 0` pattern is empty on healthy ticks anyway).

Complements #2780/#2756 (per-tick retention): this changes *what* each tick retains, not *whether* ticks are retained. Part of Initiative #3020 (G0.40 wave 2). Disjoint from the vmware work in sibling #2973.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy` — clean (`Success: no issues found`)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (one advisory file-size warning, see Out of scope)
- [x] `pytest tests/test_checks_assertions.py` — 120 passed, incl. 12 new tests: count breach samples the offending series; bound + `sample_truncated`; healthy tick carries no sample; degraded tick sampled; `lt` breach samples rows-present; `[*]` projection samples projected identities; `sum`/`max`/`min` breach sampled; scalar never sampled; unknown never sampled; evidence stays JSON-serializable
- [x] Blast-radius consumer sweep — `pytest -k "checks or sensor or dashboard or watchdog or ui_checks or evidence_retention"` **574 passed**; plus prometheus + datastore-usage + notify + investigate suites (158 passed). No consumer assumes scalar-only evidence values (`detail.html` renders `tojson`, notify `_clip`s, investigator `repr`s).

## Out of scope / notes

- **Advisory only:** `checks/evaluate.py` is now 405 lines, crossing the code-quality *warn* threshold (>400; block is >600). Splitting a cohesive pure `select→compare` evaluator to satisfy a 400-line nudge would harm cohesion more than it helps; recorded rather than actioned.
- **Pre-existing, not introduced here:** evidence can already carry a non-finite float (`observed` for an `equals`/`in` comparator over a NaN scalar), which PG `jsonb` rejects on insert; the `sample` inherits the same extremely-narrow exposure (a `count` over a float list literally containing `NaN`, non-RFC JSON, on a breaching tick). Not sanitized here to stay surgical and symmetric with existing behavior.
- Docs: `docs/codebase/sensor.md` gains an *Aggregate offender sample (#2976)* subsection; the `AssertionOutcome` / `evaluate_assertion` docstrings and the net-refusal aside are updated to stay accurate.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #2976
